### PR TITLE
kube-router document is moved (dead link)

### DIFF
--- a/content/en/docs/tasks/administer-cluster/network-policy-provider/kube-router-network-policy.md
+++ b/content/en/docs/tasks/administer-cluster/network-policy-provider/kube-router-network-policy.md
@@ -16,7 +16,7 @@ You need to have a Kubernetes cluster running. If you do not already have a clus
 
 {{% capture steps %}}
 ## Installing Kube-router addon
-The Kube-router Addon comes with a Network Policy Controller that watches Kubernetes API server for any NetworkPolicy and pods updated and configures iptables rules and ipsets to allow or block traffic as directed by the policies. Please follow the [trying Kube-router with cluster installers](https://github.com/cloudnativelabs/kube-router/tree/master/Documentation#try-kube-router-with-cluster-installers) guide to install Kube-router addon.
+The Kube-router Addon comes with a Network Policy Controller that watches Kubernetes API server for any NetworkPolicy and pods updated and configures iptables rules and ipsets to allow or block traffic as directed by the policies. Please follow the [trying Kube-router with cluster installers](https://www.kube-router.io/docs/user-guide/#try-kube-router-with-cluster-installers) guide to install Kube-router addon.
 {{% /capture %}}
 
 {{% capture whatsnext %}}


### PR DESCRIPTION
NG: https://github.com/cloudnativelabs/kube-router/tree/master/Documentation#try-kube-router-with-cluster-installers
OK https://www.kube-router.io/docs/user-guide/#try-kube-router-with-cluster-installers

For example, this page contain dead link.
https://kubernetes.io/docs/tasks/administer-cluster/network-policy-provider/kube-router-network-policy/

Note:
China page don't have this link.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.11 Features: set Milestone to 1.11 and Base Branch to release-1.11
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
