### PR TITLE
Document conntrack dependency for kube-proxy

### DIFF
--- a/docs/getting-started-guides/scratch.md
+++ b/docs/getting-started-guides/scratch.md
@@ -424,6 +424,13 @@ Arguments to consider:
   - Otherwise, if taking the firewall-based security approach
     - `--master=http://$MASTER_IP`
 
+Note that on some Linux platforms, you may need to manually install the
+`conntrack` package which is a dependency of kube-proxy, or else kube-proxy
+cannot be started successfully.
+
+For more details on debugging kube-proxy problems, please refer to
+[Debug Services](/docs/tasks/debug-application-cluster/debug-service/)
+
 ### Networking
 
 Each node needs to be allocated its own CIDR range for pod networking.

--- a/docs/tasks/debug-application-cluster/debug-service.md
+++ b/docs/tasks/debug-application-cluster/debug-service.md
@@ -426,6 +426,13 @@ I1027 22:14:54.040223    5063 proxier.go:294] Adding new service "kube-system/ku
 If you see error messages about not being able to contact the master, you
 should double-check your `Node` configuration and installation steps.
 
+One of the possible reasons that `kube-proxy` cannot run correctly is that the
+required `conntrack` binary cannot be found. This may happen on some Linux
+systems, depending on how you are installing the cluster, for example, you are
+installing Kubernetes from scratch. If this is the case, you need to manually
+install the `conntrack` package (e.g. `sudo apt install conntrack` on Ubuntu)
+and then retry.
+
 ### Is kube-proxy writing iptables rules?
 
 One of the main responsibilities of `kube-proxy` is to write the `iptables`


### PR DESCRIPTION
This PR amends the kube-proxy related documents so that users get a better idea when `conntrack` dependency was not satisfied.

Fixes: #5773

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/5962)
<!-- Reviewable:end -->
