### PR TITLE
Line 203  presents in browser as a single hypeen before url

### DIFF
--- a/content/en/docs/tutorials/stateless-application/guestbook.md
+++ b/content/en/docs/tutorials/stateless-application/guestbook.md
@@ -200,7 +200,7 @@ If you deployed this application to Minikube or a local cluster, you need to fin
 
 1. Run the following command to get the IP address for the frontend Service.
 
-       minikube service frontend --url
+       minikube service frontend --url (be sure to use a double hypen before "url" in case your browser is showing a single, copy and paste will fail)
 
    The response should be similar to this:
 


### PR DESCRIPTION
This line:

>       minikube service frontend --url

Presents as this in Firefox (and Chrome)...

>       minikube service frontend --url

That 2nd option, even copied and pasted, obviously fails and gives "Please specify a service name" instead of the URL expected. Once I figured out I needed the double hyphen it worked fine.

I checked in Chrome as well, same issue.

The only addition/change I could think of was adding the following in parentheses:

"(be sure to use a double hypen before "url" in case your browser is showing a single, copy and paste will fail)"

Just trying to help anyone who could get hung up on it like I did. Maybe they didn't though and it's just me.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.11 Features: set Milestone to 1.11 and Base Branch to release-1.11
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
