### PR TITLE
Update status of aggregator in API overview doc

### DIFF
--- a/content/en/docs/concepts/overview/kubernetes-api.md
+++ b/content/en/docs/concepts/overview/kubernetes-api.md
@@ -109,8 +109,8 @@ There are two supported paths to extending the API with [custom resources](/docs
 
 1. [CustomResourceDefinition](/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/)
    is for users with very basic CRUD needs.
-1. Coming soon: users needing the full set of Kubernetes API semantics can implement their own apiserver
-   and use the [aggregator](https://git.k8s.io/community/contributors/design-proposals/api-machinery/aggregated-api-servers.md)
+1. Users needing the full set of Kubernetes API semantics can implement their own apiserver
+   and use the [aggregator](docs/tasks/access-kubernetes-api/configure-aggregation-layer.md)
    to make it seamless for clients.
 
 

--- a/content/en/docs/concepts/overview/kubernetes-api.md
+++ b/content/en/docs/concepts/overview/kubernetes-api.md
@@ -110,7 +110,7 @@ There are two supported paths to extending the API with [custom resources](/docs
 1. [CustomResourceDefinition](/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/)
    is for users with very basic CRUD needs.
 1. Users needing the full set of Kubernetes API semantics can implement their own apiserver
-   and use the [aggregator](docs/tasks/access-kubernetes-api/configure-aggregation-layer.md)
+   and use the [aggregator](/docs/tasks/access-kubernetes-api/configure-aggregation-layer/)
    to make it seamless for clients.
 
 


### PR DESCRIPTION
Aggregator is already here, so we can remove the "soon" note.

Preview: https://deploy-preview-9866--kubernetes-io-master-staging.netlify.com/docs/concepts/overview/kubernetes-api/#api-groups