### PR TITLE
Add NOTE for deprecated in-tree openstack-cloud-provider

### DIFF
--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -297,6 +297,11 @@ parameters:
 * `availability`: Availability Zone. If not specified, volumes are generally
   round-robin-ed across all active zones where Kubernetes cluster has a node.
 
+{{< note >}}
+{{< feature-state state="deprecated" for_k8s_version="1.11" >}}
+This internal provisioner of OpenStack is deprecated. Please use [the external cloud provider for OpenStack](https://github.com/kubernetes/cloud-provider-openstack).
+{{< /note >}}
+
 ### vSphere
 
 1. Create a StorageClass with a user specified disk format.


### PR DESCRIPTION
As the release note of v1.11[1], in-tree openstack-cloud-provider is
deprecated. So this adds the note for explaining it and recommending
to use the external openstack-cloud-provider.

[1]: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.11.md#new-deprecations
