### PR TITLE
Update the location of etcd.manifest

### DIFF
--- a/docs/tasks/administer-cluster/configure-upgrade-etcd.md
+++ b/docs/tasks/administer-cluster/configure-upgrade-etcd.md
@@ -374,7 +374,7 @@ STORAGE_MEDIA_TYPE=application/json
 ### Default configuration
 
 The default setup scripts use kubelet's file-based static pods feature to run etcd in a
-[pod](http://releases.k8s.io/{{page.githubbranch}}/cluster/saltbase/salt/etcd/etcd.manifest). This manifest should only
+[pod](http://releases.k8s.io/{{page.githubbranch}}/cluster/gce/manifests/etcd.manifest). This manifest should only
 be run on master VMs. The default location that kubelet scans for manifests is
 `/etc/kubernetes/manifests/`.
 


### PR DESCRIPTION
Cluster/saltbase has been deprecated. The file was moved under GCE.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6993)
<!-- Reviewable:end -->
