### PR TITLE
fix the formatting when describing the CN

### DIFF
--- a/docs/tasks/access-kubernetes-api/setup-extension-api-server.md
+++ b/docs/tasks/access-kubernetes-api/setup-extension-api-server.md
@@ -31,7 +31,7 @@ Alternatively, you can use an existing 3rd party solution, such as [apiserver-bu
 1. You may need to make an RBAC rule allowing you to add APIService objects, or get your cluster administrator to make one. (Since API extensions affect the entire cluster, it is not recommended to do testing/development/debug of an API extension in a live cluster.)
 1. Create the Kubernetes namespace you want to run your extension api-service in.
 1. Create/get a CA cert to be used to sign the server cert the extension api-server uses for HTTPS.
-1. Create a server cert/key for the api-server to use for HTTPS. This cert should be signed by the above CA. It should also have a CN of the Kube DNS name. This is derived from the Kubernetes service and be of the form <service name>.<service name namespace>.svc
+1. Create a server cert/key for the api-server to use for HTTPS. This cert should be signed by the above CA. It should also have a CN of the Kube DNS name. This is derived from the Kubernetes service and be of the form `<service name>.<service name namespace>.svc`
 1. Create a Kubernetes secret with the server cert/key in your namespace.
 1. Create a Kubernetes deployment for the extension api-server and make sure you are loading the secret as a volume. It should contain a reference to a working image of your extension api-server. The deployment should also be in your namespace.
 1. Make sure that your extension-apiserver loads those certs from that volume and that they are used in the HTTPS handshake.


### PR DESCRIPTION
Without the in-line code block, service name and service namespace are hidden.