### PR TITLE
Update kubeadm-upgrade-1-8.md

### DIFF
--- a/docs/tasks/administer-cluster/kubeadm-upgrade-1-8.md
+++ b/docs/tasks/administer-cluster/kubeadm-upgrade-1-8.md
@@ -115,7 +115,7 @@ Components that must be upgraded manually after you've upgraded the control plan
 COMPONENT   CURRENT      AVAILABLE
 Kubelet     1 x v1.7.1   v1.8.0
 
-Upgrade to the latest experimental version:
+Upgrade to the latest stable version:
 
 COMPONENT            CURRENT   AVAILABLE
 API Server           v1.7.1    v1.8.0


### PR DESCRIPTION
If we are getting releases from the stable channel, I think the plan output would say stable instead of experimental. At least, that is what I see in this video, around 40:15 mins in: https://www.youtube.com/watch?v=x9doB5eJWgQ&feature=youtu.be

> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7337)
<!-- Reviewable:end -->
