### PR TITLE
Update bootstrap-token feature state on authentication page

### DIFF
--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -120,7 +120,7 @@ Authorization: Bearer 31ada4fd-adec-460c-809a-9e56ceb75269
 
 ### Bootstrap Tokens
 
-This feature is currently in **alpha**.
+This feature is currently in **beta**.
 
 To allow for streamlined bootstrapping for new clusters, Kubernetes includes a
 dynamically-managed Bearer token type called a *Bootstrap Token*. These tokens


### PR DESCRIPTION
According to `content/en/docs/reference/access-authn-authz/bootstrap-tokens.md` bootstrap tokens are in state  `beta` but here it's still listed as `alpha`
