### PR TITLE
Add ppc64le arch to weave net

### DIFF
--- a/docs/setup/independent/create-cluster-kubeadm.md
+++ b/docs/setup/independent/create-cluster-kubeadm.md
@@ -332,7 +332,7 @@ please see [here](https://kubernetes.io/docs/concepts/cluster-administration/net
 
 The official Weave Net set-up guide is [here](https://www.weave.works/docs/net/latest/kube-addon/).
 
-**Note:** Weave Net works on `amd64`, `arm` and `arm64` without any extra action required.
+**Note:** Weave Net works on `amd64`, `arm`, `arm64` and `ppc64le` without any extra action required.
 Weave Net sets hairpin mode by default. This allows Pods to access themselves via their Service IP address
 if they don't know their PodIP.
 


### PR DESCRIPTION
Now `ppc64le` arch is supported from `weaveworks/weave:2.1.0` version, so doc needs to be updated with architecture support, hence submitting this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6814)
<!-- Reviewable:end -->
