### PR TITLE
Corrected version required for statefulsets

### DIFF
--- a/docs/concepts/workloads/controllers/statefulset.md
+++ b/docs/concepts/workloads/controllers/statefulset.md
@@ -66,7 +66,7 @@ spec:
   selector:
     app: nginx
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
   name: web


### PR DESCRIPTION
The example doesn't work due to an invalid apiVersion. I corrected it to the working version.

> NOTE: Please check the “Allow edits from maintainers” box (see image below) to
> [allow reviewers to fix problems](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) on your patch and speed up the review process.
>
> Please delete this note before submitting the pull request.
>
> NOTE: After opening the PR, please *un-check and re-check* the "Allow edits from maintainers" box. This is a temporary workaround to address a known issue with GitHub.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/5955)
<!-- Reviewable:end -->
