### PR TITLE
update link to metrics-server repo

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -25,7 +25,7 @@ This document walks you through an example of enabling Horizontal Pod Autoscaler
 {{% capture prerequisites %}}
 
 This example requires a running Kubernetes cluster and kubectl, version 1.2 or later.
-[metrics-server](https://github.com/kubernetes/heapster) monitoring needs to be deployed in the cluster
+[metrics-server](https://github.com/kubernetes-incubator/metrics-server/) monitoring needs to be deployed in the cluster
 to provide metrics via the resource metrics API, as Horizontal Pod Autoscaler uses this API to collect metrics
 (if you followed [getting started on GCE guide](/docs/setup/turnkey/gce/),
 metrics-server monitoring will be turned-on by default).


### PR DESCRIPTION
the current text indicates metrics-server but the link points to heapster. 



