### PR TITLE
Clarify ExternalNames are hostnames

### DIFF
--- a/docs/api-reference/v1.8/index.html
+++ b/docs/api-reference/v1.8/index.html
@@ -18495,7 +18495,7 @@ Appears In:
 </tr>
 <tr>
 <td>externalName <br /> <em>string</em></td>
-<td>externalName is the external reference that kubedns or equivalent will return as a CNAME record for this service. No proxying will be involved. Must be a valid DNS name and requires Type to be ExternalName.</td>
+<td>externalName is the external reference that kubedns or equivalent will return as a CNAME record for this service. No proxying will be involved. Must be a valid <a href="https://tools.ietf.org/html/rfc1123">RFC-1123</a> hostnames and requires Type to be ExternalName.</td>
 </tr>
 <tr>
 <td>externalTrafficPolicy <br /> <em>string</em></td>


### PR DESCRIPTION
Updates api-reference documentation to clarify that ExternalNames
are RFC-1123 hostnames and not DNS names.

Fixes #52266

> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.9 Features: set Milestone to `1.9` and Base Branch to `release-1.9`
> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: Please check the “Allow edits from maintainers” box (see image below) to
> [allow reviewers to fix problems](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) on your patch and speed up the review process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6077)
<!-- Reviewable:end -->
