### PR TITLE
removing non-supported versions

### DIFF
--- a/content/en/docs/reference/_index.md
+++ b/content/en/docs/reference/_index.md
@@ -25,8 +25,6 @@ This section of the Kubernetes documentation contains references.
   * [1.11](/docs/reference/generated/kubernetes-api/v1.11/)
   * [1.10](https://v1-10.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/)
   * [1.9](https://v1-9.docs.kubernetes.io/docs/api-reference/v1.9/)
-  * [1.8](https://v1-8.docs.kubernetes.io/docs/api-reference/v1.8/)
-  * [1.7](https://v1-7.docs.kubernetes.io/docs/api-reference/v1.7/)
 
 ## API Client Libraries
 


### PR DESCRIPTION
Removed non supported doc links from API reference guide (links were also broke).