### PR TITLE
v1 is specified in apiVersion field

### DIFF
--- a/docs/concepts/overview/kubernetes-api.md
+++ b/docs/concepts/overview/kubernetes-api.md
@@ -77,7 +77,7 @@ The API group is specified in a REST path and in the `apiVersion` field of a ser
 Currently there are several API groups in use:
 
 1. the "core" (oftentimes called "legacy", due to not having explicit group name) group, which is at
-   REST path `/api/v1` and is not specified as part of the `apiVersion` field, e.g. `apiVersion: v1`.
+   REST path `/api/v1` and is specified as part of the `apiVersion` field, e.g. `apiVersion: v1`.
 1. the named groups are at REST path `/apis/$GROUP_NAME/$VERSION`, and use `apiVersion: $GROUP_NAME/$VERSION`
    (e.g. `apiVersion: batch/v1`).  Full list of supported API groups can be seen in [Kubernetes API reference](/docs/reference/).
 


### PR DESCRIPTION
The use of `not` here may be confusing to newcomers.

Is the intention to suggest the `apiVersion` field defaults to v1 unless otherwise specified?

> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.7 Features: set Milestone to `1.7` and Base Branch to `release-1.7`
> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
> NOTE: Please check the “Allow edits from maintainers” box below to allow 
> reviewers fix problems on your patch and speed up the review process.
> Please delete this note before submitting the pull request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4127)
<!-- Reviewable:end -->
