### PR TITLE
Revert lost environment variables

### DIFF
--- a/content/en/docs/tasks/tools/install-kubeadm.md
+++ b/content/en/docs/tasks/tools/install-kubeadm.md
@@ -106,8 +106,8 @@ or install Docker CE 17.03 from Docker's repositories for Ubuntu or Debian:
 apt-get update
 apt-get install -y apt-transport-https ca-certificates curl software-properties-common
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-add-apt-repository "deb https://download.docker.com/linux/$(. /etc/os-release; echo "") $(lsb_release -cs) stable"
-apt-get update && apt-get install -y docker-ce=$(apt-cache madison docker-ce | grep 17.03 | head -1 | awk '{print }')
+add-apt-repository "deb https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") $(lsb_release -cs) stable"
+apt-get update && apt-get install -y docker-ce=$(apt-cache madison docker-ce | grep 17.03 | head -1 | awk '{print $3}')
 ```
 {{% /tab %}}
 {{% tab name="CentOS, RHEL or Fedora" %}}


### PR DESCRIPTION
This PR reverts lost environment variables `$ID` and `$3` in kubeadm installation document. I don't know why but they seem to be lost by converting to Hugo from Jekyll. /ref #8316