### PR TITLE
Put Kubernetes API ref docs in the left nav.

### DIFF
--- a/content/en/docs/reference/kubernetes-api/_index.md
+++ b/content/en/docs/reference/kubernetes-api/_index.md
@@ -1,0 +1,4 @@
+---
+title: API Reference
+weight: 30
+---

--- a/content/en/docs/reference/kubernetes-api/index.md
+++ b/content/en/docs/reference/kubernetes-api/index.md
@@ -1,0 +1,5 @@
+---
+title: v1.10
+---
+
+[Kubernetes API v1.10](/docs/reference/generated/kubernetes-api/v1.10/)


### PR DESCRIPTION
This PR gives the Kubernetes API ref docs a presence in the left nav. This is not an elegant solution, but it is a step in the right direction.

https://deploy-preview-8435--kubernetes-io-master-staging.netlify.com/docs/reference/kubernetes-api/