### PR TITLE
Fix code blocks in set-up-cluster-federation-kubefed

### DIFF
--- a/content/en/docs/tasks/federation/set-up-cluster-federation-kubefed.md
+++ b/content/en/docs/tasks/federation/set-up-cluster-federation-kubefed.md
@@ -420,15 +420,15 @@ To join clusters into the federation:
 
 1. Change the context:
 
-   ```shell
-   kubectl config use-context fellowship
-   ```
-   
+    ```shell
+    kubectl config use-context fellowship
+    ```
+
 1. If you are using a managed cluster service, allow the service to access the cluster. To do this, create a `clusterrolebinding` for the account associated with your cluster service:
 
-   ```shell
-   kubectl create clusterrolebinding <your_user>-cluster-admin-binding --clusterrole=cluster-admin --user=<your_user>@example.org --context=<joining_cluster_context>
-   ```
+    ```shell
+    kubectl create clusterrolebinding <your_user>-cluster-admin-binding --clusterrole=cluster-admin --user=<your_user>@example.org --context=<joining_cluster_context>
+    ```
 
 1. Join the cluster to the federation, using `kubefed join`, and make sure you provide the following:
 

--- a/content/en/docs/tasks/federation/set-up-cluster-federation-kubefed.md
+++ b/content/en/docs/tasks/federation/set-up-cluster-federation-kubefed.md
@@ -420,11 +420,15 @@ To join clusters into the federation:
 
 1. Change the context:
 
-       kubectl config use-context fellowship
-
+   ```shell
+   kubectl config use-context fellowship
+   ```
+   
 1. If you are using a managed cluster service, allow the service to access the cluster. To do this, create a `clusterrolebinding` for the account associated with your cluster service:
 
-       kubectl create clusterrolebinding <your_user>-cluster-admin-binding --clusterrole=cluster-admin --user=<your_user>@example.org --context=<joining_cluster_context>
+   ```shell
+   kubectl create clusterrolebinding <your_user>-cluster-admin-binding --clusterrole=cluster-admin --user=<your_user>@example.org --context=<joining_cluster_context>
+   ```
 
 1. Join the cluster to the federation, using `kubefed join`, and make sure you provide the following:
 
@@ -433,7 +437,7 @@ To join clusters into the federation:
 
     For example, this command adds the cluster `gondor` to the federation running on host cluster `rivendell`:
 
-    ```
+    ```shell
     kubefed join gondor --host-cluster-context=rivendell
     ```
 
@@ -512,7 +516,7 @@ To remove a cluster from a federation, run the [`kubefed unjoin`](/docs/admin/ku
 command with the cluster name and the federation's
 `--host-cluster-context`:
 
-```
+```shell
 kubefed unjoin gondor --host-cluster-context=rivendell
 ```
 
@@ -525,7 +529,7 @@ the persistent storage volume dynamically provisioned for the
 federation control plane's etcd. You can delete the federation
 namespace by running the following command:
 
-```
+```shell
 kubectl delete ns federation-system --context=rivendell
 ```
 


### PR DESCRIPTION
Two of the code blocks don't render correctly in the [docs page](https://kubernetes.io/docs/tasks/federation/set-up-cluster-federation-kubefed/) (see *Adding a cluster to a federation* section) even though they render correctly in the GitHub preview. Hopefully this PR will fix it.

Plus fixed a few instances where the code blocks in set-up-cluster-federation-kubefed.md don't indicate the code block's language.