### PR TITLE
Add pod list in all namespaces example

### DIFF
--- a/content/en/docs/setup/turnkey/clc.md
+++ b/content/en/docs/setup/turnkey/clc.md
@@ -302,6 +302,7 @@ List existing nodes, pods, services and more, in all namespaces, or in just one:
 
 ```shell
 kubectl get nodes
+kubectl get --all-namespaces pods
 kubectl get --all-namespaces services
 kubectl get --namespace=kube-system replicationcontrollers
 ```


### PR DESCRIPTION
This patch fix content "List existing nodes, pods, services and more,
in all namespaces, or in just one:" lost pod list.

Signed-off-by: Yuanbin.Chen <cybing4@gmail.com>

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> Please delete this note before submitting the pull request.
> For 1.12 Features: set Milestone to 1.12 and Base Branch to release-1.12
> Help editing and submitting pull requests:  https://deploy-preview-9510--kubernetes-io-master-staging.netlify.com/docs/contribute/start/#submit-a-pull-request.
> Help choosing which branch to use, see
> https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use.
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>

