### PR TITLE
Correct spelling mistake

### DIFF
--- a/docs/admin/admission-controllers.md
+++ b/docs/admin/admission-controllers.md
@@ -329,7 +329,7 @@ When the admission controller sets a compute resource request, it does this by *
 the pod spec rather than mutating the `container.resources` fields.
 The annotations added contain the information on what compute resources were auto-populated.
 
-See the [InitialResouces proposal](https://git.k8s.io/community/contributors/design-proposals/autoscaling/initial-resources.md) for more details.
+See the [InitialResources proposal](https://git.k8s.io/community/contributors/design-proposals/autoscaling/initial-resources.md) for more details.
 
 ### LimitPodHardAntiAffinity
 

--- a/docs/admin/authentication.md
+++ b/docs/admin/authentication.md
@@ -373,7 +373,7 @@ users:
         refresh-token: q1bKLFOyUiosTfawzA93TzZIDzH2TNa2SMm0zEiPKTUwME6BkEo6Sql5yUWVBSWpKUGphaWpxSVAfekBOZbBhaEW+VlFUeVRGcluyVF5JT4+haZmPsluFoFu5XkpXk5BXq
       name: oidc
 ```
-Once your `id_token` expires, `kubectl` will attempt to refresh your `id_token` using your `refresh_token` and `client_secret` storing the new values for the `refresh_token` and `id_token` in your `kube/.config`.
+Once your `id_token` expires, `kubectl` will attempt to refresh your `id_token` using your `refresh_token` and `client_secret` storing the new values for the `refresh_token` and `id_token` in your `.kube/config`.
 
 
 ##### Option 2 - Use the `--token` Option

--- a/docs/admin/high-availability/building.md
+++ b/docs/admin/high-availability/building.md
@@ -219,7 +219,7 @@ endpoints. You can switch to the new reconciler by adding the flag
 {% include feature-state-alpha.md %}
 
 If you want to know more, you can check the following resources:
-- [issue kubernetes/kuberenetes#22609](https://github.com/kubernetes/kubernetes/issues/22609),
+- [issue kubernetes/kubernetes#22609](https://github.com/kubernetes/kubernetes/issues/22609),
   which gives additional context
 - [master/reconcilers/mastercount.go](https://github.com/kubernetes/kubernetes/blob/dd9981d038012c120525c9e6df98b3beb3ef19e1/pkg/master/reconcilers/mastercount.go#L63),
   the implementation of the master count reconciler


### PR DESCRIPTION
Correct some spell mistake,and correct the "kube/.config" to ".kube/config".