### PR TITLE
Update site config for l10n teams and 1.11 info

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,19 +1,10 @@
 # Reviewers can /lgtm /approve but not sufficient for auto-merge without an
 # approver
 reviewers:
-- zhangxiaoyu-zidif
-- xiangpengzhao
-- stewart-yu
-- Rajakavitha1 
+- sig-docs-en-reviews 
+
 # Approvers have all the ability of reviewers but their /approve makes
 # auto-merge happen if a /lgtm exists, or vice versa, or they can do both
 # No need for approvers to also be listed as reviewers
 approvers:
-- heckj
-- bradamant3
-- bradtopol
-- steveperry-53
-- zacharysarah
-- chenopis
-- mistyhacks
-- tengqm
+- sig-docs-en-owners

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -41,9 +41,11 @@ aliases:
     - chrislovecnm
     - mfburnett
   sig-azure: #Microsoft Azure
-    - slack
-    - colemickens
-    - jdumars
+    - andyzhangx
+    - feiskyer
+    - justaugustus
+    - karataliu
+    - khenidak
   sig-big-data: #GH: sig-big-data-pr-reviews
     - foxish
   sig-cli: #Team: CLI; GH: sig-cli-pr-reviews; e.g. kubectl
@@ -61,11 +63,25 @@ aliases:
     - smarterclayton
     - soltysh
     - sttts
-  sig-cluster-lifecycle: #GH: sig-cluster-lifecycle-pr-reviews
+  sig-cluster-lifecycle-kubeadm-approvers: # Approving changes to kubeadm documentation
     - timothysc
+    - lukemarsden
     - luxas
     - roberthbailey
-    - fabriziopandini 
+    - fabriziopandini
+  sig-cluster-lifecycle-kubeadm-reviewers: # Reviewing kubeadm documentation
+    - timothysc
+    - lukemarsden
+    - luxas
+    - roberthbailey
+    - fabriziopandini
+    - kad
+    - xiangpengzhao
+    - stealthybox
+    - liztio
+    - chuckha
+    - detiber
+    - dixudx
   sig-cluster-ops:
     - zehicle
     - jdumars
@@ -81,12 +97,71 @@ aliases:
     - apelisse
     - grodrigues3
     - spxtr
-  sig-docs: #Team: documentation; GH: sig-docs-pr-reviews
+  sig-docs: #Team: documentation; GH: sig-docs-maintainers
     - bradamant3
-    - steveperry-53
-    - zacharysarah
     - bradtopol
-    - heckj
+    - chenopis
+    - jaredbhatti
+    - kbarnard10
+    - mistyhacks
+    - ryanmcginnis
+    - steveperry-53
+    - tengqm
+    - tfogo
+    - xiangpengzhao
+    - zacharysarah
+    - zhangxiaoyu-zidif
+    - zparnold
+  sig-docs-en-owners: #Team: Documentation; GH: sig-docs-en-owners
+    - bradamant3
+    - bradtopol
+    - chenopis
+    - jaredbhatti
+    - kbarnard10
+    - mistyhacks
+    - ryanmcginnis
+    - steveperry-53
+    - stewart-yu
+    - tengqm
+    - tfogo
+    - zacharysarah
+    - zparnold
+  sig-docs-en-reviews: #Team: Documentation; GH: sig-docs-pr-reviews 
+    - jimangel
+    - rajakavitha1
+    - stewart-yu
+    - xiangpengzhao
+    - zhangxiaoyu
+  sig-docs-ja-owners: #Team: Japanese docs localization; GH: sig-docs-ja-owners
+    - cstoku
+    - nasa9084
+    - tnir
+  sig-docs-ja-reviews: #Team: Japanese docs PR reviews; GH:sig-docs-ja-reviews 
+    - cstoku
+    - makocchi-git
+    - MasayaAoyama
+    - nasa9084
+    - tnir
+  sig-docs-ko-owners: #Team Korean docs localization; GH: sig-docs-ko-owners
+    - ClaudiaJKang
+    - gochist
+  sig-docs-ko-reviews: #Team Korean docs reviews; GH: sig-docs-ko-reviews
+    - ClaudiaJKang
+    - gochist
+    - ianychoi
+  sig-docs-zh-owners: #Team Chinese docs localization; GH: sig-docs-zh-owners
+    - dchen1107
+    - haibinxie
+    - hanjiayao
+    - lichuqiang
+    - tengqm
+    - xiangpengzhao
+    - zhangxiaoyu-zidif
+  sig-docs-zh-reviews: #Team Chinese docs reviews; GH: sig-docs-zh-reviews
+    - idealhack
+    - tengqm
+    - xiangpengzhao
+    - zhangxiaoyu-zidif
   sig-federation: #Team: Federation; e.g. Federated Clusters
     - csbell
   sig-gcp: #Google Cloud Platform; GH: sig-gcp-pr-reviews
@@ -197,3 +272,4 @@ aliases:
     - floreks
   sig-windows:
     - michmike
+    

--- a/config.toml
+++ b/config.toml
@@ -7,7 +7,7 @@ enableRobotsTXT = true
 
 disableKinds = ["taxonomy", "taxonomyTerm"]
 
-ignoreFiles = [ "^OWNERS$", "README.md", "^node_modules$" ]
+ignoreFiles = [ "^OWNERS$", "README[-]+[a-z]*\\.md", "^node_modules$", "content/en/docs/doc-contributor-tools" ]
 
 contentDir = "content/en"
 
@@ -19,6 +19,12 @@ pygmentsUseClasses = false
 # See https://help.farbox.com/pygments.html
 pygmentsStyle = "emacs"
 
+# Enable Git variables like commit, lastmod
+enableGitInfo = true
+
+# Norwegian ("no") is sometimes but not currently used for testing.
+disableLanguages = ["no"]
+
 [blackfriday]
 hrefTargetBlank = true
 fractions = false
@@ -27,17 +33,29 @@ fractions = false
 date = ["date", ":filename", "publishDate", "lastmod"]
 
 [permalinks]
-  blog = "/:section/:year/:month/:day/:slug/"
+blog = "/:section/:year/:month/:day/:slug/"
 
 # Be explicit about the output formats. We (currently) only want an RSS feed for the home page.
 [outputs]
-home = [ "HTML", "RSS"]
+home = [ "HTML", "RSS", "HEADERS" ]
 page = [ "HTML"]
 section = [ "HTML"]
+
+# Add a "text/netlify" media type for auto-generating the _headers file
+[mediaTypes]
+[mediaTypes."text/netlify"]
+delimiter = ""
 
 [outputFormats]
 [outputFormats.RSS]
 baseName = "feed"
+
+# _headers file output (uses the template at layouts/index.headers)
+[outputFormats.HEADERS]
+mediatype = "text/netlify"
+baseName = "_headers"
+isPlainText = true
+notAlternative = true
 
 [params]
 
@@ -45,31 +63,49 @@ time_format_blog = "Monday, January 02, 2006"
 description = "Production-Grade Container Orchestration"
 showedit = true
 
-latest = "v1.11"
+latest = "v1.12"
 
-fullversion = "v1.11.0"
+fullversion = "v1.11.3"
 version = "v1.11"
-githubbranch = "master"
-docsbranch = "master"
-deprecated = false
+githubbranch = "v1.11.3"
+docsbranch = "release-1.11"
+deprecated = true
 currentUrl = "https://kubernetes.io/docs/home/"
-nextUrl = "http://kubernetes-io-vnext-staging.netlify.com/"
+nextUrl = "https://kubernetes-io-vnext-staging.netlify.com/"
 githubWebsiteRepo = "github.com/kubernetes/website"
 githubWebsiteRaw = "raw.githubusercontent.com/kubernetes/website"
 
+[params.pushAssets]
+css = [
+  "callouts",
+  "styles",
+  "custom-jekyll/tags"
+]
+js = [
+  "custom-jekyll/tags",
+  "script"
+]
+
 [[params.versions]]
-fullversion = "v1.11.0"
-version = "v1.11"
-githubbranch = "v1.11.0"
-docsbranch = "release-1.11"
+fullversion = "v1.12.0"
+version = "v1.12"
+githubbranch = "v1.12.0"
+docsbranch = "release-1.12"
 url = "https://kubernetes.io"
+
+[[params.versions]]
+fullversion = "v1.11.3"
+version = "v1.11"
+githubbranch = "v1.11.3"
+docsbranch = "release-1.11"
+url = "https://v1-11.docs.kubernetes.io"
 
 [[params.versions]]
 fullversion = "v1.10.3"
 version = "v1.10"
 githubbranch = "v1.10.3"
 docsbranch = "release-1.10"
-url = "https://kubernetes.io"
+url = "https://v1-10.docs.kubernetes.io"
 
 [[params.versions]]
 fullversion = "v1.9.7"
@@ -77,21 +113,6 @@ version = "v1.9"
 githubbranch = "v1.9.7"
 docsbranch = "release-1.9"
 url = "https://v1-9.docs.kubernetes.io"
-
-[[params.versions]]
-fullversion = "v1.8.4"
-version = "v1.8"
-githubbranch = "v1.8.4"
-docsbranch = "release-1.8"
-url = "https://v1-8.docs.kubernetes.io"
-
-[[params.versions]]
-fullversion = "v1.7.6"
-version = "v1.7"
-githubbranch = "v1.7.6"
-docsbranch = "release-1.7"
-url = "https://v1-7.docs.kubernetes.io"
-
 
 # Language definitions.
 
@@ -102,11 +123,29 @@ description = "Production-Grade Container Orchestration"
 languageName ="English"
 # Weight used for sorting.
 weight = 1
-[languages.cn]
+
+[languages.zh]
 title = "Kubernetes"
 description = "Production-Grade Container Orchestration"
-languageName ="Chinese"
+languageName = "中文 Chinese"
 weight = 2
-contentDir = "content/cn"
+contentDir = "content/zh"
 
+[languages.ko]
+title = "Kubernetes"
+description = "Production-Grade Container Orchestration"
+languageName = "한국어 Korean"
+weight = 3
+contentDir = "content/ko"
 
+[languages.no]
+title = "Kubernetes"
+description = "Production-Grade Container Orchestration"
+languageName ="Norsk"
+weight = 4
+contentDir = "content/no"
+
+[languages.no.params]
+time_format_blog = "02.01.2006"
+# A list of language codes to look for untranslated content, ordered from left to right.
+language_alternatives = ["en"]

--- a/content/en/OWNERS
+++ b/content/en/OWNERS
@@ -1,0 +1,11 @@
+# This is the directory for English source content.
+# Teams and members are visible at https://github.com/orgs/kubernetes/teams.
+
+reviewers:
+- sig-docs-en-reviews
+
+approvers:
+- sig-docs-en-owners
+
+labels:
+- language/en

--- a/content/ja/OWNERS
+++ b/content/ja/OWNERS
@@ -1,0 +1,11 @@
+# This is the localization project for Japanese.
+# Teams and members are visible at https://github.com/orgs/kubernetes/teams.
+
+reviewers:
+- sig-docs-ja-reviews
+
+approvers:
+- sig-docs-ja-owners
+
+labels:
+- language/ja

--- a/content/ko/OWNERS
+++ b/content/ko/OWNERS
@@ -1,0 +1,11 @@
+# This is the localization project for Korean.
+# Teams and members are visible at https://github.com/orgs/kubernetes/teams.
+
+reviewers:
+- sig-docs-ko-reviews
+
+approvers:
+- sig-docs-ko-owners
+
+labels:
+- language/ko

--- a/content/zh/OWNERS
+++ b/content/zh/OWNERS
@@ -1,0 +1,11 @@
+# This is the localization project for Chinese.
+# Teams and members are visible at https://github.com/orgs/kubernetes/teams. 
+
+reviewers:
+- sig-docs-zh-reviews
+
+approvers:
+- sig-docs-zh-owners
+
+labels:
+- language/zh

--- a/layouts/shortcodes/deprecationwarning.html
+++ b/layouts/shortcodes/deprecationwarning.html
@@ -4,7 +4,7 @@
     <div class="content deprecation-warning">
       <h3>
         Documentation for Kubernetes {{ .Page.Param "version" }} is no longer actively maintained. The version you are currently viewing is a static snapshot.
-        For up-to-date documentation, see the <a href="{{ .Params.currentUrl }}">latest</a> version.
+        For up-to-date documentation, see the <a href="{{ .Site.Params.currentUrl }}">latest</a> version.
       </h3>
     </div>
   </main>


### PR DESCRIPTION
/ref #10666 

This PR updates `release-1.11` with:
- v1.12 site configuration (👈 @zparnold)
- Site support and ownership for l10n teams (#10485)

