### PR TITLE
Update http-proxy-access-api.md, fix 404 on kubectl proxy link

### DIFF
--- a/docs/tasks/access-kubernetes-api/http-proxy-access-api.md
+++ b/docs/tasks/access-kubernetes-api/http-proxy-access-api.md
@@ -78,7 +78,7 @@ Get a list of pods:
 {% endcapture %}
 
 {% capture whatsnext %}
-Learn more about [kubectl proxy](/docs/user-guide/kubectl/{{page.version}}/#proxy).
+Learn more about [kubectl proxy](/docs/reference/generated/kubectl/kubectl-commands#proxy).
 {% endcapture %}
 
 {% include templates/task.md %}


### PR DESCRIPTION
Update kubectl proxy link to fix 404.