### PR TITLE
Add missing "Set up master Load Balancer" heading

### DIFF
--- a/content/en/docs/setup/independent/high-availability.md
+++ b/content/en/docs/setup/independent/high-availability.md
@@ -347,6 +347,7 @@ Make sure you replace:
 {{% /tab %}}
 {{< /tabs >}}
 
+## Set up master Load Balancer
 
 ## {{< tabs name="lb_mode" >}}
 {{% tab name="Choose one..." %}}


### PR DESCRIPTION
This heading is missing in the 1.10 documentations which makes it hard to find the needed information because the anchor  `setting up a master load balancer` points to nowhere. This was working in the 1.19 documentation and it was really useful.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.11 Features: set Milestone to 1.11 and Base Branch to release-1.11
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
