### PR TITLE
Document Kubefed on-prem AWS Route53 configuration

### DIFF
--- a/docs/tasks/federation/set-up-cluster-federation-kubefed.md
+++ b/docs/tasks/federation/set-up-cluster-federation-kubefed.md
@@ -371,6 +371,9 @@ kubefed init fellowship \
     --dns-provider-config="$HOME/coredns-provider.conf"
 ```
 
+For more information see
+[Setting up CoreDNS as DNS provider for Cluster Federation](/docs/tasks/federation/set-up-coredns-provider-federation/).
+
 #### AWS Route53 support
 
 It is possible to utilize AWS Route53 as a cloud DNS provider when the
@@ -407,9 +410,6 @@ kubectl -n federation-system patch deployment controller-manager --patch "$(cat 
 ```
 
 Where `<patch-file-name>` is the name of the file you created above.
-
-For more information see
-[Setting up CoreDNS as DNS provider for Cluster Federation](/docs/tasks/federation/set-up-coredns-provider-federation/).
 
 ## Adding a cluster to a federation
 

--- a/docs/tasks/federation/set-up-cluster-federation-kubefed.md
+++ b/docs/tasks/federation/set-up-cluster-federation-kubefed.md
@@ -375,7 +375,7 @@ kubefed init fellowship \
 
 It is possible to utilize AWS Route53 as a cloud DNS provider when the
 federation control plane is run on-premise. The control-manager
-deployment must be configured with AWS credentials since it cannot implicity
+Deployment must be configured with AWS credentials since it cannot implicity
 gather them from a VM running on AWS.
 
 Currently, `kubefed init` does not read AWS Route53 credentials from the
@@ -385,7 +385,7 @@ Specify AWS Route53 as your DNS provider when initializing your on-premise
 federation control plane by passing the flag `--dns-provider="aws-route53"`
 to `kubefed init`.
 
-Create a patch file with your AWS credentials named `federation-controller-manager-patch.yml`:
+Create a patch file with your AWS credentials:
 
 ```yaml
 spec:
@@ -400,11 +400,13 @@ spec:
           value: "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
 ```
 
-Patch the deployment:
+Patch the Deployment:
 
 ```shell
-kubectl -n federation-system patch deployment controller-manager --patch "$(cat federation-controller-manager-patch.yml)"
+kubectl -n federation-system patch deployment controller-manager --patch "$(cat <patch-file-name>.yml)"
 ```
+
+Where `<patch-file-name>` is the name of the file you created above.
 
 For more information see
 [Setting up CoreDNS as DNS provider for Cluster Federation](/docs/tasks/federation/set-up-coredns-provider-federation/).

--- a/docs/tasks/federation/set-up-cluster-federation-kubefed.md
+++ b/docs/tasks/federation/set-up-cluster-federation-kubefed.md
@@ -381,6 +381,10 @@ gather them from a VM running on AWS.
 Currently, `kubefed init` does not read AWS Route53 credentials from the
 `--dns-provider-config` flag, so a patch must be applied.
 
+Specify AWS Route53 as your DNS provider when initializing your on-premise
+federation control plane by passing the flag `--dns-provider="aws-route53"`
+to `kubefed init`.
+
 Create a patch file with your AWS credentials named `federation-controller-manager-patch.yml`:
 
 ```yaml

--- a/docs/tasks/federation/set-up-cluster-federation-kubefed.md
+++ b/docs/tasks/federation/set-up-cluster-federation-kubefed.md
@@ -371,6 +371,37 @@ kubefed init fellowship \
     --dns-provider-config="$HOME/coredns-provider.conf"
 ```
 
+#### AWS Route53 support
+
+It is possible to utilize AWS Route53 as a cloud DNS provider when the
+federation control plane is run on-premise. The control-manager
+deployment must be configured with AWS credentials since it cannot implicity
+gather them from a VM running on AWS.
+
+Currently, `kubefed init` does not read AWS Route53 credentials from the
+`--dns-provider-config` flag, so a patch must be applied.
+
+Create a patch file with your AWS credentials named `federation-controller-manager-patch.yml`:
+
+```yaml
+spec:
+  template:
+    spec:
+      containers:
+      - name: controller-manager
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          value: "ABCDEFG1234567890"
+        - name: AWS_SECRET_ACCESS_KEY
+          value: "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
+```
+
+Patch the deployment:
+
+```shell
+kubectl -n federation-system patch deployment controller-manager --patch "$(cat federation-controller-manager-patch.yml)"
+```
+
 For more information see
 [Setting up CoreDNS as DNS provider for Cluster Federation](/docs/tasks/federation/set-up-coredns-provider-federation/).
 

--- a/docs/tasks/federation/set-up-cluster-federation-kubefed.md
+++ b/docs/tasks/federation/set-up-cluster-federation-kubefed.md
@@ -374,7 +374,7 @@ kubefed init fellowship \
 #### AWS Route53 support
 
 It is possible to utilize AWS Route53 as a cloud DNS provider when the
-federation control plane is run on-premise. The control-manager
+federation controller-manager is run on-premise. The controller-manager
 Deployment must be configured with AWS credentials since it cannot implicity
 gather them from a VM running on AWS.
 
@@ -382,7 +382,7 @@ Currently, `kubefed init` does not read AWS Route53 credentials from the
 `--dns-provider-config` flag, so a patch must be applied.
 
 Specify AWS Route53 as your DNS provider when initializing your on-premise
-federation control plane by passing the flag `--dns-provider="aws-route53"`
+federation controller-manager by passing the flag `--dns-provider="aws-route53"`
 to `kubefed init`.
 
 Create a patch file with your AWS credentials:


### PR DESCRIPTION
Document configuring AWS Route53 as DNS provider when initializing the federation control plane in an on-premise cluster.