### PR TITLE
Hide example templates in ToC

### DIFF
--- a/content/en/docs/concepts/example-concept-template.md
+++ b/content/en/docs/concepts/example-concept-template.md
@@ -3,6 +3,7 @@ title: Example Concept Template
 reviewers:
 - chenopis
 content_template: templates/concept
+toc_hide: true
 ---
 
 {{% capture overview %}}

--- a/content/en/docs/tasks/example-task-template.md
+++ b/content/en/docs/tasks/example-task-template.md
@@ -3,6 +3,7 @@ title: Example Task Template
 reviewers:
 - chenopis
 content_template: templates/task
+toc_hide: true
 ---
 
 {{% capture overview %}}


### PR DESCRIPTION
Use `toc_hide: true` to hide example template files in ToC.