### PR TITLE
fix id about joining-your-nodes in create-cluster-kubeadm page

### DIFF
--- a/content/en/docs/getting-started-guides/windows/_index.md
+++ b/content/en/docs/getting-started-guides/windows/_index.md
@@ -246,7 +246,7 @@ The kubeadm binary can be found at [Kubernetes Releases](https://github.com/kube
 
 `kubeadm.exe join --token <token> <master-ip>:<master-port> --discovery-token-ca-cert-hash sha256:<hash>`
 
-See [joining-your-nodes](https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/#44-joining-your-nodes) for more details.
+See [joining-your-nodes](https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/#joining-your-nodes) for more details.
 
 ## Supported Features
 

--- a/content/en/docs/setup/independent/high-availability.md
+++ b/content/en/docs/setup/independent/high-availability.md
@@ -518,7 +518,7 @@ Follow the instructions [here](/docs/setup/independent/create-cluster-kubeadm/#p
 
 Next provision and set up the worker nodes. To do this, you will need to provision at least 3 Virtual Machines.
 
-1. To configure the worker nodes, [follow the same steps](/docs/setup/independent/create-cluster-kubeadm/#44-joining-your-nodes) as non-HA workloads.
+1. To configure the worker nodes, [follow the same steps](/docs/setup/independent/create-cluster-kubeadm/#joining-your-nodes) as non-HA workloads.
 
 ## Configure workers
 


### PR DESCRIPTION
It was different from the page ID of `/docs/setup/independent/high-availability/`, so I fixed it.
