### PR TITLE
Incorrect Variable name - web-ui-dashboard

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/web-ui-dashboard.md
+++ b/content/en/docs/tasks/access-application-cluster/web-ui-dashboard.md
@@ -46,7 +46,7 @@ Kubectl will handle authentication with apiserver and make Dashboard available a
 The UI can _only_ be accessed from the machine where the command is executed. See `kubectl proxy --help` for more options.
 
 ### Master server
-You may access the UI directly via the Kubernetes master apiserver. Open a browser and navigate to ``https://<master-ip>:<apiserver-port>/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/``, where `<kubernetes-master>` is IP address or domain name of the Kubernetes
+You may access the UI directly via the Kubernetes master apiserver. Open a browser and navigate to ``https://<master-ip>:<apiserver-port>/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/``, where `<master-ip>` is IP address or domain name of the Kubernetes
 master.
 
 Please note, this works only if the apiserver is set up to allow authentication with username and password. This is not currently the case with some setup tools (e.g., `kubeadm`). Refer to the  [authentication admin documentation](/docs/admin/authentication/) for information on how to configure authentication manually.


### PR DESCRIPTION
The docs reference kubernetes-master, but that is not shown anywhere, instead it should be master-ip as shown in the prior url