### PR TITLE
Update generated docs for k8s components.

### DIFF
--- a/docs/reference/generated/cloud-controller-manager.md
+++ b/docs/reference/generated/cloud-controller-manager.md
@@ -1,7 +1,7 @@
 ---
-title: cloud-controller-manager
 notitle: true
 ---
+
 ## cloud-controller-manager
 
 
@@ -26,19 +26,23 @@ cloud-controller-manager
       --cloud-provider string                    The provider of cloud services. Cannot be empty.
       --cluster-cidr string                      CIDR Range for Pods in cluster.
       --cluster-name string                      The instance prefix for the cluster. (default "kubernetes")
+      --concurrent-service-syncs int32           The number of services that are allowed to sync concurrently. Larger number = more responsive service management, but more CPU (and network) load (default 1)
       --configure-cloud-routes                   Should CIDRs allocated by allocate-node-cidrs be configured on the cloud provider. (default true)
       --contention-profiling                     Enable lock contention profiling, if profiling is enabled.
       --controller-start-interval duration       Interval between starting controller managers.
       --feature-gates mapStringBool              A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
-APIListChunking=true|false (ALPHA - default=false)
+APIListChunking=true|false (BETA - default=true)
 APIResponseCompression=true|false (ALPHA - default=false)
 Accelerators=true|false (ALPHA - default=false)
 AdvancedAuditing=true|false (BETA - default=true)
 AllAlpha=true|false (ALPHA - default=false)
 AllowExtTrafficLocalEndpoints=true|false (default=true)
 AppArmor=true|false (BETA - default=true)
+BlockVolume=true|false (ALPHA - default=false)
 CPUManager=true|false (ALPHA - default=false)
-CustomResourceValidation=true|false (ALPHA - default=false)
+CSIPersistentVolume=true|false (ALPHA - default=false)
+CustomPodDNS=true|false (ALPHA - default=false)
+CustomResourceValidation=true|false (BETA - default=true)
 DebugContainers=true|false (ALPHA - default=false)
 DevicePlugins=true|false (ALPHA - default=false)
 DynamicKubeletConfig=true|false (ALPHA - default=false)
@@ -50,15 +54,20 @@ HugePages=true|false (ALPHA - default=false)
 Initializers=true|false (ALPHA - default=false)
 KubeletConfigFile=true|false (ALPHA - default=false)
 LocalStorageCapacityIsolation=true|false (ALPHA - default=false)
+MountContainers=true|false (ALPHA - default=false)
 MountPropagation=true|false (ALPHA - default=false)
+PVCProtection=true|false (ALPHA - default=false)
 PersistentLocalVolumes=true|false (ALPHA - default=false)
 PodPriority=true|false (ALPHA - default=false)
+ResourceLimitsPriorityFunction=true|false (ALPHA - default=false)
 RotateKubeletClientCertificate=true|false (BETA - default=true)
 RotateKubeletServerCertificate=true|false (ALPHA - default=false)
+ServiceNodeExclusion=true|false (ALPHA - default=false)
 StreamingProxyRedirects=true|false (BETA - default=true)
-SupportIPVSProxyMode=true|false (ALPHA - default=false)
+SupportIPVSProxyMode=true|false (BETA - default=false)
 TaintBasedEvictions=true|false (ALPHA - default=false)
 TaintNodesByCondition=true|false (ALPHA - default=false)
+VolumeScheduling=true|false (ALPHA - default=false)
       --google-json-key string                   The Google Cloud Platform Service Account JSON Key to use for authentication.
       --kube-api-burst int32                     Burst to use while talking with kubernetes apiserver. (default 30)
       --kube-api-content-type string             Content type of requests sent to apiserver. (default "application/vnd.kubernetes.protobuf")
@@ -67,7 +76,7 @@ TaintNodesByCondition=true|false (ALPHA - default=false)
       --leader-elect                             Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability. (default true)
       --leader-elect-lease-duration duration     The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled. (default 15s)
       --leader-elect-renew-deadline duration     The interval between attempts by the acting master to renew a leadership slot before it stops leading. This must be less than or equal to the lease duration. This is only applicable if leader election is enabled. (default 10s)
-      --leader-elect-resource-lock endpoints     The type of resource object that is used for locking during leader election. Supported options are endpoints (default) and `configmap`. (default "endpoints")
+      --leader-elect-resource-lock endpoints     The type of resource object that is used for locking during leader election. Supported options are endpoints (default) and `configmaps`. (default "endpoints")
       --leader-elect-retry-period duration       The duration the clients should wait between attempting acquisition and renewal of a leadership. This is only applicable if leader election is enabled. (default 2s)
       --master string                            The address of the Kubernetes API server (overrides any value in kubeconfig).
       --min-resync-period duration               The resync period in reflectors will be random between MinResyncPeriod and 2*MinResyncPeriod. (default 12h0m0s)
@@ -75,9 +84,9 @@ TaintNodesByCondition=true|false (ALPHA - default=false)
       --node-status-update-frequency duration    Specifies how often the controller updates nodes' status. (default 5m0s)
       --port int32                               The port that the cloud-controller-manager's http service runs on. (default 10253)
       --profiling                                Enable profiling via web interface host:port/debug/pprof/. (default true)
-      --route-reconciliation-period duration     The period for reconciling routes created for Nodes by cloud provider.
+      --route-reconciliation-period duration     The period for reconciling routes created for Nodes by cloud provider. (default 10s)
       --use-service-account-credentials          If true, use individual service account credentials for each controller.
       --version version[=true]                   Print version information and quit
 ```
 
-###### Auto generated by spf13/cobra on 27-Sep-2017
+###### Auto generated by spf13/cobra on 7-Dec-2017

--- a/docs/reference/generated/kube-apiserver.md
+++ b/docs/reference/generated/kube-apiserver.md
@@ -1,7 +1,7 @@
 ---
-title: kube-apiserver
 notitle: true
 ---
+
 ## kube-apiserver
 
 
@@ -21,7 +21,7 @@ kube-apiserver
 ### Options
 
 ```
-      --admission-control stringSlice                           Ordered list of plug-ins to do admission control of resources into cluster. Comma-delimited list of: AlwaysAdmit, AlwaysDeny, AlwaysPullImages, DefaultStorageClass, DefaultTolerationSeconds, DenyEscalatingExec, DenyExecOnPrivileged, EventRateLimit, GenericAdmissionWebhook, ImagePolicyWebhook, InitialResources, Initializers, LimitPodHardAntiAffinityTopology, LimitRanger, NamespaceAutoProvision, NamespaceExists, NamespaceLifecycle, NodeRestriction, OwnerReferencesPermissionEnforcement, PersistentVolumeClaimResize, PersistentVolumeLabel, PodNodeSelector, PodPreset, PodSecurityPolicy, PodTolerationRestriction, Priority, ResourceQuota, SecurityContextDeny, ServiceAccount. (default [AlwaysAdmit])
+      --admission-control stringSlice                           Admission is divided into two phases. In the first phase, only mutating admission plugins run. In the second phase, only validating admission plugins run. The names in the below list may represent a validating plugin, a mutating plugin, or both. Within each phase, the plugins will run in the order in which they are passed to this flag. Comma-delimited list of: AlwaysAdmit, AlwaysDeny, AlwaysPullImages, DefaultStorageClass, DefaultTolerationSeconds, DenyEscalatingExec, DenyExecOnPrivileged, EventRateLimit, ExtendedResourceToleration, ImagePolicyWebhook, InitialResources, Initializers, LimitPodHardAntiAffinityTopology, LimitRanger, MutatingAdmissionWebhook, NamespaceAutoProvision, NamespaceExists, NamespaceLifecycle, NodeRestriction, OwnerReferencesPermissionEnforcement, PVCProtection, PersistentVolumeClaimResize, PersistentVolumeLabel, PodNodeSelector, PodPreset, PodSecurityPolicy, PodTolerationRestriction, Priority, ResourceQuota, SecurityContextDeny, ServiceAccount, ValidatingAdmissionWebhook. (default [AlwaysAdmit])
       --admission-control-config-file string                    File with admission control configuration.
       --advertise-address ip                                    The IP address on which to advertise the apiserver to members of the cluster. This address must be reachable by the rest of the cluster. If blank, the --bind-address will be used. If --bind-address is unspecified, the host's default interface will be used.
       --allow-privileged                                        If true, allow privileged containers. [default=false]
@@ -33,6 +33,12 @@ kube-apiserver
       --audit-log-maxsize int                                   The maximum size in megabytes of the audit log file before it gets rotated.
       --audit-log-path string                                   If set, all requests coming to the apiserver will be logged to this file.  '-' means standard out.
       --audit-policy-file string                                Path to the file that defines the audit policy configuration. Requires the 'AdvancedAuditing' feature gate. With AdvancedAuditing, a profile is required to enable auditing.
+      --audit-webhook-batch-buffer-size int                     The size of the buffer to store events before batching and sending to the webhook. Only used in batch mode. (default 10000)
+      --audit-webhook-batch-initial-backoff duration            The amount of time to wait before retrying the first failed requests. Only used in batch mode. (default 10s)
+      --audit-webhook-batch-max-size int                        The maximum size of a batch sent to the webhook. Only used in batch mode. (default 400)
+      --audit-webhook-batch-max-wait duration                   The amount of time to wait before force sending the batch that hadn't reached the max size. Only used in batch mode. (default 30s)
+      --audit-webhook-batch-throttle-burst int                  Maximum number of requests sent at the same moment if ThrottleQPS was not utilized before. Only used in batch mode. (default 15)
+      --audit-webhook-batch-throttle-qps float32                Maximum average number of requests per second. Only used in batch mode. (default 10)
       --audit-webhook-config-file string                        Path to a kubeconfig formatted file that defines the audit webhook configuration. Requires the 'AdvancedAuditing' feature gate.
       --audit-webhook-mode string                               Strategy for sending audit events. Blocking indicates sending events should block server responses. Batch causes the webhook to buffer and send events asynchronously. Known modes are batch,blocking. (default "batch")
       --authentication-token-webhook-cache-ttl duration         The duration to cache responses from the webhook token authenticator. (default 2m0s)
@@ -54,16 +60,17 @@ kube-apiserver
       --default-watch-cache-size int                            Default watch cache size. If zero, watch cache will be disabled for resources that do not have a default watch size set. (default 100)
       --delete-collection-workers int                           Number of workers spawned for DeleteCollection call. These are used to speed up namespace cleanup. (default 1)
       --deserialization-cache-size int                          Number of deserialized json objects to cache in memory.
-      --enable-aggregator-routing                               Turns on aggregator routing requests to endpoints IP rather than cluster IP.
+      --enable-aggregator-routing                               Turns on aggregator routing requests to endoints IP rather than cluster IP.
       --enable-bootstrap-token-auth                             Enable to allow secrets of type 'bootstrap.kubernetes.io/token' in the 'kube-system' namespace to be used for TLS bootstrapping authentication.
       --enable-garbage-collector                                Enables the generic garbage collector. MUST be synced with the corresponding flag of the kube-controller-manager. (default true)
       --enable-logs-handler                                     If true, install a /logs handler for the apiserver logs. (default true)
       --enable-swagger-ui                                       Enables swagger ui on the apiserver at /swagger-ui
+      --endpoint-reconciler-type string                         Use an endpoint reconciler (master-count, lease, none) (default "master-count")
       --etcd-cafile string                                      SSL Certificate Authority file used to secure etcd communication.
       --etcd-certfile string                                    SSL certification file used to secure etcd communication.
+      --etcd-compaction-interval duration                       The interval of compaction requests. If 0, the compaction request from apiserver is disabled. (default 5m0s)
       --etcd-keyfile string                                     SSL key file used to secure etcd communication.
       --etcd-prefix string                                      The prefix to prepend to all resource paths in etcd. (default "/registry")
-      --etcd-quorum-read                                        If true, enable quorum read.
       --etcd-servers stringSlice                                List of etcd servers to connect with (scheme://ip:port), comma separated.
       --etcd-servers-overrides stringSlice                      Per-resource etcd servers overrides, comma separated. The individual override format: group/resource#servers, where servers are http://ip:port, semicolon separated.
       --event-ttl duration                                      Amount of time to retain events. (default 1h0m0s)
@@ -72,15 +79,18 @@ kube-apiserver
       --experimental-keystone-url string                        If passed, activates the keystone authentication plugin.
       --external-hostname string                                The hostname to use when generating externalized URLs for this master (e.g. Swagger API Docs).
       --feature-gates mapStringBool                             A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
-APIListChunking=true|false (ALPHA - default=false)
+APIListChunking=true|false (BETA - default=true)
 APIResponseCompression=true|false (ALPHA - default=false)
 Accelerators=true|false (ALPHA - default=false)
 AdvancedAuditing=true|false (BETA - default=true)
 AllAlpha=true|false (ALPHA - default=false)
 AllowExtTrafficLocalEndpoints=true|false (default=true)
 AppArmor=true|false (BETA - default=true)
+BlockVolume=true|false (ALPHA - default=false)
 CPUManager=true|false (ALPHA - default=false)
-CustomResourceValidation=true|false (ALPHA - default=false)
+CSIPersistentVolume=true|false (ALPHA - default=false)
+CustomPodDNS=true|false (ALPHA - default=false)
+CustomResourceValidation=true|false (BETA - default=true)
 DebugContainers=true|false (ALPHA - default=false)
 DevicePlugins=true|false (ALPHA - default=false)
 DynamicKubeletConfig=true|false (ALPHA - default=false)
@@ -92,15 +102,20 @@ HugePages=true|false (ALPHA - default=false)
 Initializers=true|false (ALPHA - default=false)
 KubeletConfigFile=true|false (ALPHA - default=false)
 LocalStorageCapacityIsolation=true|false (ALPHA - default=false)
+MountContainers=true|false (ALPHA - default=false)
 MountPropagation=true|false (ALPHA - default=false)
+PVCProtection=true|false (ALPHA - default=false)
 PersistentLocalVolumes=true|false (ALPHA - default=false)
 PodPriority=true|false (ALPHA - default=false)
+ResourceLimitsPriorityFunction=true|false (ALPHA - default=false)
 RotateKubeletClientCertificate=true|false (BETA - default=true)
 RotateKubeletServerCertificate=true|false (ALPHA - default=false)
+ServiceNodeExclusion=true|false (ALPHA - default=false)
 StreamingProxyRedirects=true|false (BETA - default=true)
-SupportIPVSProxyMode=true|false (ALPHA - default=false)
+SupportIPVSProxyMode=true|false (BETA - default=false)
 TaintBasedEvictions=true|false (ALPHA - default=false)
 TaintNodesByCondition=true|false (ALPHA - default=false)
+VolumeScheduling=true|false (ALPHA - default=false)
       --google-json-key string                                  The Google Cloud Platform Service Account JSON Key to use for authentication.
       --insecure-bind-address ip                                The IP address on which to serve the --insecure-port (set to 0.0.0.0 for all interfaces). (default 127.0.0.1)
       --insecure-port int                                       The port on which to serve unsecured, unauthenticated access. It is assumed that firewall rules are set up such that this port is not reachable from outside of the cluster and that port 443 on the cluster's public address is proxied to this port. This is performed by nginx in the default setup. (default 8080)
@@ -125,7 +140,7 @@ TaintNodesByCondition=true|false (ALPHA - default=false)
       --oidc-username-claim string                              The OpenID claim to use as the user name. Note that claims other than the default ('sub') is not guaranteed to be unique and immutable. This flag is experimental, please see the authentication documentation for further details. (default "sub")
       --oidc-username-prefix string                             If provided, all usernames will be prefixed with this value. If not provided, username claims other than 'email' are prefixed by the issuer URL to avoid clashes. To skip any prefixing, provide the value '-'.
       --profiling                                               Enable profiling via web interface host:port/debug/pprof/ (default true)
-      --proxy-client-cert-file string                           Client certificate used to prove the identity of the aggregator or kube-apiserver when it must call out during a request. This includes proxying requests to a user api-server and calling out to webhook admission plugins. It is expected that this cert includes a signature from the CA in the --requestheader-client-ca-file flag. That CA is published in the 'extension-apiserver-authentication' configmap in the kube-system namespace. Components receiving calls from kube-aggregator should use that CA to perform their half of the mutual TLS verification.
+      --proxy-client-cert-file string                           Client certificate used to prove the identity of the aggregator or kube-apiserver when it must call out during a request. This includes proxying requests to a user api-server and calling out to webhook admission plugins. It is expected that this cert includes a signature from the CA in the --requestheader-client-ca-file flag. That CA is published in the 'extension-apiserver-authentication' configmap in the kube-system namespace. Components recieving calls from kube-aggregator should use that CA to perform their half of the mutual TLS verification.
       --proxy-client-key-file string                            Private key for the client certificate used to prove the identity of the aggregator or kube-apiserver when it must call out during a request. This includes proxying requests to a user api-server and calling out to webhook admission plugins.
       --repair-malformed-updates                                If true, server will do its best to fix the update request to pass the validation, e.g., setting empty UID in update request to its existing value. This flag can be turned off after we fix all the clients that send malformed updates. (default true)
       --request-timeout duration                                An optional field indicating the duration a handler must keep a request open before timing it out. This is the default request timeout for requests but may be overridden by flags such as --min-request-timeout for specific types of requests. (default 1m0s)
@@ -140,14 +155,12 @@ TaintNodesByCondition=true|false (ALPHA - default=false)
       --service-account-lookup                                  If true, validate ServiceAccount tokens exist in etcd as part of authentication. (default true)
       --service-cluster-ip-range ipNet                          A CIDR notation IP range from which to assign service cluster IPs. This must not overlap with any IP ranges assigned to nodes for pods.
       --service-node-port-range portRange                       A port range to reserve for services with NodePort visibility. Example: '30000-32767'. Inclusive at both ends of the range. (default 30000-32767)
-      --ssh-keyfile string                                      If non-empty, use secure SSH proxy to the nodes, using this user keyfile
-      --ssh-user string                                         If non-empty, use secure SSH proxy to the nodes, using this user name
       --storage-backend string                                  The storage backend for persistence. Options: 'etcd3' (default), 'etcd2'.
       --storage-media-type string                               The media type to use to store objects in storage. Some resources or storage backends may only support a specific media type and will ignore this setting. (default "application/vnd.kubernetes.protobuf")
-      --storage-versions string                                 The per-group version to store resources in. Specified in the format "group1/version1,group2/version2,...". In the case where objects are moved from one group to the other, you may specify the format "group1=group2/v1beta1,group3/v1beta1,...". You only need to pass the groups you wish to change from the defaults. It defaults to a list of preferred versions of all registered groups, which is derived from the KUBE_API_VERSIONS environment variable. (default "admission.k8s.io/v1alpha1,admissionregistration.k8s.io/v1alpha1,apps/v1beta1,authentication.k8s.io/v1,authorization.k8s.io/v1,autoscaling/v1,batch/v1,certificates.k8s.io/v1beta1,componentconfig/v1alpha1,extensions/v1beta1,federation/v1beta1,imagepolicy.k8s.io/v1alpha1,networking.k8s.io/v1,policy/v1beta1,rbac.authorization.k8s.io/v1beta1,scheduling.k8s.io/v1alpha1,settings.k8s.io/v1alpha1,storage.k8s.io/v1,v1")
+      --storage-versions string                                 The per-group version to store resources in. Specified in the format "group1/version1,group2/version2,...". In the case where objects are moved from one group to the other, you may specify the format "group1=group2/v1beta1,group3/v1beta1,...". You only need to pass the groups you wish to change from the defaults. It defaults to a list of preferred versions of all registered groups, which is derived from the KUBE_API_VERSIONS environment variable. (default "admission.k8s.io/v1beta1,admissionregistration.k8s.io/v1beta1,apps/v1beta1,authentication.k8s.io/v1,authorization.k8s.io/v1,autoscaling/v1,batch/v1,certificates.k8s.io/v1beta1,componentconfig/v1alpha1,events.k8s.io/v1beta1,extensions/v1beta1,imagepolicy.k8s.io/v1alpha1,kubeadm.k8s.io/v1alpha1,networking.k8s.io/v1,policy/v1beta1,rbac.authorization.k8s.io/v1,scheduling.k8s.io/v1alpha1,settings.k8s.io/v1alpha1,storage.k8s.io/v1,v1")
       --target-ram-mb int                                       Memory limit for apiserver in MB (used to configure sizes of caches, etc.)
-      --tls-ca-file string                                      If set, this certificate authority will used for secure access from Admission Controllers. This must be a valid PEM-encoded CA bundle. Alternatively, the certificate authority can be appended to the certificate provided by --tls-cert-file.
-      --tls-cert-file string                                    File containing the default x509 Certificate for HTTPS. (CA cert, if any, concatenated after server cert). If HTTPS serving is enabled, and --tls-cert-file and --tls-private-key-file are not provided, a self-signed certificate and key are generated for the public address and saved to /var/run/kubernetes.
+      --tls-ca-file string                                      If set, this certificate authority will used for secure access from Admission Controllers. This must be a valid PEM-encoded CA bundle. Altneratively, the certificate authority can be appended to the certificate provided by --tls-cert-file.
+      --tls-cert-file string                                    File containing the default x509 Certificate for HTTPS. (CA cert, if any, concatenated after server cert). If HTTPS serving is enabled, and --tls-cert-file and --tls-private-key-file are not provided, a self-signed certificate and key are generated for the public address and saved to the directory specified by --cert-dir.
       --tls-private-key-file string                             File containing the default x509 private key matching --tls-cert-file.
       --tls-sni-cert-key namedCertKey                           A pair of x509 certificate and private key file paths, optionally suffixed with a list of domain patterns which are fully qualified domain names, possibly with prefixed wildcard segments. If no domain patterns are provided, the names of the certificate are extracted. Non-wildcard matches trump over wildcard matches, explicit domain patterns trump over extracted names. For multiple key/certificate pairs, use the --tls-sni-cert-key multiple times. Examples: "example.crt,example.key" or "foo.crt,foo.key:*.foo.com,foo.com". (default [])
       --token-auth-file string                                  If set, the file that will be used to secure the secure port of the API server via token authentication.
@@ -156,4 +169,4 @@ TaintNodesByCondition=true|false (ALPHA - default=false)
       --watch-cache-sizes stringSlice                           List of watch cache sizes for every resource (pods, nodes, etc.), comma separated. The individual override format: resource#size, where size is a number. It takes effect when watch-cache is enabled.
 ```
 
-###### Auto generated by spf13/cobra on 27-Sep-2017
+###### Auto generated by spf13/cobra on 7-Dec-2017

--- a/docs/reference/generated/kube-controller-manager.md
+++ b/docs/reference/generated/kube-controller-manager.md
@@ -1,7 +1,7 @@
 ---
-title: kube-controller-manager
 notitle: true
 ---
+
 ## kube-controller-manager
 
 
@@ -32,7 +32,7 @@ kube-controller-manager
       --cidr-allocator-type string                                        Type of CIDR allocator to use (default "RangeAllocator")
       --cloud-config string                                               The path to the cloud provider configuration file.  Empty string for no configuration file.
       --cloud-provider string                                             The provider for cloud services.  Empty string for no provider.
-      --cluster-cidr string                                               CIDR Range for Pods in cluster.
+      --cluster-cidr string                                               CIDR Range for Pods in cluster. Requires --allocate-node-cidrs to be true
       --cluster-name string                                               The instance prefix for the cluster (default "kubernetes")
       --cluster-signing-cert-file string                                  Filename containing a PEM-encoded X509 CA certificate used to issue cluster-scoped certificates (default "/etc/kubernetes/ca/ca.pem")
       --cluster-signing-key-file string                                   Filename containing a PEM-encoded RSA or ECDSA private key used to sign cluster-scoped certificates (default "/etc/kubernetes/ca/ca.key")
@@ -49,7 +49,7 @@ kube-controller-manager
       --contention-profiling                                              Enable lock contention profiling, if profiling is enabled
       --controller-start-interval duration                                Interval between starting controller managers.
       --controllers stringSlice                                           A list of controllers to enable.  '*' enables all on-by-default controllers, 'foo' enables the controller named 'foo', '-foo' disables the controller named 'foo'.
-All controllers: attachdetach, bootstrapsigner, cronjob, csrapproving, csrsigning, daemonset, deployment, disruption, endpoint, garbagecollector, horizontalpodautoscaling, job, namespace, node, persistentvolume-binder, persistentvolume-expander, podgc, replicaset, replicationcontroller, resourcequota, route, service, serviceaccount, serviceaccount-token, statefulset, tokencleaner, ttl
+All controllers: attachdetach, bootstrapsigner, clusterrole-aggregation, cronjob, csrapproving, csrcleaner, csrsigning, daemonset, deployment, disruption, endpoint, garbagecollector, horizontalpodautoscaling, job, namespace, node, persistentvolume-binder, persistentvolume-expander, podgc, pvc-protection, replicaset, replicationcontroller, resourcequota, route, service, serviceaccount, serviceaccount-token, statefulset, tokencleaner, ttl
 Disabled-by-default controllers: bootstrapsigner, tokencleaner (default [*])
       --deployment-controller-sync-period duration                        Period for syncing the deployments. (default 30s)
       --disable-attach-detach-reconcile-sync                              Disable volume attach detach reconciler sync. Disabling this may cause volumes to be mismatched with pods. Use wisely.
@@ -59,15 +59,18 @@ Disabled-by-default controllers: bootstrapsigner, tokencleaner (default [*])
       --enable-taint-manager                                              WARNING: Beta feature. If set to true enables NoExecute Taints and will evict all not-tolerating Pod running on Nodes tainted with this kind of Taints. (default true)
       --experimental-cluster-signing-duration duration                    The length of duration signed certificates will be given. (default 8760h0m0s)
       --feature-gates mapStringBool                                       A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
-APIListChunking=true|false (ALPHA - default=false)
+APIListChunking=true|false (BETA - default=true)
 APIResponseCompression=true|false (ALPHA - default=false)
 Accelerators=true|false (ALPHA - default=false)
 AdvancedAuditing=true|false (BETA - default=true)
 AllAlpha=true|false (ALPHA - default=false)
 AllowExtTrafficLocalEndpoints=true|false (default=true)
 AppArmor=true|false (BETA - default=true)
+BlockVolume=true|false (ALPHA - default=false)
 CPUManager=true|false (ALPHA - default=false)
-CustomResourceValidation=true|false (ALPHA - default=false)
+CSIPersistentVolume=true|false (ALPHA - default=false)
+CustomPodDNS=true|false (ALPHA - default=false)
+CustomResourceValidation=true|false (BETA - default=true)
 DebugContainers=true|false (ALPHA - default=false)
 DevicePlugins=true|false (ALPHA - default=false)
 DynamicKubeletConfig=true|false (ALPHA - default=false)
@@ -79,21 +82,27 @@ HugePages=true|false (ALPHA - default=false)
 Initializers=true|false (ALPHA - default=false)
 KubeletConfigFile=true|false (ALPHA - default=false)
 LocalStorageCapacityIsolation=true|false (ALPHA - default=false)
+MountContainers=true|false (ALPHA - default=false)
 MountPropagation=true|false (ALPHA - default=false)
+PVCProtection=true|false (ALPHA - default=false)
 PersistentLocalVolumes=true|false (ALPHA - default=false)
 PodPriority=true|false (ALPHA - default=false)
+ResourceLimitsPriorityFunction=true|false (ALPHA - default=false)
 RotateKubeletClientCertificate=true|false (BETA - default=true)
 RotateKubeletServerCertificate=true|false (ALPHA - default=false)
+ServiceNodeExclusion=true|false (ALPHA - default=false)
 StreamingProxyRedirects=true|false (BETA - default=true)
-SupportIPVSProxyMode=true|false (ALPHA - default=false)
+SupportIPVSProxyMode=true|false (BETA - default=false)
 TaintBasedEvictions=true|false (ALPHA - default=false)
 TaintNodesByCondition=true|false (ALPHA - default=false)
+VolumeScheduling=true|false (ALPHA - default=false)
       --flex-volume-plugin-dir string                                     Full path of the directory in which the flex volume plugin should search for additional third party volume plugins. (default "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/")
       --google-json-key string                                            The Google Cloud Platform Service Account JSON Key to use for authentication.
       --horizontal-pod-autoscaler-downscale-delay duration                The period since last downscale, before another downscale can be performed in horizontal pod autoscaler. (default 5m0s)
       --horizontal-pod-autoscaler-sync-period duration                    The period for syncing the number of pods in horizontal pod autoscaler. (default 30s)
+      --horizontal-pod-autoscaler-tolerance float                         The minimum change (from 1.0) in the desired-to-actual metrics ratio for the horizontal pod autoscaler to consider scaling. (default 0.1)
       --horizontal-pod-autoscaler-upscale-delay duration                  The period since last upscale, before another upscale can be performed in horizontal pod autoscaler. (default 3m0s)
-      --horizontal-pod-autoscaler-use-rest-clients                        WARNING: alpha feature.  If set to true, causes the horizontal pod autoscaler controller to use REST clients through the kube-aggregator, instead of using the legacy metrics client through the API server proxy.  This is required for custom metrics support in the horizontal pod autoscaler.
+      --horizontal-pod-autoscaler-use-rest-clients                        WARNING: alpha feature.  If set to true, causes the horizontal pod autoscaler controller to use REST clients through the kube-aggregator, instead of using the legacy metrics client through the API server proxy.  This is required for custom metrics support in the horizontal pod autoscaler. (default true)
       --insecure-experimental-approve-all-kubelet-csrs-for-group string   This flag does nothing.
       --kube-api-burst int32                                              Burst to use while talking with kubernetes apiserver (default 30)
       --kube-api-content-type string                                      Content type of requests sent to apiserver. (default "application/vnd.kubernetes.protobuf")
@@ -103,7 +112,7 @@ TaintNodesByCondition=true|false (ALPHA - default=false)
       --leader-elect                                                      Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability. (default true)
       --leader-elect-lease-duration duration                              The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled. (default 15s)
       --leader-elect-renew-deadline duration                              The interval between attempts by the acting master to renew a leadership slot before it stops leading. This must be less than or equal to the lease duration. This is only applicable if leader election is enabled. (default 10s)
-      --leader-elect-resource-lock endpoints                              The type of resource object that is used for locking during leader election. Supported options are endpoints (default) and `configmap`. (default "endpoints")
+      --leader-elect-resource-lock endpoints                              The type of resource object that is used for locking during leader election. Supported options are endpoints (default) and `configmaps`. (default "endpoints")
       --leader-elect-retry-period duration                                The duration the clients should wait between attempting acquisition and renewal of a leadership. This is only applicable if leader election is enabled. (default 2s)
       --master string                                                     The address of the Kubernetes API server (overrides any value in kubeconfig)
       --min-resync-period duration                                        The resync period in reflectors will be random between MinResyncPeriod and 2*MinResyncPeriod (default 12h0m0s)
@@ -128,7 +137,7 @@ TaintNodesByCondition=true|false (ALPHA - default=false)
       --route-reconciliation-period duration                              The period for reconciling routes created for Nodes by cloud provider. (default 10s)
       --secondary-node-eviction-rate float32                              Number of nodes per second on which pods are deleted in case of node failure when a zone is unhealthy (see --unhealthy-zone-threshold for definition of healthy/unhealthy). Zone refers to entire cluster in non-multizone clusters. This value is implicitly overridden to 0 if the cluster size is smaller than --large-cluster-size-threshold. (default 0.01)
       --service-account-private-key-file string                           Filename containing a PEM-encoded private RSA or ECDSA key used to sign service account tokens.
-      --service-cluster-ip-range string                                   CIDR Range for Services in cluster.
+      --service-cluster-ip-range string                                   CIDR Range for Services in cluster. Requires --allocate-node-cidrs to be true
       --service-sync-period duration                                      The period for syncing services with their external load balancers (default 5m0s)
       --terminated-pod-gc-threshold int32                                 Number of terminated pods that can exist before the terminated pod garbage collector starts deleting terminated pods. If <= 0, the terminated pod garbage collector is disabled. (default 12500)
       --unhealthy-zone-threshold float32                                  Fraction of Nodes in a zone which needs to be not Ready (minimum 3) for zone to be treated as unhealthy.  (default 0.55)
@@ -136,4 +145,4 @@ TaintNodesByCondition=true|false (ALPHA - default=false)
       --version version[=true]                                            Print version information and quit
 ```
 
-###### Auto generated by spf13/cobra on 27-Sep-2017
+###### Auto generated by spf13/cobra on 7-Dec-2017

--- a/docs/reference/generated/kube-proxy.md
+++ b/docs/reference/generated/kube-proxy.md
@@ -1,7 +1,7 @@
 ---
-title: kube-proxy
 notitle: true
 ---
+
 ## kube-proxy
 
 
@@ -11,8 +11,8 @@ notitle: true
 
 The Kubernetes network proxy runs on each node. This
 reflects services as defined in the Kubernetes API on each node and can do simple
-TCP,UDP stream forwarding or round robin TCP,UDP forwarding across a set of backends.
-Service cluster ips and ports are currently found through Docker-links-compatible
+TCP and UDP stream forwarding or round robin TCP and UDP forwarding across a set of backends.
+Service cluster IPs and ports are currently found through Docker-links-compatible
 environment variables specifying ports opened by the service proxy. There is an optional
 addon that provides cluster DNS for these cluster IPs. The user must create a service
 with the apiserver API to configure the proxy.
@@ -25,8 +25,9 @@ kube-proxy
 
 ```
       --azure-container-registry-config string       Path to the file container Azure container registry configuration information.
-      --bind-address ip                              The IP address for the proxy server to serve on (set to 0.0.0.0 for all IPv4 interfaces and :: for all IPv6 interfaces) (default 0.0.0.0)
+      --bind-address ip                              The IP address for the proxy server to serve on (set to 0.0.0.0 for all interfaces) (default 0.0.0.0)
       --cleanup                                      If true cleanup iptables and ipvs rules and exit.
+      --cleanup-ipvs                                 If true make kube-proxy cleanup ipvs rules before running.  Default is true (default true)
       --cluster-cidr string                          The CIDR range of pods in the cluster. When configured, traffic sent to a Service cluster IP from outside this range will be masqueraded and traffic sent from pods to an external LoadBalancer IP will be directed to the respective cluster IP instead
       --config string                                The path to the configuration file.
       --config-sync-period duration                  How often configuration from the apiserver is refreshed.  Must be greater than 0. (default 15m0s)
@@ -35,15 +36,18 @@ kube-proxy
       --conntrack-tcp-timeout-close-wait duration    NAT timeout for TCP connections in the CLOSE_WAIT state (default 1h0m0s)
       --conntrack-tcp-timeout-established duration   Idle timeout for established TCP connections (0 to leave as-is) (default 24h0m0s)
       --feature-gates mapStringBool                  A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
-APIListChunking=true|false (ALPHA - default=false)
+APIListChunking=true|false (BETA - default=true)
 APIResponseCompression=true|false (ALPHA - default=false)
 Accelerators=true|false (ALPHA - default=false)
 AdvancedAuditing=true|false (BETA - default=true)
 AllAlpha=true|false (ALPHA - default=false)
 AllowExtTrafficLocalEndpoints=true|false (default=true)
 AppArmor=true|false (BETA - default=true)
+BlockVolume=true|false (ALPHA - default=false)
 CPUManager=true|false (ALPHA - default=false)
-CustomResourceValidation=true|false (ALPHA - default=false)
+CSIPersistentVolume=true|false (ALPHA - default=false)
+CustomPodDNS=true|false (ALPHA - default=false)
+CustomResourceValidation=true|false (BETA - default=true)
 DebugContainers=true|false (ALPHA - default=false)
 DevicePlugins=true|false (ALPHA - default=false)
 DynamicKubeletConfig=true|false (ALPHA - default=false)
@@ -55,17 +59,22 @@ HugePages=true|false (ALPHA - default=false)
 Initializers=true|false (ALPHA - default=false)
 KubeletConfigFile=true|false (ALPHA - default=false)
 LocalStorageCapacityIsolation=true|false (ALPHA - default=false)
+MountContainers=true|false (ALPHA - default=false)
 MountPropagation=true|false (ALPHA - default=false)
+PVCProtection=true|false (ALPHA - default=false)
 PersistentLocalVolumes=true|false (ALPHA - default=false)
 PodPriority=true|false (ALPHA - default=false)
+ResourceLimitsPriorityFunction=true|false (ALPHA - default=false)
 RotateKubeletClientCertificate=true|false (BETA - default=true)
 RotateKubeletServerCertificate=true|false (ALPHA - default=false)
+ServiceNodeExclusion=true|false (ALPHA - default=false)
 StreamingProxyRedirects=true|false (BETA - default=true)
-SupportIPVSProxyMode=true|false (ALPHA - default=false)
+SupportIPVSProxyMode=true|false (BETA - default=false)
 TaintBasedEvictions=true|false (ALPHA - default=false)
 TaintNodesByCondition=true|false (ALPHA - default=false)
+VolumeScheduling=true|false (ALPHA - default=false)
       --google-json-key string                       The Google Cloud Platform Service Account JSON Key to use for authentication.
-      --healthz-bind-address ip                      The IP address and port for the health check server to serve on (set to 0.0.0.0 for all IPv4 interfaces and :: for all IPv6 interfaces) (default 0.0.0.0:10256)
+      --healthz-bind-address ip                      The IP address and port for the health check server to serve on (set to 0.0.0.0 for all interfaces) (default 0.0.0.0:10256)
       --healthz-port int32                           The port to bind the health check server. Use 0 to disable. (default 10256)
       --hostname-override string                     If non-empty, will use this string as identification instead of the actual hostname.
       --iptables-masquerade-bit int32                If using the pure iptables proxy, the bit of the fwmark space to mark packets requiring SNAT with.  Must be within the range [0, 31]. (default 14)
@@ -73,14 +82,14 @@ TaintNodesByCondition=true|false (ALPHA - default=false)
       --iptables-sync-period duration                The maximum interval of how often iptables rules are refreshed (e.g. '5s', '1m', '2h22m').  Must be greater than 0. (default 30s)
       --ipvs-min-sync-period duration                The minimum interval of how often the ipvs rules can be refreshed as endpoints and services change (e.g. '5s', '1m', '2h22m').
       --ipvs-scheduler string                        The ipvs scheduler type when proxy mode is ipvs
-      --ipvs-sync-period duration                    The maximum interval of how often ipvs rules are refreshed (e.g. '5s', '1m', '2h22m').  Must be greater than 0.
-      --kube-api-burst int                           Burst to use while talking with kubernetes apiserver (default 10)
+      --ipvs-sync-period duration                    The maximum interval of how often ipvs rules are refreshed (e.g. '5s', '1m', '2h22m').  Must be greater than 0. (default 30s)
+      --kube-api-burst int32                         Burst to use while talking with kubernetes apiserver (default 10)
       --kube-api-content-type string                 Content type of requests sent to apiserver. (default "application/vnd.kubernetes.protobuf")
       --kube-api-qps float32                         QPS to use while talking with kubernetes apiserver (default 5)
       --kubeconfig string                            Path to kubeconfig file with authorization information (the master location is set by the master flag).
       --masquerade-all                               If using the pure iptables proxy, SNAT all traffic sent via Service cluster IPs (this not commonly needed)
       --master string                                The address of the Kubernetes API server (overrides any value in kubeconfig)
-      --metrics-bind-address ip                      The IP address and port for the metrics server to serve on (set to 0.0.0.0 for all IPv4 interfaces and :: for all IPv6 interfaces) (default 127.0.0.1:10249)
+      --metrics-bind-address ip                      The IP address and port for the metrics server to serve on (set to 0.0.0.0 for all interfaces) (default 127.0.0.1:10249)
       --oom-score-adj int32                          The oom-score-adj value for kube-proxy process. Values must be within the range [-1000, 1000] (default -999)
       --profiling                                    If true enables profiling via web interface on /debug/pprof handler.
       --proxy-mode ProxyMode                         Which proxy mode to use: 'userspace' (older) or 'iptables' (faster) or 'ipvs'(experimental)'. If blank, use the best-available proxy (currently iptables).  If the iptables proxy is selected, regardless of how, but the system's kernel or iptables versions are insufficient, this always falls back to the userspace proxy.
@@ -90,4 +99,4 @@ TaintNodesByCondition=true|false (ALPHA - default=false)
       --write-config-to string                       If set, write the default configuration values to this file and exit.
 ```
 
-###### Auto generated by spf13/cobra on 27-Sep-2017
+###### Auto generated by spf13/cobra on 7-Dec-2017

--- a/docs/reference/generated/kube-scheduler.md
+++ b/docs/reference/generated/kube-scheduler.md
@@ -1,7 +1,7 @@
 ---
-title: kube-scheduler
 notitle: true
 ---
+
 ## kube-scheduler
 
 
@@ -24,20 +24,24 @@ kube-scheduler
 ### Options
 
 ```
-      --address string                           The IP address to serve on (set to 0.0.0.0 for all interfaces) (default "0.0.0.0")
-      --algorithm-provider string                The scheduling algorithm provider to use, one of: ClusterAutoscalerProvider | DefaultProvider (default "DefaultProvider")
+      --address string                           The IP address to serve on (set to 0.0.0.0 for all interfaces)
+      --algorithm-provider string                The scheduling algorithm provider to use, one of: ClusterAutoscalerProvider | DefaultProvider
       --azure-container-registry-config string   Path to the file container Azure container registry configuration information.
+      --config string                            The path to the configuration file.
       --contention-profiling                     Enable lock contention profiling, if profiling is enabled
       --feature-gates mapStringBool              A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
-APIListChunking=true|false (ALPHA - default=false)
+APIListChunking=true|false (BETA - default=true)
 APIResponseCompression=true|false (ALPHA - default=false)
 Accelerators=true|false (ALPHA - default=false)
 AdvancedAuditing=true|false (BETA - default=true)
 AllAlpha=true|false (ALPHA - default=false)
 AllowExtTrafficLocalEndpoints=true|false (default=true)
 AppArmor=true|false (BETA - default=true)
+BlockVolume=true|false (ALPHA - default=false)
 CPUManager=true|false (ALPHA - default=false)
-CustomResourceValidation=true|false (ALPHA - default=false)
+CSIPersistentVolume=true|false (ALPHA - default=false)
+CustomPodDNS=true|false (ALPHA - default=false)
+CustomResourceValidation=true|false (BETA - default=true)
 DebugContainers=true|false (ALPHA - default=false)
 DevicePlugins=true|false (ALPHA - default=false)
 DynamicKubeletConfig=true|false (ALPHA - default=false)
@@ -49,36 +53,41 @@ HugePages=true|false (ALPHA - default=false)
 Initializers=true|false (ALPHA - default=false)
 KubeletConfigFile=true|false (ALPHA - default=false)
 LocalStorageCapacityIsolation=true|false (ALPHA - default=false)
+MountContainers=true|false (ALPHA - default=false)
 MountPropagation=true|false (ALPHA - default=false)
+PVCProtection=true|false (ALPHA - default=false)
 PersistentLocalVolumes=true|false (ALPHA - default=false)
 PodPriority=true|false (ALPHA - default=false)
+ResourceLimitsPriorityFunction=true|false (ALPHA - default=false)
 RotateKubeletClientCertificate=true|false (BETA - default=true)
 RotateKubeletServerCertificate=true|false (ALPHA - default=false)
+ServiceNodeExclusion=true|false (ALPHA - default=false)
 StreamingProxyRedirects=true|false (BETA - default=true)
-SupportIPVSProxyMode=true|false (ALPHA - default=false)
+SupportIPVSProxyMode=true|false (BETA - default=false)
 TaintBasedEvictions=true|false (ALPHA - default=false)
 TaintNodesByCondition=true|false (ALPHA - default=false)
+VolumeScheduling=true|false (ALPHA - default=false)
       --google-json-key string                   The Google Cloud Platform Service Account JSON Key to use for authentication.
       --kube-api-burst int32                     Burst to use while talking with kubernetes apiserver (default 100)
       --kube-api-content-type string             Content type of requests sent to apiserver. (default "application/vnd.kubernetes.protobuf")
       --kube-api-qps float32                     QPS to use while talking with kubernetes apiserver (default 50)
       --kubeconfig string                        Path to kubeconfig file with authorization and master location information.
-      --leader-elect                             Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability. (default true)
+      --leader-elect                             Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability.
       --leader-elect-lease-duration duration     The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled. (default 15s)
       --leader-elect-renew-deadline duration     The interval between attempts by the acting master to renew a leadership slot before it stops leading. This must be less than or equal to the lease duration. This is only applicable if leader election is enabled. (default 10s)
-      --leader-elect-resource-lock endpoints     The type of resource object that is used for locking during leader election. Supported options are endpoints (default) and `configmap`. (default "endpoints")
+      --leader-elect-resource-lock endpoints     The type of resource object that is used for locking during leader election. Supported options are endpoints (default) and `configmaps`. (default "endpoints")
       --leader-elect-retry-period duration       The duration the clients should wait between attempting acquisition and renewal of a leadership. This is only applicable if leader election is enabled. (default 2s)
       --lock-object-name string                  Define the name of the lock object. (default "kube-scheduler")
       --lock-object-namespace string             Define the namespace of the lock object. (default "kube-system")
       --master string                            The address of the Kubernetes API server (overrides any value in kubeconfig)
       --policy-config-file string                File with scheduler policy configuration. This file is used if policy ConfigMap is not provided or --use-legacy-policy-config==true
       --policy-configmap string                  Name of the ConfigMap object that contains scheduler's policy configuration. It must exist in the system namespace before scheduler initialization if --use-legacy-policy-config==false. The config must be provided as the value of an element in 'Data' map with the key='policy.cfg'
-      --policy-configmap-namespace string        The namespace where policy ConfigMap is located. The system namespace will be used if this is not provided or is empty. (default "kube-system")
+      --policy-configmap-namespace string        The namespace where policy ConfigMap is located. The system namespace will be used if this is not provided or is empty.
       --port int32                               The port that the scheduler's http service runs on (default 10251)
-      --profiling                                Enable profiling via web interface host:port/debug/pprof/ (default true)
+      --profiling                                Enable profiling via web interface host:port/debug/pprof/
       --scheduler-name string                    Name of the scheduler, used to select which pods will be processed by this scheduler, based on pod's "spec.SchedulerName". (default "default-scheduler")
       --use-legacy-policy-config                 When set to true, scheduler will ignore policy ConfigMap and uses policy config file
       --version version[=true]                   Print version information and quit
 ```
 
-###### Auto generated by spf13/cobra on 27-Sep-2017
+###### Auto generated by spf13/cobra on 7-Dec-2017

--- a/docs/reference/generated/kubelet.md
+++ b/docs/reference/generated/kubelet.md
@@ -1,7 +1,7 @@
 ---
-title: kubelet
 notitle: true
 ---
+
 ## kubelet
 
 
@@ -16,7 +16,7 @@ various mechanisms (primarily through the apiserver) and ensures that the contai
 described in those PodSpecs are running and healthy. The kubelet doesn't manage
 containers which were not created by Kubernetes.
 
-Other than from a PodSpec from the apiserver, there are three ways that a container
+Other than from an PodSpec from the apiserver, there are three ways that a container
 manifest can be provided to the Kubelet.
 
 File: Path passed as a flag on the command line. Files under this path will be monitored
@@ -36,71 +36,74 @@ kubelet
 ### Options
 
 ```
-      --address ip                                               The IP address for the Kubelet to serve on (set to 0.0.0.0 for all IPv4 interfaces and :: for all IPv6 interfaces) (default 0.0.0.0)
-      --allow-privileged                                         If true, allow containers to request privileged mode.
-      --anonymous-auth                                           Enables anonymous requests to the Kubelet server. Requests that are not rejected by another authentication method are treated as anonymous requests. Anonymous requests have a username of system:anonymous, and a group name of system:unauthenticated. (default true)
-      --authentication-token-webhook                             Use the TokenReview API to determine authentication for bearer tokens.
-      --authentication-token-webhook-cache-ttl duration          The duration to cache responses from the webhook token authenticator. (default 2m0s)
-      --authorization-mode string                                Authorization mode for Kubelet server. Valid options are AlwaysAllow or Webhook. Webhook mode uses the SubjectAccessReview API to determine authorization. (default "AlwaysAllow")
-      --authorization-webhook-cache-authorized-ttl duration      The duration to cache 'authorized' responses from the webhook authorizer. (default 5m0s)
-      --authorization-webhook-cache-unauthorized-ttl duration    The duration to cache 'unauthorized' responses from the webhook authorizer. (default 30s)
-      --azure-container-registry-config string                   Path to the file container Azure container registry configuration information.
-      --bootstrap-kubeconfig string                              Path to a kubeconfig file that will be used to get client certificate for kubelet. If the file specified by --kubeconfig does not exist, the bootstrap kubeconfig is used to request a client certificate from the API server. On success, a kubeconfig file referencing the generated client certificate and key is written to the path specified by --kubeconfig. The client certificate and key file will be stored in the directory pointed by --cert-dir.
-      --cadvisor-port int32                                      The port of the localhost cAdvisor endpoint (set to 0 to disable) (default 4194)
-      --cert-dir string                                          The directory where the TLS certs are located. If --tls-cert-file and --tls-private-key-file are provided, this flag will be ignored. (default "/var/run/kubernetes")
-      --cgroup-driver string                                     Driver that the kubelet uses to manipulate cgroups on the host.  Possible values: 'cgroupfs', 'systemd' (default "cgroupfs")
-      --cgroup-root string                                       Optional root cgroup to use for pods. This is handled by the container runtime on a best effort basis. Default: '', which means use the container runtime default.
-      --cgroups-per-qos                                          Enable creation of QoS cgroup hierarchy, if true top level QoS and pod cgroups are created. (default true)
-      --chaos-chance float                                       If > 0.0, introduce random client errors and latency. Intended for testing.
-      --client-ca-file string                                    If set, any request presenting a client certificate signed by one of the authorities in the client-ca-file is authenticated with an identity corresponding to the CommonName of the client certificate.
-      --cloud-config string                                      The path to the cloud provider configuration file.  Empty string for no configuration file.
-      --cloud-provider string                                    The provider for cloud services. By default, kubelet will attempt to auto-detect the cloud provider (deprecated). Specify empty string for running with no cloud provider, this will be the default in upcoming releases. (default "auto-detect")
-      --cluster-dns stringSlice                                  Comma-separated list of DNS server IP address.  This value is used for containers DNS server in case of Pods with "dnsPolicy=ClusterFirst". Note: all DNS servers appearing in the list MUST serve the same set of records otherwise name resolution within the cluster may not work correctly. There is no guarantee as to which DNS server may be contacted for name resolution.
-      --cluster-domain string                                    Domain for this cluster.  If set, kubelet will configure all containers to search this domain in addition to the host's search domains
-      --cni-bin-dir string                                       <Warning: Alpha feature> The full path of the directory in which to search for CNI plugin binaries. Default: /opt/cni/bin
-      --cni-conf-dir string                                      <Warning: Alpha feature> The full path of the directory in which to search for CNI config files. Default: /etc/cni/net.d
-      --container-runtime string                                 The container runtime to use. Possible values: 'docker', 'rkt'. (default "docker")
-      --container-runtime-endpoint string                        [Experimental] The endpoint of remote runtime service. Currently unix socket is supported on Linux, and tcp is supported on windows.  Examples:'unix:///var/run/dockershim.sock', 'tcp://localhost:3735' (default "unix:///var/run/dockershim.sock")
-      --containerized                                            Experimental support for running kubelet in a container.  Intended for testing.
-      --contention-profiling                                     Enable lock contention profiling, if profiling is enabled
-      --cpu-cfs-quota                                            Enable CPU CFS quota enforcement for containers that specify CPU limits (default true)
-      --cpu-manager-policy string                                <Warning: Alpha feature> CPU Manager policy to use. Possible values: 'none', 'static'. Default: 'none' (default "none")
-      --cpu-manager-reconcile-period NodeStatusUpdateFrequency   <Warning: Alpha feature> CPU Manager reconciliation period. Examples: '10s', or '1m'. If not supplied, defaults to NodeStatusUpdateFrequency (default 10s)
-      --docker-disable-shared-pid                                The Container Runtime Interface (CRI) defaults to using a shared PID namespace for containers in a pod when running with Docker 1.13.1 or higher. Setting this flag reverts to the previous behavior of isolated PID namespaces. This ability will be removed in a future Kubernetes release. (default true)
-      --docker-endpoint string                                   Use this for the docker endpoint to communicate with (default "unix:///var/run/docker.sock")
-      --dynamic-config-dir string                                The Kubelet will use this directory for checkpointing downloaded configurations and tracking configuration health. The Kubelet will create this directory if it does not already exist. The path may be absolute or relative; relative paths start at the Kubelet's current working directory. Providing this flag enables dynamic Kubelet configuration. Presently, you must also enable the DynamicKubeletConfig feature gate to pass this flag.
-      --enable-controller-attach-detach                          Enables the Attach/Detach controller to manage attachment/detachment of volumes scheduled to this node, and disables kubelet from executing any attach/detach operations (default true)
-      --enable-custom-metrics                                    Support for gathering custom metrics.
-      --enable-debugging-handlers                                Enables server endpoints for log collection and local running of containers and commands (default true)
-      --enable-server                                            Enable the Kubelet's server (default true)
-      --enforce-node-allocatable stringSlice                     A comma separated list of levels of node allocatable enforcement to be enforced by kubelet. Acceptible options are 'pods', 'system-reserved' & 'kube-reserved'. If the latter two options are specified, '--system-reserved-cgroup' & '--kube-reserved-cgroup' must also be set respectively. See https://git.k8s.io/community/contributors/design-proposals/node-allocatable.md for more details. (default [pods])
-      --event-burst int32                                        Maximum size of a bursty event records, temporarily allows event records to burst to this number, while still not exceeding event-qps. Only used if --event-qps > 0 (default 10)
-      --event-qps int32                                          If > 0, limit event creations per second to this value. If 0, unlimited. (default 5)
-      --eviction-hard string                                     A set of eviction thresholds (e.g. memory.available<1Gi) that if met would trigger a pod eviction. (default "memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%")
-      --eviction-max-pod-grace-period int32                      Maximum allowed grace period (in seconds) to use when terminating pods in response to a soft eviction threshold being met.  If negative, defer to pod specified value.
-      --eviction-minimum-reclaim string                          A set of minimum reclaims (e.g. imagefs.available=2Gi) that describes the minimum amount of resource the kubelet will reclaim when performing a pod eviction if that resource is under pressure.
-      --eviction-pressure-transition-period duration             Duration for which the kubelet has to wait before transitioning out of an eviction pressure condition. (default 5m0s)
-      --eviction-soft string                                     A set of eviction thresholds (e.g. memory.available<1.5Gi) that if met over a corresponding grace period would trigger a pod eviction.
-      --eviction-soft-grace-period string                        A set of eviction grace periods (e.g. memory.available=1m30s) that correspond to how long a soft eviction threshold must hold before triggering a pod eviction.
-      --exit-on-lock-contention                                  Whether kubelet should exit upon lock-file contention.
-      --experimental-allocatable-ignore-eviction                 When set to 'true', Hard Eviction Thresholds will be ignored while calculating Node Allocatable. See https://git.k8s.io/community/contributors/design-proposals/node-allocatable.md for more details. [default=false]
-      --experimental-allowed-unsafe-sysctls stringSlice          Comma-separated whitelist of unsafe sysctls or unsafe sysctl patterns (ending in *). Use these at your own risk.
-      --experimental-bootstrap-kubeconfig string                 deprecated: use --bootstrap-kubeconfig
-      --experimental-check-node-capabilities-before-mount        [Experimental] if set true, the kubelet will check the underlying node for required components (binaries, etc.) before performing the mount
-      --experimental-kernel-memcg-notification                   If enabled, the kubelet will integrate with the kernel memcg notification to determine if memory eviction thresholds are crossed rather than polling.
-      --experimental-mounter-path string                         [Experimental] Path of mounter binary. Leave empty to use the default mount.
-      --experimental-qos-reserved mapStringString                A set of ResourceName=Percentage (e.g. memory=50%) pairs that describe how pod resource requests are reserved at the QoS level. Currently only memory is supported. [default=none]
-      --fail-swap-on                                             Makes the Kubelet fail to start if swap is enabled on the node.  (default true)
-      --feature-gates string                                     A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
-APIListChunking=true|false (ALPHA - default=false)
+      --address ip                                                                                                The IP address for the Kubelet to serve on (set to 0.0.0.0 for all interfaces) (default 0.0.0.0)
+      --allow-privileged                                                                                          If true, allow containers to request privileged mode.
+      --anonymous-auth                                                                                            Enables anonymous requests to the Kubelet server. Requests that are not rejected by another authentication method are treated as anonymous requests. Anonymous requests have a username of system:anonymous, and a group name of system:unauthenticated. (default true)
+      --authentication-token-webhook                                                                              Use the TokenReview API to determine authentication for bearer tokens.
+      --authentication-token-webhook-cache-ttl duration                                                           The duration to cache responses from the webhook token authenticator. (default 2m0s)
+      --authorization-mode string                                                                                 Authorization mode for Kubelet server. Valid options are AlwaysAllow or Webhook. Webhook mode uses the SubjectAccessReview API to determine authorization. (default "AlwaysAllow")
+      --authorization-webhook-cache-authorized-ttl duration                                                       The duration to cache 'authorized' responses from the webhook authorizer. (default 5m0s)
+      --authorization-webhook-cache-unauthorized-ttl duration                                                     The duration to cache 'unauthorized' responses from the webhook authorizer. (default 30s)
+      --azure-container-registry-config string                                                                    Path to the file container Azure container registry configuration information.
+      --bootstrap-checkpoint-path string                                                                          <Warning: Alpha feature> Path to to the directory where the checkpoints are stored
+      --bootstrap-kubeconfig string                                                                               Path to a kubeconfig file that will be used to get client certificate for kubelet. If the file specified by --kubeconfig does not exist, the bootstrap kubeconfig is used to request a client certificate from the API server. On success, a kubeconfig file referencing the generated client certificate and key is written to the path specified by --kubeconfig. The client certificate and key file will be stored in the directory pointed by --cert-dir.
+      --cadvisor-port int32                                                                                       The port of the localhost cAdvisor endpoint (set to 0 to disable) (default 4194)
+      --cert-dir string                                                                                           The directory where the TLS certs are located. If --tls-cert-file and --tls-private-key-file are provided, this flag will be ignored. (default "/var/lib/kubelet/pki")
+      --cgroup-driver string                                                                                      Driver that the kubelet uses to manipulate cgroups on the host.  Possible values: 'cgroupfs', 'systemd' (default "cgroupfs")
+      --cgroup-root string                                                                                        Optional root cgroup to use for pods. This is handled by the container runtime on a best effort basis. Default: '', which means use the container runtime default.
+      --cgroups-per-qos                                                                                           Enable creation of QoS cgroup hierarchy, if true top level QoS and pod cgroups are created. (default true)
+      --chaos-chance float                                                                                        If > 0.0, introduce random client errors and latency. Intended for testing.
+      --client-ca-file string                                                                                     If set, any request presenting a client certificate signed by one of the authorities in the client-ca-file is authenticated with an identity corresponding to the CommonName of the client certificate.
+      --cloud-config string                                                                                       The path to the cloud provider configuration file.  Empty string for no configuration file.
+      --cloud-provider string                                                                                     The provider for cloud services. Specify empty string for running with no cloud provider.
+      --cluster-dns stringSlice                                                                                   Comma-separated list of DNS server IP address.  This value is used for containers DNS server in case of Pods with "dnsPolicy=ClusterFirst". Note: all DNS servers appearing in the list MUST serve the same set of records otherwise name resolution within the cluster may not work correctly. There is no guarantee as to which DNS server may be contacted for name resolution.
+      --cluster-domain string                                                                                     Domain for this cluster.  If set, kubelet will configure all containers to search this domain in addition to the host's search domains
+      --cni-bin-dir string                                                                                        <Warning: Alpha feature> The full path of the directory in which to search for CNI plugin binaries. Default: /opt/cni/bin
+      --cni-conf-dir string                                                                                       <Warning: Alpha feature> The full path of the directory in which to search for CNI config files. Default: /etc/cni/net.d
+      --container-runtime string                                                                                  The container runtime to use. Possible values: 'docker', 'rkt'. (default "docker")
+      --container-runtime-endpoint string                                                                         [Experimental] The endpoint of remote runtime service. Currently unix socket is supported on Linux, and tcp is supported on windows.  Examples:'unix:///var/run/dockershim.sock', 'tcp://localhost:3735' (default "unix:///var/run/dockershim.sock")
+      --containerized                                                                                             Experimental support for running kubelet in a container.  Intended for testing.
+      --contention-profiling                                                                                      Enable lock contention profiling, if profiling is enabled
+      --cpu-cfs-quota                                                                                             Enable CPU CFS quota enforcement for containers that specify CPU limits (default true)
+      --cpu-manager-policy string                                                                                 <Warning: Alpha feature> CPU Manager policy to use. Possible values: 'none', 'static'. Default: 'none' (default "none")
+      --cpu-manager-reconcile-period NodeStatusUpdateFrequency                                                    <Warning: Alpha feature> CPU Manager reconciliation period. Examples: '10s', or '1m'. If not supplied, defaults to NodeStatusUpdateFrequency (default 10s)
+      --docker-disable-shared-pid                                                                                 The Container Runtime Interface (CRI) defaults to using a shared PID namespace for containers in a pod when running with Docker 1.13.1 or higher. Setting this flag reverts to the previous behavior of isolated PID namespaces. This ability will be removed in a future Kubernetes release. (default true)
+      --docker-endpoint string                                                                                    Use this for the docker endpoint to communicate with (default "unix:///var/run/docker.sock")
+      --dynamic-config-dir string                                                                                 The Kubelet will use this directory for checkpointing downloaded configurations and tracking configuration health. The Kubelet will create this directory if it does not already exist. The path may be absolute or relative; relative paths start at the Kubelet's current working directory. Providing this flag enables dynamic Kubelet configuration. Presently, you must also enable the DynamicKubeletConfig feature gate to pass this flag.
+      --enable-controller-attach-detach                                                                           Enables the Attach/Detach controller to manage attachment/detachment of volumes scheduled to this node, and disables kubelet from executing any attach/detach operations (default true)
+      --enable-debugging-handlers                                                                                 Enables server endpoints for log collection and local running of containers and commands (default true)
+      --enable-server                                                                                             Enable the Kubelet's server (default true)
+      --enforce-node-allocatable stringSlice                                                                      A comma separated list of levels of node allocatable enforcement to be enforced by kubelet. Acceptible options are 'pods', 'system-reserved' & 'kube-reserved'. If the latter two options are specified, '--system-reserved-cgroup' & '--kube-reserved-cgroup' must also be set respectively. See https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/ for more details. (default [pods])
+      --event-burst int32                                                                                         Maximum size of a bursty event records, temporarily allows event records to burst to this number, while still not exceeding event-qps. Only used if --event-qps > 0 (default 10)
+      --event-qps int32                                                                                           If > 0, limit event creations per second to this value. If 0, unlimited. (default 5)
+      --eviction-hard mapStringString                                                                             A set of eviction thresholds (e.g. memory.available<1Gi) that if met would trigger a pod eviction. (default imagefs.available<15%,memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%)
+      --eviction-max-pod-grace-period int32                                                                       Maximum allowed grace period (in seconds) to use when terminating pods in response to a soft eviction threshold being met.  If negative, defer to pod specified value.
+      --eviction-minimum-reclaim mapStringString                                                                  A set of minimum reclaims (e.g. imagefs.available=2Gi) that describes the minimum amount of resource the kubelet will reclaim when performing a pod eviction if that resource is under pressure.
+      --eviction-pressure-transition-period duration                                                              Duration for which the kubelet has to wait before transitioning out of an eviction pressure condition. (default 5m0s)
+      --eviction-soft mapStringString                                                                             A set of eviction thresholds (e.g. memory.available<1.5Gi) that if met over a corresponding grace period would trigger a pod eviction.
+      --eviction-soft-grace-period mapStringString                                                                A set of eviction grace periods (e.g. memory.available=1m30s) that correspond to how long a soft eviction threshold must hold before triggering a pod eviction.
+      --exit-on-lock-contention                                                                                   Whether kubelet should exit upon lock-file contention.
+      --experimental-allocatable-ignore-eviction                                                                  When set to 'true', Hard Eviction Thresholds will be ignored while calculating Node Allocatable. See https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/ for more details. [default=false]
+      --experimental-allowed-unsafe-sysctls stringSlice                                                           Comma-separated whitelist of unsafe sysctls or unsafe sysctl patterns (ending in *). Use these at your own risk.
+      --experimental-bootstrap-kubeconfig string                                                                  deprecated: use --bootstrap-kubeconfig
+      --experimental-check-node-capabilities-before-mount                                                         [Experimental] if set true, the kubelet will check the underlying node for required componenets (binaries, etc.) before performing the mount
+      --experimental-kernel-memcg-notification                                                                    If enabled, the kubelet will integrate with the kernel memcg notification to determine if memory eviction thresholds are crossed rather than polling.
+      --experimental-mounter-path string                                                                          [Experimental] Path of mounter binary. Leave empty to use the default mount.
+      --experimental-qos-reserved mapStringString                                                                 A set of ResourceName=Percentage (e.g. memory=50%) pairs that describe how pod resource requests are reserved at the QoS level. Currently only memory is supported. [default=none]
+      --fail-swap-on                                                                                              Makes the Kubelet fail to start if swap is enabled on the node.  (default true)
+      --feature-gates mapStringBool                                                                               A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
+APIListChunking=true|false (BETA - default=true)
 APIResponseCompression=true|false (ALPHA - default=false)
 Accelerators=true|false (ALPHA - default=false)
 AdvancedAuditing=true|false (BETA - default=true)
 AllAlpha=true|false (ALPHA - default=false)
 AllowExtTrafficLocalEndpoints=true|false (default=true)
 AppArmor=true|false (BETA - default=true)
+BlockVolume=true|false (ALPHA - default=false)
 CPUManager=true|false (ALPHA - default=false)
-CustomResourceValidation=true|false (ALPHA - default=false)
+CSIPersistentVolume=true|false (ALPHA - default=false)
+CustomPodDNS=true|false (ALPHA - default=false)
+CustomResourceValidation=true|false (BETA - default=true)
 DebugContainers=true|false (ALPHA - default=false)
 DevicePlugins=true|false (ALPHA - default=false)
 DynamicKubeletConfig=true|false (ALPHA - default=false)
@@ -112,85 +115,90 @@ HugePages=true|false (ALPHA - default=false)
 Initializers=true|false (ALPHA - default=false)
 KubeletConfigFile=true|false (ALPHA - default=false)
 LocalStorageCapacityIsolation=true|false (ALPHA - default=false)
+MountContainers=true|false (ALPHA - default=false)
 MountPropagation=true|false (ALPHA - default=false)
+PVCProtection=true|false (ALPHA - default=false)
 PersistentLocalVolumes=true|false (ALPHA - default=false)
 PodPriority=true|false (ALPHA - default=false)
+ResourceLimitsPriorityFunction=true|false (ALPHA - default=false)
 RotateKubeletClientCertificate=true|false (BETA - default=true)
 RotateKubeletServerCertificate=true|false (ALPHA - default=false)
+ServiceNodeExclusion=true|false (ALPHA - default=false)
 StreamingProxyRedirects=true|false (BETA - default=true)
-SupportIPVSProxyMode=true|false (ALPHA - default=false)
+SupportIPVSProxyMode=true|false (BETA - default=false)
 TaintBasedEvictions=true|false (ALPHA - default=false)
 TaintNodesByCondition=true|false (ALPHA - default=false)
-      --file-check-frequency duration                            Duration between checking config files for new data (default 20s)
-      --google-json-key string                                   The Google Cloud Platform Service Account JSON Key to use for authentication.
-      --hairpin-mode string                                      How should the kubelet setup hairpin NAT. This allows endpoints of a Service to loadbalance back to themselves if they should try to access their own Service. Valid values are "promiscuous-bridge", "hairpin-veth" and "none". (default "promiscuous-bridge")
-      --healthz-bind-address ip                                  The IP address for the healthz server to serve on. (set to 0.0.0.0 for all IPv4 interfaces and :: for all IPv6 interfaces) (default 127.0.0.1)
-      --healthz-port int32                                       The port of the localhost healthz endpoint (set to 0 to disable) (default 10248)
-      --host-ipc-sources stringSlice                             Comma-separated list of sources from which the Kubelet allows pods to use the host ipc namespace. (default [*])
-      --host-network-sources stringSlice                         Comma-separated list of sources from which the Kubelet allows pods to use of host network. (default [*])
-      --host-pid-sources stringSlice                             Comma-separated list of sources from which the Kubelet allows pods to use the host pid namespace. (default [*])
-      --hostname-override string                                 If non-empty, will use this string as identification instead of the actual hostname.
-      --http-check-frequency duration                            Duration between checking http for new data (default 20s)
-      --image-gc-high-threshold int32                            The percent of disk usage after which image garbage collection is always run. (default 85)
-      --image-gc-low-threshold int32                             The percent of disk usage before which image garbage collection is never run. Lowest disk usage to garbage collect to. (default 80)
-      --image-pull-progress-deadline duration                    If no pulling progress is made before this deadline, the image pulling will be cancelled. (default 1m0s)
-      --image-service-endpoint string                            [Experimental] The endpoint of remote image service. If not specified, it will be the same with container-runtime-endpoint by default. Currently unix socket is supported on Linux, and tcp is supported on windows.  Examples:'unix:///var/run/dockershim.sock', 'tcp://localhost:3735'
-      --init-config-dir string                                   The Kubelet will look in this directory for the init configuration. The path may be absolute or relative; relative paths start at the Kubelet's current working directory. Omit this argument to use the built-in default configuration values. Presently, you must also enable the DynamicKubeletConfig feature gate to pass this flag.
-      --iptables-drop-bit int32                                  The bit of the fwmark space to mark packets for dropping. Must be within the range [0, 31]. (default 15)
-      --iptables-masquerade-bit int32                            The bit of the fwmark space to mark packets for SNAT. Must be within the range [0, 31]. Please match this parameter with corresponding parameter in kube-proxy. (default 14)
-      --kube-api-burst int32                                     Burst to use while talking with kubernetes apiserver (default 10)
-      --kube-api-content-type string                             Content type of requests sent to apiserver. (default "application/vnd.kubernetes.protobuf")
-      --kube-api-qps int32                                       QPS to use while talking with kubernetes apiserver (default 5)
-      --kube-reserved mapStringString                            A set of ResourceName=ResourceQuantity (e.g. cpu=200m,memory=500Mi, storage=1Gi) pairs that describe resources reserved for kubernetes system components. Currently cpu, memory and local storage for root file system are supported. See http://kubernetes.io/docs/user-guide/compute-resources for more detail. [default=none]
-      --kube-reserved-cgroup string                              Absolute name of the top level cgroup that is used to manage kubernetes components for which compute resources were reserved via '--kube-reserved' flag. Ex. '/kube-reserved'. [default='']
-      --kubeconfig string                                        Path to a kubeconfig file, specifying how to connect to the API server. (default "/var/lib/kubelet/kubeconfig")
-      --kubelet-cgroups string                                   Optional absolute name of cgroups to create and run the Kubelet in.
-      --lock-file string                                         <Warning: Alpha feature> The path to file for kubelet to use as a lock file.
-      --make-iptables-util-chains                                If true, kubelet will ensure iptables utility rules are present on host. (default true)
-      --manifest-url string                                      URL for accessing the container manifest
-      --manifest-url-header string                               HTTP header to use when accessing the manifest URL, with the key separated from the value with a ':', as in 'key:value'
-      --max-open-files int                                       Number of files that can be opened by Kubelet process. (default 1000000)
-      --max-pods int32                                           Number of Pods that can run on this Kubelet. (default 110)
-      --minimum-image-ttl-duration duration                      Minimum age for an unused image before it is garbage collected.  Examples: '300ms', '10s' or '2h45m'. (default 2m0s)
-      --network-plugin string                                    <Warning: Alpha feature> The name of the network plugin to be invoked for various events in kubelet/pod lifecycle
-      --network-plugin-mtu int32                                 <Warning: Alpha feature> The MTU to be passed to the network plugin, to override the default. Set to 0 to use the default 1460 MTU.
-      --node-ip string                                           IP address of the node. If set, kubelet will use this IP address for the node
-      --node-labels mapStringString                              <Warning: Alpha feature> Labels to add when registering the node in the cluster.  Labels must be key=value pairs separated by ','.
-      --node-status-update-frequency duration                    Specifies how often kubelet posts node status to master. Note: be cautious when changing the constant, it must work with nodeMonitorGracePeriod in nodecontroller. (default 10s)
-      --oom-score-adj int32                                      The oom-score-adj value for kubelet process. Values must be within the range [-1000, 1000] (default -999)
-      --pod-cidr string                                          The CIDR to use for pod IP addresses, only used in standalone mode.  In cluster mode, this is obtained from the master.
-      --pod-infra-container-image string                         The image whose network/ipc namespaces containers in each pod will use. (default "gcr.io/google_containers/pause-amd64:3.0")
-      --pod-manifest-path string                                 Path to to the directory containing pod manifest files to run, or the path to a single pod manifest file. Files starting with dots will be ignored.
-      --pods-per-core int32                                      Number of Pods per core that can run on this Kubelet. The total number of Pods on this Kubelet cannot exceed max-pods, so max-pods will be used if this calculation results in a larger number of Pods allowed on the Kubelet. A value of 0 disables this limit.
-      --port int32                                               The port for the Kubelet to serve on. (default 10250)
-      --protect-kernel-defaults                                  Default kubelet behaviour for kernel tuning. If set, kubelet errors if any of kernel tunables is different than kubelet defaults.
-      --provider-id string                                       Unique identifier for identifying the node in a machine database, i.e cloudprovider
-      --read-only-port int32                                     The read-only port for the Kubelet to serve on with no authentication/authorization (set to 0 to disable) (default 10255)
-      --really-crash-for-testing                                 If true, when panics occur crash. Intended for testing.
-      --register-node                                            Register the node with the apiserver. If --kubeconfig is not provided, this flag is irrelevant, as the Kubelet won't have an apiserver to register with. Default=true. (default true)
-      --register-with-taints []api.Taint                         Register the node with the given list of taints (comma separated "<key>=<value>:<effect>"). No-op if register-node is false.
-      --registry-burst int32                                     Maximum size of a bursty pulls, temporarily allows pulls to burst to this number, while still not exceeding registry-qps. Only used if --registry-qps > 0 (default 10)
-      --registry-qps int32                                       If > 0, limit registry pull QPS to this value.  If 0, unlimited. (default 5)
-      --resolv-conf string                                       Resolver configuration file used as the basis for the container DNS resolution configuration. (default "/etc/resolv.conf")
-      --rkt-api-endpoint string                                  The endpoint of the rkt API service to communicate with. Only used if --container-runtime='rkt'. (default "localhost:15441")
-      --rkt-path string                                          Path of rkt binary. Leave empty to use the first rkt in $PATH.  Only used if --container-runtime='rkt'.
-      --root-dir string                                          Directory path for managing kubelet files (volume mounts,etc). (default "/var/lib/kubelet")
-      --rotate-certificates                                      <Warning: Beta feature> Auto rotate the kubelet client certificates by requesting new certificates from the kube-apiserver when the certificate expiration approaches.
-      --runonce                                                  If true, exit after spawning pods from local manifests or remote urls. Exclusive with --enable-server
-      --runtime-cgroups string                                   Optional absolute name of cgroups to create and run the runtime in.
-      --runtime-request-timeout duration                         Timeout of all runtime requests except long running request - pull, logs, exec and attach. When timeout exceeded, kubelet will cancel the request, throw out an error and retry later. (default 2m0s)
-      --seccomp-profile-root string                              Directory path for seccomp profiles. (default "/var/lib/kubelet/seccomp")
-      --serialize-image-pulls                                    Pull images one at a time. We recommend *not* changing the default value on nodes that run docker daemon with version < 1.9 or an Aufs storage backend. Issue #10959 has more details. (default true)
-      --streaming-connection-idle-timeout duration               Maximum time a streaming connection can be idle before the connection is automatically closed. 0 indicates no timeout. Example: '5m' (default 4h0m0s)
-      --sync-frequency duration                                  Max period between synchronizing running containers and config (default 1m0s)
-      --system-cgroups /                                         Optional absolute name of cgroups in which to place all non-kernel processes that are not already inside a cgroup under /. Empty for no container. Rolling back the flag requires a reboot.
-      --system-reserved mapStringString                          A set of ResourceName=ResourceQuantity (e.g. cpu=200m,memory=500Mi) pairs that describe resources reserved for non-kubernetes components. Currently only cpu and memory are supported. See http://kubernetes.io/docs/user-guide/compute-resources for more detail. [default=none]
-      --system-reserved-cgroup string                            Absolute name of the top level cgroup that is used to manage non-kubernetes components for which compute resources were reserved via '--system-reserved' flag. Ex. '/system-reserved'. [default='']
-      --tls-cert-file string                                     File containing x509 Certificate used for serving HTTPS (with intermediate certs, if any, concatenated after server cert). If --tls-cert-file and --tls-private-key-file are not provided, a self-signed certificate and key are generated for the public address and saved to the directory passed to --cert-dir.
-      --tls-private-key-file string                              File containing x509 private key matching --tls-cert-file.
-      --version version[=true]                                   Print version information and quit
-      --volume-plugin-dir string                                 <Warning: Alpha feature> The full path of the directory in which to search for additional third party volume plugins (default "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/")
-      --volume-stats-agg-period duration                         Specifies interval for kubelet to calculate and cache the volume disk usage for all pods and volumes.  To disable volume calculations, set to 0. (default 1m0s)
+VolumeScheduling=true|false (ALPHA - default=false)
+      --file-check-frequency duration                                                                             Duration between checking config files for new data (default 20s)
+      --google-json-key string                                                                                    The Google Cloud Platform Service Account JSON Key to use for authentication.
+      --hairpin-mode string                                                                                       How should the kubelet setup hairpin NAT. This allows endpoints of a Service to loadbalance back to themselves if they should try to access their own Service. Valid values are "promiscuous-bridge", "hairpin-veth" and "none". (default "promiscuous-bridge")
+      --healthz-bind-address ip                                                                                   The IP address for the healthz server to serve on. (set to 0.0.0.0 for all interfaces) (default 127.0.0.1)
+      --healthz-port int32                                                                                        The port of the localhost healthz endpoint (set to 0 to disable) (default 10248)
+      --host-ipc-sources stringSlice                                                                              Comma-separated list of sources from which the Kubelet allows pods to use the host ipc namespace. (default [*])
+      --host-network-sources stringSlice                                                                          Comma-separated list of sources from which the Kubelet allows pods to use of host network. (default [*])
+      --host-pid-sources stringSlice                                                                              Comma-separated list of sources from which the Kubelet allows pods to use the host pid namespace. (default [*])
+      --hostname-override string                                                                                  If non-empty, will use this string as identification instead of the actual hostname.
+      --http-check-frequency duration                                                                             Duration between checking http for new data (default 20s)
+      --image-gc-high-threshold int32                                                                             The percent of disk usage after which image garbage collection is always run. (default 85)
+      --image-gc-low-threshold int32                                                                              The percent of disk usage before which image garbage collection is never run. Lowest disk usage to garbage collect to. (default 80)
+      --image-pull-progress-deadline duration                                                                     If no pulling progress is made before this deadline, the image pulling will be cancelled. (default 1m0s)
+      --image-service-endpoint string                                                                             [Experimental] The endpoint of remote image service. If not specified, it will be the same with container-runtime-endpoint by default. Currently unix socket is supported on Linux, and tcp is supported on windows.  Examples:'unix:///var/run/dockershim.sock', 'tcp://localhost:3735'
+      --init-config-dir string                                                                                    The Kubelet will look in this directory for the init configuration. The path may be absolute or relative; relative paths start at the Kubelet's current working directory. Omit this argument to use the built-in default configuration values. Presently, you must also enable the KubeletConfigFile feature gate to pass this flag.
+      --iptables-drop-bit int32                                                                                   The bit of the fwmark space to mark packets for dropping. Must be within the range [0, 31]. (default 15)
+      --iptables-masquerade-bit int32                                                                             The bit of the fwmark space to mark packets for SNAT. Must be within the range [0, 31]. Please match this parameter with corresponding parameter in kube-proxy. (default 14)
+      --kube-api-burst int32                                                                                      Burst to use while talking with kubernetes apiserver (default 10)
+      --kube-api-content-type string                                                                              Content type of requests sent to apiserver. (default "application/vnd.kubernetes.protobuf")
+      --kube-api-qps int32                                                                                        QPS to use while talking with kubernetes apiserver (default 5)
+      --kube-reserved mapStringString                                                                             A set of ResourceName=ResourceQuantity (e.g. cpu=200m,memory=500Mi,ephemeral-storage=1Gi) pairs that describe resources reserved for kubernetes system components. Currently cpu, memory and local ephemeral storage for root file system are supported. See http://kubernetes.io/docs/user-guide/compute-resources for more detail. [default=none]
+      --kube-reserved-cgroup string                                                                               Absolute name of the top level cgroup that is used to manage kubernetes components for which compute resources were reserved via '--kube-reserved' flag. Ex. '/kube-reserved'. [default='']
+      --kubeconfig string                                                                                         Path to a kubeconfig file, specifying how to connect to the API server. (default "/var/lib/kubelet/kubeconfig")
+      --kubelet-cgroups string                                                                                    Optional absolute name of cgroups to create and run the Kubelet in.
+      --lock-file string                                                                                          <Warning: Alpha feature> The path to file for kubelet to use as a lock file.
+      --make-iptables-util-chains                                                                                 If true, kubelet will ensure iptables utility rules are present on host. (default true)
+      --manifest-url string                                                                                       URL for accessing the container manifest
+      --manifest-url-header --manifest-url-header 'a:hello,b:again,c:world' --manifest-url-header 'b:beautiful'   Comma-separated list of HTTP headers to use when accessing the manifest URL. Multiple headers with the same name will be added in the same order provided. This flag can be repeatedly invoked. For example: --manifest-url-header 'a:hello,b:again,c:world' --manifest-url-header 'b:beautiful'
+      --max-open-files int                                                                                        Number of files that can be opened by Kubelet process. (default 1000000)
+      --max-pods int32                                                                                            Number of Pods that can run on this Kubelet. (default 110)
+      --minimum-image-ttl-duration duration                                                                       Minimum age for an unused image before it is garbage collected.  Examples: '300ms', '10s' or '2h45m'. (default 2m0s)
+      --network-plugin string                                                                                     <Warning: Alpha feature> The name of the network plugin to be invoked for various events in kubelet/pod lifecycle
+      --network-plugin-mtu int32                                                                                  <Warning: Alpha feature> The MTU to be passed to the network plugin, to override the default. Set to 0 to use the default 1460 MTU.
+      --node-ip string                                                                                            IP address of the node. If set, kubelet will use this IP address for the node
+      --node-labels mapStringString                                                                               <Warning: Alpha feature> Labels to add when registering the node in the cluster.  Labels must be key=value pairs separated by ','.
+      --node-status-update-frequency duration                                                                     Specifies how often kubelet posts node status to master. Note: be cautious when changing the constant, it must work with nodeMonitorGracePeriod in nodecontroller. (default 10s)
+      --oom-score-adj int32                                                                                       The oom-score-adj value for kubelet process. Values must be within the range [-1000, 1000] (default -999)
+      --pod-cidr string                                                                                           The CIDR to use for pod IP addresses, only used in standalone mode.  In cluster mode, this is obtained from the master.
+      --pod-infra-container-image string                                                                          The image whose network/ipc namespaces containers in each pod will use. (default "gcr.io/google_containers/pause-amd64:3.0")
+      --pod-manifest-path string                                                                                  Path to the directory containing pod manifest files to run, or the path to a single pod manifest file. Files starting with dots will be ignored.
+      --pods-per-core int32                                                                                       Number of Pods per core that can run on this Kubelet. The total number of Pods on this Kubelet cannot exceed max-pods, so max-pods will be used if this calculation results in a larger number of Pods allowed on the Kubelet. A value of 0 disables this limit.
+      --port int32                                                                                                The port for the Kubelet to serve on. (default 10250)
+      --protect-kernel-defaults                                                                                   Default kubelet behaviour for kernel tuning. If set, kubelet errors if any of kernel tunables is different than kubelet defaults.
+      --provider-id string                                                                                        Unique identifier for identifying the node in a machine database, i.e cloudprovider
+      --read-only-port int32                                                                                      The read-only port for the Kubelet to serve on with no authentication/authorization (set to 0 to disable) (default 10255)
+      --really-crash-for-testing                                                                                  If true, when panics occur crash. Intended for testing.
+      --register-node                                                                                             Register the node with the apiserver. If --kubeconfig is not provided, this flag is irrelevant, as the Kubelet won't have an apiserver to register with. Default=true. (default true)
+      --register-with-taints []api.Taint                                                                          Register the node with the given list of taints (comma separated "<key>=<value>:<effect>"). No-op if register-node is false.
+      --registry-burst int32                                                                                      Maximum size of a bursty pulls, temporarily allows pulls to burst to this number, while still not exceeding registry-qps. Only used if --registry-qps > 0 (default 10)
+      --registry-qps int32                                                                                        If > 0, limit registry pull QPS to this value.  If 0, unlimited. (default 5)
+      --resolv-conf string                                                                                        Resolver configuration file used as the basis for the container DNS resolution configuration. (default "/etc/resolv.conf")
+      --rkt-api-endpoint string                                                                                   The endpoint of the rkt API service to communicate with. Only used if --container-runtime='rkt'. (default "localhost:15441")
+      --rkt-path string                                                                                           Path of rkt binary. Leave empty to use the first rkt in $PATH.  Only used if --container-runtime='rkt'.
+      --root-dir string                                                                                           Directory path for managing kubelet files (volume mounts,etc). (default "/var/lib/kubelet")
+      --rotate-certificates                                                                                       <Warning: Beta feature> Auto rotate the kubelet client certificates by requesting new certificates from the kube-apiserver when the certificate expiration approaches.
+      --runonce                                                                                                   If true, exit after spawning pods from local manifests or remote urls. Exclusive with --enable-server
+      --runtime-cgroups string                                                                                    Optional absolute name of cgroups to create and run the runtime in.
+      --runtime-request-timeout duration                                                                          Timeout of all runtime requests except long running request - pull, logs, exec and attach. When timeout exceeded, kubelet will cancel the request, throw out an error and retry later. (default 2m0s)
+      --seccomp-profile-root string                                                                               <Warning: Alpha feature> Directory path for seccomp profiles. (default "/var/lib/kubelet/seccomp")
+      --serialize-image-pulls                                                                                     Pull images one at a time. We recommend *not* changing the default value on nodes that run docker daemon with version < 1.9 or an Aufs storage backend. Issue #10959 has more details. (default true)
+      --streaming-connection-idle-timeout duration                                                                Maximum time a streaming connection can be idle before the connection is automatically closed. 0 indicates no timeout. Example: '5m' (default 4h0m0s)
+      --sync-frequency duration                                                                                   Max period between synchronizing running containers and config (default 1m0s)
+      --system-cgroups /                                                                                          Optional absolute name of cgroups in which to place all non-kernel processes that are not already inside a cgroup under /. Empty for no container. Rolling back the flag requires a reboot.
+      --system-reserved mapStringString                                                                           A set of ResourceName=ResourceQuantity (e.g. cpu=200m,memory=500Mi,ephemeral-storage=1Gi) pairs that describe resources reserved for non-kubernetes components. Currently only cpu and memory are supported. See http://kubernetes.io/docs/user-guide/compute-resources for more detail. [default=none]
+      --system-reserved-cgroup string                                                                             Absolute name of the top level cgroup that is used to manage non-kubernetes components for which compute resources were reserved via '--system-reserved' flag. Ex. '/system-reserved'. [default='']
+      --tls-cert-file string                                                                                      File containing x509 Certificate used for serving HTTPS (with intermediate certs, if any, concatenated after server cert). If --tls-cert-file and --tls-private-key-file are not provided, a self-signed certificate and key are generated for the public address and saved to the directory passed to --cert-dir.
+      --tls-private-key-file string                                                                               File containing x509 private key matching --tls-cert-file.
+      --version version[=true]                                                                                    Print version information and quit
+      --volume-plugin-dir string                                                                                  <Warning: Alpha feature> The full path of the directory in which to search for additional third party volume plugins (default "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/")
+      --volume-stats-agg-period duration                                                                          Specifies interval for kubelet to calculate and cache the volume disk usage for all pods and volumes.  To disable volume calculations, set to 0. (default 1m0s)
 ```
 
-###### Auto generated by spf13/cobra on 27-Sep-2017
+###### Auto generated by spf13/cobra on 7-Dec-2017

--- a/skip_title_check.txt
+++ b/skip_title_check.txt
@@ -7,6 +7,12 @@ docs/user-guide/pods/_viewing-a-pod.md
 docs/user-guide/simple-yaml.md
 docs/user-guide/update-demo/images/kitten/README.md
 docs/user-guide/update-demo/images/nautilus/README.md
+docs/reference/generated/cloud-controller-manager.md
+docs/reference/generated/kube-apiserver.md
+docs/reference/generated/kube-controller-manager.md
+docs/reference/generated/kube-proxy.md
+docs/reference/generated/kube-scheduler.md
+docs/reference/generated/kubelet.md
 docs/reference/setup-tools/kubeadm/generated/README.md
 docs/reference/setup-tools/kubeadm/generated/kubeadm.md
 docs/reference/setup-tools/kubeadm/generated/kubeadm_alpha.md


### PR DESCRIPTION
Update these generated ref docs:

* [cloud-controller-manager](https://deploy-preview-6614--kubernetes-io-vnext-staging.netlify.com/docs/reference/generated/cloud-controller-manager/)
* [kube-apiserver](https://deploy-preview-6614--kubernetes-io-vnext-staging.netlify.com/docs/reference/generated/kube-apiserver/)
* [kube-controller-manager](https://deploy-preview-6614--kubernetes-io-vnext-staging.netlify.com/docs/reference/generated/kube-controller-manager/)
* [kube-proxy](https://deploy-preview-6614--kubernetes-io-vnext-staging.netlify.com/docs/reference/generated/kube-proxy/)
* [kube-scheduler](https://deploy-preview-6614--kubernetes-io-vnext-staging.netlify.com/docs/reference/generated/kube-scheduler/)
* [kubelet](https://deploy-preview-6614--kubernetes-io-vnext-staging.netlify.com/docs/reference/generated/kubelet/)

These ref pages are generated by [gen_kube_docs.go](https://github.com/kubernetes/kubernetes/blob/release-1.9/cmd/genkubedocs/gen_kube_docs.go), which is called by [generate-docs.sh](https://github.com/kubernetes/kubernetes/blob/release-1.9/hack/generate-docs.sh).

Note: generate-docs.sh produces other files that I have not included in this PR. For example, generate-docs.sh produces reference docs for kubeadm. I have not included the kubeadm ref docs here, because they are included in #6103. Also, generate-docs.sh produces reference docs for kubectl. I have not included those here, because I will handle them in a separate PR.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6614)
<!-- Reviewable:end -->
