### PR TITLE
Add link to glossary page from tutorial

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -6,6 +6,8 @@ This section of the Kubernetes documentation contains tutorials.
 A tutorial shows how to accomplish a goal that is larger than a single
 [task](/docs/tasks/). Typically a tutorial has several sections,
 each of which has a sequence of steps.
+Before walking through each tutorial, you may want to bookmark the 
+[Standardized Glossary](/docs/reference/glossary/) page for later references.
 
 * [Kubernetes Basics](/docs/tutorials/kubernetes-basics/) is an in-depth interactive tutorial that helps you understand the Kubernetes system and try out some basic Kubernetes features.
 


### PR DESCRIPTION
It is highly likely that new users are not familiar with the technical terms when start sailing through the tutorials. This PR reminds user there is a glossary page for references.

Related: #6084

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6293)
<!-- Reviewable:end -->
