### PR TITLE
Delete 'port' for more clarity

### DIFF
--- a/docs/concepts/containers/container-environment-variables.md
+++ b/docs/concepts/containers/container-environment-variables.md
@@ -41,7 +41,7 @@ as are any environment variables specified statically in the Docker image.
 A list of all services that were running when a Container was created is available to that Container as environment variables.
 Those environment variables match the syntax of Docker links.
 
-For a service named *foo* that maps to a container port named *bar*,
+For a service named *foo* that maps to a container named *bar*,
 the following variables are defined:
 
 ```shell


### PR DESCRIPTION
Imho, it is more understandable without 'port', i.e. a service maps to a container and not to a port

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6781)
<!-- Reviewable:end -->
