### PR TITLE
Kubernetes basic github deadlink

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
@@ -90,7 +90,7 @@ weight: 10
 
         <div class="row">
             <div class="col-md-8">
-                <p>For our first Deployment, we'll use a <a href="https://nodejs.org">Node.js</a> application packaged in a Docker container. The source code and the Dockerfile are available in the <a href="https://github.com/kubernetes/website/tree/master/docs/tutorials/kubernetes-basics">GitHub repository</a> for the Kubernetes Basics.</p>
+                <p>For our first Deployment, we'll use a <a href="https://nodejs.org">Node.js</a> application packaged in a Docker container. The source code and the Dockerfile are available in the <a href="https://github.com/kubernetes/website/tree/master/content/en/docs/tutorials/kubernetes-basics">GitHub repository</a> for the Kubernetes Basics.</p>
 
                 <p>Now that you know what Deployments are, let's go to the online tutorial and deploy our first app!</p>
 


### PR DESCRIPTION
NG: https://github.com/kubernetes/website/tree/master/docs/tutorials/kubernetes-basics
OK: https://github.com/kubernetes/website/tree/master/content/en/docs/tutorials/kubernetes-basics

For example, this page contain dead link.
https://kubernetes.io/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/

Note:
China page don't have this link.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.11 Features: set Milestone to 1.11 and Base Branch to release-1.11
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
