### PR TITLE
Create Deployments instead of Pods

### DIFF
--- a/content/cn/docs/tasks/inject-data-application/envars.yaml
+++ b/content/cn/docs/tasks/inject-data-application/envars.yaml
@@ -1,13 +1,22 @@
 apiVersion: v1
-kind: Pod
+kind: Deployment
 metadata:
-  name: envar-demo
-  labels:
-    purpose: demonstrate-envars
-spec:
-  containers:
-  - name: envar-demo-container
-    image: gcr.io/google-samples/node-hello:1.0
-    env:
-    - name: DEMO_GREETING
-      value: "Hello from the environment"
+  name: demonstrate-envars
+spec: # DeploymentSpec
+  selector:
+      matchLabels:
+        app: node-hello
+      replicas: 2
+      template: # PodTemplateSpec
+        metadata:
+            labels:
+              app: node-hello
+        spec: #PodSpec
+          containers:
+          - name: envar-demo-container
+            image: gcr.io/google-samples/node-hello:1.0
+            env:
+            - name: DEMO_GREETING
+              value: "Hello from the environment"
+            - name: DEMO_FAREWELL
+              value: "Such a sweet sorrow"

--- a/content/en/docs/tasks/inject-data-application/commands.yaml
+++ b/content/en/docs/tasks/inject-data-application/commands.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-kind: Pod
+kind: Deployment
 metadata:
   name: command-demo
   labels:
@@ -10,4 +10,3 @@ spec:
     image: debian
     command: ["printenv"]
     args: ["HOSTNAME", "KUBERNETES_PORT"]
-  restartPolicy: OnFailure

--- a/content/en/docs/tasks/inject-data-application/dapi-volume-resources.yaml
+++ b/content/en/docs/tasks/inject-data-application/dapi-volume-resources.yaml
@@ -1,23 +1,23 @@
 apiVersion: v1
-kind: Pod
+kind: Deployment
 metadata:
   name: kubernetes-downwardapi-volume-example-2
 spec:
   containers:
     - name: client-container
-      image: k8s.gcr.io/busybox:1.24
+      image: gcr.io/google_containers/busybox:1.24
       command: ["sh", "-c"]
       args:
       - while true; do
           echo -en '\n';
-          if [[ -e /etc/podinfo/cpu_limit ]]; then
-            echo -en '\n'; cat /etc/podinfo/cpu_limit; fi;
-          if [[ -e /etc/podinfo/cpu_request ]]; then
-            echo -en '\n'; cat /etc/podinfo/cpu_request; fi;
-          if [[ -e /etc/podinfo/mem_limit ]]; then
-            echo -en '\n'; cat /etc/podinfo/mem_limit; fi;
-          if [[ -e /etc/podinfo/mem_request ]]; then
-            echo -en '\n'; cat /etc/podinfo/mem_request; fi;
+          if [[ -e /etc/cpu_limit ]]; then
+            echo -en '\n'; cat /etc/cpu_limit; fi;
+          if [[ -e /etc/cpu_request ]]; then
+            echo -en '\n'; cat /etc/cpu_request; fi;
+          if [[ -e /etc/mem_limit ]]; then
+            echo -en '\n'; cat /etc/mem_limit; fi;
+          if [[ -e /etc/mem_request ]]; then
+            echo -en '\n'; cat /etc/mem_request; fi;
           sleep 5;
         done;
       resources:
@@ -29,10 +29,10 @@ spec:
           cpu: "250m"
       volumeMounts:
         - name: podinfo
-          mountPath: /etc/podinfo
+          mountPath: /etc
           readOnly: false
   volumes:
-    - name: podinfo
+    - name: deploymentInfo
       downwardAPI:
         items:
           - path: "cpu_limit"
@@ -51,4 +51,3 @@ spec:
             resourceFieldRef:
               containerName: client-container
               resource: requests.memory
-

--- a/content/en/docs/tasks/inject-data-application/dapi-volume.yaml
+++ b/content/en/docs/tasks/inject-data-application/dapi-volume.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-kind: Pod
+kind: Deployment
 metadata:
   name: kubernetes-downwardapi-volume-example
   labels:
@@ -12,22 +12,22 @@ metadata:
 spec:
   containers:
     - name: client-container
-      image: k8s.gcr.io/busybox
+      image: gcr.io/google_containers/busybox
       command: ["sh", "-c"]
       args:
       - while true; do
-          if [[ -e /etc/podinfo/labels ]]; then
-            echo -en '\n\n'; cat /etc/podinfo/labels; fi;
-          if [[ -e /etc/podinfo/annotations ]]; then
-            echo -en '\n\n'; cat /etc/podinfo/annotations; fi;
+          if [[ -e /etc/labels ]]; then
+            echo -en '\n\n'; cat /etc/labels; fi;
+          if [[ -e /etc/annotations ]]; then
+            echo -en '\n\n'; cat /etc/annotations; fi;
           sleep 5;
         done;
       volumeMounts:
-        - name: podinfo
-          mountPath: /etc/podinfo
+        - name: deploymentInfo
+          mountPath: /etc
           readOnly: false
   volumes:
-    - name: podinfo
+    - name: deploymentInfo
       downwardAPI:
         items:
           - path: "labels"
@@ -36,4 +36,3 @@ spec:
           - path: "annotations"
             fieldRef:
               fieldPath: metadata.annotations
-

--- a/content/en/docs/tasks/inject-data-application/define-command-argument-container.md
+++ b/content/en/docs/tasks/inject-data-application/define-command-argument-container.md
@@ -1,58 +1,60 @@
 ---
-title: Define a Command and Arguments for a Container
-content_template: templates/task
+title: Defining a Command and Arguments for a Container
+redirect_from:
+- "/docs/concepts/configuration/container-command-args/"
+- "/docs/concepts/configuration/container-command-arg.html"
 ---
 
-{{% capture overview %}}
+{% capture overview %}
 
 This page shows how to define commands and arguments when you run a container
-in a {{< glossary_tooltip term_id="pod" >}}.
+in a Kubernetes Deployment.
 
-{{% /capture %}}
-
-
-{{% capture prerequisites %}}
-
-{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
-
-{{% /capture %}}
+{% endcapture %}
 
 
-{{% capture steps %}}
+{% capture prerequisites %}
 
-## Define a command and arguments when you create a Pod
+{% include task-tutorial-prereqs.md %}
 
-When you create a Pod, you can define a command and arguments for the
-containers that run in the Pod. To define a command, include the `command`
+{% endcapture %}
+
+
+{% capture steps %}
+
+## Defining a command and arguments when you create a Deployment
+
+When you create a Deployment, you can define a command and arguments for the
+containers that run in the Deployment. To define a command, include the `command`
 field in the configuration file. To define arguments for the command, include
 the `args` field in the configuration file. The command and arguments that
-you define cannot be changed after the Pod is created.
+you define cannot be changed after the Deployment is created.
 
 The command and arguments that you define in the configuration file
 override the default command and arguments provided by the container image.
 If you define args, but do not define a command, the default command is used
 with your new arguments.
 
-In this exercise, you create a Pod that runs one container. The configuration
-file for the Pod defines a command and two arguments:
+In this exercise, you create a Deployment that runs one container. The configuration
+file for the Deployment defines a command and two arguments:
 
-{{< code file="commands.yaml" >}}
+{% include code.html language="yaml" file="commands.yaml" ghlink="/docs/tasks/inject-data-application/commands.yaml" %}
 
-1. Create a Pod based on the YAML configuration file:
+1. Create a Deployment based on the YAML configuration file:
 
-       kubectl create -f https://k8s.io/docs/tasks/inject-data-application/commands.yaml
+        kubectl create -f http://k8s.io/docs/tasks/inject-data-application/commands.yaml
 
-1. List the running Pods:
+1. List the running Deployments:
 
-       kubectl get pods
+        kubectl get deployments
 
-    The output shows that the container that ran in the command-demo Pod has
+    The output shows that the container that ran in the command-demo Deployment has
     completed.
 
 1. To see the output of the command that ran in the container, view the logs
-from the Pod:
+from the Deployment:
 
-       kubectl logs command-demo
+        kubectl logs command-demo
 
     The output shows the values of the HOSTNAME and KUBERNETES_PORT environment
     variables:
@@ -60,7 +62,7 @@ from the Pod:
         command-demo
         tcp://10.3.240.1:443
 
-## Use environment variables to define arguments
+## Using environment variables to define arguments
 
 In the preceding example, you defined the arguments directly by
 providing strings. As an alternative to providing strings directly,
@@ -72,18 +74,16 @@ you can define arguments by using environment variables:
     command: ["/bin/echo"]
     args: ["$(MESSAGE)"]
 
-This means you can define an argument for a Pod using any of
+This means you can define an argument for a Deployment using any of
 the techniques available for defining environment variables, including
-[ConfigMaps](/docs/tasks/configure-pod-container/configure-pod-configmap/)
+[ConfigMaps](/docs/tasks/configure-pod-container/configmap/)
 and
 [Secrets](/docs/concepts/configuration/secret/).
 
-{{< note >}}
-**Note:** The environment variable appears in parentheses, `"$(VAR)"`. This is
+NOTE: The environment variable appears in parentheses, `"$(VAR)"`. This is
 required for the variable to be expanded in the `command` or `args` field.
-{{< /note >}}
 
-## Run a command in a shell
+## Running a command in a shell
 
 In some cases, you need your command to run in a shell. For example, your
 command might consist of several commands piped together, or it might be a shell
@@ -127,16 +127,16 @@ Here are some examples:
 |     `[/ep-1]`      |   `[foo bar]`    |   `[/ep-2]`         |     `[zoo boo]`    | `[ep-2 zoo boo]` |
 
 
-{{% /capture %}}
+{% endcapture %}
 
-{{% capture whatsnext %}}
+{% capture whatsnext %}
 
 * Learn more about [containers and commands](/docs/user-guide/containers/).
-* Learn more about [configuring pods and containers](/docs/tasks/).
-* Learn more about [running commands in a container](/docs/tasks/debug-application-cluster/get-shell-running-container/).
-* See [Container](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#container-v1-core).
+* Learn more about [configuring containers](/docs/user-guide/configuring-containers/).
+* Learn more about [running commands in a container](/docs/tasks/kubectl/get-shell-running-container/).
+* See [Container](/docs/api-reference/v1.6/#container-v1-core).
 
-{{% /capture %}}
+{% endcapture %}
 
 
-
+{% include templates/task.md %}

--- a/content/en/docs/tasks/inject-data-application/define-command-argument-container.md
+++ b/content/en/docs/tasks/inject-data-application/define-command-argument-container.md
@@ -1,26 +1,24 @@
 ---
 title: Defining a Command and Arguments for a Container
-redirect_from:
-- "/docs/concepts/configuration/container-command-args/"
-- "/docs/concepts/configuration/container-command-arg.html"
+content_template: templates/task
 ---
 
-{% capture overview %}
+{{% capture overview %}}
 
 This page shows how to define commands and arguments when you run a container
 in a Kubernetes Deployment.
 
-{% endcapture %}
+{{% endcapture %}}
 
 
-{% capture prerequisites %}
+{{% capture prerequisites %}}
 
-{% include task-tutorial-prereqs.md %}
+{{% include task-tutorial-prereqs.md %}}
 
-{% endcapture %}
+{{% endcapture %}}
 
 
-{% capture steps %}
+{{% capture steps %}}
 
 ## Defining a command and arguments when you create a Deployment
 
@@ -38,15 +36,15 @@ with your new arguments.
 In this exercise, you create a Deployment that runs one container. The configuration
 file for the Deployment defines a command and two arguments:
 
-{% include code.html language="yaml" file="commands.yaml" ghlink="/docs/tasks/inject-data-application/commands.yaml" %}
+{{% include code.html language="yaml" file="commands.yaml" ghlink="/docs/tasks/inject-data-application/commands.yaml" %}}
 
 1. Create a Deployment based on the YAML configuration file:
 
-        kubectl create -f http://k8s.io/docs/tasks/inject-data-application/commands.yaml
+      kubectl create -f https://k8s.io/docs/tasks/inject-data-application/commands.yaml
 
 1. List the running Deployments:
 
-        kubectl get deployments
+      kubectl get deployments
 
     The output shows that the container that ran in the command-demo Deployment has
     completed.
@@ -54,7 +52,7 @@ file for the Deployment defines a command and two arguments:
 1. To see the output of the command that ran in the container, view the logs
 from the Deployment:
 
-        kubectl logs command-demo
+      kubectl logs command-demo
 
     The output shows the values of the HOSTNAME and KUBERNETES_PORT environment
     variables:
@@ -80,8 +78,10 @@ the techniques available for defining environment variables, including
 and
 [Secrets](/docs/concepts/configuration/secret/).
 
+{{< note >}}
 NOTE: The environment variable appears in parentheses, `"$(VAR)"`. This is
 required for the variable to be expanded in the `command` or `args` field.
+{{< /note >}}
 
 ## Running a command in a shell
 
@@ -127,16 +127,16 @@ Here are some examples:
 |     `[/ep-1]`      |   `[foo bar]`    |   `[/ep-2]`         |     `[zoo boo]`    | `[ep-2 zoo boo]` |
 
 
-{% endcapture %}
+{{% endcapture %}}
 
-{% capture whatsnext %}
+{{% capture whatsnext %}}
 
 * Learn more about [containers and commands](/docs/user-guide/containers/).
 * Learn more about [configuring containers](/docs/user-guide/configuring-containers/).
 * Learn more about [running commands in a container](/docs/tasks/kubectl/get-shell-running-container/).
 * See [Container](/docs/api-reference/v1.6/#container-v1-core).
 
-{% endcapture %}
+{{% endcapture %}}
 
 
-{% include templates/task.md %}
+{{% include templates/task.md %}}

--- a/content/en/docs/tasks/inject-data-application/define-environment-variable-container.md
+++ b/content/en/docs/tasks/inject-data-application/define-environment-variable-container.md
@@ -1,58 +1,60 @@
 ---
-title: Define Environment Variables for a Container
-content_template: templates/task
+title: Defining Environment Variables for a Container
+redirect_from:
+- "/docs/tasks/configure-pod-container/define-environment-variable-container/"
+- "/docs/tasks/configure-pod-container/define-environment-variable-container.html"
 ---
 
-{{% capture overview %}}
+{% capture overview %}
 
-This page shows how to define environment variables for a container
-in a Kubernetes Pod.
+This page shows how to define environment variables when you run a container
+in a Kubernetes Deployment.
 
-{{% /capture %}}
-
-
-{{% capture prerequisites %}}
-
-{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
-
-{{% /capture %}}
+{% endcapture %}
 
 
-{{% capture steps %}}
+{% capture prerequisites %}
 
-## Define an environment variable for a container
+{% include task-tutorial-prereqs.md %}
 
-When you create a Pod, you can set environment variables for the containers
-that run in the Pod. To set environment variables, include the `env` or
+{% endcapture %}
+
+
+{% capture steps %}
+
+## Defining an environment variable for a container
+
+When you create a Deployment, you can set environment variables for the containers
+that run in the Deployment. To set environment variables, include the `env` or
 `envFrom` field in the configuration file.
 
-In this exercise, you create a Pod that runs one container. The configuration
-file for the Pod defines an environment variable with name `DEMO_GREETING` and
+In this exercise, you create a Deployment that runs one container. The configuration
+file for the Deployment defines an environment variable with name `DEMO_GREETING` and
 value `"Hello from the environment"`. Here is the configuration file for the
-Pod:
+Deployment:
 
-{{< code file="envars.yaml" >}}
+{% include code.html language="yaml" file="envars.yaml" ghlink="/docs/tasks/inject-data-application/envars.yaml" %}
 
-1. Create a Pod based on the YAML configuration file:
+1. Create a Deployment based on the YAML configuration file:
 
-       kubectl create -f https://k8s.io/docs/tasks/inject-data-application/envars.yaml
+        kubectl create -f http://k8s.io/docs/tasks/inject-data-application/envars.yaml
 
-1. List the running Pods:
+1. List the running Deployments:
 
-       kubectl get pods -l purpose=demonstrate-envars
+        kubectl get deployments -l name=demonstrate-envars
 
     The output is similar to this:
 
         NAME            READY     STATUS    RESTARTS   AGE
         envar-demo      1/1       Running   0          9s
 
-1. Get a shell to the container running in your Pod:
+1. Get a shell to the container running in your Deployment:
 
-       kubectl exec -it envar-demo -- /bin/bash
+        kubectl exec -it envar-demo -- /bin/bash
 
 1. In your shell, run the `printenv` command to list the environment variables.
 
-       root@envar-demo:/# printenv
+        root@envar-demo:/# printenv
 
     The output is similar to this:
 
@@ -61,24 +63,18 @@ Pod:
         HOSTNAME=envar-demo
         ...
         DEMO_GREETING=Hello from the environment
-        DEMO_FAREWELL=Such a sweet sorrow
 
 1. To exit the shell, enter `exit`.
 
-{{< note >}}
-**Note:** The environment variables set using the `env` or `envFrom` field
-will override any environment variables specified in the container image.
-{{< /note >}}
+{% endcapture %}
 
-{{% /capture %}}
-
-{{% capture whatsnext %}}
+{% capture whatsnext %}
 
 * Learn more about [environment variables](/docs/tasks/configure-pod-container/environment-variable-expose-pod-information/).
 * Learn about [using secrets as environment variables](/docs/user-guide/secrets/#using-secrets-as-environment-variables).
-* See [EnvVarSource](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#envvarsource-v1-core).
+* See [EnvVarSource](/docs/api-reference/v1.6/#envvarsource-v1-core).
 
-{{% /capture %}}
+{% endcapture %}
 
 
-
+{% include templates/task.md %}

--- a/content/en/docs/tasks/inject-data-application/define-environment-variable-container.md
+++ b/content/en/docs/tasks/inject-data-application/define-environment-variable-container.md
@@ -1,26 +1,24 @@
 ---
 title: Defining Environment Variables for a Container
-redirect_from:
-- "/docs/tasks/configure-pod-container/define-environment-variable-container/"
-- "/docs/tasks/configure-pod-container/define-environment-variable-container.html"
+content_template: templates/task
 ---
 
-{% capture overview %}
+{{% capture overview %}}
 
 This page shows how to define environment variables when you run a container
 in a Kubernetes Deployment.
 
-{% endcapture %}
+{{% endcapture %}}
 
 
-{% capture prerequisites %}
+{{% capture prerequisites %}}
 
-{% include task-tutorial-prereqs.md %}
+{{% include task-tutorial-prereqs.md %}}
 
-{% endcapture %}
+{{% endcapture %}}
 
 
-{% capture steps %}
+{{% capture steps %}}
 
 ## Defining an environment variable for a container
 
@@ -33,15 +31,15 @@ file for the Deployment defines an environment variable with name `DEMO_GREETING
 value `"Hello from the environment"`. Here is the configuration file for the
 Deployment:
 
-{% include code.html language="yaml" file="envars.yaml" ghlink="/docs/tasks/inject-data-application/envars.yaml" %}
+{{% include code.html language="yaml" file="envars.yaml" ghlink="/docs/tasks/inject-data-application/envars.yaml" %}}
 
 1. Create a Deployment based on the YAML configuration file:
 
-        kubectl create -f http://k8s.io/docs/tasks/inject-data-application/envars.yaml
+      kubectl create -f https://k8s.io/docs/tasks/inject-data-application/envars.yaml
 
 1. List the running Deployments:
 
-        kubectl get deployments -l name=demonstrate-envars
+      kubectl get deployments -l name=demonstrate-envars
 
     The output is similar to this:
 
@@ -50,11 +48,11 @@ Deployment:
 
 1. Get a shell to the container running in your Deployment:
 
-        kubectl exec -it envar-demo -- /bin/bash
+      kubectl exec -it envar-demo -- /bin/bash
 
 1. In your shell, run the `printenv` command to list the environment variables.
 
-        root@envar-demo:/# printenv
+      root@envar-demo:/# printenv
 
     The output is similar to this:
 
@@ -66,15 +64,15 @@ Deployment:
 
 1. To exit the shell, enter `exit`.
 
-{% endcapture %}
+{{% endcapture %}}
 
-{% capture whatsnext %}
+{{% capture whatsnext %}}
 
 * Learn more about [environment variables](/docs/tasks/configure-pod-container/environment-variable-expose-pod-information/).
 * Learn about [using secrets as environment variables](/docs/user-guide/secrets/#using-secrets-as-environment-variables).
 * See [EnvVarSource](/docs/api-reference/v1.6/#envvarsource-v1-core).
 
-{% endcapture %}
+{{% endcapture %}}
 
 
-{% include templates/task.md %}
+{{% include templates/task.md %}}

--- a/content/en/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
+++ b/content/en/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
@@ -45,8 +45,10 @@ The first element specifies that the value of the Deployment's
 The second element specifies that the value of the Deployment's `annotations`
 field should be stored in a file named `annotations`.
 
+{{< note >}}
 **Note**: The fields in this example are Deployment fields. They are not
 fields of the Container in the Deployment.
+{{< /note >}}
 
 Create the Deployment:
 
@@ -86,6 +88,7 @@ kubectl exec -it kubernetes-downwardapi-volume-example -- sh
 In your shell, view the `labels` file:
 
 ```shell
+cat /etc/deploymentinfo/labels
 /
 ```
 
@@ -101,13 +104,13 @@ zone="us-est-coast"
 Similarly, view the `annotations` file:
 
 ```shell
-/
+/cat /etc/deploymentinfo/annotations
 ```
 
-View the files in the `/etc` directory:
+View the files in the `/etc/deployment info` directory:
 
 ```shell
-/
+/ls -laR /etc/deploymentinfo
 ```
 
 In the output, you can see that the `labels` and `annotations` files
@@ -136,6 +139,7 @@ atomically using
 Exit the shell:
 
 ```shell
+exit
 /
 ```
 
@@ -172,6 +176,7 @@ kubectl exec -it kubernetes-downwardapi-volume-example-2 -- sh
 In your shell, view the `cpu_limit` file:
 
 ```shell
+cat /etc/deploymentinfo/cpu_limit
 ```
 You can use similar commands to view the `cpu_request`, `mem_limit` and
 `mem_request` files.

--- a/content/en/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
+++ b/content/en/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
@@ -1,67 +1,69 @@
 ---
-title: Expose Pod Information to Containers Through Files
-content_template: templates/task
+title: Exposing Deployment Information to Containers Through Files
+redirect_from:
+- "/docs/user-guide/downward-api/"
+- "/docs/user-guide/downward-api/index.html"
+- "/docs/user-guide/downward-api/volume/"
+- "/docs/user-guide/downward-api/volume/index.html"
+- "/docs/tasks/configure-pod-container/downward-api-volume-expose-pod-information/"
+- "/docs/tasks/configure-pod-container/downward-api-volume-expose-pod-information.html"
 ---
 
-{{% capture overview %}}
+{% capture overview %}
 
-This page shows how a Pod can use a DownwardAPIVolumeFile to expose information
-about itself to Containers running in the Pod. A DownwardAPIVolumeFile can expose
-Pod fields and Container fields.
+This page shows how a Deployment can use a DownwardAPIVolumeFile to expose information about itself to Containers running in the Deployment. A DownwardAPIVolumeFile can expose Deployment fields and Container fields.
 
-{{% /capture %}}
+{% endcapture %}
 
 
-{{% capture prerequisites %}}
+{% capture prerequisites %}
 
-{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+{% include task-tutorial-prereqs.md %}
 
-{{% /capture %}}
+{% endcapture %}
 
-{{% capture steps %}}
+{% capture steps %}
 
 ## The Downward API
 
-There are two ways to expose Pod and Container fields to a running Container:
+There are two ways to expose Deployment and Container fields to a running Container:
 
 * [Environment variables](/docs/tasks/configure-pod-container/environment-variable-expose-pod-information/)
 * DownwardAPIVolumeFiles
 
-Together, these two ways of exposing Pod and Container fields are called the
+Together, these two ways of exposing Deployment and Container fields are called the
 *Downward API*.
 
-## Store Pod fields
+## Storing Deployment fields
 
-In this exercise, you create a Pod that has one Container.
-Here is the configuration file for the Pod:
+In this exercise, you create a Deployment that has one Container.
+Here is the configuration file for the Deployment:
 
-{{< code file="dapi-volume.yaml" >}}
+{% include code.html language="yaml" file="dapi-volume.yaml" ghlink="/docs/tasks/inject-data-application/dapi-volume.yaml" %}
 
-In the configuration file, you can see that the Pod has a `downwardAPI` Volume,
-and the Container mounts the Volume at `/etc/podinfo`.
+In the configuration file, you can see that the Deployment has a `downwardAPI` Volume,
+and the Container mounts the Volume at `/etc`.
 
 Look at the `items` array under `downwardAPI`. Each element of the array is a
-[DownwardAPIVolumeFile](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#downwardapivolumefile-v1-core).
-The first element specifies that the value of the Pod's
+[DownwardAPIVolumeFile](/docs/resources-reference/v1.6/#downwardapivolumefile-v1-core).
+The first element specifies that the value of the Deployment's
 `metadata.labels` field should be stored in a file named `labels`.
-The second element specifies that the value of the Pod's `annotations`
+The second element specifies that the value of the Deployment's `annotations`
 field should be stored in a file named `annotations`.
 
-{{< note >}}
-**Note:** The fields in this example are Pod fields. They are not
-fields of the Container in the Pod.
-{{< /note >}}
+**Note**: The fields in this example are Deployment fields. They are not
+fields of the Container in the Deployment.
 
-Create the Pod:
+Create the Deployment:
 
 ```shell
-kubectl create -f https://k8s.io/docs/tasks/inject-data-application/dapi-volume.yaml
+kubectl create -f http://k8s.io/docs/tasks/inject-data-application/dapi-volume.yaml
 ```
 
-Verify that Container in the Pod is running:
+Verify that Container in the Deployment is running:
 
 ```shell
-kubectl get pods
+kubectl get deployments
 ```
 
 View the Container's logs:
@@ -81,7 +83,7 @@ build="two"
 builder="john-doe"
 ```
 
-Get a shell into the Container that is running in your Pod:
+Get a shell into the Container that is running in your Deployment:
 
 ```
 kubectl exec -it kubernetes-downwardapi-volume-example -- sh
@@ -90,10 +92,10 @@ kubectl exec -it kubernetes-downwardapi-volume-example -- sh
 In your shell, view the `labels` file:
 
 ```shell
-/# cat /etc/podinfo/labels
+/# cat /etc/labels
 ```
 
-The output shows that all of the Pod's labels have been written
+The output shows that all of the Deployment's labels have been written
 to the `labels` file:
 
 ```shell
@@ -105,19 +107,19 @@ zone="us-est-coast"
 Similarly, view the `annotations` file:
 
 ```shell
-/# cat /etc/podinfo/annotations
+/# cat /etc/annotations
 ```
 
-View the files in the `/etc/podinfo` directory:
+View the files in the `/etc` directory:
 
 ```shell
-/# ls -laR /etc/podinfo
+/# ls -laR /etc
 ```
 
 In the output, you can see that the `labels` and `annotations` files
 are in a temporary subdirectory: in this example,
-`..2982_06_02_21_47_53.299460680`. In the `/etc/podinfo` directory, `..data` is
-a symbolic link to the temporary subdirectory. Also in  the `/etc/podinfo` directory,
+`..2982_06_02_21_47_53.299460680`. In the `/etc` directory, `..data` is
+a symbolic link to the temporary subdirectory. Also in  the `/etc` directory,
 `labels` and `annotations` are symbolic links.
 
 ```
@@ -137,28 +139,22 @@ written to a new temporary directory, and the `..data` symlink is updated
 atomically using
 [rename(2)](http://man7.org/linux/man-pages/man2/rename.2.html).
 
-{{< note >}}
-**Note:** A container using Downward API as a
-[subPath](/docs/concepts/storage/volumes/#using-subpath) volume mount will not
-receive Downward API updates.
-{{< /note >}}
-
 Exit the shell:
 
 ```shell
 /# exit
 ```
 
-## Store Container fields
+## Storing Container fields
 
-The preceding exercise, you stored Pod fields in a DownwardAPIVolumeFile.
+The preceding exercise, you stored Deployment fields in a DownwardAPIVolumeFile.
 In this next exercise, you store Container fields. Here is the configuration
-file for a Pod that has one Container:
+file for a Deployment that has one Container:
 
-{{< code file="dapi-volume-resources.yaml" >}}
+{% include code.html language="yaml" file="dapi-volume-resources.yaml" ghlink="/docs/tasks/inject-data-application/dapi-volume-resources.yaml" %}
 
-In the configuration file, you can see that the Pod has a `downwardAPI` Volume,
-and the Container mounts the Volume at `/etc/podinfo`.
+In the configuration file, you can see that the Deployment has a `downwardAPI` Volume,
+and the Container mounts the Volume at `/etc`.
 
 Look at the `items` array under `downwardAPI`. Each element of the array is a
 DownwardAPIVolumeFile.
@@ -167,13 +163,13 @@ The first element specifies that in the Container named `client-container`,
 the value of the `limits.cpu` field
 should be stored in a file named `cpu_limit`.
 
-Create the Pod:
+Create the Deployment:
 
 ```shell
-kubectl create -f https://k8s.io/docs/tasks/inject-data-application/dapi-volume-resources.yaml
+kubectl create -f http://k8s.io/docs/tasks/inject-data-application/dapi-volume-resources.yaml
 ```
 
-Get a shell into the Container that is running in your Pod:
+Get a shell into the Container that is running in your Deployment:
 
 ```
 kubectl exec -it kubernetes-downwardapi-volume-example-2 -- sh
@@ -182,48 +178,40 @@ kubectl exec -it kubernetes-downwardapi-volume-example-2 -- sh
 In your shell, view the `cpu_limit` file:
 
 ```shell
-/# cat /etc/podinfo/cpu_limit
+/# cat /etc/cpu_limit
 ```
 You can use similar commands to view the `cpu_request`, `mem_limit` and
 `mem_request` files.
 
-{{% /capture %}}
+{% endcapture %}
 
-{{% capture discussion %}}
+{% capture discussion %}
 
 ## Capabilities of the Downward API
 
-The following information is available to containers through environment
-variables and `downwardAPI` volumes:
+The following information is available to Containers through environment
+variables and DownwardAPIVolumeFiles:
 
-* Information available via `fieldRef`:
-  * `spec.nodeName` - the node’s name
-  * `status.hostIP` - the node's IP
-  * `metadata.name` - the pod’s name
-  * `metadata.namespace` - the pod’s namespace
-  * `status.podIP` - the pod’s IP address
-  * `spec.serviceAccountName` - the pod’s service account name
-  * `metadata.uid` - the pod’s UID
-  * `metadata.labels['<KEY>']` - the value of the pod’s label `<KEY>` (for example, `metadata.labels['mylabel']`); available in Kubernetes 1.9+
-  * `metadata.annotations['<KEY>']` - the value of the pod’s annotation `<KEY>` (for example, `metadata.annotations['myannotation']`); available in Kubernetes 1.9+
-* Information available via `resourceFieldRef`:
-  * A Container’s CPU limit
-  * A Container’s CPU request
-  * A Container’s memory limit
-  * A Container’s memory request
+* The node’s name
+* The Deployment's name
+* The Deployment's namespace
+* The Deployment's IP address
+* The Deployment's service account name
+* A Container’s CPU limit
+* A container’s CPU request
+* A Container’s memory limit
+* A Container’s memory request
 
 In addition, the following information is available through
-`downwardAPI` volume `fieldRef`:
+DownwardAPIVolumeFiles.
 
-* `metadata.labels` - all of the pod’s labels, formatted as `label-key="escaped-label-value"` with one label per line
-* `metadata.annotations` - all of the pod’s annotations, formatted as `annotation-key="escaped-annotation-value"` with one annotation per line
+* The Deployment's labels
+* The Deployment's annotations
 
-{{< note >}}
-**Note:** If CPU and memory limits are not specified for a Container, the
+**Note**: If CPU and memory limits are not specified for a Container, the
 Downward API defaults to the node allocatable value for CPU and memory.
-{{< /note >}}
 
-## Project keys to specific paths and file permissions
+## Projecting keys to specific paths and file permissions
 
 You can project keys to specific paths and specific permissions on a per-file
 basis. For more information, see
@@ -239,21 +227,20 @@ or API server.
 An example is an existing application that assumes a particular well-known
 environment variable holds a unique identifier. One possibility is to wrap the
 application, but that is tedious and error prone, and it violates the goal of low
-coupling. A better option would be to use the Pod's name as an identifier, and
-inject the Pod's name into the well-known environment variable.
+coupling. A better option would be to use the Deployment's name as an identifier, and
+inject the Deployment's name into the well-known environment variable.
 
-{{% /capture %}}
-
-
-{{% capture whatsnext %}}
-
-* [PodSpec](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#podspec-v1-core)
-* [Volume](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#volume-v1-core)
-* [DownwardAPIVolumeSource](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#downwardapivolumesource-v1-core)
-* [DownwardAPIVolumeFile](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#downwardapivolumefile-v1-core)
-* [ResourceFieldSelector](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#resourcefieldselector-v1-core)
-
-{{% /capture %}}
+{% endcapture %}
 
 
+{% capture whatsnext %}
 
+* [PodSpec](/docs/resources-reference/v1.6/#podspec-v1-core)
+* [Volume](/docs/resources-reference/v1.6/#volume-v1-core)
+* [DownwardAPIVolumeSource](/docs/resources-reference/v1.6/#downwardapivolumesource-v1-core)
+* [DownwardAPIVolumeFile](/docs/resources-reference/v1.6/#downwardapivolumefile-v1-core)
+* [ResourceFieldSelector](/docs/resources-reference/v1.6/#resourcefieldselector-v1-core)
+
+{% endcapture %}
+
+{% include templates/task.md %}

--- a/content/en/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
+++ b/content/en/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
@@ -1,28 +1,22 @@
 ---
-title: Exposing Deployment Information to Containers Through Files
-redirect_from:
-- "/docs/user-guide/downward-api/"
-- "/docs/user-guide/downward-api/index.html"
-- "/docs/user-guide/downward-api/volume/"
-- "/docs/user-guide/downward-api/volume/index.html"
-- "/docs/tasks/configure-pod-container/downward-api-volume-expose-pod-information/"
-- "/docs/tasks/configure-pod-container/downward-api-volume-expose-pod-information.html"
+title: Exposing Pod Information to Containers Through Files
+content_template: templates/task
 ---
 
-{% capture overview %}
+{{% capture overview %}}
 
 This page shows how a Deployment can use a DownwardAPIVolumeFile to expose information about itself to Containers running in the Deployment. A DownwardAPIVolumeFile can expose Deployment fields and Container fields.
 
-{% endcapture %}
+{{% endcapture %}}
 
 
-{% capture prerequisites %}
+{{% capture prerequisites %}}
 
-{% include task-tutorial-prereqs.md %}
+{{% include task-tutorial-prereqs.md %}}
 
-{% endcapture %}
+{{% endcapture %}}
 
-{% capture steps %}
+{{% capture steps %}}
 
 ## The Downward API
 
@@ -39,7 +33,7 @@ Together, these two ways of exposing Deployment and Container fields are called 
 In this exercise, you create a Deployment that has one Container.
 Here is the configuration file for the Deployment:
 
-{% include code.html language="yaml" file="dapi-volume.yaml" ghlink="/docs/tasks/inject-data-application/dapi-volume.yaml" %}
+{{% include code.html language="yaml" file="dapi-volume.yaml" ghlink="/docs/tasks/inject-data-application/dapi-volume.yaml" %}
 
 In the configuration file, you can see that the Deployment has a `downwardAPI` Volume,
 and the Container mounts the Volume at `/etc`.
@@ -57,7 +51,7 @@ fields of the Container in the Deployment.
 Create the Deployment:
 
 ```shell
-kubectl create -f http://k8s.io/docs/tasks/inject-data-application/dapi-volume.yaml
+kubectl create -f https://k8s.io/docs/tasks/inject-data-application/dapi-volume.yaml
 ```
 
 Verify that Container in the Deployment is running:
@@ -92,7 +86,7 @@ kubectl exec -it kubernetes-downwardapi-volume-example -- sh
 In your shell, view the `labels` file:
 
 ```shell
-/# cat /etc/labels
+/
 ```
 
 The output shows that all of the Deployment's labels have been written
@@ -107,13 +101,13 @@ zone="us-est-coast"
 Similarly, view the `annotations` file:
 
 ```shell
-/# cat /etc/annotations
+/
 ```
 
 View the files in the `/etc` directory:
 
 ```shell
-/# ls -laR /etc
+/
 ```
 
 In the output, you can see that the `labels` and `annotations` files
@@ -142,7 +136,7 @@ atomically using
 Exit the shell:
 
 ```shell
-/# exit
+/
 ```
 
 ## Storing Container fields
@@ -151,7 +145,7 @@ The preceding exercise, you stored Deployment fields in a DownwardAPIVolumeFile.
 In this next exercise, you store Container fields. Here is the configuration
 file for a Deployment that has one Container:
 
-{% include code.html language="yaml" file="dapi-volume-resources.yaml" ghlink="/docs/tasks/inject-data-application/dapi-volume-resources.yaml" %}
+{{% include code.html language="yaml" file="dapi-volume-resources.yaml" ghlink="/docs/tasks/inject-data-application/dapi-volume-resources.yaml" %}}
 
 In the configuration file, you can see that the Deployment has a `downwardAPI` Volume,
 and the Container mounts the Volume at `/etc`.
@@ -166,7 +160,7 @@ should be stored in a file named `cpu_limit`.
 Create the Deployment:
 
 ```shell
-kubectl create -f http://k8s.io/docs/tasks/inject-data-application/dapi-volume-resources.yaml
+kubectl create -f https://k8s.io/docs/tasks/inject-data-application/dapi-volume-resources.yaml
 ```
 
 Get a shell into the Container that is running in your Deployment:
@@ -178,14 +172,13 @@ kubectl exec -it kubernetes-downwardapi-volume-example-2 -- sh
 In your shell, view the `cpu_limit` file:
 
 ```shell
-/# cat /etc/cpu_limit
 ```
 You can use similar commands to view the `cpu_request`, `mem_limit` and
 `mem_request` files.
 
-{% endcapture %}
+{{% endcapture %}}
 
-{% capture discussion %}
+{{% capture discussion %}}
 
 ## Capabilities of the Downward API
 
@@ -208,8 +201,10 @@ DownwardAPIVolumeFiles.
 * The Deployment's labels
 * The Deployment's annotations
 
+{{< note >}}
 **Note**: If CPU and memory limits are not specified for a Container, the
 Downward API defaults to the node allocatable value for CPU and memory.
+{{< /note >}}
 
 ## Projecting keys to specific paths and file permissions
 
@@ -230,10 +225,10 @@ application, but that is tedious and error prone, and it violates the goal of lo
 coupling. A better option would be to use the Deployment's name as an identifier, and
 inject the Deployment's name into the well-known environment variable.
 
-{% endcapture %}
+{{% endcapture %}}
 
 
-{% capture whatsnext %}
+{{% capture whatsnext %}}
 
 * [PodSpec](/docs/resources-reference/v1.6/#podspec-v1-core)
 * [Volume](/docs/resources-reference/v1.6/#volume-v1-core)
@@ -241,6 +236,6 @@ inject the Deployment's name into the well-known environment variable.
 * [DownwardAPIVolumeFile](/docs/resources-reference/v1.6/#downwardapivolumefile-v1-core)
 * [ResourceFieldSelector](/docs/resources-reference/v1.6/#resourcefieldselector-v1-core)
 
-{% endcapture %}
+{{% endcapture %}}
 
-{% include templates/task.md %}
+{{% include templates/task.md %}}


### PR DESCRIPTION
#8180 (Write the Docs!) Updated the three linked articles in the issue to create Pods instead of Deployments, and changed the Pod yaml files to Deployment.

Notes:
- Titles on these may need updating. However, I'm not sure if there should just be additional articles for creating Pods and creating Deployments.
- Some of the links go to documentation related to Pods for these, and I'm not 100% on what we should link to instead. I'm not familiar with the entire docset.

Thanks!
