### PR TITLE
Remove marketing fluff, correct case of govc

### DIFF
--- a/docs/getting-started-guides/vsphere.md
+++ b/docs/getting-started-guides/vsphere.md
@@ -12,7 +12,7 @@ This page covers how to get started with deploying Kubernetes on vSphere and det
 
 ### Getting started with the vSphere Cloud Provider
 
-Kubernetes comes with *vSphere Cloud Provider*, a cloud provider for vSphere that allows Kubernetes Pods to use enterprise grade vSphere Storage.
+Kubernetes comes with *vSphere Cloud Provider*, a cloud provider for vSphere that allows Kubernetes Pods to use vSphere Storage.
 
 ### Deploy Kubernetes on vSphere
 
@@ -22,9 +22,9 @@ Detailed steps can be found at the [getting started with Kubernetes-Anywhere on 
 
 ### vSphere Cloud Provider
 
-vSphere Cloud Provider allows Kubernetes to use vSphere managed enterprise grade storage. It supports:
+vSphere Cloud Provider allows Kubernetes to use vSphere-managed storage. It supports:
 
-- Enterprise class services such as de-duplication and encryption with vSAN, QoS, high availability and data reliability.
+- Services such as de-duplication and encryption with vSAN, QoS, high availability and data reliability.
 - Policy based management at granularity of container volumes.
 - Volumes, Persistent Volumes, Storage Classes, dynamic provisioning of volumes, and scalable deployment of Stateful Apps with StatefulSets.
 
@@ -52,9 +52,9 @@ If a Kubernetes cluster has not been deployed using Kubernetes-Anywhere, follow 
 
 The disk.EnableUUID parameter must be set to "TRUE" for each Node VM. This step is necessary so that the VMDK always presents a consistent UUID to the VM, thus allowing the disk to be mounted properly. 
 
-For each of the virtual machine nodes that will be participating in the cluster, follow the steps below using [GOVC tool](https://github.com/vmware/govmomi/tree/master/govc)
+For each of the virtual machine nodes that will be participating in the cluster, follow the steps below using [govc tool](https://github.com/vmware/govmomi/tree/master/govc)
 
-* Set up GOVC environment
+* Set up the **govc** environment
 
       export GOVC_URL='vCenter IP OR FQDN'
       export GOVC_USERNAME='vCenter User'


### PR DESCRIPTION
Remove marketing fluff words that distract from technical documentation.

Also corrects the case of the govc tool.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6669)
<!-- Reviewable:end -->
