### PR TITLE
remove show-all option description since it is now defaulted to true

### DIFF
--- a/docs/concepts/workloads/controllers/jobs-run-to-completion.md
+++ b/docs/concepts/workloads/controllers/jobs-run-to-completion.md
@@ -70,12 +70,11 @@ Events:
   1m           1m          1        {job-controller }                Normal      SuccessfulCreate  Created pod: pi-dtn4q
 ```
 
-To view completed pods of a job, use `kubectl get pods --show-all`.  The `--show-all` will show completed pods too.
 
 To list all the pods that belong to a job in a machine readable form, you can use a command like this:
 
 ```shell
-$ pods=$(kubectl get pods  --show-all --selector=job-name=pi --output=jsonpath={.items..metadata.name})
+$ pods=$(kubectl get pods  --selector=job-name=pi --output=jsonpath={.items..metadata.name})
 $ echo $pods
 pi-aiw0a
 ```
@@ -215,9 +214,8 @@ policy for the embedded template to "`Never`".
 
 ## Job Termination and Cleanup
 
-When a Job completes, no more Pods are created, but the Pods are not deleted either.  Since they are terminated,
-they don't show up with `kubectl get pods`, but they will show up with `kubectl get pods -a`.  Keeping them around
-allows you to still view the logs of completed pods to check for errors, warnings, or other diagnostic output.
+When a Job completes, no more Pods are created, but the Pods are not deleted either. Keeping them around allows
+you to still view the logs of completed pods to check for errors, warnings, or other diagnostic output.
 The job object also remains after it is completed so that you can view its status.  It is up to the user to delete
 old jobs after noting their status.  Delete the job with `kubectl` (e.g. `kubectl delete jobs/pi` or `kubectl delete -f ./job.yaml`).  When you delete the job using `kubectl`, all the pods it created are deleted too.
 

--- a/docs/tasks/job/parallel-processing-expansion.md
+++ b/docs/tasks/job/parallel-processing-expansion.md
@@ -85,7 +85,7 @@ do not care to see.)
 We can check on the pods as well using the same label selector:
 
 ```shell
-$ kubectl get pods -l jobgroup=jobexample --show-all
+$ kubectl get pods -l jobgroup=jobexample
 NAME                        READY     STATUS      RESTARTS   AGE
 process-item-apple-kixwv    0/1       Completed   0          4m
 process-item-banana-wrsf7   0/1       Completed   0          4m
@@ -96,7 +96,7 @@ There is not a single command to check on the output of all jobs at once,
 but looping over all the pods is pretty easy:
 
 ```shell
-$ for p in $(kubectl get pods -l jobgroup=jobexample --show-all -o name)
+$ for p in $(kubectl get pods -l jobgroup=jobexample -o name)
 do
   kubectl logs $p
 done


### PR DESCRIPTION
show-all is now defaulted to true and deprecated:
https://github.com/kubernetes/kubernetes/pull/60210
It will be inert in 1.11 and removed in a future release.
This patch fix related description on jobs doc.
