### PR TITLE
Update administer-cluster docs to point to generated kubectl docs

### DIFF
--- a/docs/tasks/administer-cluster/access-cluster-api.md
+++ b/docs/tasks/administer-cluster/access-cluster-api.md
@@ -55,7 +55,7 @@ Run it like this:
 $ kubectl proxy --port=8080 &
 ```
 
-See [kubectl proxy](/docs/user-guide/kubectl/{{page.version}}/#proxy) for more details.
+See [kubectl proxy](/docs/reference/generated/kubectl/kubectl-commands/#proxy) for more details.
 
 Then you can explore the API with curl, wget, or a browser, like so:
 

--- a/docs/tasks/administer-cluster/access-cluster-services.md
+++ b/docs/tasks/administer-cluster/access-cluster-services.md
@@ -27,7 +27,7 @@ You have several options for connecting to nodes, pods and services from outside
   - Access services through public IPs.
     - Use a service with type `NodePort` or `LoadBalancer` to make the service reachable outside
       the cluster.  See the [services](/docs/user-guide/services) and
-      [kubectl expose](/docs/user-guide/kubectl/{{page.version}}/#expose) documentation.
+      [kubectl expose](/docs/reference/generated/kubectl/kubectl-commands/#expose) documentation.
     - Depending on your cluster environment, this may just expose the service to your corporate network,
       or it may expose it to the internet.  Think about whether the service being exposed is secure.
       Does it do its own authentication?
@@ -43,7 +43,7 @@ You have several options for connecting to nodes, pods and services from outside
     - Only works for HTTP/HTTPS.
     - Described [here](#manually-constructing-apiserver-proxy-urls).
   - Access from a node or pod in the cluster.
-    - Run a pod, and then connect to a shell in it using [kubectl exec](/docs/user-guide/kubectl/{{page.version}}/#exec).
+    - Run a pod, and then connect to a shell in it using [kubectl exec](/docs/reference/generated/kubectl/kubectl-commands/#exec).
       Connect to other nodes, pods, and services from that shell.
     - Some clusters may allow you to ssh to a node in the cluster. From there you may be able to
       access cluster services. This is a non-standard method, and will work on some clusters but

--- a/docs/tasks/administer-cluster/cluster-management.md
+++ b/docs/tasks/administer-cluster/cluster-management.md
@@ -211,4 +211,4 @@ You can use `kubectl convert` command to convert config files between different 
 kubectl convert -f pod.yaml --output-version v1
 ```
 
-For more options, please refer to the usage of [kubectl convert](/docs/user-guide/kubectl/{{page.version}}/#convert) command.
+For more options, please refer to the usage of [kubectl convert](/docs/reference/generated/kubectl/kubectl-commands/#convert) command.

--- a/docs/tasks/administer-cluster/namespaces-walkthrough.md
+++ b/docs/tasks/administer-cluster/namespaces-walkthrough.md
@@ -201,7 +201,7 @@ $ kubectl run snowflake --image=kubernetes/serve_hostname --replicas=2
 ```
 We have just created a deployment whose replica size is 2 that is running the pod called snowflake with a basic container that just serves the hostname.
 Note that `kubectl run` creates deployments only on Kubernetes cluster >= v1.2. If you are running older versions, it creates replication controllers instead.
-If you want to obtain the old behavior, use `--generator=run/v1` to create replication controllers. See [`kubectl run`](/docs/user-guide/kubectl/{{page.version}}/#run) for more details.
+If you want to obtain the old behavior, use `--generator=run/v1` to create replication controllers. See [`kubectl run`](/docs/reference/generated/kubectl/kubectl-commands/#run) for more details.
 
 ```shell
 $ kubectl get deployment

--- a/docs/tasks/administer-cluster/namespaces.md
+++ b/docs/tasks/administer-cluster/namespaces.md
@@ -238,7 +238,7 @@ $ kubectl run snowflake --image=kubernetes/serve_hostname --replicas=2
 ```
 We have just created a deployment whose replica size is 2 that is running the pod called snowflake with a basic container that just serves the hostname.
 Note that `kubectl run` creates deployments only on Kubernetes cluster >= v1.2. If you are running older versions, it creates replication controllers instead.
-If you want to obtain the old behavior, use `--generator=run/v1` to create replication controllers. See [`kubectl run`](/docs/user-guide/kubectl/{{page.version}}/#run) for more details.
+If you want to obtain the old behavior, use `--generator=run/v1` to create replication controllers. See [`kubectl run`](/docs/reference/generated/kubectl/kubectl-commands/#run) for more details.
 
 ```shell
 $ kubectl get deployment

--- a/docs/tasks/administer-cluster/safely-drain-node.md
+++ b/docs/tasks/administer-cluster/safely-drain-node.md
@@ -38,7 +38,7 @@ and will respect the `PodDisruptionBudgets` you have specified.
 
 **Note:** By default `kubectl drain` will ignore certain system pods on the node
 that cannot be killed; see
-the [kubectl drain](/docs/user-guide/kubectl/{{page.version}}/#drain)
+the [kubectl drain](/docs/reference/generated/kubectl/kubectl-commands/#drain)
 documentation for more details.
 
 When `kubectl drain` returns successfully, that indicates that all of
@@ -89,7 +89,7 @@ budget are blocked.
 
 ## The Eviction API
 
-If you prefer not to use [kubectl drain](/docs/user-guide/kubectl/{{page.version}}/#drain) (such as
+If you prefer not to use [kubectl drain](/docs/reference/generated/kubectl/kubectl-commands/#drain) (such as
 to avoid calling to an external command, or to get finer control over the pod
 eviction process), you can also programmatically cause evictions using the eviction API.
 

--- a/docs/tasks/administer-cluster/sysctl-cluster.md
+++ b/docs/tasks/administer-cluster/sysctl-cluster.md
@@ -131,12 +131,12 @@ containers, resource shortage or complete breakage of a node.
 It is good practice to consider nodes with special sysctl settings as
 _tainted_ within a cluster, and only schedule pods onto them which need those
 sysctl settings. It is suggested to use the Kubernetes [_taints and toleration_
-feature](/docs/user-guide/kubectl/{{page.version}}/#taint) to implement this.
+feature](/docs/reference/generated/kubectl/kubectl-commands/#taint) to implement this.
 
 A pod with the _unsafe_ sysctls will fail to launch on any node which has not
 enabled those two _unsafe_ sysctls explicitly. As with _node-level_ sysctls it
 is recommended to use
-[_taints and toleration_ feature](/docs/user-guide/kubectl/{{page.version}}/#taint) or
+[_taints and toleration_ feature](/docs/reference/generated/kubectl/kubectl-commands/#taint) or
 [taints on nodes](/docs/concepts/configuration/taint-and-toleration/)
 to schedule those pods onto the right nodes.
 


### PR DESCRIPTION
Since we now generate kubectl doc for each release, it is no longer necessary to use the old redirects. I plan to clean up the references in a few reasonably batched PRs, and finally delete the redirect.
