### PR TITLE
Add maintainers, organize all by alpha

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,19 +1,21 @@
 # Reviewers can /lgtm /approve but not sufficient for auto-merge without an
 # approver
 reviewers:
-- zhangxiaoyu-zidif
-- xiangpengzhao
+- Rajakavitha1
 - stewart-yu
-- Rajakavitha1 
+- xiangpengzhao
+- zhangxiaoyu-zidif
+
 # Approvers have all the ability of reviewers but their /approve makes
 # auto-merge happen if a /lgtm exists, or vice versa, or they can do both
 # No need for approvers to also be listed as reviewers
 approvers:
-- heckj
 - bradamant3
 - bradtopol
-- steveperry-53
-- zacharysarah
 - chenopis
+- kbarnard10
 - mistyhacks
+- steveperry-53
 - tengqm
+- zacharysarah
+- zparnold


### PR DESCRIPTION
This PR:
- Adds @kbarnard10 as an approver per [Slack discussion](https://kubernetes.slack.com/archives/CA1MMM1HU/p1530212688000505)
- Adds @zparnold as an approver per [1.12 release team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.12/release_team.md)
- Sorts reviewers and approvers alphabetically

