### PR TITLE
Add controlPlaneEndpoint to config file reference

### DIFF
--- a/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -98,6 +98,7 @@ apiVersion: kubeadm.k8s.io/v1alpha1
 kind: MasterConfiguration
 api:
   advertiseAddress: <address|string>
+  controlPlaneEndpoint: <string>
   bindPort: <int>
 etcd:
   endpoints:


### PR DESCRIPTION
First-time kubeadm user here: The v1.10.0 docs indicate that config file use is experimental, but judging from the comments on https://github.com/kubernetes/kubernetes/pull/59288 it looks like new features are beginning to be supported only in the config file. controlPlaneEndpoint is super useful for us and while I suspect the kubeadm init docs will ultimately be re-written to emphasize the config file options rather than flags (with appropriate examples and descriptions as the flags have now), it would've saved us some time today if we'd seen controlPlaneEndpoint in the config file example.
