### PR TITLE
pull image private: fix example variable name

### DIFF
--- a/docs/tasks/configure-pod-container/private-reg-pod.yaml
+++ b/docs/tasks/configure-pod-container/private-reg-pod.yaml
@@ -7,5 +7,5 @@ spec:
   - name: private-reg-container
     image: <your-private-image>
   imagePullSecrets:
-  - name: regsecret
+  - name: regcred
 


### PR DESCRIPTION
In the docs the secret is called regcred instead of regsecret

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7510)
<!-- Reviewable:end -->
