### PR TITLE
clean up -a from doc

### DIFF
--- a/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases.md
+++ b/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases.md
@@ -53,7 +53,7 @@ This Pod can be started with the following commands:
 $ kubectl apply -f hostaliases-pod.yaml
 pod "hostaliases-pod" created
 
-$ kubectl get pod -a -o=wide
+$ kubectl get pod -o=wide
 NAME                           READY     STATUS      RESTARTS   AGE       IP              NODE
 hostaliases-pod                0/1       Completed   0          6s        10.244.135.10   node3
 ```

--- a/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/docs/concepts/workloads/controllers/cron-jobs.md
@@ -95,7 +95,7 @@ your job name and pod name would be different.
 
 ```shell
 # Replace "hello-4111706356" with the job name in your system
-$ pods=$(kubectl get pods -a --selector=job-name=hello-4111706356 --output=jsonpath={.items..metadata.name})
+$ pods=$(kubectl get pods --selector=job-name=hello-4111706356 --output=jsonpath={.items..metadata.name})
 
 $ echo $pods
 hello-4111706356-o9qcm


### PR DESCRIPTION
-a/--show-all has been set to true by default in 1.10
And it will be inert in 1.11

It's OK to remove them from the 1.10 doc.

https://github.com/kubernetes/kubernetes/pull/60210 


>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.10 Features: set Milestone to 1.10 and Base Branch to release-1.10
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
