### PR TITLE
Link to Baidu's CCM implementation

### DIFF
--- a/content/en/docs/concepts/architecture/cloud-controller.md
+++ b/content/en/docs/concepts/architecture/cloud-controller.md
@@ -255,6 +255,7 @@ The following cloud providers have implemented CCMs:
 * [Azure](https://github.com/kubernetes/kubernetes/tree/master/pkg/cloudprovider/providers/azure)
 * [GCE](https://github.com/kubernetes/kubernetes/tree/master/pkg/cloudprovider/providers/gce)
 * [AWS](https://github.com/kubernetes/kubernetes/tree/master/pkg/cloudprovider/providers/aws)
+* [BaiduCloud](https://github.com/baidu/cloud-provider-baiducloud)
 
 ## Cluster Administration
 


### PR DESCRIPTION
**What this PR does / why we need it:**
[BaiduCloud Container Engine](https://cloud.baidu.com/product/cce.html) is a high-performance and scalable container application management service using Kubernetes.
As the gold member of CNCF, we create this PR to add a link to Baidu's CCM implementation.

**Related:**
- [Baidu Joins Cloud Native Computing Foundation As Gold Member](https://www.cncf.io/announcement/2017/12/06/baidu-joins-cloud-native-computing-foundation-gold-member/)
- https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/providers/0022-cloud-provider-baiducloud.md