### PR TITLE
Remove remaining OIR documentation.

### DIFF
--- a/docs/concepts/configuration/manage-compute-resources-container.md
+++ b/docs/concepts/configuration/manage-compute-resources-container.md
@@ -383,10 +383,8 @@ The API server restricts quantities of Extended Resources to whole numbers.
 Examples of _valid_ quantities are `3`, `3000m` and `3Ki`. Examples of
 _invalid_ quantities are `0.5` and `1500m`.
 
-**Note:** Extended Resources replace Opaque Integer
-Resources. Users can use any domain
-name prefix outside of the `kubernetes.io/` domain instead of the previous
-`pod.alpha.kubernetes.io/opaque-int-resource-` prefix.
+**Note:** Extended Resources replace Opaque Integer Resources.
+Users can use any domain name prefix other than "`kubernetes.io`" which is reserved.
 {: .note}
 
 There are two steps required to use Extended Resources. First, the

--- a/docs/concepts/configuration/manage-compute-resources-container.md
+++ b/docs/concepts/configuration/manage-compute-resources-container.md
@@ -367,90 +367,6 @@ run on. Each node has a maximum amount of local ephemeral storage it can provide
 
 For container-level isolation, if a Container's writable layer and logs usage exceeds its storage limit, the pod will be evicted. For pod-level isolation, if the sum of the local ephemeral storage usage from all containers and also the pod's EmptyDir volumes exceeds the limit, the pod will be evicted.
 
-## Opaque integer resources (alpha feature)
-
-{% include feature-state-deprecated.md %}
-
-Kubernetes version 1.5 introduces Opaque integer resources. Opaque
-integer resources allow cluster operators to advertise new node-level
-resources that would be otherwise unknown to the system.
-
-Users can consume these resources in Pod specs just like CPU and memory.
-The scheduler takes care of the resource accounting so that no more than the
-available amount is simultaneously allocated to Pods.
-
-**Note:** Opaque Integer Resources will be removed in version 1.9.
-[Extended Resources](#extended-resources) are a replacement for Opaque Integer
-Resources. Users can use any domain name prefix outside of the `kubernetes.io/`
-domain instead of the previous `pod.alpha.kubernetes.io/opaque-int-resource-`
-prefix.
-{: .note}
-
-Opaque integer resources are resources that begin with the prefix
-`pod.alpha.kubernetes.io/opaque-int-resource-`. The API server
-restricts quantities of these resources to whole numbers. Examples of
-_valid_ quantities are `3`, `3000m` and `3Ki`. Examples of _invalid_
-quantities are `0.5` and `1500m`.
-
-There are two steps required to use opaque integer resources. First, the
-cluster operator must advertise a per-node opaque resource on one or more
-nodes. Second, users must request the opaque resource in Pods.
-
-To advertise a new opaque integer resource, the cluster operator should
-submit a `PATCH` HTTP request to the API server to specify the available
-quantity in the `status.capacity` for a node in the cluster. After this
-operation, the node's `status.capacity` will include a new resource. The
-`status.allocatable` field is updated automatically with the new resource
-asynchronously by the kubelet. Note that because the scheduler uses the
-node `status.allocatable` value when evaluating Pod fitness, there may
-be a short delay between patching the node capacity with a new resource and the
-first pod that requests the resource to be scheduled on that node.
-
-**Example:**
-
-Here is an example showing how to use `curl` to form an HTTP request that
-advertises five "foo" resources on node `k8s-node-1` whose master is
-`k8s-master`.
-
-```shell
-curl --header "Content-Type: application/json-patch+json" \
---request PATCH \
---data '[{"op": "add", "path": "/status/capacity/pod.alpha.kubernetes.io~1opaque-int-resource-foo", "value": "5"}]' \
-http://k8s-master:8080/api/v1/nodes/k8s-node-1/status
-```
-
-**Note**: In the preceding request, `~1` is the encoding for the character `/`
-in the patch path. The operation path value in JSON-Patch is interpreted as a
-JSON-Pointer. For more details, see
-[IETF RFC 6901, section 3](https://tools.ietf.org/html/rfc6901#section-3).
-
-To consume an opaque resource in a Pod, include the name of the opaque
-resource as a key in the `spec.containers[].resources.requests` map.
-
-The Pod is scheduled only if all of the resource requests are
-satisfied, including cpu, memory and any opaque resources. The Pod will
-remain in the `PENDING` state as long as the resource request cannot be met by
-any node.
-
-**Example:**
-
-The Pod below requests 2 cpus and 1 "foo" (an opaque resource.)
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: my-pod
-spec:
-  containers:
-  - name: my-container
-    image: myimage
-    resources:
-      requests:
-        cpu: 2
-        pod.alpha.kubernetes.io/opaque-int-resource-foo: 1
-```
-
 ## Extended Resources
 
 Kubernetes version 1.8 introduces Extended Resources. Extended Resources are
@@ -467,8 +383,8 @@ The API server restricts quantities of Extended Resources to whole numbers.
 Examples of _valid_ quantities are `3`, `3000m` and `3Ki`. Examples of
 _invalid_ quantities are `0.5` and `1500m`.
 
-**Note:** Extended Resources replace [Opaque Integer
-Resources](#opaque-integer-resources-alpha-feature). Users can use any domain
+**Note:** Extended Resources replace Opaque Integer
+Resources. Users can use any domain
 name prefix outside of the `kubernetes.io/` domain instead of the previous
 `pod.alpha.kubernetes.io/opaque-int-resource-` prefix.
 {: .note}


### PR DESCRIPTION
Existing OIR tasks were ported to use extended resources instead in #6531. This PR removes the remaining opaque integer resource documentation. This feature was deprecated in v1.8 and removed in v1.9.

Please cherry-pick this to the v1.9 docs branch post merge.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6700)
<!-- Reviewable:end -->
