### PR TITLE
Fixes #9078 by adding note and link to table

### DIFF
--- a/content/en/docs/tasks/inject-data-application/define-command-argument-container.md
+++ b/content/en/docs/tasks/inject-data-application/define-command-argument-container.md
@@ -34,6 +34,11 @@ override the default command and arguments provided by the container image.
 If you define args, but do not define a command, the default command is used
 with your new arguments.
 
+{{< note >}}
+**Note:** the `command` field corresponds to `entrypoint` in some container
+runtimes. Refer to the [Notes](#notes) below.
+{{< /note >}}
+
 In this exercise, you create a Pod that runs one container. The configuration
 file for the Pod defines a command and two arguments:
 


### PR DESCRIPTION
Fixes #9078 by adding note and link to table that disambiguates 'command' and 'entrypoint'
