### PR TITLE
Update links in Browse Docs section of home page

### DIFF
--- a/_data/reference.yml
+++ b/_data/reference.yml
@@ -64,7 +64,7 @@ toc:
   - docs/reference/kubectl/cheatsheet.md
 
 - title: Setup Tools Reference
-  landing_page: /docs/admin/kubeadm/
+  landing_page: /docs/reference/setup-tools/kubeadm/kubeadm/
   section:
   - title: Kubeadm
     section:
@@ -101,8 +101,9 @@ toc:
   - docs/reference/generated/federation-controller-manager.md
 
 - title: Kubernetes Design Docs
-  landing_page: https://git.k8s.io/community/contributors/design-proposals/architecture/architecture.md
+  landing_page: /docs/reference/design-docs/overview/
   section:
+  - docs/reference/design-docs/overview.md
   - title: Kubernetes Architecture
     path: https://git.k8s.io/community/contributors/design-proposals/architecture/architecture.md
   - title: Kubernetes Design Overview

--- a/_data/setup.yml
+++ b/_data/setup.yml
@@ -23,8 +23,9 @@ toc:
   - docs/getting-started-guides/alternatives.md
 
 - title: Hosted Solutions
-  landing_page: https://cloud.google.com/container-engine/docs/before-you-begin/
+  landing_page: /docs/setup/hosted-solutions/overview/
   section:
+  - docs/setup/hosted-solutions/overview.md
   - title: Running Kubernetes on Google Kubernetes Engine
     path: https://cloud.google.com/kubernetes-engine/docs/before-you-begin/
   - title: Running Kubernetes on Azure Container Service
@@ -33,13 +34,13 @@ toc:
     path: https://console.bluemix.net/docs/containers/container_index.html
 
 - title: Turn-key Cloud Solutions
-  landing_page: /docs/getting-started-guides/gce/
+  landing_page: /docs/getting-started-guides/alibaba-cloud/
   section:
-  - docs/getting-started-guides/gce.md
+  - docs/getting-started-guides/alibaba-cloud.md
   - docs/getting-started-guides/aws.md
   - docs/getting-started-guides/azure.md
-  - docs/getting-started-guides/alibaba-cloud.md
   - docs/getting-started-guides/clc.md
+  - docs/getting-started-guides/gce.md
   - title: Running Kubernetes on IBM Cloud
     path: https://github.com/patrocinio/kubernetes-softlayer
   - docs/getting-started-guides/stackpoint.md
@@ -107,9 +108,15 @@ toc:
 
   - docs/admin/node-conformance.md
 
-- docs/concepts/cluster-administration/addons.md
-- docs/admin/salt.md
-- docs/admin/cluster-large.md
-- docs/admin/multiple-zones.md
-- docs/admin/high-availability/index.md
-- docs/getting-started-guides/binary_release.md
+- title: Installing Addons
+  path: /docs/concepts/cluster-administration/addons/
+- title: Configuring Kubernetes with Salt
+  path: /docs/admin/salt/
+- title: Building Large Clusters
+  path: /docs/admin/cluster-large/
+- title: Running in Multiple Zones
+  path: /docs/admin/multiple-zones/
+- title: Building High-Availability Clusters
+  path: /docs/admin/high-availability/
+- title: Downloading or Building Kubernetes
+  path: /docs/getting-started-guides/binary_release/

--- a/_data/tasks.yml
+++ b/_data/tasks.yml
@@ -12,7 +12,7 @@ toc:
   - docs/setup/independent/install-kubeadm.md
 
 - title: Configure Pods and Containers
-  landing_page: /docs/tasks/configure-pod-container/assign-memory-resource/
+  landing_page: /docs/tasks/configure-pod-container/configure-pod-initialization/
   section:
   - docs/tasks/configure-pod-container/assign-memory-resource.md
   - docs/tasks/configure-pod-container/assign-cpu-resource.md
@@ -35,7 +35,7 @@ toc:
   - docs/tools/kompose/user-guide.md
 
 - title: Inject Data Into Applications
-  landing_page: /docs/tasks/inject-data-application/define-command-argument-container/
+  landing_page: /docs/tasks/inject-data-application/define-environment-variable-container/
   section:
   - docs/tasks/inject-data-application/define-command-argument-container.md
   - docs/tasks/inject-data-application/define-environment-variable-container.md
@@ -85,7 +85,7 @@ toc:
     path: https://github.com/kubernetes/kubernetes/tree/release-1.5/examples/cluster-dns
 
 - title: Monitor, Log, and Debug
-  landing_page: /docs/tasks/debug-application-cluster/core-metrics-pipeline/
+  landing_page: /docs/tasks/debug-application-cluster/resource-usage-monitoring/
   section:
   - docs/tasks/debug-application-cluster/core-metrics-pipeline.md
   - docs/tasks/debug-application-cluster/resource-usage-monitoring.md
@@ -108,6 +108,7 @@ toc:
     path: https://github.com/kubernetes/kubernetes/tree/release-1.5/examples/explorer
 
 - title: Extend Kubernetes
+  landing_page: /docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/
   section:
   - docs/tasks/access-kubernetes-api/http-proxy-access-api.md
   - docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions.md
@@ -182,7 +183,7 @@ toc:
   - docs/tasks/administer-cluster/pvc-protection.md
 
 - title: Federation - Run an App on Multiple Clusters
-  landing_page: /docs/tasks/federation/federation-service-discovery/
+  landing_page: /docs/tasks/federation/set-up-cluster-federation-kubefed/
   section:
   - docs/tasks/federation/federation-service-discovery.md
   - docs/tasks/federation/set-up-cluster-federation-kubefed.md

--- a/_data/tutorials.yml
+++ b/_data/tutorials.yml
@@ -32,15 +32,19 @@ toc:
     - docs/tutorials/kubernetes-basics/update-intro.html
     - docs/tutorials/kubernetes-basics/update-interactive.html
 - title: Online Training Courses
-  landing_page: https://www.udacity.com/course/scalable-microservices-with-kubernetes--ud615
+  landing_page: /docs/tutorials/online-training/overview/
   section:
+  - docs/tutorials/online-training/overview.md
   - title: Scalable Microservices with Kubernetes (Udacity)
     path: https://www.udacity.com/course/scalable-microservices-with-kubernetes--ud615
   - title: Introduction to Kubernetes (edX)
     path: https://www.edx.org/course/introduction-kubernetes-linuxfoundationx-lfs158x#
-- docs/tutorials/stateless-application/hello-minikube.md
-- docs/user-guide/walkthrough/index.md
-- docs/user-guide/walkthrough/k8s201.md
+- title: Hello Minikube
+  path: /docs/tutorials/stateless-application/hello-minikube/
+- title: Kubernetes 101
+  path: /docs/user-guide/walkthrough/
+- title: Kubernetes 201
+  path: /docs/user-guide/walkthrough/k8s201/
 - title: Configuration
   landing_page: /docs/tutorials/configuration/configure-redis-using-configmap/
   section:
@@ -53,7 +57,7 @@ toc:
   - docs/tutorials/object-management-kubectl/imperative-object-management-configuration.md
   - docs/tutorials/object-management-kubectl/declarative-object-management-configuration.md
 - title: Stateless Applications
-  landing_page: /docs/tasks/run-application/run-stateless-application-deployment/
+  landing_page: /docs/tutorials/stateless-application/guestbook/
   section:
   - docs/tasks/run-application/run-stateless-application-deployment.md
   - docs/tutorials/stateless-application/guestbook.md

--- a/docs/reference/design-docs/overview.md
+++ b/docs/reference/design-docs/overview.md
@@ -1,0 +1,28 @@
+---
+title: Overview of Kubernetes Design Docs
+---
+
+{% capture overview %}
+
+Here are some documents that describe aspects of the Kubernetes design:
+
+{% endcapture %}
+
+{% capture body %}
+
+* [Kubernetes Architecture](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture/architecture.md)
+
+* [Kubernetes Design Overview](https://github.com/kubernetes/kubernetes/tree/release-1.6/docs/design)
+
+* [Kubernetes Identity and Access Management](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/auth/access.md)
+
+* [Kubernetes OpenVSwitch GRE/VxLAN networking](https://deploy-preview-6994--kubernetes-io-user-journeys.netlify.com/docs/admin/ovs-networking/)
+
+* [Security Contexts](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/auth/security_context.md)
+
+* [Security in Kubernetes](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/auth/security.md)
+
+{% endcapture %}
+
+
+{% include templates/concept.md %}

--- a/docs/setup/hosted-solutions/overview.md
+++ b/docs/setup/hosted-solutions/overview.md
@@ -1,0 +1,20 @@
+---
+title: Hosted Kubernetes Solutions
+---
+
+{% capture overview %}
+
+TODO
+
+{% endcapture %}
+
+
+{% capture body %}
+
+TODO
+
+{% endcapture %}
+
+
+{% include templates/concept.md %}
+

--- a/docs/tutorials/online-training/overview.md
+++ b/docs/tutorials/online-training/overview.md
@@ -1,0 +1,21 @@
+---
+title: Overview of Kubernetes Online Training
+---
+
+{% capture overview %}
+
+Here are some of the sites that offer online training for Kubernetes:
+
+{% endcapture %}
+
+{% capture body %}
+
+* [Scalable Microservices with Kubernetes (Udacity)](https://www.udacity.com/course/scalable-microservices-with-kubernetes--ud615)
+
+* [Introduction to Kubernetes (edX)](https://www.udacity.com/course/scalable-microservices-with-kubernetes--ud615)
+
+{% endcapture %}
+
+
+{% include templates/concept.md %}
+


### PR DESCRIPTION
The home page in the new User Journeys design has a link to the main topic for each heading in the TOC. This PR updates some of those links.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6994)
<!-- Reviewable:end -->
