### PR TITLE
windows: Add windows prefix for windows services

### DIFF
--- a/content/en/docs/getting-started-guides/windows/_index.md
+++ b/content/en/docs/getting-started-guides/windows/_index.md
@@ -354,13 +354,13 @@ This means that you can now register them as Windows services via `sc` command. 
 
 To create the service:
 ```
-PS > sc.exe create <component_name> binPath= "<path_to_binary> --service <other_args>"
-CMD > sc create <component_name> binPath= "<path_to_binary> --service <other_args>"
+PS > sc.exe create <component_name> binPath= "<path_to_binary> --windows-service <other_args>"
+CMD > sc create <component_name> binPath= "<path_to_binary> --windows-service <other_args>"
 ```
 Please note that if the arguments contain spaces, it must be escaped. Example:
 ```
-PS > sc.exe create kubelet binPath= "C:\kubelet.exe --service --hostname-override 'minion' <other_args>"
-CMD > sc create kubelet binPath= "C:\kubelet.exe --service --hostname-override 'minion' <other_args>"
+PS > sc.exe create kubelet binPath= "C:\kubelet.exe --windows-service --hostname-override 'minion' <other_args>"
+CMD > sc create kubelet binPath= "C:\kubelet.exe --windows-service --hostname-override 'minion' <other_args>"
 ```
 To start the service:
 ```


### PR DESCRIPTION
The binaries themself indicate:
```
 --windows-service                              Enable Windows Service Control Manager API integration
```

It also doesn't appear to have changed, since it's like this since this landed:
https://github.com/kubernetes/kubernetes/commit/4ea363d98e9cf1fb7c83da3fe6d7db95a904cae3#diff-34a9920a4db69d1542b66bcb6fe4ac1eR39

Possibly an oversight after changing it before the merge.
This ensures the documentation is consistent with the code and help outputted by kubernetes binaries again.

/sig windows

