### PR TITLE
[kubeadm] Update the doc about extra volume in kubeadm config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ _site/**
 CNAME
 .travis.yml
 .idea/
+.vscode/
 
 # Vim ignore
 # source: https://github.com/github/gitignore/blob/master/Global/Vim.gitignore

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -146,14 +146,20 @@ apiServerExtraVolumes:
 - name: <value|string>
   hostPath: <value|string>
   mountPath: <value|string>
+  writable: <value|bool>
+  pathType: <value|string>
 controllerManagerExtraVolumes:
 - name: <value|string>
   hostPath: <value|string>
   mountPath: <value|string>
+  writable: <value|bool>
+  pathType: <value|string>
 schedulerExtraVolumes:
 - name: <value|string>
   hostPath: <value|string>
   mountPath: <value|string>
+  writable: <value|bool>
+  pathType: <value|string>
 apiServerCertSANs:
 - <name1|string>
 - <name2|string>


### PR DESCRIPTION
Since we have supported the `writable ` and `pathType ` in the kubeadm config file, so update this doc.

ref  [kubernetes/kubernetes#63452](https://github.com/kubernetes/kubernetes/pull/63452)

Signed-off-by: Xianglin Gao <xianglin.gxl@alibaba-inc.com>
