### PR TITLE
Fix CSS for edit buttons and page history

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -856,6 +856,13 @@ html.search #docsContent h1 { margin-bottom: 0; border-bottom: 0; padding-bottom
   #docs .flyout-button { display: none; }
   #docs .logo { position: relative; float: left; display: block; width: 180px; height: 88px; top: 0; left: 0; transform: none; background-image: url(../images/nav_logo.svg); }
   #docs.flip-nav .logo, #docs.open-nav .logo { background-image: url(../images/nav_logo2.svg); }
+  div#pre-footer {
+    background-color: #fff;
+    text-align: center;
+  }
+  div#pre-footer .issue-button-container {
+    padding-bottom: 10px;
+  }
   div#pre-footer div#lastedit.lastedit {
     padding: 0 0 10px 20px;
     color: #bbb;


### PR DESCRIPTION
Iteration after #9309 based on style issues that were not apparently in Netlify (or I didn't notice)

This PR makes the background of the div holding the buttons and page history white, and centered across the page (this should work OK in mobile, as well, rather than being pushed directly against the left margin.

/assign @steveperry-53 

🙏 
