### PR TITLE
Fix typo in Actual parallelism section

### DIFF
--- a/docs/concepts/workloads/controllers/jobs-run-to-completion.md
+++ b/docs/concepts/workloads/controllers/jobs-run-to-completion.md
@@ -162,7 +162,7 @@ job "myjob" scaled
 You can also use the `scale` subresource of the Job resource.
 
 Actual parallelism (number of pods running at any instant) may be more or less than requested
-parallelism, for a variety or reasons:
+parallelism, for a variety of reasons:
 
 - For Fixed Completion Count jobs, the actual number of pods running in parallel will not exceed the number of
   remaining completions.   Higher values of `.spec.parallelism` are effectively ignored.


### PR DESCRIPTION
Fix typo in Actual parallelism section

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6186)
<!-- Reviewable:end -->
