### PR TITLE
Update double quotes format in yaml section

### DIFF
--- a/docs/tasks/administer-cluster/dns-custom-nameservers.md
+++ b/docs/tasks/administer-cluster/dns-custom-nameservers.md
@@ -73,9 +73,9 @@ metadata:
   namespace: kube-system
 data:
   stubDomains: |
-    {“acme.local”: [“1.2.3.4”]}
+    {"acme.local": ["1.2.3.4"]}
   upstreamNameservers: |
-    [“8.8.8.8”, “8.8.4.4”]
+    ["8.8.8.8", "8.8.4.4"]
 ```
 
 As specified, DNS requests with the “.acme.local” suffix
@@ -158,7 +158,7 @@ metadata:
   namespace: kube-system
 data:
   stubDomains: |
-    {“consul.local”: [“10.150.0.1”]}
+    {"consul.local": ["10.150.0.1"]}
 ```
 
 Note that the cluster administrator did not wish to override the node’s
@@ -180,7 +180,7 @@ metadata:
   namespace: kube-system
 data:
   upstreamNameservers: |
-    [“172.16.0.1”]
+    ["172.16.0.1"]
 ```
 
 ## Debugging DNS resolution


### PR DESCRIPTION
Update double quotes format in yaml to avoid issue on copy/paste action :-)

I lost 1 hour before seeing the issue of double quotes format in my yaml file through the logs
=> kubectl logs --namespace=kube-system $(kubectl get pods --namespace=kube-system -l k8s-app=kube-dns -o name) -c kubedns

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6835)
<!-- Reviewable:end -->
