### PR TITLE
admission: correction on podnodeselector

### DIFF
--- a/docs/admin/admission-controllers.md
+++ b/docs/admin/admission-controllers.md
@@ -454,7 +454,7 @@ plugins:
 ```
 
 #### Configuration Annotation Format
-`PodNodeSelector` uses the annotation key `scheduler.kubernetes.io/node-selector` to assign node selectors to namespaces.
+`PodNodeSelector` uses the annotation key `scheduler.alpha.kubernetes.io/node-selector` to assign node selectors to namespaces.
 
 ```yaml
 apiVersion: v1
@@ -467,7 +467,7 @@ metadata:
 
 #### Internal Behavior
 This admission controller has the following behavior:
-  1. If the `Namespace` has an annotation with a key `scheduler.kubernetes.io/nodeSelector`, use its value as the
+  1. If the `Namespace` has an annotation with a key `scheduler.alpha.kubernetes.io/node-selector`, use its value as the
      node selector.
   1. If the namespace lacks such an annotation, use the `clusterDefaultNodeSelector` defined in the `PodNodeSelector`
      plugin configuration file as the node selector.
@@ -475,12 +475,14 @@ This admission controller has the following behavior:
   1. Evaluate the pod's node selector against the namespace-specific whitelist defined the plugin configuration file.
      Conflicts result in rejection.
 
-**Note:** `PodTolerationRestriction` is more versatile and powerful than `PodNodeSelector` and can encompass the scenarios supported by `PodNodeSelector`.
+**Note:** PodNodeSelector allows forcing pods to run on specifically labeled nodes. Also see the PodTolerationRestriction 
+admission plugin, which allows preventing pods from running on specifically tainted nodes.
 {: .note}
 
 ### PersistentVolumeClaimResize
 
 This admission controller implements additional validations for checking incoming `PersistentVolumeClaim` resize requests.
+
 **Note:** Support for volume resizing is available as an alpha feature. Admins must set the feature gate `ExpandPersistentVolumes`
 to `true` to enable resizing.
 {: .note}


### PR DESCRIPTION
podtolerationrestriction does not encompass all the use cases of
podnodeselector, in a case where not all nodes are tainted, then
podtolerationrestriction can not ensure pods are scheduled on the
specific set of nodes.
