### PR TITLE
fix description about jobs

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/jobs-run-to-completion.md
+++ b/content/en/docs/concepts/workloads/controllers/jobs-run-to-completion.md
@@ -205,8 +205,7 @@ policy for the embedded template to "`Never`".
 
 ## Job Termination and Cleanup
 
-When a Job completes, no more Pods are created, but the Pods are not deleted either.  Since they are terminated,
-they don't show up with `kubectl get pods`, but they will show up with `kubectl get pods -a`.  Keeping them around
+When a Job completes, no more Pods are created, but the Pods are not deleted either.  Keeping them around
 allows you to still view the logs of completed pods to check for errors, warnings, or other diagnostic output.
 The job object also remains after it is completed so that you can view its status.  It is up to the user to delete
 old jobs after noting their status.  Delete the job with `kubectl` (e.g. `kubectl delete jobs/pi` or `kubectl delete -f ./job.yaml`). When you delete the job using `kubectl`, all the pods it created are deleted too.


### PR DESCRIPTION
I have tested with kubectl 1.10 and kubectl in master branch, completed
job pods show up in output.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.11 Features: set Milestone to 1.11 and Base Branch to release-1.11
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
