### PR TITLE
Update the content under versioning.

### DIFF
--- a/content/en/docs/contribute/style/style-guide.md
+++ b/content/en/docs/contribute/style/style-guide.md
@@ -149,7 +149,9 @@ The output is similar to this:
 
 ### Versioning Kubernetes examples
 
-Code examples and configuration examples that include version information should be consistent with the accompanying text. Identify the Kubernetes version in the **Before you begin** section.
+Code examples and configuration examples that include version information should be consistent with the accompanying text. 
+
+If the information is version specific, the Kubernetes version needs to be defined in the `prerequisites` section of the [Task template](/docs/contribute/style/page-templates/#task-template) or the [Tutorial template] (/docs/contribute/style/page-templates/#tutorial-template). Once the page is saved, the `prerequisites` section is shown as **Before you begin**.
 
 To specify the Kubernetes version for a task or tutorial page, include `min-kubernetes-server-version` in the front matter of the page.
 


### PR DESCRIPTION
It was not clear what "Before you begin" meant and how it needs to be added only if the task or tutorial is version specific. Therefore, added this info in.

Preview: https://deploy-preview-9919--kubernetes-io-master-staging.netlify.com/docs/contribute/style/style-guide/#versioning-kubernetes-examples