### PR TITLE
add Jim Angel to approvers list

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -119,6 +119,7 @@ aliases:
     - chenopis
     - cody-clark
     - jaredbhatti
+    - jimangel
     - kbarnard10
     - mistyhacks
     - ryanmcginnis


### PR DESCRIPTION
Jim is the docs lead for the 1.14 release, and also leading the way with some other initiatives for sig-docs.

/assign @chenopis @tfogo 

(will check back and reassign if folks are still on vacation ...)