### PR TITLE
Verify Google Analytics client is accessible before sending events

### DIFF
--- a/static/js/user-journeys/home.js
+++ b/static/js/user-journeys/home.js
@@ -200,7 +200,11 @@ $( document ).ready(function() {
       urlParamHash.set("level", null);
 
       // record Google Analytics event
-      ga('send', 'event', 'user-journeys', 'click', 'path', type);
+      try {
+        ga('send', 'event', 'user-journeys', 'click', 'path', type);
+      } catch (ignored) {
+
+      }
 
     }
 
@@ -221,7 +225,11 @@ $( document ).ready(function() {
         urlParamHash.set('persona', persona);
 
         // record Google Analytics event
-        ga('send', 'event', 'user-journeys', 'click', 'persona', persona);
+        try {
+          ga('send', 'event', 'user-journeys', 'click', 'persona', persona);
+        } catch (ignored) {
+
+        }
 
       }
       // Use default level if not specified, in order to display the proper
@@ -250,7 +258,11 @@ $( document ).ready(function() {
         urlParamHash.set('level', level);
 
         // record Google Analytics event
-        ga('send', 'event', 'user-journeys', 'click', 'level', level);
+        try {
+          ga('send', 'event', 'user-journeys', 'click', 'level', level);
+        } catch (ignored) {
+
+        }
 
       }
 


### PR DESCRIPTION
Resolves issue #9654

This will surface when using any sort of tracking prevention system. Silently failing seems like the best course.

I wrapped each report individually as this only appears a few times in one file. Though a central function that acts as a delegate to GA client calls is an alternative.