### PR TITLE
Add doc about docker daemon in minikube tutorial

### DIFF
--- a/docs/tutorials/stateless-application/hello-minikube.md
+++ b/docs/tutorials/stateless-application/hello-minikube.md
@@ -76,7 +76,7 @@ Determine whether you can access sites like [https://cloud.google.com/container-
 curl --proxy "" https://cloud.google.com/container-registry/
 ```
 
-Make sure that the Docker daemon is started.
+Make sure that the Docker daemon is started. You can determine if docker is running by using a command such as:
 
 ```shell
 docker images

--- a/docs/tutorials/stateless-application/hello-minikube.md
+++ b/docs/tutorials/stateless-application/hello-minikube.md
@@ -76,6 +76,8 @@ Determine whether you can access sites like [https://cloud.google.com/container-
 curl --proxy "" https://cloud.google.com/container-registry/
 ```
 
+Make sure that the Docker daemon is started.
+
 If NO proxy is required, start the Minikube cluster:
 
 ```shell

--- a/docs/tutorials/stateless-application/hello-minikube.md
+++ b/docs/tutorials/stateless-application/hello-minikube.md
@@ -78,6 +78,10 @@ curl --proxy "" https://cloud.google.com/container-registry/
 
 Make sure that the Docker daemon is started.
 
+```shell
+docker images
+```
+
 If NO proxy is required, start the Minikube cluster:
 
 ```shell


### PR DESCRIPTION
Adding documentation to first start the Docker daemon before doing `minikube start --vm-driver=xhyve` in the Minikube tutorial https://kubernetes.io/docs/tutorials/stateless-application/hello-minikube/.

Fixes https://github.com/kubernetes/website/issues/7159.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7373)
<!-- Reviewable:end -->
