### PR TITLE
Fix apiVersion used for ClusterRole

### DIFF
--- a/cn/docs/concepts/architecture/cloud-controller.md
+++ b/cn/docs/concepts/architecture/cloud-controller.md
@@ -172,7 +172,7 @@ v1/ServiceAccount:
 针对CCM的RBAC ClusterRole如下所示：
 
 ```yaml
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cloud-controller-manager

--- a/docs/concepts/architecture/cloud-controller.md
+++ b/docs/concepts/architecture/cloud-controller.md
@@ -174,7 +174,7 @@ v1/ServiceAccount:
 The RBAC ClusterRole for the CCM looks like this:
 
 ```yaml
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cloud-controller-manager


### PR DESCRIPTION
The rbac.authorization.k8s.io API group has graduated to v1 GA. We should encourage users to use this GA version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6774)
<!-- Reviewable:end -->
