### PR TITLE
fix github links due to /content/en move

### DIFF
--- a/content/en/docs/concepts/configuration/assign-pod-node.md
+++ b/content/en/docs/concepts/configuration/assign-pod-node.md
@@ -22,7 +22,7 @@ that a pod ends up on a machine with an SSD attached to it, or to co-locate pods
 services that communicate a lot into the same availability zone.
 
 You can find all the files for these examples [in our docs
-repo here](https://github.com/kubernetes/website/tree/{{< param "docsbranch" >}}/docs/concepts/configuration/).
+repo here](https://github.com/kubernetes/website/tree/{{< param "docsbranch" >}}/content/en/docs/concepts/configuration/).
 
 {{% /capture %}}
 

--- a/content/en/docs/home/contribute/generated-reference/federation-api.md
+++ b/content/en/docs/home/contribute/generated-reference/federation-api.md
@@ -67,7 +67,7 @@ image to generate this set of reference docs:
 * /docs/api-reference/v1/definitions.html
 
 The generated files do not get published automatically. They have to be manually copied to the
-[kubernetes/website](https://github.com/kubernetes/website/tree/master/docs/reference/generated)
+[kubernetes/website](https://github.com/kubernetes/website/tree/master/content/en/docs/reference/generated)
 repository.
 
 These files are published at


### PR DESCRIPTION
Minor link updates due to Hugo migration, which moved docs into `/content/en`.