### PR TITLE
Update version for PriorityClass

### DIFF
--- a/content/en/docs/concepts/configuration/pod-priority-preemption.md
+++ b/content/en/docs/concepts/configuration/pod-priority-preemption.md
@@ -132,7 +132,7 @@ that use the name of the deleted PriorityClass.
 ### Example PriorityClass
 
 ```yaml
-apiVersion: scheduling.k8s.io/v1alpha1
+apiVersion: scheduling.k8s.io/v1beta1
 kind: PriorityClass
 metadata:
   name: high-priority


### PR DESCRIPTION
With K8s 1.11 it should be `scheduling.k8s.io/v1beta1`
