### PR TITLE
Updated Fedora guides to use kubeadm and kube 1.10

### DIFF
--- a/content/en/docs/getting-started-guides/fedora/OWNERS
+++ b/content/en/docs/getting-started-guides/fedora/OWNERS
@@ -1,5 +1,3 @@
 reviewers:
-- aveshagarwal
-- eparis
-- thockin
+- chrisnegus
 

--- a/content/en/docs/getting-started-guides/fedora/fedora_manual_config.md
+++ b/content/en/docs/getting-started-guides/fedora/fedora_manual_config.md
@@ -1,184 +1,232 @@
 ---
 reviewers:
-- aveshagarwal
-- eparis
-- thockin
-title: Fedora (Single Node)
+- chrisnegus
+title: Kubernetes on Fedora (Single Node)
 ---
 
-{{< toc >}}
+* TOC
+{:toc}
+
+To try out Kubernetes on Fedora, you have a few choices:
+
+* **kubeadm** - The kubeadm command provides a toolkit to bootstrap a Kubernetes cluster that is reasonable secure, extensible, and upgradable. See this document for details on using kubeadm with flannel networking to set up Kubernetes in Fedora (either as a single-node or multi-node configuration).
+* **minikube** - With minikube, you run a single-node Kubernetes cluster in a virtual machine on your laptop or desktop system. See [Running Kubernetes Locally via Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) for details. See [Alternative Container Runtimes](https://kubernetes.io/docs/getting-started-guides/minikube/#alternative-container-runtimes) to replace Docker with CRI-O or rkt runtimes for minikube.
+
+OpenShift implementations of Kubernetes are also available with Fedora:
+
+* **minishift** - Like minikube, **minishift** runs a virtual machine to start up a single-node Kubernetes cluster. With minishift, however, OpenShift is the platform set up to manage Kubernetes. Use instructions from [Installing Minishift](https://docs.openshift.org/latest/minishift/getting-started/installing.html), being sure to set up the [KVM driver](https://docs.openshift.org/latest/minishift/getting-started/setting-up-driver-plugin.html#kvm-driver-fedora) before starting minishift.
+
+* **oc cluster up** - A quick way to directly set up an OpenShift cluster on Fedora is to install a few required packages, then run **oc cluster up**, as described in [Start a local OpenShift all-in-one cluster](https://developer.fedoraproject.org/deployment/openshift/about.html).
+
+* **openshift-ansible** - Use ansible playbooks to set up OpenShift in a single-node cluster directly on a Fedora system. Ansible playbooks for running OpenShift are available from the [Kubespray](https://github.com/kubernetes-incubator/kubespray) Github site.
+
+The description here for running Kubernetes using kubeadm has been tested on Fedora and Fedora Atomic distributions. The resulting Kubernetes configuration has these attributes:
+
+* Tested on Fedora 28 Server and Fedora 28 Atomic Host Workstation
+* Single node Kubernetes cluster (continue to Kubernetes Multi-node Setup to add nodes)
+* Flannel networking
+* Pod address range of 10.244.0.0/16
+* For the single-node setup, master and node are on a single system, so the master is allowed to run pods
+
 
 ## Prerequisites
 
-1. You need 2 or more machines with Fedora installed. These can be either bare metal machines or virtual machines.
+Get and set up the latest Fedora or Fedora Atomic on any cloud, virtualization, or bare metal environment. To do that, you can obtain appropriate media and instructions for: 
 
-## Instructions
+* [Fedora Server Download](https://getfedora.org/en/server/download/) or
+* [Fedora Atomic Host Workstation Download](https://getfedora.org/en/workstation/download/)
 
-This is a getting started guide for Fedora.  It is a manual configuration so you understand all the underlying packages / services / ports, etc...
+Follow these steps to prepare the system:
 
-This guide will only get ONE node (previously minion) working.  Multiple nodes require a functional [networking configuration](/docs/concepts/cluster-administration/networking/) done outside of Kubernetes.  Although the additional Kubernetes configuration requirements should be obvious.
+1. Make sure that operating system software is up to date. On Fedora Atomic, type:
 
-The Kubernetes package provides a few services: kube-apiserver, kube-scheduler, kube-controller-manager, kubelet, kube-proxy.  These services are managed by systemd and the configuration resides in a central location: `/etc/kubernetes`.  We will break the services up between the hosts.  The first host, fed-master, will be the Kubernetes master.  This host will run the kube-apiserver, kube-controller-manager, and kube-scheduler.  In addition, the master will also run _etcd_ (not needed if _etcd_ runs on a different host but this guide assumes that _etcd_ and Kubernetes master run on the same host).  The remaining host, fed-node will be the node and run kubelet, proxy and docker.
+    <pre><tt># <b>atomic host upgrade</b>
+    # <b>systemctl reboot</b>
+    </tt></pre>
 
-**System Information:**
+   On a Fedora Server or Fedora Workstation system, type:
 
-Hosts:
+    <pre><tt># <b>dnf update -y</b>
+    # <b>systemctl reboot</b>
+    </tt></pre>
 
-```conf
-fed-master = 192.168.121.9
-fed-node = 192.168.121.65
-```
+    Once the system comes up, log in again and run the next steps.
 
-**Prepare the hosts:**
+2. Disable swap. Comment out (#) any swap areas from /etc/fstab. For example, a commented out swap line in /etc/fstab might appear as follows:
 
-* Install Kubernetes on all hosts - fed-{master,node}.  This will also pull in docker. Also install etcd on fed-master.  This guide has been tested with Kubernetes-0.18 and beyond.
-* Running on AWS EC2 with RHEL 7.2, you need to enable "extras" repository for yum by editing `/etc/yum.repos.d/redhat-rhui.repo` and changing the `enable=0` to `enable=1` for extras.
+    <pre><tt>
+    <b>#</b> /dev/mapper/fedora--atomic-swap swap  swap  defaults  0 0
+    </tt></pre>
 
-```shell
-dnf -y install kubernetes
-```
+3. Disable selinux. Change the SELINUX type in /etc/sysconfig/selinux to permissive, so it appears as follows:
 
-* Install etcd
+        SELINUX=permissive
 
-```shell
-dnf -y install etcd
-```
+4. Immediately disable swap and SELinux:
 
-* Add master and node to `/etc/hosts` on all machines (not needed if hostnames already in DNS). Make sure that communication works between fed-master and fed-node by using a utility such as ping.
+    <pre><tt>
+    # <b>swapoff -a</b>
+    # <b>setenforce 0</b>
+    </tt></pre>
 
-```shell
-echo "192.168.121.9    fed-master
-192.168.121.65    fed-node" >> /etc/hosts
-```
+5. Disable firewalld. On Fedora Server or Workstation only (firewalld is not enabled on Fedora Atomic by default), type the following.
 
-* Edit `/etc/kubernetes/config` (which should be the same on all hosts) to set
-the name of the master server:
+    <pre><tt>
+    # <b>systemctl stop firewalld</b>
+    # <b>systemctl disable firewalld</b>
+    </tt></pre>
 
-```shell
-# Comma separated list of nodes in the etcd cluster
-KUBE_MASTER="--master=http://fed-master:8080"
-```
+{{< note >}}
+**Note:** Although disabling security features, such as SELinux and Firewalld, are currently needed to get this procedure to work properly, disabling them is not good practice when using Kubernetes in production. For that reason, this procedure is best used for trying and learning about Kubernetes in non-production environments.
+{{< /note >}}
 
-* Disable the firewall on both the master and node, as Docker does not play well with other firewall rule managers.  Please note that iptables.service does not exist on the default Fedora Server install.
+## Set up Kubernetes
 
-```shell
-systemctl mask firewalld.service
-systemctl stop firewalld.service
+1. Install kubernetes-kubeadm for your OS:
 
-systemctl disable iptables.service
-systemctl stop iptables.service
-```
+    Fedora Atomic Host
 
-**Configure the Kubernetes services on the master.**
+    <pre><tt># <b>rpm-ostree install kubernetes-kubeadm ethtool ebtables runc cri-tools -r</b>
+    <i>Log in again after automatic reboot</i>
+    </tt></pre>
 
-* Edit `/etc/kubernetes/apiserver` to appear as such.  The service-cluster-ip-range IP addresses must be an unused block of addresses, not used anywhere else.  They do not need to be routed or assigned to anything.
+    Fedora Workstation or Server
 
-```shell
-# The address on the local server to listen to.
-KUBE_API_ADDRESS="--address=0.0.0.0"
+    <pre><tt># <b>dnf install kubernetes-kubeadm ethtool ebtables runc cri-tools -y</b>
+    </tt></pre>
 
-# Comma separated list of nodes in the etcd cluster
-KUBE_ETCD_SERVERS="--etcd-servers=http://127.0.0.1:2379"
+2. Enable kubelet service, which manages pods on each node. (The kubelet service will start automatically after you run kubeadm init in the next step.)
 
-# Address range to use for services
-KUBE_SERVICE_ADDRESSES="--service-cluster-ip-range=10.254.0.0/16"
+    <pre><tt># <b>systemctl enable --now kubelet</b>
+    </tt></pre>
 
-# Add your own!
-KUBE_API_ARGS=""
-```
+3. Initialize Kubernetes. Options choose a set of IP addresses used for pods on the node and skips checks that will fail because of a later docker version:
 
-* Edit `/etc/etcd/etcd.conf` to let etcd listen on all available IPs instead of 127.0.0.1. If you have not done this, you might see an error such as "connection refused".
+    <pre><tt># <b>kubeadm init --pod-network-cidr=10.244.0.0/16 \
+        --ignore-preflight-errors=SystemVerification</b>
+    ...
+    Your Kubernetes master has initialized successfully!
+    </tt></pre>
 
-```shell
-ETCD_LISTEN_CLIENT_URLS="http://0.0.0.0:2379"
-```
+    If the initialization should fail, you can type **kubedm reset** and try the initialization again.
 
-* Start the appropriate services on master:
+    {{< note >}}
+    **Note:** The output from kubeadm init shows commands to run next. To add another node later, be sure to save the kubeadm join command line, which included token information you need to connect to the master. 
+    {{< /note >}}
 
-```shell
-for SERVICES in etcd kube-apiserver kube-controller-manager kube-scheduler; do
-    systemctl restart $SERVICES
-    systemctl enable $SERVICES
-    systemctl status $SERVICES
-done
-```
+4. Create a .kube directory in your home directory, add a configuration file, and change ownership (to be able to use kubectl later as a regular user, login as that user and append sudo to the cp and chown commands here):
 
-**Configure the Kubernetes services on the node.**
+    <pre><tt># <b>mkdir -p $HOME/.kube</b>
+   # <b>cp -i /etc/kubernetes/admin.conf $HOME/.kube/config</b>
+   # <b>chown $(id -u):$(id -g) $HOME/.kube/config</b>
+    </tt></pre>
 
-***We need to configure the kubelet on the node.***
+5. Apply the flannel network plugin:
 
-* Edit `/etc/kubernetes/kubelet` to appear as such:
+    <pre><tt># <b>kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml</b>
+    clusterrole.rbac.authorization.k8s.io "flannel" created
+    clusterrolebinding.rbac.authorization.k8s.io "flannel" created
+    serviceaccount "flannel" created
+    configmap "kube-flannel-cfg" created
+    daemonset.extensions "kube-flannel-ds" created
+    </tt></pre>
 
-```shell
-###
-# Kubernetes kubelet (node) config
+6. Allow pods to run on the master. Pods do not run on the master by default, for security reasons. For single-node clusters, you must override the default. In this example, replace fed28 with the name of your master system. If you plan to add a node, this is not required:
 
-# The address for the info server to serve on (set to 0.0.0.0 or "" for all interfaces)
-KUBELET_ADDRESS="--address=0.0.0.0"
+    <pre><tt># <b>kubectl taint node fed28 node-role.kubernetes.io/master:NoSchedule-</b>
+    node "fed28" untainted
+    </tt></pre>
 
-# You may leave this blank to use the actual hostname
-KUBELET_HOSTNAME="--hostname-override=fed-node"
+7. Check that the etcd and all kube- services are running:
 
-# location of the api-server
-KUBELET_ARGS="--cgroup-driver=systemd --kubeconfig=/etc/kubernetes/master-kubeconfig.yaml --require-kubeconfig"
+    <pre><tt># <b>kubectl get pods --all-namespaces</b>
+    NAMESPACE     NAME                          READY STATUS   RESTARTS   AGE
+    kube-system   etcd-fed28                    1/1   Running  0          26m
+    kube-system   kube-apiserver-fed28          1/1   Running  1          26m
+    kube-system   kube-controller-manager-fed28 1/1   Running  1          26m
+    kube-system   kube-dns-86f4d74b45-ptr4c     3/3   Running  0          26m
+    kube-system   kube-flannel-ds-mkp2x         1/1   Running  0          19m
+    kube-system   kube-proxy-cdkf2              1/1   Running  0          26m
+    kube-system   kube-scheduler-fed28          1/1   Running  1          26m
+    </tt></pre>
 
-# Add your own!
-KUBELET_ARGS=""
+At this point, you have a working kubernetes single-node cluster. Next try running a pod.
 
-```
+## Try Kubernetes with an nginx pod
+To make sure your Kubernetes cluster is working, try running an Nginx (Web server and reverse proxy server) from a pod.
 
-```yaml
-kind: Config
-clusters:
-- name: local
-  cluster:
-    server: http://fed-master:8080
-users:
-- name: kubelet
-contexts:
-- context:
-    cluster: local
-    user: kubelet
-  name: kubelet-context
-current-context: kubelet-context
-```
+1. Get and run three replicas of the nginx pod, opening port 80 to access its content:
 
-* Start the appropriate services on the node (fed-node).
+    <pre><tt># <b>kubectl run nginx --image=nginx --port=80 --replicas=3</b>
+    deployment "nginx" created
+    </tt></pre>
 
-```shell
-for SERVICES in kube-proxy kubelet docker; do 
-    systemctl restart $SERVICES
-    systemctl enable $SERVICES
-    systemctl status $SERVICES 
-done
-```
+2. List information about running pods. The first set of output shows nginx pods being created; the second shows them running:
 
-* Check to make sure now the cluster can see the fed-node on fed-master, and its status changes to _Ready_.
+    <pre><tt># <b>kubectl get pods -o wide</b>
+    NAME                 READY STATUS     RESTARTS   AGE IP     NODE
+    nginx-7587c6fdb6-6mvmt 0/1 ContainerCreating 0   10s <none> fed28
+    nginx-7587c6fdb6-6nzq8 0/1 ContainerCreating 0   10s <none> fed28
+    nginx-7587c6fdb6-7xssr 0/1 ContainerCreating 0   10s <none> fed28
+    # <b>kubectl get pods -o wide</b>
+    NAME                 READY STATUS   RESTARTS AGE IP         NODE
+    nginx-7587c6fdb6-6mvmt 0/1 Running  0        10s 10.244.0.3 fed28
+    nginx-7587c6fdb6-6nzq8 0/1 Running  0        10s 10.244.0.4 fed28
+    nginx-7587c6fdb6-7xssr 0/1 Running  0        10s 10.244.0.5 fed28
+    </tt></pre>
 
-```shell
-kubectl get nodes
-NAME            STATUS      AGE      VERSION
-fed-node        Ready       4h
-```
+3. Expose nginx ports so they are accessible from the host:
 
-* Deletion of nodes:
+    <pre><tt># <b>kubectl expose deployment nginx --type NodePort</b>
+    service "nginx" exposed
+    # <b>kubectl get svc</b>
+    NAME       TYPE        CLUSTER-IP      EXTERNAL-IP  PORT(S)       AGE
+    kubernetes ClusterIP   10.96.0.1       <none>       443/TCP       1h
+    nginx      NodePort    10.102.237.87   <none>       80:30361/TCP  20s
+    </tt></pre>
 
-To delete _fed-node_ from your Kubernetes cluster, one should run the following on fed-master (Please do not do it, it is just for information):
+4. Check that nginx service is accessible (using the CLUSTER-IP from your output above or the exposed port from the local host). If you are running the service from a cloud or virtual machine, the exposed port lets you access the service from your local system using the VM’s name or IP address:
 
-```shell
-kubectl delete -f ./node.json
-```
+    <pre><tt># <b>curl http://10.102.237.87:80</b>
+    &lt;h1&gt;Welcome to nginx!&lt;h1&gt;
+    &lt;p&gt;If you see this page, the nginx web server is successfully installed and working.
+    Further configuration is required.&lt;p&gt;
 
-*You should be finished!*
+    # <b>curl http://fed28:30361</b>
+    &gt;h1&lt;Welcome to nginx!&gt;h1&gt; ...
+    </tt></pre>
 
-**The cluster should be running! Launch a test pod.**
+5. Try optional tools. As you use Kubernetes, there are other tools available with Fedora you might find useful for working with containers. These include:
+
+    * **[buildah](https://github.com/projectatomic/buildah)** - Used to build containers without the docker command or service.
+    * **[skopeo](https://github.com/projectatomic/skopeo)** - Used to interact with local and remote container images and registries.
+    * **[runc](https://github.com/projectatomic/runc)** - Runs containers without requiring an active runtime environment. 
+
+   The tools may already be installed. If not, to install these packages for your OS:
+
+    Fedora Atomic Host
+    <pre><tt># <b>rpm-ostree install -r buildah skopeo runc</b>
+    <i>Log in again after automatic reboot</i>
+    </tt></pre>
+
+    Fedora Workstation or Server
+    <pre><tt># <b>dnf install buildah skopeo runc</b>
+    </tt></pre>
+
+At this point, your Kubernetes cluster is ready to use
+
+To add other systems to expand Kubernetes from a single-node to a multi-node cluster, refer to [Kubernetes on Fedora - Multi-node](https://kubernetes.io/docs/getting-started-guides/fedora/flannel_multi_node_cluster/) for details.
+
 
 ## Support Level
 
 
 IaaS Provider        | Config. Mgmt | OS     | Networking  | Docs                                              | Conforms | Support Level
 -------------------- | ------------ | ------ | ----------  | ---------------------------------------------     | ---------| ----------------------------
-Bare-metal           | custom       | Fedora | _none_      | [docs](/docs/getting-started-guides/fedora/fedora_manual_config)            |          | Project
+Bare-metal           | custom       | Fedora | flannel     | [docs](/docs/getting-started-guides/fedora/fedora_manual_config/)      |          | Community
+libvirt              | custom       | Fedora | flannel     | [docs](/docs/getting-started-guides/fedora/fedora_manual_config/)      |          | Community
+KVM                  | custom       | Fedora | flannel     | [docs](/docs/getting-started-guides/fedora/fedora_manual_config/)      |          | Community
+
 
 For support level information on all solutions, see the [Table of solutions](/docs/getting-started-guides/#table-of-solutions) chart.
 

--- a/content/en/docs/getting-started-guides/fedora/flannel_multi_node_cluster.md
+++ b/content/en/docs/getting-started-guides/fedora/flannel_multi_node_cluster.md
@@ -1,192 +1,128 @@
 ---
 reviewers:
-- dchen1107
-- erictune
-- thockin
-title: Fedora (Multi Node)
+- chrisnegus
+title: Kubernetes on Fedora (Multi Node)
 ---
 
-{{< toc >}}
+* TOC
+{:toc}
 
-This document describes how to deploy Kubernetes on multiple hosts to set up a multi-node cluster and networking with flannel. Follow fedora [getting started guide](/docs/getting-started-guides/fedora/fedora_manual_config/) to setup 1 master (fed-master) and 2 or more nodes. Make sure that all nodes have different names (fed-node1, fed-node2 and so on) and labels (fed-node1-label, fed-node2-label, and so on) to avoid any conflict. Also make sure that the Kubernetes master host is running etcd, kube-controller-manager, kube-scheduler, and kube-apiserver services, and the nodes are running docker, kube-proxy and kubelet services. Now install flannel on Kubernetes nodes. Flannel on each node configures an overlay network that docker uses. Flannel runs on each node to setup a unique class-C container network.
+
+To set up a multi-node Kubernetes cluster on Fedora using **kubeadm**, do the following:
+
+* **Set up the master**: Follow the [Kubernetes on Fedora - Single-node](https://kubernetes.io/docs/getting-started-guides/fedora/fedora_manual_config/) instructions to set up a Kubernetes Master. After running kubeadm init on the master, copy the **kubeadm join** line from the output. This includes token information needed to connect the node to the master. 
+* **Set up nodes**: Use the instruction below to configure each additional node. 
 
 ## Prerequisites
 
-You need 2 or more machines with Fedora installed.
+For each node you want to add, follow the Prerequisites and these step from the Setup section of the [Kubernetes on Fedora - Single-node](https://kubernetes.io/docs/getting-started-guides/fedora/fedora_manual_config/) instructions:
 
-## Master Setup
+* Prerequisites
+* Install kubernetes-kubeadm and other software
+* Enable kubelet
 
-**Perform following commands on the Kubernetes master**
+## Set up Nodes
 
-* Configure flannel by creating a `flannel-config.json` in your current directory on fed-master. Flannel provides udp and vxlan among other overlay networking backend options. In this guide, we choose kernel based vxlan backend. The contents of the json are:
+1. Join node to the cluster. Using the output from the **kubeadm init** command you ran earlier on the master, run the **kubeadm join** command. The basic structure of the command is as follows:
 
-```json
-{
-    "Network": "18.16.0.0/16",
-    "SubnetLen": 24,
-    "Backend": {
-        "Type": "vxlan",
-        "VNI": 1
-     }
-}
-```
+    **IMPORTANT**: You may need the **--ignore-preflight-errors=all** option.
 
-**NOTE:** Choose an IP range that is *NOT* part of the public IP address range.
+    <pre><tt><b>kubeadm join hostname:6443 --ignore-preflight-errors=all  \
+        --token xxxxxx.xxxxxxxxxxxxxxxx \
+        --discovery-token-ca-cert-hash   \
+        sha256:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</b>
+    </tt></pre>
 
-Add the configuration to the etcd server on fed-master.
+    For example:
 
-```shell
-etcdctl set /coreos.com/network/config < flannel-config.json
-```
+    <pre><tt># <b>kubeadm join 192.168.122.238:6443 --ignore-preflight-errors=all \
+         --token e50a48.61b21631a693c840 \
+         --discovery-token-ca-cert-hash \
+         sha256:5bdcd80b15c68e9afd4c52f0346e7c7013634f3ca...</b>
+    ...
+    [discovery] Trying to connect to API Server "192.168.122.238:6443"
+    [discovery] Created cluster-info discovery client, requesting info from "https://192.168.122.238:6443"
+    [discovery] Requesting info from "https://192.168.122.238:6443" again to validate TLS against the pinned public key
+    [discovery] Cluster info signature and contents are valid and TLS certificate validates against pinned roots, will use API Server "192.168.122.238:6443"
+    [discovery] Successfully established connection with API Server "192.168.122.238:6443"
 
-* Verify that the key exists in the etcd server on fed-master.
+    This node has joined the cluster:
+    * Certificate signing request was sent to master and a response
+      was received.
+    * The Kubelet was informed of the new secure connection details.
 
-```shell
-etcdctl get /coreos.com/network/config
-```
+    Run 'kubectl get nodes' on the master to see this node join the cluster.
+    </tt></pre>
 
-## Node Setup
+2. Return to the master and check that the node has joined. 
 
-**Perform following commands on all Kubernetes nodes**
-
-Install the flannel package
-
-```shell
-# dnf -y install flannel
-```
-
-Edit the flannel configuration file /etc/sysconfig/flanneld as follows:
-
-```shell
-# Flanneld configuration options
-
-# etcd url location.  Point this to the server where etcd runs
-FLANNEL_ETCD="http://fed-master:2379"
-
-# etcd config key.  This is the configuration key that flannel queries
-# For address range assignment
-FLANNEL_ETCD_KEY="/coreos.com/network"
-
-# Any additional options that you want to pass
-FLANNEL_OPTIONS=""
-```
-
-**Note:** By default, flannel uses the interface for the default route. If you have multiple interfaces and would like to use an interface other than the default route one, you could add "-iface=" to FLANNEL_OPTIONS. For additional options, run `flanneld --help` on command line.
-
-Enable the flannel service.
-
-```shell
-systemctl enable flanneld
-```
-
-If docker is not running, then starting flannel service is enough and skip the next step.
-
-```shell
-systemctl start flanneld
-```
-
-If docker is already running, then stop docker, delete docker bridge (docker0), start flanneld and restart docker as follows. Another alternative is to just reboot the system (`systemctl reboot`).
-
-```shell
-systemctl stop docker
-ip link delete docker0
-systemctl start flanneld
-systemctl start docker
-```
+    <pre><tt># <b>kubectl get node</b>
+    NAME        STATUS    ROLES     AGE       VERSION
+    fed28       Ready     master    2d        v1.10.1
+    fed28-02    Ready     <none>    4m        v1.10.1
+    </tt></pre>
 
 
-## **Test the cluster and flannel configuration**
+The node is now available to be used in the Kubernetes cluster. New pods should run on that node.
 
-Now check the interfaces on the nodes. Notice there is now a flannel.1 interface, and the ip addresses of docker0 and flannel.1 interfaces are in the same network. You will notice that docker0 is assigned a subnet (18.16.29.0/24 as shown below) on each Kubernetes node out of the IP range configured above. A working output should look like this:
+## Troubleshooting Nodes
 
-```shell
-# ip -4 a|grep inet
-    inet 127.0.0.1/8 scope host lo
-    inet 192.168.122.77/24 brd 192.168.122.255 scope global dynamic eth0
-    inet 18.16.29.0/16 scope global flannel.1
-    inet 18.16.29.1/24 scope global docker0
-```
+If you were unable to join the cluster, here are a few things to try:
 
-From any node in the cluster, check the cluster members by issuing a query to etcd server via curl (only partial output is shown using `grep -E "\{|\}|key|value"`). If you set up a 1 master and 3 nodes cluster, you should see one block for each node showing the subnets they have been assigned. You can associate those subnets to each node by the MAC address (VtepMAC) and IP address (Public IP) that is listed in the output.
+**Reset**. If you find that you have made some mistakes while setting up the node, you can always reset Kubernetes on the node by typing:
 
-```shell
-curl -s http://fed-master:2379/v2/keys/coreos.com/network/subnets | python -mjson.tool
-```
+<pre><tt># <b>kubeadm reset</b>
+</tt></pre>
 
-```json
-{
-    "node": {
-        "key": "/coreos.com/network/subnets",
-            {
-                "key": "/coreos.com/network/subnets/18.16.29.0-24",
-                "value": "{\"PublicIP\":\"192.168.122.77\",\"BackendType\":\"vxlan\",\"BackendData\":{\"VtepMAC\":\"46:f1:d0:18:d0:65\"}}"
-            },
-            {
-                "key": "/coreos.com/network/subnets/18.16.83.0-24",
-                "value": "{\"PublicIP\":\"192.168.122.36\",\"BackendType\":\"vxlan\",\"BackendData\":{\"VtepMAC\":\"ca:38:78:fc:72:29\"}}"
-            },
-            {
-                "key": "/coreos.com/network/subnets/18.16.90.0-24",
-                "value": "{\"PublicIP\":\"192.168.122.127\",\"BackendType\":\"vxlan\",\"BackendData\":{\"VtepMAC\":\"92:e2:80:ba:2d:4d\"}}"
-            }
-    }
-}
-```
 
-From all nodes, review the `/run/flannel/subnet.env` file.  This file was generated automatically by flannel.
+After that, run kubeadm init again. To get everything working, you may need to restart the kubelet service again as well (**systemctl restart kubelet**).
+ 
+**Token expired**. If the token on the master has been changed or expired, you could see an error relating to a token problem when you try to join the cluster. For example:
 
-```shell
-# cat /run/flannel/subnet.env
-FLANNEL_SUBNET=18.16.29.1/24
-FLANNEL_MTU=1450
-FLANNEL_IPMASQ=false
-```
+    There is no JWS signed token in the cluster-info ConfigMap
 
-At this point, we have etcd running on the Kubernetes master, and flannel / docker running on Kubernetes nodes. Next steps are for testing cross-host container communication which will confirm that docker and flannel are configured properly.
+To correct a problem with tokens, you can generate a new token on the master, then apply that information to each node when you join. For example:
 
-Issue the following commands on any 2 nodes:
+On the Master:
 
-```shell
-# docker run -it fedora:latest bash
-bash-4.3# 
-```
+<pre><tt># <b>kubeadm token create</b>
+e50a48.61b21631a693c840
+</tt></pre>
 
-This will place you inside the container. Install iproute and iputils packages to install ip and ping utilities. Due to a [bug](https://bugzilla.redhat.com/show_bug.cgi?id=1142311), it is required to modify capabilities of ping binary to work around "Operation not permitted" error.
 
-```shell
-bash-4.3# dnf -y install iproute iputils
-bash-4.3# setcap cap_net_raw-ep /usr/bin/ping
-```
+On the Node (be sure to use the new token):
 
-Now note the IP address on the first node:
+<pre><tt># <b>kubeadm join --ignore-preflight-errors=all --token \
+  <i>e50a48.61b21631a693c840</i> 192.168.122.238:6443 \
+  --discovery-token-ca-cert-hash \
+  sha256:5bdcd80b15c68e9afd4c52f0346e7c7013634f3ca3727b3610d9a308380a9444</b>
+</tt></pre>
 
-```shell
-bash-4.3# ip -4 a l eth0 | grep inet
-    inet 18.16.29.4/24 scope global eth0
-```
 
-And also note the IP address on the other node:
+**Kubelet won’t start (bad token)**: If you find that you can join the cluster, but kubelet is not able to connect to the master, the node won’t appear when you type **kubectl get node**. This failure may occur because the kubelet.conf file contains an old token. To fix this, edit /etc/kubernetes/bootstrap-kubelet.conf and change the token value. For example:
 
-```shell
-bash-4.3# ip a l eth0 | grep inet
-    inet 18.16.90.4/24 scope global eth0
-```
-Now ping from the first node to the other node:
+<pre><ttkind: Config
+preferences: {}
+users:
+- name: tls-bootstrap-token-user
+  user:
+    token: e50a48.61b21631a693c840
 
-```shell
-bash-4.3# ping 18.16.90.4
-PING 18.16.90.4 (18.16.90.4) 56(84) bytes of data.
-64 bytes from 18.16.90.4: icmp_seq=1 ttl=62 time=0.275 ms
-64 bytes from 18.16.90.4: icmp_seq=2 ttl=62 time=0.372 ms
-```
 
-Now Kubernetes multi-node cluster is set up with overlay networking set up by flannel.
+**Check that the node is working properly**. Once the node is working properly, you should see that new containers have started. These should include flannel, kube-proxy, and pause-amd64. Run the following on the node to check that:
+
+<pre><tt># <b>docker ps</b>
+CONTAINER ID IMAGE                     COMMAND              CREATED         STATUS        PORTS  NAMES
+e2a80db5a3d6 quay.io/coreos/flannel... "/opt/bin/flanneld"  12 minutes ago  Up 12 minutes        k8s_kube-proxy_kube-proxy-r9shd_kube-system_198a1c85-2dcf-11e8-adbb-5254003effb8_0
+gcr.io/google_containers/kube-proxy... "/usr/local/bin/ku"  12 minutes ago  Up 12 minutes        k8s_kube-proxy_kube-proxy-r9shd_kube-system_198a1c85-2dcf-11e8-adbb-5254003effb8_0
+f4e8f1cdf9ad gcr.io/google_contain...  "/pause"             14 minutes ago  Up 14 minutes        k8s_POD_kube-proxy-r9shd_kube-system_198a1c85-2dcf-11e8-adbb-5254003effb8_0
+ef8821b8757d gcr.io/google_contain...  "/pause"             14 minutes ago  Up 14 minutes        k8s_POD_kube-flannel-ds-84bfh_kube-system_1966574d-2dcf-11e8-adbb-5254003effb8_0
+</tt></pre>
 
 ## Support Level
 
-
 IaaS Provider        | Config. Mgmt | OS     | Networking  | Docs                                              | Conforms | Support Level
 -------------------- | ------------ | ------ | ----------  | ---------------------------------------------     | ---------| ----------------------------
-Bare-metal           | custom       | Fedora | flannel     | [docs](/docs/getting-started-guides/fedora/flannel_multi_node_cluster/)      |          | Community ([@aveshagarwal](https://github.com/aveshagarwal))
-libvirt              | custom       | Fedora | flannel     | [docs](/docs/getting-started-guides/fedora/flannel_multi_node_cluster/)      |          | Community ([@aveshagarwal](https://github.com/aveshagarwal))
-KVM                  | custom       | Fedora | flannel     | [docs](/docs/getting-started-guides/fedora/flannel_multi_node_cluster/)      |          | Community ([@aveshagarwal](https://github.com/aveshagarwal))
+Bare-metal           | custom       | Fedora | flannel     | [docs](/docs/getting-started-guides/fedora/flannel_multi_node_cluster/)      |          | Community 
+libvirt              | custom       | Fedora | flannel     | [docs](/docs/getting-started-guides/fedora/flannel_multi_node_cluster/)      |          | Community 
+KVM                  | custom       | Fedora | flannel     | [docs](/docs/getting-started-guides/fedora/flannel_multi_node_cluster/)      |          | Community 


### PR DESCRIPTION
This is a re-submission of changes to two guides for installing Kubernetes on Fedora using kubeadm. My original pull request ([8009](https://github.com/kubernetes/website/pull/8009)) was rejected because it was too close to the overhaul of the Kubernetes docs.

As I stated in the earlier pull request:

The two Fedora kube [single-node](https://kubernetes.io/docs/getting-started-guides/fedora/fedora_manual_config/) and [multi-node](https://kubernetes.io/docs/getting-started-guides/fedora/flannel_multi_node_cluster/) getting started guides were outdated. These two issues suggested the two docs be updated to use kubeadm:

[#7302](https://github.com/kubernetes/website/issues/7302)
[#7278](https://github.com/kubernetes/website/issues/7301)

I totally rewrote both of those documents to use kubeadm (as well as to reflect how the procedures work for Kubernetes 1.10).

