### PR TITLE
Bring the "trademark usage" policy link inline

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -28,7 +28,7 @@
             &copy; {{ 'now' | date: "%Y" }} The Kubernetes Authors | Documentation Distributed under <a href="https://git.k8s.io/website/LICENSE" class="light-text">CC BY 4.0</a>
         </div>
         <div id="miceType" class="center">
-            Copyright &copy; {{ 'now' | date: "%Y" }} The Linux Foundation&reg;. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our Trademark Usage page: <a href="https://www.linuxfoundation.org/trademark-usage" class="light-text">https://www.linuxfoundation.org/trademark-usage</a>
+            Copyright &copy; {{ 'now' | date: "%Y" }} The Linux Foundation&reg;. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage" class="light-text">Trademark Usage page</a>
         </div>
     </main>
 </footer>


### PR DESCRIPTION
Make the 'trademark usage page' a hyperlink, thus removing the display of the raw URL (and condensing the footer from three lines to two.)

I assume there is some legalese reason why this has to be on Every Page, but other Collaborative Projects don't have it at all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6753)
<!-- Reviewable:end -->
