### PR TITLE
Fix #9805 - Correct tags to avoid HTML encoding issue

### DIFF
--- a/content/en/docs/concepts/overview/object-management-kubectl/imperative-command.md
+++ b/content/en/docs/concepts/overview/object-management-kubectl/imperative-command.md
@@ -73,7 +73,7 @@ that must be set:
 The `kubectl` command also supports update commands driven by an aspect of the object.
 Setting this aspect may set different fields for different object types:
 
-- `set` <field>: Set an aspect of an object.
+- `set` `<field>`: Set an aspect of an object.
 
 {{< note >}}
 In Kubernetes version 1.5, not every verb-driven command has an associated aspect-driven command.
@@ -160,5 +160,3 @@ kubectl create --edit -f /tmp/srv.yaml
 - [Kubectl Command Reference](/docs/reference/generated/kubectl/kubectl/)
 - [Kubernetes API Reference](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/)
 {{% /capture %}}
-
-

--- a/content/en/docs/concepts/workloads/pods/init-containers.md
+++ b/content/en/docs/concepts/workloads/pods/init-containers.md
@@ -83,7 +83,7 @@ Here are some ideas for how to use Init Containers:
 
 * Register this Pod with a remote server from the downward API with a command like:
 
-      curl -X POST http://$MANAGEMENT_SERVICE_HOST:$MANAGEMENT_SERVICE_PORT/register -d 'instance=$(<POD_NAME>)&ip=$(<POD_IP>)'
+      `curl -X POST http://$MANAGEMENT_SERVICE_HOST:$MANAGEMENT_SERVICE_PORT/register -d 'instance=$(<POD_NAME>)&ip=$(<POD_IP>)'`
 
 * Wait for some time before starting the app Container with a command like `sleep 60`.
 * Clone a git repository into a volume.

--- a/content/en/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
+++ b/content/en/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
@@ -73,14 +73,14 @@ If you have a DNS Deployment, your scale target is:
 
     Deployment/<your-deployment-name>
 
-where <dns-deployment-name> is the name of your DNS Deployment. For example, if
+where `<your-deployment-name>` is the name of your DNS Deployment. For example, if
 your DNS Deployment name is coredns, your scale target is Deployment/coredns.
 
 If you have a DNS ReplicationController, your scale target is:
 
     ReplicationController/<your-rc-name>
 
-where <your-rc-name> is the name of your DNS ReplicationController. For example,
+where `<your-rc-name>` is the name of your DNS ReplicationController. For example,
 if your DNS ReplicationController name is kube-dns-v20, your scale target is
 ReplicationController/kube-dns-v20.
 
@@ -238,6 +238,3 @@ is under consideration as a future development.
 Learn more about the
 [implementation of cluster-proportional-autoscaler](https://github.com/kubernetes-incubator/cluster-proportional-autoscaler).
 {{% /capture %}}
-
-
-


### PR DESCRIPTION
There are a couple of encoding issues which are not yet fixed in this issue #9805 

The change is made in the following three pages. Attaching before and after changes to view. 

1.  https://kubernetes.io/docs/concepts/overview/object-management-kubectl/imperative-command/#how-to-update-objects

<img width="1103" alt="screen shot 1940-11-17 at 5 27 29 pm" src="https://user-images.githubusercontent.com/6227784/52340411-b9c77280-2a35-11e9-900b-07002e892935.png">
<img width="1122" alt="screen shot 1940-11-17 at 5 28 07 pm" src="https://user-images.githubusercontent.com/6227784/52340418-bd5af980-2a35-11e9-923f-c88c461b9ec9.png">

2. https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#examples

<img width="962" alt="screen shot 1940-11-17 at 5 23 32 pm" src="https://user-images.githubusercontent.com/6227784/52340531-f7c49680-2a35-11e9-9ae0-6a0a8da21569.png">
<img width="1094" alt="screen shot 1940-11-17 at 5 16 03 pm" src="https://user-images.githubusercontent.com/6227784/52340538-fd21e100-2a35-11e9-81dd-9e1fa6eea543.png">

3. https://kubernetes.io/docs/tasks/administer-cluster/dns-horizontal-autoscaling/#determining-your-scale-target

<img width="1160" alt="screen shot 1940-11-17 at 5 21 37 pm" src="https://user-images.githubusercontent.com/6227784/52340602-2c385280-2a36-11e9-9134-c781ec562894.png">
<img width="1146" alt="screen shot 1940-11-17 at 5 22 56 pm" src="https://user-images.githubusercontent.com/6227784/52340609-30647000-2a36-11e9-8d87-b5582fb4342c.png">

As mentioned in the original Issue, I verified the other links provided and rest all look good/ are fixed. 
