### PR TITLE
kubeadm-alpha: CoreDNS related changes

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-alpha.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-alpha.md
@@ -129,12 +129,14 @@ Alternatively, you can use [kubeadm config](kubeadm-config.md).
 You can install all the available addons with the `all` subcommand, or
 install them selectively.
 
-Please note that if kubeadm is invoked with `--feature-gates=CoreDNS=true`,  [CoreDNS](https://coredns.io/) is installed instead of `kube-dns`.
+{{< note >}}
+**Note:** If `kubeadm` is invoked with `--feature-gates=CoreDNS=false`, kube-dns is installed.
+{{< /note >}}
 
 {{< tabs name="tab-addon" >}}
 {{< tab name="all" include="generated/kubeadm_alpha_phase_addon_all.md" />}}
 {{< tab name="kube-proxy" include="generated/kubeadm_alpha_phase_addon_kube-proxy.md" />}}
-{{< tab name="kube-dns" include="generated/kubeadm_alpha_phase_addon_kube-dns.md" />}}
+{{< tab name="coredns" include="generated/kubeadm_alpha_phase_addon_coredns.md" />}}
 {{< /tabs >}}
 
 


### PR DESCRIPTION
Update note about CoreDNS feature gate.

This change also updates a tab as a kubeadm sub-command
will change.

It looks for a new generated file:
generated/kubeadm_alpha_phase_addon_coredns.md
instead of:
generated/kubeadm_alpha_phase_addon_kube-dns.md

--------
Updates https://github.com/kubernetes/kubeadm/issues/843

blocked by this PR against `kubernetes/kubernetes`:
https://github.com/kubernetes/kubernetes/pull/64274

we need to fix the CLI first.
