### PR TITLE
update link for cri-containerd on kubeadm install page

### DIFF
--- a/content/en/docs/setup/independent/install-kubeadm.md
+++ b/content/en/docs/setup/independent/install-kubeadm.md
@@ -87,7 +87,7 @@ The container runtime used by default is Docker, which is enabled through the bu
 
 Other CRI-based runtimes include:
 
-- [cri-containerd](https://github.com/containerd/cri-containerd)
+- [containerd](https://github.com/containerd/cri) (CRI plugin built into containerd)
 - [cri-o](https://github.com/kubernetes-incubator/cri-o)
 - [frakti](https://github.com/kubernetes/frakti)
 - [rkt](https://github.com/kubernetes-incubator/rktlet)


### PR DESCRIPTION
built in cri plugin for containerd now GA, replaces cri-containerd shim

https://kubernetes.io/blog/2018/05/24/kubernetes-containerd-integration-goes-ga/


