### PR TITLE
The FlexVolume plugin supports ReadWriteMany depending on the driver

### DIFF
--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -335,7 +335,7 @@ In the CLI, the access modes are abbreviated to:
 | CephFS               | &#x2713;     | &#x2713;    | &#x2713;     |
 | Cinder               | &#x2713;     | -           | -            |
 | FC                   | &#x2713;     | &#x2713;    | -            |
-| Flexvolume           | &#x2713;     | &#x2713;    | -            |
+| Flexvolume           | &#x2713;     | &#x2713;    | depends on the driver |
 | Flocker              | &#x2713;     | -           | -            |
 | GCEPersistentDisk    | &#x2713;     | &#x2713;    | -            |
 | Glusterfs            | &#x2713;     | &#x2713;    | &#x2713;     |


### PR DESCRIPTION
I was able to successfully use https://github.com/juliohm1978/kubernetes-cifs-volumedriver to mount a SMB share from multiple nodes. 

The current docs are misleading, as it is generally possible.