### PR TITLE
Remove unresponsive K8 Playground (ERR_CONNECTION_TIMED_OUT)

### DIFF
--- a/content/en/includes/task-tutorial-prereqs.md
+++ b/content/en/includes/task-tutorial-prereqs.md
@@ -5,4 +5,3 @@ cluster, you can create one by using
 or you can use one of these Kubernetes playgrounds:
 
 * [Katacoda](https://www.katacoda.com/courses/kubernetes/playground)
-* [Play with Kubernetes](http://labs.play-with-k8s.com/)


### PR DESCRIPTION
Getting ERR_CONNECTION_TIMED_OUT for http://labs.play-with-k8s.com/

Is this the same as training.play-with-kubernetes.com? Should it be updated instead?
