### PR TITLE
Replace kubernetes-users mailing list links with discuss forum link

### DIFF
--- a/content/en/docs/setup/scratch.md
+++ b/content/en/docs/setup/scratch.md
@@ -865,7 +865,7 @@ pinging or SSH-ing from one node to another.
 ### Getting Help
 
 If you run into trouble, see the section on [troubleshooting](/docs/setup/turnkey/gce/#troubleshooting), post to the
-[kubernetes-users group](https://groups.google.com/forum/#!forum/kubernetes-users), or come ask questions on [Slack](/docs/troubleshooting#slack).
+[Kubernetes Forum](https://discuss.kubernetes.io), or come ask questions on [Slack](/docs/troubleshooting#slack).
 
 ## Support Level
 

--- a/content/en/docs/setup/turnkey/gce.md
+++ b/content/en/docs/setup/turnkey/gce.md
@@ -71,7 +71,7 @@ cluster/kube-up.sh
 If you want more than one cluster running in your project, want to use a different name, or want a different number of worker nodes, see the `<kubernetes>/cluster/gce/config-default.sh` file for more fine-grained configuration before you start up your cluster.
 
 If you run into trouble, please see the section on [troubleshooting](/docs/setup/turnkey/gce/#troubleshooting), post to the
-[kubernetes-users group](https://groups.google.com/forum/#!forum/kubernetes-users), or come ask questions on [Slack](/docs/troubleshooting/#slack).
+[Kubernetes Forum](https://discuss.kubernetes.io), or come ask questions on [Slack](/docs/troubleshooting/#slack).
 
 The next few steps will show you:
 

--- a/content/en/docs/tasks/debug-application-cluster/debug-service.md
+++ b/content/en/docs/tasks/debug-application-cluster/debug-service.md
@@ -623,7 +623,7 @@ us know, so we can help investigate!
 
 Contact us on
 [Slack](/docs/troubleshooting/#slack) or
-[email](https://groups.google.com/forum/#!forum/kubernetes-users) or
+[Forum](https://discuss.kubernetes.io) or
 [GitHub](https://github.com/kubernetes/kubernetes).
 
 {{% /capture %}}

--- a/content/en/docs/tasks/debug-application-cluster/troubleshooting.md
+++ b/content/en/docs/tasks/debug-application-cluster/troubleshooting.md
@@ -84,9 +84,9 @@ these channels for localized support and info:
 - Spain: `#es-users`
 - Turkey: `#tr-users`, `#tr-events`
 
-### Mailing List
+### Forum
 
-The Kubernetes / Google Kubernetes Engine mailing list is [kubernetes-users@googlegroups.com](https://groups.google.com/forum/#!forum/kubernetes-users)
+The Kubernetes Official Forum [discuss.kubernetes.io](https://discuss.kubernetes.io)
 
 ### Bugs and Feature requests
 


### PR DESCRIPTION
This PR updates the links that currently point to the [Google Groups Kubernetes Mailing List](https://groups.google.com/forum/#!forum/kubernetes-users) to the new [discuss.kubernetes.io](https://discuss.kubernetes.io) forum. 

The mailing list has been archived and set to read only. For more information on this, see issue https://github.com/kubernetes/community/issues/2492

/cc @castrojo 