### PR TITLE
Update Flannel manifest URL

### DIFF
--- a/content/en/docs/setup/independent/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/independent/create-cluster-kubeadm.md
@@ -317,14 +317,10 @@ Set `/proc/sys/net/bridge/bridge-nf-call-iptables` to `1` by running `sysctl net
 to pass bridged IPv4 traffic to iptables' chains. This is a requirement for some CNI plugins to work, for more information
 please see [here](https://kubernetes.io/docs/concepts/cluster-administration/network-plugins/#network-plugin-requirements).
 
-```shell
-kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/v0.10.0/Documentation/kube-flannel.yml
-```
-Note that `flannel` works on `amd64`, `arm`, `arm64` and `ppc64le`, but until `flannel v0.11.0` is released
-you need to use the following manifest that supports all the architectures:
+Note that `flannel` works on `amd64`, `arm`, `arm64` and `ppc64le`.
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/c5d10c8/Documentation/kube-flannel.yml
+kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/bc79dd1505b0c8681ece4de4c0d86c5cd2643275/Documentation/kube-flannel.yml
 ```
 
 For more information about `flannel`, see [the CoreOS flannel repository on GitHub


### PR DESCRIPTION
Current manifest of flannel is old for Kubernetes v1.12 .
Cluster deployment is failed at installing pod network add-on.
This PR update flannel manifest URL.
And this PR change manifest URL to single link, because of 
new manifest support multi-arch.

Fixes #10569

/cc @neolit123 

