### PR TITLE
kubeadm-upgrade.md: include a generated page about 'diff' and adjust notes

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-upgrade.md
@@ -17,7 +17,7 @@ cluster if necessary.
 ## kubeadm upgrade guidance
 
 Every upgrade process might be a bit different, so we've documented each minor upgrade process individually.
-Please check these documents out for more detailed how-to-upgrade guidance:
+For more version-specific upgrade guidance, see the following resources:
 
  * [1.6 to 1.7 upgrades](/docs/tasks/administer-cluster/kubeadm-upgrade-1-7/)
  * [1.7.x to 1.7.y upgrades](/docs/tasks/administer-cluster/kubeadm-upgrade-1-8/)
@@ -27,11 +27,17 @@ Please check these documents out for more detailed how-to-upgrade guidance:
  * [1.9.x to 1.9.y upgrades](/docs/tasks/administer-cluster/kubeadm-upgrade-1-9/)
  * [1.9.x to 1.9.y HA cluster upgrades](/docs/tasks/administer-cluster/kubeadm-upgrade-ha/)
 
+In Kubernetes v1.11.0 and later, you can use `kubeadm upgrade diff` to see the changes that would be
+applied to static pod manifests.
+
 ## kubeadm upgrade plan {#cmd-upgrade-plan}
 {{< include "generated/kubeadm_upgrade_plan.md" >}}
 
 ## kubeadm upgrade apply  {#cmd-upgrade-apply}
 {{< include "generated/kubeadm_upgrade_apply.md" >}}
+
+## kubeadm upgrade diff {#cmd-upgrade-diff}
+{{< include "generated/kubeadm_upgrade_diff.md" >}}
 
 {{% /capture %}}
 


### PR DESCRIPTION
kubeadm-upgrade: include new command `kubeadm upgrade diff` …

 Also:
- Include note that this was added in 1.11.
- Modify the note about upgrade guidance.

Fixes kubernetes/kubeadm#832

## NOTE!!!: ##

EDIT: @tengqm mentioned that we:
- don't have to include generated pages in PRs
- the HTML styling issue explained bellow will be fixed (soon)

---------
the generated page `kubeadm_upgrade_diff.md` does not have HTML formatting like the two other generated pages here - e.g.:
https://github.com/kubernetes/website/blob/master/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade_apply.md.

logged issue about the above:
https://github.com/kubernetes/website/issues/8723
