### PR TITLE
Use alpine instead of busybox for nslookup examples

### DIFF
--- a/content/en/docs/concepts/workloads/pods/init-containers.md
+++ b/content/en/docs/concepts/workloads/pods/init-containers.md
@@ -113,12 +113,12 @@ metadata:
     pod.beta.kubernetes.io/init-containers: '[
         {
             "name": "init-myservice",
-            "image": "busybox",
+            "image": "alpine",
             "command": ["sh", "-c", "until nslookup myservice; do echo waiting for myservice; sleep 2; done;"]
         },
         {
             "name": "init-mydb",
-            "image": "busybox",
+            "image": "alpine",
             "command": ["sh", "-c", "until nslookup mydb; do echo waiting for mydb; sleep 2; done;"]
         }
     ]'


### PR DESCRIPTION
nslookup in the busybox image seems to be broken.
It always returns with 0 even when the lookup fails. Additionally, it fails to resolve DNS paths.
See https://github.com/docker-library/busybox/issues/27
