### PR TITLE
fix typo in doc kubeadm-alpha

### DIFF
--- a/docs/reference/setup-tools/kubeadm/kubeadm-alpha.md
+++ b/docs/reference/setup-tools/kubeadm/kubeadm-alpha.md
@@ -9,7 +9,7 @@ title: kubeadm alpha
  from the community. Please try it out and give us feedback!
 {: .caution}
 
-In v1.8.0, kubeadm introduced the `kubeadm alpha phase` command with the aim of making kubeadm more modular. This modularity enables you to invoke atomic sub-steps of the boostrap process; you can let kubeadm do some parts and fill in yourself where you need customizations.
+In v1.8.0, kubeadm introduced the `kubeadm alpha phase` command with the aim of making kubeadm more modular. This modularity enables you to invoke atomic sub-steps of the bootstrap process; you can let kubeadm do some parts and fill in yourself where you need customizations.
 
 `kubeadm alpha phase` is consistent with [kubeadm init workflow](kubeadm-init.md#init-workflow), 
 and behind the scene both use the same code.


### PR DESCRIPTION
Found the typo when doing translation in https://github.com/kubernetes/kubernetes-docs-cn/pull/165

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6933)
<!-- Reviewable:end -->
