### PR TITLE
Update HostAliases entries for new implementation

### DIFF
--- a/content/en/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases.md
+++ b/content/en/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases.md
@@ -107,10 +107,8 @@ fe00::2	ip6-allrouters
 10.200.0.5	hostaliases-pod
 
 # Entries added by HostAliases.
-127.0.0.1	foo.local
-127.0.0.1	bar.local
-10.1.2.3	foo.remote
-10.1.2.3	bar.remote
+127.0.0.1	foo.local	bar.local
+10.1.2.3	foo.remote	bar.remote
 ```
 
 With the additional entries specified at the bottom.


### PR DESCRIPTION
https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/ says the HostAliases feature puts entries for each hostname, but since https://github.com/kubernetes/kubernetes/commit/ab507dfc1f0c824386ea6ca0efc1abe7968981fd the feature has put entries for each IP address instead.
This updates it for the latest implementation.

fixes: #12250 