### PR TITLE
JSONPaths with spaces must be double-quoted on Windows

### DIFF
--- a/content/en/docs/reference/kubectl/jsonpath.md
+++ b/content/en/docs/reference/kubectl/jsonpath.md
@@ -73,3 +73,10 @@ $ kubectl get pods -o=jsonpath='{.items[0]}'
 $ kubectl get pods -o=jsonpath='{.items[0].metadata.name}'
 $ kubectl get pods -o=jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.startTime}{"\n"}{end}'
 ```
+
+On Windows, you must _double_ quote any JSONPath template that contains spaces (not single quote as shown above for bash). This in turn means that you must use a single quote or escaped double quote around any literals in the template. For example:
+
+```cmd
+C:\> kubectl get pods -o=jsonpath="{range .items[*]}{.metadata.name}{'\t'}{.status.startTime}{'\n'}{end}"
+C:\> kubectl get pods -o=jsonpath="{range .items[*]}{.metadata.name}{\"\t\"}{.status.startTime}{\"\n\"}{end}"
+```


### PR DESCRIPTION
The last example JSONPath on https://kubernetes.io/docs/reference/kubectl/jsonpath/ did not work on Windows because of different quoting rules.  This PR describes the required quoting on Windows and gives examples.

Fixes #9606.