### PR TITLE
re: Issue #6976 - Registry secret type and datakey updated for 1.9

### DIFF
--- a/docs/tasks/configure-pod-container/pull-image-private-registry.md
+++ b/docs/tasks/configure-pod-container/pull-image-private-registry.md
@@ -70,28 +70,28 @@ The output is similar to this:
 
     apiVersion: v1
     data:
-      .dockercfg: eyJodHRwczovL2luZGV4L ... J0QUl6RTIifX0=
+      .dockerconfigjson: eyJodHRwczovL2luZGV4L ... J0QUl6RTIifX0=
     kind: Secret
     metadata:
       ...
       name: regsecret
       ...
-    type: kubernetes.io/dockercfg
+    type: kubernetes.io/dockerconfigjson
 
-The value of the `.dockercfg` field is a base64 representation of your secret data.
+The value of the `.dockerconfigjson` field is a base64 representation of your secret data.
 
 Copy the base64 representation of the secret data into a file named `secret64`.
 
 **Important**: Make sure there are no line breaks in your `secret64` file.
 
-To understand what is in the `.dockercfg` field, convert the secret data to a
+To understand what is in the `.dockerconfigjson` field, convert the secret data to a
 readable format:
 
     base64 -d secret64
 
 The output is similar to this:
 
-    {"yourprivateregistry.com":{"username":"janedoe","password":"xxxxxxxxxxx","email":"jdoe@example.com","auth":"c3R...zE2"}}
+    {"auths":{"yourprivateregistry.com":{"username":"janedoe","password":"xxxxxxxxxxx","email":"jdoe@example.com","auth":"c3R...zE2"}}}
 
 Notice that the secret data contains the authorization token from your
 `config.json` file.


### PR DESCRIPTION
kubectl 1.9+ updated registry secret type and datakey: 's/.dockercfg/.dockerconfigjson, and datakey now wrapped in 'auths' element. See https://github.com/kubernetes/kubernetes/issues/57427 for more information. 

Checked against kubectl 1.9.2

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7248)
<!-- Reviewable:end -->
