### PR TITLE
Document that HugePages feature gate is Beta

### DIFF
--- a/docs/reference/feature-gates.md
+++ b/docs/reference/feature-gates.md
@@ -50,7 +50,8 @@ different Kubernetes components.
 | `ExpandPersistentVolumes` | `false` | Alpha | 1.8 | 1.8 |
 | `ExperimentalCriticalPodAnnotation` | `false` | Alpha | 1.5 | |
 | `ExperimentalHostUserNamespaceDefaulting` | `false` | Beta | 1.5 | |
-| `HugePages` | `false` | Alpha | 1.8 | |
+| `HugePages` | `false` | Alpha | 1.8 | 1.9 |
+| `HugePages` | `true` | Beta| 1.10 | |
 | `Initializers` | `false` | Alpha | 1.7 | |
 | `KubeletConfigFile` | `false` | Alpha | 1.8 | 1.9 |
 | `LocalStorageCapacityIsolation` | `false` | Alpha | 1.7 | |

--- a/docs/tasks/manage-hugepages/scheduling-hugepages.md
+++ b/docs/tasks/manage-hugepages/scheduling-hugepages.md
@@ -5,10 +5,10 @@ title: Manage HugePages
 ---
 
 {% capture overview %}
-{% include feature-state-alpha.md %}
+{% include feature-state-beta.md %}
 
 Kubernetes supports the allocation and consumption of pre-allocated huge pages
-by applications in a Pod as an **alpha** feature. This page describes how users
+by applications in a Pod as a **beta** feature. This page describes how users
 can consume huge pages and the current limitations.
 
 {% endcapture %}
@@ -18,8 +18,6 @@ can consume huge pages and the current limitations.
 1. Kubernetes nodes must pre-allocate huge pages in order for the node to report
    its huge page capacity. A node may only pre-allocate huge pages for a single
    size.
-1. A special **alpha** feature gate `HugePages` has to be set to true across the
-   system: `--feature-gates=HugePages=true`.
 
 The nodes will automatically discover and report all huge page resources as a
 schedulable resource.


### PR DESCRIPTION
The `HugePages` feature gate has graduated to Beta in v1.10. This PR
documents this fact.

Reference: kubernetes/kubernetes#56939

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7387)
<!-- Reviewable:end -->
