### PR TITLE
Update service.md

### DIFF
--- a/docs/concepts/services-networking/service.md
+++ b/docs/concepts/services-networking/service.md
@@ -453,8 +453,8 @@ cloud provider does not support the feature, the field will be ignored.
 
 **Special notes for Azure**: To use user-specified public type `loadBalancerIP`, a static type
 public IP address resource needs to be created first, and it should be in the same resource
-group of the cluster. Then you could specify the assigned IP address as `loadBalancerIP`. You 
-have to specify `securityGroupName` in the cloud provider configuration file.
+group of the cluster. Specify the assigned IP address as loadBalancerIP. Verify you have 
+securityGroupName in the cloud provider configuration file.
 
 #### Internal load balancer
 In a mixed environment it is sometimes necessary to route traffic from services inside the same VPC.

--- a/docs/concepts/services-networking/service.md
+++ b/docs/concepts/services-networking/service.md
@@ -453,7 +453,8 @@ cloud provider does not support the feature, the field will be ignored.
 
 **Special notes for Azure**: To use user-specified public type `loadBalancerIP`, a static type
 public IP address resource needs to be created first, and it should be in the same resource
-group of the cluster. Then you could specify the assigned IP address as `loadBalancerIP`.
+group of the cluster. Then you could specify the assigned IP address as `loadBalancerIP`. You 
+have to specify `securityGroupName` in the cloud provider configuration file.
 
 #### Internal load balancer
 In a mixed environment it is sometimes necessary to route traffic from services inside the same VPC.


### PR DESCRIPTION
`securityGroupName` is the required value when creating LoadBalancer type service in Azure.
I got the following error without `securityGroupName` value.
> Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)