### PR TITLE
Typo in StatefulSet concept doc.

### DIFF
--- a/docs/concepts/workloads/controllers/statefulset.md
+++ b/docs/concepts/workloads/controllers/statefulset.md
@@ -116,7 +116,7 @@ regardless of which node it's (re)scheduled on.
 ### Ordinal Index
 
 For a StatefulSet with N replicas, each Pod in the StatefulSet will be
-assigned an integer ordinal, in the range [0,N], that is unique over the Set.
+assigned an integer ordinal, in the range [0,N-1], that is unique over the Set.
 
 ### Stable Network ID
 


### PR DESCRIPTION
Under Pod Identity -> Ordinal Index it says ordinals are in the
range [0,N] but the example below suggests they're in [0,N-1].

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7043)
<!-- Reviewable:end -->
