### PR TITLE
Removed helm and kompose from third party tooling section

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -34,16 +34,12 @@ development and testing purposes.
 [Dashboard](/docs/tasks/web-ui-dashboard/), the web-based user interface of Kubernetes, allows you to deploy containerized applications
 to a Kubernetes cluster, troubleshoot them, and manage the cluster and its resources itself. 
 
-## Third-Party Tools
-
-Kubernetes supports various third-party tools. These include, but are not limited to:
-
 #### Helm
 
 [Kubernetes Helm](https://github.com/kubernetes/helm) is a tool for managing packages of pre-configured
 Kubernetes resources, aka Kubernetes charts.
 
-Use Helm to: 
+Use Helm to:
 
 * Find and use popular software packaged as Kubernetes charts
 * Share your own applications as Kubernetes charts
@@ -51,9 +47,9 @@ Use Helm to:
 * Intelligently manage your Kubernetes manifest files
 * Manage releases of Helm packages
 
-#### Kompose 
+#### Kompose
 
-[Kompose](https://github.com/kubernetes-incubator/kompose) is a tool to help Docker Compose users move to Kubernetes. 
+[Kompose](https://github.com/kubernetes-incubator/kompose) is a tool to help Docker Compose users move to Kubernetes.
 
 Use Kompose to:
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -4,6 +4,8 @@ approvers:
 title: Tools
 ---
 
+Kubernetes contains several built-in tools to help you work with the Kubernetes system
+
 #### Kubectl
 
 [`kubectl`](/docs/user-guide/kubectl/) is the command line tool for Kubernetes. It controls the Kubernetes cluster manager.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -4,13 +4,7 @@ approvers:
 title: Tools
 ---
 
-Kubernetes contains several built-in tools to help you work with the Kubernetes system, and also supports third-party tooling.
-
-## Native Tools
-
-Kubernetes contains the following built-in tools:
-
-#### Kubectl 
+#### Kubectl
 
 [`kubectl`](/docs/user-guide/kubectl/) is the command line tool for Kubernetes. It controls the Kubernetes cluster manager.
 


### PR DESCRIPTION
Towards #7524 
#### Problem:
The page https://kubernetes.io/docs/tools/ says the helm and Kompose are third-party resources but have been integrated into the main GitHub branch.
#### Fix
Updated web page such that these items are listed with the rest, not as third-party
#### Page Updated
https://kubernetes.io/docs/tools/

<!-- Fixes #7524 -->