### PR TITLE
Make path more explicit for blog images

### DIFF
--- a/content/en/docs/home/contribute/blog-post.md
+++ b/content/en/docs/home/contribute/blog-post.md
@@ -104,7 +104,7 @@ Write your post using the following guidelines.
 
 ### Add images
 
-Add any image files the post contains to `/images/blog/`.
+Add any image files the post contains to `/static/images/blog/`.
 
 The preferred image format is SVG.
 


### PR DESCRIPTION
It wasn't clear to me in the instructions that the blog images are under /static. 