### PR TITLE
Fix env variable for etcd quorum reads

### DIFF
--- a/content/en/docs/tasks/administer-cluster/highly-available-master.md
+++ b/content/en/docs/tasks/administer-cluster/highly-available-master.md
@@ -31,7 +31,7 @@ To create a new HA-compatible cluster, you must set the following flags in your 
 * `MULTIZONE=true` - to prevent removal of master replicas kubelets from zones different than server's default zone.
 Required if you want to run master replicas in different zones, which is recommended.
 
-* `ENABLE_ETCD_QUORUM_READS=true` - to ensure that reads from all API servers will return most up-to-date data.
+* `ENABLE_ETCD_QUORUM_READ=true` - to ensure that reads from all API servers will return most up-to-date data.
 If true, reads will be directed to leader etcd replica.
 Setting this value to true is optional: reads will be more reliable but will also be slower.
 


### PR DESCRIPTION
The variable kube-up.sh consumes for enabling etcd quorum reads is singular. See
https://github.com/kubernetes/kubernetes/blob/f8c4907bec4fcb7d86d955c06b9c362b61e58933/cluster/gce/config-default.sh#L109