### PR TITLE
pod-security-policy.md: improve AllowPrivilegeEscalation description

### DIFF
--- a/docs/concepts/policy/pod-security-policy.md
+++ b/docs/concepts/policy/pod-security-policy.md
@@ -480,14 +480,10 @@ from changing the effective user ID, and prevent files from enabling extra
 capabilities (e.g. it will prevent the use of the `ping` tool). This behavior is
 required to effectively enforce `MustRunAsNonRoot`.
 
-It defaults to `nil`. The default behavior of `nil` allows privilege escalation
-so as to not break setuid binaries. Setting it to `false` ensures that no child
-process of a container can gain more privileges than its parent.
-
 **AllowPrivilegeEscalation** - Gates whether or not a user is allowed to set the
 security context of a container to `allowPrivilegeEscalation=true`. This
-defaults to allowed. When set to false, the container's
-`allowPrivilegeEscalation` is defaulted to false.
+defaults to allowed so as to not break setuid binaries. Setting it to `false`
+ensures that no child process of a container can gain more privileges than its parent.
 
 **DefaultAllowPrivilegeEscalation** - Sets the default for the
 `allowPrivilegeEscalation` option. The default behavior without this is to allow


### PR DESCRIPTION
This PR improves `AllowPrivilegeEscalation` description in the following ways:
- the paragraph that explains default behavior mentions `nil` but it's Go-specific value and not interesting/relevant to cluster admin
- as we have 2 options, it wasn't clear what exactly option has this default
- as we already explains default value of each option, the dedicated paragraph isn't needed

PTAL @tallclair @liggitt @jessfraz
CC @simo5