### PR TITLE
reference missing ('kubelet config annotate-cri') phase on additional controller nodes

### DIFF
--- a/content/en/docs/setup/independent/high-availability.md
+++ b/content/en/docs/setup/independent/high-availability.md
@@ -306,6 +306,7 @@ done
     ```sh
     kubeadm alpha phase kubeconfig all --config kubeadm-config.yaml
     kubeadm alpha phase controlplane all --config kubeadm-config.yaml
+    kubeadm alpha phase kubelet config annotate-cri --config kubeadm-config.yaml
     kubeadm alpha phase mark-master --config kubeadm-config.yaml
     ```
 
@@ -393,6 +394,7 @@ done
     ```sh
     kubeadm alpha phase kubeconfig all --config kubeadm-config.yaml
     kubeadm alpha phase controlplane all --config kubeadm-config.yaml
+    kubeadm alpha phase kubelet config annotate-cri --config kubeadm-config.yaml
     kubeadm alpha phase mark-master --config kubeadm-config.yaml
     ```
 


### PR DESCRIPTION
Hi all, 

AFAICT `kubeadm alpha phase kubelet config annotate-cri` should be invoked, for consistency in all joining controller nodes (to match what is already done by default in the seed/initial one via `kubeadm init`).  

best regards, 

António

