### PR TITLE
Remove unnecessary redirects and point to the generated kubectl docs directly

### DIFF
--- a/docs/getting-started-guides/minikube.md
+++ b/docs/getting-started-guides/minikube.md
@@ -229,7 +229,7 @@ This command shuts down and deletes the minikube virtual machine. No data or sta
 
 ### Kubectl
 
-The `minikube start` command creates a "[kubectl context](/docs/user-guide/kubectl/{{page.version}}/#-em-set-context-em-)" called "minikube".
+The `minikube start` command creates a "[kubectl context](/docs/reference/generated/kubectl/kubectl-commands/#-em-set-context-em-)" called "minikube".
 This context contains the configuration to communicate with your minikube cluster.
 
 Minikube sets this context to default automatically, but if you need to switch back to it in the future, run:

--- a/docs/tasks/configure-pod-container/pull-image-private-registry.md
+++ b/docs/tasks/configure-pod-container/pull-image-private-registry.md
@@ -133,7 +133,7 @@ Create a Pod that uses your Secret, and verify that the Pod is running:
 
 * Learn more about [Secrets](/docs/concepts/configuration/secret/).
 * Learn more about [using a private registry](/docs/concepts/containers/images/#using-a-private-registry).
-* See [kubectl create secret docker-registry](/docs/user-guide/kubectl/{{page.version}}/#-em-secret-docker-registry-em-).
+* See [kubectl create secret docker-registry](/docs/reference/generated/kubectl/kubectl-commands/#-em-secret-docker-registry-em-).
 * See [Secret](/docs/reference/generated/kubernetes-api/{{page.version}}/#secret-v1-core).
 * See the `imagePullSecrets` field of [PodSpec](/docs/reference/generated/kubernetes-api/{{page.version}}/#podspec-v1-core).
 

--- a/docs/tasks/debug-application-cluster/get-shell-running-container.md
+++ b/docs/tasks/debug-application-cluster/get-shell-running-container.md
@@ -137,7 +137,7 @@ kubectl exec -it my-pod --container main-app -- /bin/bash
 
 {% capture whatsnext %}
 
-* [kubectl exec](/docs/user-guide/kubectl/{{page.version}}/#exec)
+* [kubectl exec](/docs/reference/generated/kubectl/kubectl-commands/#exec)
 
 {% endcapture %}
 


### PR DESCRIPTION
Since we now generate kubectl doc for each release, it is no longer necessary to use the old redirects. I plan to clean up the references in a few reasonably batched PRs, and finally delete the redirect.