### PR TITLE
fix reference to site variable for deprecation

### DIFF
--- a/layouts/partials/deprecation-warning.html
+++ b/layouts/partials/deprecation-warning.html
@@ -4,7 +4,7 @@
     <div class="content deprecation-warning">
       <h3>
         Documentation for Kubernetes {{ .Param "version" }} is no longer actively maintained. The version you are currently viewing is a static snapshot.
-        For up-to-date documentation, see the <a href="{{ .Site.Params.currentUrl }}">latest</a> version.
+        For up-to-date documentation, see the <a href="{{ .Site.currentUrl }}">latest</a> version.
       </h3>
     </div>
   </main>


### PR DESCRIPTION
In `/layouts/partials/deprecation-warning.html`, `{{ .Site.Params.currentUrl }}` should be `{{ .Site.currentUrl }}`.