### PR TITLE
Adding Kubernetes Kubeadm + Digital Rebar integration for On-Prem installs

### DIFF
--- a/content/en/docs/setup/on-premises-metal/krib.md
+++ b/content/en/docs/setup/on-premises-metal/krib.md
@@ -1,0 +1,95 @@
+---
+title: Installing Kubernetes with Digital Rebar Provision (DRP) via KRIB
+krib-version: 2.4
+author: Rob Hirschfeld (zehicle)
+---
+
+## Overview
+
+This guide helps to install a Kubernetes cluster hosted on bare metal with [Digital Rebar Provision](https://github.com/digitalrebar/provision).
+
+Digital Rebar Provision (DRP) is an integrated Golang DHCP, bare metal provisioning (PXE/iPXE) and workflow automation platform.  While [DRP can be used to run](https://provision.readthedocs.io/en/tip/doc/integrations/ansible.html) [Kubespray](../kubespray), it also offers a self-contained Kubernetes installation known as [KRIB (Kubernetes Rebar Integrated Bootstrap)](https://github.com/digitalrebar/provision-content/tree/master/krib).
+
+{{< note >}}
+**Note:** KRIB is not a _stand-alone_ installer: Digital Rebar templates drive a standard [kubeadm](/docs/admin/kubeadm/) configuration that manages the Kubernetes installation with the [Digital Rebar cluster pattern](https://provision.readthedocs.io/en/tip/doc/arch/cluster.html#rs-cluster-pattern) to elect leaders _without supervision_.
+{{< /note >}}
+
+
+KRIB features:
+
+* zero-touch, self-configuring cluster without pre-configuration or inventory
+* very fast, no-ssh required automation
+* bare metal, on-premises focused platform
+* highly available cluster options (including splitting etcd from the controllers)
+* dynamic generation of a TLS infrastructure
+* composable attributes and automatic detection of hardware by profile
+* options for persistent, immutable and image-based deployments
+* support for Ubuntu 18.04 and CentOS/RHEL 7
+
+## Creating a cluster
+
+Review [Digital Rebar documentation](https://https://provision.readthedocs.io/en/tip/README.html) for details about installing the platform.
+
+The Digital Rebar Provision Golang binary is installed on a Linux-like system with 16 Gb of RAM or larger (Packet.net Tiny and Rasberry Pi are also acceptable).
+
+### (1/5) Discover servers
+
+Following the [Digital Rebar installation](https://provision.readthedocs.io/en/tip/doc/quickstart.html), allow one or more servers to boot through the _Sledgehammer_ discovery process to register with the API.  This will automatically install the Digital Rebar runner and to allow for next steps.
+
+### (2/5) Install KRIB Content and Certificate Plugin
+
+Upload the KRIB Content bundle (or build from [source](https://github.com/digitalrebar/provision-content/tree/master/krib)) and the Cert Plugin for your DRP platform (e.g.: [amd64 Linux v2.4.0](https://s3-us-west-2.amazonaws.com/rebar-catalog/certs/v2.4.0-0-02301d35f9f664d6c81d904c92a9c81d3fd41d2c/amd64/linux/certs)).  Both are freely available via the [RackN UX](https://portal.rackn.io).
+
+### (3/5) Start your cluster deployment
+
+{{< note >}}
+**Note:** KRIB documentation is dynamically generated from the source and will be more up to date than this guide.
+{{< /note >}}
+
+Following the [KRIB documentation](https://provision.readthedocs.io/en/tip/doc/content-packages/krib.html), create a Profile for your cluster and assign your target servers into the cluster Profile.  The Profile must set `krib\cluster-name` and `etcd\cluster-name` Params to be the name of the Profile.  Cluster configuration choices can be made by adding additional Params to the Profile; however, safe defaults are provided for all Params.
+
+Once all target servers are assigned, start a KRIB installation Workflow by assigning one of the included Workflows to all cluster servers.  For example, selecting `krib-live-cluster` will perform an immutable deployment into the Sledgehammer discovery operating system.  You may use one of the pre-created read-only Workflows or choose to build your own custom variation.
+
+For basic installs, no further action is required.  You may choose to assign the controllers, etcd servers or other configuration values.
+
+### (4/5) Monitor your cluster deployment
+
+Digital Rebar Provision provides detailed logging and live updates during the installation process.  Workflow events are available via a websocket connection or monitoring the Jobs list.
+
+During the installation, KRIB writes cluster configuration data back into the cluster Profile.
+
+### (5/5) Access your cluster
+
+The cluster is available for access via *kubectl* once the `krib/cluster-admin-conf` Param has been set.  This Param contains the `kubeconfig` information necessary to access the cluster. 
+
+For example, if you named the cluster Profile `krib` then the following commands would allow you to connect to the installed cluster from your local terminal.
+
+  ::
+
+    drpcli profiles get krib params krib/cluster-admin-conf > admin.conf
+    export KUBECONFIG=admin.conf
+    kubectl get nodes
+
+
+The installation continues after the `krib/cluster-admin-conf` is set to install the Kubernetes UI and Helm.  You may interact with the cluster as soon as the `admin.conf` file is available.
+
+## Cluster operations
+
+KRIB provides additional Workflows to manage your cluster.  Please see the [KRIB documentation](https://provision.readthedocs.io/en/tip/doc/content-packages/krib.html) for an updated list of advanced cluster operations.
+
+### Scale your cluster
+
+You can add servers into your cluster by adding the cluster Profile to the server and running the appropriate Workflow.
+
+### Cleanup your cluster (for developers)
+
+You can reset your cluster and wipe out all configuration using the the `krib-reset-cluster` Workflow on any of the servers in the cluster.
+
+{{< caution >}}
+**Caution:** When running the reset Workflow, be sure not to accidentally target your production cluster!
+{{< /caution >}}
+
+## Feedback
+
+* Slack Channel: [#community](https://rackn.slack.com/messages/community/)
+* [GitHub Issues](https://github.com/digital/provision/issues)

--- a/content/en/docs/setup/on-premises-metal/krib.md
+++ b/content/en/docs/setup/on-premises-metal/krib.md
@@ -6,12 +6,12 @@ author: Rob Hirschfeld (zehicle)
 
 ## Overview
 
-This guide helps to install a Kubernetes cluster hosted on bare metal with [Digital Rebar Provision](https://github.com/digitalrebar/provision) using only its Content packages and *kubeadm*. 
+This guide helps to install a Kubernetes cluster hosted on bare metal with [Digital Rebar Provision](https://github.com/digitalrebar/provision).
 
-Digital Rebar Provision (DRP) is an integrated Golang DHCP, bare metal provisioning (PXE/iPXE) and workflow automation platform. While [DRP can be used to invoke](https://provision.readthedocs.io/en/tip/doc/integrations/ansible.html) [kubespray](../kubespray), it also offers a self-contained Kubernetes installation known as [KRIB (Kubernetes Rebar Integrated Bootstrap)](https://github.com/digitalrebar/provision-content/tree/master/krib).
+Digital Rebar Provision (DRP) is an integrated Golang DHCP, bare metal provisioning (PXE/iPXE) and workflow automation platform.  While [DRP can be used to run](https://provision.readthedocs.io/en/tip/doc/integrations/ansible.html) [Kubespray](../kubespray), it also offers a self-contained Kubernetes installation known as [KRIB (Kubernetes Rebar Integrated Bootstrap)](https://github.com/digitalrebar/provision-content/tree/master/krib).
 
 {{< note >}}
-**Note:** KRIB is not a _stand-alone_ installer: Digital Rebar templates drive a standard *[kubeadm](/docs/admin/kubeadm/)* configuration that manages the Kubernetes installation with the [Digital Rebar cluster pattern](https://provision.readthedocs.io/en/tip/doc/arch/cluster.html#rs-cluster-pattern) to elect leaders _without external supervision_.
+**Note:** KRIB is not a _stand-alone_ installer: Digital Rebar templates drive a standard [kubeadm](/docs/admin/kubeadm/) configuration that manages the Kubernetes installation with the [Digital Rebar cluster pattern](https://provision.readthedocs.io/en/tip/doc/arch/cluster.html#rs-cluster-pattern) to elect leaders _without supervision_.
 {{< /note >}}
 
 
@@ -30,15 +30,15 @@ KRIB features:
 
 Review [Digital Rebar documentation](https://https://provision.readthedocs.io/en/tip/README.html) for details about installing the platform.
 
-The Digital Rebar Provision Golang binary should be installed on a Linux-like system with 16 GB of RAM or larger (Packet.net Tiny and Rasberry Pi are also acceptable).
+The Digital Rebar Provision Golang binary is installed on a Linux-like system with 16 Gb of RAM or larger (Packet.net Tiny and Rasberry Pi are also acceptable).
 
 ### (1/5) Discover servers
 
-Following the [Digital Rebar installation](https://provision.readthedocs.io/en/tip/doc/quickstart.html), allow one or more servers to boot through the _Sledgehammer_ discovery process to register with the API. This will automatically install the Digital Rebar runner and to allow for next steps.
+Following the [Digital Rebar installation](https://provision.readthedocs.io/en/tip/doc/quickstart.html), allow one or more servers to boot through the _Sledgehammer_ discovery process to register with the API.  This will automatically install the Digital Rebar runner and to allow for next steps.
 
 ### (2/5) Install KRIB Content and Certificate Plugin
 
-Upload the KRIB Content bundle (or build from [source](https://github.com/digitalrebar/provision-content/tree/master/krib)) and the Cert Plugin for your DRP platform (e.g.: [amd64 Linux v2.4.0](https://s3-us-west-2.amazonaws.com/rebar-catalog/certs/v2.4.0-0-02301d35f9f664d6c81d904c92a9c81d3fd41d2c/amd64/linux/certs)). Both are freely available via the [RackN UX](https://portal.rackn.io).
+Upload the KRIB Content bundle (or build from [source](https://github.com/digitalrebar/provision-content/tree/master/krib)) and the Cert Plugin for your DRP platform (e.g.: [amd64 Linux v2.4.0](https://s3-us-west-2.amazonaws.com/rebar-catalog/certs/v2.4.0-0-02301d35f9f664d6c81d904c92a9c81d3fd41d2c/amd64/linux/certs)).  Both are freely available via the [RackN UX](https://portal.rackn.io).
 
 ### (3/5) Start your cluster deployment
 
@@ -46,15 +46,15 @@ Upload the KRIB Content bundle (or build from [source](https://github.com/digita
 **Note:** KRIB documentation is dynamically generated from the source and will be more up to date than this guide.
 {{< /note >}}
 
-Following the [KRIB documentation](https://provision.readthedocs.io/en/tip/doc/content-packages/krib.html), create a Profile for your cluster and assign your target servers into the cluster Profile. The Profile must set `krib\cluster-name` and `etcd\cluster-name` Params to be the name of the Profile. Cluster configuration choices can be made by adding additional Params to the Profile; however, safe defaults are provided for all Params.
+Following the [KRIB documentation](https://provision.readthedocs.io/en/tip/doc/content-packages/krib.html), create a Profile for your cluster and assign your target servers into the cluster Profile.  The Profile must set `krib\cluster-name` and `etcd\cluster-name` Params to be the name of the Profile.  Cluster configuration choices can be made by adding additional Params to the Profile; however, safe defaults are provided for all Params.
 
-Once all target servers are assigned to the cluster Profile, start a KRIB installation Workflow by assigning one of the included Workflows to all cluster servers. For example, selecting `krib-live-cluster` will perform an immutable deployment into the Sledgehammer discovery operating system. You may use one of the pre-created read-only Workflows or choose to build your own custom variation.
+Once all target servers are assigned, start a KRIB installation Workflow by assigning one of the included Workflows to all cluster servers.  For example, selecting `krib-live-cluster` will perform an immutable deployment into the Sledgehammer discovery operating system.  You may use one of the pre-created read-only Workflows or choose to build your own custom variation.
 
-For basic installs, no further action is required. Advanced users may choose to assign the controllers, etcd servers or other configuration values in the relevant Params.
+For basic installs, no further action is required.  You may choose to assign the controllers, etcd servers or other configuration values.
 
 ### (4/5) Monitor your cluster deployment
 
-Digital Rebar Provision provides detailed logging and live updates during the installation process. Workflow events are available via a websocket connection or monitoring the Jobs list.
+Digital Rebar Provision provides detailed logging and live updates during the installation process.  Workflow events are available via a websocket connection or monitoring the Jobs list.
 
 During the installation, KRIB writes cluster configuration data back into the cluster Profile.
 

--- a/content/en/docs/setup/on-premises-metal/krib.md
+++ b/content/en/docs/setup/on-premises-metal/krib.md
@@ -6,12 +6,12 @@ author: Rob Hirschfeld (zehicle)
 
 ## Overview
 
-This guide helps to install a Kubernetes cluster hosted on bare metal with [Digital Rebar Provision](https://github.com/digitalrebar/provision).
+This guide helps to install a Kubernetes cluster hosted on bare metal with [Digital Rebar Provision](https://github.com/digitalrebar/provision) using only its Content packages and *kubeadm*. 
 
-Digital Rebar Provision (DRP) is an integrated Golang DHCP, bare metal provisioning (PXE/iPXE) and workflow automation platform.  While [DRP can be used to run](https://provision.readthedocs.io/en/tip/doc/integrations/ansible.html) [Kubespray](../kubespray), it also offers a self-contained Kubernetes installation known as [KRIB (Kubernetes Rebar Integrated Bootstrap)](https://github.com/digitalrebar/provision-content/tree/master/krib).
+Digital Rebar Provision (DRP) is an integrated Golang DHCP, bare metal provisioning (PXE/iPXE) and workflow automation platform.  While [DRP can be used to invoke](https://provision.readthedocs.io/en/tip/doc/integrations/ansible.html) [Kubespray](../kubespray), it also offers a self-contained Kubernetes installation known as [KRIB (Kubernetes Rebar Integrated Bootstrap)](https://github.com/digitalrebar/provision-content/tree/master/krib).
 
 {{< note >}}
-**Note:** KRIB is not a _stand-alone_ installer: Digital Rebar templates drive a standard [kubeadm](/docs/admin/kubeadm/) configuration that manages the Kubernetes installation with the [Digital Rebar cluster pattern](https://provision.readthedocs.io/en/tip/doc/arch/cluster.html#rs-cluster-pattern) to elect leaders _without supervision_.
+**Note:** KRIB is not a _stand-alone_ installer: Digital Rebar templates drive a standard *[kubeadm](/docs/admin/kubeadm/)* configuration that manages the Kubernetes installation with the [Digital Rebar cluster pattern](https://provision.readthedocs.io/en/tip/doc/arch/cluster.html#rs-cluster-pattern) to elect leaders _without external supervision_.
 {{< /note >}}
 
 
@@ -24,7 +24,7 @@ KRIB features:
 * dynamic generation of a TLS infrastructure
 * composable attributes and automatic detection of hardware by profile
 * options for persistent, immutable and image-based deployments
-* support for Ubuntu 18.04 and CentOS/RHEL 7
+* support for Ubuntu 18.04, CentOS/RHEL 7 and others
 
 ## Creating a cluster
 
@@ -48,9 +48,9 @@ Upload the KRIB Content bundle (or build from [source](https://github.com/digita
 
 Following the [KRIB documentation](https://provision.readthedocs.io/en/tip/doc/content-packages/krib.html), create a Profile for your cluster and assign your target servers into the cluster Profile.  The Profile must set `krib\cluster-name` and `etcd\cluster-name` Params to be the name of the Profile.  Cluster configuration choices can be made by adding additional Params to the Profile; however, safe defaults are provided for all Params.
 
-Once all target servers are assigned, start a KRIB installation Workflow by assigning one of the included Workflows to all cluster servers.  For example, selecting `krib-live-cluster` will perform an immutable deployment into the Sledgehammer discovery operating system.  You may use one of the pre-created read-only Workflows or choose to build your own custom variation.
+Once all target servers are assigned to the cluster Profile, start a KRIB installation Workflow by assigning one of the included Workflows to all cluster servers.  For example, selecting `krib-live-cluster` will perform an immutable deployment into the Sledgehammer discovery operating system.  You may use one of the pre-created read-only Workflows or choose to build your own custom variation.
 
-For basic installs, no further action is required.  You may choose to assign the controllers, etcd servers or other configuration values.
+For basic installs, no further action is required.  Advanced users may choose to assign the controllers, etcd servers or other configuration values in the relevant Params.
 
 ### (4/5) Monitor your cluster deployment
 
@@ -83,7 +83,7 @@ You can add servers into your cluster by adding the cluster Profile to the serve
 
 ### Cleanup your cluster (for developers)
 
-You can reset your cluster and wipe out all configuration using the the `krib-reset-cluster` Workflow on any of the servers in the cluster.
+You can reset your cluster and wipe out all configuration and TLS certificates using the the `krib-reset-cluster` Workflow on any of the servers in the cluster.
 
 {{< caution >}}
 **Caution:** When running the reset Workflow, be sure not to accidentally target your production cluster!

--- a/content/en/docs/setup/on-premises-metal/krib.md
+++ b/content/en/docs/setup/on-premises-metal/krib.md
@@ -8,7 +8,7 @@ author: Rob Hirschfeld (zehicle)
 
 This guide helps to install a Kubernetes cluster hosted on bare metal with [Digital Rebar Provision](https://github.com/digitalrebar/provision) using only its Content packages and *kubeadm*. 
 
-Digital Rebar Provision (DRP) is an integrated Golang DHCP, bare metal provisioning (PXE/iPXE) and workflow automation platform.  While [DRP can be used to invoke](https://provision.readthedocs.io/en/tip/doc/integrations/ansible.html) [Kubespray](../kubespray), it also offers a self-contained Kubernetes installation known as [KRIB (Kubernetes Rebar Integrated Bootstrap)](https://github.com/digitalrebar/provision-content/tree/master/krib).
+Digital Rebar Provision (DRP) is an integrated Golang DHCP, bare metal provisioning (PXE/iPXE) and workflow automation platform. While [DRP can be used to invoke](https://provision.readthedocs.io/en/tip/doc/integrations/ansible.html) [kubespray](../kubespray), it also offers a self-contained Kubernetes installation known as [KRIB (Kubernetes Rebar Integrated Bootstrap)](https://github.com/digitalrebar/provision-content/tree/master/krib).
 
 {{< note >}}
 **Note:** KRIB is not a _stand-alone_ installer: Digital Rebar templates drive a standard *[kubeadm](/docs/admin/kubeadm/)* configuration that manages the Kubernetes installation with the [Digital Rebar cluster pattern](https://provision.readthedocs.io/en/tip/doc/arch/cluster.html#rs-cluster-pattern) to elect leaders _without external supervision_.
@@ -30,15 +30,15 @@ KRIB features:
 
 Review [Digital Rebar documentation](https://https://provision.readthedocs.io/en/tip/README.html) for details about installing the platform.
 
-The Digital Rebar Provision Golang binary is installed on a Linux-like system with 16 Gb of RAM or larger (Packet.net Tiny and Rasberry Pi are also acceptable).
+The Digital Rebar Provision Golang binary should be installed on a Linux-like system with 16 GB of RAM or larger (Packet.net Tiny and Rasberry Pi are also acceptable).
 
 ### (1/5) Discover servers
 
-Following the [Digital Rebar installation](https://provision.readthedocs.io/en/tip/doc/quickstart.html), allow one or more servers to boot through the _Sledgehammer_ discovery process to register with the API.  This will automatically install the Digital Rebar runner and to allow for next steps.
+Following the [Digital Rebar installation](https://provision.readthedocs.io/en/tip/doc/quickstart.html), allow one or more servers to boot through the _Sledgehammer_ discovery process to register with the API. This will automatically install the Digital Rebar runner and to allow for next steps.
 
 ### (2/5) Install KRIB Content and Certificate Plugin
 
-Upload the KRIB Content bundle (or build from [source](https://github.com/digitalrebar/provision-content/tree/master/krib)) and the Cert Plugin for your DRP platform (e.g.: [amd64 Linux v2.4.0](https://s3-us-west-2.amazonaws.com/rebar-catalog/certs/v2.4.0-0-02301d35f9f664d6c81d904c92a9c81d3fd41d2c/amd64/linux/certs)).  Both are freely available via the [RackN UX](https://portal.rackn.io).
+Upload the KRIB Content bundle (or build from [source](https://github.com/digitalrebar/provision-content/tree/master/krib)) and the Cert Plugin for your DRP platform (e.g.: [amd64 Linux v2.4.0](https://s3-us-west-2.amazonaws.com/rebar-catalog/certs/v2.4.0-0-02301d35f9f664d6c81d904c92a9c81d3fd41d2c/amd64/linux/certs)). Both are freely available via the [RackN UX](https://portal.rackn.io).
 
 ### (3/5) Start your cluster deployment
 
@@ -46,15 +46,15 @@ Upload the KRIB Content bundle (or build from [source](https://github.com/digita
 **Note:** KRIB documentation is dynamically generated from the source and will be more up to date than this guide.
 {{< /note >}}
 
-Following the [KRIB documentation](https://provision.readthedocs.io/en/tip/doc/content-packages/krib.html), create a Profile for your cluster and assign your target servers into the cluster Profile.  The Profile must set `krib\cluster-name` and `etcd\cluster-name` Params to be the name of the Profile.  Cluster configuration choices can be made by adding additional Params to the Profile; however, safe defaults are provided for all Params.
+Following the [KRIB documentation](https://provision.readthedocs.io/en/tip/doc/content-packages/krib.html), create a Profile for your cluster and assign your target servers into the cluster Profile. The Profile must set `krib\cluster-name` and `etcd\cluster-name` Params to be the name of the Profile. Cluster configuration choices can be made by adding additional Params to the Profile; however, safe defaults are provided for all Params.
 
-Once all target servers are assigned to the cluster Profile, start a KRIB installation Workflow by assigning one of the included Workflows to all cluster servers.  For example, selecting `krib-live-cluster` will perform an immutable deployment into the Sledgehammer discovery operating system.  You may use one of the pre-created read-only Workflows or choose to build your own custom variation.
+Once all target servers are assigned to the cluster Profile, start a KRIB installation Workflow by assigning one of the included Workflows to all cluster servers. For example, selecting `krib-live-cluster` will perform an immutable deployment into the Sledgehammer discovery operating system. You may use one of the pre-created read-only Workflows or choose to build your own custom variation.
 
-For basic installs, no further action is required.  Advanced users may choose to assign the controllers, etcd servers or other configuration values in the relevant Params.
+For basic installs, no further action is required. Advanced users may choose to assign the controllers, etcd servers or other configuration values in the relevant Params.
 
 ### (4/5) Monitor your cluster deployment
 
-Digital Rebar Provision provides detailed logging and live updates during the installation process.  Workflow events are available via a websocket connection or monitoring the Jobs list.
+Digital Rebar Provision provides detailed logging and live updates during the installation process. Workflow events are available via a websocket connection or monitoring the Jobs list.
 
 During the installation, KRIB writes cluster configuration data back into the cluster Profile.
 

--- a/content/en/docs/setup/on-premises-metal/krib.md
+++ b/content/en/docs/setup/on-premises-metal/krib.md
@@ -8,7 +8,7 @@ author: Rob Hirschfeld (zehicle)
 
 This guide helps to install a Kubernetes cluster hosted on bare metal with [Digital Rebar Provision](https://github.com/digitalrebar/provision) using only its Content packages and *kubeadm*. 
 
-Digital Rebar Provision (DRP) is an integrated Golang DHCP, bare metal provisioning (PXE/iPXE) and workflow automation platform.  While [DRP can be used to invoke](https://provision.readthedocs.io/en/tip/doc/integrations/ansible.html) [Kubespray](../kubespray), it also offers a self-contained Kubernetes installation known as [KRIB (Kubernetes Rebar Integrated Bootstrap)](https://github.com/digitalrebar/provision-content/tree/master/krib).
+Digital Rebar Provision (DRP) is an integrated Golang DHCP, bare metal provisioning (PXE/iPXE) and workflow automation platform. While [DRP can be used to invoke](https://provision.readthedocs.io/en/tip/doc/integrations/ansible.html) [kubespray](../kubespray), it also offers a self-contained Kubernetes installation known as [KRIB (Kubernetes Rebar Integrated Bootstrap)](https://github.com/digitalrebar/provision-content/tree/master/krib).
 
 {{< note >}}
 **Note:** KRIB is not a _stand-alone_ installer: Digital Rebar templates drive a standard *[kubeadm](/docs/admin/kubeadm/)* configuration that manages the Kubernetes installation with the [Digital Rebar cluster pattern](https://provision.readthedocs.io/en/tip/doc/arch/cluster.html#rs-cluster-pattern) to elect leaders _without external supervision_.
@@ -30,15 +30,15 @@ KRIB features:
 
 Review [Digital Rebar documentation](https://https://provision.readthedocs.io/en/tip/README.html) for details about installing the platform.
 
-The Digital Rebar Provision Golang binary is installed on a Linux-like system with 16 Gb of RAM or larger (Packet.net Tiny and Rasberry Pi are also acceptable).
+The Digital Rebar Provision Golang binary should be installed on a Linux-like system with 16 GB of RAM or larger (Packet.net Tiny and Rasberry Pi are also acceptable).
 
 ### (1/5) Discover servers
 
-Following the [Digital Rebar installation](https://provision.readthedocs.io/en/tip/doc/quickstart.html), allow one or more servers to boot through the _Sledgehammer_ discovery process to register with the API.  This will automatically install the Digital Rebar runner and to allow for next steps.
+Following the [Digital Rebar installation](https://provision.readthedocs.io/en/tip/doc/quickstart.html), allow one or more servers to boot through the _Sledgehammer_ discovery process to register with the API. This will automatically install the Digital Rebar runner and to allow for next steps.
 
 ### (2/5) Install KRIB Content and Certificate Plugin
 
-Upload the KRIB Content bundle (or build from [source](https://github.com/digitalrebar/provision-content/tree/master/krib)) and the Cert Plugin for your DRP platform (e.g.: [amd64 Linux v2.4.0](https://s3-us-west-2.amazonaws.com/rebar-catalog/certs/v2.4.0-0-02301d35f9f664d6c81d904c92a9c81d3fd41d2c/amd64/linux/certs)).  Both are freely available via the [RackN UX](https://portal.rackn.io).
+Upload the KRIB Content bundle (or build from [source](https://github.com/digitalrebar/provision-content/tree/master/krib)) and the Cert Plugin for your DRP platform (e.g.: [amd64 Linux v2.4.0](https://s3-us-west-2.amazonaws.com/rebar-catalog/certs/v2.4.0-0-02301d35f9f664d6c81d904c92a9c81d3fd41d2c/amd64/linux/certs)). Both are freely available via the [RackN UX](https://portal.rackn.io).
 
 ### (3/5) Start your cluster deployment
 
@@ -46,21 +46,21 @@ Upload the KRIB Content bundle (or build from [source](https://github.com/digita
 **Note:** KRIB documentation is dynamically generated from the source and will be more up to date than this guide.
 {{< /note >}}
 
-Following the [KRIB documentation](https://provision.readthedocs.io/en/tip/doc/content-packages/krib.html), create a Profile for your cluster and assign your target servers into the cluster Profile.  The Profile must set `krib\cluster-name` and `etcd\cluster-name` Params to be the name of the Profile.  Cluster configuration choices can be made by adding additional Params to the Profile; however, safe defaults are provided for all Params.
+Following the [KRIB documentation](https://provision.readthedocs.io/en/tip/doc/content-packages/krib.html), create a Profile for your cluster and assign your target servers into the cluster Profile. The Profile must set `krib\cluster-name` and `etcd\cluster-name` Params to be the name of the Profile. Cluster configuration choices can be made by adding additional Params to the Profile; however, safe defaults are provided for all Params.
 
-Once all target servers are assigned to the cluster Profile, start a KRIB installation Workflow by assigning one of the included Workflows to all cluster servers.  For example, selecting `krib-live-cluster` will perform an immutable deployment into the Sledgehammer discovery operating system.  You may use one of the pre-created read-only Workflows or choose to build your own custom variation.
+Once all target servers are assigned to the cluster Profile, start a KRIB installation Workflow by assigning one of the included Workflows to all cluster servers. For example, selecting `krib-live-cluster` will perform an immutable deployment into the Sledgehammer discovery operating system. You may use one of the pre-created read-only Workflows or choose to build your own custom variation.
 
-For basic installs, no further action is required.  Advanced users may choose to assign the controllers, etcd servers or other configuration values in the relevant Params.
+For basic installs, no further action is required. Advanced users may choose to assign the controllers, etcd servers or other configuration values in the relevant Params.
 
 ### (4/5) Monitor your cluster deployment
 
-Digital Rebar Provision provides detailed logging and live updates during the installation process.  Workflow events are available via a websocket connection or monitoring the Jobs list.
+Digital Rebar Provision provides detailed logging and live updates during the installation process. Workflow events are available via a websocket connection or monitoring the Jobs list.
 
 During the installation, KRIB writes cluster configuration data back into the cluster Profile.
 
 ### (5/5) Access your cluster
 
-The cluster is available for access via *kubectl* once the `krib/cluster-admin-conf` Param has been set.  This Param contains the `kubeconfig` information necessary to access the cluster. 
+The cluster is available for access via *kubectl* once the `krib/cluster-admin-conf` Param has been set. This Param contains the `kubeconfig` information necessary to access the cluster. 
 
 For example, if you named the cluster Profile `krib` then the following commands would allow you to connect to the installed cluster from your local terminal.
 
@@ -71,11 +71,11 @@ For example, if you named the cluster Profile `krib` then the following commands
     kubectl get nodes
 
 
-The installation continues after the `krib/cluster-admin-conf` is set to install the Kubernetes UI and Helm.  You may interact with the cluster as soon as the `admin.conf` file is available.
+The installation continues after the `krib/cluster-admin-conf` is set to install the Kubernetes UI and Helm. You may interact with the cluster as soon as the `admin.conf` file is available.
 
 ## Cluster operations
 
-KRIB provides additional Workflows to manage your cluster.  Please see the [KRIB documentation](https://provision.readthedocs.io/en/tip/doc/content-packages/krib.html) for an updated list of advanced cluster operations.
+KRIB provides additional Workflows to manage your cluster. Please see the [KRIB documentation](https://provision.readthedocs.io/en/tip/doc/content-packages/krib.html) for an updated list of advanced cluster operations.
 
 ### Scale your cluster
 

--- a/content/en/docs/setup/on-premises-metal/krib.md
+++ b/content/en/docs/setup/on-premises-metal/krib.md
@@ -6,12 +6,12 @@ author: Rob Hirschfeld (zehicle)
 
 ## Overview
 
-This guide helps to install a Kubernetes cluster hosted on bare metal with [Digital Rebar Provision](https://github.com/digitalrebar/provision).
+This guide helps to install a Kubernetes cluster hosted on bare metal with [Digital Rebar Provision](https://github.com/digitalrebar/provision) using only its Content packages and *kubeadm*. 
 
-Digital Rebar Provision (DRP) is an integrated Golang DHCP, bare metal provisioning (PXE/iPXE) and workflow automation platform.  While [DRP can be used to run](https://provision.readthedocs.io/en/tip/doc/integrations/ansible.html) [Kubespray](../kubespray), it also offers a self-contained Kubernetes installation known as [KRIB (Kubernetes Rebar Integrated Bootstrap)](https://github.com/digitalrebar/provision-content/tree/master/krib).
+Digital Rebar Provision (DRP) is an integrated Golang DHCP, bare metal provisioning (PXE/iPXE) and workflow automation platform.  While [DRP can be used to invoke](https://provision.readthedocs.io/en/tip/doc/integrations/ansible.html) [Kubespray](../kubespray), it also offers a self-contained Kubernetes installation known as [KRIB (Kubernetes Rebar Integrated Bootstrap)](https://github.com/digitalrebar/provision-content/tree/master/krib).
 
 {{< note >}}
-**Note:** KRIB is not a _stand-alone_ installer: Digital Rebar templates drive a standard [kubeadm](/docs/admin/kubeadm/) configuration that manages the Kubernetes installation with the [Digital Rebar cluster pattern](https://provision.readthedocs.io/en/tip/doc/arch/cluster.html#rs-cluster-pattern) to elect leaders _without supervision_.
+**Note:** KRIB is not a _stand-alone_ installer: Digital Rebar templates drive a standard *[kubeadm](/docs/admin/kubeadm/)* configuration that manages the Kubernetes installation with the [Digital Rebar cluster pattern](https://provision.readthedocs.io/en/tip/doc/arch/cluster.html#rs-cluster-pattern) to elect leaders _without external supervision_.
 {{< /note >}}
 
 
@@ -48,9 +48,9 @@ Upload the KRIB Content bundle (or build from [source](https://github.com/digita
 
 Following the [KRIB documentation](https://provision.readthedocs.io/en/tip/doc/content-packages/krib.html), create a Profile for your cluster and assign your target servers into the cluster Profile.  The Profile must set `krib\cluster-name` and `etcd\cluster-name` Params to be the name of the Profile.  Cluster configuration choices can be made by adding additional Params to the Profile; however, safe defaults are provided for all Params.
 
-Once all target servers are assigned, start a KRIB installation Workflow by assigning one of the included Workflows to all cluster servers.  For example, selecting `krib-live-cluster` will perform an immutable deployment into the Sledgehammer discovery operating system.  You may use one of the pre-created read-only Workflows or choose to build your own custom variation.
+Once all target servers are assigned to the cluster Profile, start a KRIB installation Workflow by assigning one of the included Workflows to all cluster servers.  For example, selecting `krib-live-cluster` will perform an immutable deployment into the Sledgehammer discovery operating system.  You may use one of the pre-created read-only Workflows or choose to build your own custom variation.
 
-For basic installs, no further action is required.  You may choose to assign the controllers, etcd servers or other configuration values.
+For basic installs, no further action is required.  Advanced users may choose to assign the controllers, etcd servers or other configuration values in the relevant Params.
 
 ### (4/5) Monitor your cluster deployment
 

--- a/content/en/docs/setup/pick-right-solution.md
+++ b/content/en/docs/setup/pick-right-solution.md
@@ -162,6 +162,7 @@ These solutions are combinations of cloud providers and operating systems not co
 ### Bare Metal
 
 * [CoreOS](/docs/setup/custom-cloud/coreos/)
+* [Digital Rebar](/docs/setup/on-premises-metal/krib/)
 * [Fedora (Single Node)](/docs/getting-started-guides/fedora/fedora_manual_config/)
 * [Fedora (Multi Node)](/docs/getting-started-guides/fedora/flannel_multi_node_cluster/)
 * [Kubernetes on Ubuntu](/docs/getting-started-guides/ubuntu/)
@@ -222,7 +223,11 @@ any                  | RKE          | multi-support    | flannel or canal       
 any                  | [Gardener Cluster-Operator](https://kubernetes.io/blog/2018/05/17/gardener/) | multi-support | multi-support | [docs](https://gardener.cloud) | [Project/Community](https://github.com/gardener) and [Commercial]( https://cloudplatform.sap.com/)
 Alibaba Cloud Container Service For Kubernetes | ROS        | CentOS | flannel/Terway       | [docs](https://www.aliyun.com/product/containerservice)                    |  Commercial
 Agile Stacks       | Terraform   | CoreOS | multi-support | [docs](https://www.agilestacks.com/products/kubernetes) | Commercial
+<<<<<<< HEAD
 IBM Cloud Kubernetes Service | | Ubuntu | calico | [docs](https://console.bluemix.net/docs/containers/container_index.html) | Commercial
+=======
+Digital Rebar        | kubeadm      | any    | metal       | [docs](/docs/setup/on-premises-metal/krib/)                                  | Community ([@digitalrebar](https://github.com/digitalrebar))
+>>>>>>> add Digital Rebar KRIB to installer lists
 
 
 {{< note >}}

--- a/content/en/docs/setup/pick-right-solution.md
+++ b/content/en/docs/setup/pick-right-solution.md
@@ -223,11 +223,8 @@ any                  | RKE          | multi-support    | flannel or canal       
 any                  | [Gardener Cluster-Operator](https://kubernetes.io/blog/2018/05/17/gardener/) | multi-support | multi-support | [docs](https://gardener.cloud) | [Project/Community](https://github.com/gardener) and [Commercial]( https://cloudplatform.sap.com/)
 Alibaba Cloud Container Service For Kubernetes | ROS        | CentOS | flannel/Terway       | [docs](https://www.aliyun.com/product/containerservice)                    |  Commercial
 Agile Stacks       | Terraform   | CoreOS | multi-support | [docs](https://www.agilestacks.com/products/kubernetes) | Commercial
-<<<<<<< HEAD
 IBM Cloud Kubernetes Service | | Ubuntu | calico | [docs](https://console.bluemix.net/docs/containers/container_index.html) | Commercial
-=======
 Digital Rebar        | kubeadm      | any    | metal       | [docs](/docs/setup/on-premises-metal/krib/)                                  | Community ([@digitalrebar](https://github.com/digitalrebar))
->>>>>>> add Digital Rebar KRIB to installer lists
 
 
 {{< note >}}

--- a/content/en/docs/tasks/administer-cluster/cluster-management.md
+++ b/content/en/docs/tasks/administer-cluster/cluster-management.md
@@ -73,6 +73,7 @@ Different providers, and tools, will manage upgrades differently.  It is recomme
 * [kops](https://github.com/kubernetes/kops)
 * [kubespray](https://github.com/kubernetes-incubator/kubespray)
 * [CoreOS Tectonic](https://coreos.com/tectonic/docs/latest/admin/upgrade.html)
+* [Digital Rebar](https://provision.readthedocs.io/en/tip/doc/content-packages/krib.html)
 * ...
 
 ## Resizing a cluster


### PR DESCRIPTION
Xref: #10117 

**This is a...** 
- [X] Feature Request
- [ ] Bug Report

**Problem:**

Current documentation is missing information about Kubernetes Rebar Integrated Bootstrap (KRIB).  It is a zero touch provisioning approach that relies on community tooling (kubeadm) to create simple and HA clusters including rolling upgrades, helm and sonobuoy integrations (so far).

**Proposed Solution:**

Create missing documentation pages and links in documentation set.  Provide brief "how to" in the docs website that relies strongly on the KRIB documentation as the definitive source.

**Page to Update:**

https://kubernetes.io/docs/setup/pick-right-solution/
https://kubernetes.io/docs/tasks/administer-cluster/cluster-management.md
NEW > https://kubernetes.io/docs/setup/on-premises-metal/krib.md

<!--Kubernetes Version:-->
1.9+

<!--Additional Information:-->
Digital Rebar and KRIB are APLv2.