### PR TITLE
Added overview concept guide to all ways to extend

### DIFF
--- a/_data/concepts.yml
+++ b/_data/concepts.yml
@@ -24,6 +24,7 @@ toc:
 
 - title: Extending Kubernetes
   section:
+  - docs/concepts/overview/extending.md
   - title: Extending the Kubernetes API
     section:
     - docs/concepts/api-extension/apiserver-aggregation.md

--- a/_data/glossary/platform-developer.yaml
+++ b/_data/glossary/platform-developer.yaml
@@ -2,9 +2,10 @@ id: platform-developer
 name: Platform Developer
 aka:
   - Kubernetes Developer
+  - Extension Developer
 tags:
   - user-type
 short-description: >
   A person who customizes the Kubernetes platform to fit the needs of their project.
 long-description: >
-  A platform developer may, for example, use [Custom Resources](/docs/concepts/api-extension/custom-resources/) or [Extend the Kubernetes API with the aggregation layer](/docs/concepts/api-extension/apiserver-aggregation/) to add functionality to their instance of Kubernetes, specifically for their application.
+  A platform developer may, for example, use [Custom Resources](/docs/concepts/api-extension/custom-resources/) or [Extend the Kubernetes API with the aggregation layer](/docs/concepts/api-extension/apiserver-aggregation/) to add functionality to their instance of Kubernetes, specifically for their application.  Some Platfor Developers are also {% glossary_tooltip text="contributors" term_id="member" %} and develop extensions which are contributed to the Kubernetes community.  Others develop closed-source commercial or site-specific extensions.

--- a/docs/concepts/overview/extending.md
+++ b/docs/concepts/overview/extending.md
@@ -9,17 +9,21 @@ approvers:
 
 {% capture overview %}
 
-Kubernetes is highly configurable and extensible.  As a result,
+Kubernetes is highly configurable and extensible. As a result,
 there is rarely a need to fork or submit patches to the Kubernetes
-project code.  
+project code.
 
-This guide describes the options for customizing a kubernetes
-cluster.  It is aimed at **Cluster Administrators** who want to
-understand how to adapt their kubernetes cluster to the needs of
-their work environment.  Developers who are prospective **Extension
-Authors** and **Kubernetes Project Contributors** will also find it
+This guide describes the options for customizing a Kubernetes
+cluster. It is aimed at **Cluster Operators** who want to
+understand how to adapt their Kubernetes cluster to the needs of
+their work environment. Developers who are prospective **Platform
+Developers** or Kubernetes Project **Contributors** will also find it
 useful as an introduction to what extension points and patterns
 exist, and their tradeoffs and limitations.
+
+{% glossary_definition term_id="cluster-operator" length="all" %}
+{% glossary_definition term_id="platform-developer" length="all" %}
+{% glossary_definition term_id="contributor" length="all" %}
 
 {% endcapture %}
 
@@ -28,57 +32,55 @@ exist, and their tradeoffs and limitations.
 
 ## Overview
 
-Customization approaches can be broadly divided into **configuration**, which only involves changing flags, local configuration files, or API resources; and **extensions**, which involve running additional programs or services.  This document is primarily about extensions.
+Customization approaches can be broadly divided into *configuration*, which only involves changing flags, local configuration files, or API resources; and *extensions*, which involve running additional programs or services. This document is primarily about extensions.
 
 ## Configuration
 
-**Configuration files** and **flags** are documented in the Reference section of the online documentation, under each binary:
+*Configuration files* and *flags* are documented in the Reference section of the online documentation, under each binary:
 
 * [kubelet](/docs/admin/kubelet/)
 * [kube-apiserver](/docs/admin/kube-apiserver/)
 * [kube-controller-manager](/docs/admin/kube-controller-manager/)
 * [kube-scheduler](/docs/admin/kube-scheduler/).
 
-Flags and configuration files may not always be changable in a hosted Kubernetes service or a distribution with managed installation.  When they are changable, they are usually only changeable by the cluster administrator.    Also, they are subject to change in future Kubernetes versions, and setting them may require restarting processes.  For those reasons, they should be used only when there are no other options.
+Flags and configuration files may not always be changable in a hosted Kubernetes service or a distribution with managed installation. When they are changable, they are usually only changeable by the cluster administrator. Also, they are subject to change in future Kubernetes versions, and setting them may require restarting processes. For those reasons, they should be used only when there are no other options.
 
-**Built-in Policy APIs**, such as [ResourceQuota](/docs/concepts/policy/resource-quotas/), [PodSecurityPolicies](/docs/concepts/policy/pod-security-policy/), [NetworkPolicy](/docs/concepts/services-networking/network-policies/) and Role-based Access Control ([RBAC](/docs/admin/authorization/rbac/)), are built-in Kubernetes APIs.  APIs are typically used with hosted Kubernetes services, and with managed Kubernetes installations.   They are declarative and use the same conventions are other Kubernetes resources like pods, so new cluster configuration can be repeatable and be managed the same way as applications.  And, where they are stable, they enjoy a [defined support policy](/docs/reference/deprecation-policy/) like other Kubernetes APIs.  For these reasons, they are preferred over **configuration files** and **flags** where suitable.
-
-The remainder of this guide is about Extensions.
+*Built-in Policy APIs*, such as [ResourceQuota](/docs/concepts/policy/resource-quotas/), [PodSecurityPolicies](/docs/concepts/policy/pod-security-policy/), [NetworkPolicy](/docs/concepts/services-networking/network-policies/) and Role-based Access Control ([RBAC](/docs/admin/authorization/rbac/)), are built-in Kubernetes APIs. APIs are typically used with hosted Kubernetes services and with managed Kubernetes installations. They are declarative and use the same conventions as other Kubernetes resources like pods, so new cluster configuration can be repeatable and be managed the same way as applications. And, where they are stable, they enjoy a [defined support policy](/docs/reference/deprecation-policy/) like other Kubernetes APIs. For these reasons, they are preferred over *configuration files* and *flags* where suitable.
 
 ## Extensions
 
-Extensions are software components that extend and deeply integrate with kubernetes. 
+Extensions are software components that extend and deeply integrate with Kubernetes.
 They adapt it to support new types and new kinds of hardware.
 
-Most cluster administrators will use a hosted or distribution 
-instance of Kubernetes.  As a result, most Kubernetes users will need to 
+Most cluster administrators will use a hosted or distribution
+instance of Kubernetes. As a result, most Kubernetes users will need to
 install extensions and fewer will need to author new ones.
 
 ## Extension Patterns
 
-Kubernetes is designed to be automated by writing client programs.  Any
+Kubernetes is designed to be automated by writing client programs. Any
 program that reads and/or writes to the Kubernetes API can provide useful
-automation.  **Automation** can run on the cluster or off it.  By following
+automation. *Automation* can run on the cluster or off it. By following
 the guidance in this doc you can write highly available and robust automation.
 Automation generally works with any Kubernetes cluster, including hosted
-clusters, and managed installations.
+clusters and managed installations.
 
 There is a specific pattern for writing client programs that work well with
-Kubernetes called the **Controller** pattern.  Controllers typically read an
+Kubernetes called the *Controller* pattern. Controllers typically read an
 object's `.spec`, possibly do things, and then update the object's `.status`.
 
-A controller is a client of Kubernetes.  When Kubernetes is the client and
-calls out to a remote service, it is called a **Webhook.  **The remote service
-is called a **Webhook Backend**.  Like Controllers, Webhooks do add a point of
-failure.  
+A controller is a client of Kubernetes. When Kubernetes is the client and
+calls out to a remote service, it is called a *Webhook*. The remote service
+is called a *Webhook Backend*. Like Controllers, Webhooks do add a point of
+failure.
 
 In the webhook model, Kubernetes makes a network request to a remote service.
-In the **Binary Plugin** model, kubernetes executes a binary (program).
+In the *Binary Plugin* model, Kubernetes executes a binary (program).
 Binary plugins are used by the kubelet (e.g. [Flex Volume
 Plugins](https://github.com/kubernetes/community/blob/master/contributors/devel/flexvolume.md)
 and [Network
 Plugins](/docs/concepts/cluster-administration/network-plugins/))
-and by kubectl.  Plugin interfaces are still evolving, and may change.
+and by kubectl.
 
 Below is a diagram showing how the extensions points interact with the
 Kubernetes control plane.
@@ -90,31 +92,31 @@ Kubernetes control plane.
 
 ## Extension Points
 
-This diagram shows the extension points in a Kubernetes system.  
+This diagram shows the extension points in a Kubernetes system.
 
 <img src="https://docs.google.com/drawings/d/e/2PACX-1vSH5ZWUO2jH9f34YHenhnCd14baEb4vT-pzfxeFC7NzdNqRDgdz4DDAVqArtH4onOGqh0bhwMX0zGBb/pub?w=425&h=809">
 
 <!-- image source diagrams: https://docs.google.com/drawings/d/1k2YdJgNTtNfW7_A8moIIkij-DmVgEhNrn3y2OODwqQQ/view -->
 
-*   Kubectl plugins extend the kubectl binary ①.  [Link for 1.8 docs branch: docs/tasks/extend-kubectl/kubectl-plugins ] They only affect the individual user's local environment.  These extension points are described in the [Client Extensions](todo) section.
-*   The apiserver ②  handles all requests.  Several types of extension points in the apiserver allow authenticating requests, or blocking them based on their content, editing content, and handling deletion.  These are described in the [API Access Extensions](todo) section. 
-*   The apiserver serves various kinds of **resources**, ③.  **Built-in resource kinds**, like `pods`, are defined by the Kubernetes project and can't be changed.  You can also add resources that you definde are several ways to add **Custom Resources** to your API-Server.  Custom Resources are often used with API Access Extensions.
-*   The kubernetes scheduler, ④, decides which nodes to place pods on.  There are several ways to extend scheduling.  These are described in the [Scheduler Extensions](bloop) section.
-*   Much of the behavior of Kubernetes is implemented by programs called Controllers, ⑤, which are clients of the API-Server.  You can write your own, as described in the [Controllers](boo) section.  Controllers are often used in conjunction with Custom Resources.
-*   The kubelet runs on servers, and mediates access to the network, ⑥, and storage, ⑦.  These are described in the [Infrastructure Extensions](poof) section.
+1.   Users often interact with the Kubernetes API using `kubectl`. [Kubectl plugins](docs/tasks/extend-kubectl/kubectl-plugins) extend the kubectl binary. They only affect the individual user's local environment, and so cannot enforce site-wide policies.
+2.   The apiserver handles all requests. Several types of extension points in the apiserver allow authenticating requests, or blocking them based on their content, editing content, and handling deletion. These are described in the [API Access Extensions](docs/concepts/overview/extending#api-access-extensions) section.
+3.   The apiserver serves various kinds of *resources*. *Built-in resource kinds*, like `pods`, are defined by the Kubernetes project and can't be changed. You can also add resources that you define, or that other projects have defined, called *Custom Resources*, as explained in the [Custom Resources](docs/concepts/overview/extending#custom-resources) section. Custom Resources are often used with API Access Extensions.
+4.   The Kubernetes scheduler decides which nodes to place pods on. There are several ways to extend scheduling. These are described in the [Scheduler Extensions](docs/concepts/overview/extending#shceduler-extensions) section.
+5.   Much of the behavior of Kubernetes is implemented by programs called Controllers which are clients of the API-Server. Controllers are often used in conjunction with Custom Resources.
+6.   The kubelet runs on servers, and helps pods appear like virtual servers with their own IPs on the cluster network. [Network Plugins](docs/concepts/overview/extending#network-plugins) allow for different implementations of pod networking.
+7.  The kubelet also mounts and unmounts volumes for containers. New types of storage can be supported via [Storage Plugins](docs/concepts/overview/extending#storage-plugins).
 
-If you are unsure where to start, this flowchart can help.  Note that some solutions may involve several types of extensions.
-
+If you are unsure where to start, this flowchart can help. Note that some solutions may involve several types of extensions.
 
 
 <img src="https://docs.google.com/drawings/d/e/2PACX-1vRWXNNIVWFDqzDY0CsKZJY3AR8sDeFDXItdc5awYxVH8s0OLherMlEPVUpxPIB1CSUu7GPk7B2fEnzM/pub?w=1440&h=1080">
 
-<!-- image source drawing: https://docs.google.com/drawings/d/1sdviU6lDz4BpnzJNHfNpQrqI9F19QZ07KnhnxVrp2yg/edit --> 
+<!-- image source drawing: https://docs.google.com/drawings/d/1sdviU6lDz4BpnzJNHfNpQrqI9F19QZ07KnhnxVrp2yg/edit -->
 
 ## API Extensions
 ### User-Defined Types
 
-Consider adding a Custom Resource to Kubernetes if you want to define new controllers, application configuration objects  or other declarative APIs, and to manage them using Kubernetes tools, such as `kubectl`.  
+Consider adding a Custom Resource to Kubernetes if you want to define new controllers, application configuration objects or other declarative APIs, and to manage them using Kubernetes tools, such as `kubectl`.
 
 Do not use a Custom Resource as data storage for application, user, or monitoring data.
 
@@ -123,41 +125,41 @@ For more about Custom Resources, see the [Custom Resources concept guide](/docs/
 
 ### Combining New APIs with Automation
 
-Often, when you add a new API, you also add a control loop that reads and/or writes the new APIs.  When the combination of a Custom API and a control loop is used to manage a specific, usually stateful, application, this is called the **Operator** pattern.  Custom APIs and control loops can also be used to control other resources, such as storage, policies, and so on.
+Often, when you add a new API, you also add a control loop that reads and/or writes the new APIs. When the combination of a Custom API and a control loop is used to manage a specific, usually stateful, application, this is called the *Operator* pattern. Custom APIs and control loops can also be used to control other resources, such as storage, policies, and so on.
 
 ### Changing Built-in Resources
 
-When you extend the Kubernetes API by adding custom resources, the added resources always fall into a new API Groups.  You cannot replace or change existing API groups.
+When you extend the Kubernetes API by adding custom resources, the added resources always fall into a new API Groups. You cannot replace or change existing API groups.
 Adding an API does not directly let you affect the behavior of existing APIs (e.g. Pods), but API Access Extensions do.
 
 
 ### API Access Extensions
 
-When a request reaches the Kubernetes API Server, it is first Authenticated, then Authorized, then subject to various types of Admission Control.  See [[Accessing the API](/docs/admin/accessing-the-api/)] for more on this flow.
+When a request reaches the Kubernetes API Server, it is first Authenticated, then Authorized, then subject to various types of Admission Control. See [[Accessing the API](/docs/admin/accessing-the-api/)] for more on this flow.
 
-Each of these steps offers extension points.  
+Each of these steps offers extension points.
 
-Kubernetes has several built-in authentication methods that it supports.  It can also sit behind an authenticating proxy, and it can send a token from an Authorization header to a remote service for verification (a webhook).  All of these methods are covered in the [Authentication documentation](/docs/admin/authentication/).
+Kubernetes has several built-in authentication methods that it supports. It can also sit behind an authenticating proxy, and it can send a token from an Authorization header to a remote service for verification (a webhook). All of these methods are covered in the [Authentication documentation](/docs/admin/authentication/).
 
 ### Authentication
 
 [Authentication](/docs/admin/authentication) maps headers or certificates in all requests to a username for the client making the request.
 
-Kubernetes provides several built-in authentication methods, and an [Authentication webhook](/docs/admin/authentication/#webhook-token-authentication) method if those don't meet your needs. 
+Kubernetes provides several built-in authentication methods, and an [Authentication webhook](/docs/admin/authentication/#webhook-token-authentication) method if those don't meet your needs.
 
 
 ### Authorization
 
- [Authorization](/docs/admin/authorization/webhook/) determines whether specific users can read, write, and do other operations on API resources.  It just works at the level of whole resources -- it doesn't discriminate based on arbitrary object fields.  If the built-in authorization options don't meet your needs, and [Authorization webhook](/docs/admin/authorization/webhook/) allows calling out to user-provided code to make an authorization decision.
+ [Authorization](/docs/admin/authorization/webhook/) determines whether specific users can read, write, and do other operations on API resources. It just works at the level of whole resources -- it doesn't discriminate based on arbitrary object fields. If the built-in authorization options don't meet your needs, and [Authorization webhook](/docs/admin/authorization/webhook/) allows calling out to user-provided code to make an authorization decision.
 
 
 ### Dynamic Admission Control
 
-After a request is authorized, if it is a write operation, it also t goes through [Admission Control](/docs/admin/admission-controllers/) steps.   In addition to the built-in steps, there are several extensions:
+After a request is authorized, if it is a write operation, it also t goes through [Admission Control](/docs/admin/admission-controllers/) steps. In addition to the built-in steps, there are several extensions:
 
 *   The [Image Policy webhook](/docs/admin/admission-controllers/#imagepolicywebhook) restricts what images can be run in containers.
 *   To make arbitrary admission control decisions, a general [Admission webhook](/docs/admin/extensible-admission-controllers/#external-admission-webhooks) can be used. Admission Webhooks can reject creations or updates.
-*   [Initializers](/docs/admin/extensible-admission-controllers/#initializers) are controllers that can modify objects before they are created.  Intializers can modify initial object creations but cannot affect updates to objects.  Initializers can also reject objects. 
+*   [Initializers](/docs/admin/extensible-admission-controllers/#initializers) are controllers that can modify objects before they are created. Intializers can modify initial object creations but cannot affect updates to objects. Initializers can also reject objects.
 
 ## Infrastructure Extensions
 
@@ -178,23 +180,23 @@ Plugin](/docs/concepts/cluster-administration/device-plugins/).
 
 ### Network Plugins
 
-Different networking fabrics can be supported via node-level [Network Plugins](/docs/admin/network-plugins/). 
+Different networking fabrics can be supported via node-level [Network Plugins](/docs/admin/network-plugins/).
 
 ### Scheduler Extensions
 
 The scheduler is a special type of controller that watches pods, and assigns
-pods to nodes.  The default scheduler can be be replaced entirely, while
-continuing to use other kubernetes components, or [multiple
+pods to nodes. The default scheduler can be be replaced entirely, while
+continuing to use other Kubernetes components, or [multiple
 schedulers](/docs/tasks/administer-cluster/configure-multiple-schedulers/)
-can run at the same time.  
+can run at the same time.
 
 This is a significant undertaking, and almost all Kubernetes users find they
-do not need to modify the scheduler.  
+do not need to modify the scheduler.
 
 The scheduler also supports a
 [webhook](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/scheduler_extender.md)
-that permits a webhook backend  (scheduler extension) to filter and prioritize
-the nodes chosen for a pod. 
+that permits a webhook backend (scheduler extension) to filter and prioritize
+the nodes chosen for a pod.
 
 {% endcapture %}
 

--- a/docs/concepts/overview/extending.md
+++ b/docs/concepts/overview/extending.md
@@ -1,0 +1,217 @@
+---
+title: Extending your Kubernetes Cluster
+approvers:
+- erictune
+- lavalamp
+- cheftako
+- chenopis
+---
+
+{% capture overview %}
+
+Kubernetes is highly configurable and extensible.  As a result,
+there is rarely a need to fork or submit patches to the Kubernetes
+project code.  
+
+This guide describes the options for customizing a kubernetes
+cluster.  It is aimed at **Cluster Administrators** who want to
+understand how to adapt their kubernetes cluster to the needs of
+their work environment.  Developers who are prospective **Extension
+Authors** and **Kubernetes Project Contributors** will also find it
+useful as an introduction to what extension points and patterns
+exist, and their tradeoffs and limitations.
+
+{% endcapture %}
+
+
+{% capture body %}
+
+## Overview
+
+Customization approaches can be broadly divided into **configuration**, which only involves changing flags, local configuration files, or API resources; and **extensions**, which involve running additional programs or services.  This document is primarily about extensions.
+
+## Configuration
+
+**Configuration files** and **flags** are documented in the Reference section of the online documentation, under each binary:
+
+* [kubelet](/docs/admin/kubelet/)
+* [kube-apiserver](/docs/admin/kube-apiserver/)
+* [kube-controller-manager](/docs/admin/kube-controller-manager/)
+* [kube-scheduler](/docs/admin/kube-scheduler/).
+
+Flags and configuration files may not always be changable in a hosted Kubernetes service or a distribution with managed installation.  When they are changable, they are usually only changeable by the cluster administrator.    Also, they are subject to change in future Kubernetes versions, and setting them may require restarting processes.  For those reasons, they should be used only when there are no other options.
+
+**Built-in Policy APIs**, such as [ResourceQuota](/docs/concepts/policy/resource-quotas/), [PodSecurityPolicies](/docs/concepts/policy/pod-security-policy/), [NetworkPolicy](/docs/concepts/services-networking/network-policies/) and Role-based Access Control ([RBAC](/docs/admin/authorization/rbac/)), are built-in Kubernetes APIs.  APIs are typically used with hosted Kubernetes services, and with managed Kubernetes installations.   They are declarative and use the same conventions are other Kubernetes resources like pods, so new cluster configuration can be repeatable and be managed the same way as applications.  And, where they are stable, they enjoy a [defined support policy](/docs/reference/deprecation-policy/) like other Kubernetes APIs.  For these reasons, they are preferred over **configuration files** and **flags** where suitable.
+
+The remainder of this guide is about Extensions.
+
+## Extensions
+
+Extensions are software components that extend and deeply integrate with kubernetes. 
+They adapt it to support new types and new kinds of hardware.
+
+Most cluster administrators will use a hosted or distribution 
+instance of Kubernetes.  As a result, most Kubernetes users will need to 
+install extensions and fewer will need to author new ones.
+
+## Extension Patterns
+
+Kubernetes is designed to be automated by writing client programs.  Any
+program that reads and/or writes to the Kubernetes API can provide useful
+automation.  **Automation** can run on the cluster or off it.  By following
+the guidance in this doc you can write highly available and robust automation.
+Automation generally works with any Kubernetes cluster, including hosted
+clusters, and managed installations.
+
+There is a specific pattern for writing client programs that work well with
+Kubernetes called the **Controller** pattern.  Controllers typically read an
+object's `.spec`, possibly do things, and then update the object's `.status`.
+
+A controller is a client of Kubernetes.  When Kubernetes is the client and
+calls out to a remote service, it is called a **Webhook.  **The remote service
+is called a **Webhook Backend**.  Like Controllers, Webhooks do add a point of
+failure.  
+
+In the webhook model, Kubernetes makes a network request to a remote service.
+In the **Binary Plugin** model, kubernetes executes a binary (program).
+Binary plugins are used by the kubelet (e.g. [Flex Volume
+Plugins](https://github.com/kubernetes/community/blob/master/contributors/devel/flexvolume.md)
+and [Network
+Plugins](/docs/concepts/cluster-administration/network-plugins/))
+and by kubectl.  Plugin interfaces are still evolving, and may change.
+
+Below is a diagram showing how the extensions points interact with the
+Kubernetes control plane.
+
+<img src="https://docs.google.com/drawings/d/e/2PACX-1vQBRWyXLVUlQPlp7BvxvV9S1mxyXSM6rAc_cbLANvKlu6kCCf-kGTporTMIeG5GZtUdxXz1xowN7RmL/pub?w=960&h=720">
+
+<!-- image source drawing https://docs.google.com/drawings/d/1muJ7Oxuj_7Gtv7HV9-2zJbOnkQJnjxq-v1ym_kZfB-4/edit?ts=5a01e054 -->
+
+
+## Extension Points
+
+This diagram shows the extension points in a Kubernetes system.  
+
+<img src="https://docs.google.com/drawings/d/e/2PACX-1vSH5ZWUO2jH9f34YHenhnCd14baEb4vT-pzfxeFC7NzdNqRDgdz4DDAVqArtH4onOGqh0bhwMX0zGBb/pub?w=425&h=809">
+
+<!-- image source diagrams: https://docs.google.com/drawings/d/1k2YdJgNTtNfW7_A8moIIkij-DmVgEhNrn3y2OODwqQQ/view -->
+
+*   Kubectl plugins extend the kubectl binary ①.  [Link for 1.8 docs branch: docs/tasks/extend-kubectl/kubectl-plugins ] They only affect the individual user's local environment.  These extension points are described in the [Client Extensions](todo) section.
+*   The apiserver ②  handles all requests.  Several types of extension points in the apiserver allow authenticating requests, or blocking them based on their content, editing content, and handling deletion.  These are described in the [API Access Extensions](todo) section. 
+*   The apiserver serves various kinds of **resources**, ③.  **Built-in resource kinds**, like `pods`, are defined by the Kubernetes project and can't be changed.  You can also add resources that you definde are several ways to add **Custom Resources** to your API-Server.  Custom Resources are often used with API Access Extensions.
+*   The kubernetes scheduler, ④, decides which nodes to place pods on.  There are several ways to extend scheduling.  These are described in the [Scheduler Extensions](bloop) section.
+*   Much of the behavior of Kubernetes is implemented by programs called Controllers, ⑤, which are clients of the API-Server.  You can write your own, as described in the [Controllers](boo) section.  Controllers are often used in conjunction with Custom Resources.
+*   The kubelet runs on servers, and mediates access to the network, ⑥, and storage, ⑦.  These are described in the [Infrastructure Extensions](poof) section.
+
+If you are unsure where to start, this flowchart can help.  Note that some solutions may involve several types of extensions.
+
+
+
+<img src="https://docs.google.com/drawings/d/e/2PACX-1vRWXNNIVWFDqzDY0CsKZJY3AR8sDeFDXItdc5awYxVH8s0OLherMlEPVUpxPIB1CSUu7GPk7B2fEnzM/pub?w=1440&h=1080">
+
+<!-- image source drawing: https://docs.google.com/drawings/d/1sdviU6lDz4BpnzJNHfNpQrqI9F19QZ07KnhnxVrp2yg/edit --> 
+
+## API Extensions
+### User-Defined Types
+
+Consider adding a Custom Resource to Kubernetes if you want to define new controllers, application configuration objects  or other declarative APIs, and to manage them using Kubernetes tools, such as `kubectl`.  
+
+Do not use a Custom Resource as data storage for application, user, or monitoring data.
+
+For more about Custom Resources, see the [Custom Resources concept guide](/docs/concepts/api-extension/custom-resources.md).
+
+
+### Combining New APIs with Automation
+
+Often, when you add a new API, you also add a control loop that reads and/or writes the new APIs.  When the combination of a Custom API and a control loop is used to manage a specific, usually stateful, application, this is called the **Operator** pattern.  Custom APIs and control loops can also be used to control other resources, such as storage, policies, and so on.
+
+### Changing Built-in Resources
+
+When you extend the Kubernetes API by adding custom resources, the added resources always fall into a new API Groups.  You cannot replace or change existing API groups.
+Adding an API does not directly let you affect the behavior of existing APIs (e.g. Pods), but API Access Extensions do.
+
+
+### API Access Extensions
+
+When a request reaches the Kubernetes API Server, it is first Authenticated, then Authorized, then subject to various types of Admission Control.  See [[Accessing the API](/docs/admin/accessing-the-api/)] for more on this flow.
+
+Each of these steps offers extension points.  
+
+Kubernetes has several built-in authentication methods that it supports.  It can also sit behind an authenticating proxy, and it can send a token from an Authorization header to a remote service for verification (a webhook).  All of these methods are covered in the [Authentication documentation](/docs/admin/authentication/).
+
+### Authentication
+
+[Authentication](/docs/admin/authentication) maps headers or certificates in all requests to a username for the client making the request.
+
+Kubernetes provides several built-in authentication methods, and an [Authentication webhook](/docs/admin/authentication/#webhook-token-authentication) method if those don't meet your needs. 
+
+
+### Authorization
+
+ [Authorization](/docs/admin/authorization/webhook/) determines whether specific users can read, write, and do other operations on API resources.  It just works at the level of whole resources -- it doesn't discriminate based on arbitrary object fields.  If the built-in authorization options don't meet your needs, and [Authorization webhook](/docs/admin/authorization/webhook/) allows calling out to user-provided code to make an authorization decision.
+
+
+### Dynamic Admission Control
+
+After a request is authorized, if it is a write operation, it also t goes through [Admission Control](/docs/admin/admission-controllers/) steps.   In addition to the built-in steps, there are several extensions:
+
+*   The [Image Policy webhook](/docs/admin/admission-controllers/#imagepolicywebhook) restricts what images can be run in containers.
+*   To make arbitrary admission control decisions, a general [Admission webhook](/docs/admin/extensible-admission-controllers/#external-admission-webhooks) can be used. Admission Webhooks can reject creations or updates.
+*   [Initializers](/docs/admin/extensible-admission-controllers/#initializers) are controllers that can modify objects before they are created.  Intializers can modify initial object creations but cannot affect updates to objects.  Initializers can also reject objects. 
+
+## Infrastructure Extensions
+
+
+### Storage Plugins
+
+[Flex Volumes](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/flexvolume-deployment.md
+) allow users to mount volume types without built-in support by having the
+Kubelet call a Binary Plugin to mount the volume.
+
+
+### Device Plugins
+
+Device plugins allow a node to discover new Node resources (in addition to the
+builtin ones like cpu and memory) via a [Device
+Plugin](/docs/concepts/cluster-administration/device-plugins/).
+
+
+### Network Plugins
+
+Different networking fabrics can be supported via node-level [Network Plugins](/docs/admin/network-plugins/). 
+
+### Scheduler Extensions
+
+The scheduler is a special type of controller that watches pods, and assigns
+pods to nodes.  The default scheduler can be be replaced entirely, while
+continuing to use other kubernetes components, or [multiple
+schedulers](/docs/tasks/administer-cluster/configure-multiple-schedulers/)
+can run at the same time.  
+
+This is a significant undertaking, and almost all Kubernetes users find they
+do not need to modify the scheduler.  
+
+The scheduler also supports a
+[webhook](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/scheduler_extender.md)
+that permits a webhook backend  (scheduler extension) to filter and prioritize
+the nodes chosen for a pod. 
+
+{% endcapture %}
+
+
+{% capture whatsnext %}
+
+* Learn more about [Custom Resources](/docs/concepts/api-extension/custom-resources/)
+* Learn about [Dynamic admission control](/docs/admin/extensible-admission-controller)
+* Learn more about Infrastructure extensions
+  * [Network Plugins](/docs/concepts/cluster-administration/network-plugin)
+  * [Device Plugins](/docs/concepts/cluster-administration/device-plugins.md)
+* Learn about [kubectl plugins](/docs/tasks/extend-kubectl/kubectl-plugin)
+* See examples of Automation
+  * [List of Operators](https://github.com/coreos/awesome-kubernetes-extensions)
+
+{% endcapture %}
+
+{% include templates/concept.md %}
+
+


### PR DESCRIPTION
 Added overview concept guide to all ways to extend kubernetes.

Builds on https://github.com/kubernetes/website/pull/6220

To be followed by more detail on "Automation" and on "User-defined types".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6224)
<!-- Reviewable:end -->
