### PR TITLE
Simplify base64 encoding of CSR

### DIFF
--- a/docs/tasks/tls/managing-tls-in-a-cluster.md
+++ b/docs/tasks/tls/managing-tls-in-a-cluster.md
@@ -102,7 +102,7 @@ metadata:
 spec:
   groups:
   - system:authenticated
-  request: $(cat server.csr | base64 | tr -d '\n')
+  request: $(base64 -w0 < server.csr)
   usages:
   - digital signature
   - key encipherment


### PR DESCRIPTION
- using `base64`'s built-in wrapping control, the usage of `tr` can be replaced
- using a simple shell redirect replaces the abuse of `cat`