### PR TITLE
Fix dead link to kube-dns README file

### DIFF
--- a/content/en/docs/tasks/administer-cluster/dns-debugging-resolution.md
+++ b/content/en/docs/tasks/administer-cluster/dns-debugging-resolution.md
@@ -188,7 +188,7 @@ for more details on Cluster Federation and multi-site support.
 ## References
 
 - [DNS for Services and Pods](/docs/concepts/services-networking/dns-pod-service/)
-- [Docs for the DNS cluster addon](http://releases.k8s.io/{{< param "githubbranch" >}}/cluster/addons/dns/README.md)
+- [Docs for the DNS cluster addon](http://releases.k8s.io/{{< param "githubbranch" >}}/cluster/addons/dns/kube-dns/README.md)
 
 ## What's next
 - [Autoscaling the DNS Service in a Cluster](/docs/tasks/administer-cluster/dns-horizontal-autoscaling/).


### PR DESCRIPTION
Link to the DNS cluster addon documentation currently points to a non-existing README file.

This PR fixes the link to the kube-dns README, since kube-dns is the DNS addon mentioned in the rest of the page (in contrast to coredns).
