### PR TITLE
fix version navigation in release v1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,16 @@ go:
 install:
 - export PATH=$GOPATH/bin:$PATH
 - mkdir -p $HOME/gopath/src/k8s.io
-- mv $TRAVIS_BUILD_DIR $HOME/gopath/src/k8s.io/kubernetes.github.io
+- mv $TRAVIS_BUILD_DIR $HOME/gopath/src/k8s.io/website
 
 # (1) Fetch dependencies for us to run the tests in test/examples_test.go
-- go get -t -v k8s.io/kubernetes.github.io/test
+- go get -t -v k8s.io/website/test
 
 # Simplified deduplication of dependencies.
-- cd $GOPATH/src/k8s.io/kubernetes/
-- git checkout release-1.7
+- pushd $GOPATH/src/k8s.io/kubernetes && git checkout release-1.7 && popd
 - cp -L -R $GOPATH/src/k8s.io/kubernetes/vendor/ $GOPATH/src/
 - rm -r $GOPATH/src/k8s.io/kubernetes/vendor/
 
 script:
-- go test -v k8s.io/kubernetes.github.io/test
+- go test -v k8s.io/website/test
 - ./verify-docs-format.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,11 @@ install:
 - mv $TRAVIS_BUILD_DIR $HOME/gopath/src/k8s.io/website
 
 # (1) Fetch dependencies for us to run the tests in test/examples_test.go
-- pushd $GOPATH/src/k8s.io/website && git checkout -t origin/release-1.7 && popd
-- go get -t -v k8s.io/website/test
-
-# Simplified deduplication of dependencies.
+- pushd $GOPATH/src/k8s.io && git clone https://github.com/kubernetes/kubernetes && popd
 - pushd $GOPATH/src/k8s.io/kubernetes && git checkout release-1.7 && popd
 - cp -L -R $GOPATH/src/k8s.io/kubernetes/vendor/ $GOPATH/src/
 - rm -r $GOPATH/src/k8s.io/kubernetes/vendor/
+- go get -t -v k8s.io/website/test
 
 script:
 - go test -v k8s.io/website/test

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ install:
 - go get -t -v k8s.io/kubernetes.github.io/test
 
 # Simplified deduplication of dependencies.
+- cd $GOPATH/src/k8s.io/kubernetes/
+- git checkout release-1.7
 - cp -L -R $GOPATH/src/k8s.io/kubernetes/vendor/ $GOPATH/src/
 - rm -r $GOPATH/src/k8s.io/kubernetes/vendor/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
 - mv $TRAVIS_BUILD_DIR $HOME/gopath/src/k8s.io/website
 
 # (1) Fetch dependencies for us to run the tests in test/examples_test.go
-- pushd $GOPATH/src/k8s.io/website && git checkout release-1.7 && popd
+- pushd $GOPATH/src/k8s.io/website && git checkout -t origin/release-1.7 && popd
 - go get -t -v k8s.io/website/test
 
 # Simplified deduplication of dependencies.

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ install:
 - export PATH=$GOPATH/bin:$PATH
 - mkdir -p $HOME/gopath/src/k8s.io
 - mv $TRAVIS_BUILD_DIR $HOME/gopath/src/k8s.io/website
+- cd $HOME/gopath/src/k8s.io/website
 
 # (1) Fetch dependencies for us to run the tests in test/examples_test.go
 - pushd $GOPATH/src/k8s.io && git clone https://github.com/kubernetes/kubernetes && popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
 - mv $TRAVIS_BUILD_DIR $HOME/gopath/src/k8s.io/website
 
 # (1) Fetch dependencies for us to run the tests in test/examples_test.go
+- pushd $GOPATH/src/k8s.io/website && git checkout release-1.7 && popd
 - go get -t -v k8s.io/website/test
 
 # Simplified deduplication of dependencies.

--- a/_config.yml
+++ b/_config.yml
@@ -23,11 +23,16 @@ defaults:
       githubbranch: "v1.7.3"
       docsbranch: "release-1.7"
       versions:
+      - fullversion: "v1.11.0"
+          version: "v1.11"
+          githubbranch: "v1.11.0"
+          docsbranch: "release-1.11"
+          url:  https://kubernetes.io/
       - fullversion: "v1.10.0"
           version: "v1.10"
           githubbranch: "v1.10.0"
           docsbranch: "release-1.10"
-          url: https://kubernetes.io/
+          url:  https://v1-10.docs.kubernetes.io/
         - fullversion: "v1.9.0"
           version: "v1.9"
           githubbranch: "v1.9.0"

--- a/_config.yml
+++ b/_config.yml
@@ -48,11 +48,6 @@ defaults:
           githubbranch: "v1.7.3"
           docsbranch: "release-1.7"
           url: https://v1-7.docs.kubernetes.io/docs/home/
-        - fullversion: "v1.6.8"
-          version: "v1.6"
-          githubbranch: "v1.6.8"
-          docsbranch: "release-1.6"
-          url: https://v1-6.docs.kubernetes.io/docs/home/
       deprecated: true
       currentUrl: https://kubernetes.io/docs/home/
       nextUrl: http://kubernetes-io-vnext-staging.netlify.com/

--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,7 @@ defaults:
           version: "v1.11"
           githubbranch: "v1.11.0"
           docsbranch: "release-1.11"
-          url:  https://kubernetes.io/
+          url:  https://kubernetes.io/docs
       - fullversion: "v1.10.0"
           version: "v1.10"
           githubbranch: "v1.10.0"

--- a/_config.yml
+++ b/_config.yml
@@ -23,11 +23,16 @@ defaults:
       githubbranch: "v1.7.3"
       docsbranch: "release-1.7"
       versions:
+      - fullversion: "v1.10.0"
+          version: "v1.10"
+          githubbranch: "v1.10.0"
+          docsbranch: "release-1.10"
+          url: https://kubernetes.io/
         - fullversion: "v1.9.0"
           version: "v1.9"
           githubbranch: "v1.9.0"
           docsbranch: "release-1.9"
-          url: https://kubernetes.io/docs/home/
+          url: https://v1-9.docs.kubernetes.io/docs/home/
         - fullversion: "v1.8.4"
           version: "v1.8"
           githubbranch: "v1.8.4"

--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,7 @@ defaults:
           version: "v1.11"
           githubbranch: "v1.11.0"
           docsbranch: "release-1.11"
-          url:  https://kubernetes.io/docs
+          url:  https://kubernetes.io/docs/
       - fullversion: "v1.10.0"
           version: "v1.10"
           githubbranch: "v1.10.0"

--- a/_config.yml
+++ b/_config.yml
@@ -48,11 +48,6 @@ defaults:
           githubbranch: "v1.6.8"
           docsbranch: "release-1.6"
           url: https://v1-6.docs.kubernetes.io/docs/home/
-        - fullversion: "v1.5.7"
-          version: "v1.5"
-          githubbranch: "v1.5.7"
-          docsbranch: "release-1.5"
-          url: https://v1-5.docs.kubernetes.io/docs/
       deprecated: true
       currentUrl: https://kubernetes.io/docs/home/
       nextUrl: http://kubernetes-io-vnext-staging.netlify.com/


### PR DESCRIPTION
- In `release v1.7`, navigating selector to version `v1.10` disappears
- modified `_config.yml` in branch `release-1.7`

Signed-off-by: harshvkarn <harshvkarn54@gmail.com>

