### PR TITLE
Update systemctl en/disable to start/stop service

### DIFF
--- a/content/en/docs/getting-started-guides/fedora/fedora_manual_config.md
+++ b/content/en/docs/getting-started-guides/fedora/fedora_manual_config.md
@@ -65,8 +65,7 @@ KUBE_MASTER="--master=http://fed-master:8080"
 systemctl mask firewalld.service
 systemctl stop firewalld.service
 
-systemctl disable iptables.service
-systemctl stop iptables.service
+systemctl disable --now iptables.service
 ```
 
 **Configure the Kubernetes services on the master.**
@@ -97,8 +96,7 @@ ETCD_LISTEN_CLIENT_URLS="http://0.0.0.0:2379"
 
 ```shell
 for SERVICES in etcd kube-apiserver kube-controller-manager kube-scheduler; do
-    systemctl restart $SERVICES
-    systemctl enable $SERVICES
+    systemctl enable --now $SERVICES
     systemctl status $SERVICES
 done
 ```
@@ -146,8 +144,7 @@ current-context: kubelet-context
 
 ```shell
 for SERVICES in kube-proxy kubelet docker; do 
-    systemctl restart $SERVICES
-    systemctl enable $SERVICES
+    systemctl enable --now $SERVICES
     systemctl status $SERVICES 
 done
 ```

--- a/content/en/docs/setup/independent/install-kubeadm.md
+++ b/content/en/docs/setup/independent/install-kubeadm.md
@@ -156,7 +156,7 @@ sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
 
 yum install -y kubelet kubeadm kubectl --disableexcludes=kubernetes
 
-systemctl enable kubelet && systemctl start kubelet
+systemctl enable --now kubelet
 ```
 
   **Note:**
@@ -210,7 +210,7 @@ curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/bu
 Enable and start `kubelet`:
 
 ```bash
-systemctl enable kubelet && systemctl start kubelet
+systemctl enable --now kubelet
 ```
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
If there is a combination of `systemctl` commands where in one you are
enabling it and in another you are starting it, that can be done in one
single command with an additional flag called `--now`. This commit
changes those two command steps in docs to one command.

The help of systemctl shows the following explanation of `--now`:

```
Start or stop unit in addition to enabling or disabling it
```
