### PR TITLE
Some flags are not available in config

### DIFF
--- a/docs/user-guide/kubectl/v1.8/index.html
+++ b/docs/user-guide/kubectl/v1.8/index.html
@@ -7536,7 +7536,7 @@ source <span class="hljs-variable">$HOME</span>/.bash_profile</span>
 <td>output</td>
 <td>o</td>
 <td></td>
-<td>Output format. One of: json&#124;yaml&#124;wide&#124;name&#124;custom-columns=...&#124;custom-columns-file=...&#124;go-template=...&#124;go-template-file=...&#124;jsonpath=...&#124;jsonpath-file=... See custom columns [<a href="http://kubernetes.io/docs/user-guide/kubectl-overview/#custom-columns">http://kubernetes.io/docs/user-guide/kubectl-overview/#custom-columns</a>], golang template [<a href="http://golang.org/pkg/text/template/#pkg-overview">http://golang.org/pkg/text/template/#pkg-overview</a>] and jsonpath template [<a href="http://kubernetes.io/docs/user-guide/jsonpath">http://kubernetes.io/docs/user-guide/jsonpath</a>]. </td>
+<td>Output format. Using default output format or: name </td>
 </tr>
 </tbody>
 </table>
@@ -7781,7 +7781,7 @@ source <span class="hljs-variable">$HOME</span>/.bash_profile</span>
 <td>output</td>
 <td>o</td>
 <td></td>
-<td>Output format. One of: json&#124;yaml&#124;wide&#124;name&#124;custom-columns=...&#124;custom-columns-file=...&#124;go-template=...&#124;go-template-file=...&#124;jsonpath=...&#124;jsonpath-file=... See custom columns [<a href="http://kubernetes.io/docs/user-guide/kubectl-overview/#custom-columns">http://kubernetes.io/docs/user-guide/kubectl-overview/#custom-columns</a>], golang template [<a href="http://golang.org/pkg/text/template/#pkg-overview">http://golang.org/pkg/text/template/#pkg-overview</a>] and jsonpath template [<a href="http://kubernetes.io/docs/user-guide/jsonpath">http://kubernetes.io/docs/user-guide/jsonpath</a>]. </td>
+<td>Output format. One of: json&#124;yaml&#124;name&#124;custom-columns=...&#124;custom-columns-file=...&#124;go-template=...&#124;go-template-file=...&#124;jsonpath=...&#124;jsonpath-file=... See custom columns [<a href="http://kubernetes.io/docs/user-guide/kubectl-overview/#custom-columns">http://kubernetes.io/docs/user-guide/kubectl-overview/#custom-columns</a>], golang template [<a href="http://golang.org/pkg/text/template/#pkg-overview">http://golang.org/pkg/text/template/#pkg-overview</a>] and jsonpath template [<a href="http://kubernetes.io/docs/user-guide/jsonpath">http://kubernetes.io/docs/user-guide/jsonpath</a>](default print headers). </td>
 </tr>
 <tr>
 <td>output-version</td>


### PR DESCRIPTION
```
[chaowang@localhost kubernetes]$ kubectl config get-contexts -o=wide
--output wide is not available in kubectl config get-contexts; resetting to default output format
CURRENT   NAME               CLUSTER            AUTHINFO           NAMESPACE
*         local-up-cluster   local-up-cluster   local-up-cluster   
```
sourcecode:[get_contests.go](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/config/get_contexts.go#L73) & [view.go](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/config/view.go#L73)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6438)
<!-- Reviewable:end -->
