### PR TITLE
Include Kubernetes abbreviation k8s

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -8,7 +8,7 @@ cid: home
 
 {{< blocks/section id="oceanNodes" >}}
 {{% blocks/feature image="flower" %}}
-### [Kubernetes]({{< relref "/docs/concepts/overview/what-is-kubernetes" >}}) is an open-source system for automating deployment, scaling, and management of containerized applications.
+### [Kubernetes (k8s)]({{< relref "/docs/concepts/overview/what-is-kubernetes" >}}) is an open-source system for automating deployment, scaling, and management of containerized applications.
 
 It groups containers that make up an application into logical units for easy management and discovery. Kubernetes builds upon [15 years of experience of running production workloads at Google](http://queue.acm.org/detail.cfm?id=2898444), combined with best-of-breed ideas and practices from the community.
 {{% /blocks/feature %}}


### PR DESCRIPTION
I was at Kubecon last week, and a few times I encountered people who did not know that k8s == Kubernetes. Therefore, we should mention this abbreviation on the front page.