### PR TITLE
Remove reference to OVS as a called-out option for on-prem networking model

### DIFF
--- a/docs/concepts/cluster-administration/cluster-administration-overview.md
+++ b/docs/concepts/cluster-administration/cluster-administration-overview.md
@@ -21,7 +21,7 @@ Before choosing a guide, here are some considerations:
  - **If you are designing for high-availability**, learn about configuring [clusters in multiple zones](/docs/concepts/cluster-administration/federation/).
  - Will you be using **a hosted Kubernetes cluster**, such as [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/), or **hosting your own cluster**?
  - Will your cluster be **on-premises**, or **in the cloud (IaaS)**? Kubernetes does not directly support hybrid clusters. Instead, you can set up multiple clusters.
- - **If you are configuring Kubernetes on-premises**, consider which [networking model](/docs/concepts/cluster-administration/networking/) fits best. One option for custom networking is [*OpenVSwitch GRE/VxLAN networking*](/docs/admin/ovs-networking/), which uses OpenVSwitch to set up networking between pods across Kubernetes nodes.
+ - **If you are configuring Kubernetes on-premises**, consider which [networking model](/docs/concepts/cluster-administration/networking/) fits best.
  - Will you be running Kubernetes on **"bare metal" hardware** or on **virtual machines (VMs)**?
  - Do you **just want to run a cluster**, or do you expect to do **active development of Kubernetes project code**? If the
    latter, choose an actively-developed distro. Some distros only use binary releases, but


### PR DESCRIPTION
The referenced document was stale and has been deleted. See https://github.com/kubernetes/website/pull/6410

Also, it doesn't seem necessary to call out OVS specifically as an option for on-prem networking model.