### PR TITLE
Minor improvements on upgrade for kubeadm

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-12.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-12.md
@@ -39,8 +39,9 @@ This page explains how to upgrade a Kubernetes cluster created with `kubeadm` fr
 
     {{< tabs name="k8s_install" >}}
     {{% tab name="Ubuntu, Debian or HypriotOS" %}}
-    apt-get update
-    apt-get upgrade -y kubeadm
+    apt-mark unhold kubeadm && \
+    apt-get update && apt-get upgrade -y kubeadm && \
+    apt-mark hold kubeadm
     {{% /tab %}}
     {{% tab name="CentOS, RHEL or Fedora" %}}
     yum upgrade -y kubeadm --disableexcludes=kubernetes

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-13.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-13.md
@@ -39,8 +39,9 @@ This page explains how to upgrade a Kubernetes cluster created with `kubeadm` fr
 
     {{< tabs name="k8s_install" >}}
     {{% tab name="Ubuntu, Debian or HypriotOS" %}}
-    apt-get update
-    apt-get upgrade -y kubelet kubeadm
+    apt-mark unhold kubelet kubeadm && \
+    apt-get update && apt-get upgrade -y kubelet kubeadm && \
+    apt-mark hold kubelet kubeadm
     {{% /tab %}}
     {{% tab name="CentOS, RHEL or Fedora" %}}
     yum upgrade -y kubeadm --disableexcludes=kubernetes

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-ha-1-12.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-ha-1-12.md
@@ -37,7 +37,7 @@ Upgrade `kubeadm` to the version that matches the version of Kubernetes that you
 
 ```shell
 apt-mark unhold kubeadm && \
-apt-get update && apt-get install -y kubeadm && \
+apt-get update && apt-get upgrade -y kubeadm && \
 apt-mark hold kubeadm
 ```
 

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-ha-1-13.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-ha-1-13.md
@@ -36,7 +36,7 @@ Upgrade `kubeadm` to the version that matches the version of Kubernetes that you
 
 ```shell
 apt-mark unhold kubeadm && \
-apt-get update && apt-get install -y kubeadm && \
+apt-get update && apt-get upgrade -y kubeadm && \
 apt-mark hold kubeadm
 ```
 


### PR DESCRIPTION
Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>

Fixes: https://github.com/kubernetes/kubeadm/issues/1301

1. we should suggest apt-mark unhold before and apt-mark hold again after, similar to what already implemented in HA upgrade instructions

2. `apt-get install -y kubeadm` should be  `apt-get upgrade -y kubeadm`  in HA upgrade instructions