### PR TITLE
Code style not working on kubernetes.io

### DIFF
--- a/content/en/docs/tasks/administer-cluster/change-pv-reclaim-policy.md
+++ b/content/en/docs/tasks/administer-cluster/change-pv-reclaim-policy.md
@@ -32,9 +32,9 @@ the corresponding `PersistentVolume` is not be deleted. Instead, it is moved to 
 
 1. List the PersistentVolumes in your cluster:
 
-       ```
-       kubectl get pv
-       ```
+    ```shell
+    kubectl get pv
+    ```
 
     The output is similar to this:
 
@@ -48,17 +48,17 @@ the corresponding `PersistentVolume` is not be deleted. Instead, it is moved to 
 
 1. Choose one of your PersistentVolumes and change its reclaim policy:
 
-       ```
-       kubectl patch pv <your-pv-name> -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
-       ```
+    ```shell
+    kubectl patch pv <your-pv-name> -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+    ```
 
     where `<your-pv-name>` is the name of your chosen PersistentVolume.
 
 1. Verify that your chosen PersistentVolume has the right policy:
 
-       ```
-       kubectl get pv
-       ```
+    ```shell
+    kubectl get pv
+    ```
 
     The output is similar to this:
 

--- a/content/en/docs/tasks/administer-cluster/change-pv-reclaim-policy.md
+++ b/content/en/docs/tasks/administer-cluster/change-pv-reclaim-policy.md
@@ -32,7 +32,9 @@ the corresponding `PersistentVolume` is not be deleted. Instead, it is moved to 
 
 1. List the PersistentVolumes in your cluster:
 
+       ```
        kubectl get pv
+       ```
 
     The output is similar to this:
 
@@ -46,13 +48,17 @@ the corresponding `PersistentVolume` is not be deleted. Instead, it is moved to 
 
 1. Choose one of your PersistentVolumes and change its reclaim policy:
 
+       ```
        kubectl patch pv <your-pv-name> -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+       ```
 
     where `<your-pv-name>` is the name of your chosen PersistentVolume.
 
 1. Verify that your chosen PersistentVolume has the right policy:
 
+       ```
        kubectl get pv
+       ```
 
     The output is similar to this:
 


### PR DESCRIPTION
Code style based on tab works on github markdown, but it is not working on kubernetes.io. In addition to that, `<your-pv-name>` argument on line 50 is hidden on kubernetes.io, because it is being processed as a HTML tag.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> Please delete this note before submitting the pull request.
>
> For 1.13 Features: set Milestone to 1.13 and Base Branch to dev-1.13
>
> Help editing and submitting pull requests:
> https://kubernetes.io/docs/contribute/start/#improve-existing-content.
>
> Help choosing which branch to use:
> https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use.
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>

