### PR TITLE
Remove 'Create an Issue' button on docs/setup page

### DIFF
--- a/_layouts/docwithnav.html
+++ b/_layouts/docwithnav.html
@@ -55,18 +55,20 @@
         {{ content }}
 
         <p><a href=""><img src="https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/{{ page.path }}?pixel" alt="Analytics" /></a></p>
-        {% if page.url != "/404.html" and page.url != "/docs/search/" %}
+        {% if page.url != "/404.html" and page.url != "/docs/search/"%}
+	{% unless page.no_issue %}
         <script type="text/javascript">
             PDRTJS_settings_8345992 = {
                 "id" : "8345992",
                 "unique_id" : "{{ page.url }}",
                 "title" : "{{ page.title }}",
-                "permalink" : "https://kubernetes.io{{ page.url }}"
+                "permalink" : "http://kubernetes.github.io{{ page.url }}"
             };
             (function(d,c,j){if(!document.getElementById(j)){var pd=d.createElement(c),s;pd.id=j;pd.src=('https:'==document.location.protocol)?'https://polldaddy.com/js/rating/rating.js':'http://i0.poll.fm/js/rating/rating.js';s=document.getElementsByTagName(c)[0];s.parentNode.insertBefore(pd,s);}}(document,'script','pd-rating-js'));
         </script>
-        <a href="" onclick="window.open('https://github.com/kubernetes/website/issues/new?title=Issue%20with%20' +
+        <a href="" onclick="window.open('https://github.com/kubernetes/kubernetes.github.io/issues/new?title=Issue%20with%20' +
         'k8s.io'+window.location.pathname)" class="button issue">Create an Issue</a>
+	{% endunless %}
         {% unless page.noedit %}
           <a href="/editdocs#{{ page.path }}" class="button issue">Edit this Page</a>
         {% endunless %}

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -3,6 +3,7 @@ approvers:
 - brendandburns
 - erictune
 - mikedanese
+no_issue: true
 title: Setup
 ---
 


### PR DESCRIPTION
The "Create an Issue" button on the https://k8s.io/docs/setup page is so appealing that many visitors have been allured to try a click. This has somehow result in some empty issue reports.
This PR is an attempt to fix it by removing the button.
Basically, there seems no need to change that page frequently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6214)
<!-- Reviewable:end -->
