### PR TITLE
fix a trivial misspelling

### DIFF
--- a/content/en/blog/_posts/2015-07-00-How-Did-Quake-Demo-From-Dockercon-Work.md
+++ b/content/en/blog/_posts/2015-07-00-How-Did-Quake-Demo-From-Dockercon-Work.md
@@ -121,7 +121,7 @@ CONTAINER ID  IMAGE           COMMAND           CREATED        STATUS
 docker\_cr.sh
   ```
 
-Since the command line arguments to CRIU were long, a helper script called docker\_cr.sh was provided in the CRIU source tree to simplify the proces.  So, for the above container, one would simply C/R the container as follows (for details see [http://criu.org/Docker](http://criu.org/Docker)):
+Since the command line arguments to CRIU were long, a helper script called docker\_cr.sh was provided in the CRIU source tree to simplify the process.  So, for the above container, one would simply C/R the container as follows (for details see [http://criu.org/Docker](http://criu.org/Docker)):
 
 ```  
 $ sudo docker\_cr.sh -c 4397   


### PR DESCRIPTION
fix a trivial misspelling in blog:
proces -> process

