### PR TITLE
Adds a note regarding the toleration of node-role.kubernetes.io/master

### DIFF
--- a/docs/concepts/workloads/controllers/daemonset.md
+++ b/docs/concepts/workloads/controllers/daemonset.md
@@ -129,6 +129,8 @@ labelled as critical, the Daemon pods are created with an additional
 
 Note that all above `NoSchedule` taints above are created only in version 1.8 or later if the alpha feature `TaintNodesByCondition` is enabled.
 
+Also note that the `node-role.kubernetes.io/master` `NoSchedule` toleration specified in the above example is needed on 1.6 or later to schedule on *master* nodes as this is not a default toleration.
+
 ## Communicating with Daemon Pods
 
 Some possible patterns for communicating with Pods in a DaemonSet are:

--- a/docs/concepts/workloads/controllers/daemonset.yaml
+++ b/docs/concepts/workloads/controllers/daemonset.yaml
@@ -14,6 +14,9 @@ spec:
       labels:
         name: fluentd-elasticsearch
     spec:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       containers:
       - name: fluentd-elasticsearch
         image: gcr.io/google-containers/fluentd-elasticsearch:1.20


### PR DESCRIPTION
Also updates the example fluentd daemonset which should run on all
nodes.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6461)
<!-- Reviewable:end -->
