### PR TITLE
[Doc/HPA] Correcting default HPA sync period

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -37,7 +37,7 @@ to match the observed average CPU utilization to the target specified by user.
 
 The Horizontal Pod Autoscaler is implemented as a control loop, with a period controlled
 by the controller manager's `--horizontal-pod-autoscaler-sync-period` flag (with a default
-value of 30 seconds).
+value of 15 seconds).
 
 During each period, the controller manager queries the resource utilization against the
 metrics specified in each HorizontalPodAutoscaler definition.  The controller manager


### PR DESCRIPTION
Horizontal Pod Autoscaler default sync period is 15 seconds
https://github.com/kubernetes/kubernetes/blob/1b28775db1290a772967d192a19a8ec447053cd5/pkg/controller/apis/config/v1alpha1/defaults.go#L159
