### PR TITLE
Update Create an External Load Balancer Doc

### DIFF
--- a/docs/tasks/access-application-cluster/create-external-load-balancer.md
+++ b/docs/tasks/access-application-cluster/create-external-load-balancer.md
@@ -106,6 +106,7 @@ which should produce output like this:
 The IP address is listed next to `LoadBalancer Ingress`.
 
 **Note**: If you are running your service on Minikube, you can find the assigned IP address and port with:
+
 ```bash
 minikube service example-service --url
 ```

--- a/docs/tasks/access-application-cluster/create-external-load-balancer.md
+++ b/docs/tasks/access-application-cluster/create-external-load-balancer.md
@@ -106,7 +106,7 @@ which should produce output like this:
 The IP address is listed next to `LoadBalancer Ingress`.
 
 **Note**: If you are running your service on Minikube, you can find the assigned IP address and port with:
-
+{: .note}
 ```bash
 minikube service example-service --url
 ```

--- a/docs/tasks/access-application-cluster/create-external-load-balancer.md
+++ b/docs/tasks/access-application-cluster/create-external-load-balancer.md
@@ -105,6 +105,11 @@ which should produce output like this:
 
 The IP address is listed next to `LoadBalancer Ingress`.
 
+**Note**: If you are running your service on Minikube, you can find the assigned IP address and port with:
+```bash
+minikube service example-service --url
+```
+
 ## Preserving the client source IP
 
 Due to the implementation of this feature, the source IP seen in the target


### PR DESCRIPTION
The `Create an External Load Balancer` readme has a `Finding your IP address` section which describes steps that do not work when running the service in Minikube. @jimmidyson describes how to find your ip address while running in Minikube here: https://github.com/kubernetes/minikube/issues/384#issuecomment-234409957. This change adds this helpful bit to the docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6938)
<!-- Reviewable:end -->
