### PR TITLE
Update OWNERS for 1.8

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,21 @@
+# Reviewers can /lgtm /approve but not sufficient for auto-merge without an
+# approver
 reviewers:
-- a-mccarthy
-- abiogenesis-now
+- rajakavitha1
+- stewart-yu
+- xiangpengzhao
+- zhangxiaoyu-zidif
+
+# Approvers have all the ability of reviewers but their /approve makes
+# auto-merge happen if a /lgtm exists, or vice versa, or they can do both
+# No need for approvers to also be listed as reviewers
+approvers:
 - bradamant3
+- bradtopol
+- chenopis
+- kbarnard10
+- mistyhacks
 - steveperry-53
+- tengqm
 - zacharysarah
+- zparnold


### PR DESCRIPTION
🚨 THIS PR MUST BE MERGED MANUALLY 🚨 

This PR updates the OWNERS file for previous, pre-Prow releases of Kubernetes.

Right now, OWNERS files in branches `release-1.7` through `release-1.9` only list reviewers. Because there are no approvers in the OWNERS file, this makes it impossible to approve changes to those branches using Prow. 

While technically we don't accept changes to deprecated branches, this PR solves a problem that would prevent merging fixes for critical/security issues.

Related PRs:

Branch | PR
---|---
`release-1.7` | #9490 
`release-1.8` | #9492 
`release-1.9` | #9491 