### PR TITLE
Revamp rkt and add CRI-O as alternative runtime

### DIFF
--- a/docs/getting-started-guides/minikube.md
+++ b/docs/getting-started-guides/minikube.md
@@ -18,7 +18,7 @@ Minikube is a tool that makes it easy to run Kubernetes locally. Minikube runs a
   * NodePorts
   * ConfigMaps and Secrets
   * Dashboards
-  * Container Runtime: Docker, and [rkt](https://github.com/coreos/rkt)
+  * Container Runtime: Docker, [rkt](https://github.com/rkt/rkt) and [CRI-O](https://github.com/kubernetes-incubator/cri-o)
   * Enabling CNI (Container Network Interface)
   * Ingress
 
@@ -75,15 +75,38 @@ Stopping local Kubernetes cluster...
 Stopping "minikube"...
 ```
 
-### Using rkt container engine
+### Alternative Container Runtimes
 
-To use [rkt](https://github.com/coreos/rkt) as the container runtime run:
+#### CRI-O
+
+To use [CRI-O](https://github.com/kubernetes-incubator/cri-o) as the container runtime, run:
+
+```bash
+$ minikube start \
+    --network-plugin=cni \
+    --container-runtime=cri-o \
+    --bootstrapper=kubeadm
+```
+
+Or you can use the extended version:
+
+```bash
+$ minikube start \
+    --network-plugin=cni \
+    --extra-config=kubelet.container-runtime=remote \
+    --extra-config=kubelet.container-runtime-endpoint=/var/run/crio.sock \
+    --extra-config=image-service-endpoint=/var/run/crio.sock \
+    --bootstrapper=kubeadm
+```
+
+#### rkt container engine
+
+To use [rkt](https://github.com/rkt/rkt) as the container runtime run:
 
 ```shell
 $ minikube start \
     --network-plugin=cni \
-    --container-runtime=rkt \
-    --iso-url=https://github.com/coreos/minikube-iso/releases/download/v0.0.5/minikube-v0.0.5.iso
+    --container-runtime=rkt
 ```
 
 This will use an alternative minikube ISO image containing both rkt, and Docker, and enable CNI networking.


### PR DESCRIPTION
- Add CRI-O as an available container runtime after: https://github.com/kubernetes/minikube/pull/1998
- Remove the need of an alternative ISO for rkt since now the ISO contains all the runtimes [as the doc states](https://github.com/kubernetes/minikube/blob/master/docs/contributors/minikube_iso.md#minikube-iso-image)
Signed-off-by: Lorenzo Fontana <lo@linux.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6371)
<!-- Reviewable:end -->
