### PR TITLE
Added api version in authn and authz example.

### DIFF
--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -410,6 +410,8 @@ file format. Within the file, `clusters` refers to the remote service and
 ```yaml
 # Kubernetes API version
 apiVersion: v1
+# kind of the API object
+kind: Config
 # clusters refers to the remote service.
 clusters:
   - name: name-of-remote-authn-service

--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -408,7 +408,7 @@ file format. Within the file, `clusters` refers to the remote service and
 `users` refers to the API server webhook. An example would be:
 
 ```yaml
-#Kubernetes API version
+# Kubernetes API version
 apiVersion: v1
 # clusters refers to the remote service.
 clusters:

--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -408,6 +408,8 @@ file format. Within the file, `clusters` refers to the remote service and
 `users` refers to the API server webhook. An example would be:
 
 ```yaml
+#Kubernetes API version
+apiVersion: v1
 # clusters refers to the remote service.
 clusters:
   - name: name-of-remote-authn-service

--- a/content/en/docs/reference/access-authn-authz/webhook.md
+++ b/content/en/docs/reference/access-authn-authz/webhook.md
@@ -29,7 +29,7 @@ file format. Within the file "users" refers to the API Server webhook and
 A configuration example which uses HTTPS client auth:
 
 ```yaml
-#Kubernetes API version
+# Kubernetes API version
 apiVersion: v1
 # clusters refers to the remote service.
 clusters:

--- a/content/en/docs/reference/access-authn-authz/webhook.md
+++ b/content/en/docs/reference/access-authn-authz/webhook.md
@@ -29,6 +29,8 @@ file format. Within the file "users" refers to the API Server webhook and
 A configuration example which uses HTTPS client auth:
 
 ```yaml
+#Kubernetes API version
+apiVersion: v1
 # clusters refers to the remote service.
 clusters:
   - name: name-of-remote-authz-service

--- a/content/en/docs/reference/access-authn-authz/webhook.md
+++ b/content/en/docs/reference/access-authn-authz/webhook.md
@@ -31,6 +31,8 @@ A configuration example which uses HTTPS client auth:
 ```yaml
 # Kubernetes API version
 apiVersion: v1
+# kind of the API object
+kind: Config
 # clusters refers to the remote service.
 clusters:
   - name: name-of-remote-authz-service


### PR DESCRIPTION
Updated authn and authz example. For novice user using these examples are very helpful. Without api version api-server fails to restart.