### PR TITLE
Adding information about staged master upgrades

### DIFF
--- a/docs/getting-started-guides/ubuntu/upgrades.md
+++ b/docs/getting-started-guides/ubuntu/upgrades.md
@@ -84,7 +84,11 @@ Once the latest charm is deployed, the channel for Kubernetes can be selected by
     juju config kubernetes-master channel=1.x/stable
 
 Where `x` is the minor version of Kubernetes. For example, `1.6/stable`. See above for Channel definitions.
+Once you've configured kubernetes-master with the appropriate channel, run the upgrade action on each master:
 
+    juju run-action kubernetes-master/0 upgrade
+    juju run-action kubernetes-master/1 upgrade
+    ...
 
 ### Worker Upgrades
 


### PR DESCRIPTION
Master upgrades are staged after PR #55990 to kubernetes(https://github.com/kubernetes/kubernetes/pull/55990). This is the documentation update showing how to upgrade the master after that change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6370)
<!-- Reviewable:end -->
