### PR TITLE
Fix responsive around sidebar on blog

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -87,7 +87,7 @@
 
 
   <div class="row blog-content" >
-   <div class="col-xs-10 col-sm-9 col-lg-9 text">
+   <div class="col-xs-12 col-lg-9 text">
 
        <h4 class="date-header">{{ page.date | date: ' %A, %B %-d, %Y' }} </h4>
       <h3 class="post-title entry-title">  {{page.title}} </h3>
@@ -113,7 +113,7 @@
     </div>
 
 
-    <div class="col-xs-1 col-sm-1 col-sm-3 col-lg-3 text">
+    <div class="col-xs-12 col-lg-3 text">
       <div ="widget-content">
         <link href='http://kubernetes.io/feed.xml' rel='alternate' type='application/atom+xml'>
         <a class="widget-link" href="https://kubernetes.io/feed.xml"> <i class="fas fa-rss fab-icon"> </i> </a>

--- a/css/blog.css
+++ b/css/blog.css
@@ -488,6 +488,14 @@ img.big-img {
   width: 100%;
 }
 
+.blog-content img {
+  max-width: 100%;
+}
+
+.blog-content .content {
+  overflow-x: scroll;
+}
+
 /* .content img {
 max-width: 100%;
 } */


### PR DESCRIPTION
Fix responsive layout broken after blog migration (#7247)

For mobile, we would see as below:

<img width="330" alt="blog-on-mobile-device" src="https://user-images.githubusercontent.com/10229505/39491708-822cacb2-4d8d-11e8-822c-c0fcb2bd4b65.png">
