### PR TITLE
fix the example for dns-pod-service

### DIFF
--- a/content/en/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/en/docs/concepts/services-networking/dns-pod-service.md
@@ -251,7 +251,7 @@ options ndots:2 edns0
 For IPv6 setup, search path and name server should be setup like this:
 
 ```
-$ kubectl exec -it busybox -- cat /etc/resolv.conf
+$ kubectl exec -it dns-example -- cat /etc/resolv.conf
 nameserver fd00:79:30::a
 search default.svc.cluster.local svc.cluster.local cluster.local
 options ndots:5


### PR DESCRIPTION
Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>

Fixes: #https://github.com/kubernetes/website/issues/11505

It should be pod name (dns-example) instead of image name (busybox)
