### PR TITLE
Fix links to featured case studies

### DIFF
--- a/layouts/case-studies/list.html
+++ b/layouts/case-studies/list.html
@@ -63,6 +63,6 @@
 <div class="case-study">
 	{{ with $logo }}<img src="{{ .RelPermalink }}" alt="{{ .Title }}">{{ end }}
 	<p class="quote">"{{ .page.Params.quote | html }}"</p>
-	<a href="{{ .RelPermalink }}"{{ if $isForeignLanguage }} target="_blank"{{ end }}>{{ T "main_read_about"}} {{ .page.LinkTitle }}</a>
+	<a href="{{ .page.RelPermalink }}"{{ if $isForeignLanguage }} target="_blank"{{ end }}>{{ T "main_read_about"}} {{ .page.LinkTitle }}</a>
 </div>
 {{ end }}


### PR DESCRIPTION
**Problem:** Links to featured case studies are broken on User Case Studies. cf. #10355.

**Proposed Solution:** Fix Hugo layout and/or template files.

**Page to Update:** https://kubernetes.io/case-studies/


Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

Closes #10460