### PR TITLE
Clarify caching of exec auth tokens

### DIFF
--- a/docs/admin/authentication.md
+++ b/docs/admin/authentication.md
@@ -828,7 +828,8 @@ Kubernetes API.
 
 Optionally, this output can include the expiry of the token formatted as a RFC3339 timestamp.
 If an expiry is omitted, the bearer token is cached until the server responds with a 401 HTTP
-status code.
+status code. Note that this caching is only for the duration of process and therefore triggered
+each time the tool using the auth is invoked.
 
 ```json
 {

--- a/docs/admin/authentication.md
+++ b/docs/admin/authentication.md
@@ -828,8 +828,8 @@ Kubernetes API.
 
 Optionally, this output can include the expiry of the token formatted as a RFC3339 timestamp.
 If an expiry is omitted, the bearer token is cached until the server responds with a 401 HTTP
-status code. Note that this caching is only for the duration of process and therefore triggered
-each time the tool using the auth is invoked.
+status code. Note that this caching is only for the duration of process and therefore the plugin 
+is triggered each time the tool using the plugin is invoked.
 
 ```json
 {


### PR DESCRIPTION
As discussed on slack with @liggitt and @ericchiang , wanted to add clarification to the documentation about the caching of the token in exec auth.
