### PR TITLE
Redirect to the current page for older documentation

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -27,8 +27,9 @@
                     {{ .Site.Params.version }} <span class="ui-icon ui-icon-carat-1-s"></span>
                 </a>
                 <ul>
+                {{ $path := .Page.URL }}
                 {{ range .Site.Params.versions }}
-                    <li><a href="{{  .url }}">{{ .version }}</a></li>
+                    <li><a href="{{  .url }}{{ $path }}">{{ .version }}</a></li>
                 {{ end }}
                 </ul>
             </li>


### PR DESCRIPTION
When you are viewing the documentation and want to go to a previous version (say `v.1.x`) via the header, it takes you the homepage for `v.1.x`'s docs.

This patch will redirect you to the current page of `v.1.x`'s docs.