### PR TITLE
[Proposal] Update a command to run correctly for a reader

### DIFF
--- a/content/en/docs/tasks/job/automated-tasks-with-cron-jobs.md
+++ b/content/en/docs/tasks/job/automated-tasks-with-cron-jobs.md
@@ -93,7 +93,7 @@ Note that the job name and pod name are different.
 
 ```shell
 # Replace "hello-4111706356" with the job name in your system
-$ pods=$(kubectl get pods --selector=job-name=hello-4111706356 --output=jsonpath={.items..metadata.name})
+$ pods=$(kubectl get pods --show-all --selector=job-name=hello-4111706356 --output=jsonpath={.items..metadata.name})
 
 $ echo $pods
 hello-4111706356-o9qcm


### PR DESCRIPTION
# Issue
The command of jobs does not run correctly if its job already finished.
Some readers may confuse that they can't succeed to run a command to follow this tutorial.
So, we should add `--show-all` option to show pods that may be completed.

# The log to show that we need to add an --show-all option
```
$ kubectl get jobs
NAME               DESIRED   SUCCESSFUL   AGE
busybox            1         0            27d
hello-1529501040   1         1            2m
hello-1529501100   1         1            1m
hello-1529501160   1         1            43s
$ kubectl get pods --selector=job-name=hello-1529501160
No resources found, use --show-all to see completed objects.
$ kubectl get pods --show-all --selector=job-name=hello-1529501160
NAME                     READY     STATUS      RESTARTS   AGE
hello-1529501160-dckjv   0/1       Completed   0          1m
```

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.11 Features: set Milestone to 1.11 and Base Branch to release-1.11
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
