### PR TITLE
Add when storage key name changed

### DIFF
--- a/content/en/docs/tasks/administer-cluster/reserve-compute-resources.md
+++ b/content/en/docs/tasks/administer-cluster/reserve-compute-resources.md
@@ -248,4 +248,7 @@ the proper part of the cgroup hierarchy.
 As of Kubernetes version 1.7, `kubelet` supports specifying `storage` as a resource
 for `kube-reserved` and `system-reserved`.
 
+As of Kubernetes version 1.8, the `storage` key name was changed to `ephemeral-storage`
+for the alpha release.
+
 {{% /capture %}}


### PR DESCRIPTION
It seems the name changed in k8s 1.8 which was reflected in https://github.com/kubernetes/website/pull/5490 but the last section still mentions the old name without saying it has changed.