### PR TITLE
Add information on supported version skew and upgrade order

### DIFF
--- a/content/en/docs/reference/using-api/deprecation-policy.md
+++ b/content/en/docs/reference/using-api/deprecation-policy.md
@@ -87,7 +87,7 @@ no less than:**
    * **Beta: 9 months or 3 releases (whichever is longer)**
    * **Alpha: 0 releases**
 
-This covers the maximum supported version skew of 2 releases.
+This covers the [maximum supported version skew of 2 releases](/docs/setup/version-skew-policy/).
 
 {{< note >}}
 Until [#52185](https://github.com/kubernetes/kubernetes/issues/52185) is

--- a/content/en/docs/setup/independent/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/independent/create-cluster-kubeadm.md
@@ -589,8 +589,10 @@ Due to that we can't see into the future, kubeadm CLI vX.Y may or may not be abl
 Example: kubeadm v1.8 can deploy both v1.7 and v1.8 clusters and upgrade v1.7 kubeadm-created clusters to
 v1.8.
 
-Please also check our [installation guide](/docs/setup/independent/install-kubeadm/#installing-kubeadm-kubelet-and-kubectl)
-for more information on the version skew between kubelets and the control plane.
+See these resources for more information on supported version skew between kubelets and the control plane, and other Kubernetes components:
+
+* Kubernetes [version and version-skew policy](/docs/setup/version-skew-policy/)
+* Kubeadm-specific [installation guide](/docs/setup/independent/install-kubeadm/#installing-kubeadm-kubelet-and-kubectl)
 
 ## kubeadm works on multiple platforms {#multi-platform}
 

--- a/content/en/docs/setup/independent/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/independent/create-cluster-kubeadm.md
@@ -589,7 +589,7 @@ Due to that we can't see into the future, kubeadm CLI vX.Y may or may not be abl
 Example: kubeadm v1.8 can deploy both v1.7 and v1.8 clusters and upgrade v1.7 kubeadm-created clusters to
 v1.8.
 
-See these resources for more information on supported version skew between kubelets and the control plane, and other Kubernetes components:
+These resources provide more information on supported version skew between kubelets and the control plane, and other Kubernetes components:
 
 * Kubernetes [version and version-skew policy](/docs/setup/version-skew-policy/)
 * Kubeadm-specific [installation guide](/docs/setup/independent/install-kubeadm/#installing-kubeadm-kubelet-and-kubectl)

--- a/content/en/docs/setup/independent/install-kubeadm.md
+++ b/content/en/docs/setup/independent/install-kubeadm.md
@@ -119,8 +119,10 @@ This is because kubeadm and Kubernetes require
 [special attention to upgrade](/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-11/).
 {{</ warning >}}
 
-For more information on version skews, please read our
-[version skew policy](/docs/setup/independent/create-cluster-kubeadm/#version-skew-policy).
+For more information on version skews, see:
+
+* Kubernetes [version and version-skew policy](/docs/setup/version-skew-policy/)
+* Kubeadm-specific [version skew policy](/docs/setup/independent/create-cluster-kubeadm/#version-skew-policy)
 
 {{< tabs name="k8s_install" >}}
 {{% tab name="Ubuntu, Debian or HypriotOS" %}}

--- a/content/en/docs/setup/version-skew-policy.md
+++ b/content/en/docs/setup/version-skew-policy.md
@@ -1,0 +1,128 @@
+---
+reviewers:
+- sig-api-machinery
+- sig-architecture
+- sig-cli
+- sig-cluster-lifecycle
+- sig-node
+- sig-release
+title: Kubernetes Version and Version Skew Support Policy
+content_template: templates/concept
+weight: 70
+---
+
+{{% capture overview %}}
+This document describes the maximum version skew supported between various Kubernetes components.
+Specific cluster deployment tools may place additional restrictions on version skew.
+{{% /capture %}}
+
+{{% capture body %}}
+
+## Supported versions
+
+Kubernetes versions are expressed as **x.y.z**,
+where **x** is the major version, **y** is the minor version, and **z** is the patch version, following [Semantic Versioning](http://semver.org/) terminology.
+For more information, see [Kubernetes Release Versioning](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md#kubernetes-release-versioning).
+
+The Kubernetes project maintains release branches for the most recent three minor releases,
+and expects users to be running those versions in production.
+
+Applicable bug and security fixes may be backported to those three release branches, depending on severity and feasibility.
+Patch releases are cut from those branches at a regular cadence,
+or on an as-needed basis as determined by the [patch release manager](https://github.com/kubernetes/sig-release/blob/master/release-team/role-handbooks/patch-release-manager/README.md#release-timing).
+The patch release manager is listed in the [release team for each release](https://github.com/kubernetes/sig-release/tree/master/releases/).
+
+With minor releases happening approximately every three months,
+that means each minor release is maintained for approximately nine months.
+
+## Supported version skew
+
+### `kube-apiserver`
+
+In multi-server clusters, the newest and oldest `kube-apiserver` instances must be within one minor version.
+
+Example:
+
+* newest `kube-apiserver` is at **1.13**
+* other `kube-apiserver` instances are supported at **1.13** and **1.12**
+
+### `kubelet`
+
+`kubelet` must not be newer than `kube-apiserver`, and may be up to two minor versions older.
+
+Example:
+
+* `kube-apiserver` is at **1.13**
+* `kubelet` is supported at **1.13**, **1.12**, and **1.11**
+
+Note that if version skew exists between `kube-apiserver` instances in a multi-server cluster, this narrows the allowed `kubelet` versions.
+
+Example:
+
+* `kube-apiserver` instances are at **1.13** and **1.12**
+* `kubelet` is supported at **1.12**, and **1.11** (**1.13** is not supported because that would be newer than the `kube-apiserver` instance at version **1.12**)
+
+### `kube-controller-manager` and `kube-scheduler`
+
+`kube-controller-manager` and `kube-scheduler` must not be newer than the `kube-apiserver` instances they communicate with. They are expected to match the `kube-apiserver` minor version, but may be up to one minor version older (to allow live upgrades).
+
+Example:
+
+* `kube-apiserver` is at **1.13**
+* `kube-controller-manager` and `kube-scheduler` are supported at **1.13** and **1.12**
+
+Note that if version skew exists between `kube-apiserver` instances in a multi-server cluster, and `kube-controller-manager` or `kube-scheduler` can communicate with any `kube-apiserver` instance in the cluster (for example, via a load balancer), this narrows the allowed `kube-controller-manager` or `kube-scheduler` versions.
+
+Example:
+
+* `kube-apiserver` instances are at **1.13** and **1.12**
+* `kube-controller-manager` and `kube-scheduler` communicate with a load balancer that can route to any `kube-apiserver` instance
+* `kube-controller-manager` and `kube-scheduler` are supported at **1.12** (**1.13** is not supported because that would be newer than the `kube-apiserver` instance at version **1.12**)
+
+### `kubectl`
+
+`kubectl` is supported within one minor version (older or newer) of `kube-apiserver`.
+
+Example:
+
+* `kube-apiserver` is at **1.13**
+* `kubectl` is supported at **1.14**, **1.13**, and **1.12**
+
+Note that if version skew exists between `kube-apiserver` instances in a multi-server cluster, this narrows the supported `kubectl` versions.
+
+Example:
+
+* `kube-apiserver` instances are at **1.13** and **1.12**
+* `kubectl` is supported at **1.13** and **1.12** (other versions would be more than one minor version skewed from one of the `kube-apiserver` components)
+
+## Supported component upgrade order
+
+The supported version skew between components has implications on the order in which components must be upgraded.
+This section describes the order in which components must be upgraded to transition an existing cluster from version **1.n** to version **1.(n+1)**.
+
+### `kube-apiserver`
+
+Pre-requisites:
+
+* In a multi-server cluster, other `kube-apiserver` instances are at **1.n** or **1.(n+1)** (this ensures maximum skew of 1 minor version between the oldest and newest `kube-apiserver` instance)
+* The `kube-controller-manager` and `kube-scheduler` instances that communicate with this server are at version **1.n** (this ensures they are not newer than the existing API server version, and are within 1 minor version of the new API server version)
+* `kubelet` instances on all nodes are at version **1.n** or **1.(n-1)** (this ensures they are not newer than the existing API server version, and are within 2 minor versions of the new API server version)
+* Registered admission webhooks are capable of understanding all the versions of REST resources they are registered for (including any new versions available in **1.(n+1)**)
+
+Upgrade `kube-apiserver` to **1.(n+1)**
+
+### `kube-controller-manager` and `kube-scheduler`
+
+Pre-requisites:
+
+* The `kube-apiserver` instances these components communicate with are at **1.(n+1)** (in multi-server clusters in which these control plane components communicate with any `kube-apiserver` instance in the cluster, all `kube-apiserver` instances must be upgraded before upgrading these components)
+
+Upgrade `kube-controller-manager` and `kube-scheduler` to **1.(n+1)**
+
+### `kubelet`
+
+Pre-requisites:
+
+* The `kube-apiserver` instances the `kubelet` communicates with are at **1.(n+1)**
+
+Optionally upgrade `kubelet` instances to **1.(n+1)** (or they can be left at **1.n** or **1.(n-1)**)

--- a/content/en/docs/setup/version-skew-policy.md
+++ b/content/en/docs/setup/version-skew-policy.md
@@ -62,24 +62,24 @@ Example:
 * `kube-apiserver` instances are at **1.13** and **1.12**
 * `kubelet` is supported at **1.12**, and **1.11** (**1.13** is not supported because that would be newer than the `kube-apiserver` instance at version **1.12**)
 
-### `kube-controller-manager` and `kube-scheduler`
+### `kube-controller-manager`, `kube-scheduler`, `cloud-controller-manager`
 
-`kube-controller-manager` and `kube-scheduler` must not be newer than the `kube-apiserver` instances they communicate with. They are expected to match the `kube-apiserver` minor version, but may be up to one minor version older (to allow live upgrades).
+`kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager` must not be newer than the `kube-apiserver` instances they communicate with. They are expected to match the `kube-apiserver` minor version, but may be up to one minor version older (to allow live upgrades).
 
 Example:
 
 * `kube-apiserver` is at **1.13**
-* `kube-controller-manager` and `kube-scheduler` are supported at **1.13** and **1.12**
+* `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager` are supported at **1.13** and **1.12**
 
 {{< note >}}
-If version skew exists between `kube-apiserver` instances in an HA cluster, and `kube-controller-manager` or `kube-scheduler` can communicate with any `kube-apiserver` instance in the cluster (for example, via a load balancer), this narrows the allowed `kube-controller-manager` or `kube-scheduler` versions.
+If version skew exists between `kube-apiserver` instances in an HA cluster, and these components can communicate with any `kube-apiserver` instance in the cluster (for example, via a load balancer), this narrows the allowed versions of these components.
 {{< /note >}}
 
 Example:
 
 * `kube-apiserver` instances are at **1.13** and **1.12**
-* `kube-controller-manager` and `kube-scheduler` communicate with a load balancer that can route to any `kube-apiserver` instance
-* `kube-controller-manager` and `kube-scheduler` are supported at **1.12** (**1.13** is not supported because that would be newer than the `kube-apiserver` instance at version **1.12**)
+* `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager` communicate with a load balancer that can route to any `kube-apiserver` instance
+* `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager` are supported at **1.12** (**1.13** is not supported because that would be newer than the `kube-apiserver` instance at version **1.12**)
 
 ### `kubectl`
 
@@ -110,7 +110,7 @@ Pre-requisites:
 
 * In a single-instance cluster, the existing `kube-apiserver` instance is **1.n**
 * In an HA cluster, all `kube-apiserver` instances are at **1.n** or **1.(n+1)** (this ensures maximum skew of 1 minor version between the oldest and newest `kube-apiserver` instance)
-* The `kube-controller-manager` and `kube-scheduler` instances that communicate with this server are at version **1.n** (this ensures they are not newer than the existing API server version, and are within 1 minor version of the new API server version)
+* The `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager` instances that communicate with this server are at version **1.n** (this ensures they are not newer than the existing API server version, and are within 1 minor version of the new API server version)
 * `kubelet` instances on all nodes are at version **1.n** or **1.(n-1)** (this ensures they are not newer than the existing API server version, and are within 2 minor versions of the new API server version)
 * Registered admission webhooks are able to handle the data the new `kube-apiserver` instance will send them:
   * `ValidatingWebhookConfiguration` and `MutatingWebhookConfiguration` objects are updated to include any new versions of REST resources added in **1.(n+1)**
@@ -124,13 +124,13 @@ Project policies for [API deprecation](https://kubernetes.io/docs/reference/usin
 require `kube-apiserver` to not skip minor versions when upgrading, even in single-instance clusters.
 {{< /note >}}
 
-### `kube-controller-manager` and `kube-scheduler`
+### `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager`
 
 Pre-requisites:
 
-* The `kube-apiserver` instances these components communicate with are at **1.(n+1)** (in HA clusters in which these control plane components communicate with any `kube-apiserver` instance in the cluster, all `kube-apiserver` instances must be upgraded before upgrading these components)
+* The `kube-apiserver` instances these components communicate with are at **1.(n+1)** (in HA clusters in which these control plane components can communicate with any `kube-apiserver` instance in the cluster, all `kube-apiserver` instances must be upgraded before upgrading these components)
 
-Upgrade `kube-controller-manager` and `kube-scheduler` to **1.(n+1)**
+Upgrade `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager` to **1.(n+1)**
 
 ### `kubelet`
 

--- a/content/en/docs/setup/version-skew-policy.md
+++ b/content/en/docs/setup/version-skew-policy.md
@@ -35,7 +35,7 @@ Minor releases occur approximately every 3 months, so each minor release branch 
 
 ## Supported version skew
 
-### `kube-apiserver`
+### kube-apiserver
 
 In [highly-availabile (HA) clusters](https://kubernetes.io/docs/setup/independent/high-availability/), the newest and oldest `kube-apiserver` instances must be within one minor version.
 
@@ -44,7 +44,7 @@ Example:
 * newest `kube-apiserver` is at **1.13**
 * other `kube-apiserver` instances are supported at **1.13** and **1.12**
 
-### `kubelet`
+### kubelet
 
 `kubelet` must not be newer than `kube-apiserver`, and may be up to two minor versions older.
 
@@ -62,7 +62,7 @@ Example:
 * `kube-apiserver` instances are at **1.13** and **1.12**
 * `kubelet` is supported at **1.12**, and **1.11** (**1.13** is not supported because that would be newer than the `kube-apiserver` instance at version **1.12**)
 
-### `kube-controller-manager`, `kube-scheduler`, `cloud-controller-manager`
+### kube-controller-manager, kube-scheduler, and cloud-controller-manager
 
 `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager` must not be newer than the `kube-apiserver` instances they communicate with. They are expected to match the `kube-apiserver` minor version, but may be up to one minor version older (to allow live upgrades).
 
@@ -81,7 +81,7 @@ Example:
 * `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager` communicate with a load balancer that can route to any `kube-apiserver` instance
 * `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager` are supported at **1.12** (**1.13** is not supported because that would be newer than the `kube-apiserver` instance at version **1.12**)
 
-### `kubectl`
+### kubectl
 
 `kubectl` is supported within one minor version (older or newer) of `kube-apiserver`.
 
@@ -104,7 +104,7 @@ Example:
 The supported version skew between components has implications on the order in which components must be upgraded.
 This section describes the order in which components must be upgraded to transition an existing cluster from version **1.n** to version **1.(n+1)**.
 
-### `kube-apiserver`
+### kube-apiserver
 
 Pre-requisites:
 
@@ -124,7 +124,7 @@ Project policies for [API deprecation](https://kubernetes.io/docs/reference/usin
 require `kube-apiserver` to not skip minor versions when upgrading, even in single-instance clusters.
 {{< /note >}}
 
-### `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager`
+### kube-controller-manager, kube-scheduler, and cloud-controller-manager
 
 Pre-requisites:
 
@@ -132,7 +132,7 @@ Pre-requisites:
 
 Upgrade `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager` to **1.(n+1)**
 
-### `kubelet`
+### kubelet
 
 Pre-requisites:
 

--- a/content/en/docs/user-journeys/users/cluster-operator/foundational.md
+++ b/content/en/docs/user-journeys/users/cluster-operator/foundational.md
@@ -65,7 +65,8 @@ These resources are covered in a number of articles within the Kubernetes docume
 
 As a cluster operator you may not need to use all these resources, although you should be familiar with them to understand how the cluster is being used.
 There are a number of additional resources that you should be aware of, some listed under [Intermediate Resources](/docs/user-journeys/users/cluster-operator/intermediate#section-1).
-You should also be familiar with [how to manage kubernetes resources](/docs/concepts/cluster-administration/manage-deployment/).
+You should also be familiar with [how to manage kubernetes resources](/docs/concepts/cluster-administration/manage-deployment/)
+and [supported versions and version skew between cluster components](/docs/setup/version-skew-policy/).
 
 ## Get information about your cluster
 

--- a/data/setup.yml
+++ b/data/setup.yml
@@ -136,4 +136,4 @@ toc:
 - title: Building High-Availability Clusters
   path: /docs/admin/high-availability/building/
 
-- docs/setup/skew-policy.md
+- docs/setup/version-skew-policy.md

--- a/data/setup.yml
+++ b/data/setup.yml
@@ -135,3 +135,5 @@ toc:
 
 - title: Building High-Availability Clusters
   path: /docs/admin/high-availability/building/
+
+- docs/setup/skew-policy.md


### PR DESCRIPTION
Fixes https://github.com/kubernetes/website/issues/7103

Preview available at: https://deploy-preview-11060--kubernetes-io-master-staging.netlify.com/docs/setup/version-skew-policy/

We have a document that details the deprecation policy for APIs, but no document on the website detailing supported versions and version skew between Kubernetes components.

This is important information to make clear, for many reasons:
* it has implications for component upgrade order
* it is necessary for cluster deployers to know what the skew guarantees are so they know what to deploy
* it is necessary for component owners to know what skew they are expected to support so they know what cases to handle
* it is important for reviewers to know what changes are acceptable to make in a given release

This PR attempts to clarify the currently supported state of supported Kubernetes versions and component version skew.

I'd like to resolve the following questions, get feedback from various sigs, and merge this around the time 1.13 releases (and mention it in the release notes), currently targeted for 12/3.

follow-up discussion topics/updates:
- [ ] what version skew does the `kube-proxy` component support relative to the apiserver and kubelet? @kubernetes/sig-network-pr-reviews
- [ ] is a specific upgrade order between `kube-proxy` and `kubelet` required? @kubernetes/sig-network-pr-reviews, @kubernetes/sig-node-pr-reviews
- [ ] is a specific upgrade order between `kube-controller-manager` and `kube-scheduler` required? @kubernetes/sig-api-machinery-pr-reviews, @kubernetes/sig-scheduling-pr-reviews
- [ ] should we add requirements (or at least a strong recommendation) to be at latest patch version of `1.x` prior to upgrades, and upgrade to latest patch version of `1.x+1` (since that is what we test, and what we can fix if broken)? @kubernetes/sig-architecture-pr-reviews @kubernetes/sig-release @kubernetes/sig-cluster-lifecycle-pr-reviews 
- [ ] add details to kubelet upgrade procedure (whether drain is required, whether skip-level kubelet upgrades are supported, etc) @kubernetes/sig-node-pr-reviews @kubernetes/sig-storage-pr-reviews 
- [ ] what statement should be made about new features in version 1.x when running with a 1.x+ control plane and kubelets older than 1.x? is the user responsible for labeling nodes and workloads to only steer pods using those features to nodes with those capabilities? @kubernetes/sig-node-pr-reviews @kubernetes/sig-architecture-pr-reviews 
- [ ] control plane downgrade (and safe rollback in rolling HA upgrade) (https://github.com/kubernetes/website/pull/11060#discussion_r237614607, https://github.com/kubernetes/website/pull/11060#issuecomment-440142623, https://github.com/kubernetes/website/pull/11060#discussion_r237616387)
- [ ] what is our stated support or testing for transitive or third-party dependencies?
  * are they completely out of scope?
  * is there a recommended or supported order for upgrading etcd vs. the control plane components?
  * when we say we recommend container engine A at version B for k8s release 1.n, does that imply we expect k8s release 1.n+2 to support the same?

references:
- https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md#supported-releases-and-component-skew
- https://github.com/kubernetes/sig-release/blob/master/release-team/role-handbooks/patch-release-manager/README.md#release-timing
- https://kubernetes.io/docs/reference/using-api/deprecation-policy/#deprecating-parts-of-the-api
    > This covers the maximum supported version skew of 2 releases.

relevant owners for open questions:
- [x] @kubernetes/sig-architecture-pr-reviews - overall support statement, discussed in sig-arch on 11/29 - https://github.com/kubernetes/website/pull/11060#issuecomment-445383166
- [x] @kubernetes/sig-cluster-lifecycle-pr-reviews - upgrade order and kubeadm doc updates - https://github.com/kubernetes/website/pull/11060#issuecomment-441706912
- [x] @kubernetes/sig-cli-pr-reviews - kube-apiserver/kubectl skew - https://github.com/kubernetes/website/pull/11060#pullrequestreview-176870197
- [x] @kubernetes/sig-api-machinery-pr-reviews - kube-apiserver/kube-controller-manager skew - https://github.com/kubernetes/website/pull/11060#issuecomment-440428941
- [x] @kubernetes/sig-cloud-provider - for kube-apiserver/cloud-controller-manager skew - https://github.com/kubernetes/website/pull/11060#discussion_r235075963