### PR TITLE
Update 'kubectl apply' conventions.md

### DIFF
--- a/content/en/docs/reference/kubectl/conventions.md
+++ b/content/en/docs/reference/kubectl/conventions.md
@@ -65,4 +65,4 @@ flag, which provides the object to be submitted to the cluster.
 
 ### `kubectl apply`
 
-* When you use `kubectl apply` to update resources, always create resources initially using `kubectl create` or using `--save-config`. See [managing resources with kubectl apply](/docs/concepts/cluster-administration/manage-deployment/#kubectl-apply) for more information.
+* You can use `kubectl apply` to create or update resources. However, to update a resource you should have created the resource by using `kubectl apply` or `kubectl create --save-config`. For more information about using kubectl apply to update resources, see [Managing Resources](/docs/concepts/cluster-administration/manage-deployment/#kubectl-apply).


### PR DESCRIPTION
Rewording the 'kubectl apply' convention definition to make usage more clear. Previous definition and the referenced page had conflicting instructions.
