### PR TITLE
Remove double head tag

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,35 +1,32 @@
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="shortcut icon" type="image/png" href="{{ "images/favicon.png" | relURL }}">
-
-    <link rel="stylesheet" type="text/css" href="/css/base_fonts.css"> 
-    {{ if .Params.case_study_styles }}<link rel="stylesheet" type="text/css" href="{{ "css/case_study_styles.css" | relURL }}"><!-- custom case_study_styles on -->{{ else }}<link rel="stylesheet" type="text/css" href="{{ "css/styles.css" | relURL }}"><!-- default styles.css on -->{{ end }}
-    <link rel="stylesheet" type="text/css" href="https://code.jquery.com/ui/1.12.1/themes/smoothness/jquery-ui.css">
-    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/sweetalert/1.1.3/sweetalert.min.css">
-    <link rel="stylesheet" type="text/css" href="{{ "css/callouts.css" | relURL }}">
-    <link rel="stylesheet" type="text/css" href="{{ "css/custom-jekyll/tags.css" | relURL }}">
-    {{ if .Params.deprecated }}<link rel="stylesheet" type="text/css" href="{{ "css/deprecation-warning.css" | relURL }}">{{ end }}
-    {{ if eq .Params.class "gridPage" }}<link rel="stylesheet" type="text/css" href="{{ "css/gridpage.css" | relURL }}">{{ end }}
-    {{ with .Params.css }}{{ range (split . ",") }}<link rel="stylesheet" type="text/css" href="{{ (trim . " ") | relURL }}"><!-- custom css added -->
-    {{ end }}{{ else }}<!-- no custom css detected -->{{ end }}
-    {{ if .Params.description }}
-    <meta name="description" content="{{ .Params.description }}" />
-    {{ else }}
-    <meta name="description" content="{{ .Params.title }}" />
-    {{ end }}
-    <script
-      src="https://code.jquery.com/jquery-3.2.1.min.js"
-      integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4="
-      crossorigin="anonymous"></script>
-    <script
-      src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"
-      integrity="sha256-VazP97ZCwtekAsvgPBSUwPFKdrwD3unUfSGVYrahUqU="
-      crossorigin="anonymous"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/sweetalert/1.1.3/sweetalert.min.js"></script>
-    <script src="{{ "js/script.js" | relURL }}"></script>
-    <script src="{{ "js/custom-jekyll/tags.js" | relURL }}"></script>
-    {{ with .Params.js }}{{ range (split . ",") }}<script src="{{ (trim . " ") | relURL }}"></script><!-- custom js added -->
-    {{ end }}{{ else }}<!-- no custom js detected -->{{ end }}
-</head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="shortcut icon" type="image/png" href="{{ "images/favicon.png" | relURL }}">
+<link rel="stylesheet" type="text/css" href="/css/base_fonts.css">
+{{ if .Params.case_study_styles }}<link rel="stylesheet" type="text/css" href="{{ "css/case_study_styles.css" | relURL }}"><!-- custom case_study_styles on -->{{ else }}<link rel="stylesheet" type="text/css" href="{{ "css/styles.css" | relURL }}"><!-- default styles.css on -->{{ end }}
+<link rel="stylesheet" type="text/css" href="https://code.jquery.com/ui/1.12.1/themes/smoothness/jquery-ui.css">
+<link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/sweetalert/1.1.3/sweetalert.min.css">
+<link rel="stylesheet" type="text/css" href="{{ "css/callouts.css" | relURL }}">
+<link rel="stylesheet" type="text/css" href="{{ "css/custom-jekyll/tags.css" | relURL }}">
+{{ if .Params.deprecated }}<link rel="stylesheet" type="text/css" href="{{ "css/deprecation-warning.css" | relURL }}">{{ end }}
+{{ if eq .Params.class "gridPage" }}<link rel="stylesheet" type="text/css" href="{{ "css/gridpage.css" | relURL }}">{{ end }}
+{{ with .Params.css }}{{ range (split . ",") }}<link rel="stylesheet" type="text/css" href="{{ (trim . " ") | relURL }}"><!-- custom css added -->
+{{ end }}{{ else }}<!-- no custom css detected -->{{ end }}
+{{ if .Params.description }}
+<meta name="description" content="{{ .Params.description }}" />
+{{ else }}
+<meta name="description" content="{{ .Params.title }}" />
+{{ end }}
+<script
+src="https://code.jquery.com/jquery-3.2.1.min.js"
+integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4="
+crossorigin="anonymous"></script>
+<script
+src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"
+integrity="sha256-VazP97ZCwtekAsvgPBSUwPFKdrwD3unUfSGVYrahUqU="
+crossorigin="anonymous"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/sweetalert/1.1.3/sweetalert.min.js"></script>
+<script src="{{ "js/script.js" | relURL }}"></script>
+<script src="{{ "js/custom-jekyll/tags.js" | relURL }}"></script>
+{{ with .Params.js }}{{ range (split . ",") }}<script src="{{ (trim . " ") | relURL }}"></script><!-- custom js added -->
+{{ end }}{{ else }}<!-- no custom js detected -->{{ end }}


### PR DESCRIPTION
It is also included in the base template to make it well formed.

I did not notice this until I looked for the Hugo generator tag on kubernetes.io.

The browsers seem to be smart about it, but it should be fixed.