### PR TITLE
The Kubernetes Basics link title is confusing

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/_index.html
+++ b/content/en/docs/tutorials/kubernetes-basics/_index.html
@@ -1,6 +1,6 @@
 ---
 title: Learn Kubernetes Basics
-linkTitle: Try Our Interactive Tutorials
+linkTitle: Learn Kubernetes Basics
 weight: 10
 ---
 


### PR DESCRIPTION
Update related to #9874

While the button text on the homepage makes sense (Try Our Interactive Tutorials), it looks mis-placed in the docs TOC.

Change text to "Learn Kubernetes Basics". This should be a good call to action on both the homepage and TOC.