### PR TITLE
Fixes typo

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/garbage-collection.md
+++ b/content/en/docs/concepts/workloads/controllers/garbage-collection.md
@@ -81,7 +81,7 @@ the following things are true:
 
 Once the "deletion in progress" state is set, the garbage
 collector deletes the object's dependents. Once the garbage collector has deleted all
-"blocking" dependents (objects with `ownerReference.blockOwnerDeletion=true`), it delete
+"blocking" dependents (objects with `ownerReference.blockOwnerDeletion=true`), it deletes
 the owner object.
 
 Note that in the "foregroundDeletion", only dependents with


### PR DESCRIPTION
Small typo found in the "Foreground cascading deletion" section. In the indicative present form, "to delete" should become "he/she/it deletes".