### PR TITLE
Update StatefulSet API version to 1.9 for the Cassandra example

### DIFF
--- a/docs/tutorials/stateful-application/cassandra.md
+++ b/docs/tutorials/stateful-application/cassandra.md
@@ -158,7 +158,7 @@ Use `kubectl edit` to modify the size of of a Cassandra StatefulSet.
         # and an empty file will abort the edit. If an error occurs while saving this file will be
         # reopened with the relevant failures.
         #
-        apiVersion: apps/v1beta2
+        apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
         kind: StatefulSet
         metadata:
          creationTimestamp: 2016-08-13T18:40:58Z

--- a/docs/tutorials/stateful-application/cassandra.md
+++ b/docs/tutorials/stateful-application/cassandra.md
@@ -168,7 +168,7 @@ Use `kubectl edit` to modify the size of of a Cassandra StatefulSet.
          name: cassandra
          namespace: default
          resourceVersion: "323"
-         selfLink: /apis/apps/v1beta1/namespaces/default/statefulsets/cassandra
+         selfLink: /apis/apps/v1/namespaces/default/statefulsets/cassandra
          uid: 7a219483-6185-11e6-a910-42010a8a0fc0
         spec:
          replicas: 3


### PR DESCRIPTION
Update StatefulSet API version to 1.9 for the Cassandra example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7096)
<!-- Reviewable:end -->
