### PR TITLE
Enable kubeadm generated docs

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/generated/_index.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/generated/_index.md
@@ -1,6 +1,5 @@
 ---
 title: "Kubeadm Generated"
 weight: 10
-toc_hide: true
+toc-hide: true
 ---
-


### PR DESCRIPTION
This PR:
- Enables the appearance of kubeadm generated ref docs. 

This needs a separate follow-up PR to move content from `/content/en/docs/reference/setup-tools/kubeadm` to `/static/docs/reference/generated/kubeadm`. 