### PR TITLE
PID namespace sharing is already available in docker

### DIFF
--- a/docs/concepts/workloads/pods/pod.md
+++ b/docs/concepts/workloads/pods/pod.md
@@ -40,7 +40,7 @@ filesystem.
 
 In terms of [Docker](https://www.docker.com/) constructs, a pod is modelled as
 a group of Docker containers with shared namespaces and shared
-[volumes](/docs/concepts/storage/volumes/). PID namespace sharing is not yet implemented in Docker.
+[volumes](/docs/concepts/storage/volumes/). 
 
 Like individual application containers, pods are considered to be relatively
 ephemeral (rather than durable) entities. As discussed in [life of a


### PR DESCRIPTION
Official documentation: https://docs.docker.com/engine/reference/run/#pid-settings-pid

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6727)
<!-- Reviewable:end -->
