### PR TITLE
Update pod-security-policy.md

### DIFF
--- a/docs/concepts/policy/pod-security-policy.md
+++ b/docs/concepts/policy/pod-security-policy.md
@@ -127,7 +127,7 @@ paired with system groups to grant access to all pods run in the namespace:
 ```
 
 For more examples of RBAC bindings, see [Role Binding
-Examples](docs/admin/authorization/rbac/#role-binding-examples). For a complete
+Examples](/docs/admin/authorization/rbac#role-binding-examples). For a complete
 example of authorizing a PodSecurityPolicy, see
 [below](#example).
 


### PR DESCRIPTION
Fixes dead link to RBAC authorization page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6853)
<!-- Reviewable:end -->
