### PR TITLE
Update default 'image-gc-high-threshold'

### DIFF
--- a/content/en/docs/concepts/cluster-administration/kubelet-garbage-collection.md
+++ b/content/en/docs/concepts/cluster-administration/kubelet-garbage-collection.md
@@ -42,7 +42,7 @@ Containers that are not managed by kubelet are not subject to container garbage 
 Users can adjust the following thresholds to tune image garbage collection with the following kubelet flags :
 
 1. `image-gc-high-threshold`, the percent of disk usage which triggers image garbage collection.
-Default is 90%.
+Default is 85%.
 2. `image-gc-low-threshold`, the percent of disk usage to which image garbage collection attempts
 to free. Default is 80%.
 


### PR DESCRIPTION
When I check the kubelet option document and actual kubelet config value, default is 85 instead of 90.

https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/
```
--image-gc-high-threshold int32
  The percent of disk usage after which image garbage collection is always run. (default 85)
```

https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/apis/config/v1beta1/defaults.go
```
	if obj.ImageGCHighThresholdPercent == nil {
		// default is below docker's default dm.min_free_space of 90%
		obj.ImageGCHighThresholdPercent = utilpointer.Int32Ptr(85)
	}
```

