### PR TITLE
Ensure example configs are valid JSON

### DIFF
--- a/docs/concepts/cluster-administration/certificates.md
+++ b/docs/concepts/cluster-administration/certificates.md
@@ -149,7 +149,7 @@ Finally, add the same parameters into the API server start parameters.
                   "signing",
                   "key encipherment",
                   "server auth",
-                  "client auth",
+                  "client auth"
                 ],
                 "expiry": "8760h"
               }
@@ -171,7 +171,7 @@ Finally, add the same parameters into the API server start parameters.
             "ST": "<state>",
             "L": "<city>",
             "O": "<organization>",
-            "OU": "<organization unit>",
+            "OU": "<organization unit>"
           }]
         }
 1.  Generate CA key (`ca-key.pem`) and certificate (`ca.pem`):


### PR DESCRIPTION
Example configs from the cfssl section had invalid JSON. This PR ensures they are valid JSON.