### PR TITLE
Update high-availability.md - Fix value of kubernetesVersion in the kubeadm-config.yaml

### DIFF
--- a/content/en/docs/setup/independent/high-availability.md
+++ b/content/en/docs/setup/independent/high-availability.md
@@ -143,7 +143,7 @@ different configuration.
 
         apiVersion: kubeadm.k8s.io/v1alpha2
         kind: MasterConfiguration
-        kubernetesVersion: v1.11.1
+        kubernetesVersion: v1.11.x
         apiServerCertSANs:
         - "LOAD_BALANCER_DNS"
         api:
@@ -166,6 +166,8 @@ different configuration.
             # This CIDR is a Calico default. Substitute or remove for your CNI provider.
             podSubnet: "192.168.0.0/16"
 
+1.  Replace `x` in `kubernetesVersion: v1.11.x` with the latest available version. 
+    For example: `kubernetesVersion: v1.11.1`
 
 1.  Replace the following variables in the template with the appropriate
     values for your cluster:
@@ -224,7 +226,7 @@ done
 
         apiVersion: kubeadm.k8s.io/v1alpha2
         kind: MasterConfiguration
-        kubernetesVersion: v1.11.0
+        kubernetesVersion: v1.11.x
         apiServerCertSANs:
         - "LOAD_BALANCER_DNS"
         api:
@@ -248,6 +250,9 @@ done
             # This CIDR is a calico default. Substitute or remove for your CNI provider.
             podSubnet: "192.168.0.0/16"
 
+1.  Replace `x` in `kubernetesVersion: v1.11.x` with the latest available version. 
+    For example: `kubernetesVersion: v1.11.1`
+    
 1.  Replace the following variables in the template with the appropriate values for your cluster:
 
     - `LOAD_BALANCER_DNS`
@@ -314,7 +319,7 @@ done
 
         apiVersion: kubeadm.k8s.io/v1alpha2
         kind: MasterConfiguration
-        kubernetesVersion: v1.11.0
+        kubernetesVersion: v1.11.x
         apiServerCertSANs:
         - "LOAD_BALANCER_DNS"
         api:
@@ -338,6 +343,9 @@ done
             # This CIDR is a calico default. Substitute or remove for your CNI provider.
             podSubnet: "192.168.0.0/16"
 
+1.  Replace `x` in `kubernetesVersion: v1.11.x` with the latest available version. 
+    For example: `kubernetesVersion: v1.11.1`
+    
 1.  Replace the following variables in the template with the appropriate values for your cluster:
 
     - `LOAD_BALANCER_DNS`
@@ -431,7 +439,7 @@ done
 
         apiVersion: kubeadm.k8s.io/v1alpha2
         kind: MasterConfiguration
-        kubernetesVersion: v1.11.1
+        kubernetesVersion: v1.11.x
         apiServerCertSANs:
         - "LOAD_BALANCER_DNS"
         api:
@@ -449,6 +457,9 @@ done
             # This CIDR is a calico default. Substitute or remove for your CNI provider.
             podSubnet: "192.168.0.0/16"
 
+1.  Replace `x` in `kubernetesVersion: v1.11.x` with the latest available version. 
+    For example: `kubernetesVersion: v1.11.1`
+    
 1.  Replace the following variables in the template with the appropriate values for your cluster:
 
     - `LOAD_BALANCER_DNS`

--- a/content/en/docs/setup/independent/high-availability.md
+++ b/content/en/docs/setup/independent/high-availability.md
@@ -143,7 +143,7 @@ different configuration.
 
         apiVersion: kubeadm.k8s.io/v1alpha2
         kind: MasterConfiguration
-        kubernetesVersion: v1.11.0
+        kubernetesVersion: v1.11.1
         apiServerCertSANs:
         - "LOAD_BALANCER_DNS"
         api:
@@ -431,7 +431,7 @@ done
 
         apiVersion: kubeadm.k8s.io/v1alpha2
         kind: MasterConfiguration
-        kubernetesVersion: v1.11.0
+        kubernetesVersion: v1.11.1
         apiServerCertSANs:
         - "LOAD_BALANCER_DNS"
         api:


### PR DESCRIPTION
Fix for https://github.com/kubernetes/website/issues/9594#

Changed the value of `kubernetesVersion` to `v1.11.1` in the kubeadm-config.yaml so it pulls the correct server images for the latest v1.11 release.

I don't like the idea of having to change this value for every point release. Maybe someone can come up with a better solution than submitting a change to the documentation for every minor release?