### PR TITLE
securing a cluster: add recommendations about cloud metadata APIs

### DIFF
--- a/docs/tasks/administer-cluster/securing-a-cluster.md
+++ b/docs/tasks/administer-cluster/securing-a-cluster.md
@@ -130,6 +130,16 @@ Additional protections may be available that control network rules on a per plug
 environment basis, such as per-node firewalls, physically separating cluster nodes to 
 prevent cross talk, or advanced networking policy.
 
+### Restricting cloud metadata API access
+
+Cloud platforms (AWS, Azure, GCE, etc.) often expose metadata services locally to instances.
+By default these APIs are accessible by pods running on an instance and can contain cloud
+credentials for that node, or provisioning data such as kubelet credentials. These credentials
+can be used to escalate within the cluster or to other cloud services under the same account.
+
+When running Kubernetes on a cloud platform limit permissions given to instance credentials, use
+[network policies](/docs/tasks/administer-cluster/declare-network-policy/) to restrict pod access
+to the metadata API, and avoid using provisioning data to deliver secrets.
 
 ### Controlling which nodes pods may access
 


### PR DESCRIPTION
Updates https://github.com/kubernetes/kubernetes/issues/52184

Exposing the metadata API to pods is a very common install practice and can potentially lead to escalations beyond a cluster and into the cloud account.

cc @kubernetes/sig-auth-pr-reviews 
cc @bgeesaman

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6659)
<!-- Reviewable:end -->
