### PR TITLE
Operating etcd cluster for Kubernetes bad format in the final page

### DIFF
--- a/docs/tasks/administer-cluster/configure-upgrade-etcd.md
+++ b/docs/tasks/administer-cluster/configure-upgrade-etcd.md
@@ -40,9 +40,9 @@ Use a single-node etcd cluster only for testing purpose.
 
 1. Run the following:
 
-```shell
-./etcd --client-listen-urls=http://$PRIVATE_IP:2379 --client-advertise-urls=http://$PRIVATE_IP:2379
-```
+    ```shell
+    ./etcd --client-listen-urls=http://$PRIVATE_IP:2379 --client-advertise-urls=http://$PRIVATE_IP:2379
+    ```
 
 2. Start Kubernetes API server with the flag `--etcd-servers=$PRIVATE_IP:2379`.
 
@@ -130,12 +130,12 @@ Though etcd keeps unique member IDs internally, it is recommended to use a uniqu
 
 4. Start the newly added member on a machine with the IP `10.0.0.4`:
 
-```shell
-export ETCD_NAME="member4"
-export ETCD_INITIAL_CLUSTER="member2=http://10.0.0.2:2380,member3=http://10.0.0.3:2380,member4=http://10.0.0.4:2380"
-export ETCD_INITIAL_CLUSTER_STATE=existing
-etcd [flags]
-```
+    ```shell
+    export ETCD_NAME="member4"
+    export ETCD_INITIAL_CLUSTER="member2=http://10.0.0.2:2380,member3=http://10.0.0.3:2380,member4=http://10.0.0.4:2380"
+    export ETCD_INITIAL_CLUSTER_STATE=existing
+    etcd [flags]
+    ```
 
 5. Do either of the following:
 

--- a/docs/tasks/administer-cluster/configure-upgrade-etcd.md
+++ b/docs/tasks/administer-cluster/configure-upgrade-etcd.md
@@ -40,9 +40,7 @@ Use a single-node etcd cluster only for testing purpose.
 
 1. Run the following:
 
-    ```shell
-    ./etcd --client-listen-urls=http://$PRIVATE_IP:2379 --client-advertise-urls=http://$PRIVATE_IP:2379
-    ```
+        ./etcd --client-listen-urls=http://$PRIVATE_IP:2379 --client-advertise-urls=http://$PRIVATE_IP:2379
 
 2. Start Kubernetes API server with the flag `--etcd-servers=$PRIVATE_IP:2379`.
 
@@ -130,12 +128,10 @@ Though etcd keeps unique member IDs internally, it is recommended to use a uniqu
 
 4. Start the newly added member on a machine with the IP `10.0.0.4`:
 
-    ```shell
-    export ETCD_NAME="member4"
-    export ETCD_INITIAL_CLUSTER="member2=http://10.0.0.2:2380,member3=http://10.0.0.3:2380,member4=http://10.0.0.4:2380"
-    export ETCD_INITIAL_CLUSTER_STATE=existing
-    etcd [flags]
-    ```
+        export ETCD_NAME="member4"
+        export ETCD_INITIAL_CLUSTER="member2=http://10.0.0.2:2380,member3=http://10.0.0.3:2380,member4=http://10.0.0.4:2380"
+        export ETCD_INITIAL_CLUSTER_STATE=existing
+        etcd [flags]
 
 5. Do either of the following:
 

--- a/docs/tasks/administer-cluster/configure-upgrade-etcd.md
+++ b/docs/tasks/administer-cluster/configure-upgrade-etcd.md
@@ -40,9 +40,9 @@ Use a single-node etcd cluster only for testing purpose.
 
 1. Run the following:
 
-    ``` bash
-     ./etcd --client-listen-urls=http://$PRIVATE_IP:2379 --client-advertise-urls=http://$PRIVATE_IP:2379
-    ```
+```shell
+./etcd --client-listen-urls=http://$PRIVATE_IP:2379 --client-advertise-urls=http://$PRIVATE_IP:2379
+```
 
 2. Start Kubernetes API server with the flag `--etcd-servers=$PRIVATE_IP:2379`.
 
@@ -130,12 +130,13 @@ Though etcd keeps unique member IDs internally, it is recommended to use a uniqu
 
 4. Start the newly added member on a machine with the IP `10.0.0.4`:
 
-    ```bash
-    export ETCD_NAME="member4"
-    export ETCD_INITIAL_CLUSTER="member2=http://10.0.0.2:2380,member3=http://10.0.0.3:2380,member4=http://10.0.0.4:2380"
-    export ETCD_INITIAL_CLUSTER_STATE=existing
-    etcd [flags]
-    ```
+```shell
+export ETCD_NAME="member4"
+export ETCD_INITIAL_CLUSTER="member2=http://10.0.0.2:2380,member3=http://10.0.0.3:2380,member4=http://10.0.0.4:2380"
+export ETCD_INITIAL_CLUSTER_STATE=existing
+etcd [flags]
+```
+
 5. Do either of the following:
 
    1. Update its `--etcd-servers` flag to make Kubernetes aware of the configuration changes, then restart the Kubernetes API server.


### PR DESCRIPTION
Operating etcd cluster for Kubernetes bad format in the [final page](https://kubernetes.io/docs/tasks/administer-cluster/configure-upgrade-etcd/)

The following code shows bad format in the final page of section `Starting Kubernetes API server`:

`
bash ./etcd --client-listen-urls=http://$PRIVATE_IP:2379 --client-advertise-urls=http://$PRIVATE_IP:2379
`

The following code shows bad format in the final page of section `Replacing a failed etcd member`:

`
bash export ETCD_NAME="member4" export ETCD_INITIAL_CLUSTER="member2=http://10.0.0.2:2380,member3=http://10.0.0.3:2380,member4=http://10.0.0.4:2380" export ETCD_INITIAL_CLUSTER_STATE=existing etcd [flags]
`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6056)
<!-- Reviewable:end -->
