### PR TITLE
Fix wrong parameters

### DIFF
--- a/content/en/docs/setup/independent/install-kubeadm.md
+++ b/content/en/docs/setup/independent/install-kubeadm.md
@@ -226,7 +226,7 @@ If you are using a different CRI, you have to modify the file
 `/etc/default/kubelet` with your `cgroup-driver` value, like so:
 
 ```bash
-KUBELET_KUBEADM_EXTRA_ARGS=--cgroup-driver=<value>
+KUBELET_EXTRA_ARGS=--cgroup-driver=<value>
 ```
 
 This file will be used by `kubeadm init` and `kubeadm join` to source extra


### PR DESCRIPTION
Based on these links, using KUBELET_EXTRA_ARGS is correct instead of KUBELET_KUBEADM_EXTRA_ARGS.

- https://github.com/kubernetes/kubernetes/blob/7f23a743e8c23ac6489340bbb34fa6f1d392db9d/build/debs/10-kubeadm.conf
 
- https://github.com/kubernetes/kubernetes/blob/7f23a743e8c23ac6489340bbb34fa6f1d392db9d/build/rpms/10-kubeadm.conf

- https://github.com/kubernetes/kubernetes/blob/7f23a743e8c23ac6489340bbb34fa6f1d392db9d/build/rpms/10-kubeadm.conf

- https://github.com/kubernetes/kubernetes/blob/5336866a8c58a8fe943dff1746c1f179977b3aef/CHANGELOG-1.11.md