### PR TITLE
Update scratch.md

### DIFF
--- a/content/en/docs/setup/scratch.md
+++ b/content/en/docs/setup/scratch.md
@@ -258,7 +258,7 @@ The admin user (and any users) need:
 
   - a token or a password to identify them.
   - tokens are just long alphanumeric strings, 32 chars for example. See
-    - `TOKEN=$(dd if=/dev/urandom bs=128 count=1 2>/dev/null | base64 | tr -d "=+/" | dd bs=32 count=1 2>/dev/null)`
+    - `TOKEN=$(dd if=/dev/urandom bs=128 count=1 2>/dev/null | base64 | tr -d "=+/[:space:]" | dd bs=32 count=1 2>/dev/null)`
 
 Your tokens and passwords need to be stored in a file for the apiserver
 to read.  This guide uses `/var/lib/kube-apiserver/known_tokens.csv`.


### PR DESCRIPTION
`base64` generates 76-character chunks of text, delimited by a space character. the `=+/` characters are removed, so on the (uniformly random) offchance that 44 characters are removed, the last `dd` will read a whitespace, and the token will include a whitespace, which "usually" isn't defined as an "alphanumeric character." Removing the space character as well, would mean that 142 of the characters would have to be a `=+/[:space:]`, before the token becomes shorter.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
