### PR TITLE
Fix #7692: typo in the navbar's template

### DIFF
--- a/_layouts/docsportal.html
+++ b/_layouts/docsportal.html
@@ -13,12 +13,12 @@
   <h5>{{ toc.abstract }}</h5>
   <div id="vendorStrip" class="light-text">
     <ul>
-      <li><a href="/docs/home/" {% if toc.bigheader == "Kubernetes Documentation" %}class="YAH"{% endif %}>HOME</a></li>
+      <li><a href="/docs/home/" {% if toc.bigheader == nil %}class="YAH"{% endif %}>HOME</a></li>
       <li><a href="/docs/setup/" {% if toc.bigheader == "Setup" %}class="YAH"{% endif %}>SETUP</a></li>
       <li><a href="/docs/concepts/" {% if toc.bigheader == "Concepts" %}class="YAH"{% endif %}>CONCEPTS</a></li>
       <li><a href="/docs/tasks/" {% if toc.bigheader == "Tasks" %}class="YAH"{% endif %}>TASKS</a></li>
       <li><a href="/docs/tutorials/" {% if toc.bigheader == "Tutorials" %}class="YAH"{% endif %}>TUTORIALS</a></li>
-      <li><a href="/docs/reference/" {% if toc.bigheader == "Reference Documentation" %}class="YAH"{% endif %}>REFERENCE</a></li>
+      <li><a href="/docs/reference/" {% if toc.bigheader == "Reference" %}class="YAH"{% endif %}>REFERENCE</a></li>
     </ul>
     <div id="searchBox">
       <input type="text" id="search" placeholder="Search" onkeydown="if (event.keyCode==13) window.location.replace('/docs/search/?q=' + this.value)" autofocus="autofocus">

--- a/_layouts/docwithnav.html
+++ b/_layouts/docwithnav.html
@@ -22,12 +22,12 @@
   <h5>{{ toc.abstract }}</h5>
   <div id="vendorStrip" class="light-text">
     <ul>
-      <li><a href="/docs/home/" {% if toc.bigheader == "Kubernetes Documentation" %}class="YAH"{% endif %}>HOME</a></li>
+      <li><a href="/docs/home/" {% if toc.bigheader == nil %}class="YAH"{% endif %}>HOME</a></li>
       <li><a href="/docs/setup/" {% if toc.bigheader == "Setup" %}class="YAH"{% endif %}>SETUP</a></li>
       <li><a href="/docs/concepts/" {% if toc.bigheader == "Concepts" %}class="YAH"{% endif %}>CONCEPTS</a></li>
       <li><a href="/docs/tasks/" {% if toc.bigheader == "Tasks" %}class="YAH"{% endif %}>TASKS</a></li>
       <li><a href="/docs/tutorials/" {% if toc.bigheader == "Tutorials" %}class="YAH"{% endif %}>TUTORIALS</a></li>
-      <li><a href="/docs/reference/" {% if toc.bigheader == "Reference Documentation" %}class="YAH"{% endif %}>REFERENCE</a></li>
+      <li><a href="/docs/reference/" {% if toc.bigheader == "Reference" %}class="YAH"{% endif %}>REFERENCE</a></li>
     </ul>
     <div id="searchBox">
       <input type="text" id="search" placeholder="Search" onkeydown="if (event.keyCode==13) window.location.replace('/docs/search/?q=' + this.value)" autofocus="autofocus">


### PR DESCRIPTION
This PR fixes issue #7692

*Note: [I have signed](https://identity.linuxfoundation.org/system/files/clas/signed/cla_individual-31b058dbda6d1d77a6ab907f40823f0f7e537cf5.pdf) the Linux Foundation Contributor License Agreement and agree that theses changes be published under the CC BY SA 4.0.*

---

Edit:

This PR fixes the "reference" header, but not the "home" header. This is because `toc.bigheader` is empty for the home tab, probably because the home tab uses [another layout](https://github.com/kubernetes/website/blame/master/docs/home/index.md#L5) compare to the [default one](https://github.com/kubernetes/website/blob/master/_layouts/docwithnav.html#L1-L8) used by the reference tab.

Should I amend my PR to remove the change for "home" and only leave "reference", or should I try to fix the home tab as well?
