### PR TITLE
Remove docs related to insecure serving

### DIFF
--- a/docs/admin/accessing-the-api.md
+++ b/docs/admin/accessing-the-api.md
@@ -126,30 +126,19 @@ for the corresponding API object, and then written to the object store (shown as
 ## API Server Ports and IPs
 
 The previous discussion applies to requests sent to the secure port of the API server
-(the typical case).  The API server can actually serve on 2 ports:
+(the typical case). In versions earlier than v1.10, the API server can serve
+the localhost by listening to an insecure port. This support has been removed
+since version 1.10.
 
-By default the Kubernetes API server serves HTTP on 2 ports:
+A cluster administrator can customize how the API server serves HTTPS requests:
 
-  1. `Localhost Port`:
-
-          - is intended for testing and bootstrap, and for other components of the master node
-            (scheduler, controller-manager) to talk to the API
-          - no TLS
-          - default is port 8080, change with `--insecure-port` flag.
-          - default IP is localhost, change with `--insecure-bind-address` flag.
-          - request **bypasses** authentication and authorization modules.
-          - request handled by admission control module(s).
-          - protected by need to have host access
-
-  2. `Secure Port`:
-
-          - use whenever possible
-          - uses TLS.  Set cert with `--tls-cert-file` and key with `--tls-private-key-file` flag.
-          - default is port 6443, change with `--secure-port` flag.
-          - default IP is first non-localhost network interface, change with `--bind-address` flag.
-          - request handled by authentication and authorization modules.
-          - request handled by admission control module(s).
-          - authentication and authorization modules run.
+- Set the TLS cert with `--tls-cert-file` and key with `--tls-private-key-file` flag.
+- Change the port to listen on (default to 6443) using the `--secure-port` flag.
+- Change the IP address to use by setting the `--bind-address` flag.
+  The default IP is obtained from the first non-localhost network interface.
+- Change the IP address to advertise to users by setting the `--advertise-address` flag.
+  This flag is typically used in a high-availability environment where the API
+  server clusters serve requests behind a loadbalancer with the advertised address.
 
 When the cluster is created by `kube-up.sh`, on Google Compute Engine (GCE),
 and on several other cloud providers, the API server serves on port 443.  On

--- a/docs/admin/authorization/rbac.md
+++ b/docs/admin/authorization/rbac.md
@@ -693,11 +693,11 @@ subjects:
   name: user-1
 ```
 
-When bootstrapping the first roles and role bindings, it is necessary for the initial user to grant permissions they do not yet have.
-To bootstrap initial roles and role bindings:
-
-* Use a credential with the `system:masters` group, which is bound to the `cluster-admin` super-user role by the default bindings.
-* If your API server runs with the insecure port enabled (`--insecure-port`), you can also make API calls via that port, which does not enforce authentication or authorization.
+When bootstrapping the first roles and role bindings, it is necessary for the
+initial user to grant permissions they do not yet have.
+To bootstrap initial roles and role bindings, use a credential with the
+`system:masters` group, which is bound to the `cluster-admin` super-user role
+by the default bindings.
 
 ## Command-line Utilities
 

--- a/docs/getting-started-guides/coreos/cloud-configs/master.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/master.yaml
@@ -94,8 +94,6 @@ coreos:
         --enable-admission-plugins=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota \
         --runtime-config=api/v1 \
         --allow-privileged=true \
-        --insecure-bind-address=0.0.0.0 \
-        --insecure-port=8080 \
         --kubelet-https=true \
         --secure-port=6443 \
         --service-cluster-ip-range=10.100.0.0/16 \

--- a/docs/getting-started-guides/scratch.md
+++ b/docs/getting-started-guides/scratch.md
@@ -614,7 +614,6 @@ Here are some apiserver flags you may need to set:
 If you are following the firewall-only security approach, then use these arguments:
 
 - `--token-auth-file=/dev/null`
-- `--insecure-bind-address=$MASTER_IP`
 - `--advertise-address=$MASTER_IP`
 
 If you are using the HTTPS approach, then set:


### PR DESCRIPTION
The options `--insecure-bind-address` and `--insecure-port` are both
gone in 1.10 release. This PR updates the docs to remove related
contents.