### PR TITLE
[glossary] Add prepend option to glossary definition tag

### DIFF
--- a/_plugins/README.md
+++ b/_plugins/README.md
@@ -25,6 +25,7 @@ This renders the definition of the glossary term inside a `<div>`, preserving Ma
 | --- | --- | --- |
 | `term_id` | N/A (Required) | The `id` of the glossary term whose definition will be used. (This `id` is the same as the filename of the term, i.e. `_data/glossary/<ID>.yml`.) |
 | `length` | "short" | Specifies which term definition should be used ("short" for the `short-definition`, "long" for `long-description`, "all" when both should be included). |
+| `prepend` | "Service Catalog is" | A prefix which can be attached in front of a term's short definition (which is one or more sentence fragments). |
 
 #### (2) `glossary_tooltip` tag
 

--- a/_plugins/glossary_tags.rb
+++ b/_plugins/glossary_tags.rb
@@ -55,11 +55,17 @@ module Jekyll
     class Definition < Base
       VALID_PARAM_NAMES = [
         :term_id,
-        :length
+        :length,
+        :prepend,
       ].freeze
 
       def render(context)
-        include_snippet(context)
+        text = include_snippet(context)
+        if @args[:prepend]
+          text.sub(/<p>(.)/) { "<p>#{@args[:prepend]} #{$1.downcase}" }
+        else
+          text
+        end
       end
     end
 

--- a/docs/concepts/service-catalog/index.md
+++ b/docs/concepts/service-catalog/index.md
@@ -5,7 +5,7 @@ approvers:
 ---
 
 {% capture overview %}
-{% glossary_definition term_id="service-catalog" length="all" prepend="Service Catalog is " %}  
+{% glossary_definition term_id="service-catalog" length="all" prepend="Service Catalog is" %}  
 
 A *Service Broker*, as defined by the [Open Service Broker API spec](https://github.com/openservicebrokerapi/servicebroker/blob/v2.13/spec.md), is an endpoint for a set of Managed Services offered and maintained by a third-party, which could be a cloud provider such as AWS, GCP, or Azure.
 Some examples of *Managed Services* are Microsoft Azure Cloud Queue, Amazon Simple Queue Service, and Google Cloud Pub/Sub, but they can be any software offering that can be used by an application.
@@ -55,7 +55,7 @@ Upon creation, the Service Catalog controller will create a Kubernetes `Secret` 
 
 ### Authentication
 
-Service Catalog supports these methods of authentication: 
+Service Catalog supports these methods of authentication:
 
 * Basic (username/password)
 * [OAuth 2.0 Bearer Token](https://tools.ietf.org/html/rfc6750)
@@ -118,7 +118,7 @@ The following is a sequence diagram illustrating the steps involved in listing M
 
 ### Provisioning a new instance
 
-A {% glossary_tooltip text="Cluster Operator" term_id="cluster-operator" %} can initiate the provisioning of a new instance by creating a `ServiceInstance` resource. 
+A {% glossary_tooltip text="Cluster Operator" term_id="cluster-operator" %} can initiate the provisioning of a new instance by creating a `ServiceInstance` resource.
 
 This is an example of a `ServiceInstance` resource:
 
@@ -133,7 +133,7 @@ spec:
   clusterServiceClassExternalName: cloud-provider-service
   clusterServicePlanExternalName: service-plan-name
   #####
-  # Additional parameters can be added here, 
+  # Additional parameters can be added here,
   # which may be used by the Service Broker.
   #####
 ```
@@ -148,7 +148,7 @@ The following sequence diagram illustrates the steps involved in provisioning a 
 
 ### Binding to a Managed Service
 
-After a new instance has been provisioned, a {% glossary_tooltip text="Cluster Operator" term_id="cluster-operator" %} must bind to the Managed Service to get the connection credentials and service account details necessary for the application to use the service. This is done by creating a `ServiceBinding` resource. 
+After a new instance has been provisioned, a {% glossary_tooltip text="Cluster Operator" term_id="cluster-operator" %} must bind to the Managed Service to get the connection credentials and service account details necessary for the application to use the service. This is done by creating a `ServiceBinding` resource.
 
 The following is an example of a `ServiceBinding` resource:
 
@@ -162,7 +162,7 @@ spec:
   instanceRef:
     name: cloud-queue-instance
   #####
-  # Additional information can be added here, such as a secretName or 
+  # Additional information can be added here, such as a secretName or
   # service account parameters, which may be used by the Service Broker.
   #####
 ```

--- a/docs/tasks/service-catalog/install-service-catalog-using-helm.md
+++ b/docs/tasks/service-catalog/install-service-catalog-using-helm.md
@@ -5,7 +5,7 @@ approvers:
 ---
 
 {% capture overview %}
-{% glossary_definition term_id="service-catalog" length="long" %}
+{% glossary_definition term_id="service-catalog" length="all" prepend="Service Catalog is" %}  
 
 Use [Helm](https://helm.sh/) to install Service Catalog on your Kubernetes cluster. Up to date information on this process can be found at the [kubernetes-incubator/service-catalog](https://github.com/kubernetes-incubator/service-catalog/blob/master/docs/install.md) repo.
 

--- a/docs/tasks/service-catalog/install-service-catalog-using-sc.md
+++ b/docs/tasks/service-catalog/install-service-catalog-using-sc.md
@@ -5,7 +5,7 @@ approvers:
 ---
 
 {% capture overview %}
-{% glossary_definition term_id="service-catalog" length="long" %}
+{% glossary_definition term_id="service-catalog" length="all" prepend="Service Catalog is" %}
 
 Use the [Service Catalog Installer](https://github.com/GoogleCloudPlatform/k8s-service-catalog#installation) tool to easily install or uninstall Service Catalog on your Kubernetes cluster. This CLI tool is installed as `sc` in your local environment.
 
@@ -15,7 +15,7 @@ Use the [Service Catalog Installer](https://github.com/GoogleCloudPlatform/k8s-s
 {% capture prerequisites %}
 * Understand the key concepts of [Service Catalog](/docs/concepts/service-catalog/).
 * Install [Go 1.6+](https://golang.org/dl/) and set the `GOPATH`.
-* Install the [cfssl](https://github.com/cloudflare/cfssl) tool needed for generating SSL artifacts. 
+* Install the [cfssl](https://github.com/cloudflare/cfssl) tool needed for generating SSL artifacts.
 * Service Catalog requires Kubernetes version 1.7+.
 * [Install and setup kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) so that it is configured to connect to a Kubernetes v1.7+ cluster.
 * The kubectl user must be bound to the *cluster-admin* role for it to install Service Catalog. To ensure that this is true, run the following command:
@@ -44,11 +44,11 @@ First, verify that all dependencies have been installed. Run:
 sc check
 ```
 
-If the check is successful, it should return: 
+If the check is successful, it should return:
 
 ```
 Dependency check passed. You are good to go.
-``` 
+```
 
 Next, run the install command and specify the `storageclass` that you want to use for the backup:
 


### PR DESCRIPTION
@chenopis I think it's significantly easier (and less hacky) to allow for a `prepend` option in the `glossary_definition` tag, rather than an `initial_cap` tag. 

The reason your previous attempt at this approach caused the definition to be split across two lines was because they were separate block elements (`<p>STUFF</p>`). 

Because we're including the definitions from YAML, they come prewrapped in `<p>` tags, and it's significantly easier to add the word you want in the Ruby plugin logic, then to do it after the fact (in the markdown/liquid pages). 

(FYI @steveperry-53 --- I recall your concerns about edge cases but *believe* this approach can work for now. Importantly, we are not enforcing that all glossary terms need to follow "<term name> is", which you mentioned could cause issues with plural terms. Because `prepend`'s value is still a string that we can set, in those situations, we can easily switch to "<term name> are". The control of the words still belongs to the writer, rather than to the automation).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6687)
<!-- Reviewable:end -->
