### PR TITLE
Fix not to escape html in in-page headers

### DIFF
--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -56,7 +56,7 @@
         headings.forEach(function(heading){
           if(heading.id){
             var a = document.createElement('a');
-            a.text = heading.innerHTML;
+            a.innerHTML = heading.innerHTML;
             a.href = '#'+heading.id;
             a.classList.add('inpage_heading');
             heading.innerHTML = '';


### PR DESCRIPTION
This PR fixes not to escape html in in-page headers. You can see escaped in-page header text on URL below:

-  https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#equality-based-requirement

**Before**

<img width="543" alt="screen shot 2018-08-30 at 0 05 36" src="https://user-images.githubusercontent.com/230185/44797119-61b85480-abe9-11e8-93a4-3e7ec646ac15.png">

**After**

<img width="489" alt="screen shot 2018-08-30 at 0 06 14" src="https://user-images.githubusercontent.com/230185/44797130-65e47200-abe9-11e8-9bd2-ccd93814f9c0.png">