### PR TITLE
kubeadm: update section about CA certs in high-availability.md

### DIFF
--- a/content/en/docs/setup/independent/high-availability.md
+++ b/content/en/docs/setup/independent/high-availability.md
@@ -53,7 +53,7 @@ For **Option 2**: you can skip to the next step. Any reference to `etcd0`, `etcd
 
 ### Create etcd CA certs
 
-1. Install `cfssl` and `cfssljson`:
+1. Install `cfssl` and `cfssljson` on all etcd nodes:
 
      ```bash
      curl -o /usr/local/bin/cfssl https://pkg.cfssl.org/R1.2/cfssl_linux-amd64
@@ -278,7 +278,7 @@ Run the following to generate the manifest file:
         labels:
           component: etcd
           tier: control-plane
-        name: <podname>
+        name: <name>
         namespace: kube-system
       spec:
         containers:
@@ -339,7 +339,7 @@ Run the following to generate the manifest file:
       EOF
 
 Make sure you replace:
-* `<podname>` with the name of the node you're running on (e.g. `etcd0`, `etcd1` or `etcd2`)
+* `<name>` with the name of the node you're running on (e.g. `etcd0`, `etcd1` or `etcd2`)
 * `<etcd0-ip-address>`, `<etcd1-ip-address>` and `<etcd2-ip-address>` with the public IPv4s of the other machines that host etcd.
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
Added information to install cfssl and cfssljson on all etc nodes as they are required to generate clients certificates
Added missing <name> in static pod yaml description for etcd deployment

Additionaly the first bash script in "Run kubeadm init on master0" section doesn't render correctly on kubernetes.io site (https://kubernetes.io/docs/setup/independent/high-availability/) but I don't see any pb with markdown.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.11 Features: set Milestone to 1.11 and Base Branch to release-1.11
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
