### PR TITLE
Fix coredns link

### DIFF
--- a/content/en/docs/tasks/administer-cluster/coredns.md
+++ b/content/en/docs/tasks/administer-cluster/coredns.md
@@ -72,7 +72,7 @@ For versions 1.13 and later, follow the guide outlined [here](/docs/reference/se
 ## Tuning CoreDNS
 
 When resource utilisation is a concern, it may be useful to tune the configuration of CoreDNS. For more details, check out the
-[documentation on scaling CoreDNS]((https://github.com/coredns/deployment/blob/master/kubernetes/Scaling_CoreDNS.md)).
+[documentation on scaling CoreDNS](https://github.com/coredns/deployment/blob/master/kubernetes/Scaling_CoreDNS.md).
 
 {{% /capture %}}
 


### PR DESCRIPTION
The link in this [documentation](https://kubernetes.io/docs/tasks/administer-cluster/coredns/#tuning-coredns) is broken since there are two parentheses pairs.

This PR fixes this.