### PR TITLE
Update memory-default-namespace.md

### DIFF
--- a/content/en/docs/tasks/administer-cluster/manage-resources/memory-default-namespace.md
+++ b/content/en/docs/tasks/administer-cluster/manage-resources/memory-default-namespace.md
@@ -151,7 +151,7 @@ resources:
 ```
 
 {{< note >}}
-**Note**: Kubernetes only sets Container's memory limit  if the specified memory request is less than the memory limit value specified by the LimitRange. If the specified memory request is more  than the memory limit value specified by the LimitRange , Kubernetes does not set the Container's memory limit.
+**Note**: Kubernetes rejects the  Container's memory request if it exceeds the default memory request specified by the LimitRange.
 {{< /note >}}
 
 ## Motivation for default memory limits and requests

--- a/content/en/docs/tasks/administer-cluster/manage-resources/memory-default-namespace.md
+++ b/content/en/docs/tasks/administer-cluster/manage-resources/memory-default-namespace.md
@@ -150,6 +150,10 @@ resources:
     memory: 128Mi
 ```
 
+{{< note >}}
+**Note**: Kubernetes only sets Container's memory limit  if the specified memory request is less than the memory limit value specified by the LimitRange. If the specified memory request is more  than the memory limit value specified by the LimitRange , Kubernetes does not set the Container's memory limit.
+{{< /note >}}
+
 ## Motivation for default memory limits and requests
 
 If your namespace has a resource quota,


### PR DESCRIPTION
https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/#what-if-you-specify-a-container-s-request-but-not-its-limit -- The example does not mention that Kubernetes only sets Container's memory limit  if the specified memory request is less than the memory limit value specified by the LimitRange.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> Please delete this note before submitting the pull request.
> For 1.12 Features: set Milestone to 1.12 and Base Branch to release-1.12
> Help editing and submitting pull requests:  https://deploy-preview-9510--kubernetes-io-master-staging.netlify.com/docs/contribute/start/#submit-a-pull-request.
> Help choosing which branch to use, see
> https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use.
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>

