### PR TITLE
Update DownwardAPIVolumeFiles to add divisor field

### DIFF
--- a/content/en/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
+++ b/content/en/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
@@ -165,8 +165,9 @@ Look at the `items` array under `downwardAPI`. Each element of the array is a
 DownwardAPIVolumeFile.
 
 The first element specifies that in the Container named `client-container`,
-the value of the `limits.cpu` field
-should be stored in a file named `cpu_limit`.
+the value of the `limits.cpu` field in the format specified by `1m` should be
+stored in a file named `cpu_limit`. The `divisor` field is optional and has the
+default value of `1` which means cores for cpu and bytes for memory.
 
 Create the Pod:
 

--- a/content/en/examples/pods/inject/dapi-volume-resources.yaml
+++ b/content/en/examples/pods/inject/dapi-volume-resources.yaml
@@ -39,16 +39,20 @@ spec:
             resourceFieldRef:
               containerName: client-container
               resource: limits.cpu
+              divisor: 1m
           - path: "cpu_request"
             resourceFieldRef:
               containerName: client-container
               resource: requests.cpu
+              divisor: 1m
           - path: "mem_limit"
             resourceFieldRef:
               containerName: client-container
               resource: limits.memory
+              divisor: 1Mi
           - path: "mem_request"
             resourceFieldRef:
               containerName: client-container
               resource: requests.memory
+              divisor: 1Mi
 


### PR DESCRIPTION
Added divisor field in resourceFieldRef for DownwardAPIVolumeFiles
to clarify the format in which values are returned.

Issue: https://github.com/kubernetes/kubernetes/issues/64579