### PR TITLE
Add external metrics to HPA docs

### DIFF
--- a/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -272,8 +272,9 @@ Ingress were serving a total of 10000 requests per second.
 ### Autoscaling on metrics not related to Kubernetes objects
 
 Applications running on Kubernetes may need to autoscale based on metrics that don't have an obvious
-relationship to any object in the Kubernetes cluster, such as metrics describing a hosted service used
-by Pods. In Kubernetes 1.10 and later, you can address this use case with *external metrics*.
+relationship to any object in the Kubernetes cluster, such as metrics describing a hosted service with
+no direct correlation to Kubernetes namespaces. In Kubernetes 1.10 and later, you can address this use case
+with *external metrics*.
 
 Using external metrics requires a certain level of knowledge of your monitoring system, and it requires a cluster
 monitoring setup similar to one required for using custom metrics. With external metrics, you can autoscale
@@ -295,8 +296,9 @@ section to your HorizontalPodAutoscaler manifest to specify that you need one wo
     targetAverageValue: 30
 ```
 
-Instead of using the `targetAverageValue` field, you could use the `targetValue` to define a desired
-value of your external metric.
+If your metric describes work or resources that can be divided between autoscaled pods the `targetAverageValue`
+field describes how much of that work each pod can handle. Instead of using the `targetAverageValue` field, you could use the
+`targetValue` to define a desired value of your external metric.
 
 ## Appendix: Horizontal Pod Autoscaler Status Conditions
 

--- a/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -24,8 +24,8 @@ heapster monitoring will be turned-on by default).
 To specify multiple resource metrics for a Horizontal Pod Autoscaler, you must have a Kubernetes cluster
 and kubectl at version 1.6 or later.  Furthermore, in order to make use of custom metrics, your cluster
 must be able to communicate with the API server providing the custom metrics API. Finally, to use metrics
-not related to any Kubernetes object you must have a Kubernetes cluster at version 1.10 or later and
-must be able to communicate with the API server providing external metrics API.
+not related to any Kubernetes object you must have a Kubernetes cluster at version 1.10 or later, and
+you must be able to communicate with the API server that provides the external metrics API.
 See the [Horizontal Pod Autoscaler user guide](/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-custom-metrics) for more details.
 
 ## Step One: Run & expose php-apache server
@@ -271,18 +271,19 @@ Ingress were serving a total of 10000 requests per second.
 
 ### Autoscaling on metrics not related to Kubernetes objects
 
-Applications running on Kubernetes may need to autoscale based on metrics that doesn't have obvious
-relationsip to any object within Kubernetes cluster, such as metrics describing hosted service used
-by Pods. In Kubernetes 1.10 and later this use-case can be addressed with *external metrics*.
+Applications running on Kubernetes may need to autoscale based on metrics that don't have an obvious
+relationship to any object in the Kubernetes cluster, such as metrics describing a hosted service used
+by Pods. In Kubernetes 1.10 and later, you can address this use case with *external metrics*.
 
-Using *external metrics* requires a certain level of knowledge of your monitoring system and a cluster
-monitoring setup similar to one required for using *custom metrics*. With *external metrics* you can autoscale
-based on any metric available in your monitoring system by simply providing `metricName`. Additionally
-you can use `metricSelector` to limit which metrics' time series you want to use for autoscaling.
-If multiple time series are matched by `metricSelector` the sum of their values will be used by HorizontalPodAutoscaler.
+Using external metrics requires a certain level of knowledge of your monitoring system, and it requires a cluster
+monitoring setup similar to one required for using custom metrics. With external metrics, you can autoscale
+based on any metric available in your monitoring system by providing a `metricName` field in your
+HorizontalPodAutoscaler manifest. Additionally you can use a `metricSelector` field to limit which
+metrics' time series you want to use for autoscaling. If multiple time series are matched by `metricSelector`,
+the sum of their values is used by the HorizontalPodAutoscaler.
 
-For example if your application processed tasks from a hosted queue service you could add the following
-section to HorizontalPodAutoscaler definition to specify that you need one worker per 30 outstanding tasks.
+For example if your application processes tasks from a hosted queue service, you could add the following
+section to your HorizontalPodAutoscaler manifest to specify that you need one worker per 30 outstanding tasks.
 
 ```yaml
 - type: External
@@ -294,7 +295,8 @@ section to HorizontalPodAutoscaler definition to specify that you need one worke
     targetAverageValue: 30
 ```
 
-Instead of using `targetAverageValue` field you could define a desired value of external metric by using `targetValue` field.
+Instead of using the `targetAverageValue` field, you could use the `targetValue` to define a desired
+value of your external metric.
 
 ## Appendix: Horizontal Pod Autoscaler Status Conditions
 

--- a/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -157,12 +157,14 @@ To use custom metrics with your Horizontal Pod Autoscaler, you must set the nece
 
 * [Enable the API aggregation layer](/docs/tasks/access-kubernetes-api/configure-aggregation-layer/) if you have not already done so.
 
-* Register your resource metrics API and your
-custom metrics API with the API aggregation layer. Both of these API servers must be running *on* your cluster.
+* Register your resource metrics API, your
+custom metrics API and, optionally, external metrics API with the API aggregation layer. All of these API servers must be running *on* your cluster.
 
   * *Resource Metrics API*: You can use Heapster's implementation of the resource metrics API, by running Heapster with its `--api-server` flag set to true.
 
   * *Custom Metrics API*: This must be provided by a separate component. To get started with boilerplate code, see the [kubernetes-incubator/custom-metrics-apiserver](https://github.com/kubernetes-incubator/custom-metrics-apiserver) and the [k8s.io/metrics](https://github.com/kubernetes/metrics) repositories.
+
+  * *External Metrics API*: Starting from Kubernetes 1.10 you can use this API if you need to autoscale on metrics not related to any Kubernetes object. Similarly to *Custom Metrics API* this must be provided by a separate component.
 
 * Set the appropriate flags for kube-controller-manager:
 


### PR DESCRIPTION
Add a small section about external metrics to HPA walkthrough and mention them (as optional) in section with HPA v2 requirements.