### PR TITLE
Update networking.md

### DIFF
--- a/docs/concepts/cluster-administration/networking.md
+++ b/docs/concepts/cluster-administration/networking.md
@@ -128,7 +128,7 @@ people have reported success with Flannel and Kubernetes.
 ### Google Compute Engine (GCE)
 
 For the Google Compute Engine cluster configuration scripts, we use [advanced
-routing](https://cloud.google.com/compute/docs/networking#routing) to
+routing](https://cloud.google.com/vpc/docs/routes) to
 assign each VM a subnet (default is `/24` - 254 IPs).  Any traffic bound for that
 subnet will be routed directly to the VM by the GCE network fabric.  This is in
 addition to the "main" IP address assigned to the VM, which is NAT'ed for


### PR DESCRIPTION
GCP documentation has reorganized, so the existing link took us to the general VPC overview. Fixed so it links directly to the piece on routing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6647)
<!-- Reviewable:end -->
