### PR TITLE
stepping away for a bit... removing myself from approver lists

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,7 +7,6 @@ reviewers:
 # auto-merge happen if a /lgtm exists, or vice versa, or they can do both
 # No need for approvers to also be listed as reviewers
 approvers:
-- heckj
 - bradamant3
 - bradtopol
 - steveperry-53

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -91,7 +91,6 @@ aliases:
     - steveperry-53
     - zacharysarah
     - bradtopol
-    - heckj
   sig-federation: #Team: Federation; e.g. Federated Clusters
     - csbell
   sig-gcp: #Google Cloud Platform; GH: sig-gcp-pr-reviews


### PR DESCRIPTION
My new gig is keeping me rather exceptionally busy, so in order to be a "good citizen", I'm removing my name from the files that automation uses to encourage folks for reviewers/approvers. I'm more than happy to lurk and will try and return to scribbling docs and doing good deeds as soon as I can... I want to be fair to committers too.