### PR TITLE
fix spelling errors in doc repo

### DIFF
--- a/content/en/docs/concepts/containers/images.md
+++ b/content/en/docs/concepts/containers/images.md
@@ -49,7 +49,7 @@ These commands rely on and are implemented purely on the Docker CLI. You will ne
 
 If you run into trouble with uploading stale manifests, just clean up the older manifests in `$HOME/.docker/manifests` to start fresh.
 
-For Kubernetes, we have typically used images with suffix `-$(ARCH)`. For backward compatability, please generate the older images with suffixes. The idea is to generate say `pause` image which has the manifest for all the arch(es) and say `pause-amd64` which is backwards compatible for older configurations or YAML files which may have hard coded the images with suffixes.
+For Kubernetes, we have typically used images with suffix `-$(ARCH)`. For backward compatibility, please generate the older images with suffixes. The idea is to generate say `pause` image which has the manifest for all the arch(es) and say `pause-amd64` which is backwards compatible for older configurations or YAML files which may have hard coded the images with suffixes.
 
 ## Using a Private Registry
 

--- a/content/en/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-service-account.md
@@ -295,7 +295,7 @@ spec:
 ```
 
 The kubelet will request and store the token on behalf of the pod, make the
-token avaialble to the pod at a configurable file path, and refresh the token as
+token available to the pod at a configurable file path, and refresh the token as
 it approaches expiration. Kubelet proactively rotates the token if it is older
 than 80% of its total TTL, or if the token is older than 24 hours.
 

--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -161,7 +161,7 @@ from the metrics APIs), scaling is skipped.
 
 Finally, just before HPA scales the target, the scale reccomendation is recorded.  The
 controller considers all recommendations within a configurable window choosing the
-highest recommendation from within that window. This value can be configured using the `--horizontal-pod-autoscaler-downscale-stabilization-window` flag, which defaults to 5 minutes.  
+highest recommendation from within that window. This value can be configured using the `--horizontal-pod-autoscaler-downscale-stabilization-window` flag, which defaults to 5 minutes.
 This means that scaledowns will occur gradually, smoothing out the impact of rapidly
 fluctuating metric values.
 


### PR DESCRIPTION
changelist:
```
content/en/blog/_posts/2017-02-00-Postgresql-Clusters-Kubernetes-Statefulsets.md
content/en/docs/concepts/containers/images.md
content/en/docs/concepts/containers/runtime-class.md
content/en/docs/concepts/services-networking/service.md
content/en/docs/tasks/configure-pod-container/configure-service-account.md
content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
content/en/docs/tasks/run-application/scale-stateful-set.md
```

