### PR TITLE
Fix typo in upgrade guide

### DIFF
--- a/content/en/docs/getting-started-guides/ubuntu/upgrades.md
+++ b/content/en/docs/getting-started-guides/ubuntu/upgrades.md
@@ -111,7 +111,7 @@ Given a deployment where the workers are named kubernetes-alpha.
 
 Deploy new workers:
 
-    juju deploy kubernetes-beta
+    juju deploy kubernetes-alpha
 
 Pause the old workers so your workload migrates:
 


### PR DESCRIPTION
Carry #9446 because the author is not willing to sign the CLA.

/assign @zacharysarah 