### PR TITLE
Upgrade Hugo to 0.52

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ go:
   - 1.10.2
 
 env:
-  - HUGO_VERSION=0.49
+  - HUGO_VERSION=0.52
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: go
 go:
   - 1.10.2
 
-env:
-  - HUGO_VERSION=0.52
-
 jobs:
   include:
     - name: "Testing examples"
@@ -26,9 +23,6 @@ jobs:
       - go test -v k8s.io/website/content/en/examples
     - name: "Hugo build"
       install:
-      - curl -L https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_linux-64bit.tar.gz | tar -xz
-      - mkdir -p ${TRAVIS_HOME}/bin
-      - mv hugo ${TRAVIS_HOME}/bin
-      - export PATH=${TRAVIS_HOME}/bin:$PATH
+      - make travis-hugo-build
       script:
       - hugo

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ build: ## Build site with production settings and put deliverables in ./public
 	hugo --minify
 
 build-preview: ## Build site with drafts and future posts enabled
-	hugo -D -F
+	hugo --buildDrafts --buildFuture
 
 functions-build:
 	$(NETLIFY_FUNC) build functions-src

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DOCKER       = docker
-HUGO_VERSION = 0.49
+HUGO_VERSION = 0.52
 DOCKER_IMAGE = kubernetes-hugo
 DOCKER_RUN   = $(DOCKER) run --rm --interactive --tty --volume $(CURDIR):/src
 NODE_BIN     = node_modules/.bin
@@ -13,7 +13,7 @@ help: ## Show this help.
 all: build ## Build site with production settings and put deliverables in ./public
 
 build: ## Build site with production settings and put deliverables in ./public
-	hugo
+	hugo --minify
 
 build-preview: ## Build site with drafts and future posts enabled
 	hugo -D -F
@@ -36,7 +36,7 @@ sass-develop:
 	scripts/sass.sh develop
 
 serve: ## Boot the development server.
-	hugo server --ignoreCache --disableFastRender --buildFuture
+	hugo server --ignoreCache --buildFuture
 
 docker-image:
 	$(DOCKER) build . --tag $(DOCKER_IMAGE) --build-arg HUGO_VERSION=$(HUGO_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -46,3 +46,10 @@ docker-build:
 
 docker-serve:
 	$(DOCKER_RUN) -p 1313:1313 $(DOCKER_IMAGE) hugo server --buildFuture --bind 0.0.0.0
+
+# This command is used only by Travis CI; do not run this locally
+travis-hugo-build:
+	curl -L https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_linux-64bit.tar.gz | tar -xz
+	mkdir -p ${TRAVIS_HOME}/bin
+	mv hugo ${TRAVIS_HOME}/bin
+	export PATH=${TRAVIS_HOME}/bin:$PATH

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,9 @@ functions-build:
 check-headers-file:
 	scripts/check-headers-file.sh
 
-production-build: build check-headers-file ## Build the production site and ensure that noindex headers aren't added
+production-build: check-hugo-versions build check-headers-file ## Build the production site and ensure that noindex headers aren't added
 
-non-production-build: ## Build the non-production site, which adds noindex headers to prevent indexing
+non-production-build: check-hugo-versions ## Build the non-production site, which adds noindex headers to prevent indexing
 	hugo --enableGitInfo
 
 sass-build:
@@ -53,3 +53,6 @@ travis-hugo-build:
 	mkdir -p ${TRAVIS_HOME}/bin
 	mv hugo ${TRAVIS_HOME}/bin
 	export PATH=${TRAVIS_HOME}/bin:$PATH
+
+check-hugo-versions:
+	scripts/hugo-version-check.sh $(HUGO_VERSION)

--- a/config.toml
+++ b/config.toml
@@ -4,6 +4,7 @@ title = "Kubernetes"
 defaultContentLanguage = "en"
 defaultContentLanguageInSubdir = false
 enableRobotsTXT = true
+disableBrowserError = true
 
 disableKinds = ["taxonomy", "taxonomyTerm"]
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@ functions = "functions"
 command = "make non-production-build"
 
 [build.environment]
-HUGO_VERSION = "0.49"
+HUGO_VERSION = "0.52"
 
 [context.production.environment]
 HUGO_BASEURL = "https://kubernetes.io/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@ functions = "functions"
 command = "make non-production-build"
 
 [build.environment]
-HUGO_VERSION = "0.52"
+HUGO_VERSION = "0.49"
 
 [context.production.environment]
 HUGO_BASEURL = "https://kubernetes.io/"

--- a/scripts/hugo-version-check.sh
+++ b/scripts/hugo-version-check.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+MAIN_HUGO_VERSION=$1
+NETLIFY_HUGO_VERSION=$(cat netlify.toml | grep HUGO_VERSION | awk '{ print $3 }' | tr -d '"')
+
+echo ${NETLIFY_HUGO_VERSION}
+
+if [[ ${MAIN_HUGO_VERSION} != ${NETLIFY_HUGO_VERSION} ]]; then
+    echo """
+    [FAILURE] The Hugo version set in the Makefile is ${MAIN_HUGO_VERSION} while the version in netlify.toml is ${NETLIFY_HUGO_VERSION}
+    [FAILURE] Please update these versions so that they are same (consider the higher of the two versions as canonical).
+    """
+    exit 1
+else
+    echo "[SUCCESS] The Hugo versions match between the Makefile and netlify.toml"
+    exit 0
+fi
+


### PR DESCRIPTION
Hugo version 0.52 adds support for HTML minification via the `--minify` flag. This PR updates the "current" Hugo version to 0.52.

This change will _not_ impact users running the site locally with an earlier version of Hugo. This will *only* affect the production build of the site. For users who *do* upgrade to 0.52 to run the site locally, the [in-browser error](https://gohugo.io/news/0.50-relnotes/) feature is disabled to ensure a smooth transition. We can discuss enabling that (very nice but potentially disruptive) functionality in the future.
