### PR TITLE
Fix incorrect naming of the flag --resolve-conf

### DIFF
--- a/content/en/docs/setup/independent/kubelet-integration.md
+++ b/content/en/docs/setup/independent/kubelet-integration.md
@@ -70,7 +70,7 @@ For more details on the ComponentConfig have a look at [this section](#configure
 Some hosts require specific kubelet configurations, due to differences in hardware, operating system,
 networking, or other host-specific parameters. The following list provides a few examples.
 
-- The path to the DNS resolution file, as specified by the `--resolve-conf` kubelet
+- The path to the DNS resolution file, as specified by the `--resolv-conf` kubelet
   configuration flag, may differ among operating systems, or depending on whether you are using
   `systemd-resolved`. If this path is wrong, DNS resolution will fail on the Node whose kubelet
   is configured incorrectly.


### PR DESCRIPTION
The flag is called --resolv-conf.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> Please delete this note before submitting the pull request.
>
> For 1.13 Features: set Milestone to 1.13 and Base Branch to dev-1.13
>
> Help editing and submitting pull requests:
> https://kubernetes.io/docs/contribute/start/#improve-existing-content.
>
> Help choosing which branch to use:
> https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use.
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>

