### PR TITLE
Add a chapter to existing blog for filling survey "CoreDNS adoption"

### DIFF
--- a/content/en/blog/_posts/2018-07-10-coredns-ga.md
+++ b/content/en/blog/_posts/2018-07-10-coredns-ga.md
@@ -18,10 +18,10 @@ CoreDNS is a general-purpose, authoritative DNS server that provides a backwards
 
 In this article, you will learn about the differences in the implementations of kube-dns and CoreDNS, and some of the helpful extensions offered by CoreDNS.
 
-## We expect your feedback
+## We appreciate your feedback
 
 We are conducting a survey to evaluate the adoption of CoreDNS as the DNS for Kubernetes's cluster. 
-If you are currently using CoreDNS inside a Kubernetes cluster, please, [take 5 minutes to provide us some feedback by filling this survey](https://www.surveymonkey.com/r/SKZQSLK)
+If you are currently using CoreDNS inside a Kubernetes cluster, please, [take 5 minutes to provide us some feedback by filling this survey](https://www.surveymonkey.com/r/SKZQSLK).
 
 Thank you, we appreciate your collaboration here.
 

--- a/content/en/blog/_posts/2018-07-10-coredns-ga.md
+++ b/content/en/blog/_posts/2018-07-10-coredns-ga.md
@@ -18,7 +18,14 @@ CoreDNS is a general-purpose, authoritative DNS server that provides a backwards
 
 In this article, you will learn about the differences in the implementations of kube-dns and CoreDNS, and some of the helpful extensions offered by CoreDNS.
 
-## Implemenation differences
+## We expect your feedback
+
+We are conducting a survey to evaluate the adoption of CoreDNS as the DNS for Kubernetes's cluster. 
+If you are currently using CoreDNS inside a Kubernetes cluster, please, [take 5 minutes to provide us some feedback by filling this survey](https://www.surveymonkey.com/r/SKZQSLK)
+
+Thank you, we appreciate your collaboration here.
+
+## Implementation differences
 
 In kube-dns, several containers are used within a single pod: `kubedns`, `dnsmasq`, and `sidecar`. The `kubedns`
 container watches the Kubernetes API and serves DNS records based on the [Kubernetes DNS specification](https://github.com/kubernetes/dns/blob/master/docs/specification.md), `dnsmasq` provides caching and stub domain support, and `sidecar` provides metrics and health checks.


### PR DESCRIPTION
This blog was written to present GA of CoreDNS for k8s v1.11

Following this GA, we need to get some feedback from those who are adopting CoreDNS as the DNS server in their Kubernetes clusters.

I though enhancing this blog would be a good way to advertize this survey.


I also fixed a typo.




