### PR TITLE
Get Service Catalog topic into left nav.

### DIFF
--- a/content/en/docs/concepts/service-catalog.md
+++ b/content/en/docs/concepts/service-catalog.md
@@ -3,7 +3,6 @@ title: Service Catalog
 reviewers:
 - chenopis
 content_template: templates/concept
-toc_hide: true
 ---
 
 {{% capture overview %}}


### PR DESCRIPTION
Addresses part of #8275.

The Service Catalog topic was not appearing in the left nav. Now it is.

Preview: https://deploy-preview-8517--kubernetes-io-master-staging.netlify.com/docs/concepts/service-catalog/