### PR TITLE
Gramatical fix to kompose introduction

### DIFF
--- a/docs/tools/kompose/user-guide.md
+++ b/docs/tools/kompose/user-guide.md
@@ -16,7 +16,7 @@ redirect_from:
 
 What's Kompose? It's a conversion tool for all things compose (namely Docker Compose) to container orchestrators (Kubernetes or OpenShift).
 
-More information can be found our website at [http://kompose.io](http://kompose.io)
+More information can be found on the Kompose website at [http://kompose.io](http://kompose.io).
 
 In three simple steps, we'll take you from Docker Compose to Kubernetes.
 


### PR DESCRIPTION
I just spotted a small bit of the Kompose documentation that didn't read very well.

As much of the original sentence has been preserved as possible; primarily to ensure the kompose web address is see both in text and as a href link, this way people can copy and paste it easily.