### PR TITLE
(azure): change default location, add info

### DIFF
--- a/docs/getting-started-guides/ubuntu/installation.md
+++ b/docs/getting-started-guides/ubuntu/installation.md
@@ -90,8 +90,14 @@ juju bootstrap aws/us-east-2
 or, another example, this time on Azure:
 
 ```
-juju bootstrap azure/centralus
+juju bootstrap azure/westus2
 ```
+
+If you receive this error, it is likely that the default Azure VM size (Standard D1 v2 [1 vcpu, 3.5 GB memory]) is not available in the Azure location:
+```
+ERROR failed to bootstrap model: instance provisioning failed (Failed)
+```
+
 
 You will need a controller node for each cloud or region you are deploying to. See the [controller documentation](https://jujucharms.com/docs/2.2/controllers) for more information.
 

--- a/docs/getting-started-guides/ubuntu/troubleshooting.md
+++ b/docs/getting-started-guides/ubuntu/troubleshooting.md
@@ -46,7 +46,7 @@ During normal operation the Workload should read `active`, the Agent column (whi
 
 Status can become unwieldy for large clusters, it is then recommended to check status on individual services, for example to check the status on the workers only:
 
-    juju status kubernetes-workers
+    juju status kubernetes-worker
 
 or just on the etcd cluster:
 


### PR DESCRIPTION
- Running the default bootstrap command (`juju bootstrap azure/centralus`) returned an error as the VM size requested isn't available in centralus and/or my account didn't have access to that SKU. I changed the location to one with more VM types and added a blurb about the error that occurs when the VM size isn't available.
- fixed typo in ubuntu/juju troubleshooting doc