### PR TITLE
Fix minor typo in 'Debugging Kubernetes nodes with crictl

### DIFF
--- a/content/en/docs/tasks/debug-application-cluster/crictl.md
+++ b/content/en/docs/tasks/debug-application-cluster/crictl.md
@@ -181,7 +181,7 @@ crictl exec -i -t 1f73f2d81bf98 ls
 bin   dev   etc   home  proc  root  sys   tmp   usr   var
 ```
 
-### Get a coontainer's logs
+### Get a container's logs
 
 Get all container logs:
 


### PR DESCRIPTION
This is a minor fix to a correct a typo in the documentation for [Debugging Kubernetes nodes with crictl](https://kubernetes.io/docs/tasks/debug-application-cluster/crictl/).
