### PR TITLE
Fix 1.8 CI gate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,17 @@ install:
 - export PATH=$GOPATH/bin:$PATH
 - mkdir -p $HOME/gopath/src/k8s.io
 - mv $TRAVIS_BUILD_DIR $HOME/gopath/src/k8s.io/website
+- cd $HOME/gopath/src/k8s.io/website
 
 # (1) Fetch dependencies for us to run the tests in test/examples_test.go
-- go get -t -v k8s.io/website/test
+- pushd $GOPATH/src/k8s.io && git clone https://github.com/kubernetes/kubernetes && popd
+- pushd $GOPATH/src/k8s.io/kubernetes && git checkout release-1.8 && popd
 
-# Simplified deduplication of dependencies.
+# (2) Simplified deduplication of dependencies.
 - cp -L -R $GOPATH/src/k8s.io/kubernetes/vendor/ $GOPATH/src/
 - rm -r $GOPATH/src/k8s.io/kubernetes/vendor/
+
+- go get -t -v k8s.io/website/test
 
 script:
 - go test -v k8s.io/website/test

--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -39,8 +39,8 @@ import (
 	autoscaling_validation "k8s.io/kubernetes/pkg/apis/autoscaling/validation"
 	"k8s.io/kubernetes/pkg/apis/batch"
 	batch_validation "k8s.io/kubernetes/pkg/apis/batch/validation"
-	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/apis/core/validation"
+	api "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/validation"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	ext_validation "k8s.io/kubernetes/pkg/apis/extensions/validation"
 	"k8s.io/kubernetes/pkg/apis/policy"
@@ -49,7 +49,7 @@ import (
 	storagevalidation "k8s.io/kubernetes/pkg/apis/storage/validation"
 	"k8s.io/kubernetes/pkg/capabilities"
 	"k8s.io/kubernetes/pkg/registry/batch/job"
-	schedulerapilatest "k8s.io/kubernetes/pkg/scheduler/api/latest"
+	schedulerapilatest "k8s.io/kubernetes/plugin/pkg/scheduler/api/latest"
 )
 
 func validateObject(obj runtime.Object) (errors field.ErrorList) {


### PR DESCRIPTION
This PR fixes the CI gate for release-1.8. Usually we don't fix bugs in older versions due to resource shortage. This one is about fixing the CI gate so that critical patches can still get accepted to the old branch.