### PR TITLE
Run tests against the current stable k8s version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,22 @@
 language: go
 go:
-  - 1.8.3
+  - 1.9.3
 
 # Don't want default ./... here:
 install:
 - export PATH=$GOPATH/bin:$PATH
 - mkdir -p $HOME/gopath/src/k8s.io
-- mv $TRAVIS_BUILD_DIR $HOME/gopath/src/k8s.io/website
-
-# (1) Fetch dependencies for us to run the tests in test/examples_test.go
+- mv $TRAVIS_BUILD_DIR $HOME/gopath/src/k8s.io/website && cd $HOME/gopath/src/k8s.io/website
+# Fetch dependencies for us to run the tests in test/examples_test.go
 - go get -t -v k8s.io/website/test
+# Make sure we are testing against the correct branch
+- pushd $GOPATH/src/k8s.io/kubernetes && git checkout release-1.10 && popd
 
 # Simplified deduplication of dependencies.
 - cp -L -R $GOPATH/src/k8s.io/kubernetes/vendor/ $GOPATH/src/
 - rm -r $GOPATH/src/k8s.io/kubernetes/vendor/
 
 script:
+# Run test
 - go test -v k8s.io/website/test
 - ./verify-docs-format.sh

--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -173,8 +173,8 @@ func validateObject(obj runtime.Object) (errors field.ErrorList) {
 			t.Namespace = api.NamespaceDefault
 		}
 		errors = ext_validation.ValidateIngress(t)
-	case *policy.PodSecurityPolicy:
-		errors = policy_validation.ValidatePodSecurityPolicy(t)
+	case *extensions.PodSecurityPolicy:
+		errors = ext_validation.ValidatePodSecurityPolicy(t)
 	case *extensions.ReplicaSet:
 		if t.Namespace == "" {
 			t.Namespace = api.NamespaceDefault
@@ -317,9 +317,9 @@ func TestExampleObjectSchemas(t *testing.T) {
 			"nginx-deployment": {&extensions.Deployment{}},
 		},
 		"../docs/concepts/policy": {
-			"privileged-psp": {&policy.PodSecurityPolicy{}},
-			"restricted-psp": {&policy.PodSecurityPolicy{}},
-			"example-psp":    {&policy.PodSecurityPolicy{}},
+			"privileged-psp": {&extensions.PodSecurityPolicy{}},
+			"restricted-psp": {&extensions.PodSecurityPolicy{}},
+			"example-psp":    {&extensions.PodSecurityPolicy{}},
 		},
 		"../docs/concepts/services-networking": {
 			"curlpod":          {&extensions.Deployment{}},


### PR DESCRIPTION
So far we have been running tests against the master branch of
kubernetes/kubernetes. This is creating quite some problems because the
master branch is always moving. We are actually checking the YAML files
against a version between 1.10 and 1.11.

This PR is attempting to fix the problem by checking out the
'release-1.10' branch before running the tests. We are supposed to
change the branch to be used when release-1.11 is out. With this PR
(hopefully it works), we will only need to fix the gate every time a new
release is out.

