### PR TITLE
Add a note regarding escaping characters

### DIFF
--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -529,6 +529,8 @@ secret "test-db-secret" created
 If the password you are using has special characters, you need to escape them using the `\\` character. For example, if your actual password is `S!B\*d$zDsb`, you should execute the command this way: 
 
     kubectl create secret generic dev-db-secret --from-literal=username=devuser --from-literal=password=S\\!B\\\*d\\$zDsb
+    
+You do not need to escape special characters in passwords from files (`--from-file`).
 {{< /note >}}
 
 Now make the pods:

--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -525,10 +525,11 @@ $ kubectl create secret generic test-db-secret --from-literal=username=testuser 
 secret "test-db-secret" created
 ```
 {{< note >}}
-**Note:** Beware of special characters such as $, \*, !, etc. such characters require escaping.
-In case the password you are using has special characters, such as $, \*, !, and possibly other special characters, you will have to escape them using the '\\' character, or else your password will be incomplete. For example, if your actual password is **S!B\*d$zDsb** you should execute the command this way: kubectl create secret generic dev-db-secret --from-literal=username=devuser --from-literal=password=**S\\!B\\\*d\\$zDsb**
-{{< /note >}}
+**Note:** Special characters such as `$`, `\*`, and `!` require escaping.
+If the password you are using has special characters, you need to escape them using the `\\` character. For example, if your actual password is `S!B\*d$zDsb`, you should execute the command this way: 
 
+    kubectl create secret generic dev-db-secret --from-literal=username=devuser --from-literal=password=S\\!B\\\*d\\$zDsb
+{{< /note >}}
 
 Now make the pods:
 

--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -524,6 +524,11 @@ secret "prod-db-secret" created
 $ kubectl create secret generic test-db-secret --from-literal=username=testuser --from-literal=password=iluvtests
 secret "test-db-secret" created
 ```
+{{< note >}}
+**Note:** Beware of special characters such as $, \*, !, etc. such characters require escaping.
+In case the password you are using has special characters, such as $, \*, !, and possibly other special characters, you will have to escape them using the '\\' character, or else your password will be incomplete. For example, if your actual password is **S!B\*d$zDsb** you should execute the command this way: kubectl create secret generic dev-db-secret --from-literal=username=devuser --from-literal=password=**S\\!B\\\*d\\$zDsb**
+{{< /note >}}
+
 
 Now make the pods:
 


### PR DESCRIPTION
Updated docs with a note regarding escaping characters, it's important because it won't work well otherwise.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.11 Features: set Milestone to 1.11 and Base Branch to release-1.11
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
