### PR TITLE
Add conditional for versioned url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,27 +27,27 @@ defaults:
           version: "v1.9"
           githubbranch: "v1.9.0"
           docsbranch: "release-1.9"
-          url: https://kubernetes.io/docs/home/
+          url: https://kubernetes.io
         - fullversion: "v1.8.4"
           version: "v1.8"
           githubbranch: "v1.8.4"
           docsbranch: "release-1.8"
-          url: https://v1-8.docs.kubernetes.io/docs/home/
+          url: https://v1-8.docs.kubernetes.io
         - fullversion: "v1.7.6"
           version: "v1.7"
           githubbranch: "v1.7.6"
           docsbranch: "release-1.7"
-          url: https://v1-7.docs.kubernetes.io/docs/home/
+          url: https://v1-7.docs.kubernetes.io
         - fullversion: "v1.6.8"
           version: "v1.6"
           githubbranch: "v1.6.8"
           docsbranch: "release-1.6"
-          url: https://v1-6.docs.kubernetes.io/docs/home/
+          url: https://v1-6.docs.kubernetes.io
         - fullversion: "v1.5.7"
           version: "v1.5"
           githubbranch: "v1.5.7"
           docsbranch: "release-1.5"
-          url: https://v1-5.docs.kubernetes.io/docs/
+          url: https://v1-5.docs.kubernetes.io
       deprecated: false
       currentUrl: https://kubernetes.io/docs/home/
       nextUrl: http://kubernetes-io-vnext-staging.netlify.com/

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -16,7 +16,11 @@
                 </a>
                 <ul>
                 {% for version in page.versions %}
-                  <li><a href="{{ version.url }}">{{ version.version }}</a></li>
+                    {% if page.versionedurl contains version.version %}
+                    <li><a href="{{ version.url }}{{ page.versionedurl[version.version] }}">{{ version.version }}</a></li>
+                    {% else  %}
+                    <li><a href="{{ version.url }}{{ page.url }}">{{ version.version }}</a></li>
+                    {% endif %}
                 {% endfor %}
                 </ul>
               </li>


### PR DESCRIPTION
Checks an additional variable named versionedurl for the version name,
and uses the value as the url to reference. If the versionedurl doesn't
contain an entry for the version the current path is used.

e.g. Adding the below variable to the yaml frontmatter of a page will redirect those versions to alternative pages.
 
```
versionedurl:
  v1.8: /docs/home
  v1.7: /docs/old-path-to-doc
```

An attempt to resolve #5930.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6712)
<!-- Reviewable:end -->
