### PR TITLE
Update reference to kubectl commands using redirects (concepts/configuration)

### DIFF
--- a/docs/concepts/configuration/organize-cluster-access-kubeconfig.md
+++ b/docs/concepts/configuration/organize-cluster-access-kubeconfig.md
@@ -17,7 +17,7 @@ It does not mean that there is a file named `kubeconfig`.
 By default, `kubectl` looks for a file named `config` in the `$HOME/.kube` directory.
 You can specify other kubeconfig files by setting the `KUBECONFIG` environment
 variable or by setting the
-[`--kubeconfig`](/docs/reference/generated/kubectl/kubectl-commands/{{page.version}}/) flag.
+[`--kubeconfig`](/docs/user-guide/kubectl/{{page.version}}/) flag.
 
 For step-by-step instructions on creating and specifying kubeconfig files, see
 [Configure Access to Multiple Clusters](/docs/tasks/access-application-cluster/configure-access-multiple-clusters).
@@ -146,7 +146,7 @@ are stored absolutely.
 {% capture whatsnext %}
 
 * [Configure Access to Multiple Clusters](/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)
-* [kubectl config](/docs/reference/generated/kubectl/kubectl-commands/{{page.version}}/)
+* [kubectl config](/docs/user-guide/kubectl/{{page.version}}/)
 
 {% endcapture %}
 

--- a/docs/concepts/configuration/secret.md
+++ b/docs/concepts/configuration/secret.md
@@ -119,7 +119,7 @@ data:
 
 The data field is a map.  Its keys must consist of alphanumeric characters, '-', '_' or '.'.  The values are arbitrary data, encoded using base64.
 
-Create the secret using [`kubectl create`](/docs/reference/generated/kubectl/kubectl-commands/{{page.version}}/#create):
+Create the secret using [`kubectl create`](/docs/user-guide/kubectl/{{page.version}}/#create):
 
 ```shell
 $ kubectl create -f ./secret.yaml

--- a/docs/concepts/configuration/taint-and-toleration.md
+++ b/docs/concepts/configuration/taint-and-toleration.md
@@ -22,7 +22,7 @@ onto nodes with matching taints.
 
 ## Concepts
 
-You add a taint to a node using [kubectl taint](/docs/reference/generated/kubectl/kubectl-commands/{{page.version}}/#taint).
+You add a taint to a node using [kubectl taint](/docs/user-guide/kubectl/{{page.version}}/#taint).
 For example,
 
 ```shell


### PR DESCRIPTION
It looks like a previous attempt to fix the broken URLs still left them broken, as the generated docs do not support "page.version". I've added a new redirect for v1.10 (https://github.com/kubernetes/website/pull/7982). Updating these references to use the redirect for the correct version.

There are a bunch other places that need this fix. I'll batch these into a few manageable updates.