### PR TITLE
Do not index other branches or subdomains

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,7 @@
 [build]
+# This default build command adds the robots noindex directive to the site headers
 publish = "public"
-command = "hugo"
+command = "hugo && cp netlify_noindex_headers.txt public/_headers"
 
 [context.production.environment]
 HUGO_BASEURL = "https://kubernetes.io/"
@@ -20,3 +21,7 @@ command = "hugo -b $DEPLOY_PRIME_URL"
 [context.branch-deploy.environment]
 HUGO_VERSION = "0.40.3"
 
+[context.master]
+# This context is triggered by the master branch and allows search indexing 
+publish = "public"
+command = "hugo"


### PR DESCRIPTION
**TL;DR:** Only the main site which serves out the `master` branch will be indexed by Google Search.

This PR modifies the `netlify.toml` file so that the default build command copies `netlify_noindex_headers.txt` into `public/_headers`, which adds the `X-Robots-Tag: noindex` directive in the HTTP headers for the site. However, the main site serving out the `master` branch triggers a different context, `[context.master]`, which builds the site without adding that directive.

Tested on https://k8sio-noindex.netlify.com/docs/home/
![screen shot 2018-06-19 at 1 55 58 pm](https://user-images.githubusercontent.com/24798125/41623945-2779e854-73c9-11e8-9783-93bbe5ef33e2.png)
