### PR TITLE
Small fixes and improvements in kubeadm docs

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -443,3 +443,4 @@ https://kubernetes-io-v1-7.netlify.com/*    https://v1-7.docs.kubernetes.io/:spl
 /docs/admin/kubefed_unjoin/     /docs/reference/generated/kubefed_unjoin/ 301 
 /docs/admin/kubefed_version/    /docs/reference/generated/kubefed_version/ 301    
 
+/docs/reference/generated/kubeadm/     /docs/reference/setup-tools/kubeadm/kubeadm/ 301

--- a/docs/reference/setup-tools/kubeadm/kubeadm-alpha.md
+++ b/docs/reference/setup-tools/kubeadm/kubeadm-alpha.md
@@ -224,6 +224,8 @@ Alternatively, you can use [kubeadm config](kubeadm-config.md).
 You can install all the available addons with the `all` subcommand, or 
 install them selectively.
 
+Please note that if kubeadm is invoked with `--feature-gates=CoreDNS`,  CoreDNS is installed instead of `kube-dns`.
+
 {% capture addon-all %}
 {% include_relative generated/kubeadm_alpha_phase_addon_all.md %}
 {% endcapture %}

--- a/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -31,6 +31,13 @@ following steps:
    API server, each with its own identity, as well as an additional
    kubeconfig file for administration named `admin.conf`.
 
+1. If kubeadm is invoked with `--feature-gates=DynamicKubeletConfig` enabled,
+   it writes the kubelet init configuration into the `/var/lib/kubelet/config/init/kubelet` file. 
+   See [Set Kubelet parameters via a config file](/docs/tasks/administer-cluster/kubelet-config-file.md) 
+   and [Reconfigure a Node's Kubelet in a Live Cluster](/docs/tasks/administer-cluster/reconfigure-kubelet.md) 
+   for more information about Dynamic Kubelet Configuration.
+   This functionality is now by default disabled as it is behind a feature gate, but is expected to be a default in future versions.
+
 1. Generates static Pod manifests for the API server,
    controller manager and scheduler. In case an external etcd is not provided,
    an additional static Pod manifest are generated for etcd.
@@ -39,6 +46,12 @@ following steps:
    watches this directory for Pods to create on startup.
 
    Once control plane Pods are up and running, the `kubeadm init` sequence can continue.
+
+1. If kubeadm is invoked with `--feature-gates=DynamicKubeletConfig` enabled,
+   it completes the kubelet dynamic configuration by creating a ConfigMap and some RBAC rules that enable
+   kubelets to access to it, and updates the node by pointing `Node.spec.configSource` to the 
+   newly-created ConfigMap. 
+   This functionality is now by default disabled as it is behind a feature gate, but is expected to be a default in future versions.
 
 1. Apply labels and taints to the master node so that no additional workloads will 
    run there.
@@ -120,6 +133,18 @@ controllerManagerExtraArgs:
 schedulerExtraArgs:
   <argument>: <value|string>
   <argument>: <value|string>
+apiServerExtraVolumes:
+- name: <value|string>
+  hostPath: <value|string>
+  mountPath: <value|string>
+controllerManagerExtraVolumes:
+- name: <value|string>
+  hostPath: <value|string>
+  mountPath: <value|string>
+schedulerExtraVolumes:
+- name: <value|string>
+  hostPath: <value|string>
+  mountPath: <value|string>
 apiServerCertSANs:
 - <name1|string>
 - <name2|string>

--- a/docs/reference/setup-tools/kubeadm/kubeadm-join.md
+++ b/docs/reference/setup-tools/kubeadm/kubeadm-join.md
@@ -21,6 +21,13 @@ This action consists of the following steps:
    authenticity of that data. The root CA can also be discovered directly via a
    file or URL.
 
+1. If kubeadm is invoked with `--feature-gates=DynamicKubeletConfig` enabled,
+   it first retrieves the kubelet init configuration from the master and writes it to
+   the disk. When kubelet starts up, kubeadm updates the node `Node.spec.configSource` property of the node. 
+   See [Set Kubelet parameters via a config file](/docs/tasks/administer-cluster/kubelet-config-file.md) 
+   and [Reconfigure a Node's Kubelet in a Live Cluster](/docs/tasks/administer-cluster/reconfigure-kubelet.md) 
+   for more information about Dynamic Kubelet Configuration.
+
 1. Once the cluster information is known, kubelet can start the TLS bootstrapping
    process.
 

--- a/docs/setup/independent/create-cluster-kubeadm.md
+++ b/docs/setup/independent/create-cluster-kubeadm.md
@@ -11,10 +11,10 @@ title: Using kubeadm to Create a Cluster
 
 **kubeadm** is a toolkit that help you bootstrap a best-practice Kubernetes
 cluster in an easy, reasonably secure and extensible way. It also supports
-managing [Bootstrap Tokens](#TODO) for you and upgrading/downgrading clusters.
+managing [Bootstrap Tokens](/docs/admin/bootstrap-tokens/) for you and upgrading/downgrading clusters.
 
 kubeadm aims to set up a minimum viable cluster that pass the
-[Kubernetes Conformance tests](#TODO), but installing other addons than
+[Kubernetes Conformance tests](http://blog.kubernetes.io/2017/10/software-conformance-certification.html), but installing other addons than
 really necessary for a functional cluster is out of scope.
 
 It by design does not install a networking solution for you, which means you
@@ -26,27 +26,29 @@ matter, can be a Linux laptop, virtual machine, physical/cloud server or
 Raspberry Pi. This makes kubeadm well suited to integrate with provisioning
 systems of different kinds (e.g. Terraform, Ansible, etc.).
 
-kubeadm is designed to be a good way for new users to start trying
-Kubernetes out, possibly for the first time, an way for existing users to
-test their application on and stich together a cluster easily and to be
-a building block in a larger ecosystem and/or installer tool with a larger
+kubeadm is designed to be a simple way for new users to start trying
+Kubernetes out, possibly for the first time, a way for existing users to
+test their application on and stich together a cluster easily, and also to be
+a building block in other ecosystem and/or installer tool with a larger
 scope.
 
 You can install _kubeadm_ very easily on operating systems that support
 installing deb or rpm packages. The responsible SIG for kubeadm,
-[SIG Cluster Lifecycle](#TODO), provides these packages pre-built for you,
+[SIG Cluster Lifecycle](https://github.com/kubernetes/community/tree/master/sig-cluster-lifecycle), provides these packages pre-built for you,
 but you may also on other OSes. 
 
 
 ### kubeadm Maturity
 
-| Area            | Maturity Level |
-|-----------------|--------------- |
-| Command line UX | beta           |
-| Implementation  | beta           |
-| Config file API | alpha          |
-| Self-hosting    | alpha          |
-| `kubeadm alpha` | alpha          |
+| Area                      | Maturity Level |
+|---------------------------|--------------- |
+| Command line UX           | beta           |
+| Implementation            | beta           |
+| Config file API           | alpha          |
+| Self-hosting              | alpha          |
+| kubeadm alpha subcommands | alpha          |
+| CoreDNS                   | alpha          | 
+| DynamicKubeletConfig      | alpha          |
 
 
 kubeadm's overall feature state is **Beta** and will soon be graduated to
@@ -64,12 +66,12 @@ period a patch release may be issued from the release branch if a severe bug or
 security issue is found. Here are the latest Kubernetes releases and the support
 timeframe; which also applies to `kubeadm`.
 
-| Kubernetes version | Release date | End-of-life-month |
-|--------------------|--------------|-------------------|
-| v1.6.x             | TODO         | December 2017     |
-| v1.7.x             | TODO         | March 2018        |
-| v1.8.x             | TODO         | June 2018         |
-| v1.9.x             | TODO         | September 2018    |
+| Kubernetes version | Release month  | End-of-life-month |
+|--------------------|----------------|-------------------|
+| v1.6.x             | March 2017     | December 2017     |
+| v1.7.x             | June 2017      | March 2018        |
+| v1.8.x             | September 2017 | June 2018         |
+| v1.9.x             | December 2017  | September 2018    |
 
 {% endcapture %}
 


### PR DESCRIPTION
Fixes, and small improvements to the kubeadm docs.
cc @kubernetes/sig-cluster-lifecycle-pr-reviews
cc @luxas 

Note for sig-docs reviewers, currently google search for kubeadm reference leads to https://kubernetes.io/docs/reference/generated/kubeadm/ , which does not exists anymore. 
The new redirect should fix this

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6693)
<!-- Reviewable:end -->
