### PR TITLE
Update certificates.md, missing comma, which cause command error like: "bad ip address:v3_alt.c:476:value=172.16.3.18/16 IP:172.16.3.18/16" 

### DIFF
--- a/docs/concepts/cluster-administration/certificates.md
+++ b/docs/concepts/cluster-administration/certificates.md
@@ -51,7 +51,7 @@ Finally, add the following parameters into API server start parameters:
     The sample below also assume that you are using `cluster.local` as the default
     DNS domain name.
 
-        ./easyrsa --subject-alt-name="IP:${MASTER_IP}"\
+        ./easyrsa --subject-alt-name="IP:${MASTER_IP},"\
         "IP:${MASTER_CLUSTER_IP},"\
         "DNS:kubernetes,"\
         "DNS:kubernetes.default,"\


### PR DESCRIPTION
https://kubernetes.io/docs/concepts/cluster-administration/certificates/#using-an-existing-deployment-script

a comma is missing in the first IP stentence
```
./easyrsa --subject-alt-name="IP:${MASTER_IP}"\
"IP:${MASTER_CLUSTER_IP},"\

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6929)
<!-- Reviewable:end -->


