### PR TITLE
Adding reference to kvm2

### DIFF
--- a/content/en/docs/setup/minikube.md
+++ b/content/en/docs/setup/minikube.md
@@ -33,6 +33,7 @@ the following drivers:
 
 * virtualbox
 * vmwarefusion
+* kvm2 ([driver installation](https://git.k8s.io/minikube/docs/drivers.md#kvm2-driver))
 * kvm ([driver installation](https://git.k8s.io/minikube/docs/drivers.md#kvm-driver))
 * hyperkit ([driver installation](https://git.k8s.io/minikube/docs/drivers.md#hyperkit-driver))
 * xhyve ([driver installation](https://git.k8s.io/minikube/docs/drivers.md#xhyve-driver)) (deprecated)


### PR DESCRIPTION
Connected to #8438 
The original kvm driver is now deprecated in Minikube.
Adding documentation link to kvm2 driver.
Linked docs for the kvm2 driver clearly state that this is intended to replace the kvm driver.
Leaving the link to the original kvm driver intact.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
