### PR TITLE
Update high-availability.md

### DIFF
--- a/docs/setup/independent/high-availability.md
+++ b/docs/setup/independent/high-availability.md
@@ -188,6 +188,7 @@ In order to copy certs between machines, you must enable SSH access for `scp`.
     scp root@<etcd0-ip-address>:/etc/kubernetes/pki/etcd/ca-key.pem .
     scp root@<etcd0-ip-address>:/etc/kubernetes/pki/etcd/client.pem .
     scp root@<etcd0-ip-address>:/etc/kubernetes/pki/etcd/client-key.pem .
+    scp root@<etcd0-ip-address>:/etc/kubernetes/pki/etcd/ca-config.json .
     ```
 
     Where `<etcd0-ip-address>` corresponds to the public or private IPv4 of `etcd0`.


### PR DESCRIPTION
the ca-config.json file is not copied to etcd1, and etcd2 which is needed for the cfssl command to complete properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7086)
<!-- Reviewable:end -->
