### PR TITLE
Changed NodePort to Port in documentation

### DIFF
--- a/docs/tutorials/stateless-application/expose-external-ip-address.md
+++ b/docs/tutorials/stateless-application/expose-external-ip-address.md
@@ -123,7 +123,7 @@ external IP address.
        curl http://<external-ip>:<port>
 
     where `<external-ip>` is the external IP address (`LoadBalancer Ingress`)
-    of your Service, and `<port>` is the value of `NodePort` in your Service
+    of your Service, and `<port>` is the value of `Port` in your Service
     description.
     If you are using minikube, typing `minikube service my-service` will
     automatically open the Hello World application in a browser.


### PR DESCRIPTION
This was a recommended fix by @dick-twocows in issue #7901. The fix was to change the word NodePort to Port as explained in the issue above.