### PR TITLE
Rename OWNERS assignees: to approvers:

### DIFF
--- a/cn/docs/admin/authorization/abac.md
+++ b/cn/docs/admin/authorization/abac.md
@@ -1,5 +1,5 @@
 ---
-assignees:
+approvers:
 - erictune
 - lavalamp
 - deads2k

--- a/cn/docs/admin/authorization/index.md
+++ b/cn/docs/admin/authorization/index.md
@@ -1,5 +1,5 @@
 ---
-assignees:
+approvers:
 - erictune
 - lavalamp
 - deads2k

--- a/cn/docs/admin/authorization/webhook.md
+++ b/cn/docs/admin/authorization/webhook.md
@@ -1,5 +1,5 @@
 ---
-assignees:
+approvers:
 - erictune
 - lavalamp
 - deads2k

--- a/cn/docs/admin/bootstrap-tokens.md
+++ b/cn/docs/admin/bootstrap-tokens.md
@@ -1,5 +1,5 @@
 ---
-assignees:
+approvers:
 - jbeda
 title: 使用启动引导令牌（Bootstrap Tokens）认证
 ---

--- a/cn/docs/admin/ovs-networking.md
+++ b/cn/docs/admin/ovs-networking.md
@@ -1,5 +1,5 @@
 ---
-assignees:
+approvers:
 - thockin
 title: Kubernetes OpenVSwitch GRE/VxLAN 网络
 ---

--- a/cn/docs/concepts/architecture/nodes.md
+++ b/cn/docs/concepts/architecture/nodes.md
@@ -1,5 +1,5 @@
 ---
-assignees:
+approvers:
 - caesarxuchao
 - dchen1107
 

--- a/cn/docs/concepts/overview/components.md
+++ b/cn/docs/concepts/overview/components.md
@@ -1,5 +1,5 @@
 ---
-assignees:
+approvers:
 - lavalamp
 title: Kubernetes 组件
 redirect_from:

--- a/cn/docs/concepts/policy/pod-security-policy.md
+++ b/cn/docs/concepts/policy/pod-security-policy.md
@@ -1,5 +1,5 @@
 ---
-assignees:
+approvers:
 - pweil-
 title: Pod 安全策略
 redirect_from:

--- a/cn/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases.md
+++ b/cn/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases.md
@@ -1,5 +1,5 @@
 ---
-assignees:
+approvers:
 - rickypai
 - thockin
 title: 使用 HostAliases 向 Pod /etc/hosts 文件添加条目

--- a/cn/docs/concepts/services-networking/dns-pod-service.md
+++ b/cn/docs/concepts/services-networking/dns-pod-service.md
@@ -1,5 +1,5 @@
 ---
-assignees:
+approvers:
 - davidopp
 - thockin
 title: DNS Pod 与 Service

--- a/cn/docs/concepts/services-networking/service.md
+++ b/cn/docs/concepts/services-networking/service.md
@@ -1,5 +1,5 @@
 ---
-assignees:
+approvers:
 - bprashanth
 title: Service
 redirect_from:

--- a/cn/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/cn/docs/concepts/workloads/controllers/cron-jobs.md
@@ -1,5 +1,5 @@
 ---
-assignees:
+approvers:
 - erictune
 - soltysh
 - janetkuo

--- a/cn/docs/concepts/workloads/controllers/daemonset.md
+++ b/cn/docs/concepts/workloads/controllers/daemonset.md
@@ -1,5 +1,5 @@
 ---
-assignees:
+approvers:
 - erictune
 title: DaemonSet
 redirect_from:

--- a/cn/docs/concepts/workloads/pods/init-containers.md
+++ b/cn/docs/concepts/workloads/pods/init-containers.md
@@ -1,5 +1,5 @@
 ---
-assignees:
+approvers:
 - erictune
 title: Init 容器
 redirect_from:

--- a/cn/docs/tasks/administer-cluster/apply-resource-quota-limit.md
+++ b/cn/docs/tasks/administer-cluster/apply-resource-quota-limit.md
@@ -1,5 +1,5 @@
 ---
-assignees:
+approvers:
 - derekwaynecarr
 - janetkuo
 

--- a/cn/docs/tasks/administer-cluster/cpu-memory-limit.md
+++ b/cn/docs/tasks/administer-cluster/cpu-memory-limit.md
@@ -1,5 +1,5 @@
 ---
-assignees:
+approvers:
 - derekwaynecarr
 - janetkuo
 title: 设置 Pod CPU 和内存限制

--- a/cn/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/cn/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -1,5 +1,5 @@
 ---
-assignees:
+approvers:
 - enisoc
 - erictune
 - foxish

--- a/cn/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
+++ b/cn/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
@@ -1,6 +1,6 @@
 ---
 title: "基于 Persistent Volumes 搭建 WordPress 和 MySQL 应用"
-assignees:
+approvers:
 - ahmetb
 - jeffmendoza
 ---

--- a/cn/docs/tutorials/stateful-application/zookeeper.md
+++ b/cn/docs/tutorials/stateful-application/zookeeper.md
@@ -1,5 +1,5 @@
 ---
-assignees:
+approvers:
 - bprashanth
 - enisoc
 - erictune

--- a/docs/tasks/administer-cluster/cilium-network-policy.md
+++ b/docs/tasks/administer-cluster/cilium-network-policy.md
@@ -1,5 +1,5 @@
 ---
-assignees:
+approvers:
 - danwent
 title: Use Cilium for NetworkPolicy
 ---

--- a/docs/tools/kompose/user-guide.md
+++ b/docs/tools/kompose/user-guide.md
@@ -1,6 +1,6 @@
 ---
 
-assignees:
+approvers:
 - cdrage
 
 title: Translate a Docker Compose File to Kubernetes Resources

--- a/docs/tutorials/stateful-application/cassandra.md
+++ b/docs/tutorials/stateful-application/cassandra.md
@@ -1,6 +1,6 @@
 ---
 title: "Example: Deploying Cassandra with Stateful Sets"
-assignees:
+approvers:
 - ahmetb
 ---
 

--- a/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
+++ b/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
@@ -1,6 +1,6 @@
 ---
 title: "Example: Deploying WordPress and MySQL with Persistent Volumes"
-assignees:
+approvers:
 - ahmetb
 ---
 

--- a/docs/tutorials/stateless-application/guestbook.md
+++ b/docs/tutorials/stateless-application/guestbook.md
@@ -1,6 +1,6 @@
 ---
 title: "Example: Deploying PHP Guestbook application with Redis"
-assignees:
+approvers:
 - ahmetb
 ---
 

--- a/docs/user-guide/update-demo/index.md.orig
+++ b/docs/user-guide/update-demo/index.md.orig
@@ -1,5 +1,5 @@
 ---
-assignees:
+approvers:
 - mikedanese
 title: Rolling Update Demo
 ---


### PR DESCRIPTION
They are effectively the same, assignees is deprecated

ref: kubernetes/test-infra#3851

I did this once before under kubernetes/website#4607 but we appear to have picked up a few new `assignees:` entries

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6121)
<!-- Reviewable:end -->
