### PR TITLE
Update advice on pinning output version of 'kubectl get'

### DIFF
--- a/content/en/docs/reference/kubectl/conventions.md
+++ b/content/en/docs/reference/kubectl/conventions.md
@@ -12,7 +12,7 @@ reviewers:
 For a stable output in a script:
 
 * Request one of the machine-oriented output forms, such as `-o name`, `-o json`, `-o yaml`, `-o go-template`, or `-o jsonpath`
-* Fully-qualify the version. For example, jobs.v1.batch/myjob. This will ensure that kubectl does not use its default version that can change over time.
+* Fully-qualify the version. For example, `jobs.v1.batch/myjob`. This will ensure that kubectl does not use its default version that can change over time.
 * Specify `--generator` to pin to a specific behavior forever when you use generator-based commands such as `kubectl run` or `kubectl expose`
 * Don't rely on context, preferences, or other implicit states.
 

--- a/content/en/docs/reference/kubectl/conventions.md
+++ b/content/en/docs/reference/kubectl/conventions.md
@@ -12,7 +12,7 @@ reviewers:
 For a stable output in a script:
 
 * Request one of the machine-oriented output forms, such as `-o name`, `-o json`, `-o yaml`, `-o go-template`, or `-o jsonpath`
-* Specify `--output-version`, because the output forms use a particular API version to output the resource with the exception of `-o name` output form
+* Fully-qualify the version. For example, jobs.v1.batch/myjob. This will ensure that kubectl does not use its default version that can change over time.
 * Specify `--generator` to pin to a specific behavior forever when you use generator-based commands such as `kubectl run` or `kubectl expose`
 * Don't rely on context, preferences, or other implicit states.
 


### PR DESCRIPTION
`--output-version` is deprecated.
Advice paraphrased from https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#get
