### PR TITLE
Fix redirections for generated api references

### DIFF
--- a/_data/reference.yml
+++ b/_data/reference.yml
@@ -32,7 +32,7 @@ toc:
   - docs/reference/workloads-18-19.md
 
 - title: API Reference
-  landing_page: /docs/api-reference/v1.10/
+  landing_page: /docs/reference/generated/kubernetes-api/v1.10/
   section:
   - title: v1.10
     path: /docs/reference/generated/kubernetes-api/v1.10/

--- a/_includes/api-reference-content-moved.md
+++ b/_includes/api-reference-content-moved.md
@@ -1,2 +1,0 @@
-The topics in the `/docs/api-reference/` section of the Kubernetes docs
-are being moved to the [Reference](/docs/reference/) section. The content in this topic has moved to:

--- a/_includes/templates/glossary/README.md
+++ b/_includes/templates/glossary/README.md
@@ -59,7 +59,7 @@ Every snippet must include at least the short description. The long description 
 
 * **Think of the short description as it would appear in a tooltip.** Is it sufficient to get the reader started? Is it short enough to be read inside a small UI element?
 
-  *Tip*: look at the API reference doc content (for example, https://kubernetes.io/docs/api-reference/v1.7/). Note, however, that this content should be used with care. The concept docs for Pod, for example, are clearer than the reference docs.
+  *Tip*: look at the API reference doc content (for example, https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/). Note, however, that this content should be used with care. The concept docs for Pod, for example, are clearer than the reference docs.
 
 * **The long description should follow the short description to make a complete introduction to a topic.** (This is the content that appears at the top of the content, before any generated TOC.) Does it provide information that's not already clear from the short description? Does it provide information that readers should have a general sense of before they dive into the details of the topic it helps introduce?
 

--- a/_redirects
+++ b/_redirects
@@ -56,28 +56,14 @@
 
 /docs/api/     /docs/concepts/overview/kubernetes-api/ 301
 
-/docs/api-reference/apps/v1alpha1/definitions/     https://v1-4.docs.kubernetes.io/docs/api-reference/apps/v1alpha1/definitions/ 301
-/docs/api-reference/apps/v1beta1/operations/     https://v1-4.docs.kubernetes.io/docs/api-reference/apps/v1beta1/operations/ 301
-/docs/api-reference/authorization.k8s.io/v1beta1/definitions/     https://v1-4.docs.kubernetes.io/docs/api-reference/authorization.k8s.io/v1beta1/definitions/ 301
-/docs/api-reference/authorization.k8s.io/v1beta1/operations/     https://v1-4.docs.kubernetes.io/docs/api-reference/authorization.k8s.io/v1beta1/operations/ 301
-/docs/api-reference/autoscaling/v1/operations/     https://v1-4.docs.kubernetes.io/docs/api-reference/autoscaling/v1/operations/ 301
-/docs/api-reference/batch/v1/operations/     https://v1-4.docs.kubernetes.io/docs/api-reference/batch/v1/operations/ 301
-/docs/api-reference/batch/v2alpha1/definitions/     https://v1-4.docs.kubernetes.io/docs/api-reference/batch/v2alpha1/definitions/ 301
-/docs/api-reference/certificates.k8s.io/v1alpha1/definitions/     https://v1-4.docs.kubernetes.io/docs/api-reference/certificates.k8s.io/v1alpha1/definitions/ 301
-/docs/api-reference/certificates/v1alpha1/operations/     https://v1-4.docs.kubernetes.io/docs/api-reference/certificates/v1alpha1/operations/ 301
-/docs/api-reference/extensions/v1beta1/operations/     https://v1-4.docs.kubernetes.io/docs/api-reference/extensions/v1beta1/operations/ 301
 /docs/api-reference/labels-annotations-taints/     /docs/reference/labels-annotations-taints/ 301
-/docs/api-reference/policy/v1alpha1/definitions/     https://v1-4.docs.kubernetes.io/docs/api-reference/policy/v1alpha1/definitions/ 301
-/docs/api-reference/policy/v1beta1/definitions/     https://v1-4.docs.kubernetes.io/docs/api-reference/policy/v1beta1/definitions/ 301
-/docs/api-reference/README/     https://v1-4.docs.kubernetes.io/docs/api-reference/README/ 301
-/docs/api-reference/storage.k8s.io/v1beta1/operations/     https://v1-4.docs.kubernetes.io/docs/api-reference/storage.k8s.io/v1beta1/operations/ 301
 /docs/api-reference/v1.6/*     https://v1-6.docs.kubernetes.io/docs/reference/ 301
 /docs/api-reference/v1.7/*     https://v1-7.docs.kubernetes.io/docs/reference/ 301
 /docs/api-reference/v1.8/*     https://v1-8.docs.kubernetes.io/docs/api-reference/v1.8/:splat 301
 /docs/api-reference/v1.9/     /docs/reference/generated/kubernetes-api/v1.9/ 301
-/docs/api-reference/v1/definitions/     /docs/api-reference/v1.9/ 301
-/docs/api-reference/v1/operations/     /docs/api-reference/v1.9/ 301
-/docs/api-reference/v1.9/      /docs/reference/generated/kubernetes-api/v1.9/ 301
+/docs/api-reference/v1/definitions/    /docs/reference/generated/kubernetes-api/v1.10/ 301
+/docs/api-reference/v1/definitions.html /docs/reference/generated/kubernetes-api/v1.10/ 301
+/docs/api-reference/v1/operations/     /docs/reference/generated/kubernetes-api/v1.10/ 301
 
 /docs/concepts/abstractions/controllers/garbage-collection/     /docs/concepts/workloads/controllers/garbage-collection/ 301
 /docs/concepts/abstractions/controllers/statefulsets/     /docs/concepts/workloads/controllers/statefulset/ 301
@@ -140,19 +126,17 @@
 /docs/deprecation-policy/     /docs/reference/deprecation-policy/ 301
 
 /docs/federation/api-reference/     /docs/reference/federation/v1/operations/ 301
-/docs/federation/api-reference/v1/definitions.html     /docs/federation/api-reference/v1/definitions/ 301
-/docs/federation/api-reference/v1/operations.html     /docs/federation/api-reference/v1/operations/ 301
-/docs/federation/api-reference/extensions/v1beta1/definitions/     /docs/reference/federation/extensions/v1beta1/definitions/ 301
-/docs/federation/api-reference/extensions/v1beta1/definitions.html     /docs/federation/api-reference/extensions/v1beta1/definitions/ 301
-/docs/federation/api-reference/extensions/v1beta1/operations/     /docs/reference/federation/extensions/v1beta1/operations/ 301
-/docs/federation/api-reference/federation/v1beta1/definitions/     /docs/reference/federation/extensions/v1beta1/definitions/ 301
-/docs/federation/api-reference/federation/v1beta1/definitions.html     /docs/federation/api-reference/federation/v1beta1/definitions/ 301
-/docs/federation/api-reference/federation/v1beta1/operations/     /docs/reference/federation/extensions/v1beta1/operations/ 301
-/docs/federation/api-reference/extensions/v1beta1/operations.html     /docs/federation/api-reference/extensions/v1beta1/operations/ 301
-/docs/federation/api-reference/federation/v1beta1/operations.html     /docs/federation/api-reference/federation/v1beta1/operations/ 301
-/docs/federation/api-reference/README/     /docs/reference/federation/ 301
-/docs/federation/api-reference/v1/definitions/     /docs/reference/federation/v1/definitions/ 301
-/docs/federation/api-reference/v1/operations/     /docs/reference/federation/v1/operations/ 301
+/docs/federation/api-reference/v1/definitions.html    /docs/reference/generated/federation/v1/definitions/ 301
+/docs/federation/api-reference/v1/operations.html     /docs/reference/generated/federation/v1/operations/ 301
+/docs/federation/api-reference/extensions/v1beta1/definitions/       /docs/reference/generated/federation/extensions/v1beta1/definitions/ 301
+/docs/federation/api-reference/extensions/v1beta1/definitions.html   /docs/reference/generated/federation/extensions/v1beta1/definitions/ 301
+/docs/federation/api-reference/extensions/v1beta1/operations/      /docs/reference/generated/federation/extensions/v1beta1/operations/ 301
+/docs/federation/api-reference/extensions/v1beta1/operations.html  /docs/reference/generated/federation/extensions/v1beta1/operations/ 301
+/docs/federation/api-reference/federation/v1beta1/definitions/      /docs/reference/generated/federation/extensions/v1beta1/definitions/ 301
+/docs/federation/api-reference/federation/v1beta1/definitions.html  /docs/reference/generated/federation/extensions/v1beta1/definitions/ 301
+/docs/federation/api-reference/federation/v1beta1/operations/      /docs/reference/generated/federation/extensions/v1beta1/operations/ 301
+/docs/federation/api-reference/federation/v1beta1/operations.html  /docs/reference/generated/federation/extensions/v1beta1/operations/ 301
+/docs/federation/api-reference/README/     /docs/reference/generated/federation/ 301
 
 /docs/getting-started-guide/*     /docs/setup/ 301
 /docs/getting-started-guides/     /docs/setup/pick-right-solution/ 301

--- a/docs/admin/extensible-admission-controllers.md
+++ b/docs/admin/extensible-admission-controllers.md
@@ -83,8 +83,8 @@ how to [authenticate apiservers](#authenticate-apiservers).
 ### Deploy the admission webhook service
 
 The webhook server in the e2e test is deployed in the Kubernetes cluster, via
-the [deployment API](/docs/api-reference/{{page.version}}/#deployment-v1beta1-apps).
-The test also creates a [service](/docs/api-reference/{{page.version}}/#service-v1-core)
+the [deployment API](/docs/reference/generated/kubernetes-api/{{page.version}}/#deployment-v1beta1-apps).
+The test also creates a [service](/docs/reference/generated/kubernetes-api/{{page.version}}/#service-v1-core)
 as the front-end of the webhook server. See
 [code](https://github.com/kubernetes/kubernetes/blob/v1.10.0-beta.1/test/e2e/apimachinery/webhook.go#L196).
 
@@ -259,7 +259,7 @@ you need to:
 ### Deploy an initializer controller
 
 You should deploy an initializer controller via the [deployment
-API](/docs/api-reference/{{page.version}}/#deployment-v1beta1-apps).
+API](/docs/reference/generated/kubernetes-api/{{page.version}}/#deployment-v1beta1-apps).
 
 ### Configure initializers on the fly
 
@@ -390,9 +390,9 @@ See [caesarxuchao/example-webhook-admission-controller deployment](https://githu
 for an example deployment.
 
 The webhook admission controller should be deployed via the
-[deployment API](/docs/api-reference/{{page.version}}/#deployment-v1beta1-apps).
+[deployment API](/docs/reference/generated/kubernetes-api/{{page.version}}/#deployment-v1beta1-apps).
 You also need to create a
-[service](/docs/api-reference/{{page.version}}/#service-v1-core) as the
+[service](/docs/reference/generated/kubernetes-api/{{page.version}}/#service-v1-core) as the
 front-end of the deployment.
 
 ### Configure webhook admission controller on the fly

--- a/docs/concepts/architecture/nodes.md
+++ b/docs/concepts/architecture/nodes.md
@@ -281,5 +281,5 @@ on each kubelet where you want to reserve resources.
 ## API Object
 
 Node is a top-level resource in the Kubernetes REST API. More details about the
-API object can be found at: [Node API
-object](/docs/api-reference/{{page.version}}/#node-v1-core).
+API object can be found at:
+[Node API object](/docs/reference/generated/kubernetes-api/{{page.version}}/#node-v1-core).

--- a/docs/concepts/cluster-administration/device-plugins.md
+++ b/docs/concepts/cluster-administration/device-plugins.md
@@ -47,7 +47,7 @@ and reports two healthy devices on a node, the node status is updated
 to advertise 2 `vendor-domain/foo`.
 
 Then, users can request devices in a
-[Container](/docs/api-reference/{{page.version}}/#container-v1-core)
+[Container](/docs/reference/generated/kubernetes-api/{{page.version}}/#container-v1-core)
 specification as they request other types of resources, with the following limitations:
   * Extended resources are only supported as integer resources and cannot be overcommitted.
   * Devices cannot be shared among Containers.
@@ -118,9 +118,9 @@ The canonical directory `/var/lib/kubelet/device-plugins` requires privileged ac
 so a device plugin must run in a privileged security context.
 If a device plugin is running as a DaemonSet, `/var/lib/kubelet/device-plugins`
 must be mounted as a
-[Volume](/docs/api-reference/{{page.version}}/#volume-v1-core)
+[Volume](/docs/reference/generated/kubernetes-api/{{page.version}}/#volume-v1-core)
 in the plugin's
-[PodSpec](/docs/api-reference/{{page.version}}/#podspec-v1-core).
+[PodSpec](/docs/reference/generated/kubernetes-api/{{page.version}}/#podspec-v1-core).
 
 Kubernetes device plugin support is still in alpha. As development continues, its API version can
 change in incompatible ways. We recommend that device plugin developers do the following:

--- a/docs/concepts/configuration/manage-compute-resources-container.md
+++ b/docs/concepts/configuration/manage-compute-resources-container.md
@@ -239,7 +239,7 @@ the node.
 
 The amount of resources available to Pods is less than the node capacity, because
 system daemons use a portion of the available resources. The `allocatable` field
-[NodeStatus](/docs/api-reference/{{page.version}}/#nodestatus-v1-core)
+[NodeStatus](/docs/reference/generated/kubernetes-api/{{page.version}}/#nodestatus-v1-core)
 gives the amount of resources that are available to Pods. For more information, see
 [Node Allocatable Resources](https://git.k8s.io/community/contributors/design-proposals/node/node-allocatable.md).
 
@@ -534,9 +534,9 @@ consistency across providers and platforms.
 
 * Get hands-on experience [assigning CPU resources to containers and pods](/docs/tasks/configure-pod-container/assign-cpu-resource/).
 
-* [Container](/docs/api-reference/{{page.version}}/#container-v1-core)
+* [Container](/docs/reference/generated/kubernetes-api/{{page.version}}/#container-v1-core)
 
-* [ResourceRequirements](/docs/api-reference/{{page.version}}/#resourcerequirements-v1-core)
+* [ResourceRequirements](/docs/reference/generated/kubernetes-api/{{page.version}}/#resourcerequirements-v1-core)
 
 {% endcapture %}
 

--- a/docs/concepts/overview/object-management-kubectl/declarative-config.md
+++ b/docs/concepts/overview/object-management-kubectl/declarative-config.md
@@ -976,7 +976,7 @@ template:
 - [Managing Kubernetes Objects Using Imperative Commands](/docs/concepts/overview/object-management-kubectl/imperative-command/)
 - [Imperative Management of Kubernetes Objects Using Configuration Files](/docs/concepts/overview/object-management-kubectl/imperative-config/)
 - [Kubectl Command Reference](/docs/user-guide/kubectl/{{page.version}}/)
-- [Kubernetes API Reference](/docs/api-reference/{{page.version}}/)
+- [Kubernetes API Reference](/docs/reference/generated/kubernetes-api/{{page.version}}/)
 {% endcapture %}
 
 {% include templates/concept.md %}

--- a/docs/concepts/overview/object-management-kubectl/imperative-command.md
+++ b/docs/concepts/overview/object-management-kubectl/imperative-command.md
@@ -153,7 +153,7 @@ kubectl create --edit -f /tmp/srv.yaml
 - [Managing Kubernetes Objects Using Object Configuration (Imperative)](/docs/concepts/overview/object-management-kubectl/imperative-config/)
 - [Managing Kubernetes Objects Using Object Configuration (Declarative)](/docs/concepts/overview/object-management-kubectl/declarative-config/)
 - [Kubectl Command Reference](/docs/user-guide/kubectl/{{page.version}}/)
-- [Kubernetes API Reference](/docs/api-reference/{{page.version}}/)
+- [Kubernetes API Reference](/docs/reference/generated/kubernetes-api/{{page.version}}/)
 {% endcapture %}
 
 {% include templates/concept.md %}

--- a/docs/concepts/overview/object-management-kubectl/imperative-config.md
+++ b/docs/concepts/overview/object-management-kubectl/imperative-config.md
@@ -24,7 +24,7 @@ for a discussion of the advantages and disadvantage of each kind of object manag
 ## How to create objects
 
 You can use `kubectl create -f` to create an object from a configuration file.
-Refer to the [kubernetes API reference](/docs/api-reference/{{page.version}}/)
+Refer to the [kubernetes API reference](/docs/reference/generated/kubernetes-api/{{page.version}}/)
 for details.
 
 - `kubectl create -f <filename|url>`
@@ -131,7 +131,7 @@ template:
 - [Managing Kubernetes Objects Using Imperative Commands](/docs/concepts/overview/object-management-kubectl/imperative-command/)
 - [Managing Kubernetes Objects Using Object Configuration (Declarative)](/docs/concepts/overview/object-management-kubectl/declarative-config/)
 - [Kubectl Command Reference](/docs/user-guide/kubectl/{{page.version}}/)
-- [Kubernetes API Reference](/docs/api-reference/{{page.version}}/)
+- [Kubernetes API Reference](/docs/reference/generated/kubernetes-api/{{page.version}}/)
 {% endcapture %}
 
 {% include templates/concept.md %}

--- a/docs/concepts/overview/object-management-kubectl/overview.md
+++ b/docs/concepts/overview/object-management-kubectl/overview.md
@@ -66,7 +66,7 @@ operation (create, replace, etc.), optional flags and at least one file
 name. The file specified must contain a full definition of the object
 in YAML or JSON format.
 
-See the [API reference](/docs/api-reference/{{page.version}}/)
+See the [API reference](/docs/reference/generated/kubernetes-api/{{page.version}}/)
 for more details on object definitions.
 
 **Warning:** The imperative `replace` command replaces the existing
@@ -168,7 +168,7 @@ Disadvantages compared to imperative object configuration:
 - [Managing Kubernetes Objects Using Object Configuration (Imperative)](/docs/concepts/overview/object-management-kubectl/imperative-config/)
 - [Managing Kubernetes Objects Using Object Configuration (Declarative)](/docs/concepts/overview/object-management-kubectl/declarative-config/)
 - [Kubectl Command Reference](/docs/user-guide/kubectl/{{page.version}}/)
-- [Kubernetes API Reference](/docs/api-reference/{{page.version}}/)
+- [Kubernetes API Reference](/docs/reference/generated/kubernetes-api/{{page.version}}/)
 
 {% comment %}
 {% endcomment %}

--- a/docs/concepts/services-networking/connect-applications-service.md
+++ b/docs/concepts/services-networking/connect-applications-service.md
@@ -64,7 +64,7 @@ This is equivalent to `kubectl create -f` the following yaml:
 
 {% include code.html language="yaml" file="nginx-svc.yaml" ghlink="/docs/concepts/services-networking/nginx-svc.yaml" %}
 
-This specification will create a Service which targets TCP port 80 on any Pod with the `run: my-nginx` label, and expose it on an abstracted Service port (`targetPort`: is the port the container accepts traffic on, `port`: is the abstracted Service port, which can be any port other pods use to access the Service). View [service API object](/docs/api-reference/{{page.version}}/#service-v1-core) to see the list of supported fields in service definition.
+This specification will create a Service which targets TCP port 80 on any Pod with the `run: my-nginx` label, and expose it on an abstracted Service port (`targetPort`: is the port the container accepts traffic on, `port`: is the abstracted Service port, which can be any port other pods use to access the Service). View [service API object](/docs/reference/generated/kubernetes-api/{{page.version}}/#service-v1-core) to see the list of supported fields in service definition.
 Check your Service:
 
 ```shell

--- a/docs/concepts/services-networking/network-policies.md
+++ b/docs/concepts/services-networking/network-policies.md
@@ -25,7 +25,7 @@ Pods become isolated by having a NetworkPolicy that selects them. Once there is 
 
 ## The `NetworkPolicy` Resource
 
-See the [api-reference](/docs/api-reference/{{page.version}}/#networkpolicy-v1-networking) for a full definition of the resource.
+See the [NetworkPolicy](/docs/reference/generated/kubernetes-api/{{page.version}}/#networkpolicy-v1-networking) for a full definition of the resource.
 
 An example `NetworkPolicy` might look like this:
 

--- a/docs/concepts/services-networking/service.md
+++ b/docs/concepts/services-networking/service.md
@@ -889,8 +889,8 @@ Iptables operations slow down dramatically in large scale cluster e.g 10,000 Ser
 ## API Object
 
 Service is a top-level resource in the Kubernetes REST API. More details about the
-API object can be found at: [Service API
-object](/docs/api-reference/{{page.version}}/#service-v1-core).
+API object can be found at:
+[Service API object](/docs/reference/generated/kubernetes-api/{{page.version}}/#service-v1-core).
 
 ## For More Information
 

--- a/docs/concepts/workloads/controllers/replicationcontroller.md
+++ b/docs/concepts/workloads/controllers/replicationcontroller.md
@@ -236,8 +236,8 @@ The ReplicationController is intended to be a composable building-block primitiv
 ## API Object
 
 Replication controller is a top-level resource in the Kubernetes REST API. More details about the
-API object can be found at: [ReplicationController API
-object](/docs/api-reference/{{page.version}}/#replicationcontroller-v1-core).
+API object can be found at:
+[ReplicationController API object](/docs/reference/generated/kubernetes-api/{{page.version}}/#replicationcontroller-v1-core).
 
 ## Alternatives to ReplicationController
 

--- a/docs/concepts/workloads/pods/disruptions.md
+++ b/docs/concepts/workloads/pods/disruptions.md
@@ -131,7 +131,7 @@ during application updates is configured in the controller spec.
 (Learn about [updating a deployment](/docs/concepts/workloads/controllers/deployment/#updating-a-deployment).)
 
 When a pod is evicted using the eviction API, it is gracefully terminated (see
-`terminationGracePeriodSeconds` in [PodSpec](/docs/api-reference/{{page.version}}/#podspec-v1-core).)
+`terminationGracePeriodSeconds` in [PodSpec](/docs/reference/generated/kubernetes-api/{{page.version}}/#podspec-v1-core).)
 
 ## PDB Example
 

--- a/docs/concepts/workloads/pods/init-containers.md
+++ b/docs/concepts/workloads/pods/init-containers.md
@@ -32,7 +32,10 @@ Init Containers are exactly like regular Containers, except:
 If an Init Container fails for a Pod, Kubernetes restarts the Pod repeatedly until the Init
 Container succeeds. However, if the Pod has a `restartPolicy` of Never, it is not restarted.
 
-To specify a Container as an Init Container, add the `initContainers` field on the PodSpec as a JSON array of objects of type [v1.Container](/docs/api-reference/{{page.version}}/#container-v1-core) alongside the app `containers` array.
+To specify a Container as an Init Container, add the `initContainers` field on the PodSpec as
+a JSON array of objects of type
+[Container](/docs/reference/generated/kubernetes-api/{{page.version}}/#container-v1-core)
+alongside the app `containers` array.
 The status of the init containers is returned in `status.initContainerStatuses`
 field as an array of the container statuses (similar to the `status.containerStatuses`
 field).

--- a/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -17,7 +17,7 @@ This page describes the lifecycle of a Pod.
 ## Pod phase
 
 A Pod's `status` field is a
-[PodStatus](/docs/api-reference/{{page.version}}/#podstatus-v1-core)
+[PodStatus](/docs/reference/generated/kubernetes-api/{{page.version}}/#podstatus-v1-core)
 object, which has a `phase` field.
 
 The phase of a Pod is a simple, high-level summary of where the Pod is in its
@@ -52,7 +52,7 @@ Here are the possible values for `phase`:
 ## Pod conditions
 
 A Pod has a PodStatus, which has an array of
-[PodConditions](/docs/api-reference/{{page.version}}/#podcondition-v1-core). Each element
+[PodConditions](/docs/reference/generated/kubernetes-api/{{page.version}}/#podcondition-v1-core). Each element
 of the PodCondition array has a `type` field and a `status` field. The `type`
 field is a string, with possible values PodScheduled, Ready, Initialized, and
 Unschedulable. The `status` field is a string, with possible values True, False,
@@ -60,22 +60,22 @@ and Unknown.
 
 ## Container probes
 
-A [Probe](/docs/api-reference/{{page.version}}/#probe-v1-core) is a diagnostic
+A [Probe](/docs/reference/generated/kubernetes-api/{{page.version}}/#probe-v1-core) is a diagnostic
 performed periodically by the [kubelet](/docs/admin/kubelet/)
 on a Container. To perform a diagnostic,
 the kubelet calls a
 [Handler](https://godoc.org/k8s.io/kubernetes/pkg/api/v1#Handler) implemented by
 the Container. There are three types of handlers:
 
-* [ExecAction](/docs/api-reference/{{page.version}}/#execaction-v1-core):
+* [ExecAction](/docs/reference/generated/kubernetes-api/{{page.version}}/#execaction-v1-core):
   Executes a specified command inside the Container. The diagnostic
   is considered successful if the command exits with a status code of 0.
 
-* [TCPSocketAction](/docs/api-reference/{{page.version}}/#tcpsocketaction-v1-core):
+* [TCPSocketAction](/docs/reference/generated/kubernetes-api/{{page.version}}/#tcpsocketaction-v1-core):
   Performs a TCP check against the Container's IP address on
   a specified port. The diagnostic is considered successful if the port is open.
 
-* [HTTPGetAction](/docs/api-reference/{{page.version}}/#httpgetaction-v1-core):
+* [HTTPGetAction](/docs/reference/generated/kubernetes-api/{{page.version}}/#httpgetaction-v1-core):
   Performs an HTTP Get request against the Container's IP
   address on a specified port and path. The diagnostic is considered successful
   if the response has a status code greater than or equal to 200 and less than 400.
@@ -129,11 +129,11 @@ to stop.
 ## Pod and Container status
 
 For detailed information about Pod Container status, see
-[PodStatus](/docs/api-reference/{{page.version}}/#podstatus-v1-core)
+[PodStatus](/docs/reference/generated/kubernetes-api/{{page.version}}/#podstatus-v1-core)
 and
-[ContainerStatus](/docs/api-reference/{{page.version}}/#containerstatus-v1-core).
+[ContainerStatus](/docs/reference/generated/kubernetes-api/{{page.version}}/#containerstatus-v1-core).
 Note that the information reported as Pod status depends on the current
-[ContainerState](/docs/api-reference/{{page.version}}/#containerstatus-v1-core).
+[ContainerState](/docs/reference/generated/kubernetes-api/{{page.version}}/#containerstatus-v1-core).
 
 ## Restart policy
 

--- a/docs/concepts/workloads/pods/pod.md
+++ b/docs/concepts/workloads/pods/pod.md
@@ -197,5 +197,5 @@ spec.containers[0].securityContext.privileged: forbidden '<*>(0xc20b222db0)true'
 ## API Object
 
 Pod is a top-level resource in the Kubernetes REST API. More details about the
-API object can be found at: [Pod API
-object](/docs/api-reference/{{page.version}}/#pod-v1-core).
+API object can be found at:
+[Pod API object](/docs/reference/generated/kubernetes-api/{{page.version}}/#pod-v1-core).

--- a/docs/reference/api-overview.md
+++ b/docs/reference/api-overview.md
@@ -14,7 +14,7 @@ This page contains an overview of the Kubernetes API.
 {% capture body %}
 The REST API is the fundamental fabric of Kubernetes. All operations and communications between components are REST API calls handled by the API Server, including external user commands. Consequently, everything in the Kubernetes
 platform is treated as an API object and has a corresponding entry in the
-[API](/docs/api-reference/{{page.version}}/).
+[API](/docs/reference/generated/kubernetes-api/{{page.version}}/).
 
 Most operations can be performed through the
 [kubectl](/docs/user-guide/kubectl-overview/) command-line interface or other

--- a/docs/reference/labels-annotations-taints.md
+++ b/docs/reference/labels-annotations-taints.md
@@ -105,9 +105,6 @@ pods from mounting volumes in a different zone.  If your infrastructure doesn't 
 need to add the zone labels to the volumes at all.
 
 
-
-
-
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/api-reference/labels-annotations-taints.md?pixel)]()
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/reference/labels-annotations-taints.md?pixel)]()
 <!-- END MUNGE: GENERATED_ANALYTICS -->

--- a/docs/tasks/access-application-cluster/communicate-containers-same-pod-shared-volume.md
+++ b/docs/tasks/access-application-cluster/communicate-containers-same-pod-shared-volume.md
@@ -139,9 +139,9 @@ the shared Volume is lost.
 * See
 [Configuring a Pod to Use a Volume for Storage](/docs/tasks/configure-pod-container/configure-volume-storage/).
 
-* See [Volume](/docs/api-reference/{{page.version}}/#volume-v1-core).
+* See [Volume](/docs/reference/generated/kubernetes-api/{{page.version}}/#volume-v1-core).
 
-* See [Pod](/docs/api-reference/{{page.version}}/#pod-v1-core).
+* See [Pod](/docs/reference/generated/kubernetes-api/{{page.version}}/#pod-v1-core).
 
 {% endcapture %}
 

--- a/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions.md
+++ b/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions.md
@@ -9,7 +9,7 @@ reviewers:
 This page shows how to install a
 [custom resource](/docs/concepts/api-extension/custom-resources/)
 into the Kubernetes API by creating a
-[CustomResourceDefinition](/docs/api-reference/{{page.version}}/#customresourcedefinition-v1beta1-apiextensions).
+[CustomResourceDefinition](/docs/reference/generated/kubernetes-api/{{page.version}}/#customresourcedefinition-v1beta1-apiextensions).
 {% endcapture %}
 
 {% capture prerequisites %}
@@ -544,7 +544,7 @@ crontabs/my-new-cron-object   3s
 
 {% capture whatsnext %}
 * Learn how to [Migrate a ThirdPartyResource to CustomResourceDefinition](/docs/tasks/access-kubernetes-api/migrate-third-party-resource/).
-* See [CustomResourceDefinition](/docs/api-reference/{{page.version}}/#customresourcedefinition-v1beta1-apiextensions).
+* See [CustomResourceDefinition](/docs/reference/generated/kubernetes-api/{{page.version}}/#customresourcedefinition-v1beta1-apiextensions).
 {% endcapture %}
 
 {% include templates/task.md %}

--- a/docs/tasks/access-kubernetes-api/extend-api-third-party-resource.md
+++ b/docs/tasks/access-kubernetes-api/extend-api-third-party-resource.md
@@ -139,6 +139,4 @@ $ kubectl get crontab -o json
 
 * [Migrate a ThirdPartyResource to a CustomResourceDefinition](/docs/tasks/access-kubernetes-api/migrate-third-party-resource/)
 * [Extend the Kubernetes API with CustomResourceDefinitions](/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/)
-* [ThirdPartyResource](/docs/api-reference/v1.7/#thirdpartyresource-v1beta1-extensions)
-
-
+* [ThirdPartyResource](https://v1-7.docs.kubernetes.io/docs/reference/v1.7/#thirdpartyresource-v1beta1-extensions)

--- a/docs/tasks/access-kubernetes-api/migrate-third-party-resource.md
+++ b/docs/tasks/access-kubernetes-api/migrate-third-party-resource.md
@@ -7,7 +7,7 @@ reviewers:
 
 {% capture overview %}
 This page shows how to migrate data stored in a ThirdPartyResource (TPR) to a
-[CustomResourceDefinition](/docs/api-reference/{{page.version}}/#customresourcedefinition-v1beta1-apiextensions) (CRD).
+[CustomResourceDefinition](/docs/reference/generated/kubernetes-api/{{page.version}}/#customresourcedefinition-v1beta1-apiextensions) (CRD).
 
 Kubernetes does not automatically migrate existing TPRs.
 This is due to API changes introduced as part of
@@ -163,7 +163,7 @@ you **on a best-effort basis**.
 {% capture whatsnext %}
 * Learn more about [custom resources](/docs/concepts/api-extension/custom-resources/).
 * Learn more about [using CustomResourceDefinitions](/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/).
-* See [CustomResourceDefinition](/docs/api-reference/{{page.version}}/#customresourcedefinition-v1beta1-apiextensions).
+* See [CustomResourceDefinition](/docs/reference/generated/kubernetes-api/{{page.version}}/#customresourcedefinition-v1beta1-apiextensions).
 {% endcapture %}
 
 {% include templates/task.md %}

--- a/docs/tasks/administer-cluster/change-pv-reclaim-policy.md
+++ b/docs/tasks/administer-cluster/change-pv-reclaim-policy.md
@@ -72,9 +72,9 @@ the corresponding `PersistentVolume` is not be deleted. Instead, it is moved to 
 
 ### Reference
 
-* [PersistentVolume](/docs/api-reference/{{page.version}}/#persistentvolume-v1-core)
-* [PersistentVolumeClaim](/docs/api-reference/{{page.version}}/#persistentvolumeclaim-v1-core)
-* See the `persistentVolumeReclaimPolicy` field of [PersistentVolumeSpec](/docs/api-reference/{{page.version}}/#persistentvolumeclaim-v1-core).
+* [PersistentVolume](/docs/reference/generated/kubernetes-api/{{page.version}}/#persistentvolume-v1-core)
+* [PersistentVolumeClaim](/docs/reference/generated/kubernetes-api/{{page.version}}/#persistentvolumeclaim-v1-core)
+* See the `persistentVolumeReclaimPolicy` field of [PersistentVolumeSpec](/docs/reference/generated/kubernetes-api/{{page.version}}/#persistentvolumeclaim-v1-core).
 {% endcapture %}
 
 {% include templates/task.md %}

--- a/docs/tasks/administer-cluster/cpu-constraint-namespace.md
+++ b/docs/tasks/administer-cluster/cpu-constraint-namespace.md
@@ -7,7 +7,7 @@ title: Configure Minimum and Maximum CPU Constraints for a Namespace
 
 This page shows how to set minimum and maximum values for the CPU resources used by Containers
 and Pods in a namespace. You specify minimum and maximum CPU values in a
-[LimitRange](/docs/api-reference/{{page.version}}/#limitrange-v1-core)
+[LimitRange](/docs/reference/generated/kubernetes-api/{{page.version}}/#limitrange-v1-core)
 object. If a Pod does not meet the constraints imposed by the LimitRange, it cannot be created
 in the namespace.
 

--- a/docs/tasks/administer-cluster/memory-constraint-namespace.md
+++ b/docs/tasks/administer-cluster/memory-constraint-namespace.md
@@ -7,7 +7,7 @@ title: Configure Minimum and Maximum Memory Constraints for a Namespace
 
 This page shows how to set minimum and maximum values for memory used by Containers
 running in a namespace. You specify minimum and maximum memory values in a
-[LimitRange](/docs/api-reference/{{page.version}}/#limitrange-v1-core)
+[LimitRange](/docs/reference/generated/kubernetes-api/{{page.version}}/#limitrange-v1-core)
 object. If a Pod does not meet the constraints imposed by the LimitRange,
 it cannot be created in the namespace.
 

--- a/docs/tasks/administer-cluster/quota-api-object.md
+++ b/docs/tasks/administer-cluster/quota-api-object.md
@@ -9,7 +9,7 @@ This page shows how to configure quotas for API objects, including
 PersistentVolumeClaims and Services. A quota restricts the number of
 objects, of a particular type, that can be created in a namespace.
 You specify quotas in a
-[ResourceQuota](/docs/api-reference/{{page.version}}/#resourcequota-v1-core)
+[ResourceQuota](/docs/reference/generated/kubernetes-api/{{page.version}}/#resourcequota-v1-core)
 object.
 
 {% endcapture %}

--- a/docs/tasks/administer-cluster/quota-memory-cpu-namespace.md
+++ b/docs/tasks/administer-cluster/quota-memory-cpu-namespace.md
@@ -7,7 +7,7 @@ title: Configure Memory and CPU Quotas for a Namespace
 
 This page shows how to set quotas for the total amount memory and CPU that
 can be used by all Containers running in a namespace. You specify quotas in a
-[ResourceQuota](/docs/api-reference/{{page.version}}/#resourcequota-v1-core)
+[ResourceQuota](/docs/reference/generated/kubernetes-api/{{page.version}}/#resourcequota-v1-core)
 object.
 
 {% endcapture %}

--- a/docs/tasks/administer-cluster/quota-pod-namespace.md
+++ b/docs/tasks/administer-cluster/quota-pod-namespace.md
@@ -7,7 +7,7 @@ title: Configure a Pod Quota for a Namespace
 
 This page shows how to set a quota for the total number of Pods that can run
 in a namespace. You specify quotas in a
-[ResourceQuota](/docs/api-reference/{{page.version}}/#resourcequota-v1-core)
+[ResourceQuota](/docs/reference/generated/kubernetes-api/{{page.version}}/#resourcequota-v1-core)
 object.
 
 {% endcapture %}

--- a/docs/tasks/configure-pod-container/assign-cpu-resource.md
+++ b/docs/tasks/configure-pod-container/assign-cpu-resource.md
@@ -225,7 +225,7 @@ could use all of the CPU resources available on the Node where it is running.
 
 * The Container is running in a namespace that has a default CPU limit, and the
 Container is automatically assigned the default limit. Cluster administrators can use a
-[LimitRange](https://kubernetes.io/docs/api-reference/{{page.version}}/#limitrange-v1-core/)
+[LimitRange](/docs/reference/generated/kubernetes-api/{{page.version}}/#limitrange-v1-core/)
 to specify a default value for the CPU limit.
 
 ## Motivation for CPU requests and limits

--- a/docs/tasks/configure-pod-container/assign-memory-resource.md
+++ b/docs/tasks/configure-pod-container/assign-memory-resource.md
@@ -321,7 +321,7 @@ could use all of the memory available on the Node where it is running.
 
 * The Container is running in a namespace that has a default memory limit, and the
 Container is automatically assigned the default limit. Cluster administrators can use a
-[LimitRange](https://kubernetes.io/docs/api-reference/{{page.version}}/#limitrange-v1-core)
+[LimitRange](/docs/reference/generated/kubernetes-api/{{page.version}}/#limitrange-v1-core)
 to specify a default value for the memory limit.
 
 ## Motivation for memory requests and limits

--- a/docs/tasks/configure-pod-container/attach-handler-lifecycle-event.md
+++ b/docs/tasks/configure-pod-container/attach-handler-lifecycle-event.md
@@ -90,9 +90,9 @@ This limitation is tracked in [issue #55087](https://github.com/kubernetes/kuber
 
 ### Reference
 
-* [Lifecycle](/docs/api-reference/{{page.version}}/#lifecycle-v1-core)
-* [Container](/docs/api-reference/{{page.version}}/#container-v1-core)
-* See `terminationGracePeriodSeconds` in [PodSpec](/docs/api-reference/{{page.version}}/#podspec-v1-core)
+* [Lifecycle](/docs/reference/generated/kubernetes-api/{{page.version}}/#lifecycle-v1-core)
+* [Container](/docs/reference/generated/kubernetes-api/{{page.version}}/#container-v1-core)
+* See `terminationGracePeriodSeconds` in [PodSpec](/docs/reference/generated/kubernetes-api/{{page.version}}/#podspec-v1-core)
 
 {% endcapture %}
 

--- a/docs/tasks/configure-pod-container/configure-liveness-readiness-probes.md
+++ b/docs/tasks/configure-pod-container/configure-liveness-readiness-probes.md
@@ -196,7 +196,7 @@ will be restarted.
 ## Use a named port
 
 You can use a named
-[ContainerPort](/docs/api-reference/{{page.version}}/#containerport-v1-core)
+[ContainerPort](/docs/reference/generated/kubernetes-api/{{page.version}}/#containerport-v1-core)
 for HTTP or TCP liveness checks:
 
 ```yaml
@@ -247,7 +247,7 @@ for it, and that containers are restarted when they fail.
 Eventually, some of this section could be moved to a concept topic.
 {% endcomment %}
 
-[Probes](/docs/api-reference/{{page.version}}/#probe-v1-core) have a number of fields that
+[Probes](/docs/reference/generated/kubernetes-api/{{page.version}}/#probe-v1-core) have a number of fields that
 you can use to more precisely control the behavior of liveness and readiness
 checks:
 
@@ -264,7 +264,7 @@ liveness. Minimum value is 1.
 try `failureThreshold` times before giving up. Giving up in case of liveness probe means restarting the Pod. In case of readiness probe the Pod will be marked Unready.
 Defaults to 3. Minimum value is 1.
 
-[HTTP probes](/docs/api-reference/{{page.version}}/#httpgetaction-v1-core)
+[HTTP probes](/docs/reference/generated/kubernetes-api/{{page.version}}/#httpgetaction-v1-core)
 have additional fields that can be set on `httpGet`:
 
 * `host`: Host name to connect to, defaults to the pod IP. You probably want to
@@ -294,9 +294,9 @@ case, you should not use `host`, but rather set the `Host` header in `httpHeader
 
 ### Reference
 
-* [Pod](/docs/api-reference/{{page.version}}/#pod-v1-core)
-* [Container](/docs/api-reference/{{page.version}}/#container-v1-core)
-* [Probe](/docs/api-reference/{{page.version}}/#probe-v1-core)
+* [Pod](/docs/reference/generated/kubernetes-api/{{page.version}}/#pod-v1-core)
+* [Container](/docs/reference/generated/kubernetes-api/{{page.version}}/#container-v1-core)
+* [Probe](/docs/reference/generated/kubernetes-api/{{page.version}}/#probe-v1-core)
 
 {% endcapture %}
 

--- a/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
+++ b/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
@@ -54,7 +54,7 @@ PersistentVolume uses a file or directory on the Node to emulate network-attache
 In a production cluster, you would not use hostPath. Instead a cluster administrator
 would provision a network resource like a Google Compute Engine persistent disk,
 an NFS share, or an Amazon Elastic Block Store volume. Cluster administrators can also
-use [StorageClasses](/docs/api-reference/{{page.version}}/#storageclass-v1-storage)
+use [StorageClasses](/docs/reference/generated/kubernetes-api/{{page.version}}/#storageclass-v1-storage)
 to set up
 [dynamic provisioning](http://blog.kubernetes.io/2016/10/dynamic-provisioning-and-storage-in-kubernetes.html).
 
@@ -200,10 +200,10 @@ PersistentVolume are not present on the Pod resource itself.
 
 ### Reference
 
-* [PersistentVolume](/docs/api-reference/{{page.version}}/#persistentvolume-v1-core)
-* [PersistentVolumeSpec](/docs/api-reference/{{page.version}}/#persistentvolumespec-v1-core)
-* [PersistentVolumeClaim](/docs/api-reference/{{page.version}}/#persistentvolumeclaim-v1-core)
-* [PersistentVolumeClaimSpec](/docs/api-reference/{{page.version}}/#persistentvolumeclaimspec-v1-core)
+* [PersistentVolume](/docs/reference/generated/kubernetes-api/{{page.version}}/#persistentvolume-v1-core)
+* [PersistentVolumeSpec](/docs/reference/generated/kubernetes-api/{{page.version}}/#persistentvolumespec-v1-core)
+* [PersistentVolumeClaim](/docs/reference/generated/kubernetes-api/{{page.version}}/#persistentvolumeclaim-v1-core)
+* [PersistentVolumeClaimSpec](/docs/reference/generated/kubernetes-api/{{page.version}}/#persistentvolumeclaimspec-v1-core)
 
 {% endcapture %}
 

--- a/docs/tasks/configure-pod-container/configure-volume-storage.md
+++ b/docs/tasks/configure-pod-container/configure-volume-storage.md
@@ -83,7 +83,7 @@ you will see something like this:
 
 At this point, the Container has terminated and restarted. This is because the
 redis Pod has a
-[restartPolicy](/docs/api-reference/{{page.version}}/#podspec-v1-core)
+[restartPolicy](/docs/reference/generated/kubernetes-api/{{page.version}}/#podspec-v1-core)
 of `Always`.
 
 1. Get a shell into the restarted Container:
@@ -96,9 +96,9 @@ of `Always`.
 
 {% capture whatsnext %}
 
-* See [Volume](/docs/api-reference/{{page.version}}/#volume-v1-core).
+* See [Volume](/docs/reference/generated/kubernetes-api/{{page.version}}/#volume-v1-core).
 
-* See [Pod](/docs/api-reference/{{page.version}}/#pod-v1-core).
+* See [Pod](/docs/reference/generated/kubernetes-api/{{page.version}}/#pod-v1-core).
 
 * In addition to the local disk storage provided by `emptyDir`, Kubernetes
 supports many different network-attached storage solutions, including PD on

--- a/docs/tasks/configure-pod-container/pull-image-private-registry.md
+++ b/docs/tasks/configure-pod-container/pull-image-private-registry.md
@@ -126,8 +126,8 @@ Create a Pod that uses your Secret, and verify that the Pod is running:
 * Learn more about [Secrets](/docs/concepts/configuration/secret/).
 * Learn more about [using a private registry](/docs/concepts/containers/images/#using-a-private-registry).
 * See [kubectl create secret docker-registry](/docs/user-guide/kubectl/{{page.version}}/#-em-secret-docker-registry-em-).
-* See [Secret](/docs/api-reference/{{page.version}}/#secret-v1-core).
-* See the `imagePullSecrets` field of [PodSpec](/docs/api-reference/{{page.version}}/#podspec-v1-core).
+* See [Secret](/docs/reference/generated/kubernetes-api/{{page.version}}/#secret-v1-core).
+* See the `imagePullSecrets` field of [PodSpec](/docs/reference/generated/kubernetes-api/{{page.version}}/#podspec-v1-core).
 
 {% endcapture %}
 

--- a/docs/tasks/configure-pod-container/security-context.md
+++ b/docs/tasks/configure-pod-container/security-context.md
@@ -304,7 +304,7 @@ for definitions of the capability constants.
 To assign SELinux labels to a Container, include the `seLinuxOptions` field in
 the `securityContext` section of your Pod or Container manifest. The
 `seLinuxOptions` field is an
-[SELinuxOptions](/docs/api-reference/{{page.version}}/#selinuxoptions-v1-core)
+[SELinuxOptions](/docs/reference/generated/kubernetes-api/{{page.version}}/#selinuxoptions-v1-core)
 object. Here's an example that applies an SELinux level:
 
 ```yaml
@@ -341,8 +341,8 @@ label given to all Containers in the Pod as well as the Volumes.
 
 {% capture whatsnext %}
 
-* [PodSecurityContext](/docs/api-reference/{{page.version}}/#podsecuritycontext-v1-core)
-* [SecurityContext](/docs/api-reference/{{page.version}}/#securitycontext-v1-core)
+* [PodSecurityContext](/docs/reference/generated/kubernetes-api/{{page.version}}/#podsecuritycontext-v1-core)
+* [SecurityContext](/docs/reference/generated/kubernetes-api/{{page.version}}/#securitycontext-v1-core)
 * [Tuning Docker with the newest security enhancements](https://opensource.com/business/15/3/docker-security-tuning)
 * [Security Contexts design document](https://git.k8s.io/community/contributors/design-proposals/auth/security_context.md)
 * [Ownership Management design document](https://git.k8s.io/community/contributors/design-proposals/storage/volume-ownership-management.md)

--- a/docs/tasks/debug-application-cluster/determine-reason-pod-failure.md
+++ b/docs/tasks/debug-application-cluster/determine-reason-pod-failure.md
@@ -111,7 +111,7 @@ is empty and the container exited with an error. The log output is limited to
 {% capture whatsnext %}
 
 * See the `terminationMessagePath` field in
-  [Container](/docs/api-reference/{{page.version}}/#container-v1-core).
+  [Container](/docs/reference/generated/kubernetes-api/{{page.version}}/#container-v1-core).
 * Learn about [retrieving logs](/docs/concepts/cluster-administration/logging/).
 * Learn about [Go templates](https://golang.org/pkg/text/template/).
 

--- a/docs/tasks/debug-application-cluster/monitor-node-health.md
+++ b/docs/tasks/debug-application-cluster/monitor-node-health.md
@@ -13,7 +13,7 @@ title: Monitor Node Health
 *Node problem detector* is a [DaemonSet](/docs/concepts/workloads/controllers/daemonset/) monitoring the
 node health. It collects node problems from various daemons and reports them
 to the apiserver as [NodeCondition](/docs/concepts/architecture/nodes/#condition)
-and [Event](/docs/api-reference/{{page.version}}/#event-v1-core).
+and [Event](/docs/reference/generated/kubernetes-api/{{page.version}}/#event-v1-core).
 
 It supports some known kernel issue detection now, and will detect more and
 more node problems over time.

--- a/docs/tasks/debug-application-cluster/troubleshooting.md
+++ b/docs/tasks/debug-application-cluster/troubleshooting.md
@@ -28,7 +28,7 @@ practical instructions for getting started. [Tasks](/docs/tasks/) show how to
 accomplish commonly used tasks, and [Tutorials](/docs/tutorials/) are more
 comprehensive walkthroughs of real-world, industry-specific, or end-to-end
 development scenarios. The [Reference](/docs/reference/) section provides
-detailed documentation on the [Kubernetes API](/docs/api-reference/{{page.version}}/)
+detailed documentation on the [Kubernetes API](/docs/reference/generated/kubernetes-api/{{page.version}}/)
 and command-line interfaces (CLIs), such as [`kubectl`](/docs/user-guide/kubectl-overview/).
 
 You may also find the Stack Overflow topics relevant:

--- a/docs/tasks/inject-data-application/define-command-argument-container.md
+++ b/docs/tasks/inject-data-application/define-command-argument-container.md
@@ -132,7 +132,7 @@ Here are some examples:
 * Learn more about [containers and commands](/docs/user-guide/containers/).
 * Learn more about [configuring pods and containers](/docs/tasks/).
 * Learn more about [running commands in a container](/docs/tasks/debug-application-cluster/get-shell-running-container/).
-* See [Container](/docs/api-reference/{{page.version}}/#container-v1-core).
+* See [Container](/docs/reference/generated/kubernetes-api/{{page.version}}/#container-v1-core).
 
 {% endcapture %}
 

--- a/docs/tasks/inject-data-application/define-environment-variable-container.md
+++ b/docs/tasks/inject-data-application/define-environment-variable-container.md
@@ -74,7 +74,7 @@ will override any environment variables specified in the container image.
 
 * Learn more about [environment variables](/docs/tasks/configure-pod-container/environment-variable-expose-pod-information/).
 * Learn about [using secrets as environment variables](/docs/user-guide/secrets/#using-secrets-as-environment-variables).
-* See [EnvVarSource](/docs/api-reference/{{page.version}}/#envvarsource-v1-core).
+* See [EnvVarSource](/docs/reference/generated/kubernetes-api/{{page.version}}/#envvarsource-v1-core).
 
 {% endcapture %}
 

--- a/docs/tasks/inject-data-application/distribute-credentials-secure.md
+++ b/docs/tasks/inject-data-application/distribute-credentials-secure.md
@@ -163,9 +163,9 @@ Here is a configuration file you can use to create a Pod:
 
 ### Reference
 
-* [Secret](/docs/api-reference/{{page.version}}/#secret-v1-core)
-* [Volume](/docs/api-reference/{{page.version}}/#volume-v1-core)
-* [Pod](/docs/api-reference/{{page.version}}/#pod-v1-core)
+* [Secret](/docs/reference/generated/kubernetes-api/{{page.version}}/#secret-v1-core)
+* [Volume](/docs/reference/generated/kubernetes-api/{{page.version}}/#volume-v1-core)
+* [Pod](/docs/reference/generated/kubernetes-api/{{page.version}}/#pod-v1-core)
 
 {% endcapture %}
 

--- a/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
+++ b/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
@@ -40,7 +40,7 @@ In the configuration file, you can see that the Pod has a `downwardAPI` Volume,
 and the Container mounts the Volume at `/etc/podinfo`.
 
 Look at the `items` array under `downwardAPI`. Each element of the array is a
-[DownwardAPIVolumeFile](/docs/api-reference/{{page.version}}/#downwardapivolumefile-v1-core).
+[DownwardAPIVolumeFile](/docs/reference/generated/kubernetes-api/{{page.version}}/#downwardapivolumefile-v1-core).
 The first element specifies that the value of the Pod's
 `metadata.labels` field should be stored in a file named `labels`.
 The second element specifies that the value of the Pod's `annotations`
@@ -239,11 +239,11 @@ inject the Pod's name into the well-known environment variable.
 
 {% capture whatsnext %}
 
-* [PodSpec](/docs/api-reference/{{page.version}}/#podspec-v1-core)
-* [Volume](/docs/api-reference/{{page.version}}/#volume-v1-core)
-* [DownwardAPIVolumeSource](/docs/api-reference/{{page.version}}/#downwardapivolumesource-v1-core)
-* [DownwardAPIVolumeFile](/docs/api-reference/{{page.version}}/#downwardapivolumefile-v1-core)
-* [ResourceFieldSelector](/docs/api-reference/{{page.version}}/#resourcefieldselector-v1-core)
+* [PodSpec](/docs/reference/generated/kubernetes-api/{{page.version}}/#podspec-v1-core)
+* [Volume](/docs/reference/generated/kubernetes-api/{{page.version}}/#volume-v1-core)
+* [DownwardAPIVolumeSource](/docs/reference/generated/kubernetes-api/{{page.version}}/#downwardapivolumesource-v1-core)
+* [DownwardAPIVolumeFile](/docs/reference/generated/kubernetes-api/{{page.version}}/#downwardapivolumefile-v1-core)
+* [ResourceFieldSelector](/docs/reference/generated/kubernetes-api/{{page.version}}/#resourcefieldselector-v1-core)
 
 {% endcapture %}
 

--- a/docs/tasks/inject-data-application/environment-variable-expose-pod-information.md
+++ b/docs/tasks/inject-data-application/environment-variable-expose-pod-information.md
@@ -25,7 +25,7 @@ Pod fields and Container fields.
 There are two ways to expose Pod and Container fields to a running Container:
 
 * Environment variables
-* [DownwardAPIVolumeFiles](/docs/api-reference/{{page.version}}/#downwardapivolumefile-v1-core)
+* [DownwardAPIVolumeFiles](/docs/reference/generated/kubernetes-api/{{page.version}}/#downwardapivolumefile-v1-core)
 
 Together, these two ways of exposing Pod and Container fields are called the
 *Downward API*.
@@ -40,7 +40,7 @@ configuration file for the Pod:
 
 In the configuration file, you can see five environment variables. The `env`
 field is an array of
-[EnvVars](/docs/api-reference/{{page.version}}/#envvar-v1-core).
+[EnvVars](/docs/reference/generated/kubernetes-api/{{page.version}}/#envvar-v1-core).
 The first element in the array specifies that the `MY_NODE_NAME` environment
 variable gets its value from the Pod's `spec.nodeName` field. Similarly, the
 other environment variables get their names from Pod fields.
@@ -118,7 +118,7 @@ container:
 
 In the configuration file, you can see four environment variables. The `env`
 field is an array of
-[EnvVars](/docs/api-reference/{{page.version}}/#envvar-v1-core).
+[EnvVars](/docs/reference/generated/kubernetes-api/{{page.version}}/#envvar-v1-core).
 The first element in the array specifies that the `MY_CPU_REQUEST` environment
 variable gets its value from the `requests.cpu` field of a Container named
 `test-container`. Similarly, the other environment variables get their values
@@ -156,12 +156,12 @@ The output shows the values of selected environment variables:
 {% capture whatsnext %}
 
 * [Defining Environment Variables for a Container](/docs/tasks/inject-data-application/define-environment-variable-container/)
-* [PodSpec](/docs/api-reference/{{page.version}}/#podspec-v1-core)
-* [Container](/docs/api-reference/{{page.version}}/#container-v1-core)
-* [EnvVar](/docs/api-reference/{{page.version}}/#envvar-v1-core)
-* [EnvVarSource](/docs/api-reference/{{page.version}}/#envvarsource-v1-core)
-* [ObjectFieldSelector](/docs/api-reference/{{page.version}}/#objectfieldselector-v1-core)
-* [ResourceFieldSelector](/docs/api-reference/{{page.version}}/#resourcefieldselector-v1-core)
+* [PodSpec](/docs/reference/generated/kubernetes-api/{{page.version}}/#podspec-v1-core)
+* [Container](/docs/reference/generated/kubernetes-api/{{page.version}}/#container-v1-core)
+* [EnvVar](/docs/reference/generated/kubernetes-api/{{page.version}}/#envvar-v1-core)
+* [EnvVarSource](/docs/reference/generated/kubernetes-api/{{page.version}}/#envvarsource-v1-core)
+* [ObjectFieldSelector](/docs/reference/generated/kubernetes-api/{{page.version}}/#objectfieldselector-v1-core)
+* [ResourceFieldSelector](/docs/reference/generated/kubernetes-api/{{page.version}}/#resourcefieldselector-v1-core)
 
 {% endcapture %}
 

--- a/docs/tasks/run-application/rolling-update-replication-controller.md
+++ b/docs/tasks/run-application/rolling-update-replication-controller.md
@@ -10,9 +10,9 @@ title: Perform Rolling Update Using a Replication Controller
 ## Overview
 
 **Note**: The preferred way to create a replicated application is to use a
-[Deployment](/docs/api-reference/{{page.version}}/#deployment-v1beta1-apps),
+[Deployment](/docs/reference/generated/kubernetes-api/{{page.version}}/#deployment-v1beta1-apps),
 which in turn uses a
-[ReplicaSet](/docs/api-reference/{{page.version}}/#replicaset-v1beta1-extensions).
+[ReplicaSet](/docs/reference/generated/kubernetes-api/{{page.version}}/#replicaset-v1beta1-extensions).
 For more information, see
 [Running a Stateless Application Using a Deployment](/docs/tasks/run-application/run-stateless-application-deployment/).
 {: .note}


### PR DESCRIPTION
We have been using redirections in many pages when referencing the API
docs generated. Since the relocation of the generated files, this is
becoming difficult to maintain. This PR redirects all such links to the
generated artifacts so we can easily detect missing links if any.

closes: #7874
