### PR TITLE
fixed wording that kubelet CAN detect cgroup driver

### DIFF
--- a/content/en/docs/setup/independent/kubelet-integration.md
+++ b/content/en/docs/setup/independent/kubelet-integration.md
@@ -79,7 +79,7 @@ networking, or other host-specific parameters. The following list provides a few
   unless you are using a cloud provider. You can use the `--hostname-override` flag to override the
   default behavior if you need to specify a Node name different from the machine's hostname.
 
-- Currently, the kubelet cannot automatically detects the cgroup driver used by the CRI runtime,
+- Currently, the kubelet automatically detects the cgroup driver used by the CRI runtime,
   but the value of `--cgroup-driver` must match the cgroup driver used by the CRI runtime to ensure
   the health of the kubelet.
 


### PR DESCRIPTION
<!-- Thanks for filing an issue! Before submitting, please fill in the following information. -->
<!-- See https://kubernetes.io/docs/contribute/start/ for guidance on writing an actionable issue description. -->

<!--Required Information-->

**This is a...** 
<!-- choose one by changing [ ] to [x] -->
- [ ] Feature Request
- [x] Bug Report

**Problem:**
The wording about kubelet detecting cgroups is confusing.

**Proposed Solution:**
Remove the word "Cannot"

**Page to Update:**
https://kubernetes.io/docs/setup/independent/kubelet-integration/#configure-kubelets-using-kubeadm

<!--Optional Information (remove the comment tags around information you would like to include)-->
<!--Kubernetes Version:-->

<!--Additional Information:-->
