### PR TITLE
Fix Documentation link in nav back to Home

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -1,3 +1,3 @@
 ---
-title: Home
+title: Documentation
 ---

--- a/content/en/docs/home/_index.md
+++ b/content/en/docs/home/_index.md
@@ -8,7 +8,7 @@ cid: userJourneys
 css: /css/style_user_journeys.css
 js: /js/user-journeys/home.js, https://use.fontawesome.com/4bcc658a89.js
 display_browse_numbers: true
-linkTitle: "Documentation"
+linkTitle: "Home"
 main_menu: true
 weight: 5
 ---

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,7 +5,7 @@
 
     <div class="nav-buttons" data-auto-burger="primary">
         <ul class="global-nav">
-            {{ $sections := slice "docs/home" "blog" "partners" "community" "case-studies" }}
+            {{ $sections := slice "docs" "blog" "partners" "community" "case-studies" }}
             {{ range $sections }}
             {{ with $.Site.GetPage "section" . }}<li><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></li>{{ end }}
             {{ end }}


### PR DESCRIPTION
Currently, the link in the subnav for the /docs/home landing page is "Documentation," which is confusing.
 
<img width="670" alt="screen shot 2018-08-20 at 9 51 27 am" src="https://user-images.githubusercontent.com/24798125/44344471-c42d8a00-a45e-11e8-92a8-0e15a08ac2e8.png">

I am resorting it back to "Home," which is what it was prior to the Hugo migration.

<img width="785" alt="screen shot 2018-08-20 at 9 51 56 am" src="https://user-images.githubusercontent.com/24798125/44344477-c7c11100-a45e-11e8-938f-3accf42f4970.png">
