### PR TITLE
Fix toc in user-guide/walkthrough/k8s201.md

### DIFF
--- a/content/en/docs/user-guide/walkthrough/k8s201.md
+++ b/content/en/docs/user-guide/walkthrough/k8s201.md
@@ -69,7 +69,7 @@ Here is a Deployment that instantiates two nginx Pods:
 {{< code file="deployment.yaml" >}}
 
 
-#### Deployment Management
+### Deployment Management
 
 Create an nginx Deployment:
 
@@ -122,7 +122,7 @@ For example, here is a service that balances across the Pods created in the prev
 {{< code file="service.yaml" >}}
 
 
-#### Service Management
+### Service Management
 
 Create an nginx service ([service.yaml](/docs/user-guide/walkthrough/service.yaml)):
 
@@ -181,14 +181,14 @@ application and taking action to fix it.  It's important that the system be outs
 your application fails and the health checking agent is part of your application, it may fail as well and you'll never know.
 In Kubernetes, the health check monitor is the Kubelet agent.
 
-#### Process Health Checking
+### Process Health Checking
 
 The simplest form of health-checking is just process level health checking.  The Kubelet constantly asks the Docker daemon
 if the container process is still running, and if not, the container process is restarted.  In all of the Kubernetes examples
 you have run so far, this health checking was actually already enabled.  It's on for every single container that runs in
 Kubernetes.
 
-#### Application Health Checking
+### Application Health Checking
 
 However, in many cases this low-level health checking is insufficient.  Consider, for example, the following code:
 


### PR DESCRIPTION
The TOC looked like:
3. Deployments
   1.1 Deployment Management
4. Services
   1.1 Service Management

The problem is that the headings went from "##" to "####", use "###" for
second level heading to cleanup TOC.
