### PR TITLE
Improve "authenticating to k8s api from a pod" docs

### DIFF
--- a/docs/tasks/administer-cluster/access-cluster-api.md
+++ b/docs/tasks/administer-cluster/access-cluster-api.md
@@ -168,17 +168,22 @@ There are [client libraries](/docs/reference/client-libraries/) for accessing th
 
 ### Accessing the API from a Pod
 
-When accessing the API from a pod, locating and authenticating
+When accessing the API from a Pod, locating and authenticating
 to the API server are somewhat different.
 
-The recommended way to locate the apiserver within the pod is with
-the `kubernetes` DNS name, which resolves to a Service IP which in turn
-will be routed to an apiserver.
+The easiest way to use the Kubernetes API from a Pod is to use
+one of the official [client libraries](/docs/reference/client-libraries/). These
+libraries can automatically discover the apiserver and authenticate automatically.
 
-The recommended way to authenticate to the apiserver is with a
-[service account](/docs/user-guide/service-accounts) credential.  By kube-system, a pod
+While running in a Pod, the Kubernetes apiserver is accessible via a Service named
+`kubernetes` in the `default` namespace. Therefore, Pods can use the 
+`kubernetes.default` hostname to query the apiserver. Official client libraries
+do this automatically.
+
+From within a Pod, the recommended way to authenticate to the apiserver is with a
+[service account](/docs/user-guide/service-accounts) credential. By default, a Pod
 is associated with a service account, and a credential (token) for that
-service account is placed into the filesystem tree of each container in that pod,
+service account is placed into the filesystem tree of each container in that Pod,
 at `/var/run/secrets/kubernetes.io/serviceaccount/token`.
 
 If available, a certificate bundle is placed into the filesystem tree of each
@@ -188,17 +193,21 @@ used to verify the serving certificate of the apiserver.
 Finally, the default namespace to be used for namespaced API operations is placed in a file
 at `/var/run/secrets/kubernetes.io/serviceaccount/namespace` in each container.
 
-From within a pod the recommended ways to connect to API are:
+From within a Pod, the recommended ways to connect to the Kubernetes API are:
 
-  - run a kubectl proxy as one of the containers in the pod, or as a background
-    process within a container.  This proxies the
-    Kubernetes API to the localhost interface of the pod, so that other processes
-    in any container of the pod can access it.  See this [example of using kubectl proxy
-    in a pod](https://github.com/kubernetes/examples/tree/{{page.githubbranch}}/staging/kubectl-container/).
-  - use the Go client library, and create a client using the `rest.InClusterConfig()` and `kubernetes.NewForConfig()` functions.
-    They handle locating and authenticating to the apiserver. [example](https://git.k8s.io/client-go/examples/in-cluster-client-configuration/main.go)
+  - use one of the official [client libraries](/docs/reference/client-libraries/)
+    as they handle API host discovery and authentication out of the box.
+    For Go client, the `rest.InClusterConfig()` function assists with this.
+    See [an example here](https://git.k8s.io/client-go/examples/in-cluster-client-configuration/main.go).
 
-In each case, the credentials of the pod are used to communicate securely with the apiserver.
+  - if you would like to query the API without an official client library, you can run `kubectl proxy`
+    as the [command](/docs/tasks/inject-data-application/define-command-argument-container/)
+    of a new sidecar container in the Pod. This way, `kubectl proxy` will authenticate
+    to the API and expose it on the `localhost` interface of the Pod, so that other containers
+    in the Pod can use it directly.
+
+In each case, the service account credentials of the Pod are used to communicate
+securely with the apiserver.
 
 {% endcapture %}
 

--- a/docs/tasks/administer-cluster/access-cluster-api.md
+++ b/docs/tasks/administer-cluster/access-cluster-api.md
@@ -36,10 +36,10 @@ kubectl.  Complete documentation is found in the [kubectl manual](/docs/user-gui
 
 ### Directly accessing the REST API
 
-Kubectl handles locating and authenticating to the apiserver. If you want to directly access the REST API with an http client like
-`curl` or `wget`, or a browser, there are multiple ways you can locate and authenticate against the apiserver:
+kubectl handles locating and authenticating to the API server. If you want to directly access the REST API with an http client like
+`curl` or `wget`, or a browser, there are multiple ways you can locate and authenticate against the API server:
 
- 1. Run kubectl in proxy mode (recommended).  This method is recommended, since it uses the stored apiserver location abd verifies the identity of the apiserver using a self-signed cert.  No Man-in-the-middle (MITM) attack is possible using this method .
+ 1. Run kubectl in proxy mode (recommended).  This method is recommended, since it uses the stored apiserver location and verifies the identity of the API server using a self-signed cert.  No man-in-the-middle (MITM) attack is possible using this method.
  1. Alternatively, you can provide the location and credentials directly to the http client. This works with for client code that is confused by proxies.  To protect against man in the middle attacks, you'll need to import a root cert into your browser.
 
  Using the Go or Python client libraries provides accessing kubectl in proxy mode.
@@ -47,7 +47,7 @@ Kubectl handles locating and authenticating to the apiserver. If you want to dir
 #### Using kubectl proxy
 
 The following command runs kubectl in a mode where it acts as a reverse proxy.  It handles
-locating the apiserver and authenticating.
+locating the API server and authenticating.
 
 Run it like this:
 
@@ -77,7 +77,7 @@ $ curl http://localhost:8080/api/
 #### Without kubectl proxy
 
 It is possible to avoid using kubectl proxy by passing an authentication token
-directly to the apiserver, like this:
+directly to the API server, like this:
 
 ``` shell
 $ APISERVER=$(kubectl config view | grep server | cut -f 2- -d ":" | tr -d " ")
@@ -104,7 +104,7 @@ and client certificates to access the server.  (These are installed in the
 may take special configuration to get your http client to use root
 certificate.
 
-On some clusters, the apiserver does not require authentication; it may serve
+On some clusters, the API server does not require authentication; it may serve
 on localhost, or be protected by a firewall.  There is not a standard
 for this.  [Configuring Access to the API](/docs/admin/accessing-the-api)
 describes how a cluster admin can configure this.  Such approaches may conflict
@@ -121,7 +121,7 @@ Kubernetes officially supports client libraries for [Go](#go-client) and
 * Write an application atop of the client-go clients. Note that client-go defines its own API objects, so if needed, please import API definitions from client-go rather than from the main repository, e.g., `import "k8s.io/client-go/1.4/pkg/api/v1"` is correct.
 
 The Go client can use the same [kubeconfig file](/docs/concepts/cluster-administration/authenticate-across-clusters-kubeconfig/)
-as the kubectl CLI does to locate and authenticate to the apiserver. See this [example](https://git.k8s.io/client-go/examples/out-of-cluster-client-configuration/main.go):
+as the kubectl CLI does to locate and authenticate to the API server. See this [example](https://git.k8s.io/client-go/examples/out-of-cluster-client-configuration/main.go):
 
 ```golang
 import (
@@ -148,7 +148,7 @@ If the application is deployed as a Pod in the cluster, please refer to the [nex
 To use [Python client](https://github.com/kubernetes-incubator/client-python), run the following command: `pip install kubernetes` See [Python Client Library page](https://github.com/kubernetes-incubator/client-python) for more installation options.
 
 The Python client can use the same [kubeconfig file](/docs/concepts/cluster-administration/authenticate-across-clusters-kubeconfig/)
-as the kubectl CLI does to locate and authenticate to the apiserver. See this [example](https://github.com/kubernetes-incubator/client-python/tree/master/examples/example1.py):
+as the kubectl CLI does to locate and authenticate to the API server. See this [example](https://github.com/kubernetes-incubator/client-python/tree/master/examples/example1.py):
 
 ```python
 from kubernetes import client, config
@@ -173,14 +173,14 @@ to the API server are somewhat different.
 
 The easiest way to use the Kubernetes API from a Pod is to use
 one of the official [client libraries](/docs/reference/client-libraries/). These
-libraries can automatically discover the apiserver and authenticate automatically.
+libraries can automatically discover the API server and authenticate.
 
 While running in a Pod, the Kubernetes apiserver is accessible via a Service named
 `kubernetes` in the `default` namespace. Therefore, Pods can use the 
-`kubernetes.default` hostname to query the apiserver. Official client libraries
+`kubernetes.default` hostname to query the API server. Official client libraries
 do this automatically.
 
-From within a Pod, the recommended way to authenticate to the apiserver is with a
+From within a Pod, the recommended way to authenticate to the API server is with a
 [service account](/docs/user-guide/service-accounts) credential. By default, a Pod
 is associated with a service account, and a credential (token) for that
 service account is placed into the filesystem tree of each container in that Pod,
@@ -188,26 +188,26 @@ at `/var/run/secrets/kubernetes.io/serviceaccount/token`.
 
 If available, a certificate bundle is placed into the filesystem tree of each
 container at `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`, and should be
-used to verify the serving certificate of the apiserver.
+used to verify the serving certificate of the API server.
 
 Finally, the default namespace to be used for namespaced API operations is placed in a file
 at `/var/run/secrets/kubernetes.io/serviceaccount/namespace` in each container.
 
 From within a Pod, the recommended ways to connect to the Kubernetes API are:
 
-  - use one of the official [client libraries](/docs/reference/client-libraries/)
-    as they handle API host discovery and authentication out of the box.
+  - Use one of the official [client libraries](/docs/reference/client-libraries/)
+    as they handle API host discovery and authentication automatically.
     For Go client, the `rest.InClusterConfig()` function assists with this.
     See [an example here](https://git.k8s.io/client-go/examples/in-cluster-client-configuration/main.go).
 
-  - if you would like to query the API without an official client library, you can run `kubectl proxy`
+  - If you would like to query the API without an official client library, you can run `kubectl proxy`
     as the [command](/docs/tasks/inject-data-application/define-command-argument-container/)
     of a new sidecar container in the Pod. This way, `kubectl proxy` will authenticate
     to the API and expose it on the `localhost` interface of the Pod, so that other containers
     in the Pod can use it directly.
 
 In each case, the service account credentials of the Pod are used to communicate
-securely with the apiserver.
+securely with the API server.
 
 {% endcapture %}
 


### PR DESCRIPTION
Helps with https://github.com/kubernetes/kubernetes/issues/22121.
Also removing the link to kubectl-container example which is staged for removal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6259)
<!-- Reviewable:end -->
