### PR TITLE
Rewrite links for environment-variable-expose-pod-information to new location

### DIFF
--- a/content/cn/docs/tasks/inject-data-application/define-environment-variable-container.md
+++ b/content/cn/docs/tasks/inject-data-application/define-environment-variable-container.md
@@ -63,7 +63,7 @@ content_template: templates/task
 
 {{% capture whatsnext %}}
 
-* 有关环境变量的更多信息，请参阅[这里](/docs/tasks/configure-pod-container/environment-variable-expose-pod-information/)。
+* 有关环境变量的更多信息，请参阅[这里](/docs/tasks/inject-data-application/environment-variable-expose-pod-information/)。
 * 有关如何通过环境变量来使用Secret，请参阅[这里](/docs/user-guide/secrets/#using-secrets-as-environment-variables)。
 * 关于[EnvVarSource](/docs/api-reference/{{< param "version" >}}/#envvarsource-v1-core)资源的信息。
 

--- a/content/cn/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
+++ b/content/cn/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
@@ -22,7 +22,7 @@ content_template: templates/task
 
 有两种方式可以将Pod和Container字段呈现给运行中的容器：
 
-* [环境变量](/docs/tasks/configure-pod-container/environment-variable-expose-pod-information/)
+* [环境变量](/docs/tasks/inject-data-application/environment-variable-expose-pod-information/)
 * DownwardAPIVolumeFile
 
 这两种呈现Pod和Container字段的方式都称为*Downward API*。

--- a/content/en/docs/tasks/inject-data-application/define-environment-variable-container.md
+++ b/content/en/docs/tasks/inject-data-application/define-environment-variable-container.md
@@ -113,7 +113,7 @@ Upon creation, the command `echo Warm greetings to The Most Honorable Kubernetes
 
 {{% capture whatsnext %}}
 
-* Learn more about [environment variables](/docs/tasks/configure-pod-container/environment-variable-expose-pod-information/).
+* Learn more about [environment variables](/docs/tasks/inject-data-application/environment-variable-expose-pod-information/).
 * Learn about [using secrets as environment variables](/docs/user-guide/secrets/#using-secrets-as-environment-variables).
 * See [EnvVarSource](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#envvarsource-v1-core).
 

--- a/content/en/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
+++ b/content/en/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
@@ -25,7 +25,7 @@ Pod fields and Container fields.
 
 There are two ways to expose Pod and Container fields to a running Container:
 
-* [Environment variables](/docs/tasks/configure-pod-container/environment-variable-expose-pod-information/)
+* [Environment variables](/docs/tasks/inject-data-application/environment-variable-expose-pod-information/)
 * DownwardAPIVolumeFiles
 
 Together, these two ways of exposing Pod and Container fields are called the

--- a/data/tasks.yml
+++ b/data/tasks.yml
@@ -24,7 +24,7 @@ toc:
   - docs/tasks/configure-pod-container/configure-projected-volume-storage.md
   - docs/tasks/configure-pod-container/projected-volume.md
   - docs/tasks/configure-pod-container/security-context.md
-  - docs/tasks/configure-pod-container/environment-variable-expose-pod-information.md
+  - docs/tasks/inject-data-application/environment-variable-expose-pod-information.md
   - docs/tasks/configure-pod-container/configure-service-account.md
   - docs/tasks/configure-pod-container/pull-image-private-registry.md
   - docs/tasks/configure-pod-container/configure-liveness-readiness-probes.md


### PR DESCRIPTION
We have a redirect, so these links aren't broken, but we shouldn't
rely on the redirect - that ends up with long chains of complicated
redirects and makes validating the markdown harder.