### PR TITLE
Warn LXD users with an IPv6-enabed bridge

### DIFF
--- a/content/en/docs/getting-started-guides/ubuntu/local.md
+++ b/content/en/docs/getting-started-guides/ubuntu/local.md
@@ -18,7 +18,8 @@ sudo snap install conjure-up --classic
 sudo usermod -a -G lxd $(whoami)
 ```
 
-Note: If conjure-up asks you to "Setup an ipv6 subnet" with LXD, answer NO. ipv6 with Juju/LXD is currently unsupported.
+Note: If conjure-up asks you to "Setup an IPv6 subnet" with LXD, answer NO. IPv6 with Juju/LXD is currently unsupported.
+If you already have a bridge configured, e.g. `lxdbr0`, [disable IPv6 on the bridge](https://docs.conjure-up.io/stable/en/troubleshoot#common-problems), otherwise you won't be able to choose it.
 {{% /capture %}}
 
 {{% capture steps %}}


### PR DESCRIPTION
It took me some time to find out why `conjure-up` was only giving me the option to choose the `docker0` bridge.

By default, when running `lxd init`, IPv6 NAT will be configured on the the bridge, and `conjure-up` simply ignore IPv6-enabled bridges.
The solution is here : https://docs.conjure-up.io/stable/en/troubleshoot#common-problems

These two commands:

```sh
lxc network set lxdbr0 ipv6.nat false
lxc network set lxdbr0 ipv6.address none
```

I only added the link in the doc though. 

I assume a lot of people will run into this issue, so it's worth adding this in the page.