### PR TITLE
Corrected a minor issue in linking to Slack

### DIFF
--- a/content/en/docs/contribute/participating.md
+++ b/content/en/docs/contribute/participating.md
@@ -84,7 +84,7 @@ in the Kubernetes organization. Follow these steps:
 1.  Find two reviewers or approvers to [sponsor](/docs/contribute/advanced#sponsor-a-new-contributor)
     your membership.
     
-      Ask for sponsorship in the #sig-docs channel on the 
+      Ask for sponsorship in the [#sig-docs channel on the 
       Kubernetes Slack instance](https://kubernetes.slack.com) or on the
       [SIG Docs mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-docs).
       


### PR DESCRIPTION
The current document had a minor issue: " Ask for sponsorship in the #sig-docs channel on the Kubernetes Slack instance](https://kubernetes.slack.com) "

I am assuming you wanted to link #sig-docs channel on the Kubernetes Slack instance to https://kubernetes.slack.com. Therefore, corrected it.