### PR TITLE
Update PodAffinity/PodAntiAffinity Use-Case

### DIFF
--- a/docs/concepts/configuration/assign-pod-node.md
+++ b/docs/concepts/configuration/assign-pod-node.md
@@ -248,7 +248,7 @@ spec:
         image: redis:3.2-alpine
 ```
 
-The below yaml snippet of the webserver deployment has `podAffinity` configured. This informs the scheduler that all its replicas are to be co-located with pods that have selector label `app=store`
+The below yaml snippet of the webserver deployment has `podAntiAffinity` and `podAffinity` configured. This informs the scheduler that all its replicas are to be co-located with pods that have selector label `app=store`. This will also ensure that each web-server replica does not co-locate on a single node.
 
 ```yaml
 apiVersion: apps/v1beta1 # for versions before 1.6.0 use extensions/v1beta1
@@ -263,6 +263,15 @@ spec:
         app: web-store
     spec:
       affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - web-store
+            topologyKey: "kubernetes.io/hostname"
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/docs/concepts/configuration/assign-pod-node.md
+++ b/docs/concepts/configuration/assign-pod-node.md
@@ -286,7 +286,7 @@ spec:
         image: nginx:1.12-alpine
 ```
 
-if we create the above two deployments, our three node cluster could look like below.
+If we create the above two deployments, our three node cluster should look like below.
 
 |       node-1         |       node-2        |       node-3       |
 |:--------------------:|:-------------------:|:------------------:|
@@ -306,7 +306,7 @@ web-server-1287567482-6f7v5    1/1       Running   0          7m        10.192.4
 web-server-1287567482-s330j    1/1       Running   0          7m        10.192.3.2   kube-node-2
 ```
 
-Best practice is to configure these highly available stateful workloads such as redis with AntiAffinity rules for more guaranteed spreading, which we will see in the next section.
+Best practice is to configure these highly available stateful workloads such as redis with AntiAffinity rules for more guaranteed spreading.
 
 ##### Never co-located in the same node
 


### PR DESCRIPTION
Updated PodAffinity use-case to reflect use of PodAntiAffinity. Under the previous Redis deployment manifest example, each replica may not be guaranteed its own node due to variety of node resource allocations. Also added missing container image to webserver deployment example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6291)
<!-- Reviewable:end -->
