### PR TITLE
specify password for mysql image

### DIFF
--- a/docs/concepts/configuration/manage-compute-resources-container.md
+++ b/docs/concepts/configuration/manage-compute-resources-container.md
@@ -94,7 +94,7 @@ spec:
     image: mysql
     env:
     - name: MYSQL_ROOT_PASSWORD
-      value: "passwd"
+      value: "password"
     resources:
       requests:
         memory: "64Mi"

--- a/docs/concepts/configuration/manage-compute-resources-container.md
+++ b/docs/concepts/configuration/manage-compute-resources-container.md
@@ -92,6 +92,9 @@ spec:
   containers:
   - name: db
     image: mysql
+    env:
+    - name: MYSQL_ROOT_PASSWORD
+      value: "passwd"
     resources:
       requests:
         memory: "64Mi"
@@ -338,6 +341,9 @@ spec:
   containers:
   - name: db
     image: mysql
+    env:
+    - name: MYSQL_ROOT_PASSWORD
+      value: "password"
     resources:
       requests:
         ephemeral-storage: "2Gi"


### PR DESCRIPTION
If don't specify a password, Then
> error: database is uninitialized and password option is not specified
  You need to specify one of MYSQL_ROOT_PASSWORD, MYSQL_ALLOW_EMPTY_PASSWORD and MYSQL_RANDOM_ROOT_PASSWORD

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/5990)
<!-- Reviewable:end -->
