### PR TITLE
Switched to using HTML tags for the images so they can support sizing.

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-overview.md
+++ b/content/en/docs/concepts/workloads/pods/pod-overview.md
@@ -38,7 +38,7 @@ Pods are designed to support multiple cooperating processes (as containers) that
 
 Note that grouping multiple co-located and co-managed containers in a single Pod is a relatively advanced use case. You should use this pattern only in specific instances in which your containers are tightly coupled. For example, you might have a container that acts as a web server for files in a shared volume, and a separate "sidecar" container that updates those files from a remote source, as in the following diagram:
 
-![pod diagram](/images/docs/pod.svg){: style="max-width: 50%" }
+<img src="/src/docs/pod.svg" width="50%" alttext="pod diagram" />
 
 Pods provide two kinds of shared resources for their constituent containers: *networking* and *storage*.
 

--- a/content/en/docs/concepts/workloads/pods/pod.md
+++ b/content/en/docs/concepts/workloads/pods/pod.md
@@ -58,7 +58,7 @@ that means that it exists as long as that pod (with that UID) exists. If that
 pod is deleted for any reason, even if an identical replacement is created, the
 related thing (e.g. volume) is also destroyed and created anew.
 
-![pod diagram](/images/docs/pod.svg){: style="max-width: 50%" }
+<img src="/src/docs/pod.svg" width="50%" alttext="pod diagram" />
 
 *A multi-container pod that contains a file puller and a
 web server that uses a persistent volume for shared storage between the containers.*


### PR DESCRIPTION
I was reading through some of the introductory documentation here:

https://kubernetes.io/docs/concepts/workloads/pods/pod/
https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/

I noticed that the styling on the ```pod.svg``` was getting emitted in the rendered HTML. Looks like that syntax isn't supported by whatever markdown processor is being used so I swapped it to a HTML tag.
