### PR TITLE
Fix js error in homepage

### DIFF
--- a/_includes/footer-scripts.html
+++ b/_includes/footer-scripts.html
@@ -32,6 +32,7 @@ ga('send', 'pageview');
 
     function hideNav(toc){
         if (!toc) toc = document.querySelector('#docsToc')
+        if (!toc) return
             var container = toc.querySelector('.container')
 
                 // container is built dynamically, so it may not be present on the first runloop


### PR DESCRIPTION
When  document.querySelector('#docsToc') is null ,get TypeError Cannot read property 'querySelector' of null 。

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.10 Features: set Milestone to 1.10 and Base Branch to release-1.10
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
