### PR TITLE
Fix link on DaemonSet AppArmor loader example

### DIFF
--- a/content/en/docs/tutorials/clusters/apparmor.md
+++ b/content/en/docs/tutorials/clusters/apparmor.md
@@ -307,7 +307,7 @@ nodes. There are lots of ways to setup the profiles though, such as:
 
 * Through a [DaemonSet](/docs/concepts/workloads/controllers/daemonset/) that runs a Pod on each node to
   ensure the correct profiles are loaded. An example implementation can be found
-  [here](https://git.k8s.io/contrib/apparmor/loader).
+  [here](https://git.k8s.io/kubernetes/test/images/apparmor-loader).
 * At node initialization time, using your node initialization scripts (e.g. Salt, Ansible, etc.) or
   image.
 * By copying the profiles to each node and loading them through SSH, as demonstrated in the


### PR DESCRIPTION
It was moved from kubernetes/contrib to kubernetes/kubernetes repository in https://github.com/kubernetes/contrib/commit/c7b70969bc31f7551bc2d8a6717d4d0532073cb4
