### PR TITLE
include image-pull-policy=Never for kubectl run

### DIFF
--- a/content/en/docs/tutorials/hello-minikube.md
+++ b/content/en/docs/tutorials/hello-minikube.md
@@ -204,10 +204,12 @@ Pod and restarts the Pod's Container if it terminates. Deployments are the
 recommended way to manage the creation and scaling of Pods.
 
 Use the `kubectl run` command to create a Deployment that manages a Pod. The
-Pod runs a Container based on your `hello-node:v1` Docker image:
+Pod runs a Container based on your `hello-node:v1` Docker image. We set the 
+`--image-pull-policy=Never` flag to ensure that your local image is run rather
+than trying to pull a non-existent image from your docker registry:
 
 ```shell
-kubectl run hello-node --image=hello-node:v1 --port=8080
+kubectl run hello-node --image=hello-node:v1 --port=8080 --image-pull-policy=Never
 ```
 
 View the Deployment:

--- a/content/en/docs/tutorials/hello-minikube.md
+++ b/content/en/docs/tutorials/hello-minikube.md
@@ -204,9 +204,9 @@ Pod and restarts the Pod's Container if it terminates. Deployments are the
 recommended way to manage the creation and scaling of Pods.
 
 Use the `kubectl run` command to create a Deployment that manages a Pod. The
-Pod runs a Container based on your `hello-node:v1` Docker image. We set the 
-`--image-pull-policy=Never` flag to ensure that your local image is run rather
-than trying to pull a non-existent image from your docker registry:
+Pod runs a Container based on your `hello-node:v1` Docker image. Set the 
+`--image-pull-policy` flag to `Never` to always use the local image, rather than
+pulling it from your Docker registry (since you haven't pushed it there):
 
 ```shell
 kubectl run hello-node --image=hello-node:v1 --port=8080 --image-pull-policy=Never


### PR DESCRIPTION
default functionality for `kubectl run` sets `imagePullPolicy=Always`. This causes an error because the image is local to the machine, rather than in a docker registry.

This PR fixes the example docs by configuring the `imagePullPolicy=Never` and as such, allowing image to be loaded from local filesystem.