### PR TITLE
Add instructions to remove docker images; fixes #6874

### DIFF
--- a/docs/tutorials/stateless-application/hello-minikube.md
+++ b/docs/tutorials/stateless-application/hello-minikube.md
@@ -381,7 +381,7 @@ kubectl delete service hello-node
 kubectl delete deployment hello-node
 ```
 
-Optionally, remove the Docker images created:
+Optionally, force removal of the Docker images created:
 
 ```shell
 docker rmi hello-node:v1 hello-node:v2 -f

--- a/docs/tutorials/stateless-application/hello-minikube.md
+++ b/docs/tutorials/stateless-application/hello-minikube.md
@@ -381,6 +381,12 @@ kubectl delete service hello-node
 kubectl delete deployment hello-node
 ```
 
+Optionally, remove the Docker images created:
+
+```shell
+docker rmi hello-node:v1 hello-node:v2 -f
+```
+
 Optionally, stop the Minikube VM:
 
 ```shell


### PR DESCRIPTION
On cleanup of Minikube, adds instructions to optionally remove Docker images created in tutorial setup

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7264)
<!-- Reviewable:end -->
