### PR TITLE
change URL to kubectl commands

### DIFF
--- a/content/en/docs/reference/kubectl/kubectl.md
+++ b/content/en/docs/reference/kubectl/kubectl.md
@@ -48,46 +48,46 @@ kubectl [flags]
 
 ### SEE ALSO
 
-* [kubectl alpha](kubectl_alpha.md)	 - Commands for features in alpha
-* [kubectl annotate](kubectl_annotate.md)	 - Update the annotations on a resource
-* [kubectl api-resources](kubectl_api-resources.md)	 - Print the supported API resources on the server
-* [kubectl api-versions](kubectl_api-versions.md)	 - Print the supported API versions on the server, in the form of "group/version"
-* [kubectl apply](kubectl_apply.md)	 - Apply a configuration to a resource by filename or stdin
-* [kubectl attach](kubectl_attach.md)	 - Attach to a running container
-* [kubectl auth](kubectl_auth.md)	 - Inspect authorization
-* [kubectl autoscale](kubectl_autoscale.md)	 - Auto-scale a Deployment, ReplicaSet, or ReplicationController
-* [kubectl certificate](kubectl_certificate.md)	 - Modify certificate resources.
-* [kubectl cluster-info](kubectl_cluster-info.md)	 - Display cluster info
-* [kubectl completion](kubectl_completion.md)	 - Output shell completion code for the specified shell (bash or zsh)
-* [kubectl config](kubectl_config.md)	 - Modify kubeconfig files
-* [kubectl convert](kubectl_convert.md)	 - Convert config files between different API versions
-* [kubectl cordon](kubectl_cordon.md)	 - Mark node as unschedulable
-* [kubectl cp](kubectl_cp.md)	 - Copy files and directories to and from containers.
-* [kubectl create](kubectl_create.md)	 - Create a resource from a file or from stdin.
-* [kubectl delete](kubectl_delete.md)	 - Delete resources by filenames, stdin, resources and names, or by resources and label selector
-* [kubectl describe](kubectl_describe.md)	 - Show details of a specific resource or group of resources
-* [kubectl drain](kubectl_drain.md)	 - Drain node in preparation for maintenance
-* [kubectl edit](kubectl_edit.md)	 - Edit a resource on the server
-* [kubectl exec](kubectl_exec.md)	 - Execute a command in a container
-* [kubectl explain](kubectl_explain.md)	 - Documentation of resources
-* [kubectl expose](kubectl_expose.md)	 - Take a replication controller, service, deployment or pod and expose it as a new Kubernetes Service
-* [kubectl get](kubectl_get.md)	 - Display one or many resources
-* [kubectl label](kubectl_label.md)	 - Update the labels on a resource
-* [kubectl logs](kubectl_logs.md)	 - Print the logs for a container in a pod
-* [kubectl options](kubectl_options.md)	 - Print the list of flags inherited by all commands
-* [kubectl patch](kubectl_patch.md)	 - Update field(s) of a resource using strategic merge patch
-* [kubectl plugin](kubectl_plugin.md)	 - Runs a command-line plugin
-* [kubectl port-forward](kubectl_port-forward.md)	 - Forward one or more local ports to a pod
-* [kubectl proxy](kubectl_proxy.md)	 - Run a proxy to the Kubernetes API server
-* [kubectl replace](kubectl_replace.md)	 - Replace a resource by filename or stdin
-* [kubectl rollout](kubectl_rollout.md)	 - Manage the rollout of a resource
-* [kubectl run](kubectl_run.md)	 - Run a particular image on the cluster
-* [kubectl scale](kubectl_scale.md)	 - Set a new size for a Deployment, ReplicaSet, Replication Controller, or Job
-* [kubectl set](kubectl_set.md)	 - Set specific features on objects
-* [kubectl taint](kubectl_taint.md)	 - Update the taints on one or more nodes
-* [kubectl top](kubectl_top.md)	 - Display Resource (CPU/Memory/Storage) usage.
-* [kubectl uncordon](kubectl_uncordon.md)	 - Mark node as schedulable
-* [kubectl version](kubectl_version.md)	 - Print the client and server version information
-* [kubectl wait](kubectl_wait.md)	 - Experimental: Wait for one condition on one or many resources
+* [kubectl alpha](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#alpha)	 - Commands for features in alpha
+* [kubectl annotate](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#annotate)	 - Update the annotations on a resource
+* [kubectl api-resources](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#api-resources)	 - Print the supported API resources on the server
+* [kubectl api-versions](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#api-versions)	 - Print the supported API versions on the server, in the form of "group/version"
+* [kubectl apply](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#apply)	 - Apply a configuration to a resource by filename or stdin
+* [kubectl attach](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#attach)	 - Attach to a running container
+* [kubectl auth](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#auth)	 - Inspect authorization
+* [kubectl autoscale](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#autoscale)	 - Auto-scale a Deployment, ReplicaSet, or ReplicationController
+* [kubectl certificate](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#certificate)	 - Modify certificate resources.
+* [kubectl cluster-info](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#cluster-info)	 - Display cluster info
+* [kubectl completion](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#completion)	 - Output shell completion code for the specified shell (bash or zsh)
+* [kubectl config](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#config)	 - Modify kubeconfig files
+* [kubectl convert](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#convert)	 - Convert config files between different API versions
+* [kubectl cordon](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#cordon)	 - Mark node as unschedulable
+* [kubectl cp](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#cp)	 - Copy files and directories to and from containers.
+* [kubectl create](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#create)	 - Create a resource from a file or from stdin.
+* [kubectl delete](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#delete)	 - Delete resources by filenames, stdin, resources and names, or by resources and label selector
+* [kubectl describe](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#describe)	 - Show details of a specific resource or group of resources
+* [kubectl drain](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#drain)	 - Drain node in preparation for maintenance
+* [kubectl edit](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#edit)	 - Edit a resource on the server
+* [kubectl exec](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#exec)	 - Execute a command in a container
+* [kubectl explain](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#explain)	 - Documentation of resources
+* [kubectl expose](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#expose)	 - Take a replication controller, service, deployment or pod and expose it as a new Kubernetes Service
+* [kubectl get](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#get)	 - Display one or many resources
+* [kubectl label](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#label)	 - Update the labels on a resource
+* [kubectl logs](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#logs)	 - Print the logs for a container in a pod
+* [kubectl options](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#options)	 - Print the list of flags inherited by all commands
+* [kubectl patch](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#patch)	 - Update field(s) of a resource using strategic merge patch
+* [kubectl plugin](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#plugin)	 - Runs a command-line plugin
+* [kubectl port-forward](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#port-forward)	 - Forward one or more local ports to a pod
+* [kubectl proxy](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#proxy)	 - Run a proxy to the Kubernetes API server
+* [kubectl replace](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#replace)	 - Replace a resource by filename or stdin
+* [kubectl rollout](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#rollout)	 - Manage the rollout of a resource
+* [kubectl run](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#run)	 - Run a particular image on the cluster
+* [kubectl scale](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#scale)	 - Set a new size for a Deployment, ReplicaSet, Replication Controller, or Job
+* [kubectl set](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#set)	 - Set specific features on objects
+* [kubectl taint](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#taint)	 - Update the taints on one or more nodes
+* [kubectl top](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#top)	 - Display Resource (CPU/Memory/Storage) usage.
+* [kubectl uncordon](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#uncordon)	 - Mark node as schedulable
+* [kubectl version](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#version)	 - Print the client and server version information
+* [kubectl wait](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#wait)	 - Experimental: Wait for one condition on one or many resources
 
 ###### Auto generated by spf13/cobra on 16-Jun-2018


### PR DESCRIPTION
FIx #10131
At this time, there are no .md pages corresponding to each commands.
Therefore, I added a reference page anchor.