### PR TITLE
Revert "fix max container back off cap (#8979)"

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/jobs-run-to-completion.md
+++ b/content/en/docs/concepts/workloads/controllers/jobs-run-to-completion.md
@@ -193,7 +193,7 @@ due to a logical error in configuration etc.
 To do so, set `.spec.backoffLimit` to specify the number of retries before
 considering a Job as failed. The back-off limit is set by default to 6. Failed
 Pods associated with the Job are recreated by the Job controller with an
-exponential back-off delay (10s, 20s, 40s ...) capped at five minutes. The
+exponential back-off delay (10s, 20s, 40s ...) capped at six minutes. The
 back-off count is reset if no new failed Pods appear before the Job's next
 status check.
 


### PR DESCRIPTION
This reverts commit 8f04c2e1ae1261308da4e662befd7d160999e302 introduced in https://github.com/kubernetes/website/pull/8979

/assign @mistyhacks 
/cc @ccding

