### PR TITLE
kubeadm-setup: add page about control plane flags

### DIFF
--- a/content/en/docs/setup/independent/control-plane-flags.md
+++ b/content/en/docs/setup/independent/control-plane-flags.md
@@ -1,0 +1,81 @@
+---
+reviewers:
+- sig-cluster-lifecycle
+title: Customizing control plane configuration with kubeadm
+content_template: templates/concept
+weight: 50
+---
+
+{{% capture overview %}}
+
+kubeadm’s configuration exposes the following fields that can be used to override the default flags passed to control plane components such as the APIServer, ControllerManager and Scheduler:
+
+- `APIServerExtraArgs`
+- `ControllerManagerExtraArgs`
+- `SchedulerExtraArgs`
+
+These fields consist of `key: value` pairs. To override a flag for a control plane component:
+
+1.  Add the appropriate field to your configuration.
+2.  Add the flags to override to the field.
+
+For more details on each field in the configuration you can navigate to our
+[API reference pages](https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm#MasterConfiguration).
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+## APIServer flags
+
+For details, see the [reference documentation for kube-apiserver](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/).
+
+Example usage:
+```yaml
+apiVersion: kubeadm.k8s.io/v1alpha2
+kind: MasterConfiguration
+kubernetesVersion: v1.11.0
+metadata:
+  name: 1.11-sample
+apiServerExtraArgs:
+  advertise-address: 192.168.0.103
+  anonymous-auth: false
+  enable-admission-plugins: AlwaysPullImages,DefaultStorageClass
+  audit-log-path: /home/johndoe/audit.log
+```
+
+## ControllerManager flags
+
+For details, see the [reference documentation for kube-controller-manager](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/).
+
+Example usage:
+```yaml
+apiVersion: kubeadm.k8s.io/v1alpha2
+kind: MasterConfiguration
+kubernetesVersion: v1.11.0
+metadata:
+  name: 1.11-sample
+controllerManagerExtraArgs:
+  cluster-signing-key-file: /home/johndoe/keys/ca.key
+  bind-address: 0.0.0.0
+  deployment-controller-sync-period: 50
+```
+
+## Scheduler flags
+
+For details, see the [reference documentation for kube-scheduler](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-scheduler/).
+
+Example usage:
+```yaml
+apiVersion: kubeadm.k8s.io/v1alpha2
+kind: MasterConfiguration
+kubernetesVersion: v1.11.0
+metadata:
+  name: 1.11-sample
+schedulerExtraArgs:
+  address: 0.0.0.0
+  config: /home/johndoe/schedconfig.yaml
+  kubeconfig: /home/johndoe/kubeconfig.yaml
+```
+
+{{% /capture %}}


### PR DESCRIPTION
This page adds instructions on how to use the kubeadm config
to pass flags to control plane components.

The provided examples are pretty basic. Later this can be expanded with
actual user stories.

Updates https://github.com/kubernetes/kubeadm/issues/849

/cc @fabriziopandini @luxas @timstclair @kubernetes/sig-cluster-lifecycle-pr-reviews  
/assign @Bradamant3 

notes:
- it's against the master branch as discussed on the kubeadm office hours from 13th June.
- i've ended up picking `setup/independent` as the location for this. 
- let me know of changes that i need to make - e.g. hugo formatting?
- this obviously has to be extended with actual user content but we plan to do that in time.

