### PR TITLE
Clean up OWNERS* files with permissions by alias

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,24 +1,10 @@
 # Reviewers can /lgtm /approve but not sufficient for auto-merge without an
 # approver
 reviewers:
-- Rajakavitha1
-- stewart-yu
-- xiangpengzhao
-- zhangxiaoyu-zidif
+- sig-docs-en-reviews 
 
 # Approvers have all the ability of reviewers but their /approve makes
 # auto-merge happen if a /lgtm exists, or vice versa, or they can do both
 # No need for approvers to also be listed as reviewers
 approvers:
-- bradamant3
-- bradtopol
-- chenopis
-- jaredbhatti
-- kbarnard10
-- mistyhacks
-- ryanmcginnis
-- steveperry-53
-- tengqm
-- tfogo
-- zacharysarah
-- zparnold
+- sig-docs-en-owners

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -97,21 +97,39 @@ aliases:
     - apelisse
     - grodrigues3
     - spxtr
-  sig-docs: #Team: documentation; GH: sig-docs-pr-reviews
+  sig-docs: #Team: documentation; GH: sig-docs-maintainers
     - bradamant3
     - bradtopol
     - chenopis
+    - jaredbhatti
     - kbarnard10
     - mistyhacks
-    - rajakavitha1
     - ryanmcginnis
     - steveperry-53
-    - stewart-yu
     - tengqm
+    - tfogo
     - xiangpengzhao
     - zacharysarah
     - zhangxiaoyu-zidif
     - zparnold
+  sig-docs-en-owners: #Team: Documentation; GH: sig-docs-en-owners
+    - bradamant3
+    - bradtopol
+    - chenopis
+    - jaredbhatti
+    - kbarnard10
+    - mistyhacks
+    - ryanmcginnis
+    - steveperry-53
+    - tengqm
+    - tfogo
+    - zacharysarah
+    - zparnold
+  sig-docs-en-reviews: #Team: Documentation; GH: sig-docs-pr-reviews 
+    - rajakavitha1
+    - stewart-yu
+    - xiangpengzhao
+    - zhangxiaoyu
   sig-federation: #Team: Federation; e.g. Federated Clusters
     - csbell
   sig-gcp: #Google Cloud Platform; GH: sig-gcp-pr-reviews


### PR DESCRIPTION
This PR:
- Updates OWNERS_ALIASES with membership based on (visible to maintainers only):
    - https://github.com/orgs/kubernetes/teams/sig-docs-maintainers
    - https://github.com/orgs/kubernetes/teams/sig-docs-pr-reviews

- De-duplicates permissions by setting OWNERS by alias


