### PR TITLE
Fix some spelling issues in admin docs

### DIFF
--- a/docs/admin/accessing-the-api.md
+++ b/docs/admin/accessing-the-api.md
@@ -24,7 +24,7 @@ following diagram:
 In a typical Kubernetes cluster, the API served on port 443.  A TLS connection is
 established.  The API server presents a certificate.  This certificate is
 often self-signed, so `$USER/.kube/config` on the user's machine typically
-contains the root certficate for the API server's certificate, which when specified
+contains the root certificate for the API server's certificate, which when specified
 is used in place of the system default root certificates.  This certificate is typically
 automatically written into your `$USER/.kube/config` when you create a cluster yourself
 using `kube-up.sh`.  If the cluster has multiple users, then the creator needs to share
@@ -92,7 +92,7 @@ to restrict what users can do.
 
 
 The Authorization step is designed to operate on attributes that are likely to be common to most
-REST requests, such as object name, kind, etc.  This is intended to facilitate interation with
+REST requests, such as object name, kind, etc.  This is intended to facilitate interaction with
 existing organization-wide or cloud-provider-wide access control systems (which may handle
 other APIs besides the Kubernetes API.
 
@@ -148,7 +148,7 @@ By default the Kubernetes APIserver serves HTTP on 2 ports:
           - default IP is first non-localhost network interface, change with `--bind-address` flag.
           - request handled by authentication and authorization modules.
           - request handled by admission control module(s).
-          - authentication and authoriation modules run.
+          - authentication and authorization modules run.
 
 When the cluster is created by `kube-up.sh`, on Google Compute Engine (GCE),
 and on several other cloud providers, the API server serves on port 443.  On

--- a/docs/admin/cluster-management.md
+++ b/docs/admin/cluster-management.md
@@ -92,7 +92,7 @@ an extended period of time (10min but it may change in the future).
 Cluster autoscaler is configured per instance group (GCE) or node pool (GKE).
 
 If you are using GCE then you can either enable it while creating a cluster with kube-up.sh script. 
-To configure cluser autoscaler you have to set 3 environment variables:
+To configure cluster autoscaler you have to set 3 environment variables:
 
 * `KUBE_ENABLE_CLUSTER_AUTOSCALER` - it enables cluster autoscaler if set to true.
 * `KUBE_AUTOSCALING_MIN_NODES` - minimum number of nodes in the cluster.

--- a/docs/admin/limitrange/index.md
+++ b/docs/admin/limitrange/index.md
@@ -184,7 +184,7 @@ Note that this pod specifies explicit resource *limits* and *requests* so it did
 default values.
 
 Note: The *limits* for CPU resource are enforced in the default Kubernetes setup on the physical node
-that runs the container unless the administrator deploys the kubelet with the folllowing flag:
+that runs the container unless the administrator deploys the kubelet with the following flag:
 
 ```shell
 $ kubelet --help

--- a/docs/admin/node-conformance.md
+++ b/docs/admin/node-conformance.md
@@ -32,7 +32,7 @@ node. At least, the node should have properly installed:
 * Container Runtime (Docker)
 * Kubelet
 
-Node conformance test validates kernel configurations. If the kenrel module
+Node conformance test validates kernel configurations. If the kernel module
 `configs` is built as module in your environment, it must be loaded before the
 test. (See [Caveats #3](#caveats) for more information)
 

--- a/docs/admin/node.md
+++ b/docs/admin/node.md
@@ -110,14 +110,14 @@ Currently, there are three components that interact with the Kubernetes node int
 Node controller is a component in Kubernetes master which manages Node
 objects.
 
-Node controller has mutliple roles in Node's life. First is assigning a CIDR block to
+Node controller has multiple roles in Node's life. First is assigning a CIDR block to
 the Node when it is registered (if CIDR assignment is turned on). Second is keeping the
 node controller's list of nodes up to date with the cloud provider's list of available
 machines. When running in cloud environment whenever a node is unhealthy node controller
 asks cloud provider if the VM for that node is still available. If not, the node
 controller deletes the node from its list of nodes.
 
-Third responsibiliy is monitoring Node's health. Node controller is responsible for updating
+Third responsibility is monitoring Node's health. Node controller is responsible for updating
 the NodeReady condition of NodeStatus to ConditionUnknown when a node becomes unreachable
 (i.e. node controller stops receiving heartbeats e.g. due to the node being down), and then
 later evicting all the pods from the node (using graceful termination) if the node continues
@@ -179,7 +179,7 @@ Modifications include setting labels on the Node, and marking it unschedulable.
 Labels on nodes can be used in conjunction with node selectors on pods to control scheduling,
 e.g. to constrain a Pod to only be eligible to run on a subset of the nodes.
 
-Making a node unscheduleable will prevent new pods from being scheduled to that
+Making a node unschedulable will prevent new pods from being scheduled to that
 node, but will not affect any existing pods on the node.  This is useful as a
 preparatory step before a node reboot, etc.  For example, to mark a node
 unschedulable, run this command:

--- a/docs/admin/out-of-resource.md
+++ b/docs/admin/out-of-resource.md
@@ -130,7 +130,7 @@ The following node conditions are defined that correspond to the specified evict
 | Node Condition | Eviction Signal  | Description                                                      |
 |----------------|------------------|------------------------------------------------------------------|
 | `MemoryPressure` | `memory.available` | Available memory on the node has satisfied an eviction threshold |
-| `DiskPressure` | `nodefs.available`, `nodefs.inodesFree`, `imagefs.available`, or `imagefs.inodesFree` | Available disk space and inodes on either the node's root filesytem or image filesystem has satisfied an eviction threshold |
+| `DiskPressure` | `nodefs.available`, `nodefs.inodesFree`, `imagefs.available`, or `imagefs.inodesFree` | Available disk space and inodes on either the node's root filesystem or image filesystem has satisfied an eviction threshold |
 
 The `kubelet` will continue to report node status updates at the frequency specified by
 `--node-status-update-frequency` which defaults to `10s`.
@@ -349,7 +349,7 @@ in favor of the simpler configuation supported around eviction.
 The `kubelet` currently polls `cAdvisor` to collect memory usage stats at a regular interval.  If memory usage
 increases within that window rapidly, the `kubelet` may not observe `MemoryPressure` fast enough, and the `OOMKiller`
 will still be invoked.  We intend to integrate with the `memcg` notification API in a future release to reduce this
-latency, and instead have the kernel tell us when a threshold has been crossed immmediately.
+latency, and instead have the kernel tell us when a threshold has been crossed immediately.
 
 If you are not trying to achieve extreme utilization, but a sensible measure of overcommit, a viable workaround for
 this issue is to set eviction thresholds at approximately 75% capacity.  This increases the ability of this feature

--- a/docs/admin/rescheduler.md
+++ b/docs/admin/rescheduler.md
@@ -49,7 +49,7 @@ It's enabled by default. It can be disabled:
 
 ### Marking add-on as critical
 
-To be critical an add-on has to run in `kube-system` namespace (cofigurable via flag)
+To be critical an add-on has to run in `kube-system` namespace (configurable via flag)
 and have the following annotations specified:
 * `scheduler.alpha.kubernetes.io/critical-pod` set to empty string
 * `scheduler.alpha.kubernetes.io/tolerations` set to `[{"key":"CriticalAddonsOnly", "operator":"Exists"}]`

--- a/docs/admin/resourcequota/index.md
+++ b/docs/admin/resourcequota/index.md
@@ -125,7 +125,7 @@ The quota can be configured to quota either value.
 
 If the quota has a value specified for `requests.cpu` or `requests.memory`, then it requires that every incoming
 container makes an explicit request for those resources.  If the quota has a value specified for `limits.cpu` or `limits.memory`,
-then it requires that every incoming container specifies an explict limit for those resources.
+then it requires that every incoming container specifies an explicit limit for those resources.
 
 ## Viewing and Setting Quotas
 

--- a/docs/admin/resourcequota/walkthrough.md
+++ b/docs/admin/resourcequota/walkthrough.md
@@ -232,7 +232,7 @@ services.loadbalancers 0      2
 services.nodeports     0      0
 ```
 
-As you can see, the pod that was created is consuming explict amounts of compute resources, and the usage is being
+As you can see, the pod that was created is consuming explicit amounts of compute resources, and the usage is being
 tracked by Kubernetes properly.
 
 ## Step 5: Advanced quota scopes


### PR DESCRIPTION
This patch fixes some spelling mistakes in all the admin related docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6344)
<!-- Reviewable:end -->
