### PR TITLE
Correct ResourceQuota PriorityClass-related admission control configuration example

### DIFF
--- a/content/en/docs/concepts/policy/resource-quotas.md
+++ b/content/en/docs/concepts/policy/resource-quotas.md
@@ -551,10 +551,10 @@ plugins:
     kind: Configuration
     limitedResources:
     - resource: pods
-    matchScopes:
-    - operator : In
-      scopeName: PriorityClass
-      values: ["cluster-services"]
+      matchScopes:
+      - scopeName: PriorityClass 
+        operator: In
+        values: ["cluster-services"]
 ```
 
 Now, "cluster-services" pods will be allowed in only those namespaces where a quota object with a matching `scopeSelector` is present.
@@ -562,8 +562,8 @@ For example:
 ```yaml
     scopeSelector:
       matchExpressions:
-      - operator : In
-        scopeName: PriorityClass
+      - scopeName: PriorityClass
+        operator: In
         values: ["cluster-services"]
 ```
 


### PR DESCRIPTION
[The `LimitedResource` type](https://sourcegraph.com/github.com/kubernetes/kubernetes@d4d02762340bfb6ac93afd10884a3d9941b7322f/-/blob/plugin/pkg/admission/resourcequota/apis/resourcequota/v1alpha1/types.go#L35-69) has the field "MatchScopes" as a sibling to the field "Resource," but the YAML document in the example showed the "MatchScopes" field as a child of the top-level `Configuration` type. Correct the example to match the actual schema.

While we're here, swap the order of the "scopeName" and "operator" fields used in the YAML, to make it clearer in infix style that the operator binds the scope name to a (possibly empty) set of values.

(Per [preceding discussion in the "sig-scheduling" channel](https://kubernetes.slack.com/archives/C09TP78DV/p1546532348038000) of the "Kubernetes" Slack team)