### PR TITLE
Add link for IBM Cloud Private-CE on Linux Containers project

### DIFF
--- a/docs/setup/pick-right-solution.md
+++ b/docs/setup/pick-right-solution.md
@@ -35,6 +35,8 @@ a Kubernetes cluster from scratch.
 
 * [IBM Cloud Private-CE (Community Edition)](https://github.com/IBM/deploy-ibm-cloud-private) can use VirtualBox on your machine to deploy Kubernetes to one or more VMs for development and test scenarios. Scales to full multi-node cluster.
 
+* [IBM Cloud Private-CE (Community Edition) on Linux Containers](https://github.com/HSBawa/icp-ce-on-linux-containers) is a Terraform/Packer/BASH based IaC to create a seven node (1 Boot, 1 Master, 1 Management, 1 Proxy and 3 Workers) LXD cluster on  Linux Host.
+
 # Hosted Solutions
 
 * [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/) offers managed Kubernetes clusters.

--- a/docs/setup/pick-right-solution.md
+++ b/docs/setup/pick-right-solution.md
@@ -35,7 +35,7 @@ a Kubernetes cluster from scratch.
 
 * [IBM Cloud Private-CE (Community Edition)](https://github.com/IBM/deploy-ibm-cloud-private) can use VirtualBox on your machine to deploy Kubernetes to one or more VMs for development and test scenarios. Scales to full multi-node cluster.
 
-* [IBM Cloud Private-CE (Community Edition) on Linux Containers](https://github.com/HSBawa/icp-ce-on-linux-containers) is a Terraform/Packer/BASH based IaC to create a seven node (1 Boot, 1 Master, 1 Management, 1 Proxy and 3 Workers) LXD cluster on  Linux Host.
+* [IBM Cloud Private-CE (Community Edition) on Linux Containers](https://github.com/HSBawa/icp-ce-on-linux-containers) is a Terraform/Packer/BASH based Infrastructure as Code (IaC) scripts to create a seven node (1 Boot, 1 Master, 1 Management, 1 Proxy and 3 Workers) LXD cluster on  Linux Host.
 
 # Hosted Solutions
 


### PR DESCRIPTION
IBM Cloud Private-CE (Community Edition) on Linux Containers is a Terraform/Packer/BASH based IaC to create a seven node (1 Boot, 1 Master, 1 Management, 1 Proxy and 3 Workers) LXD cluster on  Linux Host. Supported versions are: ICP 2.1.0.1 + Kubernetes 1.8.3 and ICP 2.1.0.2 + Kubernetes 1.9.1

Goal of this project was to create a Terraform based solution that can be easily configured to meet user needs for development purposes. This IaC script can be applied to Local or Cloud based Linux Host (Ubuntu). Additionally, environment specific TFVARS can allow simpler integration with DevOps pipeline.  

Detailed information can be found at https://github.com/HSBawa/icp-ce-on-linux-containers.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.10 Features: set Milestone to 1.10 and Base Branch to release-1.10
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
