### PR TITLE
Add Chinese language alternatives setting

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -159,4 +159,5 @@ time_format_blog = "02.01.2006"
 language_alternatives = ["en"]
 
 [languages.zh.params]
-language_alternatives = ["en"]
+time_format_blog = "2006.01.02" # YYYY.MM.DD
+language_alternatives = ["en"] # fallback to `en` if no Chinese content

--- a/config.toml
+++ b/config.toml
@@ -159,5 +159,5 @@ time_format_blog = "02.01.2006"
 language_alternatives = ["en"]
 
 [languages.zh.params]
-time_format_blog = "2006.01.02" # YYYY.MM.DD
-language_alternatives = ["en"] # fallback to `en` if no Chinese content
+time_format_blog = "2006.01.02"
+language_alternatives = ["en"]

--- a/config.toml
+++ b/config.toml
@@ -157,3 +157,6 @@ contentDir = "content/no"
 time_format_blog = "02.01.2006"
 # A list of language codes to look for untranslated content, ordered from left to right.
 language_alternatives = ["en"]
+
+[languages.zh.params]
+language_alternatives = ["en"]


### PR DESCRIPTION
Add `en` as fallback language for Chinese localized content