### PR TITLE
Add Container Name into Pod Example

### DIFF
--- a/docs/api-reference/v1.8/index.html
+++ b/docs/api-reference/v1.8/index.html
@@ -7944,7 +7944,8 @@ $</span><span class="bash"> kubectl proxy</span>
   <span class="hljs-attribute">name</span>: pod-example
 <span class="hljs-attribute">spec</span>:
   <span class="hljs-attribute">containers</span>:
-  - <span class="hljs-attribute">image</span>: <span class="hljs-attribute">ubuntu</span>:trusty
+  - <span class="hljs-attribute">name</span>: <span class="hljs-attribute">ubuntu</span>
+    <span class="hljs-attribute">image</span>: <span class="hljs-attribute">ubuntu</span>:trusty
     <span class="hljs-attribute">command</span>: [<span class="hljs-string">"echo"</span>]
     <span class="hljs-attribute">args</span>: [<span class="hljs-string">"Hello World"</span>]
 </code></pre>
@@ -7958,7 +7959,8 @@ $</span><span class="bash"> kubectl proxy</span>
   <span class="hljs-attribute">name</span>: pod-example
 <span class="hljs-attribute">spec</span>:
   <span class="hljs-attribute">containers</span>:
-  - <span class="hljs-attribute">image</span>: <span class="hljs-attribute">ubuntu</span>:trusty
+  - <span class="hljs-attribute">name</span>: <span class="hljs-attribute">ubuntu</span>
+    <span class="hljs-attribute">image</span>: <span class="hljs-attribute">ubuntu</span>:trusty
     <span class="hljs-attribute">command</span>: [<span class="hljs-string">"echo"</span>]
     <span class="hljs-attribute">args</span>: [<span class="hljs-string">"Hello World"</span>]
 </code></pre>


### PR DESCRIPTION
what this PR does / why we need it:

[pod-v1-core example](https://kubernetes.io/docs/api-reference/v1.8/#pod-v1-core) should have a container name so that the users can copy and run the example directly.

Fixes #https://github.com/kubernetes/kubernetes/issues/55838

Release note:

```release-note
None
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6401)
<!-- Reviewable:end -->
