### PR TITLE
Minor text edit

### DIFF
--- a/content/en/docs/tasks/job/automated-tasks-with-cron-jobs.md
+++ b/content/en/docs/tasks/job/automated-tasks-with-cron-jobs.md
@@ -144,7 +144,7 @@ The format also includes extended `vixie cron` step values. As explained in the 
 > asterisk, so if you want to say ``every two hours'', just use ``*/2''.
 
 {{< note >}}
-The question mark (`?`) in the schedule has the same meaning as an asterisk `*`, that is, it stands for any of available value for a given field.
+A question mark (`?`) in the schedule has the same meaning as an asterisk `*`, that is, it stands for any of available value for a given field.
 {{< /note >}}
 
 ### Job Template


### PR DESCRIPTION
Using "The" indicates that the question mark was already discussed previously, which is not the case.

