### PR TITLE
Add openstack internal load balancer option

### DIFF
--- a/docs/concepts/services-networking/service.md
+++ b/docs/concepts/services-networking/service.md
@@ -497,8 +497,19 @@ metadata:
 ```
 {% endcapture %}
 
-{% assign tab_names = 'Default,GCP,AWS,Azure' | split: ',' | compact %}
-{% assign tab_contents = site.emptyArray | push: default_tab | push: gcp | push: aws | push: azure %}
+{% capture openstack %}
+```yaml
+[...]
+metadata:
+    name: my-service
+    annotations:
+        service.beta.kubernetes.io/openstack-internal-load-balancer: "true"
+[...]
+```
+{% endcapture %}
+
+{% assign tab_names = 'Default,GCP,AWS,Azure,OpenStack' | split: ',' | compact %}
+{% assign tab_contents = site.emptyArray | push: default_tab | push: gcp | push: aws | push: azure | push: openstack %}
 {% include tabs.md %}
 
 #### SSL support on AWS


### PR DESCRIPTION
This pull request adds the option to create a service of type Load Balancer internally with openstack cloud provider.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6617)
<!-- Reviewable:end -->
