### PR TITLE
Add Docker build capability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Credit to Julien Guyomard (https://github.com/jguyomard)
+
+FROM alpine:latest
+
+MAINTAINER Luc Perkins <lperkins@linuxfoundation.org>
+
+RUN apk add --no-cache \
+    curl \
+    git \
+    openssh-client \
+    rsync
+
+ARG HUGO_VERSION=
+
+RUN mkdir -p /usr/local/src && \
+    cd /usr/local/src && \
+    curl -L https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_linux-64bit.tar.gz | tar -xz && \
+    mv hugo /usr/local/bin/hugo && \
+    curl -L https://bin.equinox.io/c/dhgbqpS8Bvy/minify-stable-linux-amd64.tgz | tar -xz && \
+    mv minify /usr/local/bin && \
+    addgroup -Sg 1000 hugo && \
+    adduser -Sg hugo -u 1000 -h /src hugo
+
+WORKDIR /src
+
+EXPOSE 1313

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --no-cache \
     openssh-client \
     rsync
 
-ARG HUGO_VERSION=
+ARG HUGO_VERSION
 
 RUN mkdir -p /usr/local/src && \
     cd /usr/local/src && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-# Credit to Julien Guyomard (https://github.com/jguyomard)
+# Credit to Julien Guyomard (https://github.com/jguyomard). This Dockerfile
+# is essentially based on his Dockerfile at
+# https://github.com/jguyomard/docker-hugo/blob/master/Dockerfile. The only significant
+# change is that the Hugo version is now an overridable argument rather than a fixed
+# environment variable.
 
 FROM alpine:latest
 

--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,11 @@ build-preview: ## Build site with drafts and future posts enabled.
 serve: ## Boot the development server.
 	hugo server
 
-stage: ## This needs to be updated for Hugo
-	#docker run -ti --rm -v "${PWD}":/k8sdocs -p 4000:4000 gcr.io/google-samples/k8sdocs:1.1
-
 docker-image:
 	$(DOCKER) build . --tag $(DOCKER_IMAGE) --build-arg HUGO_VERSION=$(HUGO_VERSION)
 
 docker-build:
 	$(DOCKER_RUN) $(DOCKER_IMAGE) hugo
+
+stage:
+	$(DOCKER_RUN) -p 1313:1313 $(DOCKER_IMAGE) hugo server --watch --bind 0.0.0.0

--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,6 @@ docker-build:
 
 docker-serve:
 	$(DOCKER_RUN) -p 1313:1313 $(DOCKER_IMAGE) hugo server --watch --bind 0.0.0.0
+
+docker-serve-background:
+	$(DOCKER_RUN) -p 1313:1313 --detach $(DOCKER_IMAGE) hugo server --watch --bind 0.0.0.0

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+DOCKER       = docker
+HUGO_VERSION = 0.40.3
+DOCKER_IMAGE = kubernetes-hugo
+DOCKER_RUN   = $(DOCKER) run --rm --interactive --tty --volume $(PWD):/src
+
 .PHONY: all build sass build-preview help serve
 
 help: ## Show this help.
@@ -20,3 +25,12 @@ serve: ## Boot the development server.
 
 stage: ## This needs to be updated for Hugo
 	#docker run -ti --rm -v "${PWD}":/k8sdocs -p 4000:4000 gcr.io/google-samples/k8sdocs:1.1
+
+docker-image:
+	$(DOCKER) build . --tag $(DOCKER_IMAGE) --build-arg HUGO_VERSION=$(HUGO_VERSION)
+
+docker-build:
+	$(DOCKER_RUN) $(DOCKER_IMAGE) hugo
+
+docker-serve:
+	$(DOCKER_RUN) -p 1313:1313 $(DOCKER_IMAGE) hugo server --watch --bind 0.0.0.0

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,3 @@ docker-image:
 
 docker-build:
 	$(DOCKER_RUN) $(DOCKER_IMAGE) hugo
-
-docker-serve:
-	$(DOCKER_RUN) -p 1313:1313 $(DOCKER_IMAGE) hugo server --watch --bind 0.0.0.0
-
-docker-serve-background:
-	$(DOCKER_RUN) -p 1313:1313 --detach $(DOCKER_IMAGE) hugo server --watch --bind 0.0.0.0

--- a/README.md
+++ b/README.md
@@ -16,6 +16,37 @@ For more information about contributing to the Kubernetes documentation, see:
 * [Using Page Templates](http://kubernetes.io/docs/home/contribute/page-templates/)
 * [Documentation Style Guide](http://kubernetes.io/docs/home/contribute/style-guide/)
 
+## Building the site using Docker
+
+If you'd like, you can build the Kubernetes docs using Docker. To get started, build the image locally:
+
+```bash
+$ make docker-image
+
+# The underlying command:
+$ docker build . \
+  --tag kubernetes-hugo \
+  --build-arg HUGO_VERSION=0.40.3
+```
+
+You can create an image for a different version of Hugo by changing the value of the `HUGO_VERSION` argument for the build. You *must* specify a version or the image will not build.
+Once the `kubernetes-hugo` image has been built locally, you can build the site:
+
+```bash
+$ make docker-serve
+
+# The underlying command:
+$ docker run \
+  --rm \
+  --interactive \
+  --tty \
+  --volume $(PWD):/src \
+  kubernetes-hugo:latest \
+  hugo
+```
+
+As when building without using a Docker container, the results of the build will be published to the `public` directory (the default output directory for [Hugo](https://gohugo.io), the static site generator used to build this site).
+
 ## Thank you!
 
 Kubernetes thrives on community participation, and we really appreciate your


### PR DESCRIPTION
When the Kubernetes docs were built using Jekyll, there was an option to build the site using Docker (obviating the need to install anything locally). This PR adds a similar capability for the new Hugo-based site, as well as instructions.

With this setup, Docker images can be built that correspond to the desired Hugo version. At the moment this setup does *not* allow for publishing official images to Docker Hub or elsewhere but that could be easily added later.