### PR TITLE
Fix non 1.11 api ref on k8s.io/docs/reference/

### DIFF
--- a/content/en/docs/reference/_index.md
+++ b/content/en/docs/reference/_index.md
@@ -12,10 +12,10 @@ weight: 70
 * [Kubernetes API Overview](/docs/reference/using-api/api-overview/) - Overview of the API for Kubernetes.
 * Kubernetes API Versions
   * [1.11](/docs/reference/generated/kubernetes-api/v1.11/)
-  * [1.10](https://v1-10.docs/kubernetes.io/docs/reference/)
-  * [1.9](https://v1-9.docs.kubernetes.io/docs/reference/)
-  * [1.8](https://v1-8.docs.kubernetes.io/docs/reference/)
-  * [1.7](https://v1-7.docs.kubernetes.io/docs/reference/)
+  * [1.10](https://v1-10.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/)
+  * [1.9](https://v1-9.docs.kubernetes.io/docs/api-reference/v1.9/)
+  * [1.8](https://v1-8.docs.kubernetes.io/docs/api-reference/v1.8/)
+  * [1.7](https://v1-7.docs.kubernetes.io/docs/api-reference/v1.7/)
 
 ## API Client Libraries
 

--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -675,7 +675,7 @@ rules:
 
 ## client-go credential plugins
 
-{% assign for_k8s_version="v1.11" %}{% include feature-state-beta.md %}
+{{< feature-state for_k8s_version="v1.11" state="beta" >}}
 
 `k8s.io/client-go` and tools using it such as `kubectl` and `kubelet` are able to execute an
 external command to receive user credentials.


### PR DESCRIPTION
Addresses [#9313](https://github.com/kubernetes/website/issues/9313) with the old api ref urls.