### PR TITLE
remove "recommended" from Minikube description

### DIFF
--- a/content/en/docs/setup/pick-right-solution.md
+++ b/content/en/docs/setup/pick-right-solution.md
@@ -32,7 +32,7 @@ a Kubernetes cluster from scratch.
 
 ## Local-machine Solutions
 
-* [Minikube](/docs/setup/minikube/) is the recommended method for creating a local, single-node Kubernetes cluster for development and testing. Setup is completely automated and doesn't require a cloud provider account.
+* [Minikube](/docs/setup/minikube/) is a method for creating a local, single-node Kubernetes cluster for development and testing. Setup is completely automated and doesn't require a cloud provider account.
 
 * [microk8s](https://microk8s.io/) provides a single command installation of the latest Kubernetes release on a local machine for development and testing. Setup is quick, fast (~30 sec) and supports many plugins including Istio with a single command.
 


### PR DESCRIPTION
Now that there are multiple predictable and stable upstream solutions to deploy Kubernetes, we should not express an opinion as to which one to recommend without also mentioning the reasons for it.