### PR TITLE
Update load-balance-access-application-cluster.md

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/load-balance-access-application-cluster.md
+++ b/content/en/docs/tasks/access-application-cluster/load-balance-access-application-cluster.md
@@ -75,10 +75,8 @@ load-balanced access to an application running in a cluster.
    external IP address remains in the pending state.
    {{< /note >}}
 
-       ```
        NAME              CLUSTER-IP   EXTERNAL-IP   PORT(S)    AGE
        example-service   10.0.0.160   <pending>     8080/TCP   40s
-       ```
 
 1. Use your Service object to access the Hello World application:
 
@@ -104,9 +102,7 @@ load-balanced access to an application running in a cluster.
    value for your service. Then enter this command to access the Hello World
    application:
 
-       ```
        curl <minikube-node-ip-address>:<service-node-port>
-       ```
 
    where `<minikube-node-ip-address>` us the IP address of your Minikube node,
    and `<service-node-port>` is the NodePort value for your service.

--- a/content/en/docs/tasks/access-application-cluster/load-balance-access-application-cluster.md
+++ b/content/en/docs/tasks/access-application-cluster/load-balance-access-application-cluster.md
@@ -75,12 +75,16 @@ load-balanced access to an application running in a cluster.
    external IP address remains in the pending state.
    {{< /note >}}
 
+       ```
        NAME              CLUSTER-IP   EXTERNAL-IP   PORT(S)    AGE
        example-service   10.0.0.160   <pending>     8080/TCP   40s
+       ```
 
 1. Use your Service object to access the Hello World application:
 
+       ```
        curl <your-external-ip-address>:8080
+       ```
 
    where `<your-external-ip-address>` is the external IP address of your
    service.
@@ -100,7 +104,9 @@ load-balanced access to an application running in a cluster.
    value for your service. Then enter this command to access the Hello World
    application:
 
+       ```
        curl <minikube-node-ip-address>:<service-node-port>
+       ```
 
    where `<minikube-node-ip-address>` us the IP address of your Minikube node,
    and `<service-node-port>` is the NodePort value for your service.


### PR DESCRIPTION
It seems there is a difference in handling MD format on github and kubernetes.io site. On k8s site "curl <your-external-ip-address>:8080" shows up as "curl :8080" as "<your-external-ip-address>" treated as html tag. It also resets section numbering (Use your Service object to access the Hello World application: is marked as "1." while it should be "5.")
"curl <minikube-node-ip-address>:<service-node-port>" seems to be treated correctly but I hope extra explicit formatting will not break it. Alas Preview on github is not very useful to validate it.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.12 Features: set Milestone to 1.12 and Base Branch to release-1.12
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
> Please delete this note before submitting the pull request.

