### PR TITLE
Added IPv6 information for Kubelet arguments

### DIFF
--- a/docs/reference/generated/kube-proxy.md
+++ b/docs/reference/generated/kube-proxy.md
@@ -25,7 +25,7 @@ kube-proxy
 
 ```
       --azure-container-registry-config string       Path to the file container Azure container registry configuration information.
-      --bind-address ip                              The IP address for the proxy server to serve on (set to 0.0.0.0 for all interfaces) (default 0.0.0.0)
+      --bind-address ip                              The IP address for the proxy server to serve on (set to 0.0.0.0 for all IPv4 interfaces and :: for all IPv6 interfaces) (default 0.0.0.0)
       --cleanup                                      If true cleanup iptables and ipvs rules and exit.
       --cluster-cidr string                          The CIDR range of pods in the cluster. When configured, traffic sent to a Service cluster IP from outside this range will be masqueraded and traffic sent from pods to an external LoadBalancer IP will be directed to the respective cluster IP instead
       --config string                                The path to the configuration file.
@@ -65,7 +65,7 @@ SupportIPVSProxyMode=true|false (ALPHA - default=false)
 TaintBasedEvictions=true|false (ALPHA - default=false)
 TaintNodesByCondition=true|false (ALPHA - default=false)
       --google-json-key string                       The Google Cloud Platform Service Account JSON Key to use for authentication.
-      --healthz-bind-address ip                      The IP address and port for the health check server to serve on (set to 0.0.0.0 for all interfaces) (default 0.0.0.0:10256)
+      --healthz-bind-address ip                      The IP address and port for the health check server to serve on (set to 0.0.0.0 for all IPv4 interfaces and :: for all IPv6 interfaces) (default 0.0.0.0:10256)
       --healthz-port int32                           The port to bind the health check server. Use 0 to disable. (default 10256)
       --hostname-override string                     If non-empty, will use this string as identification instead of the actual hostname.
       --iptables-masquerade-bit int32                If using the pure iptables proxy, the bit of the fwmark space to mark packets requiring SNAT with.  Must be within the range [0, 31]. (default 14)
@@ -80,7 +80,7 @@ TaintNodesByCondition=true|false (ALPHA - default=false)
       --kubeconfig string                            Path to kubeconfig file with authorization information (the master location is set by the master flag).
       --masquerade-all                               If using the pure iptables proxy, SNAT all traffic sent via Service cluster IPs (this not commonly needed)
       --master string                                The address of the Kubernetes API server (overrides any value in kubeconfig)
-      --metrics-bind-address ip                      The IP address and port for the metrics server to serve on (set to 0.0.0.0 for all interfaces) (default 127.0.0.1:10249)
+      --metrics-bind-address ip                      The IP address and port for the metrics server to serve on (set to 0.0.0.0 for all IPv4 interfaces and :: for all IPv6 interfaces) (default 127.0.0.1:10249)
       --oom-score-adj int32                          The oom-score-adj value for kube-proxy process. Values must be within the range [-1000, 1000] (default -999)
       --profiling                                    If true enables profiling via web interface on /debug/pprof handler.
       --proxy-mode ProxyMode                         Which proxy mode to use: 'userspace' (older) or 'iptables' (faster) or 'ipvs'(experimental)'. If blank, use the best-available proxy (currently iptables).  If the iptables proxy is selected, regardless of how, but the system's kernel or iptables versions are insufficient, this always falls back to the userspace proxy.

--- a/docs/reference/generated/kubelet.md
+++ b/docs/reference/generated/kubelet.md
@@ -36,7 +36,7 @@ kubelet
 ### Options
 
 ```
-      --address ip                                               The IP address for the Kubelet to serve on (set to 0.0.0.0 for all interfaces) (default 0.0.0.0)
+      --address ip                                               The IP address for the Kubelet to serve on (set to 0.0.0.0 for all IPv4 interfaces and :: for all IPv6 interfaces) (default 0.0.0.0)
       --allow-privileged                                         If true, allow containers to request privileged mode.
       --anonymous-auth                                           Enables anonymous requests to the Kubelet server. Requests that are not rejected by another authentication method are treated as anonymous requests. Anonymous requests have a username of system:anonymous, and a group name of system:unauthenticated. (default true)
       --authentication-token-webhook                             Use the TokenReview API to determine authentication for bearer tokens.
@@ -124,7 +124,7 @@ TaintNodesByCondition=true|false (ALPHA - default=false)
       --file-check-frequency duration                            Duration between checking config files for new data (default 20s)
       --google-json-key string                                   The Google Cloud Platform Service Account JSON Key to use for authentication.
       --hairpin-mode string                                      How should the kubelet setup hairpin NAT. This allows endpoints of a Service to loadbalance back to themselves if they should try to access their own Service. Valid values are "promiscuous-bridge", "hairpin-veth" and "none". (default "promiscuous-bridge")
-      --healthz-bind-address ip                                  The IP address for the healthz server to serve on. (set to 0.0.0.0 for all interfaces) (default 127.0.0.1)
+      --healthz-bind-address ip                                  The IP address for the healthz server to serve on. (set to 0.0.0.0 for all IPv4 interfaces and :: for all IPv6 interfaces) (default 127.0.0.1)
       --healthz-port int32                                       The port of the localhost healthz endpoint (set to 0 to disable) (default 10248)
       --host-ipc-sources stringSlice                             Comma-separated list of sources from which the Kubelet allows pods to use the host ipc namespace. (default [*])
       --host-network-sources stringSlice                         Comma-separated list of sources from which the Kubelet allows pods to use of host network. (default [*])


### PR DESCRIPTION
in docs\reference\generated\kubelet.md , IPv6 information was added for the following arguments.

 --address ip 
 --healthz-bind-address ip

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6498)
<!-- Reviewable:end -->
