### PR TITLE
Fix tocs and template in docs/home/contribute

### DIFF
--- a/content/en/docs/home/contribute/content-organization.md
+++ b/content/en/docs/home/contribute/content-organization.md
@@ -1,16 +1,19 @@
 ---
 title: Content Organization
 date: 2018-04-30
+content_template: templates/concept
 weight: 42
 ---
 
+{{< toc >}}
+
+{{% capture overview %}}
+
 This site uses Hugo. In Hugo, [content organization](https://gohugo.io/content-management/organization/) is a core concept.
 
-Also see:
+{{% /capture %}}
 
-* [Custom Hugo Shortcodes](/docs/home/contribute/includes)
-* [Style Guide](/docs/home/contribute/style-guide)
-
+{{% capture body %}}
 
 {{% note %}}
 **Hugo Tip:** Start Hugo with `hugo server --navigateToChanged` for content edit-sessions.
@@ -127,4 +130,13 @@ Some important notes to the files in the bundles:
 ## Styles
 
 The `SASS` source of the stylesheets for this site is stored below `src/sass` and can be built with `make sass` (note that Hugo will get `SASS` support soon, see https://github.com/gohugoio/hugo/issues/4243).
+
+{{% /capture %}}
+
+{{% capture whatsnext %}}
+
+* [Custom Hugo Shortcodes](/docs/home/contribute/includes)
+* [Style Guide](/docs/home/contribute/style-guide)
+
+{{% /capture %}}
 

--- a/content/en/docs/home/contribute/localization.md
+++ b/content/en/docs/home/contribute/localization.md
@@ -1,13 +1,22 @@
 ---
 title: Localizing Kubernetes Documentation
+content_template: templates/concept
 approvers:
 - chenopis
 - zacharysarah
 ---
 
+{{% capture overview %}}
+
 We're happy to add localizations (l10n) of Kubernetes documentation to the website!
 
 Localizations must meet the following requirements for _workflow_ (how to localize) and _output_ (what to localize).
+
+{{% /capture %}}
+
+{{< toc >}}
+
+{{% capture body %}}
 
 ## Workflow  
 
@@ -72,12 +81,18 @@ Home | [All heading and subheading URLs](https://kubernetes.io/docs/home/)
 Setup | [All heading and subheading URLs](https://kubernetes.io/docs/setup/)
 Tutorials | [Kubernetes Basics](https://kubernetes.io/docs/tutorials/), [Hello Minikube](https://kubernetes.io/docs/tutorials/stateless-application/hello-minikube/)
 
-## Next steps
+{{% /capture %}}
+
+{{% capture whatsnext %}}
 
 Once a l10n meets requirements for workflow and minimum output, SIG docs will:
-- Work with the localization team to implement language selection on the website
+
+- Work with the localization team to implement language selection on the website.
 - Publicize availability through [Cloud Native Computing Foundation](https://www.cncf.io/) (CNCF) channels.
 
 {{< note >}}
 **Note:** Implementation of language selection is pending Kubernetes' first completed localization project.
 {{< /note >}}
+
+
+{{% /capture %}}


### PR DESCRIPTION
These pages did not use any template and the displayed toc started
with two bullet points.

Fixes:
* Use the concept template everywhere and add capture markers.
* Rework content-organization.md to move the references to a "whatsnext"
  section.
* Fix in localization.md a misparsed list.

This follows #8995.
