### PR TITLE
Fix typo in kubectl-plugins.md

### DIFF
--- a/content/en/docs/tasks/extend-kubectl/kubectl-plugins.md
+++ b/content/en/docs/tasks/extend-kubectl/kubectl-plugins.md
@@ -135,7 +135,7 @@ and handle flag validation as part of their own implementation. For plugins writ
 
 Taking our `kubectl-foo-bar-baz` plugin from the above scenario, we further explore additional cases where users invoke our plugin while providing additional flags and arguments.
 For example, in a situation where a user invokes the command `kubectl foo bar baz arg1 --flag=value arg2`, the plugin mechanism will first try to find the plugin with the longest possible name, which in this case
-would be `kubectk-foo-bar-baz-arg1`. Upon not finding that plugin, it then treats the last dash-separated value as an argument (`arg1` in this case), and attempts to find the next longest possible name, `kubectl-foo-bar-baz`.
+would be `kubectl-foo-bar-baz-arg1`. Upon not finding that plugin, it then treats the last dash-separated value as an argument (`arg1` in this case), and attempts to find the next longest possible name, `kubectl-foo-bar-baz`.
 Upon finding a plugin with this name, it then invokes that plugin, passing all args and flags after its name to the plugin executable.
 
 Example:


### PR DESCRIPTION
`kubectk-foo-bar-baz-arg1` => `kubectl-foo-bar-baz-arg1`