### PR TITLE
Remove stale OWNERS file

### DIFF
--- a/docs/getting-started-guides/docker-multinode/OWNERS
+++ b/docs/getting-started-guides/docker-multinode/OWNERS
@@ -1,4 +1,0 @@
-approvers:
-- dchen1107
-- resouer
-


### PR DESCRIPTION
cc @dchen1107 @resouer

There are no other files in `docs/getting-started-guides/docker-multinode`, so nothing to own really.

There is an entry in `_redirects`, but I don't think that's the reason we have this stale OWNERS file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7241)
<!-- Reviewable:end -->