### PR TITLE
One character fix to unbreak Netlify

### DIFF
--- a/content/en/docs/concepts/policy/resource-quotas.md
+++ b/content/en/docs/concepts/policy/resource-quotas.md
@@ -161,8 +161,8 @@ The following types are supported:
 | `secrets` | The total number of secrets that can exist in the namespace. |
 
 For example, `pods` quota counts and enforces a maximum on the number of `pods`
-created in a single namespace that are not terminal. You might want to set a `pods` 
-quota on a namespace to avoid the case where a user creates many small pods and 
+created in a single namespace that are not terminal. You might want to set a `pods`
+quota on a namespace to avoid the case where a user creates many small pods and
 exhausts the cluster's supply of Pod IPs.
 
 ## Quota Scopes
@@ -202,7 +202,7 @@ field in the quota spec.
 
 A quota is matched and consumed only if `scopeSelector` in the quota spec selects the pod.
 
-{{< note > }}
+{{< note >}}
 **Note:** You need to enable the feature gate `ResourceQuotaScopeSelectors`before using resource quotas
 per PriorityClass.
 {{< /note >}}


### PR DESCRIPTION
This PR fixes a one-space error introduced in [#9086/L205](https://github.com/kubernetes/website/pull/9086/files#diff-6b7ada18d433f9d891d597ad980085f0R205) that caused all subsequent Netlify builds to break.

This PR highlights the fragility of Black Friday-flavor Markdown, and serves as an excellent point of discussion for why we should consider porting Kramdown (in which the majority of repo content was composed) to Go.

/assign @mistyhacks 