### PR TITLE
StorageOS example dead link

### DIFF
--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -885,7 +885,7 @@ spec:
 ```
 
 For more information including Dynamic Provisioning and Persistent Volume Claims, please see the
-[StorageOS examples](https://github.com/kubernetes/kubernetes/tree/master/examples/volumes/storageos).
+[StorageOS examples](https://github.com/kubernetes/examples/blob/master/staging/volumes/storageos).
 
 ### vsphereVolume
 


### PR DESCRIPTION
NG: https://github.com/kubernetes/kubernetes/tree/master/examples/volumes/storageos
OK: https://github.com/kubernetes/examples/blob/master/staging/volumes/storageos

For example, this page contain dead link.
https://kubernetes.io/docs/concepts/storage/volumes/#storageos

Old page is this, so I think its change is correct.
https://github.com/kubernetes/kubernetes/tree/release-1.10/examples/volumes/storageos

Note:
China page don't have this link.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.11 Features: set Milestone to 1.11 and Base Branch to release-1.11
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
