### PR TITLE
Prune inactive maintainers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,8 +4,6 @@ reviewers:
 - xiangpengzhao
 approvers:
 - heckj
-- a-mccarthy
-- abiogenesis-now
 - bradamant3
 - bradtopol
 - steveperry-53

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -87,12 +87,11 @@ aliases:
     - grodrigues3
     - spxtr
   sig-docs: #Team: documentation; GH: sig-docs-pr-reviews
-    - a-mccarthy
-    - abiogenesis-now
     - bradamant3
     - steveperry-53
     - zacharysarah
     - bradtopol
+    - heckj
   sig-federation: #Team: Federation; e.g. Federated Clusters
     - csbell
   sig-gcp: #Google Cloud Platform; GH: sig-gcp-pr-reviews
@@ -204,4 +203,3 @@ aliases:
     - floreks
   sig-windows:
     - michmike
-


### PR DESCRIPTION
This PR prunes inactive maintainers from OWNERS and OWNERS_ALIASES.

This PR also requires manual repo maintenance:
- [x] Remove pruned maintainers from the SIG Docs Maintainers repo team (@zacharysarah)