### PR TITLE
Experiment: Does folder-level OWNERS file work?

### DIFF
--- a/content/en/docs/getting-started-guides/fedora/_index.md
+++ b/content/en/docs/getting-started-guides/fedora/_index.md
@@ -1,5 +1,5 @@
 ---
 title: "Bare Metal"
-weight: 60
+weight: 61
 ---
 


### PR DESCRIPTION
Do not merge. This is an experiment. I want to know if the bot will read the folder-level OWNERS and suggest reviewers from that file.

And the answer is yes. The bot suggests aveshagarwal and thockin. These are two of the reviewers listed in /docs/getting-started-guides/fedora/OWNERS.

Note that there are no reviewers listed in the front matter of the one file changed here.

