### PR TITLE
kube-apiserver: remove merge conflict marker

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/kube-apiserver.md
+++ b/content/en/docs/reference/command-line-tools-reference/kube-apiserver.md
@@ -567,7 +567,6 @@ kube-apiserver [flags]
     </tr>
 
     <tr>
-<<<<<<< HEAD
       <td colspan="2">--encryption-provider-config string</td>
     </tr>
     <tr>
@@ -575,8 +574,6 @@ kube-apiserver [flags]
     </tr>
 
     <tr>
-=======
->>>>>>> Generate copmonents and tools reference
       <td colspan="2">--external-hostname string</td>
     </tr>
     <tr>
@@ -937,11 +934,7 @@ kube-apiserver [flags]
       <td colspan="2">--storage-backend string</td>
     </tr>
     <tr>
-<<<<<<< HEAD
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The storage backend for persistence. Options: 'etcd3' (default)</td>
-=======
-      <td></td><td style="line-height: 130%; word-wrap: break-word;">The storage backend for persistence. Options: 'etcd3' (default).</td>
->>>>>>> Generate copmonents and tools reference
     </tr>
 
     <tr>


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/71747

Looks like an incorrect merge got in.

- Current Preview: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/

- Preview after this PR: https://deploy-preview-11543--kubernetes-io-master-staging.netlify.com/docs/reference/command-line-tools-reference/kube-apiserver/