### PR TITLE
Couple nits for dnsConfig doc

### DIFF
--- a/docs/concepts/services-networking/custom-dns.yaml
+++ b/docs/concepts/services-networking/custom-dns.yaml
@@ -10,7 +10,7 @@ spec:
   dnsPolicy: "None"
   dnsConfig:
     nameservers:
-      - "1.2.3.4"
+      - 1.2.3.4
     searches:
       - ns1.svc.cluster.local
       - my.dns.search.suffix

--- a/docs/concepts/services-networking/dns-pod-service.md
+++ b/docs/concepts/services-networking/dns-pod-service.md
@@ -240,7 +240,8 @@ in its `/etc/resolv.conf` file:
 ```
 nameserver 1.2.3.4
 search ns1.svc.cluster.local my.dns.search.suffix
-options ndots:2 edns0
+options ndots:2
+options edns0
 ```
 
 {% endcapture %}


### PR DESCRIPTION
Missed a mistake from previous review --- "options" in resolv.conf should be multi-line.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6652)
<!-- Reviewable:end -->
