### PR TITLE
Fix instructions to start minikube with RBAC

### DIFF
--- a/content/en/docs/setup/minikube.md
+++ b/content/en/docs/setup/minikube.md
@@ -258,7 +258,7 @@ To change the `MaxPods` setting to 5 on the Kubelet, pass this flag: `--extra-co
 
 This feature also supports nested structs. To change the `LeaderElection.LeaderElect` setting to `true` on the scheduler, pass this flag: `--extra-config=scheduler.LeaderElection.LeaderElect=true`.
 
-To set the `AuthorizationMode` on the `apiserver` to `RBAC`, you can use: `--extra-config=apiserver.Authorization.Mode=RBAC`.
+To set the `AuthorizationMode` on the `apiserver` to `RBAC`, you can use: `--extra-config=apiserver.authorization-mode=RBAC`.
 
 ### Stopping a Cluster
 The `minikube stop` command can be used to stop your cluster.


### PR DESCRIPTION
**Minikube version**:  v0.30.0


When starting minikube with `--extra-config=apiserver.Authorization.Mode=RBAC`, the apiserver
container exits with the following error:

```
error: unknown flag: --Authorization.Mode
```

Starting it with `--extra-config=apiserver.authorization-mode=RBAC`
instead fixes the issue.
