### PR TITLE
Don't encourage people to mount downwardAPI volumes on /etc

### DIFF
--- a/cn/docs/tasks/inject-data-application/dapi-volume-resources.yaml
+++ b/cn/docs/tasks/inject-data-application/dapi-volume-resources.yaml
@@ -10,14 +10,14 @@ spec:
       args:
       - while true; do
           echo -en '\n';
-          if [[ -e /etc/cpu_limit ]]; then
-            echo -en '\n'; cat /etc/cpu_limit; fi;
+          if [[ -e /etc/podinfo/cpu_limit ]]; then
+            echo -en '\n'; cat /etc/podinfo/cpu_limit; fi;
           if [[ -e /etc/cpu_request ]]; then
-            echo -en '\n'; cat /etc/cpu_request; fi;
+            echo -en '\n'; cat /etc/podinfo/cpu_request; fi;
           if [[ -e /etc/mem_limit ]]; then
-            echo -en '\n'; cat /etc/mem_limit; fi;
+            echo -en '\n'; cat /etc/podinfo/mem_limit; fi;
           if [[ -e /etc/mem_request ]]; then
-            echo -en '\n'; cat /etc/mem_request; fi;
+            echo -en '\n'; cat /etc/podinfo/mem_request; fi;
           sleep 5;
         done;
       resources:
@@ -29,7 +29,7 @@ spec:
           cpu: "250m"
       volumeMounts:
         - name: podinfo
-          mountPath: /etc
+          mountPath: /etc/podinfo
           readOnly: false
   volumes:
     - name: podinfo

--- a/cn/docs/tasks/inject-data-application/dapi-volume.yaml
+++ b/cn/docs/tasks/inject-data-application/dapi-volume.yaml
@@ -16,15 +16,15 @@ spec:
       command: ["sh", "-c"]
       args:
       - while true; do
-          if [[ -e /etc/labels ]]; then 
-            echo -en '\n\n'; cat /etc/labels; fi;
-          if [[ -e /etc/annotations ]]; then
-            echo -en '\n\n'; cat /etc/annotations; fi;
+          if [[ -e /etc/podinfo/labels ]]; then
+            echo -en '\n\n'; cat /etc/podinfo/labels; fi;
+          if [[ -e /etc/podinfo/annotations ]]; then
+            echo -en '\n\n'; cat /etc/podinfo/annotations; fi;
           sleep 5;
         done;
       volumeMounts:
         - name: podinfo
-          mountPath: /etc
+          mountPath: /etc/podinfo
           readOnly: false
   volumes:
     - name: podinfo

--- a/docs/tasks/inject-data-application/dapi-volume-resources.yaml
+++ b/docs/tasks/inject-data-application/dapi-volume-resources.yaml
@@ -10,14 +10,14 @@ spec:
       args:
       - while true; do
           echo -en '\n';
-          if [[ -e /etc/cpu_limit ]]; then
-            echo -en '\n'; cat /etc/cpu_limit; fi;
-          if [[ -e /etc/cpu_request ]]; then
-            echo -en '\n'; cat /etc/cpu_request; fi;
-          if [[ -e /etc/mem_limit ]]; then
-            echo -en '\n'; cat /etc/mem_limit; fi;
-          if [[ -e /etc/mem_request ]]; then
-            echo -en '\n'; cat /etc/mem_request; fi;
+          if [[ -e /etc/podinfo/cpu_limit ]]; then
+            echo -en '\n'; cat /etc/podinfo/cpu_limit; fi;
+          if [[ -e /etc/podinfo/cpu_request ]]; then
+            echo -en '\n'; cat /etc/podinfo/cpu_request; fi;
+          if [[ -e /etc/podinfo/mem_limit ]]; then
+            echo -en '\n'; cat /etc/podinfo/mem_limit; fi;
+          if [[ -e /etc/podinfo/mem_request ]]; then
+            echo -en '\n'; cat /etc/podinfo/mem_request; fi;
           sleep 5;
         done;
       resources:
@@ -29,7 +29,7 @@ spec:
           cpu: "250m"
       volumeMounts:
         - name: podinfo
-          mountPath: /etc
+          mountPath: /etc/podinfo
           readOnly: false
   volumes:
     - name: podinfo

--- a/docs/tasks/inject-data-application/dapi-volume.yaml
+++ b/docs/tasks/inject-data-application/dapi-volume.yaml
@@ -16,15 +16,15 @@ spec:
       command: ["sh", "-c"]
       args:
       - while true; do
-          if [[ -e /etc/labels ]]; then 
-            echo -en '\n\n'; cat /etc/labels; fi;
-          if [[ -e /etc/annotations ]]; then
-            echo -en '\n\n'; cat /etc/annotations; fi;
+          if [[ -e /etc/podinfo/labels ]]; then
+            echo -en '\n\n'; cat /etc/podinfo/labels; fi;
+          if [[ -e /etc/podinfo/annotations ]]; then
+            echo -en '\n\n'; cat /etc/podinfo/annotations; fi;
           sleep 5;
         done;
       volumeMounts:
         - name: podinfo
-          mountPath: /etc
+          mountPath: /etc/podinfo
           readOnly: false
   volumes:
     - name: podinfo


### PR DESCRIPTION
Because API data volumes like downwardAPI are expected to be fully
managed by Kubernetes and are now mounted read-only, this causes
problems with other files in /etc like /etc/resolv.conf that Docker
tries to add to the volume. Our examples should show such volumes
being mounted to a dedicated subdirectory for the volume.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7484)
<!-- Reviewable:end -->
