### PR TITLE
cloud_providers: aws, node naming updates

### DIFF
--- a/content/en/docs/concepts/cluster-administration/cloud-providers.md
+++ b/content/en/docs/concepts/cluster-administration/cloud-providers.md
@@ -16,7 +16,22 @@ be used when running Kubernetes on Amazon Web Services.
 
 ### Node Name
 
+#### Default
+
 The AWS cloud provider uses the private DNS name of the AWS instance as the name of the Kubernetes Node object.
+
+#### Explicit
+
+<aside class="warning"> Switching from default node names to explicit node names can orphan volumes</aside>
+
+
+Setting node names with the tag `kubernetes.io/node-name` can be enabled by configuring the kublet's `cloud-config`:
+
+```
+[Global]
+ExplicitNodeNames=true
+```
+
 
 ### Load Balancers
 You can setup [external load balancers](/docs/tasks/access-application-cluster/create-external-load-balancer/)

--- a/content/en/docs/concepts/cluster-administration/cloud-providers.md
+++ b/content/en/docs/concepts/cluster-administration/cloud-providers.md
@@ -22,16 +22,15 @@ The AWS cloud provider uses the private DNS name of the AWS instance as the name
 
 #### Explicit
 
-<aside class="warning"> Switching from default node names to explicit node names can orphan volumes</aside>
+<aside class="warning"> In general, the name of an existing Node should not be changed once the node is registerd. Switching from default node names to explicit node names can orphan volumes, invalidate kublet credentials</aside>
+<aside class="warning"> Requires all compoents: kubelet, kube-apiserver, and kube-controller-manager to be at 1.12 or higher</aside>
 
-
-Setting node names with the tag `kubernetes.io/node-name` can be enabled by configuring the kublet's `cloud-config`:
+Setting node names with the aws instance metadata tag `kubernetes.io/node-name` can be enabled by configuring the kublet's `cloud-config`:
 
 ```
 [Global]
 ExplicitNodeNames=true
 ```
-
 
 ### Load Balancers
 You can setup [external load balancers](/docs/tasks/access-application-cluster/create-external-load-balancer/)


### PR DESCRIPTION
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.12 Features: set Milestone to 1.12 and Base Branch to release-1.12
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

#### Release
This is dependent on https://github.com/kubernetes/kubernetes/pull/61878 getting merged; so correspondingly release is dependent on that

#### Update

In https://github.com/kubernetes/kubernetes/pull/61878 explicit node names were made configurable by instance tags and cloud-config variables. This documents that change.

//cc @liggitt 