### PR TITLE
Fix the unavailable link

### DIFF
--- a/content/en/docs/reference/access-authn-authz/webhook.md
+++ b/content/en/docs/reference/access-authn-authz/webhook.md
@@ -145,7 +145,7 @@ Access to other non-resource paths can be disallowed without restricting access
 to the REST api.
 
 For further documentation refer to the authorization.v1beta1 API objects and
-[webhook.go](https://github.com/kubernetes/kubernetes/blob/{{< param "githubbranch" >}}/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go).
+[webhook.go](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go).
 
 {{% /capture %}}
 


### PR DESCRIPTION
Fix the unavailable link
Line 148: the hyper link for webhook.go is unavailable.