### PR TITLE
Fixed broken Link to Salt setup documentation

### DIFF
--- a/content/en/docs/setup/scratch.md
+++ b/content/en/docs/setup/scratch.md
@@ -470,7 +470,7 @@ traffic to the internet, but have no problem with them inside your GCE Project.
 
 The previous steps all involved "conventional" system administration techniques for setting up
 machines.  You may want to use a Configuration Management system to automate the node configuration
-process.  There are examples of [Saltstack](/docs/admin/salt/), Ansible, Juju, and CoreOS Cloud Config in the
+process.  There are examples of [Saltstack](/docs/setup/salt/), Ansible, Juju, and CoreOS Cloud Config in the
 various Getting Started Guides.
 
 ## Bootstrapping the Cluster


### PR DESCRIPTION
Currently the hyperlink to Salt gives you a 404 error. This fixes the issue by correcting the url.