### PR TITLE
update federation control plane turn down command

### DIFF
--- a/docs/tasks/federation/set-up-cluster-federation-kubefed.md
+++ b/docs/tasks/federation/set-up-cluster-federation-kubefed.md
@@ -483,7 +483,7 @@ federation control plane's etcd. You can delete the federation
 namespace by running the following command:
 
 ```
-kubectl delete ns federation-system --host-cluster-context=rivendell
+kubectl delete ns federation-system --context=rivendell
 ```
 
 Note that `rivendell` is the host cluster name, replace that with the


### PR DESCRIPTION
**kubectl** uses `--context` option for specifying the context, the option `--host-cluster-context` is for **kubefed join**.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7332)
<!-- Reviewable:end -->
