### PR TITLE
Revert "Document the unconfined profile for AppArmor"

### DIFF
--- a/docs/tutorials/clusters/apparmor.md
+++ b/docs/tutorials/clusters/apparmor.md
@@ -132,7 +132,6 @@ specifies the profile to apply. The `profile_ref` can be one of:
 
 * `runtime/default` to apply the runtime's default profile
 * `localhost/<profile_name>` to apply the profile loaded on the host with the name `<profile_name>`
-* `unconfined` to indicate that no profiles will be loaded
 
 See the [API Reference](#api-reference) for the full details on the annotation and profile name formats.
 
@@ -411,7 +410,6 @@ Specifying the profile a container will run with:
 - `localhost/<profile_name>`: Refers to a profile loaded on the node (localhost) by name.
   - The possible profile names are detailed in the
     [core policy reference](http://wiki.apparmor.net/index.php/AppArmor_Core_Policy_Reference#Profile_names_and_attachment_specifications).
-- `unconfined`: This effectively disables AppArmor on the container.
 
 Any other profile reference format is invalid.
 


### PR DESCRIPTION
Reverts kubernetes/website#6201

Needs rebase onto master

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6268)
<!-- Reviewable:end -->
