### PR TITLE
Updated jobs-run-to-completion.md

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/jobs-run-to-completion.md
+++ b/content/en/docs/concepts/workloads/controllers/jobs-run-to-completion.md
@@ -192,8 +192,8 @@ due to a logical error in configuration etc.
 To do so, set `.spec.backoffLimit` to specify the number of retries before
 considering a Job as failed. The back-off limit is set by default to 6. Failed
 Pods associated with the Job are recreated by the Job controller with an
-exponential back-off delay (10s, 20s, 40s ...) capped at six minutes, The
-back-off limit is reset if no new failed Pods appear before the Job's next
+exponential back-off delay (10s, 20s, 40s ...) capped at six minutes. The
+back-off count is reset if no new failed Pods appear before the Job's next
 status check.
 
 {{< note >}}


### PR DESCRIPTION
Updated text "The back-off limit is reset..." under Pod Backoff failure policy
For issue #8156 
Write the Docs Portland 2018 