### PR TITLE
Container > containers

### DIFF
--- a/content/en/docs/home/contribute/style-guide.md
+++ b/content/en/docs/home/contribute/style-guide.md
@@ -43,7 +43,7 @@ leads to an awkward construction.
 
 <table>
   <tr><th>Do</th><th>Don't</th></tr>
-  <tr><td>The Pod has two Containers.</td><td>The pod has two containers.</td></tr>
+  <tr><td>The Pod has two containers.</td><td>The pod has two containers.</td></tr>
   <tr><td>The Deployment is responsible for ...</td><td>The Deployment object is responsible for ...</td></tr>
   <tr><td>A PodList is a list of Pods.</td><td>A Pod List is a list of pods.</td></tr>
   <tr><td>The two ContainerPorts ...</td><td>The two ContainerPort objects ...</td></tr>


### PR DESCRIPTION
It is confusing to capitalize "container" because it isn't really a primitive or API object. Furthermore, this guideline doesn't appear to be closely followed. I propose that we don't advise writers to capitalize "container" when used on its own.