### PR TITLE
Fix link opening in new window

### DIFF
--- a/content/en/docs/home/contribute/create-pull-request.md
+++ b/content/en/docs/home/contribute/create-pull-request.md
@@ -6,17 +6,17 @@ content_template: templates/task
 {{% capture overview %}}
 
 To contribute to the Kubernetes documentation, create a pull request against the
-[kubernetes/website](https://github.com/kubernetes/website){: target="_blank"}
+<a href="https://github.com/kubernetes/website" target="_blank" class="_">kubernetes/website</a>
 repository. This page shows how to create a pull request.
 
 {{% /capture %}}
 
 {{% capture prerequisites %}}
 
-1. Create a [GitHub account](https://github.com){: target="_blank"}.
+1. Create a <a href="https://github.com/" target="_blank" class="_">Github account</a>.
 
 1. Sign the
-[Linux Foundation Contributor License Agreement](https://identity.linuxfoundation.org/projects/cncf){: target="_blank"}.
+  <a href="https://identity.linuxfoundation.org/projects/cncf" target="_blank" class="_">Linux Foundation Contributor License Agreement (CLA)</a>.
 
 Documentation will be published under the [CC BY SA 4.0](https://git.k8s.io/website/LICENSE) license.
 
@@ -27,8 +27,8 @@ Documentation will be published under the [CC BY SA 4.0](https://git.k8s.io/webs
 ## Creating a fork of the Kubernetes documentation repository
 
 1. Go to the
-[kubernetes/website](https://github.com/kubernetes/website){: target="_blank"}
-repository.
+   <a href="https://github.com/kubernetes/website" target="_blank" class="_">kubernetes/website</a>
+   repository.
 
 1. In the upper-right corner, click **Fork**. This creates a copy of the
 Kubernetes documentation repository in your GitHub account. The copy

--- a/content/en/docs/home/contribute/review-issues.md
+++ b/content/en/docs/home/contribute/review-issues.md
@@ -5,7 +5,8 @@ content_template: templates/concept
 
 {{% capture overview %}}
 
-This page explains how documentation issues are reviewed and prioritized for the [kubernetes/website](https://github.com/kubernetes/website){: target="_blank"} repository. The purpose is to provide a way to organize issues and make it easier to contribute to Kubernetes documentation. The following should be used as the standard way of prioritizing, labeling, and interacting with issues.
+This page explains how documentation issues are reviewed and prioritized for the
+<a href="https://github.com/kubernetes/website" target="_blank" class="_">kubernetes/website</a> repository. The purpose is to provide a way to organize issues and make it easier to contribute to Kubernetes documentation. The following should be used as the standard way of prioritizing, labeling, and interacting with issues.
 {{% /capture %}}
 
 {{% capture body %}}

--- a/content/en/docs/home/contribute/stage-documentation-changes.md
+++ b/content/en/docs/home/contribute/stage-documentation-changes.md
@@ -34,7 +34,7 @@ can see your changes.
 
 You can use the k8sdocs Docker image to run a local staging server. If you're
 interested, you can view the
-[Dockerfile](https://git.k8s.io/website/staging-container/Dockerfile){: target="_blank"}
+<a href="https://git.k8s.io/website/staging-container/Dockerfile" target="_blank" class="_">Dockerfile</a>
 for this image.
 
 1. Install Docker if you don't already have it.
@@ -54,9 +54,9 @@ web server:
 
 ## Staging locally without Docker
 
-1. [Install Ruby 2.2 or later](https://www.ruby-lang.org){: target="_blank"}.
+1. <a href="https://www.ruby-lang.org" target="_blank" class="_">Install Ruby 2.2 or later</a>.
 
-1. [Install RubyGems](https://rubygems.org){: target="_blank"}.
+1. <a href="https://rubygems.org" target="_blank" class="_">Install Ruby Gems</a>.
 
 1. Verify that Ruby and RubyGems are installed:
 


### PR DESCRIPTION
The way we previously did it in Jekyll doesn't work
with Black Friday. There are a few workarounds, but
the easiest way to fix it is to just change those
links to HTML email.

Fixes #8350 

(see https://code.luasoftware.com/tutorials/hugo/how-to-create-link-with-target-blanks-in-hugo-markdown/)

> The `class="_"` is a trick to make syntax highlighting not break because of an unclosed `_` in editors like Atom.
