### PR TITLE
fixed a typo in docs/concepts/configuration/pod-priority-preemption.md

### DIFF
--- a/content/en/docs/concepts/configuration/pod-priority-preemption.md
+++ b/content/en/docs/concepts/configuration/pod-priority-preemption.md
@@ -202,7 +202,7 @@ spec:
 In Kubernetes 1.9 and later, when Pod priority is enabled, scheduler orders
 pending Pods by their priority and a pending Pod is placed ahead of other
 pending Pods with lower priority in the scheduling queue. As a result, the
-higher priority Pod may be scheduled sooner that Pods with lower priority if its
+higher priority Pod may be scheduled sooner than Pods with lower priority if its
 scheduling requirements are met. If such Pod cannot be scheduled, scheduler will
 continue and tries to schedule other lower priority Pods.
 

--- a/content/en/docs/concepts/configuration/pod-priority-preemption.md
+++ b/content/en/docs/concepts/configuration/pod-priority-preemption.md
@@ -202,7 +202,7 @@ spec:
 In Kubernetes 1.9 and later, when Pod priority is enabled, scheduler orders
 pending Pods by their priority and a pending Pod is placed ahead of other
 pending Pods with lower priority in the scheduling queue. As a result, the
-higher priority Pod may by scheduled sooner that Pods with lower priority if its
+higher priority Pod may be scheduled sooner that Pods with lower priority if its
 scheduling requirements are met. If such Pod cannot be scheduled, scheduler will
 continue and tries to schedule other lower priority Pods.
 


### PR DESCRIPTION
"Pod may by scheduled" > "Pod may be scheduled"

