### PR TITLE
Updated the numbering of instructions

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -299,7 +299,9 @@ metadata:
 
 1.  Define an environment variable as a key-value pair in a ConfigMap:
 
-    kubectl create configmap special-config --from-literal=special.how=very 
+    ```shell
+    kubectl create configmap special-config --from-literal=special.how=very
+    ```
 
 1.  Assign the `special.how` value defined in the ConfigMap to the `SPECIAL_LEVEL_KEY` environment variable in the Pod specification.
 

--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -305,8 +305,11 @@ metadata:
 
 1.  Assign the `special.how` value defined in the ConfigMap to the `SPECIAL_LEVEL_KEY` environment variable in the Pod specification.
 
+    ```shell
     kubectl edit pod dapi-test-pod
+    ```
 
+    ```yaml
     apiVersion: v1
     kind: Pod
     metadata:
@@ -326,6 +329,7 @@ metadata:
                   # Specify the key associated with the value
                   key: special.how
       restartPolicy: Never
+    ```
 
 1.  Save the changes to the Pod specification. Now, the Pod's output includes `SPECIAL_LEVEL_KEY=very`. 
  
@@ -333,6 +337,7 @@ metadata:
  
 1.  As with the previous example, create the ConfigMaps first.
 
+    ```yaml
     apiVersion: v1
     kind: ConfigMap
     metadata:
@@ -340,17 +345,21 @@ metadata:
       namespace: default
     data:
       special.how: very
+    ```
 
+    ```yaml
     apiVersion: v1
     kind: ConfigMap
     metadata:
       name: env-config
       namespace: default
     data:
-      log_level: INFO 
+      log_level: INFO
+    ```
 
 1.  Define the environment variables in the Pod specification.
 
+    ```yaml
     apiVersion: v1
     kind: Pod
     metadata:
@@ -372,6 +381,7 @@ metadata:
                   name: env-config
                   key: log_level
       restartPolicy: Never
+    ```
  
 1.  Save the changes to the Pod specification. Now, the Pod's output includes `SPECIAL_LEVEL_KEY=very` and `LOG_LEVEL=INFO`. 
 
@@ -383,6 +393,7 @@ metadata:
 
 1.  Create a ConfigMap containing multiple key-value pairs. 
 
+    ```yaml
     apiVersion: v1
     kind: ConfigMap
     metadata:
@@ -391,9 +402,11 @@ metadata:
     data:
       SPECIAL_LEVEL: very
       SPECIAL_TYPE: charm
+    ```
 
 1.  Use `envFrom` to define all of the ConfigMap's data as container environment variables. The key from the ConfigMap becomes the environment variable name in the Pod.
    
+    ```yaml
     apiVersion: v1
     kind: Pod
     metadata:
@@ -407,6 +420,7 @@ metadata:
           - configMapRef:
               name: special-config
       restartPolicy: Never
+    ```
 
 1. Save the changes to the Pod specification. Now, the Pod's output includes `SPECIAL_LEVEL=very` and `SPECIAL_TYPE=charm`. 
 

--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -297,132 +297,116 @@ metadata:
 
 ### Define a container environment variable with data from a single ConfigMap
 
-1. Define an environment variable as a key-value pair in a ConfigMap:
+1.  Define an environment variable as a key-value pair in a ConfigMap:
 
-   ```shell
-   kubectl create configmap special-config --from-literal=special.how=very 
-   ```
+    kubectl create configmap special-config --from-literal=special.how=very 
 
-2. Assign the `special.how` value defined in the ConfigMap to the `SPECIAL_LEVEL_KEY` environment variable in the Pod specification.
+1.  Assign the `special.how` value defined in the ConfigMap to the `SPECIAL_LEVEL_KEY` environment variable in the Pod specification.
 
-   ```shell
-   kubectl edit pod dapi-test-pod
-   ```
+    kubectl edit pod dapi-test-pod
 
-   ```yaml
-   apiVersion: v1
-   kind: Pod
-   metadata:
-     name: dapi-test-pod
-   spec:
-     containers:
-       - name: test-container
-         image: k8s.gcr.io/busybox
-         command: [ "/bin/sh", "-c", "env" ]
-         env:
-           # Define the environment variable
-           - name: SPECIAL_LEVEL_KEY
-             valueFrom:
-               configMapKeyRef:
-                 # The ConfigMap containing the value you want to assign to SPECIAL_LEVEL_KEY
-                 name: special-config
-                 # Specify the key associated with the value
-                 key: special.how
-     restartPolicy: Never
-   ```
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: dapi-test-pod
+    spec:
+      containers:
+        - name: test-container
+          image: k8s.gcr.io/busybox
+          command: [ "/bin/sh", "-c", "env" ]
+          env:
+            # Define the environment variable
+            - name: SPECIAL_LEVEL_KEY
+              valueFrom:
+                configMapKeyRef:
+                  # The ConfigMap containing the value you want to assign to SPECIAL_LEVEL_KEY
+                  name: special-config
+                  # Specify the key associated with the value
+                  key: special.how
+      restartPolicy: Never
 
-3. Save the changes to the Pod specification. Now, the Pod's output includes `SPECIAL_LEVEL_KEY=very`. 
+1.  Save the changes to the Pod specification. Now, the Pod's output includes `SPECIAL_LEVEL_KEY=very`. 
  
 ### Define container environment variables with data from multiple ConfigMaps
  
-1. As with the previous example, create the ConfigMaps first.
+1.  As with the previous example, create the ConfigMaps first.
 
-   ```yaml
-   apiVersion: v1
-   kind: ConfigMap
-   metadata:
-     name: special-config
-     namespace: default
-   data:
-     special.how: very
-   ```
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: special-config
+      namespace: default
+    data:
+      special.how: very
 
-   ```yaml
-   apiVersion: v1
-   kind: ConfigMap
-   metadata:
-     name: env-config
-     namespace: default
-   data:
-     log_level: INFO
-   ``` 
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: env-config
+      namespace: default
+    data:
+      log_level: INFO 
 
-2. Define the environment variables in the Pod specification.
+1.  Define the environment variables in the Pod specification.
 
-   ```yaml
-   apiVersion: v1
-   kind: Pod
-   metadata:
-     name: dapi-test-pod
-   spec:
-     containers:
-       - name: test-container
-         image: k8s.gcr.io/busybox
-         command: [ "/bin/sh", "-c", "env" ]
-         env:
-           - name: SPECIAL_LEVEL_KEY
-             valueFrom:
-               configMapKeyRef:
-                 name: special-config
-                 key: special.how
-           - name: LOG_LEVEL
-             valueFrom:
-               configMapKeyRef:
-                 name: env-config
-                 key: log_level
-     restartPolicy: Never
-   ```
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: dapi-test-pod
+    spec:
+      containers:
+        - name: test-container
+          image: k8s.gcr.io/busybox
+          command: [ "/bin/sh", "-c", "env" ]
+          env:
+            - name: SPECIAL_LEVEL_KEY
+              valueFrom:
+                configMapKeyRef:
+                  name: special-config
+                  key: special.how
+            - name: LOG_LEVEL
+              valueFrom:
+                configMapKeyRef:
+                  name: env-config
+                  key: log_level
+      restartPolicy: Never
  
-3. Save the changes to the Pod specification. Now, the Pod's output includes `SPECIAL_LEVEL_KEY=very` and `LOG_LEVEL=INFO`. 
+1.  Save the changes to the Pod specification. Now, the Pod's output includes `SPECIAL_LEVEL_KEY=very` and `LOG_LEVEL=INFO`. 
 
 ## Configure all key-value pairs in a ConfigMap as container environment variables 
 
    {{< note >}}
-   **Note:** This functionality is available to users running Kubernetes v1.6 and later.
+   **Note:** This functionality is available in Kubernetes v1.6 and later.
    {{< /note >}}
 
-1. Create a ConfigMap containing multiple key-value pairs. 
+1.  Create a ConfigMap containing multiple key-value pairs. 
 
-   ```yaml
-   apiVersion: v1
-   kind: ConfigMap
-   metadata:
-     name: special-config
-     namespace: default
-   data:
-     SPECIAL_LEVEL: very
-     SPECIAL_TYPE: charm
-   ```
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: special-config
+      namespace: default
+    data:
+      SPECIAL_LEVEL: very
+      SPECIAL_TYPE: charm
 
-2. Use `envFrom` to define all of the ConfigMap's data as container environment variables. The key from the ConfigMap becomes the environment variable name in the Pod.
+1.  Use `envFrom` to define all of the ConfigMap's data as container environment variables. The key from the ConfigMap becomes the environment variable name in the Pod.
    
-   ```yaml
-   apiVersion: v1
-   kind: Pod
-   metadata:
-     name: dapi-test-pod
-   spec:
-     containers:
-       - name: test-container
-         image: k8s.gcr.io/busybox
-         command: [ "/bin/sh", "-c", "env" ]
-         envFrom:
-         - configMapRef:
-             name: special-config
-     restartPolicy: Never
-   ```
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: dapi-test-pod
+    spec:
+      containers:
+        - name: test-container
+          image: k8s.gcr.io/busybox
+          command: [ "/bin/sh", "-c", "env" ]
+          envFrom:
+          - configMapRef:
+              name: special-config
+      restartPolicy: Never
 
-3. Save the changes to the Pod specification. Now, the Pod's output includes `SPECIAL_LEVEL=very` and `SPECIAL_TYPE=charm`. 
+1. Save the changes to the Pod specification. Now, the Pod's output includes `SPECIAL_LEVEL=very` and `SPECIAL_TYPE=charm`. 
 
 
 ## Use ConfigMap-defined environment variables in Pod commands  
@@ -602,9 +586,9 @@ data:
 
 ### Restrictions
 
-1. You must create a ConfigMap before referencing it in a Pod specification (unless you mark the ConfigMap as "optional"). If you reference a ConfigMap that doesn't exist, the Pod won't start. Likewise, references to keys that don't exist in the ConfigMap will prevent the pod from starting.
+- You must create a ConfigMap before referencing it in a Pod specification (unless you mark the ConfigMap as "optional"). If you reference a ConfigMap that doesn't exist, the Pod won't start. Likewise, references to keys that don't exist in the ConfigMap will prevent the pod from starting.
 
-2. If you use `envFrom` to define environment variables from ConfigMaps, keys that are considered invalid will be skipped. The pod will be allowed to start, but the invalid names will be recorded in the event log (`InvalidVariableNames`). The log message lists each skipped key. For example:
+- If you use `envFrom` to define environment variables from ConfigMaps, keys that are considered invalid will be skipped. The pod will be allowed to start, but the invalid names will be recorded in the event log (`InvalidVariableNames`). The log message lists each skipped key. For example:
 
    ```shell
    kubectl get events
@@ -612,9 +596,9 @@ data:
    0s       0s        1     dapi-test-pod Pod              Warning   InvalidEnvironmentVariableNames   {kubelet, 127.0.0.1}  Keys [1badkey, 2alsobad] from the EnvFrom configMap default/myconfig were skipped since they are considered invalid environment variable names.
    ```
 
-3. ConfigMaps reside in a specific [namespace](/docs/concepts/overview/working-with-objects/namespaces/). A ConfigMap can only be referenced by pods residing in the same namespace.
+- ConfigMaps reside in a specific [namespace](/docs/concepts/overview/working-with-objects/namespaces/). A ConfigMap can only be referenced by pods residing in the same namespace.
 
-4. Kubelet doesn't support the use of ConfigMaps for pods not found on the API server. 
+- Kubelet doesn't support the use of ConfigMaps for pods not found on the API server. 
    This includes pods created via the Kubelet's --manifest-url flag, --config flag, or the Kubelet REST API.
    
    {{< note >}}

--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -303,7 +303,7 @@ metadata:
    kubectl create configmap special-config --from-literal=special.how=very 
    ```
 
-1. Assign the `special.how` value defined in the ConfigMap to the `SPECIAL_LEVEL_KEY` environment variable in the Pod specification.
+2. Assign the `special.how` value defined in the ConfigMap to the `SPECIAL_LEVEL_KEY` environment variable in the Pod specification.
 
    ```shell
    kubectl edit pod dapi-test-pod
@@ -331,7 +331,7 @@ metadata:
      restartPolicy: Never
    ```
 
-1. Save the changes to the Pod specification. Now, the Pod's output includes `SPECIAL_LEVEL_KEY=very`. 
+3. Save the changes to the Pod specification. Now, the Pod's output includes `SPECIAL_LEVEL_KEY=very`. 
  
 ### Define container environment variables with data from multiple ConfigMaps
  
@@ -357,7 +357,7 @@ metadata:
      log_level: INFO
    ``` 
 
-1. Define the environment variables in the Pod specification.
+2. Define the environment variables in the Pod specification.
 
    ```yaml
    apiVersion: v1
@@ -383,7 +383,7 @@ metadata:
      restartPolicy: Never
    ```
  
-1. Save the changes to the Pod specification. Now, the Pod's output includes `SPECIAL_LEVEL_KEY=very` and `LOG_LEVEL=info`. 
+3. Save the changes to the Pod specification. Now, the Pod's output includes `SPECIAL_LEVEL_KEY=very` and `LOG_LEVEL=INFO`. 
 
 ## Configure all key-value pairs in a ConfigMap as container environment variables 
 
@@ -404,7 +404,7 @@ metadata:
      SPECIAL_TYPE: charm
    ```
 
-1. Use `envFrom` to define all of the ConfigMap's data as container environment variables. The key from the ConfigMap becomes the environment variable name in the Pod.
+2. Use `envFrom` to define all of the ConfigMap's data as container environment variables. The key from the ConfigMap becomes the environment variable name in the Pod.
    
    ```yaml
    apiVersion: v1
@@ -422,7 +422,7 @@ metadata:
      restartPolicy: Never
    ```
 
-1. Save the changes to the Pod specification. Now, the Pod's output includes `SPECIAL_LEVEL=very` and `SPECIAL_TYPE=charm`. 
+3. Save the changes to the Pod specification. Now, the Pod's output includes `SPECIAL_LEVEL=very` and `SPECIAL_TYPE=charm`. 
 
 
 ## Use ConfigMap-defined environment variables in Pod commands  
@@ -604,7 +604,7 @@ data:
 
 1. You must create a ConfigMap before referencing it in a Pod specification (unless you mark the ConfigMap as "optional"). If you reference a ConfigMap that doesn't exist, the Pod won't start. Likewise, references to keys that don't exist in the ConfigMap will prevent the pod from starting.
 
-1. If you use `envFrom` to define environment variables from ConfigMaps, keys that are considered invalid will be skipped. The pod will be allowed to start, but the invalid names will be recorded in the event log (`InvalidVariableNames`). The log message lists each skipped key. For example:
+2. If you use `envFrom` to define environment variables from ConfigMaps, keys that are considered invalid will be skipped. The pod will be allowed to start, but the invalid names will be recorded in the event log (`InvalidVariableNames`). The log message lists each skipped key. For example:
 
    ```shell
    kubectl get events
@@ -612,9 +612,9 @@ data:
    0s       0s        1     dapi-test-pod Pod              Warning   InvalidEnvironmentVariableNames   {kubelet, 127.0.0.1}  Keys [1badkey, 2alsobad] from the EnvFrom configMap default/myconfig were skipped since they are considered invalid environment variable names.
    ```
 
-1. ConfigMaps reside in a specific [namespace](/docs/concepts/overview/working-with-objects/namespaces/). A ConfigMap can only be referenced by pods residing in the same namespace.
+3. ConfigMaps reside in a specific [namespace](/docs/concepts/overview/working-with-objects/namespaces/). A ConfigMap can only be referenced by pods residing in the same namespace.
 
-1. Kubelet doesn't support the use of ConfigMaps for pods not found on the API server. 
+4. Kubelet doesn't support the use of ConfigMaps for pods not found on the API server. 
    This includes pods created via the Kubelet's --manifest-url flag, --config flag, or the Kubelet REST API.
    
    {{< note >}}


### PR DESCRIPTION
All of the instructions were numbered like this:
-1. do something
-1. then do this
-1. finally, do this.

I just changed them accordingly to be 1-2-3. There was also a case typo in the `LOG_LEVEL=info` which should be `LOG_LEVEL=INFO` based on the data in the yaml file.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> Please delete this note before submitting the pull request.
> For 1.12 Features: set Milestone to 1.12 and Base Branch to release-1.12
> Help editing and submitting pull requests:  https://deploy-preview-9510--kubernetes-io-master-staging.netlify.com/docs/contribute/start/#submit-a-pull-request.
> Help choosing which branch to use, see
> https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use.
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>

