### PR TITLE
Fix typo in style-guide

### DIFF
--- a/content/en/docs/home/contribute/style-guide.md
+++ b/content/en/docs/home/contribute/style-guide.md
@@ -271,7 +271,7 @@ For example:
     1. Preheat oven to 350˚F
 
     1. Prepare the batter, and pour into springform pan.
-       {{</* note */>}}**Note:** Grease the pan for best results.{{</* note */>}}
+       {{</* note */>}}**Note:** Grease the pan for best results.{{</* /note */>}}
 
     1. Bake for 20-25 minutes or until set.
 


### PR DESCRIPTION
Add missing "/" to close the tag properly, the example is wrong
otherwise.
