### PR TITLE
change the pod's request.cpu and request.limit

### DIFF
--- a/docs/concepts/configuration/manage-compute-resources-container.md
+++ b/docs/concepts/configuration/manage-compute-resources-container.md
@@ -231,8 +231,8 @@ Allocated resources:
   680m (34%)      400m (20%)    920Mi (12%)        1070Mi (14%)
 ```
 
-In the preceding output, you can see that if a Pod requests more than 1120m
-CPUs or 6.23Gi of memory, it will not fit on the node.
+In the preceding output, you can see that if a Pod requests more than 1800m
+CPUs or 7.13Gi of memory, it will not fit on the node.
 
 By looking at the `Pods` section, you can see which Pods are taking up space on
 the node.


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/25783555/31928504-fc8a1f38-b8ca-11e7-8aad-8fa84cda60b6.png)

the node Allocatable cpu is 1800m and memory is 7474992Ki ,so then a Pod with a request of cpu: 1800m  or  7474992Ki  will never be scheduled

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6028)
<!-- Reviewable:end -->
