### PR TITLE
Fix the toc of docs/tutorials/k8s201/

### DIFF
--- a/content/en/docs/tutorials/k8s201.md
+++ b/content/en/docs/tutorials/k8s201.md
@@ -5,6 +5,8 @@ reviewers:
 title: Kubernetes 201
 ---
 
+{{< toc >}}
+
 ## Labels, Deployments, Services and Health Checking
 
 If you went through [Kubernetes 101](/docs/tutorials/k8s1.1/), you learned about kubectl, Pods, Volumes, and multiple containers.
@@ -14,9 +16,6 @@ scaling.
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
 
 In order for the kubectl usage examples to work, make sure you have an examples directory locally, either from [a release](https://github.com/kubernetes/kubernetes/releases) or [the source](https://github.com/kubernetes/kubernetes).
-
-* TOC
-{{< toc >}}
 
 
 ## Labels


### PR DESCRIPTION
the toc of https://kubernetes.io/docs/tutorials/k8s201/  looks strange  now