### PR TITLE
Minor line-break change

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-projected-volume-storage.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-projected-volume-storage.md
@@ -50,10 +50,10 @@ the Pod:
        kubectl get --watch pod test-projected-volume
 ```
     The output looks like this:
-
+```shell
        NAME                    READY     STATUS    RESTARTS   AGE
        test-projected-volume   1/1       Running   0          14s
-
+```
 1. In another terminal, get a shell to the running Container:
 ```shell
        kubectl exec -it test-projected-volume -- /bin/sh


### PR DESCRIPTION
Fixing a minor Line break on this page. 

The output of this command does not have a line break in the below page. 
`   kubectl get --watch pod test-projected-volume
`

https://kubernetes.io/docs/tasks/configure-pod-container/configure-projected-volume-storage/#configure-a-projected-volume-for-a-pod

