### PR TITLE
Fix context name used when deleting namespace in federation

### DIFF
--- a/docs/tasks/federation/set-up-cluster-federation-kubefed.md
+++ b/docs/tasks/federation/set-up-cluster-federation-kubefed.md
@@ -473,7 +473,6 @@ command with the cluster name and the federation's
 kubefed unjoin gondor --host-cluster-context=rivendell
 ```
 
-
 ## Turning down the federation control plane
 
 Proper cleanup of federation control plane is not fully implemented in
@@ -484,8 +483,8 @@ federation control plane's etcd. You can delete the federation
 namespace by running the following command:
 
 ```
-kubectl delete ns federation-system --context=rivendell
+kubectl delete ns federation-system --host-cluster-context=rivendell
 ```
 
-Note that `rivendell` is the host cluster name, replace that with the appropriate name in your configuration.
-
+Note that `rivendell` is the host cluster name, replace that with the
+appropriate name in your configuration.


### PR DESCRIPTION
Closes: #3043

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7044)
<!-- Reviewable:end -->
