### PR TITLE
glossary entry for PodPreset

### DIFF
--- a/_data/glossary/podpreset.yaml
+++ b/_data/glossary/podpreset.yaml
@@ -1,0 +1,12 @@
+id: podpreset
+name: PodPreset
+tags:
+- operation
+short-description: >
+  An API object that injects information like secrets, volume mounts,
+  and environment variables into pods at creation time.
+long-description: >
+  This object chooses the pods to inject information into with the
+  standard selectors. This allows the podspec definitions to be
+  nonspecific, decoupling the podspec from environment specific
+  configuration.

--- a/_data/glossary/podpreset.yaml
+++ b/_data/glossary/podpreset.yaml
@@ -3,10 +3,10 @@ name: PodPreset
 tags:
 - operation
 short-description: >
-  An API object that injects information like secrets, volume mounts,
+  An API object that injects information such as secrets, volume mounts,
   and environment variables into pods at creation time.
 long-description: >
-  This object chooses the pods to inject information into with the
+  This object chooses the pods to inject information into using
   standard selectors. This allows the podspec definitions to be
   nonspecific, decoupling the podspec from environment specific
   configuration.


### PR DESCRIPTION
we use or wanted this and it was partially created for https://github.com/kubernetes-incubator/service-catalog . I don't know if that's appropriate to mention in the glossary. It moved from the core apiserver to our service catalog apiserver.

I don't know what options are available for tags, so I just picked one.

@bradtopol WDYT?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7468)
<!-- Reviewable:end -->
