### PR TITLE
Add Google Customer Survey code

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -40,3 +40,4 @@ crossorigin="anonymous"></script>
 <script src="{{ "js/custom-jekyll/tags.js" | relURL }}"></script>
 {{ with .Params.js }}{{ range (split . ",") }}<script src="{{ (trim . " ") | relURL }}"></script><!-- custom js added -->
 {{ end }}{{ else }}<!-- no custom js detected -->{{ end }}
+<script async="" defer="" src="//survey.g.doubleclick.net/async_survey?site=6ip6epxiqjqn4qgzemchgtfziy"></script>


### PR DESCRIPTION
This PR adds survey functionality to gather site user satisfaction data.

This will be turned off by default but allows us to schedule and run custom user feedback surveys via https://www.google.com/analytics/surveys/#?modal_active=none 

Example:
![screen shot 2018-06-19 at 2 19 39 pm](https://user-images.githubusercontent.com/24798125/41624895-e28558c0-73cb-11e8-82e0-fcab06c47535.png)
