### PR TITLE
Add Git info to per-page template

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -19,6 +19,9 @@ pygmentsUseClasses = false
 # See https://help.farbox.com/pygments.html
 pygmentsStyle = "emacs"
 
+# Enable Git variables like commit, lastmod
+enableGitInfo = true
+
 [blackfriday]
 hrefTargetBlank = true
 fractions = false
@@ -27,7 +30,7 @@ fractions = false
 date = ["date", ":filename", "publishDate", "lastmod"]
 
 [permalinks]
-  blog = "/:section/:year/:month/:day/:slug/"
+blog = "/:section/:year/:month/:day/:slug/"
 
 # Be explicit about the output formats. We (currently) only want an RSS feed for the home page.
 [outputs]

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -16,36 +16,38 @@
 			{{ block "side-menu" . }}<div id="docsToc" style="display:none;"></div>{{ end }}
 			<div id="{{ block "content-id" . }}docsContent{{ end }}">
 				{{ block "content" . }}{{ end }}
-				<div class="issue-button-container">
-					<p><a href=""><img src="https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/{{ .Path }}?pixel" alt="Analytics" /></a></p>
-					{{ if and (ne .Kind "404") (not (strings.Contains .Path "search")) }}
-					{{ if not .Params.no_issue }}
-					<script type="text/javascript">
-					PDRTJS_settings_8345992 = {
-					"id" : "8345992",
-					"unique_id" : "{{ .RelPermalink }}",
-					"title" : "{{ .Title }}",
-					"permalink" : "{{ .Permalink }}"
-					};
-					(function(d,c,j){if(!document.getElementById(j)){var pd=d.createElement(c),s;pd.id=j;pd.src=('https:'==document.location.protocol)?'https://polldaddy.com/js/rating/rating.js':'http://i0.poll.fm/js/rating/rating.js';s=document.getElementsByTagName(c)[0];s.parentNode.insertBefore(pd,s);}}(document,'script','pd-rating-js'));
-					</script>
-					<a href="" onclick="window.open('https://github.com/kubernetes/website/issues/new?title=Issue%20with%20' +
-					'k8s.io'+window.location.pathname)" class="button issue">Create an Issue</a>
-					{{ end }}
-					{{ end }}
-					{{ if not .Params.noedit }}
-					<a href="{{ printf "%s#%s" ("docs/editdocs" | relURL) .Path | safeURL }}" class="button issue">Edit this Page</a>
-					{{ end }}
-				</div>
-        {{ if not .Params.showcommit }}
-          {{ if $.GitInfo }}
-        <div id="lastedit">
-          {{ .GitInfo.AuthorDate.Format "Page last modified on January 02, 2006 at 3:04 PM PST" }} by <a href="https://github.com/kubernetes/website/commit/{{ .GitInfo.Hash }}/">{{ .GitInfo.Subject }}</a>
-        </div>
-          {{ end }}
-        {{ end }}
 			</div>
 		</section>
+    <div id="pre-footer"> <!-- This is at the bottom of every topic underneath the TOC and content -->
+      <div class="issue-button-container">
+        <p><a href=""><img src="https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/{{ .Path }}?pixel" alt="Analytics" /></a></p>
+        {{ if and (ne .Kind "404") (not (strings.Contains .Path "search")) }}
+        {{ if not .Params.no_issue }}
+        <script type="text/javascript">
+        PDRTJS_settings_8345992 = {
+        "id" : "8345992",
+        "unique_id" : "{{ .RelPermalink }}",
+        "title" : "{{ .Title }}",
+        "permalink" : "{{ .Permalink }}"
+        };
+        (function(d,c,j){if(!document.getElementById(j)){var pd=d.createElement(c),s;pd.id=j;pd.src=('https:'==document.location.protocol)?'https://polldaddy.com/js/rating/rating.js':'http://i0.poll.fm/js/rating/rating.js';s=document.getElementsByTagName(c)[0];s.parentNode.insertBefore(pd,s);}}(document,'script','pd-rating-js'));
+        </script>
+        <a href="" onclick="window.open('https://github.com/kubernetes/website/issues/new?title=Issue%20with%20' +
+        'k8s.io'+window.location.pathname)" class="button issue">Create an Issue</a>
+        {{ end }}
+        {{ end }}
+        {{ if not .Params.noedit }}
+        <a href="{{ printf "%s#%s" ("docs/editdocs" | relURL) .Path | safeURL }}" class="button issue">Edit this Page</a>
+        {{ end }}
+      </div>
+      {{ if not .Params.showcommit }}
+        {{ if $.GitInfo }}
+      <div id="lastedit" class="lastedit issue-button-container">
+        {{ .GitInfo.AuthorDate.Format "Page last modified on January 02, 2006 at 3:04 PM PST" }} by <a href="https://github.com/kubernetes/website/commit/{{ .GitInfo.Hash }}/">{{ .GitInfo.Subject }}</a>
+      </div>
+        {{ end }}
+      {{ end }}
+    </div>
 		{{ partialCached "footer.html" . }}
 		{{ partialCached "footer-scripts.html" . }}
 	</body>

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -37,6 +37,13 @@
 					<a href="{{ printf "%s#%s" ("docs/editdocs" | relURL) .Path | safeURL }}" class="button issue">Edit this Page</a>
 					{{ end }}
 				</div>
+        {{ if not .Params.showcommit }}
+          {{ if $.GitInfo }}
+        <div id="lastedit">
+          {{ .GitInfo.AuthorDate.Format "Page last modified on January 02, 2006 at 3:04 PM PST" }} by <a href="https://github.com/kubernetes/website/commit/{{ .GitInfo.Hash }}/">{{ .GitInfo.Subject }}</a>
+        </div>
+          {{ end }}
+        {{ end }}
 			</div>
 		</section>
 		{{ partialCached "footer.html" . }}

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -43,7 +43,7 @@
       {{ if not .Params.showcommit }}
         {{ if $.GitInfo }}
       <div id="lastedit" class="lastedit issue-button-container">
-        {{ .GitInfo.AuthorDate.Format "Page last modified on January 02, 2006 at 3:04 PM PST" }} by <a href="https://github.com/kubernetes/website/commit/{{ .GitInfo.Hash }}/">{{ .GitInfo.Subject }}</a>
+        {{ .GitInfo.AuthorDate.Format "Page last modified on January 02, 2006 at 3:04 PM PST" }} by <a href="https://github.com/kubernetes/website/commit/{{ .GitInfo.Hash }}/">{{ .GitInfo.Subject }}</a> (<a href="https://github.com/kubernetes/website/commits/master/content/en/{{ .File.Path }}">Page history</a>)
       </div>
         {{ end }}
       {{ end }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
 # This default build command adds the robots noindex directive to the site headers
 publish = "public"
-command = "hugo && cp netlify_noindex_headers.txt public/_headers"
+command = "hugo --enableGitInfo && cp netlify_noindex_headers.txt public/_headers"
 
 [context.production.environment]
 HUGO_BASEURL = "https://kubernetes.io/"
@@ -10,13 +10,13 @@ HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]
-command = "hugo -b $DEPLOY_PRIME_URL"
+command = "hugo --enableGitInfo -b $DEPLOY_PRIME_URL"
 
 [context.deploy-preview.environment]
 HUGO_VERSION = "0.40.3"
 
 [context.branch-deploy]
-command = "hugo -b $DEPLOY_PRIME_URL"
+command = "hugo --enableGitInfo -b $DEPLOY_PRIME_URL"
 
 [context.branch-deploy.environment]
 HUGO_VERSION = "0.40.3"

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -856,15 +856,14 @@ html.search #docsContent h1 { margin-bottom: 0; border-bottom: 0; padding-bottom
   #docs .flyout-button { display: none; }
   #docs .logo { position: relative; float: left; display: block; width: 180px; height: 88px; top: 0; left: 0; transform: none; background-image: url(../images/nav_logo.svg); }
   #docs.flip-nav .logo, #docs.open-nav .logo { background-image: url(../images/nav_logo2.svg); }
-  #docs #lastedit {
-    padding: 10px 0;
-    text-align: center;
+  div#pre-footer div#lastedit.lastedit {
+    padding: 0 0 10px 20px;
     color: #bbb;
-    font-size: 90%;
+    font-size: 13px;
   }
-  #docs #lastedit a {
-    color: #3371e3 !important;
-    text-decoration: none underline;
+  div#pre-footer div#lastedit.lastedit a {
+    color: #3371e3;
+    text-decoration: underline;
   }
   #encyclopedia { padding: 50px 50px 100px 100px; clear: both; }
   #docsToc { position: relative; float: left; padding: 0 20px; left: 0; width: 350px; z-index: auto; }

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -476,6 +476,7 @@ dd { margin-bottom: 16px; }
 
 #docsContent #TableOfContents ul, #docsContent #TableOfContents li { list-style: disk; }
 
+
 .fixed footer { position: fixed; bottom: 0; }
 
 #miceType { clear: both; font-size: 11px; line-height: 18px; color: #aaa; }
@@ -855,6 +856,16 @@ html.search #docsContent h1 { margin-bottom: 0; border-bottom: 0; padding-bottom
   #docs .flyout-button { display: none; }
   #docs .logo { position: relative; float: left; display: block; width: 180px; height: 88px; top: 0; left: 0; transform: none; background-image: url(../images/nav_logo.svg); }
   #docs.flip-nav .logo, #docs.open-nav .logo { background-image: url(../images/nav_logo2.svg); }
+  #docs #lastedit {
+    padding: 10px 0;
+    text-align: center;
+    color: #bbb;
+    font-size: 90%;
+  }
+  #docs #lastedit a {
+    color: #3371e3 !important;
+    text-decoration: none underline;
+  }
   #encyclopedia { padding: 50px 50px 100px 100px; clear: both; }
   #docsToc { position: relative; float: left; padding: 0 20px; left: 0; width: 350px; z-index: auto; }
   #docsToc .push-menu-close-button { display: none; }


### PR DESCRIPTION
Add a per-page footer element to show the last modification date and link to the commit that did it

To disable this, set a page's frontmatter variable `showcommit` to false.
Fixes #1973

/assign @chenopis 
/assign @steveperry-53 