### PR TITLE
Change Get ExternalIPs to InternalIPs

### DIFF
--- a/docs/reference/kubectl/cheatsheet.md
+++ b/docs/reference/kubectl/cheatsheet.md
@@ -122,8 +122,8 @@ $ kubectl get pods --selector=app=cassandra rc -o \
 # Get all running pods in the namespace
 $ kubectl get pods --field-selector=status.phase=Running
 
-# Get ExternalIPs of all nodes
-$ kubectl get nodes -o jsonpath='{.items[*].status.addresses[?(@.type=="ExternalIP")].address}'
+# Get InternalIPs of all nodes
+$ kubectl get nodes -o jsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}'
 
 # List Names of Pods that belong to Particular RC
 # "jq" command useful for transformations that are too complex for jsonpath, it can be found at https://stedolan.github.io/jq/


### PR DESCRIPTION
Many Kubernetes clusters will not have external IPs so the get externalIPs will return null. Changing this to InternalIPs should at least return a value.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.10 Features: set Milestone to 1.10 and Base Branch to release-1.10
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
