### PR TITLE
Fix service type for lb task

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/load-balance-access-application-cluster.md
+++ b/content/en/docs/tasks/access-application-cluster/load-balance-access-application-cluster.md
@@ -55,7 +55,7 @@ load-balanced access to an application running in a cluster.
 1. Create a Service object that exposes the deployment:
 
        ```
-       kubectl expose deployment <your-deployment-name> --type=NodePort --name=example-service
+       kubectl expose deployment <your-deployment-name> --type=LoadBalancer --name=example-service
        ```
 
     where `<your-deployment-name>` is the name of your deployment.


### PR DESCRIPTION
There is an error in the task [Provide Load-Balanced Access to an Application in a Cluster](https://kubernetes.io/docs/tasks/access-application-cluster/load-balance-access-application-cluster/)

The expose command states `--type=NodePort` instead of `--type=LoadBalancer`.
This PR solves this issue
