### PR TITLE
Updated configure-service-account.md

### DIFF
--- a/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/docs/tasks/configure-pod-container/configure-service-account.md
@@ -178,7 +178,7 @@ myregistrykey    kubernetes.io/.dockerconfigjson   1       1d
 Next, modify the default service account for the namespace to use this secret as an imagePullSecret.
 
 ```shell
-kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "myregistrykey"}]}'
+kubectl patch serviceaccount default -p '{\"imagePullSecrets\": [{\"name\": \"acrkey\"}]}'
 ```
 
 Interactive version requiring manual edit:


### PR DESCRIPTION
Fixes #7100 
Error from server resolved by escaping kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "myregistrykey"}]}' JSON string by '\'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7147)
<!-- Reviewable:end -->
