### PR TITLE
Fixed typo with wrong HTTP status codes range of what is healthy

### DIFF
--- a/content/en/docs/tutorials/k8s201.md
+++ b/content/en/docs/tutorials/k8s201.md
@@ -213,7 +213,7 @@ Kubelet to ensure that your application is operating correctly for a definition 
 
 Currently, there are three types of application health checks that you can choose from:
 
-   * HTTP Health Checks - The Kubelet will call a web hook.  If it returns between 200 and 399, it is considered success, failure otherwise. See health check examples [here](/docs/user-guide/liveness/).
+   * HTTP Health Checks - The Kubelet will call a web hook.  If it returns between 200 and 299, it is considered success, failure otherwise. See health check examples [here](/docs/user-guide/liveness/).
    * Container Exec - The Kubelet will execute a command inside your container.  If it exits with status 0 it will be considered a success. See health check examples [here](/docs/user-guide/liveness/).
    * TCP Socket - The Kubelet will attempt to open a socket to your container.  If it can establish a connection, the container is considered healthy, if it can't it is considered a failure.
 


### PR DESCRIPTION
The original said "200-399" range is considered healthy. In reality 300-399 range is not healthy, only 200-299 range is healthy. Most likely - just an accidental typo.

