### PR TITLE
move port flag to expose

### DIFF
--- a/content/en/docs/tutorials/hello-minikube.md
+++ b/content/en/docs/tutorials/hello-minikube.md
@@ -75,7 +75,7 @@ recommended way to manage the creation and scaling of Pods.
 Pod runs a Container based on the provided Docker image. 
 
     ```shell
-    kubectl create deployment hello-node --image=gcr.io/hello-minikube-zero-install/hello-node --port=8080
+    kubectl create deployment hello-node --image=gcr.io/hello-minikube-zero-install/hello-node
     ```
 
 2. View the Deployment:
@@ -127,7 +127,7 @@ Kubernetes [*Service*](/docs/concepts/services-networking/service/).
 1. Expose the Pod to the public internet using the `kubectl expose` command:
 
     ```shell
-    kubectl expose deployment hello-node --type=LoadBalancer
+    kubectl expose deployment hello-node --type=LoadBalancer --port=8080
     ```
     
     The `--type=LoadBalancer` flag indicates that you want to expose your Service


### PR DESCRIPTION
Current commnads produce errors 

```
$ kubectl create deployment hello-node --image=gcr.io/hello-minikube-zero-install/hello-node --port=8080
Error: unknown flag: --port
```
```
$ kubectl expose deployment hello-node --type=LoadBalancer
error: couldn't find port via --port flag or introspection
```

Moving `--port=8080` from `kubectl create` to `kubectl expose` causes `minikube service hello-nod` to work with Minikube locally. (KataCode seems to hang.) 

