### PR TITLE
kubeadm-ts-guide: add entry about centos and docker 1.13.87

### DIFF
--- a/content/en/docs/setup/independent/troubleshooting-kubeadm.md
+++ b/content/en/docs/setup/independent/troubleshooting-kubeadm.md
@@ -226,18 +226,21 @@ Disabling SELinux or setting `allowPrivilegeEscalation` to `true` can compromise
 the security of your cluster.
 {{< /warning >}}
 
-## etcd pods are constantly restarting
+## etcd pods restart continually
 
-This problem can be observed on CentOS 7 with Docker 1.13.1.87.
-This specific version of Docker has a regression that can prevent the kubelet
-from executing into the etcd container with the following error:
+If you encounter the following error:
 
 ```
 rpc error: code = 2 desc = oci runtime error: exec failed: container_linux.go:247: starting container process caused "process_linux.go:110: decoding init error from pipe caused \"read parent: connection reset by peer\""
 ```
 
-The workaround is to either roll back to an older version of Docker like 1.13.1-75 or
-install one of the more recent recommended versions like 18.06:
+this issue appears if you run CentOS 7 with Docker 1.13.1.87.
+This version of Docker can prevent the kubelet from executing into the etcd container.
+
+To work around the issue, choose one of these options:
+
+- Roll back to an earlier version of Docker, such as 1.13.1-75
+- Install one of the more recent recommended versions, such as 18.06:
 
 ```bash
 yum install docker-ce-18.06.1.ce-3.el7.x86_64

--- a/content/en/docs/setup/independent/troubleshooting-kubeadm.md
+++ b/content/en/docs/setup/independent/troubleshooting-kubeadm.md
@@ -226,4 +226,21 @@ Disabling SELinux or setting `allowPrivilegeEscalation` to `true` can compromise
 the security of your cluster.
 {{< /warning >}}
 
+## etcd pods are constantly restarting
+
+This problem can be observed on CentOS 7 with Docker 1.13.1.87.
+This specific version of Docker has a regression that can prevent the kubelet
+from executing into the etcd container with the following error:
+
+```
+rpc error: code = 2 desc = oci runtime error: exec failed: container_linux.go:247: starting container process caused "process_linux.go:110: decoding init error from pipe caused \"read parent: connection reset by peer\""
+```
+
+The workaround is to either roll back to an older version of Docker like 1.13.1-75 or
+install one of the more recent recommended versions like 18.06:
+
+```bash
+yum install docker-ce-18.06.1.ce-3.el7.x86_64
+```
+
 {{% /capture %}}


### PR DESCRIPTION
@kubernetes/sig-cluster-lifecycle 
/assign @mauilion 
(for tech review)
/sig cluster-lifecycle
/fixes kubernetes/kubeadm#1299
