### PR TITLE
[ja] fix home content

### DIFF
--- a/content/ja/docs/concepts/_index.md
+++ b/content/ja/docs/concepts/_index.md
@@ -1,0 +1,75 @@
+---
+title: Concepts
+main_menu: true
+content_template: templates/concept
+weight: 40
+---
+
+{{% capture overview %}}
+
+The Concepts section helps you learn about the parts of the Kubernetes system and the abstractions Kubernetes uses to represent your cluster, and helps you obtain a deeper understanding of how Kubernetes works.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+## Overview
+
+To work with Kubernetes, you use *Kubernetes API objects* to describe your cluster's *desired state*: what applications or other workloads you want to run, what container images they use, the number of replicas, what network and disk resources you want to make available, and more. You set your desired state by creating objects using the Kubernetes API, typically via the command-line interface, `kubectl`. You can also use the Kubernetes API directly to interact with the cluster and set or modify your desired state.
+
+Once you've set your desired state, the *Kubernetes Control Plane* works to make the cluster's current state match the desired state. To do so, Kubernetes performs a variety of tasks automatically--such as starting or restarting containers, scaling the number of replicas of a given application, and more. The Kubernetes Control Plane consists of a collection of processes running on your cluster: 
+
+* The **Kubernetes Master** is a collection of three processes that run on a single node in your cluster, which is designated as the master node. Those processes are: [kube-apiserver](/docs/admin/kube-apiserver/), [kube-controller-manager](/docs/admin/kube-controller-manager/) and [kube-scheduler](/docs/admin/kube-scheduler/).
+* Each individual non-master node in your cluster runs two processes:
+  * **[kubelet](/docs/admin/kubelet/)**, which communicates with the Kubernetes Master.
+  * **[kube-proxy](/docs/admin/kube-proxy/)**, a network proxy which reflects Kubernetes networking services on each node.
+
+## Kubernetes Objects
+
+Kubernetes contains a number of abstractions that represent the state of your system: deployed containerized applications and workloads, their associated network and disk resources, and other information about what your cluster is doing. These abstractions are represented by objects in the Kubernetes API; see the [Kubernetes Objects overview](/docs/concepts/abstractions/overview/) for more details. 
+
+The basic Kubernetes objects include:
+
+* [Pod](/docs/concepts/workloads/pods/pod-overview/)
+* [Service](/docs/concepts/services-networking/service/)
+* [Volume](/docs/concepts/storage/volumes/)
+* [Namespace](/docs/concepts/overview/working-with-objects/namespaces/)
+
+In addition, Kubernetes contains a number of higher-level abstractions called Controllers. Controllers build upon the basic objects, and provide additional functionality and convenience features. They include:
+
+* [ReplicaSet](/docs/concepts/workloads/controllers/replicaset/)
+* [Deployment](/docs/concepts/workloads/controllers/deployment/)
+* [StatefulSet](/docs/concepts/workloads/controllers/statefulset/)
+* [DaemonSet](/docs/concepts/workloads/controllers/daemonset/)
+* [Job](/docs/concepts/workloads/controllers/jobs-run-to-completion/)
+
+## Kubernetes Control Plane
+
+The various parts of the Kubernetes Control Plane, such as the Kubernetes Master and kubelet processes, govern how Kubernetes communicates with your cluster. The Control Plane maintains a record of all of the Kubernetes Objects in the system, and runs continuous control loops to manage those objects' state. At any given time, the Control Plane's control loops will respond to changes in the cluster and work to make the actual state of all the objects in the system match the desired state that you provided.
+
+For example, when you use the Kubernetes API to create a Deployment object, you provide a new desired state for the system. The Kubernetes Control Plane records that object creation, and carries out your instructions by starting the required applications and scheduling them to cluster nodes--thus making the cluster's actual state match the desired state.
+
+### Kubernetes Master
+
+The Kubernetes master is responsible for maintaining the desired state for your cluster. When you interact with Kubernetes, such as by using the `kubectl` command-line interface, you're communicating with your cluster's Kubernetes master.
+
+> The "master" refers to a collection of processes managing the cluster state.  Typically these processes are all run on a single node in the cluster, and this node is also referred to as the master. The master can also be replicated for availability and redundancy.
+
+### Kubernetes Nodes
+
+The nodes in a cluster are the machines (VMs, physical servers, etc) that run your applications and cloud workflows. The Kubernetes master controls each node; you'll rarely interact with nodes directly.
+
+#### Object Metadata
+
+
+* [Annotations](/docs/concepts/overview/working-with-objects/annotations/)
+
+{{% /capture %}}
+
+{{% capture whatsnext %}}
+
+If you would like to write a concept page, see
+[Using Page Templates](/docs/home/contribute/page-templates/)
+for information about the concept page type and the concept template.
+
+{{% /capture %}}

--- a/content/ja/docs/concepts/overview/_index.md
+++ b/content/ja/docs/concepts/overview/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Overview"
+weight: 20
+---
+


### PR DESCRIPTION
`/ja/docs/` で `what-is-kubernetes.md` が表示されるのを修正。
一旦表示されないように

- `docs/concept/_index.md`
- `docs/concept/overview/index.md`

をenからコピーして対応。