### PR TITLE
Doc fix for firewalld in fedora_manual_config.md

### DIFF
--- a/docs/getting-started-guides/fedora/fedora_manual_config.md
+++ b/docs/getting-started-guides/fedora/fedora_manual_config.md
@@ -60,11 +60,14 @@ the name of the master server:
 KUBE_MASTER="--master=http://fed-master:8080"
 ```
 
-* Disable the firewall on both the master and node, as docker does not play well with other firewall rule managers.  Please note that iptables-services does not exist on default fedora server install.
+* Disable the firewall on both the master and node, as Docker does not play well with other firewall rule managers.  Please note that iptables.service does not exist on the default Fedora Server install.
 
 ```shell
-systemctl disable iptables-services firewalld
-systemctl stop iptables-services firewalld
+systemctl mask firewalld.service
+systemctl stop firewalld.service
+
+systemctl disable iptables.service
+systemctl stop iptables.service
 ```
 
 **Configure the Kubernetes services on the master.**


### PR DESCRIPTION
The command `systemctl disable firewalld.service` does not actually disable the firewall in Fedora Server, the firewalld service must instead be masked to prevent `firewalld.service` from restarting upon the next reboot.
Also fixed the name of the `iptables.service`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7154)
<!-- Reviewable:end -->
