### PR TITLE
Fixing font import 404s

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/update/update-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/update/update-intro.html
@@ -10,6 +10,7 @@ weight: 10
 <body>
 
 <link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css?family=Roboto+Slab:300,400,700" rel="stylesheet">
 
 <div class="layout" id="top">
 


### PR DESCRIPTION
This PR addresses a font import issue pointed out in the Kubernetes site latency presentation. The SVG files on this page rely on a font that wasn't being imported.

cc @chenopis 