### PR TITLE
Fix sections in install-kubectl

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl.md
+++ b/content/en/docs/tasks/tools/install-kubectl.md
@@ -14,11 +14,12 @@ Use the Kubernetes command-line tool, [kubectl](/docs/user-guide/kubectl/), to d
 Use a version of kubectl that is the same version as your server or later. Using an older kubectl with a newer server might produce validation errors.
 {{% /capture %}}
 
+
+{{% capture steps %}}
+
 ## Install kubectl
 
 Here are a few methods to install kubectl.
-
-{{% capture steps %}}
 
 ## Install kubectl binary via native package management
 
@@ -260,7 +261,7 @@ Or when using [Oh-My-Zsh](http://ohmyz.sh/), edit the ~/.zshrc file and update t
 ```shell
 source <(kubectl completion zsh)
 ```
-
+{{% /capture %}}
 
 {{% capture whatsnext %}}
 [Learn how to launch and expose your application.](/docs/tasks/access-application-cluster/service-access-application-cluster/)


### PR DESCRIPTION
This commit adds a missing closing capture and puts "## Install kubectl" inside the relevant capture.

Note that the missing close was also missing before Hugo-migration, so the section ordering is still not the same as the Jekyll version of the site. But I think it is more correct.

Note that content outside the capture template blocks, is included as defined is this template:

https://github.com/kubernetes/website/blob/master/layouts/partials/templates/task.html#L8

https://deploy-preview-8588--kubernetes-io-master-staging.netlify.com/docs/tasks/tools/install-kubectl/

See #8277