### PR TITLE
fix version selector in v1.10 

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -94,14 +94,6 @@ githubbranch = "v1.7.16"
 docsbranch = "release-1.7"
 url = "https://v1-7.docs.kubernetes.io"
 
-[[params.versions]]
-fullversion = "v1.6.13"
-version = "v1.6"
-githubbranch = "v1.6.13"
-docsbranch = "release-1.6"
-url = "https://v1-6.docs.kubernetes.io"
-
-
 # Language definitions.
 
 [languages]

--- a/config.toml
+++ b/config.toml
@@ -60,9 +60,16 @@ githubWebsiteRepo = "github.com/kubernetes/website"
 githubWebsiteRaw = "raw.githubusercontent.com/kubernetes/website"
 
 [[params.versions]]
+fullversion = "v1.11.0"
+version = "v1.11"
+githubbranch = "master"
+docsbranch = "release-1.10"
+url = "https://kubernetes.io/docs/"
+
+[[params.versions]]
 fullversion = "v1.10.5"
 version = "v1.10"
-githubbranch = "master"
+githubbranch = "v1.10.5"
 docsbranch = "release-1.10"
 url = "https://v1-10.docs.kubernetes.io"
 

--- a/config.toml
+++ b/config.toml
@@ -63,7 +63,7 @@ githubWebsiteRaw = "raw.githubusercontent.com/kubernetes/website"
 fullversion = "v1.11.0"
 version = "v1.11"
 githubbranch = "master"
-docsbranch = "release-1.10"
+docsbranch = "release-1.11"
 url = "https://kubernetes.io/docs/"
 
 [[params.versions]]


### PR DESCRIPTION
- fix version selector in v1.10
- remove `v1.6` support from version selector, as it is depreciated
