### PR TITLE
Learn Kuberentes Basics button too narrow

### DIFF
--- a/sass/_base.sass
+++ b/sass/_base.sass
@@ -334,7 +334,7 @@ ul.global-nav
 
 .open-nav, .y-enough
 	#tryKubernetes
-		width: 150px
+		width: 200px
 		background-color: $blue
 		border-color: $blue
 


### PR DESCRIPTION
tryKubernetes button is currently 150px wide and cuts off part of "Learn Kubernetes Basics" text

