### PR TITLE
antiaffinity selector zk-hs never matches

### DIFF
--- a/docs/tutorials/stateful-application/zookeeper.yaml
+++ b/docs/tutorials/stateful-application/zookeeper.yaml
@@ -63,7 +63,7 @@ spec:
                   - key: "app"
                     operator: In
                     values:
-                    - zk-hs
+                    - zk
               topologyKey: "kubernetes.io/hostname"
       containers:
       - name: kubernetes-zookeeper


### PR DESCRIPTION
Tested in minikube by replacing the zookeeper image with the pause container and the scheduler was able to schedule all 3 pods on the minikube node. Changing it to zk, made the pods zk-1 and zk-2 pending with scheduling failure as expected.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
