### PR TITLE
sysctl-cluster.md: use PSP from policy API group

### DIFF
--- a/docs/tasks/administer-cluster/sysctl-cluster.md
+++ b/docs/tasks/administer-cluster/sysctl-cluster.md
@@ -151,7 +151,7 @@ in a pod spec. It's a comma-separated list of plain sysctl names or sysctl patte
 Here is an example, it authorizes binding user creating pod with corresponding sysctls.
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: sysctl-psp


### PR DESCRIPTION
This PR updates PSP example to use `policy/v1beta1` API group as `extensions/v1beta` now is deprecated.

PTAL @liggitt @tallclair
CC @simo5