### PR TITLE
Fix links to javascripts referenced in 1.11 apiref doc

### DIFF
--- a/static/docs/reference/generated/kubernetes-api/v1.11/index.html
+++ b/static/docs/reference/generated/kubernetes-api/v1.11/index.html
@@ -48549,9 +48549,9 @@ $ curl -X GET 'http://127.0.0.1:8001/apis/extensions/v1beta1/watch/namespaces/de
 </TABLE>
 </DIV>
 </DIV>
-<SCRIPT src="/js/jquery-2.2.0.min.js"></SCRIPT>
+<SCRIPT src="/js/jquery-3.2.1.min.js"></SCRIPT>
 <SCRIPT src="jquery.scrollTo.min.js"></SCRIPT>
-<SCRIPT src="/js/bootstrap.min.js"></SCRIPT>
+<SCRIPT src="/js/bootstrap-3.3.7.min.js"></SCRIPT>
 <SCRIPT src="navData.js"></SCRIPT>
 <SCRIPT src="scroll.js"></SCRIPT>
 </BODY>


### PR DESCRIPTION
Closes: #11826 

