### PR TITLE
Fix id string for kube-proxy glossary term

### DIFF
--- a/content/en/docs/reference/glossary/kube-proxy.md
+++ b/content/en/docs/reference/glossary/kube-proxy.md
@@ -1,6 +1,6 @@
 ---
 title: kube-proxy
-id: kube proxy
+id: kube-proxy
 date: 2018-04-12
 full_link: /docs/reference/generated/kube-proxy
 short_description: >


### PR DESCRIPTION
-Added hyphen to id string so that glossary term displays
extension text.