### PR TITLE
Fix no title elements in HTML fo all pages

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,4 +1,5 @@
 <meta charset="utf-8">
+<title>{{ if .Title }}{{ .Title }} - {{ end }}{{ .Site.Title }}</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="shortcut icon" type="image/png" href="{{ "images/favicon.png" | relURL }}">
 <link rel="stylesheet" type="text/css" href="/css/base_fonts.css">


### PR DESCRIPTION
This PR fixes no title elements in HTML of all pages. They will be added in the format `TITLE - Kubernetes`. 

/fix #8447