### PR TITLE
Hide the sidebar TOC for the Interactive Scenarios

### DIFF
--- a/docs/tutorials/kubernetes-basics/cluster-interactive.html
+++ b/docs/tutorials/kubernetes-basics/cluster-interactive.html
@@ -9,6 +9,7 @@ title: Interactive Tutorial - Creating a Cluster
 <body>
 
 <link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
+<link href="/docs/tutorials/kubernetes-basics/public/css/overrides.css" rel="stylesheet">
 <script src="https://katacoda.com/embed.js"></script>
 
 <div class="layout" id="top">

--- a/docs/tutorials/kubernetes-basics/deploy-interactive.html
+++ b/docs/tutorials/kubernetes-basics/deploy-interactive.html
@@ -9,6 +9,7 @@ title: Interactive Tutorial - Deploying an App
 <body>
 
 <link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
+<link href="/docs/tutorials/kubernetes-basics/public/css/overrides.css" rel="stylesheet">
 <script src="https://katacoda.com/embed.js"></script>
 
 <div class="layout" id="top">

--- a/docs/tutorials/kubernetes-basics/explore-interactive.html
+++ b/docs/tutorials/kubernetes-basics/explore-interactive.html
@@ -9,6 +9,7 @@ title: Interactive Tutorial - Exploring Your App
 <body>
 
 <link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
+<link href="/docs/tutorials/kubernetes-basics/public/css/overrides.css" rel="stylesheet">
 <script src="https://katacoda.com/embed.js"></script>
 
 <div class="layout" id="top">

--- a/docs/tutorials/kubernetes-basics/expose-interactive.html
+++ b/docs/tutorials/kubernetes-basics/expose-interactive.html
@@ -9,6 +9,7 @@ title: Interactive Tutorial - Exposing Your App
 <body>
 
 <link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
+<link href="/docs/tutorials/kubernetes-basics/public/css/overrides.css" rel="stylesheet">
 <script src="https://katacoda.com/embed.js"></script>
 
 <div class="layout" id="top">

--- a/docs/tutorials/kubernetes-basics/public/css/overrides.css
+++ b/docs/tutorials/kubernetes-basics/public/css/overrides.css
@@ -1,0 +1,27 @@
+#docsToc .push-menu-close-button,
+#docs .flyout-button {
+  display: block;
+}
+
+#docsToc {
+  position: fixed;
+  background-color: #fff;
+  top: 0;
+  left: 0;
+  width: 0;
+  padding: 0;
+  overflow: hidden;
+  z-index: 999999;
+  transition: 0.3s;
+}
+
+.open-toc #docsToc {
+  padding: 50px 20px;
+  width: 400px;
+  max-width: 100vw;
+  overflow-y: auto;
+}
+
+#docsContent {
+  width: 100%;
+}

--- a/docs/tutorials/kubernetes-basics/scale-interactive.html
+++ b/docs/tutorials/kubernetes-basics/scale-interactive.html
@@ -9,6 +9,7 @@ title: Interactive Tutorial - Scaling Your App
 <body>
 
 <link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
+<link href="/docs/tutorials/kubernetes-basics/public/css/overrides.css" rel="stylesheet">
 <script src="https://katacoda.com/embed.js"></script>
 
 <div class="layout" id="top">

--- a/docs/tutorials/kubernetes-basics/update-interactive.html
+++ b/docs/tutorials/kubernetes-basics/update-interactive.html
@@ -9,6 +9,7 @@ title: Interactive Tutorial - Updating Your App
 <body>
 
 <link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
+<link href="/docs/tutorials/kubernetes-basics/public/css/overrides.css" rel="stylesheet">
 <script src="https://katacoda.com/embed.js"></script>
 
 <div class="layout" id="top">


### PR DESCRIPTION
Based on discussions with @steveperry-53 and @heckj 

These changes forces the existing tablet view (with TOC hidden) on the interactive scenarios. The change will give the content and terminal window more space making it easier for users to understand Kubernetes. Users will be able to navigate to the next page in the tutorial via the button underneath the existing scenario.

Current site:
![screenshot 2017-11-05 22 12 07](https://user-images.githubusercontent.com/82614/32419710-91faa20e-c276-11e7-8560-4896ca50e761.png)

Changed - by default, sidebar will be hidden:
![kc-no-sidebar-closed](https://user-images.githubusercontent.com/82614/32419718-ab7ccd74-c276-11e7-9bea-2758d4caaa77.png)

Changed - Main View:
![screenshot 2017-11-05 22 15 31](https://user-images.githubusercontent.com/82614/32419730-e1642a2c-c276-11e7-85dd-d4ced97f0c58.png)
 
Changed - With sidebar open via hamburger menu in the corner:
![kc-no-sidebar-open](https://user-images.githubusercontent.com/82614/32419720-b2b2acee-c276-11e7-9004-6f83d2ee8abc.png)

The other pages on the site remain unchanged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6196)
<!-- Reviewable:end -->
