### PR TITLE
Add Oracle Cloud Infrastructure CCM example link

### DIFF
--- a/docs/tasks/administer-cluster/running-cloud-controller.md
+++ b/docs/tasks/administer-cluster/running-cloud-controller.md
@@ -61,6 +61,7 @@ For cloud controller managers not in Kubernetes core, you can find the respectiv
 
 * [DigitalOcean](https://github.com/digitalocean/digitalocean-cloud-controller-manager)
 * [keepalived](https://github.com/munnerz/keepalived-cloud-provider)
+* [Oracle Cloud Infrastructure](https://github.com/oracle/oci-cloud-controller-manager)
 * [Rancher](https://github.com/rancher/rancher-cloud-controller-manager)
 
 For providers already in Kubernetes core, you can run the in-tree cloud controller manager as a Daemonset in your cluster, use the following as a guideline:


### PR DESCRIPTION
Adds link to newly open-sourced [Oracle Cloud Infrastructure](https://cloud.oracle.com/iaas) (OCI) [cloud controller manager](https://github.com/oracle/oci-cloud-controller-manager).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6846)
<!-- Reviewable:end -->
