### PR TITLE
Concepts left-nav additions

### DIFF
--- a/_data/concepts.yml
+++ b/_data/concepts.yml
@@ -22,10 +22,17 @@ toc:
   - docs/concepts/architecture/master-node-communication.md
   - docs/concepts/architecture/cloud-controller.md
 
-- title: Extending the Kubernetes API
+- title: Extending Kubernetes
   section:
-  - docs/concepts/api-extension/custom-resources.md
-  - docs/concepts/api-extension/apiserver-aggregation.md
+  - title: Extending the Kubernetes API
+    section:
+    - docs/concepts/api-extension/apiserver-aggregation.md
+    - docs/concepts/api-extension/custom-resources.md
+  - title: Compute, Storage, and Networking Extensions
+    section:
+    - docs/concepts/cluster-administration/network-plugins.md
+    - docs/concepts/cluster-administration/device-plugins.md
+    - docs/concepts/cluster-administration/sysctl-cluster.md
 
 - title: Containers
   section:


### PR DESCRIPTION

Renames
Concepts → Extending the Kubernetes API
to
Concepts → Extending Kubernetes

Adds in subsections

Adds concept guides for other (non-API) extensions.

Subsequent commits will add an overview for all the ways to extend kubernetes,
hence the subsections in this commit.

This change is applicable to 1.8, hence pull against master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6220)
<!-- Reviewable:end -->
