### PR TITLE
Remove rkt-api-endpoint and rkt-path arguments in the doc (#9538)

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/kubelet.md
+++ b/content/en/docs/reference/command-line-tools-reference/kubelet.md
@@ -970,20 +970,6 @@ kubelet [flags]
     </tr>
 
      <tr>
-       <td colspan="2">--rkt-api-endpoint string</td> 
-    </tr>
-    <tr>
-      <td></td><td style="line-height: 130%; word-wrap: break-word;">The endpoint of the rkt API service to communicate with. Only used if --container-runtime='rkt'. (default "localhost:15441")</td>
-    </tr>
-
-     <tr>
-       <td colspan="2">--rkt-path string</td> 
-    </tr>
-    <tr>
-      <td></td><td style="line-height: 130%; word-wrap: break-word;">Path of rkt binary. Leave empty to use the first rkt in $PATH.</td>
-    </tr>
-
-     <tr>
        <td colspan="2">--root-dir string</td> 
     </tr>
     <tr>


### PR DESCRIPTION
Kubelet help return not exist rkt-api-endpoint and rkt-path arguments,
So delete not exist arguments.

Signed-off-by: Yuanbin.Chen <cybing4@gmail.com>

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.12 Features: set Milestone to 1.12 and Base Branch to release-1.12
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
> Please delete this note before submitting the pull request.

