### PR TITLE
fix: update kubelet --kubeconfig description

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/kubelet.md
+++ b/content/en/docs/reference/command-line-tools-reference/kubelet.md
@@ -721,7 +721,7 @@ kubelet [flags]
        <td colspan="2">--kubeconfig string</td> 
     </tr>
     <tr>
-      <td></td><td style="line-height: 130%; word-wrap: break-word;">Path to a kubeconfig file, specifying how to connect to the API server. (default "/var/lib/kubelet/kubeconfig")</td>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;">Path to a kubeconfig file, specifying how to connect to the API server. Providing --kubeconfig enables API server mode, omitting --kubeconfig enables standalone mode. </td>
     </tr>
 
      <tr>


### PR DESCRIPTION
The description of `--kubeconfig` is looks outdated. Its default value was also changed.
This PR updates the description base on 
https://github.com/kubernetes/kubernetes/blob/master/cmd/kubelet/app/options/options.go#L376