### PR TITLE
Document owner ref restrictions explicitly

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/garbage-collection.md
+++ b/content/en/docs/concepts/workloads/controllers/garbage-collection.md
@@ -60,6 +60,14 @@ metadata:
   ...
 ```
 
+{{< note >}}
+Cross-namespace owner references is disallowed by design. This means: 
+1) Namespace-scoped dependents can only specify owners in the same namespace,
+and owners that are cluster-scoped.
+2) Cluster-scoped dependents can only specify cluster-scoped owners, but not
+namespace-scoped owners.
+{{< /note >}}
+
 ## Controlling how the garbage collector deletes dependents
 
 When you delete an object, you can specify whether the object's dependents are


### PR DESCRIPTION
This is not a new feature, just an undocumented old behavior. 

cc @caesarxuchao @liggitt 