### PR TITLE
Fix patch image command in rolling update section

### DIFF
--- a/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -465,7 +465,7 @@ In one terminal window, patch the `web` StatefulSet to change the container
 image again.
 
 ```shell
-kubectl patch statefulset web --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"k8s.gcr.io/nginx-slim:0.8"}]'
+kubectl patch statefulset web --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"gcr.io/google_containers/nginx-slim:0.8"}]'
 statefulset "web" patched
 ```
 


### PR DESCRIPTION
Fixes one part of the issue #7056 about patch command failing to update.

It changes the image URL to another different than the used previously to create the StatefulSet to make the patch command works without fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7124)
<!-- Reviewable:end -->
