### PR TITLE
Fix the double hyphen inside minikube docs

### DIFF
--- a/content/en/docs/tasks/tools/install-minikube.md
+++ b/content/en/docs/tasks/tools/install-minikube.md
@@ -32,7 +32,7 @@ If you do not already have a hypervisor installed, install one now.
 [KVM](http://www.linux-kvm.org/).
 
   {{< note >}}
-   **Note:** Minikube also supports a `--vm-driver=none` option that runs the Kubernetes components on the host and not in a VM.  Docker is required to use this driver but a hypervisor is not required.
+   **Note:** Minikube also supports a `-\-vm-driver=none` option that runs the Kubernetes components on the host and not in a VM.  Docker is required to use this driver but a hypervisor is not required.
   {{< /note >}}
 
 * For Windows, install


### PR DESCRIPTION
Signed-off-by: chandan kumar <chandan.kr404@gmail.com>

Fix the `double hyphen` issue inside the `minikube installation docs`
- Add one `Backslash` between the two `hyphens`

Affect on :- https://kubernetes.io/docs/tasks/tools/install-minikube/

Issue: #9163 