### PR TITLE
Temporarily enable Norwegian to test site nav behavior

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -23,7 +23,7 @@ pygmentsStyle = "emacs"
 enableGitInfo = true
 
 # Norwegian ("no") is sometimes but not currently used for testing.
-disableLanguages = ["no"]
+# disableLanguages = ["no"]
 
 [blackfriday]
 hrefTargetBlank = true


### PR DESCRIPTION
This PR temporarily enables Norwegian as a test language.

/assign @bradtopol 