### PR TITLE
fixing feature flag in client-go docs

### DIFF
--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -675,7 +675,7 @@ rules:
 
 ## client-go credential plugins
 
-{% assign for_k8s_version="v1.11" %}{% include feature-state-beta.md %}
+{{< feature-state for_k8s_version="v1.11" state="beta" >}}
 
 `k8s.io/client-go` and tools using it such as `kubectl` and `kubelet` are able to execute an
 external command to receive user credentials.


### PR DESCRIPTION
Fixing minor flag issue on docs page. [#9340](https://github.com/kubernetes/website/issues/9340)

**Before**: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins
**After**: https://deploy-preview-9341--kubernetes-io-master-staging.netlify.com/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins

