### PR TITLE
Fix edit page buttons

### DIFF
--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -37,7 +37,7 @@
         {{ end }}
         {{ end }}
         {{ if not .Params.noedit }}
-        <a href="{{ printf "%s#%s" ("docs/editdocs" | relURL) .Path | safeURL }}" class="button issue">{{ T "main_edit_this_page" }}</a>
+        <a href="https://github.com/kubernetes/website/edit/master/content/{{ .Site.Language.Lang }}/{{ .File.Path }}" class="button issue">{{ T "main_edit_this_page" }}</a>
         {{ end }}
       </div>
       {{ if not .Params.showcommit }}

--- a/layouts/partials/docs/content_page.html
+++ b/layouts/partials/docs/content_page.html
@@ -1,4 +1,4 @@
-<p><a href="https://github.com/kubernetes/website/edit/master/content/en/{{ .page.File.Path }}" id="editPageButton" target="_blank">Edit This Page</a></p>
+<p><a href="https://github.com/kubernetes/website/edit/master/content/{{ .page.Lang }}/{{ .page.File.Path }}" id="editPageButton" target="_blank">Edit This Page</a></p>
 {{ if not .page.Params.notitle }}
 <h1>{{ .page.Title }}</h1>
 {{ end }}


### PR DESCRIPTION
The "Edit This Page" button at the bottom of the page is broken. Currently, it uses `/docs/editdocs#`, e.g. https://kubernetes.io/docs/editdocs#docs/contribute/style/style-guide.md, but it should be like the one at the top of the page, e.g. https://github.com/kubernetes/website/edit/master/content/en/docs/contribute/style/style-guide.md

Also, the edit button at the top of the page has the `en` language hardcoded into the URL.

<img width="309" alt="screen shot 2018-10-05 at 1 40 12 pm" src="https://user-images.githubusercontent.com/24798125/46559153-3be73500-c8a4-11e8-8ec1-483137484ae4.png">

Preview: https://deploy-preview-10517--kubernetes-io-master-staging.netlify.com/docs/contribute/style/style-guide/