### PR TITLE
Update NVIDIA device plugin runtime installation link

### DIFF
--- a/docs/tasks/manage-gpus/scheduling-gpus.md
+++ b/docs/tasks/manage-gpus/scheduling-gpus.md
@@ -131,7 +131,7 @@ The [official NVIDIA GPU device plugin](https://github.com/NVIDIA/k8s-device-plu
 has the following requirements:
 - Kubernetes nodes have to be pre-installed with NVIDIA drivers.
 - Kubernetes nodes have to be pre-installed with [nvidia-docker 2.0](https://github.com/NVIDIA/nvidia-docker)
-- nvidia-container-runtime must be configured as the [default runtime](https://github.com/NVIDIA/nvidia-docker/wiki/Advanced-topics#default-runtime)
+- nvidia-container-runtime must be configured as the [default runtime](https://github.com/NVIDIA/k8s-device-plugin#preparing-your-gpu-nodes)
   for docker instead of runc.
 - NVIDIA drivers ~= 361.93
 


### PR DESCRIPTION
Hello!

- [x] Uncheck / Recheck Allow edits from maintainers

Small update to the driver links as our github page now explains in more detail how to set the nvidia runtime as the default one.

[Link to the updated document](https://deploy-preview-6795--kubernetes-io-master-staging.netlify.com/docs/tasks/manage-gpus/scheduling-gpus/)

cc @jiayingz @vishh @mindprince 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6795)
<!-- Reviewable:end -->
