### PR TITLE
fix revisionHistoryLimit default value to 10

### DIFF
--- a/docs/concepts/workloads/controllers/deployment.md
+++ b/docs/concepts/workloads/controllers/deployment.md
@@ -818,7 +818,7 @@ to a previous revision, or even pause it if you need to apply multiple tweaks in
 
 You can set `.spec.revisionHistoryLimit` field in a Deployment to specify how many old ReplicaSets for
 this Deployment you want to retain. The rest will be garbage-collected in the background. By default,
-all revision history will be kept. In a future version, it will default to switch to 2.
+it is 10.
 
 **Note:** Explicitly setting this field to 0, will result in cleaning up all the history of your Deployment
 thus that Deployment will not be able to roll back.


### PR DESCRIPTION
ref here:
https://github.com/kubernetes/kubernetes/blob/a5c3c8d16c74d1fb710a88497f970ef6045f90d4/pkg/apis/apps/v1/defaults.go#L64

here shows that the default value is 10.