### PR TITLE
kubeadm-init: update link about v1alpha3 example

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -106,8 +106,8 @@ It is **recommended** that you migrate your old `v1alpha2` configuration to `v1a
 the [kubeadm config migrate](/docs/reference/setup-tools/kubeadm/kubeadm-config/) command,
 because `v1alpha2` will be removed in Kubernetes 1.13.
 
-For more details on each field in the configuration you can navigate to our
-[API reference pages.] (https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm)
+For more details on each field in the `v1alpha3` configuration you can navigate to our
+[API reference pages.] (https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha3)
 
 ### Adding kube-proxy parameters {#kube-proxy}
 


### PR DESCRIPTION
adjust a small mistake.
we should link to the v1alpha3 directly for now!

refs: https://github.com/kubernetes/kubeadm/issues/1152

/kind bug
/priority critical-urgent
/assign @fabriziopandini @rosti 
/cc @kubernetes/sig-cluster-lifecycle-pr-reviews 
/cc @kubernetes/sig-docs-pr-reviews 
