### PR TITLE
Updated dns-pod-service.md

### DIFF
--- a/content/en/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/en/docs/concepts/services-networking/dns-pod-service.md
@@ -148,6 +148,8 @@ A record at that name, pointing to the Pod's IP. Both pods "`busybox1`" and
 The Endpoints object can specify the `hostname` for any endpoint addresses,
 along with its IP.
 
+**Note:** As A records are not created for Pod names, `hostname`  is required for the Pod's A record to be created. Otherwise a Pod with no `hostname` but with `subdomain`only, will only create the A record for the headless service (`default-subdomain.my-namespace.svc.cluster.local`), with the Pod's IP.
+
 ### Pod's DNS Policy
 
 DNS policies can be set on a per-pod basis. Currently Kubernetes supports the

--- a/content/en/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/en/docs/concepts/services-networking/dns-pod-service.md
@@ -148,7 +148,9 @@ A record at that name, pointing to the Pod's IP. Both pods "`busybox1`" and
 The Endpoints object can specify the `hostname` for any endpoint addresses,
 along with its IP.
 
+{{< note >}}
 **Note:** As A records are not created for Pod names, `hostname`  is required for the Pod's A record to be created. Otherwise a Pod with no `hostname` but with `subdomain`only, will only create the A record for the headless service (`default-subdomain.my-namespace.svc.cluster.local`), with the Pod's IP.
+{{< /note >}}
 
 ### Pod's DNS Policy
 

--- a/content/en/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/en/docs/concepts/services-networking/dns-pod-service.md
@@ -149,7 +149,7 @@ The Endpoints object can specify the `hostname` for any endpoint addresses,
 along with its IP.
 
 {{< note >}}
-**Note:** As A records are not created for Pod names, `hostname`  is required for the Pod's A record to be created. Otherwise a Pod with no `hostname` but with `subdomain`only, will only create the A record for the headless service (`default-subdomain.my-namespace.svc.cluster.local`), with the Pod's IP.
+**Note:** As A records are not created for Pod names, `hostname`  is required for the Pod's A record to be created. Otherwise a Pod with no `hostname` but with `subdomain`only, will only create the A record for the headless service (`default-subdomain.my-namespace.svc.cluster.local`), pointing to the Pod's IP.
 {{< /note >}}
 
 ### Pod's DNS Policy

--- a/content/en/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/en/docs/concepts/services-networking/dns-pod-service.md
@@ -149,7 +149,7 @@ The Endpoints object can specify the `hostname` for any endpoint addresses,
 along with its IP.
 
 {{< note >}}
-**Note:** As A records are not created for Pod names, `hostname`  is required for the Pod's A record to be created. Otherwise a Pod with no `hostname` but with `subdomain`only, will only create the A record for the headless service (`default-subdomain.my-namespace.svc.cluster.local`), pointing to the Pod's IP.
+**Note:** Because A records are not created for Pod names, `hostname` is required for the Pod's A record to be created. A Pod with no `hostname` but with `subdomain` only will only create the A record for the headless service (`default-subdomain.my-namespace.svc.cluster.local`), pointing to the Pod's IP address.
 {{< /note >}}
 
 ### Pod's DNS Policy


### PR DESCRIPTION
Added a note about A records creation, as I have ran into several people who miss understand the text which says the `hostname` field is optional, and that the Pods name is its own hostname, but dont realize that this doesn't mean that it creates an A record in kube-dns with the Pod's name.
