### PR TITLE
kubeadm-init: update the example for the MasterConfiguration

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -97,87 +97,160 @@ still considered alpha and may change in future versions.
 
 It's possible to configure `kubeadm init` with a configuration file instead of command
 line flags, and some more advanced features may only be available as
-configuration file options.  This file is passed in the `--config` option.
+configuration file options. This file is passed in the `--config` option.
+
+In Kubernetes 1.11 and later, the default configuration can be printed out using the
+[kubeadm config print-default](/docs/reference/setup-tools/kubeadm/kubeadm-config/) command.
+
+For more details on each field in the configuration you can navigate to our
+[API reference pages.] (https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm#MasterConfiguration)
+
+Example of the kubeadm MasterConfiguration version `v1alpha2`:
 
 ```yaml
-apiVersion: kubeadm.k8s.io/v1alpha1
+apiVersion: kubeadm.k8s.io/v1alpha2
 kind: MasterConfiguration
+kubernetesVersion: v1.11.0
 api:
-  advertiseAddress: <address|string>
-  controlPlaneEndpoint: <string>
-  bindPort: <int>
+  advertiseAddress: 192.168.0.102
+  bindPort: 6443
+  controlPlaneEndpoint: ""
+auditPolicy:
+  logDir: /var/log/kubernetes/audit
+  logMaxAge: 2
+  path: ""
+bootstrapTokens:
+- groups:
+  - system:bootstrappers:kubeadm:default-node-token
+  token: abcdef.0123456789abcdef
+  ttl: 24h0m0s
+  usages:
+  - signing
+  - authentication
+certificatesDir: /etc/kubernetes/pki
+clusterName: kubernetes
 etcd:
-  endpoints:
-  - <endpoint1|string>
-  - <endpoint2|string>
-  caFile: <path|string>
-  certFile: <path|string>
-  keyFile: <path|string>
-  dataDir: <path|string>
-  extraArgs:
-    <argument>: <value|string>
-    <argument>: <value|string>
-  image: <string>
-  serverCertSANs:
-  - <name1|string>
-  - <name2|string>
-  peerCertSANs:
-  - <name1|string>
-  - <name2|string>
+  local:
+    dataDir: /var/lib/etcd
+    image: ""
+imageRepository: k8s.gcr.io
 kubeProxy:
   config:
-    mode: <value|string>
-    bindAddress: <address|string>
-    clusterCIDR: <cidr>
+    bindAddress: 0.0.0.0
+    clientConnection:
+      acceptContentTypes: ""
+      burst: 10
+      contentType: application/vnd.kubernetes.protobuf
+      kubeconfig: /var/lib/kube-proxy/kubeconfig.conf
+      qps: 5
+    clusterCIDR: ""
+    configSyncPeriod: 15m0s
+    conntrack:
+      max: null
+      maxPerCore: 32768
+      min: 131072
+      tcpCloseWaitTimeout: 1h0m0s
+      tcpEstablishedTimeout: 24h0m0s
+    enableProfiling: false
+    healthzBindAddress: 0.0.0.0:10256
+    hostnameOverride: ""
+    iptables:
+      masqueradeAll: false
+      masqueradeBit: 14
+      minSyncPeriod: 0s
+      syncPeriod: 30s
+    ipvs:
+      ExcludeCIDRs: null
+      minSyncPeriod: 0s
+      scheduler: ""
+      syncPeriod: 30s
+    metricsBindAddress: 127.0.0.1:10249
+    mode: ""
+    nodePortAddresses: null
+    oomScoreAdj: -999
+    portRange: ""
+    resourceContainer: /kube-proxy
+    udpIdleTimeout: 250ms
+kubeletConfiguration:
+  baseConfig:
+    address: 0.0.0.0
+    authentication:
+      anonymous:
+        enabled: false
+      webhook:
+        cacheTTL: 2m0s
+        enabled: true
+      x509:
+        clientCAFile: /etc/kubernetes/pki/ca.crt
+    authorization:
+      mode: Webhook
+      webhook:
+        cacheAuthorizedTTL: 5m0s
+        cacheUnauthorizedTTL: 30s
+    cgroupDriver: cgroupfs
+    cgroupsPerQOS: true
+    clusterDNS:
+    - 10.96.0.10
+    clusterDomain: cluster.local
+    containerLogMaxFiles: 5
+    containerLogMaxSize: 10Mi
+    contentType: application/vnd.kubernetes.protobuf
+    cpuCFSQuota: true
+    cpuManagerPolicy: none
+    cpuManagerReconcilePeriod: 10s
+    enableControllerAttachDetach: true
+    enableDebuggingHandlers: true
+    enforceNodeAllocatable:
+    - pods
+    eventBurst: 10
+    eventRecordQPS: 5
+    evictionHard:
+      imagefs.available: 15%
+      memory.available: 100Mi
+      nodefs.available: 10%
+      nodefs.inodesFree: 5%
+    evictionPressureTransitionPeriod: 5m0s
+    failSwapOn: true
+    fileCheckFrequency: 20s
+    hairpinMode: promiscuous-bridge
+    healthzBindAddress: 127.0.0.1
+    healthzPort: 10248
+    httpCheckFrequency: 20s
+    imageGCHighThresholdPercent: 85
+    imageGCLowThresholdPercent: 80
+    imageMinimumGCAge: 2m0s
+    iptablesDropBit: 15
+    iptablesMasqueradeBit: 14
+    kubeAPIBurst: 10
+    kubeAPIQPS: 5
+    makeIPTablesUtilChains: true
+    maxOpenFiles: 1000000
+    maxPods: 110
+    nodeStatusUpdateFrequency: 10s
+    oomScoreAdj: -999
+    podPidsLimit: -1
+    port: 10250
+    registryBurst: 10
+    registryPullQPS: 5
+    resolvConf: /etc/resolv.conf
+    rotateCertificates: true
+    runtimeRequestTimeout: 2m0s
+    serializeImagePulls: true
+    staticPodPath: /etc/kubernetes/manifests
+    streamingConnectionIdleTimeout: 4h0m0s
+    syncFrequency: 1m0s
+    volumeStatsAggPeriod: 1m0s
 networking:
-  dnsDomain: <string>
-  serviceSubnet: <cidr>
-  podSubnet: <cidr>
-kubernetesVersion: <string>
-cloudProvider: <string>
-nodeName: <string>
-authorizationModes:
-- <authorizationMode1|string>
-- <authorizationMode2|string>
-token: <string>
-tokenTTL: <time duration>
-selfHosted: <bool>
-apiServerExtraArgs:
-  <argument>: <value|string>
-  <argument>: <value|string>
-controllerManagerExtraArgs:
-  <argument>: <value|string>
-  <argument>: <value|string>
-schedulerExtraArgs:
-  <argument>: <value|string>
-  <argument>: <value|string>
-apiServerExtraVolumes:
-- name: <value|string>
-  hostPath: <value|string>
-  mountPath: <value|string>
-  writable: <value|bool>
-  pathType: <value|string>
-controllerManagerExtraVolumes:
-- name: <value|string>
-  hostPath: <value|string>
-  mountPath: <value|string>
-  writable: <value|bool>
-  pathType: <value|string>
-schedulerExtraVolumes:
-- name: <value|string>
-  hostPath: <value|string>
-  mountPath: <value|string>
-  writable: <value|bool>
-  pathType: <value|string>
-apiServerCertSANs:
-- <name1|string>
-- <name2|string>
-certificatesDir: <string>
-imageRepository: <string>
-unifiedControlPlaneImage: <string>
-featureGates:
-  <feature>: <bool>
-  <feature>: <bool>
+  dnsDomain: cluster.local
+  podSubnet: ""
+  serviceSubnet: 10.96.0.0/12
+nodeRegistration:
+  criSocket: /var/run/dockershim.sock
+  name: your-host-name
+  taints:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+unifiedControlPlaneImage: ""
 ```
 
 ### Adding kube-proxy parameters {#kube-proxy}
@@ -195,7 +268,7 @@ For example, to add additional feature-gate arguments to the API server, your [c
 will need to look like this:
 
 ```
-apiVersion: kubeadm.k8s.io/v1alpha1
+apiVersion: kubeadm.k8s.io/v1alpha2
 kind: MasterConfiguration
 apiServerExtraArgs:
   feature-gates: APIResponseCompression=true


### PR DESCRIPTION
kubeadm-init: update the example for the MasterConfigration
- include godocs link for MasterConfiguration
- include example MasterConfiguration
- add note that `kubeadm config print-default` can be used

/assign @Bradamant3 
/assign @timothysc 
/cc @kubernetes/sig-cluster-lifecycle-pr-reviews 

Fixes kubernetes/kubeadm#892

/priority important-soon

this was decided in the kubeadm office hours meeting from 06.06.2018.
