### PR TITLE
Remove imported/ references

### DIFF
--- a/content/en/docs/contribute/start.md
+++ b/content/en/docs/contribute/start.md
@@ -29,7 +29,7 @@ using Hugo. The source is in Github at
 [https://github.com/kubernetes/website](https://github.com/kubernetes/website).
 Most of the documentation source is stored in `/content/en/docs/`. Some of the
 reference documentation is automatically generated from scripts, mostly in the
-`/content/en/docs/imported/` subdirectory.
+`update-imported-docs/` directory.
 
 You can file issues, edit content, and review changes from others, all from the
 Github website. You can also use Github's embedded history and search tools.
@@ -154,8 +154,8 @@ process guidelines and information about deadlines.
 ### Sign the CLA
 
 Before you can contribute code or documentation to Kubernetes, you **must** read
-the [Contributor guide](/docs/imported/community/guide/) and
-[sign the Contributor License Agreement (CLA)](/docs/imported/community/guide/#sign-the-cla).
+the [Contributor guide](/docs/community/guide/) and
+[sign the Contributor License Agreement (CLA)](/docs/community/guide/#sign-the-cla).
 Don't worry -- this doesn't take long!
 
 ### Find something to work on

--- a/content/en/docs/reference/glossary/code-contributor.md
+++ b/content/en/docs/reference/glossary/code-contributor.md
@@ -2,7 +2,7 @@
 title: Code Contributor
 id: code-contributor
 date: 2018-04-12
-full_link: /docs/imported/community/devel/
+full_link: /docs/community/devel/
 short_description: >
   A person who develops and contributes code to the Kubernetes open source codebase.
 

--- a/content/en/docs/setup/building-from-source.md
+++ b/content/en/docs/setup/building-from-source.md
@@ -5,7 +5,7 @@ reviewers:
 title: Building from Source
 ---
 
-You can either build a release from source or download a pre-built release.  If you do not plan on developing Kubernetes itself, we suggest using a pre-built version of the current release, which can be found in the [Release Notes](/docs/imported/release/notes/).
+You can either build a release from source or download a pre-built release.  If you do not plan on developing Kubernetes itself, we suggest using a pre-built version of the current release, which can be found in the [Release Notes](/docs/setup/release/notes/).
 
 The Kubernetes source code can be downloaded from the [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes) repo.
 

--- a/layouts/docs/docsportal_home.html
+++ b/layouts/docs/docsportal_home.html
@@ -45,7 +45,7 @@
       The open source project is hosted by the Cloud Native Computing Foundation (<a href="https://www.cncf.io/about">CNCF</a>).
     </p>
     <div class="aboutcolumn" markdown="1">
-      <a href="{{ "docs/imported/release/notes/" | relURL }}">Download Current Release</a>
+      <a href="{{ "docs/setup/release/notes/" | relURL }}">Download Current Release</a>
     </div>
     <div class="aboutcolumn" markdown="1">
       <a href="{{ "docs/home/supported-doc-versions/" | relURL }}">Supported Doc Versions</a>

--- a/static/_redirects
+++ b/static/_redirects
@@ -210,6 +210,8 @@
 /docs/home/contribute/blog-post/ /docs/contribute/start/ 301
 /docs/home/contribute/write-new-topic/ /docs/contribute/style/write-new-topic/ 301
 
+/docs/imported/release/notes/ /docs/setup/release/notes/ 301
+
 /docs/reference/deprecation-policy/     /docs/reference/using-api/deprecation-policy/ 301
 /docs/reference/federation/v1beta1/definitions/     /docs/reference/federation/extensions/v1beta1/definitions/ 301
 /docs/reference/federation/v1beta1/operations/     /docs/reference/federation/extensions/v1beta1/operations/ 301


### PR DESCRIPTION
Goal was to fix "Download Current Release" on `docs/home/`

Supplementary fixes from #9916 

 - Removed remaining `imported/` references to fix the glossary
 - Updated links to CLA
 - Added redirect for `/docs/imported/release/notes/` as it may be used externally with more frequency


Signed-off-by: GuessWhoSamFoo <sfoohei@gmail.com>
