### PR TITLE
Correct '--output' flag in cheatsheet

### DIFF
--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -282,7 +282,7 @@ kubectl api-resources --api-group=extensions # All resources in the "extensions"
 
 ### Formatting output
 
-To output details to your terminal window in a specific format, you can add either the `-o` or `-output` flags to a supported `kubectl` command.
+To output details to your terminal window in a specific format, you can add either the `-o` or `--output` flags to a supported `kubectl` command.
 
 Output format | Description
 --------------| -----------


### PR DESCRIPTION
A minor update to the [kubectl Cheat Sheet](https://kubernetes.io/docs/reference/kubectl/cheatsheet/). The Cheat sheet says that the '-output' flag can be used to format the output of a command, this should be '--output'. This PR corrects this.