### PR TITLE
Target docker-serve does not exist + removed $

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ For more information about contributing to the Kubernetes documentation, see:
 If you'd like, you can build the Kubernetes docs using Docker. To get started, build the image locally:
 
 ```bash
-$ make docker-image
+make docker-image
 
 # The underlying command:
-$ docker build . \
+docker build . \
   --tag kubernetes-hugo \
   --build-arg HUGO_VERSION=0.40.3
 ```
@@ -33,16 +33,17 @@ You can create an image for a different version of Hugo by changing the value of
 Once the `kubernetes-hugo` image has been built locally, you can build the site:
 
 ```bash
-$ make docker-serve
+make stage
 
 # The underlying command:
-$ docker run \
+docker run \
   --rm \
   --interactive \
   --tty \
   --volume $(PWD):/src \
-  kubernetes-hugo:latest \
-  hugo
+  -p 1313:1313 \
+  kubernetes-hugo \
+  hugo server --watch --bind 0.0.0.0
 ```
 
 As when building without using a Docker container, the results of the build will be published to the `public` directory (the default output directory for [Hugo](https://gohugo.io), the static site generator used to build this site).


### PR DESCRIPTION
#### What's this PR do?

* Fixes `README.md` with the correct command to run `hugo` (**BUG: make: *** No rule to make target `docker-serve'.  Stop.**)

* Removes `$` in front of the commands (**BUG: [markdownlint] MD014/commands-show-output: Dollar signs used before commands without showing output**)

#### Where should the reviewer start?

* `README.md` lines `24`, `27`, `36`, `39`, `44-46`

#### How should this be manually tested?

`make docker-build stage`

#### Risk involved?

No

#### Screenshots (if appropriate)

N/A