### PR TITLE
Fixing broken links in section "For more information about contributing"

### DIFF
--- a/editdocs.md
+++ b/editdocs.md
@@ -53,13 +53,13 @@ $( document ).ready(function() {
 
 For more information about contributing to the Kubernetes documentation, see:
 
-* [Creating a Documentation Pull Request](/docs/home/contribute/create-pull-request/)
-* [Writing a New Topic](/docs/home/contribute/write-new-topic/)
-* [Staging Your Documentation Changes](/docs/home/contribute/stage-documentation-changes/)
-* [Using Page Templates](/docs/home/contribute/page-templates/)
-* [Documentation Style Guide](/docs/home/contribute/style-guide/)
+* [Creating a Documentation Pull Request](/docs/home/contribute/create-pull-request.md)
+* [Writing a New Topic](/docs/home/contribute/write-new-topic.md)
+* [Staging Your Documentation Changes](/docs/home/contribute/stage-documentation-changes.md)
+* [Using Page Templates](/docs/home/contribute/page-templates.md)
+* [Documentation Style Guide](/docs/home/contribute/style-guide.md)
 * How to work with generated documentation
-  * [Generating Reference Documentation for Kubernetes Federation API](/docs/home/contribute/generated-reference/federation-api/)
-  * [Generating Reference Documentation for kubectl Commands](/docs/home/contribute/generated-reference/kubectl/)
-  * [Generating Reference Documentation for the Kubernetes API](/docs/home/contribute/generated-reference/kubernetes-api/)
-  * [Generating Reference Pages for Kubernetes Components and Tools](/docs/home/contribute/generated-reference/kubernetes-components/)
+  * [Generating Reference Documentation for Kubernetes Federation API](/docs/home/contribute/generated-reference/federation-api.md)
+  * [Generating Reference Documentation for kubectl Commands](/docs/home/contribute/generated-reference/kubectl.md)
+  * [Generating Reference Documentation for the Kubernetes API](/docs/home/contribute/generated-reference/kubernetes-api.md)
+  * [Generating Reference Pages for Kubernetes Components and Tools](/docs/home/contribute/generated-reference/kubernetes-components.md)


### PR DESCRIPTION
There is a markdown (*.md) file for each of these help links in the source, which was not linked correctly from the editdocs. Editing each url to redirect to correct .md file

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.11 Features: set Milestone to 1.11 and Base Branch to release-1.11
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
