### PR TITLE
Typo fix: kubeadmin->kubeadm

### DIFF
--- a/content/en/docs/tasks/administer-cluster/network-policy-provider/romana-network-policy.md
+++ b/content/en/docs/tasks/administer-cluster/network-policy-provider/romana-network-policy.md
@@ -22,7 +22,7 @@ Complete steps 1, 2, and 3 of  the [kubeadm getting started guide](/docs/getting
 
 ## Installing Romana with kubeadm
 
-Follow the [containerized installation guide](https://github.com/romana/romana/tree/master/containerize) for kubeadmin.
+Follow the [containerized installation guide](https://github.com/romana/romana/tree/master/containerize) for kubeadm.
 
 ## Applying network policies
 


### PR DESCRIPTION
A typo in the section [Installing Romana with kubeadm]:
line:25 kubeadmin->kubeadm
kubeadm is a proper noun in here.