### PR TITLE
Alias for kubectl that works with completion

### DIFF
--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -29,7 +29,7 @@ source <(kubectl completion bash) # setup autocomplete in bash into the current 
 echo "source <(kubectl completion bash)" >> ~/.bashrc # add autocomplete permanently to your bash shell.
 ```
 
-Use a shorthand alias for `kubectl` that also works with completion: 
+You can also use a shorthand alias for `kubectl` that also works with completion: 
 
 ```bash
 alias k=kubectl

--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -29,6 +29,13 @@ source <(kubectl completion bash) # setup autocomplete in bash into the current 
 echo "source <(kubectl completion bash)" >> ~/.bashrc # add autocomplete permanently to your bash shell.
 ```
 
+Use a shorthand alias for `kubectl` that also works with completion: 
+
+```bash
+alias k=kubectl
+complete -F __start_kubectl k
+```
+
 ### ZSH
 
 ```bash


### PR DESCRIPTION
Use a shorthand alias for `kubectl` that also works with completion. Using completion is great but typing `kubectl` each time is annoying.