### PR TITLE
fix a clerical error in audit truncate description

### DIFF
--- a/content/en/docs/tasks/debug-application-cluster/audit.md
+++ b/content/en/docs/tasks/debug-application-cluster/audit.md
@@ -191,7 +191,7 @@ and in the logs to monitor the state of the auditing subsystem.
 
 ### Truncate
 
-Both log and webhook backends support batching. As an example, the following is the list of flags
+Both log and webhook backends support truncating. As an example, the following is the list of flags
 available for the log backend:
 
  - `audit-log-truncate-enabled` whether event and batch truncating is enabled.


### PR DESCRIPTION
writer copy the previous description but forget to modify.