### PR TITLE
Remove extra '$' char from 'kubectl patch' example

### DIFF
--- a/content/en/docs/tasks/run-application/update-api-object-kubectl-patch.md
+++ b/content/en/docs/tasks/run-application/update-api-object-kubectl-patch.md
@@ -306,7 +306,7 @@ The following commands are equivalent:
 
 ```shell
 kubectl patch deployment patch-demo --patch "$(cat patch-file.yaml)"
-kubectl patch deployment patch-demo --patch $'spec:\n template:\n  spec:\n   containers:\n   - name: patch-demo-ctr-2\n     image: redis'
+kubectl patch deployment patch-demo --patch 'spec:\n template:\n  spec:\n   containers:\n   - name: patch-demo-ctr-2\n     image: redis'
 
 kubectl patch deployment patch-demo --patch "$(cat patch-file.json)"
 kubectl patch deployment patch-demo --patch '{"spec": {"template": {"spec": {"containers": [{"name": "patch-demo-ctr-2","image": "redis"}]}}}}'


### PR DESCRIPTION
- Tested the command out and the `$` char is extraneous.