### PR TITLE
Fix the wrong link to pod-priority-preemption

### DIFF
--- a/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods.md
+++ b/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods.md
@@ -23,7 +23,7 @@ vacated by the evicted critical add-on pod or the amount of resources available 
 accordance with the [deprecation policy](/docs/reference/deprecation-policy) for beta features.**
 
 **To avoid eviction of critical pods, you must
-[enable priorities in scheduler](docs/concepts/configuration/pod-priority-preemption/)
+[enable priorities in scheduler](/docs/concepts/configuration/pod-priority-preemption/)
 before upgrading to Kubernetes 1.10 or higher.**
 
 Rescheduler ensures that critical add-ons are always scheduled


### PR DESCRIPTION
Fix the hyperlink typo which point the wrong address to
https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/docs/concepts/configuration/pod-priority-preemption/

And should cherry-pick to release-1.9 & release-1.10 branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7545)
<!-- Reviewable:end -->
