### PR TITLE
Fix a broken reference to the kubectl doc

### DIFF
--- a/docs/reference/kubectl/docker-cli-to-kubectl.md
+++ b/docs/reference/kubectl/docker-cli-to-kubectl.md
@@ -228,7 +228,7 @@ There is no direct analog of `docker login` in kubectl. If you are interested in
 
 #### docker version
 
-To get the version of client and server, see [kubectl version](/docs/reference/generated/kubectl/kubectl-commands{{page.version}}/#version).
+To get the version of client and server, see [kubectl version](/docs/user-guide/kubectl/{{page.version}}/#version).
 
 docker:
 


### PR DESCRIPTION
Missed this one in my last fix (https://github.com/kubernetes/website/pull/7989), since the URL was malformed and didn't match my search pattern.
