### PR TITLE
Correct internal behavior list in admission-controllers doc

### DIFF
--- a/content/en/docs/reference/access-authn-authz/admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/admission-controllers.md
@@ -465,12 +465,13 @@ metadata:
 
 #### Internal Behavior
 This admission controller has the following behavior:
+
   1. If the `Namespace` has an annotation with a key `scheduler.alpha.kubernetes.io/node-selector`, use its value as the
      node selector.
-  1. If the namespace lacks such an annotation, use the `clusterDefaultNodeSelector` defined in the `PodNodeSelector`
+  2. If the namespace lacks such an annotation, use the `clusterDefaultNodeSelector` defined in the `PodNodeSelector`
      plugin configuration file as the node selector.
-  1. Evaluate the pod's node selector against the namespace node selector for conflicts. Conflicts result in rejection.
-  1. Evaluate the pod's node selector against the namespace-specific whitelist defined the plugin configuration file.
+  3. Evaluate the pod's node selector against the namespace node selector for conflicts. Conflicts result in rejection.
+  4. Evaluate the pod's node selector against the namespace-specific whitelist defined the plugin configuration file.
      Conflicts result in rejection.
 
 {{< note >}}

--- a/content/en/docs/reference/access-authn-authz/admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/admission-controllers.md
@@ -466,13 +466,13 @@ metadata:
 #### Internal Behavior
 This admission controller has the following behavior:
 
-  1. If the `Namespace` has an annotation with a key `scheduler.alpha.kubernetes.io/node-selector`, use its value as the
-     node selector.
-  2. If the namespace lacks such an annotation, use the `clusterDefaultNodeSelector` defined in the `PodNodeSelector`
-     plugin configuration file as the node selector.
-  3. Evaluate the pod's node selector against the namespace node selector for conflicts. Conflicts result in rejection.
-  4. Evaluate the pod's node selector against the namespace-specific whitelist defined the plugin configuration file.
-     Conflicts result in rejection.
+1. If the `Namespace` has an annotation with a key `scheduler.alpha.kubernetes.io/node-selector`, use its value as the
+node selector.
+2. If the namespace lacks such an annotation, use the `clusterDefaultNodeSelector` defined in the `PodNodeSelector`
+plugin configuration file as the node selector.
+3. Evaluate the pod's node selector against the namespace node selector for conflicts. Conflicts result in rejection.
+4. Evaluate the pod's node selector against the namespace-specific whitelist defined the plugin configuration file.
+Conflicts result in rejection.
 
 {{< note >}}
 **Note:** PodNodeSelector allows forcing pods to run on specifically labeled nodes. Also see the PodTolerationRestriction 


### PR DESCRIPTION
This PR corrects the numbered list in the internal behavior section of the admission-controllers doc.

Current View:
https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#internal-behavior
