### PR TITLE
Add necessity of metrics-server for HPA

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -61,11 +61,15 @@ or the custom metrics API (for all other metrics).
   in question), and compared to the target value, to produce a ratio as above.
 
 The HorizontalPodAutoscaler normally fetches metrics from a series of aggregated APIs (`metrics.k8s.io`,
-`custom.metrics.k8s.io`, and `external.metrics.k8s.io`).  The `metrics.k8s.io` API is generally provided by metrics-server,
-so please note that metrics-server needs to be launched in general. See [metrics-server](https://kubernetes.io/docs/tasks/debug-application-cluster/core-metrics-pipeline/#metrics-server)
-for further details about how to launch the metrics-server.
-The HorizontalPodAutoscaler can also fetch metrics directly from Heapster.  Fetching metrics from
-Heapster is deprecated as of Kubernetes 1.11.
+`custom.metrics.k8s.io`, and `external.metrics.k8s.io`).  The `metrics.k8s.io` API is usually provided by
+metrics-server, which needs to be launched separately. See
+[metrics-server](https://kubernetes.io/docs/tasks/debug-application-cluster/core-metrics-pipeline/#metrics-server)
+for instructions. The HorizontalPodAutoscaler can also fetch metrics directly from Heapster.
+
+{{< note >}}
+{{< feature-state state="deprecated" for_k8s_version="1.11" >}}
+Fetching metrics from Heapster is deprecated as of Kubernetes 1.11.
+{{< /note >}}
 
 See [Support for metrics APIs](#support-for-metrics-apis) for more details.
 

--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -61,8 +61,11 @@ or the custom metrics API (for all other metrics).
   in question), and compared to the target value, to produce a ratio as above.
 
 The HorizontalPodAutoscaler normally fetches metrics from a series of aggregated APIs (`metrics.k8s.io`,
-`custom.metrics.k8s.io`, and `external.metrics.k8s.io`).  It can also fetch metrics directly
-from Heapster.  Fetching metrics from Heapster is deprecated as of Kubernetes 1.11.
+`custom.metrics.k8s.io`, and `external.metrics.k8s.io`).  The `metrics.k8s.io` API is generally provided by metrics-server,
+so please note that metrics-server needs to be launched in general. See [metrics-server](https://kubernetes.io/docs/tasks/debug-application-cluster/core-metrics-pipeline/#metrics-server)
+for further details about how to launch the metrics-server.
+The HorizontalPodAutoscaler can also fetch metrics directly from Heapster.  Fetching metrics from
+Heapster is deprecated as of Kubernetes 1.11.
 
 See [Support for metrics APIs](#support-for-metrics-apis) for more details.
 


### PR DESCRIPTION
Current HPA doc1 mentions metrics-server like

  For resource metrics, this is the metrics.k8s.io API,
  generally provided by metrics-server. It can be launched
  as a cluster addon.

The metrics.k8s.io API is mandatory for HPA, so the above means
metrics-server needs to be launched for HPA. However it is difficult
to understand that requirement because the above seems metrics-server
as just a addon, and that is described on small section.
In addition, many people are facing HPA issue that fetching metrics
doesn't work on the internet like

  $ kubectl get hpa
  NAME      REFERENCE          TARGETS         MINPODS   MAXPODS   REPLICAS   AGE
  nginx     Deployment/nginx   <unknown>/50%   1         3         0          7s

The above sample "<unknown>" shows HPA feature cannot get current
metrics due to metrics-server doesn't work fine.

This adds necessity of metrics-server for HPA directly to solve
the problem.

fixes: #9728
