### PR TITLE
Added IPv6 info to kube-proxy arguments

### DIFF
--- a/docs/reference/generated/kube-proxy.md
+++ b/docs/reference/generated/kube-proxy.md
@@ -25,7 +25,7 @@ kube-proxy
 
 ```
       --azure-container-registry-config string       Path to the file container Azure container registry configuration information.
-      --bind-address ip                              The IP address for the proxy server to serve on (set to 0.0.0.0 for all interfaces) (default 0.0.0.0)
+      --bind-address ip                              The IP address for the proxy server to serve on (set to 0.0.0.0 for all IPv4 interfaces and :: for all IPv6 interfaces) (default 0.0.0.0)
       --cleanup                                      If true cleanup iptables and ipvs rules and exit.
       --cluster-cidr string                          The CIDR range of pods in the cluster. When configured, traffic sent to a Service cluster IP from outside this range will be masqueraded and traffic sent from pods to an external LoadBalancer IP will be directed to the respective cluster IP instead
       --config string                                The path to the configuration file.
@@ -65,7 +65,7 @@ SupportIPVSProxyMode=true|false (ALPHA - default=false)
 TaintBasedEvictions=true|false (ALPHA - default=false)
 TaintNodesByCondition=true|false (ALPHA - default=false)
       --google-json-key string                       The Google Cloud Platform Service Account JSON Key to use for authentication.
-      --healthz-bind-address ip                      The IP address and port for the health check server to serve on (set to 0.0.0.0 for all interfaces) (default 0.0.0.0:10256)
+      --healthz-bind-address ip                      The IP address and port for the health check server to serve on (set to 0.0.0.0 for all IPv4 interfaces and :: for all IPv6 interfaces) (default 0.0.0.0:10256)
       --healthz-port int32                           The port to bind the health check server. Use 0 to disable. (default 10256)
       --hostname-override string                     If non-empty, will use this string as identification instead of the actual hostname.
       --iptables-masquerade-bit int32                If using the pure iptables proxy, the bit of the fwmark space to mark packets requiring SNAT with.  Must be within the range [0, 31]. (default 14)
@@ -80,7 +80,7 @@ TaintNodesByCondition=true|false (ALPHA - default=false)
       --kubeconfig string                            Path to kubeconfig file with authorization information (the master location is set by the master flag).
       --masquerade-all                               If using the pure iptables proxy, SNAT all traffic sent via Service cluster IPs (this not commonly needed)
       --master string                                The address of the Kubernetes API server (overrides any value in kubeconfig)
-      --metrics-bind-address ip                      The IP address and port for the metrics server to serve on (set to 0.0.0.0 for all interfaces) (default 127.0.0.1:10249)
+      --metrics-bind-address ip                      The IP address and port for the metrics server to serve on (set to 0.0.0.0 for all IPv4 interfaces and :: for all IPv6 interfaces) (default 127.0.0.1:10249)
       --oom-score-adj int32                          The oom-score-adj value for kube-proxy process. Values must be within the range [-1000, 1000] (default -999)
       --profiling                                    If true enables profiling via web interface on /debug/pprof handler.
       --proxy-mode ProxyMode                         Which proxy mode to use: 'userspace' (older) or 'iptables' (faster) or 'ipvs'(experimental)'. If blank, use the best-available proxy (currently iptables).  If the iptables proxy is selected, regardless of how, but the system's kernel or iptables versions are insufficient, this always falls back to the userspace proxy.


### PR DESCRIPTION
IPv6 information added to the following arguments

--bind-address ip
--healthz-bind-address ip 
--metrics-bind-address ip 

@leblancd @rpothier @pmichali

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6493)
<!-- Reviewable:end -->
