### PR TITLE
Update reference to kubectl commands using redirects (reference)

### DIFF
--- a/docs/reference/kubectl/docker-cli-to-kubectl.md
+++ b/docs/reference/kubectl/docker-cli-to-kubectl.md
@@ -13,7 +13,7 @@ You can use the Kubernetes command line tool kubectl to interact with the api. Y
 
 #### docker run
 
-To run an nginx Deployment and expose the Deployment, see [kubectl run](/docs/reference/generated/kubectl/kubectl-commands/{{page.version}}/#run).
+To run an nginx Deployment and expose the Deployment, see [kubectl run](/docs/user-guide/kubectl/{{page.version}}/#run).
 
 docker:
 
@@ -59,7 +59,7 @@ To destroy the Deployment and its pods you need to run `kubectl delete deploymen
 
 #### docker ps
 
-To list what is currently running, see [kubectl get](/docs/reference/generated/kubectl/kubectl-commands/{{page.version}}/#get).
+To list what is currently running, see [kubectl get](/docs/user-guide/kubectl/{{page.version}}/#get).
 
 docker:
 
@@ -81,7 +81,7 @@ ubuntu                      0/1       Completed   0          20s
 
 #### docker attach
 
-To attach a process that is already running in a container, see [kubectl attach](/docs/reference/generated/kubectl/kubectl-commands/{{page.version}}/#attach).
+To attach a process that is already running in a container, see [kubectl attach](/docs/user-guide/kubectl/{{page.version}}/#attach).
 
 docker:
 
@@ -109,7 +109,7 @@ To detach from the container, you can type the escape sequence Ctrl+P followed b
 
 #### docker exec
 
-To execute a command in a container, see [kubectl exec](/docs/reference/generated/kubectl/kubectl-commands/{{page.version}}/#exec).
+To execute a command in a container, see [kubectl exec](/docs/user-guide/kubectl/{{page.version}}/#exec).
 
 docker:
 
@@ -154,7 +154,7 @@ For more information, see [Get a Shell to a Running Container](/docs/tasks/debug
 
 #### docker logs
 
-To follow stdout/stderr of a process that is running, see [kubectl logs](/docs/reference/generated/kubectl/kubectl-commands/{{page.version}}/#logs).
+To follow stdout/stderr of a process that is running, see [kubectl logs](/docs/user-guide/kubectl/{{page.version}}/#logs).
 
 
 docker:
@@ -185,7 +185,7 @@ For more information, see [Logging Architecture](docs/concepts/cluster-administr
 
 #### docker stop and docker rm
 
-To stop and delete a running process, see [kubectl delete](/docs/reference/generated/kubectl/kubectl-commands/{{page.version}}/#delete).
+To stop and delete a running process, see [kubectl delete](/docs/user-guide/kubectl/{{page.version}}/#delete).
 
 docker:
 
@@ -256,7 +256,7 @@ Server Version: version.Info{Major:"1", Minor:"6", GitVersion:"v1.6.9+a3d1dfa6f4
 
 #### docker info
 
-To get miscellaneous information about the environment and configuration, see [kubectl cluster-info](/docs/reference/generated/kubectl/kubectl-commands/{{page.version}}/#cluster-info).
+To get miscellaneous information about the environment and configuration, see [kubectl cluster-info](/docs/user-guide/kubectl/{{page.version}}/#cluster-info).
 
 docker:
 


### PR DESCRIPTION
It looks like a previous attempt to fix the broken URLs still left them broken, as the generated docs do not support "page.version". I've added a new redirect for v1.10 (#7982). Updating these references to use the redirect for the correct version.

There are a bunch other places that need this fix. I'll batch these into a few manageable updates.