### PR TITLE
Fix small css layout bug in mobile

### DIFF
--- a/_sass/_base.sass
+++ b/_sass/_base.sass
@@ -554,7 +554,7 @@ section
 		font-weight: bold
 
 	li + li
-		margin-left: 20px
+		margin-left: 0
 
 
 #docs

--- a/_sass/_desktop.sass
+++ b/_sass/_desktop.sass
@@ -316,3 +316,8 @@ $video-section-height: 550px
 @media screen and (min-width: 1300px)
 	#vendorStrip
 		padding-right: 100px
+
+@media screen and (min-width: 456px)
+	#vendorStrip
+		li + li
+			margin-left: 20px


### PR DESCRIPTION
Too much left margin on the #vendorStrip's list items was causing a small
layout bug where the right hamburger menu was accidentally hidden (mobile).

Hopefully this [gif](https://media.giphy.com/media/3ohjUSlnOaQfimzaJG/200w_d.gif) will clarify.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6694)
<!-- Reviewable:end -->
