### PR TITLE
Fix cassandra-statefulset.yaml indent level

### DIFF
--- a/content/en/examples/application/cassandra/cassandra-statefulset.yaml
+++ b/content/en/examples/application/cassandra/cassandra-statefulset.yaml
@@ -34,8 +34,8 @@ spec:
             cpu: "500m"
             memory: 1Gi
           requests:
-           cpu: "500m"
-           memory: 1Gi
+            cpu: "500m"
+            memory: 1Gi
         securityContext:
           capabilities:
             add:


### PR DESCRIPTION
It looks a bit strange, when I looking doc.
So just fix indent level that two spaces per level in cassandra-statefulset.yaml.
