### PR TITLE
Redirect the v1.9 kubectl user guide to the correct document

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -332,7 +332,7 @@
 /docs/user-guide/kubectl-overview/     /docs/reference/kubectl/overview/
 /docs/user-guide/kubectl/     /docs/reference/generated/kubectl/kubectl-options/
 /docs/user-guide/kubectl/v1.8/*     https://v1-8.docs.kubernetes.io/docs/reference/generated/kubectl/kubectl-commands/:splat 301    
-/docs/user-guide/kubectl/v1.9/*     /docs/reference/generated/kubectl/kubectl-commands/:splat 301
+/docs/user-guide/kubectl/v1.9/*     https://v1-9.docs.kubernetes.io/docs/reference/generated/kubectl/kubectl-commands/:splat 301
 /docs/user-guide/kubectl/v1.10/*     /docs/reference/generated/kubectl/kubectl-commands/:splat 301
 /docs/user-guide/kubectl-conventions/     /docs/reference/kubectl/conventions/
 /docs/user-guide/kubectl-cheatsheet/     /docs/reference/kubectl/cheatsheet/  


### PR DESCRIPTION
Missed this change when adding the redirect for v1.10.