### PR TITLE
Merge missing translations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DOCKER       = docker
-HUGO_VERSION = 0.47.1
+HUGO_VERSION = 0.49
 DOCKER_IMAGE = kubernetes-hugo
 DOCKER_RUN   = $(DOCKER) run --rm --interactive --tty --volume $(PWD):/src
 

--- a/config.toml
+++ b/config.toml
@@ -23,7 +23,7 @@ pygmentsStyle = "emacs"
 enableGitInfo = true
 
 # This is currently used for testing.
-disableLanguages = ["no"]
+# disableLanguages = ["no"]
 
 [blackfriday]
 hrefTargetBlank = true
@@ -142,6 +142,8 @@ description = "Production-Grade Container Orchestration"
 languageName ="Norsk"
 weight = 3
 contentDir = "content/no"
+[languages.no.params]
+time_format_blog = "02.01.2006"
 # A list of language codes to look for untranslated content, ordered from left to right.
 language_alternatives = ["en"]
 

--- a/config.toml
+++ b/config.toml
@@ -22,8 +22,8 @@ pygmentsStyle = "emacs"
 # Enable Git variables like commit, lastmod
 enableGitInfo = true
 
-# This is currently used for testing.
-# disableLanguages = ["no"]
+# Norwegian ("no") is sometimes but not currently used for testing.
+disableLanguages = ["no"]
 
 [blackfriday]
 hrefTargetBlank = true

--- a/content/no/blog/_index.md
+++ b/content/no/blog/_index.md
@@ -1,0 +1,4 @@
+---
+title: Kubernetes Blogg
+linkTitle: Blogg
+---

--- a/content/no/blog/_posts/2018-09-06-2018-steering-committee-election-cycle-kicks-off.md
+++ b/content/no/blog/_posts/2018-09-06-2018-steering-committee-election-cycle-kicks-off.md
@@ -1,0 +1,6 @@
+---
+title:  '2018 Norsk oversettelse'
+date:   2018-09-06
+---
+
+Norsk oversettelse.

--- a/content/no/case-studies/_index.md
+++ b/content/no/case-studies/_index.md
@@ -1,4 +1,8 @@
 ---
 title: Eksempler på Kubernetes-bruk
+linkTitle: Kubernetes-brukere
+class: gridPage
+cid: caseStudies
+
 
 ---

--- a/content/no/case-studies/adform/index.html
+++ b/content/no/case-studies/adform/index.html
@@ -1,0 +1,115 @@
+---
+title: Adform bruker-historie
+linkTitle: Adform
+case_study_styles: true
+cid: caseStudies
+css: /css/style_case_studies.css
+featured: true
+weight: 47
+quote: Her er en norsk oversettelse.
+---
+
+<div class="banner1 desktop" style="background-image: url('/images/CaseStudy_adform_banner1.jpg')">
+  <h1> CASE STUDY:<img src="/images/adform_logo.png" style="width:15%;margin-bottom:0%" class="header_logo"><br> <div class="subhead">Improving Performance and Morale with Cloud Native
+
+</div></h1>
+
+</div>
+
+<div class="details">
+    Company &nbsp;<b>AdForm</b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Location &nbsp;<b>Copenhagen, Denmark</b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Industry &nbsp;<b>Adtech</b>
+</div>
+
+<hr>
+<section class="section1">
+<div class="cols">
+  <div class="col1">
+    <h2>Challenge</h2>
+    <a href="https://site.adform.com/">Adform’s</a> mission is to provide a secure and transparent full stack of advertising technology to enable digital ads across devices. The company has a large infrastructure: <a href="https://www.openstack.org/">OpenStack</a>-based private clouds running on 1,100 physical servers in 7 data centers around the world, 3 of which were opened in the past year. With the company’s growth, the infrastructure team felt that "our private cloud was not really flexible enough," says IT System Engineer Edgaras Apšega. "The biggest pain point is that our developers need to maintain their virtual machines, so rolling out technology and new software takes time. We were really struggling with our releases, and we didn’t have self-healing infrastructure."
+
+
+<br>
+
+ <h2>Solution</h2>
+    The team, which had already been using <a href="https://prometheus.io/">Prometheus</a> for monitoring, embraced <a href="https://kubernetes.io/">Kubernetes</a> and cloud native practices in 2017. "To start our Kubernetes journey, we had to adapt all our software, so we had to choose newer frameworks," says Apšega. "We also adopted the microservices way, so observability is much better because you can inspect the bug or the services separately."
+
+
+</div>
+
+<div class="col2">
+
+<h2>Impact</h2>
+ "Kubernetes helps our business a lot because our features are coming to market faster," says Apšega. The release process went from several hours to several minutes. Autoscaling has been at least 6 times faster than the semi-manual VM bootstrapping and application deployment required before. The team estimates that the company has experienced cost savings of 4-5x due to less hardware and fewer man hours needed to set up the hardware and virtual machines, metrics, and logging. Utilization of the hardware resources has been reduced as well, with containers notching 2-3 times more efficiency over virtual machines. "The deployments are very easy because developers just push the code and it automatically appears on Kubernetes," says Apšega. Prometheus has also had a positive impact: "It provides high availability for metrics and alerting. We monitor everything starting from hardware to applications. Having all the metrics in <a href="https://grafana.com/">Grafana</a> dashboards provides great insight on your systems."
+
+
+</div>
+
+</div>
+</section>
+<div class="banner2">
+  <div class="banner2text">
+"Kubernetes enabled the self-healing and immutable infrastructure. We can do faster releases, so our developers are really happy. They can ship our features faster than before, and that makes our clients happier."<span style="font-size:14px;letter-spacing:0.12em;padding-top:20px;text-transform:uppercase;line-height:14px"><br><br>— Edgaras Apšega, IT Systems Engineer, Adform</span>
+
+  </div>
+</div>
+
+
+<section class="section2">
+<div class="fullcol">
+<h2>Adform made <a href="https://www.wsj.com/articles/fake-ad-operation-used-to-steal-from-publishers-is-uncovered-1511290981">headlines</a> last year when it detected the HyphBot ad fraud network that was costing some businesses hundreds of thousands of dollars a day.</h2>With its mission to provide a secure and transparent full stack of advertising technology to enable an open internet, Adform published a <a href="https://site.adform.com/media/85132/hyphbot_whitepaper_.pdf">white paper</a> revealing what it did—and others could too—to limit customers’ exposure to the scam. <br><br>
+In that same spirit, Adform is sharing its cloud native journey. "When you see that everyone shares their best practices, it inspires you to contribute back to the project," says IT Systems Engineer Edgaras Apšega.<br><br>
+The company has a large infrastructure: <a href="https://www.openstack.org/">OpenStack</a>-based private clouds running on 1,100 physical servers in their own seven data centers around the world, three of which were opened in the past year. With the company’s growth, the infrastructure team felt that "our private cloud was not really flexible enough," says Apšega. "The biggest pain point is that our developers need to maintain their virtual machines, so rolling out technology and new software really takes time. We were really struggling with our releases, and we didn’t have self-healing infrastructure."
+
+
+</div>
+</section>
+<div class="banner3" style="background-image: url('/images/CaseStudy_adform_banner3.jpg')">
+  <div class="banner3text">
+    "The fact that Cloud Native Computing Foundation incubated Kubernetes was a really big point for us because it was vendor neutral. And we can see that a community really gathers around it. Everyone shares their experiences, their knowledge, and the fact that it’s open source, you can contribute."<span style="font-size:14px;letter-spacing:0.12em;padding-top:20px;text-transform:uppercase;line-height:14px"><br><br>— Edgaras Apšega, IT Systems Engineer, Adform</span>
+  </div>
+</div>
+<section class="section3">
+<div class="fullcol">
+
+The team, which had already been using Prometheus for monitoring, embraced Kubernetes, microservices, and cloud native practices. "The fact that Cloud Native Computing Foundation incubated Kubernetes was a really big point for us because it was vendor neutral," says Apšega. "And we can see that a community really gathers around it."<br><br>
+A proof of concept project was started, with a Kubernetes cluster running on bare metal in the data center. When developers saw how quickly containers could be spun up compared to the virtual machine process, "they wanted to ship their containers in production right away, and we were still doing proof of concept," says IT Systems Engineer Andrius Cibulskis.
+Of course, a lot of work still had to be done. "First of all, we had to learn Kubernetes, see all of the moving parts, how they glue together," says Apšega. "Second of all, the whole CI/CD part had to be redone, and our DevOps team had to invest more man hours to implement it. And third is that developers had to rewrite the code, and they’re still doing it."
+<br><br>
+The first production cluster was launched in the spring of 2018, and is now up to 20 physical machines dedicated for pods throughout three data centers, with plans for separate clusters in the other four data centers. The user-facing Adform application platform, data distribution platform, and back ends are now all running on Kubernetes. "Many APIs for critical applications are being developed for Kubernetes," says Apšega. "Teams are rewriting their applications to .NET core, because it supports containers, and preparing to move to Kubernetes. And new applications, by default, go in containers."
+
+
+</div>
+</section>
+<div class="banner4" style="background-image: url('/images/CaseStudy_adform_banner4.jpg')">
+  <div class="banner4text">
+"Releases are really nice for them, because they just push their code to Git and that’s it. They don’t have to worry about their virtual machines anymore." <span style="font-size:14px;letter-spacing:0.12em;padding-top:20px;text-transform:uppercase;line-height:14px"><br><br>— Andrius Cibulskis, IT Systems Engineer, Adform</span>
+  </div>
+</div>
+
+<section class="section5">
+<div class="fullcol">
+This big push has been driven by the real impact that these new practices have had. "Kubernetes helps our business a lot because our features are coming to market faster," says Apšega. "The deployments are very easy because developers just push the code and it automatically appears on Kubernetes." The release process went from several hours to several minutes. Autoscaling is at least six times faster than the semi-manual VM bootstrapping and application deployment required before. <br><br>
+The team estimates that the company has experienced cost savings of 4-5x due to less hardware and fewer man hours needed to set up the hardware and virtual machines, metrics, and logging. Utilization of the hardware resources has been reduced as well, with containers notching two to three times more efficiency over virtual machines. <br><br>
+Prometheus has also had a positive impact: "It provides high availability for metrics and alerting," says Apšega. "We monitor everything starting from hardware to applications. Having all the metrics in Grafana dashboards provides great insight on our systems."
+
+
+
+</div>
+
+<div class="banner5">
+  <div class="banner5text">
+ "I think that our company just started our cloud native journey. It seems like a huge road ahead, but we’re really happy that we joined it." <span style="font-size:14px;letter-spacing:0.12em;padding-top:20px;text-transform:uppercase;line-height:14px"><br><br>— Edgaras Apšega, IT Systems Engineer, Adform</span>
+  </div>
+</div>
+
+<div class="fullcol">
+All of these benefits have trickled down to individual team members, whose working lives have been changed for the better. "They used to have to get up at night to re-start some services, and now Kubernetes handles all of that," says Apšega. Adds Cibulskis: "Releases are really nice for them, because they just push their code to Git and that’s it. They don’t have to worry about their virtual machines anymore." Even the security teams have been impacted. "Security teams are always not happy," says Apšega, "and now they’re happy because they can easily inspect the containers."
+The company plans to remain in the data centers for now, "mostly because we want to keep all the data, to not share it in any way," says Cibulskis, "and it’s cheaper at our scale." But, Apšega says, the possibility of using a hybrid cloud for computing is intriguing: "One of the projects we’re interested in is the <a href="https://github.com/virtual-kubelet/virtual-kubelet">Virtual Kubelet</a> that lets you spin up the working nodes on different clouds to do some computing."
+<br><br>
+Apšega, Cibulskis and their colleagues are keeping tabs on how the cloud native ecosystem develops, and are excited to contribute where they can. "I think that our company just started our cloud native journey," says Apšega. "It seems like a huge road ahead, but we’re really happy that we joined it."
+
+
+
+</div>
+
+</section>

--- a/content/no/docs/_index.md
+++ b/content/no/docs/_index.md
@@ -1,0 +1,3 @@
+---
+title: Dokumentasjon
+---

--- a/content/no/docs/contribute/_index.md
+++ b/content/no/docs/contribute/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Hjelp til med Kubernetes-dokumentasjonen"
+weight: 80
+---
+
+## Quamquam conversa
+
+Tooltip: {{< glossary_tooltip text="Pod" term_id="pod" >}}. Tooltip 2 (translated): {{< glossary_tooltip term_id="container" >}}.
+
+Capere mirabile gaudet vetitorum proturbat sponte amplexus videamus
+*exsultantemque* maenala partibus radice seris [submersum at
+vitta](http://flamine.org/nostrae) transcurrere nitidum lumina septem.
+Recentibus superas discedens duobus fessusque Stygias ubera et terrarumque
+monstri conprensus amantis Martius orbes. Ad secreta Medusae diurnis movit
+aspicite, patruo, nunc referre, abit prior ab, Est! Et esse **et** flexi
+periuria, venturis mihi finis nunc premis, citharae.
+
+> Exit relinquant testataque habet varios et Mermeros longaque incidit vestes
+> unda quae daulida. Temeraria fugant patriorum plures, stabat, in illam;
+> vilisque labori virosque; ad, nomine, vires. Hiatu occulte vindice, bracchia
+> ille sustulit adspicit data? Tibi recto flammas sine non, partes esset,
+> tendens omnes.
+
+## Ante dos Caucason stetit eadem errabat ipsa
+
+Quid videbatur nimium sonus, in tibi, contingere viriles erit! Se vitat oculi
+viginti, posse, pectus veteres. Citharae *carmina* subdidit, corruit pulcherrime
+mortalia turaque nostri aequora tempora credas repugnat loqui! Parnasi seu ument
+ea fulgore, teres **ut adamanta longis** dant spatium est *ille* prosilit iacto?

--- a/content/no/docs/home/_index.md
+++ b/content/no/docs/home/_index.md
@@ -1,0 +1,19 @@
+---
+title: Kubernetes-dokumentasjon
+layout: docsportal_home
+noedit: true
+cid: userJourneys
+css: /css/style_user_journeys.css
+display_browse_numbers: true
+linkTitle: "Dokumentasjon"
+main_menu: true
+weight: 5
+menu:
+  main:
+    title: "Dokumentasjon"
+    weight: 20
+    post: >
+      <p>Lær å bruke Kubernetes gjenom eksempler of referansedokumentasjon. Du kan også <a href="/editdocs/" data-auto-burger-exclude>hjelpe</a>!</p>
+---
+
+

--- a/content/no/docs/reference/_index.md
+++ b/content/no/docs/reference/_index.md
@@ -1,0 +1,14 @@
+---
+title: Referanse
+weight: 70
+main_menu: true
+---
+
+## Referanse 1
+
+
+## Referanse 2
+
+## Referanse 3
+
+## Referanse 4

--- a/content/no/docs/reference/glossary/container.md
+++ b/content/no/docs/reference/glossary/container.md
@@ -1,0 +1,19 @@
+---
+title: "Kontainer"
+id: container
+date: 2018-04-12
+full_link: /docs/concepts/overview/what-is-kubernetes/#why-containers
+short_description: >
+  En lett-vekts kontainer med alle avhengigheter.
+
+aka: 
+tags:
+- fundamental
+- workload
+---
+ En lett-vekts kontainer med alle avhengigheter.
+
+<!--more--> 
+
+Mer tekst her.
+

--- a/content/no/docs/reference/glossary/index.md
+++ b/content/no/docs/reference/glossary/index.md
@@ -1,0 +1,4 @@
+---
+title: "Ordliste"
+layout: glossary
+---

--- a/content/no/docs/setup/_index.md
+++ b/content/no/docs/setup/_index.md
@@ -1,0 +1,8 @@
+---
+no_issue: true
+weight: 30
+title: Oppsett
+main_menu: true
+---
+
+Dette er en midlertidig norsk oversettelse.

--- a/content/no/docs/setup/pick-right-solution.md
+++ b/content/no/docs/setup/pick-right-solution.md
@@ -1,0 +1,6 @@
+---
+title: Å velge den rette løsningen
+weight: 10
+---
+
+Dette er en midlertidig norsk oversettelse.

--- a/content/no/docs/tutorials/kubernetes-basics/_index.md
+++ b/content/no/docs/tutorials/kubernetes-basics/_index.md
@@ -1,0 +1,5 @@
+---
+title: Grunnleggende Kubernetes
+linkTitle: Prøv Kubernetes
+weight: 10
+---

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -45,6 +45,21 @@ other = """The Kubernetes Authors | Documentation Distributed under <a href="htt
 [main_copyright_notice]
 other = """The Linux Foundation &reg;. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage" class="light-text">Trademark Usage page</a>"""
 
+# Labels for the docs portal home page.
+[docs_label_browse]
+other = "Browse Docs"
+
+[docs_label_contributors]
+other = "Contributors"
+
+[docs_label_users]
+other = "Users"
+
+[docs_label_i_am]
+other = "I AM..."
+
+
+
 # Community links
 [community_twitter_name]
 other = "Twitter"

--- a/i18n/no.toml
+++ b/i18n/no.toml
@@ -45,6 +45,10 @@ other = """Kubernetes-forfatterene | Dokumentasjonen er utgitt med <a href="http
 [main_copyright_notice]
 other = """The Linux Foundation &reg;. Alle retter er reservert. The Linux Foundation har registrerte varemerker. For en oversikt, se <a href="https://www.linuxfoundation.org/trademark-usage" class="light-text">Bruk av varemerker</a>"""
 
+# Labels for the docs portal home page.
+[docs_label_browse]
+other = "All dokumentasjon"
+
 # Community links
 [community_twitter_name]
 other = "Twitter"

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -1,5 +1,14 @@
 {{ define "main" }}
-	{{ range (.Paginator 1).Pages }}
+	{{ $pages := ($.Paginator 1).Pages }}
+	{{ with $.Site.Params.language_alternatives }}
+	{{ range . }}
+          {{ with (where $.Translations ".Lang" . ) }}
+          {{ $p := index . 0 }}
+          {{ $pages = $pages | lang.Merge ($p.Paginator 1).Pages }}
+          {{ end }}
+          {{ end }}
+	{{ end }}
+	{{ range $pages }}
 	{{ .Render "post" }}
 	{{ end }}
 	<div class="PageNavigation">

--- a/layouts/case-studies/list.html
+++ b/layouts/case-studies/list.html
@@ -1,11 +1,20 @@
 {{ define "main" }}
-{{ $featured := where .Pages "Params.featured" true }}
+{{ $pages := .Pages }}
+{{ with $.Site.Params.language_alternatives }}
+{{ range . }}
+       {{ with (where $.Translations ".Lang" . ) }}
+       {{ $p := index . 0 }}      
+       {{ $pages = $pages | lang.Merge $p.Pages }}
+       {{ end }}
+{{ end }}
+{{ end }}  
+{{ $featured := (where $pages "Params.featured" true).ByWeight | first 4 }}
 <section id="mainContent">
 	<main>
 		<div class="content">
 			<div class="case-studies">
 				{{ range $featured }}
-				{{ template "case-study-featured-block" . }}
+				{{ template "case-study-featured-block" (dict "ctx" $ "page" .) }}
 				{{ end }}
 			</div>
 		</div>
@@ -33,9 +42,9 @@
 {{ end }}
 <section id="users">
 	<main>
-		<h3>Kubernetes Users</h3>
+		<h3>{{ .Title }}</h3>
 		<div id="usersGrid">
-			{{ range .Pages.ByTitle }}
+			{{ range $pages.ByTitle }}
 			{{ $logo := .Resources.GetMatch "**logo*.png" }}
 			{{ $p := . }}
 			<a target="_blank" href="{{ with $p.Params.content_url }}{{ . | safeURL }}{{ else }}{{ .RelPermalink }}{{ end }}">{{ with $logo }}<img src="{{ .RelPermalink }}" alt="{{ $p.LinkTitle }}">{{ else }}
@@ -49,10 +58,11 @@
 {{ .Content }}
 {{ end }}
 {{ define "case-study-featured-block" }}
-{{ $logo := .Resources.GetMatch "**{feature,logo}*.png" }}
+{{ $isForeignLanguage := (ne .page.Lang .ctx.Lang)}}
+{{ $logo := .page.Resources.GetMatch "**{feature,logo}*.png" }}
 <div class="case-study">
 	{{ with $logo }}<img src="{{ .RelPermalink }}" alt="{{ .Title }}">{{ end }}
-	<p class="quote">"{{ .Params.quote | html }}"</p>
-	<a href="{{ .RelPermalink }}">Read about {{ .LinkTitle }}</a>
+	<p class="quote">"{{ .page.Params.quote | html }}"</p>
+	<a href="{{ .RelPermalink }}"{{ if $isForeignLanguage }} target="_blank"{{ end }}>{{ T "main_read_about"}} {{ .page.LinkTitle }}</a>
 </div>
 {{ end }}

--- a/layouts/docs/docsportal_home.html
+++ b/layouts/docs/docsportal_home.html
@@ -2,8 +2,10 @@
     {{ if not .Params.notitle }}
 	 <h1>{{ .Title }}</h1>
     {{ end }}
+    {{ if eq .Lang "en" }}
     {{ template "docs-portal-user-journey" . }}
-    {{ partial "docs/browse.html" (where .Parent.Sections ".Params.toc_hide" "!=" true) }}
+    {{ end }}
+    {{ partial "docs/browse.html" .Parent }}
 {{ end }}
 
 {{ define "content-id" }}content{{ end }}
@@ -54,13 +56,13 @@
 </div>
 
 <div class="paths">
-    <div class="navButton users">Users</div>
-    <div class="navButton contributors">Contributors</div>
-    <a> <div class="navButton browse">Browse Docs</div></a>
+    <div class="navButton users">{{ T "docs_label_users" }}</div>
+    <div class="navButton contributors">{{ T "docs_label_contributors" }}</div>
+    <a> <div class="navButton browse">{{ T "docs_label_browse" }}</div></a>
 </div>
 
 <div id="cardWrapper">
-  <div class="display-bar">I AM...</div>
+  <div class="display-bar">{{ T "docs_label_i_am" }}</div>
   <div class='cards' markdown="1">
   <div class='docsection1' id='persona-definition'>.</div>
   </div>

--- a/layouts/docs/glossary.html
+++ b/layouts/docs/glossary.html
@@ -26,8 +26,10 @@
 	<span class="tag-option"><a id="deselect-all-tags" href="javascript:void(0)">Deselect all</a></span>
 </div>
 <p>Click on the <a href="javascript:void(0)" class="no-underline">[+]</a> indicators below to get a longer explanation for any particular term.</p>
-{{ $glossary_terms :=  (.Site.GetPage "page" "docs/reference/glossary").Resources.ByType "page" }}
-{{ $glossary_terms := sort $glossary_terms "Title" "asc" }}
+{{ partial "docs/glossary-terms.html" . }}
+{{ $glossary_items := $.Scratch.Get "glossary_items" }}
+{{ with $glossary_items }}
+{{ $glossary_terms := sort . "Title" "asc" }}
 <ul>
 	{{ range $glossary_terms }}
 	{{ $.Scratch.Set "tag_classes" "" }}
@@ -52,5 +54,6 @@
 	</li>
 	{{ end }}
 </ul>
+{{ end }}
 {{ end }}
 

--- a/layouts/partials/blog/archive.html
+++ b/layouts/partials/blog/archive.html
@@ -1,5 +1,14 @@
+{{ $pages := .CurrentSection.Pages }}
+{{ with $.Site.Params.language_alternatives }}
+  {{ range . }}
+          {{ with (where $.CurrentSection.Translations ".Lang" . ) }}
+          {{ $p := index . 0 }}      
+          {{ $pages = $pages | lang.Merge $p.Pages }}
+          {{ end }}
+  {{ end }}
+ {{ end }}  
 <div class="panel-group" id="blog-archive">
-  {{ range $i, $e := .CurrentSection.Pages.GroupByPublishDate "2006" }}
+  {{ range $i, $e := $pages.GroupByPublishDate "2006" }}
   <div class="panel panel-default">
     <div class="panel-heading">
       <h4 class="panel-title">
@@ -11,7 +20,8 @@
       <div class="panel-body">
         <ul class="list-group">
           {{ range .Pages }}
-          <li class="list-group-item"><a href="{{ .Permalink }}">{{ .LinkTitle }}</a> <span class="date">{{ .PublishDate.Format "Jan 2" }}</span> </li>
+          {{ $isForeignLanguage := (ne .Lang $.Lang)}}
+          <li class="list-group-item"><a href="{{ .Permalink }}"{{ if $isForeignLanguage }} target="_blank" {{ end }}>{{ .LinkTitle }}</a> <span class="date">{{ .PublishDate.Format "Jan 2" }}</span>{{ if $isForeignLanguage }} <small>({{ .Lang | upper }})</small>{{ end }}</li>
           {{ end }}
         </ul>
       </div>

--- a/layouts/partials/docs/browse.html
+++ b/layouts/partials/docs/browse.html
@@ -1,22 +1,31 @@
 
 <div id='browsedocsWrapper'>
 <div class="browseheader" id="browsedocs">
-    <a name="browsedocs">Browse Docs</a>
+    <a name="browsedocs">{{ T "docs_label_browse" }}</a>
   </div>
 <div class="browsedocs">
-{{ range . }}
-{{ template "docs-browse-section"  . }}
-{{ end }}
+{{ template "docs-browse-section" (dict "ctx" . "page" .) }}
 </div><!-- end browsedocs -->
 
-
 {{ define "docs-browse-section" }}
+{{ $pages := .page.Pages }}
+{{ $sections := .page.Sections }}
+{{ with $.ctx.Site.Params.language_alternatives }}
+  {{ range . }} 
+    {{ with (where $.page.Translations ".Lang" . ) }}
+    {{ $p := index . 0 }}
+    {{ $pages =  $pages | lang.Merge $p.Pages }}
+    {{ $sections =  $sections | lang.Merge $p.Sections }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+{{ $pages := where $pages ".Params.toc_hide" "!=" true }}
+{{ $sections := where $sections ".Params.toc_hide" "!=" true }}
+{{ if not .page.Parent.IsHome }}
 <div class="browsesection">
   <div class="docstitle">
-    <h3><a href="{{ .RelPermalink }}">{{ .Params.bigheader | default .Title }}</a></h3>
+    <h3><a href="{{ .page.RelPermalink }}">{{ .page.Params.bigheader | default .page.Title }}</a></h3>
   </div>
-  {{ $pages := .Pages | union .Sections }}
-  {{ $pages := where $pages ".Params.toc_hide" "!=" true }}
   {{ if ge (len $pages) 1 }}
   <div class="pages">
   {{ $num_pages := len $pages }}
@@ -27,7 +36,8 @@
     {{ if eq $offset 1 }}
       <div class="browsecolumn">
     {{ end }}
-    <a href="{{ .RelPermalink }}">{{ printf "%02d - %s" (add $i 1) .LinkTitle }}</a><br>
+    {{ $isForeignLanguage := (ne .Lang $.ctx.Lang)}}
+    <a href="{{ .RelPermalink }}"{{ if $isForeignLanguage }} target="_blank" {{ end }}>{{ printf "%02d - %s" (add $i 1) .LinkTitle }}{{ if $isForeignLanguage }} <small>({{ .Lang | upper }})</small>{{ end }}</a><br>
     {{ if or (eq $offset $column_size) (eq (add $i 1) $num_pages)}}
       </div>
     {{ end }}
@@ -36,4 +46,8 @@
   </div><!-- end pages -->
   {{ end }}
 </div><!-- end browsesection -->
+{{ end }}
+{{ range $sections.ByWeight }}
+{{ template "docs-browse-section" (dict "ctx" $.ctx "page" .)  }}
+{{ end }}
 {{ end }}

--- a/layouts/partials/docs/glossary-terms.html
+++ b/layouts/partials/docs/glossary-terms.html
@@ -1,0 +1,13 @@
+{{ $glossaryBundle := .Site.GetPage "page" "docs/reference/glossary" }}
+{{- if $glossaryBundle -}}
+	{{ $pages := $glossaryBundle.Resources.ByType "page" }}
+	{{- range $.Site.Params.language_alternatives -}}
+		{{- with (where $glossaryBundle.Translations ".Lang" . ) -}}
+		{{ $p := (index . 0) }}
+		{{ $pages = $pages | lang.Merge ($p.Resources.ByType "page") }}
+		{{ end }}
+	{{ end }}
+	{{- $.Scratch.Set "glossary_items"  $pages -}}
+{{- else -}}
+{{- errorf "[%s] Glossary Bundle not found for language. Create at least an index.md file inside docs/reference/glossary" .Page.Site.Language.Lang -}}
+{{- end -}}

--- a/layouts/partials/tree.html
+++ b/layouts/partials/tree.html
@@ -1,27 +1,37 @@
 <a class="item" data-title="{{ .LinkTitle }}" href="{{ .RelPermalink }}"></a>
-{{ template "section-tree-nav" . }}
+{{ template "section-tree-nav" (dict "ctx" . "section" .) }}
 {{ define "section-tree-nav" }}
-	{{ $sections := where (union .Pages .Sections).ByWeight ".Params.toc_hide" "!=" true }}
+	{{ $pages :=  (union .section.Pages .section.Sections) }}
+	{{ with $.ctx.Site.Params.language_alternatives }}
+		{{ range . }}	
+			{{ with (where $.section.Translations ".Lang" . ) }}
+			{{ $p := index . 0 }}
+			{{ $pages =  $pages | lang.Merge (union $p.Pages $p.Sections) }}
+			{{ end }}
+		{{ end }}
+	{{ end }}
+	{{ $sections := where $pages.ByWeight ".Params.toc_hide" "!=" true }}
 	{{ range $sections }}
 		{{ if .IsPage }}
-		{{ template "section-tree-nav-page" . }}
+			{{ template "section-tree-nav-page"  (dict "ctx" $.ctx "page" .) }}
 		{{ else }}
-		{{ template "section-tree-nav-section" . }}
+			{{ template "section-tree-nav-section" (dict "ctx" $.ctx "section" .) }}
 		{{ end }}
 	{{ end }}
 {{ end }}
 {{ define "section-tree-nav-section" }}
-	<div class="item" data-title="{{ .LinkTitle }}">
-		<div class="container">
-		{{ if ge (len .Content) 10 }}
+<div class="item" data-title="{{ .section.LinkTitle }}">
+	<div class="container">
+		{{ if ge (len .section.Content) 10 }}
 		{{/* The section page has content, so link to it. */}}
-		<a class="item" data-title="{{ .LinkTitle }}" href="{{ .RelPermalink }}"></a>
+		{{ $isForeignLanguage := (ne .section.Lang $.ctx.Lang)}}
+		<a class="item" {{ if $isForeignLanguage }}target="_blank" {{ end }}data-title="{{ .section.LinkTitle }}{{ if $isForeignLanguage }} <small>({{ .section.Lang | upper }})</small>{{ end }}" href="{{ .section.RelPermalink }}"></a>
 		{{ end }}
 		{{ template "section-tree-nav" . }}
-		</div>
 	</div>
+</div>
 {{ end }}
 {{ define "section-tree-nav-page" }}
-<a class="item" data-title="{{ .LinkTitle }}" href="{{ .RelPermalink }}"></a>
+{{ $isForeignLanguage := (ne .page.Lang $.ctx.Lang)}}
+<a class="item" {{ if $isForeignLanguage }}target="_blank" {{ end }}data-title="{{ .page.LinkTitle }}{{ if $isForeignLanguage }} <small>({{ .page.Lang | upper }})</small>{{ end }}" href="{{ .page.RelPermalink }}"></a>
 {{ end }}
-

--- a/layouts/shortcodes/glossary_tooltip.html
+++ b/layouts/shortcodes/glossary_tooltip.html
@@ -1,8 +1,11 @@
 {{- $id := .Get "term_id" -}}
 {{- $text := .Get "text" -}}
-{{- $glossaryBundle := .Site.GetPage "page" "docs/reference/glossary" -}}
-{{- $glossaryItems :=  $glossaryBundle.Resources.ByType "page" -}}
-{{- $term_info := $glossaryItems.GetMatch (printf "%s*" $id ) -}}
+{{- partial "docs/glossary-terms.html" $.Page -}}
+{{- $glossary_items := $.Page.Scratch.Get "glossary_items" -}}
+{{- if not $glossary_items -}}
+{{- errorf "[%s] No glossary items found" .Page.Site.Language.Lang -}}
+{{- else -}}
+{{- $term_info := $glossary_items.GetMatch (printf "%s*" $id ) -}}
 {{- if not $term_info -}}
 {{- errorf "[%s] %q: %q is not a valid glossary term_id, see ./docs/reference/glossary/* for a full list" .Page.Site.Language.Lang .Page.Path $id -}}
 {{- end }}
@@ -19,4 +22,5 @@
   {{- $tooltip | safeHTML -}}
 	</span>
 </a>
+{{- end -}}
 {{- end -}}

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@ publish = "public"
 command = "make non-production-build"
 
 [build.environment]
-HUGO_VERSION = "0.47.1"
+HUGO_VERSION = "0.49"
 
 [context.production.environment]
 HUGO_BASEURL = "https://kubernetes.io/"

--- a/resources/_gen/assets/sass/sass/styles.sass_a6e533854c4de092afe9278041939937.content
+++ b/resources/_gen/assets/sass/sass/styles.sass_a6e533854c4de092afe9278041939937.content
@@ -1,0 +1,1925 @@
+html, body {
+  margin: 0;
+  padding: 0; }
+
+input, button {
+  outline: none; }
+
+button {
+  cursor: pointer; }
+
+ul, li {
+  list-style: none; }
+
+ul {
+  margin: 0;
+  padding: 0; }
+
+a {
+  text-decoration: none; }
+
+.clear {
+  display: block;
+  clear: both; }
+
+.light-text {
+  color: white; }
+
+.right {
+  float: right; }
+
+.left {
+  float: left; }
+
+.center {
+  text-align: center; }
+
+*, .button {
+  box-sizing: border-box;
+  font-family: "Roboto", sans-serif;
+  background: none;
+  margin: 0;
+  border: 0; }
+
+body {
+  font-family: "Roboto", sans-serif; }
+
+h1, h2, h5, p {
+  font-weight: 300; }
+
+h3, h4 {
+  font-weight: 400; }
+
+html, body {
+  margin: 0;
+  padding: 0; }
+
+input, button {
+  outline: none; }
+
+button {
+  cursor: pointer; }
+
+ul, li {
+  list-style: none; }
+
+ul {
+  margin: 0;
+  padding: 0; }
+
+a {
+  text-decoration: none; }
+
+.clear {
+  display: block;
+  clear: both; }
+
+.light-text {
+  color: white; }
+
+.right {
+  float: right; }
+
+.left {
+  float: left; }
+
+.center {
+  text-align: center; }
+
+h1 {
+  font-size: 32px;
+  line-height: 40px; }
+
+h2 {
+  font-size: 28px;
+  line-height: 60px; }
+
+h3 {
+  font-size: 24px;
+  line-height: 32px; }
+
+h4 {
+  font-size: 20px;
+  line-height: 40px; }
+
+h5 {
+  font-size: 16px;
+  line-height: 36px; }
+
+p {
+  font-size: 14px;
+  line-height: 22px; }
+
+section, header, #vendorStrip {
+  padding-left: 20px;
+  padding-right: 20px; }
+  section main, header main, #vendorStrip main {
+    width: 100%;
+    max-width: 100%; }
+
+header {
+  height: 80px; }
+
+.nav-buttons {
+  height: 80px;
+  line-height: 80px; }
+  .nav-buttons .button + * {
+    margin-left: 30px; }
+
+#hamburger {
+  width: 50px;
+  height: 50px; }
+
+#mainNav {
+  padding: 140px 0 30px; }
+  #mainNav h5 {
+    margin-bottom: 1em; }
+  #mainNav h3 {
+    margin-bottom: 0.6em; }
+  #mainNav .nav-box {
+    width: 20%; }
+  #mainNav .nav-box + .nav-box {
+    margin-left: calc(20% / 3); }
+  #mainNav main + main {
+    margin-top: 60px; }
+  #mainNav .left .button {
+    height: 50px;
+    line-height: 50px;
+    font-size: 18px; }
+
+.open-nav #tryKubernetes, .y-enough #tryKubernetes {
+  margin-left: 30px; }
+
+#hero {
+  padding-top: 80px; }
+
+#docs #hero h1, #docs #hero h5 {
+  padding-left: 20px;
+  padding-right: 20px; }
+
+#vendorStrip {
+  height: 88px;
+  line-height: 88px;
+  font-size: 16px; }
+
+body {
+  background-color: white; }
+
+section {
+  position: relative;
+  background-color: white; }
+
+section main, header main, footer main {
+  position: relative;
+  margin: auto; }
+
+p {
+  font-size: 14px;
+  font-weight: 400; }
+
+.button {
+  display: inline-block;
+  border-radius: 6px;
+  padding: 0 20px;
+  line-height: 40px;
+  color: white;
+  background-color: #3371e3;
+  text-decoration: none; }
+
+#cellophane {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: none; }
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 8888;
+  background-color: transparent;
+  box-shadow: 0 0 0 transparent;
+  overflow: hidden;
+  transition: 0.3s;
+  text-align: center; }
+
+.logo {
+  position: relative;
+  float: left;
+  display: block;
+  width: 180px;
+  height: 88px;
+  top: 0;
+  left: 0;
+  transform: none;
+  background-image: url(/images/nav_logo.svg);
+  background-size: contain;
+  background-position: center center;
+  background-repeat: no-repeat; }
+
+#docs .flyout-button {
+  position: fixed;
+  top: 20px;
+  left: 20px;
+  width: 50px;
+  height: 50px;
+  background-image: url(/images/toc_icon.png);
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-size: auto;
+  border-radius: 50%;
+  transition: 0.3s;
+  z-index: 99999; }
+
+#docs.open-nav .flyout-button {
+  display: none; }
+
+#docs .logo {
+  position: absolute;
+  top: 40px;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: block;
+  width: 45px;
+  height: 44px;
+  background-image: url(/images/favicon.png); }
+
+#docs.flip-nav .flyout-button {
+  background-image: url(/images/toc_icon_grey.png); }
+
+.nav-buttons {
+  float: right; }
+
+#viewDocs, #tryKubernetes {
+  display: none; }
+
+#viewDocs {
+  border: 2px solid white;
+  background-color: transparent;
+  transition: 0.3s; }
+  #viewDocs:hover {
+    background-color: white;
+    color: #303030; }
+
+#tryKubernetes {
+  width: 0;
+  padding: 0 0;
+  border: 1px solid transparent;
+  background-color: transparent;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: middle;
+  overflow: hidden;
+  transition: 0.3s; }
+
+#hamburger {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  padding: 0;
+  border: 0;
+  background: none; }
+  #hamburger div, #hamburger:before, #hamburger:after {
+    position: absolute;
+    left: 15%;
+    width: 70%;
+    height: 2px;
+    background-color: #3371e3;
+    transition: 0.3s;
+    content: ""; }
+  #hamburger div {
+    top: calc(50% - 1px); }
+  #hamburger:before {
+    top: 24%; }
+  #hamburger:after {
+    bottom: 24%; }
+  #hamburger:hover div, #hamburger:hover:before, #hamburger:hover:after {
+    background-color: white; }
+
+#mainNav h5 {
+  color: #3371e3;
+  font-weight: normal; }
+
+#mainNav main {
+  white-space: nowrap;
+  overflow: hidden;
+  clear: both; }
+
+#mainNav .nav-box {
+  float: left;
+  white-space: normal; }
+
+#mainNav h3 a {
+  color: #3371e3;
+  text-decoration: none; }
+
+ul.global-nav {
+  display: none; }
+  ul.global-nav li {
+    display: inline-block;
+    margin-right: 14px; }
+    ul.global-nav li a {
+      color: #fff;
+      font-weight: 400;
+      padding: 0;
+      position: relative; }
+      ul.global-nav li a.active:after {
+        position: absolute;
+        width: 100%;
+        height: 2px;
+        content: '';
+        bottom: -4px;
+        left: 0;
+        background: #fff; }
+      ul.global-nav li a .ui-icon {
+        filter: brightness(0) invert(1); }
+    ul.global-nav li ul {
+      display: none;
+      position: fixed;
+      top: 40px;
+      text-align: left; }
+      ul.global-nav li ul li {
+        display: block;
+        height: 28px; }
+        ul.global-nav li ul li a {
+          background: #303030;
+          color: #fff;
+          padding: 7px; }
+      ul.global-nav li ul li:last-child a {
+        border-radius: 7px; }
+  ul.global-nav li:hover ul {
+    display: block; }
+
+.flip-nav ul.global-nav li a,
+.open-nav ul.global-nav li a {
+  color: #303030; }
+
+.flip-nav ul.global-nav li a .ui-icon {
+  filter: brightness(0); }
+
+.flip-nav ul.global-nav li ul li a {
+  background: #fff;
+  color: #303030; }
+
+.flip-nav ul.global-nav li a.active:after,
+.flip-nav ul.global-nav li ul li a.active:after,
+.open-nav ul.global-nav li a.active:after {
+  background: #3371e3; }
+
+.flip-nav header {
+  background-color: white; }
+
+.open-nav body {
+  overflow: hidden; }
+
+.open-nav #cellophane {
+  display: block;
+  z-index: 9998; }
+
+.open-nav header {
+  background-color: #e8e8e8;
+  z-index: 9999; }
+
+.open-nav #hamburger div {
+  opacity: 0; }
+
+.open-nav #hamburger:before, .open-nav #hamburger:after {
+  left: 12px;
+  transform-origin: 0 1px; }
+
+.open-nav #hamburger:before {
+  transform: rotate(45deg); }
+
+.open-nav #hamburger:after {
+  transform: rotate(-45deg); }
+
+.open-nav #tryKubernetes, .y-enough #tryKubernetes {
+  width: 150px;
+  background-color: #3371e3;
+  border-color: #3371e3; }
+
+.flip-nav header, .open-nav header {
+  box-shadow: 0 1px 2px #4c4c4c; }
+
+.flip-nav #viewDocs, .open-nav #viewDocs {
+  border-color: #303030;
+  color: #303030; }
+  .flip-nav #viewDocs:hover, .open-nav #viewDocs:hover {
+    border-color: #3371e3;
+    background-color: #3371e3;
+    color: white; }
+
+.flip-nav #hamburger:hover div, .flip-nav #hamburger:hover:before, .flip-nav #hamburger:hover:after, .open-nav #hamburger:hover div, .open-nav #hamburger:hover:before, .open-nav #hamburger:hover:after {
+  background-color: #303030; }
+
+#hero {
+  background-image: url(/images/texture.png);
+  background-color: #303030;
+  text-align: center;
+  padding-left: 0;
+  padding-right: 0;
+  margin-bottom: 0;
+  position: relative; }
+  #hero.bot-bar:after {
+    display: block;
+    margin-bottom: -20px;
+    height: 8px;
+    width: 100%;
+    background-color: rgba(255, 255, 255, 0.1);
+    content: ''; }
+  #hero.no-sub h5 {
+    display: none; }
+  #hero.no-sub h1 {
+    margin-bottom: 20px; }
+
+#home #hero:after {
+  display: none; }
+
+#vendorStrip {
+  position: relative;
+  background-color: rgba(255, 255, 255, 0.1);
+  font-weight: 100;
+  white-space: nowrap;
+  text-align: center; }
+  #vendorStrip li a {
+    color: rgba(255, 255, 255, 0.5); }
+    #vendorStrip li a.YAH {
+      color: white;
+      position: relative; }
+
+footer {
+  width: 100%;
+  background-image: url(/images/texture.png);
+  background-color: #303030; }
+  footer main {
+    padding: 20px 0; }
+  footer nav a {
+    width: 100%;
+    text-align: center;
+    display: inline-block;
+    margin: 10px 0;
+    font-size: 24px;
+    font-weight: 300;
+    color: white;
+    text-decoration: none; }
+  footer .social {
+    margin: 20px 0; }
+    footer .social div {
+      text-align: center;
+      margin-bottom: 20px; }
+    footer .social div:last-child {
+      margin: 30px 0; }
+    footer .social span {
+      display: block;
+      margin-bottom: 8px; }
+    footer .social input {
+      text-align: center; }
+
+#search, #wishField {
+  background-color: transparent;
+  padding: 10px;
+  font-size: 16px;
+  font-weight: 100;
+  color: white;
+  border: 1px solid white;
+  transition: 0.3s; }
+  #search:focus, #wishField:focus {
+    background-color: #f7f7f7;
+    color: #303030; }
+
+.social a {
+  display: inline-block;
+  background-image: url(/images/social_sprite.png);
+  background-repeat: no-repeat;
+  background-size: auto;
+  width: 50px;
+  height: 50px;
+  border-radius: 5px;
+  margin-right: 10px; }
+  .social a:hover {
+    background-color: #fff; }
+  .social a span {
+    position: absolute;
+    display: block;
+    height: 0;
+    overflow: hidden; }
+  .social a.button {
+    background-image: none;
+    width: auto;
+    height: auto; }
+    .social a.button:hover {
+      color: #3371e3; }
+
+a.twitter {
+  background-position: 0 0; }
+  a.twitter:hover {
+    background-position: 0 100%; }
+
+a.stack-overflow {
+  background-position: -50px 0; }
+  a.stack-overflow:hover {
+    background-position: -50px 100%; }
+
+a.slack {
+  background-position: -100px 0; }
+  a.slack:hover {
+    background-position: -100px 100%; }
+
+a.github {
+  background-position: -150px 0; }
+  a.github:hover {
+    background-position: -150px 100%; }
+
+a.mailing-list {
+  background-position: -200px 0; }
+  a.mailing-list:hover {
+    background-position: -200px 100%; }
+
+a.calendar {
+  background-position: -250px 0; }
+  a.calendar:hover {
+    background-position: -250px 100%; }
+
+#viewDocs {
+  display: none; }
+
+section {
+  background-color: white; }
+
+#hero {
+  background-color: #303030; }
+  #hero h5 {
+    margin: 20px 0;
+    line-height: 28px; }
+
+#vendorStrip {
+  position: relative; }
+  #vendorStrip ul {
+    float: left; }
+  #vendorStrip li {
+    display: inline-block;
+    height: 100%; }
+  #vendorStrip a {
+    display: block;
+    height: 100%;
+    color: white;
+    font-size: 0.75em;
+    font-weight: bold; }
+  #vendorStrip li + li {
+    margin-left: 0; }
+
+#docs #vendorStrip {
+  line-height: 44px; }
+  #docs #vendorStrip ul {
+    float: none; }
+  #docs #vendorStrip #searchBox {
+    float: none;
+    display: block;
+    width: 80%;
+    margin: 0 auto;
+    height: 44px;
+    line-height: 44px;
+    position: relative; }
+    #docs #vendorStrip #searchBox:before {
+      position: absolute;
+      width: 15px;
+      height: 15px;
+      content: '';
+      right: 8px;
+      top: 7px;
+      background-image: url(/images/search-icon.svg);
+      background-repeat: no-repeat;
+      background-size: 100% 100%;
+      z-index: 1; }
+  #docs #vendorStrip #search {
+    width: 100%;
+    padding: 0 10px;
+    height: 30px;
+    line-height: 30px;
+    font-size: 16px;
+    vertical-align: top;
+    background: #fff;
+    border: none;
+    border-radius: 4px;
+    position: relative; }
+
+#encyclopedia {
+  position: relative;
+  padding: 50px 20px 20px 20px;
+  overflow: hidden;
+  font-size: 14px; }
+  #encyclopedia > div {
+    height: 100%; }
+
+#docsToc {
+  position: fixed;
+  background-color: white;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 100vh;
+  overflow: hidden;
+  padding: 50px 0;
+  z-index: 999999;
+  transition: 0.3s; }
+  #docsToc .yah > .title {
+    background-color: #f7f7f7;
+    border-left: 3px solid #3371e3;
+    padding: 7.5px 10px 7.5px 18px;
+    margin-left: -3px;
+    color: #3371e3; }
+
+.open-toc body {
+  overflow: hidden; }
+
+.open-toc #docsToc {
+  padding: 50px 20px;
+  width: 400px;
+  max-width: 100vw;
+  overflow-y: auto; }
+
+.pi-accordion > .container:first-child > .item:first-child > .title:first-child {
+  padding-left: 0;
+  font-size: 1.5em;
+  font-weight: 700; }
+
+.pi-accordion > .container:first-child > .item.yah:first-child > .title:first-child {
+  margin-left: -20px !important; }
+
+.pi-accordion .item {
+  overflow: hidden; }
+
+.pi-accordion .title {
+  color: #303030;
+  position: relative;
+  padding: 7.5px 10px 7.5px 18px;
+  cursor: pointer;
+  transition: 0.3s; }
+  .pi-accordion .title:hover {
+    color: #3371e3; }
+
+.pi-accordion a.item > .title {
+  color: black; }
+  .pi-accordion a.item > .title:hover {
+    color: #3371e3; }
+
+.pi-accordion div.item > .title:before {
+  content: "";
+  position: absolute;
+  top: 12px;
+  left: 2px;
+  border-style: solid;
+  border-width: 5px 0 5px 8px;
+  border-color: transparent transparent transparent #3371e3;
+  transform: rotate(0deg);
+  transition: 0.3s; }
+
+.pi-accordion .wrapper {
+  position: relative;
+  width: 100%;
+  transition: height 0.3s; }
+
+.pi-accordion .content {
+  padding-left: 20px;
+  opacity: 0;
+  transition: 0.3s; }
+
+.pi-accordion .item.on > .title:before {
+  transform: rotate(90deg); }
+
+.pi-accordion .item.on > .wrapper > .content {
+  opacity: 1; }
+
+dt {
+  margin-bottom: 8px; }
+
+dd {
+  margin-bottom: 16px; }
+
+.pi-pushmenu {
+  display: none;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  transition: opacity 0.3s; }
+  .pi-pushmenu.on {
+    opacity: 1; }
+  .pi-pushmenu .overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.4); }
+  .pi-pushmenu .sled {
+    position: absolute;
+    top: 0;
+    width: 0;
+    height: 100%;
+    background-color: white;
+    overflow: auto;
+    transition: 0.3s; }
+  .pi-pushmenu.on .sled {
+    width: 400px;
+    max-width: 100vw; }
+  .pi-pushmenu .top-bar {
+    height: 0;
+    line-height: 60px;
+    background-color: #444; }
+  .pi-pushmenu ul {
+    margin-top: 25px; }
+  .pi-pushmenu li {
+    position: relative;
+    display: block;
+    width: 100%;
+    min-height: 45px;
+    padding: 0 60px 0 20px;
+    border-bottom: 1px solid #cccccc; }
+  .pi-pushmenu a {
+    display: inline-block;
+    width: 100%;
+    height: 45px;
+    line-height: 45px;
+    font-family: "Roboto", sans-serif;
+    font-size: 20px;
+    color: #3371e3; }
+  .pi-pushmenu .button {
+    background: none;
+    padding: 0; }
+  .pi-pushmenu ul ul {
+    padding: 0 20px; }
+    .pi-pushmenu ul ul li {
+      min-height: 40px; }
+    .pi-pushmenu ul ul a {
+      height: 40px;
+      line-height: 40px;
+      font-size: 18px;
+      color: #555555; }
+
+.push-menu-close-button {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 50px;
+  height: 50px; }
+  .push-menu-close-button:before, .push-menu-close-button:after {
+    content: "";
+    position: absolute;
+    top: calc(50% - 1px);
+    left: 25%;
+    width: 50%;
+    height: 2px;
+    background-color: black; }
+  .push-menu-close-button:before {
+    transform: rotate(45deg); }
+  .push-menu-close-button:after {
+    transform: rotate(-45deg); }
+
+#docsContent {
+  position: relative;
+  float: right;
+  width: 100%; }
+  #docsContent * + h2, #docsContent * + h3, #docsContent * + h4, #docsContent * + h5, #docsContent * + h6 {
+    margin-top: 30px; }
+  #docsContent h1, #docsContent h2, #docsContent h3, #docsContent h4, #docsContent h5, #docsContent h6 {
+    line-height: normal;
+    font-weight: 500;
+    margin-bottom: 30px;
+    padding-bottom: 10px; }
+    #docsContent h1:before, #docsContent h2:before, #docsContent h3:before, #docsContent h4:before, #docsContent h5:before, #docsContent h6:before {
+      display: block;
+      content: " ";
+      margin-top: -100px;
+      height: 100px;
+      visibility: hidden; }
+  #docsContent h1, #docsContent h2 {
+    border-bottom: 1px solid #cccccc; }
+  #docsContent h1 {
+    font-size: 32px;
+    padding-right: 60px; }
+  #docsContent h2 {
+    font-size: 28px; }
+  #docsContent h3 {
+    font-size: 24px;
+    font-weight: 300;
+    margin-bottom: 5px; }
+  #docsContent h4 {
+    font-size: 20px;
+    margin-bottom: 0px; }
+  #docsContent h5, #docsContent h6 {
+    font-size: 16px;
+    font-weight: 500; }
+  #docsContent p {
+    font-size: 16px;
+    font-weight: 300;
+    line-height: 1.75em; }
+  #docsContent p + p {
+    margin-top: 10px; }
+  #docsContent code {
+    display: inline-block;
+    box-sizing: border-box;
+    background-color: #f7f7f7;
+    color: #303030;
+    font-family: "Roboto Mono", monospace;
+    vertical-align: baseline;
+    font-size: 14px;
+    font-weight: bold;
+    padding: 2px 4px; }
+  #docsContent a code {
+    color: #3371e3;
+    text-decoration: underline; }
+  #docsContent pre .pi, #docsContent pre .s {
+    margin: 0;
+    padding: 0; }
+  #docsContent .highlight code span, #docsContent code, #docsContent pre code {
+    font-family: "Roboto Mono", monospace; }
+  #docsContent code, #docsContent pre code {
+    color: #303030; }
+  #docsContent pre code {
+    padding: 0; }
+  #docsContent pre {
+    background-color: #f7f7f7;
+    display: block;
+    margin: 20px 0;
+    padding: 15px;
+    position: relative;
+    overflow-x: auto; }
+  #docsContent h1 code, #docsContent h2 code, #docsContent h3 code, #docsContent h4 code, #docsContent h5 code, #docsContent h6 code {
+    font-size: inherit;
+    background-color: transparent; }
+  #docsContent .includecode {
+    table-layout: fixed; }
+  #docsContent .includecode, #docsContent .includecode th, #docsContent .includecode td {
+    padding: 0 !important; }
+  #docsContent .includecode th {
+    text-align: right !important;
+    padding: 10px !important; }
+  #docsContent .includecode th a, #docsContent .includecode th a code {
+    color: white !important;
+    background-color: transparent !important; }
+  #docsContent .includecode pre {
+    margin: 0 !important; }
+  #docsContent ul li {
+    list-style: disc; }
+  #docsContent ol li {
+    list-style: decimal; }
+  #docsContent ul, #docsContent ol {
+    margin: 20px 0;
+    padding-left: 30px;
+    font-weight: 300; }
+  #docsContent ul ul, #docsContent ol ol, #docsContent ul ol, #docsContent ol ul {
+    margin: 0.75em 0; }
+  #docsContent li {
+    margin-bottom: 0.75em;
+    font-size: 16px;
+    line-height: 1.75em; }
+  #docsContent table {
+    width: 100%;
+    border: 1px solid #ccc;
+    border-spacing: 0;
+    margin-top: 30px;
+    margin-bottom: 30px; }
+  #docsContent thead, #docsContent tr:nth-child(even) {
+    background-color: #f7f7f7; }
+  #docsContent thead {
+    background-color: #555;
+    color: white; }
+  #docsContent th, #docsContent td {
+    padding: 8px;
+    text-align: left;
+    margin: 0; }
+  #docsContent th {
+    font-weight: normal; }
+  #docsContent td {
+    font-size: 0.85em; }
+  #docsContent #editPageButton {
+    position: absolute;
+    top: -25px;
+    right: 5px;
+    width: 50px;
+    height: 50px;
+    line-height: 50px;
+    border-radius: 50%;
+    white-space: nowrap;
+    text-indent: 50px;
+    overflow: hidden;
+    background: #3371e3 url(/images/icon-pencil.svg) no-repeat;
+    background-position: 12px 10px;
+    background-size: 29px 29px; }
+  #docsContent #markdown-toc, #docsContent #TableOfContents {
+    margin-bottom: 20px; }
+    #docsContent #markdown-toc ul, #docsContent #markdown-toc li, #docsContent #TableOfContents ul, #docsContent #TableOfContents li {
+      list-style: disc;
+      color: #3371e3; }
+    #docsContent #markdown-toc ul, #docsContent #TableOfContents ul {
+      padding: 0 15px;
+      margin: 0; }
+    #docsContent #markdown-toc li, #docsContent #TableOfContents li {
+      padding: 0;
+      line-height: 1.5em;
+      margin-bottom: 0; }
+    #docsContent #markdown-toc a, #docsContent #TableOfContents a {
+      position: relative;
+      color: #3371e3;
+      font-weight: 700; }
+  #docsContent img {
+    max-width: 100%; }
+  #docsContent #TableOfContents > ul > li {
+    list-style: none; }
+  #docsContent #TableOfContents ul, #docsContent #TableOfContents li {
+    list-style: disk; }
+
+.fixed footer {
+  position: fixed;
+  bottom: 0; }
+
+#miceType {
+  clear: both;
+  font-size: 11px;
+  line-height: 18px;
+  color: #aaa; }
+
+html.search #docsContent {
+  position: relative;
+  float: none;
+  width: 90%;
+  max-width: 850px;
+  margin: 0 auto; }
+  html.search #docsContent #editPageButton {
+    display: none; }
+  html.search #docsContent table {
+    border: 0;
+    margin-bottom: 0; }
+  html.search #docsContent td {
+    padding: 0; }
+  html.search #docsContent h1 {
+    margin-bottom: 0;
+    border-bottom: 0;
+    padding-bottom: 0;
+    padding-left: 8px; }
+
+#home.flip-nav .logo, #home.open-nav .logo {
+  background-image: url(/images/nav_logo2.svg); }
+
+#home #hero {
+  margin-bottom: 0;
+  padding-bottom: 1px; }
+  #home #hero main {
+    padding: 0 10px;
+    margin-bottom: 30px; }
+  #home #hero #vendorStrip {
+    display: none; }
+
+#oceanNodes {
+  padding-top: 60px;
+  padding-bottom: 60px; }
+  #oceanNodes a {
+    color: #3371e3; }
+  #oceanNodes main {
+    margin-bottom: 60px;
+    min-height: 160px; }
+  #oceanNodes .image-wrapper {
+    max-width: 75%;
+    margin: 0 auto 20px;
+    text-align: center; }
+    #oceanNodes .image-wrapper img {
+      width: 100%;
+      max-width: 160px; }
+  #oceanNodes main:first-child .image-wrapper {
+    max-width: 100%; }
+    #oceanNodes main:first-child .image-wrapper img {
+      max-width: 491px; }
+  #oceanNodes h3 {
+    margin-bottom: 30px; }
+
+#video {
+  height: 200px; }
+
+#video {
+  width: 100%;
+  position: relative;
+  background-position: center center;
+  background-size: cover; }
+  #video > .light-text {
+    display: none;
+    position: absolute;
+    top: 50%;
+    left: 75%;
+    width: 525px;
+    padding-right: 80px;
+    transform: translate(-50%, -50%);
+    color: white; }
+  #video h2 {
+    font-size: 32px;
+    line-height: 44px;
+    margin-bottom: 20px; }
+  #video p {
+    margin-bottom: 20px; }
+  #video #desktopKCButton {
+    position: relative;
+    font-size: 18px;
+    background-color: #303030;
+    border-radius: 8px;
+    color: #ffffff;
+    padding: 20px 10px 20px 10px; }
+  #video #desktopShowVideoButton {
+    position: relative;
+    font-size: 24px;
+    background-color: white;
+    border-radius: 8px;
+    color: #3371e3;
+    padding: 15px 30px 15px 80px;
+    margin-bottom: 15px; }
+    #video #desktopShowVideoButton:before {
+      content: "";
+      position: absolute;
+      position: absolute;
+      top: 50%;
+      left: 40px;
+      transform: translate(-50%, -50%);
+      width: 0;
+      height: 0;
+      border-style: solid;
+      border-width: 10px 0 10px 20px;
+      border-color: transparent transparent transparent #3371e3; }
+  #video #mobileShowVideoButton {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 80px;
+    height: 80px;
+    border-radius: 50%;
+    background-color: transparent;
+    border: 5px solid rgba(255, 255, 255, 0.2);
+    overflow: visible; }
+    #video #mobileShowVideoButton:after {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      left: 40px;
+      content: "";
+      width: 0;
+      height: 0;
+      border-style: solid;
+      border-width: 20px 0 20px 30px;
+      border-color: transparent transparent transparent #ffffff; }
+
+#videoPlayer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.9);
+  display: none; }
+  #videoPlayer iframe {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 80vw;
+    height: 45vw;
+    max-width: 142.22222222vh;
+    max-height: 80vh; }
+  #videoPlayer #closeButton {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    width: 50px;
+    height: 50px;
+    border: 2px solid transparent;
+    transition: 0.3s; }
+    #videoPlayer #closeButton:before, #videoPlayer #closeButton:after {
+      content: "";
+      position: absolute;
+      top: calc(50% - 1px);
+      left: 10%;
+      width: 80%;
+      height: 2px;
+      background-color: white; }
+    #videoPlayer #closeButton:before {
+      transform: rotate(45deg); }
+    #videoPlayer #closeButton:after {
+      transform: rotate(-45deg); }
+    #videoPlayer #closeButton:hover {
+      border-color: white; }
+
+#cncf {
+  padding-top: 60px;
+  padding-bottom: 140px;
+  background-color: #f7f7f7;
+  background-image: url(/images/cncf-color.png);
+  background-position: center 100px;
+  background-repeat: no-repeat;
+  background-size: 300px; }
+
+#features {
+  padding-top: 140px;
+  background-color: #f7f7f7;
+  background-image: url(/images/wheel.png);
+  background-position: center 60px;
+  background-repeat: no-repeat;
+  background-size: auto; }
+
+.feature-box {
+  width: 100%;
+  overflow: hidden;
+  clear: both; }
+  .feature-box h4 {
+    line-height: normal;
+    margin-bottom: 15px; }
+  .feature-box > div:first-child {
+    float: left; }
+  .feature-box > div:last-child {
+    float: right; }
+
+#features h3 {
+  margin-bottom: 20px; }
+
+#features .feature-box {
+  margin-bottom: 0; }
+  #features .feature-box > div {
+    width: 100%;
+    margin-bottom: 40px; }
+
+#community.open-nav .logo, #community.flip-nav .logo, .gridPage.open-nav .logo, .gridPage.flip-nav .logo {
+  background-image: url(/images/nav_logo2.svg); }
+
+#community #hero, .gridPage #hero {
+  padding-bottom: 20px; }
+
+#community #mainContent, .gridPage #mainContent {
+  padding: 20px 0; }
+  #community #mainContent main, .gridPage #mainContent main {
+    max-width: none; }
+  #community #mainContent a, .gridPage #mainContent a {
+    color: #3371e3; }
+  #community #mainContent .content, .gridPage #mainContent .content {
+    margin-bottom: 30px;
+    padding: 30px 0; }
+    #community #mainContent .content h1, #community #mainContent .content h2, #community #mainContent .content h3, #community #mainContent .content h4, #community #mainContent .content h5, #community #mainContent .content h6, #community #mainContent .content p, .gridPage #mainContent .content h1, .gridPage #mainContent .content h2, .gridPage #mainContent .content h3, .gridPage #mainContent .content h4, .gridPage #mainContent .content h5, .gridPage #mainContent .content h6, .gridPage #mainContent .content p {
+      line-height: normal;
+      max-width: 1200px;
+      padding: 0 20px;
+      margin: 0 auto 20px; }
+    #community #mainContent .content:nth-child(even), .gridPage #mainContent .content:nth-child(even) {
+      background-color: #f7f7f7; }
+  #community #mainContent .company-logos, .gridPage #mainContent .company-logos {
+    text-align: center;
+    max-width: 1200px;
+    margin: 0 auto; }
+    #community #mainContent .company-logos img, .gridPage #mainContent .company-logos img {
+      width: auto;
+      margin: 10px;
+      background-color: #f7f7f7; }
+  #community #mainContent .partner-logos, .gridPage #mainContent .partner-logos {
+    text-align: center;
+    max-width: 1200px;
+    margin: 0 auto; }
+    #community #mainContent .partner-logos img, .gridPage #mainContent .partner-logos img {
+      width: auto;
+      margin: 10px;
+      background-color: #ffffff;
+      box-shadow: 0 5px 5px rgba(0, 0, 0, 0.24), 0 0 5px rgba(0, 0, 0, 0.12); }
+  #community #mainContent #calendarMeetings, .gridPage #mainContent #calendarMeetings {
+    position: relative;
+    width: 80vw;
+    height: 60vw;
+    max-width: 1200px;
+    max-height: 900px;
+    margin: 20px auto; }
+  #community #mainContent #calendarEvents, .gridPage #mainContent #calendarEvents {
+    position: relative;
+    width: 80vw;
+    height: 30vw;
+    max-width: 1200px;
+    max-height: 450px;
+    margin: 20px auto; }
+  #community #mainContent iframe, .gridPage #mainContent iframe {
+    position: absolute;
+    border: 0;
+    width: 100%;
+    height: 100%; }
+
+.ui-icon {
+  display: inline-block !important; }
+
+#feature-state-dialog-link {
+  text-decoration: none !important;
+  padding: 5px !important; }
+  #feature-state-dialog-link a:visited {
+    color: #454545 !important; }
+  #feature-state-dialog-link a code {
+    display: inline-block !important;
+    box-sizing: border-box !important;
+    background-color: #f7f7f7 !important;
+    color: #303030 !important;
+    font-family: "Roboto Mono", monospace !important;
+    vertical-align: baseline !important;
+    font-size: 14px !important;
+    font-weight: bold !important;
+    padding: 0px 4px !important; }
+
+#feature-state-dialog {
+  background: #fff !important;
+  border: 1px solid #ddd !important;
+  padding: 0.5em 1em !important; }
+  #feature-state-dialog ul, #feature-state-dialog li {
+    list-style: disc !important;
+    margin: 4px 12px !important; }
+  #feature-state-dialog p {
+    margin: 8px 0px !important; }
+  #feature-state-dialog code {
+    display: inline-block !important;
+    box-sizing: border-box !important;
+    background-color: #f7f7f7 !important;
+    color: #303030 !important;
+    font-family: "Roboto Mono", monospace !important;
+    vertical-align: baseline !important;
+    font-size: 14px !important;
+    font-weight: bold !important;
+    padding: 0px 4px !important; }
+
+.ui-dialog {
+  background: #f7f7f7 !important;
+  padding: 0.5em; }
+
+.ui-dialog-content {
+  position: relative;
+  float: right;
+  width: 100%; }
+  .ui-dialog-content * + h2, .ui-dialog-content * + h3, .ui-dialog-content * + h4, .ui-dialog-content * + h5, .ui-dialog-content * + h6 {
+    margin-top: 30px; }
+  .ui-dialog-content h1, .ui-dialog-content h2, .ui-dialog-content h3, .ui-dialog-content h4, .ui-dialog-content h5, .ui-dialog-content h6 {
+    line-height: normal;
+    font-weight: 500;
+    margin-bottom: 30px;
+    padding-bottom: 10px; }
+    .ui-dialog-content h1:before, .ui-dialog-content h2:before, .ui-dialog-content h3:before, .ui-dialog-content h4:before, .ui-dialog-content h5:before, .ui-dialog-content h6:before {
+      display: block;
+      content: " ";
+      margin-top: -100px;
+      height: 100px;
+      visibility: hidden; }
+  .ui-dialog-content h1, .ui-dialog-content h2 {
+    border-bottom: 1px solid #cccccc; }
+  .ui-dialog-content h1 {
+    font-size: 32px;
+    padding-right: 60px; }
+  .ui-dialog-content h2 {
+    font-size: 28px; }
+  .ui-dialog-content h3 {
+    font-size: 24px;
+    font-weight: 300;
+    margin-bottom: 5px; }
+  .ui-dialog-content h4 {
+    font-size: 20px;
+    margin-bottom: 0px; }
+  .ui-dialog-content h5, .ui-dialog-content h6 {
+    font-size: 16px;
+    font-weight: 500; }
+  .ui-dialog-content p {
+    font-size: 16px;
+    font-weight: 300;
+    line-height: 1.75em; }
+  .ui-dialog-content p + p {
+    margin-top: 10px; }
+  .ui-dialog-content code {
+    display: inline-block;
+    box-sizing: border-box;
+    background-color: #f7f7f7;
+    color: #303030;
+    font-family: "Roboto Mono", monospace;
+    vertical-align: baseline;
+    font-size: 14px;
+    font-weight: bold;
+    padding: 2px 4px; }
+  .ui-dialog-content a code {
+    color: #3371e3;
+    text-decoration: underline; }
+  .ui-dialog-content pre .pi, .ui-dialog-content pre .s {
+    margin: 0;
+    padding: 0; }
+  .ui-dialog-content .highlight code span, .ui-dialog-content code, .ui-dialog-content pre code {
+    font-family: "Roboto Mono", monospace; }
+  .ui-dialog-content code, .ui-dialog-content pre code {
+    color: #303030; }
+  .ui-dialog-content pre code {
+    padding: 0; }
+  .ui-dialog-content pre {
+    background-color: #f7f7f7;
+    display: block;
+    margin: 20px 0;
+    padding: 15px;
+    position: relative;
+    overflow-x: auto; }
+  .ui-dialog-content h1 code, .ui-dialog-content h2 code, .ui-dialog-content h3 code, .ui-dialog-content h4 code, .ui-dialog-content h5 code, .ui-dialog-content h6 code {
+    font-family: inherit;
+    font-size: inherit;
+    background-color: transparent; }
+  .ui-dialog-content .includecode {
+    table-layout: fixed; }
+  .ui-dialog-content .includecode, .ui-dialog-content .includecode th, .ui-dialog-content .includecode td {
+    padding: 0 !important; }
+  .ui-dialog-content .includecode th {
+    text-align: right !important;
+    padding: 10px !important; }
+  .ui-dialog-content .includecode th a, .ui-dialog-content .includecode th a code {
+    color: white !important;
+    background-color: transparent !important; }
+  .ui-dialog-content .includecode pre {
+    margin: 0 !important; }
+  .ui-dialog-content ul li {
+    list-style: disc; }
+  .ui-dialog-content ol li {
+    list-style: decimal; }
+  .ui-dialog-content ul, .ui-dialog-content ol {
+    margin: 20px 0;
+    padding-left: 30px;
+    font-weight: 300; }
+  .ui-dialog-content ul ul, .ui-dialog-content ol ol, .ui-dialog-content ul ol, .ui-dialog-content ol ul {
+    margin: 0.75em 0; }
+  .ui-dialog-content li {
+    margin-bottom: 0.75em;
+    font-size: 16px;
+    line-height: 1.75em; }
+  .ui-dialog-content table {
+    width: 100%;
+    border: 1px solid #ccc;
+    border-spacing: 0;
+    margin-top: 30px;
+    margin-bottom: 30px; }
+  .ui-dialog-content thead, .ui-dialog-content tr:nth-child(even) {
+    background-color: #f7f7f7; }
+  .ui-dialog-content thead {
+    background-color: #555;
+    color: white; }
+  .ui-dialog-content th, .ui-dialog-content td {
+    padding: 8px;
+    text-align: left;
+    margin: 0; }
+  .ui-dialog-content th {
+    font-weight: normal; }
+  .ui-dialog-content td {
+    font-size: 0.85em; }
+  .ui-dialog-content #editPageButton {
+    position: absolute;
+    top: -25px;
+    right: 5px;
+    width: 50px;
+    height: 50px;
+    line-height: 50px;
+    border-radius: 50%;
+    white-space: nowrap;
+    text-indent: 50px;
+    overflow: hidden;
+    background: #3371e3 url(/images/icon-pencil.svg) no-repeat;
+    background-position: 12px 10px;
+    background-size: 29px 29px; }
+  .ui-dialog-content #markdown-toc {
+    margin-bottom: 20px; }
+    .ui-dialog-content #markdown-toc ul, .ui-dialog-content #markdown-toc li {
+      list-style: disc;
+      color: #3371e3; }
+    .ui-dialog-content #markdown-toc ul {
+      padding: 0 15px;
+      margin: 0; }
+    .ui-dialog-content #markdown-toc li {
+      padding: 0;
+      line-height: 1.5em;
+      margin-bottom: 0; }
+    .ui-dialog-content #markdown-toc a {
+      position: relative;
+      color: #3371e3;
+      font-weight: 700; }
+  .ui-dialog-content img {
+    max-width: 100%; }
+  .ui-dialog-content a {
+    text-decoration: underline; }
+
+.ui-dialog-buttonpane {
+  background: #f7f7f7 !important; }
+
+.ui-widget-header {
+  background: transparent !important;
+  background-color: transparent !important;
+  border: 0px !important; }
+
+.ui-tabs ul, .ui-tabs ol, .ui-tabs li {
+  padding: 0px !important;
+  list-style: none !important;
+  margin-bottom: 0px !important;
+  margin-left: 4px !important; }
+
+.ui-tabs-panel ul li {
+  list-style: disc !important; }
+
+.ui-tabs-panel ol li {
+  list-style: decimal !important; }
+
+.ui-widget-content {
+  border: 0px !important; }
+  .ui-widget-content table {
+    margin: 0px !important; }
+
+.ui-tabs .ui-tabs-panel {
+  border: 1px solid #ccc !important; }
+
+.ui-tabs-anchor {
+  text-decoration: none !important; }
+
+#talkToUs h3, #talkToUs h4 {
+  text-align: center; }
+
+#talkToUs h3 {
+  margin-bottom: 15px; }
+
+#talkToUs h4 {
+  line-height: normal;
+  margin-bottom: 50px; }
+  #talkToUs h4 br {
+    display: none; }
+
+#talkToUs #bigSocial {
+  overflow: hidden; }
+  #talkToUs #bigSocial div {
+    width: 100%;
+    float: left;
+    padding: 30px;
+    padding-top: 110px;
+    background-position: center top;
+    background-size: auto;
+    background-repeat: no-repeat; }
+  #talkToUs #bigSocial div:nth-child(1) {
+    background-image: url(/images/twitter_icon.png); }
+  #talkToUs #bigSocial div:nth-child(2) {
+    background-image: url(/images/github_icon.png); }
+  #talkToUs #bigSocial div:nth-child(3) {
+    background-image: url(/images/slack_icon.png); }
+  #talkToUs #bigSocial div:nth-child(4) {
+    background-image: url(/images/stackoverflow_icon.png); }
+  #talkToUs #bigSocial div + div {
+    margin-top: 20px;
+    margin-left: 0; }
+  #talkToUs #bigSocial a {
+    display: inline-block;
+    color: #3371e3;
+    font-size: 24px;
+    font-weight: 400;
+    text-decoration: none;
+    margin-bottom: 15px; }
+  #talkToUs #bigSocial a, #talkToUs #bigSocial p {
+    text-align: center;
+    width: 100%; }
+
+#home #talkToUs main {
+  padding: 30px 0; }
+
+#home #talkToUs h5 {
+  font-size: 20px; }
+
+#home #caseStudiesWrapper {
+  position: relative;
+  text-align: center;
+  margin-bottom: 30px; }
+  #home #caseStudiesWrapper img {
+    padding-bottom: 1rem; }
+  #home #caseStudiesWrapper div {
+    position: relative;
+    display: inline-block;
+    vertical-align: top;
+    width: 100%;
+    min-height: 230px;
+    margin-bottom: 60px;
+    padding-right: 1rem;
+    background-position: top center; }
+  #home #caseStudiesWrapper p {
+    font-size: 20px; }
+  #home #caseStudiesWrapper a {
+    position: absolute;
+    bottom: -30px;
+    left: 50%;
+    transform: translateX(-50%);
+    color: #3371e3;
+    font-weight: 400; }
+
+/* Google Search */
+.cse .gsc-control-cse, .gsc-control-cse {
+  padding: 0; }
+
+.gsc-control-cse table, .gsc-control-cse-en table {
+  margin: 0px !important; }
+
+.gsc-above-wrapper-area {
+  border-bottom: 0; }
+
+/* Bing Search */
+#bing-results-container {
+  margin-top: 30px;
+  margin-left: 20px; }
+
+.bing-result {
+  margin-bottom: 20px; }
+
+.bing-result-name a {
+  font-size: 16px;
+  color: #0000CC; }
+
+.bing-result-url {
+  color: #008000;
+  font-size: 13px; }
+
+.bing-result-snippet {
+  color: #000;
+  font-size: 11px; }
+
+#bing-pagination-container {
+  margin: 10px;
+  margin-left: 20px; }
+
+.bing-page-anchor {
+  text-decoration: none !important;
+  cursor: pointer;
+  color: #0000CC;
+  margin-right: 8px; }
+
+@media screen and (min-width: 750px) {
+  h1 {
+    font-size: 32px;
+    line-height: 40px; }
+  h2 {
+    font-size: 28px;
+    line-height: 60px; }
+  h3 {
+    font-size: 24px;
+    line-height: 32px; }
+  h4 {
+    font-size: 20px;
+    line-height: 40px; }
+  h5 {
+    font-size: 16px;
+    line-height: 36px; }
+  p {
+    font-size: 14px;
+    line-height: 22px; }
+  section, header, #vendorStrip {
+    padding-left: 20px;
+    padding-right: 20px; }
+    section main, header main, #vendorStrip main {
+      width: 100%;
+      max-width: 100%; }
+  header {
+    height: 80px; }
+  .nav-buttons {
+    height: 80px;
+    line-height: 80px; }
+    .nav-buttons .button + * {
+      margin-left: 30px; }
+  #hamburger {
+    width: 50px;
+    height: 50px; }
+  #mainNav {
+    padding: 140px 0 30px; }
+    #mainNav h5 {
+      margin-bottom: 1em; }
+    #mainNav h3 {
+      margin-bottom: 0.6em; }
+    #mainNav .nav-box {
+      width: 20%; }
+    #mainNav .nav-box + .nav-box {
+      margin-left: calc(20% / 3); }
+    #mainNav main + main {
+      margin-top: 60px; }
+    #mainNav .left .button {
+      height: 50px;
+      line-height: 50px;
+      font-size: 18px; }
+  .open-nav #tryKubernetes, .y-enough #tryKubernetes {
+    margin-left: 30px; }
+  #hero {
+    padding-top: 80px; }
+  #docs #hero h1, #docs #hero h5 {
+    padding-left: 20px;
+    padding-right: 20px; }
+  #vendorStrip {
+    height: 88px;
+    line-height: 88px;
+    font-size: 16px; }
+  p {
+    font-size: 16px;
+    line-height: 24px;
+    letter-spacing: 0.1px; }
+  h1 {
+    font-size: 36px;
+    line-height: 44px; }
+  h3 {
+    font-size: 28px;
+    line-height: 36px; }
+  h4 {
+    font-size: 24px;
+    line-height: 40px; }
+  #home #viewDocs, #home #tryKubernetes {
+    display: inline-block; }
+  #vendorStrip {
+    display: block;
+    text-align: center; }
+    #vendorStrip img {
+      max-height: 24px;
+      vertical-align: middle;
+      margin: 0 30px; }
+  #docs #vendorStrip li a {
+    font-size: 1em;
+    font-weight: normal; }
+  #docs #vendorStrip li li + li {
+    margin-left: 60px; }
+  #oceanNodes h3 {
+    text-align: left;
+    margin-bottom: 18px; }
+  #oceanNodes main {
+    position: relative;
+    clear: both;
+    display: table; }
+    #oceanNodes main .content {
+      display: table-cell;
+      position: relative;
+      vertical-align: middle; }
+    #oceanNodes main .image-wrapper {
+      position: absolute;
+      top: 50%;
+      max-width: 25%;
+      max-height: 100%;
+      transform: translateY(-50%); }
+    #oceanNodes main:nth-child(odd) {
+      padding-right: 210px; }
+      #oceanNodes main:nth-child(odd) .image-wrapper {
+        right: 0; }
+    #oceanNodes main:nth-child(even) {
+      padding-left: 210px; }
+      #oceanNodes main:nth-child(even) .image-wrapper {
+        left: 0; }
+    #oceanNodes main:nth-child(1) {
+      padding-right: 0; }
+      #oceanNodes main:nth-child(1) h3, #oceanNodes main:nth-child(1) p {
+        text-align: center; }
+      #oceanNodes main:nth-child(1) .image-wrapper {
+        position: relative;
+        display: block;
+        float: none;
+        max-width: 100%;
+        transform: none; }
+      #oceanNodes main:nth-child(1) .content {
+        display: block; }
+    #oceanNodes main img {
+      width: 100%; }
+  #video {
+    height: 400px;
+    display: block; }
+    #video > .light-text {
+      display: block; }
+  #mobileShowVideoButton {
+    display: none; }
+  #features {
+    padding-bottom: 60px; }
+    #features .feature-box {
+      margin-bottom: 30px; }
+      #features .feature-box:last-child {
+        margin-bottom: 0; }
+    #features h3 {
+      margin-bottom: 40px; }
+    #features .feature-box > div {
+      width: 45%;
+      margin-bottom: 0; }
+  #talkToUs #bigSocial div {
+    width: calc(50% - 15px); }
+  #talkToUs #bigSocial div + div {
+    margin-top: 0; }
+  #talkToUs #bigSocial div:nth-child(2) {
+    margin-left: 20px; }
+  #talkToUs #bigSocial div:nth-child(3) {
+    margin-top: 20px; }
+  #talkToUs #bigSocial div:nth-child(4) {
+    margin-top: 20px;
+    margin-left: 20px; }
+  #talkToUs #bigSocial a {
+    display: inline-block;
+    color: #3371e3;
+    font-weight: 400;
+    text-decoration: none; }
+  footer nav {
+    text-align: center; }
+    footer nav a {
+      width: 30%;
+      padding: 0 20px; }
+  footer .social {
+    text-align: center; }
+    footer .social div {
+      display: inline-block; }
+    footer .social div:last-child {
+      display: block;
+      margin: 0; }
+    footer .social span {
+      display: inline-block;
+      margin-right: 10px; }
+    footer .social input {
+      text-align: left; }
+  #home #caseStudiesWrapper div {
+    width: 48%; } }
+
+@media screen and (min-width: 1025px) {
+  #hamburger {
+    display: none; }
+  ul.global-nav {
+    display: inline-block; }
+  #docs #vendorStrip #searchBox:before {
+    top: 15px; }
+  #vendorStrip {
+    height: 44px;
+    line-height: 44px; }
+    #vendorStrip li a.YAH:after {
+      content: "";
+      display: block;
+      position: absolute;
+      left: 0;
+      bottom: 0;
+      width: 100%;
+      height: 4px;
+      background-color: #3371e3; }
+    #vendorStrip #searchBox {
+      float: right; }
+  #home #hero #vendorStrip {
+    display: block; }
+  #docs #hero h1, #docs #hero h5 {
+    text-align: left; }
+  #docs #hero #vendorStrip ul {
+    float: left; }
+  #docs #hero #vendorStrip #searchBox {
+    float: right;
+    width: 250px; }
+  #docs #hero #vendorStrip #search {
+    vertical-align: middle; }
+  #docs .flyout-button {
+    display: none; }
+  #docs .logo {
+    position: relative;
+    float: left;
+    display: block;
+    width: 180px;
+    height: 88px;
+    top: 0;
+    left: 0;
+    transform: none;
+    background-image: url(../images/nav_logo.svg); }
+  #docs.flip-nav .logo, #docs.open-nav .logo {
+    background-image: url(../images/nav_logo2.svg); }
+  #encyclopedia {
+    padding: 50px 50px 100px 100px;
+    clear: both; }
+  #docsToc {
+    position: relative;
+    float: left;
+    padding: 0 20px;
+    left: 0;
+    width: 350px;
+    z-index: auto; }
+    #docsToc .push-menu-close-button {
+      display: none; }
+  #docsContent {
+    width: calc(100% - 400px); }
+    #docsContent #editPageButton {
+      right: -25px; }
+  section main, header main, footer main {
+    max-width: 1200px; }
+  header, #vendorStrip, #encyclopedia, #hero h1, #hero h5, #docs #hero h1, #docs #hero h5,
+  #community #hero h1, .gridPage #hero h1, #community #hero h5, .gridPage #hero h5 {
+    padding-left: 100px;
+    padding-right: 100px; }
+  #vendorStrip {
+    padding-right: 10px; }
+  #home section main, #home header main, #home footer main {
+    max-width: 1000px; }
+  #oceanNodes main {
+    position: relative;
+    max-width: 830px; }
+    #oceanNodes main:nth-child(1) {
+      max-width: 1000px;
+      padding-right: 475px; }
+      #oceanNodes main:nth-child(1) h3, #oceanNodes main:nth-child(1) p {
+        text-align: left; }
+      #oceanNodes main:nth-child(1) .image-wrapper {
+        position: absolute;
+        max-width: 48%;
+        transform: translateY(-50%); }
+        #oceanNodes main:nth-child(1) .image-wrapper img {
+          max-width: 425px; }
+  #video {
+    height: 550px;
+    position: relative;
+    background-position: center center;
+    background-size: cover; }
+  #talkToUs h4 br {
+    display: block; }
+  #talkToUs #bigSocial div {
+    width: calc(25% - 18px); }
+  #talkToUs #bigSocial div + div {
+    margin-left: 20px; }
+  footer {
+    width: 100%;
+    background-image: url(../images/texture.png);
+    background-color: #303030; }
+    footer main {
+      padding: 20px 0; }
+    footer nav {
+      overflow: hidden;
+      margin-bottom: 20px; }
+      footer nav a {
+        width: 16.65%;
+        float: left;
+        font-size: 24px;
+        font-weight: 300;
+        white-space: nowrap; }
+    footer .social {
+      padding: 0 30px;
+      max-width: 1200px; }
+      footer .social div {
+        float: left; }
+      footer .social div:last-child {
+        float: right; }
+  #search, #wishField {
+    background-color: transparent;
+    padding: 10px;
+    font-size: 16px;
+    font-weight: 100;
+    color: white;
+    border: 1px solid white;
+    transition: 0.3s; }
+    #search:focus, #wishField:focus {
+      background-color: #f7f7f7;
+      color: #303030; }
+  .social a {
+    display: inline-block;
+    background-image: url(../images/social_sprite.png);
+    background-repeat: no-repeat;
+    background-size: auto;
+    width: 50px;
+    height: 50px;
+    border-radius: 5px;
+    margin-right: 10px; }
+    .social a:hover {
+      background-color: #fff; }
+    .social a span {
+      position: absolute;
+      display: block;
+      height: 0;
+      overflow: hidden; }
+  a.twitter {
+    background-position: 0 0; }
+    a.twitter:hover {
+      background-position: 0 100%; }
+  a.stack-overflow {
+    background-position: -50px 0; }
+    a.stack-overflow:hover {
+      background-position: -50px 100%; }
+  a.slack {
+    background-position: -100px 0; }
+    a.slack:hover {
+      background-position: -100px 100%; }
+  a.github {
+    background-position: -150px 0; }
+    a.github:hover {
+      background-position: -150px 100%; }
+  a.mailing-list {
+    background-position: -200px 0; }
+    a.mailing-list:hover {
+      background-position: -200px 100%; }
+  a.calendar {
+    background-position: -250px 0; }
+    a.calendar:hover {
+      background-position: -250px 100%; }
+  #community #hero, .gridPage #hero {
+    text-align: left; }
+    #community #hero h1, .gridPage #hero h1 {
+      padding: 20px 100px; }
+  #community #tryKubernetes, .gridPage #tryKubernetes {
+    width: auto;
+    background-color: #3371e3;
+    padding: 0 20px; }
+  #bigSocial div {
+    width: calc(25% - 18px); }
+  #home #caseStudiesWrapper div {
+    width: 24%;
+    min-height: 260px; } }
+
+@media screen and (min-width: 1300px) {
+  #vendorStrip {
+    padding-right: 100px; } }
+
+@media screen and (min-width: 456px) {
+  #vendorStrip li + li {
+    margin-left: 20px; } }

--- a/resources/_gen/assets/sass/sass/styles.sass_a6e533854c4de092afe9278041939937.json
+++ b/resources/_gen/assets/sass/sass/styles.sass_a6e533854c4de092afe9278041939937.json
@@ -1,0 +1,1 @@
+{"Target":"css/styles.css","MediaType":"text/css","Data":{}}


### PR DESCRIPTION
This is the last batch of "language related changes" from me for now.

**Note that before this gets merged, the dummy Norwegian translation needs to be disabled in config.toml.**

It's easier to get a grasp of this PR by looking at the content tree for the Norwegian translation:

```bash
content/no
├── _common-resources
│   └── index.md
├── _index.html
├── blog
│   ├── _index.md
│   └── _posts
│       └── 2018-09-06-2018-steering-committee-election-cycle-kicks-off.md
├── case-studies
│   ├── _index.md
│   └── adform
│       └── index.html
└── docs
    ├── _index.md
    ├── contribute
    │   └── _index.md
    ├── home
    │   └── _index.md
    ├── reference
    │   ├── _index.md
    │   └── glossary
    │       ├── container.md
    │       └── index.md
    ├── setup
    │   ├── _index.md
    │   └── pick-right-solution.md
    └── tutorials
        └── kubernetes-basics
            └── _index.md
```

In summary, this is what's needed for a new language:

* The section content files (see "_index*", esp. note the home page) with its menu definitions. 
* A translation of the language bundle in /i18n
* A language configuration in config.toml

In that language configuration, you can specify an ordered list of one or more languages to fill inn missing translations from. In this PR, `no` has this set to `language_alternatives = ["en"]`.

This language merging has an effect in

* Blog. The last blog entry from `language_alternatives` will be shown on front page if not translated. Also, the archive is merged.
* Docs browser
* Docs left tree nav
* Glossary page, glossary tooltip
* Case studies

Links to "foreign language" is marked with its language and opens up in a new window.

There is certainly more to be done in this area (the glossary page contains some untranslated text, and the user journey is only available in English, to mention some examples. But think now at least it makes sense to let other languages in.)

This PR updates Hugo to 0.48. That is built with Go 1.11, which makes the relevant template constructs much simpler.

/cc @zacharysarah @chenopis 




