### PR TITLE
update jsonpath docs to include negative indices

### DIFF
--- a/docs/reference/kubectl/jsonpath.md
+++ b/docs/reference/kubectl/jsonpath.md
@@ -8,6 +8,7 @@ And we add three functions in addition to the original JSONPath syntax:
 1. The `$` operator is optional since the expression always starts from the root object by default.
 2. We can use `""` to quote text inside JSONPath expressions.
 3. We can use `range` operator to iterate lists.
+4. We can use negative slice indices to step backwards through a list. Negative indices do not "wrap around" a list. They are valid as long as `-index + listLenght >= 0`.
 
 The result object is printed as its String() function.
 


### PR DESCRIPTION
Related PR: https://github.com/kubernetes/kubernetes/pull/48778

Adds mention of negative index use (support for these is added in the linked PR).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6662)
<!-- Reviewable:end -->
