### PR TITLE
Change glossary to sort_natural

### DIFF
--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -37,7 +37,7 @@ default_active_tag: fundamental
 
 <p>Click on the <a href="javascript:void(0)" class="no-underline">[+]</a> indicators below to get a longer explanation for any particular term.</p>
 
-{% assign glossary_terms = site.data.glossary | where_exp: "term", "term.id != '_example'" | sort: 'name' %}
+{% assign glossary_terms = site.data.glossary | where_exp: "term", "term.id != '_example'" | sort_natural: 'name' %}
 
 <ul>
 {% for term in glossary_terms %}


### PR DESCRIPTION
The default sort in liquid is ASCIIbetical, but there is a built in
sort_natural that allows you to sort things in human sensible
ways. This updates the glossary list to use sort_natural instead.

Fixes issue #7491

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7523)
<!-- Reviewable:end -->
