### PR TITLE
Remove toc_hide:true flag so things appear in nav.

### DIFF
--- a/content/en/docs/tasks/job/coarse-parallel-processing-work-queue/_index.md
+++ b/content/en/docs/tasks/job/coarse-parallel-processing-work-queue/_index.md
@@ -1,6 +1,5 @@
 ---
 title: Coarse Parallel Processing Using a Work Queue
-toc_hide: true
 ---
 
 {{< toc >}}

--- a/content/en/docs/tasks/job/fine-parallel-processing-work-queue/_index.md
+++ b/content/en/docs/tasks/job/fine-parallel-processing-work-queue/_index.md
@@ -1,6 +1,5 @@
 ---
 title: Fine Parallel Processing Using a Work Queue
-toc_hide: true
 ---
 
 {{< toc >}}


### PR DESCRIPTION
Write the Docs 2018 commit.

Removes toc_hide:true flag from frontmatter of two task topics, as they are not currently appearing in the left-hand nav.
