### PR TITLE
Update Scheduling GPUs document to use device plugins

### DIFF
--- a/docs/tasks/manage-gpus/scheduling-gpus.md
+++ b/docs/tasks/manage-gpus/scheduling-gpus.md
@@ -6,18 +6,44 @@ title: Schedule GPUs
 
 {% capture overview %}
 
-Kubernetes includes **experimental** support for managing NVIDIA GPUs spread across nodes.
-This page describes how users can consume GPUs and the current limitations.
+{% include feature-state-alpha.md %}
+
+Kubernetes includes **experimental** support for managing NVIDIA GPUs spread across nodes using the device plugins alpha feature.
+This page describes NVIDIA's supported method on how users can consume GPUs as well as the current limitations.
+
+Starting in version 1.8, Kubernetes provides a [device plugin framework](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/resource-management/device-plugin.md)
+for vendors to advertise their resources to the kubelet without changing Kubernetes core code.
+
+Instead of writing custom Kubernetes code, vendors can implement a device plugin that can be deployed manually or as a DaemonSet.
+The targeted devices include GPUs, High-performance NICs, FPGAs, InfiniBand, and other similar computing resources that may require vendor specific initialization and setup.
 
 {% endcapture %}
 
 {% capture prerequisites %}
 
-1. Kubernetes nodes have to be pre-installed with Nvidia drivers. Kubelet will not detect Nvidia GPUs otherwise. Try to re-install Nvidia drivers if kubelet fails to expose Nvidia GPUs as part of Node Capacity. After installing the driver, run `nvidia-docker-plugin` to confirm that all drivers have been loaded.
-2. A special **alpha** feature gate `Accelerators` has to be set to true across the system: `--feature-gates="Accelerators=true"`.
-3. Nodes must be using `docker engine` as the container runtime.
+The list of prerequisites for using NVIDIA GPUs is described below:
+1. Kubernetes version needs to be greater than version 1.8
+2. Kubernetes nodes have to be pre-installed with NVIDIA drivers.
+3. Kubernetes nodes have to be pre-installed with [nvidia-docker 2.0](https://github.com/NVIDIA/nvidia-docker)
+4. The `DevicePlugins` feature gate enabled
+5. docker configured as the [default runtime](https://github.com/NVIDIA/nvidia-docker/wiki/Advanced-topics#default-runtime).
+6. NVIDIA drivers ~= 361.93
 
-The nodes will automatically discover and expose all Nvidia GPUs as a schedulable resource.
+Finally, once your cluster is running you will have to deploy the NVIDIA device plugin:
+```
+$ # This command is for Kubernetes v1.8
+$ kubectl create -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v1.8/nvidia-device-plugin.yml
+
+$ # This command is for Kubernetes v1.9
+$ kubectl create -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v1.9/nvidia-device-plugin.yml
+```
+
+Once you have accomplished all these steps, the nodes will automatically discover and expose
+all NVIDIA GPUs as a schedulable resource as well as expose the GPUs correctly in your container.
+
+Please note that GKE offers a different device plugin that auto installs the NVIDIA driver and does not
+require nvidia-docker at: [https://github.com/GoogleCloudPlatform/container-engine-accelerators](https://github.com/GoogleCloudPlatform/container-engine-accelerators).
+It only works on COS and support is handled by the GKE GPU team.
 
 {% endcapture %}
 
@@ -25,28 +51,29 @@ The nodes will automatically discover and expose all Nvidia GPUs as a schedulabl
 
 ## API
 
-Nvidia GPUs can be consumed via container level resource requirements using the resource name `alpha.kubernetes.io/nvidia-gpu`.
+NVIDIA GPUs can be consumed via container level resource requirements using the resource name `nvidia.com/gpu`.
 
 ```yaml
 apiVersion: v1
-kind: Pod 
+kind: Pod
 metadata:
   name: gpu-pod
-spec: 
-  containers: 
-    - 
-      name: gpu-container-1
-      image: gcr.io/google_containers/pause:2.0
-      resources: 
-        limits: 
-          alpha.kubernetes.io/nvidia-gpu: 2 # requesting 2 GPUs
-    -
-      name: gpu-container-2
-      image: gcr.io/google_containers/pause:2.0
-      resources: 
-        limits: 
-          alpha.kubernetes.io/nvidia-gpu: 3 # requesting 3 GPUs
+spec:
+  containers:
+    - name: cuda-container
+      image: nvidia/cuda:9.0
+      resources:
+        limits:
+          nvidia.com/gpu: 2 # requesting 2 GPUs
+    - name: digits-container
+      image: nvidia/digits:6.0
+      resources:
+        limits:
+          nvidia.com/gpu: 2 # requesting 2 GPUs
 ```
+
+You can also use GPUs in `InitContainers` but this is not supported by the NVIDIA device plugin
+as it's usage can lead to weird behavior in case of GPU errors or container crash as the state is not reset.
 
 - GPUs are only supposed to be specified in the `limits` section, which means:
   * You can specify GPU `limits` without specifying `requests` because Kubernetes
@@ -104,53 +131,13 @@ spec:
           alpha.kubernetes.io/nvidia-gpu: 2
 ```
 
-This will ensure that the pod will be scheduled to a node that has a `Tesla K80` or a `Tesla P100` Nvidia GPU.
-
-### Warning
-
-The API presented here **will change** in an upcoming release to better support GPUs, and hardware accelerators in general, in Kubernetes.
-
-## Access to CUDA libraries
-
-As of now, CUDA libraries are expected to be pre-installed on the nodes.
-
-To mitigate this, you can copy the libraries to a more permissive folder in ``/var/lib/`` or change the permissions directly. (Future releases will automatically perform this operation)
-
-Pods can access the libraries using `hostPath` volumes.
-
-```yaml
-kind: Pod
-apiVersion: v1
-metadata:
-  name: gpu-pod
-spec:
-  containers:
-  - name: gpu-container-1
-    image: gcr.io/google_containers/pause:2.0
-    resources:
-      limits:
-        alpha.kubernetes.io/nvidia-gpu: 1
-    volumeMounts:
-    - mountPath: /usr/local/nvidia/bin
-      name: bin
-    - mountPath: /usr/lib/nvidia
-      name: lib
-  volumes:
-  - hostPath:
-      path: /usr/lib/nvidia-375/bin
-    name: bin
-  - hostPath:
-      path: /usr/lib/nvidia-375
-    name: lib
-```
+This will ensure that the pod will be scheduled to a node that has a `Tesla K80` or a `Tesla P100` NVIDIA GPU.
 
 ## Future
 
-- Support for hardware accelerators is in its early stages in Kubernetes.
-- GPUs and other accelerators will soon be a native compute resource across the system.
+- Support for hardware accelerators is in its early stages in Kubernetes but is expected to graduate to beta in 1.10.
 - Better APIs will be introduced to provision and consume accelerators in a scalable manner.
 - Kubernetes will automatically ensure that applications consuming GPUs get the best possible performance.
-- Key usability problems like access to CUDA libraries will be addressed.
 
 {% endcapture %}
 


### PR DESCRIPTION
Hello!

- [X] Uncheck / Recheck Allow edits from maintainers

I've created this PR so that the documents now use the DevicePlugins options rather than the Accelerators options that we plan to deprecate as soon as DevicePlugins graduates to beta.

Also added the NVIDIA supported and recommended way to deploy the device plugin as well as the GKE one (though I don't know a lot about it).

[Link to the edited page](https://deploy-preview-6722--kubernetes-io-master-staging.netlify.com/docs/tasks/manage-gpus/scheduling-gpus/)

Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6722)
<!-- Reviewable:end -->
