### PR TITLE
Update assign-pod-node.md

### DIFF
--- a/content/en/docs/concepts/configuration/assign-pod-node.md
+++ b/content/en/docs/concepts/configuration/assign-pod-node.md
@@ -46,7 +46,7 @@ Run `kubectl get nodes` to get the names of your cluster's nodes. Pick out the o
 
 If this fails with an "invalid command" error, you're likely using an older version of kubectl that doesn't have the `label` command. In that case, see the [previous version](https://github.com/kubernetes/kubernetes/blob/a053dbc313572ed60d89dae9821ecab8bfd676dc/examples/node-selection/README.md) of this guide for instructions on how to manually set labels on a node.
 
-You can verify that it worked by re-running `kubectl get nodes --show-labels` and checking that the node now has a label.If the labels are not displayed completely,you can also use `kubectl describe node "nodename"` to display the labels.
+You can verify that it worked by re-running `kubectl get nodes --show-labels` and checking that the node now has a label.You can also use `kubectl describe node "nodename"` to see the full list of labels of the given node.
 
 ### Step Two: Add a nodeSelector field to your pod configuration
 

--- a/content/en/docs/concepts/configuration/assign-pod-node.md
+++ b/content/en/docs/concepts/configuration/assign-pod-node.md
@@ -46,7 +46,7 @@ Run `kubectl get nodes` to get the names of your cluster's nodes. Pick out the o
 
 If this fails with an "invalid command" error, you're likely using an older version of kubectl that doesn't have the `label` command. In that case, see the [previous version](https://github.com/kubernetes/kubernetes/blob/a053dbc313572ed60d89dae9821ecab8bfd676dc/examples/node-selection/README.md) of this guide for instructions on how to manually set labels on a node.
 
-You can verify that it worked by re-running `kubectl get nodes --show-labels` and checking that the node now has a label.You can also use `kubectl describe node "nodename"` to see the full list of labels of the given node.
+You can verify that it worked by re-running `kubectl get nodes --show-labels` and checking that the node now has a label. You can also use `kubectl describe node "nodename"` to see the full list of labels of the given node.
 
 ### Step Two: Add a nodeSelector field to your pod configuration
 

--- a/content/en/docs/concepts/configuration/assign-pod-node.md
+++ b/content/en/docs/concepts/configuration/assign-pod-node.md
@@ -46,7 +46,7 @@ Run `kubectl get nodes` to get the names of your cluster's nodes. Pick out the o
 
 If this fails with an "invalid command" error, you're likely using an older version of kubectl that doesn't have the `label` command. In that case, see the [previous version](https://github.com/kubernetes/kubernetes/blob/a053dbc313572ed60d89dae9821ecab8bfd676dc/examples/node-selection/README.md) of this guide for instructions on how to manually set labels on a node.
 
-You can verify that it worked by re-running `kubectl get nodes --show-labels` and checking that the node now has a label.
+You can verify that it worked by re-running `kubectl get nodes --show-labels` and checking that the node now has a label.If the labels are not displayed completely,you can also use `kubectl describe node "nodename"` to display the labels.
 
 ### Step Two: Add a nodeSelector field to your pod configuration
 


### PR DESCRIPTION
Use `kubectl get nodes --show-labels` to show the labels will not show the compelte labels like this:
```
root@master:/home# kubectl get nodes --show-labels
NAME            STATUS   ROLES    AGE   VERSION   LABELS
master          Ready    master   41h   v1.13.1   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,kubernetes.io/hostname=master,node-role.kubernetes.io/master=
server01        Ready    <none>   41h   v1.13.1   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,func=database,kubernetes.io/hostname=moon-server01
```
and the command `kubectl describe node "nodename" ` will show all labels the node have.Will be a better method to see all labels.