### PR TITLE
Add CRI installation instructions page

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -358,7 +358,7 @@ Here's a breakdown of what/why:
    certificates from the `kube-apiserver` when the certificate expiration approaches.
 * `--cert-dir`the directory where the TLS certs are located.
 
-### Use kubeadm with other CRI runtimes
+### Use kubeadm with CRI runtimes
 
 Since v1.6.0, Kubernetes has enabled the use of CRI, Container Runtime Interface, by default.
 The container runtime used by default is Docker, which is enabled through the built-in
@@ -370,6 +370,8 @@ Other CRI-based runtimes include:
 - [cri-o](https://github.com/kubernetes-incubator/cri-o)
 - [frakti](https://github.com/kubernetes/frakti)
 - [rkt](https://github.com/kubernetes-incubator/rktlet)
+
+Refer to the [CRI installation instructions](/docs/setup/cri.md) for more information.
 
 After you have successfully installed `kubeadm` and `kubelet`, execute
 these two additional steps:

--- a/content/en/docs/setup/cri.md
+++ b/content/en/docs/setup/cri.md
@@ -1,0 +1,226 @@
+---
+reviewers:
+- vincepri
+- bart0sh
+title: CRI installation
+content_template: templates/concept
+weight: 100
+---
+{{% capture overview %}}
+Since v1.6.0, Kubernetes has enabled the use of CRI, Container Runtime Interface, by default.
+This page contains installation instruction for various runtimes.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+Please proceed with executing the following commands based on your OS as root.
+You may become the root user by executing `sudo -i` after SSH-ing to each host.
+
+## Docker
+
+On each of your machines, install Docker.
+Version 18.06 is recommended, but 1.11, 1.12, 1.13 and 17.03 are known to work as well.
+Keep track of the latest verified Docker version in the Kubernetes release notes.
+
+Use the following commands to install Docker on your system:
+
+{{< tabs name="tab-cri-docker-installation" >}}
+{{< tab name="Ubuntu 16.04" codelang="bash" >}}
+# Install Docker from Ubuntu's repositories:
+apt-get update
+apt-get install -y docker.io
+
+# or install Docker CE 18.06 from Docker's repositories for Ubuntu or Debian:
+
+## Install prerequisites.
+apt-get update && apt-get install apt-transport-https ca-certificates curl software-properties-common
+
+## Download GPG key.
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+
+## Add docker apt repository.
+add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable"
+
+## Install docker.
+apt-get update && apt-get install docker-ce=18.06.0~ce~3-0~ubuntu
+
+# Setup daemon.
+cat > /etc/docker/daemon.json <<EOF
+{
+  "exec-opts": ["native.cgroupdriver=systemd"],
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "100m"
+  },
+  "storage-driver": "overlay2"
+}
+EOF
+
+mkdir -p /etc/systemd/system/docker.service.d
+
+# Restart docker.
+systemctl daemon-reload
+systemctl restart docker
+{{< /tab >}}
+{{< tab name="CentOS/RHEL 7.4+" codelang="bash" >}}
+
+# Install Docker from CentOS/RHEL repository:
+yum install -y docker
+
+# or install Docker CE 18.06 from Docker's CentOS repositories:
+
+## Install prerequisites.
+yum install yum-utils device-mapper-persistent-data lvm2
+
+## Add docker repository.
+yum-config-manager \
+    --add-repo \
+    https://download.docker.com/linux/centos/docker-ce.repo
+
+## Install docker.
+yum update && yum install docker-ce-18.06.1.ce
+
+# Setup daemon.
+cat > /etc/docker/daemon.json <<EOF
+{
+  "exec-opts": ["native.cgroupdriver=systemd"],
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "100m"
+  },
+  "storage-driver": "overlay2",
+  "storage-opts": [
+    "overlay2.override_kernel_check=true"
+  ]
+}
+EOF
+
+mkdir -p /etc/systemd/system/docker.service.d
+
+# Restart docker.
+systemctl daemon-reload
+systemctl restart docker
+{{< /tab >}}
+{{< /tabs >}}
+
+Refer to the [official Docker installation guides](https://docs.docker.com/engine/installation/)
+for more information.
+
+## CRI-O
+
+This section contains the necessary steps to install `CRI-O` as CRI runtime.
+
+Use the following commands to install CRI-O on your system:
+
+### Prerequisites
+
+```shell
+modprobe overlay
+modprobe br_netfilter
+
+# Setup required sysctl params, these persist across reboots.
+cat > /etc/sysctl.d/99-kubernetes-cri.conf <<EOF
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+EOF
+
+sysctl --system
+```
+
+{{< tabs name="tab-cri-cri-o-installation" >}}
+{{< tab name="Ubuntu 16.04" codelang="bash" >}}
+
+# Install prerequisites
+apt-get update
+apt-get install software-properties-common
+
+add-apt-repository ppa:projectatomic/ppa
+apt-get update
+
+# Install CRI-O
+apt-get install cri-o-1.11
+
+{{< /tab >}}
+{{< tab name="CentOS/RHEL 7.4+" codelang="bash" >}}
+
+# Install prerequisites
+yum-config-manager --add-repo=https://cbs.centos.org/repos/paas7-crio-311-candidate/x86_64/os/
+
+# Install CRI-O
+yum install --nogpgcheck cri-o
+
+{{< /tab >}}
+{{< /tabs >}}
+
+### Start CRI-O
+
+```
+systemctl start crio
+```
+
+Refer to the [CRI-O installation guide](https://github.com/kubernetes-sigs/cri-o#getting-started)
+for more information.
+
+## Containerd
+
+This section contains the necessary steps to use `containerd` as CRI runtime.
+
+Use the following commands to install Containerd on your system:
+
+### Prerequisites
+
+```shell
+modprobe overlay
+modprobe br_netfilter
+
+# Setup required sysctl params, these persist across reboots.
+cat > /etc/sysctl.d/99-kubernetes-cri.conf <<EOF
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+EOF
+
+sysctl --system
+```
+
+{{< tabs name="tab-cri-containerd-installation" >}}
+{{< tab name="Ubuntu 16.04+" codelang="bash" >}}
+apt-get install -y libseccomp2
+{{< /tab >}}
+{{< tab name="CentOS/RHEL 7.4+" codelang="bash" >}}
+yum install -y libseccomp
+{{< /tab >}}
+{{< /tabs >}}
+
+### Install containerd
+
+[Containerd releases](https://github.com/containerd/containerd/releases) are published regularly, the values below are hardcoded to the latest version available at the time of writing. Please check for newer versions and hashes [here](https://storage.googleapis.com/cri-containerd-release).
+
+```shell
+# Export required environment variables.
+export CONTAINERD_VERSION="1.1.2"
+export CONTAINERD_SHA256="d4ed54891e90a5d1a45e3e96464e2e8a4770cd380c21285ef5c9895c40549218"
+
+# Download containerd tar.
+wget https://storage.googleapis.com/cri-containerd-release/cri-containerd-${CONTAINERD_VERSION}.linux-amd64.tar.gz
+
+# Check hash.
+echo "${CONTAINERD_SHA256} cri-containerd-${CONTAINERD_VERSION}.linux-amd64.tar.gz" | sha256sum --check -
+
+# Unpack.
+tar --no-overwrite-dir -C / -xzf cri-containerd-${CONTAINERD_VERSION}.linux-amd64.tar.gz
+
+# Start containerd.
+systemctl start containerd
+```
+
+## Other CRI runtimes: rktlet and frakti
+
+Refer to the [Frakti QuickStart guide](https://github.com/kubernetes/frakti#quickstart) and [Rktlet Getting Started guide](https://github.com/kubernetes-incubator/rktlet/blob/master/docs/getting-started-guide.md) for more information.
+
+{{% /capture %}}

--- a/content/en/docs/setup/independent/install-kubeadm.md
+++ b/content/en/docs/setup/independent/install-kubeadm.md
@@ -79,57 +79,20 @@ The pod network plugin you use (see below) may also require certain ports to be
 open. Since this differs with each pod network plugin, please see the
 documentation for the plugins about what port(s) those need.
 
-## Installing Docker
+## Installing runtime
 
-On each of your machines, install Docker.
-Version 17.03 is recommended, but 1.11, 1.12 and 1.13 are known to work as well.
-Versions 17.06+ _might work_, but have not yet been tested and verified by the Kubernetes node team.
-Keep track of the latest verified Docker version in the Kubernetes release notes.
+Since v1.6.0, Kubernetes has enabled the use of CRI, Container Runtime Interface, by default.
+The container runtime used by default is Docker, which is enabled through the built-in
+`dockershim` CRI implementation inside of the `kubelet`.
 
-Please proceed with executing the following commands based on your OS as root. You may become the root user by executing `sudo -i` after SSH-ing to each host.
+Other CRI-based runtimes include:
 
-If you already have the required versions of the Docker installed, you can move on to next section.
-If not, you can use the following commands to install Docker on your system:
+- [cri-containerd](https://github.com/containerd/cri-containerd)
+- [cri-o](https://github.com/kubernetes-incubator/cri-o)
+- [frakti](https://github.com/kubernetes/frakti)
+- [rkt](https://github.com/kubernetes-incubator/rktlet)
 
-{{< tabs name="docker_install" >}}
-{{% tab name="Ubuntu, Debian or HypriotOS" %}}
-Install Docker from Ubuntu's repositories:
-
-```bash
-apt-get update
-apt-get install -y docker.io
-```
-
-or install Docker CE 17.03 from Docker's repositories for Ubuntu or Debian:
-
-```bash
-apt-get update
-apt-get install -y apt-transport-https ca-certificates curl software-properties-common
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-add-apt-repository "deb https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") $(lsb_release -cs) stable"
-apt-get update && apt-get install -y docker-ce=$(apt-cache madison docker-ce | grep 17.03 | head -1 | awk '{print $3}')
-```
-{{% /tab %}}
-{{% tab name="CentOS, RHEL or Fedora" %}}
-Install Docker using your operating system's bundled package:
-
-```bash
-yum install -y docker
-systemctl enable docker && systemctl start docker
-```
-{{% /tab %}}
-{{% tab name="Container Linux" %}}
-Enable and start Docker:
-
-```bash
-systemctl enable docker && systemctl start docker
-```
-{{% /tab %}}
-{{< /tabs >}}
-
-
-Refer to the [official Docker installation guides](https://docs.docker.com/engine/installation/)
-for more information.
+Refer to the [CRI installation instructions](/docs/setup/cri.md) for more information.
 
 ## Installing kubeadm, kubelet and kubectl
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Added cri-installation page with CRI installation instructions
Referenced it from kubeadm-init and install-kubeadm pages.

**Which issue this PR fixes**
Fixes: kubernetes/kubeadm#1086, kubernetes/website#9692

**Release note**:
```release-note
NONE
```