### PR TITLE
Bug in coredns ConfigMap spec

### DIFF
--- a/content/en/docs/tasks/administer-cluster/dns-custom-nameservers.md
+++ b/content/en/docs/tasks/administer-cluster/dns-custom-nameservers.md
@@ -71,7 +71,8 @@ kind: ConfigMap
 metadata:
   name: coredns
   namespace: kube-system
-Corefile: |
+data:
+  Corefile: |
     .:53 {
         errors
         health
@@ -139,7 +140,8 @@ kind: ConfigMap
 metadata:
   name: coredns
   namespace: kube-system
-Corefile: |
+data:
+  Corefile: |
     .:53 {
         errors
         health


### PR DESCRIPTION
Missing the `data` label in configmap spec.  Attempting to create the file as is results in:
```
error: error validating "STDIN": error validating data: ValidationError(ConfigMap): unknown field "Corefile" in io.k8s.api.core.v1.ConfigMap; if you choose to ignore these errors, turn validation off with --validate=false
```