### PR TITLE
Add redirect for broken kubelet auth link

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -32,6 +32,7 @@
 /docs/admin/ha-master-gce.md/     /docs/tasks/administer-cluster/highly-available-master/ 301
 /docs/admin/high-availability/      /docs/admin/high-availability/building/ 301
 /docs/admin/kubeadm-upgrade-1-7/     /docs/tasks/administer-cluster/upgrade-downgrade/kubeadm-upgrade-1-7/ 301
+/docs/admin/kubelet-authentication-authorization/     /docs/reference/command-line-tools-reference/kubelet-authentication-authorization/ 301
 /docs/admin/limitrange/     /docs/tasks/administer-cluster/cpu-memory-limit/ 301
 /docs/admin/limitrange/Limits/     /docs/tasks/administer-cluster/limit-storage-consumption/#limitrange-to-limit-requests-for-storage/ 301
 /docs/admin/master-node-communication/     /docs/concepts/architecture/master-node-communication/ 301
@@ -495,7 +496,7 @@ https://kubernetes-io-v1-7.netlify.com/*    https://v1-7.docs.kubernetes.io/:spl
 
 /docs/reference/generated/kubeadm/     /docs/reference/setup-tools/kubeadm/kubeadm/ 301
 
-/editdocs/     /docs/home/contribute/     301 
+/editdocs/     /docs/home/contribute/     301
 
 /docs/admin/accessing-the-api/     /docs/reference/access-authn-authz/controlling-access/ 301
 /docs/admin/admission-controllers/     /docs/reference/access-authn-authz/admission-controllers/ 301


### PR DESCRIPTION
This PR fixes the following broken link on [Securing a Cluster](https://kubernetes.io/docs/tasks/administer-cluster/securing-a-cluster/) page by adding a serverside redirect to the correct page: [Kubelet authentication/authorization reference](https://kubernetes.io/docs/admin/kubelet-authentication-authorization)

