### PR TITLE
Add new field selectors doc

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/field-selectors.md
+++ b/content/en/docs/concepts/overview/working-with-objects/field-selectors.md
@@ -3,13 +3,13 @@ title: Field Selectors
 weight: 60
 ---
 
-_Field selectors_ enable you to [select Kubernetes resources](/docs/concepts/overview/working-with-objects/kubernetes-objects) on the basis of the value of one or more resource fields. Here are some example field selector queries:
+_Field selectors_ let you [select Kubernetes resources](/docs/concepts/overview/working-with-objects/kubernetes-objects) based on the value of one or more resource fields. Here are some example field selector queries:
 
 * `metadata.name=my-service`
 * `metadata.namespace!=default`
 * `status.phase=Pending`
 
-This `kubectl` command, for example, would select all Pods for which the value of the [`status.phase`](/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase) field is `Running`:
+This `kubectl` command selects all Pods for which the value of the [`status.phase`](/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase) field is `Running`:
 
 ```shell
 $ kubectl get pods --field-selector status.phase=Running
@@ -26,7 +26,7 @@ $ kubectl get pods --field-selector ""
 
 ## Supported fields
 
-Which fields can be used with field selectors varies by Kubernetes resource type. *All* resource types do, however, support the `metadata.name` and `metadata.namespace` fields. If you attempt to use field selectors on a field that isn't supported for that resource, you will receive an error. Here's an example:
+Supported field selectors vary by Kubernetes resource type. All resource types support the `metadata.name` and `metadata.namespace` fields. Using unsupported field selectors produces an error. For example:
 
 ```shell
 $ kubectl get ingress --field-selector foo.bar=baz
@@ -35,19 +35,15 @@ Error from server (BadRequest): Unable to find "ingresses" that match label sele
 
 ## Supported operators
 
-The `!=` field selector operator is supported in addition to `=` (used in the example directly above). This `kubectl` command, for example, would select all Kubernetes Services that are not in the `default` namespace:
+You can use the `!=` and `=` operators with field selectors. This `kubectl` command, for example, selects all Kubernetes Services that aren't in the `default` namespace:
 
 ```shell
 $ kubectl get services --field-selector metadata.namespace!=default
 ```
 
-{{< warning >}}
-Please note that *only* the `=` and `!=` operators are supported as field selector operators. [Label selector](/docs/concepts/overview/working-with-objects/labels) syntax should *not* be taken as a general guide to field selector syntax. If you require more complex queries involving selectors like [`in` or `notin`](/docs/concepts/overview/working-with-objects/labels#set-based-requirement), you may be better served by label selectors.
-{{< /warning >}}
-
 ## Chained selectors
 
-As with [label](/docs/concepts/overview/working-with-objects/labels) and other selectors, field selectors can be chained together as a comma-separated list. This `kubectl` command would select all Pods for which the `status.phase` does not equal `Running` *and* the `spec.restartPolicy` field equals `Always`:
+As with [label](/docs/concepts/overview/working-with-objects/labels) and other selectors, field selectors can be chained together as a comma-separated list. This `kubectl` command selects all Pods for which the `status.phase` does not equal `Running` and the `spec.restartPolicy` field equals `Always`:
 
 ```shell
 $ kubectl get pods --field-selector=status.phase!=Running,spec.restartPolicy=Always
@@ -55,7 +51,7 @@ $ kubectl get pods --field-selector=status.phase!=Running,spec.restartPolicy=Alw
 
 ## Multiple resource types
 
-Field selectors can be used to select across multiple resource types. This `kubectl` command would select all Statefulsets *and* Services that are not in the `default` namespace:
+You use field selectors across multiple resource types. This `kubectl` command selects all Statefulsets and Services that are not in the `default` namespace:
 
 ```shell
 $ kubectl get statefulsets,services --field-selector metadata.namespace!=default

--- a/content/en/docs/concepts/overview/working-with-objects/field-selectors.md
+++ b/content/en/docs/concepts/overview/working-with-objects/field-selectors.md
@@ -35,7 +35,7 @@ Error from server (BadRequest): Unable to find "ingresses" that match label sele
 
 ## Supported operators
 
-You can use the `!=` and `=` operators with field selectors. This `kubectl` command, for example, selects all Kubernetes Services that aren't in the `default` namespace:
+You can use the `=`, `==`, and `!=` operators with field selectors (`=` and `==` mean the same thing). This `kubectl` command, for example, selects all Kubernetes Services that aren't in the `default` namespace:
 
 ```shell
 $ kubectl get services --field-selector metadata.namespace!=default

--- a/content/en/docs/concepts/overview/working-with-objects/field-selectors.md
+++ b/content/en/docs/concepts/overview/working-with-objects/field-selectors.md
@@ -1,0 +1,62 @@
+---
+title: Field Selectors
+weight: 60
+---
+
+_Field selectors_ enable you to [select Kubernetes resources](/docs/concepts/overview/working-with-objects/kubernetes-objects) on the basis of the value of one or more resource fields. Here are some example field selector queries:
+
+* `metadata.name=my-service`
+* `metadata.namespace!=default`
+* `status.phase=Pending`
+
+This `kubectl` command, for example, would select all Pods for which the value of the [`status.phase`](/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase) field is `Running`:
+
+```shell
+$ kubectl get pods --field-selector status.phase=Running
+```
+
+{{< note >}}
+Field selectors are essentially resource *filters*. By default, no selectors/filters are applied, meaning that all resources of the specified type are selected. This makes the following `kubectl` queries equivalent:
+
+```shell
+$ kubectl get pods
+$ kubectl get pods --field-selector ""
+```
+{{< /note >}}
+
+## Supported fields
+
+Which fields can be used with field selectors varies by Kubernetes resource type. *All* resource types do, however, support the `metadata.name` and `metadata.namespace` fields. If you attempt to use field selectors on a field that isn't supported for that resource, you will receive an error. Here's an example:
+
+```shell
+$ kubectl get ingress --field-selector foo.bar=baz
+Error from server (BadRequest): Unable to find "ingresses" that match label selector "", field selector "foo.bar=baz": "foo.bar" is not a known field selector: only "metadata.name", "metadata.namespace"
+```
+
+## Supported operators
+
+The `!=` field selector operator is supported in addition to `=` (used in the example directly above). This `kubectl` command, for example, would select all Kubernetes Services that are not in the `default` namespace:
+
+```shell
+$ kubectl get services --field-selector metadata.namespace!=default
+```
+
+{{< warning >}}
+Please note that *only* the `=` and `!=` operators are supported as field selector operators. [Label selector](/docs/concepts/overview/working-with-objects/labels) syntax should *not* be taken as a general guide to field selector syntax. If you require more complex queries involving selectors like [`in` or `notin`](/docs/concepts/overview/working-with-objects/labels#set-based-requirement), you may be better served by label selectors.
+{{< /warning >}}
+
+## Chained selectors
+
+As with [label](/docs/concepts/overview/working-with-objects/labels) and other selectors, field selectors can be chained together as a comma-separated list. This `kubectl` command would select all Pods for which the `status.phase` does not equal `Running` *and* the `spec.restartPolicy` field equals `Always`:
+
+```shell
+$ kubectl get pods --field-selector=status.phase!=Running,spec.restartPolicy=Always
+```
+
+## Multiple resource types
+
+Field selectors can be used to select across multiple resource types. This `kubectl` command would select all Statefulsets *and* Services that are not in the `default` namespace:
+
+```shell
+$ kubectl get statefulsets,services --field-selector metadata.namespace!=default
+```


### PR DESCRIPTION
This PR addresses issue #8645 by adding documentation for kubectl field selectors, which are currently mentioned only in passing in the existing documentation.