### PR TITLE
Redirect to decoding a secret

### DIFF
--- a/content/en/docs/tasks/administer-cluster/encrypt-data.md
+++ b/content/en/docs/tasks/administer-cluster/encrypt-data.md
@@ -142,7 +142,8 @@ program to retrieve the contents of your secret.
     kubectl describe secret secret1 -n default
     ```
 
-    should match `mykey: mydata`
+    should match `mykey: bXlkYXRh`, mydata is encoded, check [decoding a secret](/docs/concepts/configuration/secret#decoding-a-secret) to
+    completely decode the secret.
 
 
 ## Ensure all secrets are encrypted


### PR DESCRIPTION
In this Document Encrypting Secret data at REST, the example to verify decrypt secret is bit confusing,
on doing $ kubectl describe secret secret1 -n default
"should match mykey: mydata" never match because data is enoded, It creates confusion for a while.
This commit redirects it to decoding the secret

