### PR TITLE
add date blog metadata for indexing

### DIFF
--- a/content/en/blog/_posts/2018-03-26-kubernetes-1.10-stabilizing-storage-security-networking.md
+++ b/content/en/blog/_posts/2018-03-26-kubernetes-1.10-stabilizing-storage-security-networking.md
@@ -6,6 +6,7 @@ modified_time: '2018-03-27T11:01:39.569-07:00'
 blogger_id: tag:blogger.com,1999:blog-112706738355446097.post-6519705795358457586
 blogger_orig_url: http://blog.kubernetes.io/2018/03/kubernetes-1.10-stabilizing-storage-security-networking.html
 slug: kubernetes-1.10-stabilizing-storage-security-networking
+date: 2018-03-26
 ---
 
 ***Editor's note: today's post is by the [1.10 Release

--- a/content/en/blog/_posts/2018-04-11-migrating-the-kubernetes-blog.md
+++ b/content/en/blog/_posts/2018-04-11-migrating-the-kubernetes-blog.md
@@ -2,6 +2,7 @@
 title: 'Migrating the Kubernetes blog'
 author: zcorleissen
 slug: migrating-the-kubernetes-blog
+date: 2018-04-11
 ---
 
 We recently migrated the Kubernetes blog from the Blogger platform to GitHub. With the change in platform comes a change in URL: formerly at [http://blog.kubernetes.io](http://blog.kubernetes.io), the blog now resides at [https://kubernetes.io/blog](https://kubernetes.io/blog).

--- a/content/en/blog/_posts/2018-04-24-kubernetes-application-survey-results-2018.md
+++ b/content/en/blog/_posts/2018-04-24-kubernetes-application-survey-results-2018.md
@@ -2,6 +2,7 @@
 title: 'Kubernetes Application Survey 2018 Results'
 author: mattfarina
 slug: kubernetes-application-survey-results-2018
+date: 2018-04-24
 ---
 
 Understanding how people use or want to use Kubernetes can help us shape everything from what we build to how we do it. To help us understand how application developers, application operators, and ecosystem tool developers are using and want to use Kubernetes, the Application Definition Working Group recently performed a survey. The survey focused in on these types of user roles and the features and sub-projects owned by the Kubernetes organization. That included kubectl, Dashboard, Minikube, Helm, the Workloads API, etc.


### PR DESCRIPTION
Issues:
https://github.com/kubernetes/website/issues/8823
and more article has same problem, I fix all.

you can see here,
https://deploy-preview-8830--kubernetes-io-master-staging.netlify.com/blog/

and now, 3 contents are not shown.
2018-03-26-kubernetes-1.10-stabilizing-storage-security-networking.md
2018-04-11-migrating-the-kubernetes-blog.md
2018-04-24-kubernetes-application-survey-results-2018.md

![screen shot 2018-05-31 at 11 02 53 am](https://user-images.githubusercontent.com/8783194/40759860-df8222e0-64ce-11e8-94b5-ea7c1b9aabe8.png)


>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.11 Features: set Milestone to 1.11 and Base Branch to release-1.11
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
