### PR TITLE
Clarify step 6 for generating the API keys with cfssl regaring json filenames

### DIFF
--- a/content/en/docs/concepts/cluster-administration/certificates.md
+++ b/content/en/docs/concepts/cluster-administration/certificates.md
@@ -183,7 +183,7 @@ Finally, add the same parameters into the API server start parameters.
 
         ../cfssl gencert -initca ca-csr.json | ../cfssljson -bare ca
 1.  Create a JSON config file for generating keys and certificates for the API
-    server as shown below. Be sure to replace the values in angle brackets with
+    server, for example, `server-csr.json`. Be sure to replace the values in angle brackets with
     real values you want to use. The `MASTER_CLUSTER_IP` is the service cluster
     IP for the API server as described in previous subsection.
     The sample below also assumes that you are using `cluster.local` as the default


### PR DESCRIPTION
This is just a tiny change regarding certificate generation with cfssl to make the docs  more consistent and less ambiguous. 

All other steps state the the name of the json file to work on (e.g. in step 4 `for example, ca-csr.json`). I changed step 6 do be consistent with this. The proposed filename `server-csr.json` is the same name that is used in step 7 to generate the keys.