### PR TITLE
add min-height for kcsp iframe

### DIFF
--- a/content/en/partners/_index.html
+++ b/content/en/partners/_index.html
@@ -49,7 +49,7 @@ cid: partners
 </head>
 <body>
     <div id="frameHolder">
-      <iframe id="landscape" frameBorder="0" scrolling="no" style="width: 1px; min-width: 100%" src=""></iframe>
+      <iframe id="landscape" frameBorder="0" scrolling="no" style="width: 1px; min-width: 100%; min-height:600px" src=""></iframe>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/3.6.0/iframeResizer.js"></script>
       <script>
         document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
add min-height for kcsp iframe to fix the iframe's height is too low that can not show the entire kcsp member when first loading the page.
