### PR TITLE
move troubleshooting out of home menu, into tasks

### DIFF
--- a/_data/docs-home.yml
+++ b/_data/docs-home.yml
@@ -9,8 +9,6 @@ toc:
 - title: Release Roadmap
   path: https://github.com/kubernetes/kubernetes/milestones/
 
-- docs/tasks/debug-application-cluster/troubleshooting.md
-
 - title: Contributing to the Kubernetes Docs
   section:
   - editdocs.md

--- a/_data/tasks.yml
+++ b/_data/tasks.yml
@@ -77,6 +77,12 @@ toc:
   - title: Configuring DNS for a Cluster
     path: https://github.com/kubernetes/kubernetes/tree/release-1.5/examples/cluster-dns
 
+- title: Troubleshoot
+  landing_page: docs/tasks/debug-application-cluster/troubleshooting.md
+  section:
+  - docs/tasks/debug-application-cluster/debug-cluster.md
+  - docs/tasks/debug-application-cluster/debug-application.md
+
 - title: Monitor, Log, and Debug
   section:
   - docs/tasks/debug-application-cluster/core-metrics-pipeline.md
@@ -90,8 +96,6 @@ toc:
   - docs/tasks/debug-application-cluster/debug-init-containers.md
   - docs/tasks/debug-application-cluster/debug-pod-replication-controller.md
   - docs/tasks/debug-application-cluster/debug-service.md
-  - docs/tasks/debug-application-cluster/debug-cluster.md
-  - docs/tasks/debug-application-cluster/debug-application.md
   - docs/tasks/debug-application-cluster/debug-stateful-set.md
   - docs/tasks/debug-application-cluster/debug-application-introspection.md
   - docs/tasks/debug-application-cluster/audit.md


### PR DESCRIPTION
Finally fixed branch, commit history -- this PR is per a now old-ish conversation in a user-journeys meeting, about fixing up the home page nav and finding a better home for the troubleshooting content. Probably only stage 1 in a multi-stage reorg and rewrite.
