### PR TITLE
Improve landing pages for user stories

### DIFF
--- a/content/en/docs/user-journeys/_index.md
+++ b/content/en/docs/user-journeys/_index.md
@@ -1,3 +1,0 @@
----
-toc_hide: true
----

--- a/content/en/docs/user-journeys/users/application-developer/_index.md
+++ b/content/en/docs/user-journeys/users/application-developer/_index.md
@@ -1,5 +1,0 @@
----
-title: "Application Developer"
-weight: 10
----
-

--- a/content/en/docs/user-journeys/users/cluster-operator/_index.md
+++ b/content/en/docs/user-journeys/users/cluster-operator/_index.md
@@ -1,5 +1,0 @@
----
-title: "Cluster Operator"
-weight: 20
----
-


### PR DESCRIPTION
In issue #9229 I was made aware that the landing pages for user stories ([application developer](https://kubernetes.io/docs/user-journeys/users/application-developer) and [cluster operator](https://kubernetes.io/docs/user-journeys/users/cluster-operator)) bring up big error messages. This PR fixes that by providing a various basic, non-broken page.

This is not a huge priority given that there are no direct links to those landing pages in the docs but better not to make readers confront errors.