### PR TITLE
Add missing step from Fedora getting started docs

### DIFF
--- a/docs/getting-started-guides/fedora/fedora_manual_config.md
+++ b/docs/getting-started-guides/fedora/fedora_manual_config.md
@@ -127,6 +127,7 @@ KUBELET_ARGS="--cgroup-driver=systemd --kubeconfig=/etc/kubernetes/master-kubeco
 KUBELET_ARGS=""
 
 ```
+* Create the file `/etc/kubernetes/master-kubeconfig.yaml` with the contents:
 
 ```yaml
 kind: Config


### PR DESCRIPTION
The Fedora single-node guide included the text of the kubeconfig.yaml file,
but was missing text indicating that it needed to be created, and the path
which should be used.
