### PR TITLE
IPv6: Updating doc related to IPv6.

### DIFF
--- a/docs/concepts/services-networking/service.md
+++ b/docs/concepts/services-networking/service.md
@@ -732,7 +732,7 @@ groups are modified with the following IP rules:
 Be aware that if `spec.loadBalancerSourceRanges` is not set, Kubernetes will
 allow traffic from `0.0.0.0/0` to the Node Security Group(s). If nodes have
 public IP addresses, be aware that non-NLB traffic can also reach all instances
-in those modified security groups. IPv6 is not yet supported for source ranges.
+in those modified security groups.
 
 In order to limit which client IP's can access the Network Load Balancer,
 specify `loadBalancerSourceRanges`.

--- a/docs/getting-started-guides/scratch.md
+++ b/docs/getting-started-guides/scratch.md
@@ -96,7 +96,7 @@ to implement one of the above options:
   - This can be done by manually running commands, or through a set of externally maintained scripts.
   - You have to implement this yourself, but it can give you an extra degree of flexibility.
 
-You will need to select an address range for the Pod IPs. Note that IPv6 is not yet supported for Pod IPs.
+You will need to select an address range for the Pod IPs.
 
 - Various approaches:
   - GCE: each project has its own `10.0.0.0/8`.  Carve off a `/16` for each


### PR DESCRIPTION
Made updates for files, related to IPv6 to address issue 7566. Note: The release notes
cover 1.9. When 1.10 release notes are added, the comment about
the /66 restriction for IPv6 can be removed.
