### PR TITLE
Update scheduling-hugepages.md

### DIFF
--- a/docs/tasks/manage-hugepages/scheduling-hugepages.md
+++ b/docs/tasks/manage-hugepages/scheduling-hugepages.md
@@ -68,12 +68,14 @@ spec:
   than the pod request.
 - Applications that consume huge pages via `shmget()` with `SHM_HUGETLB` must
   run with a supplemental group that matches `proc/sys/vm/hugetlb_shm_group`.
+- Huge page usage in a namespace is controllable via ResourceQuota similar
+to other compute resources like `cpu` or `memory` via the `hugepages-<size>`
+token.
 
 ## Future
 
 - Support container isolation of huge pages in addition to pod isolation.
 - NUMA locality guarantees as a feature of quality of service.
-- ResourceQuota support.
 - LimitRange support.
 
 {% endcapture %}

--- a/docs/tasks/manage-hugepages/scheduling-hugepages.md
+++ b/docs/tasks/manage-hugepages/scheduling-hugepages.md
@@ -69,7 +69,7 @@ spec:
 - Applications that consume huge pages via `shmget()` with `SHM_HUGETLB` must
   run with a supplemental group that matches `proc/sys/vm/hugetlb_shm_group`.
 - Huge page usage in a namespace is controllable via ResourceQuota similar
-to other compute resources like `cpu` or `memory` via the `hugepages-<size>`
+to other compute resources like `cpu` or `memory` using the `hugepages-<size>`
 token.
 
 ## Future


### PR DESCRIPTION
Fix omission from 1.9 documentation where quota support for huge pages was added.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6860)
<!-- Reviewable:end -->
