### PR TITLE
Update officially supported client libraries

### DIFF
--- a/content/en/docs/reference/_index.md
+++ b/content/en/docs/reference/_index.md
@@ -35,6 +35,8 @@ client libraries:
 
 - [Kubernetes Go client library](https://github.com/kubernetes/client-go/)
 - [Kubernetes Python client library](https://github.com/kubernetes-client/python)
+- [Kubernetes Java client library](https://github.com/kubernetes-client/java)
+- [Kubernetes JavaScript client library](https://github.com/kubernetes-client/javascript)
 
 ## CLI Reference
 


### PR DESCRIPTION
Update officially supported client libraries to match ones listed https://kubernetes.io/docs/reference/using-api/client-libraries/#officially-supported-kubernetes-client-libraries 

I was browsing and it was confusing that we listed only 2 of the supported libraries.

I think it makes sense to list them all or just link to the official list located at https://kubernetes.io/docs/reference/using-api/client-libraries/#officially-supported-kubernetes-client-libraries 

I would be happy to update the docs either way?