### PR TITLE
Fix TableOfContents style

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -427,7 +427,7 @@ dd { margin-bottom: 16px; }
 #docsContent .includecode pre { margin: 0 !important; }
 
 /* These are being clobbered by line 37 and it is affecting <ul> nested inside <ol> */
-#docsContent ul>li { list-style: disc !important; }
+#docsContent ul>li>ul { list-style: disc !important; }
 
 #docsContent ol>li { list-style: decimal !important; }
 


### PR DESCRIPTION
Recently, I found table of contents always have an extra bullet.

`hugo` generates table of contents in following format:

```html
<ul>
  // first level
  <li>
    // second level
    <ul>
      <li>item1</li>
      <li>item2</li>
      <li>...</li> 
    </ul>
  </li>
  <li>
     ...
  </li> 
</ul>
```

But in website, I didn't find any page have more than one list in first level. So I suggest to hide bullets in first level.

With this change, TOC style will be same as before.

Now: https://kubernetes.io/docs/concepts/architecture/nodes/
Before: https://v1-10.docs.kubernetes.io/docs/concepts/architecture/nodes/
With this pr: https://deploy-preview-9082--kubernetes-io-master-staging.netlify.com/docs/concepts/architecture/nodes/