### PR TITLE
inline code block is not displayed

### DIFF
--- a/content/en/docs/tasks/administer-cluster/change-default-storage-class.md
+++ b/content/en/docs/tasks/administer-cluster/change-default-storage-class.md
@@ -37,9 +37,7 @@ for details about addon manager and how to disable individual addons.
 
 ## Changing the default StorageClass
 
-1. List the StorageClasses in your cluster:
-
-       kubectl get storageclass
+1. List the StorageClasses in your cluster: `kubectl get storageclass`
 
     The output is similar to this:
 


### PR DESCRIPTION
Using `kubectl get storageclass` instead of 

```
       kubectl get storageclass
```

correctly shows the code markup.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.11 Features: set Milestone to 1.11 and Base Branch to release-1.11
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
