### PR TITLE
[do-not-merge][WIP] Cluster ops content draft for user journeys

### DIFF
--- a/user-journeys/index.html
+++ b/user-journeys/index.html
@@ -121,10 +121,59 @@
               }
             ],
             intermediate: [
-              "c1: intermediate stuff",
-              "c2: intermediate stuff",
-              "c3: intermediate stuff"
-            ],
+            {
+              label: "Managing Resources",
+              url: "https://kubernetes.io/docs/concepts/cluster-administration/manage-deployment/"
+            },
+            {
+              label: "Ingress",
+              url: "/docs/concepts/services-networking/ingress/"
+            },
+            {
+              label: "Taints and Tolerations",
+              url: "/docs/concepts/configuration/taint-and-toleration/"
+            },
+            {
+              label: "Pods and Priority",
+              url: "/docs/concepts/configuration/pod-priority-preemption/"
+            },
+            {
+              label: "Taints and Tolerations",
+              url: "/docs/concepts/configuration/taint-and-toleration/"
+            },
+            {
+              label: "Volumes",
+              url: "/docs/concepts/storage/volumes/"
+            },
+            {
+              label: "Persistent Volumes",
+              url: "/docs/concepts/storage/persistent-volumes/"
+            },
+            {
+              label: "Stateful Sets",
+              url: "/docs/concepts/workloads/controllers/statefulset/"
+            },
+            {
+              label: "Daemon Sets",
+              url: "/docs/concepts/workloads/controllers/daemonset/"
+            },
+            {
+              label: "Jobs",
+              url: "/docs/concepts/workloads/controllers/jobs-run-to-completion/"
+            },
+            {
+              label: "CronJobs",
+              url: "/docs/concepts/workloads/controllers/cron-jobs/"
+            },
+            {
+              label: "Initialization Containers",
+              url: "/docs/concepts/workloads/pods/init-containers/"
+            },
+            {
+              label: "Pod Lifecycle",
+              url: "/docs/concepts/workloads/pods/pod-lifecycle/"
+            }
+          ],
             advanced: [
               "c1: advanced stuff",
               "c2: advanced stuff",

--- a/user-journeys/index.html
+++ b/user-journeys/index.html
@@ -75,9 +75,50 @@
           cluster_operator: {
             label: "Cluster Operator",
             foundational: [
-              "c1: foundational stuff",
-              "c2: foundational stuff",
-              "c3: foundational stuff"
+              {
+                label: "What is Kubernetes?",
+                url: "/docs/concepts/overview/what-is-kubernetes/"
+              },
+              {
+                label: "Pod Overview?",
+                url: "/docs/concepts/workloads/pods/pod-overview/"
+              },
+              {
+                label: "Nodes",
+                url: "/docs/concepts/architecture/nodes/"
+              },
+              {
+                label: "Cluster Networking",
+                url: "/docs/concepts/cluster-administration/networking/"
+              },
+              {
+                label: "Deployments",
+                url: "/docs/concepts/workloads/controllers/deployment/"
+              },
+              {
+                label: "Services",
+                url: "/docs/concepts/services-networking/service/"
+              },
+              {
+                label: "Labels and Selectors",
+                url: "/docs/concepts/overview/working-with-objects/labels/"
+              },
+              {
+                label: "Annotations",
+                url: "/docs/concepts/overview/working-with-objects/annotations/"
+              },
+              {
+                label: "ConfigMap",
+                url: "/docs/tasks/configure-pod-container/configmap/"
+              },
+              {
+                label: "Secrets",
+                url: "/docs/concepts/configuration/secret/"
+              },
+              {
+                label: "Metrics",
+                url: "/docs/concepts/cluster-administration/controller-metrics/"
+              }
             ],
             intermediate: [
               "c1: intermediate stuff",


### PR DESCRIPTION
initial cluster-ops/foundational content draft

- trying to reference existing content exclusively and see if
       we can get away with not writing intermediate "glue" content for Cluster Operator
- dug through existing concept/task/setup/ref content to assemble
       foundational set based on [Cluster Operator persona](https://docs.google.com/document/d/1EdQ8acmuKGlzZy1agejLqmB7cLpTRBJKC0JYptJ-ylg/edit#heading=h.9ldf5a7ll7ee)
- review at [`/user-journeys/`](https://deploy-preview-5946--kubernetes-io-master-staging.netlify.com/user-journeys/): User -> Cluster Operator -> Foundational

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes.github.io/5946)
<!-- Reviewable:end -->