### PR TITLE
Copy-edit

### DIFF
--- a/content/en/docs/contribute/_index.md
+++ b/content/en/docs/contribute/_index.md
@@ -13,18 +13,14 @@ we're happy to have your help! Anyone can contribute, whether you're new to the
 project or you've been around a long time, and whether you self-identify as a
 developer, an end user, or someone who just can't stand seeing typos.
 
-For more ways to get involved in the Kubernetes community or to learn about us,
-also visit the [Kubernetes community site](/community/).
-
-Looking for the [style guide](/docs/contribute/style/style-guide/) or the
-[Kubernetes Community site](/community/)?
-{{% /capture %}}
+For more ways to get involved in the Kubernetes community or to learn about us, visit the [Kubernetes community site](/community/). 
+For information on the Kubernetes documentation style guide, see the [style guide](/docs/contribute/style/style-guide/).
 
 {{% capture body %}}
 
-## Types of contributor
+## Types of contributors
 
-- A _member_ of the Kubernetes organization has [signed the CLA](/docs/contribute/start#sign-the-cla)
+- A _member_ of the Kubernetes organization who has [signed the CLA](/docs/contribute/start#sign-the-cla)
   and contributed some time and effort to the project. See
   [Community membership](https://github.com/kubernetes/community/blob/master/community-membership.md)
   for specific criteria for membership.
@@ -33,8 +29,8 @@ Looking for the [style guide](/docs/contribute/style/style-guide/) or the
   added to the appropriate Github group and `OWNERS` files in the Github
   repository, by a SIG Docs Approver.
 - A SIG Docs _approver_ is a member in good standing who has shown a continued
-  commitment to the project and is granted the ability to merge pull requests
-  and thus to publish content on behalf of the Kubernetes organization.
+  commitment to the project. An approver can merge pull requests
+  and publish content on behalf of the Kubernetes organization.
   Approvers can also represent SIG Docs in the larger Kubernetes community.
   Some of the duties of a SIG Docs approver, such as coordinating a release,
   require a significant time commitment.
@@ -54,7 +50,7 @@ documentation, but it should help you get started.
   - File actionable bugs
 - [Member](/docs/contribute/start/)
   - Improve existing docs
-  - Bring up ideas for improvement on Slack or SIG docs mailing list
+  - Bring up ideas for improvement on [Slack](http://slack.k8s.io/) or the [SIG docs mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-docs)
   - Improve docs accessibility
   - Provide non-binding feedback on PRs
   - Write a blog post or case study


### PR DESCRIPTION
- The intro section had repeated text on visiting the community page. Refactored this content.
- Minor changes to content.
- Added links to Slack and the SIG docs mailing list.
