### PR TITLE
Update fedora_manual_config.md

### DIFF
--- a/content/en/docs/getting-started-guides/fedora/fedora_manual_config.md
+++ b/content/en/docs/getting-started-guides/fedora/fedora_manual_config.md
@@ -120,10 +120,7 @@ KUBELET_ADDRESS="--address=0.0.0.0"
 KUBELET_HOSTNAME="--hostname-override=fed-node"
 
 # location of the api-server
-KUBELET_ARGS="--cgroup-driver=systemd --kubeconfig=/etc/kubernetes/master-kubeconfig.yaml --require-kubeconfig"
-
-# Add your own!
-KUBELET_ARGS=""
+KUBELET_ARGS="--cgroup-driver=systemd --kubeconfig=/etc/kubernetes/master-kubeconfig.yaml"
 
 ```
 


### PR DESCRIPTION
removal of 
 ```
 # Add your own!
  KUBELET_ARGS=""
```
this line causes provided args above it to be over written

removal of flag "--require-kubeconfig" as it prevents the service from starting with error `F0708 18:41:17.411350   11725 server.go:145] unknown flag: --require-kubeconfig`

this is with v1.10.1
