### PR TITLE
Update the stateful-set tutorial to point to the generated kubectl docs

### DIFF
--- a/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -63,7 +63,7 @@ It creates a [Headless Service](/docs/concepts/services-networking/service/#head
 Download the example above, and save it to a file named `web.yaml`
 
 You will need to use two terminal windows. In the first terminal, use 
-[`kubectl get`](/docs/user-guide/kubectl/{{page.version}}/#get) to watch the creation 
+[`kubectl get`](/docs/reference/generated/kubectl/kubectl-commands/#get) to watch the creation 
 of the StatefulSet's Pods.
 
 ```shell
@@ -71,7 +71,7 @@ kubectl get pods -w -l app=nginx
 ```
 
 In the second terminal, use 
-[`kubectl create`](/docs/user-guide/kubectl/{{page.version}}/#create) to create the 
+[`kubectl create`](/docs/reference/generated/kubectl/kubectl-commands/#create) to create the 
 Headless Service and StatefulSet defined in `web.yaml`.
 
 ```shell
@@ -143,7 +143,7 @@ replicas, it creates two Pods, `web-0` and `web-1`.
 ### Using Stable Network Identities
 
 Each Pod has a stable hostname based on its ordinal index. Use
-[`kubectl exec`](/docs/user-guide/kubectl/{{page.version}}/#exec) to execute the 
+[`kubectl exec`](/docs/reference/generated/kubectl/kubectl-commands/#exec) to execute the 
 `hostname` command in each Pod. 
 
 ```shell
@@ -152,7 +152,7 @@ web-0
 web-1
 ```
 
-Use [`kubectl run`](/docs/user-guide/kubectl/{{page.version}}/#run) to execute 
+Use [`kubectl run`](/docs/reference/generated/kubectl/kubectl-commands/#run) to execute 
 a container that provides the `nslookup` command from the `dnsutils` package. 
 Using `nslookup` on the Pods' hostnames, you can examine their in-cluster DNS 
 addresses.
@@ -184,7 +184,7 @@ In one terminal, watch the StatefulSet's Pods.
 kubectl get pod -w -l app=nginx
 ```
 In a second terminal, use
-[`kubectl delete`](/docs/user-guide/kubectl/{{page.version}}/#delete) to delete all 
+[`kubectl delete`](/docs/reference/generated/kubectl/kubectl-commands/#delete) to delete all 
 the Pods in the StatefulSet.
 
 ```shell
@@ -336,8 +336,8 @@ mounted to the appropriate mount points.
 ## Scaling a StatefulSet
 Scaling a StatefulSet refers to increasing or decreasing the number of replicas. 
 This is accomplished by updating the `replicas` field. You can use either
-[`kubectl scale`](/docs/user-guide/kubectl/{{page.version}}/#scale) or
-[`kubectl patch`](/docs/user-guide/kubectl/{{page.version}}/#patch) to scale a StatefulSet.
+[`kubectl scale`](/docs/reference/generated/kubectl/kubectl-commands/#scale) or
+[`kubectl patch`](/docs/reference/generated/kubectl/kubectl-commands/#patch) to scale a StatefulSet.
 
 ### Scaling Up
 
@@ -727,7 +727,7 @@ In one terminal window, watch the Pods in the StatefulSet.
 kubectl get pods -w -l app=nginx
 ```
 
-Use [`kubectl delete`](/docs/user-guide/kubectl/{{page.version}}/#delete) to delete the 
+Use [`kubectl delete`](/docs/reference/generated/kubectl/kubectl-commands/#delete) to delete the 
 StatefulSet. Make sure to supply the `--cascade=false` parameter to the 
 command. This parameter tells Kubernetes to only delete the StatefulSet, and to 
 not delete any of its Pods.


### PR DESCRIPTION
Since we now generate kubectl doc for each release, it is no longer necessary to use the old redirects. I plan to clean up the references in a few reasonably batched PRs, and finally delete the redirect.