### PR TITLE
Allow subfolders to inherit OWNERS from parent folders

### DIFF
--- a/content/en/blog/OWNERS
+++ b/content/en/blog/OWNERS
@@ -1,11 +1,9 @@
 # Owned by Kubernetes Blog reviewers.
 options:
-  no_parent_owners: true
+  no_parent_owners: false
 reviewers:
   - kbarnard10
 approvers:
   - bobsky
-  - kbarnard10
   - natekartchner
   - sarahkconway
-  - zacharysarah

--- a/content/en/case-studies/OWNERS
+++ b/content/en/case-studies/OWNERS
@@ -1,10 +1,8 @@
 # Owned by Kubernetes Blog reviewers.
 options:
-  no_parent_owners: true
+  no_parent_owners: false
 reviewers:
   - alexcontini
 approvers:
   - alexcontini
-  - kbarnard10
   - sarahkconway
-  - zacharysarah


### PR DESCRIPTION
This PR changes blog and case-studies OWNERS files to inherit permissions from parent OWNERS files.

### TLDR

This makes reviews easier.

/assign cody-clark
