### PR TITLE
adding full-link to the glossary YAML style guide

### DIFF
--- a/_data/glossary/_example.yml
+++ b/_data/glossary/_example.yml
@@ -1,6 +1,6 @@
 id: _example
 name: Example K8s Term
-full-link: kubernetes.io/docs/link-to-long-dedicated-docs-page
+full-link: /docs/link-to-long-dedicated-docs-page
 aka:
 - Slang K8s Term
 - Misnomer

--- a/_includes/templates/glossary/README.md
+++ b/_includes/templates/glossary/README.md
@@ -6,6 +6,8 @@ To write a glossary snippet, start with a copy of the template, [`/_data/glossar
   * This field must match the name of the glossary file itself (without the `*.yml` extension). It is *not* intended to be displayed to users, and is only used programmatically.
 * (Required) `name`
   * The name of the term.
+* (Optional) `full-link`
+  * The link to any specific long-form documentation, starting with `https://` if not within the website repo, and `/docs/...` if within the repo.
 * (Required) `tags`
   * Must be one of the tags listed in the [tags directory in the website repository](https://github.com/kubernetes/website/tree/master/_data/canonical-tags).
 * (Required) `short description`


### PR DESCRIPTION
realized it was missing while reviewing a PR for a glossary entry, so adding it...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7015)
<!-- Reviewable:end -->
