### PR TITLE
Fix the title for the CoreOS page

### DIFF
--- a/docs/getting-started-guides/coreos/index.md
+++ b/docs/getting-started-guides/coreos/index.md
@@ -1,5 +1,5 @@
 ---
-title: CoreOS on AWS or GCE
+title: CoreOS
 ---
 
 * TOC

--- a/docs/setup/pick-right-solution.md
+++ b/docs/setup/pick-right-solution.md
@@ -130,7 +130,7 @@ These solutions are combinations of cloud providers and operating systems not co
 * [Fedora (Single Node)](/docs/getting-started-guides/fedora/fedora_manual_config/)
 * [Fedora (Multi Node)](/docs/getting-started-guides/fedora/flannel_multi_node_cluster/)
 * [Kubernetes on Ubuntu](/docs/getting-started-guides/ubuntu/)
-* [CoreOS on AWS or GCE](/docs/getting-started-guides/coreos/)
+* [CoreOS](/docs/getting-started-guides/coreos/)
 
 ## Integrations
 


### PR DESCRIPTION
The current title "CoreOS on AWS or GCE" is misleading because the page
actually contains information about many ways to run Kubernetes. When
the page is referenced from the navigation panel, the title becomes very
confusing.

Closes: #711

