### PR TITLE
Fixed Issue with k8s.io/docs/getting-started-guides/fedora/fedora_manual_config/

### DIFF
--- a/docs/getting-started-guides/fedora/fedora_manual_config.md
+++ b/docs/getting-started-guides/fedora/fedora_manual_config.md
@@ -121,10 +121,27 @@ KUBELET_ADDRESS="--address=0.0.0.0"
 KUBELET_HOSTNAME="--hostname-override=fed-node"
 
 # location of the api-server
-KUBELET_API_SERVER="--api-servers=http://fed-master:8080"
+KUBELET_ARGS="--cgroup-driver=systemd --kubeconfig=/etc/kubernetes/master-kubeconfig.yaml --require-kubeconfig"
 
 # Add your own!
-#KUBELET_ARGS=""
+KUBELET_ARGS=""
+
+```
+
+```yaml
+kind: Config
+clusters:
+- name: local
+  cluster:
+    server: http://fed-master:8080
+users:
+- name: kubelet
+contexts:
+- context:
+    cluster: local
+    user: kubelet
+  name: kubelet-context
+current-context: kubelet-context
 ```
 
 * Start the appropriate services on the node (fed-node).


### PR DESCRIPTION
#### Problem:
In the node configuration the line
`KUBELET_API_SERVER="--api-servers=http://fed-master:8080"`
is removed in kublet v1.6, see [here](https://github.com/coreos/coreos-kubernetes/issues/785)

#### Solution
Add this line instead:
`KUBELET_ARGS="--cgroup-driver=systemd --kubeconfig=/etc/kubernetes/master-kubeconfig.yaml --require-kubeconfig"` and contents of  `master-kubeconfig.yaml`.

#### Page updated
https://kubernetes.io/docs/getting-started-guides/fedora/fedora_manual_config/

Fixes #7417 