### PR TITLE
Fix link to k8s CoCC

### DIFF
--- a/content/en/community/code-of-conduct.md
+++ b/content/en/community/code-of-conduct.md
@@ -17,7 +17,8 @@ If you notice that this is out of date, please
 
 If you notice a violation of the Code of Conduct at an event or meeting, in
 Slack, or in another communication mechanism, reach out to
-the <a href="https://git.k8s.io/community/committee-code-of-conduct">Kubernetes Code of Conduct Committee</a>. You can reach us by email at <a href="mailto:conduct@kubernetes.io">conduct@kubernetes.io</a>.
+the <a href="https://git.k8s.io/community/committee-code-of-conduct">Kubernetes Code of Conduct Committee</a>. 
+You can reach us by email at <a href="mailto:conduct@kubernetes.io">conduct@kubernetes.io</a>.
 Your anonymity will be protected.
 
 <div class="cncf_coc_container">

--- a/content/en/community/code-of-conduct.md
+++ b/content/en/community/code-of-conduct.md
@@ -17,7 +17,7 @@ If you notice that this is out of date, please
 
 If you notice a violation of the Code of Conduct at an event or meeting, in
 Slack, or in another communication mechanism, reach out to
-the <a href="https://git.k8s.io/community/committee-code-of-conduct">Kubernetes Code of Conduct Committee</a> via <a href="mailto:conduct@kubernetes.io">conduct@kubernetes.io</a>.
+the <a href="https://git.k8s.io/community/committee-code-of-conduct">Kubernetes Code of Conduct Committee</a>. You can reach us by email at <a href="mailto:conduct@kubernetes.io">conduct@kubernetes.io</a>.
 Your anonymity will be protected.
 
 <div class="cncf_coc_container">

--- a/content/en/community/code-of-conduct.md
+++ b/content/en/community/code-of-conduct.md
@@ -17,12 +17,10 @@ If you notice that this is out of date, please
 
 If you notice a violation of the Code of Conduct at an event or meeting, in
 Slack, or in another communication mechanism, reach out to
-the [Kubernetes Code of Conduct Committee](https://github.com/kubernetes/community/tree/master/committee-code-of-conduct) <conduct@kubernetes.io>.
+the <a href="https://git.k8s.io/community/committee-code-of-conduct">Kubernetes Code of Conduct Committee</a> via <a href="mailto:conduct@kubernetes.io">conduct@kubernetes.io</a>.
 Your anonymity will be protected.
 
 <div class="cncf_coc_container">
 {{< include "/static/cncf-code-of-conduct.md" >}}
 </div>
 </div>
-
-


### PR DESCRIPTION
The link to the Code of Conduct Committee isn't rendering properly. This PR fixes the links by using html instead of markdown.

See the first paragraph of https://kubernetes.io/community/code-of-conduct/ for the bad links.