### PR TITLE
Fix reference to install-kubeadm docs

### DIFF
--- a/content/en/docs/reference/tools.md
+++ b/content/en/docs/reference/tools.md
@@ -16,7 +16,7 @@ Kubernetes contains several built-in tools to help you work with the Kubernetes 
 
 ## Kubeadm 
 
-[`kubeadm`](/docs/tasks/tools/install-kubeadm/) is the command line tool for easily provisioning a secure Kubernetes cluster on top of physical or cloud servers or virtual machines (currently in alpha).
+[`kubeadm`](/docs/setup/independent/install-kubeadm/) is the command line tool for easily provisioning a secure Kubernetes cluster on top of physical or cloud servers or virtual machines (currently in alpha).
 
 ## Kubefed
 

--- a/content/en/docs/setup/independent/setup-ha-etcd-with-kubeadm.md
+++ b/content/en/docs/setup/independent/setup-ha-etcd-with-kubeadm.md
@@ -26,7 +26,7 @@ when using kubeadm to set up a kubernetes cluster.
 * Some infrastructure to copy files between hosts. For example `ssh` and `scp`
   can satisfy this requirement.
 
-[toolbox]: /docs/tasks/tools/install-kubeadm/
+[toolbox]: /docs/setup/independent/install-kubeadm/
 
 {{% /capture %}}
 

--- a/static/_redirects
+++ b/static/_redirects
@@ -224,7 +224,6 @@
 
 /docs/roadmap/     https://github.com/kubernetes/kubernetes/milestones/ 301
 /docs/samples/     /docs/tutorials/ 301
-/docs/setup/independent/install-kubeadm/     /docs/tasks/tools/install-kubeadm/ 301
 /docs/stable/user-guide/labels/     /docs/concepts/overview/working-with-objects/labels/ 301
 
 /docs/tasks/access-application-cluster/access-cluster.md     /docs/tasks/access-application-cluster/access-cluster/ 301


### PR DESCRIPTION
The install-kubeadm doc was recently moved from tasks to setup. Fix the references and remove an incorrect redirect.


