### PR TITLE
Remove a phrase to avoid confusion

### DIFF
--- a/docs/concepts/services-networking/service.md
+++ b/docs/concepts/services-networking/service.md
@@ -17,7 +17,7 @@ in that set?
 Enter `Services`.
 
 A Kubernetes `Service` is an abstraction which defines a logical set of `Pods`
-and a policy by which to access them - sometimes called a micro-service.  The
+and a policy by which to access them.  The
 set of `Pods` targeted by a `Service` is (usually) determined by a [`Label
 Selector`](/docs/concepts/overview/working-with-objects/labels/#label-selectors) (see below for why you might want a
 `Service` without a selector).


### PR DESCRIPTION
Removed the phrase ` - sometimes called a micro-service` as It distracts from the main idea being presented - the concept of Services. If the consensus is to retain the phrase, I suggest placing it in a separate sentence.
