### PR TITLE
Rename EncryptionConfig to EncryptionConfiguration

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/federation-apiserver.md
+++ b/content/en/docs/reference/command-line-tools-reference/federation-apiserver.md
@@ -68,7 +68,7 @@ federation-apiserver [flags]
       --etcd-servers strings                                    List of etcd servers to connect with (scheme://ip:port), comma separated.
       --etcd-servers-overrides strings                          Per-resource etcd servers overrides, comma separated. The individual override format: group/resource#servers, where servers are http://ip:port, semicolon separated.
       --event-ttl duration                                      Amount of time to retain events. (default 1h0m0s)
-      --experimental-encryption-provider-config string          The file containing configuration for encryption providers to be used for storing secrets in etcd
+      --encryption-provider-config string                       The file containing configuration for encryption providers to be used for storing secrets in etcd
       --experimental-keystone-ca-file string                    If set, the Keystone server's certificate will be verified by one of the authorities in the experimental-keystone-ca-file, otherwise the host's root CA set will be used.
       --experimental-keystone-url string                        If passed, activates the keystone authentication plugin.
       --external-hostname string                                The hostname to use when generating externalized URLs for this master (e.g. Swagger API Docs).

--- a/content/en/docs/reference/command-line-tools-reference/kube-apiserver.md
+++ b/content/en/docs/reference/command-line-tools-reference/kube-apiserver.md
@@ -525,7 +525,7 @@ kube-apiserver [flags]
     </tr>
 
     <tr>
-      <td colspan="2">--experimental-encryption-provider-config string</td>
+      <td colspan="2">--encryption-provider-config string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The file containing configuration for encryption providers to be used for storing secrets in etcd</td>

--- a/content/en/docs/tasks/administer-cluster/encrypt-data.md
+++ b/content/en/docs/tasks/administer-cluster/encrypt-data.md
@@ -13,7 +13,7 @@ This page shows how to enable and configure encryption of secret data at rest.
 
 * {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
 
-* Kubernetes version 1.7.0 or later is required
+* Kubernetes version 1.13.0 or later is required
 
 * etcd v3 or later is required
 
@@ -23,15 +23,18 @@ This page shows how to enable and configure encryption of secret data at rest.
 
 ## Configuration and determining whether encryption at rest is already enabled
 
-The `kube-apiserver` process accepts an argument `--experimental-encryption-provider-config`
+The `kube-apiserver` process accepts an argument `--encryption-provider-config`
 that controls how API data is encrypted in etcd. An example configuration
 is provided below.
+
+Note:
+The alpha version of the encryption feature prior to 1.13 used the `--experimental-encryption-provider-config` flag.
 
 ## Understanding the encryption at rest configuration.
 
 ```yaml
-kind: EncryptionConfig
-apiVersion: v1
+kind: EncryptionConfiguration
+apiVersion: apiserver.config.k8s.io/v1
 resources:
   - resources:
     - secrets
@@ -66,6 +69,10 @@ resources from storage each provider that matches the stored data attempts to de
 order. If no provider can read the stored data due to a mismatch in format or secret key, an error 
 is returned which prevents clients from accessing that resource. 
 
+Note:
+The alpha version of the encryption feature prior to 1.13 required to be configured with
+`kind: EncryptionConfig` and `apiVersion: v1`.
+
 **IMPORTANT:** If any resource is not readable via the encryption config (because keys were changed), 
 the only recourse is to delete that key from the underlying etcd directly. Calls that attempt to 
 read that resource will fail until it is deleted or a valid decryption key is provided.
@@ -88,8 +95,8 @@ is the first provider, the first key is used for encryption.
 Create a new encryption config file:
 
 ```yaml
-kind: EncryptionConfig
-apiVersion: v1
+kind: EncryptionConfiguration
+apiVersion: apiserver.config.k8s.io/v1
 resources:
   - resources:
     - secrets
@@ -110,7 +117,7 @@ To create a new secret perform the following steps:
     ```
 
 2. Place that value in the secret field.
-3. Set the `--experimental-encryption-provider-config` flag on the `kube-apiserver` to point to the location of the config file.
+3. Set the `--encryption-provider-config` flag on the `kube-apiserver` to point to the location of the config file.
 4. Restart your API server.
 
 **IMPORTANT:** Your config file contains keys that can decrypt content in etcd, so you must properly restrict permissions on your masters so only the user who runs the kube-apiserver can read it.
@@ -178,8 +185,8 @@ With a single `kube-apiserver`, step 2 may be skipped.
 To disable encryption at rest place the `identity` provider as the first entry in the config:
 
 ```yaml
-kind: EncryptionConfig
-apiVersion: v1
+kind: EncryptionConfiguration
+apiVersion: apiserver.config.k8s.io/v1
 resources:
   - resources:
     - secrets

--- a/content/en/docs/tasks/administer-cluster/kms-provider.md
+++ b/content/en/docs/tasks/administer-cluster/kms-provider.md
@@ -79,8 +79,8 @@ To encrypt the data:
 1. Create a new encryption configuration file using the appropriate properties for the `kms` provider:
 
 ```yaml
-kind: EncryptionConfig
-apiVersion: v1
+kind: EncryptionConfiguration
+apiVersion: apiserver.config.k8s.io/v1
 resources:
   - resources:
     - secrets
@@ -92,8 +92,12 @@ resources:
    - identity: {}
 ```
 
-2. Set the `--experimental-encryption-provider-config` flag on the kube-apiserver to point to the location of the configuration file.
+2. Set the `--encryption-provider-config` flag on the kube-apiserver to point to the location of the configuration file.
 3. Restart your API server.
+
+Note:
+The alpha version of the encryption feature prior to 1.13 required a config file with
+`kind: EncryptionConfig` and `apiVersion: v1`, and used the `--experimental-encryption-provider-config` flag.
 
 ## Verifying that the data is encrypted
 Data is encrypted when written to etcd. After restarting your kube-apiserver, any newly created or updated secret should be encrypted when stored. To verify, you can use the etcdctl command line program to retrieve the contents of your secret.
@@ -130,8 +134,8 @@ To switch from a local encryption provider to the `kms` provider and re-encrypt 
 1. Add the `kms` provider as the first entry in the configuration file as shown in the following example.
 
 ```yaml
-kind: EncryptionConfig
-apiVersion: v1
+kind: EncryptionConfiguration
+apiVersion: apiserver.config.k8s.io/v1
 resources:
   - resources:
     - secrets
@@ -160,8 +164,8 @@ To disable encryption at rest:
 1. Place the `identity` provider as the first entry in the configuration file: 
 
 ```yaml
-kind: EncryptionConfig
-apiVersion: v1
+kind: EncryptionConfiguration
+apiVersion: apiserver.config.k8s.io/v1
 resources:
   - resources:
     - secrets


### PR DESCRIPTION
EncryptionConfig was renamed to EncryptedConfiguration and added to
the `apiserver.config.k8s.io` API group in Kubernetes 1.13.

The feature was previously in alpha and was not handling versions
properly, which lead to an originally unnoticed `v1` in the docs.

---
Related to: https://github.com/kubernetes/kubernetes/pull/67383/

