### PR TITLE
added missing EOF

### DIFF
--- a/content/en/docs/tasks/debug-application-cluster/audit.md
+++ b/content/en/docs/tasks/debug-application-cluster/audit.md
@@ -276,7 +276,7 @@ Fluent-plugin-forest and fluent-plugin-rewrite-tag-filter are plugins for fluent
 1. create a config file for fluentd
 
     ```none
-    $ cat <<EOF > /etc/fluentd/config
+    $ cat <<'EOF' > /etc/fluentd/config
     # fluentd conf runs in the same host with kube-apiserver
     <source>
         @type tail
@@ -321,6 +321,7 @@ Fluent-plugin-forest and fluent-plugin-rewrite-tag-filter are plugins for fluent
             include_time_key true
         </template>
     </match>
+    EOF
     ```
 
 1. start fluentd
@@ -373,6 +374,7 @@ different users into different files.
             path=>"/var/log/kube-audit-%{[event][user][username]}/audit"
         }
     }
+    EOF
     ```
 
 1. start logstash


### PR DESCRIPTION
`cat` commands are missing EOF, and so console is waiting for input.
As for /etc/fluentd/config, `${...}` causes a bad substitution error.