### PR TITLE
configure-pod-container/configmap/ is out of date, change it to norma…

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -290,9 +290,9 @@
 /docs/user-guide/application-troubleshooting/     /docs/tasks/debug-application-cluster/debug-application/ 301
 /docs/user-guide/compute-resources/     /docs/concepts/configuration/manage-compute-resources-container/ 301
 /docs/user-guide/config-best-practices/     /docs/concepts/configuration/overview/ 301
-/docs/user-guide/configmap/     /docs/tasks/configure-pod-container/configmap/ 301
+/docs/user-guide/configmap/     /docs/tasks/configure-pod-container/configure-pod-configmap/ 301
 /docs/user-guide/configmap/README/     /docs/tasks/configure-pod-container/configure-pod-configmap/ 301
-/docs/user-guide/configuring-containers/     /docs/tasks/configure-pod-container/configmap/ 301
+/docs/user-guide/configuring-containers/     /docs/tasks/configure-pod-container/configure-pod-configmap/ 301
 /docs/user-guide/connecting-applications/     /docs/concepts/services-networking/connect-applications-service/ 301
 /docs/user-guide/connecting-to-applications-port-forward/     /docs/tasks/access-application-cluster/port-forward-access-application-cluster/ 301
 /docs/user-guide/connecting-to-applications-proxy/     /docs/tasks/access-kubernetes-api/http-proxy-access-api/ 301


### PR DESCRIPTION
link configure-pod-container/configmap/ is out of date, change it to normal link: /configure-pod-container/configure-pod-configmap/

Signed-off-by: qiupeng-huacloud <qiupeng@chinacloud.com.cn>

> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7158)
<!-- Reviewable:end -->
