### PR TITLE
fix a typo in kubernetes api

### DIFF
--- a/docs/home/contribute/generated-reference/kubernetes-api.md
+++ b/docs/home/contribute/generated-reference/kubernetes-api.md
@@ -100,7 +100,7 @@ or more comments in the Kubernetes source code.
 will be different in your situation.
 {: .note}
 
-Here's an example of editing the a comment in the Kubernetes source code.
+Here's an example of editing a comment in the Kubernetes source code.
 
 In your local kubernetes/kubernetes repository, check out the master branch,
 and make sure it is up to date:


### PR DESCRIPTION
fix a typo in kubernetes api

> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7261)
<!-- Reviewable:end -->
