### PR TITLE
Full domain for accessing kubernetes API from pod

### DIFF
--- a/docs/tasks/access-application-cluster/access-cluster.md
+++ b/docs/tasks/access-application-cluster/access-cluster.md
@@ -151,7 +151,7 @@ When accessing the API from a pod, locating and authenticating
 to the apiserver are somewhat different.
 
 The recommended way to locate the apiserver within the pod is with
-the `kubernetes` DNS name, which resolves to a Service IP which in turn
+the `kubernetes.default.svc.cluster.local` DNS name, which resolves to a Service IP which in turn
 will be routed to an apiserver.
 
 The recommended way to authenticate to the apiserver is with a


### PR DESCRIPTION
Per https://github.com/kubernetes/kubernetes/issues/40973#issuecomment-383969128,  bare `kubernetes` is wrong, doesn't work from a pod outside `default` namespace (I confirmed experimentally).

`kubernetes.default`, `kubernetes.default.svc` and `kubernetes.default.svc.cluster.local` all seem to work.
I picked the FQDN because that's what https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/ generally documents for services, no idea if there are other reasons to prefer one?
@liggit please review.

(there is a similar doc https://kubernetes.io/docs/tasks/administer-cluster/access-cluster-api/#accessing-the-api-from-a-pod to be kept in sync)