### PR TITLE
update owners of minikube doc

### DIFF
--- a/content/en/docs/setup/minikube.md
+++ b/content/en/docs/setup/minikube.md
@@ -1,7 +1,7 @@
 ---
 reviewers:
 - dlorenc
-- r2d4
+- balopat
 - aaron-prindle
 title: Running Kubernetes Locally via Minikube
 ---


### PR DESCRIPTION
@balopat is the new owner of minikube, and the associated technical reviewer for docs

https://github.com/kubernetes/minikube/pull/3033