### PR TITLE
remove duplicate stack overflow icon

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -14,7 +14,6 @@
                 <a href="http://slack.k8s.io/" class="slack"><span>Slack</span></a>
             </div>
             <div>
-                <a href="http://stackoverflow.com/questions/tagged/kubernetes" class="stack-overflow"><span>
                 <a href="http://stackoverflow.com/questions/tagged/kubernetes" class="stack-overflow"><span>{{ T "community_stack_overflow_name" }}</span></a>
                 <a href="https://discuss.kubernetes.io" class="mailing-list"><span>{{ T "community_forum_name" }}</span></a>
                 <a href="https://calendar.google.com/calendar/embed?src=nt2tcnbtbied3l6gi2h29slvc0%40group.calendar.google.com" class="calendar"><span>{{ T "community_events_calendar" }}</span></a>


### PR DESCRIPTION
Hey guys,

Just noticed while I was enjoying the kubernetes website that looks like there's a rogue duplicate stack overflow icon (see below)

![image](https://user-images.githubusercontent.com/8244919/45637975-b5f57c80-baa3-11e8-9ea4-8d61716a96e3.png)

I assumed these are duplicate because the html looks to be incorrect and the links are the same, here's how it looks after

![image](https://user-images.githubusercontent.com/8244919/45637934-9d856200-baa3-11e8-916f-a3a25dc337fc.png)

and on mobile :)

![image](https://user-images.githubusercontent.com/8244919/45637861-68790f80-baa3-11e8-8531-e1c0a2bc8943.png)