### PR TITLE
Fixing a small issue

### DIFF
--- a/content/en/docs/getting-started-guides/ubuntu/backups.md
+++ b/content/en/docs/getting-started-guides/ubuntu/backups.md
@@ -41,7 +41,7 @@ juju deploy etcd new-etcd
 The above code snippet will deploy a single unit of etcd, as 'new-etcd'
 
 ```
-juju run-action etcd/0 restore target=/mnt/etcd-backups
+juju run-action new-etcd/0 restore target=/mnt/etcd-backups
 ```
 
 Once the restore action has completed, evaluate the cluster health. If the unit


### PR DESCRIPTION
The docs say to backup, start a new application called new-etcd, but then to restore to etcd/0 and not new-etcd/0. Fixing that so it restores to that newly created unit.
