### PR TITLE
Add arm64 and ppc64le platforms for calico

### DIFF
--- a/content/en/docs/setup/independent/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/independent/create-cluster-kubeadm.md
@@ -281,7 +281,7 @@ Please select one of the tabs to see installation instructions for the respectiv
 {{% tab name="Calico" %}}
 For more information about using Calico, see [Quickstart for Calico on Kubernetes](https://docs.projectcalico.org/latest/getting-started/kubernetes/), [Installing Calico for policy and networking](https://docs.projectcalico.org/latest/getting-started/kubernetes/installation/calico), and other related resources.
 
-For Calico to work correctly, you need to pass `--pod-network-cidr=192.168.0.0/16` to `kubeadm init` or update the `calico.yml` file to match your Pod network. Note that Calico works on `amd64` only.
+For Calico to work correctly, you need to pass `--pod-network-cidr=192.168.0.0/16` to `kubeadm init` or update the `calico.yml` file to match your Pod network. Note that Calico works on `amd64`, `arm64` and `ppc64le` only.
 
 ```shell
 kubectl apply -f https://docs.projectcalico.org/v3.3/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml


### PR DESCRIPTION
Now calico images are fat manifest and even calico manifest yamls are updated with fat manifest images and can run on amd64, arm64 and ppc64le platforms!

```
$ docker manifest inspect calico/node:v3.3.2                                                                                                                                                                                                                          130 ↵
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1371,
         "digest": "sha256:4b3e3750deeb97cf6f68e5d021f60891a0562f7412efdb545599e6ea505eaf18",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1996,
         "digest": "sha256:ae6faba939ef1ae8b017e575d8dcf055f05607618814a225f481585e12db43c5",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1996,
         "digest": "sha256:259c0199fa304a1813b0aca177fd7c414daa8ddd5483b280e94fc69d94465061",
         "platform": {
            "architecture": "ppc64le",
            "os": "linux"
         }
      }
   ]
}
```

manifests got updated part of https://github.com/projectcalico/calico/pull/2364