### PR TITLE
Rename 'Reusing Docker' section for minikube documentation

### DIFF
--- a/content/en/docs/setup/minikube.md
+++ b/content/en/docs/setup/minikube.md
@@ -164,7 +164,7 @@ This will use an alternative minikube ISO image containing both rkt, and Docker,
 See [DRIVERS](https://git.k8s.io/minikube/docs/drivers.md) for details on supported drivers and how to install
 plugins, if required.
 
-### Reusing the Docker daemon
+### Use local images by re-using the Docker daemon
 
 When using a single VM of Kubernetes, it's really handy to reuse the minikube's built-in Docker daemon; as this means you don't have to build a docker registry on your host machine and push the image into it - you can just build inside the same docker daemon as minikube which speeds up local experiments. Just make sure you tag your Docker image with something other than 'latest' and use that tag while you pull the image. Otherwise, if you do not specify version of your image, it will be assumed as `:latest`, with pull image policy of `Always` correspondingly, which may eventually result in `ErrImagePull` as you may not have any versions of your Docker image out there in the default docker registry (usually DockerHub) yet.
 


### PR DESCRIPTION
May make it easier to see the importance of this section

When I first read the documentation I didn't realise that implementing the suggestions in that section enable
you to use local images without publishing them to a repository. Maybe this change will make it easier for other developers to figure that out.