### PR TITLE
cni networking plugin now support portmapping and bandwidth

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins.md
+++ b/content/en/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins.md
@@ -48,9 +48,9 @@ In addition to the CNI plugin specified by the configuration file, Kubernetes re
 #### Support hostPort
 
 The CNI networking plugin supports `hostPort`. You can use the officical [portmap](https://github.com/containernetworking/plugins/tree/master/plugins/meta/portmap)
-plugin offered by CNI plugin team or use your own plugin with portMapping function.
+plugin offered by the CNI plugin team or use your own plugin with portMapping functionality.
 
-If you want enable `hostPort` support, you must specify `portMappings capability` in your `cni-conf-dir`.
+If you want to enable `hostPort` support, you must specify `portMappings capability` in your `cni-conf-dir`.
 For example:
 
 ```json
@@ -85,7 +85,7 @@ For example:
 #### Support traffic shaping
 
 The CNI networking plugin also supports pod ingress and egress traffic shaping. You can use the officical [bandwidth](https://github.com/containernetworking/plugins/tree/master/plugins/meta/bandwidth)
-plugin offered by CNI plugin team or use your own plugin with bandwidth contol functionality.
+plugin offered by the CNI plugin team or use your own plugin with bandwidth contol functionality.
 
 If you want to enable traffic shaping support, you must add a `bandwidth` plugin to your CNI configuration file
 (default `/etc/cni/net.d`).
@@ -120,6 +120,7 @@ If you want to enable traffic shaping support, you must add a `bandwidth` plugin
 ```
 
 Now you can add the `kubernetes.io/ingress-bandwidth` and `kubernetes.io/egress-bandwidth` annotations to your pod.
+For example:
 
 ```yaml
 apiVersion: v1

--- a/content/en/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins.md
+++ b/content/en/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins.md
@@ -47,7 +47,7 @@ In addition to the CNI plugin specified by the configuration file, Kubernetes re
 
 #### Support hostPort
 
-The CNI networking plugin supports `hostPort`. You can use the officical [portmap](https://github.com/containernetworking/plugins/tree/master/plugins/meta/portmap)
+The CNI networking plugin supports `hostPort`. You can use the official [portmap](https://github.com/containernetworking/plugins/tree/master/plugins/meta/portmap)
 plugin offered by the CNI plugin team or use your own plugin with portMapping functionality.
 
 If you want to enable `hostPort` support, you must specify `portMappings capability` in your `cni-conf-dir`.

--- a/content/en/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins.md
+++ b/content/en/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins.md
@@ -48,7 +48,7 @@ In addition to the CNI plugin specified by the configuration file, Kubernetes re
 #### Support hostPort
 
 The CNI networking plugin supports `hostPort`. You can use the officical [portmap](https://github.com/containernetworking/plugins/tree/master/plugins/meta/portmap)
-plugin offered by CNI plugin team, or use your own plugin with portMapping function.
+plugin offered by CNI plugin team or use your own plugin with portMapping function.
 
 If you want enable `hostPort` support, you must specify `portMappings capability` in your `cni-conf-dir`.
 For example:
@@ -84,10 +84,11 @@ For example:
 
 #### Support traffic shaping
 
-CNI networking plugin now can support pod ingress and egress traffic shaping, you can use the officical [bandwidth](https://github.com/containernetworking/plugins/tree/master/plugins/meta/bandwidth)
-plugin offered by CNI plugin team, or use your own plugin with bandwidth contol function.
+The CNI networking plugin also supports pod ingress and egress traffic shaping. You can use the officical [bandwidth](https://github.com/containernetworking/plugins/tree/master/plugins/meta/bandwidth)
+plugin offered by CNI plugin team or use your own plugin with bandwidth contol functionality.
 
-If you want to enable traffic shaping support, the `bandwidth` plugin need to be added to your CNI configuration file(default `/etc/cni/net.d`).
+If you want to enable traffic shaping support, you must add a `bandwidth` plugin to your CNI configuration file
+(default `/etc/cni/net.d`).
 
 ```json
 {
@@ -118,7 +119,7 @@ If you want to enable traffic shaping support, the `bandwidth` plugin need to be
 }
 ```
 
-Now you can use add `kubernetes.io/ingress-bandwidth` and `kubernetes.io/egress-bandwidth` annotation to your pod.
+Now you can add the `kubernetes.io/ingress-bandwidth` and `kubernetes.io/egress-bandwidth` annotations to your pod.
 
 ```yaml
 apiVersion: v1

--- a/content/en/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins.md
+++ b/content/en/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins.md
@@ -47,10 +47,10 @@ In addition to the CNI plugin specified by the configuration file, Kubernetes re
 
 #### Support hostPort
 
-CNI networking plugin now can support `hostPort`, you can use the officical [portmap](https://github.com/containernetworking/plugins/tree/master/plugins/meta/portmap)
+The CNI networking plugin supports `hostPort`. You can use the officical [portmap](https://github.com/containernetworking/plugins/tree/master/plugins/meta/portmap)
 plugin offered by CNI plugin team, or use your own plugin with portMapping function.
 
-If you want enable support `hostPort`, the `portMappings capability` need to be specified in your `cni-conf-dir`.
+If you want enable `hostPort` support, you must specify `portMappings capability` in your `cni-conf-dir`.
 For example:
 
 ```json


### PR DESCRIPTION
Document that cni networking plugin now support portmapping and pod bandwidth control.

xref: https://github.com/kubernetes/kubernetes/pull/63194