### PR TITLE
Add note about cron job suspend behavior

### DIFF
--- a/content/en/docs/tasks/job/automated-tasks-with-cron-jobs.md
+++ b/content/en/docs/tasks/job/automated-tasks-with-cron-jobs.md
@@ -168,6 +168,11 @@ If it is set to `true`, all subsequent executions are suspended.
 This setting does not apply to already started executions.
 Defaults to false.
 
+{{< caution >}}
+**Caution:** Executions that are suspended during their scheduled time count as missed jobs.
+When `.spec.suspend` changes from `true` to `false` on an existing cron job without a [starting deadline](#starting-deadline), the missed jobs are scheduled immediately.
+{{< /caution >}}
+
 ### Jobs History Limits
 
 The `.spec.successfulJobsHistoryLimit` and `.spec.failedJobsHistoryLimit` fields are optional.


### PR DESCRIPTION
Call out the fact that suspended cron jobs count as missed.

Preview: https://deploy-preview-9904--kubernetes-io-master-staging.netlify.com/docs/tasks/job/automated-tasks-with-cron-jobs/#suspend