### PR TITLE
Fix rendering of example federated service DNS name

### DIFF
--- a/content/en/docs/tasks/federation/federation-service-discovery.md
+++ b/content/en/docs/tasks/federation/federation-service-discovery.md
@@ -257,12 +257,13 @@ With the introduction of Federated Services and Cross-Cluster Service
 Discovery, this concept is extended to cover Kubernetes services
 running in any other cluster across your Cluster Federation, globally.
 To take advantage of this extended range, you use a slightly different
-DNS name (of the form "<servicename>.<namespace>.<federationname>",
-e.g. myservice.mynamespace.myfederation) to resolve Federated
-Services. Using a different DNS name also avoids having your existing
-applications accidentally traversing cross-zone or cross-region
-networks and you incurring perhaps unwanted network charges or
-latency, without you explicitly opting in to this behavior.
+DNS name of the form ```"<servicename>.<namespace>.<federationname>"```
+to resolve Federated Services. For example, you might use
+`myservice.mynamespace.myfederation`. Using a different DNS name also
+avoids having your existing applications accidentally traversing
+cross-zone or cross-region networks and you incurring perhaps unwanted
+network charges or latency, without you explicitly opting in to this
+behavior.
 
 So, using our NGINX example service above, and the Federated Service
 DNS name form just described, let's consider an example: A Pod in a


### PR DESCRIPTION
Fixes the bad rendering shown below from https://kubernetes.io/docs/tasks/federation/#from-pods-inside-your-federated-clusters

<img width="661" alt="screen shot 2018-06-19 at 10 41 14 pm" src="https://user-images.githubusercontent.com/7085343/41636082-04eec2fc-7412-11e8-9ea8-4cfb9bf95d69.png">