### PR TITLE
	fix sysctl miss in podsecuritypolicy descriptions.

### DIFF
--- a/docs/concepts/cluster-administration/sysctl-cluster.md
+++ b/docs/concepts/cluster-administration/sysctl-cluster.md
@@ -124,3 +124,22 @@ any node which has not enabled those two _unsafe_ sysctls explicitly. As with
 _node-level_ sysctls it is recommended to use [_taints and toleration_
 feature](/docs/user-guide/kubectl/{{page.version}}/#taint) or [taints on nodes](/docs/concepts/configuration/taint-and-toleration/)
 to schedule those pods onto the right nodes.
+
+## PodSecurityPolicy Annotations
+
+The use of sysctl in pods can be controlled via annotations on the PodSecurityPolicy.
+
+Here is an example, it authorizes binding user creating pod with corresponding
+_safe_ and _unsafe_ sysctls.
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: sysctl-psp
+  annotations:
+    security.alpha.kubernetes.io/sysctls: 'kernel.shm_rmid_forced'
+    security.alpha.kubernetes.io/unsafe-sysctls: 'net.ipv4.route.*,kernel.msg*'
+spec:
+ ...
+```

--- a/docs/concepts/policy/pod-security-policy.md
+++ b/docs/concepts/policy/pod-security-policy.md
@@ -37,6 +37,7 @@ administrator to control the following:
 | The SELinux context of the container                | [`seLinux`](#selinux)                       |
 | The AppArmor profile used by containers             | [annotations](#apparmor)                    |
 | The seccomp profile used by containers              | [annotations](#seccomp)                     |
+| The sysctl profile used by containers               | [annotations](#sysctl)                      |
 
 
 ## Enabling Pod Security Policies
@@ -554,3 +555,8 @@ specifies which values are allowed for the pod seccomp annotations. Specified as
 a comma-delimited list of allowed values. Possible values are those listed
 above, plus `*` to allow all profiles. Absence of this annotation means that the
 default cannot be changed.
+
+### Sysctl
+
+Controlled via annotations on the PodSecurityPolicy. Refer to the [Sysctl documentation](
+/docs/concepts/cluster-administration/sysctl-cluster/#podsecuritypolicy-annotations).


### PR DESCRIPTION
In descriptions of podsecuritypolicy, it lacks sysctl use in annotations.
This patch fix this.
