### PR TITLE
Space inside href text resembles a period on "scale-intro" page

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/scale/scale-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/scale/scale-intro.html
@@ -86,7 +86,7 @@ weight: 10
         <div class="row">
             <div class="col-md-8">
 
-                <p>Scaling out a Deployment will ensure new Pods are created and scheduled to Nodes with available resources. Scaling in will reduce the number of Pods to the new desired state. Kubernetes also supports <a href="http://kubernetes.io/docs/user-guide/horizontal-pod-autoscaling/"> autoscaling </a> of Pods, but it is outside of the scope of this tutorial. Scaling to zero is also possible, and it will terminate all Pods of the specified Deployment.</p>
+                <p>Scaling out a Deployment will ensure new Pods are created and scheduled to Nodes with available resources. Scaling in will reduce the number of Pods to the new desired state. Kubernetes also supports <a href="http://kubernetes.io/docs/user-guide/horizontal-pod-autoscaling/">autoscaling</a> of Pods, but it is outside of the scope of this tutorial. Scaling to zero is also possible, and it will terminate all Pods of the specified Deployment.</p>
 
                 <p>Running multiple instances of an application will require a way to distribute the traffic to all of them. Services have an integrated load-balancer that will distribute network traffic to all Pods of an exposed Deployment. Services will monitor continuously the running Pods using endpoints, to ensure the traffic is sent only to available Pods.</p>
 


### PR DESCRIPTION
Spaces inside the text of an href tag caused underlining of a blank space which resembles a period. See screenshot for example.

Current: 
![before](https://user-images.githubusercontent.com/9068425/40884187-1959de62-66c4-11e8-93a6-20b9d1853212.png)

Fix:
![after](https://user-images.githubusercontent.com/9068425/40884188-21219f72-66c4-11e8-9b7e-c027ab490ac8.png)


