### PR TITLE
Update autocomplete instructions for Oh-My-Zsh

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl.md
+++ b/content/en/docs/tasks/tools/install-kubectl.md
@@ -272,7 +272,7 @@ fi
 Or when using [Oh-My-Zsh](http://ohmyz.sh/), edit the ~/.zshrc file and update the `plugins=` line to include the kubectl plugin.
 
 ```shell
-source <(kubectl completion zsh)
+plugins=(kubectl)
 ```
 {{% /capture %}}
 


### PR DESCRIPTION
The explanation to setup auto completion of zsh with Oh-My-Zsh is correct, however the example code is incorrectly mentioned as `source <(kubectl completion zsh)`. This pull request updates it to `plugins=(kubectl)`
