### PR TITLE
Update README and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,9 @@ ARG HUGO_VERSION
 
 RUN mkdir -p /usr/local/src && \
     cd /usr/local/src && \
-    curl -L https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_linux-64bit.tar.gz | tar -xz && \
+    curl -L https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-64bit.tar.gz | tar -xz && \
+    apk add build-base && \
+    apk add libc6-compat && \
     mv hugo /usr/local/bin/hugo && \
     curl -L https://bin.equinox.io/c/dhgbqpS8Bvy/minify-stable-linux-amd64.tgz | tar -xz && \
     mv minify /usr/local/bin && \

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can create an image for a different version of Hugo by changing the value of
 Once the `kubernetes-hugo` image has been built locally, you can build the site:
 
 ```bash
-make stage
+make docker-serve
 
 # The underlying command:
 docker run \


### PR DESCRIPTION
- Updates 1 line in the README's site building instructions
- Alters Dockerfile to use extended hugo build by default, needed to properly work with hugo pipes used in the codebase since node-sass was dropped.