### PR TITLE
PR template note for 1.9

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,6 @@
+> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+> For 1.9 Features: set Milestone to `1.9` and Base Branch to `release-1.9`
+> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 > NOTE: Please check the “Allow edits from maintainers” box (see image below) to
 > [allow reviewers to fix problems](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) on your patch and speed up the review process.
 >

--- a/README.md
+++ b/README.md
@@ -18,28 +18,3 @@ For more information about contributing to the Kubernetes documentation, see:
 
 Kubernetes thrives on community participation, and we really appreciate your
 contributions to our site and our documentation!
-
---
-DRAFT MATERIAL
-
-Review the documentation style guide
-
-Familiarize yourself with Kubernetes.
-    Install Docker, minikube
-
-Review repo labels:
-    Docs labels: needs review, open issues, LGTM
-    Default priority
-
-Review expectations for [community membership](https://github.com/kubernetes/community/blob/master/community-membership.md) and start by becoming a member:
-    - Find 2 sponsors
-        - Ask for support in the []#sig-docs Slack channel](https://kubernetes.slack.com/messages/C1J0BPD2M/details/)
-    - Open and merge 5 PRs
-        - Create a [fork](https://help.github.com/articles/fork-a-repo/) of the docs repository
-        - Open PRs based on [actionable issues](https://github.com/kubernetes/kubernetes.github.io/issues?q=is%3Aopen+is%3Aissue+label%3AActionable).
-        - Observe how labels are added and changed for your PRs
-    - Attend [SIG-docs meetings](https://docs.google.com/document/d/1Ds87eRiNZeXwRBEbFr6Z7ukjbTow5RQcNZLaSvWWQsE/edit?pli=1#) for one month consecutively
-    - Attend K8s [community meetings](https://docs.google.com/document/d/1VQDIAB0OqiSjIHI8AWMvSdceWhnz56jNpZrLs6o7NJY/edit) for one month consecutively
-
-Become a reviewer:
-- Open a PR with your name added to the OWNERS file as a reviewer

--- a/README.md
+++ b/README.md
@@ -18,3 +18,28 @@ For more information about contributing to the Kubernetes documentation, see:
 
 Kubernetes thrives on community participation, and we really appreciate your
 contributions to our site and our documentation!
+
+--
+DRAFT MATERIAL
+
+Review the documentation style guide
+
+Familiarize yourself with Kubernetes.
+    Install Docker, minikube
+
+Review repo labels:
+    Docs labels: needs review, open issues, LGTM
+    Default priority
+
+Review expectations for [community membership](https://github.com/kubernetes/community/blob/master/community-membership.md) and start by becoming a member:
+    - Find 2 sponsors
+        - Ask for support in the []#sig-docs Slack channel](https://kubernetes.slack.com/messages/C1J0BPD2M/details/)
+    - Open and merge 5 PRs
+        - Create a [fork](https://help.github.com/articles/fork-a-repo/) of the docs repository
+        - Open PRs based on [actionable issues](https://github.com/kubernetes/kubernetes.github.io/issues?q=is%3Aopen+is%3Aissue+label%3AActionable).
+        - Observe how labels are added and changed for your PRs
+    - Attend [SIG-docs meetings](https://docs.google.com/document/d/1Ds87eRiNZeXwRBEbFr6Z7ukjbTow5RQcNZLaSvWWQsE/edit?pli=1#) for one month consecutively
+    - Attend K8s [community meetings](https://docs.google.com/document/d/1VQDIAB0OqiSjIHI8AWMvSdceWhnz56jNpZrLs6o7NJY/edit) for one month consecutively
+
+Become a reviewer:
+- Open a PR with your name added to the OWNERS file as a reviewer


### PR DESCRIPTION
From the K8s [docs release playbook](https://docs.google.com/document/d/1PCkAwPWadlu7beprhtQLtZzgsbO8CD7SvMVzta3fhcw/edit?ts=5963ce05#): 

> Add a reminder in the pull request template for PRs going into the new release to use the release base branch and set the Milestone

The 1.9 milestone is [here](https://github.com/kubernetes/kubernetes.github.io/milestone/16).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5943)
<!-- Reviewable:end -->
