### PR TITLE
Dev: Fixing "typo" and clearing CSS

### DIFF
--- a/static/css/blog.css
+++ b/static/css/blog.css
@@ -340,7 +340,7 @@ body {
   left: 0px;
   right: 310px;
   /* IE6 does not respect left and right together */
-  _width: expression(this.parentNode.offsetWidth - 
+  _width: expression(this.parentNode.offsetWidth -
   parseInt("0px") -
   parseInt("310px") + 'px');
   }

--- a/static/css/blog.css
+++ b/static/css/blog.css
@@ -179,7 +179,7 @@ div.header-try a {
 div.widget > h2,
 div.widget h2.title {
   margin: 0 0 1em 0;
-  font: normal bold 11px 'Roboto',,sans-serif;
+  font: normal bold 11px 'Roboto', sans-serif;
   color: #000000;
 }
 
@@ -321,8 +321,7 @@ div.post-footer {
   font-size: 16px;
   line-height: 1.5;
 }
---></style>
-<style id='template-skin-1' type='text/css'><!--
+
 body {
   min-width: 1200px;
 }
@@ -336,14 +335,16 @@ body {
   padding-left: 0px;
   padding-right: 310px;
 }
+
 .main-inner .fauxcolumn-center-outer {
   left: 0px;
   right: 310px;
   /* IE6 does not respect left and right together */
-  _width: expression(this.parentNode.offsetWidth -
-    parseInt("0px") -
-    parseInt("310px") + 'px');
+  _width: expression(this.parentNode.offsetWidth - 
+  parseInt("0px") -
+  parseInt("310px") + 'px');
   }
+
   .main-inner .fauxcolumn-left-outer {
     width: 0px;
   }
@@ -405,6 +406,7 @@ body {
 ul {
   padding: 1em;
 }
+
 /* Sidebar Icon Styles */
 .widget-link svg {
   font-size: 48px;

--- a/static/css/style_amadeus.css
+++ b/static/css/style_amadeus.css
@@ -254,203 +254,204 @@ h4 {
 
 @media screen and (max-width: 910px){
 
-h1 {
-  font-family:"Roboto", sans-serif;
-  font-weight:bold;
-  line-height:36px;
-  letter-spacing:0.03em;
-  font-size:30px !important;
-  padding-bottom:0px;
-  width:80%;
-}
+  h1 {
+    font-family:"Roboto", sans-serif;
+    font-weight:bold;
+    line-height:36px;
+    letter-spacing:0.03em;
+    font-size:30px !important;
+    padding-bottom:0px;
+    width:80%;
+  }
 
-.header_logo {
-  width:35%;
-  margin-bottom:-.5%;
-  magin-left:10px;
-}
+  .header_logo {
+    width:35%;
+    margin-bottom:-.5%;
+    margin-left:10px;
+  }
 
-.subhead {
-  font-size:18px;
-  font-weight:100;
-  line-height:27px;
-}
+  .subhead {
+    font-size:18px;
+    font-weight:100;
+    line-height:27px;
+  }
 
-.details {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  font-size:16px;
-  color:#3366ff;
-  letter-spacing:0.03em;
-  padding-bottom:2%;
-  line-height:28px;
-  padding-top:4%;
-  padding-left:10%;
-}
+  .details {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    font-size:16px;
+    color:#3366ff;
+    letter-spacing:0.03em;
+    padding-bottom:2%;
+    line-height:28px;
+    padding-top:4%;
+    padding-left:10%;
+  }
 
-.logo {
-    width:8%;
-}
+  .logo {
+      width:8%;
+  }
 
-.col1 {
-  width: 95%;
-  padding-right:8%;
-  float:left;
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#606060;
-  line-height:20px;
-  letter-spacing:0.03em;
-  font-size:14px;
-}
+  .col1 {
+    width: 95%;
+    padding-right:8%;
+    float:left;
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#606060;
+    line-height:20px;
+    letter-spacing:0.03em;
+    font-size:14px;
+  }
 
-.col2 {
-  width: 95%;
-  padding-top:2%;
-  padding-bottom:5%;
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  float:left;
-  line-height:20px;
-  color:#606060;
-  letter-spacing:0.03em;
-  font-size:14px;
-}
+  .col2 {
+    width: 95%;
+    padding-top:2%;
+    padding-bottom:5%;
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    float:left;
+    line-height:20px;
+    color:#606060;
+    letter-spacing:0.03em;
+    font-size:14px;
+  }
 
-.banner1 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:15%;
-  padding-bottom:2%;
-  padding-left:10%;
-  font-size:18px;
-  background: url('/images/CaseStudy_amadeus_banner1.jpg');
-  background-size:100% auto;
-}
+  .banner1 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:15%;
+    padding-bottom:2%;
+    padding-left:10%;
+    font-size:18px;
+    background: url('/images/CaseStudy_amadeus_banner1.jpg');
+    background-size:100% auto;
+  }
 
-.banner2 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background:none;
-  background-color:#666666;
-}
+  .banner2 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background:none;
+    background-color:#666666;
+  }
 
-.banner3 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:5%;
-  padding-bottom:5%;
-  font-size:16px;
-  letter-spacing:0.03em;
-  line-height:23px;
-  width:90%;
-  float:left;
-  background: url('/images/CaseStudy_amadeus_banner3.jpg');
-}
+  .banner3 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:5%;
+    padding-bottom:5%;
+    font-size:16px;
+    letter-spacing:0.03em;
+    line-height:23px;
+    width:90%;
+    float:left;
+    background: url('/images/CaseStudy_amadeus_banner3.jpg');
+  }
 
-.banner4 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background: url('/images/CaseStudy_amadeus_banner4.jpg');
-}
+  .banner4 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background: url('/images/CaseStudy_amadeus_banner4.jpg');
+  }
 
-.banner5 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  font-size:16px;
-  letter-spacing:0.03em;
-  line-height:23px;
-  width:100%;
-  float:left;
-  background:none;
-  background-color:#666666;
-}
+  .banner5 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    font-size:16px;
+    letter-spacing:0.03em;
+    line-height:23px;
+    width:100%;
+    float:left;
+    background:none;
+    background-color:#666666;
+  }
 
-.banner2text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:90%;
-  padding-left:5%;
-  padding-bottom:1%;
-  padding-top:1%;
-  float:left;
-  text-align:center;
-  color:#ffffff;
-}
+  .banner2text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:90%;
+    padding-left:5%;
+    padding-bottom:1%;
+    padding-top:1%;
+    float:left;
+    text-align:center;
+    color:#ffffff;
+  }
 
-.banner3text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:90%;
-  padding-left:5%;
-  padding-top:5%;
-  padding-bottom:5%;
-  text-align:center;
-}
+  .banner3text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:90%;
+    padding-left:5%;
+    padding-top:5%;
+    padding-bottom:5%;
+    text-align:center;
+  }
 
-.banner4text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:90%;
-  padding-left:5%;
-  padding-top:3%;
-  padding-bottom:3%;
-  text-align:center;
-}
+  .banner4text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:90%;
+    padding-left:5%;
+    padding-top:3%;
+    padding-bottom:3%;
+    text-align:center;
+  }
 
-.banner5text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:90%;
-  padding-left:5%;
-  padding-top:3%;
-  padding-bottom:3%;
-  text-align:center;
-}
+  .banner5text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:90%;
+    padding-left:5%;
+    padding-top:3%;
+    padding-bottom:3%;
+    text-align:center;
+  }
 
-.fullcol {
-  margin-top:6%;
-  margin-bottom:8%;
-}
+  .fullcol {
+    margin-top:6%;
+    margin-bottom:8%;
+  }
 
-h2 {
-  line-height:26px;
-  font-size:18px;
-}
+  h2 {
+    line-height:26px;
+    font-size:18px;
+  }
 
-.quote {
-  font-size:18px;
-  line-height:24px;
-}
+  .quote {
+    font-size:18px;
+    line-height:24px;
+  }
 
-.logo {
-  width:35%;
-}
+  .logo {
+    width:35%;
+  }
+} /* End Media 910px */
 
 @media screen and (max-width: 580px){
 
@@ -465,5 +466,7 @@ h2 {
   .banner1 {
     background: url('/images/CaseStudy_amadeus_banner_mobile.jpg');
 
-
+  }
 }
+
+

--- a/static/css/style_ancestry.css
+++ b/static/css/style_ancestry.css
@@ -247,197 +247,198 @@ h4 {
 
 @media screen and (max-width: 910px){
 
-h1 {
-  font-family:"Roboto", sans-serif;
-  font-weight:bold;
-  line-height:36px;
-  letter-spacing:0.03em;
-  font-size:30px !important;
-  padding-bottom:0px;
-  width:80%;
-}
+  h1 {
+    font-family:"Roboto", sans-serif;
+    font-weight:bold;
+    line-height:36px;
+    letter-spacing:0.03em;
+    font-size:30px !important;
+    padding-bottom:0px;
+    width:80%;
+  }
 
-.subhead {
-  font-size:18px;
-  font-weight:100;
-  line-height:27px;
-}
+  .subhead {
+    font-size:18px;
+    font-weight:100;
+    line-height:27px;
+  }
 
-.details {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  font-size:16px;
-  color:#3366ff;
-  letter-spacing:0.03em;
-  padding-bottom:2%;
-  line-height:28px;
-  padding-top:4%;
-  padding-left:10%;
-}
+  .details {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    font-size:16px;
+    color:#3366ff;
+    letter-spacing:0.03em;
+    padding-bottom:2%;
+    line-height:28px;
+    padding-top:4%;
+    padding-left:10%;
+  }
 
-.logo {
-    width:8%;
-}
+  .logo {
+      width:8%;
+  }
 
-.col1 {
-  width: 90%;
-  padding-left:5%;
-  padding-right:8%;
-  float:left;
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#606060;
-  line-height:20px;
-  letter-spacing:0.03em;
-  font-size:14px;
-}
+  .col1 {
+    width: 90%;
+    padding-left:5%;
+    padding-right:8%;
+    float:left;
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#606060;
+    line-height:20px;
+    letter-spacing:0.03em;
+    font-size:14px;
+  }
 
-.col2 {
-  width: 90%;
-  padding-left:5%;
-  padding-top:5%;
-  padding-bottom:5%;
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  float:left;
-  line-height:20px;
-  color:#606060;
-  letter-spacing:0.03em;
-  font-size:14px;
-}
+  .col2 {
+    width: 90%;
+    padding-left:5%;
+    padding-top:5%;
+    padding-bottom:5%;
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    float:left;
+    line-height:20px;
+    color:#606060;
+    letter-spacing:0.03em;
+    font-size:14px;
+  }
 
-.banner1 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:15%;
-  padding-bottom:2%;
-  padding-left:10%;
-  font-size:18px;
-  background: url('CaseStudy_ancestry_banner1.jpg');
-  background-size:100% auto;
-}
+  .banner1 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:15%;
+    padding-bottom:2%;
+    padding-left:10%;
+    font-size:18px;
+    background: url('CaseStudy_ancestry_banner1.jpg');
+    background-size:100% auto;
+  }
 
-.banner2 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  padding-left:0%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background:none;
-  background-color:#666666;
-}
+  .banner2 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    padding-left:0%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background:none;
+    background-color:#666666;
+  }
 
-.banner3 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:5%;
-  padding-bottom:5%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background: url('CaseStudy_ancestry_banner3.jpg');
-}
+  .banner3 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:5%;
+    padding-bottom:5%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background: url('CaseStudy_ancestry_banner3.jpg');
+  }
 
-.banner4 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:5%;
-  padding-bottom:5%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background: url('CaseStudy_ancestry_banner4.jpg');
-}
+  .banner4 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:5%;
+    padding-bottom:5%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background: url('CaseStudy_ancestry_banner4.jpg');
+  }
 
-.banner5 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background:none;
-  background-color:#666666;
-}
+  .banner5 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background:none;
+    background-color:#666666;
+  }
 
-.banner2text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:80%;
-  padding-left:10%;
-  float:left;
-  text-align:center;
-  color:#ffffff;
-}
+  .banner2text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:80%;
+    padding-left:10%;
+    float:left;
+    text-align:center;
+    color:#ffffff;
+  }
 
-.banner3text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:80%;
-  padding-left:5%;
-  padding-top:5%;
-  padding-bottom:5%;
-  text-align:center;
-}
+  .banner3text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:80%;
+    padding-left:5%;
+    padding-top:5%;
+    padding-bottom:5%;
+    text-align:center;
+  }
 
-.banner4text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:80%;
-  padding-left:10%;
-  padding-top:3%;
-  padding-bottom:3%;
-  text-align:center;
-}
+  .banner4text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:80%;
+    padding-left:10%;
+    padding-top:3%;
+    padding-bottom:3%;
+    text-align:center;
+  }
 
-.banner5text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:80%;
-  padding-left:10%;
-  float:left;
-  text-align:center;
-  color:#ffffff;
-}
+  .banner5text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:80%;
+    padding-left:10%;
+    float:left;
+    text-align:center;
+    color:#ffffff;
+  }
 
-.fullcol {
-  margin-top:6%;
-}
+  .fullcol {
+    margin-top:6%;
+  }
 
-h2 {
-  line-height:26px;
-  font-size:18px;
-}
+  h2 {
+    line-height:26px;
+    font-size:18px;
+  }
 
-.quote {
-  font-size:18px;
-  line-height:24px;
-}
+  .quote {
+    font-size:18px;
+    line-height:24px;
+  }
 
-.logo {
-  width:35%;
-}
+  .logo {
+    width:35%;
+  }
+} /* End Media 910px */
 
 @media screen and (max-width: 480px){
 
@@ -446,4 +447,5 @@ h2 {
     padding-bottom:5%;
     padding-top:2%;
   }
+
 }

--- a/static/css/style_blablacar.css
+++ b/static/css/style_blablacar.css
@@ -255,203 +255,204 @@ h4 {
 
 @media screen and (max-width: 910px){
 
-h1 {
-  font-family:"Roboto", sans-serif;
-  font-weight:bold;
-  line-height:36px;
-  letter-spacing:0.03em;
-  font-size:30px !important;
-  padding-bottom:0px;
-  width:80%;
-}
+  h1 {
+    font-family:"Roboto", sans-serif;
+    font-weight:bold;
+    line-height:36px;
+    letter-spacing:0.03em;
+    font-size:30px !important;
+    padding-bottom:0px;
+    width:80%;
+  }
 
-.header_logo {
-  width:35%;
-  margin-bottom:-.5%;
-  magin-left:10px;
-}
+  .header_logo {
+    width:35%;
+    margin-bottom:-.5%;
+    margin-left:10px;
+  }
 
-.subhead {
-  font-size:18px;
-  font-weight:100;
-  line-height:27px;
-}
+  .subhead {
+    font-size:18px;
+    font-weight:100;
+    line-height:27px;
+  }
 
-.details {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  font-size:16px;
-  color:#3366ff;
-  letter-spacing:0.03em;
-  padding-bottom:2%;
-  line-height:28px;
-  padding-top:4%;
-  padding-left:10%;
-}
+  .details {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    font-size:16px;
+    color:#3366ff;
+    letter-spacing:0.03em;
+    padding-bottom:2%;
+    line-height:28px;
+    padding-top:4%;
+    padding-left:10%;
+  }
 
-.logo {
-    width:8%;
-}
+  .logo {
+      width:8%;
+  }
 
-.col1 {
-  width: 95%;
-  padding-right:8%;
-  float:left;
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#606060;
-  line-height:20px;
-  letter-spacing:0.03em;
-  font-size:14px;
-}
+  .col1 {
+    width: 95%;
+    padding-right:8%;
+    float:left;
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#606060;
+    line-height:20px;
+    letter-spacing:0.03em;
+    font-size:14px;
+  }
 
-.col2 {
-  width: 95%;
-  padding-top:2%;
-  padding-bottom:5%;
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  float:left;
-  line-height:20px;
-  color:#606060;
-  letter-spacing:0.03em;
-  font-size:14px;
-}
+  .col2 {
+    width: 95%;
+    padding-top:2%;
+    padding-bottom:5%;
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    float:left;
+    line-height:20px;
+    color:#606060;
+    letter-spacing:0.03em;
+    font-size:14px;
+  }
 
-.banner1 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:15%;
-  padding-bottom:2%;
-  padding-left:10%;
-  font-size:18px;
-  background: url('/images/CaseStudy_blablacar_banner1.jpg');
-  background-size:100% auto;
-}
+  .banner1 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:15%;
+    padding-bottom:2%;
+    padding-left:10%;
+    font-size:18px;
+    background: url('/images/CaseStudy_blablacar_banner1.jpg');
+    background-size:100% auto;
+  }
 
-.banner2 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background:none;
-  background-color:#666666;
-}
+  .banner2 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background:none;
+    background-color:#666666;
+  }
 
-.banner3 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:5%;
-  padding-bottom:5%;
-  font-size:16px;
-  letter-spacing:0.03em;
-  line-height:23px;
-  width:90%;
-  float:left;
-  background: url('/images/CaseStudy_blablacar_banner3.jpg');
-}
+  .banner3 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:5%;
+    padding-bottom:5%;
+    font-size:16px;
+    letter-spacing:0.03em;
+    line-height:23px;
+    width:90%;
+    float:left;
+    background: url('/images/CaseStudy_blablacar_banner3.jpg');
+  }
 
-.banner4 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background: url('/images/CaseStudy_blablacar_banner4.jpg');
-}
+  .banner4 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background: url('/images/CaseStudy_blablacar_banner4.jpg');
+  }
 
-.banner5 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  font-size:16px;
-  letter-spacing:0.03em;
-  line-height:23px;
-  width:100%;
-  float:left;
-  background:none;
-  background-color:#666666;
-}
+  .banner5 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    font-size:16px;
+    letter-spacing:0.03em;
+    line-height:23px;
+    width:100%;
+    float:left;
+    background:none;
+    background-color:#666666;
+  }
 
-.banner2text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:90%;
-  padding-left:5%;
-  padding-bottom:1%;
-  padding-top:1%;
-  float:left;
-  text-align:center;
-  color:#ffffff;
-}
+  .banner2text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:90%;
+    padding-left:5%;
+    padding-bottom:1%;
+    padding-top:1%;
+    float:left;
+    text-align:center;
+    color:#ffffff;
+  }
 
-.banner3text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:90%;
-  padding-left:5%;
-  padding-top:5%;
-  padding-bottom:5%;
-  text-align:center;
-}
+  .banner3text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:90%;
+    padding-left:5%;
+    padding-top:5%;
+    padding-bottom:5%;
+    text-align:center;
+  }
 
-.banner4text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:90%;
-  padding-left:5%;
-  padding-top:3%;
-  padding-bottom:3%;
-  text-align:center;
-}
+  .banner4text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:90%;
+    padding-left:5%;
+    padding-top:3%;
+    padding-bottom:3%;
+    text-align:center;
+  }
 
-.banner5text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:90%;
-  padding-left:5%;
-  padding-top:3%;
-  padding-bottom:3%;
-  text-align:center;
-}
+  .banner5text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:90%;
+    padding-left:5%;
+    padding-top:3%;
+    padding-bottom:3%;
+    text-align:center;
+  }
 
-.fullcol {
-  margin-top:6%;
-  margin-bottom:8%;
-}
+  .fullcol {
+    margin-top:6%;
+    margin-bottom:8%;
+  }
 
-h2 {
-  line-height:26px;
-  font-size:18px;
-}
+  h2 {
+    line-height:26px;
+    font-size:18px;
+  }
 
-.quote {
-  font-size:18px;
-  line-height:24px;
-}
+  .quote {
+    font-size:18px;
+    line-height:24px;
+  }
 
-.logo {
-  width:35%;
-}
+  .logo {
+    width:35%;
+  }
+} /* End Media 910px */
 
 @media screen and (max-width: 580px){
 
@@ -464,6 +465,5 @@ h2 {
 
   .banner1 {
     background: url('/images/CaseStudy_blablacar_banner1_mobile.jpg');
-
-
+  }
 }

--- a/static/css/style_blackrock.css
+++ b/static/css/style_blackrock.css
@@ -254,206 +254,207 @@ h4 {
 
 @media screen and (max-width: 910px){
 
-h1 {
-  font-family:"Roboto", sans-serif;
-  font-weight:bold;
-  line-height:36px;
-  letter-spacing:0.03em;
-  font-size:30px !important;
-  padding-bottom:0px;
-  width:80%;
-}
+  h1 {
+    font-family:"Roboto", sans-serif;
+    font-weight:bold;
+    line-height:36px;
+    letter-spacing:0.03em;
+    font-size:30px !important;
+    padding-bottom:0px;
+    width:80%;
+  }
 
-.header_logo {
-  width:35%;
-  margin-bottom:-.5%;
-  magin-left:10px;
-}
+  .header_logo {
+    width:35%;
+    margin-bottom:-.5%;
+    margin-left:10px;
+  }
 
-.subhead {
-  font-size:18px;
-  font-weight:100;
-  line-height:27px;
-}
+  .subhead {
+    font-size:18px;
+    font-weight:100;
+    line-height:27px;
+  }
 
-.details {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  font-size:16px;
-  color:#3366ff;
-  letter-spacing:0.03em;
-  padding-bottom:2%;
-  line-height:28px;
-  padding-top:4%;
-  padding-left:10%;
-}
+  .details {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    font-size:16px;
+    color:#3366ff;
+    letter-spacing:0.03em;
+    padding-bottom:2%;
+    line-height:28px;
+    padding-top:4%;
+    padding-left:10%;
+  }
 
-.logo {
-    width:8%;
-}
+  .logo {
+      width:8%;
+  }
 
-.col1 {
-  width: 95%;
-  padding-right:8%;
-  float:left;
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#606060;
-  line-height:20px;
-  letter-spacing:0.03em;
-  font-size:14px;
-}
+  .col1 {
+    width: 95%;
+    padding-right:8%;
+    float:left;
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#606060;
+    line-height:20px;
+    letter-spacing:0.03em;
+    font-size:14px;
+  }
 
-.col2 {
-  width: 95%;
-  padding-top:2%;
-  padding-bottom:5%;
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  float:left;
-  line-height:20px;
-  color:#606060;
-  letter-spacing:0.03em;
-  font-size:14px;
-}
+  .col2 {
+    width: 95%;
+    padding-top:2%;
+    padding-bottom:5%;
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    float:left;
+    line-height:20px;
+    color:#606060;
+    letter-spacing:0.03em;
+    font-size:14px;
+  }
 
-.banner1 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:15%;
-  padding-bottom:2%;
-  padding-left:10%;
-  font-size:18px;
-  background: url('/images/CaseStudy_blackrock_banner1.jpg');
-  background-size:100% auto;
-}
+  .banner1 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:15%;
+    padding-bottom:2%;
+    padding-left:10%;
+    font-size:18px;
+    background: url('/images/CaseStudy_blackrock_banner1.jpg');
+    background-size:100% auto;
+  }
 
-.banner2 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background:none;
-  background-color:#666666;
-}
+  .banner2 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background:none;
+    background-color:#666666;
+  }
 
-.banner3 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:5%;
-  padding-bottom:5%;
-  font-size:16px;
-  letter-spacing:0.03em;
-  line-height:23px;
-  width:90%;
-  float:left;
-  background: url('/images/CaseStudy_blackrock_banner3.jpg');
-}
+  .banner3 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:5%;
+    padding-bottom:5%;
+    font-size:16px;
+    letter-spacing:0.03em;
+    line-height:23px;
+    width:90%;
+    float:left;
+    background: url('/images/CaseStudy_blackrock_banner3.jpg');
+  }
 
-.banner4 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background: url('/images/CaseStudy_blackrock_banner4.jpg');
-}
+  .banner4 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background: url('/images/CaseStudy_blackrock_banner4.jpg');
+  }
 
-.banner5 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  font-size:16px;
-  letter-spacing:0.03em;
-  line-height:23px;
-  width:100%;
-  float:left;
-  background:none;
-  background-color:#666666;
-}
+  .banner5 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    font-size:16px;
+    letter-spacing:0.03em;
+    line-height:23px;
+    width:100%;
+    float:left;
+    background:none;
+    background-color:#666666;
+  }
 
-.banner2text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:90%;
-  padding-left:5%;
-  padding-bottom:1%;
-  padding-top:1%;
-  float:left;
-  text-align:center;
-  color:#ffffff;
-}
+  .banner2text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:90%;
+    padding-left:5%;
+    padding-bottom:1%;
+    padding-top:1%;
+    float:left;
+    text-align:center;
+    color:#ffffff;
+  }
 
-.banner3text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:90%;
-  padding-left:5%;
-  padding-top:5%;
-  padding-bottom:5%;
-  text-align:center;
-}
+  .banner3text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:90%;
+    padding-left:5%;
+    padding-top:5%;
+    padding-bottom:5%;
+    text-align:center;
+  }
 
-.banner4text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:90%;
-  padding-left:5%;
-  padding-top:3%;
-  padding-bottom:3%;
-  text-align:center;
-}
+  .banner4text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:90%;
+    padding-left:5%;
+    padding-top:3%;
+    padding-bottom:3%;
+    text-align:center;
+  }
 
-.banner5text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:90%;
-  padding-left:5%;
-  padding-top:3%;
-  padding-bottom:3%;
-  text-align:center;
-}
+  .banner5text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:90%;
+    padding-left:5%;
+    padding-top:3%;
+    padding-bottom:3%;
+    text-align:center;
+  }
 
-.fullcol {
-  margin-top:6%;
-  margin-bottom:8%;
-}
+  .fullcol {
+    margin-top:6%;
+    margin-bottom:8%;
+  }
 
-h2 {
-  line-height:26px;
-  font-size:18px;
-}
+  h2 {
+    line-height:26px;
+    font-size:18px;
+  }
 
-.quote {
-  font-size:18px;
-  line-height:24px;
-}
+  .quote {
+    font-size:18px;
+    line-height:24px;
+  }
 
-.logo {
-  width:35%;
-}
+  .logo {
+    width:35%;
+  }
+} /* End Media 910px */
 
 @media screen and (max-width: 580px){
-
+  
   .header_logo {
     width:60%;
     margin-bottom:1%;

--- a/static/css/style_box.css
+++ b/static/css/style_box.css
@@ -255,194 +255,195 @@ h4 {
 
 @media screen and (max-width: 910px){
 
-h1 {
-  font-family:"Roboto", sans-serif;
-  font-weight:bold;
-  line-height:36px;
-  letter-spacing:0.03em;
-  font-size:30px !important;
-  padding-bottom:0px;
-  width:80%;
-}
+  h1 {
+    font-family:"Roboto", sans-serif;
+    font-weight:bold;
+    line-height:36px;
+    letter-spacing:0.03em;
+    font-size:30px !important;
+    padding-bottom:0px;
+    width:80%;
+  }
 
-.subhead {
-  font-size:18px;
-  font-weight:100;
-  line-height:27px;
-}
+  .subhead {
+    font-size:18px;
+    font-weight:100;
+    line-height:27px;
+  }
 
-.details {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  font-size:16px;
-  color:#3366ff;
-  letter-spacing:0.03em;
-  padding-bottom:2%;
-  line-height:28px;
-  padding-top:4%;
-  padding-left:10%;
-}
+  .details {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    font-size:16px;
+    color:#3366ff;
+    letter-spacing:0.03em;
+    padding-bottom:2%;
+    line-height:28px;
+    padding-top:4%;
+    padding-left:10%;
+  }
 
-.logo {
-    width:8%;
-}
+  .logo {
+      width:8%;
+  }
 
-.col1 {
-  width: 100%;
-  padding-left:5%;
-  padding-right:8%;
-  float:left;
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#606060;
-  line-height:20px;
-  letter-spacing:0.03em;
-  font-size:14px;
-}
+  .col1 {
+    width: 100%;
+    padding-left:5%;
+    padding-right:8%;
+    float:left;
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#606060;
+    line-height:20px;
+    letter-spacing:0.03em;
+    font-size:14px;
+  }
 
-.col2 {
-  width: 100%;
-  padding-left:5%;
-  padding-top:5%;
-  padding-bottom:5%;
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  float:left;
-  line-height:20px;
-  color:#606060;
-  letter-spacing:0.03em;
-  font-size:14px;
-}
+  .col2 {
+    width: 100%;
+    padding-left:5%;
+    padding-top:5%;
+    padding-bottom:5%;
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    float:left;
+    line-height:20px;
+    color:#606060;
+    letter-spacing:0.03em;
+    font-size:14px;
+  }
 
-.banner1 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:15%;
-  padding-bottom:2%;
-  padding-left:10%;
-  font-size:18px;
-  background: url('/images/CaseStudy_box_banner1.jpg');
-  background-size:100% auto;
-}
+  .banner1 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:15%;
+    padding-bottom:2%;
+    padding-left:10%;
+    font-size:18px;
+    background: url('/images/CaseStudy_box_banner1.jpg');
+    background-size:100% auto;
+  }
 
-.banner2 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  padding-left:0%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background:none;
-  background-color:#666666;
-}
+  .banner2 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    padding-left:0%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background:none;
+    background-color:#666666;
+  }
 
-.banner3 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:5%;
-  padding-bottom:5%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background: url('/images/CaseStudy_box_banner3.jpg');
-}
+  .banner3 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:5%;
+    padding-bottom:5%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background: url('/images/CaseStudy_box_banner3.jpg');
+  }
 
-.banner4 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:5%;
-  padding-bottom:5%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background: url('/images/CaseStudy_box_banner4.jpg');
-}
+  .banner4 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:5%;
+    padding-bottom:5%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background: url('/images/CaseStudy_box_banner4.jpg');
+  }
 
-.banner5 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  padding-left:0%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background:none;
-  background-color:#666666;
-}
+  .banner5 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    padding-left:0%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background:none;
+    background-color:#666666;
+  }
 
-.banner2text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:80%;
-  padding-left:10%;
-  float:left;
-  text-align:center;
-  color:#ffffff;
-}
+  .banner2text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:80%;
+    padding-left:10%;
+    float:left;
+    text-align:center;
+    color:#ffffff;
+  }
 
-.banner4text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:80%;
-  padding-left:10%;
-  text-align:center;
-}
+  .banner4text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:80%;
+    padding-left:10%;
+    text-align:center;
+  }
 
-.banner3text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:80%;
-  padding-left:10%;
-  text-align:center;
-}
+  .banner3text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:80%;
+    padding-left:10%;
+    text-align:center;
+  }
 
-.banner5text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:80%;
-  padding-left:10%;
-  float:left;
-  text-align:center;
-  color:#ffffff;
-}
+  .banner5text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:80%;
+    padding-left:10%;
+    float:left;
+    text-align:center;
+    color:#ffffff;
+  }
 
-.fullcol {
-  margin-top:6%;
-}
+  .fullcol {
+    margin-top:6%;
+  }
 
-h2 {
-  line-height:26px;
-  font-size:18px;
-}
+  h2 {
+    line-height:26px;
+    font-size:18px;
+  }
 
-.quote {
-  font-size:18px;
-  line-height:24px;
-}
+  .quote {
+    font-size:18px;
+    line-height:24px;
+  }
 
-.logo {
-  width:15%;
-}
+  .logo {
+    width:15%;
+  }
+} /* End Media 910px */
 
 @media screen and (max-width: 480px){
 

--- a/static/css/style_buffer.css
+++ b/static/css/style_buffer.css
@@ -256,199 +256,200 @@ h4 {
 
 @media screen and (max-width: 910px){
 
-h1 {
-  font-family:"Roboto", sans-serif;
-  font-weight:bold;
-  line-height:36px;
-  letter-spacing:0.03em;
-  font-size:30px !important;
-  padding-bottom:0px;
-  width:80%;
-}
+  h1 {
+    font-family:"Roboto", sans-serif;
+    font-weight:bold;
+    line-height:36px;
+    letter-spacing:0.03em;
+    font-size:30px !important;
+    padding-bottom:0px;
+    width:80%;
+  }
 
-.subhead {
-  font-size:18px;
-  font-weight:100;
-  line-height:27px;
-}
+  .subhead {
+    font-size:18px;
+    font-weight:100;
+    line-height:27px;
+  }
 
-.details {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  font-size:16px;
-  color:#3366ff;
-  letter-spacing:0.03em;
-  padding-bottom:2%;
-  line-height:28px;
-  padding-top:4%;
-  padding-left:10%;
-}
+  .details {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    font-size:16px;
+    color:#3366ff;
+    letter-spacing:0.03em;
+    padding-bottom:2%;
+    line-height:28px;
+    padding-top:4%;
+    padding-left:10%;
+  }
 
-.logo {
-    width:8%;
-}
+  .logo {
+      width:8%;
+  }
 
-.col1 {
-  width: 100%;
-  padding-left:5%;
-  padding-right:8%;
-  float:left;
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#606060;
-  line-height:20px;
-  letter-spacing:0.03em;
-  font-size:14px;
-}
+  .col1 {
+    width: 100%;
+    padding-left:5%;
+    padding-right:8%;
+    float:left;
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#606060;
+    line-height:20px;
+    letter-spacing:0.03em;
+    font-size:14px;
+  }
 
-.col2 {
-  width: 100%;
-  padding-left:5%;
-  padding-top:5%;
-  padding-bottom:5%;
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  float:left;
-  line-height:20px;
-  color:#606060;
-  letter-spacing:0.03em;
-  font-size:14px;
-}
+  .col2 {
+    width: 100%;
+    padding-left:5%;
+    padding-top:5%;
+    padding-bottom:5%;
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    float:left;
+    line-height:20px;
+    color:#606060;
+    letter-spacing:0.03em;
+    font-size:14px;
+  }
 
-.banner1 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:15%;
-  padding-bottom:2%;
-  padding-left:10%;
-  font-size:18px;
-  background: url('/images/CaseStudy_buffer_banner3.jpg');
-  background-size:100% auto;
-}
+  .banner1 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:15%;
+    padding-bottom:2%;
+    padding-left:10%;
+    font-size:18px;
+    background: url('/images/CaseStudy_buffer_banner3.jpg');
+    background-size:100% auto;
+  }
 
-.banner2 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  padding-left:0%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background:none;
-  background-color:#666666;
-}
+  .banner2 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    padding-left:0%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background:none;
+    background-color:#666666;
+  }
 
-.banner3 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:5%;
-  padding-bottom:5%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:80%;
-  padding-left:15%;
-  padding-right:10%;
-  float:left;
-  background: url('/images/CaseStudy_buffer_banner1.jpg);
-}
+  .banner3 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:5%;
+    padding-bottom:5%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:80%;
+    padding-left:15%;
+    padding-right:10%;
+    float:left;
+    background: url('/images/CaseStudy_buffer_banner1.jpg');
+  }
 
-.banner4 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:5%;
-  padding-bottom:5%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background: url('/images/CaseStudy_buffer_banner4.jpg');
-}
+  .banner4 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:5%;
+    padding-bottom:5%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background: url('/images/CaseStudy_buffer_banner4.jpg');
+  }
 
-.banner5 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  padding-left:0%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background:none;
-  background-color:#666666;
-}
+  .banner5 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    padding-left:0%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background:none;
+    background-color:#666666;
+  }
 
-.banner2text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:80%;
-  padding-left:10%;
-  float:left;
-  text-align:center;
-  color:#ffffff;
-}
+  .banner2text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:80%;
+    padding-left:10%;
+    float:left;
+    text-align:center;
+    color:#ffffff;
+  }
 
-.banner3text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:80%;
-  padding-left:2%;
-  padding-right:10%;
-  padding-top:5%;
-  padding-bottom:5%;
-  text-align:center;
-}
+  .banner3text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:80%;
+    padding-left:2%;
+    padding-right:10%;
+    padding-top:5%;
+    padding-bottom:5%;
+    text-align:center;
+  }
 
-.banner4text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:80%;
-  padding-left:10%;
-  text-align:center;
-}
+  .banner4text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:80%;
+    padding-left:10%;
+    text-align:center;
+  }
 
-.banner5text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:80%;
-  padding-left:10%;
-  float:left;
-  text-align:center;
-  color:#ffffff;
-}
+  .banner5text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:80%;
+    padding-left:10%;
+    float:left;
+    text-align:center;
+    color:#ffffff;
+  }
 
-.fullcol {
-  margin-top:6%;
-}
+  .fullcol {
+    margin-top:6%;
+  }
 
-h2 {
-  line-height:26px;
-  font-size:18px;
-}
+  h2 {
+    line-height:26px;
+    font-size:18px;
+  }
 
-.quote {
-  font-size:18px;
-  line-height:24px;
-}
+  .quote {
+    font-size:18px;
+    line-height:24px;
+  }
 
-.logo {
-  width:35%;
-}
+  .logo {
+    width:35%;
+  }
+} /* End Media 910px */
 
 @media screen and (max-width: 480px){
 

--- a/static/css/style_case_studies.css
+++ b/static/css/style_case_studies.css
@@ -270,7 +270,7 @@ h4 {
     .header_logo {
         width: 35%;
         margin-bottom: -.5%;
-        magin-left: 10px;
+        margin-left: 10px;
     }
 
     .subhead {

--- a/static/css/style_crowdfire.css
+++ b/static/css/style_crowdfire.css
@@ -254,204 +254,205 @@ h4 {
 
 @media screen and (max-width: 910px){
 
-h1 {
-  font-family:"Roboto", sans-serif;
-  font-weight:bold;
-  line-height:36px;
-  letter-spacing:0.03em;
-  font-size:30px !important;
-  padding-bottom:0px;
-  width:80%;
-}
+  h1 {
+    font-family:"Roboto", sans-serif;
+    font-weight:bold;
+    line-height:36px;
+    letter-spacing:0.03em;
+    font-size:30px !important;
+    padding-bottom:0px;
+    width:80%;
+  }
 
-.header_logo {
-  width:35%;
-  margin-bottom:-.5%;
-  magin-left:10px;
-}
+  .header_logo {
+    width:35%;
+    margin-bottom:-.5%;
+    margin-left:10px;
+  }
 
-.subhead {
-  font-size:18px;
-  font-weight:100;
-  line-height:27px;
-}
+  .subhead {
+    font-size:18px;
+    font-weight:100;
+    line-height:27px;
+  }
 
-.details {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  font-size:16px;
-  color:#3366ff;
-  letter-spacing:0.03em;
-  padding-bottom:2%;
-  line-height:28px;
-  padding-top:4%;
-  padding-left:10%;
-}
+  .details {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    font-size:16px;
+    color:#3366ff;
+    letter-spacing:0.03em;
+    padding-bottom:2%;
+    line-height:28px;
+    padding-top:4%;
+    padding-left:10%;
+  }
 
-.logo {
-    width:8%;
-}
+  .logo {
+      width:8%;
+  }
 
-.col1 {
-  width: 95%;
-  padding-right:8%;
-  float:left;
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#606060;
-  line-height:20px;
-  letter-spacing:0.03em;
-  font-size:14px;
-}
+  .col1 {
+    width: 95%;
+    padding-right:8%;
+    float:left;
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#606060;
+    line-height:20px;
+    letter-spacing:0.03em;
+    font-size:14px;
+  }
 
-.col2 {
-  width: 95%;
-  padding-top:2%;
-  padding-bottom:5%;
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  float:left;
-  line-height:20px;
-  color:#606060;
-  letter-spacing:0.03em;
-  font-size:14px;
-}
+  .col2 {
+    width: 95%;
+    padding-top:2%;
+    padding-bottom:5%;
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    float:left;
+    line-height:20px;
+    color:#606060;
+    letter-spacing:0.03em;
+    font-size:14px;
+  }
 
-.banner1 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:15%;
-  padding-bottom:2%;
-  padding-left:10%;
-  font-size:18px;
-  background: url('/images/CaseStudy_crowdfire_banner1.jpg');
-  background-size:100% auto;
-}
+  .banner1 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:15%;
+    padding-bottom:2%;
+    padding-left:10%;
+    font-size:18px;
+    background: url('/images/CaseStudy_crowdfire_banner1.jpg');
+    background-size:100% auto;
+  }
 
-.banner2 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background:none;
-  background-color:#666666;
-}
+  .banner2 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background:none;
+    background-color:#666666;
+  }
 
-.banner3 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:5%;
-  padding-bottom:5%;
-  font-size:16px;
-  letter-spacing:0.03em;
-  line-height:23px;
-  width:90%;
-  float:left;
-  background: url('/images/CaseStudy_crowdfire_banner3.jpg');
-}
+  .banner3 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:5%;
+    padding-bottom:5%;
+    font-size:16px;
+    letter-spacing:0.03em;
+    line-height:23px;
+    width:90%;
+    float:left;
+    background: url('/images/CaseStudy_crowdfire_banner3.jpg');
+  }
 
-.banner4 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background: url('/images/CaseStudy_crowdfire_banner4.jpg');
-}
+  .banner4 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background: url('/images/CaseStudy_crowdfire_banner4.jpg');
+  }
 
-.banner5 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  font-size:16px;
-  letter-spacing:0.03em;
-  line-height:23px;
-  width:100%;
-  float:left;
-  background:none;
-  background-color:#666666;
-}
+  .banner5 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    font-size:16px;
+    letter-spacing:0.03em;
+    line-height:23px;
+    width:100%;
+    float:left;
+    background:none;
+    background-color:#666666;
+  }
 
-.banner2text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:80%;
-  padding-left:10%;
-  padding-bottom:1%;
-  padding-top:1%;
-  float:left;
-  text-align:center;
-  color:#ffffff;
-}
+  .banner2text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:80%;
+    padding-left:10%;
+    padding-bottom:1%;
+    padding-top:1%;
+    float:left;
+    text-align:center;
+    color:#ffffff;
+  }
 
-.banner3text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:80%;
-  padding-left:10%;
-  padding-top:5%;
-  padding-bottom:5%;
-  text-align:center;
-}
+  .banner3text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:80%;
+    padding-left:10%;
+    padding-top:5%;
+    padding-bottom:5%;
+    text-align:center;
+  }
 
-.banner4text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:80%;
-  padding-left:10%;
-  padding-right:10%;
-  padding-top:3%;
-  padding-bottom:3%;
-  text-align:center;
-}
+  .banner4text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:80%;
+    padding-left:10%;
+    padding-right:10%;
+    padding-top:3%;
+    padding-bottom:3%;
+    text-align:center;
+  }
 
-.banner5text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:80%;
-  padding-left:10%;
-  padding-top:3%;
-  padding-bottom:3%;
-  text-align:center;
-}
+  .banner5text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:80%;
+    padding-left:10%;
+    padding-top:3%;
+    padding-bottom:3%;
+    text-align:center;
+  }
 
-.fullcol {
-  margin-top:6%;
-  margin-bottom:8%;
-}
+  .fullcol {
+    margin-top:6%;
+    margin-bottom:8%;
+  }
 
-h2 {
-  line-height:26px;
-  font-size:18px;
-}
+  h2 {
+    line-height:26px;
+    font-size:18px;
+  }
 
-.quote {
-  font-size:18px;
-  line-height:24px;
-}
+  .quote {
+    font-size:18px;
+    line-height:24px;
+  }
 
-.logo {
-  width:35%;
-}
+  .logo {
+    width:35%;
+  }
+} /* End Media 910px */
 
 @media screen and (max-width: 580px){
 
@@ -465,6 +466,6 @@ h2 {
 
   .banner1 {
     background: url('/images/CaseStudy_crowdfire_banner1.jpg');
-
+  }
 
 }

--- a/static/css/style_golfnow.css
+++ b/static/css/style_golfnow.css
@@ -256,199 +256,200 @@ h4 {
 
 @media screen and (max-width: 910px){
 
-h1 {
-  font-family:"Roboto", sans-serif;
-  font-weight:bold;
-  line-height:36px;
-  letter-spacing:0.03em;
-  font-size:30px !important;
-  padding-bottom:0px;
-  width:80%;
-}
+  h1 {
+    font-family:"Roboto", sans-serif;
+    font-weight:bold;
+    line-height:36px;
+    letter-spacing:0.03em;
+    font-size:30px !important;
+    padding-bottom:0px;
+    width:80%;
+  }
 
-.subhead {
-  font-size:18px;
-  font-weight:100;
-  line-height:27px;
-}
+  .subhead {
+    font-size:18px;
+    font-weight:100;
+    line-height:27px;
+  }
 
-.details {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  font-size:16px;
-  color:#3366ff;
-  letter-spacing:0.03em;
-  padding-bottom:2%;
-  line-height:28px;
-  padding-top:4%;
-  padding-left:10%;
-}
+  .details {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    font-size:16px;
+    color:#3366ff;
+    letter-spacing:0.03em;
+    padding-bottom:2%;
+    line-height:28px;
+    padding-top:4%;
+    padding-left:10%;
+  }
 
-.logo {
-    width:8%;
-}
+  .logo {
+      width:8%;
+  }
 
-.col1 {
-  width: 100%;
-  padding-left:5%;
-  padding-right:8%;
-  float:left;
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#606060;
-  line-height:20px;
-  letter-spacing:0.03em;
-  font-size:14px;
-}
+  .col1 {
+    width: 100%;
+    padding-left:5%;
+    padding-right:8%;
+    float:left;
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#606060;
+    line-height:20px;
+    letter-spacing:0.03em;
+    font-size:14px;
+  }
 
-.col2 {
-  width: 100%;
-  padding-left:5%;
-  padding-top:5%;
-  padding-bottom:5%;
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  float:left;
-  line-height:20px;
-  color:#606060;
-  letter-spacing:0.03em;
-  font-size:14px;
-}
+  .col2 {
+    width: 100%;
+    padding-left:5%;
+    padding-top:5%;
+    padding-bottom:5%;
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    float:left;
+    line-height:20px;
+    color:#606060;
+    letter-spacing:0.03em;
+    font-size:14px;
+  }
 
-.banner1 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:15%;
-  padding-bottom:2%;
-  padding-left:10%;
-  font-size:18px;
-  background: url('/images/CaseStudy_golfnow_banner1.jpg');
-  background-size:100% auto;
-}
+  .banner1 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:15%;
+    padding-bottom:2%;
+    padding-left:10%;
+    font-size:18px;
+    background: url('/images/CaseStudy_golfnow_banner1.jpg');
+    background-size:100% auto;
+  }
 
-.banner2 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  padding-left:0%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background:none;
-  background-color:#666666;
-}
+  .banner2 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    padding-left:0%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background:none;
+    background-color:#666666;
+  }
 
-.banner3 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:5%;
-  padding-bottom:5%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:80%;
-  padding-left:15%;
-  padding-right:10%;
-  float:left;
-  background: url('/images/CaseStudy_golfnow_banner3.jpg');
-}
+  .banner3 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:5%;
+    padding-bottom:5%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:80%;
+    padding-left:15%;
+    padding-right:10%;
+    float:left;
+    background: url('/images/CaseStudy_golfnow_banner3.jpg');
+  }
 
-.banner4 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:5%;
-  padding-bottom:5%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background: url('/images/CaseStudy_golfnow_banner4.jpg');
-}
+  .banner4 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:5%;
+    padding-bottom:5%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background: url('/images/CaseStudy_golfnow_banner4.jpg');
+  }
 
-.banner5 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  padding-left:0%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background:none;
-  background-color:#666666;
-}
+  .banner5 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    padding-left:0%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background:none;
+    background-color:#666666;
+  }
 
-.banner2text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:80%;
-  padding-left:10%;
-  float:left;
-  text-align:center;
-  color:#ffffff;
-}
+  .banner2text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:80%;
+    padding-left:10%;
+    float:left;
+    text-align:center;
+    color:#ffffff;
+  }
 
-.banner3text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:80%;
-  padding-left:2%;
-  padding-right:10%;
-  padding-top:5%;
-  padding-bottom:5%;
-  text-align:center;
-}
+  .banner3text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:80%;
+    padding-left:2%;
+    padding-right:10%;
+    padding-top:5%;
+    padding-bottom:5%;
+    text-align:center;
+  }
 
-.banner4text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:80%;
-  padding-left:10%;
-  text-align:center;
-}
+  .banner4text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:80%;
+    padding-left:10%;
+    text-align:center;
+  }
 
-.banner5text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:80%;
-  padding-left:10%;
-  float:left;
-  text-align:center;
-  color:#ffffff;
-}
+  .banner5text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:80%;
+    padding-left:10%;
+    float:left;
+    text-align:center;
+    color:#ffffff;
+  }
 
-.fullcol {
-  margin-top:6%;
-}
+  .fullcol {
+    margin-top:6%;
+  }
 
-h2 {
-  line-height:26px;
-  font-size:18px;
-}
+  h2 {
+    line-height:26px;
+    font-size:18px;
+  }
 
-.quote {
-  font-size:18px;
-  line-height:24px;
-}
+  .quote {
+    font-size:18px;
+    line-height:24px;
+  }
 
-.logo {
-  width:35%;
-}
+  .logo {
+    width:35%;
+  }
+} /* End Media 910px */
 
 @media screen and (max-width: 480px){
 

--- a/static/css/style_haufegroup.css
+++ b/static/css/style_haufegroup.css
@@ -254,203 +254,204 @@ h4 {
 
 @media screen and (max-width: 910px){
 
-h1 {
-  font-family:"Roboto", sans-serif;
-  font-weight:bold;
-  line-height:36px;
-  letter-spacing:0.03em;
-  font-size:30px !important;
-  padding-bottom:0px;
-  width:80%;
-}
+  h1 {
+    font-family:"Roboto", sans-serif;
+    font-weight:bold;
+    line-height:36px;
+    letter-spacing:0.03em;
+    font-size:30px !important;
+    padding-bottom:0px;
+    width:80%;
+  }
 
-.header_logo {
-  width:35%;
-  margin-bottom:-.5%;
-  magin-left:10px;
-}
+  .header_logo {
+    width:35%;
+    margin-bottom:-.5%;
+    margin-left:10px;
+  }
 
-.subhead {
-  font-size:18px;
-  font-weight:100;
-  line-height:27px;
-}
+  .subhead {
+    font-size:18px;
+    font-weight:100;
+    line-height:27px;
+  }
 
-.details {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  font-size:16px;
-  color:#3366ff;
-  letter-spacing:0.03em;
-  padding-bottom:2%;
-  line-height:28px;
-  padding-top:4%;
-  padding-left:10%;
-}
+  .details {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    font-size:16px;
+    color:#3366ff;
+    letter-spacing:0.03em;
+    padding-bottom:2%;
+    line-height:28px;
+    padding-top:4%;
+    padding-left:10%;
+  }
 
-.logo {
-    width:8%;
-}
+  .logo {
+      width:8%;
+  }
 
-.col1 {
-  width: 95%;
-  padding-right:8%;
-  float:left;
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#606060;
-  line-height:20px;
-  letter-spacing:0.03em;
-  font-size:14px;
-}
+  .col1 {
+    width: 95%;
+    padding-right:8%;
+    float:left;
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#606060;
+    line-height:20px;
+    letter-spacing:0.03em;
+    font-size:14px;
+  }
 
-.col2 {
-  width: 95%;
-  padding-top:2%;
-  padding-bottom:5%;
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  float:left;
-  line-height:20px;
-  color:#606060;
-  letter-spacing:0.03em;
-  font-size:14px;
-}
+  .col2 {
+    width: 95%;
+    padding-top:2%;
+    padding-bottom:5%;
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    float:left;
+    line-height:20px;
+    color:#606060;
+    letter-spacing:0.03em;
+    font-size:14px;
+  }
 
-.banner1 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:15%;
-  padding-bottom:2%;
-  padding-left:10%;
-  font-size:18px;
-  background: url('/images/CaseStudy_haufegroup_banner1.jpg');
-  background-size:100% auto;
-}
+  .banner1 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:15%;
+    padding-bottom:2%;
+    padding-left:10%;
+    font-size:18px;
+    background: url('/images/CaseStudy_haufegroup_banner1.jpg');
+    background-size:100% auto;
+  }
 
-.banner2 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background:none;
-  background-color:#666666;
-}
+  .banner2 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background:none;
+    background-color:#666666;
+  }
 
-.banner3 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:5%;
-  padding-bottom:5%;
-  font-size:16px;
-  letter-spacing:0.03em;
-  line-height:23px;
-  width:90%;
-  float:left;
-  background: url('/images/CaseStudy_haufegroup_banner3.jpg');
-}
+  .banner3 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:5%;
+    padding-bottom:5%;
+    font-size:16px;
+    letter-spacing:0.03em;
+    line-height:23px;
+    width:90%;
+    float:left;
+    background: url('/images/CaseStudy_haufegroup_banner3.jpg');
+  }
 
-.banner4 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background: url('/images/CaseStudy_haufegroup_banner4.jpg');
-}
+  .banner4 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background: url('/images/CaseStudy_haufegroup_banner4.jpg');
+  }
 
-.banner5 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  font-size:16px;
-  letter-spacing:0.03em;
-  line-height:23px;
-  width:100%;
-  float:left;
-  background:none;
-  background-color:#666666;
-}
+  .banner5 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    font-size:16px;
+    letter-spacing:0.03em;
+    line-height:23px;
+    width:100%;
+    float:left;
+    background:none;
+    background-color:#666666;
+  }
 
-.banner2text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:90%;
-  padding-left:5%;
-  padding-bottom:1%;
-  padding-top:1%;
-  float:left;
-  text-align:center;
-  color:#ffffff;
-}
+  .banner2text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:90%;
+    padding-left:5%;
+    padding-bottom:1%;
+    padding-top:1%;
+    float:left;
+    text-align:center;
+    color:#ffffff;
+  }
 
-.banner3text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:90%;
-  padding-left:5%;
-  padding-top:5%;
-  padding-bottom:5%;
-  text-align:center;
-}
+  .banner3text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:90%;
+    padding-left:5%;
+    padding-top:5%;
+    padding-bottom:5%;
+    text-align:center;
+  }
 
-.banner4text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:90%;
-  padding-left:5%;
-  padding-top:3%;
-  padding-bottom:3%;
-  text-align:center;
-}
+  .banner4text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:90%;
+    padding-left:5%;
+    padding-top:3%;
+    padding-bottom:3%;
+    text-align:center;
+  }
 
-.banner5text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:90%;
-  padding-left:5%;
-  padding-top:3%;
-  padding-bottom:3%;
-  text-align:center;
-}
+  .banner5text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:90%;
+    padding-left:5%;
+    padding-top:3%;
+    padding-bottom:3%;
+    text-align:center;
+  }
 
-.fullcol {
-  margin-top:6%;
-  margin-bottom:8%;
-}
+  .fullcol {
+    margin-top:6%;
+    margin-bottom:8%;
+  }
 
-h2 {
-  line-height:26px;
-  font-size:18px;
-}
+  h2 {
+    line-height:26px;
+    font-size:18px;
+  }
 
-.quote {
-  font-size:18px;
-  line-height:24px;
-}
+  .quote {
+    font-size:18px;
+    line-height:24px;
+  }
 
-.logo {
-  width:35%;
-}
+  .logo {
+    width:35%;
+  }
+} /* End Media 910px */
 
 @media screen and (max-width: 580px){
 
@@ -463,6 +464,6 @@ h2 {
 
   .banner1 {
     background: url('/images/CaseStudy_haufegroup_banner1.jpg');
-
+  }
 
 }

--- a/static/css/style_huawei.css
+++ b/static/css/style_huawei.css
@@ -254,202 +254,203 @@ h4 {
 
 @media screen and (max-width: 910px){
 
-h1 {
-  font-family:"Roboto", sans-serif;
-  font-weight:bold;
-  line-height:36px;
-  letter-spacing:0.03em;
-  font-size:30px !important;
-  padding-bottom:0px;
-  width:80%;
-}
+  h1 {
+    font-family:"Roboto", sans-serif;
+    font-weight:bold;
+    line-height:36px;
+    letter-spacing:0.03em;
+    font-size:30px !important;
+    padding-bottom:0px;
+    width:80%;
+  }
 
-.header_logo {
-  width:35%;
-  margin-bottom:-.5%;
-  magin-left:10px;
-}
+  .header_logo {
+    width:35%;
+    margin-bottom:-.5%;
+    margin-left:10px;
+  }
 
-.subhead {
-  font-size:18px;
-  font-weight:100;
-  line-height:27px;
-}
+  .subhead {
+    font-size:18px;
+    font-weight:100;
+    line-height:27px;
+  }
 
-.details {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  font-size:16px;
-  color:#3366ff;
-  letter-spacing:0.03em;
-  padding-bottom:2%;
-  line-height:28px;
-  padding-top:4%;
-  padding-left:10%;
-}
+  .details {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    font-size:16px;
+    color:#3366ff;
+    letter-spacing:0.03em;
+    padding-bottom:2%;
+    line-height:28px;
+    padding-top:4%;
+    padding-left:10%;
+  }
 
-.logo {
-    width:8%;
-}
+  .logo {
+      width:8%;
+  }
 
-.col1 {
-  width: 95%;
-  padding-right:8%;
-  float:left;
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#606060;
-  line-height:20px;
-  letter-spacing:0.03em;
-  font-size:14px;
-}
+  .col1 {
+    width: 95%;
+    padding-right:8%;
+    float:left;
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#606060;
+    line-height:20px;
+    letter-spacing:0.03em;
+    font-size:14px;
+  }
 
-.col2 {
-  width: 95%;
-  padding-top:2%;
-  padding-bottom:5%;
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  float:left;
-  line-height:20px;
-  color:#606060;
-  letter-spacing:0.03em;
-  font-size:14px;
-}
+  .col2 {
+    width: 95%;
+    padding-top:2%;
+    padding-bottom:5%;
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    float:left;
+    line-height:20px;
+    color:#606060;
+    letter-spacing:0.03em;
+    font-size:14px;
+  }
 
-.banner1 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:15%;
-  padding-bottom:2%;
-  padding-left:10%;
-  font-size:18px;
-  background: url('/images/CaseStudy_huawei_banner1.jpg');
-  background-size:100% auto;
-}
+  .banner1 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:15%;
+    padding-bottom:2%;
+    padding-left:10%;
+    font-size:18px;
+    background: url('/images/CaseStudy_huawei_banner1.jpg');
+    background-size:100% auto;
+  }
 
-.banner2 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background:none;
-  background-color:#666666;
-}
+  .banner2 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background:none;
+    background-color:#666666;
+  }
 
-.banner3 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:5%;
-  padding-bottom:5%;
-  font-size:16px;
-  letter-spacing:0.03em;
-  line-height:23px;
-  width:90%;
-  float:left;
-  background: url('/images/CaseStudy_huawei_banner3.jpg');
-}
+  .banner3 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:5%;
+    padding-bottom:5%;
+    font-size:16px;
+    letter-spacing:0.03em;
+    line-height:23px;
+    width:90%;
+    float:left;
+    background: url('/images/CaseStudy_huawei_banner3.jpg');
+  }
 
-.banner4 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background: url('/images/CaseStudy_huawei_banner4.jpg');
-}
+  .banner4 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background: url('/images/CaseStudy_huawei_banner4.jpg');
+  }
 
-.banner5 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  font-size:16px;
-  letter-spacing:0.03em;
-  line-height:23px;
-  width:100%;
-  float:left;
-  background:none;
-  background-color:#666666;
-}
+  .banner5 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    font-size:16px;
+    letter-spacing:0.03em;
+    line-height:23px;
+    width:100%;
+    float:left;
+    background:none;
+    background-color:#666666;
+  }
 
-.banner2text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:90%;
-  padding-left:5%;
-  padding-bottom:1%;
-  padding-top:1%;
-  float:left;
-  text-align:center;
-  color:#ffffff;
-}
+  .banner2text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:90%;
+    padding-left:5%;
+    padding-bottom:1%;
+    padding-top:1%;
+    float:left;
+    text-align:center;
+    color:#ffffff;
+  }
 
-.banner3text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:90%;
-  padding-left:5%;
-  padding-top:5%;
-  padding-bottom:5%;
-  text-align:center;
-}
+  .banner3text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:90%;
+    padding-left:5%;
+    padding-top:5%;
+    padding-bottom:5%;
+    text-align:center;
+  }
 
-.banner4text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:90%;
-  padding-left:5%;
-  padding-top:3%;
-  padding-bottom:3%;
-  text-align:center;
-}
+  .banner4text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:90%;
+    padding-left:5%;
+    padding-top:3%;
+    padding-bottom:3%;
+    text-align:center;
+  }
 
-.banner5text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:90%;
-  padding-left:5%;
-  padding-top:3%;
-  padding-bottom:3%;
-  text-align:center;
-}
+  .banner5text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:90%;
+    padding-left:5%;
+    padding-top:3%;
+    padding-bottom:3%;
+    text-align:center;
+  }
 
-.fullcol {
-  margin-top:6%;
-  margin-bottom:8%;
-}
+  .fullcol {
+    margin-top:6%;
+    margin-bottom:8%;
+  }
 
-h2 {
-  line-height:26px;
-  font-size:18px;
-}
+  h2 {
+    line-height:26px;
+    font-size:18px;
+  }
 
-.quote {
-  font-size:18px;
-  line-height:24px;
-}
+  .quote {
+    font-size:18px;
+    line-height:24px;
+  }
 
-.logo {
-  width:35%;
+  .logo {
+    width:35%;
+  }
 }
 
 @media screen and (max-width: 580px){
@@ -463,6 +464,6 @@ h2 {
 
   .banner1 {
     background: url('/images/CaseStudy_blablacar_banner1_mobile.jpg');
-
+  }
 
 }

--- a/static/css/style_peardeck.css
+++ b/static/css/style_peardeck.css
@@ -256,199 +256,200 @@ h4 {
 
 @media screen and (max-width: 910px){
 
-h1 {
-  font-family:"Roboto", sans-serif;
-  font-weight:bold;
-  line-height:36px;
-  letter-spacing:0.03em;
-  font-size:30px !important;
-  padding-bottom:0px;
-  width:80%;
-}
+  h1 {
+    font-family:"Roboto", sans-serif;
+    font-weight:bold;
+    line-height:36px;
+    letter-spacing:0.03em;
+    font-size:30px !important;
+    padding-bottom:0px;
+    width:80%;
+  }
 
-.subhead {
-  font-size:18px;
-  font-weight:100;
-  line-height:27px;
-}
+  .subhead {
+    font-size:18px;
+    font-weight:100;
+    line-height:27px;
+  }
 
-.details {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  font-size:16px;
-  color:#3366ff;
-  letter-spacing:0.03em;
-  padding-bottom:2%;
-  line-height:28px;
-  padding-top:4%;
-  padding-left:10%;
-}
+  .details {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    font-size:16px;
+    color:#3366ff;
+    letter-spacing:0.03em;
+    padding-bottom:2%;
+    line-height:28px;
+    padding-top:4%;
+    padding-left:10%;
+  }
 
-.logo {
-    width:8%;
-}
+  .logo {
+      width:8%;
+  }
 
-.col1 {
-  width: 100%;
-  padding-left:5%;
-  padding-right:8%;
-  float:left;
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#606060;
-  line-height:20px;
-  letter-spacing:0.03em;
-  font-size:14px;
-}
+  .col1 {
+    width: 100%;
+    padding-left:5%;
+    padding-right:8%;
+    float:left;
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#606060;
+    line-height:20px;
+    letter-spacing:0.03em;
+    font-size:14px;
+  }
 
-.col2 {
-  width: 100%;
-  padding-left:5%;
-  padding-top:5%;
-  padding-bottom:5%;
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  float:left;
-  line-height:20px;
-  color:#606060;
-  letter-spacing:0.03em;
-  font-size:14px;
-}
+  .col2 {
+    width: 100%;
+    padding-left:5%;
+    padding-top:5%;
+    padding-bottom:5%;
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    float:left;
+    line-height:20px;
+    color:#606060;
+    letter-spacing:0.03em;
+    font-size:14px;
+  }
 
-.banner1 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:15%;
-  padding-bottom:2%;
-  padding-left:10%;
-  font-size:18px;
-  background: url('/images/CaseStudy_peardeck_banner1.jpg');
-  background-size:100% auto;
-}
+  .banner1 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:15%;
+    padding-bottom:2%;
+    padding-left:10%;
+    font-size:18px;
+    background: url('/images/CaseStudy_peardeck_banner1.jpg');
+    background-size:100% auto;
+  }
 
-.banner2 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  padding-left:0%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background:none;
-  background-color:#666666;
-}
+  .banner2 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    padding-left:0%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background:none;
+    background-color:#666666;
+  }
 
-.banner3 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:5%;
-  padding-bottom:5%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:80%;
-  padding-left:15%;
-  padding-right:10%;
-  float:left;
-  background: url('/images/CaseStudy_peardeck_banner3.jpg');
-}
+  .banner3 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:5%;
+    padding-bottom:5%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:80%;
+    padding-left:15%;
+    padding-right:10%;
+    float:left;
+    background: url('/images/CaseStudy_peardeck_banner3.jpg');
+  }
 
-.banner4 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:5%;
-  padding-bottom:5%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background: url('/images/CaseStudy_peardeck_banner2.jpg');
-}
+  .banner4 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:5%;
+    padding-bottom:5%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background: url('/images/CaseStudy_peardeck_banner2.jpg');
+  }
 
-.banner5 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  padding-left:0%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background:none;
-  background-color:#666666;
-}
+  .banner5 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    padding-left:0%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background:none;
+    background-color:#666666;
+  }
 
-.banner2text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:80%;
-  padding-left:10%;
-  float:left;
-  text-align:center;
-  color:#ffffff;
-}
+  .banner2text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:80%;
+    padding-left:10%;
+    float:left;
+    text-align:center;
+    color:#ffffff;
+  }
 
-.banner3text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:80%;
-  padding-left:2%;
-  padding-right:10%;
-  padding-top:5%;
-  padding-bottom:5%;
-  text-align:center;
-}
+  .banner3text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:80%;
+    padding-left:2%;
+    padding-right:10%;
+    padding-top:5%;
+    padding-bottom:5%;
+    text-align:center;
+  }
 
-.banner4text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:80%;
-  padding-left:10%;
-  text-align:center;
-}
+  .banner4text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:80%;
+    padding-left:10%;
+    text-align:center;
+  }
 
-.banner5text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:80%;
-  padding-left:10%;
-  float:left;
-  text-align:center;
-  color:#ffffff;
-}
+  .banner5text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:80%;
+    padding-left:10%;
+    float:left;
+    text-align:center;
+    color:#ffffff;
+  }
 
-.fullcol {
-  margin-top:6%;
-}
+  .fullcol {
+    margin-top:6%;
+  }
 
-h2 {
-  line-height:26px;
-  font-size:18px;
-}
+  h2 {
+    line-height:26px;
+    font-size:18px;
+  }
 
-.quote {
-  font-size:18px;
-  line-height:24px;
-}
+  .quote {
+    font-size:18px;
+    line-height:24px;
+  }
 
-.logo {
-  width:35%;
-}
+  .logo {
+    width:35%;
+  }
+} /* End Media 910px */
 
 @media screen and (max-width: 480px){
 

--- a/static/css/style_user_journeys.css
+++ b/static/css/style_user_journeys.css
@@ -245,7 +245,7 @@ border:1px solid blue;
 
 .docscoltitle {
 float:left;
-padding-top:%;
+padding-top:0%;
 margin-right:2%;
 padding-bottom:3%;
 font-size:16pt;
@@ -298,21 +298,17 @@ color:#3371e3;
 
 .docsButton {
 
-    background-color:#3371e3;
-    color:white;
-    border: 2px solid #ffffff;
-    -moz-border-radius: 5px;
-    -webkit-border-radius: 5px;
-    border-radius: 5px; /* future proofing */
-    -khtml-border-radius: 5px; /* for old Konqueror browsers */
-    border: 2px solid #ffffff;
-    padding:1%;
-    text-decoration:none;
-    margin:%;
-  }
-
-
-
+  background-color:#3371e3;
+  color:white;
+  border: 2px solid #ffffff;
+  -moz-border-radius: 5px;
+  -webkit-border-radius: 5px;
+  border-radius: 5px; /* future proofing */
+  -khtml-border-radius: 5px; /* for old Konqueror browsers */
+  border: 2px solid #ffffff;
+  padding:1%;
+  text-decoration:none;
+  margin:0%;
 }
 
 .material-icons {
@@ -413,7 +409,7 @@ button {
 
 .navButton:focus {
 
-  background-color:#3371e3 !important</div>;
+  background-color:#3371e3 !important;
   color:white;
   border: 2px solid #ffffff;
 }
@@ -633,7 +629,7 @@ i {
 }
 
 .whitebararrow{
-  float:right
+  float:right;
   padding:3%;
   font-size:15px;
   z-index:99;
@@ -668,7 +664,7 @@ padding-bottom:5%;
 float:left;
 padding-bottom:2%;
 padding-right:2%;
-margin-bottom:10%:
+margin-bottom:10%;
 color:#3371e3 !important;
 }
 
@@ -897,7 +893,7 @@ table {
 }
 
 thead, tr:nth-child(even) {
-  background-color: $light-grey;
+  background-color: light-grey;
 }
 
 thead {
@@ -947,5 +943,5 @@ padding:5%;
 }
 
 
-}  
+}
 

--- a/static/css/style_wink.css
+++ b/static/css/style_wink.css
@@ -249,199 +249,200 @@ h4 {
 
 @media screen and (max-width: 910px){
 
-h1 {
-  font-family:"Roboto", sans-serif;
-  font-weight:bold;
-  line-height:36px;
-  letter-spacing:0.03em;
-  font-size:30px !important;
-  padding-bottom:0px;
-  width:80%;
-}
+  h1 {
+    font-family:"Roboto", sans-serif;
+    font-weight:bold;
+    line-height:36px;
+    letter-spacing:0.03em;
+    font-size:30px !important;
+    padding-bottom:0px;
+    width:80%;
+  }
 
-.subhead {
-  font-size:18px;
-  font-weight:100;
-  line-height:27px;
-}
+  .subhead {
+    font-size:18px;
+    font-weight:100;
+    line-height:27px;
+  }
 
-.details {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  font-size:16px;
-  color:#3366ff;
-  letter-spacing:0.03em;
-  padding-bottom:2%;
-  line-height:28px;
-  padding-top:4%;
-  padding-left:10%;
-}
+  .details {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    font-size:16px;
+    color:#3366ff;
+    letter-spacing:0.03em;
+    padding-bottom:2%;
+    line-height:28px;
+    padding-top:4%;
+    padding-left:10%;
+  }
 
-.logo {
-    width:8%;
-}
+  .logo {
+      width:8%;
+  }
 
-.col1 {
-  width: 100%;
-  padding-left:5%;
-  padding-right:8%;
-  float:left;
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#606060;
-  line-height:20px;
-  letter-spacing:0.03em;
-  font-size:14px;
-}
+  .col1 {
+    width: 100%;
+    padding-left:5%;
+    padding-right:8%;
+    float:left;
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#606060;
+    line-height:20px;
+    letter-spacing:0.03em;
+    font-size:14px;
+  }
 
-.col2 {
-  width: 100%;
-  padding-left:5%;
-  padding-top:5%;
-  padding-bottom:5%;
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  float:left;
-  line-height:20px;
-  color:#606060;
-  letter-spacing:0.03em;
-  font-size:14px;
-}
+  .col2 {
+    width: 100%;
+    padding-left:5%;
+    padding-top:5%;
+    padding-bottom:5%;
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    float:left;
+    line-height:20px;
+    color:#606060;
+    letter-spacing:0.03em;
+    font-size:14px;
+  }
 
-.banner1 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:15%;
-  padding-bottom:2%;
-  padding-left:10%;
-  font-size:18px;
-  background: url('/images/CaseStudy_wink_banner1.jpg');
-  background-size:100% auto;
-}
+  .banner1 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:15%;
+    padding-bottom:2%;
+    padding-left:10%;
+    font-size:18px;
+    background: url('/images/CaseStudy_wink_banner1.jpg');
+    background-size:100% auto;
+  }
 
-.banner2 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  padding-left:0%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background:none;
-  background-color:#666666;
-}
+  .banner2 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    padding-left:0%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background:none;
+    background-color:#666666;
+  }
 
-.banner3 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:5%;
-  padding-bottom:5%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:80%;
-  padding-left:15%;
-  padding-right:10%;
-  float:left;
-  background: url('/images/CaseStudy_wink_banner3.jpg');
-}
+  .banner3 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:5%;
+    padding-bottom:5%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:80%;
+    padding-left:15%;
+    padding-right:10%;
+    float:left;
+    background: url('/images/CaseStudy_wink_banner3.jpg');
+  }
 
-.banner4 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:5%;
-  padding-bottom:5%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background: url('/images/CaseStudy_wink_banner4.jpg');
-}
+  .banner4 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:5%;
+    padding-bottom:5%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background: url('/images/CaseStudy_wink_banner4.jpg');
+  }
 
-.banner5 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  padding-left:0%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background:none;
-  background-color:#666666;
-}
+  .banner5 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    padding-left:0%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background:none;
+    background-color:#666666;
+  }
 
-.banner2text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:80%;
-  padding-left:10%;
-  float:left;
-  text-align:center;
-  color:#ffffff;
-}
+  .banner2text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:80%;
+    padding-left:10%;
+    float:left;
+    text-align:center;
+    color:#ffffff;
+  }
 
-.banner3text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:80%;
-  padding-left:2%;
-  padding-right:10%;
-  padding-top:5%;
-  padding-bottom:5%;
-  text-align:center;
-}
+  .banner3text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:80%;
+    padding-left:2%;
+    padding-right:10%;
+    padding-top:5%;
+    padding-bottom:5%;
+    text-align:center;
+  }
 
-.banner4text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:80%;
-  padding-left:10%;
-  text-align:center;
-}
+  .banner4text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:80%;
+    padding-left:10%;
+    text-align:center;
+  }
 
-.banner5text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:80%;
-  padding-left:10%;
-  float:left;
-  text-align:center;
-  color:#ffffff;
-}
+  .banner5text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:80%;
+    padding-left:10%;
+    float:left;
+    text-align:center;
+    color:#ffffff;
+  }
 
-.fullcol {
-  margin-top:6%;
-}
+  .fullcol {
+    margin-top:6%;
+  }
 
-h2 {
-  line-height:26px;
-  font-size:18px;
-}
+  h2 {
+    line-height:26px;
+    font-size:18px;
+  }
 
-.quote {
-  font-size:18px;
-  line-height:24px;
-}
+  .quote {
+    font-size:18px;
+    line-height:24px;
+  }
 
-.logo {
-  width:35%;
-}
+  .logo {
+    width:35%;
+  }
+} /* End Media 910px */
 
 @media screen and (max-width: 480px){
 

--- a/static/css/style_zalando.css
+++ b/static/css/style_zalando.css
@@ -254,203 +254,204 @@ h4 {
 
 @media screen and (max-width: 910px){
 
-h1 {
-  font-family:"Roboto", sans-serif;
-  font-weight:bold;
-  line-height:36px;
-  letter-spacing:0.03em;
-  font-size:30px !important;
-  padding-bottom:0px;
-  width:80%;
-}
+  h1 {
+    font-family:"Roboto", sans-serif;
+    font-weight:bold;
+    line-height:36px;
+    letter-spacing:0.03em;
+    font-size:30px !important;
+    padding-bottom:0px;
+    width:80%;
+  }
 
-.header_logo {
-  width:35%;
-  margin-bottom:-.5%;
-  magin-left:10px;
-}
+  .header_logo {
+    width:35%;
+    margin-bottom:-.5%;
+    margin-left:10px;
+  }
 
-.subhead {
-  font-size:18px;
-  font-weight:100;
-  line-height:27px;
-}
+  .subhead {
+    font-size:18px;
+    font-weight:100;
+    line-height:27px;
+  }
 
-.details {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  font-size:16px;
-  color:#3366ff;
-  letter-spacing:0.03em;
-  padding-bottom:2%;
-  line-height:28px;
-  padding-top:4%;
-  padding-left:10%;
-}
+  .details {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    font-size:16px;
+    color:#3366ff;
+    letter-spacing:0.03em;
+    padding-bottom:2%;
+    line-height:28px;
+    padding-top:4%;
+    padding-left:10%;
+  }
 
-.logo {
-    width:8%;
-}
+  .logo {
+      width:8%;
+  }
 
-.col1 {
-  width: 95%;
-  padding-right:8%;
-  float:left;
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#606060;
-  line-height:20px;
-  letter-spacing:0.03em;
-  font-size:14px;
-}
+  .col1 {
+    width: 95%;
+    padding-right:8%;
+    float:left;
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#606060;
+    line-height:20px;
+    letter-spacing:0.03em;
+    font-size:14px;
+  }
 
-.col2 {
-  width: 95%;
-  padding-top:2%;
-  padding-bottom:5%;
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  float:left;
-  line-height:20px;
-  color:#606060;
-  letter-spacing:0.03em;
-  font-size:14px;
-}
+  .col2 {
+    width: 95%;
+    padding-top:2%;
+    padding-bottom:5%;
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    float:left;
+    line-height:20px;
+    color:#606060;
+    letter-spacing:0.03em;
+    font-size:14px;
+  }
 
-.banner1 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:15%;
-  padding-bottom:2%;
-  padding-left:10%;
-  font-size:18px;
-  background: url('/images/CaseStudy_zalando_banner1.jpg');
-  background-size:100% auto;
-}
+  .banner1 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:15%;
+    padding-bottom:2%;
+    padding-left:10%;
+    font-size:18px;
+    background: url('/images/CaseStudy_zalando_banner1.jpg');
+    background-size:100% auto;
+  }
 
-.banner2 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background:none;
-  background-color:#666666;
-}
+  .banner2 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background:none;
+    background-color:#666666;
+  }
 
-.banner3 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:5%;
-  padding-bottom:5%;
-  font-size:16px;
-  letter-spacing:0.03em;
-  line-height:23px;
-  width:90%;
-  float:left;
-  background: url('/images/CaseStudy_zalando_banner3.jpg');
-}
+  .banner3 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:5%;
+    padding-bottom:5%;
+    font-size:16px;
+    letter-spacing:0.03em;
+    line-height:23px;
+    width:90%;
+    float:left;
+    background: url('/images/CaseStudy_zalando_banner3.jpg');
+  }
 
-.banner4 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  font-size:18px;
-  letter-spacing:0.03em;
-  line-height:24px;
-  width:100%;
-  float:left;
-  background: url('/images/CaseStudy_zalando_banner4.jpg');
-}
+  .banner4 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    font-size:18px;
+    letter-spacing:0.03em;
+    line-height:24px;
+    width:100%;
+    float:left;
+    background: url('/images/CaseStudy_zalando_banner4.jpg');
+  }
 
-.banner5 {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  padding-top:4%;
-  padding-bottom:4%;
-  font-size:16px;
-  letter-spacing:0.03em;
-  line-height:23px;
-  width:100%;
-  float:left;
-  background:none;
-  background-color:#666666;
-}
+  .banner5 {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    padding-top:4%;
+    padding-bottom:4%;
+    font-size:16px;
+    letter-spacing:0.03em;
+    line-height:23px;
+    width:100%;
+    float:left;
+    background:none;
+    background-color:#666666;
+  }
 
-.banner2text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:90%;
-  padding-left:5%;
-  padding-bottom:1%;
-  padding-top:1%;
-  float:left;
-  text-align:center;
-  color:#ffffff;
-}
+  .banner2text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:90%;
+    padding-left:5%;
+    padding-bottom:1%;
+    padding-top:1%;
+    float:left;
+    text-align:center;
+    color:#ffffff;
+  }
 
-.banner3text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:90%;
-  padding-left:5%;
-  padding-top:5%;
-  padding-bottom:5%;
-  text-align:center;
-}
+  .banner3text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:90%;
+    padding-left:5%;
+    padding-top:5%;
+    padding-bottom:5%;
+    text-align:center;
+  }
 
-.banner4text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:90%;
-  padding-left:5%;
-  padding-top:3%;
-  padding-bottom:3%;
-  text-align:center;
-}
+  .banner4text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:90%;
+    padding-left:5%;
+    padding-top:3%;
+    padding-bottom:3%;
+    text-align:center;
+  }
 
-.banner5text {
-  font-family:"Roboto", sans-serif;
-  font-weight:300;
-  color:#ffffff;
-  width:90%;
-  padding-left:5%;
-  padding-top:3%;
-  padding-bottom:3%;
-  text-align:center;
-}
+  .banner5text {
+    font-family:"Roboto", sans-serif;
+    font-weight:300;
+    color:#ffffff;
+    width:90%;
+    padding-left:5%;
+    padding-top:3%;
+    padding-bottom:3%;
+    text-align:center;
+  }
 
-.fullcol {
-  margin-top:6%;
-  margin-bottom:8%;
-}
+  .fullcol {
+    margin-top:6%;
+    margin-bottom:8%;
+  }
 
-h2 {
-  line-height:26px;
-  font-size:18px;
-}
+  h2 {
+    line-height:26px;
+    font-size:18px;
+  }
 
-.quote {
-  font-size:18px;
-  line-height:24px;
-}
+  .quote {
+    font-size:18px;
+    line-height:24px;
+  }
 
-.logo {
-  width:35%;
-}
+  .logo {
+    width:35%;
+  }
+} /* End Media 910px */
 
 @media screen and (max-width: 580px){
 


### PR DESCRIPTION
blog.css :
- Removing comma at font: normal bold 11px 'Roboto',,sans-serif;
- Removing <style></style>

style_amadeus.css, style_ancestry.css, style_blablacar.css, style_box.css, style_case_studies.css, style_crowdfire.css, style_haufegroup.css, style_huawei.css, style_wink.css, style_zalando.css:
- Add tab or "space" on @media screen and (max-width: 910px)
- Add close brackets "}" /* End Media 910px */
- Change some typo "magin" to "margin".  magin-left:10px;

style_user_journeys.css:
- Fill in number "0%" at padding-top:%;
- Removing </div> at background-color:#3371e3 !important</div>;
- Change "colon" to "semicolon" at margin-bottom:10%:
- Removing "$" at background-color: $light-grey;
