### PR TITLE
fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,15 +12,15 @@ RUN apk add --no-cache \
     curl \
     git \
     openssh-client \
-    rsync
+    rsync \
+    build-base \
+    libc6-compat
 
 ARG HUGO_VERSION
 
 RUN mkdir -p /usr/local/src && \
     cd /usr/local/src && \
     curl -L https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-64bit.tar.gz | tar -xz && \
-    apk add build-base && \
-    apk add libc6-compat && \
     mv hugo /usr/local/bin/hugo && \
     curl -L https://bin.equinox.io/c/dhgbqpS8Bvy/minify-stable-linux-amd64.tgz | tar -xz && \
     mv minify /usr/local/bin && \


### PR DESCRIPTION
Without this change, `make docker-image` would fail:
```
    build-base (missing):
ERROR: unsatisfiable constraints:
    required by: world[build-base]
The command '/bin/sh -c mkdir -p /usr/local/src &&     cd /usr/local/src &&     curl -L https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-64bit.tar.gz | tar -xz &&     apk add build-base &&     apk add libc6-compat &&     mv hugo /usr/local/bin/hugo &&     curl -L https://bin.equinox.io/c/dhgbqpS8Bvy/minify-stable-linux-amd64.tgz | tar -xz &&     mv minify /usr/local/bin &&     addgroup -Sg 1000 hugo &&     adduser -Sg hugo -u 1000 -h /src hugo' returned a non-zero code: 1
```
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> Please delete this note before submitting the pull request.
> For 1.12 Features: set Milestone to 1.12 and Base Branch to release-1.12
> Help editing and submitting pull requests:  https://deploy-preview-9510--kubernetes-io-master-staging.netlify.com/docs/contribute/start/#submit-a-pull-request.
> Help choosing which branch to use, see
> https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use.
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>

