### PR TITLE
Add Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
     jekyll-paginate (1.1.0)
     jekyll-readme-index (0.0.3)
       jekyll (~> 3.0)
-    jekyll-redirect-from (0.12.1)
+    jekyll-redirect-from (0.13.0)
       jekyll (~> 3.3)
     jekyll-relative-links (0.5.1)
       jekyll (~> 3.3)
@@ -145,7 +145,7 @@ DEPENDENCIES
   jekyll-optional-front-matter (~> 0.1)
   jekyll-paginate (= 1.1.0)
   jekyll-readme-index (= 0.0.3)
-  jekyll-redirect-from (~> 0.11)
+  jekyll-redirect-from (~> 0.13)
   jekyll-relative-links (~> 0.2)
   jekyll-seo-tag
   jekyll-sitemap
@@ -173,4 +173,4 @@ DEPENDENCIES
   unicode-display_width (~> 1.1)
 
 BUNDLED WITH
-   1.15.4
+   1.16.1


### PR DESCRIPTION

Adds a Gemfile.lock to version control following community practice for Ruby projects that are not libraries. See issue #7527

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7528)
<!-- Reviewable:end -->
