### PR TITLE
Fixed misleading text in out-of-resources.md file

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -32,24 +32,6 @@
 
     <nav id="mainNav">
         <main data-auto-burger="primary">
-        <div class="nav-box">
-            <h3><a href="/docs/tutorials/stateless-application/hello-minikube/">Get Started</a></h3>
-            <p>Ready to get your hands dirty? Build a simple Kubernetes cluster that runs "Hello World" for Node.js.</p>
-        </div>
-        <div class="nav-box">
-            <h3><a href="/docs/home/">Documentation</a></h3>
-            <p>Learn how to use Kubernetes with the use of walkthroughs, samples, and reference documentation. You can even <a href="/editdocs/" data-auto-burger-exclude>help contribute to the docs</a>!</p>
-        </div>
-        <div class="nav-box">
-            <h3><a href="/community/">Community</a></h3>
-            <p>If you need help, you can connect with other Kubernetes users and the Kubernetes authors, attend community events, and watch video presentations from around the web.</p>
-        </div>
-        <div class="nav-box">
-            <h3><a href="/blog">Blog</a></h3>
-            <p>Read the latest news for Kubernetes and the containers space in general, and get technical how-tos hot off the presses.</p>
-        </div>
-        </main>
-        <main data-auto-burger="primary">
         <div class="left">
             <h5 class="github-invite">Interested in hacking on the core Kubernetes code base?</h5>
             <a href="https://github.com/kubernetes/kubernetes" class="button" data-auto-burger-exclude>View On Github</a>

--- a/docs/tasks/administer-cluster/out-of-resource.md
+++ b/docs/tasks/administer-cluster/out-of-resource.md
@@ -300,7 +300,7 @@ Consider the following scenario:
 
 * Node memory capacity: `10Gi`
 * Operator wants to reserve 10% of memory capacity for system daemons (kernel, `kubelet`, etc.)
-* Operator wants to evict Pods at 95% memory utilization to reduce thrashing and incidence of system OOM.
+* Operator wants to evict Pods at 95% memory utilization to reduce incidence of system OOM.
 
 To facilitate this scenario, the `kubelet` would be launched as follows:
 


### PR DESCRIPTION
Fixed a line in the out-of-resource page that was noticed by @dcaldwel in issue #8390.