### PR TITLE
Example: Deploying PHP Guestbook application with Redis: Missing deployment labels

### DIFF
--- a/content/en/docs/tutorials/stateless-application/guestbook/frontend-deployment.yaml
+++ b/content/en/docs/tutorials/stateless-application/guestbook/frontend-deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
 kind: Deployment
 metadata:
   name: frontend
+  labels:
+    app: guestbook
 spec:
   selector:
     matchLabels:

--- a/content/en/docs/tutorials/stateless-application/guestbook/redis-master-deployment.yaml
+++ b/content/en/docs/tutorials/stateless-application/guestbook/redis-master-deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
 kind: Deployment
 metadata:
   name: redis-master
+  labels:
+    app: redis
 spec:
   selector:
     matchLabels:

--- a/content/en/docs/tutorials/stateless-application/guestbook/redis-slave-deployment.yaml
+++ b/content/en/docs/tutorials/stateless-application/guestbook/redis-slave-deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
 kind: Deployment
 metadata:
   name: redis-slave
+  labels:
+    app: redis
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
In the tutorial [Example: Deploying PHP Guestbook application with Redis](https://kubernetes.io/docs/tutorials/stateless-application/guestbook/), the [cleanup section](https://kubernetes.io/docs/tutorials/stateless-application/guestbook/#cleaning-up) tells the user to run the commands:

```
kubectl delete deployment -l app=redis
kubectl delete deployment -l app=guestbook
```

This however requires the deployments to have these labels set inside the deployment yaml files. The commands currently result in:  

> kubectl delete deployment -l app=redis
> No resources found




