### PR TITLE
notate the lease endpoint reconciler is alpha

### DIFF
--- a/docs/admin/high-availability/building.md
+++ b/docs/admin/high-availability/building.md
@@ -209,13 +209,14 @@ continuously try to add itself to the list of endpoints while removing
 the other ones, causing a lot of extraneous updates in kube-proxy
 and other components.
 
-Starting with Kubernetes 1.9, a new reconciler implementation is available.
-It uses a *lease* that is regularly renewed by each apiserver
-replica. When a replica is down, it stops renewing its lease, and
-the other replicas notice that the lease expired and remove it
-from the list of endpoints. You can switch to the new reconciler
-by adding the flag `--endpoint-reconciler-type=lease` when starting
-your apiserver replicas.
+Starting with Kubernetes 1.9, a new alpha reconciler implementation is
+available.  It uses a *lease* that is regularly renewed by each apiserver
+replica. When a replica is down, it stops renewing its lease, and the other
+replicas notice that the lease expired and remove it from the list of
+endpoints. You can switch to the new reconciler by adding the flag
+`--endpoint-reconciler-type=lease` when starting your apiserver replicas.
+
+{% include feature-state-alpha.md %}
 
 If you want to know more, you can check the following resources:
 - [issue kubernetes/kuberenetes#22609](https://github.com/kubernetes/kubernetes/issues/22609),


### PR DESCRIPTION
Notates the lease endpoint reconciler is alpha

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7305)
<!-- Reviewable:end -->
