### PR TITLE
update PULL_REQUEST_TEMPLATE to include zh-i18n info

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,8 @@
 >^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 > Please delete this note before submitting the pull request.
 >
-> For 1.13 Features: set Milestone to 1.13 and Base Branch to dev-1.13
+> For 1.14 Features: set Milestone to 1.14 and Base Branch to dev-1.14
+> For Chinese localization, base branch to release-1.12
 >
 > Help editing and submitting pull requests:
 > https://kubernetes.io/docs/contribute/start/#improve-existing-content.
@@ -10,4 +11,3 @@
 > https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use.
 >^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >
-

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,7 @@
 > Please delete this note before submitting the pull request.
 >
 > For 1.14 Features: set Milestone to 1.14 and Base Branch to dev-1.14
+> 
 > For Chinese localization, base branch to release-1.12
 >
 > Help editing and submitting pull requests:


### PR DESCRIPTION
To include the base branch information into the `PULL_REQUEST_TEMPLATE`
- content/en to use `dev-1.14`?
- content/zh to use `release-1.12`