### PR TITLE
Update install-kubeadm.md

### DIFF
--- a/content/en/docs/setup/independent/install-kubeadm.md
+++ b/content/en/docs/setup/independent/install-kubeadm.md
@@ -164,7 +164,7 @@ apt-get update
 apt-get install -y kubelet kubeadm kubectl
 {{< /tab >}}
 {{% tab name="CentOS, RHEL or Fedora" %}}
-``
+```
 cat <<EOF > /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes


### PR DESCRIPTION
Typo. Tab section missing one back quote which prevented code displaying in a `pre` section and breaking formatting.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.11 Features: set Milestone to 1.11 and Base Branch to release-1.11
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
