### PR TITLE
Update etcd installation instructions

### DIFF
--- a/docs/getting-started-guides/scratch.md
+++ b/docs/getting-started-guides/scratch.md
@@ -537,7 +537,7 @@ availability.
 
 To run an etcd instance:
 
-1. Copy [`cluster/gce/manifests/etcd.manifest`](http://releases.k8s.io/{{page.githubbranch}}/cluster/gce/manifests/etcd.manifest)
+1. Copy [`cluster/gce/manifests/etcd.manifest`](https://github.com/kubernetes/kubernetes/blob/master/cluster/gce/manifests/etcd.manifest)
 1. Make any modifications needed
 1. Start the pod by putting it into the kubelet manifest directory
 

--- a/docs/getting-started-guides/scratch.md
+++ b/docs/getting-started-guides/scratch.md
@@ -537,7 +537,7 @@ availability.
 
 To run an etcd instance:
 
-1. Copy `cluster/gce/manifests/etcd.manifest`
+1. Copy [`cluster/gce/manifests/etcd.manifest`](http://releases.k8s.io/{{page.githubbranch}}/cluster/gce/manifests/etcd.manifest)
 1. Make any modifications needed
 1. Start the pod by putting it into the kubelet manifest directory
 

--- a/docs/getting-started-guides/scratch.md
+++ b/docs/getting-started-guides/scratch.md
@@ -537,7 +537,7 @@ availability.
 
 To run an etcd instance:
 
-1. Copy `cluster/saltbase/salt/etcd/etcd.manifest`
+1. Copy `cluster/gce/manifests/etcd.manifest`
 1. Make any modifications needed
 1. Start the pod by putting it into the kubelet manifest directory
 


### PR DESCRIPTION
Update the etcd installation instructions. Cluster/saltbase was deprecated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7010)
<!-- Reviewable:end -->
