### PR TITLE
Promote ShareProcessNamespace to beta in docs

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -83,6 +83,7 @@ different Kubernetes components.
 | `PodReadinessGates` | `false` | Alpha | 1.11 | |
 | `PodReadinessGates` | `true` | Beta | 1.12 | |
 | `PodShareProcessNamespace` | `false` | Alpha | 1.10 | |
+| `PodShareProcessNamespace` | `true` | Beta | 1.12 | |
 | `PVCProtection` | `false` | Alpha | 1.9 | 1.9 |
 | `ReadOnlyAPIDataVolumes` | `true` | Deprecated | 1.10 | |
 | `ResourceLimitsPriorityFunction` | `false` | Alpha | 1.9 | |

--- a/content/en/docs/tasks/configure-pod-container/share-process-namespace.md
+++ b/content/en/docs/tasks/configure-pod-container/share-process-namespace.md
@@ -11,7 +11,7 @@ weight: 160
 
 {{% capture overview %}}
 
-{{< feature-state state="alpha" >}}
+{{< feature-state state="beta" >}}
 
 This page shows how to configure process namespace sharing for a pod. When
 process namespace sharing is enabled, processes in a container are visible
@@ -27,8 +27,8 @@ include debugging utilities like a shell.
 
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
 
-A special **alpha** feature gate `PodShareProcessNamespace` must be set to true
-across the system: `--feature-gates=PodShareProcessNamespace=true`.
+Process Namespace Sharing is a **beta** feature that is enabled by default. It
+may be disabled by setting `--feature-gates=PodShareProcessNamespace=false`.
 
 {{% /capture %}}
 


### PR DESCRIPTION
PR requested here https://github.com/kubernetes/features/issues/495#issuecomment-414452158

Nothing has changed for this feature, only a promotion from alpha to beta.