### PR TITLE
Removes unnecessary SkyDNS references in preparation for CoreDNS change.

### DIFF
--- a/content/en/docs/concepts/cluster-administration/cluster-administration-overview.md
+++ b/content/en/docs/concepts/cluster-administration/cluster-administration-overview.md
@@ -66,7 +66,7 @@ If you are using a guide involving Salt, see [Configuring Kubernetes with Salt](
 
 ## Optional Cluster Services
 
-* [DNS Integration with SkyDNS](/docs/concepts/services-networking/dns-pod-service/) describes how to resolve a DNS name directly to a Kubernetes service.
+* [DNS Integration](/docs/concepts/services-networking/dns-pod-service/) describes how to resolve a DNS name directly to a Kubernetes service.
 
 * [Logging and Monitoring Cluster Activity](/docs/concepts/cluster-administration/logging/) explains how logging in Kubernetes works and how to implement it.
 

--- a/content/en/docs/concepts/services-networking/connect-applications-service.md
+++ b/content/en/docs/concepts/services-networking/connect-applications-service.md
@@ -134,7 +134,7 @@ KUBERNETES_SERVICE_PORT_HTTPS=443
 
 ### DNS
 
-Kubernetes offers a DNS cluster addon Service that uses skydns to automatically assign dns names to other Services. You can check if it's running on your cluster:
+Kubernetes offers a DNS cluster addon Service that automatically assigns dns names to other Services. You can check if it's running on your cluster:
 
 ```shell
 $ kubectl get services kube-dns --namespace=kube-system


### PR DESCRIPTION
The following PR removes unnecessary references to SkyDNS in prep for 1.11.  This change can be merged now as the text is still correct and will be after 1.11 

/assign @Bradamant3 
