### PR TITLE
Fix the "my-scheduler-as-kube-scheduler" ClusterRoleBinding.

### DIFF
--- a/content/en/examples/admin/sched/my-scheduler.yaml
+++ b/content/en/examples/admin/sched/my-scheduler.yaml
@@ -14,7 +14,7 @@ subjects:
   namespace: kube-system
 roleRef:
   kind: ClusterRole
-  name: kube-scheduler
+  name: system:kube-scheduler
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
The `my-scheduler-as-kube-scheduler` cluster role binding is missing the `system:` prefix:

```
E1120 09:20:58.955249       1 reflector.go:205] k8s.io/kubernetes/vendor/k8s.io/client-go/informers/factory.go:130: Failed to list *v1.PersistentVolumeClaim: persistentvolumeclaims is forbidden: User "system:serviceaccount:kube-system:custom-scheduler" cannot list persistentvolumeclaims at the cluster scope: RBAC: clusterrole.rbac.authorization.k8s.io "kube-scheduler" not found
(...)
```