### PR TITLE
Fixed a typo `illgal`

### DIFF
--- a/docs/tasks/debug-application-cluster/audit.md
+++ b/docs/tasks/debug-application-cluster/audit.md
@@ -113,7 +113,7 @@ Some new fields are supported in beta version, like `resourceNames` and `omitSta
 
 In Kubernetes 1.8 `kind` and `apiVersion` along with `rules` __must__ be provided in
 the audit policy file. A policy file with 0 rules, or a policy file that doesn't provide
-a valid `apiVersion` and `kind` value will be treated as illgal.
+a valid `apiVersion` and `kind` value will be treated as illegal.
 
 Some example audit policy files:
 


### PR DESCRIPTION
Just fixes a minor typo in `audit.md` docs.
`illgal` --> `illegal`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6674)
<!-- Reviewable:end -->
