### PR TITLE
Add ICP license to the site footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -29,5 +29,8 @@
         <div id="miceType" class="center">
             Copyright &copy; {{ now.Year }} The Linux Foundation&reg;. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage" class="light-text">Trademark Usage page</a>
         </div>
+        <div id="miceType" class="center">
+            ICP license: 京ICP备17074266号-3
+        </div>
     </main>
 </footer>


### PR DESCRIPTION
This PR adds an ICP license number to site footer layouts in order to decrease load times in China.