### PR TITLE
Fix: API version of 1.11.x to v1alpha2 and 1.12.x to v1alpha3

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-ha-1-12.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-ha-1-12.md
@@ -113,7 +113,7 @@ You should see something like the following:
 
     [upgrade/successful] SUCCESS! Your cluster was upgraded to "v1.12.0". Enjoy!
 
-The `kubeadm-config` ConfigMap is now updated from `v1alpha3` version to `v1beta1`.
+The `kubeadm-config` ConfigMap is now updated from `v1alpha2` version to `v1alpha3`.
 
 ### Upgrading additional control plane nodes
 


### PR DESCRIPTION
A tiny little mistake in [Upgrading kubeadm HA clusters from v1.11 to v1.12](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-ha-1-12/#upgrade-the-first-control-plane-node)

>The `kubeadm-config` ConfigMap is now updated from `v1alpha3` version to `v1beta1`

The `kubeadm.k8s.io` API version should be `v1alpha2` in `v1.11.x`, and `v1alpha3` in `v1.12.x`.

