### PR TITLE
State the default update strategy

### DIFF
--- a/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -453,7 +453,7 @@ images, resource requests and/or limits, labels, and annotations of the Pods in 
 StatefulSet. There are two valid update strategies, `RollingUpdate` and 
 `OnDelete`.
 
-`OnDelete` update strategy is the default for StatefulSets.
+`RollingUpdate` update strategy is the default for StatefulSets.
 
 ### Rolling Update
 

--- a/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -451,7 +451,9 @@ strategy used is determined by the `spec.updateStrategy` field of the
 StatefulSet API Object. This feature can be used to upgrade the container 
 images, resource requests and/or limits, labels, and annotations of the Pods in a 
 StatefulSet. There are two valid update strategies, `RollingUpdate` and 
-`OnDelete`. 
+`OnDelete`.
+
+`OnDelete` update strategy is the default for StatefulSets.
 
 ### Rolling Update
 


### PR DESCRIPTION
The default update strategy is not specified in the docs.

Found that without specifying on in the manifest, it defaults to ~OnDelete~ RollingUpdate.