### PR TITLE
Fix Hugo config.toml as valid

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,7 +7,7 @@ enableRobotsTXT = true
 
 disableKinds = ["taxonomy", "taxonomyTerm"]
 
-ignoreFiles = [ "^OWNERS$", "README[-]+[a-z]*\.md", "^node_modules$", "content/en/docs/doc-contributor-tools" ]
+ignoreFiles = [ "^OWNERS$", "README[-]+[a-z]*\\.md", "^node_modules$", "content/en/docs/doc-contributor-tools" ]
 
 contentDir = "content/en"
 


### PR DESCRIPTION
Closes #10604

Fix a regression from #10485. We can't run `make serve`:

```
$ make serve
hugo server --ignoreCache --disableFastRender
Error: While parsing config: (10, 30): invalid escape sequence: \.
make: *** [serve] Error 255
```

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>