### PR TITLE
Fix the format of upgrade way of v1.13

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-13.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-13.md
@@ -211,7 +211,7 @@ This page explains how to upgrade a Kubernetes cluster created with `kubeadm` fr
 
 1.  Upgrade the Kubernetes package version on each `$NODE` node by running the Linux package manager for your distribution:
 
-    {{< tabs name="k8s_install" >}}
+    {{< tabs name="k8s_upgrade" >}}
     {{% tab name="Ubuntu, Debian or HypriotOS" %}}
     apt-get update
     apt-get upgrade -y kubelet kubeadm


### PR DESCRIPTION
The upgrade way of v1.13 seems mixed between ubuntu and Red Hat,
so this fixes it.

NOTE: Previously on v1.12, [1] has fixed the same issue and the
      fixing way is the same as this one.
      [1]: https://github.com/kubernetes/website/pull/10941

Fixes: #11806
