### PR TITLE
Addition to high-availability.md

### DIFF
--- a/content/en/docs/setup/independent/high-availability.md
+++ b/content/en/docs/setup/independent/high-availability.md
@@ -176,6 +176,10 @@ Optionally replace `stable` with a different version of Kubernetes, for example 
 
 1.  Run `kubeadm init --config kubeadm-config.yaml`
 
+{{< note >}}
+You should save or copy the output from this command in order to join worker nodes.
+{{< /note >}}
+
 ### Copy required files to other control plane nodes
 
 The following certificates and other required files were created when you ran `kubeadm init`.
@@ -539,9 +543,15 @@ done
 the pod network. Make sure this corresponds to whichever pod CIDR you provided
 in the master configuration file.
 
+### Label nodes as master
+
+You can label each node as master using `kubectl label node CP1_HOSTNAME node-role.kubernetes.io/master=""`
+
 ### Install workers
 
 Each worker node can now be joined to the cluster with the command returned from any of the
 `kubeadm init` commands.
+
+
 
 {{% /capture %}}


### PR DESCRIPTION
Working through the guide I found two minor enhancement possibilities.
1. in the last step is the infomation to use the return of the `kubeadm init` command, the step may be a whole while before and maybe the output is unavailable at this time. Thus i added a note to copy/save the information when `kubeadm init` is run.
2. I wondered about the output of `kubectl get nodes` after i finished the guide and expected the role "master" to be dispayed. This wasn't the case, thus adding the necessary command

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> Please delete this note before submitting the pull request.
>
> For 1.13 Features: set Milestone to 1.13 and Base Branch to dev-1.13
>
> Help editing and submitting pull requests:
> https://kubernetes.io/docs/contribute/start/#improve-existing-content.
>
> Help choosing which branch to use:
> https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use.
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>

