### PR TITLE
Remove the beta reference from Taints and Tolerations doc

### DIFF
--- a/docs/concepts/configuration/taint-and-toleration.md
+++ b/docs/concepts/configuration/taint-and-toleration.md
@@ -195,7 +195,7 @@ running on the node as follows
  * pods that tolerate the taint with a specified `tolerationSeconds` remain
    bound for the specified amount of time
 
-The above behavior is a beta feature. In addition, Kubernetes 1.6 has alpha
+In addition, Kubernetes 1.6 has alpha
 support for representing node problems. In other words, the node controller
 automatically taints a node when certain condition is true. The built-in taints
 currently include:


### PR DESCRIPTION
Update user docs for taints and tolerations and remove the notion of Beta from the doc as part of the effort to move the feature to GA.

ref/ kubernetes/kubernetes#60281

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7493)
<!-- Reviewable:end -->
