### PR TITLE
Fixed misleading text in out-of-resources.md

### DIFF
--- a/content/en/docs/tasks/administer-cluster/out-of-resource.md
+++ b/content/en/docs/tasks/administer-cluster/out-of-resource.md
@@ -302,7 +302,7 @@ Consider the following scenario:
 
 * Node memory capacity: `10Gi`
 * Operator wants to reserve 10% of memory capacity for system daemons (kernel, `kubelet`, etc.)
-* Operator wants to evict Pods at 95% memory utilization to reduce thrashing and incidence of system OOM.
+* Operator wants to evict Pods at 95% memory utilization to reduce incidence of system OOM.
 
 To facilitate this scenario, the `kubelet` would be launched as follows:
 


### PR DESCRIPTION
Fixed a line in the out-of-resource page that was noticed by @dcaldwel in issue #8390.