### PR TITLE
Fix javascript reference in API docs

### DIFF
--- a/static/docs/reference/generated/kubernetes-api/v1.12/index.html
+++ b/static/docs/reference/generated/kubernetes-api/v1.12/index.html
@@ -49746,9 +49746,9 @@ $ curl -X GET 'http://127.0.0.1:8001/apis/extensions/v1beta1/watch/namespaces/de
 </TABLE>
 </DIV>
 </DIV>
-<SCRIPT src="/js/jquery-2.2.0.min.js"></SCRIPT>
+<SCRIPT src="/js/jquery-3.2.1.min.js"></SCRIPT>
 <SCRIPT src="jquery.scrollTo.min.js"></SCRIPT>
-<SCRIPT src="/js/bootstrap.min.js"></SCRIPT>
+<SCRIPT src="/js/bootstrap-3.3.7.min.js"></SCRIPT>
 <SCRIPT src="navData.js"></SCRIPT>
 <SCRIPT src="scroll.js"></SCRIPT>
 </BODY>


### PR DESCRIPTION
The versions of javascripts used have been updated so the references in
the generated API docs should be updated as well.

Closes: #10385

