### PR TITLE
Fix memory request limit exmaples use the default namespace

### DIFF
--- a/docs/tasks/configure-pod-container/memory-request-limit-2.yaml
+++ b/docs/tasks/configure-pod-container/memory-request-limit-2.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: memory-demo-2
+  namespace: mem-example
 spec:
   containers:
   - name: memory-demo-2-ctr

--- a/docs/tasks/configure-pod-container/memory-request-limit-3.yaml
+++ b/docs/tasks/configure-pod-container/memory-request-limit-3.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: memory-demo-3
+  namespace: mem-example
 spec:
   containers:
   - name: memory-demo-3-ctr

--- a/docs/tasks/configure-pod-container/memory-request-limit.yaml
+++ b/docs/tasks/configure-pod-container/memory-request-limit.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: memory-demo
+  namespace: mem-example
 spec:
   containers:
   - name: memory-demo-ctr


### PR DESCRIPTION
Specify the namespace to `mem-example`. So, users can copy the yaml and run the task directly.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6979)
<!-- Reviewable:end -->
