### PR TITLE
Fix broken wordpress-deployment.yaml link

### DIFF
--- a/content/en/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
+++ b/content/en/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
@@ -142,7 +142,7 @@ The following manifest describes a single-instance WordPress Deployment and Serv
 1. Create a WordPress Service and Deployment from the `wordpress-deployment.yaml` file:
 
       ```shell
-      kubectl create -f https://k8s.io/examples/wordpress/wordpress-deployment.yaml
+      kubectl create -f https://k8s.io/examples/application/wordpress/wordpress-deployment.yaml
       ```
 
 2. Verify that a PersistentVolume got dynamically provisioned:


### PR DESCRIPTION
https://k8s.io/examples/wordpress/wordpress-deployment.yaml is a 404.
https://k8s.io/examples/application/wordpress/wordpress-deployment.yaml works.