### PR TITLE
change replicaset documentation to use apps/v1 API

### DIFF
--- a/docs/concepts/workloads/controllers/frontend.yaml
+++ b/docs/concepts/workloads/controllers/frontend.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2 # for versions before 1.8.0 use apps/v1beta1
+apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
 kind: ReplicaSet
 metadata:
   name: frontend

--- a/docs/concepts/workloads/controllers/replicaset.md
+++ b/docs/concepts/workloads/controllers/replicaset.md
@@ -126,7 +126,7 @@ deleted. This allows the ReplicaSet to be replaced without affecting the running
 The `.spec.template.metadata.labels` must match the `.spec.selector`, or it will
 be rejected by the API.
 
-In Kubernetes 1.8 the API version `apps/v1beta2` on the ReplicaSet kind is the current version and is enabled by default. The API version `extensions/v1beta1` is deprecated. In API version `apps/v1beta2`, `.spec.selector` and `.metadata.labels` no longer default to `.spec.template.metadata.labels` if not set. So they must be set explicitly. Also note that `.spec.selector` is immutable after creation starting in API version `apps/v1beta2`.
+In Kubernetes 1.9 the API version `apps/v1` on the ReplicaSet kind is the current version and is enabled by default. The API version `apps/v1beta2` is deprecated.
 
 Also you should not normally create any pods whose labels match this selector, either directly, with 
 another ReplicaSet, or with another controller such as a Deployment. If you do so, the ReplicaSet thinks that it 


### PR DESCRIPTION
This PR changes replicaset documentation to use apps/v1 API.
/assign @kow3ns

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6496)
<!-- Reviewable:end -->
