### PR TITLE
Garbage collection updates for 1.9

### DIFF
--- a/docs/concepts/workloads/controllers/garbage-collection.md
+++ b/docs/concepts/workloads/controllers/garbage-collection.md
@@ -106,9 +106,11 @@ To control the cascading deletion policy, set the `deleteOptions.propagationPoli
 field on your owner object. Possible values include "Orphan",
 "Foreground", or "Background".
 
-The default garbage collection policy for many controller resources is `orphan`,
-including ReplicationController, ReplicaSet, StatefulSet, DaemonSet, and
-Deployment. So unless you specify otherwise, dependent objects are orphaned.
+Prior to Kubernetes 1.9, the default garbage collection policy for many controller resources was `orphan`.
+This included ReplicationController, ReplicaSet, StatefulSet, DaemonSet, and
+Deployment. For kinds in the extensions/v1beta1, apps/v1beta1, and apps/v1beta2 group versions, unless you 
+specify otherwise, dependent objects are orphaned by default. In Kubernetes 1.9, all kinds in the apps/v1 
+group version use a default garbage collection policy of `delete`.
 
 Here's an example that deletes dependents in background:
 

--- a/docs/concepts/workloads/controllers/garbage-collection.md
+++ b/docs/concepts/workloads/controllers/garbage-collection.md
@@ -109,8 +109,8 @@ field on your owner object. Possible values include "Orphan",
 Prior to Kubernetes 1.9, the default garbage collection policy for many controller resources was `orphan`.
 This included ReplicationController, ReplicaSet, StatefulSet, DaemonSet, and
 Deployment. For kinds in the extensions/v1beta1, apps/v1beta1, and apps/v1beta2 group versions, unless you 
-specify otherwise, dependent objects are orphaned by default. In Kubernetes 1.9, all kinds in the apps/v1 
-group version use a default garbage collection policy of `delete`.
+specify otherwise, dependent objects are orphaned by default. In Kubernetes 1.9, for all kinds in the apps/v1 
+group version, dependent objects are deleted by default.
 
 Here's an example that deletes dependents in background:
 


### PR DESCRIPTION
Updates the garbage collection documentation for the v1 workloads api.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6555)
<!-- Reviewable:end -->
