### PR TITLE
Make glossary filter container 100% width.

### DIFF
--- a/css/glossary.css
+++ b/css/glossary.css
@@ -44,6 +44,7 @@
 
 #tag-container {
   float: left;
+  width: 100%;
   border-top: 1px solid #8c8c8c;
   border-bottom: 1px solid #8c8c8c;
   padding: 7px 0px;


### PR DESCRIPTION
Fixes #7994.

Width of tag filter container doesn't scale with the page, therefore allowing following content to stack up against it on a large enough monitor. This fix ensures no gap is left.