### PR TITLE
Add doc about opening k8s dashboard in Minikube tutorial

### DIFF
--- a/docs/tutorials/stateless-application/hello-minikube.md
+++ b/docs/tutorials/stateless-application/hello-minikube.md
@@ -122,6 +122,12 @@ Verify that `kubectl` is configured to communicate with your cluster:
 kubectl cluster-info
 ```
 
+Open the kubernetes dashboard GUI in browser:
+
+```shell
+minikube dashboard
+```
+
 ## Create your Node.js application
 
 The next step is to write the application. Save this code in a folder named `hellonode`

--- a/docs/tutorials/stateless-application/hello-minikube.md
+++ b/docs/tutorials/stateless-application/hello-minikube.md
@@ -122,7 +122,7 @@ Verify that `kubectl` is configured to communicate with your cluster:
 kubectl cluster-info
 ```
 
-Open the kubernetes dashboard GUI in browser:
+Open the Kubernetes dashboard in a browser:
 
 ```shell
 minikube dashboard


### PR DESCRIPTION
Adding documentation about how to open the kubernetes dashboard using `minikube dashboard` in the Minikube tutorial https://kubernetes.io/docs/tutorials/stateless-application/hello-minikube/.

Fixes https://github.com/kubernetes/website/issues/2450.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7375)
<!-- Reviewable:end -->
