### PR TITLE
Format security note with proper highlighting

### DIFF
--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -484,7 +484,7 @@ $ kubectl create secret generic ssh-key-secret --from-file=ssh-privatekey=/path/
 
 {{< caution >}}
 **Caution:** Think carefully before sending your own ssh keys: other users of the cluster may have access to the secret.  Use a service account which you want to be accessible to all the users with whom you share the Kubernetes cluster, and can revoke if they are compromised.
-{{< caution >}}
+{{< /caution >}}
 
 
 Now we can create a pod which references the secret with the ssh key and

--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -482,7 +482,9 @@ Create a secret containing some ssh keys:
 $ kubectl create secret generic ssh-key-secret --from-file=ssh-privatekey=/path/to/.ssh/id_rsa --from-file=ssh-publickey=/path/to/.ssh/id_rsa.pub
 ```
 
-**Security Note:** Think carefully before sending your own ssh keys: other users of the cluster may have access to the secret.  Use a service account which you want to be accessible to all the users with whom you share the Kubernetes cluster, and can revoke if they are compromised.
+{{< caution >}}
+**Caution:** Think carefully before sending your own ssh keys: other users of the cluster may have access to the secret.  Use a service account which you want to be accessible to all the users with whom you share the Kubernetes cluster, and can revoke if they are compromised.
+{{< caution >}}
 
 
 Now we can create a pod which references the secret with the ssh key and


### PR DESCRIPTION
The information about security of ssh keys might benefit from standing out more. Thus included it in a caution shortcode. Formatting is now more aligned with the style guide.

Preview: https://deploy-preview-9942--kubernetes-io-master-staging.netlify.com/docs/concepts/configuration/secret/