### PR TITLE
add new examples for fieldSelector when using kubectl get

### DIFF
--- a/docs/user-guide/kubectl-cheatsheet.md
+++ b/docs/user-guide/kubectl-cheatsheet.md
@@ -119,6 +119,9 @@ $ kubectl get pods --sort-by='.status.containerStatuses[0].restartCount'
 $ kubectl get pods --selector=app=cassandra rc -o \
   jsonpath='{.items[*].metadata.labels.version}'
 
+# Get all running pods in the namespace
+$ kubectl get pods --field-selector=status.phase=Running
+
 # Get ExternalIPs of all nodes
 $ kubectl get nodes -o jsonpath='{.items[*].status.addresses[?(@.type=="ExternalIP")].address}'
 

--- a/docs/user-guide/kubectl-overview.md
+++ b/docs/user-guide/kubectl-overview.md
@@ -242,6 +242,9 @@ $ kubectl get rc,services
 
 // List all daemon sets, including uninitialized ones, in plain-text output format.
 $ kubectl get ds --include-uninitialized
+
+// List all pods running on node server01
+$ kubectl get pods --field-selector=spec.nodeName=server01
 ```
 
 `kubectl describe` - Display detailed state of one or more resources, including the uninitialized ones by default.


### PR DESCRIPTION
kubernetes/kubernetes#50140 introduced a new feature `fieldSelector` for `kubectl get`.

Update the doc to include this new feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6312)
<!-- Reviewable:end -->
