### PR TITLE
Rename experimental-bootstrap-token-auth to enable-bootstrap-token-auth

### DIFF
--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -137,7 +137,7 @@ Authorization: Bearer 781292.db7bc3a58fc5f07e
 ```
 
 You must enable the Bootstrap Token Authenticator with the
-`--experimental-bootstrap-token-auth` flag on the API Server.  You must enable
+`--enable-bootstrap-token-auth` flag on the API Server.  You must enable
 the TokenCleaner controller via the `--controllers` flag on the Controller
 Manager.  This is done with something like `--controllers=*,tokencleaner`.
 `kubeadm` will do this for you if you are using it to bootstrap a cluster.

--- a/content/zh/docs/admin/bootstrap-tokens.md
+++ b/content/zh/docs/admin/bootstrap-tokens.md
@@ -32,7 +32,7 @@ Bootstrapping](/docs/admin/kubelet-tls-bootstrapping/) 系统进行工作。
 
 所有与启动引导令牌相关的特性在 Kubernetes v1.6 版本中默认都是禁用的。
 
-你可以在 API 服务器上通过 `--experimental-bootstrap-token-auth` 参数启用启动引导令牌。
+你可以在 API 服务器上通过 `--enable-bootstrap-token-auth` 参数启用启动引导令牌。
 你可以设置控制管理器的 `--controllers` 参数来启用启动引导令牌相关的控制器，例如 `--controllers=*,tokencleaner,bootstrapsigner` 。
 在使用 `kubeadm` 时，这是自动完成的。
 

--- a/content/zh/docs/admin/kube-apiserver.md
+++ b/content/zh/docs/admin/kube-apiserver.md
@@ -104,7 +104,7 @@ kube-apiserver
 
       --event-ttl duration                                      事件驻留时间。（默认值1h0m0s)
 
-      --experimental-bootstrap-token-auth                       启用此选项以允许'kube-system'命名空间中的'bootstrap.kubernetes.io/token'类型密钥可以被用于TLS的启动认证。
+      --enable-bootstrap-token-auth                             启用此选项以允许'kube-system'命名空间中的'bootstrap.kubernetes.io/token'类型密钥可以被用于TLS的启动认证。
 
       --experimental-encryption-provider-config string          包含加密提供程序的配置的文件，该加密提供程序被用于在etcd中保存密钥。
 


### PR DESCRIPTION
Fix #10906 

Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>

