### PR TITLE
Add OWNERS for the blog after it migrates

### DIFF
--- a/blog/OWNERS
+++ b/blog/OWNERS
@@ -1,8 +1,10 @@
 # Owned by Kubernetes blog reviewers.
 options:
   no_parent_owners: true
-# reviewers: // List any reviewers here 
+# reviewers: // List any reviewers here
 approvers:
+  - bobsky
   - kbarnard10
+  - natekartchner
   - sarahkconway
   - zacharysarah

--- a/blog/OWNERS
+++ b/blog/OWNERS
@@ -1,0 +1,8 @@
+# Owned by Kubernetes blog reviewers.
+options:
+  no_parent_owners: true
+# reviewers: // List any reviewers here 
+approvers:
+  - kbarnard10
+  - sarahkconway
+  - zacharysarah


### PR DESCRIPTION
Fixes #5823 
Ref: #7247 

🛑 DO NOT MERGE UNTIL #7247 MERGES 🛑 

This PR adds blog-specific reviewers and approvers once #7247 merges.

## Action required

@kbarnard10, @sarahkconway:
Please comment:
  - [ ] Are any approvers/reviewers missing?
  - [ ] Should any approvers/reviewers be changed or removed?

The following users need to join the [Kubernetes organization as Members](https://github.com/kubernetes/community/blob/master/community-membership.md#member):
- @kbarnard10 
- @sarahkconway
- @natekartchner 
- (Optional) Bob Hrdinsky

**Note:** 
To include Nate Kartchner and/or Bob Hrdinsky as approvers or reviewers, please provide their GitHub usernames and ask them to become K8s org members as well.