### PR TITLE
Update l10n READMEs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ For more information about contributing to the Kubernetes documentation, see:
 * [Staging Your Documentation Changes](http://kubernetes.io/docs/contribute/intermediate#view-your-changes-locally)
 * [Using Page Templates](http://kubernetes.io/docs/contribute/style/page-templates/)
 * [Documentation Style Guide](http://kubernetes.io/docs/contribute/style/style-guide/)
+* [Localizing Kubernetes Documentation](https://kubernetes.io/docs/contribute/localization/)
 
 ## Running the site locally using Docker
 

--- a/content/en/docs/contribute/localization.md
+++ b/content/en/docs/contribute/localization.md
@@ -100,7 +100,7 @@ Provide guidance to localization contributors in the localized `README-**.md` fi
 - A point of contact for the localization project
 - Any information specific to the localization
 
-After you create the localized README, add a link to the file from the main English file, [`README.md`] and include contact information in English. You can provide a GitHub ID, email address, [Slack channel](https://slack.com/), or other method of contact.
+After you create the localized README, add a link to the file from the main English file, [`README.md`'s Localizing Kubernetes Documentation] and include contact information in English. You can provide a GitHub ID, email address, [Slack channel](https://slack.com/), or other method of contact.
 
 ## Translating documents
 


### PR DESCRIPTION
This PR updates [`README.md`](https://github.com/kubernetes/website/blob/master/README.md) and [`localization.md`](https://github.com/kubernetes/website/blob/master/content/en/docs/contribute/localization.md).

* Adds a link process about the l10n README files(`README-**.md`) in [`localization.md`](https://github.com/kubernetes/website/blob/master/content/en/docs/contribute/localization.md)
* Adds a link about Localizing Kubernetes Documentation in [`README.md`'s Contributing to the docs section.](https://github.com/kubernetes/website/blob/master/README.md#contributing-to-the-docs)

Fixed: #10485, #10622

/cc @zacharysarah 