### PR TITLE
Translate beta state description

### DIFF
--- a/content/ja/docs/templates/feature-state-beta.txt
+++ b/content/ja/docs/templates/feature-state-beta.txt
@@ -1,8 +1,8 @@
-This feature is currently in a *beta* state, meaning:
+この機能は、現在 *beta版* です。
 
-* The version names contain beta (e.g. v2beta3).
-* Code is well tested. Enabling the feature is considered safe. Enabled by default.
-* Support for the overall feature will not be dropped, though details may change.
-* The schema and/or semantics of objects may change in incompatible ways in a subsequent beta or stable release. When this happens, we will provide instructions for migrating to the next version. This may require deleting, editing, and re-creating API objects. The editing process may require some thought. This may require downtime for applications that rely on the feature.
-* Recommended for only non-business-critical uses because of potential for incompatible changes in subsequent releases. If you have multiple clusters that can be upgraded independently, you may be able to relax this restriction.
-* **Please do try our beta features and give feedback on them! After they exit beta, it may not be practical for us to make more changes.**
+* バージョン名には `beta` がつきます(例:`v2beta3`)。
+* コードが十分にテストされているため、この機能は安全に有効化できます。デフォルトでも有効化されています。
+* 今後も継続して、この機能は包括的にサポートされる見通しですが、細かい部分が変更になる場合があります。
+* 今後のbeta版または安定版のリリースにおいては、オブジェクトのデータの形式や意味の両方あるいはいずれかについて、互換性のない変更が入る場合があります。その際は、次期バージョンへの移行手順も提供します。その移行にあたっては、APIオブジェクトの削除・改変・再作成が必要になる場合があります。特に改変には、多少の検討が必要になることがあります。また、それを適用する際には、この機能に依存するアプリケーションの一時停止が必要になる場合があります。
+* 今後のリリースにおいて互換性のない変更が入る可能性があります。そのため、業務用途外の検証としてのみ利用が推奨されています。ただし、個別にアップグレード可能な環境が複数ある場合は、この制限事項の限りではありません。
+* **beta版の機能の積極的な試用とフィードバックにご協力をお願いします！一度beta版から安定版になると、それ以降は変更を加えることが困難になります。**　


### PR DESCRIPTION
Translate `content/en/docs/templates/feature-state-beta.txt` into `content/ja/docs/templates/feature-state-beta.txt` for #10823.

I found some terms obscure for me, so I referred to additional materials. Having written some of unclear points as follows, please be sure to check them out and give me feedback in addition to the whole translation, if possible.

* `schema` in the fourth bullet
  * my translation: "(データの)形式"
  * reference: [Kubernetes Documentation: Top Level API Objects](https://kubernetes.io/docs/reference/federation/v1/definitions/). This page uses the term "Schema" as a legend of columns in tables, seemingly meaning "data type or format".
* `semantics` in the fourth bullet
  * my translation: "意味"
  * reference: [Kubernetes Documentation: Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/). The sentence "but do not directly imply semantics to the core system" seems to imply that "semantics" is a parameter that indicates the system things.
* `non-business-critical uses` in the fifth bullet
  * my translation: "業務用途外の検証としての利用"
  * reference: https://github.com/kubernetes/community/blob/master/contributors/devel/api_changes.md#alpha-beta-and-stable-versions. "in short-lived testing clusters; in production clusters as part of a short-lived evaluation of the feature in order to provide feedback" implies evaluation use cases.