### PR TITLE
[mod] Client library link is dead

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/api-extension/custom-resources.md
+++ b/content/en/docs/concepts/extend-kubernetes/api-extension/custom-resources.md
@@ -222,7 +222,7 @@ Aggregated API servers may or may not use the same authentication, authorization
 
 ## Accessing a custom resource
 
-Kubernetes [client libraries](/docs/reference/client-libraries/) can be used to access custom resources. Not all client libraries support custom resources. The go and python client libraries do.
+Kubernetes [client libraries](/docs/reference/using-api/client-libraries/) can be used to access custom resources. Not all client libraries support custom resources. The go and python client libraries do.
 
 When you add a custom resource, you can access it using:
 

--- a/content/en/docs/concepts/overview/working-with-objects/kubernetes-objects.md
+++ b/content/en/docs/concepts/overview/working-with-objects/kubernetes-objects.md
@@ -18,7 +18,7 @@ This page explains how Kubernetes objects are represented in the Kubernetes API,
 
 A Kubernetes object is a "record of intent"--once you create the object, the Kubernetes system will constantly work to ensure that object exists. By creating an object, you're effectively telling the Kubernetes system what you want your cluster's workload to look like; this is your cluster's **desired state**.
 
-To work with Kubernetes objects--whether to create, modify, or delete them--you'll need to use the [Kubernetes API](/docs/concepts/overview/kubernetes-api/). When you use the `kubectl` command-line interface, for example, the CLI makes the necessary Kubernetes API calls for you. You can also use the Kubernetes API directly in your own programs using one of the [Client Libraries](/docs/reference/client-libraries/).
+To work with Kubernetes objects--whether to create, modify, or delete them--you'll need to use the [Kubernetes API](/docs/concepts/overview/kubernetes-api/). When you use the `kubectl` command-line interface, for example, the CLI makes the necessary Kubernetes API calls for you. You can also use the Kubernetes API directly in your own programs using one of the [Client Libraries](/docs/reference/using-api/client-libraries/).
 
 ### Object Spec and Status
 

--- a/content/en/docs/getting-started-guides/clc.md
+++ b/content/en/docs/getting-started-guides/clc.md
@@ -252,7 +252,7 @@ kubectl cluster-info
 
 ### Accessing the cluster programmatically 
 
-It's possible to use the locally stored client certificates to access the apiserver. For example, you may want to use any of the [Kubernetes API client libraries](/docs/reference/client-libraries/) to program against your Kubernetes cluster in the programming language of your choice. 
+It's possible to use the locally stored client certificates to access the apiserver. For example, you may want to use any of the [Kubernetes API client libraries](/docs/reference/using-api/client-libraries/) to program against your Kubernetes cluster in the programming language of your choice. 
 
 To demonstrate how to use these locally stored certificates, we provide the following example of using ```curl``` to communicate to the master apiserver via https:
 

--- a/content/en/docs/reference/_index.md
+++ b/content/en/docs/reference/_index.md
@@ -21,7 +21,7 @@ weight: 70
 ## API Client Libraries
 
 To call the Kubernetes API from a programming language, you can use
-[client libraries](/docs/reference/client-libraries/). Officially supported
+[client libraries](/docs/reference/using-api/client-libraries/). Officially supported
 client libraries:
 
 - [Kubernetes Go client library](https://github.com/kubernetes/client-go/)

--- a/content/en/docs/reference/using-api/api-overview.md
+++ b/content/en/docs/reference/using-api/api-overview.md
@@ -23,7 +23,7 @@ Most operations can be performed through the
 command-line tools, such as [kubeadm](/docs/reference/setup-tools/kubeadm/kubeadm/), which in turn use
 the API. However, you can also access the API directly using REST calls.
 
-Consider using one of the [client libraries](/docs/reference/client-libraries/)
+Consider using one of the [client libraries](/docs/reference/using-api/client-libraries/)
 if you are writing an application using the Kubernetes API.
 
 ## API versioning

--- a/content/en/docs/tasks/access-application-cluster/access-cluster.md
+++ b/content/en/docs/tasks/access-application-cluster/access-cluster.md
@@ -142,7 +142,7 @@ as the kubectl CLI does to locate and authenticate to the apiserver. See this [e
 
 #### Other languages
 
-There are [client libraries](/docs/reference/client-libraries/) for accessing the API from other languages.
+There are [client libraries](/docs/reference/using-api/client-libraries/) for accessing the API from other languages.
 See documentation for other libraries for how they authenticate.
 
 ### Accessing the API from a Pod

--- a/content/en/docs/tasks/administer-cluster/access-cluster-api.md
+++ b/content/en/docs/tasks/administer-cluster/access-cluster-api.md
@@ -165,7 +165,7 @@ for i in ret.items:
 
 #### Other languages
 
-There are [client libraries](/docs/reference/client-libraries/) for accessing the API from other languages. See documentation for other libraries for how they authenticate.
+There are [client libraries](/docs/reference/using-api/client-libraries/) for accessing the API from other languages. See documentation for other libraries for how they authenticate.
 
 ### Accessing the API from a Pod
 
@@ -173,7 +173,7 @@ When accessing the API from a Pod, locating and authenticating
 to the API server are somewhat different.
 
 The easiest way to use the Kubernetes API from a Pod is to use
-one of the official [client libraries](/docs/reference/client-libraries/). These
+one of the official [client libraries](/docs/reference/using-api/client-libraries/). These
 libraries can automatically discover the API server and authenticate.
 
 While running in a Pod, the Kubernetes apiserver is accessible via a Service named
@@ -196,7 +196,7 @@ at `/var/run/secrets/kubernetes.io/serviceaccount/namespace` in each container.
 
 From within a Pod, the recommended ways to connect to the Kubernetes API are:
 
-  - Use one of the official [client libraries](/docs/reference/client-libraries/)
+  - Use one of the official [client libraries](/docs/reference/using-api/client-libraries/)
     as they handle API host discovery and authentication automatically.
     For Go client, the `rest.InClusterConfig()` function assists with this.
     See [an example here](https://git.k8s.io/client-go/examples/in-cluster-client-configuration/main.go).

--- a/content/en/docs/user-journeys/users/application-developer/advanced.md
+++ b/content/en/docs/user-journeys/users/application-developer/advanced.md
@@ -106,7 +106,7 @@ If you do not have a {{< glossary_tooltip text="cluster operator" term_id="clust
 The following topics are also useful for building more complex applications:
 
 * {{< link text="Other points of extensibility within Kubernetes" url="/docs/concepts/overview/extending/" >}} -  A conceptual overview of where you can hook into the Kubernetes architecture.
-* {{< link text="Kubernetes Client Libraries" url="/docs/reference/client-libraries/" >}} - Useful for building apps that need to interact heavily with the Kubernetes API.
+* {{< link text="Kubernetes Client Libraries" url="/docs/reference/using-api/client-libraries/" >}} - Useful for building apps that need to interact heavily with the Kubernetes API.
 
 #### What's next
 Congrats on completing the Application Developer user journey! You've covered the majority of features that Kubernetes has to offer. What now?


### PR DESCRIPTION
Client library links is dead

NG: https://kubernetes.io/docs/reference/client-libraries/
OK: https://kubernetes.io/docs/reference/using-api/client-libraries/

For example, this page contain dead link.
https://kubernetes.io/docs/reference/#api-client-libraries

Old page is this, so its change is correct.
https://v1-9.docs.kubernetes.io/docs/reference/client-libraries/

Note:
China page don't have this link.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.11 Features: set Milestone to 1.11 and Base Branch to release-1.11
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
