### PR TITLE
Modify top comment in zh.toml

### DIFF
--- a/i18n/zh.toml
+++ b/i18n/zh.toml
@@ -1,4 +1,4 @@
-# i18n strings for the English (main) site.
+# i18n strings for the Chinese version of the site (https://kubernetes.io/zh/)
 
 [main_read_about]
 other = "Read about"


### PR DESCRIPTION
Currently, the comment in [`i18n/zh.toml`](i18n/zh.toml) says that the i18n strings are for English. This PR changes the wording to make it more clear that it's for Chinese.