### PR TITLE
Update downward-api-volume-expose-pod-information.md

### DIFF
--- a/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
+++ b/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
@@ -155,7 +155,7 @@ file for a Pod that has one Container:
 {% include code.html language="yaml" file="dapi-volume-resources.yaml" ghlink="/docs/tasks/inject-data-application/dapi-volume-resources.yaml" %}
 
 In the configuration file, you can see that the Pod has a `downwardAPI` Volume,
-and the Container mounts the Volume at `/etc`.
+and the Container mounts the Volume at `/etc/podinfo`.
 
 Look at the `items` array under `downwardAPI`. Each element of the array is a
 DownwardAPIVolumeFile.
@@ -179,7 +179,7 @@ kubectl exec -it kubernetes-downwardapi-volume-example-2 -- sh
 In your shell, view the `cpu_limit` file:
 
 ```shell
-/# cat /etc/cpu_limit
+/# cat /etc/podinfo/cpu_limit
 ```
 You can use similar commands to view the `cpu_request`, `mem_limit` and
 `mem_request` files.

--- a/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
+++ b/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
@@ -37,7 +37,7 @@ Here is the configuration file for the Pod:
 {% include code.html language="yaml" file="dapi-volume.yaml" ghlink="/docs/tasks/inject-data-application/dapi-volume.yaml" %}
 
 In the configuration file, you can see that the Pod has a `downwardAPI` Volume,
-and the Container mounts the Volume at `/etc`.
+and the Container mounts the Volume at `/etc/podinfo`.
 
 Look at the `items` array under `downwardAPI`. Each element of the array is a
 [DownwardAPIVolumeFile](/docs/api-reference/{{page.version}}/#downwardapivolumefile-v1-core).

--- a/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
+++ b/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
@@ -88,7 +88,7 @@ kubectl exec -it kubernetes-downwardapi-volume-example -- sh
 In your shell, view the `labels` file:
 
 ```shell
-/# cat /etc/labels
+/# cat /etc/podinfo/labels
 ```
 
 The output shows that all of the Pod's labels have been written
@@ -103,19 +103,19 @@ zone="us-est-coast"
 Similarly, view the `annotations` file:
 
 ```shell
-/# cat /etc/annotations
+/# cat /etc/podinfo/annotations
 ```
 
-View the files in the `/etc` directory:
+View the files in the `/etc/podinfo` directory:
 
 ```shell
-/# ls -laR /etc
+/# ls -laR /etc/podinfo
 ```
 
 In the output, you can see that the `labels` and `annotations` files
 are in a temporary subdirectory: in this example,
-`..2982_06_02_21_47_53.299460680`. In the `/etc` directory, `..data` is
-a symbolic link to the temporary subdirectory. Also in  the `/etc` directory,
+`..2982_06_02_21_47_53.299460680`. In the `/etc/podinfo` directory, `..data` is
+a symbolic link to the temporary subdirectory. Also in  the `/etc/podinfo` directory,
 `labels` and `annotations` are symbolic links.
 
 ```


### PR DESCRIPTION
The pod spec puts the downward api files into /etc/podinfo, not directly in /etc. Updated docs to reflect this fact.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.10 Features: set Milestone to 1.10 and Base Branch to release-1.10
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
