### PR TITLE
Update MacOS instructions to use curl

### DIFF
--- a/docs/getting-started-guides/kops.md
+++ b/docs/getting-started-guides/kops.md
@@ -34,7 +34,7 @@ Download kops from the [releases page](https://github.com/kubernetes/kops/releas
 On MacOS:
 
 ```
-wget https://github.com/kubernetes/kops/releases/download/1.8.0/kops-darwin-amd64
+curl -OL https://github.com/kubernetes/kops/releases/download/1.8.0/kops-darwin-amd64
 chmod +x kops-darwin-amd64
 mv kops-darwin-amd64 /usr/local/bin/kops
 # you can also install using Homebrew


### PR DESCRIPTION
MacOS comes with curl which makes it more convenient than wget.
This change is in response to https://github.com/kubernetes/website/issues/7275

