### PR TITLE
Fix links in kubeadm.md

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm.md
@@ -14,9 +14,9 @@ Instead, we expect higher-level and more tailored tooling to be built on top of 
 
 ## What's next
 
-* [kubeadm init](kubeadm-init.md) to bootstrap a Kubernetes master node
-* [kubeadm join](kubeadm-join.md) to bootstrap a Kubernetes worker node and join it to the cluster
-* [kubeadm upgrade](kubeadm-upgrade.md) to upgrade a Kubernetes cluster to a newer version
-* [kubeadm config](kubeadm-config.md) if you initialized your cluster using kubeadm v1.7.x or lower, to configure your cluster for `kubeadm upgrade`
-* [kubeadm token](kubeadm-token.md) to manage tokens for `kubeadm join`
-* [kubeadm reset](kubeadm-reset.md) to revert any changes made to this host by `kubeadm init` or `kubeadm join`
+* [kubeadm init](../kubeadm-init/) to bootstrap a Kubernetes master node
+* [kubeadm join](../kubeadm-join/) to bootstrap a Kubernetes worker node and join it to the cluster
+* [kubeadm upgrade](../kubeadm-upgrade/) to upgrade a Kubernetes cluster to a newer version
+* [kubeadm config](../kubeadm-config/) if you initialized your cluster using kubeadm v1.7.x or lower, to configure your cluster for `kubeadm upgrade`
+* [kubeadm token](../kubeadm-token/) to manage tokens for `kubeadm join`
+* [kubeadm reset](../kubeadm-reset/) to revert any changes made to this host by `kubeadm init` or `kubeadm join`


### PR DESCRIPTION
With hugo transition, the links have been to "X.md", correct the
relative links to the new location.

Closes: #8440