### PR TITLE
Dockerfile error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ ARG HUGO_VERSION
 RUN mkdir -p /usr/local/src && \
     cd /usr/local/src && \
     curl -L https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-64bit.tar.gz | tar -xz && \
-    apk add build-base && \
-    apk add libc6-compat && \
+    apk add --no-cache build-base && \
+    apk add --no-cache libc6-compat && \
     mv hugo /usr/local/bin/hugo && \
     curl -L https://bin.equinox.io/c/dhgbqpS8Bvy/minify-stable-linux-amd64.tgz | tar -xz && \
     mv minify /usr/local/bin && \


### PR DESCRIPTION
When I execute `make docker-image`, the following error occurs：
```
  build-base (missing):
    required by: world[build-base]
The command '/bin/sh -c mkdir -p /usr/local/src &&     cd /usr/local/src &&     curl -L https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-64bit.tar.gz | tar -xz &&     apk add build-base &&     apk add libc6-compat &&     mv hugo /usr/local/bin/hugo &&     curl -L https://bin.equinox.io/c/dhgbqpS8Bvy/minify-stable-linux-amd64.tgz | tar -xz &&     mv minify /usr/local/bin &&     addgroup -Sg 1000 hugo &&     adduser -Sg hugo -u 1000 -h /src hugo' returned a non-zero code: 1
make: *** [docker-image] Error 1
```

I change `apk add` to `apk add --no-cache`.