### PR TITLE
Replace double-quote with single-quote

### DIFF
--- a/docs/concepts/configuration/secret.md
+++ b/docs/concepts/configuration/secret.md
@@ -50,8 +50,8 @@ username and password that the pods should use is in the files
 
 ```shell
 # Create files needed for rest of example.
-$ echo -n "admin" > ./username.txt
-$ echo -n "1f2d1e2e67df" > ./password.txt
+$ echo -n 'admin' > ./username.txt
+$ echo -n '1f2d1e2e67df' > ./password.txt
 ```
 
 The `kubectl create secret` command
@@ -98,9 +98,9 @@ in json or yaml format, and then create that object.
 Each item must be base64 encoded:
 
 ```shell
-$ echo -n "admin" | base64
+$ echo -n 'admin' | base64
 YWRtaW4=
-$ echo -n "1f2d1e2e67df" | base64
+$ echo -n '1f2d1e2e67df' | base64
 MWYyZDFlMmU2N2Rm
 ```
 
@@ -157,7 +157,7 @@ type: Opaque
 Decode the password field:
 
 ```shell
-$ echo "MWYyZDFlMmU2N2Rm" | base64 --decode
+$ echo 'MWYyZDFlMmU2N2Rm' | base64 --decode
 1f2d1e2e67df
 ```
 


### PR DESCRIPTION
Replace double-quote with single-quote for terminal commands.
Although the strings in the examples work fine, users who with randomly generated passwords may have character strings that cause strange behaviors with double-quotes. Using single-quotes prevents this.
Example of a command that causes odd behaviors with double-quotes:
echo -n "RandPasswordr3!$#$3aR" | base64
This example has a series of special characters that some terminals try to interpret and replace with other text.