### PR TITLE
Update create-cluster-kubeadm.md

### DIFF
--- a/content/en/docs/setup/independent/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/independent/create-cluster-kubeadm.md
@@ -384,10 +384,10 @@ Kindly refer to this quickstart: [TungstenFabric](https://tungstenfabric.github.
 {{% /tab %}}
 {{< /tabs >}}
 
+It is necessary to join a node to the master otherwise the CoreDNS pods will be unable to start.
 
 Once a pod network has been installed, you can confirm that it is working by
 checking that the CoreDNS pod is Running in the output of `kubectl get pods --all-namespaces`.
-And once the CoreDNS pod is up and running, you can continue by joining your nodes.
 
 If your network is not working or CoreDNS is not in the Running state, check
 out our [troubleshooting docs](/docs/setup/independent/troubleshooting-kubeadm/).


### PR DESCRIPTION
Clarify in the documentation that a node must be joined before CoreDNS can start. I was mislead by the documentation into believing that the CoreDNS pods need to be running before I can join a node.

See also this discussion on Stackoverflow:
https://stackoverflow.com/questions/52609257/coredns-in-pending-state-in-kubernetus-cluster
