### PR TITLE
Use CoCC email for reporting CoC violations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,8 @@ These are just guidelines, not rules. Use your best judgment, and feel free to p
 
 ### Code of Conduct
 
-Kubernetes follows the [Cloud Native Computing Foundation (CNCF) Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to Sarah Novotny [sarahnovotny@google.com](mailto:sarahnovotny@google.com) and/or Dan Kohn [dan@linuxfoundation.org](mailto:dan@linuxfoundation.org).
+Kubernetes follows the [Cloud Native Computing Foundation (CNCF) Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to the
+[Kubernetes Code of Conduct Committee](https://github.com/kubernetes/community/tree/master/committee-code-of-conduct) <conduct@kubernetes.io>.
 
 ### Documentation and Site Decisions
 

--- a/content/en/community/_index.html
+++ b/content/en/community/_index.html
@@ -44,8 +44,8 @@ cid: community
              enforces a <a href="code-of-conduct/">Code of Conduct</a> in all
              interactions. If you notice a violation of the Code of Conduct at
              an event or meeting, in Slack, or in another communication
-             mechanism, reach out to the
-             <a href="mailto:steering-private@kubernetes.io">steering committee</a>.
+             mechanism, reach out to the <a href="https://github.com/kubernetes/community/tree/master/committee-code-of-conduct">Kubernetes Code of Conduct Committee</a>
+             <a href="mailto:conduct@kubernetes.io">conduct@kubernetes.io</a>.
              Your anonymity will be protected.</p>
            </p>
          </div>

--- a/content/en/community/code-of-conduct.md
+++ b/content/en/community/code-of-conduct.md
@@ -16,9 +16,9 @@ If you notice that this is out of date, please
 <a href="https://github.com/kubernetes/website/issues/new">file an issue</a>.
 
 If you notice a violation of the Code of Conduct at an event or meeting, in
-Slack, or in another communication mechanism, reach out to the
-<a href="mailto:steering-private@kubernetes.io">steering committee</a>. Your
-anonymity will be protected.
+Slack, or in another communication mechanism, reach out to
+the [Kubernetes Code of Conduct Committee](https://github.com/kubernetes/community/tree/master/committee-code-of-conduct) <conduct@kubernetes.io>.
+Your anonymity will be protected.
 
 <div class="cncf_coc_container">
 {{< include "/static/cncf-code-of-conduct.md" >}}

--- a/content/en/community/static/cncf-code-of-conduct.md
+++ b/content/en/community/static/cncf-code-of-conduct.md
@@ -34,7 +34,8 @@ Conduct may be permanently removed from the project team.
 This code of conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a CNCF project maintainer, Sarah Novotny <sarahnovotny@google.com>, and/or Dan Kohn <dan@linuxfoundation.org>.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting
+the [Kubernetes Code of Conduct Committee](https://github.com/kubernetes/community/tree/master/committee-code-of-conduct) <conduct@kubernetes.io>.
 
 This Code of Conduct is adapted from the Contributor Covenant
 (http://contributor-covenant.org), version 1.2.0, available at


### PR DESCRIPTION
Now that we have a Code of Conduct Committee for Kubernetes, people should contact our private email list going forward with any problems.