### PR TITLE
Graduate ExpandInUsePersistentVolumes feature to beta

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -70,7 +70,8 @@ different Kubernetes components.
 | `DynamicVolumeProvisioning` | `true` | Alpha | 1.3 | 1.7 |
 | `DynamicVolumeProvisioning` | `true` | GA | 1.8 | |
 | `EnableEquivalenceClassCache` | `false` | Alpha | 1.8 | |
-| `ExpandInUsePersistentVolumes` | `false` | Alpha | 1.11 | |
+| `ExpandInUsePersistentVolumes` | `false` | Alpha | 1.11 | 1.13 | |
+| `ExpandInUsePersistentVolumes` | `true` | Beta | 1.14 | |
 | `ExpandPersistentVolumes` | `false` | Alpha | 1.8 | 1.10 |
 | `ExpandPersistentVolumes` | `true` | Beta | 1.11 | |
 | `ExperimentalCriticalPodAnnotation` | `false` | Alpha | 1.5 | |


### PR DESCRIPTION
This PR is intend to move `ExpandInUsePersistentVolumes` feature to beta in 1.13.

xref - [kubernetes/feature#531](https://github.com/kubernetes/features/issues/531)
