### PR TITLE
Cascading deletion policy correction

### DIFF
--- a/docs/concepts/workloads/controllers/garbage-collection.md
+++ b/docs/concepts/workloads/controllers/garbage-collection.md
@@ -102,8 +102,8 @@ the background.
 
 ### Setting the cascading deletion policy
 
-To control the cascading deletion policy, set the `deleteOptions.propagationPolicy`
-field on your owner object. Possible values include "Orphan",
+To control the cascading deletion policy, set the `propagationPolicy`
+field on the `deleteOptions` argument when deleting an Object. Possible values include "Orphan",
 "Foreground", or "Background".
 
 Prior to Kubernetes 1.9, the default garbage collection policy for many controller resources was `orphan`.


### PR DESCRIPTION
In the previous version it read as if you could specify the `propagationPolicy` on the Object itself,
which isn't possible.

Change the documentation to make it clear that the `propagationPolicy` is set on the `deleteOptions`
argument when invoking a Object deletion function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6784)
<!-- Reviewable:end -->
