### PR TITLE
Substitute en.toml for pedefined english shortcodes for i18n translation

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -30,6 +30,24 @@ other = "No"
 [latest_version]
 other = "latest version."
 
+[version_check_mustbe]
+other = "Your Kubernetes server must be version "
+
+[version_check_mustbeorlater]
+other = "Your Kubernetes server must be at or later than version "
+
+[version_check_tocheck]
+other = "To check the version, enter "
+
+[caution]
+other = "Caution:"
+
+[note]
+other = "Note:"
+
+[warning]
+other = "Warning:"
+
 [main_read_about]
 other = "Read about"
 

--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -1,5 +1,53 @@
 # i18n strings for the Korean translation.
 
+[deprecation_warning]
+other = " 문서는 더 이상 적극적으로 관리되지 않음. 현재 보고있는 문서는 정적 스냅샷임. 최신 문서를 위해서는, 다음을 참고. "
+
+[objectives_heading]
+other = "목적"
+
+[cleanup_heading]
+other = "정리하기"
+
+[prerequisites_heading]
+other = "시작하기 전에"
+
+[whatsnext_heading]
+other = "다음 내용"
+
+[feedback_heading]
+other = "피드백"
+
+[feedback_question]
+other = "이 페이지가 도움이 되었나요?"
+
+[feedback_yes]
+other = "네"
+
+[feedback_no]
+other = "아니요"
+
+[latest_version]
+other = "최신 버전."
+
+[version_check_mustbe]
+other = "쿠버네티스 서버의 버전은 다음과 같아야 함. 버전: "
+
+[version_check_mustbeorlater]
+other = "쿠버네티스 서버의 버전은 다음과 같거나 더 높아야 함. 버전: "
+
+[version_check_tocheck]
+other = "버전 확인을 위해서, 다음 커맨드를 실행 "
+
+[caution]
+other = "주의:"
+
+[note]
+other = "참고:"
+
+[warning]
+other = "경고:"
+
 [main_read_about]
 other = "Read about"
 

--- a/layouts/shortcodes/caution.html
+++ b/layouts/shortcodes/caution.html
@@ -1,3 +1,3 @@
 <blockquote class="caution">
-  <div><strong>Caution:</strong> {{ .Inner | markdownify }}</div>
+  <div><strong>{{ T "caution" }}</strong> {{ .Inner | markdownify }}</div>
 </blockquote>

--- a/layouts/shortcodes/deprecationwarning.html
+++ b/layouts/shortcodes/deprecationwarning.html
@@ -3,8 +3,9 @@
   <main>
     <div class="content deprecation-warning">
       <h3>
-        Documentation for Kubernetes {{ .Page.Param "version" }} is no longer actively maintained. The version you are currently viewing is a static snapshot.
-        For up-to-date documentation, see the <a href="{{ site.Params.currentUrl }}">latest</a> version.
+	 Kubernetes {{ .Param "version" }}
+	 {{ T "deprecation_warning" }}
+	 <a href="{{ site.Params.currentUrl }}">{{ T "latest_version" }}</a>
       </h3>
     </div>
   </main>

--- a/layouts/shortcodes/note.html
+++ b/layouts/shortcodes/note.html
@@ -1,3 +1,3 @@
 <blockquote class="note">
-  <div><strong>Note:</strong> {{ .Inner | markdownify }}</div>
+  <div><strong>{{ T "note" }}</strong> {{ .Inner | markdownify }}</div>
 </blockquote>

--- a/layouts/shortcodes/version-check.html
+++ b/layouts/shortcodes/version-check.html
@@ -1,6 +1,6 @@
 {{ $minVersion := .Page.Param "min-kubernetes-server-version" }}
 {{ if eq $minVersion (.Page.Param "version")  }}
-Your Kubernetes server must be version {{ $minVersion }}.
+{{ T "version_check_mustbe" }}{{ $minVersion }}.
 {{ else if $minVersion}}
-Your Kubernetes server must be version {{ $minVersion }} or later.
-{{ end }} To check the version, enter <code>kubectl version</code>.
+{{ T "version_check_mustbeorlater" }}{{ $minVersion }}.
+{{ end }} {{ T "version_check_tocheck" }}<code>kubectl version</code>.

--- a/layouts/shortcodes/warning.html
+++ b/layouts/shortcodes/warning.html
@@ -1,3 +1,3 @@
 <blockquote class="warning">
-  <div><strong>Warning:</strong> {{ .Inner | markdownify }}</div>
+  <div><strong>{{ T "warning" }}</strong> {{ .Inner | markdownify }}</div>
 </blockquote>


### PR DESCRIPTION
To fix #12160 (Issue in l10n docs referencing EN layouts outside l10n working directory)

This PR is a complement to the merged PR #12239. 

1. Predefined English words in layouts/shortcodes has been substituted by i18n/en.toml
2. Modified i18n/ko.toml corresponding to en.toml translation.

