### PR TITLE
Name should not be specified in pod template

### DIFF
--- a/docs/concepts/workloads/controllers/job.yaml
+++ b/docs/concepts/workloads/controllers/job.yaml
@@ -4,8 +4,6 @@ metadata:
   name: pi
 spec:
   template:
-    metadata:
-      name: pi
     spec:
       containers:
       - name: pi

--- a/docs/concepts/workloads/controllers/jobs-run-to-completion.md
+++ b/docs/concepts/workloads/controllers/jobs-run-to-completion.md
@@ -240,8 +240,6 @@ spec:
   backoffLimit: 5
   activeDeadlineSeconds: 100
   template:
-    metadata:
-      name: pi
     spec:
       containers:
       - name: pi


### PR DESCRIPTION
`name` specified in pod templates will be silently ignored upon pod creation. Remove it to reduce confusion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6839)
<!-- Reviewable:end -->
