### PR TITLE
Update index.md with link to correct example files

### DIFF
--- a/docs/user-guide/walkthrough/index.md
+++ b/docs/user-guide/walkthrough/index.md
@@ -11,7 +11,7 @@ For Kubernetes 101, we will cover kubectl, pods, volumes, and multiple container
 
 {% include task-tutorial-prereqs.md %}
 
-In order for the kubectl usage examples to work, make sure you have an example directory locally, either from [a release](https://github.com/kubernetes/kubernetes/releases) or [the source](https://github.com/kubernetes/kubernetes).
+In order for the kubectl usage examples to work, make sure you have an example directory locally, either by [downloading](https://github.com/kubernetes/website/archive/master.zip) or cloning [the website repository](https://github.com/kubernetes/website) or exporting it using svn (`svn export https://github.com/kubernetes/website/trunk/docs/user-guide/walkthrough`)
 
 * TOC
 {:toc}


### PR DESCRIPTION
Suggested change for #7686 pointing to the correct repository for the example directory.

May require adaptation to point to the correct branch if desired, but I didn't know how to do that. I think this is an improvement nevertheless.