### PR TITLE
Clean keystone authentication doc

### DIFF
--- a/docs/admin/authentication.md
+++ b/docs/admin/authentication.md
@@ -536,30 +536,6 @@ checked.
 * `--requestheader-client-ca-file` Required. PEM-encoded certificate bundle. A valid client certificate must be presented and validated against the certificate authorities in the specified file before the request headers are checked for user names.
 * `--requestheader-allowed-names` Optional.  List of common names (cn). If set, a valid client certificate with a Common Name (cn) in the specified list must be presented before the request headers are checked for user names. If empty, any Common Name is allowed.
 
-
-### Keystone Password
-
-Keystone authentication is enabled by passing the `--experimental-keystone-url=<AuthURL>`
-option to the API server during startup. The plugin is implemented in
-`plugin/pkg/auth/authenticator/password/keystone/keystone.go` and currently uses
-basic auth to verify user by username and password.
-
-If you have configured self-signed certificates for the Keystone server,
-you may need to set the `--experimental-keystone-ca-file=SOMEFILE` option when
-starting the Kubernetes API server. If you set the option, the Keystone
-server's certificate is verified by one of the authorities in the
-`experimental-keystone-ca-file`. Otherwise, the certificate is verified by
-the host's root Certificate Authority.
-
-For details on how to use keystone to manage projects and users, refer to the
-[Keystone documentation](http://docs.openstack.org/developer/keystone/). Please
-note that this plugin is still experimental, under active development, and likely
-to change in subsequent releases.
-
-Please refer to the [discussion](https://github.com/kubernetes/kubernetes/pull/11798#issuecomment-129655212),
-[blueprint](https://github.com/kubernetes/kubernetes/issues/11626) and [proposed
-changes](https://github.com/kubernetes/kubernetes/pull/25536) for more details.
-
 ## Anonymous requests
 
 When enabled, requests that are not rejected by other configured authentication methods are


### PR DESCRIPTION
According to https://github.com/kubernetes/kubernetes/pull/59492， keystone authencator  is remove in 1.10
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.10 Features: set Milestone to 1.10 and Base Branch to release-1.10
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
