### PR TITLE
change docker cgroupdriver to its default cgroupfs

### DIFF
--- a/content/en/docs/setup/cri.md
+++ b/content/en/docs/setup/cri.md
@@ -50,7 +50,7 @@ apt-get update && apt-get install docker-ce=18.06.0~ce~3-0~ubuntu
 # Setup daemon.
 cat > /etc/docker/daemon.json <<EOF
 {
-  "exec-opts": ["native.cgroupdriver=systemd"],
+  "exec-opts": ["native.cgroupdriver=cgroupfs"],
   "log-driver": "json-file",
   "log-opts": {
     "max-size": "100m"


### PR DESCRIPTION
According to our practice, systemd is error prone, and kubelet will always report some errors about this. Anyway, docker have some issue with systemd cgroupdriver mode.