### PR TITLE
add container restart caution when doing upgrade to 1.9

### DIFF
--- a/docs/tasks/administer-cluster/kubeadm-upgrade-1-9.md
+++ b/docs/tasks/administer-cluster/kubeadm-upgrade-1-9.md
@@ -23,6 +23,9 @@ Before proceeding:
 - `kubeadm upgrade` now allows you to upgrade etcd. `kubeadm upgrade` will also upgrade of etcd to 3.1.10 as part of upgrading from v1.8 to v1.9 by default. This is due to the fact that etcd 3.1.10 is the officially validated etcd version for Kubernetes v1.9. The upgrade is handled automatically by kubeadm for you.
 - Note that `kubeadm upgrade` will not touch any of your workloads, only Kubernetes-internal components. As a best-practice you should back up what's important to you. For example, any app-level state, such as a database an app might depend on (like MySQL or MongoDB) must be backed up beforehand.
 
+**Caution:** All the containers will get restarted after the upgrade, due to container spec hash value gets changed.
+{: .caution}
+
 Also, note that only one minor version upgrade is supported. For example, you can only upgrade from 1.8 to 1.9, not from 1.7 to 1.9.
 
 {% endcapture %}


### PR DESCRIPTION
`v1.9.0` has introduced a new field attribute `VolumeDevices` for Container, which is causing the hash value get changed.

Adds explicit warning message when upgrading cluster to 1.9 for operators.

xref kubernetes/kubernetes#53644, kubernetes/kubernetes#57741

/cc @yujuhong @liggitt

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6894)
<!-- Reviewable:end -->
