### PR TITLE
Fix cpu request limit exmaples use the default namespace

### DIFF
--- a/docs/tasks/configure-pod-container/cpu-request-limit-2.yaml
+++ b/docs/tasks/configure-pod-container/cpu-request-limit-2.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: cpu-demo-2
+  namespace: cpu-example
 spec:
   containers:
   - name: cpu-demo-ctr-2

--- a/docs/tasks/configure-pod-container/cpu-request-limit.yaml
+++ b/docs/tasks/configure-pod-container/cpu-request-limit.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: cpu-demo
+  namespace: cpu-example
 spec:
   containers:
   - name: cpu-demo-ctr


### PR DESCRIPTION
Specify the namespace to `cpu-example`. So, users can copy the yaml and run the task directly.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6980)
<!-- Reviewable:end -->
