### PR TITLE
[css] Remove bullet styling from "tab-nav" components.

### DIFF
--- a/content/en/docs/setup/independent/high-availability.md
+++ b/content/en/docs/setup/independent/high-availability.md
@@ -266,11 +266,7 @@ Please select one of the tabs to see installation instructions for the respectiv
 
 {{% /tab %}}
 {{% tab name="Static Pods" %}}
-**Note**: This is only supported on nodes that have the all dependencies for the
-kubelet installed. If you are hosting etcd on the master nodes, this has already
-been set up. If you are hosting etcd on dedicated nodes, you should either use
-systemd or run the [installation guide](/docs/setup/independent/install-kubeadm/)
-on each dedicated etcd machine.
+**Note**: This is only supported on nodes that have the all dependencies for the kubelet installed. If you are hosting etcd on the master nodes, this has already been set up. If you are hosting etcd on dedicated nodes, you should either use systemd or run the [installation guide](/docs/setup/independent/install-kubeadm/) on each dedicated etcd machine.
 
 Run the following to generate the manifest file:
 
@@ -287,22 +283,22 @@ Run the following to generate the manifest file:
       spec:
         containers:
         - command:
-          - etcd --name <name>
-          - --data-dir /var/lib/etcd
-          - --listen-client-urls http://localhost:2379
-          - --advertise-client-urls http://localhost:2379
-          - --listen-peer-urls http://localhost:2380
-          - --initial-advertise-peer-urls http://localhost:2380
-          - --cert-file=/certs/server.pem
-          - --key-file=/certs/server-key.pem
-          - --client-cert-auth
-          - --trusted-ca-file=/certs/ca.pem
-          - --peer-cert-file=/certs/peer.pem
-          - --peer-key-file=/certs/peer-key.pem
-          - --peer-client-cert-auth
-          - --peer-trusted-ca-file=/certs/ca.pem
-          - --initial-cluster etcd0=https://<etcd0-ip-address>:2380,etcd1=https://<etcd1-ip-address>:2380,etcd2=https://<etcd2-ip-address>:2380
-          - --initial-cluster-token my-etcd-token
+          - etcd --name <name> 
+          - --data-dir /var/lib/etcd 
+          - --listen-client-urls http://localhost:2379 
+          - --advertise-client-urls http://localhost:2379 
+          - --listen-peer-urls http://localhost:2380 
+          - --initial-advertise-peer-urls http://localhost:2380 
+          - --cert-file=/certs/server.pem 
+          - --key-file=/certs/server-key.pem 
+          - --client-cert-auth 
+          - --trusted-ca-file=/certs/ca.pem 
+          - --peer-cert-file=/certs/peer.pem 
+          - --peer-key-file=/certs/peer-key.pem 
+          - --peer-client-cert-auth 
+          - --peer-trusted-ca-file=/certs/ca.pem 
+          - --initial-cluster etcd0=https://<etcd0-ip-address>:2380,etcd1=https://<etcd1-ip-address>:2380,etcd2=https://<etcd2-ip-address>:2380 
+          - --initial-cluster-token my-etcd-token 
           - --initial-cluster-state new
           image: k8s.gcr.io/etcd-amd64:3.1.10
           livenessProbe:
@@ -345,7 +341,6 @@ Run the following to generate the manifest file:
 Make sure you replace:
 * `<name>` with the name of the node you're running on (e.g. `etcd0`, `etcd1` or `etcd2`)
 * `<etcd0-ip-address>`, `<etcd1-ip-address>` and `<etcd2-ip-address>` with the public IPv4s of the other machines that host etcd.
-
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -486,7 +481,7 @@ Ensure that the following placeholders are replaced:
 
 {{< note >}}**Note:** If you are using Kubernetes 1.9+, you can replace the `apiserver-count: 3` extra argument with `endpoint-reconciler-type: lease`. For more information, see [the documentation](/docs/admin/high-availability/#endpoint-reconciler).{{< /note >}}
 
-When this is done, run kubeadm:
+1.  When this is done, run kubeadm:
       ```bash
       kubeadm init --config=config.yaml
       ```

--- a/content/en/docs/setup/independent/high-availability.md
+++ b/content/en/docs/setup/independent/high-availability.md
@@ -266,7 +266,11 @@ Please select one of the tabs to see installation instructions for the respectiv
 
 {{% /tab %}}
 {{% tab name="Static Pods" %}}
-**Note**: This is only supported on nodes that have the all dependencies for the kubelet installed. If you are hosting etcd on the master nodes, this has already been set up. If you are hosting etcd on dedicated nodes, you should either use systemd or run the [installation guide](/docs/setup/independent/install-kubeadm/) on each dedicated etcd machine.
+**Note**: This is only supported on nodes that have the all dependencies for the
+kubelet installed. If you are hosting etcd on the master nodes, this has already
+been set up. If you are hosting etcd on dedicated nodes, you should either use
+systemd or run the [installation guide](/docs/setup/independent/install-kubeadm/)
+on each dedicated etcd machine.
 
 Run the following to generate the manifest file:
 
@@ -283,22 +287,22 @@ Run the following to generate the manifest file:
       spec:
         containers:
         - command:
-          - etcd --name <name> 
-          - --data-dir /var/lib/etcd 
-          - --listen-client-urls http://localhost:2379 
-          - --advertise-client-urls http://localhost:2379 
-          - --listen-peer-urls http://localhost:2380 
-          - --initial-advertise-peer-urls http://localhost:2380 
-          - --cert-file=/certs/server.pem 
-          - --key-file=/certs/server-key.pem 
-          - --client-cert-auth 
-          - --trusted-ca-file=/certs/ca.pem 
-          - --peer-cert-file=/certs/peer.pem 
-          - --peer-key-file=/certs/peer-key.pem 
-          - --peer-client-cert-auth 
-          - --peer-trusted-ca-file=/certs/ca.pem 
-          - --initial-cluster etcd0=https://<etcd0-ip-address>:2380,etcd1=https://<etcd1-ip-address>:2380,etcd2=https://<etcd2-ip-address>:2380 
-          - --initial-cluster-token my-etcd-token 
+          - etcd --name <name>
+          - --data-dir /var/lib/etcd
+          - --listen-client-urls http://localhost:2379
+          - --advertise-client-urls http://localhost:2379
+          - --listen-peer-urls http://localhost:2380
+          - --initial-advertise-peer-urls http://localhost:2380
+          - --cert-file=/certs/server.pem
+          - --key-file=/certs/server-key.pem
+          - --client-cert-auth
+          - --trusted-ca-file=/certs/ca.pem
+          - --peer-cert-file=/certs/peer.pem
+          - --peer-key-file=/certs/peer-key.pem
+          - --peer-client-cert-auth
+          - --peer-trusted-ca-file=/certs/ca.pem
+          - --initial-cluster etcd0=https://<etcd0-ip-address>:2380,etcd1=https://<etcd1-ip-address>:2380,etcd2=https://<etcd2-ip-address>:2380
+          - --initial-cluster-token my-etcd-token
           - --initial-cluster-state new
           image: k8s.gcr.io/etcd-amd64:3.1.10
           livenessProbe:
@@ -341,6 +345,7 @@ Run the following to generate the manifest file:
 Make sure you replace:
 * `<name>` with the name of the node you're running on (e.g. `etcd0`, `etcd1` or `etcd2`)
 * `<etcd0-ip-address>`, `<etcd1-ip-address>` and `<etcd2-ip-address>` with the public IPv4s of the other machines that host etcd.
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -481,7 +486,7 @@ Ensure that the following placeholders are replaced:
 
 {{< note >}}**Note:** If you are using Kubernetes 1.9+, you can replace the `apiserver-count: 3` extra argument with `endpoint-reconciler-type: lease`. For more information, see [the documentation](/docs/admin/high-availability/#endpoint-reconciler).{{< /note >}}
 
-1.  When this is done, run kubeadm:
+When this is done, run kubeadm:
       ```bash
       kubeadm init --config=config.yaml
       ```

--- a/src/sass/styles.sass
+++ b/src/sass/styles.sass
@@ -1,4 +1,3 @@
-
 @import "reset"
 @import "skin"
 
@@ -6,5 +5,3 @@
 @import "base"
 @import "tablet"
 @import "desktop"
-
-

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -440,8 +440,9 @@ dd { margin-bottom: 16px; }
 
 #docsContent li { margin-bottom: 0.75em; font-size: 16px; line-height: 1.75em; }
 
-/* No bullets for checklists */
-#docsContent ul.task-list>li { list-style-type: none !important; }
+/* No bullets for checklists or 'UI Nav' components. */
+#docsContent ul.task-list>li,
+#docsContent ul.ui-tabs-nav>li.ui-tabs-tab { list-style-type: none !important; }
 
 #docsContent table { width: 100%; border: 1px solid #ccc; border-spacing: 0; margin-top: 30px; margin-bottom: 30px; }
 


### PR DESCRIPTION
### What does this PR do?
Attempts to fix a code block being parsed as plain text; ~whatever markdown parser is being used~ Hugo's markdown processor, [blackfriday](https://github.com/russross/blackfriday/), seems to have pretty nondeterministic (or at least unintuitive) behavior around nested lists, code blocks, and combinations thereof (thanks markdown, if only there were [a spec or something](http://commonmark.org/); meaning e.g., the inline `yaml` in the script becomes a mess of bullet points... it looks [pretty yucky](http://jstu.art/sAjc):

![image](https://user-images.githubusercontent.com/583147/41221647-b727e0b6-6d32-11e8-8989-0fe74ddd1df9.png)

While I was in here, I fixed up a couple other issues as well. See comments below for details / screenshots.