### PR TITLE
Add step to docs/getting-started-guides/ubuntu/upgrades.md to ensure kubeapi-load-balancer is updated before master & workers

### DIFF
--- a/docs/getting-started-guides/ubuntu/upgrades.md
+++ b/docs/getting-started-guides/ubuntu/upgrades.md
@@ -48,6 +48,14 @@ After the snapshot, upgrade the etcd service with:
 
 This will handle upgrades between minor versions of etcd. Instructions on how to upgrade from 2.x to 3.x can be found [here](https://github.com/juju-solutions/bundle-canonical-kubernetes/wiki/Etcd-2.3-to-3.x-upgrade) in the juju-solutions wiki.
 
+### Upgrade kubeapi-load-balancer
+
+The Kubernetes Charms are generally all updated and released at the same time. A core part of a cluster on Ubuntu is the kubeapi-load-balancer component. Incorrect or missing changes there can have an effect on API availability and access controls. To ensure API service continuity for the master and workers when they are updated, this upgrade needs to precede them.
+
+To upgrade the charm run:
+
+    juju upgrade-charm kubeapi-load-balancer
+
 ### Upgrade Kubernetes
 
 The Kubernetes Charms use snap channels to drive payloads.


### PR DESCRIPTION
Over in https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/515 we found a broken 1.8->1.9 upgrade.

After quite a bit of troubleshooting it was discovered that kubeapi-load-balancer was running an outdated juju charm version, which was blocking adding RoleBindings, ClusterRoleBindings among other things.

@Cynerva recommended that all charms be upgraded when a cluster is being updated, since everything is usually released all at once.

Thus this PR, adding a step to the ubuntu getting started updates page.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
