### PR TITLE
Fix #12434 - Empty continuation line warning while building docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,8 @@ ARG HUGO_VERSION
 
 RUN mkdir -p /usr/local/src && \
     cd /usr/local/src && \
-    #curl -L https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-64bit.tar.gz | tar -xz && \
     curl -L https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_linux-64bit.tar.gz | tar -xz && \
     mv hugo /usr/local/bin/hugo && \
-    #curl -L https://bin.equinox.io/c/dhgbqpS8Bvy/minify-stable-linux-amd64.tgz | tar -xz && \
-    #mv minify /usr/local/bin && \
     addgroup -Sg 1000 hugo && \
     adduser -Sg hugo -u 1000 -h /src hugo
 


### PR DESCRIPTION
This is a parsing error for docker versions <= "17.09.0-ce" where it checks for both empty line and a comment line after a command. 

But there is a fix for lastest docker versions - https://github.com/docker/docker-ce/commit/e25514ef0c7afd8c818b7b5c30256d10b3f10da3

which only checks for empty lines.

Please let me know if there is a need for this change. Thank you. 