### PR TITLE
Adding Non-Code Contributions blog post

### DIFF
--- a/content/en/blog/_posts/2018-10-04-non-code-contributors-guide.md
+++ b/content/en/blog/_posts/2018-10-04-non-code-contributors-guide.md
@@ -1,0 +1,43 @@
+---
+layout: blog
+title: 'Introducing the Non-Code Contributor’s Guide'
+date: 2018-10-04
+---
+
+**Author**: [Noah Abrahams](https://twitter.com/noah_abrahams) (InfoSiftr), [Jonas Rosland](https://twitter.com/jonasrosland) (VMware), [Ihor Dvoretskyi](https://twitter.com/idvoretskyi) (CNCF)
+
+It was May 2018 in Copenhagen, and the Kubernetes community was enjoying the contributor summit at KubeCon/CloudNativeCon, complete with the first run of the New Contributor Workshop. As a time of tremendous collaboration between contributors, the topics covered ranged from signing the CLA to deep technical conversations. Along with the vast exchange of information and ideas, however, came continued scrutiny of the topics at hand to ensure that the community was being as inclusive and accommodating as possible. Over that spring week, some of the pieces under the microscope included the many themes being covered, and how they were being presented, but also the overarching characteristics of the people contributing and the skill sets involved. From the discussions and analysis that followed grew the idea that the community was not benefiting as much as it could from the many people who wanted to contribute, but whose strengths were in areas other than writing code.
+
+**This all led to an effort called the [Non-Code Contributor’s Guide](https://github.com/kubernetes/community/blob/master/contributors/guide/non-code-contributions.md).**
+
+Now, it’s important to note that Kubernetes is rare, if not unique, in the open source world, in that it was defined very early on as both a project and a community.  While the project itself is focused on the codebase, it is the community of people driving it forward that makes the project successful. The community works together with an explicit set of [community values](https://github.com/kubernetes/steering/blob/master/values.md), guiding the the day-to-day behavior of contributors whether on GitHub, Slack, Discourse, or sitting together over tea or coffee.
+
+By having a community that values people first, and explicitly values a diversity of people, the Kubernetes project is building a product to serve people with diverse needs. The different backgrounds of the contributors bring different approaches to the problem solving, with different methods of collaboration, and all those different viewpoints ultimately create a better project.
+
+The Non-Code Contributor’s Guide aims to make it easy for anyone to contribute to the Kubernetes project in a way that makes sense for them. This can be in many forms, technical and non-technical, based on the person's knowledge of the project and their available time. Most individuals are not developers, and most of the world’s developers are not paid to fully work on open source projects. Based on this we have started an ever-growing list of possible ways to contribute to the Kubernetes project in a Non-Code way!
+
+## Get Involved
+
+Some of the ways that you can contribute to the Kubernetes community without writing a single line of code include:
+
+- Community education, answering questions on [Discuss](https://discuss.kubernetes.io/), [StackOverflow](https://stackoverflow.com/questions/tagged/kubernetes), and [Slack](http://slack.k8s.io/)
+- Outward facing community work such as [hosting meetups](https://www.meetup.com/pro/cncf/) and events
+- Writing [project documentation](https://github.com/kubernetes/community/tree/master/sig-docs)
+- Writing operational manuals, helping users understand how to run Kubernetes
+- Helping deliver Kubernetes, as a part of the [release team](https://github.com/kubernetes/sig-release/blob/master/release-team/README.md)
+- Project, program, and [product management](https://github.com/kubernetes/community/blob/master/sig-pm/README.md)
+- And many more!
+
+The guide to get started with Kubernetes project contribution is [documented on Github](https://github.com/kubernetes/community/tree/master/contributors/guide), and as the Non-Code Contributors Guide is a part of that Kubernetes Contributors Guide, it can be found here. As stated earlier, this list is not exhaustive and will continue to be a work in progress.   
+
+To date, the typical Non-Code contributions fall into the following categories:
+
+- Roles that are based on skill sets other than “software developer”
+- Non-Code contributions in primarily code-based roles
+- “Post-Code” roles, that are not code-based, but require knowledge of either the code base or management of the code base
+
+If you, dear reader, have any additional ideas for a Non-Code way to contribute, whether or not it fits in an existing category, the team will always appreciate if you could help us expand the list.
+
+If a contribution of the Non-Code nature appeals to you, please read the Non-Code Contributions document, and then check the [Contributor Role Board](https://discuss.kubernetes.io/c/contributors/role-board) to see if there are any open positions where your expertise could be best used!  If there are no listed open positions that match your skill set, drop on by the [#sig-contribex](https://kubernetes.slack.com/messages/sig-contribex) channel on Slack, and we’ll point you in the right direction.
+
+We hope to see you contributing to the Kubernetes community soon!

--- a/content/en/blog/_posts/2018-10-04-non-code-contributors-guide.md
+++ b/content/en/blog/_posts/2018-10-04-non-code-contributors-guide.md
@@ -10,7 +10,7 @@ It was May 2018 in Copenhagen, and the Kubernetes community was enjoying the con
 
 **This all led to an effort called the [Non-Code Contributor’s Guide](https://github.com/kubernetes/community/blob/master/contributors/guide/non-code-contributions.md).**
 
-Now, it’s important to note that Kubernetes is rare, if not unique, in the open source world, in that it was defined very early on as both a project and a community.  While the project itself is focused on the codebase, it is the community of people driving it forward that makes the project successful. The community works together with an explicit set of [community values](https://github.com/kubernetes/steering/blob/master/values.md), guiding the the day-to-day behavior of contributors whether on GitHub, Slack, Discourse, or sitting together over tea or coffee.
+Now, it’s important to note that Kubernetes is rare, if not unique, in the open source world, in that it was defined very early on as both a project and a community. While the project itself is focused on the codebase, it is the community of people driving it forward that makes the project successful. The community works together with an explicit set of [community values](https://github.com/kubernetes/steering/blob/master/values.md), guiding the the day-to-day behavior of contributors whether on GitHub, Slack, Discourse, or sitting together over tea or coffee.
 
 By having a community that values people first, and explicitly values a diversity of people, the Kubernetes project is building a product to serve people with diverse needs. The different backgrounds of the contributors bring different approaches to the problem solving, with different methods of collaboration, and all those different viewpoints ultimately create a better project.
 
@@ -28,7 +28,7 @@ Some of the ways that you can contribute to the Kubernetes community without wri
 - Project, program, and [product management](https://github.com/kubernetes/community/blob/master/sig-pm/README.md)
 - And many more!
 
-The guide to get started with Kubernetes project contribution is [documented on Github](https://github.com/kubernetes/community/tree/master/contributors/guide), and as the Non-Code Contributors Guide is a part of that Kubernetes Contributors Guide, it can be found here. As stated earlier, this list is not exhaustive and will continue to be a work in progress.   
+The guide to get started with Kubernetes project contribution is [documented on Github](https://github.com/kubernetes/community/tree/master/contributors/guide), and as the Non-Code Contributors Guide is a part of that Kubernetes Contributors Guide, it can be found [here](https://github.com/kubernetes/community/blob/master/contributors/guide/non-code-contributions.md). As stated earlier, this list is not exhaustive and will continue to be a work in progress.   
 
 To date, the typical Non-Code contributions fall into the following categories:
 
@@ -38,6 +38,6 @@ To date, the typical Non-Code contributions fall into the following categories:
 
 If you, dear reader, have any additional ideas for a Non-Code way to contribute, whether or not it fits in an existing category, the team will always appreciate if you could help us expand the list.
 
-If a contribution of the Non-Code nature appeals to you, please read the Non-Code Contributions document, and then check the [Contributor Role Board](https://discuss.kubernetes.io/c/contributors/role-board) to see if there are any open positions where your expertise could be best used!  If there are no listed open positions that match your skill set, drop on by the [#sig-contribex](https://kubernetes.slack.com/messages/sig-contribex) channel on Slack, and we’ll point you in the right direction.
+If a contribution of the Non-Code nature appeals to you, please read the Non-Code Contributions document, and then check the [Contributor Role Board](https://discuss.kubernetes.io/c/contributors/role-board) to see if there are any open positions where your expertise could be best used! If there are no listed open positions that match your skill set, drop on by the [#sig-contribex](https://kubernetes.slack.com/messages/sig-contribex) channel on Slack, and we’ll point you in the right direction.
 
 We hope to see you contributing to the Kubernetes community soon!


### PR DESCRIPTION
This will add the Non-Code Contributor's Guide blog post written by @idvoretskyi @qedrakmar and myself.

Signed-off-by: Jonas Rosland <jrosland@vmware.com>
