### PR TITLE
Custom Resource Validation: remove alpha warning, change enable instructions to disable

### DIFF
--- a/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions.md
+++ b/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions.md
@@ -190,12 +190,12 @@ Additionally, the following restrictions are applied to the schema:
 - The field `uniqueItems` cannot be set to true.
 - The field `additionalProperties` cannot be set to false.
 
-This feature is __alpha__ in v1.8 and may change in backward incompatible ways.
-Enable this feature using the `CustomResourceValidation` feature gate on
+This feature is __beta__ in v1.9.
+You can disable this feature using the `CustomResourceValidation` feature gate on
 the [kube-apiserver](/docs/admin/kube-apiserver):
 
-```
---feature-gates=CustomResourceValidation=true
+``` 		  
+--feature-gates=CustomResourceValidation=false
 ```
 
 The schema is defined in the CustomResourceDefinition. In the following example, the


### PR DESCRIPTION
@colemickens 
Duplicates #6065.
Per this issue, we are promoting Custom Resource Validation to beta in 1.9: kubernetes/kubernetes#53829

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6066)
<!-- Reviewable:end -->
