### PR TITLE
KubeCon Shanghai 2018 docs sprints - temporary approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -152,6 +152,10 @@ aliases:
     - gochist
     - ianychoi
   sig-docs-zh-owners: #Team Chinese docs localization; GH: sig-docs-zh-owners
+    - bradtopol
+    - chenopis
+    - lucperkins
+    - zacharysarah
     - dchen1107
     - haibinxie
     - hanjiayao


### PR DESCRIPTION
This PR adds approvers to `sig-docs-zh-owners` in order to help approve PRs for the KubeCon Shanghai 2018 docs sprint. 

A follow-up PR to remove these owners after the sprint concludes: <placeholder>

/assign @hanjiayao 