### PR TITLE
Update KVP example with syntax highlighting

### DIFF
--- a/docs/concepts/overview/working-with-objects/annotations.md
+++ b/docs/concepts/overview/working-with-objects/annotations.md
@@ -19,10 +19,12 @@ include characters not permitted by labels.
 
 Annotations, like labels, are key/value maps:
 
-    "annotations": {
-      "key1" : "value1",
-      "key2" : "value2"
-    }
+```json
+"annotations": {
+  "key1" : "value1",
+  "key2" : "value2"
+}
+```
 
 Here are some examples of information that could be recorded in annotations:
 


### PR DESCRIPTION
### Changes:
* Update KVP with syntax highlighting

### Notes:
* This is consistent with how this was done on the labels page preceding it in the documentation https://github.com/kubernetes/website/edit/master/docs/concepts/overview/working-with-objects/labels.md

### Before

<img width="208" alt="screen shot 2018-04-13 at 4 59 12 pm" src="https://user-images.githubusercontent.com/1013461/38757720-074e0324-3f3c-11e8-9642-cf09a350442c.png">


### After 

<img width="213" alt="screen shot 2018-04-13 at 4 59 03 pm" src="https://user-images.githubusercontent.com/1013461/38757724-0b90c2d2-3f3c-11e8-897b-356c3eec4f8b.png">
