### PR TITLE
Cache example_test results with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ env:
 jobs:
   include:
     - name: "Testing examples"
+      cache:
+        directories:
+          - $HOME/.cache/go-build
       # Don't want default ./... here:
       install:
       - export PATH=$GOPATH/bin:$PATH


### PR DESCRIPTION
Since example_test.go does not change frequently, caching the tests can bring the CI times from 50s to a few seconds if there are no changes.

Signed-off-by: GuessWhoSamFoo <sfoohei@gmail.com>


