### PR TITLE
Issue #8493 - Missing instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ _site/**
 CNAME
 .travis.yml
 .idea/
+.vscode/
 
 # Vim ignore
 # source: https://github.com/github/gitignore/blob/master/Global/Vim.gitignore

--- a/content/en/docs/admin/accessing-the-api.md
+++ b/content/en/docs/admin/accessing-the-api.md
@@ -6,7 +6,7 @@ reviewers:
 title: Controlling Access to the Kubernetes API
 ---
 
-Users [access the API](/docs/user-guide/accessing-the-cluster) using `kubectl`,
+Users [access the API](docs/tasks/access-application-cluster/access-cluster/) using `kubectl`,
 client libraries, or by making REST requests.  Both human users and
 [Kubernetes service accounts](/docs/tasks/configure-pod-container/configure-service-account/) can be
 authorized for API access.
@@ -132,24 +132,24 @@ By default the Kubernetes API server serves HTTP on 2 ports:
 
   1. `Localhost Port`:
 
-          - is intended for testing and bootstrap, and for other components of the master node
-            (scheduler, controller-manager) to talk to the API
-          - no TLS
-          - default is port 8080, change with `--insecure-port` flag.
-          - default IP is localhost, change with `--insecure-bind-address` flag.
-          - request **bypasses** authentication and authorization modules.
-          - request handled by admission control module(s).
-          - protected by need to have host access
+      - is intended for testing and bootstrap, and for other components of the master node
+        (scheduler, controller-manager) to talk to the API
+      - no TLS
+      - default is port 8080, change with `--insecure-port` flag.
+      - default IP is localhost, change with `--insecure-bind-address` flag.
+      - request **bypasses** authentication and authorization modules.
+      - request handled by admission control module(s).
+      - protected by need to have host access
 
   2. `Secure Port`:
 
-          - use whenever possible
-          - uses TLS.  Set cert with `--tls-cert-file` and key with `--tls-private-key-file` flag.
-          - default is port 6443, change with `--secure-port` flag.
-          - default IP is first non-localhost network interface, change with `--bind-address` flag.
-          - request handled by authentication and authorization modules.
-          - request handled by admission control module(s).
-          - authentication and authorization modules run.
+      - use whenever possible
+      - uses TLS.  Set cert with `--tls-cert-file` and key with `--tls-private-key-file` flag.
+      - default is port 6443, change with `--secure-port` flag.
+      - default IP is first non-localhost network interface, change with `--bind-address` flag.
+      - request handled by authentication and authorization modules.
+      - request handled by admission control module(s).
+      - authentication and authorization modules run.
 
 When the cluster is created by `kube-up.sh`, on Google Compute Engine (GCE),
 and on several other cloud providers, the API server serves on port 443.  On

--- a/content/en/docs/admin/admission-controllers.md
+++ b/content/en/docs/admin/admission-controllers.md
@@ -21,7 +21,7 @@ is authenticated and authorized.  The controllers consist of the
 administrator. In that list, there are two special controllers:
 MutatingAdmissionWebhook and ValidatingAdmissionWebhook.  These execute the
 mutating and validating (respectively) [admission control
-webhooks](/docs/admin/extensible-admission-controllers.md#external-admission-webhooks)
+webhooks](/docs/admin/extensible-admission-controllers/#external-admission-webhooks)
 which are configured in the API.
 
 Admission controllers may be "validating", "mutating", or both. Mutating
@@ -224,7 +224,8 @@ plugins:
 ...
 ```
 
-The ImagePolicyWebhook config file must reference a [kubeconfig](/docs/concepts/cluster-administration/authenticate-across-clusters-kubeconfig/) formatted file which sets up the connection to the backend. It is required that the backend communicate over TLS.
+The ImagePolicyWebhook config file must reference a [kubeconfig](docs/tasks/access-application-cluster/configure-access-multiple-clusters/)
+formatted file which sets up the connection to the backend. It is required that the backend communicate over TLS.
 
 The kubeconfig file's cluster field must point to the remote service, and the user field must contain the returned authorizer.
 
@@ -243,7 +244,7 @@ users:
     client-certificate: /path/to/cert.pem # cert for the webhook admission controller to use
     client-key: /path/to/key.pem          # key matching the cert
 ```
-For additional HTTP configuration, refer to the [kubeconfig](/docs/concepts/cluster-administration/authenticate-across-clusters-kubeconfig/) documentation.
+For additional HTTP configuration, refer to the [kubeconfig](docs/tasks/access-application-cluster/configure-access-multiple-clusters/) documentation.
 
 #### Request Payloads
 
@@ -318,7 +319,7 @@ In any case, the annotations are provided by the user and are not validated by K
 The admission controller determines the initializers of a resource based on the existing
 `InitializerConfiguration`s. It sets the pending initializers by modifying the
 metadata of the resource to be created.
-For more information, please check [Dynamic Admission Control](/docs/admin/extensible-admission-controllers.md).
+For more information, please check [Dynamic Admission Control](/docs/admin/extensible-admission-controllers/).
 
 ### InitialResources (experimental)
 
@@ -344,7 +345,7 @@ your Kubernetes deployment, you MUST use this admission controller to enforce th
 be used to apply default resource requests to Pods that don't specify any; currently, the default LimitRanger
 applies a 0.1 CPU requirement to all Pods in the `default` namespace.
 
-See the [limitRange design doc](https://git.k8s.io/community/contributors/design-proposals/resource-management/admission_control_limit_range.md) and the [example of Limit Range](/docs/tasks/configure-pod-container/limit-range/) for more details.
+See the [limitRange design doc](https://git.k8s.io/community/contributors/design-proposals/resource-management/admission_control_limit_range.md) and the [example of Limit Range](/docs/tasks/administer-cluster/memory-default-namespace/) for more details.
 
 ### MutatingAdmissionWebhook (beta in 1.9)
 
@@ -466,6 +467,7 @@ metadata:
 
 #### Internal Behavior
 This admission controller has the following behavior:
+
   1. If the `Namespace` has an annotation with a key `scheduler.alpha.kubernetes.io/node-selector`, use its value as the
      node selector.
   1. If the namespace lacks such an annotation, use the `clusterDefaultNodeSelector` defined in the `PodNodeSelector`
@@ -561,11 +563,11 @@ See the [resourceQuota design doc](https://git.k8s.io/community/contributors/des
 
 ### SecurityContextDeny
 
-This admission controller will deny any pod that attempts to set certain escalating [SecurityContext](/docs/user-guide/security-context) fields. This should be enabled if a cluster doesn't utilize [pod security policies](/docs/user-guide/pod-security-policy) to restrict the set of values a security context can take.
+This admission controller will deny any pod that attempts to set certain escalating [SecurityContext](/docs/tasks/configure-pod-container/security-context/) fields. This should be enabled if a cluster doesn't utilize [pod security policies](/docs/concepts/policy/pod-security-policy/) to restrict the set of values a security context can take.
 
 ### ServiceAccount
 
-This admission controller implements automation for [serviceAccounts](/docs/user-guide/service-accounts).
+This admission controller implements automation for [serviceAccounts](/docs/tasks/configure-pod-container/configure-service-account/).
 We strongly recommend using this admission controller if you intend to make use of Kubernetes `ServiceAccount` objects.
 
 ### Storage Object in Use Protection (beta)

--- a/content/en/docs/admin/authorization/rbac.md
+++ b/content/en/docs/admin/authorization/rbac.md
@@ -78,6 +78,8 @@ A `RoleBinding` may reference a `Role` in the same namespace.
 The following `RoleBinding` grants the "pod-reader" role to the user "jane" within the "default" namespace.
 This allows "jane" to read pods in the "default" namespace.
 
+`roleRef` is how you will actually create the binding.  The `kind` will be either `Role` or `ClusterRole`, and the `name` will reference the name of the specific `Role` or `ClusterRole` you want. In the example below, this RoleBinding is using `roleRef` to bind the user "jane" to the `Role` created above named `pod-reader`.
+
 ```yaml
 # This role binding allows "jane" to read pods in the "default" namespace.
 kind: RoleBinding
@@ -90,8 +92,8 @@ subjects:
   name: jane # Name is case sensitive
   apiGroup: rbac.authorization.k8s.io
 roleRef:
-  kind: Role
-  name: pod-reader
+  kind: Role #this must be Role or ClusterRole
+  name: pod-reader # this must match the name of the Role or ClusterRole you wish to bind to
   apiGroup: rbac.authorization.k8s.io
 ```
 

--- a/content/en/docs/admin/authorization/rbac.md
+++ b/content/en/docs/admin/authorization/rbac.md
@@ -748,81 +748,87 @@ In order from most secure to least secure, the approaches are:
 
 1. Grant a role to an application-specific service account (best practice)
 
-   This requires the application to specify a `serviceAccountName` in its pod spec,
-   and for the service account to be created (via the API, application manifest, `kubectl create serviceaccount`, etc.).
+    This requires the application to specify a `serviceAccountName` in its pod spec,
+    and for the service account to be created (via the API, application manifest, `kubectl create serviceaccount`, etc.).
 
-   For example, grant read-only permission within "my-namespace" to the "my-sa" service account:
-   
-   ```shell
-   kubectl create rolebinding my-sa-view \
-     --clusterrole=view \
-     --serviceaccount=my-namespace:my-sa \
-     --namespace=my-namespace
-   ```
+    For example, grant read-only permission within "my-namespace" to the "my-sa" service account:
+
+    ```shell
+    kubectl create rolebinding my-sa-view \
+      --clusterrole=view \
+      --serviceaccount=my-namespace:my-sa \
+      --namespace=my-namespace
+    ```
 
 2. Grant a role to the "default" service account in a namespace
 
-   If an application does not specify a `serviceAccountName`, it uses the "default" service account.
+    If an application does not specify a `serviceAccountName`, it uses the "default" service account.
 
-   **NOTE:** Permissions given to the "default" service account are available to any pod in the namespace that does not specify a `serviceAccountName`.
+    {{< note >}}**NOTE:** Permissions given to the "default" service
+    account are available to any pod in the namespace that does not
+    specify a `serviceAccountName`.{{< /note >}}
 
-   For example, grant read-only permission within "my-namespace" to the "default" service account:
-   
-   ```shell
-   kubectl create rolebinding default-view \
-     --clusterrole=view \
-     --serviceaccount=my-namespace:default \
-     --namespace=my-namespace
-   ```
+    For example, grant read-only permission within "my-namespace" to the "default" service account:
 
-   Many [add-ons](/docs/concepts/cluster-administration/addons/) currently run as the "default" service account in the "kube-system" namespace.
-   To allow those add-ons to run with super-user access, grant cluster-admin permissions to the "default" service account in the "kube-system" namespace.
-   
-   **NOTE:** Enabling this means the "kube-system" namespace contains secrets that grant super-user access to the API.
-   
-   ```shell
-   kubectl create clusterrolebinding add-on-cluster-admin \
-     --clusterrole=cluster-admin \
-     --serviceaccount=kube-system:default
-   ```
+    ```shell
+    kubectl create rolebinding default-view \
+      --clusterrole=view \
+      --serviceaccount=my-namespace:default \
+      --namespace=my-namespace
+    ```
+
+    Many [add-ons](/docs/concepts/cluster-administration/addons/) currently run as the "default" service account in the "kube-system" namespace.
+    To allow those add-ons to run with super-user access, grant cluster-admin permissions to the "default" service account in the "kube-system" namespace.
+
+    {{< note >}}**NOTE:** Enabling this means the "kube-system"
+    namespace contains secrets that grant super-user access to the
+    API.{{< /note >}}
+
+    ```shell
+    kubectl create clusterrolebinding add-on-cluster-admin \
+      --clusterrole=cluster-admin \
+      --serviceaccount=kube-system:default
+    ```
 
 3. Grant a role to all service accounts in a namespace
 
-   If you want all applications in a namespace to have a role, no matter what service account they use,
-   you can grant a role to the service account group for that namespace.
+    If you want all applications in a namespace to have a role, no matter what service account they use,
+    you can grant a role to the service account group for that namespace.
 
-   For example, grant read-only permission within "my-namespace" to all service accounts in that namespace:
-   
-   ```shell
-   kubectl create rolebinding serviceaccounts-view \
-     --clusterrole=view \
-     --group=system:serviceaccounts:my-namespace \
-     --namespace=my-namespace
-   ```
+    For example, grant read-only permission within "my-namespace" to all service accounts in that namespace:
+
+    ```shell
+    kubectl create rolebinding serviceaccounts-view \
+      --clusterrole=view \
+      --group=system:serviceaccounts:my-namespace \
+      --namespace=my-namespace
+    ```
 
 4. Grant a limited role to all service accounts cluster-wide (discouraged)
 
-   If you don't want to manage permissions per-namespace, you can grant a cluster-wide role to all service accounts.
+    If you don't want to manage permissions per-namespace, you can grant a cluster-wide role to all service accounts.
 
-   For example, grant read-only permission across all namespaces to all service accounts in the cluster:
-   
-   ```shell
-   kubectl create clusterrolebinding serviceaccounts-view \
-     --clusterrole=view \
+    For example, grant read-only permission across all namespaces to all service accounts in the cluster:
+
+    ```shell
+    kubectl create clusterrolebinding serviceaccounts-view \
+      --clusterrole=view \
      --group=system:serviceaccounts
-   ```
+    ```
 
 5. Grant super-user access to all service accounts cluster-wide (strongly discouraged)
 
-   If you don't care about partitioning permissions at all, you can grant super-user access to all service accounts.
+    If you don't care about partitioning permissions at all, you can grant super-user access to all service accounts.
 
-   **WARNING:** This allows any user with read access to secrets or the ability to create a pod to access super-user credentials.
+    {{< warning >}}**WARNING:** This allows any user with read access
+    to secrets or the ability to create a pod to access super-user
+    credentials.{{< /warning >}}
 
-   ```shell
-   kubectl create clusterrolebinding serviceaccounts-cluster-admin \
-     --clusterrole=cluster-admin \
-     --group=system:serviceaccounts
-   ```
+    ```shell
+    kubectl create clusterrolebinding serviceaccounts-cluster-admin \
+      --clusterrole=cluster-admin \
+      --group=system:serviceaccounts
+    ```
 
 ## Upgrading from 1.5
 

--- a/content/en/docs/concepts/service-catalog.md
+++ b/content/en/docs/concepts/service-catalog.md
@@ -3,7 +3,6 @@ title: Service Catalog
 reviewers:
 - chenopis
 content_template: templates/concept
-toc_hide: true
 ---
 
 {{% capture overview %}}

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -563,7 +563,7 @@ value "Filesystem") to expose the local volume as a raw block device. The
 
 When using local volumes, it is recommended to create a StorageClass with
 `volumeBindingMode` set to `WaitForFirstConsumer`. See the
-[example](storage-classes.md#local). Delaying volume binding ensures
+[example](/docs/concepts/storage/storage-classes/#local). Delaying volume binding ensures
 that the PersistentVolumeClaim binding decision will also be evaluated with any
 other node constraints the Pod may have, such as node resource requirements, node
 selectors, Pod affinity, and Pod anti-affinity.

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -10,14 +10,14 @@ content_template: templates/concept
 
 {{% capture overview %}}
 
-On-disk files in a container are ephemeral, which presents some problems for
-non-trivial applications when running in containers.  First, when a container
+On-disk files in a Container are ephemeral, which presents some problems for
+non-trivial applications when running in Containers.  First, when a Container
 crashes, kubelet will restart it, but the files will be lost - the
-container starts with a clean state.  Second, when running containers together
-in a `Pod` it is often necessary to share files between those containers.  The
+Container starts with a clean state.  Second, when running Containers together
+in a `Pod` it is often necessary to share files between those Containers.  The
 Kubernetes `Volume` abstraction solves both of these problems.
 
-Familiarity with [pods](/docs/user-guide/pods) is suggested.
+Familiarity with [Pods](/docs/user-guide/pods) is suggested.
 
 {{% /capture %}}
 
@@ -30,27 +30,27 @@ Familiarity with [pods](/docs/user-guide/pods) is suggested.
 Docker also has a concept of
 [volumes](https://docs.docker.com/engine/admin/volumes/), though it is
 somewhat looser and less managed.  In Docker, a volume is simply a directory on
-disk or in another container.  Lifetimes are not managed and until very
+disk or in another Container.  Lifetimes are not managed and until very
 recently there were only local-disk-backed volumes.  Docker now provides volume
 drivers, but the functionality is very limited for now (e.g. as of Docker 1.7
-only one volume driver is allowed per container and there is no way to pass
+only one volume driver is allowed per Container and there is no way to pass
 parameters to volumes).
 
 A Kubernetes volume, on the other hand, has an explicit lifetime - the same as
-the pod that encloses it.  Consequently, a volume outlives any containers that run
+the Pod that encloses it.  Consequently, a volume outlives any Containers that run
 within the Pod, and data is preserved across Container restarts. Of course, when a
 Pod ceases to exist, the volume will cease to exist, too.  Perhaps more
 importantly than this, Kubernetes supports many types of volumes, and a Pod can
 use any number of them simultaneously.
 
 At its core, a volume is just a directory, possibly with some data in it, which
-is accessible to the containers in a pod.  How that directory comes to be, the
+is accessible to the Containers in a Pod.  How that directory comes to be, the
 medium that backs it, and the contents of it are determined by the particular
 volume type used.
 
-To use a volume, a pod specifies what volumes to provide for the pod (the
+To use a volume, a Pod specifies what volumes to provide for the Pod (the
 `spec.volumes`
-field) and where to mount those into containers (the
+field) and where to mount those into Containers (the
 `spec.containers.volumeMounts`
 field).
 
@@ -59,7 +59,7 @@ image and volumes.  The [Docker
 image](https://docs.docker.com/userguide/dockerimages/) is at the root of the
 filesystem hierarchy, and any volumes are mounted at the specified paths within
 the image.  Volumes can not mount onto other volumes or have hard links to
-other volumes.  Each container in the Pod must independently specify where to
+other volumes.  Each Container in the Pod must independently specify where to
 mount each volume.
 
 ## Types of Volumes
@@ -98,11 +98,11 @@ We welcome additional contributions.
 ### awsElasticBlockStore
 
 An `awsElasticBlockStore` volume mounts an Amazon Web Services (AWS) [EBS
-Volume](http://aws.amazon.com/ebs/) into your pod.  Unlike
+Volume](http://aws.amazon.com/ebs/) into your Pod.  Unlike
 `emptyDir`, which is erased when a Pod is removed, the contents of an EBS
 volume are preserved and the volume is merely unmounted.  This means that an
 EBS volume can be pre-populated with data, and that data can be "handed off"
-between pods.
+between Pods.
 
 {{< caution >}}
 **Important:** You must create an EBS volume using `aws ec2 create-volume` or the AWS API before you can use it.
@@ -110,13 +110,13 @@ between pods.
 
 There are some restrictions when using an `awsElasticBlockStore` volume:
 
-* the nodes on which pods are running must be AWS EC2 instances
+* the nodes on which Pods are running must be AWS EC2 instances
 * those instances need to be in the same region and availability-zone as the EBS volume
 * EBS only supports a single EC2 instance mounting a volume
 
 #### Creating an EBS volume
 
-Before you can use an EBS volume with a pod, you need to create it.
+Before you can use an EBS volume with a Pod, you need to create it.
 
 ```shell
 aws ec2 create-volume --availability-zone=eu-west-1a --size=10 --volume-type=gp2
@@ -163,10 +163,10 @@ More details can be found [here](https://github.com/kubernetes/examples/tree/{{<
 ### cephfs
 
 A `cephfs` volume allows an existing CephFS volume to be
-mounted into your pod. Unlike `emptyDir`, which is erased when a Pod is
+mounted into your Pod. Unlike `emptyDir`, which is erased when a Pod is
 removed, the contents of a `cephfs` volume are preserved and the volume is merely
 unmounted.  This means that a CephFS volume can be pre-populated with data, and
-that data can be "handed off" between pods.  CephFS can be mounted by multiple
+that data can be "handed off" between Pods.  CephFS can be mounted by multiple
 writers simultaneously.
 
 {{< caution >}}
@@ -219,7 +219,7 @@ keyed with `log_level`.
 {{< /caution >}}
 
 {{< note >}}
-**Note:** A container using a ConfigMap as a [subPath](#using-subpath) volume mount will not
+**Note:** A Container using a ConfigMap as a [subPath](#using-subpath) volume mount will not
 receive ConfigMap updates.
 {{< /note >}}
 
@@ -229,7 +229,7 @@ A `downwardAPI` volume is used to make downward API data available to applicatio
 It mounts a directory and writes the requested data in plain text files.
 
 {{< note >}}
-**Note:** A container using Downward API as a [subPath](#using-subpath) volume mount will not
+**Note:** A Container using Downward API as a [subPath](#using-subpath) volume mount will not
 receive Downward API updates.
 {{< /note >}}
 
@@ -239,31 +239,31 @@ See the [`downwardAPI` volume example](/docs/tasks/inject-data-application/downw
 
 An `emptyDir` volume is first created when a Pod is assigned to a Node, and
 exists as long as that Pod is running on that node.  As the name says, it is
-initially empty.  Containers in the pod can all read and write the same
+initially empty.  Containers in the Pod can all read and write the same
 files in the `emptyDir` volume, though that volume can be mounted at the same
-or different paths in each container.  When a Pod is removed from a node for
+or different paths in each Container.  When a Pod is removed from a node for
 any reason, the data in the `emptyDir` is deleted forever.
 
 {{< note >}}
-**Note:** a container crashing does *NOT* remove a pod from a node, so the data in an `emptyDir` volume is safe across container crashes.
+**Note:** a Container crashing does *NOT* remove a Pod from a node, so the data in an `emptyDir` volume is safe across Container crashes.
 {{< /note >}}
 
 Some uses for an `emptyDir` are:
 
 * scratch space, such as for a disk-based merge sort
 * checkpointing a long computation for recovery from crashes
-* holding files that a content-manager container fetches while a webserver
-  container serves the data
+* holding files that a content-manager Container fetches while a webserver
+  Container serves the data
 
 By default, `emptyDir` volumes are stored on whatever medium is backing the
 node - that might be disk or SSD or network storage, depending on your
 environment.  However, you can set the `emptyDir.medium` field to `"Memory"`
 to tell Kubernetes to mount a tmpfs (RAM-backed filesystem) for you instead.
 While tmpfs is very fast, be aware that unlike disks, tmpfs is cleared on
-node reboot and any files you write will count against your container's
+node reboot and any files you write will count against your Container's
 memory limit.
 
-#### Example pod
+#### Example Pod
 
 ```yaml
 apiVersion: v1
@@ -284,7 +284,7 @@ spec:
 
 ### fc (fibre channel)
 
-An `fc` volume allows an existing fibre channel volume to be mounted in a pod.
+An `fc` volume allows an existing fibre channel volume to be mounted in a Pod.
 You can specify single or multiple target World Wide Names using the parameter
 `targetWWNs` in your volume configuration. If multiple WWNs are specified,
 targetWWNs expect that those WWNs are from multi-path connections.
@@ -297,14 +297,14 @@ See the [FC example](https://github.com/kubernetes/examples/tree/{{< param "gith
 
 ### flocker
 
-[Flocker](https://github.com/ClusterHQ/flocker) is an open-source clustered container data volume manager. It provides management
+[Flocker](https://github.com/ClusterHQ/flocker) is an open-source clustered Container data volume manager. It provides management
 and orchestration of data volumes backed by a variety of storage backends.
 
-A `flocker` volume allows a Flocker dataset to be mounted into a pod. If the
+A `flocker` volume allows a Flocker dataset to be mounted into a Pod. If the
 dataset does not already exist in Flocker, it needs to be first created with the Flocker
 CLI or by using the Flocker API. If the dataset already exists it will be
-reattached by Flocker to the node that the pod is scheduled. This means data
-can be "handed off" between pods as required.
+reattached by Flocker to the node that the Pod is scheduled. This means data
+can be "handed off" between Pods as required.
 
 {{< caution >}}
 **Important:** You must have your own Flocker installation running before you can use it.
@@ -315,10 +315,10 @@ See the [Flocker example](https://github.com/kubernetes/examples/tree/{{< param 
 ### gcePersistentDisk
 
 A `gcePersistentDisk` volume mounts a Google Compute Engine (GCE) [Persistent
-Disk](http://cloud.google.com/compute/docs/disks) into your pod.  Unlike
+Disk](http://cloud.google.com/compute/docs/disks) into your Pod.  Unlike
 `emptyDir`, which is erased when a Pod is removed, the contents of a PD are
 preserved and the volume is merely unmounted.  This means that a PD can be
-pre-populated with data, and that data can be "handed off" between pods.
+pre-populated with data, and that data can be "handed off" between Pods.
 
 {{< caution >}}
 **Important:** You must create a PD using `gcloud` or the GCE API or UI before you can use it.
@@ -326,27 +326,27 @@ pre-populated with data, and that data can be "handed off" between pods.
 
 There are some restrictions when using a `gcePersistentDisk`:
 
-* the nodes on which pods are running must be GCE VMs
+* the nodes on which Pods are running must be GCE VMs
 * those VMs need to be in the same GCE project and zone as the PD
 
 A feature of PD is that they can be mounted as read-only by multiple consumers
 simultaneously.  This means that you can pre-populate a PD with your dataset
-and then serve it in parallel from as many pods as you need.  Unfortunately,
+and then serve it in parallel from as many Pods as you need.  Unfortunately,
 PDs can only be mounted by a single consumer in read-write mode - no
 simultaneous writers allowed.
 
-Using a PD on a pod controlled by a ReplicationController will fail unless
+Using a PD on a Pod controlled by a ReplicationController will fail unless
 the PD is read-only or the replica count is 0 or 1.
 
 #### Creating a PD
 
-Before you can use a GCE PD with a pod, you need to create it.
+Before you can use a GCE PD with a Pod, you need to create it.
 
 ```shell
 gcloud compute disks create --size=500GB --zone=us-central1-a my-data-disk
 ```
 
-#### Example pod
+#### Example Pod
 
 ```yaml
 apiVersion: v1
@@ -371,7 +371,7 @@ spec:
 ### gitRepo
 
 A `gitRepo` volume is an example of what can be done as a volume plugin.  It
-mounts an empty directory and clones a git repository into it for your pod to
+mounts an empty directory and clones a git repository into it for your Pod to
 use.  In the future, such volumes may be moved to an even more decoupled model,
 rather than extending the Kubernetes API for every such use case.
 
@@ -399,11 +399,11 @@ spec:
 ### glusterfs
 
 A `glusterfs` volume allows a [Glusterfs](http://www.gluster.org) (an open
-source networked filesystem) volume to be mounted into your pod.  Unlike
+source networked filesystem) volume to be mounted into your Pod.  Unlike
 `emptyDir`, which is erased when a Pod is removed, the contents of a
 `glusterfs` volume are preserved and the volume is merely unmounted.  This
 means that a glusterfs volume can be pre-populated with data, and that data can
-be "handed off" between pods.  GlusterFS can be mounted by multiple writers
+be "handed off" between Pods.  GlusterFS can be mounted by multiple writers
 simultaneously.
 
 {{< caution >}}
@@ -415,16 +415,16 @@ See the [GlusterFS example](https://github.com/kubernetes/examples/tree/{{< para
 ### hostPath
 
 A `hostPath` volume mounts a file or directory from the host node's filesystem
-into your pod. This is not something that most Pods will need, but it offers a
+into your Pod. This is not something that most Pods will need, but it offers a
 powerful escape hatch for some applications.
 
 For example, some uses for a `hostPath` are:
 
-* running a container that needs access to Docker internals; use a `hostPath`
+* running a Container that needs access to Docker internals; use a `hostPath`
   of `/var/lib/docker`
-* running cAdvisor in a container; use a `hostPath` of `/sys`
-* allowing a pod to specify whether a given `hostPath` should exist prior to the
-  pod running, whether it should be created, and what it should exist as
+* running cAdvisor in a Container; use a `hostPath` of `/sys`
+* allowing a Pod to specify whether a given `hostPath` should exist prior to the
+  Pod running, whether it should be created, and what it should exist as
 
 In addition to the required `path` property, user can optionally specify a `type` for a `hostPath` volume.
 
@@ -444,16 +444,16 @@ The supported values for field `type` are:
 
 Watch out when using this type of volume, because:
 
-* pods with identical configuration (such as created from a podTemplate) may
+* Pods with identical configuration (such as created from a podTemplate) may
   behave differently on different nodes due to different files on the nodes
 * when Kubernetes adds resource-aware scheduling, as is planned, it will not be
   able to account for resources used by a `hostPath`
 * the files or directories created on the underlying hosts are only writable by root. You
   either need to run your process as root in a
-  [privileged container](/docs/user-guide/security-context) or modify the file
+  [privileged Container](/docs/user-guide/security-context) or modify the file
   permissions on the host to be able to write to a `hostPath` volume
 
-#### Example pod
+#### Example Pod
 
 ```yaml
 apiVersion: v1
@@ -479,10 +479,10 @@ spec:
 ### iscsi
 
 An `iscsi` volume allows an existing iSCSI (SCSI over IP) volume to be mounted
-into your pod.  Unlike `emptyDir`, which is erased when a Pod is removed, the
+into your Pod.  Unlike `emptyDir`, which is erased when a Pod is removed, the
 contents of an `iscsi` volume are preserved and the volume is merely
 unmounted.  This means that an iscsi volume can be pre-populated with data, and
-that data can be "handed off" between pods.
+that data can be "handed off" between Pods.
 
 {{< caution >}}
 **Important:** You must have your own iSCSI server running with the volume created before you can use it.
@@ -490,7 +490,7 @@ that data can be "handed off" between pods.
 
 A feature of iSCSI is that it can be mounted as read-only by multiple consumers
 simultaneously.  This means that you can pre-populate a volume with your dataset
-and then serve it in parallel from as many pods as you need.  Unfortunately,
+and then serve it in parallel from as many Pods as you need.  Unfortunately,
 iSCSI volumes can only be mounted by a single consumer in read-write mode - no
 simultaneous writers allowed.
 
@@ -514,12 +514,12 @@ Local volumes can only be used as a statically created PersistentVolume. Dynamic
 provisioning is not supported yet.
 
 Compared to `hostPath` volumes, local volumes can be used in a durable and
-portable manner without manually scheduling pods to nodes, as the system is aware
+portable manner without manually scheduling Pods to nodes, as the system is aware
 of the volume's node constraints by looking at the node affinity on the PersistentVolume.
 
 However, local volumes are still subject to the availability of the underlying
 node and are not suitable for all applications. If a node becomes unhealthy,
-then the local volume will also become inaccessible, and a pod using it will not
+then the local volume will also become inaccessible, and a Pod using it will not
 be able to run. Applications using local volumes must be able to tolerate this
 reduced availability, as well as potential data loss, depending on the
 durability characteristics of the underlying disk.
@@ -554,7 +554,7 @@ spec:
 ```
 
 PersistentVolume `nodeAffinity` is required when using local volumes. It enables
-the Kubernetes scheduler to correctly schedule pods using local volumes to the
+the Kubernetes scheduler to correctly schedule Pods using local volumes to the
 correct node.
 
 PersistentVolume `volumeMode` can now be set to "Block" (instead of the default
@@ -565,8 +565,8 @@ When using local volumes, it is recommended to create a StorageClass with
 `volumeBindingMode` set to `WaitForFirstConsumer`. See the
 [example](storage-classes.md#local). Delaying volume binding ensures
 that the PersistentVolumeClaim binding decision will also be evaluated with any
-other node constraints the pod may have, such as node resource requirements, node
-selectors, pod affinity, and pod anti-affinity.
+other node constraints the Pod may have, such as node resource requirements, node
+selectors, Pod affinity, and Pod anti-affinity.
 
 An external static provisioner can be run separately for improved management of
 the local volume lifecycle. Note that this provisioner does not support dynamic
@@ -582,10 +582,10 @@ lifecycle.
 ### nfs
 
 An `nfs` volume allows an existing NFS (Network File System) share to be
-mounted into your pod. Unlike `emptyDir`, which is erased when a Pod is
+mounted into your Pod. Unlike `emptyDir`, which is erased when a Pod is
 removed, the contents of an `nfs` volume are preserved and the volume is merely
 unmounted.  This means that an NFS volume can be pre-populated with data, and
-that data can be "handed off" between pods.  NFS can be mounted by multiple
+that data can be "handed off" between Pods.  NFS can be mounted by multiple
 writers simultaneously.
 
 {{< caution >}}
@@ -597,7 +597,7 @@ See the [NFS example](https://github.com/kubernetes/examples/tree/{{< param "git
 ### persistentVolumeClaim
 
 A `persistentVolumeClaim` volume is used to mount a
-[PersistentVolume](/docs/concepts/storage/persistent-volumes/) into a pod.  PersistentVolumes are a
+[PersistentVolume](/docs/concepts/storage/persistent-volumes/) into a Pod.  PersistentVolumes are a
 way for users to "claim" durable storage (such as a GCE PersistentDisk or an
 iSCSI volume) without knowing the details of the particular cloud environment.
 
@@ -614,9 +614,9 @@ Currently, the following types of volume sources can be projected:
 - [`downwardAPI`](#downwardapi)
 - `configMap`
 
-All sources are required to be in the same namespace as the pod. For more details, see the [all-in-one volume design document](https://github.com/kubernetes/community/blob/{{< param "githubbranch" >}}/contributors/design-proposals/node/all-in-one-volume.md).
+All sources are required to be in the same namespace as the Pod. For more details, see the [all-in-one volume design document](https://github.com/kubernetes/community/blob/{{< param "githubbranch" >}}/contributors/design-proposals/node/all-in-one-volume.md).
 
-#### Example pod with a secret, a downward API, and a configmap.
+#### Example Pod with a secret, a downward API, and a configmap.
 
 ```yaml
 apiVersion: v1
@@ -656,7 +656,7 @@ spec:
               path: my-group/my-config
 ```
 
-#### Example pod with multiple secrets with a non-default permission mode set.
+#### Example Pod with multiple secrets with a non-default permission mode set.
 
 ```yaml
 apiVersion: v1
@@ -698,7 +698,7 @@ parameters are nearly the same with two exceptions:
   for each individual projection.
 
 {{< note >}}
-**Note:** A container using a projected volume source as a [subPath](#using-subpath) volume mount will not
+**Note:** A Container using a projected volume source as a [subPath](#using-subpath) volume mount will not
 receive updates for those volume sources.
 {{< /note >}}
 
@@ -710,8 +710,8 @@ and aggregates capacity across multiple servers. Portworx runs in-guest in virtu
 machines or on bare metal Linux nodes.
 
 A `portworxVolume` can be dynamically created through Kubernetes or it can also
-be pre-provisioned and referenced inside a Kubernetes pod.
-Here is an example pod referencing a pre-provisioned PortworxVolume:
+be pre-provisioned and referenced inside a Kubernetes Pod.
+Here is an example Pod referencing a pre-provisioned PortworxVolume:
 
 ```yaml
 apiVersion: v1
@@ -735,7 +735,7 @@ spec:
 
 {{< caution >}}
 **Important:** Make sure you have an existing PortworxVolume with name `pxvol`
-before using it in the pod.
+before using it in the Pod.
 {{< /caution >}}
 
 More details and examples can be found [here](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/portworx/README.md).
@@ -743,7 +743,7 @@ More details and examples can be found [here](https://github.com/kubernetes/exam
 ### quobyte
 
 A `quobyte` volume allows an existing [Quobyte](http://www.quobyte.com) volume to
-be mounted into your pod.
+be mounted into your Pod.
 
 {{< caution >}}
 **Important:** You must have your own Quobyte setup running with the volumes
@@ -756,10 +756,10 @@ See the [Quobyte example](https://github.com/kubernetes/examples/tree/{{< param 
 
 An `rbd` volume allows a [Rados Block
 Device](http://ceph.com/docs/master/rbd/rbd/) volume to be mounted into your
-pod.  Unlike `emptyDir`, which is erased when a Pod is removed, the contents of
+Pod.  Unlike `emptyDir`, which is erased when a Pod is removed, the contents of
 a `rbd` volume are preserved and the volume is merely unmounted.  This
 means that a RBD volume can be pre-populated with data, and that data can
-be "handed off" between pods.
+be "handed off" between Pods.
 
 {{< caution >}}
 **Important:** You must have your own Ceph installation running before you can use RBD.
@@ -767,7 +767,7 @@ be "handed off" between pods.
 
 A feature of RBD is that it can be mounted as read-only by multiple consumers
 simultaneously.  This means that you can pre-populate a volume with your dataset
-and then serve it in parallel from as many pods as you need.  Unfortunately,
+and then serve it in parallel from as many Pods as you need.  Unfortunately,
 RBD volumes can only be mounted by a single consumer in read-write mode - no
 simultaneous writers allowed.
 
@@ -777,7 +777,7 @@ See the [RBD example](https://github.com/kubernetes/examples/tree/{{< param "git
 
 ScaleIO is a software-based storage platform that can use existing hardware to
 create clusters of scalable shared block networked storage. The `scaleIO` volume
-plugin allows deployed pods to access existing ScaleIO
+plugin allows deployed Pods to access existing ScaleIO
 volumes (or it can dynamically provision new volumes for persistent volume claims, see
 [ScaleIO Persistent Volumes](/docs/concepts/storage/persistent-volumes/#scaleio)).
 
@@ -786,7 +786,7 @@ volumes (or it can dynamically provision new volumes for persistent volume claim
 running with the volumes created before you can use them.
 {{< /caution >}}
 
-The following is an example pod configuration with ScaleIO:
+The following is an example Pod configuration with ScaleIO:
 
 ```yaml
 apiVersion: v1
@@ -818,8 +818,8 @@ For further detail, please the see the [ScaleIO examples](https://github.com/kub
 ### secret
 
 A `secret` volume is used to pass sensitive information, such as passwords, to
-pods.  You can store secrets in the Kubernetes API and mount them as files for
-use by pods without coupling to Kubernetes directly.  `secret` volumes are
+Pods.  You can store secrets in the Kubernetes API and mount them as files for
+use by Pods without coupling to Kubernetes directly.  `secret` volumes are
 backed by tmpfs (a RAM-backed filesystem) so they are never written to
 non-volatile storage.
 
@@ -828,7 +828,7 @@ non-volatile storage.
 {{< /caution >}}
 
 {{< note >}}
-**Note:** A container using a Secret as a [subPath](#using-subpath) volume mount will not
+**Note:** A Container using a Secret as a [subPath](#using-subpath) volume mount will not
 receive Secret updates.
 {{< /note >}}
 
@@ -837,20 +837,20 @@ Secrets are described in more detail [here](/docs/user-guide/secrets).
 ### storageOS
 
 A `storageos` volume allows an existing [StorageOS](https://www.storageos.com)
-volume to be mounted into your pod.
+volume to be mounted into your Pod.
 
-StorageOS runs as a container within your Kubernetes environment, making local
+StorageOS runs as a Container within your Kubernetes environment, making local
 or attached storage accessible from any node within the Kubernetes cluster. 
 Data can be replicated to protect against node failure. Thin provisioning and
 compression can improve utilization and reduce cost.
 
-At its core, StorageOS provides block storage to containers, accessible via a file system.
+At its core, StorageOS provides block storage to Containers, accessible via a file system.
 
-The StorageOS container requires 64-bit Linux and has no additional dependencies.
+The StorageOS Container requires 64-bit Linux and has no additional dependencies.
 A free developer license is available.
 
 {{< caution >}}
-**Important:** You must run the StorageOS container on each node that wants to
+**Important:** You must run the StorageOS Container on each node that wants to
 access StorageOS volumes or that will contribute storage capacity to the pool.
 For installation instructions, consult the
 [StorageOS documentation](https://docs.storageos.com).
@@ -898,7 +898,7 @@ A `vsphereVolume` is used to mount a vSphere VMDK Volume into your Pod.  The con
 of a volume are preserved when it is unmounted. It supports both VMFS and VSAN datastore.
 
 {{< caution >}}
-**Important:** You must create VMDK using one of the following method before using with POD.
+**Important:** You must create VMDK using one of the following method before using with Pod.
 {{< /caution >}}
 
 #### Creating a VMDK volume
@@ -951,10 +951,10 @@ More examples can be found [here](https://github.com/kubernetes/examples/tree/ma
 
 ## Using subPath
 
-Sometimes, it is useful to share one volume for multiple uses in a single pod. The `volumeMounts.subPath`
+Sometimes, it is useful to share one volume for multiple uses in a single Pod. The `volumeMounts.subPath`
 property can be used to specify a sub-path inside the referenced volume instead of its root.
 
-Here is an example of a pod with a LAMP stack (Linux Apache Mysql PHP) using a single, shared volume.
+Here is an example of a Pod with a LAMP stack (Linux Apache Mysql PHP) using a single, shared volume.
 The HTML contents are mapped to its `html` folder, and the databases will be stored in its `mysql` folder:
 
 ```yaml
@@ -990,8 +990,8 @@ spec:
 The storage media (Disk, SSD, etc.) of an `emptyDir` volume is determined by the
 medium of the filesystem holding the kubelet root dir (typically
 `/var/lib/kubelet`).  There is no limit on how much space an `emptyDir` or
-`hostPath` volume can consume, and no isolation between containers or between
-pods.
+`hostPath` volume can consume, and no isolation between Containers or between
+Pods.
 
 In the future, we expect that `emptyDir` and `hostPath` volumes will be able to
 request a certain amount of space using a [resource](/docs/user-guide/compute-resources)
@@ -1033,8 +1033,8 @@ Once a CSI compatible volume driver is deployed on a Kubernetes cluster, users
 may use the `csi` volume type to attach, mount, etc. the volumes exposed by the
 CSI driver.
 
-The `csi` volume type does not support direct reference from pod and may only be
-referenced in a pod via a `PersistentVolumeClaim` object.
+The `csi` volume type does not support direct reference from Pod and may only be
+referenced in a Pod via a `PersistentVolumeClaim` object.
 
 The following fields are available to storage administrators to configure a CSI
 persistent volume:
@@ -1055,7 +1055,7 @@ persistent volume:
   `ControllerPublishVolumeRequest`.
 - `fsType`: If the PV's `VolumeMode` is `Filesystem` then this field may be used
   to specify the filesystem that should be used to mount the volume. If the
-  volume has not been formated and formating is supported, this value will be
+  volume has not been formatted and formating is supported, this value will be
   used to format the volume. If a value is not specified, `ext4` is assumed.
   This value is passed to the CSI driver via the `VolumeCapability` field of
   `ControllerPublishVolumeRequest`, `NodeStageVolumeRequest`, and
@@ -1122,7 +1122,7 @@ Its values are:
    In other words, if the host mounts anything inside the volume mount, the
    Container will see it mounted there.
 
-   Similarly, if any pod with `Bidirectional` mount propagation to the same
+   Similarly, if any Pod with `Bidirectional` mount propagation to the same
    volume mounts anything there, the Container with `HostToContainer` mount
    propagation will see it.
 

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -1027,7 +1027,7 @@ Kubernetes) to expose arbitrary storage systems to their container workloads.
 Please read the [CSI design proposal](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/container-storage-interface.md) for more information.
 
 CSI support was introduced as alpha in Kubernetes v1.9 and moved to beta in
-Kubernets v1.10.
+Kubernetes v1.10.
 
 Once a CSI compatible volume driver is deployed on a Kubernetes cluster, users
 may use the `csi` volume type to attach, mount, etc. the volumes exposed by the

--- a/content/en/docs/concepts/workloads/pods/pod.md
+++ b/content/en/docs/concepts/workloads/pods/pod.md
@@ -58,7 +58,7 @@ that means that it exists as long as that pod (with that UID) exists. If that
 pod is deleted for any reason, even if an identical replacement is created, the
 related thing (e.g. volume) is also destroyed and created anew.
 
-{{< figure src="//images/docs/pod.svg" title="pod diagram" width="50%" >}}
+{{< figure src="/images/docs/pod.svg" title="pod diagram" width="50%" >}}
 
 *A multi-container pod that contains a file puller and a
 web server that uses a persistent volume for shared storage between the containers.*

--- a/content/en/docs/home/contribute/style-guide.md
+++ b/content/en/docs/home/contribute/style-guide.md
@@ -271,7 +271,7 @@ For example:
     1. Preheat oven to 350˚F
 
     1. Prepare the batter, and pour into springform pan.
-       {{</* note */>}}**Note:** Grease the pan for best results.{{</* note */>}}
+       {{</* note */>}}**Note:** Grease the pan for best results.{{</* /note */>}}
 
     1. Bake for 20-25 minutes or until set.
 

--- a/content/en/docs/reference/command-line-tools-reference/_index.md
+++ b/content/en/docs/reference/command-line-tools-reference/_index.md
@@ -1,0 +1,5 @@
+---
+title: Command line tools reference
+weight: 60
+toc-hide: true
+---

--- a/content/en/docs/reference/command-line-tools-reference/cloud-controller-manager.md
+++ b/content/en/docs/reference/command-line-tools-reference/cloud-controller-manager.md
@@ -1,0 +1,279 @@
+---
+title: cloud-controller-manager
+notitle: true
+weight: 90
+---
+
+## cloud-controller-manager
+
+### Synopsis
+
+The Cloud controller manager is a daemon that embeds
+the cloud specific control loops shipped with Kubernetes.
+
+```
+cloud-controller-manager [flags]
+```
+
+### Options
+
+<table style="width: 100%;">
+  <colgroup>
+    <col span="1" style="width: 10px;" />
+    <col span="1" />
+  </colgroup>
+  <tbody>
+    <tr>
+      <td colspan="2">--address ip&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 0.0.0.0</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">DEPRECATED: the IP address on which to listen for the --port port. See --bind-address instead.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--allocate-node-cidrs</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Should CIDRs for Pods be allocated and set on the cloud provider.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--azure-container-registry-config string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Path to the file containing Azure container registry configuration information.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--bind-address ip&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 0.0.0.0</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The IP address on which to listen for the --secure-port port. The associated interface(s) must be reachable by the rest of the cluster, and by CLI/web clients. If blank, all interfaces will be used (0.0.0.0 for all IPv4 interfaces and :: for all IPv6 interfaces).</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cert-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/var/run/kubernetes"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The directory where the TLS certs are located. If --tls-cert-file and --tls-private-key-file are provided, this flag will be ignored.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cidr-allocator-type string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "RangeAllocator"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Type of CIDR allocator to use</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cloud-config string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The path to the cloud provider configuration file. Empty string for no configuration file.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cloud-provider string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The provider of cloud services. Cannot be empty.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cluster-cidr string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">CIDR Range for Pods in cluster. Requires --allocate-node-cidrs to be true</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cluster-name string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "kubernetes"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The instance prefix for the cluster.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--concurrent-service-syncs int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 1</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The number of services that are allowed to sync concurrently. Larger number = more responsive service management, but more CPU (and network) load</td>
+    </tr>
+    <tr>
+      <td colspan="2">--configure-cloud-routes&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Should CIDRs allocated by allocate-node-cidrs be configured on the cloud provider.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--contention-profiling</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Enable lock contention profiling, if profiling is enabled.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--controller-start-interval duration</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Interval between starting controller managers.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--feature-gates mapStringBool</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:<br/>APIListChunking=true|false (BETA - default=true)<br/>APIResponseCompression=true|false (ALPHA - default=false)<br/>Accelerators=true|false (ALPHA - default=false)<br/>AdvancedAuditing=true|false (BETA - default=true)<br/>AllAlpha=true|false (ALPHA - default=false)<br/>AppArmor=true|false (BETA - default=true)<br/>BlockVolume=true|false (ALPHA - default=false)<br/>CPUManager=true|false (BETA - default=true)<br/>CRIContainerLogRotation=true|false (ALPHA - default=false)<br/>CSIPersistentVolume=true|false (BETA - default=true)<br/>CustomPodDNS=true|false (BETA - default=true)<br/>CustomResourceSubresources=true|false (ALPHA - default=false)<br/>CustomResourceValidation=true|false (BETA - default=true)<br/>DebugContainers=true|false (ALPHA - default=false)<br/>DevicePlugins=true|false (BETA - default=true)<br/>DynamicKubeletConfig=true|false (ALPHA - default=false)<br/>EnableEquivalenceClassCache=true|false (ALPHA - default=false)<br/>ExpandPersistentVolumes=true|false (ALPHA - default=false)<br/>ExperimentalCriticalPodAnnotation=true|false (ALPHA - default=false)<br/>ExperimentalHostUserNamespaceDefaulting=true|false (BETA - default=false)<br/>GCERegionalPersistentDisk=true|false (BETA - default=true)<br/>HugePages=true|false (BETA - default=true)<br/>HyperVContainer=true|false (ALPHA - default=false)<br/>Initializers=true|false (ALPHA - default=false)<br/>LocalStorageCapacityIsolation=true|false (BETA - default=true)<br/>MountContainers=true|false (ALPHA - default=false)<br/>MountPropagation=true|false (BETA - default=true)<br/>PersistentLocalVolumes=true|false (BETA - default=true)<br/>PodPriority=true|false (ALPHA - default=false)<br/>PodShareProcessNamespace=true|false (ALPHA - default=false)<br/>ReadOnlyAPIDataVolumes=true|false (DEPRECATED - default=true)<br/>ResourceLimitsPriorityFunction=true|false (ALPHA - default=false)<br/>RotateKubeletClientCertificate=true|false (BETA - default=true)<br/>RotateKubeletServerCertificate=true|false (ALPHA - default=false)<br/>RunAsGroup=true|false (ALPHA - default=false)<br/>ScheduleDaemonSetPods=true|false (ALPHA - default=false)<br/>ServiceNodeExclusion=true|false (ALPHA - default=false)<br/>ServiceProxyAllowExternalIPs=true|false (DEPRECATED - default=false)<br/>StorageObjectInUseProtection=true|false (BETA - default=true)<br/>StreamingProxyRedirects=true|false (BETA - default=true)<br/>SupportIPVSProxyMode=true|false (BETA - default=true)<br/>SupportPodPidsLimit=true|false (ALPHA - default=false)<br/>TaintBasedEvictions=true|false (ALPHA - default=false)<br/>TaintNodesByCondition=true|false (ALPHA - default=false)<br/>TokenRequest=true|false (ALPHA - default=false)<br/>VolumeScheduling=true|false (BETA - default=true)<br/>VolumeSubpath=true|false (default=true)</td>
+    </tr>
+    <tr>
+      <td colspan="2">-h, --help</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">help for cloud-controller-manager</td>
+    </tr>
+    <tr>
+      <td colspan="2">--http2-max-streams-per-connection int</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The limit that the server gives to clients for the maximum number of streams in an HTTP/2 connection. Zero means to use golang's default.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--kube-api-burst int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 30</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Burst to use while talking with kubernetes apiserver.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--kube-api-content-type string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "application/vnd.kubernetes.protobuf"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Content type of requests sent to apiserver.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--kube-api-qps float32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 20</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">QPS to use while talking with kubernetes apiserver.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--kubeconfig string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Path to kubeconfig file with authorization and master location information.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--leader-elect&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--leader-elect-lease-duration duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 15s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--leader-elect-renew-deadline duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The interval between attempts by the acting master to renew a leadership slot before it stops leading. This must be less than or equal to the lease duration. This is only applicable if leader election is enabled.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--leader-elect-resource-lock endpoints&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "endpoints"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The type of resource object that is used for locking during leader election. Supported options are endpoints (default) and `configmaps`.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--leader-elect-retry-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 2s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The duration the clients should wait between attempting acquisition and renewal of a leadership. This is only applicable if leader election is enabled.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--log-flush-frequency duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Maximum number of seconds between log flushes</td>
+    </tr>
+    <tr>
+      <td colspan="2">--master string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The address of the Kubernetes API server (overrides any value in kubeconfig).</td>
+    </tr>
+    <tr>
+      <td colspan="2">--min-resync-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 12h0m0s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The resync period in reflectors will be random between MinResyncPeriod and 2*MinResyncPeriod.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--node-monitor-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The period for syncing NodeStatus in NodeController.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--node-status-update-frequency duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5m0s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Specifies how often the controller updates nodes' status.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--port int&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10253</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">DEPRECATED: the port on which to serve HTTP insecurely without authentication and authorization. If 0, don't serve HTTPS at all. See --secure-port instead.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--profiling&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Enable profiling via web interface host:port/debug/pprof/</td>
+    </tr>
+    <tr>
+      <td colspan="2">--route-reconciliation-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The period for reconciling routes created for Nodes by cloud provider.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--secure-port int</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The port on which to serve HTTPS with authentication and authorization. If 0, don't serve HTTPS at all.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--tls-cert-file string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">File containing the default x509 Certificate for HTTPS. (CA cert, if any, concatenated after server cert). If HTTPS serving is enabled, and --tls-cert-file and --tls-private-key-file are not provided, a self-signed certificate and key are generated for the public address and saved to the directory specified by --cert-dir.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--tls-cipher-suites stringSlice</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Comma-separated list of cipher suites for the server. Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants). If omitted, the default Go cipher suites will be used</td>
+    </tr>
+    <tr>
+      <td colspan="2">--tls-min-version string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Minimum TLS version supported. Value must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--tls-private-key-file string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">File containing the default x509 private key matching --tls-cert-file.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--tls-sni-cert-key namedCertKey&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: []</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">A pair of x509 certificate and private key file paths, optionally suffixed with a list of domain patterns which are fully qualified domain names, possibly with prefixed wildcard segments. If no domain patterns are provided, the names of the certificate are extracted. Non-wildcard matches trump over wildcard matches, explicit domain patterns trump over extracted names. For multiple key/certificate pairs, use the --tls-sni-cert-key multiple times. Examples: "example.crt,example.key" or "foo.crt,foo.key:*.foo.com,foo.com".</td>
+    </tr>
+    <tr>
+      <td colspan="2">--use-service-account-credentials</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If true, use individual service account credentials for each controller.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--version version[=true]</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Print version information and quit</td>
+    </tr>
+  </tbody>
+</table>

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -1,0 +1,225 @@
+---
+title: Feature Gates
+weight: 10
+---
+
+{% capture overview %}
+This page contains an overview of the various feature gates an administrator
+can specify on different Kubernetes components.
+{% endcapture %}
+
+{% capture body %}
+
+## Overview
+
+Feature gates are a set of key=value pairs that describe alpha or experimental
+features.
+An administrator can use the `--feature-gates` command line flag on each component
+to turn a feature on or off.
+The following table is a summary of the feature gates that you can set on
+different Kubernetes components.
+
+- The "Since" column contains the Kubernetes release when a feature is introduced
+  or its release stage is changed.
+- The "Until" column, if not empty, contains the last Kubernetes release in which
+  you can still use a feature gate.
+
+| Feature | Default | Stage | Since | Until |
+|---------|---------|-------|-------|-------|
+| `Accelerators` | `false` | Alpha | 1.6 | 1.10 |
+| `AdvancedAuditing` | `false` | Alpha | 1.7 | 1.7 |
+| `AdvancedAuditing` | `true` | Beta | 1.8 | |
+| `AffinityInAnnotations` | `false` | Alpha | 1.6 | 1.7 |
+| `AllowExtTrafficLocalEndpoints` | `false` | Beta | 1.4 | 1.6 |
+| `AllowExtTrafficLocalEndpoints` | `true` | GA | 1.7 | |
+| `APIListChunking` | `false` | Alpha | 1.8 | 1.8 |
+| `APIListChunking` | `true` | Beta | 1.9 | |
+| `APIResponseCompression` | `false` | Alpha | 1.7 | |
+| `AppArmor` | `true` | Beta | 1.4 | |
+| `BlockVolume` | `false` | Alpha | 1.9 | |
+| `CPUManager` | `false` | Alpha | 1.8 | 1.9 |
+| `CPUManager` | `true` | Beta | 1.10 | |
+| `CRIContainerLogRotation` | `false` | Alpha | 1.10 | |
+| `CSIPersistentVolume` | `false` | Alpha | 1.9 | 1.9 |
+| `CSIPersistentVolume` | `true` | Beta | 1.10 | |
+| `CustomPodDNS` | `false` | Alpha | 1.9 | 1.9 |
+| `CustomPodDNS` | `true` | Beta| 1.10 | |
+| `CustomResourceSubresources` | `false` | Alpha | 1.10 | |
+| `CustomResourceValidation` | `false` | Alpha | 1.8 | 1.8 |
+| `CustomResourceValidation` | `true` | Beta | 1.9 | |
+| `DebugContainers` | `false` | Alpha | 1.10 | |
+| `DevicePlugins` | `false` | Alpha | 1.8 | 1.9 |
+| `DevicePlugins` | `true` | Beta | 1.10 | |
+| `DynamicKubeletConfig` | `false` | Alpha | 1.4 | |
+| `DynamicVolumeProvisioning` | `true` | Alpha | 1.3 | 1.7 |
+| `DynamicVolumeProvisioning` | `true` | GA | 1.8 | |
+| `EnableEquivalenceClassCache` | `false` | Alpha | 1.8 | |
+| `ExpandPersistentVolumes` | `false` | Alpha | 1.8 | 1.8 |
+| `ExperimentalCriticalPodAnnotation` | `false` | Alpha | 1.5 | |
+| `ExperimentalHostUserNamespaceDefaulting` | `false` | Beta | 1.5 | |
+| `GCERegionalPersistentDisk` | `true` | Beta | 1.10 | |
+| `HugePages` | `false` | Alpha | 1.8 | 1.9 |
+| `HugePages` | `true` | Beta| 1.10 | |
+| `HyperVContainer` | `false` | Alpha | 1.10 | |
+| `Initializers` | `false` | Alpha | 1.7 | |
+| `KubeletConfigFile` | `false` | Alpha | 1.8 | 1.9 |
+| `LocalStorageCapacityIsolation` | `false` | Alpha | 1.7 | 1.9 |
+| `LocalStorageCapacityIsolation` | `true` | Beta| 1.10 | |
+| `MountContainers` | `false` | Alpha | 1.9 | |
+| `MountPropagation` | `false` | Alpha | 1.8 | 1.9 |
+| `MountPropagation` | `true` | Beta | 1.10 | |
+| `PersistentLocalVolumes` | `false` | Alpha | 1.7 | 1.9 |
+| `PersistentLocalVolumes` | `true` | Beta | 1.10 | |
+| `PodPriority` | `false` | Alpha | 1.8 | |
+| `PodShareProcessNamespace` | `false` | Alpha | 1.10 | |
+| `PVCProtection` | `false` | Alpha | 1.9 | 1.9 |
+| `ReadOnlyAPIDataVolumes` | `true` | Deprecated | 1.10 | |
+| `ResourceLimitsPriorityFunction` | `false` | Alpha | 1.9 | |
+| `RotateKubeletClientCertificate` | `true` | Beta | 1.7 | |
+| `RotateKubeletServerCertificate` | `false` | Alpha | 1.7 | |
+| `RunAsGroup` | `false` | Alpha | 1.10 | |
+| `ScheduleDaemonSetPods` | `false` | Alpha | 1.10 | |
+| `ServiceNodeExclusion` | `false` | Alpha | 1.8 | |
+| `StorageObjectInUseProtection` | `true` | Beta | 1.10 | |
+| `StreamingProxyRedirects` | `true` | Beta | 1.5 | |
+| `SupportIPVSProxyMode` | `false` | Alpha | 1.8 | 1.8 |
+| `SupportIPVSProxyMode` | `false` | Beta | 1.9 | 1.9 |
+| `SupportIPVSProxyMode` | `true` | Beta | 1.10 | |
+| `SupportPodPidsLimit` | `false` | Alpha | 1.10 | |
+| `TaintBasedEvictions` | `false` | Alpha | 1.6 | |
+| `TaintNodesByCondition` | `false` | Alpha | 1.8 | |
+| `TokenRequest` | `false` | Alpha | 1.10 | |
+| `VolumeScheduling` | `false` | Alpha | 1.9 | 1.9 |
+| `VolumeScheduling` | `true` | Beta | 1.10 | |
+
+## Using a Feature
+
+### Feature Stages
+
+A feature can be in *Alpha*, *Beta* or *GA* stage.
+An *Alpha* feature means:
+
+* Disabled by default.
+* Might be buggy. Enabling the feature may expose bugs.
+* Support for feature may be dropped at any time without notice.
+* The API may change in incompatible ways in a later software release without notice.
+* Recommended for use only in short-lived testing clusters, due to increased
+  risk of bugs and lack of long-term support.
+
+A *Beta* feature means:
+
+* Enabled by default.
+* The feature is well tested. Enabling the feature is considered safe.
+* Support for the overall feature will not be dropped, though details may change.
+* The schema and/or semantics of objects may change in incompatible ways in a
+  subsequent beta or stable release. When this happens, we will provide instructions
+  for migrating to the next version. This may require deleting, editing, and
+  re-creating API objects. The editing process may require some thought.
+  This may require downtime for applications that rely on the feature.
+* Recommended for only non-business-critical uses because of potential for
+  incompatible changes in subsequent releases. If you have multiple clusters
+  that can be upgraded independently, you may be able to relax this restriction.
+
+**Note:** Please do try *Beta* features and give feedback on them!
+After they exit beta, it may not be practical for us to make more changes.
+{: .note}
+
+A *GA* feature is also referred to as a *stable* feature. It means:
+
+* The corresponding feature gate is no longer needed.
+* Stable versions of features will appear in released software for many subsequent versions.
+
+### Feature Gates
+
+Each feature gate is designed for enabling/disabling a specific feature:
+
+- `Accelerators`: Enable Nvidia GPU support when using Docker
+- `AdvancedAuditing`: Enable [advanced auditing](/docs/tasks/debug-application-cluster/audit/#advanced-audit)
+- `AffinityInAnnotations`(*deprecated*): Enable setting [Pod affinity or anti-affinitys](/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity).
+- `AllowExtTrafficLocalEndpoints`: Enable a service to route external requests to node local endpoints.
+- `APIListChunking`: Enable the API clients to retrieve (`LIST` or `GET`) resources from API server in chunks.
+- `APIResponseCompression`: Compress the API responses for `LIST` or `GET` requests.
+- `AppArmor`: Enable AppArmor based mandatory access control on Linux nodes when using Docker.
+   See [AppArmor Tutorial](/docs/tutorials/clusters/apparmor/) for more details.
+- `BlockVolume`: Enable the definition and consumption of raw block devices in Pods.
+   See [Raw Block Volume Support](/docs/concepts/storage/persistent-volumes/#raw-block-volume-support)
+   for more details.
+- `CPUManager`: Enable container level CPU affinity support, see [CPU Management Policies](/docs/tasks/administer-cluster/cpu-management-policies/).
+- `CRIContainerLogRotation`: Enable container log rotation for cri container runtime.
+- `CSIPersistentVolume`: Enable discovering and mounting volumes provisioned through a
+  [CSI (Container Storage Interface)](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/container-storage-interface.md)
+  compatible volume plugin.
+  Check the [`csi` volume type](/docs/concepts/storage/volumes/#csi) documentation for more details.
+- `CustomPodDNS`: Enable customizing the DNS settings for a Pod using its `dnsConfig` property.
+   Check [Pod's DNS Config](/docs/concepts/services-networking/dns-pod-service/#pods-dns-config)
+   for more details.
+- `CustomResourceSubresources`: Enable `/status` and `/scale` subresources
+  on resources created from [CustomResourceDefinition](/docs/concepts/api-extension/custom-resources/).
+- `CustomResourceValidation`: Enable schema based validation on resources created from
+  [CustomResourceDefinition](/docs/concepts/api-extension/custom-resources/).
+- `DebugContainers`: Enable running a "debugging" container in a Pod's namespace to
+  troubleshoot a running Pod.
+- `DevicePlugins`: Enable the [device-plugins](/docs/concepts/cluster-administration/device-plugins/)
+  based resource provisioning on nodes.
+- `DynamicKubeletConfig`: Enable the dynamic configuration of kubelet. See [Reconfigure kubelet](/docs/tasks/administer-cluster/reconfigure-kubelet/).
+- `DynamicVolumeProvisioning`(*deprecated*): Enable the [dynamic provisioning](/docs/concepts/storage/dynamic-provisioning/) of persistent volumes to Pods.
+- `EnableEquivalenceClassCache`: Enable the scheduler to cache equivalence of nodes when scheduling Pods.
+- `ExpandPersistentVolumes`: Enable the expanding of persistent volumes. See [Expanding Persistent Volumes Claims](/docs/concepts/storage/persistent-volumes/#expanding-persistent-volumes-claims).
+- `ExperimentalCriticalPodAnnotation`: Enable annotating specific pods as *critical* so that their [scheduling is guaranteed](/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/).
+- `ExperimentalHostUserNamespaceDefaultingGate`: Enabling the defaulting user
+   namespace to host. This is for containers that are using other host namespaces,
+   host mounts, or containers that are privileged or using specific non-namespaced
+   capabilities (e.g. `MKNODE`, `SYS_MODULE` etc.). This should only be enabled
+   if user namespace remapping is enabled in the Docker daemon.
+- `GCERegionalPersistentDisk`: Enable the regional PD feature on GCE.
+- `HugePages`: Enable the allocation and consumption of pre-allocated [huge pages](/docs/tasks/manage-hugepages/scheduling-hugepages/).
+- `HyperVContainer`: Enable [Hyper-V isolation](https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/hyperv-container) for Windows containers.
+- `Intializers`: Enable the [dynamic admission control](/docs/admin/extensible-admission-controllers/)
+  as an extension to the built-in [admission controllers](/docs/admin/admission-controllers/).
+  When the `Initializers` admission controller is enabled, this feature is automatically enabled.
+- `KubeletConfigFile`: Enable loading kubelet configuration from a file specified using a config file.
+  See [setting kubelet parameters via a config file](/docs/tasks/administer-cluster/kubelet-config-file/) for more details.
+- `LocalStorageCapacityIsolation`: Enable the consumption of [local ephemeral storage](/docs/concepts/configuration/manage-compute-resources-container/) and also the `sizeLimit` property of an [emptyDir volume](/docs/concepts/storage/volumes/#emptydir).
+- `MountContainers`: Enable using utility containers on host as the volume mounter.
+- `MountPropagation`: Enable sharing volume mounted by one container to other containers or pods.
+  For more details, please see [mount propagation](/docs/concepts/storage/volumes/#mount-propagation).
+- `PersistentLocalVolumes`: Enable the usage of `local` volume type in Pods.
+  Pod affinity has to be specified if requesting a `local` volume.
+- `PodPriority`: Enable the descheduling and preemption of Pods based on their [priorities](/docs/concepts/configuration/pod-priority-preemption/).
+- `PVCProtection`: Enable the prevention of a PersistentVolumeClaim (PVC) from
+  being deleted when it is still used by any Pod.
+  More details can be found [here](/docs/tasks/administer-cluster/pvc-protection/).
+- `ReadOnlyAPIDataVolumes`: Set Secret, ConfigMap, DownwardAPI and projected volumes to be mounted in read-only mode.
+  This gate exists only for backward compatibility. It will be removed in 1.11 release.
+- `ResourceLimitsPriorityFunction`: Enable a scheduler priority function that
+  assigns a lowest possible score of 1 to a node that satisfies at least one of
+  the input Pod's cpu and memory limits. The intent is to break ties between
+  nodes with same scores.
+- `RotateKubeletClientCertificate`: Enable the rotation of the client TLS certificate on the kubelet.
+  See [kubelet configuration](/docs/admin/kubelet-tls-bootstrapping/#kubelet-configuration) for more details.
+- `RotateKubeletServerCertificate`: Enable the rotation of the server TLS certificate on the kubelet.
+  See [kubelet configuration](/docs/admin/kubelet-tls-bootstrapping/#kubelet-configuration) for more details.
+- `RunAsGroup`: Enable control over the primary group ID set on the init processes of containers.
+- `ScheduleDaemonSetPods`: Enable DaemonSet Pods to be scheduled by the default scheduler instead of the DaemonSet controller.
+- `ServiceNodeExclusion`: Enable the exclusion of nodes from load balancers created by a cloud provider.
+  A node is eligible for exclusion if annotated with "`alpha.service-controller.kubernetes.io/exclude-balancer`" key.
+- `StorageObjectInUseProtection`: Postpone the deletion of PersistentVolume or
+  PersistentVolumeClaim objects if they are still being used.
+- `StreamingProxyRedirects`: Instructs the API server to intercept (and follow)
+   redirects from the backend (kubelet) for streaming requests.
+  Examples of streaming requests include the `exec`, `attach` and `port-forward` requests.
+- `SupportIPVSProxyMode`: Enable providing in-cluster service load balancing using IPVS.
+  See [service proxies](/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies) for more details.
+- `SupportPodPidsLimit`: Enable the support to limiting PIDs in Pods.
+- `TaintBasedEvictions`: Enable evicting pods from nodes based on taints on nodes and tolerations on Pods.
+  See [taints and tolerations](/docs/concepts/configuration/taint-and-toleration/) for more details.
+- `TaintNodesByCondition`: Enable automatic tainting nodes based on [node conditions](/docs/concepts/architecture/nodes/#condition).
+- `TokenRequest`: Enable the `TokenRequest` endpoint on service account resources.
+- `VolumeScheduling`: Enable volume topology aware scheduling and make the
+  PersistentVolumeClaim (PVC) binding aware of scheduling decisions. It also
+  enables the usage of [`local`](/docs/concepts/storage/volumes/#local) volume
+  type when used together with the `PersistentLocalVolumes` feature gate.
+
+{% endcapture %}
+
+{% include templates/concept.md %}

--- a/content/en/docs/reference/command-line-tools-reference/federation-apiserver.md
+++ b/content/en/docs/reference/command-line-tools-reference/federation-apiserver.md
@@ -1,0 +1,153 @@
+---
+title: federation-apiserver
+notitle: true
+weight: 100
+---
+## federation-apiserver
+
+
+
+### Synopsis
+
+
+The Kubernetes federation API server validates and configures data
+for the api objects which include pods, services, replicationcontrollers, and
+others. The API Server services REST operations and provides the frontend to the
+cluster's shared state through which all other components interact.
+
+```
+federation-apiserver [flags]
+```
+
+### Options
+
+```
+      --admission-control-config-file string                    File with admission control configuration.
+      --advertise-address ip                                    The IP address on which to advertise the apiserver to members of the cluster. This address must be reachable by the rest of the cluster. If blank, the --bind-address will be used. If --bind-address is unspecified, the host's default interface will be used.
+      --anonymous-auth                                          Enables anonymous requests to the secure port of the API server. Requests that are not rejected by another authentication method are treated as anonymous requests. Anonymous requests have a username of system:anonymous, and a group name of system:unauthenticated. (default true)
+      --audit-log-format string                                 Format of saved audits. "legacy" indicates 1-line text format for each event. "json" indicates structured json format. Requires the 'AdvancedAuditing' feature gate. Known formats are legacy,json. (default "json")
+      --audit-log-maxage int                                    The maximum number of days to retain old audit log files based on the timestamp encoded in their filename.
+      --audit-log-maxbackup int                                 The maximum number of old audit log files to retain.
+      --audit-log-maxsize int                                   The maximum size in megabytes of the audit log file before it gets rotated.
+      --audit-log-path string                                   If set, all requests coming to the apiserver will be logged to this file.  '-' means standard out.
+      --audit-policy-file string                                Path to the file that defines the audit policy configuration. Requires the 'AdvancedAuditing' feature gate. With AdvancedAuditing, a profile is required to enable auditing.
+      --audit-webhook-batch-buffer-size int                     The size of the buffer to store events before batching and sending to the webhook. Only used in batch mode. (default 10000)
+      --audit-webhook-batch-initial-backoff duration            The amount of time to wait before retrying the first failed requests. Only used in batch mode. (default 10s)
+      --audit-webhook-batch-max-size int                        The maximum size of a batch sent to the webhook. Only used in batch mode. (default 400)
+      --audit-webhook-batch-max-wait duration                   The amount of time to wait before force sending the batch that hadn't reached the max size. Only used in batch mode. (default 30s)
+      --audit-webhook-batch-throttle-burst int                  Maximum number of requests sent at the same moment if ThrottleQPS was not utilized before. Only used in batch mode. (default 15)
+      --audit-webhook-batch-throttle-qps float32                Maximum average number of requests per second. Only used in batch mode. (default 10)
+      --audit-webhook-config-file string                        Path to a kubeconfig formatted file that defines the audit webhook configuration. Requires the 'AdvancedAuditing' feature gate.
+      --audit-webhook-mode string                               Strategy for sending audit events. Blocking indicates sending events should block server responses. Batch causes the webhook to buffer and send events asynchronously. Known modes are batch,blocking. (default "batch")
+      --authentication-token-webhook-cache-ttl duration         The duration to cache responses from the webhook token authenticator. (default 2m0s)
+      --authentication-token-webhook-config-file string         File with webhook configuration for token authentication in kubeconfig format. The API server will query the remote service to determine authentication for bearer tokens.
+      --authorization-mode string                               Ordered list of plug-ins to do authorization on secure port. Comma-delimited list of: AlwaysAllow,AlwaysDeny,ABAC,Webhook,RBAC,Node. (default "AlwaysAllow")
+      --authorization-policy-file string                        File with authorization policy in csv format, used with --authorization-mode=ABAC, on the secure port.
+      --authorization-webhook-cache-authorized-ttl duration     The duration to cache 'authorized' responses from the webhook authorizer. (default 5m0s)
+      --authorization-webhook-cache-unauthorized-ttl duration   The duration to cache 'unauthorized' responses from the webhook authorizer. (default 30s)
+      --authorization-webhook-config-file string                File with webhook configuration in kubeconfig format, used with --authorization-mode=Webhook. The API server will query the remote service to determine access on the API server's secure port.
+      --basic-auth-file string                                  If set, the file that will be used to admit requests to the secure port of the API server via http basic authentication.
+      --bind-address ip                                         The IP address on which to listen for the --secure-port port. The associated interface(s) must be reachable by the rest of the cluster, and by CLI/web clients. If blank, all interfaces will be used (0.0.0.0). (default 0.0.0.0)
+      --cert-dir string                                         The directory where the TLS certs are located. If --tls-cert-file and --tls-private-key-file are provided, this flag will be ignored. (default "/var/run/kubernetes")
+      --client-ca-file string                                   If set, any request presenting a client certificate signed by one of the authorities in the client-ca-file is authenticated with an identity corresponding to the CommonName of the client certificate.
+      --contention-profiling                                    Enable lock contention profiling, if profiling is enabled
+      --cors-allowed-origins strings                            List of allowed origins for CORS, comma separated.  An allowed origin can be a regular expression to support subdomain matching. If this list is empty CORS will not be enabled.
+      --default-watch-cache-size int                            Default watch cache size. If zero, watch cache will be disabled for resources that do not have a default watch size set. (default 100)
+      --delete-collection-workers int                           Number of workers spawned for DeleteCollection call. These are used to speed up namespace cleanup. (default 1)
+      --deserialization-cache-size int                          Number of deserialized json objects to cache in memory.
+      --disable-admission-plugins strings                       admission plugins that should be disabled although they are in the default enabled plugins list. Comma-delimited list of admission plugins: Initializers, MutatingAdmissionWebhook, NamespaceLifecycle, ValidatingAdmissionWebhook. The order of plugins in this flag does not matter.
+      --enable-admission-plugins strings                        admission plugins that should be enabled in addition to default enabled ones. Comma-delimited list of admission plugins: Initializers, MutatingAdmissionWebhook, NamespaceLifecycle, ValidatingAdmissionWebhook. The order of plugins in this flag does not matter.
+      --enable-bootstrap-token-auth                             Enable to allow secrets of type 'bootstrap.kubernetes.io/token' in the 'kube-system' namespace to be used for TLS bootstrapping authentication.
+      --enable-garbage-collector                                Enables the generic garbage collector. MUST be synced with the corresponding flag of the kube-controller-manager. (default true)
+      --enable-swagger-ui                                       Enables swagger ui on the apiserver at /swagger-ui
+      --etcd-cafile string                                      SSL Certificate Authority file used to secure etcd communication.
+      --etcd-certfile string                                    SSL certification file used to secure etcd communication.
+      --etcd-compaction-interval duration                       The interval of compaction requests. If 0, the compaction request from apiserver is disabled. (default 5m0s)
+      --etcd-keyfile string                                     SSL key file used to secure etcd communication.
+      --etcd-prefix string                                      The prefix to prepend to all resource paths in etcd. (default "/registry")
+      --etcd-servers strings                                    List of etcd servers to connect with (scheme://ip:port), comma separated.
+      --etcd-servers-overrides strings                          Per-resource etcd servers overrides, comma separated. The individual override format: group/resource#servers, where servers are http://ip:port, semicolon separated.
+      --event-ttl duration                                      Amount of time to retain events. (default 1h0m0s)
+      --experimental-encryption-provider-config string          The file containing configuration for encryption providers to be used for storing secrets in etcd
+      --experimental-keystone-ca-file string                    If set, the Keystone server's certificate will be verified by one of the authorities in the experimental-keystone-ca-file, otherwise the host's root CA set will be used.
+      --experimental-keystone-url string                        If passed, activates the keystone authentication plugin.
+      --external-hostname string                                The hostname to use when generating externalized URLs for this master (e.g. Swagger API Docs).
+      --feature-gates mapStringBool                             A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
+APIListChunking=true|false (BETA - default=true)
+APIResponseCompression=true|false (ALPHA - default=false)
+Accelerators=true|false (ALPHA - default=false)
+AdvancedAuditing=true|false (BETA - default=true)
+AllAlpha=true|false (ALPHA - default=false)
+AppArmor=true|false (BETA - default=true)
+BlockVolume=true|false (ALPHA - default=false)
+CPUManager=true|false (BETA - default=true)
+CSIPersistentVolume=true|false (ALPHA - default=false)
+CustomPodDNS=true|false (ALPHA - default=false)
+CustomResourceValidation=true|false (BETA - default=true)
+DebugContainers=true|false (ALPHA - default=false)
+DevicePlugins=true|false (ALPHA - default=false)
+DynamicKubeletConfig=true|false (ALPHA - default=false)
+EnableEquivalenceClassCache=true|false (ALPHA - default=false)
+ExpandPersistentVolumes=true|false (ALPHA - default=false)
+ExperimentalCriticalPodAnnotation=true|false (ALPHA - default=false)
+ExperimentalHostUserNamespaceDefaulting=true|false (BETA - default=false)
+HugePages=true|false (BETA - default=true)
+HyperVContainer=true|false (ALPHA - default=false)
+Initializers=true|false (ALPHA - default=false)
+LocalStorageCapacityIsolation=true|false (ALPHA - default=false)
+MountContainers=true|false (ALPHA - default=false)
+MountPropagation=true|false (ALPHA - default=false)
+PVCProtection=true|false (ALPHA - default=false)
+PersistentLocalVolumes=true|false (ALPHA - default=false)
+PodPriority=true|false (ALPHA - default=false)
+PodShareProcessNamespace=true|false (ALPHA - default=false)
+ResourceLimitsPriorityFunction=true|false (ALPHA - default=false)
+RotateKubeletClientCertificate=true|false (BETA - default=true)
+RotateKubeletServerCertificate=true|false (ALPHA - default=false)
+ServiceNodeExclusion=true|false (ALPHA - default=false)
+ServiceProxyAllowExternalIPs=true|false (DEPRECATED - default=false)
+StreamingProxyRedirects=true|false (BETA - default=true)
+SupportIPVSProxyMode=true|false (BETA - default=false)
+SupportPodPidsLimit=true|false (ALPHA - default=false)
+TaintBasedEvictions=true|false (ALPHA - default=false)
+TaintNodesByCondition=true|false (ALPHA - default=false)
+VolumeScheduling=true|false (ALPHA - default=false)
+  -h, --help                                                    help for federation-apiserver
+      --log-flush-frequency duration                            Maximum number of seconds between log flushes (default 5s)
+      --master-service-namespace string                         DEPRECATED: the namespace from which the kubernetes master services should be injected into pods. (default "default")
+      --max-mutating-requests-inflight int                      The maximum number of mutating requests in flight at a given time. When the server exceeds this, it rejects requests. Zero for no limit. (default 200)
+      --max-requests-inflight int                               The maximum number of non-mutating requests in flight at a given time. When the server exceeds this, it rejects requests. Zero for no limit. (default 400)
+      --min-request-timeout int                                 An optional field indicating the minimum number of seconds a handler must keep a request open before timing it out. Currently only honored by the watch request handler, which picks a randomized value above this number as the connection timeout, to spread out load. (default 1800)
+      --oidc-ca-file string                                     If set, the OpenID server's certificate will be verified by one of the authorities in the oidc-ca-file, otherwise the host's root CA set will be used.
+      --oidc-client-id string                                   The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set.
+      --oidc-groups-claim string                                If provided, the name of a custom OpenID Connect claim for specifying user groups. The claim value is expected to be a string or array of strings. This flag is experimental, please see the authentication documentation for further details.
+      --oidc-groups-prefix string                               If provided, all groups will be prefixed with this value to prevent conflicts with other authentication strategies.
+      --oidc-issuer-url string                                  The URL of the OpenID issuer, only HTTPS scheme will be accepted. If set, it will be used to verify the OIDC JSON Web Token (JWT).
+      --oidc-username-claim string                              The OpenID claim to use as the user name. Note that claims other than the default ('sub') is not guaranteed to be unique and immutable. This flag is experimental, please see the authentication documentation for further details. (default "sub")
+      --oidc-username-prefix string                             If provided, all usernames will be prefixed with this value. If not provided, username claims other than 'email' are prefixed by the issuer URL to avoid clashes. To skip any prefixing, provide the value '-'.
+      --profiling                                               Enable profiling via web interface host:port/debug/pprof/ (default true)
+      --request-timeout duration                                An optional field indicating the duration a handler must keep a request open before timing it out. This is the default request timeout for requests but may be overridden by flags such as --min-request-timeout for specific types of requests. (default 1m0s)
+      --requestheader-allowed-names strings                     List of client certificate common names to allow to provide usernames in headers specified by --requestheader-username-headers. If empty, any client certificate validated by the authorities in --requestheader-client-ca-file is allowed.
+      --requestheader-client-ca-file string                     Root certificate bundle to use to verify client certificates on incoming requests before trusting usernames in headers specified by --requestheader-username-headers
+      --requestheader-extra-headers-prefix strings              List of request header prefixes to inspect. X-Remote-Extra- is suggested.
+      --requestheader-group-headers strings                     List of request headers to inspect for groups. X-Remote-Group is suggested.
+      --requestheader-username-headers strings                  List of request headers to inspect for usernames. X-Remote-User is common.
+      --runtime-config mapStringString                          A set of key=value pairs that describe runtime configuration that may be passed to apiserver. <group>/<version> (or <version> for the core group) key can be used to turn on/off specific api versions. api/all is special key to control all api versions, be careful setting it false, unless you know what you do. api/legacy is deprecated, we will remove it in the future, so stop using it.
+      --secure-port int                                         The port on which to serve HTTPS with authentication and authorization. If 0, don't serve HTTPS at all. (default 6443)
+      --service-account-key-file stringArray                    File containing PEM-encoded x509 RSA or ECDSA private or public keys, used to verify ServiceAccount tokens. If unspecified, --tls-private-key-file is used. The specified file can contain multiple keys, and the flag can be specified multiple times with different files.
+      --service-account-lookup                                  If true, validate ServiceAccount tokens exist in etcd as part of authentication. (default true)
+      --storage-backend string                                  The storage backend for persistence. Options: 'etcd3' (default), 'etcd2'.
+      --storage-media-type string                               The media type to use to store objects in storage. Some resources or storage backends may only support a specific media type and will ignore this setting. (default "application/vnd.kubernetes.protobuf")
+      --storage-versions string                                 The per-group version to store resources in. Specified in the format "group1/version1,group2/version2,...". In the case where objects are moved from one group to the other, you may specify the format "group1=group2/v1beta1,group3/v1beta1,...". You only need to pass the groups you wish to change from the defaults. It defaults to a list of preferred versions of all registered groups, which is derived from the KUBE_API_VERSIONS environment variable. (default "admissionregistration.k8s.io/v1beta1,apps/v1beta1,authentication.k8s.io/v1,authorization.k8s.io/v1,autoscaling/v1,batch/v1,certificates.k8s.io/v1beta1,componentconfig/v1alpha1,events.k8s.io/v1beta1,extensions/v1beta1,federation/v1beta1,imagepolicy.k8s.io/v1alpha1,networking.k8s.io/v1,policy/v1beta1,rbac.authorization.k8s.io/v1,scheduling.k8s.io/v1alpha1,settings.k8s.io/v1alpha1,storage.k8s.io/v1,v1")
+      --target-ram-mb int                                       Memory limit for apiserver in MB (used to configure sizes of caches, etc.)
+      --tls-cert-file string                                    File containing the default x509 Certificate for HTTPS. (CA cert, if any, concatenated after server cert). If HTTPS serving is enabled, and --tls-cert-file and --tls-private-key-file are not provided, a self-signed certificate and key are generated for the public address and saved to the directory specified by --cert-dir.
+      --tls-cipher-suites strings                               Comma-separated list of cipher suites for the server. Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants). If omitted, the default Go cipher suites will be used
+      --tls-min-version string                                  Minimum TLS version supported. Value must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants.
+      --tls-private-key-file string                             File containing the default x509 private key matching --tls-cert-file.
+      --tls-sni-cert-key namedCertKey                           A pair of x509 certificate and private key file paths, optionally suffixed with a list of domain patterns which are fully qualified domain names, possibly with prefixed wildcard segments. If no domain patterns are provided, the names of the certificate are extracted. Non-wildcard matches trump over wildcard matches, explicit domain patterns trump over extracted names. For multiple key/certificate pairs, use the --tls-sni-cert-key multiple times. Examples: "example.crt,example.key" or "foo.crt,foo.key:*.foo.com,foo.com". (default [])
+      --token-auth-file string                                  If set, the file that will be used to secure the secure port of the API server via token authentication.
+      --watch-cache                                             Enable watch caching in the apiserver (default true)
+      --watch-cache-sizes strings                               List of watch cache sizes for every resource (pods, nodes, etc.), comma separated. The individual override format: resource[.group]#size, where resource is lowercase plural (no version), group is optional, and size is a number. It takes effect when watch-cache is enabled. Some resources (replicationcontrollers, endpoints, nodes, pods, services, apiservices.apiregistration.k8s.io) have system defaults set by heuristics, others default to default-watch-cache-size
+```
+
+###### Auto generated by spf13/cobra on 25-Mar-2018

--- a/content/en/docs/reference/command-line-tools-reference/federation-controller-manager.md
+++ b/content/en/docs/reference/command-line-tools-reference/federation-controller-manager.md
@@ -1,0 +1,59 @@
+---
+title: federation-controller-manager
+notitle: true
+weight: 110
+---
+## federation-controller-manager
+
+
+
+### Synopsis
+
+
+The federation controller manager is a daemon that embeds
+the core control loops shipped with federation. In applications of robotics and
+automation, a control loop is a non-terminating loop that regulates the state of
+the system. In federation, a controller is a control loop that watches the shared
+state of the federation cluster through the apiserver and makes changes attempting
+to move the current state towards the desired state. Examples of controllers that
+ship with federation today is the cluster controller.
+
+```
+federation-controller-manager [flags]
+```
+
+### Options
+
+```
+      --address ip                             The IP address to serve on (set to 0.0.0.0 for all interfaces) (default 0.0.0.0)
+      --cluster-monitor-period duration        The period for syncing ClusterStatus in ClusterController. (default 40s)
+      --concurrent-job-syncs int               The number of Jobs syncing operations that will be done concurrently. Larger number = faster endpoint updating, but more CPU (and network) load (default 10)
+      --concurrent-replicaset-syncs int        The number of ReplicaSets syncing operations that will be done concurrently. Larger number = faster endpoint updating, but more CPU (and network) load (default 10)
+      --concurrent-service-syncs int           The number of service syncing operations that will be done concurrently. Larger number = faster endpoint updating, but more CPU (and network) load (default 10)
+      --contention-profiling                   Enable lock contention profiling, if profiling is enabled
+      --controllers mapStringString            A set of key=value pairs that describe controller configuration to enable/disable specific controllers. Key should be the resource name (like services) and value should be true or false. For example: services=false,ingresses=false
+      --dns-provider string                    DNS provider. Valid values are: ["aws-route53" "azure-azuredns" "coredns" "google-clouddns"]
+      --dns-provider-config string             Path to config file for configuring DNS provider.
+      --federated-api-burst int                Burst to use while talking with federation apiserver (default 30)
+      --federated-api-qps float32              QPS to use while talking with federation apiserver (default 20)
+      --federation-name string                 Federation name.
+      --federation-only-namespace string       Name of the namespace that would be created only in federation control plane. (default "federation-only")
+  -h, --help                                   help for federation-controller-manager
+      --hpa-scale-forbidden-window duration    The time window wrt cluster local hpa lastscale time, during which federated hpa would not move the hpa max/min replicas around (default 2m0s)
+      --kube-api-content-type string           ContentType of requests sent to apiserver. Passing application/vnd.kubernetes.protobuf is an experimental feature now.
+      --kubeconfig string                      Path to kubeconfig file with authorization and master location information.
+      --leader-elect                           Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability.
+      --leader-elect-lease-duration duration   The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled. (default 15s)
+      --leader-elect-renew-deadline duration   The interval between attempts by the acting master to renew a leadership slot before it stops leading. This must be less than or equal to the lease duration. This is only applicable if leader election is enabled. (default 10s)
+      --leader-elect-resource-lock endpoints   The type of resource object that is used for locking during leader election. Supported options are endpoints (default) and `configmaps`. (default "endpoints")
+      --leader-elect-retry-period duration     The duration the clients should wait between attempting acquisition and renewal of a leadership. This is only applicable if leader election is enabled. (default 2s)
+      --log-flush-frequency duration           Maximum number of seconds between log flushes (default 5s)
+      --master string                          The address of the federation API server (overrides any value in kubeconfig)
+      --port int                               The port that the controller-manager's http service runs on (default 10253)
+      --profiling                              Enable profiling via web interface host:port/debug/pprof/ (default true)
+      --service-dns-suffix string              DNS Suffix to use when publishing federated service names.  Defaults to zone-name
+      --zone-id string                         Zone ID, needed if the zone name is not unique.
+      --zone-name string                       Zone name, like example.com.
+```
+
+###### Auto generated by spf13/cobra on 25-Mar-2018

--- a/content/en/docs/reference/command-line-tools-reference/kube-apiserver.md
+++ b/content/en/docs/reference/command-line-tools-reference/kube-apiserver.md
@@ -1,0 +1,762 @@
+---
+title: kube-apiserver
+notitle: true
+weight: 40
+---
+## kube-apiserver
+
+### Synopsis
+
+The Kubernetes API server validates and configures data
+for the api objects which include pods, services, replicationcontrollers, and
+others. The API Server services REST operations and provides the frontend to the
+cluster's shared state through which all other components interact.
+
+```
+kube-apiserver [flags]
+```
+
+### Options
+
+<table style="width: 100%;">
+  <colgroup>
+    <col span="1" style="width: 10px;" />
+    <col span="1" />
+  </colgroup>
+  <tbody>
+    <tr>
+      <td colspan="2">--admission-control-config-file string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">File with admission control configuration.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--advertise-address ip</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The IP address on which to advertise the apiserver to members of the cluster. This address must be reachable by the rest of the cluster. If blank, the --bind-address will be used. If --bind-address is unspecified, the host's default interface will be used.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--allow-privileged</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If true, allow privileged containers. [default=false]</td>
+    </tr>
+    <tr>
+      <td colspan="2">--anonymous-auth&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Enables anonymous requests to the secure port of the API server. Requests that are not rejected by another authentication method are treated as anonymous requests. Anonymous requests have a username of system:anonymous, and a group name of system:unauthenticated.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--apiserver-count int&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 1</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The number of apiservers running in the cluster, must be a positive number.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--audit-log-batch-buffer-size int&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10000</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The size of the buffer to store events before batching and writing. Only used in batch mode.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--audit-log-batch-max-size int&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 400</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The maximum size of a batch. Only used in batch mode.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--audit-log-batch-max-wait duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 30s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The amount of time to wait before force writing the batch that hadn't reached the max size. Only used in batch mode.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--audit-log-batch-throttle-burst int&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 15</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Maximum number of requests sent at the same moment if ThrottleQPS was not utilized before. Only used in batch mode.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--audit-log-batch-throttle-enable</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Whether batching throttling is enabled. Only used in batch mode.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--audit-log-batch-throttle-qps float32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Maximum average number of batches per second. Only used in batch mode.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--audit-log-format string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "json"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Format of saved audits. "legacy" indicates 1-line text format for each event. "json" indicates structured json format. Requires the 'AdvancedAuditing' feature gate. Known formats are legacy,json.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--audit-log-maxage int</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The maximum number of days to retain old audit log files based on the timestamp encoded in their filename.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--audit-log-maxbackup int</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The maximum number of old audit log files to retain.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--audit-log-maxsize int</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The maximum size in megabytes of the audit log file before it gets rotated.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--audit-log-mode string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "blocking"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Strategy for sending audit events. Blocking indicates sending events should block server responses. Batch causes the backend to buffer and write events asynchronously. Known modes are batch,blocking.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--audit-log-path string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If set, all requests coming to the apiserver will be logged to this file.  '-' means standard out.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--audit-policy-file string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Path to the file that defines the audit policy configuration. Requires the 'AdvancedAuditing' feature gate. With AdvancedAuditing, a profile is required to enable auditing.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--audit-webhook-batch-buffer-size int&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10000</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The size of the buffer to store events before batching and writing. Only used in batch mode.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--audit-webhook-batch-max-size int&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 400</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The maximum size of a batch. Only used in batch mode.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--audit-webhook-batch-max-wait duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 30s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The amount of time to wait before force writing the batch that hadn't reached the max size. Only used in batch mode.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--audit-webhook-batch-throttle-burst int&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 15</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Maximum number of requests sent at the same moment if ThrottleQPS was not utilized before. Only used in batch mode.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--audit-webhook-batch-throttle-enable&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Whether batching throttling is enabled. Only used in batch mode.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--audit-webhook-batch-throttle-qps float32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Maximum average number of batches per second. Only used in batch mode.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--audit-webhook-config-file string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Path to a kubeconfig formatted file that defines the audit webhook configuration. Requires the 'AdvancedAuditing' feature gate.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--audit-webhook-initial-backoff duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The amount of time to wait before retrying the first failed request.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--audit-webhook-mode string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "batch"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Strategy for sending audit events. Blocking indicates sending events should block server responses. Batch causes the backend to buffer and write events asynchronously. Known modes are batch,blocking.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--authentication-token-webhook-cache-ttl duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 2m0s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The duration to cache responses from the webhook token authenticator.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--authentication-token-webhook-config-file string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">File with webhook configuration for token authentication in kubeconfig format. The API server will query the remote service to determine authentication for bearer tokens.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--authorization-mode string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "AlwaysAllow"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Ordered list of plug-ins to do authorization on secure port. Comma-delimited list of: AlwaysAllow,AlwaysDeny,ABAC,Webhook,RBAC,Node.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--authorization-policy-file string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">File with authorization policy in csv format, used with --authorization-mode=ABAC, on the secure port.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--authorization-webhook-cache-authorized-ttl duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5m0s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The duration to cache 'authorized' responses from the webhook authorizer.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--authorization-webhook-cache-unauthorized-ttl duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 30s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The duration to cache 'unauthorized' responses from the webhook authorizer.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--authorization-webhook-config-file string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">File with webhook configuration in kubeconfig format, used with --authorization-mode=Webhook. The API server will query the remote service to determine access on the API server's secure port.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--azure-container-registry-config string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Path to the file containing Azure container registry configuration information.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--basic-auth-file string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If set, the file that will be used to admit requests to the secure port of the API server via http basic authentication.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--bind-address ip&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 0.0.0.0</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The IP address on which to listen for the --secure-port port. The associated interface(s) must be reachable by the rest of the cluster, and by CLI/web clients. If blank, all interfaces will be used (0.0.0.0 for all IPv4 interfaces and :: for all IPv6 interfaces).</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cert-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/var/run/kubernetes"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The directory where the TLS certs are located. If --tls-cert-file and --tls-private-key-file are provided, this flag will be ignored.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--client-ca-file string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If set, any request presenting a client certificate signed by one of the authorities in the client-ca-file is authenticated with an identity corresponding to the CommonName of the client certificate.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cloud-config string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The path to the cloud provider configuration file. Empty string for no configuration file.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cloud-provider string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The provider for cloud services. Empty string for no provider.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--contention-profiling</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Enable lock contention profiling, if profiling is enabled</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cors-allowed-origins stringSlice</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">List of allowed origins for CORS, comma separated.  An allowed origin can be a regular expression to support subdomain matching. If this list is empty CORS will not be enabled.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--default-watch-cache-size int&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 100</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Default watch cache size. If zero, watch cache will be disabled for resources that do not have a default watch size set.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--delete-collection-workers int&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 1</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Number of workers spawned for DeleteCollection call. These are used to speed up namespace cleanup.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--deserialization-cache-size int</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Number of deserialized json objects to cache in memory.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--disable-admission-plugins stringSlice</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">admission plugins that should be disabled although they are in the default enabled plugins list. Comma-delimited list of admission plugins: AlwaysAdmit, AlwaysDeny, AlwaysPullImages, DefaultStorageClass, DefaultTolerationSeconds, DenyEscalatingExec, DenyExecOnPrivileged, EventRateLimit, ExtendedResourceToleration, ImagePolicyWebhook, InitialResources, Initializers, LimitPodHardAntiAffinityTopology, LimitRanger, MutatingAdmissionWebhook, NamespaceAutoProvision, NamespaceExists, NamespaceLifecycle, NodeRestriction, OwnerReferencesPermissionEnforcement, PersistentVolumeClaimResize, PersistentVolumeLabel, PodNodeSelector, PodPreset, PodSecurityPolicy, PodTolerationRestriction, Priority, ResourceQuota, SecurityContextDeny, ServiceAccount, StorageObjectInUseProtection, ValidatingAdmissionWebhook. The order of plugins in this flag does not matter.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--enable-admission-plugins stringSlice</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">admission plugins that should be enabled in addition to default enabled ones. Comma-delimited list of admission plugins: AlwaysAdmit, AlwaysDeny, AlwaysPullImages, DefaultStorageClass, DefaultTolerationSeconds, DenyEscalatingExec, DenyExecOnPrivileged, EventRateLimit, ExtendedResourceToleration, ImagePolicyWebhook, InitialResources, Initializers, LimitPodHardAntiAffinityTopology, LimitRanger, MutatingAdmissionWebhook, NamespaceAutoProvision, NamespaceExists, NamespaceLifecycle, NodeRestriction, OwnerReferencesPermissionEnforcement, PersistentVolumeClaimResize, PersistentVolumeLabel, PodNodeSelector, PodPreset, PodSecurityPolicy, PodTolerationRestriction, Priority, ResourceQuota, SecurityContextDeny, ServiceAccount, StorageObjectInUseProtection, ValidatingAdmissionWebhook. The order of plugins in this flag does not matter.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--enable-aggregator-routing</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Turns on aggregator routing requests to endoints IP rather than cluster IP.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--enable-bootstrap-token-auth</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Enable to allow secrets of type 'bootstrap.kubernetes.io/token' in the 'kube-system' namespace to be used for TLS bootstrapping authentication.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--enable-garbage-collector&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Enables the generic garbage collector. MUST be synced with the corresponding flag of the kube-controller-manager.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--enable-logs-handler&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If true, install a /logs handler for the apiserver logs.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--enable-swagger-ui</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Enables swagger ui on the apiserver at /swagger-ui</td>
+    </tr>
+    <tr>
+      <td colspan="2">--endpoint-reconciler-type string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "master-count"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Use an endpoint reconciler (master-count, lease, none)</td>
+    </tr>
+    <tr>
+      <td colspan="2">--etcd-cafile string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">SSL Certificate Authority file used to secure etcd communication.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--etcd-certfile string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">SSL certification file used to secure etcd communication.</td>
+    </tr>
+
+    <tr>
+      <td colspan="2">--etcd-compaction-interval duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5m0s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The interval of compaction requests. If 0, the compaction request from apiserver is disabled.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--etcd-count-metric-poll-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 1m0s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Frequency of polling etcd for number of resources per type. 0 disables the metric collection.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--etcd-keyfile string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">SSL key file used to secure etcd communication.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--etcd-prefix string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/registry"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The prefix to prepend to all resource paths in etcd.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--etcd-servers stringSlice</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">List of etcd servers to connect with (scheme://ip:port), comma separated.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--etcd-servers-overrides stringSlice</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Per-resource etcd servers overrides, comma separated. The individual override format: group/resource#servers, where servers are http://ip:port, semicolon separated.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--event-ttl duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 1h0m0s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Amount of time to retain events.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--experimental-encryption-provider-config string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The file containing configuration for encryption providers to be used for storing secrets in etcd</td>
+    </tr>
+    <tr>
+      <td colspan="2">--external-hostname string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The hostname to use when generating externalized URLs for this master (e.g. Swagger API Docs).</td>
+    </tr>
+    <tr>
+      <td colspan="2">--feature-gates mapStringBool</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:<br/>APIListChunking=true|false (BETA - default=true)<br/>APIResponseCompression=true|false (ALPHA - default=false)<br/>Accelerators=true|false (ALPHA - default=false)<br/>AdvancedAuditing=true|false (BETA - default=true)<br/>AllAlpha=true|false (ALPHA - default=false)<br/>AppArmor=true|false (BETA - default=true)<br/>BlockVolume=true|false (ALPHA - default=false)<br/>CPUManager=true|false (BETA - default=true)<br/>CRIContainerLogRotation=true|false (ALPHA - default=false)<br/>CSIPersistentVolume=true|false (BETA - default=true)<br/>CustomPodDNS=true|false (BETA - default=true)<br/>CustomResourceSubresources=true|false (ALPHA - default=false)<br/>CustomResourceValidation=true|false (BETA - default=true)<br/>DebugContainers=true|false (ALPHA - default=false)<br/>DevicePlugins=true|false (BETA - default=true)<br/>DynamicKubeletConfig=true|false (ALPHA - default=false)<br/>EnableEquivalenceClassCache=true|false (ALPHA - default=false)<br/>ExpandPersistentVolumes=true|false (ALPHA - default=false)<br/>ExperimentalCriticalPodAnnotation=true|false (ALPHA - default=false)<br/>ExperimentalHostUserNamespaceDefaulting=true|false (BETA - default=false)<br/>GCERegionalPersistentDisk=true|false (BETA - default=true)<br/>HugePages=true|false (BETA - default=true)<br/>HyperVContainer=true|false (ALPHA - default=false)<br/>Initializers=true|false (ALPHA - default=false)<br/>LocalStorageCapacityIsolation=true|false (BETA - default=true)<br/>MountContainers=true|false (ALPHA - default=false)<br/>MountPropagation=true|false (BETA - default=true)<br/>PersistentLocalVolumes=true|false (BETA - default=true)<br/>PodPriority=true|false (ALPHA - default=false)<br/>PodShareProcessNamespace=true|false (ALPHA - default=false)<br/>ReadOnlyAPIDataVolumes=true|false (DEPRECATED - default=true)<br/>ResourceLimitsPriorityFunction=true|false (ALPHA - default=false)<br/>RotateKubeletClientCertificate=true|false (BETA - default=true)<br/>RotateKubeletServerCertificate=true|false (ALPHA - default=false)<br/>RunAsGroup=true|false (ALPHA - default=false)<br/>ScheduleDaemonSetPods=true|false (ALPHA - default=false)<br/>ServiceNodeExclusion=true|false (ALPHA - default=false)<br/>ServiceProxyAllowExternalIPs=true|false (DEPRECATED - default=false)<br/>StorageObjectInUseProtection=true|false (BETA - default=true)<br/>StreamingProxyRedirects=true|false (BETA - default=true)<br/>SupportIPVSProxyMode=true|false (BETA - default=true)<br/>SupportPodPidsLimit=true|false (ALPHA - default=false)<br/>TaintBasedEvictions=true|false (ALPHA - default=false)<br/>TaintNodesByCondition=true|false (ALPHA - default=false)<br/>TokenRequest=true|false (ALPHA - default=false)<br/>VolumeScheduling=true|false (BETA - default=true)<br/>VolumeSubpath=true|false (default=true)</td>
+    </tr>
+    <tr>
+      <td colspan="2">-h, --help</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">help for kube-apiserver</td>
+    </tr>
+    <tr>
+      <td colspan="2">--http2-max-streams-per-connection int</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The limit that the server gives to clients for the maximum number of streams in an HTTP/2 connection. Zero means to use golang's default.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--kubelet-certificate-authority string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Path to a cert file for the certificate authority.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--kubelet-client-certificate string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Path to a client cert file for TLS.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--kubelet-client-key string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Path to a client key file for TLS.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--kubelet-https&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Use https for kubelet connections.</td>
+    </tr>
+
+    <tr>
+      <td colspan="2">--kubelet-preferred-address-types stringSlice&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: [Hostname,InternalDNS,InternalIP,ExternalDNS,ExternalIP]</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">List of the preferred NodeAddressTypes to use for kubelet connections.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--kubelet-read-only-port uint&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10255</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">DEPRECATED: kubelet port.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--kubelet-timeout duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Timeout for kubelet operations.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--kubernetes-service-node-port int</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If non-zero, the Kubernetes master service (which apiserver creates/maintains) will be of type NodePort, using this as the value of the port. If zero, the Kubernetes master service will be of type ClusterIP.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--log-flush-frequency duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Maximum number of seconds between log flushes</td>
+    </tr>
+    <tr>
+      <td colspan="2">--master-service-namespace string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "default"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">DEPRECATED: the namespace from which the kubernetes master services should be injected into pods.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--max-connection-bytes-per-sec int</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If non-zero, throttle each user connection to this number of bytes/sec. Currently only applies to long-running requests.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--max-mutating-requests-inflight int&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 200</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The maximum number of mutating requests in flight at a given time. When the server exceeds this, it rejects requests. Zero for no limit.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--max-requests-inflight int&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 400</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The maximum number of non-mutating requests in flight at a given time. When the server exceeds this, it rejects requests. Zero for no limit.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--min-request-timeout int&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 1800</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">An optional field indicating the minimum number of seconds a handler must keep a request open before timing it out. Currently only honored by the watch request handler, which picks a randomized value above this number as the connection timeout, to spread out load.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--oidc-ca-file string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If set, the OpenID server's certificate will be verified by one of the authorities in the oidc-ca-file, otherwise the host's root CA set will be used.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--oidc-client-id string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--oidc-groups-claim string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If provided, the name of a custom OpenID Connect claim for specifying user groups. The claim value is expected to be a string or array of strings. This flag is experimental, please see the authentication documentation for further details.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--oidc-groups-prefix string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If provided, all groups will be prefixed with this value to prevent conflicts with other authentication strategies.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--oidc-issuer-url string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The URL of the OpenID issuer, only HTTPS scheme will be accepted. If set, it will be used to verify the OIDC JSON Web Token (JWT).</td>
+    </tr>
+    <tr>
+      <td colspan="2">--oidc-signing-algs stringSlice&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: [RS256]</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Comma-separated list of allowed JOSE asymmetric signing algorithms. JWTs with a 'alg' header value not in this list will be rejected. Values are defined by RFC 7518 https://tools.ietf.org/html/rfc7518#section-3.1.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--oidc-username-claim string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "sub"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The OpenID claim to use as the user name. Note that claims other than the default ('sub') is not guaranteed to be unique and immutable. This flag is experimental, please see the authentication documentation for further details.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--oidc-username-prefix string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If provided, all usernames will be prefixed with this value. If not provided, username claims other than 'email' are prefixed by the issuer URL to avoid clashes. To skip any prefixing, provide the value '-'.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--profiling&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Enable profiling via web interface host:port/debug/pprof/</td>
+    </tr>
+    <tr>
+      <td colspan="2">--proxy-client-cert-file string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Client certificate used to prove the identity of the aggregator or kube-apiserver when it must call out during a request. This includes proxying requests to a user api-server and calling out to webhook admission plugins. It is expected that this cert includes a signature from the CA in the --requestheader-client-ca-file flag. That CA is published in the 'extension-apiserver-authentication' configmap in the kube-system namespace. Components receiving calls from kube-aggregator should use that CA to perform their half of the mutual TLS verification.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--proxy-client-key-file string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Private key for the client certificate used to prove the identity of the aggregator or kube-apiserver when it must call out during a request. This includes proxying requests to a user api-server and calling out to webhook admission plugins.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--repair-malformed-updates&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If true, server will do its best to fix the update request to pass the validation, e.g., setting empty UID in update request to its existing value. This flag can be turned off after we fix all the clients that send malformed updates.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--request-timeout duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 1m0s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">An optional field indicating the duration a handler must keep a request open before timing it out. This is the default request timeout for requests but may be overridden by flags such as --min-request-timeout for specific types of requests.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--requestheader-allowed-names stringSlice</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">List of client certificate common names to allow to provide usernames in headers specified by --requestheader-username-headers. If empty, any client certificate validated by the authorities in --requestheader-client-ca-file is allowed.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--requestheader-client-ca-file string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Root certificate bundle to use to verify client certificates on incoming requests before trusting usernames in headers specified by --requestheader-username-headers</td>
+    </tr>
+    <tr>
+      <td colspan="2">--requestheader-extra-headers-prefix stringSlice</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">List of request header prefixes to inspect. X-Remote-Extra- is suggested.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--requestheader-group-headers stringSlice</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">List of request headers to inspect for groups. X-Remote-Group is suggested.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--requestheader-username-headers stringSlice</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">List of request headers to inspect for usernames. X-Remote-User is common.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--runtime-config mapStringString</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">A set of key=value pairs that describe runtime configuration that may be passed to apiserver. &lt;group&gt;/&lt;version&gt; (or &lt;version&gt; for the core group) key can be used to turn on/off specific api versions. &lt;group&gt;/&lt;version&gt;/&lt;resource&gt; (or &lt;version&gt;/&lt;resource&gt; for the core group) can be used to turn on/off specific resources. api/all and api/legacy are special keys to control all and legacy api versions respectively.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--secure-port int&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 6443</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The port on which to serve HTTPS with authentication and authorization. If 0, don't serve HTTPS at all.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--service-account-api-audiences stringSlice</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Identifiers of the API. The service account token authenticator will validate that tokens used against the API are bound to at least one of these audiences.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--service-account-issuer string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Identifier of the service account token issuer. The issuer will assert this identifier in "iss" claim of issued tokens. This value is a string or URI.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--service-account-key-file stringArray</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">File containing PEM-encoded x509 RSA or ECDSA private or public keys, used to verify ServiceAccount tokens. The specified file can contain multiple keys, and the flag can be specified multiple times with different files. If unspecified, --tls-private-key-file is used. Must be specified when --service-account-signing-key is provided</td>
+    </tr>
+    <tr>
+      <td colspan="2">--service-account-lookup&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If true, validate ServiceAccount tokens exist in etcd as part of authentication.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--service-account-signing-key-file string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Path to the file that contains the current private key of the service account token issuer. The issuer will sign issued ID tokens with this private key. (Ignored unless alpha TokenRequest is enabled</td>
+    </tr>
+    <tr>
+      <td colspan="2">--service-cluster-ip-range ipNet&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10.0.0.0/24</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">A CIDR notation IP range from which to assign service cluster IPs. This must not overlap with any IP ranges assigned to nodes for pods.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--service-node-port-range portRange&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 30000-32767</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">A port range to reserve for services with NodePort visibility. Example: '30000-32767'. Inclusive at both ends of the range.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--storage-backend string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The storage backend for persistence. Options: 'etcd3' (default), 'etcd2'.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--storage-media-type string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "application/vnd.kubernetes.protobuf"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The media type to use to store objects in storage. Some resources or storage backends may only support a specific media type and will ignore this setting.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--storage-versions string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "admission.k8s.io/v1beta1,<br />admissionregistration.k8s.io/v1beta1,<br />apps/v1,<br />authentication.k8s.io/v1,<br />authorization.k8s.io/v1,<br />autoscaling/v1,<br />batch/v1,<br />certificates.k8s.io/v1beta1,<br />componentconfig/v1alpha1,<br />events.k8s.io/v1beta1,<br />extensions/v1beta1,<br />imagepolicy.k8s.io/v1alpha1,<br />kubeadm.k8s.io/v1alpha1,<br />networking.k8s.io/v1,<br />policy/v1beta1,<br />rbac.authorization.k8s.io/v1,<br />scheduling.k8s.io/v1alpha1,<br />settings.k8s.io/v1alpha1,<br />storage.k8s.io/v1,<br />v1"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The per-group version to store resources in. Specified in the format "group1/version1,group2/version2,...". In the case where objects are moved from one group to the other, you may specify the format "group1=group2/v1beta1,group3/v1beta1,...". You only need to pass the groups you wish to change from the defaults. It defaults to a list of preferred versions of all registered groups, which is derived from the KUBE_API_VERSIONS environment variable.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--target-ram-mb int</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Memory limit for apiserver in MB (used to configure sizes of caches, etc.)</td>
+    </tr>
+    <tr>
+      <td colspan="2">--tls-cert-file string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">File containing the default x509 Certificate for HTTPS. (CA cert, if any, concatenated after server cert). If HTTPS serving is enabled, and --tls-cert-file and --tls-private-key-file are not provided, a self-signed certificate and key are generated for the public address and saved to the directory specified by --cert-dir.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--tls-cipher-suites stringSlice</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Comma-separated list of cipher suites for the server. Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants). If omitted, the default Go cipher suites will be used</td>
+    </tr>
+    <tr>
+      <td colspan="2">--tls-min-version string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Minimum TLS version supported. Value must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--tls-private-key-file string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">File containing the default x509 private key matching --tls-cert-file.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--tls-sni-cert-key namedCertKey&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: []</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">A pair of x509 certificate and private key file paths, optionally suffixed with a list of domain patterns which are fully qualified domain names, possibly with prefixed wildcard segments. If no domain patterns are provided, the names of the certificate are extracted. Non-wildcard matches trump over wildcard matches, explicit domain patterns trump over extracted names. For multiple key/certificate pairs, use the --tls-sni-cert-key multiple times. Examples: "example.crt,example.key" or "foo.crt,foo.key:*.foo.com,foo.com".</td>
+    </tr>
+    <tr>
+      <td colspan="2">--token-auth-file string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If set, the file that will be used to secure the secure port of the API server via token authentication.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--version version[=true]</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Print version information and quit</td>
+    </tr>
+    <tr>
+      <td colspan="2">--watch-cache&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Enable watch caching in the apiserver</td>
+    </tr>
+    <tr>
+      <td colspan="2">--watch-cache-sizes stringSlice</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">List of watch cache sizes for every resource (pods, nodes, etc.), comma separated. The individual override format: resource[.group]#size, where resource is lowercase plural (no version), group is optional, and size is a number. It takes effect when watch-cache is enabled. Some resources (replicationcontrollers, endpoints, nodes, pods, services, apiservices.apiregistration.k8s.io) have system defaults set by heuristics, others default to default-watch-cache-size</td>
+    </tr>
+  </tbody>
+</table>

--- a/content/en/docs/reference/command-line-tools-reference/kube-controller-manager.md
+++ b/content/en/docs/reference/command-line-tools-reference/kube-controller-manager.md
@@ -1,0 +1,566 @@
+---
+title: kube-controller-manager
+notitle: true
+weight: 50
+---
+## kube-controller-manager
+
+### Synopsis
+
+The Kubernetes controller manager is a daemon that embeds
+the core control loops shipped with Kubernetes. In applications of robotics and
+automation, a control loop is a non-terminating loop that regulates the state of
+the system. In Kubernetes, a controller is a control loop that watches the shared
+state of the cluster through the apiserver and makes changes attempting to move the
+current state towards the desired state. Examples of controllers that ship with
+Kubernetes today are the replication controller, endpoints controller, namespace
+controller, and serviceaccounts controller.
+
+```
+kube-controller-manager [flags]
+```
+
+### Options
+
+<table style="width: 100%;">
+  <colgroup>
+    <col span="1" style="width: 10px;" />
+    <col span="1" />
+  </colgroup>
+  <tbody>
+    <tr>
+      <td colspan="2">--address ip&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 0.0.0.0</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">DEPRECATED: the IP address on which to listen for the --port port. See --bind-address instead.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--allocate-node-cidrs</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Should CIDRs for Pods be allocated and set on the cloud provider.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--attach-detach-reconcile-sync-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 1m0s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The reconciler sync wait time between volume attach detach. This duration must be larger than one second, and increasing this value from the default may allow for volumes to be mismatched with pods.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--azure-container-registry-config string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Path to the file containing Azure container registry configuration information.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--bind-address ip&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 0.0.0.0</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The IP address on which to listen for the --secure-port port. The associated interface(s) must be reachable by the rest of the cluster, and by CLI/web clients. If blank, all interfaces will be used (0.0.0.0 for all IPv4 interfaces and :: for all IPv6 interfaces).</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cert-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/var/run/kubernetes"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The directory where the TLS certs are located. If --tls-cert-file and --tls-private-key-file are provided, this flag will be ignored.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cidr-allocator-type string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "RangeAllocator"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Type of CIDR allocator to use</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cloud-config string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The path to the cloud provider configuration file. Empty string for no configuration file.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cloud-provider string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The provider for cloud services.  Empty string for no provider.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cluster-cidr string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">CIDR Range for Pods in cluster. Requires --allocate-node-cidrs to be true</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cluster-name string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "kubernetes"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The instance prefix for the cluster.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cluster-signing-cert-file string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/etc/kubernetes/ca/ca.pem"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Filename containing a PEM-encoded X509 CA certificate used to issue cluster-scoped certificates</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cluster-signing-key-file string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/etc/kubernetes/ca/ca.key"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Filename containing a PEM-encoded RSA or ECDSA private key used to sign cluster-scoped certificates</td>
+    </tr>
+    <tr>
+      <td colspan="2">--concurrent-deployment-syncs int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The number of deployment objects that are allowed to sync concurrently. Larger number = more responsive deployments, but more CPU (and network) load</td>
+    </tr>
+    <tr>
+      <td colspan="2">--concurrent-endpoint-syncs int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The number of endpoint syncing operations that will be done concurrently. Larger number = faster endpoint updating, but more CPU (and network) load</td>
+    </tr>
+    <tr>
+      <td colspan="2">--concurrent-gc-syncs int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 20</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The number of garbage collector workers that are allowed to sync concurrently.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--concurrent-namespace-syncs int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The number of namespace objects that are allowed to sync concurrently. Larger number = more responsive namespace termination, but more CPU (and network) load</td>
+    </tr>
+    <tr>
+      <td colspan="2">--concurrent-replicaset-syncs int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The number of replica sets that are allowed to sync concurrently. Larger number = more responsive replica management, but more CPU (and network) load</td>
+    </tr>
+    <tr>
+      <td colspan="2">--concurrent-resource-quota-syncs int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The number of resource quotas that are allowed to sync concurrently. Larger number = more responsive quota management, but more CPU (and network) load</td>
+    </tr>
+    <tr>
+      <td colspan="2">--concurrent-service-syncs int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 1</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The number of services that are allowed to sync concurrently. Larger number = more responsive service management, but more CPU (and network) load</td>
+    </tr>
+    <tr>
+      <td colspan="2">--concurrent-serviceaccount-token-syncs int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The number of service account token objects that are allowed to sync concurrently. Larger number = more responsive token generation, but more CPU (and network) load</td>
+    </tr>
+    <tr>
+      <td colspan="2">--concurrent_rc_syncs int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The number of replication controllers that are allowed to sync concurrently. Larger number = more responsive replica management, but more CPU (and network) load</td>
+    </tr>
+    <tr>
+      <td colspan="2">--configure-cloud-routes&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Should CIDRs allocated by allocate-node-cidrs be configured on the cloud provider.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--contention-profiling</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Enable lock contention profiling, if profiling is enabled.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--controller-start-interval duration</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Interval between starting controller managers.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--controllers stringSlice&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: [*]</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">A list of controllers to enable.  '*' enables all on-by-default controllers, 'foo' enables the controller named 'foo', '-foo' disables the controller named 'foo'.<br/>All controllers: attachdetach, bootstrapsigner, clusterrole-aggregation, cronjob, csrapproving, csrcleaner, csrsigning, daemonset, deployment, disruption, endpoint, garbagecollector, horizontalpodautoscaling, job, namespace, nodeipam, nodelifecycle, persistentvolume-binder, persistentvolume-expander, podgc, pv-protection, pvc-protection, replicaset, replicationcontroller, resourcequota, route, service, serviceaccount, serviceaccount-token, statefulset, tokencleaner, ttl<br/>Disabled-by-default controllers: bootstrapsigner, tokencleaner</td>
+    </tr>
+    <tr>
+      <td colspan="2">--deployment-controller-sync-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 30s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Period for syncing the deployments.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--disable-attach-detach-reconcile-sync</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Disable volume attach detach reconciler sync. Disabling this may cause volumes to be mismatched with pods. Use wisely.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--enable-dynamic-provisioning&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Enable dynamic provisioning for environments that support it.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--enable-garbage-collector&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Enables the generic garbage collector. MUST be synced with the corresponding flag of the kube-apiserver.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--enable-hostpath-provisioner</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Enable HostPath PV provisioning when running without a cloud provider. This allows testing and development of provisioning features.  HostPath provisioning is not supported in any way, won't work in a multi-node cluster, and should not be used for anything other than testing or development.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--enable-taint-manager&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">WARNING: Beta feature. If set to true enables NoExecute Taints and will evict all not-tolerating Pod running on Nodes tainted with this kind of Taints.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--experimental-cluster-signing-duration duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 8760h0m0s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The length of duration signed certificates will be given.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--external-cloud-volume-plugin string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The plugin to use when cloud provider is set to external. Can be empty, should only be set when cloud-provider is external. Currently used to allow node and volume controllers to work for in tree cloud providers.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--feature-gates mapStringBool</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:<br/>APIListChunking=true|false (BETA - default=true)<br/>APIResponseCompression=true|false (ALPHA - default=false)<br/>Accelerators=true|false (ALPHA - default=false)<br/>AdvancedAuditing=true|false (BETA - default=true)<br/>AllAlpha=true|false (ALPHA - default=false)<br/>AppArmor=true|false (BETA - default=true)<br/>BlockVolume=true|false (ALPHA - default=false)<br/>CPUManager=true|false (BETA - default=true)<br/>CRIContainerLogRotation=true|false (ALPHA - default=false)<br/>CSIPersistentVolume=true|false (BETA - default=true)<br/>CustomPodDNS=true|false (BETA - default=true)<br/>CustomResourceSubresources=true|false (ALPHA - default=false)<br/>CustomResourceValidation=true|false (BETA - default=true)<br/>DebugContainers=true|false (ALPHA - default=false)<br/>DevicePlugins=true|false (BETA - default=true)<br/>DynamicKubeletConfig=true|false (ALPHA - default=false)<br/>EnableEquivalenceClassCache=true|false (ALPHA - default=false)<br/>ExpandPersistentVolumes=true|false (ALPHA - default=false)<br/>ExperimentalCriticalPodAnnotation=true|false (ALPHA - default=false)<br/>ExperimentalHostUserNamespaceDefaulting=true|false (BETA - default=false)<br/>GCERegionalPersistentDisk=true|false (BETA - default=true)<br/>HugePages=true|false (BETA - default=true)<br/>HyperVContainer=true|false (ALPHA - default=false)<br/>Initializers=true|false (ALPHA - default=false)<br/>LocalStorageCapacityIsolation=true|false (BETA - default=true)<br/>MountContainers=true|false (ALPHA - default=false)<br/>MountPropagation=true|false (BETA - default=true)<br/>PersistentLocalVolumes=true|false (BETA - default=true)<br/>PodPriority=true|false (ALPHA - default=false)<br/>PodShareProcessNamespace=true|false (ALPHA - default=false)<br/>ReadOnlyAPIDataVolumes=true|false (DEPRECATED - default=true)<br/>ResourceLimitsPriorityFunction=true|false (ALPHA - default=false)<br/>RotateKubeletClientCertificate=true|false (BETA - default=true)<br/>RotateKubeletServerCertificate=true|false (ALPHA - default=false)<br/>RunAsGroup=true|false (ALPHA - default=false)<br/>ScheduleDaemonSetPods=true|false (ALPHA - default=false)<br/>ServiceNodeExclusion=true|false (ALPHA - default=false)<br/>ServiceProxyAllowExternalIPs=true|false (DEPRECATED - default=false)<br/>StorageObjectInUseProtection=true|false (BETA - default=true)<br/>StreamingProxyRedirects=true|false (BETA - default=true)<br/>SupportIPVSProxyMode=true|false (BETA - default=true)<br/>SupportPodPidsLimit=true|false (ALPHA - default=false)<br/>TaintBasedEvictions=true|false (ALPHA - default=false)<br/>TaintNodesByCondition=true|false (ALPHA - default=false)<br/>TokenRequest=true|false (ALPHA - default=false)<br/>VolumeScheduling=true|false (BETA - default=true)<br/>VolumeSubpath=true|false (default=true)</td>
+    </tr>
+    <tr>
+      <td colspan="2">--flex-volume-plugin-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Full path of the directory in which the flex volume plugin should search for additional third party volume plugins.</td>
+    </tr>
+    <tr>
+      <td colspan="2">-h, --help</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">help for kube-controller-manager</td>
+    </tr>
+    <tr>
+      <td colspan="2">--horizontal-pod-autoscaler-downscale-delay duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5m0s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The period since last downscale, before another downscale can be performed in horizontal pod autoscaler.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--horizontal-pod-autoscaler-sync-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 30s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The period for syncing the number of pods in horizontal pod autoscaler.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--horizontal-pod-autoscaler-tolerance float&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 0.1</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The minimum change (from 1.0) in the desired-to-actual metrics ratio for the horizontal pod autoscaler to consider scaling.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--horizontal-pod-autoscaler-upscale-delay duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 3m0s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The period since last upscale, before another upscale can be performed in horizontal pod autoscaler.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--horizontal-pod-autoscaler-use-rest-clients&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">WARNING: alpha feature.  If set to true, causes the horizontal pod autoscaler controller to use REST clients through the kube-aggregator, instead of using the legacy metrics client through the API server proxy.  This is required for custom metrics support in the horizontal pod autoscaler.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--http2-max-streams-per-connection int</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The limit that the server gives to clients for the maximum number of streams in an HTTP/2 connection. Zero means to use golang's default.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--insecure-experimental-approve-all-kubelet-csrs-for-group string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">This flag does nothing.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--kube-api-burst int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 30</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Burst to use while talking with kubernetes apiserver.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--kube-api-content-type string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "application/vnd.kubernetes.protobuf"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Content type of requests sent to apiserver.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--kube-api-qps float32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 20</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">QPS to use while talking with kubernetes apiserver.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--kubeconfig string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Path to kubeconfig file with authorization and master location information.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--large-cluster-size-threshold int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 50</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Number of nodes from which NodeController treats the cluster as large for the eviction logic purposes. --secondary-node-eviction-rate is implicitly overridden to 0 for clusters this size or smaller.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--leader-elect&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--leader-elect-lease-duration duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 15s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--leader-elect-renew-deadline duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The interval between attempts by the acting master to renew a leadership slot before it stops leading. This must be less than or equal to the lease duration. This is only applicable if leader election is enabled.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--leader-elect-resource-lock endpoints&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "endpoints"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The type of resource object that is used for locking during leader election. Supported options are endpoints (default) and `configmaps`.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--leader-elect-retry-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 2s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The duration the clients should wait between attempting acquisition and renewal of a leadership. This is only applicable if leader election is enabled.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--log-flush-frequency duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Maximum number of seconds between log flushes</td>
+    </tr>
+    <tr>
+      <td colspan="2">--master string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The address of the Kubernetes API server (overrides any value in kubeconfig).</td>
+    </tr>
+    <tr>
+      <td colspan="2">--min-resync-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 12h0m0s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The resync period in reflectors will be random between MinResyncPeriod and 2*MinResyncPeriod.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--namespace-sync-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5m0s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The period for syncing namespace life-cycle updates</td>
+    </tr>
+    <tr>
+      <td colspan="2">--node-cidr-mask-size int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 24</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Mask size for node cidr in cluster.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--node-eviction-rate float32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 0.1</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Number of nodes per second on which pods are deleted in case of node failure when a zone is healthy (see --unhealthy-zone-threshold for definition of healthy/unhealthy). Zone refers to entire cluster in non-multizone clusters.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--node-monitor-grace-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 40s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Amount of time which we allow running Node to be unresponsive before marking it unhealthy. Must be N times more than kubelet's nodeStatusUpdateFrequency, where N means number of retries allowed for kubelet to post node status.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--node-monitor-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The period for syncing NodeStatus in NodeController.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--node-startup-grace-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 1m0s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Amount of time which we allow starting Node to be unresponsive before marking it unhealthy.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--pod-eviction-timeout duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5m0s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The grace period for deleting pods on failed nodes.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--port int&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10252</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">DEPRECATED: the port on which to serve HTTP insecurely without authentication and authorization. If 0, don't serve HTTPS at all. See --secure-port instead.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--profiling&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Enable profiling via web interface host:port/debug/pprof/</td>
+    </tr>
+    <tr>
+      <td colspan="2">--pv-recycler-increment-timeout-nfs int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 30</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">the increment of time added per Gi to ActiveDeadlineSeconds for an NFS scrubber pod</td>
+    </tr>
+    <tr>
+      <td colspan="2">--pv-recycler-minimum-timeout-hostpath int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 60</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The minimum ActiveDeadlineSeconds to use for a HostPath Recycler pod.  This is for development and testing only and will not work in a multi-node cluster.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--pv-recycler-minimum-timeout-nfs int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 300</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The minimum ActiveDeadlineSeconds to use for an NFS Recycler pod</td>
+    </tr>
+    <tr>
+      <td colspan="2">--pv-recycler-pod-template-filepath-hostpath string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The file path to a pod definition used as a template for HostPath persistent volume recycling. This is for development and testing only and will not work in a multi-node cluster.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--pv-recycler-pod-template-filepath-nfs string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The file path to a pod definition used as a template for NFS persistent volume recycling</td>
+    </tr>
+    <tr>
+      <td colspan="2">--pv-recycler-timeout-increment-hostpath int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 30</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">the increment of time added per Gi to ActiveDeadlineSeconds for a HostPath scrubber pod.  This is for development and testing only and will not work in a multi-node cluster.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--pvclaimbinder-sync-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 15s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The period for syncing persistent volumes and persistent volume claims</td>
+    </tr>
+    <tr>
+      <td colspan="2">--resource-quota-sync-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5m0s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The period for syncing quota usage status in the system</td>
+    </tr>
+    <tr>
+      <td colspan="2">--root-ca-file string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If set, this root certificate authority will be included in service account's token secret. This must be a valid PEM-encoded CA bundle.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--route-reconciliation-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The period for reconciling routes created for Nodes by cloud provider.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--secondary-node-eviction-rate float32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 0.01</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Number of nodes per second on which pods are deleted in case of node failure when a zone is unhealthy (see --unhealthy-zone-threshold for definition of healthy/unhealthy). Zone refers to entire cluster in non-multizone clusters. This value is implicitly overridden to 0 if the cluster size is smaller than --large-cluster-size-threshold.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--secure-port int</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The port on which to serve HTTPS with authentication and authorization. If 0, don't serve HTTPS at all.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--service-account-private-key-file string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Filename containing a PEM-encoded private RSA or ECDSA key used to sign service account tokens.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--service-cluster-ip-range string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">CIDR Range for Services in cluster. Requires --allocate-node-cidrs to be true</td>
+    </tr>
+    <tr>
+      <td colspan="2">--terminated-pod-gc-threshold int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 12500</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Number of terminated pods that can exist before the terminated pod garbage collector starts deleting terminated pods. If &lt;= 0, the terminated pod garbage collector is disabled.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--tls-cert-file string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">File containing the default x509 Certificate for HTTPS. (CA cert, if any, concatenated after server cert). If HTTPS serving is enabled, and --tls-cert-file and --tls-private-key-file are not provided, a self-signed certificate and key are generated for the public address and saved to the directory specified by --cert-dir.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--tls-cipher-suites stringSlice</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Comma-separated list of cipher suites for the server. Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants). If omitted, the default Go cipher suites will be used</td>
+    </tr>
+    <tr>
+      <td colspan="2">--tls-min-version string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Minimum TLS version supported. Value must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--tls-private-key-file string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">File containing the default x509 private key matching --tls-cert-file.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--tls-sni-cert-key namedCertKey&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: []</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">A pair of x509 certificate and private key file paths, optionally suffixed with a list of domain patterns which are fully qualified domain names, possibly with prefixed wildcard segments. If no domain patterns are provided, the names of the certificate are extracted. Non-wildcard matches trump over wildcard matches, explicit domain patterns trump over extracted names. For multiple key/certificate pairs, use the --tls-sni-cert-key multiple times. Examples: "example.crt,example.key" or "foo.crt,foo.key:*.foo.com,foo.com".</td>
+    </tr>
+    <tr>
+      <td colspan="2">--unhealthy-zone-threshold float32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 0.55</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Fraction of Nodes in a zone which needs to be not Ready (minimum 3) for zone to be treated as unhealthy. </td>
+    </tr>
+    <tr>
+      <td colspan="2">--use-service-account-credentials</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If true, use individual service account credentials for each controller.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--version version[=true]</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Print version information and quit</td>
+    </tr>
+  </tbody>
+</table>

--- a/content/en/docs/reference/command-line-tools-reference/kube-proxy.md
+++ b/content/en/docs/reference/command-line-tools-reference/kube-proxy.md
@@ -1,0 +1,259 @@
+---
+title: kube-proxy
+notitle: true
+weight: 60
+---
+## kube-proxy
+
+### Synopsis
+
+The Kubernetes network proxy runs on each node. This
+reflects services as defined in the Kubernetes API on each node and can do simple
+TCP and UDP stream forwarding or round robin TCP and UDP forwarding across a set of backends.
+Service cluster IPs and ports are currently found through Docker-links-compatible
+environment variables specifying ports opened by the service proxy. There is an optional
+addon that provides cluster DNS for these cluster IPs. The user must create a service
+with the apiserver API to configure the proxy.
+
+```
+kube-proxy [flags]
+```
+
+### Options
+
+<table style="width: 100%;">
+  <colgroup>
+    <col span="1" style="width: 10px;" />
+    <col span="1" />
+  </colgroup>
+  <tbody>
+    <tr>
+      <td colspan="2">--azure-container-registry-config string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Path to the file containing Azure container registry configuration information.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--bind-address 0.0.0.0&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 0.0.0.0</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The IP address for the proxy server to serve on (set to 0.0.0.0 for all IPv4 interfaces and `::` for all IPv6 interfaces)</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cleanup</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If true cleanup iptables and ipvs rules and exit.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cleanup-ipvs&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If true make kube-proxy cleanup ipvs rules before running.  Default is true</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cluster-cidr string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The CIDR range of pods in the cluster. When configured, traffic sent to a Service cluster IP from outside this range will be masqueraded and traffic sent from pods to an external LoadBalancer IP will be directed to the respective cluster IP instead</td>
+    </tr>
+    <tr>
+      <td colspan="2">--config string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The path to the configuration file.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--config-sync-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 15m0s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">How often configuration from the apiserver is refreshed.  Must be greater than 0.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--conntrack-max-per-core int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 32768</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Maximum number of NAT connections to track per CPU core (0 to leave the limit as-is and ignore conntrack-min).</td>
+    </tr>
+    <tr>
+      <td colspan="2">--conntrack-min int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 131072</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Minimum number of conntrack entries to allocate, regardless of conntrack-max-per-core (set conntrack-max-per-core=0 to leave the limit as-is).</td>
+    </tr>
+    <tr>
+      <td colspan="2">--conntrack-tcp-timeout-close-wait duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 1h0m0s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">NAT timeout for TCP connections in the CLOSE_WAIT state</td>
+    </tr>
+    <tr>
+      <td colspan="2">--conntrack-tcp-timeout-established duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 24h0m0s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Idle timeout for established TCP connections (0 to leave as-is)</td>
+    </tr>
+    <tr>
+      <td colspan="2">--feature-gates mapStringBool</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:<br/>APIListChunking=true|false (BETA - default=true)<br/>APIResponseCompression=true|false (ALPHA - default=false)<br/>Accelerators=true|false (ALPHA - default=false)<br/>AdvancedAuditing=true|false (BETA - default=true)<br/>AllAlpha=true|false (ALPHA - default=false)<br/>AppArmor=true|false (BETA - default=true)<br/>BlockVolume=true|false (ALPHA - default=false)<br/>CPUManager=true|false (BETA - default=true)<br/>CRIContainerLogRotation=true|false (ALPHA - default=false)<br/>CSIPersistentVolume=true|false (BETA - default=true)<br/>CustomPodDNS=true|false (BETA - default=true)<br/>CustomResourceSubresources=true|false (ALPHA - default=false)<br/>CustomResourceValidation=true|false (BETA - default=true)<br/>DebugContainers=true|false (ALPHA - default=false)<br/>DevicePlugins=true|false (BETA - default=true)<br/>DynamicKubeletConfig=true|false (ALPHA - default=false)<br/>EnableEquivalenceClassCache=true|false (ALPHA - default=false)<br/>ExpandPersistentVolumes=true|false (ALPHA - default=false)<br/>ExperimentalCriticalPodAnnotation=true|false (ALPHA - default=false)<br/>ExperimentalHostUserNamespaceDefaulting=true|false (BETA - default=false)<br/>GCERegionalPersistentDisk=true|false (BETA - default=true)<br/>HugePages=true|false (BETA - default=true)<br/>HyperVContainer=true|false (ALPHA - default=false)<br/>Initializers=true|false (ALPHA - default=false)<br/>LocalStorageCapacityIsolation=true|false (BETA - default=true)<br/>MountContainers=true|false (ALPHA - default=false)<br/>MountPropagation=true|false (BETA - default=true)<br/>PersistentLocalVolumes=true|false (BETA - default=true)<br/>PodPriority=true|false (ALPHA - default=false)<br/>PodShareProcessNamespace=true|false (ALPHA - default=false)<br/>ReadOnlyAPIDataVolumes=true|false (DEPRECATED - default=true)<br/>ResourceLimitsPriorityFunction=true|false (ALPHA - default=false)<br/>RotateKubeletClientCertificate=true|false (BETA - default=true)<br/>RotateKubeletServerCertificate=true|false (ALPHA - default=false)<br/>RunAsGroup=true|false (ALPHA - default=false)<br/>ScheduleDaemonSetPods=true|false (ALPHA - default=false)<br/>ServiceNodeExclusion=true|false (ALPHA - default=false)<br/>ServiceProxyAllowExternalIPs=true|false (DEPRECATED - default=false)<br/>StorageObjectInUseProtection=true|false (BETA - default=true)<br/>StreamingProxyRedirects=true|false (BETA - default=true)<br/>SupportIPVSProxyMode=true|false (BETA - default=true)<br/>SupportPodPidsLimit=true|false (ALPHA - default=false)<br/>TaintBasedEvictions=true|false (ALPHA - default=false)<br/>TaintNodesByCondition=true|false (ALPHA - default=false)<br/>TokenRequest=true|false (ALPHA - default=false)<br/>VolumeScheduling=true|false (BETA - default=true)<br/>VolumeSubpath=true|false (default=true)</td>
+    </tr>
+    <tr>
+      <td colspan="2">--healthz-bind-address 0.0.0.0&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 0.0.0.0:10256</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The IP address and port for the health check server to serve on (set to 0.0.0.0 for all IPv4 interfaces and `::` for all IPv6 interfaces)</td>
+    </tr>
+    <tr>
+      <td colspan="2">--healthz-port int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10256</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The port to bind the health check server. Use 0 to disable.</td>
+    </tr>
+    <tr>
+      <td colspan="2">-h, --help</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">help for kube-proxy</td>
+    </tr>
+    <tr>
+      <td colspan="2">--hostname-override string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If non-empty, will use this string as identification instead of the actual hostname.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--iptables-masquerade-bit int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 14</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If using the pure iptables proxy, the bit of the fwmark space to mark packets requiring SNAT with.  Must be within the range [0, 31].</td>
+    </tr>
+    <tr>
+      <td colspan="2">--iptables-min-sync-period duration</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The minimum interval of how often the iptables rules can be refreshed as endpoints and services change (e.g. '5s', '1m', '2h22m').</td>
+    </tr>
+    <tr>
+      <td colspan="2">--iptables-sync-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 30s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The maximum interval of how often iptables rules are refreshed (e.g. '5s', '1m', '2h22m').  Must be greater than 0.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--ipvs-min-sync-period duration</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The minimum interval of how often the ipvs rules can be refreshed as endpoints and services change (e.g. '5s', '1m', '2h22m').</td>
+    </tr>
+    <tr>
+      <td colspan="2">--ipvs-scheduler string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The ipvs scheduler type when proxy mode is ipvs</td>
+    </tr>
+    <tr>
+      <td colspan="2">--ipvs-sync-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 30s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The maximum interval of how often ipvs rules are refreshed (e.g. '5s', '1m', '2h22m').  Must be greater than 0.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--kube-api-burst int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Burst to use while talking with kubernetes apiserver</td>
+    </tr>
+    <tr>
+      <td colspan="2">--kube-api-content-type string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "application/vnd.kubernetes.protobuf"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Content type of requests sent to apiserver.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--kube-api-qps float32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">QPS to use while talking with kubernetes apiserver</td>
+    </tr>
+    <tr>
+      <td colspan="2">--kubeconfig string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Path to kubeconfig file with authorization information (the master location is set by the master flag).</td>
+    </tr>
+    <tr>
+      <td colspan="2">--log-flush-frequency duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Maximum number of seconds between log flushes</td>
+    </tr>
+    <tr>
+      <td colspan="2">--masquerade-all</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If using the pure iptables proxy, SNAT all traffic sent via Service cluster IPs (this not commonly needed)</td>
+    </tr>
+    <tr>
+      <td colspan="2">--master string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The address of the Kubernetes API server (overrides any value in kubeconfig)</td>
+    </tr>
+    <tr>
+      <td colspan="2">--metrics-bind-address 0.0.0.0&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 127.0.0.1:10249</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The IP address and port for the metrics server to serve on (set to 0.0.0.0 for all IPv4 interfaces and `::` for all IPv6 interfaces)</td>
+    </tr>
+    <tr>
+      <td colspan="2">--nodeport-addresses stringSlice</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">A string slice of values which specify the addresses to use for NodePorts. Values may be valid IP blocks (e.g. 1.2.3.0/24, 1.2.3.4/32). The default empty string slice ([]) means to use all local addresses.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--oom-score-adj int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: -999</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The oom-score-adj value for kube-proxy process. Values must be within the range [-1000, 1000]</td>
+    </tr>
+    <tr>
+      <td colspan="2">--profiling</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If true enables profiling via web interface on /debug/pprof handler.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--proxy-mode ProxyMode</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Which proxy mode to use: 'userspace' (older) or 'iptables' (faster) or 'ipvs' (experimental). If blank, use the best-available proxy (currently iptables).  If the iptables proxy is selected, regardless of how, but the system's kernel or iptables versions are insufficient, this always falls back to the userspace proxy.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--proxy-port-range port-range</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Range of host ports (beginPort-endPort, inclusive) that may be consumed in order to proxy service traffic. If unspecified (0-0) then ports will be randomly chosen.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--udp-timeout duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 250ms</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">How long an idle UDP connection will be kept open (e.g. '250ms', '2s').  Must be greater than 0. Only applicable for proxy-mode=userspace</td>
+    </tr>
+    <tr>
+      <td colspan="2">--version version[=true]</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Print version information and quit</td>
+    </tr>
+    <tr>
+      <td colspan="2">--write-config-to string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If set, write the default configuration values to this file and exit.</td>
+    </tr>
+  </tbody>
+</table>

--- a/content/en/docs/reference/command-line-tools-reference/kube-scheduler.md
+++ b/content/en/docs/reference/command-line-tools-reference/kube-scheduler.md
@@ -1,0 +1,199 @@
+---
+title: kube-scheduler
+notitle: true
+weight: 70
+---
+## kube-scheduler
+
+### Synopsis
+
+The Kubernetes scheduler is a policy-rich, topology-aware,
+workload-specific function that significantly impacts availability, performance,
+and capacity. The scheduler needs to take into account individual and collective
+resource requirements, quality of service requirements, hardware/software/policy
+constraints, affinity and anti-affinity specifications, data locality, inter-workload
+interference, deadlines, and so on. Workload-specific requirements will be exposed
+through the API as necessary.
+
+```
+kube-scheduler [flags]
+```
+
+### Options
+
+<table style="width: 100%;">
+  <colgroup>
+    <col span="1" style="width: 10px;" />
+    <col span="1" />
+  </colgroup>
+  <tbody>
+    <tr>
+      <td colspan="2">--address string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The IP address to serve on (set to 0.0.0.0 for all IPv4 interfaces and :: for all IPv6 interfaces).</td>
+    </tr>
+    <tr>
+      <td colspan="2">--algorithm-provider string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The scheduling algorithm provider to use, one of: ClusterAutoscalerProvider | DefaultProvider</td>
+    </tr>
+    <tr>
+      <td colspan="2">--azure-container-registry-config string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Path to the file containing Azure container registry configuration information.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--config string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The path to the configuration file.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--contention-profiling</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Enable lock contention profiling, if profiling is enabled</td>
+    </tr>
+    <tr>
+      <td colspan="2">--feature-gates mapStringBool</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:<br/>APIListChunking=true|false (BETA - default=true)<br/>APIResponseCompression=true|false (ALPHA - default=false)<br/>Accelerators=true|false (ALPHA - default=false)<br/>AdvancedAuditing=true|false (BETA - default=true)<br/>AllAlpha=true|false (ALPHA - default=false)<br/>AppArmor=true|false (BETA - default=true)<br/>BlockVolume=true|false (ALPHA - default=false)<br/>CPUManager=true|false (BETA - default=true)<br/>CRIContainerLogRotation=true|false (ALPHA - default=false)<br/>CSIPersistentVolume=true|false (BETA - default=true)<br/>CustomPodDNS=true|false (BETA - default=true)<br/>CustomResourceSubresources=true|false (ALPHA - default=false)<br/>CustomResourceValidation=true|false (BETA - default=true)<br/>DebugContainers=true|false (ALPHA - default=false)<br/>DevicePlugins=true|false (BETA - default=true)<br/>DynamicKubeletConfig=true|false (ALPHA - default=false)<br/>EnableEquivalenceClassCache=true|false (ALPHA - default=false)<br/>ExpandPersistentVolumes=true|false (ALPHA - default=false)<br/>ExperimentalCriticalPodAnnotation=true|false (ALPHA - default=false)<br/>ExperimentalHostUserNamespaceDefaulting=true|false (BETA - default=false)<br/>GCERegionalPersistentDisk=true|false (BETA - default=true)<br/>HugePages=true|false (BETA - default=true)<br/>HyperVContainer=true|false (ALPHA - default=false)<br/>Initializers=true|false (ALPHA - default=false)<br/>LocalStorageCapacityIsolation=true|false (BETA - default=true)<br/>MountContainers=true|false (ALPHA - default=false)<br/>MountPropagation=true|false (BETA - default=true)<br/>PersistentLocalVolumes=true|false (BETA - default=true)<br/>PodPriority=true|false (ALPHA - default=false)<br/>PodShareProcessNamespace=true|false (ALPHA - default=false)<br/>ReadOnlyAPIDataVolumes=true|false (DEPRECATED - default=true)<br/>ResourceLimitsPriorityFunction=true|false (ALPHA - default=false)<br/>RotateKubeletClientCertificate=true|false (BETA - default=true)<br/>RotateKubeletServerCertificate=true|false (ALPHA - default=false)<br/>RunAsGroup=true|false (ALPHA - default=false)<br/>ScheduleDaemonSetPods=true|false (ALPHA - default=false)<br/>ServiceNodeExclusion=true|false (ALPHA - default=false)<br/>ServiceProxyAllowExternalIPs=true|false (DEPRECATED - default=false)<br/>StorageObjectInUseProtection=true|false (BETA - default=true)<br/>StreamingProxyRedirects=true|false (BETA - default=true)<br/>SupportIPVSProxyMode=true|false (BETA - default=true)<br/>SupportPodPidsLimit=true|false (ALPHA - default=false)<br/>TaintBasedEvictions=true|false (ALPHA - default=false)<br/>TaintNodesByCondition=true|false (ALPHA - default=false)<br/>TokenRequest=true|false (ALPHA - default=false)<br/>VolumeScheduling=true|false (BETA - default=true)<br/>VolumeSubpath=true|false (default=true)</td>
+    </tr>
+    <tr>
+      <td colspan="2">-h, --help</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">help for kube-scheduler</td>
+    </tr>
+    <tr>
+      <td colspan="2">--kube-api-burst int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 100</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Burst to use while talking with kubernetes apiserver</td>
+    </tr>
+    <tr>
+      <td colspan="2">--kube-api-content-type string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "application/vnd.kubernetes.protobuf"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Content type of requests sent to apiserver.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--kube-api-qps float32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 50</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">QPS to use while talking with kubernetes apiserver</td>
+    </tr>
+    <tr>
+      <td colspan="2">--kubeconfig string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Path to kubeconfig file with authorization and master location information.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--leader-elect&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--leader-elect-lease-duration duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 15s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--leader-elect-renew-deadline duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The interval between attempts by the acting master to renew a leadership slot before it stops leading. This must be less than or equal to the lease duration. This is only applicable if leader election is enabled.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--leader-elect-resource-lock endpoints&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "endpoints"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The type of resource object that is used for locking during leader election. Supported options are endpoints (default) and `configmaps`.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--leader-elect-retry-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 2s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The duration the clients should wait between attempting acquisition and renewal of a leadership. This is only applicable if leader election is enabled.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--lock-object-name string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "kube-scheduler"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Define the name of the lock object.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--lock-object-namespace string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "kube-system"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Define the namespace of the lock object.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--log-flush-frequency duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Maximum number of seconds between log flushes</td>
+    </tr>
+    <tr>
+      <td colspan="2">--master string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The address of the Kubernetes API server (overrides any value in kubeconfig)</td>
+    </tr>
+    <tr>
+      <td colspan="2">--policy-config-file string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">File with scheduler policy configuration. This file is used if policy ConfigMap is not provided or --use-legacy-policy-config==true</td>
+    </tr>
+    <tr>
+      <td colspan="2">--policy-configmap string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Name of the ConfigMap object that contains scheduler's policy configuration. It must exist in the system namespace before scheduler initialization if --use-legacy-policy-config==false. The config must be provided as the value of an element in 'Data' map with the key='policy.cfg'</td>
+    </tr>
+    <tr>
+      <td colspan="2">--policy-configmap-namespace string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The namespace where policy ConfigMap is located. The system namespace will be used if this is not provided or is empty.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--port int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10251</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The port that the scheduler's http service runs on</td>
+    </tr>
+    <tr>
+      <td colspan="2">--profiling</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Enable profiling via web interface host:port/debug/pprof/</td>
+    </tr>
+    <tr>
+      <td colspan="2">--scheduler-name string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "default-scheduler"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Name of the scheduler, used to select which pods will be processed by this scheduler, based on pod's "spec.SchedulerName".</td>
+    </tr>
+    <tr>
+      <td colspan="2">--use-legacy-policy-config</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">When set to true, scheduler will ignore policy ConfigMap and uses policy config file</td>
+    </tr>
+    <tr>
+      <td colspan="2">--version version[=true]</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Print version information and quit</td>
+    </tr>
+  </tbody>
+</table>

--- a/content/en/docs/reference/command-line-tools-reference/kubelet-authentication-authorization.md
+++ b/content/en/docs/reference/command-line-tools-reference/kubelet-authentication-authorization.md
@@ -1,0 +1,88 @@
+---
+reviewers:
+- liggitt
+title: Kubelet authentication/authorization
+weight: 30
+---
+
+* TOC
+{:toc}
+
+## Overview
+
+A kubelet's HTTPS endpoint exposes APIs which give access to data of varying sensitivity,
+and allow you to perform operations with varying levels of power on the node and within containers.
+
+This document describes how to authenticate and authorize access to the kubelet's HTTPS endpoint.
+
+## Kubelet authentication
+
+By default, requests to the kubelet's HTTPS endpoint that are not rejected by other configured
+authentication methods are treated as anonymous requests, and given a username of `system:anonymous`
+and a group of `system:unauthenticated`.
+
+To disable anonymous access and send `401 Unauthorized` responses to unauthenticated requests:
+
+* start the kubelet with the `--anonymous-auth=false` flag
+
+To enable X509 client certificate authentication to the kubelet's HTTPS endpoint:
+
+* start the kubelet with the `--client-ca-file` flag, providing a CA bundle to verify client certificates with
+* start the apiserver with `--kubelet-client-certificate` and `--kubelet-client-key` flags
+* see the [apiserver authentication documentation](/docs/admin/authentication/#x509-client-certs) for more details
+
+To enable API bearer tokens (including service account tokens) to be used to authenticate to the kubelet's HTTPS endpoint:
+
+* ensure the `authentication.k8s.io/v1beta1` API group is enabled in the API server
+* start the kubelet with the `--authentication-token-webhook` and `--kubeconfig` flags
+* the kubelet calls the `TokenReview` API on the configured API server to determine user information from bearer tokens
+
+## Kubelet authorization
+
+Any request that is successfully authenticated (including an anonymous request) is then authorized. The default authorization mode is `AlwaysAllow`, which allows all requests.
+
+There are many possible reasons to subdivide access to the kubelet API:
+
+* anonymous auth is enabled, but anonymous users' ability to call the kubelet API should be limited
+* bearer token auth is enabled, but arbitrary API users' (like service accounts) ability to call the kubelet API should be limited
+* client certificate auth is enabled, but only some of the client certificates signed by the configured CA should be allowed to use the kubelet API
+
+To subdivide access to the kubelet API, delegate authorization to the API server:
+
+* ensure the `authorization.k8s.io/v1beta1` API group is enabled in the API server
+* start the kubelet with the `--authorization-mode=Webhook` and the `--kubeconfig` flags
+* the kubelet calls the `SubjectAccessReview` API on the configured API server to determine whether each request is authorized
+
+The kubelet authorizes API requests using the same [request attributes](/docs/admin/authorization/#request-attributes) approach as the apiserver.
+
+The verb is determined from the incoming request's HTTP verb:
+
+HTTP verb | request verb
+----------|---------------
+POST      | create
+GET, HEAD | get
+PUT       | update
+PATCH     | patch
+DELETE    | delete
+
+The resource and subresource is determined from the incoming request's path:
+
+Kubelet API  | resource | subresource
+-------------|----------|------------
+/stats/\*     | nodes    | stats
+/metrics/\*   | nodes    | metrics
+/logs/\*      | nodes    | log
+/spec/\*      | nodes    | spec
+*all others* | nodes    | proxy
+
+The namespace and API group attributes are always an empty string, and
+the resource name is always the name of the kubelet's `Node` API object.
+
+When running in this mode, ensure the user identified by the `--kubelet-client-certificate` and `--kubelet-client-key`
+flags passed to the apiserver is authorized for the following attributes:
+
+* verb=\*, resource=nodes, subresource=proxy
+* verb=\*, resource=nodes, subresource=stats
+* verb=\*, resource=nodes, subresource=log
+* verb=\*, resource=nodes, subresource=spec
+* verb=\*, resource=nodes, subresource=metrics

--- a/content/en/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping.md
+++ b/content/en/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping.md
@@ -1,0 +1,224 @@
+---
+reviewers:
+- ericchiang
+- mikedanese
+- jcbsmpsn
+title: TLS bootstrapping
+weight: 80
+---
+
+* TOC
+{:toc}
+
+## Overview
+
+This document describes how to set up TLS client certificate bootstrapping for kubelets.
+Kubernetes 1.4 introduced an API for requesting certificates from a cluster-level Certificate Authority (CA). The original intent of this API is to enable provisioning of TLS client certificates for kubelets. The proposal can be found [here](https://github.com/kubernetes/kubernetes/pull/20439)
+and progress on the feature is being tracked as [feature #43](https://github.com/kubernetes/features/issues/43).
+
+## kube-apiserver configuration
+
+The API server should be configured with an [authenticator](/docs/admin/authentication/) that can authenticate tokens as a user in the `system:bootstrappers` group.
+
+This group will later be used in the controller-manager configuration to scope approvals in the default approval
+controller. As this feature matures, you should ensure tokens are bound to a Role-Based Access Control (RBAC) policy which limits requests
+(using the bootstrap token) strictly to client requests related to certificate provisioning. With RBAC in place, scoping the tokens to a group allows for great flexibility (e.g. you could disable a particular bootstrap group's access when you are done provisioning the nodes).
+
+While any authentication strategy can be used for the kubelet's initial bootstrap credentials, the following two authenticators are recommended for ease of provisioning.
+
+1. [Bootstrap Tokens](/docs/admin/bootstrap-tokens/) - __alpha__
+2. [Token authentication file](#token-authentication-file)
+
+Using bootstrap tokens is currently __alpha__ and will simplify the management of bootstrap token management especially in a HA scenario.
+
+### Token authentication file
+Tokens are arbitrary but should represent at least 128 bits of entropy derived from a secure random number
+generator (such as /dev/urandom on most modern systems). There are multiple ways you can generate a token. For example:
+
+`head -c 16 /dev/urandom | od -An -t x | tr -d ' '`
+
+will generate tokens that look like `02b50b05283e98dd0fd71db496ef01e8`
+
+The token file should look like the following example, where the first three values can be anything and the quoted group
+name should be as depicted:
+
+```
+02b50b05283e98dd0fd71db496ef01e8,kubelet-bootstrap,10001,"system:bootstrappers"
+```
+
+Add the `--token-auth-file=FILENAME` flag to the kube-apiserver command (in your systemd unit file perhaps) to enable the token file.
+See docs [here](/docs/admin/authentication/#static-token-file) for further details.
+
+### Client certificate CA bundle
+
+Add the `--client-ca-file=FILENAME` flag to the kube-apiserver command to enable client certificate authentication,
+referencing a certificate authority bundle containing the signing certificate (e.g. `--client-ca-file=/var/lib/kubernetes/ca.pem`).
+
+## kube-controller-manager configuration
+The API for requesting certificates adds a certificate-issuing control loop to the Kubernetes Controller Manager. This takes the form of a
+[cfssl](https://blog.cloudflare.com/introducing-cfssl/) local signer using assets on disk. Currently, all certificates issued have one year validity and a default set of key usages.
+
+### Signing assets
+You must provide a Certificate Authority in order to provide the cryptographic materials necessary to issue certificates.
+This CA should be trusted by kube-apiserver for authentication with the `--client-ca-file=FILENAME` flag. The management
+of the CA is beyond the scope of this document but it is recommended that you generate a dedicated CA for Kubernetes.
+Both certificate and key are assumed to be PEM-encoded.
+
+The kube-controller-manager flags are:
+
+```
+--cluster-signing-cert-file="/etc/path/to/kubernetes/ca/ca.crt" --cluster-signing-key-file="/etc/path/to/kubernetes/ca/ca.key"
+```
+
+### Approval controller
+
+In 1.7 the experimental "group auto approver" controller is dropped in favor of the new `csrapproving` controller
+that ships as part of [kube-controller-manager](/docs/admin/kube-controller-manager/) and is enabled by default.
+The controller uses the [`SubjectAccessReview` API](/docs/admin/authorization/#checking-api-access) to determine
+if a given user is authorized to request a CSR, then approves based on the authorization outcome. To prevent
+conflicts with other approvers, the builtin approver doesn't explicitly deny CSRs, only ignoring unauthorized requests.
+
+The controller categorizes CSRs into three subresources:
+
+1. `nodeclient` - a request by a user for a client certificate with `O=system:nodes` and `CN=system:node:(node name)`.
+2. `selfnodeclient` - a node renewing a client certificate with the same `O` and `CN`.
+3. `selfnodeserver` - a node renewing a serving certificate. (ALPHA, requires feature gate)
+
+The checks to determine if a CSR is a `selfnodeserver` request is currently tied to the kubelet's credential rotation
+implementation, an __alpha__ feature. As such, the definition of `selfnodeserver` will likely change in a future and
+requires the `RotateKubeletServerCertificate` feature gate on the controller manager. The feature progress can be
+tracked at [kubernetes/features#267](https://github.com/kubernetes/features/issues/267).
+
+```
+--feature-gates=RotateKubeletServerCertificate=true
+```
+
+The following RBAC `ClusterRoles` represent the `nodeclient`, `selfnodeclient`, and `selfnodeserver` capabilities. Similar roles
+may be automatically created in future releases.
+
+```yml
+# A ClusterRole which instructs the CSR approver to approve a user requesting
+# node client credentials.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: approve-node-client-csr
+rules:
+- apiGroups: ["certificates.k8s.io"]
+  resources: ["certificatesigningrequests/nodeclient"]
+  verbs: ["create"]
+---
+# A ClusterRole which instructs the CSR approver to approve a node renewing its
+# own client credentials.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: approve-node-client-renewal-csr
+rules:
+- apiGroups: ["certificates.k8s.io"]
+  resources: ["certificatesigningrequests/selfnodeclient"]
+  verbs: ["create"]
+---
+# A ClusterRole which instructs the CSR approver to approve a node requesting a
+# serving cert matching its client cert.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: approve-node-server-renewal-csr
+rules:
+- apiGroups: ["certificates.k8s.io"]
+  resources: ["certificatesigningrequests/selfnodeserver"]
+  verbs: ["create"]
+```
+
+As of 1.8, equivalent roles to the ones listed above are automatically created as part of the default RBAC roles.
+For 1.8 clusters admins are recommended to bind tokens to the following roles instead of creating their own:
+
+* `system:certificates.k8s.io:certificatesigningrequests:nodeclient`
+    - Automatically approve CSRs for client certs bound to this role.
+* `system:certificates.k8s.io:certificatesigningrequests:selfnodeclient`
+    - Automatically approve CSRs when a client bound to its role renews its own certificate.
+
+These powers can be granted to credentials, such as bootstrapping tokens. For example, to replicate the behavior
+provided by the removed auto-approval flag, of approving all CSRs by a single group:
+
+```
+# REMOVED: This flag no longer works as of 1.7.
+--insecure-experimental-approve-all-kubelet-csrs-for-group="system:bootstrappers"
+```
+
+An admin would create a `ClusterRoleBinding` targeting that group.
+
+```yml
+# Approve all CSRs for the group "system:bootstrappers"
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: auto-approve-csrs-for-group
+subjects:
+- kind: Group
+  name: system:bootstrappers
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: approve-node-client-csr
+  apiGroup: rbac.authorization.k8s.io
+```
+
+To let a node renew its own credentials, an admin can construct a `ClusterRoleBinding` targeting
+that node's credentials:
+
+```yml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: node1-client-cert-renewal
+subjects:
+- kind: User
+  name: system:node:node-1 # Let "node-1" renew its client certificate.
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: approve-node-client-renewal-csr
+  apiGroup: rbac.authorization.k8s.io
+```
+
+Deleting the binding will prevent the node from renewing its client credentials, effectively
+removing it from the cluster once its certificate expires.
+
+## kubelet configuration
+To request a client certificate from kube-apiserver, the kubelet first needs a path to a kubeconfig file that contains the
+bootstrap authentication token. You can use `kubectl config set-cluster`, `set-credentials`, and `set-context` to build this kubeconfig. Provide the name `kubelet-bootstrap` to `kubectl config set-credentials` and include `--token=<token-value>` as follows:
+
+```
+kubectl config set-credentials kubelet-bootstrap --token=${BOOTSTRAP_TOKEN} --kubeconfig=bootstrap.kubeconfig
+```
+
+When starting the kubelet, if the file specified by `--kubeconfig` does not exist, the bootstrap kubeconfig is used to request a client certificate from the API server. On approval of the certificate request and receipt back by the kubelet, a kubeconfig file referencing the generated key and obtained certificate is written to the path specified by `--kubeconfig`. The certificate and key file will be placed in the directory specified by `--cert-dir`.
+
+**Note:** The following flags are required to enable this bootstrapping when starting the kubelet:
+
+```
+--bootstrap-kubeconfig="/path/to/bootstrap/kubeconfig"
+```
+
+Additionally, in 1.7 the kubelet implements __alpha__ features for enabling rotation of both its client and/or serving certs.
+These can be enabled through the respective `RotateKubeletClientCertificate` and `RotateKubeletServerCertificate` feature
+flags on the kubelet, but may change in backward incompatible ways in future releases.
+
+```
+--feature-gates=RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
+```
+
+`RotateKubeletClientCertificate` causes the kubelet to rotate its client certificates by creating new CSRs as its existing
+credentials expire. `RotateKubeletServerCertificate` causes the kubelet to both request a serving certificate after
+bootstrapping its client credentials and rotate the certificate. The serving cert currently does not request DNS or IP
+SANs.
+
+## kubectl approval
+The signing controller does not immediately sign all certificate requests. Instead, it waits until they have been flagged with an
+"Approved" status by an appropriately-privileged user. This is intended to eventually be an automated process handled by an external
+approval controller, but for the alpha version of the API it can be done manually by a cluster administrator using kubectl.
+An administrator can list CSRs with `kubectl get csr` and describe one in detail with `kubectl describe csr <name>`. Before the 1.6 release there were
+[no direct approve/deny commands](https://github.com/kubernetes/kubernetes/issues/30163) so an approver had to update
+the Status field directly ([rough how-to](https://github.com/gtank/csrctl)). Later versions of Kubernetes offer `kubectl certificate approve <name>` and `kubectl certificate deny <name>` commands.

--- a/content/en/docs/reference/command-line-tools-reference/kubelet.md
+++ b/content/en/docs/reference/command-line-tools-reference/kubelet.md
@@ -1,0 +1,802 @@
+---
+title: kubelet
+notitle: true
+weight: 20
+---
+## kubelet
+
+
+
+### Synopsis
+
+
+The kubelet is the primary "node agent" that runs on each
+node. The kubelet works in terms of a PodSpec. A PodSpec is a YAML or JSON object
+that describes a pod. The kubelet takes a set of PodSpecs that are provided through
+various mechanisms (primarily through the apiserver) and ensures that the containers
+described in those PodSpecs are running and healthy. The kubelet doesn't manage
+containers which were not created by Kubernetes.
+
+Other than from an PodSpec from the apiserver, there are three ways that a container
+manifest can be provided to the Kubelet.
+
+File: Path passed as a flag on the command line. Files under this path will be monitored
+periodically for updates. The monitoring period is 20s by default and is configurable
+via a flag.
+
+HTTP endpoint: HTTP endpoint passed as a parameter on the command line. This endpoint
+is checked every 20 seconds (also configurable with a flag).
+
+HTTP server: The kubelet can also listen for HTTP and respond to a simple API
+(underspec'd currently) to submit a new manifest.
+
+```
+kubelet
+```
+
+### Options
+
+<table style="width: 100%;">
+  <colgroup>
+    <col span="1" style="width: 10px;">
+    <col span="1">
+  </colgroup>
+  <tbody>
+    <tr>
+      <td colspan="2">--address 0.0.0.0&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 0.0.0.0</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The IP address for the Kubelet to serve on (set to 0.0.0.0 for all IPv4 interfaces and `::` for all IPv6 interfaces)</td>
+    </tr>
+    <tr>
+      <td colspan="2">--allow-privileged</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If true, allow containers to request privileged mode.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--anonymous-auth&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Enables anonymous requests to the Kubelet server. Requests that are not rejected by another authentication method are treated as anonymous requests. Anonymous requests have a username of system:anonymous, and a group name of system:unauthenticated.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--authentication-token-webhook</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Use the TokenReview API to determine authentication for bearer tokens.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--authentication-token-webhook-cache-ttl duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 2m0s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The duration to cache responses from the webhook token authenticator.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--authorization-mode string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "AlwaysAllow"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Authorization mode for Kubelet server. Valid options are AlwaysAllow or Webhook. Webhook mode uses the SubjectAccessReview API to determine authorization.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--authorization-webhook-cache-authorized-ttl duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5m0s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The duration to cache 'authorized' responses from the webhook authorizer.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--authorization-webhook-cache-unauthorized-ttl duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 30s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The duration to cache 'unauthorized' responses from the webhook authorizer.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--azure-container-registry-config string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Path to the file container Azure container registry configuration information.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--bootstrap-checkpoint-path string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%"><Warning: Alpha feature> Path to to the directory where the checkpoints are stored</td>
+    </tr>
+    <tr>
+      <td colspan="2">--bootstrap-kubeconfig string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Path to a kubeconfig file that will be used to get client certificate for kubelet. If the file specified by --kubeconfig does not exist, the bootstrap kubeconfig is used to request a client certificate from the API server. On success, a kubeconfig file referencing the generated client certificate and key is written to the path specified by --kubeconfig. The client certificate and key file will be stored in the directory pointed by --cert-dir.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cadvisor-port int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 4194</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The port of the localhost cAdvisor endpoint (set to 0 to disable)</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cert-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/var/lib/kubelet/pki"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The directory where the TLS certs are located. If --tls-cert-file and --tls-private-key-file are provided, this flag will be ignored.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cgroup-driver string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "cgroupfs"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Driver that the kubelet uses to manipulate cgroups on the host.  Possible values: 'cgroupfs', 'systemd'</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cgroup-root string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Optional root cgroup to use for pods. This is handled by the container runtime on a best effort basis. Default: '', which means use the container runtime default.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cgroups-per-qos&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Enable creation of QoS cgroup hierarchy, if true top level QoS and pod cgroups are created.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--chaos-chance float</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If > 0.0, introduce random client errors and latency. Intended for testing.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--client-ca-file string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If set, any request presenting a client certificate signed by one of the authorities in the client-ca-file is authenticated with an identity corresponding to the CommonName of the client certificate.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cloud-config string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The path to the cloud provider configuration file.  Empty string for no configuration file.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cloud-provider string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The provider for cloud services. Specify empty string for running with no cloud provider.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cluster-dns stringSlice</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Comma-separated list of DNS server IP address.  This value is used for containers DNS server in case of Pods with "dnsPolicy=ClusterFirst". Note: all DNS servers appearing in the list MUST serve the same set of records otherwise name resolution within the cluster may not work correctly. There is no guarantee as to which DNS server may be contacted for name resolution.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cluster-domain string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Domain for this cluster.  If set, kubelet will configure all containers to search this domain in addition to the host's search domains</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cni-bin-dir string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%"><Warning: Alpha feature> The full path of the directory in which to search for CNI plugin binaries. Default: /opt/cni/bin</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cni-conf-dir string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%"><Warning: Alpha feature> The full path of the directory in which to search for CNI config files. Default: /etc/cni/net.d</td>
+    </tr>
+    <tr>
+      <td colspan="2">--config string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The Kubelet will load its initial configuration from this file. The path may be absolute or relative; relative paths start at the Kubelet's current working directory. Omit this flag to use the built-in default configuration values. You must also enable the KubeletConfigFile feature gate to pass this flag.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--container-runtime string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "docker"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The container runtime to use. Possible values: 'docker', 'rkt'.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--container-runtime-endpoint string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "unix:///var/run/dockershim.sock"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">[Experimental] The endpoint of remote runtime service. Currently unix socket is supported on Linux, and tcp is supported on windows.  Examples:'unix:///var/run/dockershim.sock', 'tcp://localhost:3735'</td>
+    </tr>
+    <tr>
+      <td colspan="2">--containerized</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Experimental support for running kubelet in a container.  Intended for testing.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--contention-profiling</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Enable lock contention profiling, if profiling is enabled</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cpu-cfs-quota&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Enable CPU CFS quota enforcement for containers that specify CPU limits</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cpu-manager-policy string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "none"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%"><Warning: Alpha feature> CPU Manager policy to use. Possible values: 'none', 'static'. Default: 'none'</td>
+    </tr>
+    <tr>
+      <td colspan="2">--cpu-manager-reconcile-period NodeStatusUpdateFrequency&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%"><Warning: Alpha feature> CPU Manager reconciliation period. Examples: '10s', or '1m'. If not supplied, defaults to NodeStatusUpdateFrequency</td>
+    </tr>
+    <tr>
+      <td colspan="2">--docker-disable-shared-pid&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The Container Runtime Interface (CRI) defaults to using a shared PID namespace for containers in a pod when running with Docker 1.13.1 or higher. Setting this flag reverts to the previous behavior of isolated PID namespaces. This ability will be removed in a future Kubernetes release.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--docker-endpoint string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "unix:///var/run/docker.sock"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Use this for the docker endpoint to communicate with</td>
+    </tr>
+    <tr>
+      <td colspan="2">--dynamic-config-dir string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The Kubelet will use this directory for checkpointing downloaded configurations and tracking configuration health. The Kubelet will create this directory if it does not already exist. The path may be absolute or relative; relative paths start at the Kubelet's current working directory. Providing this flag enables dynamic Kubelet configuration. Presently, you must also enable the DynamicKubeletConfig feature gate to pass this flag.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--enable-controller-attach-detach&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Enables the Attach/Detach controller to manage attachment/detachment of volumes scheduled to this node, and disables kubelet from executing any attach/detach operations</td>
+    </tr>
+    <tr>
+      <td colspan="2">--enable-debugging-handlers&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Enables server endpoints for log collection and local running of containers and commands</td>
+    </tr>
+    <tr>
+      <td colspan="2">--enable-server&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Enable the Kubelet's server</td>
+    </tr>
+    <tr>
+      <td colspan="2">--enforce-node-allocatable stringSlice&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: [pods]</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">A comma separated list of levels of node allocatable enforcement to be enforced by kubelet. Acceptible options are 'pods', 'system-reserved' & 'kube-reserved'. If the latter two options are specified, '--system-reserved-cgroup' & '--kube-reserved-cgroup' must also be set respectively. See https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/ for more details.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--event-burst int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Maximum size of a bursty event records, temporarily allows event records to burst to this number, while still not exceeding event-qps. Only used if --event-qps > 0</td>
+    </tr>
+    <tr>
+      <td colspan="2">--event-qps int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If > 0, limit event creations per second to this value. If 0, unlimited.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--eviction-hard mapStringString&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: imagefs.available<15%!,(MISSING)memory.available<100Mi,nodefs.available<10%!,(MISSING)nodefs.inodesFree<5%!<(MISSING)/td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">A set of eviction thresholds (e.g. memory.available<1Gi) that if met would trigger a pod eviction.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--eviction-max-pod-grace-period int32</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Maximum allowed grace period (in seconds) to use when terminating pods in response to a soft eviction threshold being met.  If negative, defer to pod specified value.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--eviction-minimum-reclaim mapStringString</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">A set of minimum reclaims (e.g. imagefs.available=2Gi) that describes the minimum amount of resource the kubelet will reclaim when performing a pod eviction if that resource is under pressure.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--eviction-pressure-transition-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5m0s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Duration for which the kubelet has to wait before transitioning out of an eviction pressure condition.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--eviction-soft mapStringString</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">A set of eviction thresholds (e.g. memory.available<1.5Gi) that if met over a corresponding grace period would trigger a pod eviction.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--eviction-soft-grace-period mapStringString</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">A set of eviction grace periods (e.g. memory.available=1m30s) that correspond to how long a soft eviction threshold must hold before triggering a pod eviction.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--exit-on-lock-contention</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Whether kubelet should exit upon lock-file contention.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--experimental-allocatable-ignore-eviction</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">When set to 'true', Hard Eviction Thresholds will be ignored while calculating Node Allocatable. See https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/ for more details. [default=false]</td>
+    </tr>
+    <tr>
+      <td colspan="2">--experimental-allowed-unsafe-sysctls stringSlice</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Comma-separated whitelist of unsafe sysctls or unsafe sysctl patterns (ending in *). Use these at your own risk.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--experimental-bootstrap-kubeconfig string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">deprecated: use --bootstrap-kubeconfig</td>
+    </tr>
+    <tr>
+      <td colspan="2">--experimental-check-node-capabilities-before-mount</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">[Experimental] if set true, the kubelet will check the underlying node for required componenets (binaries, etc.) before performing the mount</td>
+    </tr>
+    <tr>
+      <td colspan="2">--experimental-kernel-memcg-notification</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If enabled, the kubelet will integrate with the kernel memcg notification to determine if memory eviction thresholds are crossed rather than polling.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--experimental-mounter-path string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">[Experimental] Path of mounter binary. Leave empty to use the default mount.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--experimental-qos-reserved mapStringString</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">A set of ResourceName=Percentage (e.g. memory=50%!)(MISSING) pairs that describe how pod resource requests are reserved at the QoS level. Currently only memory is supported. [default=none]</td>
+    </tr>
+    <tr>
+      <td colspan="2">--fail-swap-on&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Makes the Kubelet fail to start if swap is enabled on the node. </td>
+    </tr>
+    <tr>
+      <td colspan="2">--feature-gates mapStringBool</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:<br/>APIListChunking=true|false (BETA - default=true)<br/>APIResponseCompression=true|false (ALPHA - default=false)<br/>Accelerators=true|false (ALPHA - default=false)<br/>AdvancedAuditing=true|false (BETA - default=true)<br/>AllAlpha=true|false (ALPHA - default=false)<br/>AllowExtTrafficLocalEndpoints=true|false (default=true)<br/>AppArmor=true|false (BETA - default=true)<br/>BlockVolume=true|false (ALPHA - default=false)<br/>CPUManager=true|false (BETA - default=true)<br/>CSIPersistentVolume=true|false (ALPHA - default=false)<br/>CustomPodDNS=true|false (ALPHA - default=false)<br/>CustomResourceValidation=true|false (BETA - default=true)<br/>DebugContainers=true|false (ALPHA - default=false)<br/>DevicePlugins=true|false (ALPHA - default=false)<br/>DynamicKubeletConfig=true|false (ALPHA - default=false)<br/>EnableEquivalenceClassCache=true|false (ALPHA - default=false)<br/>ExpandPersistentVolumes=true|false (ALPHA - default=false)<br/>ExperimentalCriticalPodAnnotation=true|false (ALPHA - default=false)<br/>ExperimentalHostUserNamespaceDefaulting=true|false (BETA - default=false)<br/>HugePages=true|false (BETA - default=true)<br/>Initializers=true|false (ALPHA - default=false)<br/>KubeletConfigFile=true|false (ALPHA - default=false)<br/>LocalStorageCapacityIsolation=true|false (ALPHA - default=false)<br/>MountContainers=true|false (ALPHA - default=false)<br/>MountPropagation=true|false (ALPHA - default=false)<br/>PVCProtection=true|false (ALPHA - default=false)<br/>PersistentLocalVolumes=true|false (ALPHA - default=false)<br/>PodPriority=true|false (ALPHA - default=false)<br/>ResourceLimitsPriorityFunction=true|false (ALPHA - default=false)<br/>RotateKubeletClientCertificate=true|false (BETA - default=true)<br/>RotateKubeletServerCertificate=true|false (ALPHA - default=false)<br/>ServiceNodeExclusion=true|false (ALPHA - default=false)<br/>StreamingProxyRedirects=true|false (BETA - default=true)<br/>SupportIPVSProxyMode=true|false (BETA - default=false)<br/>TaintBasedEvictions=true|false (ALPHA - default=false)<br/>TaintNodesByCondition=true|false (ALPHA - default=false)<br/>VolumeScheduling=true|false (ALPHA - default=false)</td>
+    </tr>
+    <tr>
+      <td colspan="2">--file-check-frequency duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 20s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Duration between checking config files for new data</td>
+    </tr>
+    <tr>
+      <td colspan="2">--google-json-key string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The Google Cloud Platform Service Account JSON Key to use for authentication.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--hairpin-mode string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "promiscuous-bridge"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">How should the kubelet setup hairpin NAT. This allows endpoints of a Service to loadbalance back to themselves if they should try to access their own Service. Valid values are "promiscuous-bridge", "hairpin-veth" and "none".</td>
+    </tr>
+    <tr>
+      <td colspan="2">--healthz-bind-address 0.0.0.0&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 127.0.0.1</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The IP address for the healthz server to serve on (set to 0.0.0.0 for all IPv4 interfaces and `::` for all IPv6 interfaces)</td>
+    </tr>
+    <tr>
+      <td colspan="2">--healthz-port int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10248</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The port of the localhost healthz endpoint (set to 0 to disable)</td>
+    </tr>
+    <tr>
+      <td colspan="2">--host-ipc-sources stringSlice&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: [*]</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Comma-separated list of sources from which the Kubelet allows pods to use the host ipc namespace.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--host-network-sources stringSlice&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: [*]</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Comma-separated list of sources from which the Kubelet allows pods to use of host network.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--host-pid-sources stringSlice&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: [*]</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Comma-separated list of sources from which the Kubelet allows pods to use the host pid namespace.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--hostname-override string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If non-empty, will use this string as identification instead of the actual hostname.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--http-check-frequency duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 20s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Duration between checking http for new data</td>
+    </tr>
+    <tr>
+      <td colspan="2">--image-gc-high-threshold int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 85</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The percent of disk usage after which image garbage collection is always run.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--image-gc-low-threshold int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 80</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The percent of disk usage before which image garbage collection is never run. Lowest disk usage to garbage collect to.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--image-pull-progress-deadline duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 1m0s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If no pulling progress is made before this deadline, the image pulling will be cancelled.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--image-service-endpoint string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">[Experimental] The endpoint of remote image service. If not specified, it will be the same with container-runtime-endpoint by default. Currently unix socket is supported on Linux, and tcp is supported on windows.  Examples:'unix:///var/run/dockershim.sock', 'tcp://localhost:3735'</td>
+    </tr>
+    <tr>
+      <td colspan="2">--iptables-drop-bit int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 15</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The bit of the fwmark space to mark packets for dropping. Must be within the range [0, 31].</td>
+    </tr>
+    <tr>
+      <td colspan="2">--iptables-masquerade-bit int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 14</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The bit of the fwmark space to mark packets for SNAT. Must be within the range [0, 31]. Please match this parameter with corresponding parameter in kube-proxy.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--kube-api-burst int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Burst to use while talking with kubernetes apiserver</td>
+    </tr>
+    <tr>
+      <td colspan="2">--kube-api-content-type string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "application/vnd.kubernetes.protobuf"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Content type of requests sent to apiserver.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--kube-api-qps int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">QPS to use while talking with kubernetes apiserver</td>
+    </tr>
+    <tr>
+      <td colspan="2">--kube-reserved mapStringString</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">A set of ResourceName=ResourceQuantity (e.g. cpu=200m,memory=500Mi,ephemeral-storage=1Gi) pairs that describe resources reserved for kubernetes system components. Currently cpu, memory and local ephemeral storage for root file system are supported. See http://kubernetes.io/docs/user-guide/compute-resources for more detail. [default=none]</td>
+    </tr>
+    <tr>
+      <td colspan="2">--kube-reserved-cgroup string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Absolute name of the top level cgroup that is used to manage kubernetes components for which compute resources were reserved via '--kube-reserved' flag. Ex. '/kube-reserved'. [default='']</td>
+    </tr>
+    <tr>
+      <td colspan="2">--kubeconfig string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/var/lib/kubelet/kubeconfig"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Path to a kubeconfig file, specifying how to connect to the API server.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--kubelet-cgroups string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Optional absolute name of cgroups to create and run the Kubelet in.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--lock-file string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%"><Warning: Alpha feature> The path to file for kubelet to use as a lock file.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--make-iptables-util-chains&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If true, kubelet will ensure iptables utility rules are present on host.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--manifest-url string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">URL for accessing the container manifest</td>
+    </tr>
+    <tr>
+      <td colspan="2">--manifest-url-header --manifest-url-header 'a:hello,b:again,c:world' --manifest-url-header 'b:beautiful'</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Comma-separated list of HTTP headers to use when accessing the manifest URL. Multiple headers with the same name will be added in the same order provided. This flag can be repeatedly invoked. For example: --manifest-url-header 'a:hello,b:again,c:world' --manifest-url-header 'b:beautiful'</td>
+    </tr>
+    <tr>
+      <td colspan="2">--max-open-files int&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 1000000</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Number of files that can be opened by Kubelet process.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--max-pods int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 110</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Number of Pods that can run on this Kubelet.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--minimum-image-ttl-duration duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 2m0s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Minimum age for an unused image before it is garbage collected.  Examples: '300ms', '10s' or '2h45m'.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--network-plugin string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%"><Warning: Alpha feature> The name of the network plugin to be invoked for various events in kubelet/pod lifecycle</td>
+    </tr>
+    <tr>
+      <td colspan="2">--network-plugin-mtu int32</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%"><Warning: Alpha feature> The MTU to be passed to the network plugin, to override the default. Set to 0 to use the default 1460 MTU.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--node-ip string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">IP address of the node. If set, kubelet will use this IP address for the node</td>
+    </tr>
+    <tr>
+      <td colspan="2">--node-labels mapStringString</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%"><Warning: Alpha feature> Labels to add when registering the node in the cluster.  Labels must be key=value pairs separated by ','.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--node-status-update-frequency duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Specifies how often kubelet posts node status to master. Note: be cautious when changing the constant, it must work with nodeMonitorGracePeriod in nodecontroller.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--oom-score-adj int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: -999</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The oom-score-adj value for kubelet process. Values must be within the range [-1000, 1000]</td>
+    </tr>
+    <tr>
+      <td colspan="2">--pod-cidr string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The CIDR to use for pod IP addresses, only used in standalone mode.  In cluster mode, this is obtained from the master.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--pod-infra-container-image string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "gcr.io/google_containers/pause-amd64:3.1"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The image whose network/ipc namespaces containers in each pod will use.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--pod-manifest-path string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Path to the directory containing pod manifest files to run, or the path to a single pod manifest file. Files starting with dots will be ignored.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--pods-per-core int32</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Number of Pods per core that can run on this Kubelet. The total number of Pods on this Kubelet cannot exceed max-pods, so max-pods will be used if this calculation results in a larger number of Pods allowed on the Kubelet. A value of 0 disables this limit.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--port int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10250</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The port for the Kubelet to serve on.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--protect-kernel-defaults</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Default kubelet behaviour for kernel tuning. If set, kubelet errors if any of kernel tunables is different than kubelet defaults.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--provider-id string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Unique identifier for identifying the node in a machine database, i.e cloudprovider</td>
+    </tr>
+    <tr>
+      <td colspan="2">--read-only-port int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10255</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The read-only port for the Kubelet to serve on with no authentication/authorization (set to 0 to disable)</td>
+    </tr>
+    <tr>
+      <td colspan="2">--really-crash-for-testing</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If true, when panics occur crash. Intended for testing.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--register-node&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Register the node with the apiserver. If --kubeconfig is not provided, this flag is irrelevant, as the Kubelet won't have an apiserver to register with. Default=true.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--register-with-taints []api.Taint</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Register the node with the given list of taints (comma separated "<key>=<value>:<effect>"). No-op if register-node is false.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--registry-burst int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Maximum size of a bursty pulls, temporarily allows pulls to burst to this number, while still not exceeding registry-qps. Only used if --registry-qps > 0</td>
+    </tr>
+    <tr>
+      <td colspan="2">--registry-qps int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If > 0, limit registry pull QPS to this value.  If 0, unlimited.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--resolv-conf string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/etc/resolv.conf"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Resolver configuration file used as the basis for the container DNS resolution configuration.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--rkt-api-endpoint string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "localhost:15441"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">The endpoint of the rkt API service to communicate with. Only used if --container-runtime='rkt'.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--rkt-path string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Path of rkt binary. Leave empty to use the first rkt in $PATH.  Only used if --container-runtime='rkt'.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--root-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/var/lib/kubelet"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Directory path for managing kubelet files (volume mounts,etc).</td>
+    </tr>
+    <tr>
+      <td colspan="2">--rotate-certificates</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%"><Warning: Beta feature> Auto rotate the kubelet client certificates by requesting new certificates from the kube-apiserver when the certificate expiration approaches.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--runonce</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">If true, exit after spawning pods from local manifests or remote urls. Exclusive with --enable-server</td>
+    </tr>
+    <tr>
+      <td colspan="2">--runtime-cgroups string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Optional absolute name of cgroups to create and run the runtime in.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--runtime-request-timeout duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 2m0s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Timeout of all runtime requests except long running request - pull, logs, exec and attach. When timeout exceeded, kubelet will cancel the request, throw out an error and retry later.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--seccomp-profile-root string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/var/lib/kubelet/seccomp"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%"><Warning: Alpha feature> Directory path for seccomp profiles.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--serialize-image-pulls&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Pull images one at a time. We recommend *not* changing the default value on nodes that run docker daemon with version < 1.9 or an Aufs storage backend. Issue #10959 has more details.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--streaming-connection-idle-timeout duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 4h0m0s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Maximum time a streaming connection can be idle before the connection is automatically closed. 0 indicates no timeout. Example: '5m'</td>
+    </tr>
+    <tr>
+      <td colspan="2">--sync-frequency duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 1m0s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Max period between synchronizing running containers and config</td>
+    </tr>
+    <tr>
+      <td colspan="2">--system-cgroups /</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Optional absolute name of cgroups in which to place all non-kernel processes that are not already inside a cgroup under /. Empty for no container. Rolling back the flag requires a reboot.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--system-reserved mapStringString</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">A set of ResourceName=ResourceQuantity (e.g. cpu=200m,memory=500Mi,ephemeral-storage=1Gi) pairs that describe resources reserved for non-kubernetes components. Currently only cpu and memory are supported. See http://kubernetes.io/docs/user-guide/compute-resources for more detail. [default=none]</td>
+    </tr>
+    <tr>
+      <td colspan="2">--system-reserved-cgroup string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Absolute name of the top level cgroup that is used to manage non-kubernetes components for which compute resources were reserved via '--system-reserved' flag. Ex. '/system-reserved'. [default='']</td>
+    </tr>
+    <tr>
+      <td colspan="2">--tls-cert-file string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">File containing x509 Certificate used for serving HTTPS (with intermediate certs, if any, concatenated after server cert). If --tls-cert-file and --tls-private-key-file are not provided, a self-signed certificate and key are generated for the public address and saved to the directory passed to --cert-dir.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--tls-private-key-file string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">File containing x509 private key matching --tls-cert-file.</td>
+    </tr>
+    <tr>
+      <td colspan="2">--version version[=true]</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Print version information and quit</td>
+    </tr>
+    <tr>
+      <td colspan="2">--volume-plugin-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%"><Warning: Alpha feature> The full path of the directory in which to search for additional third party volume plugins</td>
+    </tr>
+    <tr>
+      <td colspan="2">--volume-stats-agg-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 1m0s</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%">Specifies interval for kubelet to calculate and cache the volume disk usage for all pods and volumes.  To disable volume calculations, set to 0.</td>
+    </tr>
+  </tbody>
+</table>

--- a/content/en/docs/reference/kubectl/kubectl-cmds.md
+++ b/content/en/docs/reference/kubectl/kubectl-cmds.md
@@ -1,0 +1,5 @@
+---
+title: kubectl Commands
+---
+
+[kubectl Command Reference](/docs/reference/generated/kubectl/kubectl-commands/)

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -336,7 +336,7 @@ In order to set up a cluster where the master and worker nodes communicate with 
 
    `kubeadm init --apiserver-advertise-address=<private-master-ip>`
 
-2. When a worker node has been provisioned, add a flag to `/etc/systemd/system/kubelet.service.d/10-kubeadm.conf` that specifies the private IP of the worker node:
+2. When a master or worker node has been provisioned, add a flag to `/etc/systemd/system/kubelet.service.d/10-kubeadm.conf` that specifies the private IP of the worker node:
 
    `--node-ip=<private-node-ip>`
 

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -117,6 +117,12 @@ etcd:
     <argument>: <value|string>
     <argument>: <value|string>
   image: <string>
+  serverCertSANs:
+  - <name1|string>
+  - <name2|string>
+  peerCertSANs:
+  - <name1|string>
+  - <name2|string>
 kubeProxy:
   config:
     mode: <value|string>

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-version.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-version.md
@@ -8,7 +8,7 @@ content_template: templates/concept
 weight: 80
 ---
 {{% capture overview %}}
-This command prints the verison of kubeadm.
+This command prints the version of kubeadm.
 {{% /capture %}}
 
 {{% capture body %}}

--- a/content/en/docs/setup/independent/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/independent/create-cluster-kubeadm.md
@@ -115,7 +115,7 @@ The master is the machine where the control plane components run, including
 etcd (the cluster database) and the API server (which the kubectl CLI
 communicates with).
 
-To initialize the master, pick one of the machines you previously installed
+To initialize the master, first choose the pod network plugin you want and check if it requires any parameters to be passed to kubeadm while initializing the cluster. Pick one of the machines you previously installed
 kubeadm on, and run:
 
 ```bash

--- a/content/en/docs/setup/independent/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/independent/create-cluster-kubeadm.md
@@ -284,7 +284,7 @@ to pass bridged IPv4 traffic to iptables' chains. This is a requirement for some
 please see [here](https://kubernetes.io/docs/concepts/cluster-administration/network-plugins/#network-plugin-requirements).
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/v0.9.1/Documentation/kube-flannel.yml
+kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/v0.10.0/Documentation/kube-flannel.yml
 ```
 
  - For more information about `flannel`, please see [here](https://github.com/coreos/flannel).

--- a/content/en/docs/setup/independent/install-kubeadm.md
+++ b/content/en/docs/setup/independent/install-kubeadm.md
@@ -164,11 +164,11 @@ apt-get update
 apt-get install -y kubelet kubeadm kubectl
 {{< /tab >}}
 {{% tab name="CentOS, RHEL or Fedora" %}}
-``
+```
 cat <<EOF > /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-\
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
 enabled=1
 gpgcheck=1
 repo_gpgcheck=1

--- a/content/en/docs/setup/independent/install-kubeadm.md
+++ b/content/en/docs/setup/independent/install-kubeadm.md
@@ -200,7 +200,7 @@ Install CNI plugins (required for most pod network):
 ```bash
 CNI_VERSION="v0.6.0"
 mkdir -p /opt/cni/bin
-curl -L "https://github.com/containernetworking/plugins/releases/download//cni-plugins-amd64-.tgz" | tar -C /opt/cni/bin -xz
+curl -L "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-amd64-${CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz
 ```
 
 Install `kubeadm`, `kubelet`, `kubectl` and add a `kubelet` systemd service:
@@ -210,12 +210,12 @@ RELEASE="$(curl -sSL https://dl.k8s.io/release/stable.txt)"
 
 mkdir -p /opt/bin
 cd /opt/bin
-curl -L --remote-name-all https://storage.googleapis.com/kubernetes-release/release//bin/linux/amd64/{kubeadm,kubelet,kubectl}
+curl -L --remote-name-all https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/amd64/{kubeadm,kubelet,kubectl}
 chmod +x {kubeadm,kubelet,kubectl}
 
-curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes//build/debs/kubelet.service" | sed "s:/usr/bin:/opt/bin:g" > /etc/systemd/system/kubelet.service
+curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/kubelet.service" | sed "s:/usr/bin:/opt/bin:g" > /etc/systemd/system/kubelet.service
 mkdir -p /etc/systemd/system/kubelet.service.d
-curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes//build/debs/10-kubeadm.conf" | sed "s:/usr/bin:/opt/bin:g" > /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/10-kubeadm.conf" | sed "s:/usr/bin:/opt/bin:g" > /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 ```
 
 Enable and start `kubelet`:

--- a/content/en/docs/tasks/administer-cluster/setup-ha-etcd-with-kubeadm.md
+++ b/content/en/docs/tasks/administer-cluster/setup-ha-etcd-with-kubeadm.md
@@ -1,0 +1,203 @@
+---
+reviewers:
+- chuckha
+title: Set up a High-Availablity Etcd Cluster With Kubeadm
+content_template: templates/task
+---
+
+{{% capture overview %}}
+
+Kubeadm defaults to running a single member etcd cluster in a static pod managed
+by the kubelet on the control plane node. This is not a highly-available setup
+as the the etcd cluster contains only one member and cannot sustain any members
+becoming unavailable. This task walks through the process of creating a highly
+available etcd cluster of three members that can be used as an external etcd
+when using kubeadm to set up a kubernetes cluster.
+
+{{% /capture %}}
+
+{{% capture prerequisites %}}
+
+* Three hosts that can talk to each other over ports 2379 and 2380. This
+  document assumes these default ports. However, they are configurable through
+  the kubeadm config file.
+* Each host must [have docker, kubelet, and kubeadm installed][toolbox].
+* Some infrastructure to copy files between hosts (e.g., ssh).
+
+[toolbox]: /docs/setup/independent/install-kubeadm/
+
+{{% /capture %}}
+
+{{% capture steps %}}
+
+The general approach is to generate all certs on one node and only distribute
+the *necessary* files to the other nodes.
+
+## Create configuration files for kubeadm
+
+Using the template provided below, create one kubeadm configuration file for
+each host that will have an etcd member running on it. Update the value of
+`CURRENT_HOST` and `NAME` before running the `cat` command.
+
+```
+export HOST0=10.0.0.1 # Update HOST0, HOST1, and HOST2 with the IPs or resolvable names of your hosts
+export HOST1=10.0.0.2
+export HOST2=10.0.0.3
+
+# Create temp directories to store files that will end up on other hosts.
+mkdir -p /tmp/${HOST0}/certs /tmp/${HOST1}/certs /tmp/${HOST2}/certs
+
+export CURRENT_HOST="${HOST0}" # Update on each ranging through HOST0, HOST1 and HOST2
+export NAME=infra0 # Update to use infra0 for HOST0, infra1 for HOST1 and infra2 for HOST2
+
+cat << EOF > /tmp/${CURRENT_HOST}/kubeadmcfg.yaml
+apiVersion: "kubeadm.k8s.io/v1alpha1"
+kind: MasterConfiguration
+etcd:
+    serverCertSANs:
+    - "${CURRENT_HOST}"
+    peerCertSANs:
+    - "${CURRENT_HOST}"
+    extraArgs:
+        initial-cluster: infra0=https://${HOST0}:2380,infra1=https://${HOST1}:2380,infra2=https://${HOST2}:2380
+        initial-cluster-state: new
+        name: ${NAME}
+        listen-peer-urls: https://${CURRENT_HOST}:2380
+        listen-client-urls: https://${CURRENT_HOST}:2379
+        advertise-client-urls: https://${CURRENT_HOST}:2379
+        initial-advertise-peer-urls: https://${CURRENT_HOST}:2380
+EOF
+```
+
+## Generate certificates needed for the etcd cluster
+
+### Certificate Authority
+
+If you already have a CA then the only action that is copying the CA's `crt` and
+`key` file to `/etc/kubernetes/pki/etcd/ca.crt` and
+`/etc/kubernetes/pki/etcd/ca.key`. After those files have been copied, please
+skip to the Certificate Swizzling section below.
+
+If you do not already have a CA then run this command on `$HOST0` (where you
+generated the configuration files for kubeadm).
+
+```
+kubeadm alpha phase certs etcd-ca
+```
+
+This creates two files
+
+1. `/etc/kubernetes/pki/etcd/ca.crt`
+2. `/etc/kubernetes/pki/etcd/ca.key`
+
+### Create certificates for each member
+
+In this step we create all the certs for each host in our cluster.
+
+```
+kubeadm alpha phase certs etcd-server --config=/tmp/${HOST2}/kubeadmcfg.yaml
+kubeadm alpha phase certs etcd-peer --config=/tmp/${HOST2}/kubeadmcfg.yaml
+kubeadm alpha phase certs etcd-healthcheck-client --config=/tmp/${HOST2}/kubeadmcfg.yaml
+# Move the generated certs out of the generated directory
+find /etc/kubernetes/pki/etcd -not -name ca.crt -not -name ca.key -type f -exec mv {} /tmp/${HOST2}/certs \;
+cp /etc/kubernetes/pki/etcd/ca.crt /tmp/${HOST2}/certs
+
+kubeadm alpha phase certs etcd-server --config=/tmp/${HOST1}/kubeadmcfg.yaml
+kubeadm alpha phase certs etcd-peer --config=/tmp/${HOST1}/kubeadmcfg.yaml
+kubeadm alpha phase certs etcd-healthcheck-client --config=/tmp/${HOST1}/kubeadmcfg.yaml
+# Move the generated certs out of the generated directory
+find /etc/kubernetes/pki/etcd -not -name ca.crt -not -name ca.key -type f -exec mv {} /tmp/${HOST1}/certs \;
+cp /etc/kubernetes/pki/etcd/ca.crt /tmp/${HOST1}/certs
+
+kubeadm alpha phase certs etcd-server --config=/tmp/${HOST0}/kubeadmcfg.yaml
+kubeadm alpha phase certs etcd-peer --config=/tmp/${HOST0}/kubeadmcfg.yaml
+kubeadm alpha phase certs etcd-healthcheck-client --config=/tmp/${HOST0}/kubeadmcfg.yaml
+# No need to move the certs because they are for HOST0
+```
+
+### Copy certs and configs to other hosts
+
+Copy the certs and configs in each tmp directory to the respective hosts and put
+the certs owned by root:root in `/etc/kubernetes/pki/etcd/`.
+
+The steps to get these files on `$HOST1` might look like this if you can ssh
+between hosts:
+
+```
+root@HOST0 $ scp -i /home/ubuntu/.ssh/id_rsa -r /tmp/${HOST1}/* ubuntu@${HOST1}:/home/ubuntu
+root@HOST0 $ ssh -i /home/ubuntu/.ssh/id_rsa ubuntu@${HOST1}
+ubuntu@HOST1 $ sudo -s
+root@HOST1 $ chown -R root:root certs
+root@HOST1 $ mv certs/* /etc/kubernetes/pki/etcd/
+# Repeat for HOST2
+```
+
+### List of all generated certs
+
+This is a list of all the files you have generated and where on which host they
+should live.
+
+#### Host 0
+
+1. `/etc/kubernetes/pki/etcd/ca.crt`
+1. `/etc/kubernetes/pki/etcd/ca.key`
+1. `/etc/kubernetes/pki/etcd/server.crt`
+1. `/etc/kubernetes/pki/etcd/server.key`
+1. `/etc/kubernetes/pki/etcd/peer.crt`
+1. `/etc/kubernetes/pki/etcd/peer.key`
+1. `/etc/kubernetes/pki/etcd/healthcheck-client.crt`
+1. `/etc/kubernetes/pki/etcd/healthcheck-client.key`
+1. `/tmp/${HOST0}/kubeadmcfg.yaml`
+
+#### Host 1
+
+1. `/etc/kubernetes/pki/etcd/ca.crt`
+1. `/etc/kubernetes/pki/etcd/server.crt`
+1. `/etc/kubernetes/pki/etcd/server.key`
+1. `/etc/kubernetes/pki/etcd/peer.crt`
+1. `/etc/kubernetes/pki/etcd/peer.key`
+1. `/etc/kubernetes/pki/etcd/healthcheck-client.crt`
+1. `/etc/kubernetes/pki/etcd/healthcheck-client.key`
+1. `/home/ubuntu/kubeadmcfg.yaml`
+
+#### Host 2
+
+1. `/etc/kubernetes/pki/etcd/ca.crt`
+1. `/etc/kubernetes/pki/etcd/server.crt`
+1. `/etc/kubernetes/pki/etcd/server.key`
+1. `/etc/kubernetes/pki/etcd/peer.crt`
+1. `/etc/kubernetes/pki/etcd/peer.key`
+1. `/etc/kubernetes/pki/etcd/healthcheck-client.crt`
+1. `/etc/kubernetes/pki/etcd/healthcheck-client.key`
+1. `/home/ubuntu/kubeadmcfg.yaml`
+
+## Manifests
+
+Now that the certs and configs are in place we can create the manifest. On each
+host run the `kubeadm` command to generate a static manifest for etcd.
+
+```
+root@HOST0 $ kubeadm alpha phase etcd local --config=/tmp/${HOST0}/kubeadmcfg.yaml
+root@HOST1 $ kubeadm alpha phase etcd local --config=/home/ubuntu/kubeadmcfg.yaml
+root@HOST2 $ kubeadm alpha phase etcd local --config=/home/ubuntu/kubeadmcfg.yaml
+```
+
+## Optional: Check the cluster health
+
+```
+docker run --rm -it --net host -v /etc/kubernetes:/etc/kubernetes quay.io/coreos/etcd:v3.2.14 etcdctl --cert-file /etc/kubernetes/pki/etcd/peer.crt --key-file /etc/kubernetes/pki/etcd/peer.key --ca-file /etc/kubernetes/pki/etcd/ca.crt --endpoints https://${HOST0}:2379 cluster-health
+...
+cluster is healthy
+```
+
+{{% /capture %}}
+
+{{% capture whatsnext %}}
+
+Once your have a working 3 member etcd cluster, you can continue [setting up an
+HA control plane using
+kubeadm](/docs/tasks/administer-cluster/highly-available-master/).
+
+{{% /capture %}}
+
+

--- a/content/en/docs/tasks/configure-pod-container/configure-projected-volume-storage.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-projected-volume-storage.md
@@ -24,36 +24,37 @@ Here is the configuration file for the Pod:
 {{< code file="projected-volume.yaml" >}}
 
 1. Create the Secrets:
-
-       # Create files containing the username and password:
+```shell
+    # Create files containing the username and password:
        echo -n "admin" > ./username.txt
        echo -n "1f2d1e2e67df" > ./password.txt
 
-       # Package these files into secrets:
+    # Package these files into secrets:
        kubectl create secret generic user --from-file=./username.txt
        kubectl create secret generic pass --from-file=./password.txt
-
+```
 1. Create the Pod:
-
+```shell
        kubectl create -f https://k8s.io/docs/tasks/configure-pod-container/projected-volume.yaml
-
+```
 1. Verify that the Pod's Container is running, and then watch for changes to
 the Pod:
-
+```shell
        kubectl get --watch pod test-projected-volume
-
+```
     The output looks like this:
 
        NAME                    READY     STATUS    RESTARTS   AGE
        test-projected-volume   1/1       Running   0          14s
 
 1. In another terminal, get a shell to the running Container:
-
+```shell
        kubectl exec -it test-projected-volume -- /bin/sh
-
+```
 1. In your shell, verify that the `projected-volume` directory contains your projected sources:
-
-       / # ls /projected-volume/
+```shell
+       ls /projected-volume/
+```
 {{% /capture %}}
 
 {{% capture whatsnext %}}

--- a/content/en/docs/tasks/tools/install-kubectl.md
+++ b/content/en/docs/tasks/tools/install-kubectl.md
@@ -52,7 +52,7 @@ kubectl is available as a [snap](https://snapcraft.io/) application.
 
 1. If you are on Ubuntu or one of other Linux distributions that support [snap](https://snapcraft.io/docs/core/install) package manager, you can install with:
 
-       sudo snap install kubectl --classic
+        sudo snap install kubectl --classic
 
 2. Run `kubectl version` to verify that the version you've installed is sufficiently up-to-date.
 
@@ -60,7 +60,7 @@ kubectl is available as a [snap](https://snapcraft.io/) application.
 
 1. If you are on macOS and using [Homebrew](https://brew.sh/) package manager, you can install with:
 
-       brew install kubectl
+        brew install kubectl
 
 2. Run `kubectl version` to verify that the version you've installed is sufficiently up-to-date.
 
@@ -68,8 +68,8 @@ kubectl is available as a [snap](https://snapcraft.io/) application.
 
 1. If you are on Windows and using [Powershell Gallery](https://www.powershellgallery.com/) package manager, you can install and update with:
 
-       Install-Script -Name install-kubectl -Scope CurrentUser -Force
-       install-kubectl.ps1 [-DownloadLocation <path>]
+        Install-Script -Name install-kubectl -Scope CurrentUser -Force
+        install-kubectl.ps1 [-DownloadLocation <path>]
 
 If no Downloadlocation is specified, kubectl will be installed in users temp Directory
 2. The installer creates $HOME/.kube and instructs it to create a config file
@@ -81,15 +81,15 @@ re-run install-kubectl.ps1 to install latest binaries
 
 1. If you are on Windows and using [Chocolatey](https://chocolatey.org) package manager, you can install with:
 
-       choco install kubernetes-cli
+        choco install kubernetes-cli
 
 2. Run `kubectl version` to verify that the version you've installed is sufficiently up-to-date.
 3. Configure kubectl to use a remote Kubernetes cluster:
 
-       cd C:\users\yourusername (Or wherever your %HOME% directory is)
-       mkdir .kube
-       cd .kube
-       New-Item config -type file
+        cd C:\users\yourusername (Or wherever your %HOME% directory is)
+        mkdir .kube
+        cd .kube
+        New-Item config -type file
 
 Edit the config file with a text editor of your choice, such as Notepad for example.
 
@@ -100,7 +100,7 @@ kubectl can be installed as part of the Google Cloud SDK.
 1. Install the [Google Cloud SDK](https://cloud.google.com/sdk/).
 2. Run the following command to install `kubectl`:
 
-       gcloud components install kubectl
+        gcloud components install kubectl
 
 3. Run `kubectl version` to verify that the version you've installed is sufficiently up-to-date.
 

--- a/content/en/docs/tasks/tools/install-kubectl.md
+++ b/content/en/docs/tasks/tools/install-kubectl.md
@@ -107,7 +107,7 @@ kubectl can be installed as part of the Google Cloud SDK.
 ## Install kubectl binary via curl
 
 {{< tabs name="kubectl_install_curl" >}}
-{{% tab name="macos" %}}
+{{% tab name="macOS" %}}
 1. Download the latest release with the command:
 
     ```		 
@@ -134,7 +134,7 @@ kubectl can be installed as part of the Google Cloud SDK.
     sudo mv ./kubectl /usr/local/bin/kubectl
     ```
 {{% /tab %}}
-{{% tab name="linux" %}}
+{{% tab name="Linux" %}}
 
 1. Download the latest release with the command:
 
@@ -162,7 +162,7 @@ kubectl can be installed as part of the Google Cloud SDK.
     sudo mv ./kubectl /usr/local/bin/kubectl
     ```
 {{% /tab %}}
-{{% tab  name="win" %}}
+{{% tab  name="Windows" %}}
 1. Download the latest release {{< param "fullversion" >}} from [this link](https://storage.googleapis.com/kubernetes-release/release/{{< param "fullversion" >}}/bin/windows/amd64/kubectl.exe).
 
     Or if you have `curl` installed, use this command:

--- a/content/en/docs/user-guide/walkthrough/k8s201.md
+++ b/content/en/docs/user-guide/walkthrough/k8s201.md
@@ -69,7 +69,7 @@ Here is a Deployment that instantiates two nginx Pods:
 {{< code file="deployment.yaml" >}}
 
 
-#### Deployment Management
+### Deployment Management
 
 Create an nginx Deployment:
 
@@ -122,7 +122,7 @@ For example, here is a service that balances across the Pods created in the prev
 {{< code file="service.yaml" >}}
 
 
-#### Service Management
+### Service Management
 
 Create an nginx service ([service.yaml](/docs/user-guide/walkthrough/service.yaml)):
 
@@ -181,14 +181,14 @@ application and taking action to fix it.  It's important that the system be outs
 your application fails and the health checking agent is part of your application, it may fail as well and you'll never know.
 In Kubernetes, the health check monitor is the Kubelet agent.
 
-#### Process Health Checking
+### Process Health Checking
 
 The simplest form of health-checking is just process level health checking.  The Kubelet constantly asks the Docker daemon
 if the container process is still running, and if not, the container process is restarted.  In all of the Kubernetes examples
 you have run so far, this health checking was actually already enabled.  It's on for every single container that runs in
 Kubernetes.
 
-#### Application Health Checking
+### Application Health Checking
 
 However, in many cases this low-level health checking is insufficient.  Consider, for example, the following code:
 

--- a/content/en/docs/user-journeys/users/application-developer/intermediate.md
+++ b/content/en/docs/user-journeys/users/application-developer/intermediate.md
@@ -16,6 +16,7 @@ content_template: templates/user-journey-content
   This page assumes that you've experimented with Kubernetes before. At this point, you should have basic experience interacting with a Kubernetes cluster (locally with Minikube, or elsewhere), and using API objects like Deployments to run your applications.<br><br>If not, you should review the {{< link text="Beginner App Developer" url="/docs/user-journeys/users/application-developer/foundational/" >}} topics first.
 {{< /note  >}}
 After checking out the current page and its linked sections, you should have a better understanding of the following:
+
 * Additional Kubernetes workload patterns, beyond Deployments
 * What it takes to make a Kubernetes application production-ready
 * Community tools that can improve your development workflow
@@ -35,20 +36,21 @@ The following API objects provide functionality for additional workload types, w
 
 Like Deployments, these API objects run indefinitely on a cluster until they are manually terminated. They are best for long-running applications.
 
-* **{{< glossary_tooltip text="StatefulSets" term_id="statefulset" >}}** - Like Deployments, StatefulSets allow you to specify that a certain number of replicas should be running for your application.
+*  **{{< glossary_tooltip text="StatefulSets" term_id="statefulset" >}}** - Like Deployments, StatefulSets allow you to specify that a
+   certain number of replicas should be running for your application.
 
-  {{< note  >}}
-  It's misleading to say that Deployments can't handle stateful workloads. Using {{< glossary_tooltip text="PersistentVolumes" term_id="persistent-volume" >}}, you can persist data beyond the lifecycle of any individual Pod in your Deployment.
-  {{< /note  >}}
-     However, StatefulSets can provide stronger guarantees about "recovery" behavior than Deployments. StatefulSets maintain a sticky, stable identity for their Pods. The following table provides some concrete examples of what this might look like:
+    {{< note  >}} It's misleading to say that Deployments can't handle stateful workloads. Using {{< glossary_tooltip text="PersistentVolumes" term_id="persistent-volume" >}}, you can persist data beyond the lifecycle of any individual Pod in your Deployment.
+    {{< /note  >}}
 
-    | | Deployment | StatefulSet |
+    However, StatefulSets can provide stronger guarantees about "recovery" behavior than Deployments. StatefulSets maintain a sticky, stable identity for their Pods. The following table provides some concrete examples of what this might look like:
+
+    |   | Deployment | StatefulSet |
     |---|---|---|
     | **Example Pod name** | `example-b1c4` | `example-0` |
     | **When a Pod dies** | Reschedule on *any* node, with new name `example-a51z` | Reschedule on same node, as `example-0` |
     | **When a node becomes unreachable** | Pod(s) are scheduled onto new node, with new names | Pod(s) are marked as "Unknown", and aren't rescheduled unless the Node object is forcefully deleted |
 
-     In practice, this means that StatefulSets are best suited for scenarios where replicas (Pods) need to coordinate their workloads in a strongly consistent manner. Guaranteeing an identity for each Pod helps avoid {{< link text="split-brain" url="https://en.wikipedia.org/wiki/Split-brain_(computing)" >}} side effects in the case when a node becomes unreachable ({{< link text="network partition" url="https://en.wikipedia.org/wiki/Network_partition" >}}). This makes StatefulSets a great fit for distributed datastores like Cassandra or Elasticsearch.
+    In practice, this means that StatefulSets are best suited for scenarios where replicas (Pods) need to coordinate their workloads in a strongly consistent manner. Guaranteeing an identity for each Pod helps avoid {{< link text="split-brain" url="https://en.wikipedia.org/wiki/Split-brain_(computing)" >}} side effects in the case when a node becomes unreachable ({{< link text="network partition" url="https://en.wikipedia.org/wiki/Network_partition" >}}). This makes StatefulSets a great fit for distributed datastores like Cassandra or Elasticsearch.
 
 
 * **{{< glossary_tooltip text="DaemonSets" term_id="daemonset" >}}** - DaemonSets run continuously on every node in your cluster, even as nodes are added or swapped in. This guarantee is particularly useful for setting up global behavior across your cluster, such as:
@@ -80,6 +82,7 @@ The beginner tutorials on this site, such as the {{< link text="Guestbook app" u
 You are likely interacting with your Kubernetes cluster via {{< glossary_tooltip text="kubectl" term_id="kubectl" >}}. kubectl can be used to debug the current state of your cluster (such as checking the number of nodes), or to modify live Kubernetes objects (such as updating a workload's replica count with `kubectl scale`).
 
 When using kubectl to update your Kubernetes objects, it's important to be aware that different commands correspond to different approaches:
+
 * {{< link text="Purely imperative" url="/docs/tutorials/object-management-kubectl/imperative-object-management-command/" >}}
 * {{< link text="Imperative with local configuration files" url="/docs/tutorials/object-management-kubectl/imperative-object-management-configuration/" >}} (typically YAML)
 * {{< link text="Declarative with local configuration files" url="/docs/tutorials/object-management-kubectl/declarative-object-management-configuration/" >}} (typically YAML)
@@ -93,10 +96,12 @@ For additional configuration best practices, familiarize yourself with {{< link 
 You may be familiar with the *principle of least privilege*---if you are too generous with permissions when writing or using software, the negative effects of a compromise can escalate out of control. Would you be cautious handing out `sudo` privileges to software on your OS? If so, you should be just as careful when granting your workload permissions to the {{< glossary_tooltip text="Kubernetes API" term_id="kubernetes-api" >}} server! The API server is the gateway for your cluster's source of truth; it provides endpoints to read or modify cluster state.
 
 You (or your {{< glossary_tooltip text="cluster operator" term_id="cluster-operator" >}}) can lock down API access with the following:
+
 * **{{< glossary_tooltip text="ServiceAccounts" term_id="service-account" >}}** - An "identity" that your Pods can be tied to
 * **{{< glossary_tooltip text="RBAC" term_id="rbac" >}}** - One way of granting your ServiceAccount explicit permissions
 
 For even more comprehensive reading about security best practices, consider checking out the following topics:
+
 * {{< link text="Authentication" url="/docs/admin/authentication/" >}} (Is the user who they say they are?)
 * {{< link text="Authorization" url="/docs/admin/authorization/" >}} (Does the user actually have permissions to do what they're asking?)
 
@@ -105,6 +110,7 @@ For even more comprehensive reading about security best practices, consider chec
 If your workloads are operating in a *multi-tenant* environment with multiple teams or projects, your container(s) are not necessarily running alone on their node(s). They are sharing node resources with other containers which you do not own.
 
 Even if your cluster operator is managing the cluster on your behalf, it is helpful to be aware of the following:
+
 * **{{< glossary_tooltip text="Namespaces" term_id="namespace" >}}**, used for isolation
 * **{{< link text="Resource quotas" url="/docs/concepts/policy/resource-quotas/" >}}**, which affect what your team's workloads can use
 * **{{< link text="Memory" url="/docs/tasks/configure-pod-container/assign-memory-resource/" >}} and {{< link text="CPU" url="/docs/tasks/configure-pod-container/assign-cpu-resource/" >}} requests**, for a given Pod or container
@@ -121,6 +127,7 @@ As an app developer, you'll likely encounter the following tools in your workflo
 `kubectl` is a command-line tool that allows you to easily read or modify your Kubernetes cluster. It provides convenient, short commands for common operations like scaling app instances and getting node info. How does kubectl do this? It's basically just a user-friendly wrapper for making API requests. It's written using {{< link text="client-go" url="https://github.com/kubernetes/client-go/#client-go" >}}, the Go library for the Kubernetes API.
 
 To learn about the most commonly used kubectl commands, check out the {{< link text="kubectl cheatsheet" url="/docs/reference/kubectl/cheatsheet/" >}}. It explains topics such as the following:
+
 * {{< link text="kubeconfig files" url="/docs/tasks/access-application-cluster/configure-access-multiple-clusters/" >}} - Your kubeconfig file tells kubectl what cluster to talk to, and can reference multiple clusters (such as dev and prod).
 * {{< link text="The various output formats available" url="/docs/reference/kubectl/cheatsheet/#formatting-output" >}} - This is useful to know when you are using `kubectl get` to list information about certain API objects.
 
@@ -151,6 +158,7 @@ In addition, {{< link text="the Kubernetes blog" url="http://blog.kubernetes.io/
 
 #### What's next
 If you feel fairly comfortable with the topics on this page and want to learn more, check out the following user journeys:
+
 * {{< link text="Advanced App Developer" url="/docs/user-journeys/users/application-developer/advanced/" >}} - Dive deeper, with the next level of this journey.
 * {{< link text="Foundational Cluster Operator" url="/docs/user-journeys/users/cluster-operator/foundational/" >}} - Build breadth, by exploring other journeys.
 {{% /capture %}}

--- a/static/_redirects
+++ b/static/_redirects
@@ -172,6 +172,16 @@
 /docs/home/deprecation-policy/     /docs/reference/deprecation-policy/ 301
 /docs/reference/federation/v1beta1/definitions/     /docs/reference/federation/extensions/v1beta1/definitions/ 301
 /docs/reference/federation/v1beta1/operations/     /docs/reference/federation/extensions/v1beta1/operations/ 301
+
+/docs/reference/generated/cloud-controller-manager/     /docs/reference/command-line-tools-reference/cloud-controller-manager/ 301
+/docs/reference/generated/federation-apiserver/     /docs/reference/command-line-tools-reference/federation-apiserver/ 301
+/docs/reference/generated/federation-controller-manager/     /docs/reference/command-line-tools-reference/federation-controller-manager/ 301
+/docs/reference/generated/kubelet/     /docs/reference/command-line-tools-reference/kubelet/ 301
+/docs/reference/generated/kube-apiserver/     /docs/reference/command-line-tools-reference/kube-apiserver/ 301
+/docs/reference/generated/kube-controller-manager/     /docs/reference/command-line-tools-reference/kube-controller-manager/ 301
+/docs/reference/generated/kube-proxy/     /docs/reference/command-line-tools-reference/kube-proxy/ 301
+/docs/reference/generated/kube-scheduler/     /docs/reference/command-line-tools-reference/kube-scheduler/ 301
+
 /docs/reference/generated/kubectl/kubectl-options/     /docs/reference/generated/kubectl/kubectl/ 301
 /docs/reference/generated/kubectl/kubectl/kubectl_*.md    /docs/reference/generated/kubectl/kubectl-commands#:splat 301
 

--- a/static/_redirects
+++ b/static/_redirects
@@ -185,6 +185,13 @@
 /docs/reference/generated/kubectl/kubectl-options/     /docs/reference/generated/kubectl/kubectl/ 301
 /docs/reference/generated/kubectl/kubectl/kubectl_*.md    /docs/reference/generated/kubectl/kubectl-commands#:splat 301
 
+/docs/reference/generated/kubefed/     /docs/reference/setup-tools/kubefed/kubefed/ 301
+/docs/reference/generated/kubefed_init/     /docs/reference/setup-tools/kubefed/kubefed-init/ 301
+/docs/reference/generated/kubefed_join/     /docs/reference/setup-tools/kubefed/kubefed-join/ 301
+/docs/reference/generated/kubefed_options/     /docs/reference/setup-tools/kubefed/kubefed-options/ 301
+/docs/reference/generated/kubefed_unjoin/     /docs/reference/setup-tools/kubefed/kubefed-unjoin/ 301
+/docs/reference/generated/kubefed_version/     /docs/reference/setup-tools/kubefed/kubefed-version/ 301
+
 /docs/reporting-security-issues/     /security/ 301
 
 /docs/resources-reference/1_6/*     /docs/resources-reference/v1.6/ 301


### PR DESCRIPTION
Fix #8493 (in clusters created according to the instructions `kubelet`, `kube-controller-manager` and `kube-scheduler` would connect to local IPs rather than the VIP, API server `advertisedAddress` pointing to local IPs, too). 

- change to kubeadm-init.yaml: configure `advertiseAddress` to the VIP
- added section with instructions for configuring `kubelet`, `kube-controller-manager` and `kube-scheduler` to use the VIP

