### PR TITLE
Fix for kubctl/conventions

### DIFF
--- a/content/en/docs/reference/kubectl/conventions.md
+++ b/content/en/docs/reference/kubectl/conventions.md
@@ -65,4 +65,4 @@ flag, which provides the object to be submitted to the cluster.
 
 ### `kubectl apply`
 
-* When you use `kubectl apply` to update resources, always create resources initially using `kubectl apply` or using `--save-config`. See [managing resources with kubectl apply](/docs/concepts/cluster-administration/manage-deployment/#kubectl-apply) for more information.
+* When you use `kubectl apply` to update resources, always create resources initially using `kubectl create` or using `--save-config`. See [managing resources with kubectl apply](/docs/concepts/cluster-administration/manage-deployment/#kubectl-apply) for more information.


### PR DESCRIPTION
As the linked document explains, initially "create" instead of "apply"
should be used. Fix wording.

Closes: #8265 