### PR TITLE
Clarify the meaning of 'ServiceIP' in diagrams

### DIFF
--- a/docs/concepts/services-networking/service.md
+++ b/docs/concepts/services-networking/service.md
@@ -171,6 +171,8 @@ By default, the choice of backend is round robin.
 
 ![Services overview diagram for userspace proxy](/images/docs/services-userspace-overview.svg)
 
+Note that in the above diagram, `clusterIP` is shown as `ServiceIP`.
+
 ### Proxy-mode: iptables
 
 In this mode, kube-proxy watches the Kubernetes master for the addition and
@@ -187,6 +189,8 @@ userspace proxier, the iptables proxier cannot automatically retry another
 having working [readiness probes](/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#defining-readiness-probes).
 
 ![Services overview diagram for iptables proxy](/images/docs/services-iptables-overview.svg)
+
+Note that in the above diagram, `clusterIP` is shown as `ServiceIP`.
 
 ### Proxy-mode: ipvs
 


### PR DESCRIPTION
This PR is to address the concern about labels used in service diagrams.
The PR adds a note to explain the `ServiceIP` shown in the figure
instead of redrawing and pushing a new diagram.

Closes: #1286
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6770)
<!-- Reviewable:end -->
