### PR TITLE
Update cri.md

### DIFF
--- a/content/en/docs/setup/cri.md
+++ b/content/en/docs/setup/cri.md
@@ -27,25 +27,24 @@ Use the following commands to install Docker on your system:
 
 {{< tabs name="tab-cri-docker-installation" >}}
 {{< tab name="Ubuntu 16.04" codelang="bash" >}}
-# Install Docker from Ubuntu's repositories:
-apt-get update
-apt-get install -y docker.io
+# Install Docker CE
+## Set up the repository:
+### Update the apt package index
+    apt-get update
 
-# or install Docker CE 18.06 from Docker's repositories for Ubuntu or Debian:
+### Install packages to allow apt to use a repository over HTTPS
+    apt-get update && apt-get install apt-transport-https ca-certificates curl software-properties-common
 
-## Install prerequisites.
-apt-get update && apt-get install apt-transport-https ca-certificates curl software-properties-common
+### Add Docker’s official GPG key
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 
-## Download GPG key.
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+### Add docker apt repository.
+    add-apt-repository \
+    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+    $(lsb_release -cs) \
+    stable"
 
-## Add docker apt repository.
-add-apt-repository \
-   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-   $(lsb_release -cs) \
-   stable"
-
-## Install docker.
+## Install docker ce.
 apt-get update && apt-get install docker-ce=18.06.0~ce~3-0~ubuntu
 
 # Setup daemon.
@@ -68,20 +67,17 @@ systemctl restart docker
 {{< /tab >}}
 {{< tab name="CentOS/RHEL 7.4+" codelang="bash" >}}
 
-# Install Docker from CentOS/RHEL repository:
-yum install -y docker
+# Install Docker CE
+## Set up the repository
+### Install required packages.
+    yum install yum-utils device-mapper-persistent-data lvm2
 
-# or install Docker CE 18.06 from Docker's CentOS repositories:
-
-## Install prerequisites.
-yum install yum-utils device-mapper-persistent-data lvm2
-
-## Add docker repository.
+### Add docker repository.
 yum-config-manager \
     --add-repo \
     https://download.docker.com/linux/centos/docker-ce.repo
 
-## Install docker.
+## Install docker ce.
 yum update && yum install docker-ce-18.06.1.ce
 
 ## Create /etc/docker directory.


### PR DESCRIPTION
I removed the instruction regarding the installation of docker (1.13.1) as listed in #11779 and updated the instructions for Docker CE (1.18.1) because the official Docker documents only have instructions for Docker CE and Docker EE as listed in https://github.com/docker/docker.github.io/blob/master/install/linux/docker-ce/ubuntu.md. It may not be a good idea to have instructions for Docker 1.13 in our documents considering that the Official Docker Install guide recommends uninstalling older versions.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> Please delete this note before submitting the pull request.
>
> For 1.14 Features: set Milestone to 1.14 and Base Branch to dev-1.14
> 
> For Chinese localization, base branch to release-1.12
>
> Help editing and submitting pull requests:
> https://kubernetes.io/docs/contribute/start/#improve-existing-content.
>
> Help choosing which branch to use:
> https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use.
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
