### PR TITLE
Remove double negative

### DIFF
--- a/docs/concepts/storage/storage-classes.md
+++ b/docs/concepts/storage/storage-classes.md
@@ -111,8 +111,8 @@ Persistent Volumes that are dynamically created by a storage class will have the
 mount options specified in the `mountOptions` field of the class.
 
 If the volume plugin does not support mount options but mount options are
-specified, provisioning will fail. Mount options are not validated on neither
-the class nor PV, so mount of the PV will simply fail if one is invalid.
+specified, provisioning will fail. Mount options are not validated on either
+the class or PV, so mount of the PV will simply fail if one is invalid.
 
 ## Parameters
 


### PR DESCRIPTION
Grammatical fix to increase accuracy and readability. Previously a double-negative where I believe a single negative was intended. 


