### PR TITLE
Fix the version number which include ipvs feture.

### DIFF
--- a/docs/concepts/services-networking/service.md
+++ b/docs/concepts/services-networking/service.md
@@ -154,7 +154,7 @@ than `ExternalName`.
 In Kubernetes v1.0, `Services` are a "layer 4" (TCP/UDP over IP) construct, the 
 proxy was purely in userspace.  In Kubernetes v1.1, the `Ingress` API was added
 (beta) to represent "layer 7"(HTTP) services, iptables proxy was added too, 
-and become the default operating mode since Kubernetes v1.2. In Kubernetes v1.8-beta,
+and become the default operating mode since Kubernetes v1.2. In Kubernetes v1.8.0-beta.0,
 ipvs proxy was added.
 
 ### Proxy-mode: userspace

--- a/docs/concepts/services-networking/service.md
+++ b/docs/concepts/services-networking/service.md
@@ -154,7 +154,7 @@ than `ExternalName`.
 In Kubernetes v1.0, `Services` are a "layer 4" (TCP/UDP over IP) construct, the 
 proxy was purely in userspace.  In Kubernetes v1.1, the `Ingress` API was added
 (beta) to represent "layer 7"(HTTP) services, iptables proxy was added too, 
-and become the default operating mode since Kubernetes v1.2. In Kubernetes v1.9-alpha,
+and become the default operating mode since Kubernetes v1.2. In Kubernetes v1.8-beta,
 ipvs proxy was added.
 
 ### Proxy-mode: userspace


### PR DESCRIPTION
The tag v1.8.0-beta.0 and v1.9.0-alpha.0 are most the same time.

But this sentence.“In Kubernetes v1.9-alpha, ipvs proxy was added.”, may be misleading: the ipvs feture added until release 1.9, actually, release 1.8 include it.

Modify the descriptions in order to let people know that release 1.8 already contains this feature and can try it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6800)
<!-- Reviewable:end -->
