### PR TITLE
typo etcd image label

### DIFF
--- a/docs/setup/independent/high-availability.md
+++ b/docs/setup/independent/high-availability.md
@@ -334,7 +334,7 @@ Please select one of the tabs to see installation instructions for the respectiv
        - --initial-cluster etcd0=https://<etcd0-ip-address>:2380,etcd1=https://<etcd1-ip-address>:2380,etcd1=https://<etcd2-ip-address>:2380 \
        - --initial-cluster-token my-etcd-token \
        - --initial-cluster-state new
-       image: gcr.io/google_containers/etcd-amd64:3.1.0
+       image: gcr.io/google_containers/etcd-amd64:3.1.10
        livenessProbe:
        httpGet:
            path: /health

--- a/docs/setup/independent/high-availability.md
+++ b/docs/setup/independent/high-availability.md
@@ -331,7 +331,7 @@ Please select one of the tabs to see installation instructions for the respectiv
        - --peer-key-file=/certs/peer-key.pem \
        - --peer-client-cert-auth \
        - --peer-trusted-ca-file=/certs/ca.pem \
-       - --initial-cluster etcd0=https://<etcd0-ip-address>:2380,etcd1=https://<etcd1-ip-address>:2380,etcd1=https://<etcd2-ip-address>:2380 \
+       - --initial-cluster etcd0=https://<etcd0-ip-address>:2380,etcd1=https://<etcd1-ip-address>:2380,etcd2=https://<etcd2-ip-address>:2380 \
        - --initial-cluster-token my-etcd-token \
        - --initial-cluster-state new
        image: gcr.io/google_containers/etcd-amd64:3.1.10


### PR DESCRIPTION
there is no gcr.io/google_containers/etcd-amd64:3.1.0, but there is: gcr.io/google_containers/etcd-amd64:3.1.10
(see https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/etcd-amd64?gcrImageListsize=50)
As 3.1.10 is the preferred version for k8s 1.9 (as stated above), I guess this was a typo

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.10 Features: set Milestone to 1.10 and Base Branch to release-1.10
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7508)
<!-- Reviewable:end -->
