### PR TITLE
Redirect command-line ref docs.

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -172,6 +172,16 @@
 /docs/home/deprecation-policy/     /docs/reference/deprecation-policy/ 301
 /docs/reference/federation/v1beta1/definitions/     /docs/reference/federation/extensions/v1beta1/definitions/ 301
 /docs/reference/federation/v1beta1/operations/     /docs/reference/federation/extensions/v1beta1/operations/ 301
+
+/docs/reference/generated/cloud-controller-manager/     /docs/reference/command-line-reference-tools/cloud-controller-manager/ 301
+/docs/reference/generated/federation-api-server/     /docs/reference/command-line-reference-tools/federation-api-server/ 301
+/docs/reference/generated/federation-controller-manager/     /docs/reference/command-line-reference-tools/federation-controller-manager/ 301
+/docs/reference/generated/kubelet/     /docs/reference/command-line-reference-tools/kubelet/ 301
+/docs/reference/generated/kube-api-server/     /docs/reference/command-line-reference-tools/kube-api-server/ 301
+/docs/reference/generated/kube-controller-manager/     /docs/reference/command-line-reference-tools/kube-controller-manager/ 301
+/docs/reference/generated/kube-proxy/     /docs/reference/command-line-reference-tools/kube-proxy/ 301
+/docs/reference/generated/kube-scheduler/     /docs/reference/command-line-reference-tools/kube-scheduler/ 301
+
 /docs/reference/generated/kubectl/kubectl-options/     /docs/reference/generated/kubectl/kubectl/ 301
 /docs/reference/generated/kubectl/kubectl/kubectl_*.md    /docs/reference/generated/kubectl/kubectl-commands#:splat 301
 

--- a/static/_redirects
+++ b/static/_redirects
@@ -173,14 +173,14 @@
 /docs/reference/federation/v1beta1/definitions/     /docs/reference/federation/extensions/v1beta1/definitions/ 301
 /docs/reference/federation/v1beta1/operations/     /docs/reference/federation/extensions/v1beta1/operations/ 301
 
-/docs/reference/generated/cloud-controller-manager/     /docs/reference/command-line-reference-tools/cloud-controller-manager/ 301
-/docs/reference/generated/federation-api-server/     /docs/reference/command-line-reference-tools/federation-api-server/ 301
-/docs/reference/generated/federation-controller-manager/     /docs/reference/command-line-reference-tools/federation-controller-manager/ 301
-/docs/reference/generated/kubelet/     /docs/reference/command-line-reference-tools/kubelet/ 301
-/docs/reference/generated/kube-api-server/     /docs/reference/command-line-reference-tools/kube-api-server/ 301
-/docs/reference/generated/kube-controller-manager/     /docs/reference/command-line-reference-tools/kube-controller-manager/ 301
-/docs/reference/generated/kube-proxy/     /docs/reference/command-line-reference-tools/kube-proxy/ 301
-/docs/reference/generated/kube-scheduler/     /docs/reference/command-line-reference-tools/kube-scheduler/ 301
+/docs/reference/generated/cloud-controller-manager/     /docs/reference/command-line-tools-reference/cloud-controller-manager/ 301
+/docs/reference/generated/federation-api-server/     /docs/reference/command-line-tools-reference/federation-api-server/ 301
+/docs/reference/generated/federation-controller-manager/     /docs/reference/command-line-tools-reference/federation-controller-manager/ 301
+/docs/reference/generated/kubelet/     /docs/reference/command-line-tools-reference/kubelet/ 301
+/docs/reference/generated/kube-api-server/     /docs/reference/command-line-tools-reference/kube-api-server/ 301
+/docs/reference/generated/kube-controller-manager/     /docs/reference/command-line-tools-reference/kube-controller-manager/ 301
+/docs/reference/generated/kube-proxy/     /docs/reference/command-line-tools-reference/kube-proxy/ 301
+/docs/reference/generated/kube-scheduler/     /docs/reference/command-line-tools-reference/kube-scheduler/ 301
 
 /docs/reference/generated/kubectl/kubectl-options/     /docs/reference/generated/kubectl/kubectl/ 301
 /docs/reference/generated/kubectl/kubectl/kubectl_*.md    /docs/reference/generated/kubectl/kubectl-commands#:splat 301

--- a/static/_redirects
+++ b/static/_redirects
@@ -174,10 +174,10 @@
 /docs/reference/federation/v1beta1/operations/     /docs/reference/federation/extensions/v1beta1/operations/ 301
 
 /docs/reference/generated/cloud-controller-manager/     /docs/reference/command-line-tools-reference/cloud-controller-manager/ 301
-/docs/reference/generated/federation-api-server/     /docs/reference/command-line-tools-reference/federation-api-server/ 301
+/docs/reference/generated/federation-apiserver/     /docs/reference/command-line-tools-reference/federation-apiserver/ 301
 /docs/reference/generated/federation-controller-manager/     /docs/reference/command-line-tools-reference/federation-controller-manager/ 301
 /docs/reference/generated/kubelet/     /docs/reference/command-line-tools-reference/kubelet/ 301
-/docs/reference/generated/kube-api-server/     /docs/reference/command-line-tools-reference/kube-api-server/ 301
+/docs/reference/generated/kube-apiserver/     /docs/reference/command-line-tools-reference/kube-apiserver/ 301
 /docs/reference/generated/kube-controller-manager/     /docs/reference/command-line-tools-reference/kube-controller-manager/ 301
 /docs/reference/generated/kube-proxy/     /docs/reference/command-line-tools-reference/kube-proxy/ 301
 /docs/reference/generated/kube-scheduler/     /docs/reference/command-line-tools-reference/kube-scheduler/ 301


### PR DESCRIPTION
Partially addresses #8494.

To test, try this URL:
https://deploy-preview-8504--kubernetes-io-master-staging.netlify.com/docs/reference/generated/kubelet/

and see that it gets redirected to
https://deploy-preview-8504--kubernetes-io-master-staging.netlify.com/docs/reference/command-line-tools-reference/kubelet/

Also verify that these URLs get redirected:

https://deploy-preview-8504--kubernetes-io-master-staging.netlify.com/docs/reference/generated/kube-controller-manager/

https://deploy-preview-8504--kubernetes-io-master-staging.netlify.com/docs/reference/generated/kube-proxy/

https://deploy-preview-8504--kubernetes-io-master-staging.netlify.com/docs/reference/generated/kube-scheduler/

https://deploy-preview-8504--kubernetes-io-master-staging.netlify.com/docs/reference/generated/kube-apiserver/

https://deploy-preview-8504--kubernetes-io-master-staging.netlify.com/docs/reference/generated/federation-apiserver/

https://deploy-preview-8504--kubernetes-io-master-staging.netlify.com/docs/reference/generated/federation-controller-manager/

