### PR TITLE
Kubernetes Repository URL HTTPS

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl.md
+++ b/content/en/docs/tasks/tools/install-kubectl.md
@@ -28,7 +28,7 @@ Here are a few methods to install kubectl.
 {{< tab name="Ubuntu, Debian or HypriotOS" codelang="bash" >}}
 sudo apt-get update && sudo apt-get install -y apt-transport-https
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list
+echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list
 sudo apt-get update
 sudo apt-get install -y kubectl
 {{< /tab >}}


### PR DESCRIPTION
If you follow the instructions for 
```
Install kubectl binary using native package management
```
On Ubuntu 18.04 you'll get this apt error:
```
Err:3 http://apt.kubernetes.io kubernetes-xenial InRelease
```
Which means that apt was unable to get repository information because it was a 403 (forbidden).
Changing to HTTPS eliminates error.