### PR TITLE
Update Calico installation URL

### DIFF
--- a/docs/setup/independent/create-cluster-kubeadm.md
+++ b/docs/setup/independent/create-cluster-kubeadm.md
@@ -257,7 +257,7 @@ Refer to the Calico documentation for a [kubeadm quickstart](https://docs.projec
  - Calico works on `amd64` only.
 
 ```shell
-kubectl apply -f https://docs.projectcalico.org/v2.6/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
+kubectl apply -f https://docs.projectcalico.org/v3.0/getting-started/kubernetes/installation/hosted/kubeadm/1.7/calico.yaml
 ```
 {% endcapture %}
 


### PR DESCRIPTION
Calico official page[1] shows Calico installation URL is
https://docs.projectcalico.org/v3.0/getting-started/kubernetes/installation/hosted/kubeadm/1.7/calico.yaml
but the kubeadm installation pages showed
https://docs.projectcalico.org/v2.6/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
then, many people cannot deploy Kubernetes environments with Calico as
[2]
This commit updates the URL.

[1]: https://docs.projectcalico.org/v3.0/getting-started/kubernetes/
[2]: https://github.com/kubernetes/kubernetes/issues/55471

fixes #7396 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7397)
<!-- Reviewable:end -->
