### PR TITLE
adding missing step for additional control plane nodes

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-ha.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-ha.md
@@ -150,6 +150,12 @@ Add an annotation for the cri-socket to the current node, for example to use doc
 kubectl annotate node <nodename> kubeadm.alpha.kubernetes.io/cri-socket=/var/run/dockershim.sock
 ```
 
+Apply the modified kubeadm-config on the node:
+
+```shell
+kubectl apply -f kubeadm-config-cm.yaml --force
+```
+
 Start the upgrade:
 
 ```shell


### PR DESCRIPTION
There appears to be a missing step instructing the user to apply the kubeadm-config on each of the additional control plane nodes