### PR TITLE
Add OWNERS_ALIASES for SIG reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -32,7 +32,7 @@ aliases:
   sig-contributor-experience:
     - sig-contributor-experience-pr-reviews
   sig-docs:
-    - sig-docs-maintainers
+    - sig-docs-pr-reviews
   sig-federation: #Federation: Federated Clusters
     - csbell
   sig-gcp:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,79 @@
+aliases:
+  sig-api-machinery: #API Server: Annotations, Labels
+    - sig-api-machinery-pr-reviews
+  sig-apps: #Workloads: ConfigMaps, CronJobs, CustomResourceDefinitions, DaemonSets, Deployments, Jobs, Secrets, StatefulSets
+    - sig-apps-pr-reviews
+  sig-architecture:
+    - sig-architecture-pr-reviews
+  sig-auth:
+    - sig-auth-pr-reviews
+  sig-autoscaling:
+    - sig-autoscaling-pr-reviews
+  sig-aws:
+    - justinsb
+    - kris-nova
+    - chrislovecnm
+    - mfburnett
+  sig-azure:
+    - slack
+    - colemickens
+    - jdumars
+  sig-big-data:
+    - sig-big-data-pr-reviews
+  sig-cli: #CLI: kubectl
+    - sig-cli-pr-reviews
+  sig-cluster-lifecycle:
+    - sig-cluster-lifecycle-pr-reviews
+  sig-cluster-ops:
+    - zehicle
+    - jdumars
+  sig-contribex:
+    - sig-contributor-experience-pr-reviews
+  sig-contributor-experience:
+    - sig-contributor-experience-pr-reviews
+  sig-docs:
+    - sig-docs-maintainers
+  sig-federation: #Federation: Federated Clusters
+    - csbell
+  sig-gcp:
+    - sig-gcp-pr-reviews
+  sig-instrumentation:
+    - sig-instrumentation-pr-reviews
+  sig-multicluster:
+    - sig-multicluster-pr-reviews
+  sig-network: #Network: Ingress, Network Policies, Services
+    - sig-network-pr-reviews
+  sig-node: #Node: Containers, Docker, Images, OS images, Pods, Registries
+    - sig-node-pr-reviews
+  sig-onprem:
+    - sig-onprem-pr-reviews
+  sig-openstack:
+    - sig-openstack-pr-reviews
+  sig-pm:
+    - apsinha
+    - idvoretskyi
+    - calebamiles
+  sig-product-management:
+    - apsinha
+    - idvoretskyi
+    - calebamiles
+  sig-release:
+    - sig-release-pr-reviews
+  sig-rktnetes:
+    - calebamiles
+  sig-scalability:
+    - sig-scalability-pr-reviews
+  sig-scheduling: #Sharing: Scheduler
+    - sig-scheduling-pr-reviews
+  sig-service-catalog:
+    - sig-service-catalog-pr-reviews
+  sig-storage: #Storage: Volumes
+    - sig-storage-pr-reviews
+  sig-testing:
+    - sig-testing-pr-reviews
+  sig-ui:
+    - danielromlein
+    - floreks
+  sig-windows:
+    - michmike
+

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,55 +1,158 @@
 aliases:
-  sig-api-machinery: #API Server: Annotations, Labels
-    - sig-api-machinery-pr-reviews
-  sig-apps: #Workloads: ConfigMaps, CronJobs, CustomResourceDefinitions, DaemonSets, Deployments, Jobs, Secrets, StatefulSets
-    - sig-apps-pr-reviews
-  sig-architecture:
-    - sig-architecture-pr-reviews
-  sig-auth:
-    - sig-auth-pr-reviews
-  sig-autoscaling:
-    - sig-autoscaling-pr-reviews
-  sig-aws:
+  sig-api-machinery: #Team: API Server; GH: sig-api-machinery-pr-reviews; e.g. Annotations, Labels
+    - lavalamp
+    - sttts
+    - liggitt
+    - smarterclayton
+    - deads2k
+  sig-apps: #Team: Workloads; GH: sig-apps-pr-reviews; e.g. ConfigMaps, CronJobs, CustomResourceDefinitions, DaemonSets, Deployments, Jobs, Secrets, StatefulSets
+    - enisoc
+    - erictune
+    - foxish
+    - janetkuo
+    - kow3ns
+    - lukaszo
+    - mfojtik
+    - smarterclayton
+    - soltysh
+    - tnozicka
+  sig-architecture: #GH: sig-architecture-pr-reviews
+    - smarterclayton
+    - bgrant0607
+  sig-auth: #GH: sig-auth-pr-reviews
+    - php-coder
+    - liggitt
+    - mikedanese
+    - ericchiang
+    - mattmoyer
+    - enj
+    - deads2k
+    - davidopp
+  sig-autoscaling: #GH: sig-autoscaling-pr-reviews
+    - DirectXMan12
+    - bskiba
+    - aleksandra-malinowska
+    - MaciekPytel
+    - davidopp
+    - mwielgus
+  sig-aws: #Amazon AWS
     - justinsb
     - kris-nova
     - chrislovecnm
     - mfburnett
-  sig-azure:
+  sig-azure: #Microsoft Azure
     - slack
     - colemickens
     - jdumars
-  sig-big-data:
-    - sig-big-data-pr-reviews
-  sig-cli: #CLI: kubectl
-    - sig-cli-pr-reviews
-  sig-cluster-lifecycle:
-    - sig-cluster-lifecycle-pr-reviews
+  sig-big-data: #GH: sig-big-data-pr-reviews
+    - foxish
+  sig-cli: #Team: CLI; GH: sig-cli-pr-reviews; e.g. kubectl
+    - adohe
+    - deads2k
+    - derekwaynecarr
+    - dims
+    - dshulyak
+    - eparis
+    - ericchiang
+    - ghodss
+    - mengqiy
+    - rootfs
+    - shiywang
+    - smarterclayton
+    - soltysh
+    - sttts
+  sig-cluster-lifecycle: #GH: sig-cluster-lifecycle-pr-reviews
+    - jbeda
+    - timothysc
+    - lukemarsden
+    - pipejakob
+    - dmmcquay
+    - mattmoyer
+    - luxas
+    - roberthbailey
+    - medinatiger
   sig-cluster-ops:
     - zehicle
     - jdumars
-  sig-contribex:
-    - sig-contributor-experience-pr-reviews
-  sig-contributor-experience:
-    - sig-contributor-experience-pr-reviews
-  sig-docs:
-    - sig-docs-pr-reviews
-  sig-federation: #Federation: Federated Clusters
+  sig-contribex: #aka Contributor Experience; GH: sig-contributor-experience-pr-reviews
+    - rmmh
+    - cblecker
+    - apelisse
+    - grodrigues3
+    - spxtr
+  sig-contributor-experience: #GH: sig-contributor-experience-pr-reviews
+    - rmmh
+    - cblecker
+    - apelisse
+    - grodrigues3
+    - spxtr
+  sig-docs: #Team: documentation; GH: sig-docs-pr-reviews
+    - a-mccarthy
+    - abiogenesis-now
+    - bradamant3
+    - steveperry-53
+    - zacharysarah
+  sig-federation: #Team: Federation; e.g. Federated Clusters
     - csbell
-  sig-gcp:
-    - sig-gcp-pr-reviews
-  sig-instrumentation:
-    - sig-instrumentation-pr-reviews
-  sig-multicluster:
-    - sig-multicluster-pr-reviews
-  sig-network: #Network: Ingress, Network Policies, Services
-    - sig-network-pr-reviews
-  sig-node: #Node: Containers, Docker, Images, OS images, Pods, Registries
-    - sig-node-pr-reviews
-  sig-onprem:
-    - sig-onprem-pr-reviews
-  sig-openstack:
-    - sig-openstack-pr-reviews
-  sig-pm:
+  sig-gcp: #Google Cloud Platform; GH: sig-gcp-pr-reviews
+    - abgworrall
+  sig-instrumentation: #GH: sig-instrumentation-pr-reviews; e.g. metrics, logging, events
+    - DirectXMan12
+    - x13n
+    - kawych
+    - crassirostris
+    - brancz
+    - fabxc
+    - loburm
+    - piosz
+    - fgrzadkowski
+  sig-multicluster: #GH: sig-multicluster-pr-reviews; e.g. resiliency against availability zone outages; hybrid clouds; spanning multiple cloud providers; migration to public clouds
+    - madhusudancs
+    - marun
+    - jianhuiz
+    - shashidharatd
+    - nikhiljindal
+    - quinton-hoole
+    - mwielgus
+    - csbell
+  sig-network: #Team: Network; GH: sig-network-pr-reviews; e.g. Ingress, Network Policies, Services
+    - bowei
+    - caseydavenport
+    - danwinship
+    - dcbw
+    - dnardo
+    - freehan
+    - mrhohn
+    - nicksardo
+    - thockin
+  sig-node: #Team: Node; GH: sig-node-pr-reviews; e.g. Containers, Docker, Images, OS images, Pods, Registries
+    - Random-Liu
+    - dashpole
+    - dchen1107
+    - derekwaynecarr
+    - dims
+    - feiskyer
+    - mtaufen
+    - ncdc
+    - pmorie
+    - resouer
+    - sjpotter
+    - tallclair
+    - tmrts
+    - vishh
+    - yifan-gu
+    - yujuhong
+  sig-onprem: #On-premises; GH: sig-onprem-pr-reviews
+    - zen
+    - idvoretskyi
+    - pigmej
+    - feiskyer
+    - nebril
+  sig-openstack: #GH: sig-openstack-pr-reviews
+    - idvoretskyi
+    - xsgordon
+    - NickrenREN
+  sig-pm: #aka Product Management
     - apsinha
     - idvoretskyi
     - calebamiles
@@ -57,21 +160,45 @@ aliases:
     - apsinha
     - idvoretskyi
     - calebamiles
-  sig-release:
-    - sig-release-pr-reviews
+  sig-release: #GH: sig-release-pr-reviews
+    - calebamiles
+    - enisoc
+    - pwittrock
   sig-rktnetes:
     - calebamiles
-  sig-scalability:
-    - sig-scalability-pr-reviews
-  sig-scheduling: #Sharing: Scheduler
-    - sig-scheduling-pr-reviews
-  sig-service-catalog:
-    - sig-service-catalog-pr-reviews
-  sig-storage: #Storage: Volumes
-    - sig-storage-pr-reviews
-  sig-testing:
-    - sig-testing-pr-reviews
-  sig-ui:
+  sig-scalability: #GH: sig-scalability-pr-reviews
+    - jbeda
+    - spiffxp
+    - lavalamp
+    - countspongebob
+  sig-scheduling: #Team: Sharing; GH: sig-scheduling-pr-reviews; e.g. Scheduler
+    - bsalamat
+    - davidopp
+    - jayunit100
+    - k82cn
+    - resouer
+    - timothysc
+    - wojtek-t
+  sig-service-catalog: #GH: sig-service-catalog-pr-reviews; e.g. Service Broker
+    - pmorie
+    - jessfraz
+    - pwittrock
+    - droot
+    - seans3
+  sig-storage: #Team: Storage; GH: sig-storage-pr-reviews; e.g. Volumes
+    - childsb
+    - jsafrane
+    - rootfs
+    - saad-ali
+    - matchstick
+    - msau42
+  sig-testing: #GH: sig-testing-pr-reviews
+    - fejta
+    - ixdy
+    - rmmh
+    - spiffxp
+    - spxtr
+  sig-ui: #User Interface
     - danielromlein
     - floreks
   sig-windows:


### PR DESCRIPTION
This mimics the [OWNERS_ALIASES](https://github.com/kubernetes/kubernetes/blob/master/OWNERS_ALIASES) mechanism in [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes) repo to help automate the assignment of PR reviewers. The list of SIGs and their corresponding `*-pr-reviews` aliases were taken from the [kubernetes/community](https://github.com/kubernetes/community) repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6837)
<!-- Reviewable:end -->

  