### PR TITLE
Pod priority to be enabled for kubelet

### DIFF
--- a/docs/concepts/configuration/pod-priority-preemption.md
+++ b/docs/concepts/configuration/pod-priority-preemption.md
@@ -39,8 +39,7 @@ The following sections provide more information about these steps.
 ## Enabling priority and preemption
 
 Pod priority and preemption is disabled by default in Kubernetes 1.8.
-To enable the feature, set this command-line flag for the API server 
-and the scheduler:
+To enable the feature, set this command-line flag for the API server,scheduler and kubelet:
 
 ```
 --feature-gates=PodPriority=true


### PR DESCRIPTION
The document only mentioned enabling the feature for API and Scheduler but it needs to be enabled for kubelet as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6334)
<!-- Reviewable:end -->
