### PR TITLE
Reference ahmetb's recipes repo for more scenarios enabled by NetworkPolicy

### DIFF
--- a/docs/concepts/services-networking/network-policies.md
+++ b/docs/concepts/services-networking/network-policies.md
@@ -186,3 +186,4 @@ This ensures that even pods that aren't selected by any other NetworkPolicy will
 
 - See the [Declare Network Policy](/docs/tasks/administer-cluster/declare-network-policy/)
   walkthrough for further examples.
+- See more [Recipes](https://github.com/ahmetb/kubernetes-network-policy-recipes) for common scenarios enabled by the NetworkPolicy resource.


### PR DESCRIPTION
I was looking for more examples illustrating what scenarios can be enabled by NetworkPolicy and the canonical usage patterns. I came upon ahmetb's repository and found the tutorials/recipes there very helpful. I think a reference to this repo in the main document as additional reading will be beneficial.
