### PR TITLE
kubeadm: add version note in implementation-details.md

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/implementation-details.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/implementation-details.md
@@ -8,6 +8,9 @@ content_template: templates/concept
 weight: 100
 ---
 {{% capture overview %}}
+
+{{< feature-state for_k8s_version="v1.10" state="stable" >}}
+
 `kubeadm init` and `kubeadm join` together provides a nice user experience for creating a best-practice but bare Kubernetes cluster from scratch.
 However, it might not be obvious _how_ kubeadm does that.
 


### PR DESCRIPTION
implementation-details.md is outdated for k8s 1.11.
Add note that this page applies to k8s 1.10.

The page should be updated for k8s 1.11 in a later stage
in the release cycle.

refs https://github.com/kubernetes/kubeadm/issues/900

/assign @Bradamant3 
/cc @kubernetes/sig-cluster-lifecycle-pr-reviews @luxas @timothysc 
