### PR TITLE
Adding name arguement in kubeadm-config.yaml

### DIFF
--- a/content/en/docs/setup/independent/high-availability.md
+++ b/content/en/docs/setup/independent/high-availability.md
@@ -151,6 +151,7 @@ Optionally replace `stable` with a different version of Kubernetes, for example 
         etcd:
           local:
             extraArgs:
+              name: "CP0_HOSTNAME"
               listen-client-urls: "https://127.0.0.1:2379,https://CP0_IP:2379"
               advertise-client-urls: "https://CP0_IP:2379"
               listen-peer-urls: "https://CP0_IP:2380"
@@ -230,6 +231,7 @@ Remember that your config may differ from this example.
         etcd:
           local:
             extraArgs:
+              name: "CP1_HOSTNAME"
               listen-client-urls: "https://127.0.0.1:2379,https://CP1_IP:2379"
               advertise-client-urls: "https://CP1_IP:2379"
               listen-peer-urls: "https://CP1_IP:2380"
@@ -320,6 +322,7 @@ Remember that your config may differ from this example.
         etcd:
           local:
             extraArgs:
+              name: "CP2_HOSTNAME"
               listen-client-urls: "https://127.0.0.1:2379,https://CP2_IP:2379"
               advertise-client-urls: "https://CP2_IP:2379"
               listen-peer-urls: "https://CP2_IP:2380"


### PR DESCRIPTION
In AWS cloud platform, omitting the name while initializing etcd cluster
causes "Couldn't find local name "$HOSTNAME in the initial cluster configuration"

It seems that the etcd tries to find short hostname, not the FQDN hostname.
To avoid this, passing the name explicitly to etcd configuration solved the problem.

[related issue1](https://github.com/coreos/bugs/issues/2054)
[related issue2](https://github.com/kubernetes/kubeadm/issues/653)