### PR TITLE
Users should choose network plugin before initializing cluster

### DIFF
--- a/content/en/docs/setup/independent/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/independent/create-cluster-kubeadm.md
@@ -115,7 +115,7 @@ The master is the machine where the control plane components run, including
 etcd (the cluster database) and the API server (which the kubectl CLI
 communicates with).
 
-To initialize the master, pick one of the machines you previously installed
+To initialize the master, first choose the pod network plugin you want and check if it requires any parameters to be passed to kubeadm while initializing the cluster. Pick one of the machines you previously installed
 kubeadm on, and run:
 
 ```bash


### PR DESCRIPTION
Before you initialize the master, choose the pod network plugin you want to use and then check if the pod network requires any other parameters that need to be passed on to kubeadm while initializing the cluster.