### PR TITLE
Fixed wrong heading type for Quobyte

### DIFF
--- a/docs/concepts/storage/storage-classes.md
+++ b/docs/concepts/storage/storage-classes.md
@@ -389,7 +389,7 @@ parameters:
   set `imageFormat` to "2". Currently supported features are `layering` only.
   Default is "", and no features are turned on.
 
-#### Quobyte
+### Quobyte
 
 ```yaml
 apiVersion: storage.k8s.io/v1


### PR DESCRIPTION
Quobyte not a sub chapter of Ceph RBD. Fixed to be a chapter by itself.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6895)
<!-- Reviewable:end -->
