### PR TITLE
Hugo: Fix getting-started-guides/scratch.md

### DIFF
--- a/content/en/docs/getting-started-guides/scratch.md
+++ b/content/en/docs/getting-started-guides/scratch.md
@@ -492,15 +492,14 @@ You will need to run one or more instances of etcd.
   - Not highly available, but easy to restore - Run one etcd instance, with its log written to a directory backed
     by durable storage (RAID, GCE PD).
     
-    {{< note >}}
-    **Note:** May result in operations outages in case of instance outage.
-    {{< /note >}}
+    {{< note >}}**Note:** May result in operations outages in case of
+    instance outage. {{< /note >}}
   - Highly available - Run 3 or 5 etcd instances with non durable storage.
   
-    {{< note >}}
-    **Note:** Log can be written to non-durable storage because storage is replicated.
-    {{< /note >}}
- See [cluster-troubleshooting](/docs/admin/cluster-troubleshooting/) for more discussion on factors affecting cluster
+    {{< note >}}**Note:** Log can be written to non-durable storage
+    because storage is replicated.{{< /note >}}
+
+See [cluster-troubleshooting](/docs/admin/cluster-troubleshooting/) for more discussion on factors affecting cluster
 availability.
 
 To run an etcd instance:


### PR DESCRIPTION
Fix the display of notes on the page so that hugo formats it correctly.
Without this change, the content is formatted as code.
