### PR TITLE
Remove command prompts and separate commands from output [Access Clusters Using the Kubernetes API]

### DIFF
--- a/content/en/docs/tasks/administer-cluster/access-cluster-api.md
+++ b/content/en/docs/tasks/administer-cluster/access-cluster-api.md
@@ -29,7 +29,7 @@ or someone else setup the cluster and provided you with credentials and a locati
 Check the location and credentials that kubectl knows about with this command:
 
 ```shell
-$ kubectl config view
+kubectl config view
 ```
 
 Many of the [examples](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/) provide an introduction to using
@@ -53,7 +53,7 @@ locating the API server and authenticating.
 Run it like this:
 
 ```shell
-$ kubectl proxy --port=8080 &
+kubectl proxy --port=8080 &
 ```
 
 See [kubectl proxy](/docs/reference/generated/kubectl/kubectl-commands/#proxy) for more details.
@@ -61,7 +61,12 @@ See [kubectl proxy](/docs/reference/generated/kubectl/kubectl-commands/#proxy) f
 Then you can explore the API with curl, wget, or a browser, like so:
 
 ```shell
-$ curl http://localhost:8080/api/
+curl http://localhost:8080/api/
+```
+
+The output is similar to this:
+
+```json
 {
   "versions": [
     "v1"
@@ -82,12 +87,21 @@ directly to the API server, like this:
 
 ``` shell
 # Check all possible clusters, as you .KUBECONFIG may have multiple contexts
-$ kubectl config view -o jsonpath='{range .clusters[*]}{.name}{"\t"}{.cluster.server}{"\n"}{end}'
+kubectl config view -o jsonpath='{range .clusters[*]}{.name}{"\t"}{.cluster.server}{"\n"}{end}'
+
 # Point to the API server refering the cluster name
-$ APISERVER=$(kubectl config view -o jsonpath='{.clusters[?(@.name=="$CLUSTER_NAME")].cluster.server}')
+APISERVER=$(kubectl config view -o jsonpath='{.clusters[?(@.name=="$CLUSTER_NAME")].cluster.server}')
+
 # Gets the token value
-$ TOKEN=$(kubectl get secrets -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='default')].data.token}"|base64 -d)
-$ curl -X GET $APISERVER/api --header "Authorization: Bearer $TOKEN" --insecure
+TOKEN=$(kubectl get secrets -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='default')].data.token}"|base64 -d)
+
+# Explore the API with TOKEN
+curl -X GET $APISERVER/api --header "Authorization: Bearer $TOKEN" --insecure
+```
+
+The output is similar to this:
+
+```json
 {
   "kind": "APIVersions",
   "versions": [


### PR DESCRIPTION
- followed the style guide
- added a tiny comment