### PR TITLE
Fix issue with k8s.io/docs/concepts/workloads/controllers/replicaset/

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/replicaset.md
+++ b/content/en/docs/concepts/workloads/controllers/replicaset.md
@@ -213,7 +213,7 @@ Alternatively, you can use the `kubectl autoscale` command to accomplish the sam
 (and it's easier!)
 
 ```shell
-kubectl autoscale rs frontend
+kubectl autoscale rs frontend --max=10
 ```
 
 ## Alternatives to ReplicaSet


### PR DESCRIPTION
Command "kubectl autoscale rs frontend" returns:
Error: required flag(s) "max" not set
Close #11906