### PR TITLE
Fix date format in Front Matter.

### DIFF
--- a/content/en/blog/_posts/2018-05-04-announcing-kubeflow-0.1.md
+++ b/content/en/blog/_posts/2018-05-04-announcing-kubeflow-0.1.md
@@ -1,7 +1,7 @@
 ---
 layout: blog
 title: Current State of Policy in Kubernetes
-date: Wednesday, May 2, 2018
+date: 2018-05-04
 ---
 
 Kubernetes has grown dramatically in its impact to the industry; and with rapid growth, we are beginning to see variations across components in how they define and apply policies.

--- a/content/en/blog/_posts/2018-05-24-kubernetes-containerd-integration-goes-ga.md
+++ b/content/en/blog/_posts/2018-05-24-kubernetes-containerd-integration-goes-ga.md
@@ -1,7 +1,7 @@
 ---
 layout: blog
 title: Kubernetes Containerd Integration Goes GA
-date: Thursday, May 24, 2018
+date: 2018-05-24
 ---
 # Kubernetes Containerd Integration Goes GA
 **Authors**: Lantao Liu, Software Engineer, Google and Mike Brown, Open Source Developer Advocate, IBM


### PR DESCRIPTION
I fixed invalid date format.

I changed the date of `content/en/blog/_posts/2018-05-04-announcing-kubeflow-0.1.md` , because I thought that changing the date on the front matters is more natural, because the URL of the page will change and the file name will be different.
(I am sorry for my poor English. :persevere:)

Related: #8823, #8830