### PR TITLE
Add glossary term for CRD

### DIFF
--- a/_data/glossary/customresourcedefinition.yaml
+++ b/_data/glossary/customresourcedefinition.yaml
@@ -1,6 +1,5 @@
 id: Custom Resource Definition
 name: Custom Resource Definition
-aka: Third Party Resource
 tags:
 - fundamental
 - operation

--- a/_data/glossary/customresourcedefinition.yaml
+++ b/_data/glossary/customresourcedefinition.yaml
@@ -1,9 +1,13 @@
-id: Custom Resource Definition
-name: Custom Resource Definition
+id: CustomResourceDefinition
+name: CustomResourceDefinition
+aka: 
+- CRD
+- Formerly Known as ThirdPartyResources (TPR)
 tags:
 - fundamental
 - operation
-full-link: docs/tasks/access-kubernetes-api/migrate-third-party-resource/
+- extension
+full-link: docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/
 short-description: >
   A custom resource definition is the representation of a customization of a particular Kubernetes installation.
 long-description: >

--- a/_data/glossary/customresourcedefinition.yaml
+++ b/_data/glossary/customresourcedefinition.yaml
@@ -1,0 +1,10 @@
+name: Custom Resource Definition
+aka: Third Party Resource
+tags:
+full-link: docs/tasks/access-kubernetes-api/migrate-third-party-resource/
+- fundamental
+- operation
+short-description: >
+  A custom resource definition is the representation of a customization of a particular Kubernetes installation.
+long-description: >
+  A resource definition that defines the endpoint in the Kubernetes API that stores a collection of API objects of a certain kind that is specified.

--- a/_data/glossary/customresourcedefinition.yaml
+++ b/_data/glossary/customresourcedefinition.yaml
@@ -1,9 +1,9 @@
 name: Custom Resource Definition
 aka: Third Party Resource
 tags:
-full-link: docs/tasks/access-kubernetes-api/migrate-third-party-resource/
 - fundamental
 - operation
+full-link: docs/tasks/access-kubernetes-api/migrate-third-party-resource/
 short-description: >
   A custom resource definition is the representation of a customization of a particular Kubernetes installation.
 long-description: >

--- a/_data/glossary/customresourcedefinition.yaml
+++ b/_data/glossary/customresourcedefinition.yaml
@@ -1,3 +1,4 @@
+id: Custom Resource Definition
 name: Custom Resource Definition
 aka: Third Party Resource
 tags:


### PR DESCRIPTION
This resolves part of issue #5993, adding **Custom Resource Definition** replacing _Third Party Resource_.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6594)
<!-- Reviewable:end -->
