### PR TITLE
remove kubectl overview link repeat

### DIFF
--- a/content/en/docs/user-guide/walkthrough/_index.md
+++ b/content/en/docs/user-guide/walkthrough/_index.md
@@ -19,7 +19,7 @@ In order for the kubectl usage examples to work, make sure you have an example d
 
 ## Kubectl CLI
 
-The easiest way to interact with Kubernetes is through the [kubectl](/docs/reference/kubectl/overview/) command-line interface.
+The easiest way to interact with Kubernetes is through the kubectl command-line interface.
 
 For more info about kubectl, including its usage, commands, and parameters, see [Overview of kubectl](/docs/reference/kubectl/overview/).
 


### PR DESCRIPTION
In _index doc the Kubectl CLI about overview link
was add in "[Overview of kubectl]", So remove not
need "[kubectl]" link.

Signed-off-by: Yuanbin.Chen <cybing4@gmail.com>

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.11 Features: set Milestone to 1.11 and Base Branch to release-1.11
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
