### PR TITLE
Hugo: Added toc_hide=true flag to file frontmatter

### DIFF
--- a/content/en/docs/concepts/example-concept-template.md
+++ b/content/en/docs/concepts/example-concept-template.md
@@ -3,6 +3,7 @@ title: Example Concept Template
 reviewers:
 - chenopis
 content_template: templates/concept
+toc_hide: true
 ---
 
 {{% capture overview %}}

--- a/content/en/docs/tasks/example-task-template.md
+++ b/content/en/docs/tasks/example-task-template.md
@@ -3,6 +3,7 @@ title: Example Task Template
 reviewers:
 - chenopis
 content_template: templates/task
+toc_hide: true
 ---
 
 {{% capture overview %}}

--- a/content/en/docs/user-journeys/users/cluster-operator/_advanced.md
+++ b/content/en/docs/user-journeys/users/cluster-operator/_advanced.md
@@ -7,6 +7,7 @@ js: https://use.fontawesome.com/4bcc658a89.js, https://cdnjs.cloudflare.com/ajax
 title: Advanced Topics
 track: "USERS > CLUSTER OPERATOR > ADVANCED"
 content_template: templates/user-journey-content
+toc_hide: true
 ---
 
 {{% capture overview %}}


### PR DESCRIPTION
Filenames taken from website/skip_toc_check.txt
Two exceptions: ../docs/search.md and ../docs/sitemap.md skipped (doesn't seem relevant)
Generated reference files covered by _index.md files in ../reference/setup-tools/ and underlying kubeadm/ (already complete; not part of this PR)

Addresses #8241 

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
