### PR TITLE
promote PodNodeSelector to stable; document detailed behavior

### DIFF
--- a/docs/admin/admission-controllers.md
+++ b/docs/admin/admission-controllers.md
@@ -457,7 +457,7 @@ plugins:
 ```
 
 #### Configuration Annotation Format
-PodNodeSelector uses the annotation key `scheduler.alpha.kubernetes.io/node-selector` to assign node selectors to namespaces.
+PodNodeSelector uses the annotation key `scheduler.kubernetes.io/node-selector` to assign node selectors to namespaces.
 
 ```yaml
 apiVersion: v1
@@ -467,6 +467,18 @@ metadata:
     scheduler.alpha.kubernetes.io/node-selector: <node-selectors-labels>
   name: namespace3
 ```
+
+#### Internal Behavior
+This admission controller has the following behavior:
+  1. If the namespace has an annotation with a key `scheduler.kubernetes.io/nodeSelector`, use its value as the
+     namespace node selector.
+  2. If the namespace lacks such an annotation, use the `clusterDefaultNodeSelector` defined in the plugin
+     configuration file as the namespace node selector.
+  3. Evaluate the pod's node selector against the namespace node selector for conflicts. Conflicts result in rejection.
+  4. Evaluate the pod's node selector against the namespace-specific whitelist defined the plugin configuration file.
+     Conflicts result in rejection.
+
+Note: PodTolerationRestriction is more versatile and powerful than PodNodeSelector and can encompass the scenarios supported by PodNodeSelector.
 
 ### PersistentVolumeClaimResize
 

--- a/docs/admin/admission-controllers.md
+++ b/docs/admin/admission-controllers.md
@@ -434,7 +434,7 @@ This admission controller defaults and limits what node selectors may be used wi
 
 #### Configuration File Format
 
-PodNodeSelector uses a configuration file to set options for the behavior of the backend.
+`PodNodeSelector` uses a configuration file to set options for the behavior of the backend.
 Note that the configuration file format will move to a versioned file in a future release.
 This file may be json or yaml and has the following format:
 
@@ -445,7 +445,7 @@ podNodeSelectorPluginConfig:
  namespace2: <node-selectors-labels>
 ```
 
-Reference the PodNodeSelector configuration file from the file provided to the API server's command line flag `--admission-control-config-file`:
+Reference the `PodNodeSelector` configuration file from the file provided to the API server's command line flag `--admission-control-config-file`:
 
 ```yaml
 kind: AdmissionConfiguration
@@ -457,7 +457,7 @@ plugins:
 ```
 
 #### Configuration Annotation Format
-PodNodeSelector uses the annotation key `scheduler.kubernetes.io/node-selector` to assign node selectors to namespaces.
+`PodNodeSelector` uses the annotation key `scheduler.kubernetes.io/node-selector` to assign node selectors to namespaces.
 
 ```yaml
 apiVersion: v1
@@ -470,15 +470,16 @@ metadata:
 
 #### Internal Behavior
 This admission controller has the following behavior:
-  1. If the namespace has an annotation with a key `scheduler.kubernetes.io/nodeSelector`, use its value as the
-     namespace node selector.
-  2. If the namespace lacks such an annotation, use the `clusterDefaultNodeSelector` defined in the plugin
-     configuration file as the namespace node selector.
-  3. Evaluate the pod's node selector against the namespace node selector for conflicts. Conflicts result in rejection.
-  4. Evaluate the pod's node selector against the namespace-specific whitelist defined the plugin configuration file.
+  1. If the `Namespace` has an annotation with a key `scheduler.kubernetes.io/nodeSelector`, use its value as the
+     node selector.
+  1. If the namespace lacks such an annotation, use the `clusterDefaultNodeSelector` defined in the `PodNodeSelector`
+     plugin configuration file as the node selector.
+  1. Evaluate the pod's node selector against the namespace node selector for conflicts. Conflicts result in rejection.
+  1. Evaluate the pod's node selector against the namespace-specific whitelist defined the plugin configuration file.
      Conflicts result in rejection.
 
-Note: PodTolerationRestriction is more versatile and powerful than PodNodeSelector and can encompass the scenarios supported by PodNodeSelector.
+**Note:** `PodTolerationRestriction` is more versatile and powerful than `PodNodeSelector` and can encompass the scenarios supported by `PodNodeSelector`.
+{: .note}
 
 ### PersistentVolumeClaimResize
 


### PR DESCRIPTION
This PR does two things:

1. Move the PodNodeSelector namespace annotation to stable (landing in v1.10)
2. Document the internal behavior of the admission controller

It can be rather confusing to understand how the annotations and plugin config file are interpreted without this PR or reading the code.

The way that falling back from the namespace annotation to the plugin configuration file is different depending on whether the code path is determining the effective namespace node selector, versus when it is determining the whitelist to evaluate against. This PR makes that distinction more clear.

(This branch currently targets `release-1.10`.)

This PR is dependent on this Kubernetes PR: https://github.com/kubernetes/kubernetes/pull/58818

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7134)
<!-- Reviewable:end -->
