### PR TITLE
Update: Using universal zsh configuration

### DIFF
--- a/docs/tasks/tools/install-kubectl.md
+++ b/docs/tasks/tools/install-kubectl.md
@@ -187,12 +187,6 @@ kubectl completion bash > $(brew --prefix)/etc/bash_completion.d/kubectl
 
 The Homebrew project is independent from Kubernetes, so the bash-completion packages are not guaranteed to work.
 
-<<<<<<< HEAD
-### Using zsh
-
-To add kubectl autocompletion to your ZSH profile, add the following line to
-the ~/.zshrc file:
-=======
 ### Using Zsh
 If you are using zsh edit the ~/.zshrc file and add the following code to enable kubectl autocompletion:
 
@@ -203,7 +197,7 @@ fi
 ```
 
 Or when using [Oh-My-Zsh](http://ohmyz.sh/), edit the ~/.zshrc file and update the `plugins=` line to include the kubectl plugin.
->>>>>>> Update install-kubectl.md
+
 
 ```shell
 source <(kubectl completion zsh)

--- a/docs/tasks/tools/install-kubectl.md
+++ b/docs/tasks/tools/install-kubectl.md
@@ -187,10 +187,23 @@ kubectl completion bash > $(brew --prefix)/etc/bash_completion.d/kubectl
 
 The Homebrew project is independent from Kubernetes, so the bash-completion packages are not guaranteed to work.
 
+<<<<<<< HEAD
 ### Using zsh
 
 To add kubectl autocompletion to your ZSH profile, add the following line to
 the ~/.zshrc file:
+=======
+### Using Zsh
+If you are using zsh edit the ~/.zshrc file and add the following code to enable kubectl autocompletion:
+
+```shell
+if [ $commands[kubectl] ]; then
+  source <(kubectl completion zsh)
+fi
+```
+
+Or when using [Oh-My-Zsh](http://ohmyz.sh/), edit the ~/.zshrc file and update the `plugins=` line to include the kubectl plugin.
+>>>>>>> Update install-kubectl.md
 
 ```shell
 source <(kubectl completion zsh)


### PR DESCRIPTION
Zsh is not only oh-my-zsh, so I added universal configuration for zsh that also can be used in prezto.

> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.8 Features: set Milestone to `1.8` and Base Branch to `release-1.8`
> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
> NOTE: Please check the “Allow edits from maintainers” box (see image below) to
> [allow reviewers to fix problems](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) on your patch and speed up the review process.
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5669)
<!-- Reviewable:end -->
