### PR TITLE
Create unique links for feature state dialogs

### DIFF
--- a/layouts/partials/templates/feature-dialog.html
+++ b/layouts/partials/templates/feature-dialog.html
@@ -1,29 +1,37 @@
-
 <a href="#" id="feature-state-dialog-link" class="ui-state-default ui-corner-all"><span class="ui-icon ui-icon-newwin"></span>{{ .page.Title }}</a>
 <div id="feature-state-dialog" class="ui-dialog-content" title="{{ .page.Title }}">
+
+<script>
+var extra_data = Math.floor((Math.random() * 50) + 1);
+
+var extra_link = "feature-state-dialog-link" + extra_data;
+$("#feature-state-dialog-link").attr('id', extra_link);
+
+var extra_dialog = "feature-state-dialog" + extra_data;
+$("#feature-state-dialog").attr('id', extra_dialog);
+
+$(`#${extra_dialog}`).dialog({
+  appendTo: `#${extra_link}`,
+  autoOpen: false,
+    width: {{ .width | default "600" }},
+    buttons: [
+        {
+            text: "Ok",
+            click: function() {
+                $( this ).dialog( "close" );
+            }
+        }
+    ]
+});
+
+$(function(){
+   $("[id^='feature-state-dialog-link']").click(function( event ) {
+    var idStr = "feature-state-dialog" + event.target.id.substring(25);
+    $(`#${idStr}`).dialog( "open" );
+    event.preventDefault();
+    });
+});
+
+</script>
 {{ .page.Content | markdownify }}
 </div>
-<script>
-$(function(){
-    
-    $( "#feature-state-dialog" ).dialog({
-        autoOpen: false,
-        width: {{ .width | default "600" }},
-        buttons: [
-            {
-                text: "Ok",
-                click: function() {
-                    $( this ).dialog( "close" );
-                }
-            }
-        ]
-    });
-
-    // Link to open the dialog
-    $( "#feature-state-dialog-link" ).click(function( event ) {
-        $( "#feature-state-dialog" ).dialog( "open" );
-        event.preventDefault();
-    });
-
-});
-</script>


### PR DESCRIPTION
There may be a more elegant way (Hugo templates?) of creating unique ids for the dialog links.
Tested on single page with two feature state links.
See issue #9894.