### PR TITLE
apply content_template (/docs/tutorials/)

### DIFF
--- a/content/en/docs/tutorials/_index.md
+++ b/content/en/docs/tutorials/_index.md
@@ -2,7 +2,10 @@
 title: Tutorials
 main_menu: true
 weight: 60
+content_template: templates/concept
 ---
+
+{{% capture overview %}}
 
 This section of the Kubernetes documentation contains tutorials.
 A tutorial shows how to accomplish a goal that is larger than a single
@@ -10,6 +13,10 @@ A tutorial shows how to accomplish a goal that is larger than a single
 each of which has a sequence of steps.
 Before walking through each tutorial, you may want to bookmark the
 [Standardized Glossary](/docs/reference/glossary/) page for later references.
+
+{{% /capture %}}
+
+{{% capture body %}}
 
 ## Basics
 
@@ -59,8 +66,12 @@ Before walking through each tutorial, you may want to bookmark the
 
 * [Using Source IP](/docs/tutorials/services/source-ip/)
 
-## What's next
+{{% /capture %}}
+
+{{% capture whatsnext %}}
 
 If you would like to write a tutorial, see
 [Using Page Templates](/docs/home/contribute/page-templates/)
 for information about the tutorial page type and the tutorial template.
+
+{{% /capture %}}


### PR DESCRIPTION
Apply `templates/concept` and remove double bullets.