### PR TITLE
Capitalized "Pod" in multiple locations

### DIFF
--- a/content/en/docs/contribute/style/style-guide.md
+++ b/content/en/docs/contribute/style/style-guide.md
@@ -149,7 +149,7 @@ The output is similar to this:
 
 ### Versioning Kubernetes examples
 
-Code examples and configuration examples that include version information should be consistent with the accompanying text. 
+Code examples and configuration examples that include version information should be consistent with the accompanying text.
 
 If the information is version specific, the Kubernetes version needs to be defined in the `prerequisites` section of the [Task template](/docs/contribute/style/page-templates/#task-template) or the [Tutorial template] (/docs/contribute/style/page-templates/#tutorial-template). Once the page is saved, the `prerequisites` section is shown as **Before you begin**.
 
@@ -194,7 +194,7 @@ Hugo [Shortcodes](https://gohugo.io/content-management/shortcodes) help create d
 1. Surround the text with an opening and closing shortcode.
 
 2. Use the following syntax to apply a style:
-    
+
     ```
     {{</* note */>}}
     **Note:** The prefix you use is the same text you use in the tag.
@@ -213,7 +213,7 @@ The output is:
 Use {{</* note */>}} to highlight a tip or a piece of information that may be helpful to know.
 
 For example:
-    
+
 ```
 {{</* note */>}}
 **Note:** You can _still_ use Markdown inside these callouts.
@@ -364,7 +364,7 @@ whether they're part of the "we" you're describing.
   <tr><th>Do</th><th>Don't</th></tr>
   <tr><td>Version 1.4 includes ...</td><td>In version 1.4, we have added ...</td></tr>
   <tr><td>Kubernetes provides a new feature for ...</td><td>We provide a new feature ...</td></tr>
-  <tr><td>This page teaches you how to use pods.</td><td>In this page, we are going to learn about pods.</td></tr>
+  <tr><td>This page teaches you how to use Pods.</td><td>In this page, we are going to learn about Pods.</td></tr>
 </table>
 
 ### Avoid jargon and idioms

--- a/content/en/docs/contribute/style/style-guide.md
+++ b/content/en/docs/contribute/style/style-guide.md
@@ -56,11 +56,11 @@ leads to an awkward construction.
 Use angle brackets for placeholders. Tell the reader what a placeholder
 represents.
 
-1. Display information about a pod:
+1. Display information about a Pod:
 
        kubectl describe pod <pod-name>
 
-    where `<pod-name>` is the name of one of your pods.
+    where `<pod-name>` is the name of one of your Pods.
 
 ### Use bold for user interface elements
 
@@ -138,7 +138,7 @@ For field values of type string or integer, use normal style without quotation m
 
 ### Separate commands from output
 
-Verify that the pod is running on your chosen node:
+Verify that the Pod is running on your chosen node:
 
     kubectl get pods --output=wide
 


### PR DESCRIPTION
This style guide states to always capitalize Pod, but in the next section it was written in lowercase in a couple places. I've capitalized them.
