### PR TITLE
Corrects example yaml indentation

### DIFF
--- a/docs/tasks/administer-cluster/dns-custom-nameservers.md
+++ b/docs/tasks/administer-cluster/dns-custom-nameservers.md
@@ -114,10 +114,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kube-dns
-    namespace: kube-system
-    data:
-      stubDomains: |
-          {“consul.local”: [“10.150.0.1”]}
+  namespace: kube-system
+data:
+  stubDomains: |
+    {“consul.local”: [“10.150.0.1”]}
 ```
 
 Note that the cluster administrator did not wish to override the node’s
@@ -136,10 +136,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kube-dns
-    namespace: kube-system
-    data:
-      upstreamNameservers: |
-          [“172.16.0.1”]
+  namespace: kube-system
+data:
+  upstreamNameservers: |
+    [“172.16.0.1”]
 ```
 
 {% endcapture %}


### PR DESCRIPTION
Tried to use these examples verbatim as was puzzled; fixed for future me-analogs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6074)
<!-- Reviewable:end -->
