### PR TITLE
Update patch versions in config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -37,7 +37,7 @@ section = [ "HTML"]
 
 [outputFormats]
 [outputFormats.RSS]
-baseName = "feed"	
+baseName = "feed"
 
 [params]
 
@@ -47,7 +47,7 @@ showedit = true
 
 latest = "v1.10"
 
-fullversion = "v1.10.0"
+fullversion = "v1.10.3"
 version = "v1.10"
 githubbranch = "master"
 docsbranch = "master"
@@ -57,16 +57,16 @@ nextUrl = "http://kubernetes-io-vnext-staging.netlify.com/"
 githubWebsiteRepo = "github.com/kubernetes/website"
 
 [[params.versions]]
-fullversion = "v1.10.0"
+fullversion = "v1.10.3"
 version = "v1.10"
-githubbranch = "v1.10.0"
+githubbranch = "v1.10.3"
 docsbranch = "release-1.10"
 url = "https://kubernetes.io"
 
 [[params.versions]]
-fullversion = "v1.9.0"
+fullversion = "v1.9.7"
 version = "v1.9"
-githubbranch = "v1.9.0"
+githubbranch = "v1.9.7"
 docsbranch = "release-1.9"
 url = "https://v1-9.docs.kubernetes.io"
 


### PR DESCRIPTION
This PR updates the patch version is the 1.9 and 1.10 releases.

I noticed that that docs sometimes presented commands with older patch version is some pages from https://github.com/kubernetes/kubernetes/issues/64054