### PR TITLE
add link to nvidia gpu scheduling guide at end of device plugin document

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
+++ b/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
@@ -142,6 +142,7 @@ For examples of device plugin implementations, see:
 
 * The official [NVIDIA GPU device plugin](https://github.com/NVIDIA/k8s-device-plugin)
     * Requires [nvidia-docker 2.0](https://github.com/NVIDIA/nvidia-docker) which allows you to run GPU enabled docker containers.
+    * A detailed guide on how to [schedule NVIDIA GPUs](/docs/tasks/manage-gpus/scheduling-gpus) on k8s.
 * The [NVIDIA GPU device plugin for COS base OS](https://github.com/GoogleCloudPlatform/container-engine-accelerators/tree/master/cmd/nvidia_gpu)
 * The [RDMA device plugin](https://github.com/hustcat/k8s-rdma-device-plugin)
 * The [Solarflare device plugin](https://github.com/vikaschoudhary16/sfc-device-plugin)


### PR DESCRIPTION

https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/ is the document about how to
schedule a nvidia gpu on k8s. It is highly related with device-plugin feature which was included in 
https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/
I think we'd better add a nvidia-gpu-scheduling document  link at the end of device-plugin document which could help user make a better understanding about this feature.