### PR TITLE
Change rewrite annotation in ingress examples

### DIFF
--- a/docs/concepts/services-networking/ingress.md
+++ b/docs/concepts/services-networking/ingress.md
@@ -60,7 +60,7 @@ kind: Ingress
 metadata:
   name: test-ingress
   annotations:
-    ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
   rules:
   - http:
@@ -126,7 +126,7 @@ kind: Ingress
 metadata:
   name: test
   annotations:
-    ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
   rules:
   - host: foo.bar.com


### PR DESCRIPTION
Since the default annotation prefix has been changed to "nginx.ingress.kubernetes.io" in nginx ingress controller, the examples in ingress doc should be updated.


