### PR TITLE
Use apps/v1 API group whenever possible

### DIFF
--- a/docs/concepts/workloads/controllers/garbage-collection.md
+++ b/docs/concepts/workloads/controllers/garbage-collection.md
@@ -52,7 +52,7 @@ kind: Pod
 metadata:
   ...
   ownerReferences:
-  - apiVersion: extensions/v1beta1
+  - apiVersion: apps/v1
     controller: true
     blockOwnerDeletion: true
     kind: ReplicaSet

--- a/docs/concepts/workloads/controllers/my-repset.yaml
+++ b/docs/concepts/workloads/controllers/my-repset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: my-repset

--- a/docs/getting-started-guides/ubuntu/rancher.md
+++ b/docs/getting-started-guides/ubuntu/rancher.md
@@ -59,7 +59,7 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -71,6 +71,7 @@ spec:
   selector:
     matchLabels:
       app: rancher
+      ima: pod
   strategy: {}
   template:
     metadata:
@@ -220,7 +221,7 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/docs/tasks/administer-cluster/cloud-controller-manager-daemonset-example.yaml
+++ b/docs/tasks/administer-cluster/cloud-controller-manager-daemonset-example.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: kube-system
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: system:cloud-controller-manager
 roleRef:
@@ -23,7 +23,7 @@ subjects:
   name: cloud-controller-manager
   namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:

--- a/docs/tasks/debug-application-cluster/debug-service.md
+++ b/docs/tasks/debug-application-cluster/debug-service.md
@@ -78,13 +78,14 @@ Note that this is the same as if you had started the `Deployment` with
 the following YAML:
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hostnames
 spec:
   selector:
-    app: hostnames
+    matchLabels:
+      app: hostnames
   replicas: 3
   template:
     metadata:

--- a/docs/tasks/debug-application-cluster/fluentd-gcp-ds.yaml
+++ b/docs/tasks/debug-application-cluster/fluentd-gcp-ds.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluentd-gcp-v2.0
@@ -8,6 +8,11 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
     version: v2.0
 spec:
+  selector:
+    matchLabels:
+      k8s-app: fluentd-gcp
+      kubernetes.io/cluster-service: "true"
+      version: v2.0
   updateStrategy:
     type: RollingUpdate
   template:

--- a/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -169,7 +169,7 @@ metadata:
   namespace: default
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: php-apache
   minReplicas: 1
@@ -250,7 +250,7 @@ metadata:
   namespace: default
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: php-apache
   minReplicas: 1

--- a/docs/tasks/run-application/hpa-php-apache.yaml
+++ b/docs/tasks/run-application/hpa-php-apache.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: php-apache
   minReplicas: 1

--- a/docs/tasks/run-application/rolling-update-replication-controller.md
+++ b/docs/tasks/run-application/rolling-update-replication-controller.md
@@ -10,9 +10,9 @@ title: Perform Rolling Update Using a Replication Controller
 ## Overview
 
 **Note**: The preferred way to create a replicated application is to use a
-[Deployment](/docs/reference/generated/kubernetes-api/{{page.version}}/#deployment-v1beta1-apps),
+[Deployment](/docs/reference/generated/kubernetes-api/{{page.version}}/#deployment-v1-apps),
 which in turn uses a
-[ReplicaSet](/docs/reference/generated/kubernetes-api/{{page.version}}/#replicaset-v1beta1-extensions).
+[ReplicaSet](/docs/reference/generated/kubernetes-api/{{page.version}}/#replicaset-v1-apps).
 For more information, see
 [Running a Stateless Application Using a Deployment](/docs/tasks/run-application/run-stateless-application-deployment/).
 {: .note}

--- a/docs/user-guide/replicasets/frontend.yaml
+++ b/docs/user-guide/replicasets/frontend.yaml
@@ -1,22 +1,17 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: frontend
-  # these labels can be applied automatically
-  # from the labels in the pod template if not set
-  # labels:
-    # app: guestbook
-    # tier: frontend
+  labels:
+    app: guestbook
+    tier: frontend
 spec:
   # this replicas value is default
   # modify it according to your case
   replicas: 3
-  # selector can be applied automatically
-  # from the labels in the pod template if not set,
-  # but we are specifying the selector here to
-  # demonstrate its usage.
   selector:
     matchLabels:
+      app: guestbook
       tier: frontend
     matchExpressions:
       - {key: tier, operator: In, values: [frontend]}

--- a/docs/user-guide/replicasets/redis-slave.yaml
+++ b/docs/user-guide/replicasets/redis-slave.yaml
@@ -1,23 +1,20 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: redis-slave
-  # these labels can be applied automatically
-  # from the labels in the pod template if not set
-  # labels:
-  #   app: redis
-  #   role: slave
-  #   tier: backend
+  labels:
+    app: redis
+    role: slave
+    tier: backend
 spec:
   # this replicas value is default
   # modify it according to your case
   replicas: 2
-  # selector can be applied automatically
-  # from the labels in the pod template if not set
-  # selector:
-  #   app: guestbook
-  #   role: slave
-  #   tier: backend
+  selector:
+    matchLabels:
+      app: redis
+      role: slave
+      tier: backend
   template:
     metadata:
       labels:


### PR DESCRIPTION
The use of extensions/v1beta1, apps/v1beta1 and apps/v1beta2 API
groups should be discouraged.

Closes: #8049

