### PR TITLE
Pin busybox to 1.28

### DIFF
--- a/content/en/examples/admin/dns/busybox.yaml
+++ b/content/en/examples/admin/dns/busybox.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
   - name: busybox
-    image: busybox
+    image: busybox:1.28
     command:
       - sleep
       - "3600"


### PR DESCRIPTION
In busybox:latest, nslookup does not work in K8s. See: https://bugs.busybox.net/show_bug.cgi?id=11161. This inconsistency makes following the [Debugging DNS Resolution](https://kubernetes.io/docs/tasks/administer-cluster/dns-debugging-resolution/) guide quite confusing/difficult (Is my cluster wonky or the image I'm testing with?). According to this [comment](https://github.com/docker-library/busybox/issues/48#issuecomment-411876340) in the Busybox Docker repo, this change was intentional upstream. At least for the time being I suggest we pin the Busybox version used to prevent confusion.