### PR TITLE
Modified into appropriate words

### DIFF
--- a/content/en/docs/setup/independent/kubelet-integration.md
+++ b/content/en/docs/setup/independent/kubelet-integration.md
@@ -11,8 +11,8 @@ weight: 40
 {{< feature-state for_k8s_version="1.11" state="stable" >}}
 
 The lifecycle of the kubeadm CLI tool is decoupled from the
-[Kubernetes Node Agent](/docs/reference/command-line-tools-reference/kubelet), which is a daemon that runs
-on each Kubernetes master or Node. The kubeadm CLI tool is executed by the user when Kubernetes is
+[kubelet](/docs/reference/command-line-tools-reference/kubelet), which is a daemon that runs
+on each Kubernetes master and Node. The kubeadm CLI tool is executed by the user when Kubernetes is
 initialized or upgraded, whereas the kubelet is always running in the background.
 
 Since the kubelet is a daemon, it needs to be maintained by some kind of a init
@@ -52,7 +52,7 @@ Virtual IPs for services are now allocated from this subnet. You also need to se
 by the kubelet, using the `--cluster-dns` flag. This setting needs to be the same for every kubelet
 on every manager and Node in the cluster. The kubelet provides a versioned, structured API object
 that can configure most parameters in the kubelet and push out this configuration to each running
-kubelet in the cluster. This object is called **the kubelet's ComponentConfig**. 
+kubelet in the cluster. This object is called **the kubelet's ComponentConfig**.
 The ComponentConfig allows the user to specify flags such as the cluster DNS IP addresses expressed as
 a list of values to a camelCased key, illustrated by the following example:
 
@@ -82,7 +82,7 @@ networking, or other host-specific parameters. The following list provides a few
 - Currently, the kubelet cannot automatically detects the cgroup driver used by the CRI runtime,
   but the value of `--cgroup-driver` must match the cgroup driver used by the CRI runtime to ensure
   the health of the kubelet.
- 
+
 - Depending on the CRI runtime your cluster uses, you may need to specify different flags to the kubelet.
   For instance, when using Docker, you need to specify flags such as `--network-plugin=cni`, but if you
   are using an external runtime, you need to specify `--container-runtime=remote` and specify the CRI

--- a/content/en/docs/setup/independent/kubelet-integration.md
+++ b/content/en/docs/setup/independent/kubelet-integration.md
@@ -12,7 +12,7 @@ weight: 40
 
 The lifecycle of the kubeadm CLI tool is decoupled from the
 [kubelet](/docs/reference/command-line-tools-reference/kubelet), which is a daemon that runs
-on each Kubernetes master and Node. The kubeadm CLI tool is executed by the user when Kubernetes is
+on each node within the Kubernetes cluster. The kubeadm CLI tool is executed by the user when Kubernetes is
 initialized or upgraded, whereas the kubelet is always running in the background.
 
 Since the kubelet is a daemon, it needs to be maintained by some kind of a init


### PR DESCRIPTION
The use of Kubelet words is more relevant than the description of the Kubernetes Node Agent.
And the kubelet is executed on the master node and Node.