### PR TITLE
Explicitly version Clientset in example

### DIFF
--- a/docs/tasks/administer-cluster/access-cluster-api.md
+++ b/docs/tasks/administer-cluster/access-cluster-api.md
@@ -136,7 +136,7 @@ import (
    // creates the clientset
    clientset, _:= kubernetes.NewForConfig(config)
    // access the API to list pods
-   pods, _:= clientset.Core().Pods("").List(v1.ListOptions{})
+   pods, _:= clientset.CoreV1().Pods("").List(v1.ListOptions{})
    fmt.Printf("There are %d pods in the cluster\n", len(pods.Items))
 ...
 ```


### PR DESCRIPTION
Core() is deprecated in favor of CoreV1, so we should use the recommended version in the example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6446)
<!-- Reviewable:end -->
