### PR TITLE
Update mysql-wordpress-persistent-volume.md

### DIFF
--- a/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
+++ b/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
@@ -12,7 +12,7 @@ A [PersistentVolume](/docs/concepts/storage/persistent-volumes/) (PV) is a piece
 **Warning:**  This deployment is not suitable for production use cases, as it uses single instance WordPress and MySQL Pods. Consider using [WordPress Helm Chart](https://github.com/kubernetes/charts/tree/master/stable/wordpress) to deploy WordPress in production.
 {: .warning}
 
-**Note:** The files provided in this tutorial are using beta Deployment APIs and are specific to kubernetes version 1.8. If you wish to use this tutorial with an earlier version of Kubernetes, please update the beta API appropriately, or reference earlier versions of this tutorial.
+**Note:** The files provided in this tutorial are using GA Deployment APIs and are specific to kubernetes version 1.9 and later. If you wish to use this tutorial with an earlier version of Kubernetes, please update the API version appropriately, or reference earlier versions of this tutorial.
 {: .note}
 
 {% endcapture %}


### PR DESCRIPTION
Earlier PR updated `Deployment` API version for v1.9. Update related notes. 

Maybe notes like this should be added to docs used yaml files  involving `Deployment`/`DaemonSet`/`ReplicaSet`/`StatefulSet`, which are GA in v1.9.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7080)
<!-- Reviewable:end -->
