### PR TITLE
Correction on command

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
@@ -146,7 +146,7 @@ for a kubelet when a Bootstrap Token was used when authenticating. If you don't 
 automatically approve kubelet client certs, you can turn it off by executing this command:
 
 ```console
-$ kubectl delete clusterrole kubeadm:node-autoapprove-bootstrap
+$ kubectl delete clusterrolebinding kubeadm:node-autoapprove-bootstrap
 ```
 
 After that, `kubeadm join` will block until the admin has manually approved the CSR in flight:


### PR DESCRIPTION
I think that kubeadm:node-autoapprove-bootstrap is a clusterrolebinding and not a clusterrole as it does not exist in the default installation of 1.12.1-00
