### PR TITLE
Make navigation and UI strings i18n friendly

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -22,6 +22,9 @@ pygmentsStyle = "emacs"
 # Enable Git variables like commit, lastmod
 enableGitInfo = true
 
+# This is currently used for testing.
+disableLanguages = ["no"]
+
 [blackfriday]
 hrefTargetBlank = true
 fractions = false
@@ -133,4 +136,12 @@ description = "Production-Grade Container Orchestration"
 languageName = "Chinese"
 weight = 2
 contentDir = "content/cn"
+[languages.no]
+title = "Kubernetes"
+description = "Production-Grade Container Orchestration"
+languageName ="Norsk"
+weight = 3
+contentDir = "content/no"
+# A list of language codes to look for untranslated content, ordered from left to right.
+language_alternatives = ["en"]
 

--- a/content/en/blog/_index.md
+++ b/content/en/blog/_index.md
@@ -1,3 +1,10 @@
 ---
-title: Blog
+title: Kubernetes Blog
+linkTitle: Blog
+menu:
+  main:
+    title: "Blog"
+    weight: 40
+    post: >
+       <p>Read the latest news for Kubernetes and the containers space in general, and get technical how-tos hot off the presses.</p>
 ---

--- a/content/en/docs/community/_index.md
+++ b/content/en/docs/community/_index.md
@@ -1,6 +1,12 @@
 ---
 title: "Community"
 weight: 80
+menu:
+  main:
+    title: "Community"
+    weight: 30
+    post: >
+       <p>If you need help, you can connect with other Kubernetes users and the Kubernetes authors, attend community events, and watch video presentations from around the web.</p>
 ---
 
 This section of the Kubernetes documentation surfaces key topics imported from the [kubernetes/community](https://github.com/kubernetes/community) repo. It is the starting point for becoming a contributor -- improving docs, improving code, giving talks etc.

--- a/content/en/docs/home/_index.md
+++ b/content/en/docs/home/_index.md
@@ -8,7 +8,13 @@ cid: userJourneys
 css: /css/style_user_journeys.css
 js: /js/user-journeys/home.js, https://use.fontawesome.com/4bcc658a89.js
 display_browse_numbers: true
-linkTitle: "Home"
+linkTitle: Documentation
 main_menu: true
 weight: 10
+menu:
+  main:
+    title: "Documentation"
+    weight: 20
+    post: >
+      <p>Learn how to use Kubernetes with the use of walkthroughs, samples, and reference documentation. You can even <a href="/editdocs/" data-auto-burger-exclude>help contribute to the docs</a>!</p>
 ---

--- a/content/en/docs/tutorials/hello-minikube.md
+++ b/content/en/docs/tutorials/hello-minikube.md
@@ -2,6 +2,12 @@
 title: Hello Minikube
 content_template: templates/tutorial
 weight: 5
+menu:
+  main:
+    title: "Get Started"
+    weight: 10
+    post: >
+      <p>Ready to get your hands dirty? Build a simple Kubernetes cluster that runs "Hello World" for Node.js.</p>
 ---
 
 {{% capture overview %}}

--- a/content/en/docs/tutorials/kubernetes-basics/_index.html
+++ b/content/en/docs/tutorials/kubernetes-basics/_index.html
@@ -10,8 +10,6 @@ weight: 10
 
 <body>
 
-<link href="./public/css/styles.css" rel="stylesheet">
-
 <div class="layout" id="top">
 
   <main class="content">

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,0 +1,55 @@
+# i18n strings for the English (main) site.
+
+[main_read_about]
+other = "Read about"
+
+[main_github_invite]
+other = "Interested in hacking on the core Kubernetes code base?"
+
+[main_github_view_on]
+other = "View On Github"
+
+[main_github_create_an_issue]
+other = "Create an Issue"
+
+[main_community_explore]
+other = "Explore the community"
+
+[main_contribute]
+other = "Contribute"
+
+[main_edit_this_page]
+other = "Edit This Page"
+
+[main_page_history]
+other ="Page History"
+
+[main_page_last_modified_on]
+other = "Page last modified on"
+
+[main_by]
+other = "by"
+
+[main_documentation_license]
+other = """The Kubernetes Authors | Documentation Distributed under <a href="https://git.k8s.io/website/LICENSE" class="light-text">CC BY 4.0</a>"""
+
+[main_copyright_notice]
+other = """The Linux Foundation &reg;. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage" class="light-text">Trademark Usage page</a>"""
+
+# Community links
+[community_twitter_name]
+other = "Twitter"
+[community_github_name]
+other = "GitHub"
+[community_slack_name]
+other = "Slack"
+[community_stack_overflow_name]
+other = "Stack Overflow"
+[community_forum_name]
+other = "Forum"
+[community_events_calendar]
+other = "Events Calendar"
+
+# UI elements
+[ui_search_placeholder]
+other = "Search"

--- a/i18n/no.toml
+++ b/i18n/no.toml
@@ -1,0 +1,55 @@
+# i18n strings for the Norwegian translation.
+
+[main_read_about]
+other = "Les om"
+
+[main_github_invite]
+other = "Interessert kode i Kubernetes?"
+
+[main_github_view_on]
+other = "Åpne på Github"
+
+[main_github_create_an_issue]
+other = "Opprett en issue"
+
+[main_community_explore]
+other = "Utforsk folkene bak Kubernetes"
+
+[main_contribute]
+other = "Bidra"
+
+[main_edit_this_page]
+other = "Endre denne siden"
+
+[main_page_history]
+other ="Side-historikk"
+
+[main_page_last_modified_on]
+other = "Side sist endret"
+
+[main_by]
+other = "av"
+
+[main_documentation_license]
+other = """Kubernetes-forfatterene | Dokumentasjonen er utgitt med <a href="https://git.k8s.io/website/LICENSE" class="light-text">CC BY 4.0-lisens</a>"""
+
+[main_copyright_notice]
+other = """The Linux Foundation &reg;. Alle retter er reservert. The Linux Foundation har registrerte varemerker. For en oversikt, se <a href="https://www.linuxfoundation.org/trademark-usage" class="light-text">Bruk av varemerker</a>"""
+
+# Community links
+[community_twitter_name]
+other = "Twitter"
+[community_github_name]
+other = "GitHub"
+[community_slack_name]
+other = "Slack"
+[community_stack_overflow_name]
+other = "Stack Overflow"
+[community_forum_name]
+other = "Forum"
+[community_events_calendar]
+other = "Kalender"
+
+# UI elements
+[ui_search_placeholder]
+other = "Søk"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -4,7 +4,7 @@
 		{{ partial "head.html" . }}
 	</head>
 	<body>
-		{{ partialCached "header.html" . "default" }}
+		{{ partial "header.html" . }}
 		{{ block "hero" . }}
 		<!--  HERO  -->
 		<section id="hero" class="light-text">

--- a/layouts/blog/baseof.html
+++ b/layouts/blog/baseof.html
@@ -7,9 +7,9 @@
 		<link rel="stylesheet" type="text/css" href="{{ "css/blog.css" | relURL }}">
 	</head>
 	<body>
-		{{ partialCached "header.html" . "blog" }}
+		{{ partial "header.html" . }}
 		<section id="hero" class="light-text no-sub">
-			<h1>Kubernetes Blog</h1>
+			<h1>{{ .Title }}</h1>
 		</section>
 		<div class="container-fluid" style="padding-top: 2em">
 			<div class="row">

--- a/layouts/case-studies/single-baseof.html
+++ b/layouts/case-studies/single-baseof.html
@@ -4,7 +4,7 @@
 		{{ partial "head.html" . }}
 	</head>
 	<body>
-		{{ partialCached "header.html" . "default" }}
+		{{ partial "header.html" . }}
 		{{ block "main" . }}{{ end }}
 		{{ partialCached "footer.html" . }}
 		{{ partialCached "footer-scripts.html" . }}

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -4,7 +4,7 @@
 	{{ partial "head.html" . }}
 	</head>
 	<body>
-		{{ partialCached "header.html" . "docs" }}
+		{{ partial "header.html" . }}
 		{{ block "hero" . }}
 		<!--  HERO  -->
 		<section id="hero" class="light-text no-sub">
@@ -30,25 +30,27 @@
         "title" : "{{ .Title }}",
         "permalink" : "{{ .Permalink }}"
         };
+        (function(d,c,j){if(!document.getElementById(j)){var pd=d.createElement(c),s;pd.id=j;pd.src=('https:'==document.location.protocol)?'https://polldaddy.com/js/rating/rating.js':'http://i0.poll.fm/js/rating/rating.js';s=document.getElementsByTagName(c)[0];s.parentNode.insertBefore(pd,s);}}(document,'script','pd-rating-js'));
         </script>
-        <a href="https://github.com/kubernetes/website/issues/new?title=Issue%20with%20k8s.io/{{ .URL }}%20%5BFile:%20/content/en/{{ .File.Path }}%5D" class="button issue" target="_blank">Report a problem</a>
+        <a href="" onclick="window.open('https://github.com/kubernetes/website/issues/new?title=Issue%20with%20' +
+        'k8s.io'+window.location.pathname)" class="button issue">{{ T "main_github_create_an_issue" }}</a>
         {{ end }}
         {{ end }}
         {{ if not .Params.noedit }}
-        <a href="https://github.com/kubernetes/website/edit/master/content/en/{{ .File.Path }}" class="button issue" target="_blank">Edit on Github</a>
+        <a href="{{ printf "%s#%s" ("docs/editdocs" | relURL) .Path | safeURL }}" class="button issue">{{ T "main_edit_this_page" }}</a>
         {{ end }}
       </div>
       {{ if not .Params.showcommit }}
         {{ if $.GitInfo }}
       <div id="lastedit" class="lastedit issue-button-container">
-        {{ .GitInfo.AuthorDate.Format "Page last modified on January 02, 2006 at 3:04 PM PST" }} by <a href="https://github.com/kubernetes/website/commit/{{ .GitInfo.Hash }}/">{{ .GitInfo.Subject }}</a> (<a href="https://github.com/kubernetes/website/commits/master/content/en/{{ .File.Path }}">Page history</a>)
+        {{ T "main_page_last_modified_on" }} {{ .GitInfo.AuthorDate.Format "January 02, 2006 at 3:04 PM PST" }} {{ T "main_by" }}  <a href="https://github.com/kubernetes/website/commit/{{ .GitInfo.Hash }}/">{{ .GitInfo.Subject }}</a> (<a href="https://github.com/kubernetes/website/commits/master/content/en/{{ .File.Path }}">{{ T "main_page_history" }}</a>)
       </div>
         {{ end }}
       {{ end }}
     </div>
 		{{ partialCached "footer.html" . }}
 		{{ partialCached "footer-scripts.html" . }}
-    <script>
+    <script language="application/javascript">
       // This script turns in-page headers into clickable and shareable
       (function addHeadingLinks(){
         var article = document.getElementById('docsContent');

--- a/layouts/partials/docs/top-menu.html
+++ b/layouts/partials/docs/top-menu.html
@@ -16,6 +16,6 @@
 		{{ end }}
 	</ul>
 	<form id="searchBox" action="/docs/search/">
-		<input type="text" id="search" name="q" placeholder="Search" aria-label="Search">
+		<input type="text" id="search" name="q" placeholder="{{ T "ui_search_placeholder" }}" aria-label="Search">
 	</form>
 </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -9,25 +9,26 @@
         </nav>
         <div class="social">
             <div>
-                <a href="https://twitter.com/kubernetesio" class="twitter"><span>twitter</span></a>
-                <a href="https://github.com/kubernetes/kubernetes" class="github"><span>Github</span></a>
+                <a href="https://twitter.com/kubernetesio" class="twitter"><span>{{ T "community_twitter_name" }}</span></a>
+                <a href="https://github.com/kubernetes/kubernetes" class="github"><span>{{ T "community_github_name" }}</span></a>
                 <a href="http://slack.k8s.io/" class="slack"><span>Slack</span></a>
             </div>
             <div>
-                <a href="http://stackoverflow.com/questions/tagged/kubernetes" class="stack-overflow"><span>Stack Overflow</span></a>
-                <a href="https://discuss.kubernetes.io" class="mailing-list"><span>Forum</span></a>
-                <a href="https://calendar.google.com/calendar/embed?src=nt2tcnbtbied3l6gi2h29slvc0%40group.calendar.google.com" class="calendar"><span>Events Calendar</span></a>
+                <a href="http://stackoverflow.com/questions/tagged/kubernetes" class="stack-overflow"><span>
+                <a href="http://stackoverflow.com/questions/tagged/kubernetes" class="stack-overflow"><span>{{ T "community_stack_overflow_name" }}</span></a>
+                <a href="https://discuss.kubernetes.io" class="mailing-list"><span>{{ T "community_forum_name" }}</span></a>
+                <a href="https://calendar.google.com/calendar/embed?src=nt2tcnbtbied3l6gi2h29slvc0%40group.calendar.google.com" class="calendar"><span>{{ T "community_events_calendar" }}</span></a>
             </div>
             <div>
-                <a href="/docs/setup/pick-right-solution/" class="button">Get Kubernetes</a>
-                <a href="https://git.k8s.io/community/contributors/guide" class="button">Contribute</a>
+                {{ with .Site.GetPage "page" "/docs/setup/pick-right-solution/" }}<a href="{{  .RelPermalink }}" class="button">{{ .LinkTitle }}</a>{{ end }}
+                <a href="https://git.k8s.io/community/contributors/guide" class="button">{{ T "main_contribute" }}</a>
             </div>
         </div>
         <div id="miceType" class="center">
-            &copy; {{ now.Year }} The Kubernetes Authors | Documentation Distributed under <a href="https://git.k8s.io/website/LICENSE" class="light-text">CC BY 4.0</a>
+            &copy; {{ now.Year }} {{ T "main_documentation_license" | safeHTML }}</a>
         </div>
         <div id="miceType" class="center">
-            Copyright &copy; {{ now.Year }} The Linux Foundation&reg;. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage" class="light-text">Trademark Usage page</a>
+            Copyright &copy; {{ now.Year }} {{ T "main_copyright_notice" | safeHTML }}
         </div>
         <div id="miceType" class="center">
             ICP license: 京ICP备17074266号-3

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,21 +1,22 @@
 <div id="cellophane" onclick="kub.toggleMenu()"></div>
 
 <header>
-    <a href="/" class="logo"></a>
+    <a href="{{ .Site.Home.RelPermalink }}" class="logo"></a>
 
     <div class="nav-buttons" data-auto-burger="primary">
         <ul class="global-nav">
-            {{ $sections := slice "docs" "blog" "partners" "community" "case-studies" }}
+            {{ $sections := slice "docs/home" "blog" "partners" "community" "case-studies" }}
             {{ range $sections }}
-            {{ with $.Site.GetPage "section" . }}<li><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></li>{{ end }}
+            {{ with $.Site.GetPage "section" . }}<li><a href="{{ .RelPermalink }}"{{ if eq .Section $.Section }} class="active"{{ end}}>{{ .LinkTitle }}</a></li>{{ end }}
             {{ end }}
-            {{ $home := .Site.Home }}
+            {{/* Link directly to documentation etc., if possible. */}}
+            {{ $langPage := cond (gt (len .Translations) 0) . .Site.Home }}
              <li>
                 <a href="#">
-                    {{ $home.Language.LanguageName }} <span class="ui-icon ui-icon-carat-1-s"></span>
+                    {{ $langPage.Language.LanguageName }} <span class="ui-icon ui-icon-carat-1-s"></span>
                 </a>
                 <ul>
-                {{ range $home.Translations }}
+                {{ range $langPage.Translations }}
                     <li><a href="{{  .RelPermalink }}">{{ .Language.LanguageName }}</a></li>
                 {{ end }}
                 </ul>
@@ -32,45 +33,37 @@
                 </ul>
             </li>
         </ul>
-        <!-- <a href="/docs/home" class="button" id="viewDocs" data-auto-burger-exclude>View Documentation</a> -->
-        <a href="/docs/tutorials/kubernetes-basics/" class="button" id="tryKubernetes" data-auto-burger-exclude>Try Kubernetes</a>
+        {{ with .Site.GetPage "section" "docs/tutorials/kubernetes-basics" }}
+        <a href="{{ .RelPermalink }}" class="button" id="tryKubernetes" data-auto-burger-exclude>{{ .LinkTitle }}</a>
+        {{ end }}
+
         <button id="hamburger" onclick="kub.toggleMenu()" data-auto-burger-exclude><div></div></button>
     </div>
 
     <nav id="mainNav">
         <main data-auto-burger="primary">
-        <div class="nav-box">
-            <h3><a href="/docs/tutorials/stateless-application/hello-minikube/">Get Started</a></h3>
-            <p>Ready to get your hands dirty? Build a simple Kubernetes cluster that runs "Hello World" for Node.js.</p>
+         {{ range .Site.Menus.main }}
+           <div class="nav-box">
+            <h3><a href="{{ .URL }}">{{ .Title }}</a></h3>
+           {{ .Post }}
         </div>
-        <div class="nav-box">
-            <h3><a href="/docs/home/">Documentation</a></h3>
-            <p>Learn how to use Kubernetes with the use of walkthroughs, samples, and reference documentation. You can even <a href="/editdocs/" data-auto-burger-exclude>help contribute to the docs</a>!</p>
-        </div>
-        <div class="nav-box">
-            <h3><a href="/community/">Community</a></h3>
-            <p>If you need help, you can connect with other Kubernetes users and the Kubernetes authors, attend community events, and watch video presentations from around the web.</p>
-        </div>
-        <div class="nav-box">
-            <h3><a href="/blog/">Blog</a></h3>
-            <p>Read the latest news for Kubernetes and the containers space in general, and get technical how-tos hot off the presses.</p>
-        </div>
+         {{ end }}
         </main>
         <main data-auto-burger="primary">
         <div class="left">
-            <h5 class="github-invite">Interested in hacking on the core Kubernetes code base?</h5>
-            <a href="https://github.com/kubernetes/kubernetes" class="button" data-auto-burger-exclude>View On Github</a>
+            <h5 class="github-invite">{{ T "main_github_invite" }}</h5>
+            <a href="https://github.com/kubernetes/kubernetes" class="button" data-auto-burger-exclude>{{ T "main_github_view_on" }}</a>
         </div>
 
         <div class="right">
-            <h5 class="github-invite">Explore the community</h5>
+            <h5 class="github-invite">{{ T "main_community_explore" }}</h5>
             <div class="social">
-                <a href="https://twitter.com/kubernetesio" class="twitter"><span>Twitter</span></a>
-                <a href="https://github.com/kubernetes/kubernetes" class="github"><span>Github</span></a>
-                <a href="http://slack.k8s.io/" class="slack"><span>Slack</span></a>
-                <a href="https://stackoverflow.com/questions/tagged/kubernetes" class="stack-overflow"><span>Stack Overflow</span></a>
-                <a href="https://discuss.kubernetes.io" class="mailing-list"><span>Forum</span></a>
-                <a href="https://calendar.google.com/calendar/embed?src=nt2tcnbtbied3l6gi2h29slvc0%40group.calendar.google.com" class="calendar"><span>Events Calendar</span></a>
+                <a href="https://twitter.com/kubernetesio" class="twitter"><span>{{ T "community_twitter_name" }}</span></a>
+                <a href="https://github.com/kubernetes/kubernetes" class="github"><span>{{ T "community_github_name" }}</span></a>
+                <a href="http://slack.k8s.io/" class="slack"><span>{{ T "community_slack_name" }} Slack</span></a>
+                <a href="https://stackoverflow.com/questions/tagged/kubernetes" class="stack-overflow"><span>{{ T "community_stack_overflow_name" }}</span></a>
+                <a href="https://discuss.kubernetes.io" class="mailing-list"><span>{{ T "community_forum_name" }}</span></a>
+                <a href="https://calendar.google.com/calendar/embed?src=nt2tcnbtbied3l6gi2h29slvc0%40group.calendar.google.com" class="calendar"><span>{{ T "community_events_calendar" }}</span></a>
             </div>
         </div>
         <div class="clear" style="clear: both"></div>

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -170,6 +170,9 @@ var kub = (function () {
     }
 
     function setHomeHeaderStyles() {
+        if (!quickstartButton[0]) {
+            return;
+        }
         var Y = window.pageYOffset;
         var quickstartBottom = quickstartButton[0].getBoundingClientRect().bottom;
 
@@ -506,11 +509,6 @@ var pushmenu = (function(){
 })();
 
 $(function() {
-
-    // Make global nav be active based on pathname
-    if ((location.pathname.split("/")[1]) !== ""){
-        $('.global-nav li a[href^="/' + location.pathname.split("/")[1] + '"]').addClass('active');
-    }
 
     // If vendor strip doesn't exist add className
     if ( !$('#vendorStrip').length > 0 ) {


### PR DESCRIPTION
This commit

* Extracts most UI strings into i18n bundles so they can be translated
* Makes a proper Hugo menu out of the hardcoded menu that is shown on smaller screens
* Changes the language selector logic to navigate to the current page in the other language if possible (e.g. the translation). If not possible, it takes you to the home page for that language.

For testing, this commit also adds Norwegian as a new language. This is turned off.