### PR TITLE
Render header links without html tags

### DIFF
--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -56,7 +56,7 @@
         headings.forEach(function(heading){
           if(heading.id){
             var a = document.createElement('a');
-            a.text = heading.innerHTML;
+            a.text = heading.textContent;
             a.href = '#'+heading.id;
             a.classList.add('inpage_heading');
             heading.innerHTML = '';


### PR DESCRIPTION
Closes #10042 

In order to create links to headers, the HTML was moved inside an `a` tag.

How Hugo normally does it:
```
<h2 id="use-kubectl-to-scale-statefulsets">
  Use <code>kubectl</code> to scale StatefulSets
</h2>
```

After JS in `baseof.html`:
```
<h2 id="use-kubectl-to-scale-statefulsets">
  <a href="#use-kubectl-to-scale-statefulsets" class="inpage_heading">
    Use <code>kubectl</code> to scale StatefulSets
  </a>
</h2>
```
This PR assumes that HTML tags inside in-page headers does not need to be parsed.

If there is a use case for tags as text in page headers somewhere (possibly span?), then maybe specific tags should be filtered instead.

Signed-off-by: GuessWhoSamFoo <sfoohei@gmail.com>
