### PR TITLE
Update manage-deployment.md

### DIFF
--- a/docs/concepts/cluster-administration/manage-deployment.md
+++ b/docs/concepts/cluster-administration/manage-deployment.md
@@ -55,7 +55,7 @@ deployment "nginx-deployment" created
 Resource creation isn't the only operation that `kubectl` can perform in bulk. It can also extract resource names from configuration files in order to perform other operations, in particular to delete the same resources you created:
 
 ```shell
-$ kubectl delete -f https://k8s.io/docs/concepts/cluster-administration/nginx/
+$ kubectl delete -f https://k8s.io/docs/concepts/cluster-administration/nginx-app.yaml
 deployment "my-nginx" deleted
 service "my-nginx-svc" deleted
 ```


### PR DESCRIPTION
If you created the resource (on your local minikube) as instructed using:
kubectl create -f https://k8s.io/docs/concepts/cluster-administration/nginx-app.yaml
then, you probably want to delete it from your minikube in the same way, in that case, the correct command is the one proposed in this PR (it replaces a command that does not work out of the box).

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
