### PR TITLE
Link to extended resources instead of deprecated opaque integer resources

### DIFF
--- a/docs/concepts/configuration/taint-and-toleration.md
+++ b/docs/concepts/configuration/taint-and-toleration.md
@@ -171,7 +171,7 @@ the special nodes and hence the admission controller should add the toleration.
 To ensure that the pods that need
 the special hardware *only* schedule onto the nodes that have the special hardware, you will need some
 additional mechanism, e.g. you could represent the special resource using
-[opaque integer resources](/docs/concepts/configuration/manage-compute-resources-container/#opaque-integer-resources-alpha-feature)
+[extended resources](/docs/concepts/configuration/manage-compute-resources-container/#extended-resources)
 and request it as a resource in the PodSpec, or you could label the nodes that have
 the special hardware and use node affinity on the pods that need the hardware.
 


### PR DESCRIPTION
Suggest the new feature, extended resoruces.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6868)
<!-- Reviewable:end -->
