### PR TITLE
Use standard stress utility in examples

### DIFF
--- a/docs/tasks/configure-pod-container/assign-memory-resource.md
+++ b/docs/tasks/configure-pod-container/assign-memory-resource.md
@@ -67,7 +67,7 @@ for the Pod:
 {% include code.html language="yaml" file="memory-request-limit.yaml" ghlink="/docs/tasks/configure-pod-container/memory-request-limit.yaml" %}
 
 In the configuration file, the `args` section provides arguments for the Container when it starts.
-The `-mem-total 150Mi` argument tells the Container to attempt to allocate 150 MiB of memory.
+The `"--vm-bytes", "150M"` arguments tell the Container to attempt to allocate 150 MiB of memory.
 
 Create the Pod:
 

--- a/docs/tasks/configure-pod-container/memory-request-limit-2.yaml
+++ b/docs/tasks/configure-pod-container/memory-request-limit-2.yaml
@@ -6,16 +6,11 @@ metadata:
 spec:
   containers:
   - name: memory-demo-2-ctr
-    image: vish/stress
+    image: polinux/stress
     resources:
       requests:
         memory: "50Mi"
       limits:
         memory: "100Mi"
-    args:
-    - -mem-total
-    - 250Mi
-    - -mem-alloc-size
-    - 10Mi
-    - -mem-alloc-sleep
-    - 1s
+    command: ["stress"]
+    args: ["--vm", "1", "--vm-bytes", "250M", "--vm-hang", "1"]

--- a/docs/tasks/configure-pod-container/memory-request-limit-3.yaml
+++ b/docs/tasks/configure-pod-container/memory-request-limit-3.yaml
@@ -6,16 +6,11 @@ metadata:
 spec:
   containers:
   - name: memory-demo-3-ctr
-    image: vish/stress
+    image: polinux/stress
     resources:
       limits:
         memory: "1000Gi"
       requests:
         memory: "1000Gi"
-    args:
-    - -mem-total
-    - 150Mi
-    - -mem-alloc-size
-    - 10Mi
-    - -mem-alloc-sleep
-    - 1s
+    command: ["stress"]
+    args: ["--vm", "1", "--vm-bytes", "150M", "--vm-hang", "1"]

--- a/docs/tasks/configure-pod-container/memory-request-limit.yaml
+++ b/docs/tasks/configure-pod-container/memory-request-limit.yaml
@@ -6,16 +6,11 @@ metadata:
 spec:
   containers:
   - name: memory-demo-ctr
-    image: vish/stress
+    image: polinux/stress
     resources:
       limits:
         memory: "200Mi"
       requests:
         memory: "100Mi"
-    args:
-    - -mem-total
-    - 150Mi
-    - -mem-alloc-size
-    - 10Mi
-    - -mem-alloc-sleep
-    - 1s
+    command: ["stress"]
+    args: ["--vm", "1", "--vm-bytes", "150M", "--vm-hang", "1"]


### PR DESCRIPTION
In memory allocation examples, replaced the use of custom stress utility with the standard one (packaged in a small Alpine-based image).
