### PR TITLE
Fix kubectl zsh completion instructions

### DIFF
--- a/docs/tasks/tools/install-kubectl.md
+++ b/docs/tasks/tools/install-kubectl.md
@@ -187,11 +187,13 @@ kubectl completion bash > $(brew --prefix)/etc/bash_completion.d/kubectl
 
 The Homebrew project is independent from Kubernetes, so the bash-completion packages are not guaranteed to work.
 
-### Using Oh-My-Zsh
-When using [Oh-My-Zsh](http://ohmyz.sh/), edit the ~/.zshrc file and update the `plugins=` line to include the kubectl plugin.
+### Using zsh
+
+To add kubectl autocompletion to your ZSH profile, add the following line to
+the ~/.zshrc file:
 
 ```shell
-plugins=(git zsh-completions kubectl)
+source <(kubectl completion zsh)
 ```
 
 {% endcapture %}


### PR DESCRIPTION
taking over from #3787.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5731)
<!-- Reviewable:end -->
