### PR TITLE
Minikube tutorial: Updating mac vm-driver.

### DIFF
--- a/content/en/docs/tutorials/hello-minikube.md
+++ b/content/en/docs/tutorials/hello-minikube.md
@@ -26,7 +26,7 @@ Minikube provides a simple way of running Kubernetes on your local machine for f
 
 {{% capture prerequisites %}}
 
-* For OS X, you need [Homebrew](https://brew.sh) to install the `xhyve` driver.
+* For OS X, you can use [Homebrew](https://brew.sh) to install Minikube.
 
   {{< note >}}
   **Note:** If you see the following Homebrew error when you run `brew update` after you update your computer to MacOS 10.13:
@@ -62,21 +62,13 @@ instead of Docker for Mac, the instructions to install Minikube may be
 slightly different. For general Minikube installation instructions, see
 the [Minikube installation guide](/docs/getting-started-guides/minikube/).
 
-Use `curl` to download and install the latest Minikube release:
-
+Use Homebrew to install the latest Minikube release:
 ```shell
-curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-darwin-amd64 && \
-  chmod +x minikube && \
-  sudo mv minikube /usr/local/bin/
+brew cask install minikube
 ```
 
-Use Homebrew to install the xhyve driver and set its permissions:
-
-```shell
-brew install docker-machine-driver-xhyve
-sudo chown root:wheel $(brew --prefix)/opt/docker-machine-driver-xhyve/bin/docker-machine-driver-xhyve
-sudo chmod u+s $(brew --prefix)/opt/docker-machine-driver-xhyve/bin/docker-machine-driver-xhyve
-```
+Install the HyperKit driver, as described by the
+[Minikube driver installation guide](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#hyperkit-driver).
 
 Use Homebrew to download the `kubectl` command-line tool, which you can
 use to interact with Kubernetes clusters:
@@ -100,28 +92,16 @@ docker images
 If NO proxy is required, start the Minikube cluster:
 
 ```shell
-minikube start --vm-driver=xhyve
+minikube start --vm-driver=hyperkit
 ```
 If a proxy server is required, use the following method to start Minikube cluster with proxy setting:
 
 ```shell
-minikube start --vm-driver=xhyve --docker-env HTTP_PROXY=http://your-http-proxy-host:your-http-proxy-port  --docker-env HTTPS_PROXY=http(s)://your-https-proxy-host:your-https-proxy-port
+minikube start --vm-driver=hyperkit --docker-env HTTP_PROXY=http://your-http-proxy-host:your-http-proxy-port  --docker-env HTTPS_PROXY=http(s)://your-https-proxy-host:your-https-proxy-port
 ```
 
-The `--vm-driver=xhyve` flag specifies that you are using Docker for Mac. The
+The `--vm-driver=hyperkit` flag specifies that you are using Docker for Mac. The
 default VM driver is VirtualBox.
-
-Note if `minikube start --vm-driver=xhyve` is unsuccessful due to the error:
-```
-Error creating machine: Error in driver during machine creation: Could not convert the UUID to MAC address: exit status 1
-```
-
-Then the following may resolve the `minikube start --vm-driver=xhyve` issue:
-```
-rm -rf ~/.minikube
-sudo chown root:wheel $(brew --prefix)/opt/docker-machine-driver-xhyve/bin/docker-machine-driver-xhyve
-sudo chmod u+s $(brew --prefix)/opt/docker-machine-driver-xhyve/bin/docker-machine-driver-xhyve
-```
 
 Now set the Minikube context. The context is what determines which cluster
 `kubectl` is interacting with. You can see all your available contexts in the


### PR DESCRIPTION
Addresses #9147

The recommended vm-driver for mac is now hyperkit, not xhyve.
Updating Minikube tutorial to reflect this.

