### PR TITLE
fix docs format error

### DIFF
--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_join.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_join.md
@@ -1,10 +1,12 @@
+在想要加入现有集群的每台机器上运行。
+
 <!--
 Run this on any machine you wish to join an existing cluster
-
-### Synopsis
 -->
 
-在想要加入现有集群的每台机器上运行。
+<!--
+### Synopsis
+-->
 
 ### 摘要
 


### PR DESCRIPTION
fix docs format error of https://v1-12.docs.kubernetes.io/zh/docs/reference/setup-tools/kubeadm/kubeadm-join/
