### PR TITLE
Fix the not-working test case yaml for /doc/concepts/storage/volumes.md

### DIFF
--- a/docs/concepts/storage/volumes.md
+++ b/docs/concepts/storage/volumes.md
@@ -818,12 +818,15 @@ spec:
     containers:
     - name: mysql
       image: mysql
+      env:
+      - name: MYSQL_ROOT_PASSWORD
+        value: "rootpasswd" 
       volumeMounts:
       - mountPath: /var/lib/mysql
         name: site-data
         subPath: mysql
     - name: php
-      image: php
+      image: php:7.0-apache
       volumeMounts:
       - mountPath: /var/www/html
         name: site-data


### PR DESCRIPTION
Fix the not-working test case yaml for /doc/concepts/storage/volumes.md

In the section "Using subPath", there is an example of pod with two containers "mysql" and "php", but when I used this yaml file to deploy this pod in my environment, the pod can not run correctly.

My environment is kubernetes version 1.7.3 with ceph storageClass to provide persistence volumes, and deployed on the bare-metals.

When I use the yaml file provided by this doc, the pod can not run, use "kubectl get pod" to get following outputs

```
root@master1:~# kubectl get pods
NAME           READY     STATUS             RESTARTS   AGE
my-lamp-site   0/2       CrashLoopBackOff   12         8m
```

So I check the logs of container mysql, the error log is as following:

```
root@master1:~# kubectl log my-lamp-site mysql
W0907 17:22:31.094909   32261 cmd.go:392] log is DEPRECATED and will be removed in a future version. Use logs instead.
error: database is uninitialized and password option is not specified
  You need to specify one of MYSQL_ROOT_PASSWORD, MYSQL_ALLOW_EMPTY_PASSWORD and MYSQL_RANDOM_ROOT_PASSWORD
```

According to the log, it seems that we should at least provided one of three environment variable, so I add MYSQL_ROOT_PASSWORD into the yaml.

However after updating the mysql, the pod still can not run. This time is php not running, the status and logs of it are as following:


```
root@master1:~# kubectl get pods
NAME           READY     STATUS             RESTARTS   AGE
my-lamp-site   1/2       CrashLoopBackOff   4          5m

root@master1:~/test# kubectl logs my-lamp-site php
Interactive shell
```

But after I update the image of php to "php:7.0-apache", the pod is running correctlly. 

This work-around solution may not be the best, but at least it can work, so I can experience the 'Sub Path' feature of Volumes.

If you are not satisfied with this work-around, you can tell me which is the best practise in your mind, and I'm willing to fulfill it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5366)
<!-- Reviewable:end -->
