### PR TITLE
Update CPU manager feature enabling

### DIFF
--- a/docs/tasks/administer-cluster/cpu-management-policies.md
+++ b/docs/tasks/administer-cluster/cpu-management-policies.md
@@ -34,7 +34,7 @@ management policies to determine some placement preferences on the node.
 ### Configuration
 
 The CPU Manager is introduced as an alpha feature in Kubernetes v1.8. It
-must be explicitly enabled in the kubelet feature gates:
+must be explicitly enabled in the kubelet feature gates before v1.10:
 `--feature-gates=CPUManager=true`.
 
 The CPU Manager policy is set with the `--cpu-manager-policy` kubelet


### PR DESCRIPTION
With `CPUManager` feature graduating to beta. No explicit enabling is
required starting v1.10.
References: kubernetes/kubernetes#55977