### PR TITLE
Remove reference to get-k8s-versions

### DIFF
--- a/content/en/docs/setup/minikube.md
+++ b/content/en/docs/setup/minikube.md
@@ -218,6 +218,7 @@ To switch back to this context later, run this command: `kubectl config use-cont
 
 #### Specifying the Kubernetes version
 
+Minikube supports running multiple different versions of Kubernetes. 
 You can specify the specific version of Kubernetes for Minikube to use by
 adding the `--kubernetes-version` string to the `minikube start` command. For
 example, to run version `v1.7.3`, you would run the following:


### PR DESCRIPTION
**Problem:**

Since PR kubernetes/minikube#2911, `get-k8s-versions` option has been removed. Reference this option in documentation is not needed any more.

**Proposed Solution:**

Remove reference `get-k8s-versions` option in documentation.

**Page to Update:**

https://kubernetes.io/docs/setup/minikube/

**Additional Information:**

`get-k8s-versions` option has been removed into Minikube 0.29.0.
