### PR TITLE
Add microk8s to foundational.md

### DIFF
--- a/content/en/docs/user-journeys/users/application-developer/foundational.md
+++ b/content/en/docs/user-journeys/users/application-developer/foundational.md
@@ -55,13 +55,21 @@ You can get basic information about your cluster with the commands `kubectl clus
 
 #### microk8s
 
-On Linux, *microk8s* might be a good alternative for a local install of upstream Kubernetes. Microk8s keeps up with the current Kubernetes, and auto-updates to the latest point release for your convenience. Microk8s does not require you to install a hypervisor or launch a virtual machine, and installs within ~30 seconds.
+On Linux, *microk8s* might be a good alternative to Minikube for a
+local install of Kubernetes. Microk8s keeps up with the current
+Kubernetes, and automatically updates to the latest point release for
+your convenience. With microk8s you don't to install a hypervisor or
+launch a virtual machine, and installation completes within ~30
+seconds.
 
 * {{< link text="Install microk8s" url="https://microk8s.io/" >}}.
 
-Once you have installed microk8s, using the prefix "microk8s." you can tab-complete a variety of commands, including accessing the included registry, container runtime and more (for example, `microk8s.kubectl`). Using the prefix ensures clean separation of the local environment vs other Kubernetes API endpoints.
+After you install microk8s, you can use its tab-completion
+functionality. All microk8s commands start with `microk8s.`. Type
+`microk8s.` (with the period) and then use the tab key to see a list
+of available commands.
 
-It also includes commands to `microk8s.enable`
+It also includes commands to enable Kubernetes subsystems. For example:
 
 * the Kubernetes Dashboard
 * the DNS service

--- a/content/en/docs/user-journeys/users/application-developer/foundational.md
+++ b/content/en/docs/user-journeys/users/application-developer/foundational.md
@@ -58,10 +58,9 @@ You can get basic information about your cluster with the commands `kubectl clus
 On Linux, *microk8s* is a good alternative to Minikube for a local
 install of Kubernetes:
 
-* there is no overhead from running a virtual machine as it runs on
-  the native OS
-* microk8s always provides the latest stable version of Kubernetes
-* installation of microk8s takes less than a minute
+* Runs on the native OS, so there is no overhead from running a virtual machine.
+* Always provides the latest stable version of Kubernetes, using built-in auto-upgrade functionality.
+* Installs in less than a minute.
 
 * {{< link text="Install microk8s" url="https://microk8s.io/" >}}.
 

--- a/content/en/docs/user-journeys/users/application-developer/foundational.md
+++ b/content/en/docs/user-journeys/users/application-developer/foundational.md
@@ -53,6 +53,25 @@ Minikube can be installed locally, and runs a simple, single-node Kubernetes clu
 
 You can get basic information about your cluster with the commands `kubectl cluster-info` and `kubectl get nodes`. However, to get a good idea of what's really going on, you need to deploy an application to your cluster. This is covered in the next section.
 
+#### microk8s
+
+On Linux, *microk8s* might be a good alternative for a local install of upstream Kubernetes. Microk8s keeps up with the current Kubernetes, and auto-updates to the latest point release for your convenience. Microk8s does not require you to install a hypervisor or launch a virtual machine, and installs within ~30 seconds.
+
+* {{< link text="Install microk8s" url="https://microk8s.io/" >}}.
+
+Once you have installed microk8s, using the prefix "microk8s." you can tab-complete a variety of commands, including accessing the included registry, container runtime and more (for example, `microk8s.kubectl`). Using the prefix ensures clean separation of the local environment vs other Kubernetes API endpoints.
+
+It also includes commands to `microk8s.enable`
+
+* the Kubernetes Dashboard
+* the DNS service
+* GPU passthrough (for NVIDIA)
+* Ingress
+* Istio
+* Metrics server
+* Registry
+* Storage
+
 ## Deploy an application
 
 #### Basic workloads

--- a/content/en/docs/user-journeys/users/application-developer/foundational.md
+++ b/content/en/docs/user-journeys/users/application-developer/foundational.md
@@ -55,12 +55,13 @@ You can get basic information about your cluster with the commands `kubectl clus
 
 #### microk8s
 
-On Linux, *microk8s* might be a good alternative to Minikube for a
-local install of Kubernetes. Microk8s keeps up with the current
-Kubernetes, and automatically updates to the latest point release for
-your convenience. With microk8s you don't to install a hypervisor or
-launch a virtual machine, and installation completes within ~30
-seconds.
+On Linux, *microk8s* is a good alternative to Minikube for a local
+install of Kubernetes:
+
+* there is no overhead from running a virtual machine as it runs on
+  the native OS
+* microk8s always provides the latest stable version of Kubernetes
+* installation of microk8s takes less than a minute
 
 * {{< link text="Install microk8s" url="https://microk8s.io/" >}}.
 


### PR DESCRIPTION
Adding microk8s as credible and stable alternative to get started with Kubernetes on a local machine. This is especially attractive for those not wanting to incur the overhead of running a VM for a local cluster.