### PR TITLE
replicationController -> ReplicaSet

### DIFF
--- a/content/en/docs/tasks/job/fine-parallel-processing-work-queue.md
+++ b/content/en/docs/tasks/job/fine-parallel-processing-work-queue.md
@@ -249,7 +249,7 @@ If running a queue service or modifying your containers to use a work queue is i
 want to consider one of the other [job patterns](/docs/concepts/jobs/run-to-completion-finite-workloads/#job-patterns).
 
 If you have a continuous stream of background processing work to run, then
-consider running your background workers with a `replicationController` instead,
+consider running your background workers with a `ReplicaSet` instead,
 and consider running a background processing library such as
 [https://github.com/resque/resque](https://github.com/resque/resque).
 


### PR DESCRIPTION
Proposing replacing `replicationController` with `ReplicaSet` here since ["ReplicaSet is the next-generation Replication Controller."](https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/).