### PR TITLE
Update cassandra-statefulset.yaml

### DIFF
--- a/docs/tutorials/stateful-application/cassandra/cassandra-statefulset.yaml
+++ b/docs/tutorials/stateful-application/cassandra/cassandra-statefulset.yaml
@@ -82,10 +82,9 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: cassandra-data
-      annotations:
-        volume.beta.kubernetes.io/storage-class: fast
     spec:
       accessModes: [ "ReadWriteOnce" ]
+      storageClassName: fast
       resources:
         requests:
           storage: 1Gi


### PR DESCRIPTION
Specifying storage class name using annotations is deprecated since v1.6. Updating it to `storageClassName` field.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7438)
<!-- Reviewable:end -->
