### PR TITLE
change path to reflect guide

### DIFF
--- a/docs/tasks/configure-pod-container/task-pv-volume.yaml
+++ b/docs/tasks/configure-pod-container/task-pv-volume.yaml
@@ -11,4 +11,4 @@ spec:
   accessModes:
     - ReadWriteOnce
   hostPath:
-    path: "/tmp/data"
+    path: "/mnt/data"


### PR DESCRIPTION
The "Configure a Pod to Use a PersistentVolume for Storage"-task specifies that the content should be located on "/mnt/data" and not "/tmp/data", however this is not reflected in the yaml.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7025)
<!-- Reviewable:end -->
