### PR TITLE
Update web.yaml

### DIFF
--- a/docs/tutorials/stateful-application/web.yaml
+++ b/docs/tutorials/stateful-application/web.yaml
@@ -12,7 +12,7 @@ spec:
   selector:
     app: nginx
 ---
-apiVersion: apps/v1
+apiVersion: apps/v1beta2
 kind: StatefulSet
 metadata:
   name: web


### PR DESCRIPTION
Fixes the error below when running kubectl create -f web.yaml

Error from server (BadRequest): error when creating "web.yaml": StatefulSet in version "v1" cannot be handled as a StatefulSet: no kind "StatefulSet" is registered for version "apps/v1"

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6742)
<!-- Reviewable:end -->
