### PR TITLE
kubeadm: remove rktlet link from install-kubeadm

### DIFF
--- a/content/en/docs/setup/independent/install-kubeadm.md
+++ b/content/en/docs/setup/independent/install-kubeadm.md
@@ -90,7 +90,6 @@ Other CRI-based runtimes include:
 - [containerd](https://github.com/containerd/cri) (CRI plugin built into containerd)
 - [cri-o](https://github.com/kubernetes-incubator/cri-o)
 - [frakti](https://github.com/kubernetes/frakti)
-- [rkt](https://github.com/kubernetes-incubator/rktlet)
 
 Refer to the [CRI installation instructions](/docs/setup/cri) for more information.
 


### PR DESCRIPTION
Since Kubernetes 1.10, the only supported CRI version is v1alpha2. However,
rktlet does not support that version and development seems stopped.
As there is no way to use rktlet with k8s >= 1.10, it's best to just remove
the rkt link from the "Install runtime" section of "Install kubeadm".

Refs kubernetes/kubeadm#1364

/assign @neolit123 
/sig cluster-lifecycle