### PR TITLE
Update run-single-instance-stateful-application.md

### DIFF
--- a/content/en/docs/tasks/run-application/run-single-instance-stateful-application.md
+++ b/content/en/docs/tasks/run-application/run-single-instance-stateful-application.md
@@ -114,7 +114,7 @@ for a secure solution.
         Namespace:    default
         StorageClass:
         Status:       Bound
-        Volume:       mysql-pv
+        Volume:       mysql-pv-volume
         Labels:       <none>
         Annotations:    pv.kubernetes.io/bind-completed=yes
                         pv.kubernetes.io/bound-by-controller=yes


### PR DESCRIPTION
After deploying the PV and PVC via the YAML file, run `kubectl describe pvc mysql-pv-claim` should show `mysql-pv-volume` as the `Volume`, instead of `mysql-pv`.

A simple docs update.