### PR TITLE
fix the yaml link in high-availability

### DIFF
--- a/docs/admin/high-availability/building.md
+++ b/docs/admin/high-availability/building.md
@@ -86,7 +86,7 @@ First, hit the etcd discovery service to create a new token:
 curl https://discovery.etcd.io/new?size=3
 ```
 
-On each node, copy the [etcd.yaml](/docs/admin/high-availability/etcd.yaml) file into `/etc/kubernetes/manifests/etcd.yaml`
+On each node, copy the [etcd.yaml](https://github.com/kubernetes/website/blob/release-1.10/docs/admin/high-availability/etcd.yaml) file into `/etc/kubernetes/manifests/etcd.yaml`
 
 The kubelet on each node actively monitors the contents of that directory, and it will create an instance of the `etcd`
 server from the definition of the pod specified in `etcd.yaml`.
@@ -154,7 +154,7 @@ The easiest way to create this directory, may be to copy it from the master node
 
 ### Starting the API Server
 
-Once these files exist, copy the [kube-apiserver.yaml](/docs/admin/high-availability/kube-apiserver.yaml) into `/etc/kubernetes/manifests/` on each master node.
+Once these files exist, copy the [kube-apiserver.yaml](https://github.com/kubernetes/website/blob/release-1.10/docs/admin/high-availability/kube-apiserver.yaml) into `/etc/kubernetes/manifests/` on each master node.
 
 The kubelet monitors this directory, and will automatically create an instance of the `kube-apiserver` container using the pod definition specified
 in the file.
@@ -246,7 +246,7 @@ touch /var/log/kube-scheduler.log
 touch /var/log/kube-controller-manager.log
 ```
 
-Next, set up the descriptions of the scheduler and controller manager pods on each node by copying [kube-scheduler.yaml](/docs/admin/high-availability/kube-scheduler.yaml) and [kube-controller-manager.yaml](/docs/admin/high-availability/kube-controller-manager.yaml) into the `/etc/kubernetes/manifests/` directory.
+Next, set up the descriptions of the scheduler and controller manager pods on each node by copying [kube-scheduler.yaml](https://github.com/kubernetes/website/blob/release-1.10/docs/admin/high-availability/kube-scheduler.yaml) and [kube-controller-manager.yaml](https://github.com/kubernetes/website/blob/release-1.10/docs/admin/high-availability/kube-controller-manager.yaml) into the `/etc/kubernetes/manifests/` directory.
 
 ## Conclusion
 


### PR DESCRIPTION
Fix the broken yaml link in https://kubernetes.io/docs/admin/high-availability/building/

close #8637 
close #8677
Signed-off-by: Xianglin Gao <xianglin.gxl@alibaba-inc.com>