### PR TITLE
Replacing the example IP address by something that could exists.

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/create-external-load-balancer.md
+++ b/content/en/docs/tasks/access-application-cluster/create-external-load-balancer.md
@@ -97,7 +97,7 @@ which should produce output like this:
     Selector:               app=example
     Type:                   LoadBalancer
     IP:                     10.67.252.103
-    LoadBalancer Ingress:   123.45.678.9
+    LoadBalancer Ingress:   123.45.67.89
     Port:                   <unnamed> 80/TCP
     NodePort:               <unnamed> 32445/TCP
     Endpoints:              10.64.0.4:80,10.64.1.5:80,10.64.2.4:80


### PR DESCRIPTION
The example `123.45.678.9` was an invalid IP address.
