### PR TITLE
Add clarification about apiVersion value in examples

### DIFF
--- a/cn/docs/admin/daemon.yaml
+++ b/cn/docs/admin/daemon.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1 
+apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: prometheus-node-exporter

--- a/cn/docs/concepts/workloads/controllers/nginx-deployment.yaml
+++ b/cn/docs/concepts/workloads/controllers/nginx-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1 # for versions before 1.6.0 use extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: nginx-deployment

--- a/docs/concepts/overview/working-with-objects/nginx-deployment.yaml
+++ b/docs/concepts/overview/working-with-objects/nginx-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment

--- a/docs/tasks/run-application/deployment-patch-demo.yaml
+++ b/docs/tasks/run-application/deployment-patch-demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: patch-demo

--- a/docs/tasks/run-application/deployment-scale.yaml
+++ b/docs/tasks/run-application/deployment-scale.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment

--- a/docs/tasks/run-application/deployment-update.yaml
+++ b/docs/tasks/run-application/deployment-update.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment

--- a/docs/tasks/run-application/deployment.yaml
+++ b/docs/tasks/run-application/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment

--- a/docs/tasks/run-application/mysql-deployment.yaml
+++ b/docs/tasks/run-application/mysql-deployment.yaml
@@ -20,7 +20,7 @@ spec:
     requests:
       storage: 20Gi
 ---
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mysql

--- a/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/mysql-deployment.yaml
+++ b/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/mysql-deployment.yaml
@@ -25,7 +25,7 @@ spec:
     requests:
       storage: 20Gi
 ---
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: wordpress-mysql

--- a/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/wordpress-deployment.yaml
+++ b/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/wordpress-deployment.yaml
@@ -25,7 +25,7 @@ spec:
     requests:
       storage: 20Gi
 ---
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: wordpress

--- a/docs/tutorials/stateless-application/guestbook/frontend-deployment.yaml
+++ b/docs/tutorials/stateless-application/guestbook/frontend-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: frontend

--- a/docs/tutorials/stateless-application/guestbook/redis-master-deployment.yaml
+++ b/docs/tutorials/stateless-application/guestbook/redis-master-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis-master

--- a/docs/tutorials/stateless-application/guestbook/redis-slave-deployment.yaml
+++ b/docs/tutorials/stateless-application/guestbook/redis-slave-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis-slave


### PR DESCRIPTION
The version apps/v1beta2 was only introduced in the v1.8. For v1.7 and v1.6, the
api version was apps/v1beta1. The current comment won't work on version
earlier than v1.8 so update it to provide a better clarification. Provide a better clarification
considering v1.7 is only two release old and still commonly used.

Fixes #7231 

> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7232)
<!-- Reviewable:end -->
