### PR TITLE
Update high-availability.md

### DIFF
--- a/content/en/docs/setup/independent/high-availability.md
+++ b/content/en/docs/setup/independent/high-availability.md
@@ -290,8 +290,8 @@ done
       CP1_IP=10.0.0.8
       CP1_HOSTNAME=cp1
 
-      KUBECONFIG=/etc/kubernetes/admin.conf kubectl exec -n kube-system etcd-${CP0_HOSTNAME} -- etcdctl --ca-file /etc/kubernetes/pki/etcd/ca.crt --cert-file /etc/kubernetes/pki/etcd/peer.crt --key-file /etc/kubernetes/pki/etcd/peer.key --endpoints=https://${CP0_IP}:2379 member add ${CP1_HOSTNAME} https://${CP1_IP}:2380
       kubeadm alpha phase etcd local --config kubeadm-config.yaml
+      KUBECONFIG=/etc/kubernetes/admin.conf kubectl exec -n kube-system etcd-${CP0_HOSTNAME} -- etcdctl --ca-file /etc/kubernetes/pki/etcd/ca.crt --cert-file /etc/kubernetes/pki/etcd/peer.crt --key-file /etc/kubernetes/pki/etcd/peer.key --endpoints=https://${CP0_IP}:2379 member add ${CP1_HOSTNAME} https://${CP1_IP}:2380
       ```
 
       - This command causes the etcd cluster to become unavailable for a


### PR DESCRIPTION
When administrator add 2nd CP into the cluster with method of stacking masters, the order of next two steps may cause errors:

1. KUBECONFIG=/etc/kubernetes/admin.conf kubectl exec -n kube-system etcd-${CP0_HOSTNAME} -- etcdctl --ca-file /etc/kubernetes/pki/etcd/ca.crt --cert-file /etc/kubernetes/pki/etcd/peer.crt --key-file /etc/kubernetes/pki/etcd/peer.key --endpoints=https://${CP0_IP}:2379 member add ${CP1_HOSTNAME} https://${CP1_IP}:2380
2. kubeadm alpha phase etcd local --config kubeadm-config.yaml

Under this order, after the command 'etcdctl member add' executed on etcd pod of CP0,  etcd on CP1 is still not runing, however etcd on CP0 need to communicate with peer etcd on CP1. This would make etcd cluster failed, sequentially the api-server of k8s cannot response. Now creating a second etcd pod is impossible. To avoid this happening, we should reverse the order of 1,2.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> Please delete this note before submitting the pull request.
>
> For 1.13 Features: set Milestone to 1.13 and Base Branch to dev-1.13
>
> Help editing and submitting pull requests:
> https://kubernetes.io/docs/contribute/start/#improve-existing-content.
>
> Help choosing which branch to use:
> https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use.
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>

