### PR TITLE
Remove Photon references

### DIFF
--- a/content/cn/docs/concepts/policy/pod-security-policy.md
+++ b/content/cn/docs/concepts/policy/pod-security-policy.md
@@ -109,7 +109,6 @@ _Pod 安全策略_ 由设置和策略组成，它们能够控制 Pod 访问的�
 1. configMap
 1. vsphereVolume
 1. quobyte
-1. photonPersistentDisk
 1. projected
 1. portworxVolume
 1. scaleIO

--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -234,7 +234,6 @@ resizing to take place. Also, file system resizing is only supported for followi
 * VsphereVolume
 * Quobyte Volumes
 * HostPath (Single node testing only -- local storage is not supported in any way and WILL NOT WORK in a multi-node cluster)
-* VMware Photon
 * Portworx Volumes
 * ScaleIO Volumes
 * StorageOS
@@ -313,7 +312,6 @@ In the CLI, the access modes are abbreviated to:
 | Glusterfs            | &#x2713;     | &#x2713;    | &#x2713;     |
 | HostPath             | &#x2713;     | -           | -            |
 | iSCSI                | &#x2713;     | &#x2713;    | -            |
-| PhotonPersistentDisk | &#x2713;     | -           | -            |
 | Quobyte              | &#x2713;     | &#x2713;    | &#x2713;     |
 | NFS                  | &#x2713;     | &#x2713;    | &#x2713;     |
 | RBD                  | &#x2713;     | &#x2713;    | -            |
@@ -367,7 +365,6 @@ The following volume types support mount options:
 * Glusterfs
 * VsphereVolume
 * Quobyte Volumes
-* VMware Photon
 
 Mount options are not validated, so mount will simply fail if one is invalid.
 

--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -69,7 +69,6 @@ for provisioning PVs. This field must be specified.
 | GCEPersistentDisk    | &#x2713;            | [GCE](#gce)                          |
 | Glusterfs            | &#x2713;            | [Glusterfs](#glusterfs)              |
 | iSCSI                | -                   | -                                    |
-| PhotonPersistentDisk | &#x2713;            | -                                    |
 | Quobyte              | &#x2713;            | [Quobyte](#quobyte)                  |
 | NFS                  | -                   | -                                    |
 | RBD                  | &#x2713;            | [Ceph RBD](#ceph-rbd)                |

--- a/content/en/docs/getting-started-guides/scratch.md
+++ b/content/en/docs/getting-started-guides/scratch.md
@@ -640,7 +640,7 @@ This pod mounts several node file system directories using the  `hostPath` volum
 
 Apiserver supports several cloud providers.
 
-- options for `--cloud-provider` flag are `aws`, `azure`, `cloudstack`, `fake`, `gce`, `mesos`, `openstack`, `ovirt`, `photon`, `rackspace`, `vsphere`, or unset.
+- options for `--cloud-provider` flag are `aws`, `azure`, `cloudstack`, `fake`, `gce`, `mesos`, `openstack`, `ovirt`, `rackspace`, `vsphere`, or unset.
 - unset used for bare metal setups.
 - support for new IaaS is added by contributing code [here](https://releases.k8s.io/{{< param "githubbranch" >}}/pkg/cloudprovider/providers)
 


### PR DESCRIPTION
github.com/vmware/photon-controller is no longer maintained, as of Oct 2017.

See also: kubernetes/kubernetes#58096
See also: kubernetes/kubernetes#63686
