### PR TITLE
Improve kubectl doc

### DIFF
--- a/docs/tasks/configure-pod-container/configmap.md
+++ b/docs/tasks/configure-pod-container/configmap.md
@@ -36,7 +36,9 @@ The data source corresponds to a key-value pair in the ConfigMap, where
 * key = the file name or the key you provided on the command line, and
 * value = the file contents or the literal value you provided on the command line.
 
-You can use [`kubectl describe`](/docs/user-guide/kubectl/{{page.version}}/#describe) or [`kubectl get`](/docs/user-guide/kubectl/{{page.version}}/#get) to retrieve information about a ConfigMap. The former shows a summary of the ConfigMap, while the latter returns the full contents of the ConfigMap.
+You can use [`kubectl describe`](/docs/user-guide/kubectl/{{page.version}}/#describe) or
+[`kubectl get`](/docs/user-guide/kubectl/{{page.version}}/#get) to retrieve information
+about a ConfigMap.
 
 ### Create ConfigMaps from directories
 

--- a/docs/user-guide/kubectl-overview.md
+++ b/docs/user-guide/kubectl-overview.md
@@ -264,6 +264,17 @@ $ kubectl describe pods <rc-name>
 $ kubectl describe pods --include-uninitialized=false
 ```
 
+**Note:** The `kubectl get` command is usually used for retrieving one or more
+resources of the same resource type. It features a rich set of flags that allows
+you to customize the output format using the `-o` or `--output` flag, for example.
+You can specify the `-w` or `--watch` flag to start watching updates to a particular
+object. The `kubectl describe` command is more focused on describing the many
+related aspects of a specified resource. It may invoke several API calls to the
+API server to build a view for the user. For example, the `kubectl describe node`
+command retrieves not only the information about the node, but also a summary of
+the pods running on it, the events generated for the node etc.
+{: .note}
+
 `kubectl delete` - Delete resources either from a file, stdin, or specifying label selectors, names, resource selectors, or resources.
 
 ```shell


### PR DESCRIPTION
Fixes: #6305

The current text about `kubectl get` and `kubectl describe` is incomplete and causing confusion.
This PR removes the text that was blamed and added a note to the kubectl overview page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6321)
<!-- Reviewable:end -->
