### PR TITLE
Remove duplication of `spec:`

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/jobs-run-to-completion.md
+++ b/content/en/docs/concepts/workloads/controllers/jobs-run-to-completion.md
@@ -279,7 +279,6 @@ kind: Job
 metadata:
   name: pi-with-ttl
 spec:
-spec:
   ttlSecondsAfterFinished: 100
   template:
     spec:


### PR DESCRIPTION
Removed duplicate of `spec:` in example.

