### PR TITLE
minor change to url syntax on /docs/setup/building-from-source

### DIFF
--- a/content/en/docs/setup/building-from-source.md
+++ b/content/en/docs/setup/building-from-source.md
@@ -7,7 +7,7 @@ title: Building from Source
 
 You can either build a release from source or download a pre-built release.  If you do not plan on developing Kubernetes itself, we suggest using a pre-built version of the current release, which can be found in the [Release Notes](/docs/imported/release/notes/).
 
-The Kubernetes source code can be downloaded from the [kubernetes/kubernetes repo](https://github.com/kubernetes/kubernetes).
+The Kubernetes source code can be downloaded from the [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes) repo.
 
 ## Building from source
 


### PR DESCRIPTION
The URL for k/k included the text after ("repo"). This PR formats it to not include the text after.
