### PR TITLE
Change deployment unavailable/surge range to match current behaviour

### DIFF
--- a/docs/concepts/workloads/controllers/deployment.md
+++ b/docs/concepts/workloads/controllers/deployment.md
@@ -214,12 +214,10 @@ nginx-deployment-1564180365-z9gth   1/1       Running   0          14s
 Next time we want to update these Pods, we only need to update the Deployment's pod template again.
 
 Deployment can ensure that only a certain number of Pods may be down while they are being updated. By
-default, it ensures that at least 1 less than the desired number of Pods are up (1 max unavailable).
+default, it ensures that at least 25% less than the desired number of Pods are up (25% max unavailable).
 
 Deployment can also ensure that only a certain number of Pods may be created above the desired number of
-Pods. By default, it ensures that at most 1 more than the desired number of Pods are up (1 max surge).
-
-In a future version of Kubernetes, the defaults will change from 1-1 to 25%-25%.
+Pods. By default, it ensures that at most 25% more than the desired number of Pods are up (25% max surge).
 
 For example, if you look at the above Deployment closely, you will see that it first created a new Pod,
 then deleted some old Pods and created new ones. It does not kill old Pods until a sufficient number of
@@ -228,41 +226,42 @@ It makes sure that number of available Pods is at least 2 and the number of tota
 
 ```shell
 $ kubectl describe deployments
-Name:           nginx-deployment
-Namespace:      default
-CreationTimestamp:  Tue, 15 Mar 2016 12:01:06 -0700
-Labels:         app=nginx
-Annotations:    deployment.kubernetes.io/revision=2
-Selector:       app=nginx
-Replicas:       3 desired | 3 updated | 3 total | 3 available | 0 unavailable
-StrategyType:       RollingUpdate
-MinReadySeconds:    0
-RollingUpdateStrategy:  1 max unavailable, 1 max surge
+Name:                   nginx-deployment
+Namespace:              default
+CreationTimestamp:      Thu, 30 Nov 2017 10:56:25 +0000
+Labels:                 app=nginx
+Annotations:            deployment.kubernetes.io/revision=2
+Selector:               app=nginx
+Replicas:               3 desired | 3 updated | 3 total | 3 available | 0 unavailable
+StrategyType:           RollingUpdate
+MinReadySeconds:        0
+RollingUpdateStrategy:  25% max unavailable, 25% max surge
 Pod Template:
-  Labels:       app=nginx
+  Labels:  app=nginx
   Containers:
    nginx:
-    Image:              nginx:1.9.1
-    Port:               80/TCP
-    Environment:        <none>
-    Mounts:             <none>
-  Volumes:              <none>
+    Image:        nginx:1.9.1
+    Port:         80/TCP
+    Environment:  <none>
+    Mounts:       <none>
+  Volumes:        <none>
 Conditions:
-  Type          Status  Reason
-  ----          ------  ------
-  Available     True    MinimumReplicasAvailable
-  Progressing   True    NewReplicaSetAvailable
-OldReplicaSets:     <none>
-NewReplicaSet:      nginx-deployment-1564180365 (3/3 replicas created)
+  Type           Status  Reason
+  ----           ------  ------
+  Available      True    MinimumReplicasAvailable
+  Progressing    True    NewReplicaSetAvailable
+OldReplicaSets:  <none>
+NewReplicaSet:   nginx-deployment-6bd4859cdb (3/3 replicas created)
 Events:
-  FirstSeen LastSeen    Count   From                     SubobjectPath   Type        Reason              Message
-  --------- --------    -----   ----                     -------------   --------    ------              -------
-  36s       36s         1       {deployment-controller }                 Normal      ScalingReplicaSet   Scaled up replica set nginx-deployment-2035384211 to 3
-  23s       23s         1       {deployment-controller }                 Normal      ScalingReplicaSet   Scaled up replica set nginx-deployment-1564180365 to 1
-  23s       23s         1       {deployment-controller }                 Normal      ScalingReplicaSet   Scaled down replica set nginx-deployment-2035384211 to 2
-  23s       23s         1       {deployment-controller }                 Normal      ScalingReplicaSet   Scaled up replica set nginx-deployment-1564180365 to 2
-  21s       21s         1       {deployment-controller }                 Normal      ScalingReplicaSet   Scaled down replica set nginx-deployment-2035384211 to 0
-  21s       21s         1       {deployment-controller }                 Normal      ScalingReplicaSet   Scaled up replica set nginx-deployment-1564180365 to 3
+  Type    Reason             Age   From                   Message
+  ----    ------             ----  ----                   -------
+  Normal  ScalingReplicaSet  2m    deployment-controller  Scaled up replica set nginx-deployment-569477d6d8 to 3
+  Normal  ScalingReplicaSet  24s   deployment-controller  Scaled up replica set nginx-deployment-6bd4859cdb to 1
+  Normal  ScalingReplicaSet  22s   deployment-controller  Scaled down replica set nginx-deployment-569477d6d8 to 2
+  Normal  ScalingReplicaSet  22s   deployment-controller  Scaled up replica set nginx-deployment-6bd4859cdb to 2
+  Normal  ScalingReplicaSet  19s   deployment-controller  Scaled down replica set nginx-deployment-569477d6d8 to 1
+  Normal  ScalingReplicaSet  19s   deployment-controller  Scaled up replica set nginx-deployment-6bd4859cdb to 3
+  Normal  ScalingReplicaSet  14s   deployment-controller  Scaled down replica set nginx-deployment-569477d6d8 to 0
 ```
 
 Here we see that when we first created the Deployment, it created a ReplicaSet (nginx-deployment-2035384211)


### PR DESCRIPTION
- Also changed the example output to match the current one

~~I was thinking about describing how to change the available/surge values with `.spec.strategy.rollingUpdate.maxSurge` and `.spec.strategy.rollingUpdate.maxUnavailable`, should I?~~ Ignore that, I realized it's explained in https://kubernetes.io/docs/concepts/workloads/controllers/deployment#strategy

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6513)
<!-- Reviewable:end -->
