### PR TITLE
Fix list formatting in kubeadm setup tutorial

### DIFF
--- a/content/en/docs/setup/independent/high-availability.md
+++ b/content/en/docs/setup/independent/high-availability.md
@@ -446,14 +446,14 @@ Only follow this step if your etcd is hosted on dedicated nodes (**Option 1**). 
 
 ## Run kubeadm init on master0 {#kubeadm-init-master0}
 
-1. In order for kubeadm to run, you first need to write a configuration file:
-     ```bash
-     cat >config.yaml <<EOF
-     apiVersion: kubeadm.k8s.io/v1alpha1
-     kind: MasterConfiguration
-     api:
+1.  In order for kubeadm to run, you first need to write a configuration file:
+      ```none
+      cat >config.yaml <<EOF
+      apiVersion: kubeadm.k8s.io/v1alpha1
+      kind: MasterConfiguration
+      api:
       advertiseAddress: <private-ip>
-     etcd:
+      etcd:
       endpoints:
       - https://<etcd0-ip-address>:2379
       - https://<etcd1-ip-address>:2379
@@ -461,34 +461,34 @@ Only follow this step if your etcd is hosted on dedicated nodes (**Option 1**). 
       caFile: /etc/kubernetes/pki/etcd/ca.pem
       certFile: /etc/kubernetes/pki/etcd/client.pem
       keyFile: /etc/kubernetes/pki/etcd/client-key.pem
-     networking:
+      networking:
       podSubnet: <podCIDR>
-     apiServerCertSANs:
-     - <load-balancer-ip>
-     apiServerExtraArgs:
+      apiServerCertSANs:
+      - <load-balancer-ip>
+      apiServerExtraArgs:
       apiserver-count: "3"
-     EOF
-     ```
+      EOF
+      ```
 
-    Ensure that the following placeholders are replaced:
+      Ensure that the following placeholders are replaced:
 
-    - `<private-ip>` with the private IPv4 of the master server.
-    - `<etcd0-ip>`, `<etcd1-ip>` and `<etcd2-ip>` with the IP addresses of your three etcd nodes
-    - `<podCIDR>` with your Pod CIDR. Please read the [CNI network section](/docs/setup/independent/create-cluster-kubeadm/#pod-network) of the docs for more information. Some CNI providers do not require a value to be set.
-    - `<load-balancer-ip>` with the virtual IP set up in the load balancer. Please read [setting up a master load balancer](/docs/setup/independent/high-availability/#set-up-master-load-balancer) section of the docs for more information.
+      - `<private-ip>` with the private IPv4 of the master server.
+      - `<etcd0-ip>`, `<etcd1-ip>` and `<etcd2-ip>` with the IP addresses of your three etcd nodes
+      - `<podCIDR>` with your Pod CIDR. Please read the [CNI network section](/docs/setup/independent/create-cluster-kubeadm/#pod-network) of the docs for more information. Some CNI providers do not require a value to be set.
+      - `<load-balancer-ip>` with the virtual IP set up in the load balancer. Please read [setting up a master load balancer](/docs/setup/independent/high-availability/#set-up-master-load-balancer) section of the docs for more information.
 
-    **Note:** If you are using Kubernetes 1.9+, you can replace the `apiserver-count: 3` extra argument with `endpoint-reconciler-type: lease`. For more information, see [the documentation](/docs/admin/high-availability/#endpoint-reconciler).
+      {{< note >}}**Note:** If you are using Kubernetes 1.9+, you can replace the `apiserver-count: 3` extra argument with `endpoint-reconciler-type: lease`. For more information, see [the documentation](/docs/admin/high-availability/#endpoint-reconciler).{{< /note >}}
 
-1. When this is done, run kubeadm:
-     ```bash
-     kubeadm init --config=config.yaml
-     ```
+1.  When this is done, run kubeadm:
+      ```bash
+      kubeadm init --config=config.yaml
+      ```
 
 ## Run kubeadm init on master1 and master2
 
 Before running kubeadm on the other masters, you need to first copy the K8s CA cert from `master0`. To do this, you have two options:
 
-#### Option 1: Copy with scp
+### Option 1: Copy with scp
 
 1. Follow the steps in the [create ssh access](#create-ssh-access) section, but instead of adding to `etcd0`'s `authorized_keys` file, add them to `master0`.
 1. Once you've done this, run:
@@ -497,7 +497,7 @@ Before running kubeadm on the other masters, you need to first copy the K8s CA c
      rm apiserver.*
      ```
 
-#### Option 2: Copy paste
+### Option 2: Copy paste
 
 Copy the contents of `/etc/kubernetes/pki/ca.crt`, `/etc/kubernetes/pki/ca.key`, `/etc/kubernetes/pki/sa.key` and `/etc/kubernetes/pki/sa.pub` and create these files manually on `master1` and `master2`.
 


### PR DESCRIPTION
There is an issue with ordered lists in the _Creating HA clusters with
kubeadm_ setup tutorial. All list items are labeled 1. This is because
the underlying markdown processor for Hugo, blackfriday, requires
list items with multiple paragraphs to have four space indentation.
(See russross/blackfriday#244)

This commit adds an extra space before paragraphs in lists so they are
correctly interpreted as multi-paragraph lists.

However, this exposes a bug in blackfriday where lines beginning with
`-` in codefenced code blocks inside lists are parsed as sub-lists.
This means code fenced code blocks inside lists that contain yaml are
malformed. (See russross/blackfriday#239)

So this commit mitigates this bug in two situations. It uses a 4-space
indented code block in one situation. In another situation where a list
only contained one element, it is no longer a list.