### PR TITLE
Add Korean language alternatives setting

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -139,12 +139,20 @@ languageName = "中文 Chinese"
 weight = 2
 contentDir = "content/zh"
 
+[languages.zh.params]
+time_format_blog = "2006.01.02"
+language_alternatives = ["en"]
+
 [languages.ko]
 title = "Kubernetes"
 description = "Production-Grade Container Orchestration"
 languageName = "한국어 Korean"
 weight = 3
 contentDir = "content/ko"
+
+[languages.ko.params]
+time_format_blog = "2006.01.02"
+language_alternatives = ["en"]
 
 [languages.no]
 title = "Kubernetes"
@@ -158,6 +166,3 @@ time_format_blog = "02.01.2006"
 # A list of language codes to look for untranslated content, ordered from left to right.
 language_alternatives = ["en"]
 
-[languages.zh.params]
-time_format_blog = "2006.01.02"
-language_alternatives = ["en"]


### PR DESCRIPTION
Add `en` as fallback language for Korean localized content. 