### PR TITLE
fix broken link in content/en/docs/setup/release/notes.md

### DIFF
--- a/content/en/docs/setup/release/notes.md
+++ b/content/en/docs/setup/release/notes.md
@@ -5,7 +5,7 @@ content_template: templates/concept
 
 {{% capture overview %}}
 
-[Documentation](https://docs.k8s.io) & [Examples](https://releases.k8s.io/release-1.11/examples)
+[Documentation](https://docs.k8s.io) & [Examples](https://github.com/kubernetes/examples)
 
 ## Downloads for v1.11.0
 


### PR DESCRIPTION
If we click "Example", we should go to https://github.com/kubernetes/kubernetes/tree/release-1.11/examples, and get 404 error.

We have checked it and found that this file has moved to https://github.com/kubernetes/examples/blob/master/README.md after release 1.10