### PR TITLE
Fix kubeconfig file path from $USER to $HOME

### DIFF
--- a/content/en/docs/reference/access-authn-authz/controlling-access.md
+++ b/content/en/docs/reference/access-authn-authz/controlling-access.md
@@ -26,10 +26,10 @@ following diagram:
 
 In a typical Kubernetes cluster, the API serves on port 443.
 The API server presents a certificate. This certificate is
-often self-signed, so `$USER/.kube/config` on the user's machine typically
+often self-signed, so `$HOME/.kube/config` on the user's machine typically
 contains the root certificate for the API server's certificate, which when specified
 is used in place of the system default root certificate.  This certificate is typically
-automatically written into your `$USER/.kube/config` when you create a cluster yourself
+automatically written into your `$HOME/.kube/config` when you create a cluster yourself
 using `kube-up.sh`.  If the cluster has multiple users, then the creator needs to share
 the certificate with other users.
 


### PR DESCRIPTION
I believe the docs are wrong; there is no kubeconfig at path `$USER/.kube/config`, but there is at `$HOME/.kube/config`, which makes it seem as though there was a minor error when writing the docs.