### PR TITLE
Add PolicyTypes to allow-all egress policy

### DIFF
--- a/docs/concepts/services-networking/network-policies.md
+++ b/docs/concepts/services-networking/network-policies.md
@@ -162,6 +162,8 @@ spec:
   podSelector: {}
   egress:
   - {}
+  policyTypes:
+  - Egress
 ```
 
 ### Default deny all ingress and all egress traffic


### PR DESCRIPTION
`PolicyTypes` default to `["Egress", "Ingress"]`,
it doesn't make sense for egress-only policy to have `Ingress` as PolicyType.