### PR TITLE
Incorrect link to redis-pod.yaml in "Configuring Redis using a ConfigMap" tutorial

### DIFF
--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -95,7 +95,7 @@ You can follow the steps below to configure a Redis cache using data stored in a
 1. Create the pod:
 
    ```shell
-   kubectl create -f https://k8s.io/tutorials/configuration/configmap/redis/redis-pod.yaml
+   kubectl create -f https://k8s.io/docs/tutorials/configuration/configmap/redis/redis-pod.yaml
    ```
 
    In the example, the config volume is mounted at `/redis-master`.


### PR DESCRIPTION
Incorrect link to redis-pod.yaml in "Configuring Redis using a ConfigMap" tutorial
