### PR TITLE
Add temporary owners for 1.13 release

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -138,6 +138,7 @@ aliases:
     - cstoku
     - nasa9084
     - tnir
+    - zacharysarah
   sig-docs-ja-reviews: #Team: Japanese docs PR reviews; GH:sig-docs-ja-reviews
     - cstoku
     - makocchi-git
@@ -147,6 +148,10 @@ aliases:
   sig-docs-ko-owners: #Team Korean docs localization; GH: sig-docs-ko-owners
     - ClaudiaJKang
     - gochist
+    - bradamant3    # Temporary for 1.13 release
+    - jimangel      # Temporary for 1.13 release
+    - tfogo         # Temporary for 1.13 release
+    - zacharysarah
   sig-docs-ko-reviews: #Team Korean docs reviews; GH: sig-docs-ko-reviews
     - ClaudiaJKang
     - gochist
@@ -155,16 +160,19 @@ aliases:
     - bradtopol
     - chenopis
     - chenrui333
-    - lucperkins
-    - zacharysarah
     - dchen1107
     - haibinxie
     - hanjiayao
     - lichuqiang
+    - lucperkins
     - markthink
     - tengqm
     - xiangpengzhao
+    - zacharysarah
     - zhangxiaoyu-zidif
+    - bradamant3    # Temporary for 1.13 release
+    - jimangel      # Temporary for 1.13 release
+    - tfogo         # Temporary for 1.13 release
   sig-docs-zh-reviews: #Team Chinese docs reviews; GH: sig-docs-zh-reviews
     - chenrui333
     - idealhack


### PR DESCRIPTION
This PR temporarily adds approvers to some language aliases to make the release process smoother.

/assign @tfogo 
/sig docs