### PR TITLE
[mod] API overview link is dead

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/api-extension/custom-resources.md
+++ b/content/en/docs/concepts/extend-kubernetes/api-extension/custom-resources.md
@@ -15,7 +15,7 @@ This page explains [*custom resources*](/docs/concepts/api-extension/custom-reso
 {{% capture body %}}
 ## Custom resources
 
-A *resource* is an endpoint in the [Kubernetes API](/docs/reference/api-overview/) that stores a collection of [API objects](/docs/concepts/overview/working-with-objects/kubernetes-objects/) of a certain kind. For example, the built-in *pods* resource contains a collection of Pod objects.
+A *resource* is an endpoint in the [Kubernetes API](/docs/reference/using-api/api-overview/) that stores a collection of [API objects](/docs/concepts/overview/working-with-objects/kubernetes-objects/) of a certain kind. For example, the built-in *pods* resource contains a collection of Pod objects.
 
 A *custom resource* is an extension of the Kubernetes API that is not necessarily available on every
 Kubernetes cluster.

--- a/content/en/docs/concepts/overview/what-is-kubernetes.md
+++ b/content/en/docs/concepts/overview/what-is-kubernetes.md
@@ -58,7 +58,7 @@ tools to checkpoint state.
 
 Additionally, the [Kubernetes control
 plane](/docs/concepts/overview/components/) is built upon the same
-[APIs](/docs/reference/api-overview/) that are available to developers
+[APIs](/docs/reference/using-api/api-overview/) that are available to developers
 and users. Users can write their own controllers, such as
 [schedulers](https://github.com/kubernetes/community/blob/{{< param "githubbranch" >}}/contributors/devel/scheduler.md),
 with [their own

--- a/content/en/docs/reference/_index.md
+++ b/content/en/docs/reference/_index.md
@@ -9,7 +9,7 @@ weight: 70
 
 ## API Reference
 
-* [Kubernetes API Overview](/docs/reference/api-overview/) - Overview of the API for Kubernetes.
+* [Kubernetes API Overview](/docs/reference/using-api/api-overview/) - Overview of the API for Kubernetes.
 * Kubernetes API Versions
   * [1.10](/docs/reference/generated/kubernetes-api/v1.10/)
   * [1.9](https://v1-9.docs.kubernetes.io/docs/reference/)

--- a/content/en/docs/reference/using-api/client-libraries.md
+++ b/content/en/docs/reference/using-api/client-libraries.md
@@ -12,7 +12,7 @@ API from various programming languages.
 {{% /capture %}}
 
 {{% capture body %}}
-To write applications using the [Kubernetes REST API](/docs/reference/api-overview/),
+To write applications using the [Kubernetes REST API](/docs/reference/using-api/api-overview/),
 you do not need to implement the API calls and request/response types yourself.
 You can use a client library for the programming language you are using.
 

--- a/content/en/docs/reference/using-api/deprecation-policy.md
+++ b/content/en/docs/reference/using-api/deprecation-policy.md
@@ -20,7 +20,7 @@ This document details the deprecation policy for various facets of the system.
 Since Kubernetes is an API-driven system, the API has evolved over time to
 reflect the evolving understanding of the problem space. The Kubernetes API is
 actually a set of APIs, called "API groups", and each API group is
-independently versioned.  [API versions](/docs/reference/api-overview/#api-versioning) fall
+independently versioned.  [API versions](/docs/reference/using-api/api-overview/#api-versioning) fall
 into 3 main tracks, each of which has different policies for deprecation:
 
 | Example  | Track                            |


### PR DESCRIPTION
NG: https://kubernetes.io/docs/reference/api-overview/
OK: https://kubernetes.io/docs/reference/using-api/api-overview/

For example, this page contain dead link.
https://kubernetes.io/docs/reference/#api-reference

Old page is this, so its change is correct.
https://v1-9.docs.kubernetes.io/docs/reference/api-overview/

Note:
China page don't have this link.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.11 Features: set Milestone to 1.11 and Base Branch to release-1.11
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
