### PR TITLE
Add an OWNERS file to /resources/

### DIFF
--- a/resources/OWNERS
+++ b/resources/OWNERS
@@ -1,0 +1,8 @@
+# Allow CSS/SASS updates from blog and case studies owners 
+options:
+  no_parent_owners: false
+reviewers:
+  - alexcontini
+approvers:
+  - alexcontini
+  


### PR DESCRIPTION
This PR adds an OWNERS file to `/resources/`.

- This PR inherits permissions from the parent [OWNERS](https://github.com/kubernetes/website/blob/master/OWNERS) file for the repo. 

   This PR doesn't restrict anyone else's permissions. 

- This PR _adds_ permission for @alexcontini to make changes to files in `/resources/`. 

   Changes to case studies frequently require updates to CSS/SASS files. It makes sense to expand approver permissions for [case studies OWNERS](https://github.com/kubernetes/website/blob/master/content/en/case-studies/OWNERS) to include changes to `/resources/*`. 

Context: https://github.com/kubernetes/website/pull/10092#issuecomment-418855714