### PR TITLE
add back example-psp.yaml

### DIFF
--- a/docs/concepts/policy/example-psp.yaml
+++ b/docs/concepts/policy/example-psp.yaml
@@ -1,0 +1,17 @@
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: example
+spec:
+  privileged: false  # Don't allow privileged pods!
+  # The rest fills in some required fields.
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  volumes:
+  - '*'


### PR DESCRIPTION
`/docs/concepts/policy/example-psp.yaml` is needed in `/docs/concepts/policy/pod-security-policy.md`. Was modified and renamed in https://github.com/kubernetes/website/pull/6378

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6683)
<!-- Reviewable:end -->
