### PR TITLE
Add Horizontal Pod Autoscaler glossary term and make HPA terminology …

### DIFF
--- a/_data/glossary/horizontal-pod-autoscaler.yaml
+++ b/_data/glossary/horizontal-pod-autoscaler.yaml
@@ -1,0 +1,15 @@
+id: horizontal-pod-autoscaler
+name: Horizontal Pod Autoscaler
+full-link: /docs/tasks/run-application/horizontal-pod-autoscale/
+aka:
+- HPA
+related:
+- pod
+tags:
+- operation
+short-description: >
+  An API resource that automatically scales the number of pod replicas based on targeted CPU
+  utilization or custom metric targets.
+long-description: >
+  HPA is typically used with replication controllers, deployments or replica sets and cannot be
+  applied to objects that cannot be scaled, for example DaemonSets.  

--- a/_data/tasks.yml
+++ b/_data/tasks.yml
@@ -52,8 +52,8 @@ toc:
   - docs/tasks/run-application/delete-stateful-set.md
   - docs/tasks/run-application/force-delete-stateful-set-pod.md
   - docs/tasks/run-application/rolling-update-replication-controller.md
-  - docs/tasks/run-application/horizontal-pod-autoscale.md
-  - docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+  - docs/tasks/run-application/horizontal-pod-autoscaler.md
+  - docs/tasks/run-application/horizontal-pod-autoscaler-walkthrough.md
   - docs/tasks/run-application/configure-pdb.md
 
 - title: Run Jobs

--- a/docs/tasks/run-application/horizontal-pod-autoscaler-walkthrough.md
+++ b/docs/tasks/run-application/horizontal-pod-autoscaler-walkthrough.md
@@ -4,14 +4,14 @@ approvers:
 - jszczepkowski
 - justinsb
 - directxman12
-title: Horizontal Pod Autoscaling Walkthrough
+title: Horizontal Pod Autoscaler Walkthrough
 ---
 
-Horizontal Pod Autoscaling automatically scales the number of pods
+Horizontal Pod Autoscaler automatically scales the number of pods
 in a replication controller, deployment or replica set based on observed CPU utilization
 (or, with beta support, on some other, application-provided metrics).
 
-This document walks you through an example of enabling Horizontal Pod Autoscaling for the php-apache server.  For more information on how Horizontal Pod Autoscaling behaves, see the [Horizontal Pod Autoscaling user guide](/docs/tasks/run-application/horizontal-pod-autoscale/).
+This document walks you through an example of enabling Horizontal Pod Autoscaler for the php-apache server.  For more information on how Horizontal Pod Autoscaler behaves, see the [Horizontal Pod Autoscaler user guide](/docs/tasks/run-application/horizontal-pod-autoscaler/).
 
 ## Prerequisites
 
@@ -24,7 +24,7 @@ heapster monitoring will be turned-on by default).
 To specify multiple resource metrics for a Horizontal Pod Autoscaler, you must have a Kubernetes cluster
 and kubectl at version 1.6 or later.  Furthermore, in order to make use of custom metrics, your cluster
 must be able to communicate with the API server providing the custom metrics API.
-See the [Horizontal Pod Autoscaling user guide](/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-custom-metrics) for more details.
+See the [Horizontal Pod Autoscaler user guide](/docs/tasks/run-application/horizontal-pod-autoscaler/#support-for-custom-metrics) for more details.
 
 ## Step One: Run & expose php-apache server
 

--- a/docs/tasks/run-application/horizontal-pod-autoscaler.md
+++ b/docs/tasks/run-application/horizontal-pod-autoscaler.md
@@ -3,18 +3,18 @@ approvers:
 - fgrzadkowski
 - jszczepkowski
 - directxman12
-title: Horizontal Pod Autoscaling
+title: Horizontal Pod Autoscaler
 ---
 
-This document describes the current state of Horizontal Pod Autoscaling in Kubernetes.
+This document describes the current state of the Horizontal Pod Autoscaler in Kubernetes.
 
-## What is Horizontal Pod Autoscaling?
+## What is the Horizontal Pod Autoscaler?
 
-With Horizontal Pod Autoscaling, Kubernetes automatically scales the number of pods
+The Horizontal Pod Autoscaler automatically scales the number of pods
 in a replication controller, deployment or replica set based on observed CPU utilization (or, with
 [custom metrics](https://git.k8s.io/community/contributors/design-proposals/instrumentation/custom-metrics-api.md)
 support, on some other application-provided metrics). Note that Horizontal
-Pod Autoscaling does not apply to objects that can't be scaled, for example, DaemonSet.
+Pod Autoscaling does not apply to objects that can't be scaled, for example, DaemonSets.
 
 The Horizontal Pod Autoscaler is implemented as a Kubernetes API resource and a controller.
 The resource determines the behavior of the controller.


### PR DESCRIPTION
KubeCon 2017

Add Horizontal Pod Autoscaler glossary term and make HPA terminology consistent in docs/tasks pages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6585)
<!-- Reviewable:end -->
