### PR TITLE
Add HyperVContainer feature gates

### DIFF
--- a/docs/reference/feature-gates.md
+++ b/docs/reference/feature-gates.md
@@ -51,6 +51,7 @@ different Kubernetes components.
 | `ExperimentalCriticalPodAnnotation` | `false` | Alpha | 1.5 | |
 | `ExperimentalHostUserNamespaceDefaulting` | `false` | Beta | 1.5 | |
 | `HugePages` | `false` | Alpha | 1.8 | |
+| `HyperVContainer` | `false` | Alpha | 1.10 | |
 | `Initializers` | `false` | Alpha | 1.7 | |
 | `KubeletConfigFile` | `false` | Alpha | 1.8 | |
 | `LocalStorageCapacityIsolation` | `false` | Alpha | 1.7 | |
@@ -143,6 +144,7 @@ Each feature gate is designed for enabling/disabling a specific feature:
    capabilities (e.g. `MKNODE`, `SYS_MODULE` etc.). This should only be enabled
    if user namespace remapping is enabled in the Docker daemon.
 - `HugePages`: Enable the allocation and consumption of pre-allocated [huge pages](/docs/tasks/manage-hugepages/scheduling-hugepages/).
+- `HyperVContainer`: Enable [Hyper-V isolation](https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/hyperv-container) for Windows containers.
 - `Intializers`: Enable the [dynamic admission control](/docs/admin/extensible-admission-controllers/)
   as an extension to the built-in [admission controllers](/docs/admin/admission-controllers/).
   When the `Initializers` admission controller is enabled, this feature is automatically enabled.


### PR DESCRIPTION
This PR adds HyperVContainer feature gates to docs.

Refer https://github.com/kubernetes/kubernetes/pull/58751.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7480)
<!-- Reviewable:end -->
