### PR TITLE
Issue #8493 - Missing instructions in "Creating HA clusters with kube…

### DIFF
--- a/content/en/docs/setup/independent/high-availability.md
+++ b/content/en/docs/setup/independent/high-availability.md
@@ -467,6 +467,7 @@ Only follow this step if your etcd is hosted on dedicated nodes (**Option 1**). 
         podSubnet: <podCIDR>
       apiServerCertSANs:
       - <virtual-ip>
+      - <private-ip>
       apiServerExtraArgs:
         apiserver-count: "3"
       EOF

--- a/content/en/docs/setup/independent/high-availability.md
+++ b/content/en/docs/setup/independent/high-availability.md
@@ -208,7 +208,7 @@ This results in the following files: `peer.pem`, `peer-key.pem`, `server.pem`, `
 
 ### {{< tabs name="etcd_mode" >}}
 {{% tab name="Choose one..." %}}
-Please select one of the tabs to see installation instructions for the respective way to run etcd.
+Please select one of the tabs to see installation instructions for the respective way to set up a virtual IP.
 {{% /tab %}}
 {{% tab name="systemd" %}}
 1. First, install etcd binaries:
@@ -347,7 +347,7 @@ Make sure you replace:
 
 ## {{< tabs name="lb_mode" >}}
 {{% tab name="Choose one..." %}}
-Please select one of the tabs to see installation instructions for the respective way to run etcd.
+Please select one of the tabs to see installation instructions for the respective way to set up a virtual IP.
 {{% /tab %}}
 {{% tab name="Cloud" %}}
 Some examples of cloud provider solutions are:
@@ -447,12 +447,13 @@ Only follow this step if your etcd is hosted on dedicated nodes (**Option 1**). 
 ## Run kubeadm init on master0 {#kubeadm-init-master0}
 
 1.  In order for kubeadm to run, you first need to write a configuration file:
-      ```none
+
+<!-- Using indentation instead of code fencing because of https://github.com/russross/blackfriday/issues/239 -->
       cat >config.yaml <<EOF
       apiVersion: kubeadm.k8s.io/v1alpha1
       kind: MasterConfiguration
       api:
-      advertiseAddress: <private-ip>
+      advertiseAddress: <virtual-ip>
       etcd:
       endpoints:
       - https://<etcd0-ip-address>:2379
@@ -464,20 +465,19 @@ Only follow this step if your etcd is hosted on dedicated nodes (**Option 1**). 
       networking:
       podSubnet: <podCIDR>
       apiServerCertSANs:
-      - <load-balancer-ip>
+      - <virtual-ip>
       apiServerExtraArgs:
       apiserver-count: "3"
       EOF
-      ```
 
-      Ensure that the following placeholders are replaced:
+Ensure that the following placeholders are replaced:
 
-      - `<private-ip>` with the private IPv4 of the master server.
-      - `<etcd0-ip>`, `<etcd1-ip>` and `<etcd2-ip>` with the IP addresses of your three etcd nodes
-      - `<podCIDR>` with your Pod CIDR. Please read the [CNI network section](/docs/setup/independent/create-cluster-kubeadm/#pod-network) of the docs for more information. Some CNI providers do not require a value to be set.
-      - `<load-balancer-ip>` with the virtual IP set up in the load balancer. Please read [setting up a master load balancer](/docs/setup/independent/high-availability/#set-up-master-load-balancer) section of the docs for more information.
+- `<private-ip>` with the private IPv4 of the master server.
+- `<etcd0-ip>`, `<etcd1-ip>` and `<etcd2-ip>` with the IP addresses of your three etcd nodes
+- `<podCIDR>` with your Pod CIDR. Please read the [CNI network section](/docs/setup/independent/create-cluster-kubeadm/#pod-network) of the docs for more information. Some CNI providers do not require a value to be set.
+- `<virtual-ip>` with the virtual IP. Please read [setting up a master load balancer](/docs/setup/independent/high-availability/#set-up-master-load-balancer) section of the docs for more information.
 
-      {{< note >}}**Note:** If you are using Kubernetes 1.9+, you can replace the `apiserver-count: 3` extra argument with `endpoint-reconciler-type: lease`. For more information, see [the documentation](/docs/admin/high-availability/#endpoint-reconciler).{{< /note >}}
+{{< note >}}**Note:** If you are using Kubernetes 1.9+, you can replace the `apiserver-count: 3` extra argument with `endpoint-reconciler-type: lease`. For more information, see [the documentation](/docs/admin/high-availability/#endpoint-reconciler).{{< /note >}}
 
 1.  When this is done, run kubeadm:
       ```bash
@@ -506,6 +506,22 @@ When this is done, you can follow the [previous step](#kubeadm-init-master0) to 
 ## Add master1 and master2 to load balancer
 
 Once kubeadm has provisioned the other masters, you can add them to the load balancer pool.
+
+## Configure kubelet, kube-scheduler and kube-controller-manager to use the virtual IP
+
+After bootstrapping the master nodes using `kubeadm`, the services `kubelet`, `kube-scheduler` and `kube-controller-manager` still connect to local IPs for the API server rather than the virtual IP. This needs to be fixed in the local configuration files on the master nodes. Make sure you replace `<virtual-ip>` with the virtual IP. Patch the configuration files and restart `kubelet` on all master nodes:
+
+   ```shell
+   sudo sed -i 's#server:.*#server: https://<virtual-ip>:6443#g' /etc/kubernetes/kubelet.conf /etc/kubernetes/scheduler.conf /etc/kubernetes/controller-manager.conf
+   sudo systemctl restart kubelet
+   ```
+
+Now restart all instances of `kube-controller-manager` and `kube-scheduler`:
+
+   ```shell
+   kubectl delete pod -n kube-system -l component=kube-controller-manager
+   kubectl delete pod -n kube-system -l component=kube-scheduler
+   ```
 
 ## Install CNI network
 

--- a/content/en/docs/setup/independent/high-availability.md
+++ b/content/en/docs/setup/independent/high-availability.md
@@ -453,21 +453,22 @@ Only follow this step if your etcd is hosted on dedicated nodes (**Option 1**). 
       apiVersion: kubeadm.k8s.io/v1alpha1
       kind: MasterConfiguration
       api:
-      advertiseAddress: <virtual-ip>
+        advertiseAddress: <virtual-ip>
+        controlPlaneEndpoint: <virtual-ip>
       etcd:
-      endpoints:
-      - https://<etcd0-ip-address>:2379
-      - https://<etcd1-ip-address>:2379
-      - https://<etcd2-ip-address>:2379
-      caFile: /etc/kubernetes/pki/etcd/ca.pem
-      certFile: /etc/kubernetes/pki/etcd/client.pem
-      keyFile: /etc/kubernetes/pki/etcd/client-key.pem
+        endpoints:
+        - https://<etcd0-ip-address>:2379
+        - https://<etcd1-ip-address>:2379
+        - https://<etcd2-ip-address>:2379
+        caFile: /etc/kubernetes/pki/etcd/ca.pem
+        certFile: /etc/kubernetes/pki/etcd/client.pem
+        keyFile: /etc/kubernetes/pki/etcd/client-key.pem
       networking:
-      podSubnet: <podCIDR>
+        podSubnet: <podCIDR>
       apiServerCertSANs:
       - <virtual-ip>
       apiServerExtraArgs:
-      apiserver-count: "3"
+        apiserver-count: "3"
       EOF
 
 Ensure that the following placeholders are replaced:
@@ -506,22 +507,6 @@ When this is done, you can follow the [previous step](#kubeadm-init-master0) to 
 ## Add master1 and master2 to load balancer
 
 Once kubeadm has provisioned the other masters, you can add them to the load balancer pool.
-
-## Configure kubelet, kube-scheduler and kube-controller-manager to use the virtual IP
-
-After bootstrapping the master nodes using `kubeadm`, the services `kubelet`, `kube-scheduler` and `kube-controller-manager` still connect to local IPs for the API server rather than the virtual IP. This needs to be fixed in the local configuration files on the master nodes. Make sure you replace `<virtual-ip>` with the virtual IP. Patch the configuration files and restart `kubelet` on all master nodes:
-
-   ```shell
-   sudo sed -i 's#server:.*#server: https://<virtual-ip>:6443#g' /etc/kubernetes/kubelet.conf /etc/kubernetes/scheduler.conf /etc/kubernetes/controller-manager.conf
-   sudo systemctl restart kubelet
-   ```
-
-Now restart all instances of `kube-controller-manager` and `kube-scheduler`:
-
-   ```shell
-   kubectl delete pod -n kube-system -l component=kube-controller-manager
-   kubectl delete pod -n kube-system -l component=kube-scheduler
-   ```
 
 ## Install CNI network
 


### PR DESCRIPTION
Fix #8493 (in clusters created according to the instructions kubelet, kube-controller-manager and kube-scheduler would connect to local IPs rather than the VIP, API server advertisedAddress pointing to local IPs, too).

- change to kubeadm-init.yaml: configure advertiseAddress to the VIP
- added section with instructions for configuring kubelet, kube-controller-manager and kube-scheduler to use the VIP

/cc @jbeda @timothysc @mattkelly 