### PR TITLE
Fix annotation for default storage class

### DIFF
--- a/content/en/blog/_posts/2016-10-00-Dynamic-Provisioning-And-Storage-In-Kubernetes.md
+++ b/content/en/blog/_posts/2016-10-00-Dynamic-Provisioning-And-Storage-In-Kubernetes.md
@@ -130,7 +130,7 @@ This claim will result in an SSD-like Persistent Disk being automatically provis
 
 
 
-Dynamic Provisioning can be enabled for a cluster such that all claims are dynamically provisioned without a storage class annotation. This behavior is enabled by the cluster administrator by marking one StorageClass object as “default”. A StorageClass can be marked as default by adding the storageclass.beta.kubernetes.io/is-default-class annotation to it.
+Dynamic Provisioning can be enabled for a cluster such that all claims are dynamically provisioned without a storage class annotation. This behavior is enabled by the cluster administrator by marking one StorageClass object as “default”. A StorageClass can be marked as default by adding the storageclass.kubernetes.io/is-default-class annotation to it.
 
 
 

--- a/content/en/blog/_posts/2017-03-00-Dynamic-Provisioning-And-Storage-Classes-Kubernetes.md
+++ b/content/en/blog/_posts/2017-03-00-Dynamic-Provisioning-And-Storage-Classes-Kubernetes.md
@@ -179,7 +179,7 @@ Name:     standard
 
 IsDefaultClass: Yes
 
-Annotations: storageclass.beta.kubernetes.io/is-default-class=true
+Annotations: storageclass.kubernetes.io/is-default-class=true
 
 Provisioner: kubernetes.io/gce-pd
 
@@ -193,7 +193,7 @@ Events:         \<none\>
 **Can I delete/turn off the default StorageClasses?**  
 You cannot delete the default storage class objects provided. Since they are installed as cluster addons, they will be recreated if they are deleted.  
 
-You can, however, disable the defaulting behavior by removing (or setting to false) the following annotation: storageclass.beta.kubernetes.io/is-default-class.  
+You can, however, disable the defaulting behavior by removing (or setting to false) the following annotation: storageclass.kubernetes.io/is-default-class.
 
 If there are no StorageClass objects marked with the default annotation, then PersistentVolumeClaim objects (without a StorageClass specified) will not trigger dynamic provisioning. They will, instead, fall back to the legacy behavior of binding to an available PersistentVolume object.  
 


### PR DESCRIPTION
Currently some docs still reference `storageclass.beta.kubernetes.io` although `storageclass.kubernetes.io` is available


