### PR TITLE
Replace {{page.docsbranch}} as it is broken on branch

### DIFF
--- a/docs/user-guide/persistent-volumes/walkthrough.md
+++ b/docs/user-guide/persistent-volumes/walkthrough.md
@@ -9,11 +9,11 @@ The purpose of this guide is to help you become familiar with [Kubernetes Persis
 nginx serving content from your persistent volume.
 
 You can view all the files for this example in [the docs repo
-here](https://github.com/kubernetes/kubernetes.github.io/tree/{{page.docsbranch}}/docs/user-guide/persistent-volumes).
+here](https://github.com/kubernetes/kubernetes.github.io/tree/release-1.4/docs/user-guide/persistent-volumes).
 
 This guide assumes knowledge of Kubernetes fundamentals and that you have a cluster up and running.
 
-See [Persistent Storage design document](https://github.com/kubernetes/kubernetes/blob/{{page.githubbranch}}/docs/design/persistent-storage.md) for more information.
+See [Persistent Storage design document](https://github.com/kubernetes/kubernetes/blob/release-1.4/docs/design/persistent-storage.md) for more information.
 
 ## Provisioning
 


### PR DESCRIPTION
I tried looking deeper into why `{{page.docsbranch}}` doesn't work on this page. It renders as 1.3 instead of 1.4.

I couldn't figure that out, but given this is an older version, I think you might as well just hard-code the branch.

If someone else knows how to fix the core issue, feel free to treat this PR as a bug report.