### PR TITLE
kubectl-cheatsheet - patch, added example for add

### DIFF
--- a/docs/user-guide/kubectl-cheatsheet.md
+++ b/docs/user-guide/kubectl-cheatsheet.md
@@ -173,7 +173,7 @@ $ kubectl patch pod valid-pod --type='json' -p='[{"op": "replace", "path": "/spe
 $ kubectl patch deployment valid-deployment  --type json   -p='[{"op": "remove", "path": "/spec/template/spec/containers/0/livenessProbe"}]'
 
 # Add a new element to a positional array 
-$ kubectl patch dc my_deployment_config --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/1", "value": {"image": "my_new_image", "name": "my_new_image"} }]'
+$ kubectl patch sa default --type='json' -p='[{"op": "add", "path": "/secrets/1", "value": {"name": "whatever" } }]'
 ```
 
 ## Editing Resources

--- a/docs/user-guide/kubectl-cheatsheet.md
+++ b/docs/user-guide/kubectl-cheatsheet.md
@@ -158,7 +158,6 @@ $ kubectl autoscale deployment foo --min=2 --max=10                # Auto scale 
 ```
 
 ## Patching Resources
-Patch a resource(s) with a strategic merge patch.
 
 ```console
 $ kubectl patch node k8s-node-1 -p '{"spec":{"unschedulable":true}}' # Partially update a node

--- a/docs/user-guide/kubectl-cheatsheet.md
+++ b/docs/user-guide/kubectl-cheatsheet.md
@@ -171,6 +171,9 @@ $ kubectl patch pod valid-pod --type='json' -p='[{"op": "replace", "path": "/spe
 
 # Disable a deployment livenessProbe using a json patch with positional arrays
 $ kubectl patch deployment valid-deployment  --type json   -p='[{"op": "remove", "path": "/spec/template/spec/containers/0/livenessProbe"}]'
+
+# Add a new element to a positional array 
+$ kubectl patch dc my_deployment_config --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/1", "value": {"image": "my_new_image", "name": "my_new_image"} }]'
 ```
 
 ## Editing Resources


### PR DESCRIPTION
Added an example showing how to add an element to a list, using `op=add` operation.

My example is specifically taken from an OpenShift `DeploymentConfig` resource, but the idea is more generic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/4546)
<!-- Reviewable:end -->
