### PR TITLE
fix wrong link to pod-preemption.md

### DIFF
--- a/docs/concepts/configuration/pod-priority-preemption.md
+++ b/docs/concepts/configuration/pod-priority-preemption.md
@@ -168,7 +168,7 @@ problematic in clusters with a high Pod creation rate.
 
 We will address this problem in the beta version of Pod preemption. The solution
 we plan to implement is
-[provided here](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/pod-preemption.md#preemption-mechanics).
+[provided here](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/pod-preemption.md#preemption-mechanics).
 
 #### PodDisruptionBudget is not supported
 


### PR DESCRIPTION
fix wrong link to pod-preemption.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6030)
<!-- Reviewable:end -->
