### PR TITLE
Correct formatting of note on creating a secret.

### DIFF
--- a/content/en/docs/tasks/inject-data-application/distribute-credentials-secure.md
+++ b/content/en/docs/tasks/inject-data-application/distribute-credentials-secure.md
@@ -42,13 +42,13 @@ username and password:
     ```shell
     kubectl create -f https://k8s.io/docs/tasks/inject-data-application/secret.yaml
     ```
+
     {{< note >}}
-    If you want to skip the Base64 encoding step, you can create a Secret by using the `kubectl create secret` command:
+ If you want to skip the Base64 encoding step, you can create a Secret by using the `kubectl create secret` command:
+ ```shell
+ kubectl create secret generic test-secret --from-literal=username='my-app' --from-literal=password='39528$vdg7Jb'
+ ```
     {{< /note >}}
-    
-    ```shell
-    kubectl create secret generic test-secret --from-literal=username='my-app' --from-literal=password='39528$vdg7Jb'
-    ```
 
 1. View information about the Secret:
 


### PR DESCRIPTION
Note should not be code-formatted and command should be inside note
block.

Before:
![screenshot-k8s-create-secret-docs-bug](https://user-images.githubusercontent.com/1205394/48148556-08733e00-e288-11e8-8bd2-f239a2bf8e68.png)

After:
![screenshot-k8s-docs-after-fix](https://user-images.githubusercontent.com/1205394/48148561-0dd08880-e288-11e8-9dfc-cee9c2495fd7.png)


Signed-off-by: Leah Hanson <lhanson@pivotal.io>


