### PR TITLE
update PULL_REQUEST_TEMPLATE to include ko-i18n info

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,6 @@
 > For Chinese localization, base branch to release-1.12
 >
 > For Korean Localization: set Base Branch to dev-1.13-ko.<latest team milestone>
-> 한글 현지화의 경우: Base Branch를 dev-1.13-ko.<최신의 팀 마일스톤>으로 설정해주세요.
 >
 > Help editing and submitting pull requests:
 > https://kubernetes.io/docs/contribute/start/#improve-existing-content.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,9 @@
 > 
 > For Chinese localization, base branch to release-1.12
 >
+> For Korean Localization: set Base Branch to dev-1.13-ko.<latest team milestone>
+> 한글 현지화의 경우: Base Branch를 dev-1.13-ko.<최신의 팀 마일스톤>으로 설정해주세요.
+>
 > Help editing and submitting pull requests:
 > https://kubernetes.io/docs/contribute/start/#improve-existing-content.
 >


### PR DESCRIPTION
Added base branch guide for ko l10n in the `PULL_REQUEST_TEMPLATE`.
This is related with #11652 