### PR TITLE
Remove the volume type "fast" from sample

### DIFF
--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -288,12 +288,9 @@ metadata:
   name: gold
 provisioner: kubernetes.io/cinder
 parameters:
-  type: fast
   availability: nova
 ```
 
-* `type`: [VolumeType](https://docs.openstack.org/user-guide/dashboard-manage-volumes.html)
-  created in Cinder. Default is empty.
 * `availability`: Availability Zone. If not specified, volumes are generally
   round-robin-ed across all active zones where Kubernetes cluster has a node.
 


### PR DESCRIPTION
The original doc contained "type: fast" which means the volume type
"fast" should exist on OpenStack/Cinder side.
However there is not any standard volume type name and most people
face the StorageClass issue when specifying this volume type.
In addition, the issue is hard to be debugged because the error
message which explains the nonexistent volume type is not output
on debugging information. Then external cloud-provider-openstack
doesn't contain the volume type "fast" today as [1].
This removes it for avoiding confusions for users who still use
the deprecated internal provisioner.

[1]: https://github.com/kubernetes/cloud-provider-openstack/blob/master/examples/persistent-volume-provisioning/cinder/cinder-storage-class.yaml
