### PR TITLE
Fix secondary nav to use Home

### DIFF
--- a/content/en/docs/home/_index.md
+++ b/content/en/docs/home/_index.md
@@ -8,7 +8,7 @@ cid: userJourneys
 css: /css/style_user_journeys.css
 js: /js/user-journeys/home.js, https://use.fontawesome.com/4bcc658a89.js
 display_browse_numbers: true
-linkTitle: Documentation
+linkTitle: "Home"
 main_menu: true
 weight: 10
 menu:

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,7 +5,7 @@
 
     <div class="nav-buttons" data-auto-burger="primary">
         <ul class="global-nav">
-            {{ $sections := slice "docs/home" "blog" "partners" "community" "case-studies" }}
+            {{ $sections := slice "docs" "blog" "partners" "community" "case-studies" }}
             {{ range $sections }}
             {{ with $.Site.GetPage "section" . }}<li><a href="{{ .RelPermalink }}"{{ if eq .Section $.Section }} class="active"{{ end}}>{{ .LinkTitle }}</a></li>{{ end }}
             {{ end }}


### PR DESCRIPTION
Fix regression caused by https://github.com/kubernetes/website/pull/10071. Rename secondary horizontal nav link to "Home" instead of "Documentation".

We want the nav to look like this:
<img width="553" alt="screen shot 2018-10-31 at 2 42 51 pm" src="https://user-images.githubusercontent.com/24798125/47820626-4f5ab400-dd1b-11e8-9851-1774226f1805.png">

Preview: https://deploy-preview-10800--kubernetes-io-master-staging.netlify.com/docs/home/