### PR TITLE
config: Get mediaTypes config in line with the Hugo version

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -41,7 +41,6 @@ section = [ "HTML"]
 # Add a "text/netlify" media type for auto-generating the _headers file
 [mediaTypes]
 [mediaTypes."text/netlify"]
-suffix = ""
 delimiter = ""
 
 [outputFormats]


### PR DESCRIPTION
This gets rid of the big WARNING when building.

Note that this is only Netlify related, so it is backwards compatible.