### PR TITLE
Fix explanation about eviction threshold

### DIFF
--- a/docs/tasks/administer-cluster/out-of-resource.md
+++ b/docs/tasks/administer-cluster/out-of-resource.md
@@ -312,7 +312,7 @@ To facilitate this scenario, the `kubelet` would be launched as follows:
 Implicit in this configuration is the understanding that "System reserved" should include the amount of memory
 covered by the eviction threshold.
 
-To reach that capacity, either some Pod is using more than its request, or the system is using more than `500Mi`.
+To reach that capacity, either some Pod is using more than its request, or the system is using more than `1.5Gi - 500Mi = 1Gi`.
 
 This configuration ensures that the scheduler does not place Pods on a node that immediately induce memory pressure
 and trigger eviction assuming those Pods use less than their configured request.


### PR DESCRIPTION
I guess the 500Mi comes from an older commit where the system-reserved was 1Gi.
But if in this example, the system has 1.5G reserved (which include the amount of memory covered by the eviction threshold of 500Mi) meaning that in reality there's 1G for the system and if the system goes above that it triggers the eviction signal, correct?
Based on that assumption I fixed the doc (adding the operation so that it's less confusing)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7311)
<!-- Reviewable:end -->
