### PR TITLE
replace `run` with `create deployment`

### DIFF
--- a/content/en/docs/tutorials/hello-minikube.md
+++ b/content/en/docs/tutorials/hello-minikube.md
@@ -71,11 +71,11 @@ tutorial has only one Container. A Kubernetes
 Pod and restarts the Pod's Container if it terminates. Deployments are the
 recommended way to manage the creation and scaling of Pods.
 
-1. Use the `kubectl run` command to create a Deployment that manages a Pod. The
+1. Use the `kubectl create` command to create a Deployment that manages a Pod. The
 Pod runs a Container based on the provided Docker image. 
 
     ```shell
-    kubectl run hello-node --image=gcr.io/hello-minikube-zero-install/hello-node --port=8080
+    kubectl create deployment hello-node --image=gcr.io/hello-minikube-zero-install/hello-node --port=8080
     ```
 
 2. View the Deployment:

--- a/content/ko/docs/tutorials/hello-minikube.md
+++ b/content/ko/docs/tutorials/hello-minikube.md
@@ -190,13 +190,13 @@ docker build -t hello-node:v1 .
 헬스를 검사해서 파드의 컨테이너가 종료되면 다시 시작해준다.
 파드의 생성 및 확장을 관리하는 방법으로 디플로이먼트를 권장한다.
 
-`kubectl run` 커맨드를 사용하여 파드를 관리하는 디플로이먼트를 만든다.
+`kubectl create` 커맨드를 사용하여 파드를 관리하는 디플로이먼트를 만든다.
 파드는 `hello-node:v1` Docker 이미지를 기반으로 한 컨테이너를 실행한다.
 (이미지를 레지스트리에 Push하지 않았기 때문에) Docker 레지스트리에서 이미지를 가져오기 보다는, 
 항상 로컬 이미지를 사용하기 위해 `--image-pull-policy` 플래그를 `Never`로 설정한다.
 
 ```shell
-kubectl run hello-node --image=hello-node:v1 --port=8080 --image-pull-policy=Never
+kubectl create deployment hello-node --image=hello-node:v1 --port=8080 --image-pull-policy=Never
 ```
 
 디플로이먼트를 확인한다.

--- a/content/ko/docs/tutorials/hello-minikube.md
+++ b/content/ko/docs/tutorials/hello-minikube.md
@@ -190,13 +190,13 @@ docker build -t hello-node:v1 .
 헬스를 검사해서 파드의 컨테이너가 종료되면 다시 시작해준다.
 파드의 생성 및 확장을 관리하는 방법으로 디플로이먼트를 권장한다.
 
-`kubectl create` 커맨드를 사용하여 파드를 관리하는 디플로이먼트를 만든다.
+`kubectl run` 커맨드를 사용하여 파드를 관리하는 디플로이먼트를 만든다.
 파드는 `hello-node:v1` Docker 이미지를 기반으로 한 컨테이너를 실행한다.
 (이미지를 레지스트리에 Push하지 않았기 때문에) Docker 레지스트리에서 이미지를 가져오기 보다는, 
 항상 로컬 이미지를 사용하기 위해 `--image-pull-policy` 플래그를 `Never`로 설정한다.
 
 ```shell
-kubectl create deployment hello-node --image=hello-node:v1 --port=8080 --image-pull-policy=Never
+kubectl run hello-node --image=hello-node:v1 --port=8080 --image-pull-policy=Never
 ```
 
 디플로이먼트를 확인한다.


### PR DESCRIPTION
because `kubectl run` is deprecated

```
$ kubectl run ...
kubectl run --generator=deployment/apps.v1beta1 is DEPRECATED and will be removed in a future version. Use kubectl create instead.
```