### PR TITLE
[WIP] Initial version - Documentation for Garbage Collection in Kubernetes

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/garbage-collection.md
+++ b/content/en/docs/concepts/workloads/controllers/garbage-collection.md
@@ -6,8 +6,14 @@ weight: 60
 
 {{% capture overview %}}
 
-The role of the Kubernetes garbage collector is to delete certain objects
-that once had an owner, but no longer have an owner.
+Garbage Collection is a process of reclaiming resources by deleting unused or unowned objects. In Kubernetes, there are two different aspects of Garbage Collection - Master level handled by [Kube-Controller-Manager](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/) and Node level managed by [Kubelet](https://kubernetes.io/docs/concepts/cluster-administration/kubelet-garbage-collection/).
+
+* Garbage Collector at Master
+  Kubernetes ships with a garbage collector controller managed via Kubernetes Controller Manager. This garbage collector is responsible for deleting Deployments and it's components.
+
+* Garbage Collector at Node (Formally Minion)
+
+  Kubelet provides the function of Garbage Collection at Node level by cleaning up unused images and containers. It will perform Garbage collection for images every five minutes and containers every minute. Along with Garbage collection, the Kubelet also performs additional resource handling as mentioned [here](https://kubernetes.io/docs/concepts/cluster-administration/kubelet-garbage-collection/). For example, Eviction Policy.
 
 {{% /capture %}}
 
@@ -107,8 +113,8 @@ field on the `deleteOptions` argument when deleting an Object. Possible values i
 
 Prior to Kubernetes 1.9, the default garbage collection policy for many controller resources was `orphan`.
 This included ReplicationController, ReplicaSet, StatefulSet, DaemonSet, and
-Deployment. For kinds in the `extensions/v1beta1`, `apps/v1beta1`, and `apps/v1beta2` group versions, unless you 
-specify otherwise, dependent objects are orphaned by default. In Kubernetes 1.9, for all kinds in the `apps/v1` 
+Deployment. For kinds in the `extensions/v1beta1`, `apps/v1beta1`, and `apps/v1beta2` group versions, unless you
+specify otherwise, dependent objects are orphaned by default. In Kubernetes 1.9, for all kinds in the `apps/v1`
 group version, dependent objects are deleted by default.
 
 Here's an example that deletes dependents in background:
@@ -170,6 +176,3 @@ Tracked at [#26120](https://github.com/kubernetes/kubernetes/issues/26120)
 [Design Doc 2](https://git.k8s.io/community/contributors/design-proposals/api-machinery/synchronous-garbage-collection.md)
 
 {{% /capture %}}
-
-
-


### PR DESCRIPTION
Fix #4322 

@zacharysarah Here's the first draft based on my initial reading. I will keep updating this Pull Request as I dig deeper. As of now, I have the following questions to add more details to the document. It would be great if you can help me find answers for them while I go through the code and experiment with the setting (Checklist to keep a track of things for clear understanding :) ). 

1. How exactly does the garbage controller delete the unused objects (Algorithm/more details)
2. Does Kube-Controller-Manager work in collaboration with Kubelet to delete unowned containers? 
3. Are there any pointers on the internal working/workflow of the garbage collector control loop?
4. Are there any configuration parameters on Controller?
5. Pointers on internal workflow on how Kubelet coordinates with Kube controller manager in maintain consistency while cleaning up containers.  How the pointers are updated?
6. Eviction policy vs Garbage Collection in Kubelet and What's the future? 
7. Tuning Garbage Collection in Kubelet. Are they any configuration parameter to change the timing of Garbage Collection. 
8. What tool do we internally use to prepare visual workflows for a better understanding? 

