### PR TITLE
Enhance documentation of .spec.startingDeadlineSeconds

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/en/docs/concepts/workloads/controllers/cron-jobs.md
@@ -36,10 +36,10 @@ If `startingDeadlineSeconds` is set to a large value or left unset (the default)
 and if `concurrencyPolicy` is set to `Allow`, the jobs will always run
 at least once.
 
-Jobs may fail to run if the CronJob controller is not running or broken for a
-span of time from before the start time of the CronJob to start time plus
-`startingDeadlineSeconds`, or if the span covers multiple start times and
-`concurrencyPolicy` does not allow concurrency.
+For every CronJob, the CronJob controller checks how many schedules it missed in the duration from its last scheduled time till now. If there are more than 100 missed schedules, then it doesn't start the job. This would mean that, for example, If `concurrencyPolicy` does not allow concurrency, a job will be counted as missed if it was attempted to be scheduled when there was a previously scheduled cronjob still running.
+
+It is important to note, that if the field `startingDeadlineSeconds` is set (not `nil`), it will count how many missed jobs occurred from the value of `startingDeadlineSeconds` till now. For example, if `startingDeadlineSeconds` is `10`, It will count how many missed jobs occurred in the last 10 seconds. 
+
 For example, suppose a cron job is set to start at exactly `08:30:00` and its
 `startingDeadlineSeconds` is set to 10, if the CronJob controller happens to
 be down from `08:29:00` to `08:42:00`, the job will not start.

--- a/content/en/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/en/docs/concepts/workloads/controllers/cron-jobs.md
@@ -38,7 +38,7 @@ at least once.
 
 For every CronJob, the CronJob controller checks how many schedules it missed in the duration from its last scheduled time till now. If there are more than 100 missed schedules, then it doesn't start the job. This would mean that, for example, If `concurrencyPolicy` does not allow concurrency, a job will be counted as missed if it was attempted to be scheduled when there was a previously scheduled cronjob still running.
 
-It is important to note, that if the field `startingDeadlineSeconds` is set (not `nil`), it will count how many missed jobs occurred from the value of `startingDeadlineSeconds` till now. For example, if `startingDeadlineSeconds` is `10`, It will count how many missed jobs occurred in the last 10 seconds. 
+It is important to note, that if the field `startingDeadlineSeconds` is set (not `nil`), it will count how many missed jobs occurred from the value of `startingDeadlineSeconds` till now. For example, if `startingDeadlineSeconds` is `200`, It will count how many missed jobs occurred in the last 200 seconds. 
 
 For example, suppose a cron job is set to start at exactly `08:30:00` and its
 `startingDeadlineSeconds` is set to 10, if the CronJob controller happens to

--- a/content/en/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/en/docs/concepts/workloads/controllers/cron-jobs.md
@@ -36,9 +36,15 @@ If `startingDeadlineSeconds` is set to a large value or left unset (the default)
 and if `concurrencyPolicy` is set to `Allow`, the jobs will always run
 at least once.
 
-For every CronJob, the CronJob controller checks how many schedules it missed in the duration from its last scheduled time till now. If there are more than 100 missed schedules, then it doesn't start the job. This would mean that, for example, If `concurrencyPolicy` does not allow concurrency, a job will be counted as missed if it was attempted to be scheduled when there was a previously scheduled cronjob still running.
+For every CronJob, the CronJob controller checks how many schedules it missed in the duration from its last scheduled time till now. If there are more than 100 missed schedules, then it will not start the job and it will log the error
 
-It is important to note, that if the field `startingDeadlineSeconds` is set (not `nil`), it will count how many missed jobs occurred from the value of `startingDeadlineSeconds` till now. For example, if `startingDeadlineSeconds` is `200`, It will count how many missed jobs occurred in the last 200 seconds. 
+````
+Cannot determine if job needs to be started. Too many missed start time (> 100). Set or decrease .spec.startingDeadlineSeconds or check clock skew.
+````
+
+It is important to note, that if the field `startingDeadlineSeconds` is set (not `nil`), the controller will count how many missed jobs occurred from the value of `startingDeadlineSeconds` till now, rather than from the last scheduled time till now. For example, if `startingDeadlineSeconds` is `200`, the controller will count how many missed jobs occurred in the last 200 seconds. 
+
+A CronJob will be counted as missed if it failed to be created at its scheduled time. For example, If `concurrencyPolicy` is set to `Forbid` and a CronJob was attempted to be scheduled when there was a previous schedule still running, then it would count as missed.
 
 For example, suppose a cron job is set to start at exactly `08:30:00` and its
 `startingDeadlineSeconds` is set to 10, if the CronJob controller happens to

--- a/content/en/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/en/docs/concepts/workloads/controllers/cron-jobs.md
@@ -36,13 +36,13 @@ If `startingDeadlineSeconds` is set to a large value or left unset (the default)
 and if `concurrencyPolicy` is set to `Allow`, the jobs will always run
 at least once.
 
-For every CronJob, the CronJob controller checks how many schedules it missed in the duration from its last scheduled time till now. If there are more than 100 missed schedules, then it will not start the job and it will log the error
+For every CronJob, the CronJob controller checks how many schedules it missed in the duration from its last scheduled time until now. If there are more than 100 missed schedules, then it does not start the job and logs the error
 
 ````
 Cannot determine if job needs to be started. Too many missed start time (> 100). Set or decrease .spec.startingDeadlineSeconds or check clock skew.
 ````
 
-It is important to note, that if the field `startingDeadlineSeconds` is set (not `nil`), the controller will count how many missed jobs occurred from the value of `startingDeadlineSeconds` till now, rather than from the last scheduled time till now. For example, if `startingDeadlineSeconds` is `200`, the controller will count how many missed jobs occurred in the last 200 seconds. 
+It is important to note that if the `startingDeadlineSeconds` field is set (not `nil`), the controller counts how many missed jobs occurred from the value of `startingDeadlineSeconds` until now rather than from the last scheduled time until now. For example, if `startingDeadlineSeconds` is `200`, the controller counts how many missed jobs occurred in the last 200 seconds. 
 
 A CronJob will be counted as missed if it failed to be created at its scheduled time. For example, If `concurrencyPolicy` is set to `Forbid` and a CronJob was attempted to be scheduled when there was a previous schedule still running, then it would count as missed.
 

--- a/content/en/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/en/docs/concepts/workloads/controllers/cron-jobs.md
@@ -44,7 +44,7 @@ Cannot determine if job needs to be started. Too many missed start time (> 100).
 
 It is important to note that if the `startingDeadlineSeconds` field is set (not `nil`), the controller counts how many missed jobs occurred from the value of `startingDeadlineSeconds` until now rather than from the last scheduled time until now. For example, if `startingDeadlineSeconds` is `200`, the controller counts how many missed jobs occurred in the last 200 seconds. 
 
-A CronJob will be counted as missed if it failed to be created at its scheduled time. For example, If `concurrencyPolicy` is set to `Forbid` and a CronJob was attempted to be scheduled when there was a previous schedule still running, then it would count as missed.
+A CronJob is counted as missed if it has failed to be created at its scheduled time. For example, If `concurrencyPolicy` is set to `Forbid` and a CronJob was attempted to be scheduled when there was a previous schedule still running, then it would count as missed.
 
 For example, suppose a cron job is set to start at exactly `08:30:00` and its
 `startingDeadlineSeconds` is set to 10, if the CronJob controller happens to

--- a/content/en/docs/tasks/job/automated-tasks-with-cron-jobs.md
+++ b/content/en/docs/tasks/job/automated-tasks-with-cron-jobs.md
@@ -146,6 +146,8 @@ After the deadline, the cron job does not start the job.
 Jobs that do not meet their deadline in this way count as failed jobs.
 If this field is not specified, the jobs have no deadline.
 
+It is important to note, that if the field `.spec.startingDeadlineSeconds` is set (not nil), the CronJob controller will count how many missed jobs occurred from the value of `.spec.startingDeadlineSeconds` till now. For example, if it set to `200`, It will count how many missed schedules occurred in the last 200 seconds. If there were more than a 100 missed schedules, the cronjob will not be scheduled. 
+
 ### Concurrency Policy
 
 The `.spec.concurrencyPolicy` field is also optional.

--- a/content/en/docs/tasks/job/automated-tasks-with-cron-jobs.md
+++ b/content/en/docs/tasks/job/automated-tasks-with-cron-jobs.md
@@ -146,7 +146,7 @@ After the deadline, the cron job does not start the job.
 Jobs that do not meet their deadline in this way count as failed jobs.
 If this field is not specified, the jobs have no deadline.
 
-It is important to note, that if the field `.spec.startingDeadlineSeconds` is set (not nil), the CronJob controller will count how many missed jobs occurred from the value of `.spec.startingDeadlineSeconds` till now. For example, if it set to `200`, It will count how many missed schedules occurred in the last 200 seconds. If there were more than a 100 missed schedules, the cronjob will not be scheduled. 
+It is important to note, that if the field `.spec.startingDeadlineSeconds` is set (not nil), the CronJob controller will count how many missed jobs occurred from the value of `.spec.startingDeadlineSeconds` till now. For example, if it is set to `200`, It will count how many missed schedules occurred in the last 200 seconds. If there were more than a 100 missed schedules, the cronjob will not be scheduled. 
 
 ### Concurrency Policy
 

--- a/content/en/docs/tasks/job/automated-tasks-with-cron-jobs.md
+++ b/content/en/docs/tasks/job/automated-tasks-with-cron-jobs.md
@@ -146,7 +146,7 @@ After the deadline, the cron job does not start the job.
 Jobs that do not meet their deadline in this way count as failed jobs.
 If this field is not specified, the jobs have no deadline.
 
-It is important to note, that if the field `.spec.startingDeadlineSeconds` is set (not nil), the CronJob controller will count how many missed jobs occurred from the value of `.spec.startingDeadlineSeconds` till now. For example, if it is set to `200`, It will count how many missed schedules occurred in the last 200 seconds. If there were more than a 100 missed schedules, the cronjob will not be scheduled. 
+It is important to note that if the `.spec.startingDeadlineSeconds` field is set (not nil), the CronJob controller counts how many missed jobs occurred from the value of `.spec.startingDeadlineSeconds` until now. For example, if it is set to `200`, it counts how many missed schedules occurred in the last 200 seconds. If there were more than 100 missed schedules, the cronjob would not be scheduled. 
 
 ### Concurrency Policy
 


### PR DESCRIPTION
This PR addresses fixing the documentation for `.spec.startingDeadlineSeconds` for cronjobs. Some behaviour of the field was not documented at all, and we were getting errors like

````
"FailedNeedsStart", "Cannot determine if job needs to be started. Too many missed start time (> 100). Set or decrease .spec.startingDeadlineSeconds or check clock skew."
````

and we didn't know why or understand why until we had to look deep down the code. So this PR attempts to clarify in the documentation such use case and why it happens.

I explained more on the behaviour of the CronJob Controller in my answer here: https://stackoverflow.com/a/51080214/5654504