### PR TITLE
Updating privileged container information

### DIFF
--- a/docs/getting-started-guides/ubuntu/operational-considerations.md
+++ b/docs/getting-started-guides/ubuntu/operational-considerations.md
@@ -115,8 +115,8 @@ juju switch default
 
 ### Running privileged containers
 
-By default, juju-deployed clusters do not support running privileged containers.
-If you need them, you have to enable the ```allow-privileged``` config on both
+By default, juju-deployed clusters only allow running privileged containers on nodes with GPUs.
+If you need privileged containers on other workers, you have to enable the ```allow-privileged``` config on both
 kubernetes-master and kubernetes-worker:
 
 ```

--- a/docs/getting-started-guides/ubuntu/operational-considerations.md
+++ b/docs/getting-started-guides/ubuntu/operational-considerations.md
@@ -116,7 +116,7 @@ juju switch default
 ### Running privileged containers
 
 By default, juju-deployed clusters only allow running privileged containers on nodes with GPUs.
-If you need privileged containers on other workers, you have to enable the ```allow-privileged``` config on both
+If you need privileged containers on other nodes, you have to enable the ```allow-privileged``` config on both
 kubernetes-master and kubernetes-worker:
 
 ```


### PR DESCRIPTION
We now use privileged containers by default on GPU-enabled nodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/website/7548)
<!-- Reviewable:end -->
