### PR TITLE
Fix syntax highlighting configure-pod-configmap.md

### DIFF
--- a/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -170,6 +170,9 @@ would produce the following ConfigMap:
 
 ```shell
 kubectl get configmap game-config-env-file -o yaml
+```
+
+```yaml
 apiVersion: v1
 data:
   allowed: '"true"'

--- a/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -195,8 +195,11 @@ kubectl create configmap config-multi-env-files \
 
 would produce the following ConfigMap:
 
-```
+```shell
 kubectl get configmap config-multi-env-files -o yaml
+```
+
+```yaml
 apiVersion: v1
 data:
   color: purple


### PR DESCRIPTION
configure-pod-configmap.md has a shell command and its yaml output in the same code block which breaks syntax highlighting. Broke these out into two code blocks with their appropriate code decorators.