### PR TITLE
kubeadm-token-create: fix wrong flag name for ttl

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_token_create.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_token_create.md
@@ -62,7 +62,7 @@ kubeadm token create [token]
     </tr>
 
     <tr>
-      <td colspan="2">--token-ttl duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 24h0m0s</td>
+      <td colspan="2">--ttl duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 24h0m0s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The duration before the token is automatically deleted (e.g. 1s, 2m, 3h). If set to '0', the token will never expire</td>


### PR DESCRIPTION
Fixes https://github.com/kubernetes/website/issues/9757

the `kubeadm token create` `--token-ttl` flag was renamed to `--ttl` possibly right after the docs were generated.
we had some pending PRs which got in quite late in `k/k`.

the `kubeadm_token_create.md` file looks like this right now:
```
...
      --ttl duration         The duration before the token is automatically deleted (e.g. 1s, 2m, 3h). If set to '0', the token will never expire (default 24h0m0s)
...
```

proof in the source code:
https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/cmd/token.go#L141

manually rename the flag in the generated docs.

/assign @tengqm 
/sig cluster-lifecycle
/area kubeadm
