### PR TITLE
Fix sample yaml for secret

### DIFF
--- a/docs/tasks/inject-data-application/secret.yaml
+++ b/docs/tasks/inject-data-application/secret.yaml
@@ -3,5 +3,5 @@ kind: Secret
 metadata:
   name: test-secret
 data:
-  username: bXktYXBwCg==
-  password: Mzk1MjgkdmRnN0piCg==
+  username: bXktYXBw
+  password: Mzk1MjgkdmRnN0pi


### PR DESCRIPTION
The sample yaml contains base64 encoded strings that were generated with
trailing returns. This is inconsistent to the result from the command in
which a user passes the key and value from command line. This PR removes
the trailing "Cg==" characters for consistency.

Closes: #7065

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7072)
<!-- Reviewable:end -->
