### PR TITLE
Fix Extended Resources consumption documentation

### DIFF
--- a/docs/concepts/configuration/manage-compute-resources-container.md
+++ b/docs/concepts/configuration/manage-compute-resources-container.md
@@ -507,7 +507,7 @@ JSON-Pointer. For more details, see
 {: .note}
 
 To consume an Extended Resource in a Pod, include the resource name as a key
-in the `spec.containers[].resources.requests` map.
+in the `spec.containers[].resources.limits` map in the container spec.
 
 **Note:** Extended resources cannot be overcommitted, so request and limit
 must be equal if both are present in a container spec.
@@ -534,6 +534,8 @@ spec:
     resources:
       requests:
         cpu: 2
+        example.com/foo: 1
+      limits:
         example.com/foo: 1
 ```
 

--- a/docs/tasks/configure-pod-container/extended-resource-pod-2.yaml
+++ b/docs/tasks/configure-pod-container/extended-resource-pod-2.yaml
@@ -9,3 +9,5 @@ spec:
     resources:
       requests:
         example.com/dongle: 2
+      limits:
+        example.com/dongle: 2

--- a/docs/tasks/configure-pod-container/extended-resource-pod.yaml
+++ b/docs/tasks/configure-pod-container/extended-resource-pod.yaml
@@ -9,3 +9,5 @@ spec:
     resources:
       requests:
         example.com/dongle: 3
+      limits:
+        example.com/dongle: 3

--- a/docs/tasks/configure-pod-container/extended-resource.md
+++ b/docs/tasks/configure-pod-container/extended-resource.md
@@ -59,6 +59,8 @@ kubectl describe pod extended-resource-demo
 The output shows dongle requests:
 
 ```yaml
+Limits:
+  example.com/dongle: 3
 Requests:
   example.com/dongle: 3
 ```


### PR DESCRIPTION
Current documentation suggests that it is valid to mention only the `resource.Requests` in the container spec and `resource.Limits` is optional to include. This is not correct. Extended resources are not allowed to be overcommitted and `Requests` only means, implicitly, that container is allowed to consume all the available resources from the node, which is contradictory to the former.
This part is being corrected in this PR.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

/cc @vishh @ConnorDoyle @jiayingz @derekwaynecarr

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6708)
<!-- Reviewable:end -->
