### PR TITLE
Remove unnecessary link

### DIFF
--- a/layouts/docs/docsportal_home.html
+++ b/layouts/docs/docsportal_home.html
@@ -41,7 +41,7 @@
 <div id='aboutWrapper'>
   <div class="aboutsection" markdown="1">
     <p>
-      Kubernetes is an open source system for managing <a href="https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/">containerized applications</a> across multiple hosts, providing basic mechanisms for deployment, maintenance, and scaling of applications.
+      Kubernetes is an open source system for managing containerized applications across multiple hosts, providing basic mechanisms for deployment, maintenance, and scaling of applications.
       The open source project is hosted by the Cloud Native Computing Foundation (<a href="https://www.cncf.io/about">CNCF</a>).
     </p>
     <div class="aboutcolumn" markdown="1">


### PR DESCRIPTION
Remove confusing link to What is Kubernetes in `/docs/home` landing page blurb.