### PR TITLE
Alphabetize languages, change weights accordingly

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -131,25 +131,30 @@ description = "Production-Grade Container Orchestration"
 languageName ="English"
 # Weight used for sorting.
 weight = 1
+
 [languages.cn]
 title = "Kubernetes"
 description = "Production-Grade Container Orchestration"
 languageName = "Chinese"
 weight = 2
 contentDir = "content/cn"
+
+[languages.ko]
+title = "Kubernetes"
+description = "Production-Grade Container Orchestration"
+languageName = "한국어 Korean"
+weight = 3
+contentDir = "content/ko"
+[languages.ko.params]
+# A list of language codes to look for untranslated content, ordered from left to right.
+
 [languages.no]
 title = "Kubernetes"
 description = "Production-Grade Container Orchestration"
 languageName ="Norsk"
-weight = 3
+weight = 4
 contentDir = "content/no"
 [languages.no.params]
 time_format_blog = "02.01.2006"
 # A list of language codes to look for untranslated content, ordered from left to right.
 language_alternatives = ["en"]
-[languages.ko]
-title = "Kubernetes"
-description = "Production-Grade Container Orchestration"
-languageName = "Korean"
-weight = 4
-contentDir = "content/ko"


### PR DESCRIPTION
This PR:
- Alphabetizes language weighting in `config.toml`
- Adds Korean characters to the Korean language selection

/assign @gochist @ClaudiaJKang 
