### PR TITLE
Fixed zookeeper YAML and Document headless reference

### DIFF
--- a/docs/tutorials/stateful-application/zookeeper.md
+++ b/docs/tutorials/stateful-application/zookeeper.md
@@ -931,12 +931,12 @@ This is because the Pods in the `zk` StatefulSet have a PodAntiAffinity specifie
                   - key: "app"
                     operator: In
                     values: 
-                    - zk-headless
+                    - zk-hs
               topologyKey: "kubernetes.io/hostname"
 ```
 
 The `requiredDuringSchedulingIgnoredDuringExecution` field tells the 
-Kubernetes Scheduler that it should never co-locate two Pods from the `zk-headless`
+Kubernetes Scheduler that it should never co-locate two Pods from the `zk-hs`
 Service in the domain defined by the `topologyKey`. The `topologyKey`
 `kubernetes.io/hostname` indicates that the domain is an individual node. Using 
 different rules, labels, and selectors, you can extend this technique to spread 

--- a/docs/tutorials/stateful-application/zookeeper.yaml
+++ b/docs/tutorials/stateful-application/zookeeper.yaml
@@ -63,7 +63,7 @@ spec:
                   - key: "app"
                     operator: In
                     values:
-                    - zk
+                    - zk-hs
               topologyKey: "kubernetes.io/hostname"
       containers:
       - name: kubernetes-zookeeper


### PR DESCRIPTION
The documentation references a zk-headless service, I believe this has been renamed to zk-hs. The StatefulSet's podAntiAffinity was also set to check "zk", which would result in an error where Pods zk-1 and zk-2 would stay "pending" indefinitely . Changing this to check the "zk-hs" service instead allows all Pods in the stateful set to successfully run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7404)
<!-- Reviewable:end -->
