### PR TITLE
Fix broken links for Korean tutorial pages

### DIFF
--- a/content/ko/docs/tutorials/kubernetes-basics/_index.html
+++ b/content/ko/docs/tutorials/kubernetes-basics/_index.html
@@ -45,25 +45,25 @@ weight: 5
           <div class="row">
             <div class="col-md-4">
               <div class="thumbnail">
-                <a href="/docs/tutorials/kubernetes-basics/cluster-intro/"><img src="./public/images/module_01.svg?v=1469803628347" alt=""></a>
+                <a href="./create-cluster/cluster-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_01.svg?v=1469803628347" alt=""></a>
                 <div class="caption">
-                  <a href="cluster-intro/"><h5>1. 쿠버네티스 클러스터 생성하기</h5></a>
+                  <a href="./create-cluster/cluster-intro/"><h5>1. 쿠버네티스 클러스터 생성하기</h5></a>
                 </div>
               </div>
             </div>
             <div class="col-md-4">
               <div class="thumbnail">
-                <a href="/docs/tutorials/kubernetes-basics/deploy-intro/"><img src="./public/images/module_02.svg?v=1469803628347" alt=""></a>
+                <a href="./deploy-app/deploy-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_02.svg?v=1469803628347" alt=""></a>
                 <div class="caption">
-                  <a href="deploy-intro/"><h5>2. 애플리케이션 배포하기</h5></a>
+                  <a href="./deploy-app/deploy-intro/"><h5>2. 애플리케이션 배포하기</h5></a>
                 </div>
               </div>
             </div>
             <div class="col-md-4">
               <div class="thumbnail">
-                <a href="/docs/tutorials/kubernetes-basics/explore-intro/"><img src="./public/images/module_03.svg?v=1469803628347" alt=""></a>
+                <a href="./explore/explore-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_03.svg?v=1469803628347" alt=""></a>
                 <div class="caption">
-                  <a href="explore-intro/"><h5>3. 앱 조사하기</h5></a>
+                  <a href="./explore/explore-intro/"><h5>3. 앱 조사하기</h5></a>
                 </div>
               </div>
             </div>
@@ -73,25 +73,25 @@ weight: 5
           <div class="row">
             <div class="col-md-4">
               <div class="thumbnail">
-                <a href="/docs/tutorials/kubernetes-basics/expose-intro/"><img src="./public/images/module_04.svg?v=1469803628347" alt=""></a>
+                <a href="./expose/expose-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_04.svg?v=1469803628347" alt=""></a>
                 <div class="caption">
-                  <a href="expose-intro/"><h5>4. 앱 외부로 노출하기</h5></a>
+                  <a href="./expose/expose-intro/"><h5>4. 앱 외부로 노출하기</h5></a>
                 </div>
               </div>
             </div>
             <div class="col-md-4">
               <div class="thumbnail">
-                <a href="/docs/tutorials/kubernetes-basics/scale-intro/"><img src="./public/images/module_05.svg?v=1469803628347" alt=""></a>
+                <a href="./scale/scale-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_05.svg?v=1469803628347" alt=""></a>
                 <div class="caption">
-                  <a href="scale-intro/"><h5>5. 애플리케이션 스케일링하기</h5></a>
+                  <a href="./scale/scale-intro/"><h5>5. 애플리케이션 스케일링하기</h5></a>
                 </div>
               </div>
             </div>
             <div class="col-md-4">
               <div class="thumbnail">
-                <a href="/docs/tutorials/kubernetes-basics/update-intro/"><img src="./public/images/module_06.svg?v=1469803628347" alt=""></a>
+                <a href="./update/update-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_06.svg?v=1469803628347" alt=""></a>
                 <div class="caption">
-                  <a href="update-intro/"><h5>6. 앱 업데이트하기</h5></a>
+                  <a href="./update/update-intro/"><h5>6. 앱 업데이트하기</h5></a>
                 </div>
               </div>
             </div>
@@ -102,7 +102,7 @@ weight: 5
 
     <div class="row">
       <div class="col-md-12">
-        <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/cluster-intro/" role="button">튜토리얼 시작하기<span class="btn__next">›</span></a>
+        <a class="btn btn-lg btn-success" href="./create-cluster/cluster-intro/" role="button">튜토리얼 시작하기<span class="btn__next">›</span></a>
       </div>
     </div>
 

--- a/content/ko/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive.html
+++ b/content/ko/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive.html
@@ -28,7 +28,7 @@ weight: 20
         </div>
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/deploy-intro/" role="button">
+                <a class="btn btn-lg btn-success" href="../../deploy-app/deploy-intro/" role="button">
                     모듈 2로 진행하기<span class="btn__next">›</span></a>
             </div>
         </div>

--- a/content/ko/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro.html
+++ b/content/ko/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro.html
@@ -119,7 +119,7 @@ weight: 10
 
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/cluster-interactive/"
+                <a class="btn btn-lg btn-success" href="../cluster-interactive/"
                    role="button">대화형 튜토리얼 시작하기 <span class="btn__next">›</span></a>
             </div>
         </div>

--- a/content/ko/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive.html
+++ b/content/ko/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive.html
@@ -32,7 +32,7 @@ weight: 20
         </div>
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/explore-intro/" role="button">
+                <a class="btn btn-lg btn-success" href="../../explore/explore-intro/" role="button">
                     모듈 3으로 진행하기<span class="btn__next">›</span></a>
             </div>
         </div>

--- a/content/ko/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
+++ b/content/ko/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
@@ -116,7 +116,7 @@ weight: 10
 
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/deploy-interactive/"
+                <a class="btn btn-lg btn-success" href="../deploy-interactive/"
                    role="button">대화형 튜토리얼 시작하기 <span class="btn__next">›</span></a>
             </div>
         </div>

--- a/content/ko/docs/tutorials/kubernetes-basics/explore/explore-interactive.html
+++ b/content/ko/docs/tutorials/kubernetes-basics/explore/explore-interactive.html
@@ -32,7 +32,7 @@ weight: 20
         </div>
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/expose-intro/" role="button">모듈 4로
+                <a class="btn btn-lg btn-success" href="../../expose/expose-intro/" role="button">모듈 4로
                     진행하기<span class="btn__next">›</span></a>
             </div>
         </div>

--- a/content/ko/docs/tutorials/kubernetes-basics/explore/explore-intro.html
+++ b/content/ko/docs/tutorials/kubernetes-basics/explore/explore-intro.html
@@ -131,7 +131,7 @@ weight: 10
 
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/explore-interactive/" role="button">대화형 튜토리얼 시작하기 <span class="btn__next">›</span></a>
+                <a class="btn btn-lg btn-success" href="../explore-interactive/" role="button">대화형 튜토리얼 시작하기 <span class="btn__next">›</span></a>
             </div>
         </div>
 

--- a/content/ko/docs/tutorials/kubernetes-basics/expose/expose-interactive.html
+++ b/content/ko/docs/tutorials/kubernetes-basics/expose/expose-interactive.html
@@ -26,7 +26,7 @@ weight: 20
         </div>
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/scale-intro/" role="button">모듈 5로 진행하기<span class="btn__next">›</span></a>
+                <a class="btn btn-lg btn-success" href="../../scale/scale-intro/" role="button">모듈 5로 진행하기<span class="btn__next">›</span></a>
             </div>
         </div>
 

--- a/content/ko/docs/tutorials/kubernetes-basics/expose/expose-intro.html
+++ b/content/ko/docs/tutorials/kubernetes-basics/expose/expose-intro.html
@@ -104,7 +104,7 @@ weight: 10
 		<br>
 		<div class="row">
 			<div class="col-md-12">
-				<a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/expose-interactive/" role="button">대화형 튜토리얼 시작<span class="btn__next">›</span></a>
+				<a class="btn btn-lg btn-success" href="../expose-interactive/" role="button">대화형 튜토리얼 시작<span class="btn__next">›</span></a>
 			</div>
 		</div>
 	</main>

--- a/content/ko/docs/tutorials/kubernetes-basics/scale/scale-interactive.html
+++ b/content/ko/docs/tutorials/kubernetes-basics/scale/scale-interactive.html
@@ -29,7 +29,7 @@ weight: 20
         </div>
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/update-intro/" role="button">
+                <a class="btn btn-lg btn-success" href="../../update/update-intro/" role="button">
                     모듈 6으로 진행하기<span class="btn__next">›</span></a>
             </div>
         </div>

--- a/content/ko/docs/tutorials/kubernetes-basics/scale/scale-intro.html
+++ b/content/ko/docs/tutorials/kubernetes-basics/scale/scale-intro.html
@@ -123,7 +123,7 @@ weight: 10
 
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/scale-interactive/"
+                <a class="btn btn-lg btn-success" href="../scale-interactive/"
                    role="button">대화형 튜토리얼 시작하기 <span class="btn__next">›</span></a>
             </div>
         </div>

--- a/content/ko/docs/tutorials/kubernetes-basics/update/update-interactive.html
+++ b/content/ko/docs/tutorials/kubernetes-basics/update/update-interactive.html
@@ -26,7 +26,7 @@ weight: 20
         </div>
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/" role="button">쿠버네티스 기초로 돌아가기<span class="btn__next">›</span></a>
+                <a class="btn btn-lg btn-success" href="../../" role="button">쿠버네티스 기초로 돌아가기<span class="btn__next">›</span></a>
             </div>
         </div>
     </main>

--- a/content/ko/docs/tutorials/kubernetes-basics/update/update-intro.html
+++ b/content/ko/docs/tutorials/kubernetes-basics/update/update-intro.html
@@ -128,7 +128,7 @@ weight: 10
 
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/update-interactive/"
+                <a class="btn btn-lg btn-success" href="../update-interactive/"
                    role="button">대화형 튜토리얼 시작하기 <span class="btn__next">›</span></a>
             </div>
         </div>


### PR DESCRIPTION
Fix broken links for images and pages in the [ko/tutorials/kubernetes-basics](https://kubernetes.io/ko/docs/tutorials/kubernetes-basics/)