### PR TITLE
 Fix SubjectAccessReview example yaml

### DIFF
--- a/content/en/docs/reference/access-authn-authz/authorization.md
+++ b/content/en/docs/reference/access-authn-authz/authorization.md
@@ -122,7 +122,7 @@ kind: SelfSubjectAccessReview
 spec:
   resourceAttributes:
     group: apps
-    name: deployments
+    resource: deployments
     verb: create
     namespace: dev
 EOF
@@ -134,7 +134,7 @@ metadata:
 spec:
   resourceAttributes:
     group: apps
-    name: deployments
+    resource: deployments
     namespace: dev
     verb: create
 status:


### PR DESCRIPTION
Fix `SubjectAccessReview` example yaml

https://github.com/kubernetes/api/blob/release-1.11/authorization/v1/types.go#L105