### PR TITLE
Two bug fixes to HA guide for kubeadm:

### DIFF
--- a/docs/setup/independent/high-availability.md
+++ b/docs/setup/independent/high-availability.md
@@ -433,7 +433,7 @@ Only follow this step if your etcd is hosted on dedicated nodes (**Option 1**). 
    apiServerCertSANs:
    - <load-balancer-ip>
    apiServerExtraArgs:
-     apiserver-count: 3
+     apiserver-count: "3"
    EOF
    ```
 
@@ -467,7 +467,7 @@ Before running kubeadm on the other masters, you need to first copy the K8s CA c
 
 #### Option 2: Copy paste
 
-1. Copy the contents of `/etc/kubernetes/pki/ca.crt` and `/etc/kubernetes/pki/ca.key` and create these files manually on `master1` and `master2`.
+1. Copy the contents of `/etc/kubernetes/pki/ca.crt`, `/etc/kubernetes/pki/ca.key`, `/etc/kubernetes/pki/sa.key` and `/etc/kubernetes/pki/sa.pub` and create these files manually on `master1` and `master2`.
 
 When this is done, you can follow the [previous step](#kubeadm-init-master0) to install the control plane with kubeadm.
 


### PR DESCRIPTION
Two bug fixes to HA guide for kubeadm:

- In the provided configuration file for kubeadm init the value for apiserver-count needs to be put in quotes.
- In addition to /etc/kubernetes/pki/ca.* also /etc/kubernetes/pki/sa.* need to be copied to the additional masters. See this comment by @petergardfjall for details.

This PR obsoletes _"Certs"_ #7425 in which I had accidentally included the commits from another PR _"HA guide for kubeadm"_ #7410.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7451)
<!-- Reviewable:end -->
