### PR TITLE
Removes self-referential link 

### DIFF
--- a/content/en/docs/tasks/inject-data-application/define-command-argument-container.md
+++ b/content/en/docs/tasks/inject-data-application/define-command-argument-container.md
@@ -137,7 +137,6 @@ Here are some examples:
 
 {{% capture whatsnext %}}
 
-* Learn more about [containers and commands](/docs/user-guide/containers/).
 * Learn more about [configuring pods and containers](/docs/tasks/).
 * Learn more about [running commands in a container](/docs/tasks/debug-application-cluster/get-shell-running-container/).
 * See [Container](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#container-v1-core).


### PR DESCRIPTION
Removes link redirects to the current page.

Link in question:
https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/

