### PR TITLE
[docs][glossary] Temp fix for broken links on StatefulSet.md

### DIFF
--- a/_data/glossary/statefulset.yml
+++ b/_data/glossary/statefulset.yml
@@ -10,9 +10,9 @@ tags:
 - workload
 - storage
 short-description: |
-  Manages the deployment and scaling of a set of [Pods](#term-pod), *and provides guarantees about the ordering and uniqueness* of these Pods.
+  Manages the deployment and scaling of a set of [Pods](/docs/concepts/workloads/pods/pod), *and provides guarantees about the ordering and uniqueness* of these Pods.
 
 long-description: |
-  Like a [Deployment](#term-deployment), a StatefulSet manages Pods that are based on an identical container spec. Unlike a Deployment, a StatefulSet maintains a sticky identity for each of their Pods. These pods are created from the same spec, but are not interchangeable&#58; each has a persistent identifier that it maintains across any rescheduling.
+  Like a [Deployment](/docs/concepts/workloads/controllers/deployment), a StatefulSet manages Pods that are based on an identical container spec. Unlike a Deployment, a StatefulSet maintains a sticky identity for each of their Pods. These pods are created from the same spec, but are not interchangeable&#58; each has a persistent identifier that it maintains across any rescheduling.
 
   A StatefulSet operates under the same pattern as any other Controller. You define your desired state in a StatefulSet *object*, and the StatefulSet *controller* makes any necessary updates to get there from the current state.


### PR DESCRIPTION
Addresses issue https://github.com/kubernetes/website/issues/5989.

This is a hotfix for now---I'll come up with a more sustainable solution (e.g. full-length-content links vs glossary links) in the next week or so.

PTAL @heckj
cc @chenopis

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/5991)
<!-- Reviewable:end -->
