### PR TITLE
kubeadm: add small v1beta1 related updates

### DIFF
--- a/content/en/docs/setup/independent/high-availability.md
+++ b/content/en/docs/setup/independent/high-availability.md
@@ -148,8 +148,9 @@ different configuration.
         apiVersion: kubeadm.k8s.io/v1beta1
         kind: ClusterConfiguration
         kubernetesVersion: stable
-        apiServerCertSANs:
-        - "LOAD_BALANCER_DNS"
+        apiServer:
+          certSANs:
+          - "LOAD_BALANCER_DNS"
         controlPlaneEndpoint: "LOAD_BALANCER_DNS:LOAD_BALANCER_PORT"
         etcd:
           local:
@@ -227,8 +228,9 @@ done
         apiVersion: kubeadm.k8s.io/v1beta1
         kind: ClusterConfiguration
         kubernetesVersion: stable
-        apiServerCertSANs:
-        - "LOAD_BALANCER_DNS"
+        apiServer:
+          certSANs:
+          - "LOAD_BALANCER_DNS"
         controlPlaneEndpoint: "LOAD_BALANCER_DNS:LOAD_BALANCER_PORT"
         etcd:
           local:
@@ -317,8 +319,9 @@ done
         apiVersion: kubeadm.k8s.io/v1beta1
         kind: ClusterConfiguration
         kubernetesVersion: stable
-        apiServerCertSANs:
-        - "LOAD_BALANCER_DNS"
+        apiServer:
+          certSANs:
+          - "LOAD_BALANCER_DNS"
         controlPlaneEndpoint: "LOAD_BALANCER_DNS:LOAD_BALANCER_PORT"
         etcd:
           local:
@@ -445,8 +448,9 @@ done
         apiVersion: kubeadm.k8s.io/v1beta1
         kind: ClusterConfiguration
         kubernetesVersion: stable
-        apiServerCertSANs:
-        - "LOAD_BALANCER_DNS"
+        apiServer:
+          certSANs:
+          - "LOAD_BALANCER_DNS"
         controlPlaneEndpoint: "LOAD_BALANCER_DNS:LOAD_BALANCER_PORT"
         etcd:
             external:

--- a/content/ko/docs/setup/independent/high-availability.md
+++ b/content/ko/docs/setup/independent/high-availability.md
@@ -146,8 +146,9 @@ different configuration.
         apiVersion: kubeadm.k8s.io/v1beta1
         kind: ClusterConfiguration
         kubernetesVersion: stable
-        apiServerCertSANs:
-        - "LOAD_BALANCER_DNS"
+        apiServer:
+          certSANs:
+          - "LOAD_BALANCER_DNS"
         controlPlaneEndpoint: "LOAD_BALANCER_DNS:LOAD_BALANCER_PORT"
         etcd:
           local:
@@ -225,8 +226,9 @@ done
         apiVersion: kubeadm.k8s.io/v1beta1
         kind: ClusterConfiguration
         kubernetesVersion: stable
-        apiServerCertSANs:
-        - "LOAD_BALANCER_DNS"
+        apiServer:
+          certSANs:
+          - "LOAD_BALANCER_DNS"
         controlPlaneEndpoint: "LOAD_BALANCER_DNS:LOAD_BALANCER_PORT"
         etcd:
           local:
@@ -315,8 +317,9 @@ done
         apiVersion: kubeadm.k8s.io/v1beta1
         kind: ClusterConfiguration
         kubernetesVersion: stable
-        apiServerCertSANs:
-        - "LOAD_BALANCER_DNS"
+        apiServer:
+          certSANs:
+          - "LOAD_BALANCER_DNS"
         controlPlaneEndpoint: "LOAD_BALANCER_DNS:LOAD_BALANCER_PORT"
         etcd:
           local:
@@ -443,8 +446,9 @@ done
         apiVersion: kubeadm.k8s.io/v1beta1
         kind: ClusterConfiguration
         kubernetesVersion: stable
-        apiServerCertSANs:
-        - "LOAD_BALANCER_DNS"
+        apiServer:
+          certSANs:
+          - "LOAD_BALANCER_DNS"
         controlPlaneEndpoint: "LOAD_BALANCER_DNS:LOAD_BALANCER_PORT"
         etcd:
             external:


### PR DESCRIPTION
fix a couple of inconsistencies in v1beta1 configs where API server SANs were still using the old fields.
can't find any more left overs from v1alpha3.

/kind bug
/sig cluster-lifecycle
cc @kubernetes/sig-cluster-lifecycle 

/assign @fabriziopandini @rosti @xiangpengzhao 
^ for lgtm

cc @tfogo 
cc @kubernetes/sig-docs-maintainers 
^ for approve

xref:
https://github.com/kubernetes/website/issues/10937

