### PR TITLE
Add note to PDB about the defaulting behavior change

### DIFF
--- a/docs/tasks/run-application/configure-pdb.md
+++ b/docs/tasks/run-application/configure-pdb.md
@@ -88,6 +88,11 @@ of the evicted pod. `minAvailable` can be either an absolute number or a percent
 of the number of pods from that set that can be unavailable after the eviction. 
 It can be either an absolute number or a percentage.
 
+**Note:** For versions 1.8 and earlier: When creating a `PodDisruptionBudget`
+object using the `kubectl` command line tool, the `minAvailable` field has a
+default value of 1 if neither `minAvailable` nor `maxAvailable` is specified.
+{: .note}
+
 You can specify only one of `maxUnavailable` and `minAvailable` in a single `PodDisruptionBudget`. 
 `maxUnavailable` can only be used to control the eviction of pods 
 that have an associated controller managing them. In the examples below, "desired replicas"


### PR DESCRIPTION
Ad a note to PDB creation task about the behavior change regarding minAvailable field.

Ref: kubernetes/kubernetes#53047

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6345)
<!-- Reviewable:end -->
