### PR TITLE
Document the removal of Accelerators feature gate

### DIFF
--- a/docs/reference/feature-gates.md
+++ b/docs/reference/feature-gates.md
@@ -25,7 +25,7 @@ different Kubernetes components.
 
 | Feature | Default | Stage | Since | Until |
 |---------|---------|-------|-------|-------|
-| `Accelerators` | `false` | Alpha | 1.6 | |
+| `Accelerators` | `false` | Alpha | 1.6 | 1.10 |
 | `AdvancedAuditing` | `false` | Alpha | 1.7 | |
 | `AdvancedAuditing` | `true` | Beta | 1.8 | |
 | `AffinityInAnnotations` | `false` | Alpha | 1.6 | 1.7 |


### PR DESCRIPTION
The `Accelerators` feature gate will be removed in 1.11. 1.10 will be
its last mile.
References: kubernetes/kubernetes#57384

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7389)
<!-- Reviewable:end -->
