### PR TITLE
Remove references to imported for Contributing guides

### DIFF
--- a/data/user-personas/contributors/code-contributor.yaml
+++ b/data/user-personas/contributors/code-contributor.yaml
@@ -5,11 +5,11 @@ index: 0
 foundational:
   - label: "Read the Developer Guide"
     icon: fa-book
-    url: "/docs/imported/community/devel/"
+    url: "/docs/community/devel/"
 intermediate:
   - label: "Learn about the Kubernetes Enhancement Proposal (KEP) process"
     icon: fa-upload
-    url: "/docs/imported/community/keps/"
+    url: "/docs/community/keps/"
   - label: "Understand the API conventions"
     icon: fa-map-o
     url: "https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md"

--- a/data/user-personas/contributors/community-contributor.yaml
+++ b/data/user-personas/contributors/community-contributor.yaml
@@ -5,10 +5,10 @@ index: 1
 foundational:
   - label: "Contribute to the Kubernetes OSS project"
     icon: fa-users
-    url: "/docs/imported/community/guide/"
+    url: "/docs/community/guide/"
   - label: "Find out about mentoring initiatives"
     icon: fa-graduation-cap
-    url: "/docs/imported/community/mentoring/"
+    url: "/docs/community/mentoring/"
 intermediate:
   - label: "Apply for community membership as a member, reviewer, approver, owner, or maintainer"
     icon: fa-user-plus

--- a/static/_redirects
+++ b/static/_redirects
@@ -212,6 +212,11 @@
 
 /docs/imported/release/notes/ /docs/setup/release/notes/ 301
 
+/docs/imported/community/devel/ /docs/community/devel/ 301
+/docs/imported/community/keps/ /docs/commuinty/keps/ 301
+/docs/imported/community/guide/ /docs/community/guide/ 301
+/docs/imported/community/mentoring/ /docs/commuinty/mentoring/ 301
+
 /docs/reference/deprecation-policy/     /docs/reference/using-api/deprecation-policy/ 301
 /docs/reference/federation/v1beta1/definitions/     /docs/reference/federation/extensions/v1beta1/definitions/ 301
 /docs/reference/federation/v1beta1/operations/     /docs/reference/federation/extensions/v1beta1/operations/ 301


### PR DESCRIPTION
Trying to open some of Contributor guides results in the error 404 as the website redirects to URLs containing `imported`.

This PR tries to fix the issue, by modifying the URLs to use the non-`imported` URLs. It also adds entries to the redirects file, so accessing via `imported` URLs redirect to the appropriate page.

Affected endpoints and possibly correct URL used in this PR:

* [Read the developer guide](https://kubernetes.io/docs/home/?path=contributors&persona=code-contributor&level=foundational): `https://kubernetes.io/docs/imported/community/devel/` -> `https://kubernetes.io/docs/community/devel/`,
* [Learn more about KEPs](https://kubernetes.io/docs/home/?path=contributors&persona=code-contributor&level=intermediate): `https://kubernetes.io/docs/imported/community/keps/` -> `https://kubernetes.io/docs/community/keps/`,
* [Contribute to k8s OSS project](https://kubernetes.io/docs/home/?path=contributors&persona=community-contributor&level=foundational): `https://kubernetes.io/docs/imported/community/guide/` -> `https://kubernetes.io/docs/community/guide/`,
* [Mentoring](https://kubernetes.io/docs/home/?path=contributors&persona=community-contributor&level=foundational): `https://kubernetes.io/docs/imported/community/mentoring/` -> `https://kubernetes.io/docs/community/mentoring/`.

This is my first PR to k/website, so it may be that I'm wrong, but please let me know if there's a better way to fix this. :)

More details about the issue can be found in #10083.
Closes #10083.