### PR TITLE
Add NA contributor Summit Blog Post

### DIFF
--- a/content/en/blog/_posts/2018-10-16-kubernetes-2018-north-american-contributor-summit.md
+++ b/content/en/blog/_posts/2018-10-16-kubernetes-2018-north-american-contributor-summit.md
@@ -1,0 +1,63 @@
+---
+layout: "Blog"
+title: "Kubernetes 2018 North American Contributor Summit"
+date: 2018-10-16    
+---
+
+**Authors:**
+[Bob Killen][bob] (University of Michigan)
+[Sahdev Zala][sahdev] (IBM),
+[Ihor Dvoretskyi][ihor] (CNCF) 
+
+
+The 2018 North American Kubernetes Contributor Summit to be hosted right before
+[CloudNativeCon/KubeCon][kubecon] Seattle is shaping up to be the largest yet.
+It is an event that brings together new and current contributors alike to
+connect and share face-to-face; and serves as an opportunity for existing
+contributors to help shape the future of community development. For new
+community members, it offers a welcoming space to learn, explore and put the
+contributor workflow to practice.
+
+Unlike previous Contributor Summits, the event now spans two-days with a more
+relaxed ‘hallway’ track and general Contributor get-together to be hosted from
+5-8pm Sunday December 9th at the [Garage Lounge and Gaming Hall][garage], just
+a short walk away from the Convention Center. There, contributors can enjoy
+billiards, bowling, trivia and more; accompanied by a variety of food and drink. 
+
+Things pick up the following day, Monday the 10th with three separate tracks: 
+
+## New Contributor Workshop:
+A half day workshop aimed at getting new and first time contributors on boarded
+and comfortable with working within the Kubernetes Community. Staying for the
+duration is required; this is not a workshop you can drop into. 
+
+## Current Contributor Track:
+Reserved for those that are actively engaged with the development of the
+project; the Current Contributor Track includes Talks, Workshops, Birds of a
+Feather, Unconferences, Steering Committee Sessions, and more! Keep an eye on
+the [schedule in GitHub][schedule] as content is frequently being updated.
+
+## Docs Sprint:
+SIG Docs will have a curated list of issues and challenges to be tackled closer
+to the event date.
+
+## To Register:
+To register for the Contributor Summit, see the [Registration section of the
+Event Details in GitHub][register]. Please note that registrations are being
+reviewed. If you select the “Current Contributor Track” and are not an active
+contributor, you will be asked to attend the New Contributor Workshop, or asked
+to be put on a waitlist. With thousands of contributors and only 300 spots, we
+need to make sure the right folks are in the room. 
+
+If you have any questions or concerns, please don’t hesitate to reach out to
+the Contributor Summit Events Team at community@kubernetes.io.
+
+Look forward to seeing everyone there!
+
+[bob]: https://twitter.com/mrbobbytables
+[sahdev]: https://twitter.com/sp_zala
+[ihor]: https://twitter.com/idvoretskyi
+[kubecon]: https://events.linuxfoundation.org/events/kubecon-cloudnativecon-north-america-2018/
+[garage]: https://www.garagebilliards.com/
+[schedule]: https://git.k8s.io/community/events/2018/12-contributor-summit#agenda
+[register]:  https://git.k8s.io/community/events/2018/12-contributor-summit#registration

--- a/content/en/blog/_posts/2018-10-16-kubernetes-2018-north-american-contributor-summit.md
+++ b/content/en/blog/_posts/2018-10-16-kubernetes-2018-north-american-contributor-summit.md
@@ -20,25 +20,25 @@ contributor workflow to practice.
 
 Unlike previous Contributor Summits, the event now spans two-days with a more
 relaxed ‘hallway’ track and general Contributor get-together to be hosted from
-5-8pm Sunday December 9th at the [Garage Lounge and Gaming Hall][garage], just
+5-8pm on Sunday December 9th at the [Garage Lounge and Gaming Hall][garage], just
 a short walk away from the Convention Center. There, contributors can enjoy
 billiards, bowling, trivia and more; accompanied by a variety of food and drink. 
 
 Things pick up the following day, Monday the 10th with three separate tracks: 
 
-## New Contributor Workshop:
-A half day workshop aimed at getting new and first time contributors on boarded
+### New Contributor Workshop:
+A half day workshop aimed at getting new and first time contributors onboarded
 and comfortable with working within the Kubernetes Community. Staying for the
 duration is required; this is not a workshop you can drop into. 
 
-## Current Contributor Track:
+### Current Contributor Track:
 Reserved for those that are actively engaged with the development of the
 project; the Current Contributor Track includes Talks, Workshops, Birds of a
 Feather, Unconferences, Steering Committee Sessions, and more! Keep an eye on
 the [schedule in GitHub][schedule] as content is frequently being updated.
 
-## Docs Sprint:
-SIG Docs will have a curated list of issues and challenges to be tackled closer
+### Docs Sprint:
+SIG-Docs will have a curated list of issues and challenges to be tackled closer
 to the event date.
 
 ## To Register:


### PR DESCRIPTION
Adds the blog post for the NA contributor summit. Date etc can be bumped pending other content or a  specific desired publish date.

/cc @idvoretskyi @spzala @parispittman @castrojo 

/assign @kbarnard10