### PR TITLE
Use hugo in Travis CI pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,33 @@ language: go
 go:
   - 1.10.2
 
-# Don't want default ./... here:
-install:
-- export PATH=$GOPATH/bin:$PATH
-- mkdir -p $HOME/gopath/src/k8s.io
-- mv $TRAVIS_BUILD_DIR $HOME/gopath/src/k8s.io/website && cd $HOME/gopath/src/k8s.io/website
+env:
+  - HUGO_VERSION=0.49
 
-# Make sure we are testing against the correct branch
-- pushd $GOPATH/src/k8s.io && git clone https://github.com/kubernetes/kubernetes && popd
-- pushd $GOPATH/src/k8s.io/kubernetes && git checkout release-1.11 && popd
-- cp -L -R $GOPATH/src/k8s.io/kubernetes/vendor/ $GOPATH/src/
-- rm -r $GOPATH/src/k8s.io/kubernetes/vendor/
+jobs:
+  include:
+    - name: "Testing examples"
+      # Don't want default ./... here:
+      install:
+      - export PATH=$GOPATH/bin:$PATH
+      - mkdir -p $HOME/gopath/src/k8s.io
+      - mv $TRAVIS_BUILD_DIR $HOME/gopath/src/k8s.io/website && cd $HOME/gopath/src/k8s.io/website
 
-# Fetch additional dependencies to run the tests in examples/examples_test.go
-- go get -t -v k8s.io/website/content/en/examples
+      # Make sure we are testing against the correct branch
+      - pushd $GOPATH/src/k8s.io && git clone https://github.com/kubernetes/kubernetes && popd
+      - pushd $GOPATH/src/k8s.io/kubernetes && git checkout release-1.11 && popd
+      - cp -L -R $GOPATH/src/k8s.io/kubernetes/vendor/ $GOPATH/src/
+      - rm -r $GOPATH/src/k8s.io/kubernetes/vendor/
 
-script:
-- go test -v k8s.io/website/content/en/examples
+      # Fetch additional dependencies to run the tests in examples/examples_test.go
+      - go get -t -v k8s.io/website/content/en/examples
+      script:
+      - go test -v k8s.io/website/content/en/examples
+    - name: "Hugo build"
+      install:
+      - curl -L https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_linux-64bit.tar.gz | tar -xz
+      - mkdir -p ${TRAVIS_HOME}/bin
+      - mv hugo ${TRAVIS_HOME}/bin
+      - export PATH=${TRAVIS_HOME}/bin:$PATH
+      script:
+      - hugo


### PR DESCRIPTION
This PR adds into the CI pipeline to avoid unintentional regressions such as one from #10485, which was fixed at #10604.

By running `hugo`, we can check:

- if `config.toml` is valid (#10485)
- if there is something missed in l10n build (#10220, #10610)

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>