### PR TITLE
Remove redirect for /docs/admin/high-availability

### DIFF
--- a/content/en/docs/admin/multiple-zones.md
+++ b/content/en/docs/admin/multiple-zones.md
@@ -70,7 +70,7 @@ federation support).
 a single master node by default.  While services are highly
 available and can tolerate the loss of a zone, the control plane is
 located in a single zone.  Users that want a highly available control
-plane should follow the [high availability](/docs/admin/high-availability) instructions.
+plane should follow the [high availability](/docs/admin/high-availability/building/) instructions.
 
 * StatefulSet volume zone spreading when using dynamic provisioning is currently not compatible with
 pod affinity or anti-affinity policies.

--- a/content/en/docs/concepts/overview/components.md
+++ b/content/en/docs/concepts/overview/components.md
@@ -20,7 +20,7 @@ cluster (for example, scheduling), and detecting and responding to cluster event
 Master components can be run on any machine in the cluster. However,
 for simplicity, set up scripts typically start all master components on
 the same machine, and do not run user containers on this machine. See
-[Building High-Availability Clusters](/docs/admin/high-availability/) for an example multi-master-VM setup.
+[Building High-Availability Clusters](/docs/admin/high-availability/building/) for an example multi-master-VM setup.
 
 ### kube-apiserver
 

--- a/content/en/docs/getting-started-guides/ubuntu/scaling.md
+++ b/content/en/docs/getting-started-guides/ubuntu/scaling.md
@@ -29,7 +29,7 @@ To scale a master node up, simply execute:
     juju add-unit kubernetes-master
 
 This will add another master node to the control plane.
-See the [building high-availability clusters](/docs/admin/high-availability)
+See the [building high-availability clusters](/docs/admin/high-availability/building)
 section of the documentation for more information.
 
 ## Kubernetes workers

--- a/content/en/docs/reference/glossary/kube-apiserver.md
+++ b/content/en/docs/reference/glossary/kube-apiserver.md
@@ -15,5 +15,5 @@ tags:
 
 <!--more--> 
 
-It is designed to scale horizontally -- that is, it scales by deploying more instances. See [Building High-Availability Clusters](/docs/admin/high-availability/).
+It is designed to scale horizontally -- that is, it scales by deploying more instances. See [Building High-Availability Clusters](/docs/admin/high-availability/building/).
 

--- a/content/en/docs/setup/independent/high-availability.md
+++ b/content/en/docs/setup/independent/high-availability.md
@@ -477,9 +477,12 @@ Ensure that the following placeholders are replaced:
 - `<private-ip>` with the private IPv4 of the master server.
 - `<etcd0-ip>`, `<etcd1-ip>` and `<etcd2-ip>` with the IP addresses of your three etcd nodes
 - `<podCIDR>` with your Pod CIDR. Please read the [CNI network section](/docs/setup/independent/create-cluster-kubeadm/#pod-network) of the docs for more information. Some CNI providers do not require a value to be set.
-- `<virtual-ip>` with the virtual IP. Please read [setting up a master load balancer](/docs/setup/independent/high-availability/#set-up-master-load-balancer) section of the docs for more information.
+- `<virtual-ip>` with the virtual IP. Please read [setting up a master load balancer](/docs/setup/independent/high-availability/building/#set-up-master-load-balancer) section of the docs for more information.
 
-{{< note >}}**Note:** If you are using Kubernetes 1.9+, you can replace the `apiserver-count: 3` extra argument with `endpoint-reconciler-type: lease`. For more information, see [the documentation](/docs/admin/high-availability/#endpoint-reconciler).{{< /note >}}
+{{< note >}}
+**Note:** If you are using Kubernetes 1.9+, you can replace the `apiserver-count: 3` extra argument with `endpoint-reconciler-type: lease`.
+For more information, see [the documentation](/docs/admin/high-availability/building/#endpoint-reconciler).
+{{< /note >}}
 
 1.  When this is done, run kubeadm:
       ```bash

--- a/content/en/docs/tasks/access-kubernetes-api/migrate-third-party-resource.md
+++ b/content/en/docs/tasks/access-kubernetes-api/migrate-third-party-resource.md
@@ -102,7 +102,7 @@ you **on a best-effort basis**.
 
     The API server attempts to prevent TPR data for the resource from changing while it
     copies objects to the CRD, but it can't guarantee consistency in all cases, such as with
-    [multiple masters](/docs/admin/high-availability/).
+    [multiple masters](/docs/admin/high-availability/building/).
     Stopping clients, such as TPR-based custom controllers, helps to avoid inconsistencies in
     the copied data.
 

--- a/content/en/docs/tasks/debug-application-cluster/debug-cluster.md
+++ b/content/en/docs/tasks/debug-application-cluster/debug-cluster.md
@@ -92,7 +92,7 @@ Mitigations:
 - Action: Use IaaS providers reliable storage (e.g. GCE PD or AWS EBS volume) for VMs with apiserver+etcd
   - Mitigates: Apiserver backing storage lost
 
-- Action: Use (experimental) [high-availability](/docs/admin/high-availability) configuration
+- Action: Use (experimental) [high-availability](/docs/admin/high-availability/building/) configuration
   - Mitigates: Master VM shutdown or master components (scheduler, API server, controller-managing) crashing
     - Will tolerate one or more simultaneous node or component failures
   - Mitigates: Apiserver backing storage (i.e., etcd's data directory) lost

--- a/static/_redirects
+++ b/static/_redirects
@@ -30,7 +30,6 @@
 /docs/admin/garbage-collection/     /docs/concepts/cluster-administration/kubelet-garbage-collection/ 301
 /docs/admin/ha-master-gce/     /docs/tasks/administer-cluster/highly-available-master/ 301
 /docs/admin/ha-master-gce.md/     /docs/tasks/administer-cluster/highly-available-master/ 301
-/docs/admin/high-availability/      /docs/admin/high-availability/building/ 301
 /docs/admin/kubeadm-upgrade-1-7/     /docs/tasks/administer-cluster/upgrade-downgrade/kubeadm-upgrade-1-7/ 301
 /docs/admin/limitrange/     /docs/tasks/administer-cluster/cpu-memory-limit/ 301
 /docs/admin/limitrange/Limits/     /docs/tasks/administer-cluster/limit-storage-consumption/#limitrange-to-limit-requests-for-storage/ 301


### PR DESCRIPTION
The current redirect entry is causing problems to the
/docs/admin/high-availability page. All links to the artifacts
referenced are generating 404 due to this problem, e.g.
kubernetes/kubernetes#64736. This PR removes the problematic
redirection by explicitly directing the link to the
/docs/admin/high-availability/building/ path.

xref: kubernetes/kubernetes#64736

