### PR TITLE
Remove legacy syntax from federation-current-state.md

### DIFF
--- a/content/en/includes/federation-current-state.md
+++ b/content/en/includes/federation-current-state.md
@@ -1,7 +1,1 @@
-**Note:** `Federation V1`, the current Kubernetes federation API which reuses the Kubernetes API 
-resources 'as is', is currently considered alpha for many of its features, and there is no clear
-path to evolve the API to GA. However, there is a `Federation V2` effort in progress to implement
-a dedicated federation API apart from the Kubernetes API. The details can be found at
-[sig-multicluster community page](https://github.com/kubernetes/community/tree/master/sig-multicluster).
-{: .note}
-
+**Note:** `Federation V1`, the current Kubernetes federation API which reuses the Kubernetes API resources 'as is', is currently considered alpha for many of its features, and there is no clear path to evolve the API to GA. However, there is a `Federation V2` effort in progress to implement a dedicated federation API apart from the Kubernetes API. The details can be found at [sig-multicluster community page](https://github.com/kubernetes/community/tree/master/sig-multicluster).


### PR DESCRIPTION
This PR:
- Removes legacy note formatting syntax
- Fixes #8512