### PR TITLE
Avoid misleading camel words

### DIFF
--- a/docs/admin/extensible-admission-controllers.md
+++ b/docs/admin/extensible-admission-controllers.md
@@ -33,11 +33,11 @@ This page describes how to use Admission Webhooks and Initializers.
 
 Admission webhooks are HTTP callbacks that receive admission requests and do
 something with them. You can define two types of admission webhooks,
-[ValidatingAdmissionWebhooks](/docs/admin/admission-controllers.md#validatingadmissionwebhook-alpha-in-18-beta-in-19)
+[validating admission Webhook](/docs/admin/admission-controllers.md#validatingadmissionwebhook-alpha-in-18-beta-in-19)
 and
-[MutatingAdmissionWebhooks](/docs/admin/admission-controllers.md#mutatingadmissionwebhook-beta-in-19).
-With `ValidatingAdmissionWebhooks`, you may reject requests to enforce custom
-admission policies. With `MutatingAdmissionWebhooks`, you may change requests to
+[mutating admission webhook](/docs/admin/admission-controllers.md#mutatingadmissionwebhook-beta-in-19).
+With validating admission Webhooks, you may reject requests to enforce custom
+admission policies. With mutating admission Webhooks, you may change requests to
 enforce custom defaults.
 
 ### Experimenting with admission webhooks


### PR DESCRIPTION
The term "`MutatingAdmissionWebhooks`" has no special meaning in the
docs. It is misleading because readers may think of it as the name of a
resource or field, or the name of the corresponding admission
controller. However, the name of the admission controller is in
singular. This PR proposes a change to avoid such misunderstandings.