### PR TITLE
Fix CI issue

### DIFF
--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -56,7 +56,7 @@ import (
 	storage_validation "k8s.io/kubernetes/pkg/apis/storage/validation"
 	"k8s.io/kubernetes/pkg/capabilities"
 	"k8s.io/kubernetes/pkg/registry/batch/job"
-	schedulerapilatest "k8s.io/kubernetes/plugin/pkg/scheduler/api/latest"
+	schedulerapilatest "k8s.io/kubernetes/pkg/scheduler/api/latest"
 )
 
 func validateObject(obj runtime.Object) (errors field.ErrorList) {


### PR DESCRIPTION
The scheduler module has been moved outside of the plugin subdirectory
in the kubernetes/kubernetes project. The gate should change
accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6867)
<!-- Reviewable:end -->
