### PR TITLE
Removed gerund from page title

### DIFF
--- a/content/en/docs/tasks/manage-daemon/rollback-daemon-set.md
+++ b/content/en/docs/tasks/manage-daemon/rollback-daemon-set.md
@@ -1,7 +1,7 @@
 ---
 reviewers:
 - janetkuo
-title: Performing a Rollback on a DaemonSet
+title: Perform a Rollback on a DaemonSet
 content_template: templates/task
 ---
 


### PR DESCRIPTION
Page titles are in the verb's infinitive form throughout the d11n. Changed the title from the gerund form to infinitive to align it with the other page titles.