### PR TITLE
Fix references to ConfigMap in Tutorials

### DIFF
--- a/docs/admin/federation/index.md
+++ b/docs/admin/federation/index.md
@@ -247,7 +247,7 @@ federation, and
 in your federation DNS.
 
 You can find more details about config maps in general at
-[config map](/docs/tasks/configure-pod-container/configmap/).
+[config map](/docs/tasks/configure-pod-container/configure-pod-configmap/).
 
 ### Kubernetes 1.4 and earlier: Setting federations flag on kube-dns-rc
 

--- a/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -7,7 +7,7 @@ title: Configuring Redis using a ConfigMap
 
 {% capture overview %}
 
-This page provides a real world example of how to configure Redis using a ConfigMap and builds upon the [Using ConfigMap Data in Pods](/docs/tasks/configure-pod-container/configure-pod-configmap/) and [Configure Containers Using a ConfigMap](/docs/tasks/configure-pod-container/configmap/) tasks. 
+This page provides a real world example of how to configure Redis using a ConfigMap and builds upon the [Configure Containers Using a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/) task. 
 
 {% endcapture %}
 
@@ -23,8 +23,7 @@ This page provides a real world example of how to configure Redis using a Config
 {% capture prerequisites %}
 
 * {% include task-tutorial-prereqs.md %}
-* Understand [Using ConfigMap Data in Pods](/docs/tasks/configure-pod-container/configure-pod-configmap/).
-* Understand [Configure Containers Using a ConfigMap](/docs/tasks/configure-pod-container/configmap/).
+* Understand [Configure Containers Using a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/).
 
 {% endcapture %}
 
@@ -120,8 +119,7 @@ You can follow the steps below to configure a Redis cache using data stored in a
 
 {% capture whatsnext %}
 
-* Learn more about [ConfigMaps](/docs/tasks/configure-pod-container/configmap/).
-* See [Using ConfigMap Data in Pods](/docs/tasks/configure-pod-container/configure-pod-configmap).
+* Learn more about [ConfigMaps](/docs/tasks/configure-pod-container/configure-pod-configmap/).
 
 {% endcapture %}
 


### PR DESCRIPTION
Fix references to ConfigMap in Tutorials.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6857)
<!-- Reviewable:end -->
