### PR TITLE
Change the way to create ConfigMap

### DIFF
--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -35,10 +35,22 @@ This page provides a real world example of how to configure Redis using a Config
 
 You can follow the steps below to configure a Redis cache using data stored in a ConfigMap.
 
-First create a ConfigMap from the `examples/pods/config/redis-config` file:
+First create a ConfigMap from the `redis-config` file:
+
+{{< codenew file="pods/config/redis-config" >}}
 
 ```shell
-kubectl create configmap example-redis-config --from-file=https://k8s.io/examples/pods/config/redis-config
+curl -OL https://k8s.io/examples/pods/config/redis-config
+kubectl create configmap example-redis-config --from-file=redis-config
+```
+
+```shell
+configmap/example-redis-config created
+```
+
+Examine the created ConfigMap:
+
+```shell
 kubectl get configmap example-redis-config -o yaml
 ```
 


### PR DESCRIPTION
closes #9849

kubectl doesn't support creating configmaps using urls. https://github.com/kubernetes/kubernetes/issues/64007#issuecomment-390141844

This PR changes the way to create example ConfigMap.