### PR TITLE
Change typo in `kubectl` output from ClusterIP to LoadBalancer

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/connecting-frontend-backend.md
+++ b/content/en/docs/tasks/access-application-cluster/connecting-frontend-backend.md
@@ -169,16 +169,16 @@ This displays the configuration for the `frontend` Service and watches for
 changes. Initially, the external IP is listed as `<pending>`:
 
 ```
-NAME       TYPE       CLUSTER-IP      EXTERNAL-IP   PORT(S)  AGE
-frontend   ClusterIP  10.51.252.116   <pending>     80/TCP   10s
+NAME       TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)  AGE
+frontend   LoadBalancer   10.51.252.116   <pending>     80/TCP   10s
 ```
 
 As soon as an external IP is provisioned, however, the configuration updates
 to include the new IP under the `EXTERNAL-IP` heading:
 
 ```
-NAME       TYPE        CLUSTER-IP      EXTERNAL-IP        PORT(S)  AGE
-frontend   ClusterIP   10.51.252.116   XXX.XXX.XXX.XXX    80/TCP   1m
+NAME       TYPE           CLUSTER-IP      EXTERNAL-IP        PORT(S)  AGE
+frontend   LoadBalancer   10.51.252.116   XXX.XXX.XXX.XXX    80/TCP   1m
 ```
 
 That IP can now be used to interact with the `frontend` service from outside the


### PR DESCRIPTION
The frontend service should show type of "LoadBalancer"
