### PR TITLE
Update references to scheduler code.

### DIFF
--- a/docs/tasks/administer-cluster/configure-multiple-schedulers.md
+++ b/docs/tasks/administer-cluster/configure-multiple-schedulers.md
@@ -13,7 +13,7 @@ learn how to run multiple schedulers in Kubernetes with an example.
 
 A detailed description of how to implement a scheduler is outside the scope of this
 document. Please refer to the kube-scheduler implementation in
-[plugin/pkg/scheduler](https://github.com/kubernetes/kubernetes/tree/{{page.githubbranch}}/plugin/pkg/scheduler)
+[pkg/scheduler](https://github.com/kubernetes/kubernetes/tree/{{page.githubbranch}}/pkg/scheduler)
 in the Kubernetes source directory for a canonical example.
 
 ### 1. Package the scheduler

--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -56,7 +56,7 @@ import (
 	storage_validation "k8s.io/kubernetes/pkg/apis/storage/validation"
 	"k8s.io/kubernetes/pkg/capabilities"
 	"k8s.io/kubernetes/pkg/registry/batch/job"
-	schedulerapilatest "k8s.io/kubernetes/plugin/pkg/scheduler/api/latest"
+	schedulerapilatest "k8s.io/kubernetes/pkg/scheduler/api/latest"
 )
 
 func validateObject(obj runtime.Object) (errors field.ErrorList) {


### PR DESCRIPTION
The scheduler code was moved in [kubernetes #57852](https://github.com/kubernetes/kubernetes/pull/57852), and we should update docs do reflect the new location.

/sig scheduling
/sig docs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6852)
<!-- Reviewable:end -->
