### PR TITLE
[zh][dev-1.13] Rename EncryptionConfig to EncryptionConfiguration

### DIFF
--- a/content/zh/docs/tasks/administer-cluster/encrypt-data.md
+++ b/content/zh/docs/tasks/administer-cluster/encrypt-data.md
@@ -66,8 +66,8 @@ is provided below.
 ## 理解静态数据加密
 
 ```yaml
-kind: EncryptionConfig
-apiVersion: v1
+kind: EncryptionConfiguration
+apiVersion: apiserver.config.k8s.io/v1
 resources:
   - resources:
     - secrets
@@ -149,8 +149,8 @@ Create a new encryption config file:
 创建一个新的加密配置文件：
 
 ```yaml
-kind: EncryptionConfig
-apiVersion: v1
+kind: EncryptionConfiguration
+apiVersion: apiserver.config.k8s.io/v1
 resources:
   - resources:
     - secrets
@@ -299,8 +299,8 @@ To disable encryption at rest place the `identity` provider as the first entry i
 要禁用 rest 加密，请将 `identity` provider 作为配置中的第一个条目：
 
 ```yaml
-kind: EncryptionConfig
-apiVersion: v1
+kind: EncryptionConfiguration
+apiVersion: apiserver.config.k8s.io/v1
 resources:
   - resources:
     - secrets


### PR DESCRIPTION
EncryptionConfig was renamed to EncryptedConfiguration and added to
the `apiserver.config.k8s.io` API group in Kubernetes 1.13.

The feature was previously in alpha and was not handling versions
properly, which lead to an originally unnoticed `v1` in the docs.

---
Related to: https://github.com/kubernetes/kubernetes/pull/67383/