### PR TITLE
Remove the deprecated '--configure-cbr0='

### DIFF
--- a/docs/getting-started-guides/scratch.md
+++ b/docs/getting-started-guides/scratch.md
@@ -405,7 +405,6 @@ Arguments to consider:
   - `--docker-root=`
   - `--root-dir=`
   - `--pod-cidr=` The CIDR to use for pod IP addresses, only used in standalone mode.  In cluster mode, this is obtained from the master.
-  - `--configure-cbr0=` (described below)
   - `--register-node` (described in [Node](/docs/admin/node/) documentation.)
 
 ### kube-proxy
@@ -440,38 +439,6 @@ needs an address from `$NODE_X_POD_CIDR` - by convention the first IP.  Call
 this `NODE_X_BRIDGE_ADDR`.  For example, if `NODE_X_POD_CIDR` is `10.0.0.0/16`,
 then `NODE_X_BRIDGE_ADDR` is `10.0.0.1/16`.  NOTE: this retains the `/16` suffix
 because of how this is used later.
-
-- Recommended, automatic approach:
-
-  1. Set `--configure-cbr0=true` option in kubelet init script and restart kubelet service.  Kubelet will configure cbr0 automatically.
-     It will wait to do this until the node controller has set Node.Spec.PodCIDR.  Since you have not setup apiserver and node controller
-     yet, the bridge will not be setup immediately.
-- Alternate, manual approach:
-
-  1. Set `--configure-cbr0=false` on kubelet and restart.
-  1. Create a bridge.
-
-        ```
-        ip link add name cbr0 type bridge
-        ```
-
-  1. Set appropriate MTU. NOTE: the actual value of MTU will depend on your network environment
-
-        ```
-        ip link set dev cbr0 mtu 1460
-        ```
-
-  1. Add the node's network to the bridge (docker will go on other side of bridge).
-
-        ```
-        ip addr add $NODE_X_BRIDGE_ADDR dev cbr0
-        ```
-
-  1. Turn it on
-
-        ```
-        ip link set dev cbr0 up
-        ```
 
 If you have turned off Docker's IP masquerading to allow pods to talk to each
 other, then you may need to do masquerading just for destination IPs outside


### PR DESCRIPTION
The flag `--configure-cbr0=` has been removed since v1.5 (https://github.com/kubernetes/kubernetes/pull/34906) but the doc still has it.

Related issues:
- https://github.com/kubernetes/kubernetes/issues/59257
- https://github.com/kubernetes/website/issues/6827
- https://github.com/kubernetes/website/issues/5285
- https://github.com/kubernetes/website/issues/3200
- https://github.com/kubernetes/website/issues/7481

@luxas Is it ok to remove this part, or reserve the maual part? 
Do [Network Plugins](https://kubernetes.io/docs/concepts/cluster-administration/network-plugins/) complete this job?

/cc @aburdenthehand

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7518)
<!-- Reviewable:end -->
