### PR TITLE
fix typo in install-kubeadm.md

### DIFF
--- a/content/en/docs/setup/independent/install-kubeadm.md
+++ b/content/en/docs/setup/independent/install-kubeadm.md
@@ -105,7 +105,7 @@ You will install these packages on all of your machines:
 * `kubectl`: the command line util to talk to your cluster.
 
 kubeadm **will not** install or manage `kubelet` or `kubectl` for you, so you will
-need to ensure they match the version of the Kubernetes control panel you want
+need to ensure they match the version of the Kubernetes control plane you want
 kubeadm to install for you. If you do not, there is a risk of a version skew occurring that
 can lead to unexpected, buggy behaviour. However, _one_ minor version skew between the
 kubelet and the control plane is supported, but the kubelet version may never exceed the API


### PR DESCRIPTION
"Kubernetes control panel" instead of "Kubernetes control plane"
