### PR TITLE
Update yaml to use correct secret name

### DIFF
--- a/docs/tasks/configure-pod-container/private-reg-pod.yaml
+++ b/docs/tasks/configure-pod-container/private-reg-pod.yaml
@@ -7,5 +7,5 @@ spec:
   - name: private-reg-container
     image: <your-private-image>
   imagePullSecrets:
-  - name: regsecret
+  - name: regcred
 


### PR DESCRIPTION
Currently, the documentation on creating a secret for pulling from a private docker registry mentions creating a secret of regcred - https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/.  The example further down however, uses a secret name of regsecret.  This updates the secret name to match the one that was created.

<img width="893" alt="screen shot 2018-02-23 at 11 25 12 am" src="https://user-images.githubusercontent.com/2954525/36607471-5b534226-188c-11e8-84f2-afcb9aa49dc1.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7496)
<!-- Reviewable:end -->
