### PR TITLE
Sweep for doubled words

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -86,7 +86,7 @@ the Pod:
 kubectl get pod my-application -o json | jq .status.conditions
 ```
 
-Now let's say that that query has yielded this JSON:
+If that query returned this example JSON:
 
 ```json
 [

--- a/content/en/docs/reference/command-line-tools-reference/kubelet.md
+++ b/content/en/docs/reference/command-line-tools-reference/kubelet.md
@@ -100,7 +100,7 @@ kubelet
       <td colspan="2">--bootstrap-checkpoint-path string</td>
     </tr>
     <tr>
-      <td></td><td style="line-height: 130%"><Warning: Alpha feature> Path to to the directory where the checkpoints are stored</td>
+      <td></td><td style="line-height: 130%"><Warning: Alpha feature> Path to the directory where the checkpoints are stored</td>
     </tr>
     <tr>
       <td colspan="2">--bootstrap-kubeconfig string</td>

--- a/content/en/docs/tasks/administer-cluster/setup-ha-etcd-with-kubeadm.md
+++ b/content/en/docs/tasks/administer-cluster/setup-ha-etcd-with-kubeadm.md
@@ -9,7 +9,7 @@ content_template: templates/task
 
 Kubeadm defaults to running a single member etcd cluster in a static pod managed
 by the kubelet on the control plane node. This is not a highly available setup
-as the the etcd cluster contains only one member and cannot sustain any members
+as the etcd cluster contains only one member and cannot sustain any members
 becoming unavailable. This task walks through the process of creating a highly
 available etcd cluster of three members that can be used as an external etcd
 when using kubeadm to set up a kubernetes cluster.

--- a/content/en/docs/tasks/configure-pod-container/translate-compose-kubernetes.md
+++ b/content/en/docs/tasks/configure-pod-container/translate-compose-kubernetes.md
@@ -410,7 +410,7 @@ services:
 
 Using `kompose up` with a `build` key:
 
-```sh
+```none
 $ kompose up
 INFO Build key detected. Attempting to build and push image 'docker.io/foo/bar' 
 INFO Building image 'docker.io/foo/bar' from directory 'build' 


### PR DESCRIPTION
I used Bash magic to audit our files for doubled words. Most were false positives, but I found a few that weren't. I'd like to get this into `master` before the 1.10 archive is cut.

/assign @zacharysarah 
/assign @Bradamant3 