### PR TITLE
Note that Rescheduler is being retired in 1.10

### DIFF
--- a/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods.md
+++ b/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods.md
@@ -20,7 +20,7 @@ vacated by the evicted critical add-on pod or the amount of resources available 
 
 ## Rescheduler: guaranteed scheduling of critical add-ons
 
-NOTE: [Rescheduler is being retired in Kubernetes 1.10](https://groups.google.com/forum/#!msg/kubernetes-dev/UmW0iNRLEO0/FmDNUhyLDQAJ) and is replaced by [Priority and Preemption](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#enabling-priority-and-preemption). In Kubernetes 1.10, you should give your critical add-on Pods high enough priority to ensure they are scheduled properly when the cluster is unser resource pressure.
+NOTE: [Rescheduler is being retired in Kubernetes 1.10](https://groups.google.com/forum/#!msg/kubernetes-dev/UmW0iNRLEO0/FmDNUhyLDQAJ) and is replaced by [Priority and Preemption](/docs/concepts/configuration/pod-priority-preemption/#enabling-priority-and-preemption). In Kubernetes 1.10, you should give your critical add-on Pods high enough priority to ensure they are scheduled properly when the cluster is unser resource pressure.
 
 Rescheduler ensures that critical add-ons are always scheduled
 (assuming the cluster has enough resources to run the critical add-on pods in the absence of regular pods).

--- a/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods.md
+++ b/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods.md
@@ -20,6 +20,8 @@ vacated by the evicted critical add-on pod or the amount of resources available 
 
 ## Rescheduler: guaranteed scheduling of critical add-ons
 
+NOTE: [Rescheduler is being retired in Kubernetes 1.10](https://groups.google.com/forum/#!msg/kubernetes-dev/UmW0iNRLEO0/FmDNUhyLDQAJ) and is replaced by [Priority and Preemption](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#enabling-priority-and-preemption). In Kubernetes 1.10, you should give your critical add-on Pods high enough priority to ensure they are scheduled properly when the cluster is unser resource pressure.
+
 Rescheduler ensures that critical add-ons are always scheduled
 (assuming the cluster has enough resources to run the critical add-on pods in the absence of regular pods).
 If the scheduler determines that no node has enough free resources to run the critical add-on pod


### PR DESCRIPTION
Add a note to the doc that Rescheduler is being retired in Kubernetes 1.10.

/sig scheduling
cc: @davidopp @thkoch2001

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7170)
<!-- Reviewable:end -->
