### PR TITLE
Rename gems to plugins

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -60,7 +60,7 @@ defaults:
 
 permalink: pretty
 
-gems:
+plugins:
   - jekyll-feed
   - jekyll-sitemap
   - jekyll-seo-tag


### PR DESCRIPTION
Rename `gems` to `plugins` in `/_config.yml`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6161)
<!-- Reviewable:end -->
