### PR TITLE
Remove links for older versions of kubernetes

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-upgrade.md
@@ -19,14 +19,10 @@ cluster if necessary.
 Every upgrade process might be a bit different, so we've documented each minor upgrade process individually.
 For more version-specific upgrade guidance, see the following resources:
 
- * [1.7.x to 1.7.y upgrades](https://v1-11.docs.kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-8/)
- * [1.7 to 1.8 upgrades](https://v1-11.docs.kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-8/)
- * [1.8.x to 1.8.y upgrades](https://v1-11.docs.kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-8/)
- * [1.8.x to 1.9.x upgrades](https://v1-11.docs.kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-9/)
- * [1.9.x to 1.9.y upgrades](https://v1-11.docs.kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-9/)
- * [1.9.x to 1.9.y HA cluster upgrades](https://v1-11.docs.kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-ha/)
  * [1.10 to 1.11 upgrades](/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-11/)
  * [1.11 to 1.12 upgrades](/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-12/)
+ 
+_For older versions, please refer to older documentation sets on the Kubernetes website._
 
 In Kubernetes v1.11.0 and later, you can use `kubeadm upgrade diff` to see the changes that would be
 applied to static pod manifests.

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-upgrade.md
@@ -19,12 +19,12 @@ cluster if necessary.
 Every upgrade process might be a bit different, so we've documented each minor upgrade process individually.
 For more version-specific upgrade guidance, see the following resources:
 
- * [1.7.x to 1.7.y upgrades](/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-8/)
- * [1.7 to 1.8 upgrades](/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-8/)
- * [1.8.x to 1.8.y upgrades](/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-8/)
- * [1.8.x to 1.9.x upgrades](/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-9/)
- * [1.9.x to 1.9.y upgrades](/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-9/)
- * [1.9.x to 1.9.y HA cluster upgrades](/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-ha/)
+ * [1.7.x to 1.7.y upgrades](https://v1-11.docs.kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-8/)
+ * [1.7 to 1.8 upgrades](https://v1-11.docs.kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-8/)
+ * [1.8.x to 1.8.y upgrades](https://v1-11.docs.kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-8/)
+ * [1.8.x to 1.9.x upgrades](https://v1-11.docs.kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-9/)
+ * [1.9.x to 1.9.y upgrades](https://v1-11.docs.kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-9/)
+ * [1.9.x to 1.9.y HA cluster upgrades](https://v1-11.docs.kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-ha/)
  * [1.10 to 1.11 upgrades](/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-11/)
  * [1.11 to 1.12 upgrades](/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-12/)
 


### PR DESCRIPTION
Upgrade paths listed on this page (1.7, etc) had broken links. Referred those links to the last working copy, which was in v1.11 docs.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> Please delete this note before submitting the pull request.
> For 1.12 Features: set Milestone to 1.12 and Base Branch to release-1.12
> Help editing and submitting pull requests:  https://deploy-preview-9510--kubernetes-io-master-staging.netlify.com/docs/contribute/start/#submit-a-pull-request.
> Help choosing which branch to use, see
> https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use.
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>

