### PR TITLE
Add link to autoscaler FAQ

### DIFF
--- a/docs/tasks/administer-cluster/cluster-management.md
+++ b/docs/tasks/administer-cluster/cluster-management.md
@@ -124,6 +124,10 @@ gcloud container clusters update mytestcluster --enable-autoscaling --min-nodes=
 
 **Cluster autoscaler expects that nodes have not been manually modified (e.g. by adding labels via kubectl) as those properties would not be propagated to the new nodes within the same instance group.**
 
+For more details about how the cluster autoscaler decides whether, when and how
+to scale a cluster, please refer to the [FAQ](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md)
+documentation from the autoscaler project.
+
 ## Maintenance on a Node
 
 If you need to reboot a node (such as for a kernel upgrade, libc upgrade, hardware repair, etc.), and the downtime is


### PR DESCRIPTION
This PR adds a link to the cluster autoscaler project documentation
which can help answer some questions related to the scaler internals.

Closes: #1408

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7045)
<!-- Reviewable:end -->
