### PR TITLE
Document the removal of the KubeletConfigFile feature gate

### DIFF
--- a/cn/docs/tasks/administer-cluster/kubelet-config-file.md
+++ b/cn/docs/tasks/administer-cluster/kubelet-config-file.md
@@ -45,7 +45,7 @@ title: 通过配置文件设置 Kubelet 参数
 ## 启动通过配置文件配置的 Kubelet 进程
 
 
-启动 Kubelet，需要打开 `KubeletConfigFile` 特性开关（feature gate）并将其 `--init-config-dir` 标志设置为包含 `kubelet` 文件的文件夹路径。Kubelet 将从 `kubelet` 文件中读取由 `KubeletConfiguration` 定义的参数，而不是从参数相关的命令行标志中读取。
+启动 Kubelet 需要将其 `--init-config-dir` 标志设置为包含 `kubelet` 文件的文件夹路径。Kubelet 将从 `kubelet` 文件中读取由 `KubeletConfiguration` 定义的参数，而不是从参数相关的命令行标志中读取。
 
 {% endcapture %}
 

--- a/docs/reference/feature-gates.md
+++ b/docs/reference/feature-gates.md
@@ -52,7 +52,7 @@ different Kubernetes components.
 | `ExperimentalHostUserNamespaceDefaulting` | `false` | Beta | 1.5 | |
 | `HugePages` | `false` | Alpha | 1.8 | |
 | `Initializers` | `false` | Alpha | 1.7 | |
-| `KubeletConfigFile` | `false` | Alpha | 1.8 | |
+| `KubeletConfigFile` | `false` | Alpha | 1.8 | 1.9 |
 | `LocalStorageCapacityIsolation` | `false` | Alpha | 1.7 | |
 | `MountContainers` | `false` | Alpha | 1.9 | |
 | `MountPropagation` | `false` | Alpha | 1.8 | |

--- a/docs/tasks/administer-cluster/kubelet-config-file.md
+++ b/docs/tasks/administer-cluster/kubelet-config-file.md
@@ -41,8 +41,7 @@ For a trick to generate a configuration file from a live node, see
 
 ## Start a Kubelet process configured via the config file
 
-Start the Kubelet with the `KubeletConfigFile` feature gate enabled and the 
-Kubelet's `--init-config-dir` flag set to the location of the directory
+Start the Kubelet with the `--init-config-dir` flag set to the location of the directory
 containing the `kubelet` file. The Kubelet will then load the parameters defined
 by `KubeletConfiguration` from the `kubelet` file, rather than from their 
 associated command-line flags.


### PR DESCRIPTION
With kubernetes/kubernetes#58978 merged, the said feature gate is
removed. This PR removes texts related to the gate and revises the
Feature Gates reference to reflect this change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7140)
<!-- Reviewable:end -->
