### PR TITLE
Fix docs/tasks page TOC

### DIFF
--- a/content/en/docs/tasks/_index.md
+++ b/content/en/docs/tasks/_index.md
@@ -2,11 +2,20 @@
 title: Tasks
 main_menu: true
 weight: 50
+content_template: templates/concept
 ---
+
+{{< toc >}}
+
+{{% capture overview %}}
 
 This section of the Kubernetes documentation contains pages that
 show how to do individual tasks. A task page shows how to do a
 single thing, typically by giving a short sequence of steps.
+
+{{% /capture %}}
+
+{{% capture body %}}
 
 ## Web UI (Dashboard)
 
@@ -68,7 +77,11 @@ Configure and schedule NVIDIA GPUs for use as a resource by nodes in a cluster.
 
 Configure and schedule huge pages as a schedulable resource in a cluster.
 
-## What's next
+{{% /capture %}}
+
+{{% capture whatsnext %}}
 
 If you would like to write a task page, see
 [Creating a Documentation Pull Request](/docs/home/contribute/create-pull-request/).
+
+{{% /capture %}}


### PR DESCRIPTION
This pages did not use any template and the displayed toc started
with two bullet points. Use the concept template.
