### PR TITLE
update KubeletPluginsWatcher feature gate

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -71,7 +71,8 @@ different Kubernetes components.
 | `HyperVContainer` | `false` | Alpha | 1.10 | |
 | `Initializers` | `false` | Alpha | 1.7 | |
 | `KubeletConfigFile` | `false` | Alpha | 1.8 | 1.9 |
-| `KubeletPluginsWatcher` | `false` | Alpha | 1.11 | |
+| `KubeletPluginsWatcher` | `false` | Alpha | 1.11 | 1.11 |
+| `KubeletPluginsWatcher` | `true` | Beta | 1.12 | |
 | `LocalStorageCapacityIsolation` | `false` | Alpha | 1.7 | 1.9 |
 | `LocalStorageCapacityIsolation` | `true` | Beta| 1.10 | |
 | `MountContainers` | `false` | Alpha | 1.9 | |


### PR DESCRIPTION
KubeletPluginsWatcher feature is beta in 1.12 release
xref: [kubernetes/kubernetes#68200](https://github.com/kubernetes/kubernetes/pull/68200)
