### PR TITLE
Update trouble shooting for flannel and vagrant

### DIFF
--- a/docs/setup/independent/troubleshooting-kubeadm.md
+++ b/docs/setup/independent/troubleshooting-kubeadm.md
@@ -164,7 +164,7 @@ kubectl -n ${NAMESPACE} logs ${POD_NAME} -c ${CONTAINER_NAME}
 
 ### Default NIC When using flannel as the pod network in Vagrant
 
-The following error indicates that something was wrong in the pod network:
+The following error might indicate that something was wrong in the pod network:
 
 ```
 Error from server (NotFound): the server could not find the requested resource

--- a/docs/setup/independent/troubleshooting-kubeadm.md
+++ b/docs/setup/independent/troubleshooting-kubeadm.md
@@ -172,6 +172,6 @@ Error from server (NotFound): the server could not find the requested resource
 
 If you're using flannel as the pod network inside vagrant, then you will have to specify the default interface name for flannel.
 
-Vagrant typically assigns two interfaces to all VMs. The first, for which all hosts are assigned the IP address 10.0.2.15, is for external traffic that gets NATed.
+Vagrant typically assigns two interfaces to all VMs. The first, for which all hosts are assigned the IP address `10.0.2.15`, is for external traffic that gets NATed.
 
-This may lead to problems with flannel. By default, flannel selects the first interface on a host. This leads to all hosts thinking they have the same public IP address. To prevent this issue, pass the --iface eth1 flag to flannel so that the second interface is chosen.
+This may lead to problems with flannel. By default, flannel selects the first interface on a host. This leads to all hosts thinking they have the same public IP address. To prevent this issue, pass the `--iface eth1` flag to flannel so that the second interface is chosen.

--- a/docs/setup/independent/troubleshooting-kubeadm.md
+++ b/docs/setup/independent/troubleshooting-kubeadm.md
@@ -161,3 +161,17 @@ kubectl -n ${NAMESPACE} describe pod ${POD_NAME}
 
 kubectl -n ${NAMESPACE} logs ${POD_NAME} -c ${CONTAINER_NAME}
 ```
+
+### Default NIC When using flannel as the pod network in Vagrant
+
+The following error indicates that something was wrong in the pod network:
+
+```
+Error from server (NotFound): the server could not find the requested resource
+```
+
+If you're using flannel as the pod network inside vagrant, then you will have to specify the default interface name for flannel.
+
+Vagrant typically assigns two interfaces to all VMs. The first, for which all hosts are assigned the IP address 10.0.2.15, is for external traffic that gets NATed.
+
+This may lead to problems with flannel. By default, flannel selects the first interface on a host. This leads to all hosts thinking they have the same public IP address. To prevent this issue, pass the --iface eth1 flag to flannel so that the second interface is chosen.


### PR DESCRIPTION
Add trouble shooting for kubeadm with flannel pod network in vagrant


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6870)
<!-- Reviewable:end -->

  