### PR TITLE
Update reference to kubectl commands using redirects (concepts/overview)

### DIFF
--- a/docs/concepts/overview/object-management-kubectl/declarative-config.md
+++ b/docs/concepts/overview/object-management-kubectl/declarative-config.md
@@ -975,7 +975,7 @@ template:
 {% capture whatsnext %}
 - [Managing Kubernetes Objects Using Imperative Commands](/docs/concepts/overview/object-management-kubectl/imperative-command/)
 - [Imperative Management of Kubernetes Objects Using Configuration Files](/docs/concepts/overview/object-management-kubectl/imperative-config/)
-- [Kubectl Command Reference](/docs/reference/generated/kubectl/kubectl-commands/{{page.version}}/)
+- [Kubectl Command Reference](/docs/user-guide/kubectl/{{page.version}}/)
 - [Kubernetes API Reference](/docs/reference/generated/kubernetes-api/{{page.version}}/)
 {% endcapture %}
 

--- a/docs/concepts/overview/object-management-kubectl/imperative-command.md
+++ b/docs/concepts/overview/object-management-kubectl/imperative-command.md
@@ -152,7 +152,7 @@ kubectl create --edit -f /tmp/srv.yaml
 {% capture whatsnext %}
 - [Managing Kubernetes Objects Using Object Configuration (Imperative)](/docs/concepts/overview/object-management-kubectl/imperative-config/)
 - [Managing Kubernetes Objects Using Object Configuration (Declarative)](/docs/concepts/overview/object-management-kubectl/declarative-config/)
-- [Kubectl Command Reference](/docs/reference/generated/kubectl/kubectl-commands/{{page.version}}/)
+- [Kubectl Command Reference](/docs/user-guide/kubectl/{{page.version}}/)
 - [Kubernetes API Reference](/docs/reference/generated/kubernetes-api/{{page.version}}/)
 {% endcapture %}
 

--- a/docs/concepts/overview/object-management-kubectl/imperative-config.md
+++ b/docs/concepts/overview/object-management-kubectl/imperative-config.md
@@ -130,7 +130,7 @@ template:
 {% capture whatsnext %}
 - [Managing Kubernetes Objects Using Imperative Commands](/docs/concepts/overview/object-management-kubectl/imperative-command/)
 - [Managing Kubernetes Objects Using Object Configuration (Declarative)](/docs/concepts/overview/object-management-kubectl/declarative-config/)
-- [Kubectl Command Reference](/docs/reference/generated/kubectl/kubectl-commands/{{page.version}}/)
+- [Kubectl Command Reference](/docs/user-guide/kubectl/{{page.version}}/)
 - [Kubernetes API Reference](/docs/reference/generated/kubernetes-api/{{page.version}}/)
 {% endcapture %}
 

--- a/docs/concepts/overview/object-management-kubectl/overview.md
+++ b/docs/concepts/overview/object-management-kubectl/overview.md
@@ -170,7 +170,7 @@ Disadvantages compared to imperative object configuration:
 - [Managing Kubernetes Objects Using Imperative Commands](/docs/concepts/overview/object-management-kubectl/imperative-command/)
 - [Managing Kubernetes Objects Using Object Configuration (Imperative)](/docs/concepts/overview/object-management-kubectl/imperative-config/)
 - [Managing Kubernetes Objects Using Object Configuration (Declarative)](/docs/concepts/overview/object-management-kubectl/declarative-config/)
-- [Kubectl Command Reference](/docs/reference/generated/kubectl/kubectl-commands/{{page.version}}/)
+- [Kubectl Command Reference](/docs/user-guide/kubectl/{{page.version}}/)
 - [Kubernetes API Reference](/docs/reference/generated/kubernetes-api/{{page.version}}/)
 
 {% comment %}

--- a/docs/concepts/overview/working-with-objects/kubernetes-objects.md
+++ b/docs/concepts/overview/working-with-objects/kubernetes-objects.md
@@ -36,7 +36,7 @@ Here's an example `.yaml` file that shows the required fields and object spec fo
 
 {% include code.html language="yaml" file="nginx-deployment.yaml" ghlink="/docs/concepts/overview/working-with-objects/nginx-deployment.yaml" %}
 
-One way to create a Deployment using a `.yaml` file like the one above is to use the [`kubectl create`](/docs/reference/generated/kubectl/kubectl-commands/{{page.version}}/#create) command in the `kubectl` command-line interface, passing the `.yaml` file as an argument. Here's an example:
+One way to create a Deployment using a `.yaml` file like the one above is to use the [`kubectl create`](/docs/user-guide/kubectl/{{page.version}}/#create) command in the `kubectl` command-line interface, passing the `.yaml` file as an argument. Here's an example:
 
 ```shell
 $ kubectl create -f https://k8s.io/docs/user-guide/nginx-deployment.yaml --record


### PR DESCRIPTION
It looks like a previous attempt to fix the broken URLs still left them broken, as the generated docs do not support "page.version". I've added a new redirect for v1.10 (#7982). Updating these references to use the redirect for the correct version.

There are a bunch other places that need this fix. I'll batch these into a few manageable updates.