### PR TITLE
Trivial markdown fix regarding the headers

### DIFF
--- a/content/en/docs/tasks/run-application/configure-pdb.md
+++ b/content/en/docs/tasks/run-application/configure-pdb.md
@@ -163,13 +163,13 @@ For example, if the above `zk-pdb` object selects the pods of a StatefulSet of s
 specifications have the exact same meaning. The use of `maxUnavailable` is recommended as it
 automatically responds to changes in the number of replicas of the corresponding controller.
 
-# Create the PDB object
+## Create the PDB object
 
 You can create the PDB object with a command like `kubectl create -f mypdb.yaml`.
 
 You cannot update PDB objects.  They must be deleted and re-created.
 
-# Check the status of the PDB
+## Check the status of the PDB
 
 Use kubectl to check that your PDB is created.
 
@@ -213,7 +213,7 @@ status:
   observedGeneration: 1
 ```
 
-# Arbitrary Controllers and Selectors
+## Arbitrary Controllers and Selectors
 
 You can skip this section if you only use PDBs with the built-in
 application controllers (Deployment, ReplicationController, ReplicaSet, and StatefulSet),


### PR DESCRIPTION
I noticed that the three last headers were missing from the index, so I inspected the markdown and realized that they had only one hashtag (#) as compared to two (##) as all the other headers had. So I simply made those three topics follow the same pattern I observed the other did.
