### PR TITLE
Add _headers file checking logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,22 @@ DOCKER_RUN   = $(DOCKER) run --rm --interactive --tty --volume $(PWD):/src
 help: ## Show this help.
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
-all: build ## Build site with production settings and put deliverables in _site.
+all: build ## Build site with production settings and put deliverables in ./public
 
-build: ## Build site with production settings and put deliverables in _site.
+build: ## Build site with production settings and put deliverables in ./public
 	hugo
 
-build-preview: ## Build site with drafts and future posts enabled.
+build-preview: ## Build site with drafts and future posts enabled
 	hugo -D -F
+
+check-headers-file:
+	scripts/check-headers-file.sh
+
+production-build: build check-headers-file ## Build the production site and ensure that noindex headers aren't added
+
+non-production-build: ## Build the non-production site and add noindex headers to prevent indexing
+	hugo --enableGitInfo
+	cp netlify_noindex_headers.txt public/_headers
 
 serve: ## Boot the development server.
 	hugo server --ignoreCache --disableFastRender

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,8 @@ check-headers-file:
 
 production-build: build check-headers-file ## Build the production site and ensure that noindex headers aren't added
 
-non-production-build: ## Build the non-production site and add noindex headers to prevent indexing
+non-production-build: ## Build the non-production site, which adds noindex headers to prevent indexing
 	hugo --enableGitInfo
-	cp netlify_noindex_headers.txt public/_headers
 
 serve: ## Boot the development server.
 	hugo server --ignoreCache --disableFastRender

--- a/layouts/index.headers
+++ b/layouts/index.headers
@@ -1,3 +1,4 @@
+{{- if eq (getenv "HUGO_ENV") "production" }}
 {{- $cssFilesFromConfig := .Site.Params.pushAssets.css -}}
 {{- $jsFilesFromConfig := .Site.Params.pushAssets.js -}}
 {{- $pages := .Site.RegularPages -}}
@@ -34,3 +35,7 @@
   {{- end -}}
 {{- end }}
 {{- end -}}
+{{- else }}
+/*
+  X-Robots-Tag: noindex
+{{- end }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
 # It is turned off for only for the production site by using [context.master] below
 # DO NOT REMOVE THIS (contact @chenopis or @sig-docs-maintainers)
 publish = "public"
-command = "hugo --enableGitInfo && cp netlify_noindex_headers.txt public/_headers"
+command = "make non-production-build"
 
 [build.environment]
 HUGO_VERSION = "0.46"
@@ -23,4 +23,4 @@ command = "hugo --enableGitInfo -b $DEPLOY_PRIME_URL"
 # This context is triggered by the `master` branch and allows search indexing
 # DO NOT REMOVE THIS (contact @chenopis or @sig-docs-maintainers)
 publish = "public"
-command = "hugo"
+command = "make production-build"

--- a/netlify_noindex_headers.txt
+++ b/netlify_noindex_headers.txt
@@ -1,3 +1,0 @@
-# Prevent bots from indexing site
-/*
-  X-Robots-Tag: noindex

--- a/scripts/check-headers-file.sh
+++ b/scripts/check-headers-file.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ "$HUGO_ENV" == "production" ]; then
+  echo "INFO: Production environment. Checking the _headers file for noindex headers."
+
+  if grep -q "noindex" public/_headers; then
+    echo "PANIC: noindex headers were found in the _headers file. This build has failed."
+    exit 1
+  else
+    echo "INFO: noindex headers were not found in the _headers file. All clear."
+    exit 0
+  fi
+else
+  echo "Non-production environment. Skipping the _headers file check."
+  exit 0
+fi


### PR DESCRIPTION
This PR adds a simple post-build check to ensure that the generated `_headers` file doesn't contain `noindex` headers in the production environment. If the `HUGO_ENV` environment variable value is `production` and the `_headers` file *does* contain `noindex`, then the build will fail and log a `PANIC` message.

This is a first-line defense against inadvertently de-indexing production site content.

## Testing

To test these changes:

```bash
# Remove the generated public folder if you have one
rm -rf public

# Run a normal production build (includes the _headers file check)
HUGO_ENV=production make production-build

# Expected output
INFO: Production environment. Checking the _headers file for noindex headers.
INFO: noindex headers were not found in the _headers file. All clear.

# Simulate failure condition (i.e. add a "X-Robots-Tag: noindex" header into the production _headers file). The headers check should now fail.
echo "/*\n  X-Robots-Tag: noindex" > public/_headers
HUGO_ENV=production make check-headers-file

# Expected output
INFO: Production environment. Checking the _headers file for noindex headers.
PANIC: noindex headers were found in the _headers file. This build has failed.
make: *** [check-headers-file] Error 1

# Run the check in a non-production environment (should succeed)
HUGO_ENV=something-else make check-headers-file

# Expected output
Non-production environment. Skipping the _headers file check.
```