### PR TITLE
FixThe404Link

### DIFF
--- a/content/en/docs/concepts/configuration/assign-pod-node.md
+++ b/content/en/docs/concepts/configuration/assign-pod-node.md
@@ -16,7 +16,7 @@ that a pod ends up on a machine with an SSD attached to it, or to co-locate pods
 services that communicate a lot into the same availability zone.
 
 You can find all the files for these examples [in our docs
-repo here](https://github.com/kubernetes/website/tree/{{< param "docsbranch" >}}/docs/user-guide/node-selection).
+repo here](https://github.com/kubernetes/website/tree/{{< param "docsbranch" >}}/content/en/docs/concepts/configuration).
 
 {{< toc >}}
 


### PR DESCRIPTION
The link is not correct. I think the link is https://github.com/kubernetes/website/tree/master/content/en/docs/concepts/configuration
But this contains more files than former link https://github.com/kubernetes/website/tree/release-1.8/docs/user-guide/node-selection
so maybe we should delete this line 