### PR TITLE
Update run-application docs to point to the generated kubectl docs

### DIFF
--- a/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -95,7 +95,7 @@ In addition, there is a special `kubectl autoscale` command for easy creation of
 For instance, executing `kubectl autoscale rc foo --min=2 --max=5 --cpu-percent=80`
 will create an autoscaler for replication controller *foo*, with target CPU utilization set to `80%`
 and the number of replicas between 2 and 5.
-The detailed documentation of `kubectl autoscale` can be found [here](/docs/user-guide/kubectl/{{page.version}}/#autoscale).
+The detailed documentation of `kubectl autoscale` can be found [here](/docs/reference/generated/kubectl/kubectl-commands/#autoscale).
 
 
 ## Autoscaling during rolling update
@@ -182,5 +182,5 @@ custom metrics API and, optionally, external metrics API with the API aggregatio
 ## Further reading
 
 * Design documentation: [Horizontal Pod Autoscaling](https://git.k8s.io/community/contributors/design-proposals/autoscaling/horizontal-pod-autoscaler.md).
-* kubectl autoscale command: [kubectl autoscale](/docs/user-guide/kubectl/{{page.version}}/#autoscale).
+* kubectl autoscale command: [kubectl autoscale](/docs/reference/generated/kubectl/kubectl-commands/#autoscale).
 * Usage example of [Horizontal Pod Autoscaler](/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/).

--- a/docs/tasks/run-application/rolling-update-replication-controller.md
+++ b/docs/tasks/run-application/rolling-update-replication-controller.md
@@ -17,7 +17,7 @@ For more information, see
 [Running a Stateless Application Using a Deployment](/docs/tasks/run-application/run-stateless-application-deployment/).
 {: .note}
 
-To update a service without an outage, `kubectl` supports what is called [rolling update](/docs/user-guide/kubectl/{{page.version}}/#rolling-update), which updates one pod at a time, rather than taking down the entire service at the same time. See the [rolling update design document](https://git.k8s.io/community/contributors/design-proposals/cli/simple-rolling-update.md) for more information.
+To update a service without an outage, `kubectl` supports what is called [rolling update](/docs/reference/generated/kubectl/kubectl-commands/#rolling-update), which updates one pod at a time, rather than taking down the entire service at the same time. See the [rolling update design document](https://git.k8s.io/community/contributors/design-proposals/cli/simple-rolling-update.md) for more information.
 
 Note that `kubectl rolling-update` only supports Replication Controllers. However, if you deploy applications with Replication Controllers,
 consider switching them to [Deployments](/docs/concepts/workloads/controllers/deployment/). A Deployment is a higher-level controller that automates rolling updates
@@ -132,7 +132,7 @@ Optional fields are:
   is `1m0s`. Valid units are as described for `--poll-interval` above.
 
 Additional information about the `kubectl rolling-update` command is available
-from the [`kubectl` reference](/docs/user-guide/kubectl/{{page.version}}/#rolling-update).
+from the [`kubectl` reference](/docs/reference/generated/kubectl/kubectl-commands/#rolling-update).
 
 ## Walkthrough
 

--- a/docs/tasks/run-application/run-replicated-stateful-application.md
+++ b/docs/tasks/run-application/run-replicated-stateful-application.md
@@ -349,7 +349,7 @@ and then return on its own.
 
 If your Kubernetes cluster has multiple Nodes, you can simulate Node downtime
 (such as when Nodes are upgraded) by issuing a
-[drain](/docs/user-guide/kubectl/{{page.version}}/#drain).
+[drain](/docs/reference/generated/kubectl/kubectl-commands/#drain).
 
 First determine which Node one of the MySQL Pods is on:
 

--- a/docs/tasks/run-application/run-single-instance-stateful-application.md
+++ b/docs/tasks/run-application/run-single-instance-stateful-application.md
@@ -181,7 +181,7 @@ underlying resource upon deleting the PersistentVolume.
 
 * Learn more about [Deploying applications](/docs/user-guide/deploying-applications/)
 
-* [kubectl run documentation](/docs/user-guide/kubectl/{{page.version}}/#run)
+* [kubectl run documentation](/docs/reference/generated/kubectl/kubectl-commands/#run)
 
 * [Volumes](/docs/concepts/storage/volumes/) and [Persistent Volumes](/docs/concepts/storage/persistent-volumes/)
 

--- a/docs/tasks/run-application/update-api-object-kubectl-patch.md
+++ b/docs/tasks/run-application/update-api-object-kubectl-patch.md
@@ -316,12 +316,12 @@ kubectl patch deployment patch-demo --patch '{"spec": {"template": {"spec": {"co
 In this exercise, you used `kubectl patch` to change the live configuration
 of a Deployment object. You did not change the configuration file that you originally used to
 create the Deployment object. Other commands for updating API objects include
-[kubectl annotate](/docs/user-guide/kubectl/{{page.version}}/#annotate),
-[kubectl edit](/docs/user-guide/kubectl/{{page.version}}/#edit),
-[kubectl replace](/docs/user-guide/kubectl/{{page.version}}/#replace),
-[kubectl scale](/docs/user-guide/kubectl/{{page.version}}/#scale),
+[kubectl annotate](/docs/reference/generated/kubectl/kubectl-commands/#annotate),
+[kubectl edit](/docs/reference/generated/kubectl/kubectl-commands/#edit),
+[kubectl replace](/docs/reference/generated/kubectl/kubectl-commands/#replace),
+[kubectl scale](/docs/reference/generated/kubectl/kubectl-commands/#scale),
 and
-[kubectl apply](/docs/user-guide/kubectl/{{page.version}}/#apply).
+[kubectl apply](/docs/reference/generated/kubectl/kubectl-commands/#apply).
 
 {% endcapture %}
 


### PR DESCRIPTION
Since we now generate kubectl doc for each release, it is no longer necessary to use the old redirects. I plan to clean up the references in a few reasonably batched PRs, and finally delete the redirect.
