### PR TITLE
Download Kubernetes fix

### DIFF
--- a/layouts/blog/baseof.html
+++ b/layouts/blog/baseof.html
@@ -27,7 +27,7 @@
 						<a class="widget-link" href="http://slack.k8s.io"><i class="fab fa-slack fab-icon"> </i> #kubernetes-users </a>
 						<a class="widget-link" href="http://stackoverflow.com/questions/tagged/kubernetes"><i class="fab fa-stack-overflow fab-icon"></i> Stack Overflow</a>
 						<a class="widget-link" href="https://discuss.kubernetes.io"><i class="fab fa-discourse fab-icon"></i>Forum</a>
-						<a class="widget-link" href="http://get.k8s.io/"><i class="fab fa-stack-overflow fab-icon"></i> Download Kubernetes</a>
+						<a class="widget-link" href="http://get.k8s.io/" download="kubernetes"><i class="fab fa-stack-overflow fab-icon"></i> Download Kubernetes</a>
 					</div>
 					{{ partialCached "blog/archive.html" . }}
 				</div>


### PR DESCRIPTION
- Updated the file _baseof.html_ to make **Download Kubernetes** link downloadable in Kubernetes blog.

![image](https://user-images.githubusercontent.com/29581152/41817923-1336dcb0-77c2-11e8-9899-61ff3af3441c.png)

Fix to issue: #9170 