### PR TITLE
Corrected the typo in the group in runtime-config for ValidatingAdmissionWebhook and MutatingAdmissionWebhook

### DIFF
--- a/docs/admin/admission-controllers.md
+++ b/docs/admin/admission-controllers.md
@@ -321,7 +321,7 @@ If a webhook called by this has side effects (for example, decrementing quota) i
 webhooks or validating admission controllers will permit the request to finish.
 
 If you disable the MutatingAdmissionWebhook, you must also disable the
-`MutatingWebhookConfiguration` object in the `admissionregistration/v1beta1`
+`MutatingWebhookConfiguration` object in the `admissionregistration.k8s.io/v1beta1`
 group/version via the `--runtime-config` flag (both are on by default in
 versions >= 1.9).
 
@@ -522,7 +522,7 @@ If a webhook called by this has side effects (for example, decrementing quota) i
 webhooks or other validating admission controllers will permit the request to finish.
 
 If you disable the ValidatingAdmissionWebhook, you must also disable the
-`ValidatingWebhookConfiguration` object in the `admissionregistration/v1beta1`
+`ValidatingWebhookConfiguration` object in the `admissionregistration.k8s.io/v1beta1`
 group/version via the `--runtime-config` flag (both are on by default in
 versions >= 1.9).
 


### PR DESCRIPTION
Corrected the typo in the group in runtime-config for ValidatingAdmissionWebhook and MutatingAdmissionWebhook. It should be admissionregistration.k8s.io (was admissionregistration).

> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6866)
<!-- Reviewable:end -->
