### PR TITLE
Update maximum cluster size guidance

### DIFF
--- a/docs/concepts/cluster-administration/federation.md
+++ b/docs/concepts/cluster-administration/federation.md
@@ -165,7 +165,8 @@ users in the event of a cluster failure), then you need to have `R * (U + 1)` cl
 (`U + 1` in each of `R` regions).  In any case, try to put each cluster in a different zone.
 
 Finally, if any of your clusters would need more than the maximum recommended number of nodes for a Kubernetes cluster, then
-you may need even more clusters.  Kubernetes v1.3 supports clusters up to 1000 nodes in size.
+you may need even more clusters.  Kubernetes v1.3 supports clusters up to 1000 nodes in size. Kubernetes v1.8 supports
+clusters up to 5000 nodes. See [Building Large Clusters](/docs/admin/cluster-large/) for more details.
 
 {% endcapture %}
 

--- a/docs/concepts/cluster-administration/federation.md
+++ b/docs/concepts/cluster-administration/federation.md
@@ -166,7 +166,7 @@ users in the event of a cluster failure), then you need to have `R * (U + 1)` cl
 
 Finally, if any of your clusters would need more than the maximum recommended number of nodes for a Kubernetes cluster, then
 you may need even more clusters.  Kubernetes v1.3 supports clusters up to 1000 nodes in size. Kubernetes v1.8 supports
-clusters up to 5000 nodes. See [Building Large Clusters](/docs/admin/cluster-large/) for more details.
+clusters up to 5000 nodes. See [Building Large Clusters](/docs/admin/cluster-large/) for more guidance.
 
 {% endcapture %}
 


### PR DESCRIPTION
This document was published when v1.3 was the prevailing k8s version. This change provides newer guidance with respect to using large clusters.

> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.9 Features: set Milestone to `1.9` and Base Branch to `release-1.9`
> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: Please check the “Allow edits from maintainers” box (see image below) to
> [allow reviewers to fix problems](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) on your patch and speed up the review process.
>
> Please delete this note before submitting the pull request.
>
> NOTE: After opening the PR, please *un-check and re-check* the "Allow edits from maintainers" box. This is a temporary workaround to address a known issue with GitHub.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6135)
<!-- Reviewable:end -->
