### PR TITLE
Add .editorconfig to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ nohup.out
 
 # Hugo output
 public/
+
+# User-specific editorconfig files
+.editorconfig


### PR DESCRIPTION
I find [`.editorconfig`](https://editorconfig.org/) files to be an indispensable part of my doc-writing workflow. I'd like to be able to apply my own when working on the k8s website without imposing an editor config on others. This PR makes Git ignore any user-specific `.editorconfig` files.