### PR TITLE
Storage Protection was renamed to Storage Object in Use Protection

### DIFF
--- a/docs/admin/admission-controllers.md
+++ b/docs/admin/admission-controllers.md
@@ -414,10 +414,6 @@ This admission controller also protects the access to `metadata.ownerReferences[
 of an object, so that only users with "update" permission to the `finalizers`
 subresource of the referenced *owner* can change it.
 
-### Storage Object in Use Protection (beta)
-{% assign for_k8s_version="v1.10" %}{% include feature-state-beta.md %}
-The `StorageObjectInUseProtection` plugin adds the `kubernetes.io/pvc-protection` or `kubernetes.io/pv-protection` finalizers to newly created Persistent Volume Claims (PVCs) or Persistent Volumes (PV). In case a user deletes a PVC or PV the PVC or PV is not removed until the finalizer is removed from the PVC or PV by PVC or PV Protection Controller. Refer to the [Storage Object in Use Protection](/docs/concepts/storage/persistent-volumes/#storage-object-in-use-protection) for more detailed information.
-
 ### PersistentVolumeLabel (DEPRECATED)
 
 This admission controller automatically attaches region or zone labels to PersistentVolumes
@@ -569,6 +565,10 @@ This admission controller will deny any pod that attempts to set certain escalat
 
 This admission controller implements automation for [serviceAccounts](/docs/user-guide/service-accounts).
 We strongly recommend using this admission controller if you intend to make use of Kubernetes `ServiceAccount` objects.
+
+### Storage Object in Use Protection (beta)
+{% assign for_k8s_version="v1.10" %}{% include feature-state-beta.md %}
+The `StorageObjectInUseProtection` plugin adds the `kubernetes.io/pvc-protection` or `kubernetes.io/pv-protection` finalizers to newly created Persistent Volume Claims (PVCs) or Persistent Volumes (PV). In case a user deletes a PVC or PV the PVC or PV is not removed until the finalizer is removed from the PVC or PV by PVC or PV Protection Controller. Refer to the [Storage Object in Use Protection](/docs/concepts/storage/persistent-volumes/#storage-object-in-use-protection) for more detailed information.
 
 ### ValidatingAdmissionWebhook (alpha in 1.8; beta in 1.9)
 

--- a/docs/admin/admission-controllers.md
+++ b/docs/admin/admission-controllers.md
@@ -414,9 +414,9 @@ This admission controller also protects the access to `metadata.ownerReferences[
 of an object, so that only users with "update" permission to the `finalizers`
 subresource of the referenced *owner* can change it.
 
-### Storage Protection (beta)
+### Storage Object in Use Protection (beta)
 {% assign for_k8s_version="v1.10" %}{% include feature-state-beta.md %}
-The `StorageProtection` plugin adds the `kubernetes.io/pvc-protection` or `kubernetes.io/pv-protection` finalizers to newly created Persistent Volume Claims (PVCs) or Persistent Volumes (PV). In case a user deletes a PVC or PV the PVC or PV is not removed until the finalizer is removed from the PVC or PV by PVC or PV Protection Controller. Refer to the [PVC Protection](/docs/concepts/storage/persistent-volumes/#persistent-volume-claim-protection) for more detailed information.
+The `StorageObjectInUseProtection` plugin adds the `kubernetes.io/pvc-protection` or `kubernetes.io/pv-protection` finalizers to newly created Persistent Volume Claims (PVCs) or Persistent Volumes (PV). In case a user deletes a PVC or PV the PVC or PV is not removed until the finalizer is removed from the PVC or PV by PVC or PV Protection Controller. Refer to the [Storage Object in Use Protection](/docs/concepts/storage/persistent-volumes/#storage-object-in-use-protection) for more detailed information.
 
 ### PersistentVolumeLabel (DEPRECATED)
 

--- a/docs/concepts/storage/persistent-volumes.md
+++ b/docs/concepts/storage/persistent-volumes.md
@@ -70,14 +70,14 @@ Pods use claims as volumes. The cluster inspects the claim to find the bound vol
 
 Once a user has a claim and that claim is bound, the bound PV belongs to the user for as long as they need it. Users schedule Pods and access their claimed PVs by including a `persistentVolumeClaim` in their Pod's volumes block. [See below for syntax details](#claims-as-volumes).
 
-### Storage Protection
+### Storage Object in Use Protection
 {% assign for_k8s_version="v1.10" %}{% include feature-state-beta.md %}
-The purpose of the Storage Protection feature is to ensure that Persistent Volume Claims (PVCs) in active use by a pod are not removed from the system as this may result in data loss.
+The purpose of the Storage Object in Use Protection feature is to ensure that Persistent Volume Claims (PVCs) in active use by a pod are not removed from the system as this may result in data loss.
 
 **Note:** PVC is in active use by a pod when the pod status is `Pending` and the pod is assigned to a node or the pod status is `Running`.
 {: .note}
 
-When the [Storage Protection beta feature](/docs/tasks/administer-cluster/pvc-protection/) is enabled, if a user deletes a PVC in active use by a pod, the PVC is not removed immediately. PVC removal is postponed until the PVC is no longer actively used by any pods.
+When the [Storage Object in Use Protection beta feature](/docs/tasks/administer-cluster/pvc-protection/) is enabled, if a user deletes a PVC in active use by a pod, the PVC is not removed immediately. PVC removal is postponed until the PVC is no longer actively used by any pods.
 
 You can see that a PVC is protected when the PVC's status is `Terminating` and the `Finalizers` list includes `kubernetes.io/pvc-protection`:
 ```shell

--- a/docs/tasks/administer-cluster/pvc-protection.md
+++ b/docs/tasks/administer-cluster/pvc-protection.md
@@ -2,7 +2,7 @@
 approvers:
 - msau42
 - jsafrane
-title: Storage Protection
+title: Storage Object in Use Protection
 ---
 
 {% capture overview %}
@@ -14,13 +14,13 @@ Persistent volume claims (PVCs) that are in active use by a pod can be protected
 
 {% capture prerequisites %}
 
-- The Storage Protection feature is enabled in a version of Kubernetes in which it is supported.
+- The Storage Object in Use Protection feature is enabled in a version of Kubernetes in which it is supported.
 
 {% endcapture %}
 
 {% capture steps %}
 
-## Storage Protection feature used for PVC Protection
+## Storage Object in Use Protection feature used for PVC Protection
 
 The example below uses a GCE PD `StorageClass`, however, similar steps can be performed for any volume type.
 


### PR DESCRIPTION
Documentation for PR: https://github.com/kubernetes/kubernetes/pull/59901

Target release: 1.10

