### PR TITLE
Fix minor typo

### DIFF
--- a/docs/tasks/administer-cluster/out-of-resource.md
+++ b/docs/tasks/administer-cluster/out-of-resource.md
@@ -80,7 +80,7 @@ where:
 
 * `eviction-signal` is an eviction signal token as defined in the previous table.
 * `operator` is the desired relational operator, such as `<` (less than).
-* `quantity` is the eviction threshhold quantity, such as `1Gi`. These tokens must
+* `quantity` is the eviction threshold quantity, such as `1Gi`. These tokens must
 match the quantity representation used by Kubernetes. An eviction threshold can also
 be expressed as a percentage using the `%` token.
 


### PR DESCRIPTION
`threshold` was spelled `threshhold`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7310)
<!-- Reviewable:end -->
