### PR TITLE
Remove redirect and point to the generated kubectl doc directly

### DIFF
--- a/docs/getting-started-guides/minikube.md
+++ b/docs/getting-started-guides/minikube.md
@@ -229,7 +229,7 @@ This command shuts down and deletes the minikube virtual machine. No data or sta
 
 ### Kubectl
 
-The `minikube start` command creates a "[kubectl context](/docs/user-guide/kubectl/{{page.version}}/#-em-set-context-em-)" called "minikube".
+The `minikube start` command creates a "[kubectl context](/docs/reference/generated/kubectl/kubectl-commands/#-em-set-context-em-)" called "minikube".
 This context contains the configuration to communicate with your minikube cluster.
 
 Minikube sets this context to default automatically, but if you need to switch back to it in the future, run:

--- a/docs/reference/kubectl/docker-cli-to-kubectl.md
+++ b/docs/reference/kubectl/docker-cli-to-kubectl.md
@@ -13,7 +13,7 @@ You can use the Kubernetes command line tool kubectl to interact with the api. Y
 
 #### docker run
 
-To run an nginx Deployment and expose the Deployment, see [kubectl run](/docs/user-guide/kubectl/{{page.version}}/#run).
+To run an nginx Deployment and expose the Deployment, see [kubectl run](/docs/reference/generated/kubectl/kubectl-commands/#run).
 
 docker:
 
@@ -59,7 +59,7 @@ To destroy the Deployment and its pods you need to run `kubectl delete deploymen
 
 #### docker ps
 
-To list what is currently running, see [kubectl get](/docs/user-guide/kubectl/{{page.version}}/#get).
+To list what is currently running, see [kubectl get](/docs/reference/generated/kubectl/kubectl-commands/#get).
 
 docker:
 
@@ -81,7 +81,7 @@ ubuntu                      0/1       Completed   0          20s
 
 #### docker attach
 
-To attach a process that is already running in a container, see [kubectl attach](/docs/user-guide/kubectl/{{page.version}}/#attach).
+To attach a process that is already running in a container, see [kubectl attach](/docs/reference/generated/kubectl/kubectl-commands/#attach).
 
 docker:
 
@@ -109,7 +109,7 @@ To detach from the container, you can type the escape sequence Ctrl+P followed b
 
 #### docker exec
 
-To execute a command in a container, see [kubectl exec](/docs/user-guide/kubectl/{{page.version}}/#exec).
+To execute a command in a container, see [kubectl exec](/docs/reference/generated/kubectl/kubectl-commands/#exec).
 
 docker:
 
@@ -154,7 +154,7 @@ For more information, see [Get a Shell to a Running Container](/docs/tasks/debug
 
 #### docker logs
 
-To follow stdout/stderr of a process that is running, see [kubectl logs](/docs/user-guide/kubectl/{{page.version}}/#logs).
+To follow stdout/stderr of a process that is running, see [kubectl logs](/docs/reference/generated/kubectl/kubectl-commands/#logs).
 
 
 docker:
@@ -185,7 +185,7 @@ For more information, see [Logging Architecture](/docs/concepts/cluster-administ
 
 #### docker stop and docker rm
 
-To stop and delete a running process, see [kubectl delete](/docs/user-guide/kubectl/{{page.version}}/#delete).
+To stop and delete a running process, see [kubectl delete](/docs/reference/generated/kubectl/kubectl-commands/#delete).
 
 docker:
 
@@ -228,7 +228,7 @@ There is no direct analog of `docker login` in kubectl. If you are interested in
 
 #### docker version
 
-To get the version of client and server, see [kubectl version](/docs/user-guide/kubectl/{{page.version}}/#version).
+To get the version of client and server, see [kubectl version](/docs/reference/generated/kubectl/kubectl-commands/#version).
 
 docker:
 
@@ -256,7 +256,7 @@ Server Version: version.Info{Major:"1", Minor:"6", GitVersion:"v1.6.9+a3d1dfa6f4
 
 #### docker info
 
-To get miscellaneous information about the environment and configuration, see [kubectl cluster-info](/docs/user-guide/kubectl/{{page.version}}/#cluster-info).
+To get miscellaneous information about the environment and configuration, see [kubectl cluster-info](/docs/reference/generated/kubectl/kubectl-commands/#cluster-info).
 
 docker:
 

--- a/docs/tasks/access-application-cluster/access-cluster.md
+++ b/docs/tasks/access-application-cluster/access-cluster.md
@@ -53,7 +53,7 @@ Run it like this:
 $ kubectl proxy --port=8080 &
 ```
 
-See [kubectl proxy](/docs/user-guide/kubectl/{{page.version}}/#proxy) for more details.
+See [kubectl proxy](/docs/reference/generated/kubectl/kubectl-commands/#proxy) for more details.
 
 Then you can explore the API with curl, wget, or a browser, replacing localhost
 with [::1] for IPv6, like so:
@@ -194,7 +194,7 @@ You have several options for connecting to nodes, pods and services from outside
   - Access services through public IPs.
     - Use a service with type `NodePort` or `LoadBalancer` to make the service reachable outside
       the cluster.  See the [services](/docs/user-guide/services) and
-      [kubectl expose](/docs/user-guide/kubectl/{{page.version}}/#expose) documentation.
+      [kubectl expose](/docs/reference/generated/kubectl/kubectl-commands/#expose) documentation.
     - Depending on your cluster environment, this may just expose the service to your corporate network,
       or it may expose it to the internet.  Think about whether the service being exposed is secure.
       Does it do its own authentication?
@@ -210,7 +210,7 @@ You have several options for connecting to nodes, pods and services from outside
     - Only works for HTTP/HTTPS.
     - Described [here](#manually-constructing-apiserver-proxy-urls).
   - Access from a node or pod in the cluster.
-    - Run a pod, and then connect to a shell in it using [kubectl exec](/docs/user-guide/kubectl/{{page.version}}/#exec).
+    - Run a pod, and then connect to a shell in it using [kubectl exec](/docs/reference/generated/kubectl/kubectl-commands/#exec).
       Connect to other nodes, pods, and services from that shell.
     - Some clusters may allow you to ssh to a node in the cluster.  From there you may be able to
       access cluster services.  This is a non-standard method, and will work on some clusters but

--- a/docs/tasks/access-application-cluster/configure-access-multiple-clusters.md
+++ b/docs/tasks/access-application-cluster/configure-access-multiple-clusters.md
@@ -335,7 +335,7 @@ export KUBECONFIG=$KUBECONFIG_SAVED
 {% capture whatsnext %}
 
 * [Organizing Cluster Access Using kubeconfig Files](/docs/concepts/configuration/organize-cluster-access-kubeconfig/)
-* [kubectl config](/docs/user-guide/kubectl/{{page.version}}/)
+* [kubectl config](/docs/reference/generated/kubectl/kubectl-commands/)
 
 {% endcapture %}
 

--- a/docs/tasks/access-application-cluster/create-external-load-balancer.md
+++ b/docs/tasks/access-application-cluster/create-external-load-balancer.md
@@ -74,7 +74,7 @@ resource (in the case of the example above, a replication controller named
 `example`).
 
 For more information, including optional flags, refer to the
-[`kubectl expose` reference](/docs/user-guide/kubectl/{{page.version}}/#expose).
+[`kubectl expose` reference](/docs/reference/generated/kubectl/kubectl-commands/#expose).
 
 ## Finding your IP address
 

--- a/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
+++ b/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
@@ -132,7 +132,7 @@ The support to UDP protocol is being tracked in
 
 
 {% capture whatsnext %}
-Learn more about [kubectl port-forward](/docs/user-guide/kubectl/{{page.version}}/#port-forward).
+Learn more about [kubectl port-forward](/docs/reference/generated/kubectl/kubectl-commands/#port-forward).
 {% endcapture %}
 
 

--- a/docs/tasks/administer-cluster/access-cluster-api.md
+++ b/docs/tasks/administer-cluster/access-cluster-api.md
@@ -55,7 +55,7 @@ Run it like this:
 $ kubectl proxy --port=8080 &
 ```
 
-See [kubectl proxy](/docs/user-guide/kubectl/{{page.version}}/#proxy) for more details.
+See [kubectl proxy](/docs/reference/generated/kubectl/kubectl-commands/#proxy) for more details.
 
 Then you can explore the API with curl, wget, or a browser, like so:
 

--- a/docs/tasks/administer-cluster/access-cluster-services.md
+++ b/docs/tasks/administer-cluster/access-cluster-services.md
@@ -27,7 +27,7 @@ You have several options for connecting to nodes, pods and services from outside
   - Access services through public IPs.
     - Use a service with type `NodePort` or `LoadBalancer` to make the service reachable outside
       the cluster.  See the [services](/docs/user-guide/services) and
-      [kubectl expose](/docs/user-guide/kubectl/{{page.version}}/#expose) documentation.
+      [kubectl expose](/docs/reference/generated/kubectl/kubectl-commands/#expose) documentation.
     - Depending on your cluster environment, this may just expose the service to your corporate network,
       or it may expose it to the internet.  Think about whether the service being exposed is secure.
       Does it do its own authentication?
@@ -43,7 +43,7 @@ You have several options for connecting to nodes, pods and services from outside
     - Only works for HTTP/HTTPS.
     - Described [here](#manually-constructing-apiserver-proxy-urls).
   - Access from a node or pod in the cluster.
-    - Run a pod, and then connect to a shell in it using [kubectl exec](/docs/user-guide/kubectl/{{page.version}}/#exec).
+    - Run a pod, and then connect to a shell in it using [kubectl exec](/docs/reference/generated/kubectl/kubectl-commands/#exec).
       Connect to other nodes, pods, and services from that shell.
     - Some clusters may allow you to ssh to a node in the cluster. From there you may be able to
       access cluster services. This is a non-standard method, and will work on some clusters but

--- a/docs/tasks/administer-cluster/cluster-management.md
+++ b/docs/tasks/administer-cluster/cluster-management.md
@@ -211,4 +211,4 @@ You can use `kubectl convert` command to convert config files between different 
 kubectl convert -f pod.yaml --output-version v1
 ```
 
-For more options, please refer to the usage of [kubectl convert](/docs/user-guide/kubectl/{{page.version}}/#convert) command.
+For more options, please refer to the usage of [kubectl convert](/docs/reference/generated/kubectl/kubectl-commands/#convert) command.

--- a/docs/tasks/administer-cluster/namespaces-walkthrough.md
+++ b/docs/tasks/administer-cluster/namespaces-walkthrough.md
@@ -201,7 +201,7 @@ $ kubectl run snowflake --image=kubernetes/serve_hostname --replicas=2
 ```
 We have just created a deployment whose replica size is 2 that is running the pod called snowflake with a basic container that just serves the hostname.
 Note that `kubectl run` creates deployments only on Kubernetes cluster >= v1.2. If you are running older versions, it creates replication controllers instead.
-If you want to obtain the old behavior, use `--generator=run/v1` to create replication controllers. See [`kubectl run`](/docs/user-guide/kubectl/{{page.version}}/#run) for more details.
+If you want to obtain the old behavior, use `--generator=run/v1` to create replication controllers. See [`kubectl run`](/docs/reference/generated/kubectl/kubectl-commands/#run) for more details.
 
 ```shell
 $ kubectl get deployment

--- a/docs/tasks/administer-cluster/namespaces.md
+++ b/docs/tasks/administer-cluster/namespaces.md
@@ -238,7 +238,7 @@ $ kubectl run snowflake --image=kubernetes/serve_hostname --replicas=2
 ```
 We have just created a deployment whose replica size is 2 that is running the pod called snowflake with a basic container that just serves the hostname.
 Note that `kubectl run` creates deployments only on Kubernetes cluster >= v1.2. If you are running older versions, it creates replication controllers instead.
-If you want to obtain the old behavior, use `--generator=run/v1` to create replication controllers. See [`kubectl run`](/docs/user-guide/kubectl/{{page.version}}/#run) for more details.
+If you want to obtain the old behavior, use `--generator=run/v1` to create replication controllers. See [`kubectl run`](/docs/reference/generated/kubectl/kubectl-commands/#run) for more details.
 
 ```shell
 $ kubectl get deployment

--- a/docs/tasks/administer-cluster/safely-drain-node.md
+++ b/docs/tasks/administer-cluster/safely-drain-node.md
@@ -38,7 +38,7 @@ and will respect the `PodDisruptionBudgets` you have specified.
 
 **Note:** By default `kubectl drain` will ignore certain system pods on the node
 that cannot be killed; see
-the [kubectl drain](/docs/user-guide/kubectl/{{page.version}}/#drain)
+the [kubectl drain](/docs/reference/generated/kubectl/kubectl-commands/#drain)
 documentation for more details.
 
 When `kubectl drain` returns successfully, that indicates that all of
@@ -89,7 +89,7 @@ budget are blocked.
 
 ## The Eviction API
 
-If you prefer not to use [kubectl drain](/docs/user-guide/kubectl/{{page.version}}/#drain) (such as
+If you prefer not to use [kubectl drain](/docs/reference/generated/kubectl/kubectl-commands/#drain) (such as
 to avoid calling to an external command, or to get finer control over the pod
 eviction process), you can also programmatically cause evictions using the eviction API.
 

--- a/docs/tasks/administer-cluster/sysctl-cluster.md
+++ b/docs/tasks/administer-cluster/sysctl-cluster.md
@@ -131,12 +131,12 @@ containers, resource shortage or complete breakage of a node.
 It is good practice to consider nodes with special sysctl settings as
 _tainted_ within a cluster, and only schedule pods onto them which need those
 sysctl settings. It is suggested to use the Kubernetes [_taints and toleration_
-feature](/docs/user-guide/kubectl/{{page.version}}/#taint) to implement this.
+feature](/docs/reference/generated/kubectl/kubectl-commands/#taint) to implement this.
 
 A pod with the _unsafe_ sysctls will fail to launch on any node which has not
 enabled those two _unsafe_ sysctls explicitly. As with _node-level_ sysctls it
 is recommended to use
-[_taints and toleration_ feature](/docs/user-guide/kubectl/{{page.version}}/#taint) or
+[_taints and toleration_ feature](/docs/reference/generated/kubectl/kubectl-commands/#taint) or
 [taints on nodes](/docs/concepts/configuration/taint-and-toleration/)
 to schedule those pods onto the right nodes.
 

--- a/docs/tasks/configure-pod-container/pull-image-private-registry.md
+++ b/docs/tasks/configure-pod-container/pull-image-private-registry.md
@@ -133,7 +133,7 @@ Create a Pod that uses your Secret, and verify that the Pod is running:
 
 * Learn more about [Secrets](/docs/concepts/configuration/secret/).
 * Learn more about [using a private registry](/docs/concepts/containers/images/#using-a-private-registry).
-* See [kubectl create secret docker-registry](/docs/user-guide/kubectl/{{page.version}}/#-em-secret-docker-registry-em-).
+* See [kubectl create secret docker-registry](/docs/reference/generated/kubectl/kubectl-commands/#-em-secret-docker-registry-em-).
 * See [Secret](/docs/reference/generated/kubernetes-api/{{page.version}}/#secret-v1-core).
 * See the `imagePullSecrets` field of [PodSpec](/docs/reference/generated/kubernetes-api/{{page.version}}/#podspec-v1-core).
 

--- a/docs/tasks/debug-application-cluster/get-shell-running-container.md
+++ b/docs/tasks/debug-application-cluster/get-shell-running-container.md
@@ -137,7 +137,7 @@ kubectl exec -it my-pod --container main-app -- /bin/bash
 
 {% capture whatsnext %}
 
-* [kubectl exec](/docs/user-guide/kubectl/{{page.version}}/#exec)
+* [kubectl exec](/docs/reference/generated/kubectl/kubectl-commands/#exec)
 
 {% endcapture %}
 

--- a/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -95,7 +95,7 @@ In addition, there is a special `kubectl autoscale` command for easy creation of
 For instance, executing `kubectl autoscale rc foo --min=2 --max=5 --cpu-percent=80`
 will create an autoscaler for replication controller *foo*, with target CPU utilization set to `80%`
 and the number of replicas between 2 and 5.
-The detailed documentation of `kubectl autoscale` can be found [here](/docs/user-guide/kubectl/{{page.version}}/#autoscale).
+The detailed documentation of `kubectl autoscale` can be found [here](/docs/reference/generated/kubectl/kubectl-commands/#autoscale).
 
 
 ## Autoscaling during rolling update
@@ -182,5 +182,5 @@ custom metrics API and, optionally, external metrics API with the API aggregatio
 ## Further reading
 
 * Design documentation: [Horizontal Pod Autoscaling](https://git.k8s.io/community/contributors/design-proposals/autoscaling/horizontal-pod-autoscaler.md).
-* kubectl autoscale command: [kubectl autoscale](/docs/user-guide/kubectl/{{page.version}}/#autoscale).
+* kubectl autoscale command: [kubectl autoscale](/docs/reference/generated/kubectl/kubectl-commands/#autoscale).
 * Usage example of [Horizontal Pod Autoscaler](/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/).

--- a/docs/tasks/run-application/rolling-update-replication-controller.md
+++ b/docs/tasks/run-application/rolling-update-replication-controller.md
@@ -17,7 +17,7 @@ For more information, see
 [Running a Stateless Application Using a Deployment](/docs/tasks/run-application/run-stateless-application-deployment/).
 {: .note}
 
-To update a service without an outage, `kubectl` supports what is called [rolling update](/docs/user-guide/kubectl/{{page.version}}/#rolling-update), which updates one pod at a time, rather than taking down the entire service at the same time. See the [rolling update design document](https://git.k8s.io/community/contributors/design-proposals/cli/simple-rolling-update.md) for more information.
+To update a service without an outage, `kubectl` supports what is called [rolling update](/docs/reference/generated/kubectl/kubectl-commands/#rolling-update), which updates one pod at a time, rather than taking down the entire service at the same time. See the [rolling update design document](https://git.k8s.io/community/contributors/design-proposals/cli/simple-rolling-update.md) for more information.
 
 Note that `kubectl rolling-update` only supports Replication Controllers. However, if you deploy applications with Replication Controllers,
 consider switching them to [Deployments](/docs/concepts/workloads/controllers/deployment/). A Deployment is a higher-level controller that automates rolling updates
@@ -132,7 +132,7 @@ Optional fields are:
   is `1m0s`. Valid units are as described for `--poll-interval` above.
 
 Additional information about the `kubectl rolling-update` command is available
-from the [`kubectl` reference](/docs/user-guide/kubectl/{{page.version}}/#rolling-update).
+from the [`kubectl` reference](/docs/reference/generated/kubectl/kubectl-commands/#rolling-update).
 
 ## Walkthrough
 

--- a/docs/tasks/run-application/run-replicated-stateful-application.md
+++ b/docs/tasks/run-application/run-replicated-stateful-application.md
@@ -349,7 +349,7 @@ and then return on its own.
 
 If your Kubernetes cluster has multiple Nodes, you can simulate Node downtime
 (such as when Nodes are upgraded) by issuing a
-[drain](/docs/user-guide/kubectl/{{page.version}}/#drain).
+[drain](/docs/reference/generated/kubectl/kubectl-commands/#drain).
 
 First determine which Node one of the MySQL Pods is on:
 

--- a/docs/tasks/run-application/run-single-instance-stateful-application.md
+++ b/docs/tasks/run-application/run-single-instance-stateful-application.md
@@ -181,7 +181,7 @@ underlying resource upon deleting the PersistentVolume.
 
 * Learn more about [Deploying applications](/docs/user-guide/deploying-applications/)
 
-* [kubectl run documentation](/docs/user-guide/kubectl/{{page.version}}/#run)
+* [kubectl run documentation](/docs/reference/generated/kubectl/kubectl-commands/#run)
 
 * [Volumes](/docs/concepts/storage/volumes/) and [Persistent Volumes](/docs/concepts/storage/persistent-volumes/)
 

--- a/docs/tasks/run-application/update-api-object-kubectl-patch.md
+++ b/docs/tasks/run-application/update-api-object-kubectl-patch.md
@@ -316,12 +316,12 @@ kubectl patch deployment patch-demo --patch '{"spec": {"template": {"spec": {"co
 In this exercise, you used `kubectl patch` to change the live configuration
 of a Deployment object. You did not change the configuration file that you originally used to
 create the Deployment object. Other commands for updating API objects include
-[kubectl annotate](/docs/user-guide/kubectl/{{page.version}}/#annotate),
-[kubectl edit](/docs/user-guide/kubectl/{{page.version}}/#edit),
-[kubectl replace](/docs/user-guide/kubectl/{{page.version}}/#replace),
-[kubectl scale](/docs/user-guide/kubectl/{{page.version}}/#scale),
+[kubectl annotate](/docs/reference/generated/kubectl/kubectl-commands/#annotate),
+[kubectl edit](/docs/reference/generated/kubectl/kubectl-commands/#edit),
+[kubectl replace](/docs/reference/generated/kubectl/kubectl-commands/#replace),
+[kubectl scale](/docs/reference/generated/kubectl/kubectl-commands/#scale),
 and
-[kubectl apply](/docs/user-guide/kubectl/{{page.version}}/#apply).
+[kubectl apply](/docs/reference/generated/kubectl/kubectl-commands/#apply).
 
 {% endcapture %}
 

--- a/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -63,7 +63,7 @@ It creates a [Headless Service](/docs/concepts/services-networking/service/#head
 Download the example above, and save it to a file named `web.yaml`
 
 You will need to use two terminal windows. In the first terminal, use 
-[`kubectl get`](/docs/user-guide/kubectl/{{page.version}}/#get) to watch the creation 
+[`kubectl get`](/docs/reference/generated/kubectl/kubectl-commands/#get) to watch the creation 
 of the StatefulSet's Pods.
 
 ```shell
@@ -71,7 +71,7 @@ kubectl get pods -w -l app=nginx
 ```
 
 In the second terminal, use 
-[`kubectl create`](/docs/user-guide/kubectl/{{page.version}}/#create) to create the 
+[`kubectl create`](/docs/reference/generated/kubectl/kubectl-commands/#create) to create the 
 Headless Service and StatefulSet defined in `web.yaml`.
 
 ```shell
@@ -143,7 +143,7 @@ replicas, it creates two Pods, `web-0` and `web-1`.
 ### Using Stable Network Identities
 
 Each Pod has a stable hostname based on its ordinal index. Use
-[`kubectl exec`](/docs/user-guide/kubectl/{{page.version}}/#exec) to execute the 
+[`kubectl exec`](/docs/reference/generated/kubectl/kubectl-commands/#exec) to execute the 
 `hostname` command in each Pod. 
 
 ```shell
@@ -152,7 +152,7 @@ web-0
 web-1
 ```
 
-Use [`kubectl run`](/docs/user-guide/kubectl/{{page.version}}/#run) to execute 
+Use [`kubectl run`](/docs/reference/generated/kubectl/kubectl-commands/#run) to execute 
 a container that provides the `nslookup` command from the `dnsutils` package. 
 Using `nslookup` on the Pods' hostnames, you can examine their in-cluster DNS 
 addresses.
@@ -184,7 +184,7 @@ In one terminal, watch the StatefulSet's Pods.
 kubectl get pod -w -l app=nginx
 ```
 In a second terminal, use
-[`kubectl delete`](/docs/user-guide/kubectl/{{page.version}}/#delete) to delete all 
+[`kubectl delete`](/docs/reference/generated/kubectl/kubectl-commands/#delete) to delete all 
 the Pods in the StatefulSet.
 
 ```shell
@@ -336,8 +336,8 @@ mounted to the appropriate mount points.
 ## Scaling a StatefulSet
 Scaling a StatefulSet refers to increasing or decreasing the number of replicas. 
 This is accomplished by updating the `replicas` field. You can use either
-[`kubectl scale`](/docs/user-guide/kubectl/{{page.version}}/#scale) or
-[`kubectl patch`](/docs/user-guide/kubectl/{{page.version}}/#patch) to scale a StatefulSet.
+[`kubectl scale`](/docs/reference/generated/kubectl/kubectl-commands/#scale) or
+[`kubectl patch`](/docs/reference/generated/kubectl/kubectl-commands/#patch) to scale a StatefulSet.
 
 ### Scaling Up
 
@@ -727,7 +727,7 @@ In one terminal window, watch the Pods in the StatefulSet.
 kubectl get pods -w -l app=nginx
 ```
 
-Use [`kubectl delete`](/docs/user-guide/kubectl/{{page.version}}/#delete) to delete the 
+Use [`kubectl delete`](/docs/reference/generated/kubectl/kubectl-commands/#delete) to delete the 
 StatefulSet. Make sure to supply the `--cascade=false` parameter to the 
 command. This parameter tells Kubernetes to only delete the StatefulSet, and to 
 not delete any of its Pods.

--- a/docs/tutorials/stateful-application/zookeeper.md
+++ b/docs/tutorials/stateful-application/zookeeper.md
@@ -77,7 +77,7 @@ and a [StatefulSet](/docs/concepts/workloads/controllers/statefulset/).
 {% include code.html language="yaml" file="zookeeper.yaml" ghlink="/docs/tutorials/stateful-application/zookeeper.yaml" %}
 
 Open a terminal, and use the
-[`kubectl apply`](/docs/user-guide/kubectl/{{page.version}}/#apply) command to create the
+[`kubectl apply`](/docs/reference/generated/kubectl/kubectl-commands/#apply) command to create the
 manifest.
 
 ```shell
@@ -94,7 +94,7 @@ poddisruptionbudget "zk-pdb" created
 statefulset "zk" created
 ```
 
-Use [`kubectl get`](/docs/user-guide/kubectl/{{page.version}}/#get) to watch the
+Use [`kubectl get`](/docs/reference/generated/kubectl/kubectl-commands/#get) to watch the
 StatefulSet controller create the StatefulSet's Pods.
 
 ```shell
@@ -129,7 +129,7 @@ a [ZooKeeper](http://www-us.apache.org/dist/zookeeper/stable/) server.
 
 Because there is no terminating algorithm for electing a leader in an anonymous network, Zab requires explicit membership configuration to perform leader election. Each server in the ensemble needs to have a unique identifier, all servers need to know the global set of identifiers, and each identifier needs to be associated with a network address.
 
-Use [`kubectl exec`](/docs/user-guide/kubectl/{{page.version}}/#exec) to get the hostnames
+Use [`kubectl exec`](/docs/reference/generated/kubectl/kubectl-commands/#exec) to get the hostnames
 of the Pods in the `zk` StatefulSet.
 
 ```shell
@@ -307,7 +307,7 @@ in memory state, to storage media. Using WALs to provide durability is a common
 technique for applications that use consensus protocols to achieve a replicated
 state machine.
 
-Use the [`kubectl delete`](/docs/user-guide/kubectl/{{page.version}}/#delete) command to delete the
+Use the [`kubectl delete`](/docs/reference/generated/kubectl/kubectl-commands/#delete) command to delete the
 `zk` StatefulSet.
 
 ```shell
@@ -514,7 +514,7 @@ log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} [myid:%X{myid}] - %-
 
 This is the simplest possible way to safely log inside the container. Because the applications write logs to standard out, Kubernetes will handle log rotation for you. Kubernetes also implements a sane retention policy that ensures application logs written to standard out and standard error do not exhaust local storage media.
 
-Use [`kubectl logs`](/docs/user-guide/kubectl/{{page.version}}/#logs) to retrieve the last 20 log lines from one of the Pods.
+Use [`kubectl logs`](/docs/reference/generated/kubectl/kubectl-commands/#logs) to retrieve the last 20 log lines from one of the Pods.
 
 ```shell
 kubectl logs zk-0 --tail 20
@@ -872,7 +872,7 @@ Use this command to get the nodes in your cluster.
 kubectl get nodes
 ```
 
-Use [`kubectl cordon`](/docs/user-guide/kubectl/{{page.version}}/#cordon) to
+Use [`kubectl cordon`](/docs/reference/generated/kubectl/kubectl-commands/#cordon) to
 cordon all but four of the nodes in your cluster.
 
 ```shell
@@ -909,7 +909,7 @@ kubernetes-minion-group-ixsl
 kubernetes-minion-group-i4c4
 ```
 
-Use [`kubectl drain`](/docs/user-guide/kubectl/{{page.version}}/#drain) to cordon and
+Use [`kubectl drain`](/docs/reference/generated/kubectl/kubectl-commands/#drain) to cordon and
 drain the node on which the `zk-0` Pod is scheduled.
 
 ```shell
@@ -1020,7 +1020,7 @@ dataLength = 5
 numChildren = 0
 ```
 
-Use [`kubectl uncordon`](/docs/user-guide/kubectl/{{page.version}}/#uncordon) to uncordon the first node.
+Use [`kubectl uncordon`](/docs/reference/generated/kubectl/kubectl-commands/#uncordon) to uncordon the first node.
 
 ```shell
 kubectl uncordon kubernetes-minion-group-pb41


### PR DESCRIPTION
Since we now generate the kubectl doc for each release, it is no longer necessary to use the old redirects. Cleaning up the references throughout the documents.
