### PR TITLE
Move @bradtopol from SIG Docs reviewer to approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,12 +2,12 @@ reviewers:
 - tengqm
 - zhangxiaoyu-zidif
 - xiangpengzhao
-- bradtopol
 approvers:
 - heckj
 - a-mccarthy
 - abiogenesis-now
 - bradamant3
+- bradtopol
 - steveperry-53
 - zacharysarah
 - chenopis


### PR DESCRIPTION
This PR moves @bradtopol from reviewer to approver for SIG Docs.

I will also add him to @kubernetes/sig-docs-maintainers.