### PR TITLE
remove duplicated and conflicted TOC instrument

### DIFF
--- a/docs/concepts/services-networking/dns-pod-service.md
+++ b/docs/concepts/services-networking/dns-pod-service.md
@@ -8,9 +8,6 @@ title: DNS for Services and Pods
 This page provides an overview of DNS support by Kubernetes.
 {% endcapture %}
 
-* TOC
-{:toc}
-
 {% capture body %}
 
 ## Introduction


### PR DESCRIPTION
`capture overview` and `{:toc}` maybe duplicated and generated a strange page view like this:

<img width="623" alt="k8s-website-toc" src="https://user-images.githubusercontent.com/1212008/34866531-d0e8abde-f7b7-11e7-8e63-34c302fb9db9.png">

And this PR will render page like this:

<img width="537" alt="k8s-doc-without-toc" src="https://user-images.githubusercontent.com/1212008/34866550-e21f23ce-f7b7-11e7-8709-8b1df39065fc.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6944)
<!-- Reviewable:end -->
