### PR TITLE
Fix reference to Resource QoS for the PodStatus API

### DIFF
--- a/docs/api-reference/v1.9/index.html
+++ b/docs/api-reference/v1.9/index.html
@@ -8263,7 +8263,7 @@ Appears In:
 </tr>
 <tr>
 <td>qosClass <br /> <em>string</em></td>
-<td>The Quality of Service (QOS) classification assigned to the pod based on resource requirements See PodQOSClass type for available QOS classes More info: <a href="https://github.com/kubernetes/kubernetes/blob/master/docs/design/resource-qos.md">https://github.com/kubernetes/kubernetes/blob/master/docs/design/resource-qos.md</a></td>
+<td>The Quality of Service (QOS) classification assigned to the pod based on resource requirements See PodQOSClass type for available QOS classes More info: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/">https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/</a></td>
 </tr>
 <tr>
 <td>reason <br /> <em>string</em></td>


### PR DESCRIPTION
Fix reference to Resource QoS for the PodStatus API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6957)
<!-- Reviewable:end -->
