### PR TITLE
Add optional 1.11+ step 

### DIFF
--- a/content/en/docs/setup/independent/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/independent/create-cluster-kubeadm.md
@@ -73,6 +73,8 @@ with the default gateway to advertise the master's IP. To use a different
 network interface, specify the `--apiserver-advertise-address=<ip-address>` argument 
 to `kubeadm init`. To deploy an IPv6 Kubernetes cluster using IPv6 addressing, you 
 must specify an IPv6 address, for example `--apiserver-advertise-address=fd00::101`
+1. (Optional) Run `kubeadm config images pull` prior to `kubeadm init` to verify 
+connectivity to gcr.io registries.   
 
 Now run:
 


### PR DESCRIPTION
Blocked by https://github.com/kubernetes/website/pull/8981 . 

Adds an explicit optional step for 1.11+ to bisect inbound issues and to outline a clear workflow option for new users. 

This does not need to make 1.11 and can be merged to master after https://github.com/kubernetes/website/pull/8981 is merged, this PR is rebased, and post 1.11 release.  

So no one needs to worry too much about this one, I know everyone is busy.   

xref: kubernetes/kubeadm#894 

/assign @Bradamant3  
