### PR TITLE
Change glossary snippet length options

### DIFF
--- a/_includes/templates/glossary/snippet.md
+++ b/_includes/templates/glossary/snippet.md
@@ -1,5 +1,7 @@
 {% assign term_data = site.data.glossary.[include.term] %}
 
+{% if include.length == "all" or include.length == "short" %}
+
 {% if term_data.short-description %}
 
 {{ term_data.short-description | markdownify }}
@@ -10,7 +12,9 @@
 
 {% endif %}
 
-{% if include.length == "long" %}
+{% endif %}
+
+{% if include.length == "all" or include.length == "long" %}
 
 {% if term_data.long-description %}
 

--- a/docs/concepts/services-networking/ingress.md
+++ b/docs/concepts/services-networking/ingress.md
@@ -5,7 +5,7 @@ title: Ingress
 ---
 
 {% capture overview %}
-{% include templates/glossary/snippet.md term="ingress" length="long" %}
+{% include templates/glossary/snippet.md term="ingress" length="all" %}
 {% endcapture %}
 
 {% capture body %}

--- a/docs/concepts/workloads/controllers/statefulset.md
+++ b/docs/concepts/workloads/controllers/statefulset.md
@@ -13,7 +13,7 @@ title: StatefulSets
 **StatefulSet is the workload API object used to manage stateful applications. 
 StatefulSets are beta in 1.8.**
 
-{% include templates/glossary/snippet.md term="statefulset" length="long" %}
+{% include templates/glossary/snippet.md term="statefulset" length="all" %}
 {% endcapture %}
 
 {% capture body %}


### PR DESCRIPTION
Refactor snippets to support `short`, `long`, and `all` as options so either description or both can be used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6101)
<!-- Reviewable:end -->
