### PR TITLE
* Changed range syntax to use paren to indicate range {0..N-1}.

### DIFF
--- a/docs/concepts/workloads/controllers/statefulset.md
+++ b/docs/concepts/workloads/controllers/statefulset.md
@@ -116,7 +116,7 @@ regardless of which node it's (re)scheduled on.
 ### Ordinal Index
 
 For a StatefulSet with N replicas, each Pod in the StatefulSet will be
-assigned an integer ordinal, in the range [0,N), that is unique over the Set.
+assigned an integer ordinal, from 0 up through N-1, that is unique over the Set.
 
 ### Stable Network ID
 

--- a/docs/concepts/workloads/controllers/statefulset.md
+++ b/docs/concepts/workloads/controllers/statefulset.md
@@ -116,7 +116,7 @@ regardless of which node it's (re)scheduled on.
 ### Ordinal Index
 
 For a StatefulSet with N replicas, each Pod in the StatefulSet will be
-assigned an integer ordinal, in the range [0,N], that is unique over the Set.
+assigned an integer ordinal, in the range [0,N), that is unique over the Set.
 
 ### Stable Network ID
 


### PR DESCRIPTION
Changes the range notation for the stateful set ordinal from `[0,N]` to `[0,N)`.

Fixes #7507

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7509)
<!-- Reviewable:end -->
