### PR TITLE
fix JSON syntax

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-service-account.md
@@ -193,7 +193,7 @@ myregistrykey    kubernetes.io/.dockerconfigjson   1       1d
 Next, modify the default service account for the namespace to use this secret as an imagePullSecret.
 
 ```shell
-kubectl patch serviceaccount default -p '{\"imagePullSecrets\": [{\"name\": \"myregistrykey\"}]}'
+kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "myregistrykey"}]}'
 ```
 
 Interactive version requiring manual edit:


### PR DESCRIPTION
When i hit the command
```
kubectl patch serviceaccount default -p '{\"imagePullSecrets\": [{\"name\": \"myregistrykey\"}]}'
```
then i got this error
```
Error from server (BadRequest): invalid character '\\' looking for beginning of object key string
```

But i stripped all back slashes, and it worked.

If this issue is caused only in my specific environment, 
close this pull-request.

My environment is ...
- Docker for Mac: Version 18.06.0-ce-mac70 (26399), Kubernetes: v1.10.3