### PR TITLE
Redirect changed URLs.

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -175,7 +175,8 @@
 
 /docs/hellonode/     /docs/tutorials/stateless-application/hello-minikube/ 301
 /docs/home/coreos/     /docs/getting-started-guides/coreos/ 301
-/docs/home/deprecation-policy/     /docs/reference/deprecation-policy/ 301
+/docs/home/deprecation-policy/     /docs/reference/using-api/deprecation-policy/ 301
+/docs/reference/deprecation-policy/     /docs/reference/using-api/deprecation-policy/ 301
 /docs/reference/federation/v1beta1/definitions/     /docs/reference/federation/extensions/v1beta1/definitions/ 301
 /docs/reference/federation/v1beta1/operations/     /docs/reference/federation/extensions/v1beta1/operations/ 301
 
@@ -196,8 +197,8 @@
 /docs/reference/generated/kubefed_options/     /docs/reference/setup-tools/kubefed/kubefed-options/ 301
 /docs/reference/generated/kubefed_unjoin/     /docs/reference/setup-tools/kubefed/kubefed-unjoin/ 301
 /docs/reference/generated/kubefed_version/     /docs/reference/setup-tools/kubefed/kubefed-version/ 301
-
 /docs/reference/kubectl/kubectl/kubectl_*.md    /docs/reference/generated/kubectl/kubectl-commands#:splat 301
+/docs/reference/workloads-18-19/     https://v1-9.docs.kubernetes.io/docs/reference/workloads-18-19/ 301
 
 /docs/reporting-security-issues/     /security/ 301
 


### PR DESCRIPTION
Fix a couple of URLs that were pointed out in the sig-docs Slack channel.

To test, try these URLs, and verify that they get redirected:

* https://deploy-preview-8715--kubernetes-io-master-staging.netlify.com/docs/home/deprecation-policy/
* https://deploy-preview-8715--kubernetes-io-master-staging.netlify.com/docs/reference/workloads-18-19/