### PR TITLE
Make sure that Minikube is installed prior to kubectl

### DIFF
--- a/content/en/docs/tasks/tools/install-minikube.md
+++ b/content/en/docs/tasks/tools/install-minikube.md
@@ -36,13 +36,14 @@ If you do not already have a hypervisor installed, install the appropriate one f
 * Windows: [VirtualBox](https://www.virtualbox.org/wiki/Downloads) or
 [Hyper-V](https://msdn.microsoft.com/en-us/virtualization/hyperv_on_windows/quick_start/walkthrough_install).
 
-## Install kubectl
-
-* Install kubectl according to the instructions in [Install and Set Up kubectl](/docs/tasks/tools/install-kubectl/).
 
 ## Install Minikube
 
 * Install Minikube according to the instructions for the [latest release](https://github.com/kubernetes/minikube/releases).
+
+## Install kubectl
+
+* Install kubectl according to the instructions in [Install and Set Up kubectl](/docs/tasks/tools/install-kubectl/).
 
 {{% /capture %}}
 


### PR DESCRIPTION
I was having a lot of trouble getting kubectl to configure, getting the error:

The connection to the server localhost:8080 was refused - did you specify the right host or port?

 But I just needed to install and start Minikube first and then configure kubectl and all my problems were solved.

