### PR TITLE
Fix reference to ConfigMap on the kubernetes.io homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@ cid: home
                     wrong, Kubernetes will rollback the change for you. Take advantage of a growing ecosystem of deployment solutions.</p>
             </div>
             <div>
-                <h4><a href="/docs/concepts/configuration/secret/">Secret</a> and <a href="/docs/tasks/configure-pod-container/configmap/">configuration</a> management</h4>
+                <h4><a href="/docs/concepts/configuration/secret/">Secret</a> and <a href="/docs/tasks/configure-pod-container/configure-pod-configmap/">configuration</a> management</h4>
                 <p>Deploy and update secrets and application configuration without rebuilding your image and without
                     exposing secrets in your stack configuration.</p>
             </div>


### PR DESCRIPTION
Fix reference to ConfigMap on the kubernetes.io homepage。

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6844)
<!-- Reviewable:end -->
