### PR TITLE
Increase min version, because YAML has been changed to apps/v1.

### DIFF
--- a/docs/tasks/run-application/run-stateless-application-deployment.md
+++ b/docs/tasks/run-application/run-stateless-application-deployment.md
@@ -1,6 +1,6 @@
 ---
 title: Run a Stateless Application Using a Deployment
-min-kubernetes-server-version: v1.8
+min-kubernetes-server-version: v1.9
 ---
 
 {% capture overview %}


### PR DESCRIPTION
This increases min-kubernetes-server-version in the front matter of a task page. This is needed because someone changed the version to apps/v1 in the YAML file.

The **Before you begin** section in this topic now says your Kubernetes server version must be 1.9.
[Run a Stateless Application Using a Deployment](https://deploy-preview-7385--kubernetes-io-master-staging.netlify.com/docs/tasks/run-application/run-stateless-application-deployment/)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7385)
<!-- Reviewable:end -->
