### PR TITLE
Fix: unifying .spec spelling in concepts/workloads/pods

### DIFF
--- a/content/en/docs/concepts/workloads/pods/disruptions.md
+++ b/content/en/docs/concepts/workloads/pods/disruptions.md
@@ -112,7 +112,7 @@ and the tool periodically retries all failed requests until all pods
 are terminated, or until a configurable timeout is reached.
 
 A PDB specifies the number of replicas that an application can tolerate having, relative to how
-many it is intended to have.  For example, a Deployment which has a `spec.replicas: 5` is
+many it is intended to have.  For example, a Deployment which has a `.spec.replicas: 5` is
 supposed to have 5 pods at any given time.  If its PDB allows for there to be 4 at a time,
 then the Eviction API will allow voluntary disruption of one, but not two pods, at a time.
 

--- a/content/en/docs/concepts/workloads/pods/init-containers.md
+++ b/content/en/docs/concepts/workloads/pods/init-containers.md
@@ -37,8 +37,8 @@ To specify a Container as an Init Container, add the `initContainers` field on t
 a JSON array of objects of type
 [Container](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#container-v1-core)
 alongside the app `containers` array.
-The status of the init containers is returned in `status.initContainerStatuses`
-field as an array of the container statuses (similar to the `status.containerStatuses`
+The status of the init containers is returned in `.status.initContainerStatuses`
+field as an array of the container statuses (similar to the `.status.containerStatuses`
 field).
 
 ### Differences from regular Containers
@@ -310,15 +310,15 @@ reasons:
 ## Support and compatibility
 
 A cluster with Apiserver version 1.6.0 or greater supports Init Containers
-using the `spec.initContainers` field. Previous versions support Init Containers
-using the alpha or beta annotations. The `spec.initContainers` field is also mirrored
+using the `.spec.initContainers` field. Previous versions support Init Containers
+using the alpha or beta annotations. The `.spec.initContainers` field is also mirrored
 into alpha and beta annotations so that Kubelets version 1.3.0 or greater can execute
 Init Containers, and so that a version 1.6 apiserver can safely be rolled back to version
 1.5.x without losing Init Container functionality for existing created pods.
 
 In Apiserver and Kubelet versions 1.8.0 or greater, support for the alpha and beta annotations
 is removed, requiring a conversion from the deprecated annotations to the
-`spec.initContainers` field.
+`.spec.initContainers` field.
 
 {{% /capture %}}
 

--- a/content/en/docs/concepts/workloads/pods/podpreset.md
+++ b/content/en/docs/concepts/workloads/pods/podpreset.md
@@ -51,7 +51,7 @@ Pods, Kubernetes modifies the Pod Spec. For changes to `Env`, `EnvFrom`, and
 the Pod; for changes to `Volume`, Kubernetes modifies the Pod Spec.
 
 {{< note >}}
-**Note:** A Pod Preset is capable of modifying the `spec.containers` field in a
+**Note:** A Pod Preset is capable of modifying the `.spec.containers` field in a
 Pod spec when appropriate. *No* resource definition from the Pod Preset will be 
 applied to the `initContainers` field.
 {{< /note >}}


### PR DESCRIPTION
same problem like https://github.com/kubernetes/website/pull/8542
have already do a total review for this directory