### PR TITLE
format skew within cassandra.md in the table of section Modifying the…

### DIFF
--- a/docs/tutorials/stateful-application/cassandra.md
+++ b/docs/tutorials/stateful-application/cassandra.md
@@ -154,26 +154,24 @@ Use `kubectl edit` to modify the size of of a Cassandra StatefulSet.
    **Note:** The following sample is an excerpt of the StatefulSet file.
    {: .note}
 
-    ```yaml   
-    # Please edit the object below. Lines beginning with a '#' will be ignored,
-    # and an empty file will abort the edit. If an error occurs while saving this file will be
-    # reopened with the relevant failures.
-    #
-    apiVersion: apps/v1beta2
-    kind: StatefulSet
-    metadata:
-     creationTimestamp: 2016-08-13T18:40:58Z
-     generation: 1
-     labels:
-       app: cassandra
-     name: cassandra
-     namespace: default
-     resourceVersion: "323"
-     selfLink: /apis/apps/v1beta1/namespaces/default/statefulsets/cassandra
-     uid: 7a219483-6185-11e6-a910-42010a8a0fc0
-    spec:
-     replicas: 3
-    ``` 
+        # Please edit the object below. Lines beginning with a '#' will be ignored,
+        # and an empty file will abort the edit. If an error occurs while saving this file will be
+        # reopened with the relevant failures.
+        #
+        apiVersion: apps/v1beta2
+        kind: StatefulSet
+        metadata:
+         creationTimestamp: 2016-08-13T18:40:58Z
+         generation: 1
+         labels:
+           app: cassandra
+         name: cassandra
+         namespace: default
+         resourceVersion: "323"
+         selfLink: /apis/apps/v1beta1/namespaces/default/statefulsets/cassandra
+         uid: 7a219483-6185-11e6-a910-42010a8a0fc0
+        spec:
+         replicas: 3
 
 2. Change the number of replicas to 4, and then save the manifest. 
 


### PR DESCRIPTION
format skew in the table of section [modifying-the-cassandra-statefulset](https://kubernetes.io/docs/tutorials/stateful-application/cassandra/#modifying-the-cassandra-statefulset) 

`
yaml # Please edit the object below. Lines beginning with a '#' will be ignored, # and an empty file will abort the edit. If an error occurs while saving this file will be # reopened with the relevant failures. # apiVersion: apps/v1beta2 kind: StatefulSet metadata: creationTimestamp: 2016-08-13T18:40:58Z generation: 1 labels: app: cassandra name: cassandra namespace: default resourceVersion: "323" selfLink: /apis/apps/v1beta1/namespaces/default/statefulsets/cassandra uid: 7a219483-6185-11e6-a910-42010a8a0fc0 spec: replicas: 3
`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6072)
<!-- Reviewable:end -->
