### PR TITLE
add a couple missing hyphens (like "in-cluster")

### DIFF
--- a/docs/admin/authentication.md
+++ b/docs/admin/authentication.md
@@ -178,7 +178,7 @@ If unspecified, the API server's TLS private key will be used.
 Service accounts are usually created automatically by the API server and
 associated with pods running in the cluster through the `ServiceAccount`
 [Admission Controller](/docs/admin/admission-controllers/). Bearer tokens are
-mounted into pods at well known locations, and allow in cluster processes to
+mounted into pods at well-known locations, and allow in-cluster processes to
 talk to the API server. Accounts may be explicitly associated with pods using the
 `serviceAccountName` field of a `PodSpec`.
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7066)
<!-- Reviewable:end -->
