### PR TITLE
resolves jekyll rendering error

### DIFF
--- a/cn/docs/concepts/cluster-administration/device-plugins.md
+++ b/cn/docs/concepts/cluster-administration/device-plugins.md
@@ -1,7 +1,7 @@
 ---
 approvers:
 title: 设备插件
-描述： 使用 Kubernetes 设备插件框架来为 GPUs、 NICs、 FPGAs、 InfiniBand 和其他类似的需要供应商特别设置的资源开发插件。
+description: 使用 Kubernetes 设备插件框架来为 GPUs、 NICs、 FPGAs、 InfiniBand 和其他类似的需要供应商特别设置的资源开发插件。
 ---
 
 {% include feature-state-alpha.md %}


### PR DESCRIPTION
 - chinese isn't understood for keys in YAML frontmatter in jekyll, so
   replaced it with the english equivalent that doesn't throw the
following error on rendering:

`Error reading file src/kubernetes.github.io/cn/docs/concepts/cluster-administration/device-plugins.md: (<unknown>): could not find expected ':' while scanning a simple key at line 4 column 1`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/5976)
<!-- Reviewable:end -->
