### PR TITLE
Fix service's port in Hello Minikube tutorial

### DIFF
--- a/content/en/docs/tutorials/hello-minikube.md
+++ b/content/en/docs/tutorials/hello-minikube.md
@@ -160,7 +160,8 @@ Kubernetes [*Service*](/docs/concepts/services-networking/service/).
 
 4. Katacoda environment only: Click the plus sign, and then click **Select port to view on Host 1**.
 
-5. Katacoda environment only: Type `8080`, and then click **Display Port**. 
+5. Katacoda environment only: Type `30369` (see port opposite to `8080` in services output), and then click
+**Display Port**. 
 
     This opens up a browser window that serves your app and shows the "Hello World" message.
 


### PR DESCRIPTION
Port `8080` is the internal port of container and to follow the tutorial, user must use exposed one.
