### PR TITLE
ExternalName cleanup

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -773,6 +773,12 @@ spec:
   type: ExternalName
   externalName: my.database.example.com
 ```
+{{< note >}}
+ExternalName _can_ be an IP, but it won't be resolved either by CoreDNS or ingress-nginx as the canonical use for ExternalName is to be a canonical DNS name. If you want to hardcode IPs, have a look at headless services.
+{{< /note >}}
+
+
+
 
 When looking up the host `my-service.prod.svc.CLUSTER`, the cluster DNS service
 will return a `CNAME` record with the value `my.database.example.com`. Accessing

--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -758,10 +758,6 @@ for supported instance types.
 
 ### Type ExternalName {#externalname}
 
-{{< note >}}
-ExternalName Services are available only with `kube-dns` version 1.7 and later.
-{{< /note >}}
-
 Services of type ExternalName map a service to a DNS name (specified using
 the `spec.externalName` parameter) rather than to a typical selector like
 `my-service` or `cassandra`. This Service definition, for example, would map

--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -758,9 +758,10 @@ for supported instance types.
 
 ### Type ExternalName {#externalname}
 
-Services of type ExternalName map a service to a DNS name (specified using
-the `spec.externalName` parameter) rather than to a typical selector like
-`my-service` or `cassandra`. This Service definition, for example, would map
+Services of type ExternalName map a service to a DNS name, not to a typical selector such as
+`my-service` or `cassandra`. You specify these services with the `spec.externalName` parameter.
+
+This Service definition, for example, maps
 the `my-service` Service in the `prod` namespace to `my.database.example.com`:
 
 ```yaml
@@ -774,11 +775,9 @@ spec:
   externalName: my.database.example.com
 ```
 {{< note >}}
-ExternalName _can_ be an IP, but it won't be resolved either by CoreDNS or ingress-nginx as the canonical use for ExternalName is to be a canonical DNS name. If you want to hardcode IPs, have a look at headless services.
+ExternalName can be an IP address, but IP addresses are not resolved by CoreDNS or ingress-nginx because ExternalName
+is intended to specify a canonical DNS name. To hardcode an IP address, consider headless services.
 {{< /note >}}
-
-
-
 
 When looking up the host `my-service.prod.svc.CLUSTER`, the cluster DNS service
 will return a `CNAME` record with the value `my.database.example.com`. Accessing

--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -775,7 +775,7 @@ spec:
   externalName: my.database.example.com
 ```
 {{< note >}}
-ExternalName can be an IP address, but IP addresses are not resolved by CoreDNS or ingress-nginx because ExternalName
+ExternalName accepts an IPv4 address string, but as a DNS name comprised of digits, not as an IP address. ExternalNames that resemble IPv4 addresses are not resolved by CoreDNS or ingress-nginx because ExternalName
 is intended to specify a canonical DNS name. To hardcode an IP address, consider headless services.
 {{< /note >}}
 


### PR DESCRIPTION
1. Removed the kube-dns note as CoreDNS is now the default.

2. Clarification on when ExternalName is an IP, it can't be resolved either by CoreDNS or ingress-nginx -> nameserver as it's taken as an A record but it's an IP.