### PR TITLE
Use ClusterFirst dnsPolicy

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/init-containers.yaml
+++ b/content/en/docs/tasks/configure-pod-container/init-containers.yaml
@@ -23,7 +23,7 @@ spec:
     volumeMounts:
     - name: workdir
       mountPath: "/work-dir"
-  dnsPolicy: Default
+  dnsPolicy: ClusterFirst
   volumes:
   - name: workdir
     emptyDir: {}

--- a/content/en/docs/tasks/configure-pod-container/init-containers.yaml
+++ b/content/en/docs/tasks/configure-pod-container/init-containers.yaml
@@ -23,7 +23,6 @@ spec:
     volumeMounts:
     - name: workdir
       mountPath: "/work-dir"
-  dnsPolicy: ClusterFirst
   volumes:
   - name: workdir
     emptyDir: {}


### PR DESCRIPTION
Look docs here [https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/) the Default dnsPolicy will make external name unaccessible.

> NOTE: “Default” is not the default DNS policy. If dnsPolicy is not explicitly specified, then “ClusterFirst” is used.

Which "Default" is not default is REALLY confusing.