### PR TITLE
Document that LocalStorageCapacityIsolation is beta

### DIFF
--- a/docs/reference/feature-gates.md
+++ b/docs/reference/feature-gates.md
@@ -57,7 +57,8 @@ different Kubernetes components.
 | `HyperVContainer` | `false` | Alpha | 1.10 | |
 | `Initializers` | `false` | Alpha | 1.7 | |
 | `KubeletConfigFile` | `false` | Alpha | 1.8 | 1.9 |
-| `LocalStorageCapacityIsolation` | `false` | Alpha | 1.7 | |
+| `LocalStorageCapacityIsolation` | `false` | Alpha | 1.7 | 1.9 |
+| `LocalStorageCapacityIsolation` | `true` | Beta| 1.10 | |
 | `MountContainers` | `false` | Alpha | 1.9 | |
 | `MountPropagation` | `false` | Alpha | 1.8 | |
 | `PersistentLocalVolumes` | `false` | Alpha | 1.7 | |


### PR DESCRIPTION
A follow-up to the kubernetes/kubernetes#60159 change which has promoted
the `LocalStorageCapacityIsolation` feature gate to Beta.
