### PR TITLE
Fix mismatched note to be a warning callout.

### DIFF
--- a/docs/tasks/debug-application-cluster/logging-stackdriver.md
+++ b/docs/tasks/debug-application-cluster/logging-stackdriver.md
@@ -43,7 +43,7 @@ Stackdriver Logging agents to the running cluster.
 
 **Warning:** The Stackdriver logging daemon has known issues on platforms other
 than Google Kubernetes Engine. Proceed at your own risk.
-{: .note}
+{: .warning}
 
 ### Deploying to an existing cluster
 


### PR DESCRIPTION
In #8071 I updated the Stackdriver logging docs to use the default namespace throughout, and added a callout warning that this daemon has issues on non-GKE platforms. @x13n pointed out that this callout syntax was wrong, and it still rendered properly, but as a note instead of a warning. This fixes that.