### PR TITLE
Trivial: Update HPA description

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -60,7 +60,7 @@ or the custom metrics API (for all other metrics).
 * For object metrics, a single metric is fetched (which describes the object
   in question), and compared to the target value, to produce a ratio as above.
 
-The HorizontalPodAutoscaler normally fetches metrics from a series of aggregated APIs (`metrics.k8s.io`,\
+The HorizontalPodAutoscaler normally fetches metrics from a series of aggregated APIs (`metrics.k8s.io`,
 `custom.metrics.k8s.io`, and `external.metrics.k8s.io`).  It can also fetch metrics directly
 from Heapster.  Fetching metrics from Heapster is deprecated as of Kubernetes 1.11.
 

--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -92,8 +92,8 @@ We can list autoscalers by `kubectl get hpa` and get detailed description by `ku
 Finally, we can delete an autoscaler using `kubectl delete hpa`.
 
 In addition, there is a special `kubectl autoscale` command for easy creation of a Horizontal Pod Autoscaler.
-For instance, executing `kubectl autoscale rc foo --min=2 --max=5 --cpu-percent=80`
-will create an autoscaler for replication controller *foo*, with target CPU utilization set to `80%`
+For instance, executing `kubectl autoscale rs foo --min=2 --max=5 --cpu-percent=80`
+will create an autoscaler for replication set *foo*, with target CPU utilization set to `80%`
 and the number of replicas between 2 and 5.
 The detailed documentation of `kubectl autoscale` can be found [here](/docs/reference/generated/kubectl/kubectl-commands/#autoscale).
 


### PR DESCRIPTION
Current HPA page[1] contains an unnecessary new line between
"metrics.k8s.io" and "custom.metrics.k8s.io", but that does
not have any meaning. This removes it for the readability.

In addition, RS is now the recommended way to set up replication as RC doc[2].
This replaces RC with RS for HPA doc.

[1]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale
[2]: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/
