### PR TITLE
docs/tasks: Add hyperkit to hypervisor list

### DIFF
--- a/docs/tasks/tools/install-minikube.md
+++ b/docs/tasks/tools/install-minikube.md
@@ -23,7 +23,8 @@ If you do not already have a hypervisor installed, install one now.
 * For OS X, install
 [xhyve driver](https://git.k8s.io/minikube/docs/drivers.md#xhyve-driver),
 [VirtualBox](https://www.virtualbox.org/wiki/Downloads), or
-[VMware Fusion](https://www.vmware.com/products/fusion).
+[VMware Fusion](https://www.vmware.com/products/fusion), or
+[HyperKit](https://github.com/moby/hyperkit).
 
 * For Linux, install
 [VirtualBox](https://www.virtualbox.org/wiki/Downloads) or


### PR DESCRIPTION
Add the hyperkit to the list of hypervisor supported in OSX and mark
xhyve as deprecated, following what it has been sent in PR https://github.com/kubernetes/website/pull/6639

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6779)
<!-- Reviewable:end -->
