### PR TITLE
Adding patch command to forceful delete zombie stateful pod

### DIFF
--- a/content/en/docs/tasks/run-application/force-delete-stateful-set-pod.md
+++ b/content/en/docs/tasks/run-application/force-delete-stateful-set-pod.md
@@ -67,6 +67,12 @@ If you're using any version of kubectl <= 1.4, you should omit the `--force` opt
 kubectl delete pods <pod> --grace-period=0
 ```
 
+If even after these commands the pod is stuck on `Unknown` state, use the following command to remove the pod from the cluster:
+
+```shell
+kubectl patch pod <pod> -p '{"metadata":{"finalizers":null}}'
+```
+
 Always perform force deletion of StatefulSet Pods carefully and with complete knowledge of the risks involved.
 
 {{% /capture %}}


### PR DESCRIPTION
This adds a command which can help delete zombies stateful pods.

Issue: https://github.com/kubernetes/kubernetes/issues/65766