### PR TITLE
Fix vsphere node name docs

### DIFF
--- a/content/en/docs/concepts/cluster-administration/cloud-providers.md
+++ b/content/en/docs/concepts/cluster-administration/cloud-providers.md
@@ -358,7 +358,9 @@ Note that the Kubernetes Node name must match the Photon VM name (or if `overrid
 
 ### Node Name
 
-The VSphere cloud provider uses the hostname of the node (as determined by the kubelet or overridden with `--hostname-override`) as the name of the Kubernetes Node object.
+The VSphere cloud provider uses the detected hostname of the node (as determined by the kubelet) as the name of the Kubernetes Node object.
+
+The `--hostname-override` parameter is ignored by the VSphere cloud provider.
 
 ## IBM Cloud Kubernetes Service
 


### PR DESCRIPTION
In all supported releases, the vsphere cloud provider ignores the `--hostname-override` parameter and uses the auto-detected node name instead:

https://github.com/kubernetes/kubernetes/blob/release-1.9/pkg/cloudprovider/providers/vsphere/vsphere.go#L235
https://github.com/kubernetes/kubernetes/blob/release-1.9/pkg/cloudprovider/providers/vsphere/vsphere.go#L575-L578

https://github.com/kubernetes/kubernetes/blob/release-1.10/pkg/cloudprovider/providers/vsphere/vsphere.go#L235
https://github.com/kubernetes/kubernetes/blob/release-1.10/pkg/cloudprovider/providers/vsphere/vsphere.go#L568-L570

https://github.com/kubernetes/kubernetes/blob/release-1.11/pkg/cloudprovider/providers/vsphere/vsphere.go#L265
https://github.com/kubernetes/kubernetes/blob/release-1.11/pkg/cloudprovider/providers/vsphere/vsphere.go#L650-L653

https://github.com/kubernetes/kubernetes/blob/release-1.12/pkg/cloudprovider/providers/vsphere/vsphere.go#L282
https://github.com/kubernetes/kubernetes/blob/release-1.12/pkg/cloudprovider/providers/vsphere/vsphere.go#L681-L683

This fixes the cloud provider documentation to accurately reflect what the vsphere provider does with the `--hostname-override` parameter (ignores it)