### PR TITLE
Update list of sig-docs-pr-reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -90,6 +90,7 @@ aliases:
     - rajakavitha1
     - ryanmcginnis
     - steveperry-53
+    - stewart-yu
     - tengqm
     - xiangpengzhao
     - zacharysarah

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -85,6 +85,7 @@ aliases:
     - bradamant3
     - bradtopol
     - chenopis
+    - kbarnard10
     - mistyhacks
     - rajakavitha1
     - ryanmcginnis
@@ -93,6 +94,7 @@ aliases:
     - xiangpengzhao
     - zacharysarah
     - zhangxiaoyu-zidif
+    - zparnold
   sig-federation: #Team: Federation; e.g. Federated Clusters
     - csbell
   sig-gcp: #Google Cloud Platform; GH: sig-gcp-pr-reviews

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -65,7 +65,7 @@ aliases:
     - timothysc
     - luxas
     - roberthbailey
-    - fabriziopandini 
+    - fabriziopandini
   sig-cluster-ops:
     - zehicle
     - jdumars
@@ -83,10 +83,16 @@ aliases:
     - spxtr
   sig-docs: #Team: documentation; GH: sig-docs-pr-reviews
     - bradamant3
-    - steveperry-53
-    - zacharysarah
     - bradtopol
-    - heckj
+    - chenopis
+    - mistyhacks
+    - rajakavitha1
+    - ryanmcginnis
+    - steveperry-53
+    - tengqm
+    - xiangpengzhao
+    - zacharysarah
+    - zhangxiaoyu-zidif
   sig-federation: #Team: Federation; e.g. Federated Clusters
     - csbell
   sig-gcp: #Google Cloud Platform; GH: sig-gcp-pr-reviews


### PR DESCRIPTION
This PR freshens OWNERS_ALIASES with a current list of contributors for @kubernetes/sig-docs-pr-reviews.