### PR TITLE
Add ianychoi to sig-docs-ko-owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -148,6 +148,7 @@ aliases:
   sig-docs-ko-owners: #Team Korean docs localization; GH: sig-docs-ko-owners
     - ClaudiaJKang
     - gochist
+    - ianychoi
     - zacharysarah
   sig-docs-ko-reviews: #Team Korean docs reviews; GH: sig-docs-ko-reviews
     - ClaudiaJKang


### PR DESCRIPTION
Add @ianychoi as an approver for ko l10n work.

@ianychoi is already added to @kubernetes/sig-docs-ko-owners 