### PR TITLE
Add crds as abbreviated alias

### DIFF
--- a/cn/docs/user-guide/kubectl-overview.md
+++ b/cn/docs/user-guide/kubectl-overview.md
@@ -93,7 +93,7 @@ Operation       | Syntax    |       Description
 `configmaps` |`cm`
 `controllerrevisions` |
 `cronjobs` |
-`customresourcedefinition` |`crd`
+`customresourcedefinition` |`crd`, `crds`
 `daemonsets` |`ds`
 `deployments` |`deploy`
 `endpoints` |`ep`

--- a/docs/reference/kubectl/cheatsheet.md
+++ b/docs/reference/kubectl/cheatsheet.md
@@ -250,7 +250,7 @@ Resource type   | Abbreviated alias
 `configmaps` |`cm`
 `controllerrevisions` |
 `cronjobs` |
-`customresourcedefinition` |`crd`
+`customresourcedefinition` |`crd`, `crds`
 `daemonsets` |`ds`
 `deployments` |`deploy`
 `endpoints` |`ep`


### PR DESCRIPTION
`crds` was added as a short name for CustomResourceDefinition in https://github.com/kubernetes/kubernetes/pull/59061.

Preview link: https://deploy-preview-7437--kubernetes-io-vnext-staging.netlify.com/docs/reference/kubectl/cheatsheet/

/cc sttts

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7437)
<!-- Reviewable:end -->
