### PR TITLE
Update OWNERS_ALIASES for sig-openstack

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -149,9 +149,9 @@ aliases:
     - feiskyer
     - nebril
   sig-openstack: #GH: sig-openstack-pr-reviews
-    - idvoretskyi
-    - xsgordon
-    - NickrenREN
+    - hogepodge
+    - dklyle
+    - rjmorse
   sig-pm: #aka Product Management
     - apsinha
     - idvoretskyi


### PR DESCRIPTION
This patch updates the OWNERS_ALIASES file to reflect the leadership
changes in sig-openstack.[1]

[1] https://github.com/kubernetes/community/blob/master/OWNERS_ALIASES#L68

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
