### PR TITLE
PV: Add StorageOS in the mount options supported list

### DIFF
--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -395,6 +395,7 @@ The following volume types support mount options:
 * Glusterfs
 * VsphereVolume
 * Quobyte Volumes
+* StorageOS
 
 Mount options are not validated, so mount will simply fail if one is invalid.
 


### PR DESCRIPTION
StorageOS in-tree storage plugin uses the mount options specified in the volume spec https://github.com/kubernetes/kubernetes/blob/v1.13.0-alpha.0/pkg/volume/storageos/storageos.go#L139

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> Please delete this note before submitting the pull request.
> For 1.12 Features: set Milestone to 1.12 and Base Branch to release-1.12
> Help editing and submitting pull requests:  https://deploy-preview-9510--kubernetes-io-master-staging.netlify.com/docs/contribute/start/#submit-a-pull-request.
> Help choosing which branch to use, see
> https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use.
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>

