### PR TITLE
Provide command to "untaint" a node

### DIFF
--- a/docs/concepts/configuration/taint-and-toleration.md
+++ b/docs/concepts/configuration/taint-and-toleration.md
@@ -31,6 +31,12 @@ kubectl taint nodes node1 key=value:NoSchedule
 
 places a taint on node `node1`. The taint has key `key`, value `value`, and taint effect `NoSchedule`.
 This means that no pod will be able to schedule onto `node1` unless it has a matching toleration.
+
+To remove the taint added by the command above, you can run:
+```shell
+kubectl taint nodes kube11 key:NoSchedule-
+```
+
 You specify a toleration for a pod in the PodSpec. Both of the following tolerations "match" the
 taint created by the `kubectl taint` line above, and thus a pod with either toleration would be able
 to schedule onto `node1`:


### PR DESCRIPTION
Had a lot of trouble finding the exact way to "un-do" the tainting example provided here. Even the great folks on Slack couldn't provide the correct command to achieve this, even though it seems so trivial now that I know it.  :-)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6885)
<!-- Reviewable:end -->

  