### PR TITLE
_index modify for translation correction

### DIFF
--- a/content/zh/_index.html
+++ b/content/zh/_index.html
@@ -17,8 +17,8 @@ cid: "home"
         <div class="image-wrapper"><img src="https://d33wubrfki0l68.cloudfront.net/33a12d8be0bc50be4738443101616e968c7afb8f/2c641/_common-resources/images/scalable.png" alt="images/scalable.png"></div>
         <div class="content">
             
-            <h4>星际尺度</h4>
-            <p>根据同样的原则设计，允许 Google 每周运行数十亿个容器，Kubernetes 可以在不增加您的 ops 团队的情况下进行弹性扩展。</p>
+            <h4>全球规模</h4>
+            <p>基于允许 Google 每周运行数十亿个容器的原则进行设计，Kubernetes 可以在不增加您的运维团队的情况下进行弹性扩展。</p>
         </div>
     </main>
     <main>


### PR DESCRIPTION
"Planet Scale" means a global scale which  "全球规模" will be better for this description in chinese. 
"Designed on the same principles that allows Google to run billions of containers a week" to "基于允许 Google 每周运行数十亿个容器的原则进行设计",  it's more natural in chinese.
