### PR TITLE
Disable line wrapping of base64 output

### DIFF
--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -110,8 +110,8 @@ metadata:
   name: mysecret
 type: Opaque
 data:
-  password: $(echo -n "s33msi4" | base64)
-  username: $(echo -n "jane" | base64)
+  password: $(echo -n "s33msi4" | base64 -w0)
+  username: $(echo -n "jane" | base64 -w0)
 EOF
 
 ```


### PR DESCRIPTION
Use `base64` with line wrapping disabled to avoid unexpected errors when encoding long values.

If you are encoding a string with `base64` that will result in a string longer than 76 chars, the YAML parser will *hopefully* throw errors at you stating an invalid format.