### PR TITLE
add initializerconfiguration to kubectl valid resource type

### DIFF
--- a/docs/user-guide/kubectl-overview.md
+++ b/docs/user-guide/kubectl-overview.md
@@ -102,6 +102,7 @@ Resource type    | Abbreviated alias
 `events` |`ev`
 `horizontalpodautoscalers` |`hpa`
 `ingresses` |`ing`
+`initializerconfiguration` |`ic`
 `jobs` |
 `limitranges` |`limits`
 `namespaces` |`ns`


### PR DESCRIPTION
xref [kubernetes #51089](https://github.com/kubernetes/kubernetes/pull/51089): add "initializerconfiguration" as kubectl valid resource

/cc @mengqiy

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5260)
<!-- Reviewable:end -->
