### PR TITLE
Increase consistency, and style guide compliance

### DIFF
--- a/docs/concepts/policy/resource-quotas.md
+++ b/docs/concepts/policy/resource-quotas.md
@@ -18,15 +18,15 @@ Resource quotas work like this:
 
 - Different teams work in different namespaces.  Currently this is voluntary, but
   support for making this mandatory via ACLs is planned.
-- The administrator creates one or more Resource Quota objects for each namespace.
+- The administrator creates one or more `ResourceQuotas` for each namespace.
 - Users create resources (pods, services, etc.) in the namespace, and the quota system
-  tracks usage to ensure it does not exceed hard resource limits defined in a Resource Quota.
+  tracks usage to ensure it does not exceed hard resource limits defined in a `ResourceQuota`.
 - If creating or updating a resource violates a quota constraint, the request will fail with HTTP
   status code `403 FORBIDDEN` with a message explaining the constraint that would have been violated.
 - If quota is enabled in a namespace for compute resources like `cpu` and `memory`, users must specify
   requests or limits for those values; otherwise, the quota system may reject pod creation.  Hint: Use
   the LimitRange admission controller to force defaults for pods that make no compute resource requirements.
-  See the [walkthrough](/docs/tasks/administer-cluster/quota-memory-cpu-namespace/) for an example to avoid this problem.
+  See the [walkthrough](/docs/tasks/administer-cluster/quota-memory-cpu-namespace/) for an example of how to avoid this problem.
 
 Examples of policies that could be created using namespaces and quotas are:
 
@@ -42,13 +42,13 @@ Neither contention nor changes to quota will affect already created resources.
 
 ## Enabling Resource Quota
 
-Resource Quota support is enabled by default for many Kubernetes distributions.  It is
+Resource quota support is enabled by default for many Kubernetes distributions.  It is
 enabled when the apiserver `--admission-control=` flag has `ResourceQuota` as
 one of its arguments.
 
-Resource Quota is enforced in a particular namespace when there is a
-`ResourceQuota` object in that namespace.  There should be at most one
-`ResourceQuota` object in a namespace.
+A resource quota is enforced in a particular namespace when there is a
+`ResourceQuota` in that namespace.  There should be at most one
+`ResourceQuota` in a namespace.
 
 ## Compute Resource Quota
 
@@ -84,7 +84,7 @@ define a quota as follows:
 * `gold.storageclass.storage.k8s.io/requests.storage: 500Gi`
 * `bronze.storageclass.storage.k8s.io/requests.storage: 100Gi`
 
-In release 1.8, quota support for local ephemeral storage is added as alpha feature
+In release 1.8, quota support for local ephemeral storage is added as an alpha feature:
 
 | Resource Name | Description |
 | ------------------------------- |----------------------------------------------------------- |
@@ -111,9 +111,9 @@ are supported:
 For example, `pods` quota counts and enforces a maximum on the number of `pods`
 created in a single namespace.
 
-You might want to set a pods quota on a namespace
+You might want to set a `pods` quota on a namespace
 to avoid the case where a user creates many small pods and exhausts the cluster's
-supply of Pod IPs.
+supply of pod IPs.
 
 ## Quota Scopes
 
@@ -220,7 +220,7 @@ services.loadbalancers  0       2
 
 ## Quota and Cluster Capacity
 
-Resource Quota objects are independent of the Cluster Capacity. They are
+`ResourceQuotas` are independent of the cluster capacity. They are
 expressed in absolute units.  So, if you add nodes to your cluster, this does *not*
 automatically give each namespace the ability to consume more resources.
 
@@ -231,8 +231,8 @@ Sometimes more complex policies may be desired, such as:
     limit to prevent accidental resource exhaustion.
   - Detect demand from one namespace, add nodes, and increase quota.
 
-Such policies could be implemented using ResourceQuota as a building-block, by
-writing a 'controller' which watches the quota usage and adjusts the quota
+Such policies could be implemented using `ResourceQuotas` as building blocks, by
+writing a "controller" that watches the quota usage and adjusts the quota
 hard limits of each namespace according to other signals.
 
 Note that resource quota divides up aggregate cluster resources, but it creates no


### PR DESCRIPTION
- not using object after API objects per https://kubernetes.io/docs/home/contribute/style-guide/#use-camel-case-for-api-objects

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7503)
<!-- Reviewable:end -->
