### PR TITLE
Update tasks/access-application-cluster docs to point to the generated kubectl docs

### DIFF
--- a/docs/tasks/access-application-cluster/access-cluster.md
+++ b/docs/tasks/access-application-cluster/access-cluster.md
@@ -53,7 +53,7 @@ Run it like this:
 $ kubectl proxy --port=8080 &
 ```
 
-See [kubectl proxy](/docs/user-guide/kubectl/{{page.version}}/#proxy) for more details.
+See [kubectl proxy](/docs/reference/generated/kubectl/kubectl-commands/#proxy) for more details.
 
 Then you can explore the API with curl, wget, or a browser, replacing localhost
 with [::1] for IPv6, like so:
@@ -194,7 +194,7 @@ You have several options for connecting to nodes, pods and services from outside
   - Access services through public IPs.
     - Use a service with type `NodePort` or `LoadBalancer` to make the service reachable outside
       the cluster.  See the [services](/docs/user-guide/services) and
-      [kubectl expose](/docs/user-guide/kubectl/{{page.version}}/#expose) documentation.
+      [kubectl expose](/docs/reference/generated/kubectl/kubectl-commands/#expose) documentation.
     - Depending on your cluster environment, this may just expose the service to your corporate network,
       or it may expose it to the internet.  Think about whether the service being exposed is secure.
       Does it do its own authentication?
@@ -210,7 +210,7 @@ You have several options for connecting to nodes, pods and services from outside
     - Only works for HTTP/HTTPS.
     - Described [here](#manually-constructing-apiserver-proxy-urls).
   - Access from a node or pod in the cluster.
-    - Run a pod, and then connect to a shell in it using [kubectl exec](/docs/user-guide/kubectl/{{page.version}}/#exec).
+    - Run a pod, and then connect to a shell in it using [kubectl exec](/docs/reference/generated/kubectl/kubectl-commands/#exec).
       Connect to other nodes, pods, and services from that shell.
     - Some clusters may allow you to ssh to a node in the cluster.  From there you may be able to
       access cluster services.  This is a non-standard method, and will work on some clusters but

--- a/docs/tasks/access-application-cluster/configure-access-multiple-clusters.md
+++ b/docs/tasks/access-application-cluster/configure-access-multiple-clusters.md
@@ -335,7 +335,7 @@ export KUBECONFIG=$KUBECONFIG_SAVED
 {% capture whatsnext %}
 
 * [Organizing Cluster Access Using kubeconfig Files](/docs/concepts/configuration/organize-cluster-access-kubeconfig/)
-* [kubectl config](/docs/user-guide/kubectl/{{page.version}}/)
+* [kubectl config](/docs/reference/generated/kubectl/kubectl-commands/)
 
 {% endcapture %}
 

--- a/docs/tasks/access-application-cluster/create-external-load-balancer.md
+++ b/docs/tasks/access-application-cluster/create-external-load-balancer.md
@@ -74,7 +74,7 @@ resource (in the case of the example above, a replication controller named
 `example`).
 
 For more information, including optional flags, refer to the
-[`kubectl expose` reference](/docs/user-guide/kubectl/{{page.version}}/#expose).
+[`kubectl expose` reference](/docs/reference/generated/kubectl/kubectl-commands/#expose).
 
 ## Finding your IP address
 

--- a/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
+++ b/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
@@ -132,7 +132,7 @@ The support to UDP protocol is being tracked in
 
 
 {% capture whatsnext %}
-Learn more about [kubectl port-forward](/docs/user-guide/kubectl/{{page.version}}/#port-forward).
+Learn more about [kubectl port-forward](/docs/reference/generated/kubectl/kubectl-commands/#port-forward).
 {% endcapture %}
 
 


### PR DESCRIPTION
Since we now generate kubectl doc for each release, it is no longer necessary to use the old redirects. I plan to clean up the references in a few reasonably batched PRs, and finally delete the redirect.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.11 Features: set Milestone to 1.11 and Base Branch to release-1.11
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
