### PR TITLE
add description for service account token

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-projected-volume-storage.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-projected-volume-storage.md
@@ -8,7 +8,7 @@ weight: 70
 ---
 
 {{% capture overview %}}
-This page shows how to use a [`projected`](/docs/concepts/storage/volumes/#projected) volume to mount several existing volume sources into the same directory. Currently, `secret`, `configMap`, and `downwardAPI` volumes can be projected.
+This page shows how to use a [`projected`](/docs/concepts/storage/volumes/#projected) volume to mount several existing volume sources into the same directory. Currently, `secret`, `configMap`, `downwardAPI` and `serviceAccountToken` volumes can be projected. Notice that `serviceAccountToken` is not a volume type itself.
 {{% /capture %}}
 
 {{% capture prerequisites %}}

--- a/content/en/docs/tasks/configure-pod-container/configure-projected-volume-storage.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-projected-volume-storage.md
@@ -8,7 +8,13 @@ weight: 70
 ---
 
 {{% capture overview %}}
-This page shows how to use a [`projected`](/docs/concepts/storage/volumes/#projected) volume to mount several existing volume sources into the same directory. Currently, `secret`, `configMap`, `downwardAPI` and `serviceAccountToken` volumes can be projected. Notice that `serviceAccountToken` is not a volume type itself.
+This page shows how to use a [`projected`](/docs/concepts/storage/volumes/#projected) volume to mount
+several existing volume sources into the same directory. Currently, `secret`, `configMap`, `downwardAPI`,
+and `serviceAccountToken` volumes can be projected. 
+
+{{< note >}}
+`serviceAccountToken` is not a volume type.
+{{< /note >}}
 {{% /capture %}}
 
 {{% capture prerequisites %}}

--- a/content/en/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-service-account.md
@@ -250,9 +250,10 @@ TODO: Test and explain how to use additional non-K8s secrets with an existing se
 
 ## Service Account Volume Projection
 
-From v1.11, k8s supports a new way to project service account token into a Pod.
-Users can specify token request with audiences, expirationSeconds. Besides, the service account token would become invalid when the Pod is deleted.
-A Projected Volume named [ServiceAccountToken](/docs/concepts/storage/volumes/#projected) is designed to request and store the token.
+Kubernetes 1.11 and higher supports a new way to project a service account token into a Pod.
+You can specify a token request with audiences, expirationSeconds. The service account token
+becomes invalid when the Pod is deleted. A Projected Volume named
+[ServiceAccountToken](/docs/concepts/storage/volumes/#projected) requests and stores the token.
 
 {{% /capture %}}
 

--- a/content/en/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-service-account.md
@@ -248,4 +248,12 @@ spec:
 TODO: Test and explain how to use additional non-K8s secrets with an existing service account.
 -->
 
+## Service Account Volume Projection
+
+From v1.11, k8s supports a new way to project service account token into a Pod.
+Users can specify token request with audiences, expirationSeconds. Besides, the service account token would become invalid when the Pod is deleted.
+A Projected Volume named [ServiceAccountToken](/docs/concepts/storage/volumes/#projected) is designed to request and store the token.
+
 {{% /capture %}}
+
+


### PR DESCRIPTION
PR https://github.com/kubernetes/website/pull/9182 has added docs for the service account projection feature. This PR gives a brief introduction of this new feature in serviceaccount docs.
ref:https://github.com/kubernetes/kubernetes/pull/63819


