### PR TITLE
Update cheatsheet.md - added missing --v=9 option

### DIFF
--- a/docs/reference/kubectl/cheatsheet.md
+++ b/docs/reference/kubectl/cheatsheet.md
@@ -301,4 +301,5 @@ Verbosity | Description
 `--v=6` | Display requested resources.
 `--v=7` | Display HTTP request headers.
 `--v=8` | Display HTTP request contents.
+`--v=9` | Display HTTP request contents without truncation of contents.
 


### PR DESCRIPTION
Missing the untruncated output option on Verbosity.

> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/6997)
<!-- Reviewable:end -->
