### PR TITLE
Update Container Runtime explanation

### DIFF
--- a/content/en/docs/concepts/overview/components.md
+++ b/content/en/docs/concepts/overview/components.md
@@ -76,7 +76,8 @@ network rules on the host and performing connection forwarding.
 
 ### Container Runtime
 
-The container runtime is the software that is responsible for running containers. Kubernetes supports several runtimes: [Docker](http://www.docker.com), [rkt](https://coreos.com/rkt/), [runc](https://github.com/opencontainers/runc) and any OCI [runtime-spec](https://github.com/opencontainers/runtime-spec) implementation.
+The container runtime is the software that is responsible for running containers.
+Kubernetes supports several runtimes: [Docker](http://www.docker.com), [containerd](https://containerd.io), [cri-o](https://cri-o.io/), [rktlet](https://github.com/kubernetes-incubator/rktlet) and any implementation of the [Kubernetes CRI (Container Runtime Interface)](https://github.com/kubernetes/community/blob/master/contributors/devel/container-runtime-interface.md).
 
 ## Addons
 


### PR DESCRIPTION
It is accurate that Container Runtime is any implementation of CRI(Container Runtime Interface) rather than OCI runtime-spec implementation.
Example implementation is containerd, cri-o and rktlet.

fixes: #11703  