### PR TITLE
Federation link is dead

### DIFF
--- a/content/en/docs/concepts/cluster-administration/federation.md
+++ b/content/en/docs/concepts/cluster-administration/federation.md
@@ -96,7 +96,7 @@ The following guides explain some of the resources in detail:
 * [Services](/docs/concepts/cluster-administration/federation-service-discovery/)
 
 
-The [API reference docs](/docs/reference/generated/federation/) list all the
+The [API reference docs](/docs/reference/federation/) list all the
 resources supported by federation apiserver.
 
 ## Cascading deletion

--- a/content/en/docs/tasks/administer-federation/cluster.md
+++ b/content/en/docs/tasks/administer-federation/cluster.md
@@ -110,7 +110,7 @@ Currently, only integers are supported with `Gt` or `Lt`.
 ## Clusters API reference
 
 The full clusters API reference is currently in `federation/v1beta1` and more details can be found in the
-[Federation API reference page](/docs/reference/generated/federation/).
+[Federation API reference page](/docs/reference/federation/).
 
 {{% /capture %}}
 


### PR DESCRIPTION
NG: https://kubernetes.io/docs/reference/generated/federation/
OK: https://kubernetes.io/docs/reference/federation/

For example, this page contain dead link.
https://kubernetes.io/docs/concepts/cluster-administration/federation/#api-resources

Old page is this, and I trace link from this page.
I think this change is meanable, so I think its change is correct.
https://v1-9.docs.kubernetes.io//docs/reference/generated/federation/

Note:
China page don't have this link.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.11 Features: set Milestone to 1.11 and Base Branch to release-1.11
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
