### PR TITLE
add eg for stable level api overview

### DIFF
--- a/content/en/docs/concepts/overview/kubernetes-api.md
+++ b/content/en/docs/concepts/overview/kubernetes-api.md
@@ -80,7 +80,7 @@ in more detail in the [API Changes documentation](https://git.k8s.io/community/c
     multiple clusters which can be upgraded independently, you may be able to relax this restriction.
   - **Please do try our beta features and give feedback on them!  Once they exit beta, it may not be practical for us to make more changes.**
 - Stable level:
-  - The version name is `vX` where `X` is an integer.
+  - The version name is `vX` where `X` is an integer (e.g. `v1`).
   - Stable versions of features will appear in released software for many subsequent versions.
 
 ## API groups

--- a/content/en/docs/concepts/overview/kubernetes-api.md
+++ b/content/en/docs/concepts/overview/kubernetes-api.md
@@ -80,7 +80,7 @@ in more detail in the [API Changes documentation](https://git.k8s.io/community/c
     multiple clusters which can be upgraded independently, you may be able to relax this restriction.
   - **Please do try our beta features and give feedback on them!  Once they exit beta, it may not be practical for us to make more changes.**
 - Stable level:
-  - The version name is `vX` where `X` is an integer (e.g. `v1`).
+  - The version name is `vX` where `X` is an integer, for example, `v1`.
   - Stable versions of features will appear in released software for many subsequent versions.
 
 ## API groups


### PR DESCRIPTION
Adding an e.g. to the stable level API overview. 