### PR TITLE
correct new worker deploy cmd

### DIFF
--- a/content/en/docs/getting-started-guides/ubuntu/upgrades.md
+++ b/content/en/docs/getting-started-guides/ubuntu/upgrades.md
@@ -111,7 +111,7 @@ Given a deployment where the workers are named kubernetes-alpha.
 
 Deploy new workers:
 
-    juju deploy kubernetes-beta
+    juju deploy kubernetes-alpha
 
 Pause the old workers so your workload migrates:
 


### PR DESCRIPTION
This fixes what I believe is a typo in the deploy new worker command. If I'm wrong in this isn't a typo, I'd suggest making a note in the documentation about why it says `beta` instead of `alpha`.

Thanks!