### PR TITLE
Use official homebrew package name

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl.md
+++ b/content/en/docs/tasks/tools/install-kubectl.md
@@ -61,7 +61,7 @@ kubectl is available as a [snap](https://snapcraft.io/) application.
 
 1. If you are on macOS and using [Homebrew](https://brew.sh/) package manager, you can install with:
 
-        brew install kubectl
+        brew install kubernetes-cli
 
 2. Run `kubectl version` to verify that the version you've installed is sufficiently up-to-date.
 

--- a/content/en/docs/tutorials/hello-minikube.md
+++ b/content/en/docs/tutorials/hello-minikube.md
@@ -82,7 +82,7 @@ Use Homebrew to download the `kubectl` command-line tool, which you can
 use to interact with Kubernetes clusters:
 
 ```shell
-brew install kubectl
+brew install kubernetes-cli
 ```
 
 Determine whether you can access sites like [https://cloud.google.com/container-registry/](https://cloud.google.com/container-registry/) directly without a proxy, by opening a new terminal and using
@@ -183,8 +183,10 @@ sure you are using the Minikube Docker daemon:
 eval $(minikube docker-env)
 ```
 
+{{< note >}}
 **Note:** Later, when you no longer wish to use the Minikube host, you can undo
 this change by running `eval $(minikube docker-env -u)`.
+{{< /note >}}
 
 Build your Docker image, using the Minikube Docker daemon (mind the trailing dot):
 


### PR DESCRIPTION
closes #9247 

Currently we can install `kubectl` via homebrew by using either package name `kubectl` or `kubernetes-cli`.

`kubectl` is an alias for `kubernetes-cli`.
https://github.com/Homebrew/homebrew-core/blob/master/Aliases/kubectl

To: approvers(reviewers)
If we should use an official homebrew package name for installing `kubectl`, please merge this PR (including another minor fix) .
If not, I will close this PR.