### PR TITLE
Fix Interactive Landscape references

### DIFF
--- a/content/en/partners/_index.html
+++ b/content/en/partners/_index.html
@@ -44,9 +44,9 @@ cid: partners
 <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
 <script type="text/javascript">
 
-			var defaultLink = "https://landscape.cncf.io/grouping=landscape&landscape=kubernetes-certified-service-provider&embed=true";
-			var firstLink = "https://landscape.cncf.io/grouping=landscape&landscape=certified-kubernetes-distribution,certified-kubernetes-hosted,certified-kubernetes-installer&embed=true";
-      var secondLink = "https://landscape.cncf.io/grouping=landscape&landscape=kubernetes-training-partner&embed=true";
+			var defaultLink = "https://landscape.cncf.io/grouping=category&category=kubernetes-certified-service-provider&embed=true";
+			var firstLink = "https://landscape.cncf.io/grouping=category&category=certified-kubernetes-distribution,certified-kubernetes-hosted,certified-kubernetes-installer&embed=true";
+      var secondLink = "https://landscape.cncf.io/grouping=category&category=kubernetes-training-partner&embed=true";
 
       function updateSrc(buttonId) {
       	if (buttonId == "kcsp") {


### PR DESCRIPTION
Apologies, but we (accidentally) made a breaking change in the CNCF Interactive Landscape by changing the name `landscape` to `category` (so as to reduce confusion from name reuse). We can back out that change if necessary, but if you could you please approve this fix, we will be careful to avoid breaking changes going forward.