### PR TITLE
Update missing kubever on weave network

### DIFF
--- a/content/en/docs/setup/independent/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/independent/create-cluster-kubeadm.md
@@ -327,7 +327,7 @@ if they don't know their PodIP.
 ```shell
 export kubever=$(kubectl version | base64 | tr -d '
 ')
-kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version="
+kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$kubever"
 ```
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
```
$ export kubever=$(kubectl version | base64 | tr -d '
> ')
$ kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version="
error: unable to read URL "https://cloud.weave.works/k8s/net?k8s-version=", server reported 400 Bad Request, status code=400
```
```
$ kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$kubever"
serviceaccount "weave-net" created
clusterrole.rbac.authorization.k8s.io "weave-net" created
clusterrolebinding.rbac.authorization.k8s.io "weave-net" created
role.rbac.authorization.k8s.io "weave-net" created
rolebinding.rbac.authorization.k8s.io "weave-net" created
daemonset.extensions "weave-net" created
```

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.11 Features: set Milestone to 1.11 and Base Branch to release-1.11
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
