### PR TITLE
--port options should added on kubectl expose command

### DIFF
--- a/content/en/docs/tutorials/hello-minikube.md
+++ b/content/en/docs/tutorials/hello-minikube.md
@@ -75,7 +75,7 @@ recommended way to manage the creation and scaling of Pods.
 Pod runs a Container based on the provided Docker image. 
 
     ```shell
-    kubectl create deployment hello-node --image=gcr.io/hello-minikube-zero-install/hello-node --port=8080
+    kubectl create deployment hello-node --image=gcr.io/hello-minikube-zero-install/hello-node
     ```
 
 2. View the Deployment:
@@ -127,7 +127,7 @@ Kubernetes [*Service*](/docs/concepts/services-networking/service/).
 1. Expose the Pod to the public internet using the `kubectl expose` command:
 
     ```shell
-    kubectl expose deployment hello-node --type=LoadBalancer
+    kubectl expose deployment hello-node --type=LoadBalancer --port=8080
     ```
     
     The `--type=LoadBalancer` flag indicates that you want to expose your Service


### PR DESCRIPTION
As I testing, --port options should added on kubectl expose command.
Fixed cmd can works very well.

```shell
# kubectl create deployment hello-node --image=gcr.io/hello-minikube-zero-install/hello-node
deployment "hello-node" created
# kubectl expose deployment hello-node --type=LoadBalancer --port=8080
service "hello-node" exposed
# kubectl get svc
NAME         TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
hello-node   LoadBalancer   10.96.179.234   <pending>     8080:31187/TCP   50s
kubernetes   ClusterIP      10.96.0.1       <none>        443/TCP          3h
```
