### PR TITLE
Note on creating LimitRange for GPU, huge-pages resources

### DIFF
--- a/docs/tasks/administer-cluster/cpu-constraint-namespace.md
+++ b/docs/tasks/administer-cluster/cpu-constraint-namespace.md
@@ -79,6 +79,11 @@ CPU request and limit to the Container.
 
 * Verify that the Container specifies a CPU limit that is less than or equal to 800 millicpu.
 
+**Note:** When creating a `LimitRange` object, you can specify limits on huge-pages
+or GPUs as well. However, when both `default` and `defaultRequest` are specified
+on these resources, the two values must be the same.
+{: .note}
+
 Here's the configuration file for a Pod that has one Container. The Container manifest
 specifies a CPU request of 500 millicpu and a CPU limit of 800 millicpu. These satisfy the
 minimum and maximum CPU constraints imposed by the LimitRange.


### PR DESCRIPTION
Add a note about the constraints on LimitRange object.

Xref: kubernetes/kubernetes#54919

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6346)
<!-- Reviewable:end -->
