### PR TITLE
typo in `ScalingLimited`

### DIFF
--- a/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -304,7 +304,7 @@ For this HorizontalPodAutoscaler, we can see several conditions in a healthy sta
 whether or not any backoff-related conditions would prevent scaling.  The second, `ScalingActive`,
 indicates whether or not the HPA is enabled (i.e. the replica count of the target is not zero) and
 is able to calculate desired scales. When it is `False`, it generally indicates problems with
-fetching metrics.  Finally, the last condition, `ScalingLimitted`, indicates that the desired scale
+fetching metrics.  Finally, the last condition, `ScalingLimited`, indicates that the desired scale
 was capped by the maximum or minimum of the HorizontalPodAutoscaler.  This is an indication that
 you may wish to raise or lower the minimum or maximum replica count constraints on your
 HorizontalPodAutoscaler.


### PR DESCRIPTION
changed to just have one t


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6903)
<!-- Reviewable:end -->

  