### PR TITLE
ADD --horizontal-pod-autoscaler-use-rest-clients flag to kube-controller-manager.md

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/kube-controller-manager.md
+++ b/content/en/docs/reference/command-line-tools-reference/kube-controller-manager.md
@@ -396,6 +396,13 @@ kube-controller-manager [flags]
     </tr>
 
     <tr>
+      <td colspan="2">--horizontal-pod-autoscaler-use-rest-clients Default: true</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;">If set to true, causes the horizontal pod autoscaler controller to use REST clients through the kube-aggregator, instead of using the legacy metrics client through the API server proxy.  This is required for custom metrics support in the horizontal pod autoscaler.</td>
+    </tr>
+
+    <tr>
       <td colspan="2">--http2-max-streams-per-connection int</td>
     </tr>
     <tr>


### PR DESCRIPTION
I did not find description about flag `--horizontal-pod-autoscaler-use-rest-clients`, so I've added it.
