### PR TITLE
Redirect kubefed ref pages to Hugo locations.

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -185,6 +185,13 @@
 /docs/reference/generated/kubectl/kubectl-options/     /docs/reference/generated/kubectl/kubectl/ 301
 /docs/reference/generated/kubectl/kubectl/kubectl_*.md    /docs/reference/generated/kubectl/kubectl-commands#:splat 301
 
+/docs/reference/generated/kubefed/     /docs/reference/setup-tools/kubefed/kubefed/ 301
+/docs/reference/generated/kubefed_init/     /docs/reference/setup-tools/kubefed/kubefed_init/ 301
+/docs/reference/generated/kubefed_join/     /docs/reference/setup-tools/kubefed/kubefed_join/ 301
+/docs/reference/generated/kubefed_options/     /docs/reference/setup-tools/kubefed/kubefed_options/ 301
+/docs/reference/generated/kubefed_unjoin/     /docs/reference/setup-tools/kubefed/kubefed_unjoin/ 301
+/docs/reference/generated/kubefed_version/     /docs/reference/setup-tools/kubefed/kubefed_version/ 301
+
 /docs/reporting-security-issues/     /security/ 301
 
 /docs/resources-reference/1_6/*     /docs/resources-reference/v1.6/ 301

--- a/static/_redirects
+++ b/static/_redirects
@@ -186,11 +186,11 @@
 /docs/reference/generated/kubectl/kubectl/kubectl_*.md    /docs/reference/generated/kubectl/kubectl-commands#:splat 301
 
 /docs/reference/generated/kubefed/     /docs/reference/setup-tools/kubefed/kubefed/ 301
-/docs/reference/generated/kubefed_init/     /docs/reference/setup-tools/kubefed/kubefed_init/ 301
-/docs/reference/generated/kubefed_join/     /docs/reference/setup-tools/kubefed/kubefed_join/ 301
-/docs/reference/generated/kubefed_options/     /docs/reference/setup-tools/kubefed/kubefed_options/ 301
-/docs/reference/generated/kubefed_unjoin/     /docs/reference/setup-tools/kubefed/kubefed_unjoin/ 301
-/docs/reference/generated/kubefed_version/     /docs/reference/setup-tools/kubefed/kubefed_version/ 301
+/docs/reference/generated/kubefed_init/     /docs/reference/setup-tools/kubefed/kubefed-init/ 301
+/docs/reference/generated/kubefed_join/     /docs/reference/setup-tools/kubefed/kubefed-join/ 301
+/docs/reference/generated/kubefed_options/     /docs/reference/setup-tools/kubefed/kubefed-options/ 301
+/docs/reference/generated/kubefed_unjoin/     /docs/reference/setup-tools/kubefed/kubefed-unjoin/ 301
+/docs/reference/generated/kubefed_version/     /docs/reference/setup-tools/kubefed/kubefed-version/ 301
 
 /docs/reporting-security-issues/     /security/ 301
 


### PR DESCRIPTION
To test, verify that
https://deploy-preview-8509--kubernetes-io-master-staging.netlify.com/docs/reference/generated/kubefed/
gets redirected to
https://deploy-preview-8509--kubernetes-io-master-staging.netlify.com/docs/reference/setup-tools/kubefed/kubefed/

Also verify that these URLs get redirected:

https://deploy-preview-8509--kubernetes-io-master-staging.netlify.com/docs/reference/generated/kubefed_init/

https://deploy-preview-8509--kubernetes-io-master-staging.netlify.com/docs/reference/generated/kubefed_join/

https://deploy-preview-8509--kubernetes-io-master-staging.netlify.com/docs/reference/generated/kubefed_options/

https://deploy-preview-8509--kubernetes-io-master-staging.netlify.com/docs/reference/generated/kubefed_unjoin/

https://deploy-preview-8509--kubernetes-io-master-staging.netlify.com/docs/reference/generated/kubefed_version/


