### PR TITLE
kubeadm: update CoreDNS maturity level to GA

### DIFF
--- a/content/en/docs/setup/independent/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/independent/create-cluster-kubeadm.md
@@ -48,7 +48,7 @@ but you may also on other OSes.
 | Config file API           | alpha          |
 | Self-hosting              | alpha          |
 | kubeadm alpha subcommands | alpha          |
-| CoreDNS                   | alpha          |
+| CoreDNS                   | GA             |
 | DynamicKubeletConfig      | alpha          |
 
 

--- a/content/en/docs/tasks/administer-cluster/coredns.md
+++ b/content/en/docs/tasks/administer-cluster/coredns.md
@@ -31,6 +31,8 @@ kubeadm init --feature-gates=CoreDNS=true
 
 This installs CoreDNS instead of kube-dns.
 
+In Kubernetes 1.11, it is available as a GA feature. `CoreDNS` will be enabled by default.
+
 ## Using a custom CoreDNS image repository with kubeadm
 
 To use a custom image repository for the CoreDNS image, e.g. one located in your own Docker registry,


### PR DESCRIPTION
coredns has been bumped to GA in kubeadm.
xref: kubernetes/kubernetes#63509
/cc timothysc  luxas detiber

This should be only available since v1.11.