### PR TITLE
Graduate cpu manager

### DIFF
--- a/docs/tasks/administer-cluster/cpu-management-policies.md
+++ b/docs/tasks/administer-cluster/cpu-management-policies.md
@@ -1,5 +1,9 @@
 ---
 title: Control CPU Management Policies on the Node
+approvers:
+- sjenning
+- ConnorDoyle
+- balajismaniam
 ---
 
 * TOC

--- a/docs/tasks/administer-cluster/cpu-management-policies.md
+++ b/docs/tasks/administer-cluster/cpu-management-policies.md
@@ -6,6 +6,8 @@ approvers:
 - balajismaniam
 ---
 
+{% include feature-state-beta.md %}
+
 * TOC
 {:toc}
 


### PR DESCRIPTION
The CPU manager is now on by default and marked as beta per the feature gates. This change occurred in `master` following the v1.9 code freeze. This doc change is in preparation for v1.10.

Also adds some active feature owners as approvers to this doc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6699)
<!-- Reviewable:end -->
