### PR TITLE
Replace Chinese comments into International English

### DIFF
--- a/cn/_includes/templates/concept.md
+++ b/cn/_includes/templates/concept.md
@@ -24,7 +24,7 @@
 
 {% if whatsnext %}
 
-## 开始下一步
+## What's next
 
 {{ whatsnext }}
 


### PR DESCRIPTION
There is a Chinese inside the codes, now replace them with International English

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5932)
<!-- Reviewable:end -->
