### PR TITLE
Fix pipe to base64 -d to -D

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
+++ b/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
@@ -90,7 +90,7 @@ The value of the `.dockerconfigjson` field is a base64 representation of your Do
 To understand what is in the `.dockerconfigjson` field, convert the secret data to a
 readable format:
 
-    kubectl get secret regcred --output="jsonpath={.data.\.dockerconfigjson}" | base64 -d
+    kubectl get secret regcred --output="jsonpath={.data.\.dockerconfigjson}" | base64 -D
 
 The output is similar to this:
 
@@ -98,7 +98,7 @@ The output is similar to this:
 
 To understand what is in the `auth` field, convert the base64-encoded data to a readable format:
 
-    echo "c3R...zE2" | base64 -d
+    echo "c3R...zE2" | base64 -D
 
 The output, username and password concatenated with a `:`, is similar to this:
 

--- a/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
+++ b/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
@@ -90,7 +90,7 @@ The value of the `.dockerconfigjson` field is a base64 representation of your Do
 To understand what is in the `.dockerconfigjson` field, convert the secret data to a
 readable format:
 
-    kubectl get secret regcred --output="jsonpath={.data.\.dockerconfigjson}" | base64 -D
+    kubectl get secret regcred --output="jsonpath={.data.\.dockerconfigjson}" | base64 --decode
 
 The output is similar to this:
 
@@ -98,7 +98,7 @@ The output is similar to this:
 
 To understand what is in the `auth` field, convert the base64-encoded data to a readable format:
 
-    echo "c3R...zE2" | base64 -D
+    echo "c3R...zE2" | base64 --decode
 
 The output, username and password concatenated with a `:`, is similar to this:
 


### PR DESCRIPTION
Mac: `-d` does not work -D does

Eg. echo "c3R...zE2" | base64 -D

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.11 Features: set Milestone to 1.11 and Base Branch to release-1.11
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
