### PR TITLE
Fix Makefile and README for make docker-serve on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DOCKER       = docker
 HUGO_VERSION = 0.49
 DOCKER_IMAGE = kubernetes-hugo
-DOCKER_RUN   = $(DOCKER) run --rm --interactive --tty --volume $(PWD):/src
+DOCKER_RUN   = $(DOCKER) run --rm --interactive --tty --volume $(CURDIR):/src
 NODE_BIN     = node_modules/.bin
 NETLIFY_FUNC = $(NODE_BIN)/netlify-lambda
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ For more information about contributing to the Kubernetes documentation, see:
 
 The recommended way to run the Kubernetes website locally is to run a specialized [Docker](https://docker.com) image that includes the [Hugo](https://gohugo.io) static site generator.
 
+> If you are running on Windows, you'll need a few more tools which you can install with [Chocolatey](https://chocolatey.org). `choco install make`
+
 > If you'd prefer to run the website locally without Docker, see [Running the site locally using Hugo](#running-the-site-locally-using-hugo) below.
 
 If you have Docker [up and running](https://www.docker.com/get-started), build the `kubernetes-hugo` Docker image locally:


### PR DESCRIPTION
This PR includes two quick fixes:

1. Clarify an extra prerequisite needed on Windows
2. Fix the `Makefile` to use an OS-agnostic way to get the source directory that needs to be mapped with Docker

With this change, these two steps succeed on Windows with Docker for Windows installed:
```
make docker-image
…

make docker-serve
docker run --rm --interactive --tty --volume C:/Users/plang/Source/website:/src -p 1313:1313 kubernetes-hugo hugo server --watch --bind 0.0.0.0

                   |  EN  | ZH  | KO
+------------------+------+-----+-----+
  Pages            | 1678 | 175 |  62
  Paginator pages  |  249 |   4 |   0
  Non-page files   |  485 | 272 | 275
  Static files     |  809 | 809 | 809
  Processed images |    0 |   0 |   0
  Aliases          |    3 |   2 |   1
  Sitemaps         |    2 |   1 |   1
  Cleaned          |    0 |   0 |   0

Total in 9996 ms
Watching for changes in /src/{content,data,i18n,layouts,static}
Watching for config changes in /src/config.toml
Serving pages from memory
Running in Fast Render Mode. For full rebuilds on change: hugo server --disableFastRender
Web Server is available at http://localhost:1313/ (bind address 0.0.0.0)
```