### PR TITLE
Update access-cluster.md for IPv6

### DIFF
--- a/docs/tasks/access-application-cluster/access-cluster.md
+++ b/docs/tasks/access-application-cluster/access-cluster.md
@@ -55,7 +55,8 @@ $ kubectl proxy --port=8080 &
 
 See [kubectl proxy](/docs/user-guide/kubectl/{{page.version}}/#proxy) for more details.
 
-Then you can explore the API with curl, wget, or a browser, like so:
+Then you can explore the API with curl, wget, or a browser, replacing localhost
+with [::1] for IPv6, like so:
 
 ```shell
 $ curl http://localhost:8080/api/


### PR DESCRIPTION
Update access-cluster.md with a comment that for IPv6 the user should use [::1] for the localhost

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6534)
<!-- Reviewable:end -->
