### PR TITLE
Fix typo for kubeadm in instruction for upgrading

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-11.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-11.md
@@ -217,7 +217,7 @@ To keep `kube-dns`, pass `--feature-flags=CoreDNS=false` to `kubeadm upgrade app
     apt-get upgrade -y kubelet kubeadm
     {{% /tab %}}
     {{% tab name="CentOS, RHEL or Fedora" %}}
-    yum upgrade -y kubelet kubedam
+    yum upgrade -y kubelet kubeadm
     {{% /tab %}}
     {{< /tabs >}}
 


### PR DESCRIPTION
This  PR fix the typo for kubeadm in instruction for upgrading kubelet and kubeadm.

Note: Minor fix, Can be merged safely.

