### PR TITLE
netlify: Update to Hugo 0.47.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DOCKER       = docker
-HUGO_VERSION = 0.44
+HUGO_VERSION = 0.47.1
 DOCKER_IMAGE = kubernetes-hugo
 DOCKER_RUN   = $(DOCKER) run --rm --interactive --tty --volume $(PWD):/src
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@ publish = "public"
 command = "hugo --enableGitInfo && cp netlify_noindex_headers.txt public/_headers"
 
 [build.environment]
-HUGO_VERSION = "0.46"
+HUGO_VERSION = "0.47.1"
 
 [context.production.environment]
 HUGO_BASEURL = "https://kubernetes.io/"


### PR DESCRIPTION
The relevant fix for kubernetes.io is the "Page last modified on" line (Git revision info), which in this version now works correctly across languages.