### PR TITLE
Add L10n repo branch structure info

### DIFF
--- a/content/en/docs/home/contribute/localization.md
+++ b/content/en/docs/home/contribute/localization.md
@@ -38,11 +38,16 @@ Source files reside in the `/docs/` directory.
 
 ### Repository
 
-A l10n team will have a repository specifically dedicated to its work, for example: [kubernetes/kubernetes-docs-cn](https://github.com/kubernetes/kubernetes-docs-cn).
+A l10n team will have a repository specifically dedicated to its work, for example: [kubernetes/kubernetes-docs-zh](https://github.com/kubernetes/kubernetes-docs-zh).
 
 {{< note >}}
 **Note:** To open a l10n repository, [contact the SIG docs lead](https://kubernetes.slack.com/messages/C1J0BPD2M) on Slack for assistance.
 {{< /note >}}
+
+#### Repository structure
+
+Each l10n repository must have branches for the different Kubernetes documentation release versions, matching the branches in the main [kubernetes/website](https://github.com/kubernetes/website) documentation repository. For example, the kubernetes/website `release-1.10` branch (https://github.com/kubernetes/website/tree/release-1.10) has a corresponding branch in the kubernetes/kubernetes-docs-zh repository (https://github.com/kubernetes/kubernetes-docs-zh/tree/release-1.10). These version branches keep track of the differences in the documentation between Kubernetes versions.
+
 
 ### Project
 
@@ -53,7 +58,7 @@ Projects must include columns for:
 - In progress
 - Done
 
-For example: the [Chinese localization project](https://github.com/kubernetes/kubernetes-docs-cn/projects/1).
+For example: the [Chinese localization project](https://github.com/kubernetes/kubernetes-docs-zh/projects/1).
 
 ### Team function
 


### PR DESCRIPTION
Specify that each L10n repo much mirror the `release-x.y` branch structure in kubernetes/website.

Preview: https://deploy-preview-9206--kubernetes-io-master-staging.netlify.com/docs/home/contribute/localization/