### PR TITLE
Update container-lifecycle-hooks document for preStop hook

### DIFF
--- a/content/en/docs/concepts/containers/container-lifecycle-hooks.md
+++ b/content/en/docs/concepts/containers/container-lifecycle-hooks.md
@@ -36,7 +36,7 @@ No parameters are passed to the handler.
 
 `PreStop`
 
-This hook is called immediately before a container is terminated.
+This hook is called immediately before a container is terminated due to an API request or management event such as liveness probe failure, preemption, resource contention and others. A call to the preStop hook fails if the container is already in terminated or completed state.
 It is blocking, meaning it is synchronous,
 so it must complete before the call to delete the container can be sent.
 No parameters are passed to the handler.


### PR DESCRIPTION
The changes are in line with one of the request for documentation update as per PR #55807 wherein it was observed that the preStop hook is not commissioned when the container is already in the terminated or completed state.

Reference comment: https://github.com/kubernetes/kubernetes/issues/55807#issuecomment-459933280

cc @mgdevstack, @brahmaroutu  