### PR TITLE
Fixed Cyrillic с in 'kube-proxy-cm'

### DIFF
--- a/docs/setup/independent/high-availability.md
+++ b/docs/setup/independent/high-availability.md
@@ -577,7 +577,7 @@ Next provision and set up the worker nodes. To do this, you will need to provisi
 1. Reconfigure kube-proxy to access kube-apiserver via the load balancer:
 
    ```shell
-   kubectl get configmap -n kube-system kube-proxy -o yaml > kube-proxy-сm.yaml
+   kubectl get configmap -n kube-system kube-proxy -o yaml > kube-proxy-cm.yaml
    sed -i 's#server:.*#server: https://<masterLoadBalancerFQDN>:6443#g' kube-proxy-cm.yaml
    kubectl apply -f kube-proxy-cm.yaml --force
    # restart all kube-proxy pods to ensure that they load the new configmap


### PR DESCRIPTION
There was a typo (wrong character) in kube-proxy-cm.yaml - Cyrillic с (UTF-8 0x0441) was used instead of Latin c.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.10 Features: set Milestone to 1.10 and Base Branch to release-1.10
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
