### PR TITLE
Document unconfined apparmor profile

### DIFF
--- a/docs/tutorials/clusters/apparmor.md
+++ b/docs/tutorials/clusters/apparmor.md
@@ -132,6 +132,7 @@ specifies the profile to apply. The `profile_ref` can be one of:
 
 * `runtime/default` to apply the runtime's default profile
 * `localhost/<profile_name>` to apply the profile loaded on the host with the name `<profile_name>`
+* `unconfined` to indicate that no profiles will be loaded
 
 See the [API Reference](#api-reference) for the full details on the annotation and profile name formats.
 
@@ -410,6 +411,7 @@ Specifying the profile a container will run with:
 - `localhost/<profile_name>`: Refers to a profile loaded on the node (localhost) by name.
   - The possible profile names are detailed in the
     [core policy reference](http://wiki.apparmor.net/index.php/AppArmor_Core_Policy_Reference#Profile_names_and_attachment_specifications).
+- `unconfined`: This effectively disables AppArmor on the container.
 
 Any other profile reference format is invalid.
 


### PR DESCRIPTION
Rebases #6201 onto `master` instead of `release-1.9`.

/cc @tengqm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6269)
<!-- Reviewable:end -->
