### PR TITLE
remove field-selector from 1.8

### DIFF
--- a/docs/reference/kubectl/cheatsheet.md
+++ b/docs/reference/kubectl/cheatsheet.md
@@ -119,9 +119,6 @@ $ kubectl get pods --sort-by='.status.containerStatuses[0].restartCount'
 $ kubectl get pods --selector=app=cassandra rc -o \
   jsonpath='{.items[*].metadata.labels.version}'
 
-# Get all running pods in the namespace
-$ kubectl get pods --field-selector=status.phase=Running
-
 # Get ExternalIPs of all nodes
 $ kubectl get nodes -o jsonpath='{.items[*].status.addresses[?(@.type=="ExternalIP")].address}'
 

--- a/docs/reference/kubectl/overview.md
+++ b/docs/reference/kubectl/overview.md
@@ -242,9 +242,6 @@ $ kubectl get rc,services
 
 // List all daemon sets, including uninitialized ones, in plain-text output format.
 $ kubectl get ds --include-uninitialized
-
-// List all pods running on node server01
-$ kubectl get pods --field-selector=spec.nodeName=server01
 ```
 
 `kubectl describe` - Display detailed state of one or more resources, including the uninitialized ones by default.


### PR DESCRIPTION
#6312 added docs for `kubectl get --field-selector`, which is targeted for v1.9.
We should not cherry-pick to v1.8, which would cause some confusions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6671)
<!-- Reviewable:end -->
