### PR TITLE
Correct OpenStack Cloud Provider Table Layout

### DIFF
--- a/docs/concepts/cluster-administration/cloud-providers.md
+++ b/docs/concepts/cluster-administration/cloud-providers.md
@@ -62,12 +62,12 @@ be used when using OpenStack with Kubernetes. The OpenStack cloud provider
 implementation for Kubernetes supports the use of these OpenStack services from
 the underlying cloud, where available:
 
-Service                  | API Version(s) | Required
--------------------------+----------------+----------
-Block Storage (Cinder)   | V1†, V2        | No
-Compute (Nova)           | V2             | No
-Identity (Keystone)      | V2‡,  V3         | Yes
-Load Balancing (Neutron) | V1§, V2        | No
+| Service                  | API Version(s) | Required |
+|--------------------------|----------------|----------|
+| Block Storage (Cinder)   | V1†, V2        | No       |
+| Compute (Nova)           | V2             | No       |
+| Identity (Keystone)      | V2‡,  V3       | Yes      |
+| Load Balancing (Neutron) | V1§, V2        | No       |
 
 † Block Storage V1 API support is deprecated, support for Block Storage V3 will
   be added in the future.


### PR DESCRIPTION
Correct the OpenStack cloud provider table layout to use GitHub
compatiable markdown.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6138)
<!-- Reviewable:end -->
