### PR TITLE
Remove unnecessary kubelet as upgraded package

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-12.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-12.md
@@ -40,13 +40,13 @@ This page explains how to upgrade a Kubernetes cluster created with `kubeadm` fr
     {{< tabs name="k8s_install" >}}
     {{% tab name="Ubuntu, Debian or HypriotOS" %}}
     apt-get update
-    apt-get upgrade -y kubelet kubeadm
+    apt-get upgrade -y kubeadm
     {{% /tab %}}
     {{% tab name="CentOS, RHEL or Fedora" %}}
     yum upgrade -y kubeadm --disableexcludes=kubernetes
     {{% /tab %}}
     {{< /tabs >}}
-    
+
 1.  Verify that the download works and has the expected version:
 
     ```shell
@@ -227,7 +227,7 @@ This page explains how to upgrade a Kubernetes cluster created with `kubeadm` fr
 
 1.  Upgrade the Kubernetes package version on each `$NODE` node by running the Linux package manager for your distribution:
 
-    {{< tabs name="k8s_install" >}}
+    {{< tabs name="k8s_upgrade" >}}
     {{% tab name="Ubuntu, Debian or HypriotOS" %}}
     apt-get update
     apt-get upgrade -y kubelet kubeadm


### PR DESCRIPTION
The first step of [1], kubeadm is necessary to be upgraded because we
need to run kubeadm upgrade plan. Then, the line shows `upgrade kubeadm:`.
However, the commandline contains kubelet also. That seems copy&paste
mistake and unnecessary. This removes it.
In addition, the format of another tab is broken. This fixes it also by
naming another tab.

[1]: https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-12/#upgrade-the-control-plane

fixes: #10940 