### PR TITLE
Fix mismatched hostnames in documentation

### DIFF
--- a/content/en/docs/concepts/services-networking/ingress.md
+++ b/content/en/docs/concepts/services-networking/ingress.md
@@ -294,7 +294,7 @@ spec:
 If you create an ingress resource without any hosts defined in the rules, then any
 web traffic to the IP address of your ingress controller can be matched without a name based
 virtual host being required. For example, the following ingress resource will route traffic 
-requested for `first.bar.com` to `service1`, `second.bar.com` to `service2`, and any traffic
+requested for `first.bar.com` to `service1`, `second.foo.com` to `service2`, and any traffic
 to the IP address without a hostname defined in request (that is, without a request header being
 presented) to `service3`.
 


### PR DESCRIPTION
Match hostnames in description to example. `service2` in the description matches `second.foo.com` in the example.