### PR TITLE
Add two new reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,6 +3,8 @@
 reviewers:
 - zhangxiaoyu-zidif
 - xiangpengzhao
+- stewart-yu
+- Rajakavitha1 
 # Approvers have all the ability of reviewers but their /approve makes
 # auto-merge happen if a /lgtm exists, or vice versa, or they can do both
 # No need for approvers to also be listed as reviewers


### PR DESCRIPTION
This PR adds two new reviewers to OWNERS:
- [stewart-yu](https://github.com/kubernetes/website/pulls?q=is%3Apr+author%3Astewart-yu+is%3Aclosed)
- [rajakavitha1](https://github.com/kubernetes/website/pulls?q=is%3Apr+is%3Aclosed+author%3ARajakavitha1)

Reviewers can `/lgtm` but not `/approve` PRs.
Prow automatically assigns reviewers based on entries in OWNERS.