### PR TITLE
Edit button on translated pages working as well now

### DIFF
--- a/layouts/partials/docs/content-page.html
+++ b/layouts/partials/docs/content-page.html
@@ -1,5 +1,5 @@
 {{- $filepath := .page.File.Path }}
-{{- $editLink := printf "https://github.com/kubernetes/website/edit/master/content/en/%s" $filepath }}
+{{- $editLink := printf "https://github.com/kubernetes/website/edit/master/content/%s/%s" .page.Language.Lang $filepath }}
 <p>
   <a href="{{ $editLink }}" id="editPageButton" target="_blank">
     Edit This Page


### PR DESCRIPTION
This change fixes the Edit button which will then be linking to the correct content in GitHub. Previously it was always linking to the "en" content.

This will solve issue #12202