### PR TITLE
Update the OWNERS for the kubeadm documentation

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -61,16 +61,25 @@ aliases:
     - smarterclayton
     - soltysh
     - sttts
-  sig-cluster-lifecycle: #GH: sig-cluster-lifecycle-pr-reviews
-    - jbeda
+  sig-cluster-lifecycle-kubeadm-approvers: # Approving changes to kubeadm documentation
     - timothysc
     - lukemarsden
-    - pipejakob
-    - dmmcquay
-    - mattmoyer
     - luxas
     - roberthbailey
-    - medinatiger
+    - fabriziopandini
+  sig-cluster-lifecycle-kubeadm-reviewers: # Reviewing kubeadm documentation
+    - timothysc
+    - lukemarsden
+    - luxas
+    - roberthbailey
+    - fabriziopandini
+    - kad
+    - xiangpengzhao
+    - stealthybox
+    - liztio
+    - chuckha
+    - detiber
+    - dixudx
   sig-cluster-ops:
     - zehicle
     - jdumars

--- a/content/en/docs/reference/setup-tools/kubeadm/implementation-details.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/implementation-details.md
@@ -1,8 +1,8 @@
 ---
 approvers:
-- mikedanese
-- luxas
-- jbeda
+- sig-cluster-lifecycle-kubeadm-approvers
+reviewers:
+- sig-cluster-lifecycle-kubeadm-reviewers
 title: Implementation details
 content_template: templates/concept
 weight: 100

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-alpha.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-alpha.md
@@ -1,8 +1,8 @@
 ---
 approvers:
-- mikedanese
-- luxas
-- jbeda
+- sig-cluster-lifecycle-kubeadm-approvers
+reviewers:
+- sig-cluster-lifecycle-kubeadm-reviewers
 title: kubeadm alpha
 weight: 90
 ---

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-config.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-config.md
@@ -1,8 +1,8 @@
 ---
 approvers:
-- mikedanese
-- luxas
-- jbeda
+- sig-cluster-lifecycle-kubeadm-approvers
+reviewers:
+- sig-cluster-lifecycle-kubeadm-reviewers
 title: kubeadm config
 content_template: templates/concept
 weight: 50

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -1,8 +1,8 @@
 ---
 approvers:
-- mikedanese
-- luxas
-- jbeda
+- sig-cluster-lifecycle-kubeadm-approvers
+reviewers:
+- sig-cluster-lifecycle-kubeadm-reviewers
 title: kubeadm init
 content_template: templates/concept
 weight: 20

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
@@ -1,8 +1,8 @@
 ---
 approvers:
-- mikedanese
-- luxas
-- jbeda
+- sig-cluster-lifecycle-kubeadm-approvers
+reviewers:
+- sig-cluster-lifecycle-kubeadm-reviewers
 title: kubeadm join
 content_template: templates/concept
 weight: 30

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-reset.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-reset.md
@@ -1,8 +1,8 @@
 ---
 approvers:
-- mikedanese
-- luxas
-- jbeda
+- sig-cluster-lifecycle-kubeadm-approvers
+reviewers:
+- sig-cluster-lifecycle-kubeadm-reviewers
 title: kubeadm reset
 content_template: templates/concept
 weight: 60

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-token.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-token.md
@@ -1,8 +1,8 @@
 ---
 approvers:
-- mikedanese
-- luxas
-- jbeda
+- sig-cluster-lifecycle-kubeadm-approvers
+reviewers:
+- sig-cluster-lifecycle-kubeadm-reviewers
 title: kubeadm token
 content_template: templates/concept
 weight: 70

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-upgrade.md
@@ -1,8 +1,8 @@
 ---
 approvers:
-- mikedanese
-- luxas
-- jbeda
+- sig-cluster-lifecycle-kubeadm-approvers
+reviewers:
+- sig-cluster-lifecycle-kubeadm-reviewers
 title: kubeadm upgrade
 content_template: templates/concept
 weight: 40

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-version.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-version.md
@@ -1,8 +1,8 @@
 ---
 approvers:
-- mikedanese
-- luxas
-- jbeda
+- sig-cluster-lifecycle-kubeadm-approvers
+reviewers:
+- sig-cluster-lifecycle-kubeadm-reviewers
 title: kubeadm version
 content_template: templates/concept
 weight: 80

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm.md
@@ -1,8 +1,8 @@
 ---
 approvers:
-- mikedanese
-- luxas
-- jbeda
+- sig-cluster-lifecycle-kubeadm-approvers
+reviewers:
+- sig-cluster-lifecycle-kubeadm-reviewers
 title: Overview of kubeadm
 weight: 10
 ---

--- a/content/en/docs/setup/independent/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/independent/create-cluster-kubeadm.md
@@ -1,9 +1,8 @@
 ---
+approvers:
+- sig-cluster-lifecycle-kubeadm-approvers
 reviewers:
-- mikedanese
-- luxas
-- errordeveloper
-- jbeda
+- sig-cluster-lifecycle-kubeadm-reviewers
 title: Using kubeadm to Create a Cluster
 content_template: templates/task
 ---

--- a/content/en/docs/setup/independent/high-availability.md
+++ b/content/en/docs/setup/independent/high-availability.md
@@ -1,9 +1,8 @@
 ---
+approvers:
+- sig-cluster-lifecycle-kubeadm-approvers
 reviewers:
-- mikedanese
-- luxas
-- errordeveloper
-- jbeda
+- sig-cluster-lifecycle-kubeadm-reviewers
 title: Creating HA clusters with kubeadm
 content_template: templates/task
 ---

--- a/content/en/docs/setup/independent/install-kubeadm.md
+++ b/content/en/docs/setup/independent/install-kubeadm.md
@@ -1,4 +1,8 @@
 ---
+approvers:
+- sig-cluster-lifecycle-kubeadm-approvers
+reviewers:
+- sig-cluster-lifecycle-kubeadm-reviewers
 title: Installing kubeadm
 content_template: templates/task
 ---

--- a/content/en/docs/setup/independent/troubleshooting-kubeadm.md
+++ b/content/en/docs/setup/independent/troubleshooting-kubeadm.md
@@ -1,4 +1,8 @@
 ---
+approvers:
+- sig-cluster-lifecycle-kubeadm-approvers
+reviewers:
+- sig-cluster-lifecycle-kubeadm-reviewers
 title: Troubleshooting kubeadm
 ---
 


### PR DESCRIPTION
The same thing as https://github.com/kubernetes/kubernetes/pull/63551, for this repo
/assign @timothysc @heckj 

@heckj can you confirm that owners aliases work in this repo?