### PR TITLE
Point kubectl command reference to the generated document (docs/reference)

### DIFF
--- a/docs/reference/kubectl/docker-cli-to-kubectl.md
+++ b/docs/reference/kubectl/docker-cli-to-kubectl.md
@@ -13,7 +13,7 @@ You can use the Kubernetes command line tool kubectl to interact with the api. Y
 
 #### docker run
 
-To run an nginx Deployment and expose the Deployment, see [kubectl run](/docs/user-guide/kubectl/{{page.version}}/#run).
+To run an nginx Deployment and expose the Deployment, see [kubectl run](/docs/reference/generated/kubectl/kubectl-commands/#run).
 
 docker:
 
@@ -59,7 +59,7 @@ To destroy the Deployment and its pods you need to run `kubectl delete deploymen
 
 #### docker ps
 
-To list what is currently running, see [kubectl get](/docs/user-guide/kubectl/{{page.version}}/#get).
+To list what is currently running, see [kubectl get](/docs/reference/generated/kubectl/kubectl-commands/#get).
 
 docker:
 
@@ -81,7 +81,7 @@ ubuntu                      0/1       Completed   0          20s
 
 #### docker attach
 
-To attach a process that is already running in a container, see [kubectl attach](/docs/user-guide/kubectl/{{page.version}}/#attach).
+To attach a process that is already running in a container, see [kubectl attach](/docs/reference/generated/kubectl/kubectl-commands/#attach).
 
 docker:
 
@@ -109,7 +109,7 @@ To detach from the container, you can type the escape sequence Ctrl+P followed b
 
 #### docker exec
 
-To execute a command in a container, see [kubectl exec](/docs/user-guide/kubectl/{{page.version}}/#exec).
+To execute a command in a container, see [kubectl exec](/docs/reference/generated/kubectl/kubectl-commands/#exec).
 
 docker:
 
@@ -154,7 +154,7 @@ For more information, see [Get a Shell to a Running Container](/docs/tasks/debug
 
 #### docker logs
 
-To follow stdout/stderr of a process that is running, see [kubectl logs](/docs/user-guide/kubectl/{{page.version}}/#logs).
+To follow stdout/stderr of a process that is running, see [kubectl logs](/docs/reference/generated/kubectl/kubectl-commands/#logs).
 
 
 docker:
@@ -185,7 +185,7 @@ For more information, see [Logging Architecture](/docs/concepts/cluster-administ
 
 #### docker stop and docker rm
 
-To stop and delete a running process, see [kubectl delete](/docs/user-guide/kubectl/{{page.version}}/#delete).
+To stop and delete a running process, see [kubectl delete](/docs/reference/generated/kubectl/kubectl-commands/#delete).
 
 docker:
 
@@ -228,7 +228,7 @@ There is no direct analog of `docker login` in kubectl. If you are interested in
 
 #### docker version
 
-To get the version of client and server, see [kubectl version](/docs/user-guide/kubectl/{{page.version}}/#version).
+To get the version of client and server, see [kubectl version](/docs/reference/generated/kubectl/kubectl-commands/#version).
 
 docker:
 
@@ -256,7 +256,7 @@ Server Version: version.Info{Major:"1", Minor:"6", GitVersion:"v1.6.9+a3d1dfa6f4
 
 #### docker info
 
-To get miscellaneous information about the environment and configuration, see [kubectl cluster-info](/docs/user-guide/kubectl/{{page.version}}/#cluster-info).
+To get miscellaneous information about the environment and configuration, see [kubectl cluster-info](/docs/reference/generated/kubectl/kubectl-commands/#cluster-info).
 
 docker:
 


### PR DESCRIPTION
Since we now generate kubectl doc for each release, it is no longer necessary to use the old redirects. I plan to clean up the references in a few reasonably batched PRs, and finally delete the redirect.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.11 Features: set Milestone to 1.11 and Base Branch to release-1.11
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
