### PR TITLE
etcd manifest needs kubelet PodPriority feature

### DIFF
--- a/content/en/docs/setup/independent/setup-ha-etcd-with-kubeadm.md
+++ b/content/en/docs/setup/independent/setup-ha-etcd-with-kubeadm.md
@@ -54,7 +54,7 @@ this example.
     cat << EOF > /etc/systemd/system/kubelet.service.d/20-etcd-service-manager.conf
     [Service]
     ExecStart=
-    ExecStart=/usr/bin/kubelet --address=127.0.0.1 --pod-manifest-path=/etc/kubernetes/manifests --allow-privileged=true
+    ExecStart=/usr/bin/kubelet --address=127.0.0.1 --pod-manifest-path=/etc/kubernetes/manifests --allow-privileged=true  --feature-gates=PodPriority=true
     Restart=always
     EOF
 


### PR DESCRIPTION
The generated etcd manifest specified `priorityClassName: system-cluster-critical`, so kubelet need to open PodPriority feature.

