### PR TITLE
Fixed Wrong file path #12478

### DIFF
--- a/content/en/docs/setup/independent/kubelet-integration.md
+++ b/content/en/docs/setup/independent/kubelet-integration.md
@@ -184,7 +184,7 @@ This file specifies the default locations for all of the files managed by kubead
 - The file containing the kubelet's ComponentConfig is `/var/lib/kubelet/config.yaml`.
 - The dynamic environment file that contains `KUBELET_KUBEADM_ARGS` is sourced from `/var/lib/kubelet/kubeadm-flags.env`.
 - The file that can contain user-specified flag overrides with `KUBELET_EXTRA_ARGS` is sourced from
-  `/etc/default/kubelet` (for DEBs), or `/etc/systconfig/kubelet` (for RPMs). `KUBELET_EXTRA_ARGS`
+  `/etc/default/kubelet` (for DEBs), or `/etc/sysconfig/kubelet` (for RPMs). `KUBELET_EXTRA_ARGS`
   is last in the flag chain and has the highest priority in the event of conflicting settings.
 
 ## Kubernetes binaries and package contents


### PR DESCRIPTION
Page to Update:
https://kubernetes.io/docs/setup/independent/kubelet-integration

Problem:
Path mentioned is /etc/systconfig/kubelet

Proposed Solution:
Correct path for the file is /etc/sysconfig/kubelet

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> Please delete this note before submitting the pull request.
>
> For 1.14 Features: set Milestone to 1.14 and Base Branch to dev-1.14
> 
> For Chinese localization, base branch to release-1.12
>
> For Korean Localization: set Base Branch to dev-1.13-ko.<latest team milestone>
>
> Help editing and submitting pull requests:
> https://kubernetes.io/docs/contribute/start/#improve-existing-content.
>
> Help choosing which branch to use:
> https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use.
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
