### PR TITLE
pod-security-policy.md: minor fix

### DIFF
--- a/docs/concepts/policy/pod-security-policy.md
+++ b/docs/concepts/policy/pod-security-policy.md
@@ -523,9 +523,8 @@ for the default list of capabilities when using the Docker runtime.
 
 ### SELinux
 
-- *MustRunAs* - Requires `seLinuxOptions` to be configured if not using
-pre-allocated values. Uses `seLinuxOptions` as the default. Validates against
-`seLinuxOptions`.
+- *MustRunAs* - Requires `seLinuxOptions` to be configured. Uses
+`seLinuxOptions` as the default. Validates against `seLinuxOptions`.
 - *RunAsAny* - No default provided. Allows any `seLinuxOptions` to be
 specified.
 


### PR DESCRIPTION
Because PSP doesn't support a concept of "pre-allocated values", I removed mentioning of it in the doc to not confuse readers.

This addresses my comment there: https://github.com/kubernetes/website/pull/6378#discussion_r152636625

PTAL @pweil- @liggitt @tallclair 
CC @simo5