### PR TITLE
Update naming for Azure Kubernetes Service (AKS)

### DIFF
--- a/content/en/docs/setup/turnkey/azure.md
+++ b/content/en/docs/setup/turnkey/azure.md
@@ -5,25 +5,25 @@ reviewers:
 title: Running Kubernetes on Azure
 ---
 
-## Azure Container Service
+## Azure Kubernetes Service (AKS)
 
-The [Azure Container Service](https://azure.microsoft.com/en-us/services/container-service/) offers simple
-deployments of one of three open source orchestrators: DC/OS, Swarm, and Kubernetes clusters.
+The [Azure Kubernetes Service)](https://azure.microsoft.com/en-us/services/kubernetes-service/) offers simple
+deployments for Kubernetes clusters.
 
-For an example of deploying a Kubernetes cluster onto Azure via the Azure Container Service:
+For an example of deploying a Kubernetes cluster onto Azure via the Azure Kubernetes Service:
 
-**[Microsoft Azure Container Service - Kubernetes Walkthrough](https://docs.microsoft.com/en-us/azure/aks/intro-kubernetes)**
+**[Microsoft Azure Kubernetes Service](https://docs.microsoft.com/en-us/azure/aks/intro-kubernetes)**
 
 ## Custom Deployments: ACS-Engine
 
-The core of the Azure Container Service is **open source** and available on GitHub for the community
+The core of the Azure Kubernetes Service is **open source** and available on GitHub for the community
 to use and contribute to: **[ACS-Engine](https://github.com/Azure/acs-engine)**.
 
-ACS-Engine is a good choice if you need to make customizations to the deployment beyond what the Azure Container
+ACS-Engine is a good choice if you need to make customizations to the deployment beyond what the Azure Kubernetes
 Service officially supports. These customizations include deploying into existing virtual networks, utilizing multiple
-agent pools, and more. Some community contributions to ACS-Engine may even become features of the Azure Container Service.
+agent pools, and more. Some community contributions to ACS-Engine may even become features of the Azure Kubernetes Service.
 
-The input to ACS-Engine is similar to the ARM template syntax used to deploy a cluster directly with the Azure Container Service.
+The input to ACS-Engine is similar to the ARM template syntax used to deploy a cluster directly with the Azure Kubernetes Service.
 The resulting output is an Azure Resource Manager Template that can then be checked into source control and can then be used
 to deploy Kubernetes clusters into Azure.
 
@@ -36,4 +36,3 @@ The CoreOS Tectonic Installer for Azure is **open source** and available on GitH
 Tectonic Installer is a good choice when you need to make cluster customizations as it is built on [Hashicorp's Terraform](https://www.terraform.io/docs/providers/azurerm/) Azure Resource Manager (ARM) provider. This enables users to customize or integrate using familiar Terraform tooling.
 
 You can get started using the [Tectonic Installer for Azure Guide](https://coreos.com/tectonic/docs/latest/install/azure/azure-terraform.html).
-


### PR DESCRIPTION
Updating naming and links for Azure Kubernetes Service (AKS), rather than Azure *Container* Service.
