### PR TITLE
Optimize Linux shell installation-command of minikube

### DIFF
--- a/content/en/docs/tasks/tools/install-minikube.md
+++ b/content/en/docs/tasks/tools/install-minikube.md
@@ -56,7 +56,7 @@ curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/miniku
 Here's an easy way to add the Minikube executable to your path:
 
 ```shell
-sudo cp minikube /usr/local/bin && rm minikube
+sudo mv minikube /usr/local/bin
 ```
 
 ### Linux


### PR DESCRIPTION
Use `mv` instead the combination of `cp` and `rm` to put minikube into `/usr/local/bin`
