### PR TITLE
Fix double hyphens for minikube installation

### DIFF
--- a/docs/tasks/tools/install-minikube.md
+++ b/docs/tasks/tools/install-minikube.md
@@ -29,7 +29,7 @@ If you do not already have a hypervisor installed, install one now.
 [VirtualBox](https://www.virtualbox.org/wiki/Downloads) or
 [KVM](http://www.linux-kvm.org/).
 
-   **Note:** Minikube also supports a `--vm-driver=none` option that runs the Kubernetes components on the host and not in a VM.  Docker is required to use this driver but a hypervisor is not required.
+   **Note:** Minikube also supports a `-\-vm-driver=none` option that runs the Kubernetes components on the host and not in a VM.  Docker is required to use this driver but a hypervisor is not required.
   {: .note}
 
 * For Windows, install


### PR DESCRIPTION
Signed-off-by: chandan kumar <chandan.kr404@gmail.com>

Fix the double hyphens issue inside minikube installation docs
https://kubernetes.io/docs/tasks/tools/install-minikube/

Issue: #9163 