### PR TITLE
Minor doc change for GAing Pod DNS Config

### DIFF
--- a/content/en/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/en/docs/concepts/services-networking/dns-pod-service.md
@@ -170,10 +170,10 @@ following pod-specific DNS policies. These policies are specified in the
   for details on how DNS queries are handled in those cases.
 - "`ClusterFirstWithHostNet`": For Pods running with hostNetwork, you should
   explicitly set its DNS policy "`ClusterFirstWithHostNet`".
-- "`None`": A new option value introduced in Kubernetes v1.9 (Beta in v1.10). It
-  allows a Pod to ignore DNS settings from the Kubernetes environment. All DNS
-  settings are supposed to be provided using the `dnsConfig` field in the Pod Spec.
-  See [DNS config](#dns-config) subsection below.
+- "`None`": It allows a Pod to ignore DNS settings from the Kubernetes
+  environment. All DNS settings are supposed to be provided using the
+  `dnsConfig` field in the Pod Spec.
+  See [Pod's DNS config](#pod-s-dns-config) subsection below.
 
 {{< note >}}
 "Default" is not the default DNS policy. If `dnsPolicy` is not
@@ -205,13 +205,7 @@ spec:
 
 ### Pod's DNS Config
 
-Kubernetes v1.9 introduces an Alpha feature (Beta in v1.10) that allows users more
-control on the DNS settings for a Pod. This feature is enabled by default in v1.10.
-To enable this feature in v1.9, the cluster administrator
-needs to enable the `CustomPodDNS` feature gate on the apiserver and the kubelet,
-for example, "`--feature-gates=CustomPodDNS=true,...`".
-When the feature gate is enabled, users can set the `dnsPolicy` field of a Pod
-to "`None`" and they can add a new field `dnsConfig` to a Pod Spec.
+Pod's DNS Config allows users more control on the DNS settings for a Pod.
 
 The `dnsConfig` field is optional and it can work with any `dnsPolicy` settings.
 However, when a Pod's `dnsPolicy` is set to "`None`", the `dnsConfig` field has
@@ -256,6 +250,16 @@ nameserver fd00:79:30::a
 search default.svc.cluster.local svc.cluster.local cluster.local
 options ndots:5
 ```
+
+### Feature availability
+
+The availability of Pod DNS Config and DNS Policy "`None`"" is shown as below.
+
+| k8s version | Feature support |
+| :---------: |:-----------:|
+| 1.14 | Stable |
+| 1.10 | Beta (on by default)|
+| 1.9 | Alpha |
 
 {{% /capture %}}
 


### PR DESCRIPTION
Ref https://github.com/kubernetes/enhancements/issues/504, Pod DNS Config (configurable pod resolv.conf) is becoming GA in k8s 1.14.