### PR TITLE
update Debian install-kubeadm docs to latest version

### DIFF
--- a/docs/setup/independent/install-kubeadm.md
+++ b/docs/setup/independent/install-kubeadm.md
@@ -86,7 +86,7 @@ apt-get update
 apt-get install -y docker.io
 ```
 
-or install Docker CE 17.03 from Docker's repositories for Ubuntu or Debian:
+or install Docker CE 17.09 from Docker's repositories for Ubuntu or Debian:
 
 ```bash
 apt-get update && apt-get install -y curl apt-transport-https
@@ -94,7 +94,7 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 cat <<EOF >/etc/apt/sources.list.d/docker.list
 deb https://download.docker.com/linux/$(lsb_release -si | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable
 EOF
-apt-get update && apt-get install -y docker-ce=$(apt-cache madison docker-ce | grep 17.03 | head -1 | awk '{print $3}')
+apt-get update && apt-get install -y docker-ce=$(apt-cache madison docker-ce | grep 17.09 | head -1 | awk '{print $3}')
 ```
 
 {% endcapture %}

--- a/docs/setup/independent/install-kubeadm.md
+++ b/docs/setup/independent/install-kubeadm.md
@@ -91,9 +91,10 @@ or install Docker CE 17.09 from Docker's repositories for Ubuntu or Debian:
 ```bash
 apt-get update && apt-get install -y curl apt-transport-https
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-cat <<EOF >/etc/apt/sources.list.d/docker.list
-deb https://download.docker.com/linux/$(lsb_release -si | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable
-EOF
+add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \
+   $(lsb_release -cs) \
+   stable"
 apt-get update && apt-get install -y docker-ce=$(apt-cache madison docker-ce | grep 17.09 | head -1 | awk '{print $3}')
 ```
 

--- a/docs/setup/independent/install-kubeadm.md
+++ b/docs/setup/independent/install-kubeadm.md
@@ -90,7 +90,7 @@ or install Docker CE 17.09 from Docker's repositories for Ubuntu or Debian:
 
 ```bash
 apt-get update
-apt-get install \
+apt-get install -y \
     apt-transport-https \
     ca-certificates \
     curl \

--- a/docs/setup/independent/install-kubeadm.md
+++ b/docs/setup/independent/install-kubeadm.md
@@ -89,7 +89,12 @@ apt-get install -y docker.io
 or install Docker CE 17.09 from Docker's repositories for Ubuntu or Debian:
 
 ```bash
-apt-get update && apt-get install -y curl apt-transport-https
+apt-get update
+apt-get install \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    software-properties-common
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 add-apt-repository \
    "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \
@@ -130,6 +135,9 @@ as Docker (e.g. `cgroupfs`).
 {% assign tab_contents = site.emptyArray | push: docker_ubuntu | push: docker_centos %}
 
 {% include tabs.md %}
+
+Refer to the [official Docker installation guides](https://docs.docker.com/engine/installation/)
+for more information.
 
 ## Installing kubeadm, kubelet and kubectl
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/website/issues/6113

I also found [this guide](https://docs.docker.com/engine/installation/linux/docker-ce/debian/#install-docker-ce-1) about installing Docker CE on Debian, and the `add-apt-repository` command felt more natural than using `cat` directly, so I threw that in here.

Tested the installation steps on a Ubuntu Xenial VM, which isn't quite Debian but should be Good Enough™.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6430)
<!-- Reviewable:end -->
