### PR TITLE
[WIP] Change version list in header

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -24,10 +24,11 @@
             <li>
                 <a href="#">
                     {{ .Site.Params.version }} <span class="ui-icon ui-icon-carat-1-s"></span>
+                    {{ $site_version := .Site.Params.version }}
                 </a>
                 <ul>
                 {{ range .Site.Params.versions }}
-                    <li><a href="{{  .url }}">{{ .version }}</a></li>
+                    {{ if ne .version $site_version }} <li><a href="{{  .url }}">{{ .version }}</a></li> {{ end }}
                 {{ end }}
                 </ul>
             </li>


### PR DESCRIPTION
- Update the list of versions to exclude the current site version (not duplicated in list).
- Tested locally, but in switching to the other versions, the site re-directs to the live website, and some of the older versions are not available.
- I think having the duplicate version number in the list is distracting, but I see why it is useful for navigation. This change may not be needed.
- There seems to be a problem with loading the home page, when switching between versions. If I navigate from version 1.11 to 1.10, and then select 1.11 in the list again, the home page is not re-loaded. If I click 1.11 again from the list then the home page is loaded correctly again.
https://v1-11.docs.kubernetes.io/  -->
https://v1-10.docs.kubernetes.io/  -->
https://kubernetes.io/docs/home/?path=users&persona=app-developer&level=foundational  -->
https://v1-11.docs.kubernetes.io/  -->
- For versions of the documentation that are no longer maintained, it would be great to remove the links to other doc versions that are not available (v1.5, v1.6). 
- If I select lang = Chinese, the current version is 1.11, the home page is now translated to Chinese and the version is 1.11. However, if I select v1.11 from the list, the home page is reloaded and displays the English version.
 