### PR TITLE
Typo fix: ManagedResources-> managedResources

### DIFF
--- a/content/en/docs/concepts/configuration/manage-compute-resources-container.md
+++ b/content/en/docs/concepts/configuration/manage-compute-resources-container.md
@@ -450,7 +450,7 @@ extender.
     {
       "urlPrefix":"<extender-endpoint>",
       "bindVerb": "bind",
-      "ManagedResources": [
+      "managedResources": [
         {
           "name": "example.com/foo",
           "ignoredByScheduler": true


### PR DESCRIPTION
ManagedResources should be managedResources
see the define 
https://github.com/kubernetes/kubernetes/blob/release-1.10/pkg/scheduler/api/v1/types.go#L174