### PR TITLE
converting the leaf OWNER files to reviewers

### DIFF
--- a/docs/admin/OWNERS
+++ b/docs/admin/OWNERS
@@ -1,4 +1,4 @@
-approvers:
+reviewers:
 - derekwaynecarr
 - mikedanese
 

--- a/docs/admin/federation/OWNERS
+++ b/docs/admin/federation/OWNERS
@@ -1,4 +1,4 @@
-approvers:
+reviewers:
 - madhusudancs
 - mml
 - nikhiljindal

--- a/docs/admin/high-availability/OWNERS
+++ b/docs/admin/high-availability/OWNERS
@@ -1,4 +1,4 @@
-approvers:
+reviewers:
 - davidopp
 - lavalamp
 

--- a/docs/admin/limitrange/OWNERS
+++ b/docs/admin/limitrange/OWNERS
@@ -1,4 +1,4 @@
-approvers:
+reviewers:
 - derekwaynecarr
 - janetkuo
 

--- a/docs/admin/multiple-schedulers/OWNERS
+++ b/docs/admin/multiple-schedulers/OWNERS
@@ -1,4 +1,4 @@
-approvers:
+reviewers:
 - davidopp
 - madhusudancs
 

--- a/docs/admin/resourcequota/OWNERS
+++ b/docs/admin/resourcequota/OWNERS
@@ -1,3 +1,3 @@
-approvers:
+reviewers:
 - derekwaynecarr
 

--- a/docs/getting-started-guides/OWNERS
+++ b/docs/getting-started-guides/OWNERS
@@ -1,3 +1,3 @@
-approvers:
+reviewers:
 - errordeveloper
 

--- a/docs/getting-started-guides/coreos/OWNERS
+++ b/docs/getting-started-guides/coreos/OWNERS
@@ -1,3 +1,3 @@
-approvers:
+reviewers:
 - errordeveloper
 

--- a/docs/getting-started-guides/fedora/OWNERS
+++ b/docs/getting-started-guides/fedora/OWNERS
@@ -1,4 +1,4 @@
-approvers:
+reviewers:
 - aveshagarwal
 - eparis
 - thockin

--- a/docs/getting-started-guides/rkt/OWNERS
+++ b/docs/getting-started-guides/rkt/OWNERS
@@ -1,4 +1,4 @@
-approvers:
+reviewers:
 - lavalamp
 - yifan-gu
 

--- a/docs/user-guide/OWNERS
+++ b/docs/user-guide/OWNERS
@@ -1,4 +1,4 @@
-approvers:
+reviewers:
 - erictune
 - janetkuo
 - satnam6502

--- a/docs/user-guide/configmap/OWNERS
+++ b/docs/user-guide/configmap/OWNERS
@@ -1,4 +1,4 @@
-approvers:
+reviewers:
 - dchen1107
 - pmorie
 

--- a/docs/user-guide/downward-api/OWNERS
+++ b/docs/user-guide/downward-api/OWNERS
@@ -1,4 +1,4 @@
-approvers:
+reviewers:
 - bgrant0607
 - mikedanese
 

--- a/docs/user-guide/environment-guide/OWNERS
+++ b/docs/user-guide/environment-guide/OWNERS
@@ -1,3 +1,3 @@
-approvers:
+reviewers:
 - mikedanese
 

--- a/docs/user-guide/federation/OWNERS
+++ b/docs/user-guide/federation/OWNERS
@@ -1,3 +1,3 @@
-approvers:
+reviewers:
 - quinton-hoole
 

--- a/docs/user-guide/horizontal-pod-autoscaling/OWNERS
+++ b/docs/user-guide/horizontal-pod-autoscaling/OWNERS
@@ -1,4 +1,4 @@
-approvers:
+reviewers:
 - fgrzadkowski
 - janetkuo
 - jszczepkowski

--- a/docs/user-guide/jobs/OWNERS
+++ b/docs/user-guide/jobs/OWNERS
@@ -1,4 +1,4 @@
-approvers:
+reviewers:
 - caesarxuchao
 - erictune
 - soltysh

--- a/docs/user-guide/liveness/OWNERS
+++ b/docs/user-guide/liveness/OWNERS
@@ -1,3 +1,3 @@
-approvers:
+reviewers:
 - mikedanese
 

--- a/docs/user-guide/nginx/OWNERS
+++ b/docs/user-guide/nginx/OWNERS
@@ -1,3 +1,3 @@
-approvers:
+reviewers:
 - janetkuo
 

--- a/docs/user-guide/node-selection/OWNERS
+++ b/docs/user-guide/node-selection/OWNERS
@@ -1,4 +1,4 @@
-approvers:
+reviewers:
 - dchen1107
 - mikedanese
 

--- a/docs/user-guide/persistent-volumes/OWNERS
+++ b/docs/user-guide/persistent-volumes/OWNERS
@@ -1,4 +1,4 @@
-approvers:
+reviewers:
 - jsafrane
 - mikedanese
 - saad-ali

--- a/docs/user-guide/pod-preset/OWNERS
+++ b/docs/user-guide/pod-preset/OWNERS
@@ -1,2 +1,2 @@
-approvers:
+reviewers:
 - jessfraz

--- a/docs/user-guide/projected-volume/OWNERS
+++ b/docs/user-guide/projected-volume/OWNERS
@@ -1,4 +1,4 @@
-approvers:
+reviewers:
 - jpeeler
 - pmorie
 

--- a/docs/user-guide/replicasets/OWNERS
+++ b/docs/user-guide/replicasets/OWNERS
@@ -1,4 +1,4 @@
-approvers:
+reviewers:
 - bprashanth
 - madhusudancs
 

--- a/docs/user-guide/secrets/OWNERS
+++ b/docs/user-guide/secrets/OWNERS
@@ -1,4 +1,4 @@
-approvers:
+reviewers:
 - mikedanese
 - pmorie
 

--- a/docs/user-guide/services/OWNERS
+++ b/docs/user-guide/services/OWNERS
@@ -1,4 +1,4 @@
-approvers:
+reviewers:
 - bprashanth
 - janetkuo
 - mikedanese

--- a/docs/user-guide/update-demo/OWNERS
+++ b/docs/user-guide/update-demo/OWNERS
@@ -1,4 +1,4 @@
-approvers:
+reviewers:
 - janetkuo
 - mikedanese
 

--- a/docs/user-guide/walkthrough/OWNERS
+++ b/docs/user-guide/walkthrough/OWNERS
@@ -1,4 +1,4 @@
-approvers:
+reviewers:
 - eparis
 - janetkuo
 - mikedanese


### PR DESCRIPTION
resolves #7289

specifically, if the individuals listed in these leaf-node OWNERS
files issue an `/lgtm` comment on documents, it will no longer be taken
as an approver lgtm override that will merge the documents. This
preserves them in being chosen for reviews to the documents, and still
supports them using `/lgtm` to indicate technical accuracy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7291)
<!-- Reviewable:end -->
