### PR TITLE
Hugo Extended requires glibc on Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,23 @@ RUN apk add --no-cache \
     curl \
     git \
     openssh-client \
-    rsync
+    rsync \
+    libstdc++
+
+# Install glibc: This is required for HUGO-extended (including SASS) to work.
+
+ENV GLIBC_VERSION 2.28-r0
+RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
+    &&  wget "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC_VERSION/glibc-$GLIBC_VERSION.apk" \
+    &&  apk --no-cache add "glibc-$GLIBC_VERSION.apk" \
+    &&  rm "glibc-$GLIBC_VERSION.apk" \
+    &&  wget "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC_VERSION/glibc-bin-$GLIBC_VERSION.apk" \
+    &&  apk --no-cache add "glibc-bin-$GLIBC_VERSION.apk" \
+    &&  rm "glibc-bin-$GLIBC_VERSION.apk" \
+    &&  wget "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC_VERSION/glibc-i18n-$GLIBC_VERSION.apk" \
+    &&  apk --no-cache add "glibc-i18n-$GLIBC_VERSION.apk" \
+    &&  rm "glibc-i18n-$GLIBC_VERSION.apk"
+
 
 ARG HUGO_VERSION
 
@@ -20,7 +36,6 @@ RUN mkdir -p /usr/local/src && \
     cd /usr/local/src && \
     curl -L https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-64bit.tar.gz | tar -xz && \
     apk add build-base && \
-    apk add libc6-compat && \
     mv hugo /usr/local/bin/hugo && \
     curl -L https://bin.equinox.io/c/dhgbqpS8Bvy/minify-stable-linux-amd64.tgz | tar -xz && \
     mv minify /usr/local/bin && \


### PR DESCRIPTION
When building the website from scratch using Docker, as the image is using Alpine and Hugo Extended it would fail to build.

According to https://github.com/gohugoio/hugo/issues/4961, Hugo Extended requires glibc.

/cc @lucperkins as you originally created the Dockerfile