### PR TITLE
Fix typo in the cron job intro

### DIFF
--- a/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/docs/concepts/workloads/controllers/cron-jobs.md
@@ -137,7 +137,7 @@ be down from `08:29:00` to `08:42:00`, the job will not start.
 Set a longer `startingDeadlineSeconds` if starting later is better than not
 starting at all.
 
-The job is only responsible for creating Jobs that match its schedule, and the
+The job is only responsible for creating Jobs that match its schedule, and
 the Job in turn is responsible for the management of the Pods it represents.
 
 ## Writing a Cron Job Spec

--- a/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/docs/concepts/workloads/controllers/cron-jobs.md
@@ -137,7 +137,7 @@ be down from `08:29:00` to `08:42:00`, the job will not start.
 Set a longer `startingDeadlineSeconds` if starting later is better than not
 starting at all.
 
-The job is only responsible for creating Jobs that match its schedule, and
+The Cronjob is only responsible for creating Jobs that match its schedule, and
 the Job in turn is responsible for the management of the Pods it represents.
 
 ## Writing a Cron Job Spec


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7019)
<!-- Reviewable:end -->
