### PR TITLE
troubleshooting-kubeadm: add guide for fixing stale CoreDNS pods

### DIFF
--- a/content/en/docs/setup/independent/troubleshooting-kubeadm.md
+++ b/content/en/docs/setup/independent/troubleshooting-kubeadm.md
@@ -238,4 +238,25 @@ EOF
 )"
 
 ```
+
+## `coredns` pods have `CrashLoopBackOff` or `Error` state
+
+If you have nodes that are running SELinux with an older version of Docker you might experience a scenario
+where the `coredns` pods are not starting. To solve that you can try one of the following options:
+
+- Upgrade to a [newer version of Docker](/docs/setup/independent/install-kubeadm/#installing-docker).
+- [Disable SELinux](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/security-enhanced_linux/sect-security-enhanced_linux-enabling_and_disabling_selinux-disabling_selinux).
+- Modify the `coredns` deployment to set `allowPrivilegeEscalation` to `true`:
+
+```bash
+kubectl -n kube-system get deployment coredns -o yaml | \
+  sed 's/allowPrivilegeEscalation: false/allowPrivilegeEscalation: true/g' | \
+  kubectl apply -f -
+```
+
+{{< warning >}}
+**Warning**: Disabling SELinux or setting `allowPrivilegeEscalation` to `true` can compromise
+the security of your cluster.
+{{< /warning >}}
+
 {{% /capture %}}


### PR DESCRIPTION
fixes kubernetes/kubeadm#998

/assign @chrisohaver 
/assign @Bradamant3 
@kubernetes/sig-cluster-lifecycle-pr-reviews 

preview:
https://deploy-preview-9872--kubernetes-io-master-staging.netlify.com/docs/setup/independent/troubleshooting-kubeadm/#coredns-pods-have-crashloopbackoff-or-error-state
