### PR TITLE
`--show-all` is now defaulted to true and deprecated

### DIFF
--- a/docs/concepts/workloads/controllers/jobs-run-to-completion.md
+++ b/docs/concepts/workloads/controllers/jobs-run-to-completion.md
@@ -70,12 +70,10 @@ Events:
   1m           1m          1        {job-controller }                Normal      SuccessfulCreate  Created pod: pi-dtn4q
 ```
 
-To view completed pods of a job, use `kubectl get pods --show-all`.  The `--show-all` will show completed pods too.
-
 To list all the pods that belong to a job in a machine readable form, you can use a command like this:
 
 ```shell
-$ pods=$(kubectl get pods  --show-all --selector=job-name=pi --output=jsonpath={.items..metadata.name})
+$ pods=$(kubectl get pods  --selector=job-name=pi --output=jsonpath={.items..metadata.name})
 $ echo $pods
 pi-aiw0a
 ```

--- a/docs/tasks/job/parallel-processing-expansion.md
+++ b/docs/tasks/job/parallel-processing-expansion.md
@@ -85,7 +85,7 @@ do not care to see.)
 We can check on the pods as well using the same label selector:
 
 ```shell
-$ kubectl get pods -l jobgroup=jobexample --show-all
+$ kubectl get pods -l jobgroup=jobexample
 NAME                        READY     STATUS      RESTARTS   AGE
 process-item-apple-kixwv    0/1       Completed   0          4m
 process-item-banana-wrsf7   0/1       Completed   0          4m
@@ -96,7 +96,7 @@ There is not a single command to check on the output of all jobs at once,
 but looping over all the pods is pretty easy:
 
 ```shell
-$ for p in $(kubectl get pods -l jobgroup=jobexample --show-all -o name)
+$ for p in $(kubectl get pods -l jobgroup=jobexample -o name)
 do
   kubectl logs $p
 done


### PR DESCRIPTION
Default value of `--show-all` is true now, and will be inert soon.

ref: [k8s #60210](https://github.com/kubernetes/kubernetes/pull/60210)