### PR TITLE
update travis config to match master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,5 @@ install:
 
 script:
 # TODO(bep)
-#- go test -v k8s.io/website/test
+- go test -v k8s.io/website/test #fixed in master branch by https://github.com/kubernetes/website/pull/8388
 #- ./verify-docs-format.sh


### PR DESCRIPTION
This was fixed a few days ago but only on the master branch. Found while trying to troubleshoot Netlify failures to post deploy URLs to 1.11 PRs. Might as well fix builds while we're at it ...

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
