### PR TITLE
Fix High availability Kubernetes diagram image link error

### DIFF
--- a/content/en/docs/admin/high-availability/building.md
+++ b/content/en/docs/admin/high-availability/building.md
@@ -30,7 +30,7 @@ The steps involved are as follows:
 
 Here's what the system should look like when it's finished:
 
-![High availability Kubernetes diagram](/images/docs/ha.svg)
+![High availability Kubernetes diagram](/static/images/docs/ha.svg)
 
 ## Initial set-up
 


### PR DESCRIPTION
Signed-off-by: Yuanbin.Chen <cybing4@gmail.com>

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.11 Features: set Milestone to 1.11 and Base Branch to release-1.11
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
