### PR TITLE
Fixes missing gpg keys

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl.md
+++ b/content/en/docs/tasks/tools/install-kubectl.md
@@ -42,6 +42,8 @@ gpgcheck=1
 repo_gpgcheck=1
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOF
+rpm --import "https://packages.cloud.google.com/yum/doc/yum-key.gpg"
+rpm --import "https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg"
 yum install -y kubectl
 {{< /tab >}}
 {{< /tabs >}}


### PR DESCRIPTION
Currently keys will be downloaded on every install procedure. This commit fixes this by importing the keys.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
