### PR TITLE
Fix mistake in dynamic-provisioning

### DIFF
--- a/docs/concepts/storage/dynamic-provisioning.md
+++ b/docs/concepts/storage/dynamic-provisioning.md
@@ -116,7 +116,7 @@ When a default `StorageClass` exists in a cluster and a user creates a
 `storageClassName` field pointing to the default storage class.
 
 Note that there can be at most one *default* storage class on a cluster, or
-a `PersistentVolumeClaim` with `storageClassName` explicitly specified cannot
+a `PersistentVolumeClaim` without `storageClassName` explicitly specified cannot
 be created.
 
 {% endcapture %}


### PR DESCRIPTION
IMHO, if we have more than one storageClass that marked as default, PersistentVolumeClaim with storageClassName still could be created normally, it's the PersistentVolumeClaims without  storageClassName that would fail to be filled in with default storageClass.
Plz correct me if I misunderstood something :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6547)
<!-- Reviewable:end -->
