### PR TITLE
Removed doc line descibing invocation of swagger UI

### DIFF
--- a/docs/concepts/overview/kubernetes-api.md
+++ b/docs/concepts/overview/kubernetes-api.md
@@ -24,7 +24,7 @@ What constitutes a compatible change and how to change the API are detailed by t
 
 ## OpenAPI and Swagger definitions
 
-Complete API details are documented using [Swagger v1.2](http://swagger.io/) and [OpenAPI](https://www.openapis.org/). The Kubernetes apiserver (aka "master") exposes an API that can be used to retrieve the Swagger v1.2 Kubernetes API spec located at `/swaggerapi`. You can also enable a UI to browse the API documentation at `/swagger-ui` by passing the `--enable-swagger-ui=true` flag to apiserver.
+Complete API details are documented using [Swagger v1.2](http://swagger.io/) and [OpenAPI](https://www.openapis.org/). The Kubernetes apiserver (aka "master") exposes an API that can be used to retrieve the Swagger v1.2 Kubernetes API spec located at `/swaggerapi`.
 
 Starting with Kubernetes 1.4, OpenAPI spec is also available at [`/swagger.json`](https://git.k8s.io/kubernetes/api/openapi-spec/swagger.json). While we are transitioning from Swagger v1.2 to OpenAPI (aka Swagger v2.0), some of the tools such as kubectl and swagger-ui are still using v1.2 spec. OpenAPI spec is in Beta as of Kubernetes 1.5.
 


### PR DESCRIPTION
Towards #6685 

#### Problem:
The documentation about swagger-ui is no longer accurate with v1.8.2. It says:

You can also enable a UI to browse the API documentation at /swagger-ui by passing the --enable-swagger-ui=true flag to apiserver.

If you do this the api server stops responding. The journalctl output has many errors such as:
Dec 15 19:45:44 lfs458-node-9q6r kubelet[1640]: E1215 19:45:44.171210 1640 reflector.go:205] k8s.io/kubernetes/pkg/kubelet/kubelet.go:413: Failed to list *v1.Service: Get https://10.128.0.3:6443/api/v1/services?resourceVersion=0: dial tcp 10 .128.0.3:6443: getsockopt: connection refused
As well the kubectl commands stop working. I edited the file under /etc/kubernetes/manifests/kube-apiserver.yaml to add the flag.

#### Solution
Remove this from the documentation until the proper process is figured out if it will even continue.

#### Page Updated
https://kubernetes.io/docs/concepts/overview/kubernetes-api/

<!-- Fixes #6685 -->