### PR TITLE
install-kubeadm: update the recommended Docker version

### DIFF
--- a/content/en/docs/tasks/tools/install-kubeadm.md
+++ b/content/en/docs/tasks/tools/install-kubeadm.md
@@ -84,8 +84,9 @@ documentation for the plugins about what port(s) those need.
 ## Installing Docker
 
 On each of your machines, install Docker.
-Version v1.12 is recommended, but v1.11, v1.13 and 17.03 are known to work as well.
+Version 17.03 is recommended, but 1.11, 1.12 and 1.13 are known to work as well.
 Versions 17.06+ _might work_, but have not yet been tested and verified by the Kubernetes node team.
+Keep track of the latest verified Docker version in the Kubernetes release notes.
 
 Please proceed with executing the following commands based on your OS as root. You may become the root user by executing `sudo -i` after SSH-ing to each host.
 


### PR DESCRIPTION
```
Bump the recommended version to 17.03.
17.03 is verified by SIG-Node and is much more recent than 1.12.
```

Fixes #7393

this should be against the `master` branch. i'm not sure what the state of the 17.06 verification by sig-node is ATM for k8s 1.11.

discussions:
https://github.com/kubernetes/kubernetes/issues/42926#issuecomment-330278333
https://github.com/kubernetes/kubeadm/issues/604#issuecomment-353607973

source code refs:
https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/system/docker_validator_test.go#L65
https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/system/docker_validator.go#L41
