### PR TITLE
Fixing seeming typo in the `--field-selector` example

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/field-selectors.md
+++ b/content/en/docs/concepts/overview/working-with-objects/field-selectors.md
@@ -46,7 +46,7 @@ $ kubectl get services --field-selector metadata.namespace!=default
 As with [label](/docs/concepts/overview/working-with-objects/labels) and other selectors, field selectors can be chained together as a comma-separated list. This `kubectl` command selects all Pods for which the `status.phase` does not equal `Running` and the `spec.restartPolicy` field equals `Always`:
 
 ```shell
-$ kubectl get pods --field-selector=status.phase!=Running,spec.restartPolicy=Always
+$ kubectl get pods --field-selector status.phase!=Running,spec.restartPolicy=Always
 ```
 
 ## Multiple resource types


### PR DESCRIPTION
Based on other examples, it seems like this equal sign should be a space.
