### PR TITLE
pod-network-cidr seems to be required

### DIFF
--- a/docs/setup/independent/create-cluster-kubeadm.md
+++ b/docs/setup/independent/create-cluster-kubeadm.md
@@ -96,10 +96,11 @@ etcd (the cluster database) and the API server (which the kubectl CLI
 communicates with).
 
 To initialize the master, pick one of the machines you previously installed
-kubeadm on, and run:
+kubeadm on, determine your network CIDR, and run:
 
 ``` bash
-kubeadm init
+# where the CIDR for this network would be 10.244.0.0/16
+kubeadm init --pod-network-cidr=10.244.0.0/16
 ```
 
 **Note:**


### PR DESCRIPTION
As far as I can tell, "--pod-network-cidr=<CIDR>" is required but not currently specified in the current docs. I could be wrong as it seems determinate on the network layer chosen. But it seemed to me that all of them (except for maybe one) required this init argument.

> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.8 Features: set Milestone to `1.8` and Base Branch to `release-1.8`
> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
> NOTE: Please check the “Allow edits from maintainers” box (see image below) to
> [allow reviewers to fix problems](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) on your patch and speed up the review process.
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5257)
<!-- Reviewable:end -->
