### PR TITLE
Correct federation links to new repository

### DIFF
--- a/docs/tasks/administer-federation/deployment.md
+++ b/docs/tasks/administer-federation/deployment.md
@@ -66,7 +66,7 @@ if you have 3 registered clusters and you create a Federated Deployment with
 `spec.replicas = 9`, then each Deployment in the 3 clusters will have
 `spec.replicas=3`.
 To modify the number of replicas in each cluster, you can specify
-[FederatedReplicaSetPreference](https://github.com/kubernetes/kubernetes/blob/{{page.githubbranch}}/federation/apis/federation/types.go)
+[FederatedReplicaSetPreference](https://github.com/kubernetes/federation/blob/{{page.githubbranch}}/apis/federation/types.go)
 as an annotation with key `federation.kubernetes.io/deployment-preferences`
 on Federated Deployment.
 

--- a/docs/tasks/administer-federation/job.md
+++ b/docs/tasks/administer-federation/job.md
@@ -61,7 +61,7 @@ if you have 3 registered clusters and you create a federated job with
 `spec.parallelism = 9` and `spec.completions = 18`, then each job in the 3 clusters has
 `spec.parallelism = 3` and `spec.completions = 6`.
 To modify the number of parallelism and completions in each cluster, you can specify
-[ReplicaAllocationPreferences](https://github.com/kubernetes/kubernetes/blob/{{page.githubbranch}}/federation/apis/federation/types.go)
+[ReplicaAllocationPreferences](https://github.com/kubernetes/federation/blob/{{page.githubbranch}}/apis/federation/types.go)
 as an annotation with key `federation.kubernetes.io/job-preferences`
 on the federated job.
 

--- a/docs/tasks/administer-federation/replicaset.md
+++ b/docs/tasks/administer-federation/replicaset.md
@@ -61,7 +61,7 @@ if you have 3 registered clusters and you create a federated ReplicaSet with
 `spec.replicas = 9`, then each ReplicaSet in the 3 clusters will have
 `spec.replicas=3`.
 To modify the number of replicas in each cluster, you can specify
-[FederatedReplicaSetPreference](https://github.com/kubernetes/kubernetes/blob/{{page.githubbranch}}/federation/apis/federation/types.go)
+[FederatedReplicaSetPreference](https://github.com/kubernetes/federation/blob/{{page.githubbranch}}/apis/federation/types.go)
 as an annotation with key `federation.kubernetes.io/replica-set-preferences`
 on the federated ReplicaSet.
 


### PR DESCRIPTION
Fix some links in the documentation that pointed to the old `federation/` location in the main kubernetes repository.

Related with #4476

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6234)
<!-- Reviewable:end -->
