### PR TITLE
The correct name is [Route] and not [Router]

### DIFF
--- a/docs/concepts/cluster-administration/cloud-providers.md
+++ b/docs/concepts/cluster-administration/cloud-providers.md
@@ -210,7 +210,7 @@ bs-version=v2
 
 #### Router
 These configuration options for the OpenStack provider pertain to routing and
-should appear in the `[Router]` section of the `cloud.conf` file:
+should appear in the `[Route]` section of the `cloud.conf` file:
 
 * `router-id` (Optional): If the underlying cloud's Neutron deployment supports
   the `extraroutes` extension then use `router-id` to specify a router to add


### PR DESCRIPTION
Check commit 0b57371ffab5b32dc991ff5fe60c3d58f7c2f9cc
You will see that the correct name is [Route]
You can see it also here
https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/providers/openstack/openstack.go#L137

> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.9 Features: set Milestone to `1.9` and Base Branch to `release-1.9`
> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: Please check the “Allow edits from maintainers” box (see image below) to
> [allow reviewers to fix problems](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) on your patch and speed up the review process.
>
> Please delete this note before submitting the pull request.
>
> NOTE: After opening the PR, please *un-check and re-check* the "Allow edits from maintainers" box. This is a temporary workaround to address a known issue with GitHub.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6257)
<!-- Reviewable:end -->
