### PR TITLE
Auto-assign blog PRs to kbarnard10

### DIFF
--- a/content/en/blog/OWNERS
+++ b/content/en/blog/OWNERS
@@ -1,7 +1,7 @@
 # Owned by Kubernetes blog reviewers.
 options:
   no_parent_owners: true
-# reviewers:
+reviewers:
   - kbarnard10
 approvers:
   - bobsky

--- a/content/en/blog/OWNERS
+++ b/content/en/blog/OWNERS
@@ -1,7 +1,8 @@
 # Owned by Kubernetes blog reviewers.
 options:
   no_parent_owners: true
-# reviewers: // List any reviewers here
+# reviewers:
+  - kbarnard10
 approvers:
   - bobsky
   - kbarnard10

--- a/content/en/case-studies/OWNERS
+++ b/content/en/case-studies/OWNERS
@@ -1,7 +1,8 @@
 # Owned by Kubernetes blog reviewers.
 options:
   no_parent_owners: true
-# reviewers: // List any reviewers here
+reviewers:
+  - alexcontini
 approvers:
   - alexcontini
   - kbarnard10


### PR DESCRIPTION
This PR:
- Adds @kbarnard10 as a reviewer for content/en/blog
- Adds @alexcontini as a reviewer for content/en/case-studies

These additions make them the sole reviewers at their respective levels of OWNERS permissions, which should hopefully auto-assign any relevant PRs to them and them only for blog post and case studies PRs respectively.