### PR TITLE
Remove white spaces from the user journey page.

### DIFF
--- a/static/css/style_user_journeys.css
+++ b/static/css/style_user_journeys.css
@@ -685,8 +685,8 @@ i {
   line-height:22px;
   width:65%;
   margin-left:17%;
-  margin-top : 10%;
-  padding:4%;
+  margin-top : 3%;
+  padding:1%;
 }
 
 #persona-definition {


### PR DESCRIPTION
The user journey (foundation) page has too many white spaces. Removed the spaces by adjusting the margin top and padding values.