### PR TITLE
update default value of kubelet flag pod-infra-container-image

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/kubelet.md
+++ b/content/en/docs/reference/command-line-tools-reference/kubelet.md
@@ -882,7 +882,7 @@ kubelet [flags]
        <td colspan="2">--pod-infra-container-image string</td> 
     </tr>
     <tr>
-      <td></td><td style="line-height: 130%; word-wrap: break-word;">The image whose network/ipc namespaces containers in each pod will use. (default "gcr.io/google_containers/pause-amd64:3.0")</td>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;">The image whose network/ipc namespaces containers in each pod will use. (default "k8s.gcr.io/pause:3.1")</td>
     </tr>
 
      <tr>


### PR DESCRIPTION
default value of  `pod-infra-container-image` flag has changed to `k8s.gcr.io/pause:3.1`