### PR TITLE
Note on missing/incorrect labels and scheduler behaviour with pod anti-affinity

### DIFF
--- a/content/en/docs/concepts/configuration/assign-pod-node.md
+++ b/content/en/docs/concepts/configuration/assign-pod-node.md
@@ -168,6 +168,8 @@ in the section [Interlude: built-in node labels](#interlude-built-in-node-labels
 processing which can slow down scheduling in large clusters significantly. We do
 not recommend using them in clusters larger than several hundred nodes.
 
+**Note:** Pod anti-affinity requires nodes to be consistently labelled, i.e. every node in the cluster must have an appropriate label matching `topologyKey`. If some or all nodes are missing the speficied `topologyKey` label, it can lead to unintended behavior.
+
 As with node affinity, there are currently two types of pod affinity and anti-affinity, called `requiredDuringSchedulingIgnoredDuringExecution` and
 `preferredDuringSchedulingIgnoredDuringExecution` which denote "hard" vs. "soft" requirements.
 See the description in the node affinity section earlier.


### PR DESCRIPTION
As per discussion with @bsalamat and @misterikkit adding a note to the documentation on the current behaviour of kube-scheduler when pod anti-affinity is desired but the corresponding `topologyKey` (label on the node) is missing or misspelled.

Feedback from @bsalamat during our discussion on Slack:
> Your suggested improvement looks good to me

Feedback from @misterikkit during our discussion on Slack:
> - it doesn't make sense to warn against misspellings, I feel like that's implicit.
> - I don't think we should document this as "unintended" behavior because our official docs literally > state the intention.
> - I think we would also consider a patch to consider a node to be "in the same topology as itself" regardless of labels.

@misterikkit I think it's still a valid concern because it forces the user/cluster admin to validate the current deployments for misspellings (instead of just missing labels). Also, from my point of view, it's unintended behaviour of the scheduler. As you suggest for a patch, pod anti-affinity should never place two pods on the same host, i.e. consider itself in the same topology regardless of labels.

Let me know if I should change the PR or leave it as is. I'd rather be more explicit, pointing out conditions how this behaviour could occur.

Thank you.