### PR TITLE
Fix a misleading word in containers/images.md

### DIFF
--- a/content/en/docs/concepts/containers/images.md
+++ b/content/en/docs/concepts/containers/images.md
@@ -318,7 +318,7 @@ type: kubernetes.io/dockerconfigjson
 
 If you get the error message `error: no objects passed to create`, it may mean the base64 encoded string is invalid.
 If you get an error message like `Secret "myregistrykey" is invalid: data[.dockerconfigjson]: invalid value ...`, it means
-the data was successfully un-base64 encoded, but could not be parsed as a `.docker/config.json` file.
+the data was successfully base64 encoded, but could not be parsed as a `.docker/config.json` file.
 
 #### Referring to an imagePullSecrets on a Pod
 

--- a/content/en/docs/concepts/containers/images.md
+++ b/content/en/docs/concepts/containers/images.md
@@ -318,7 +318,7 @@ type: kubernetes.io/dockerconfigjson
 
 If you get the error message `error: no objects passed to create`, it may mean the base64 encoded string is invalid.
 If you get an error message like `Secret "myregistrykey" is invalid: data[.dockerconfigjson]: invalid value ...`, it means
-the data was successfully base64 encoded, but could not be parsed as a `.docker/config.json` file.
+the base64 encoded string in the data was successfully decoded, but could not be parsed as a `.docker/config.json` file.
 
 #### Referring to an imagePullSecrets on a Pod
 


### PR DESCRIPTION
This PR update a minor misleading word in concepts/containers/images.md
(**un-base64** encoded -> **base64** decoded)

In https://kubernetes.io/docs/concepts/containers/images/#bypassing-kubectl-create-secrets , 
there is a sentence with "**un-base64** encoded".

> If you get the error message `error: no objects passed to create`, it may mean the base64 encoded string is invalid.
> If you get an error message like `Secret "myregistrykey" is invalid: data[.dockerconfigjson]: invalid value ...`, it means the data was successfully **un-base64 encoded**, but could not be parsed as a `.docker/config.json` file.

--------------------------
I updated PR as follows,
it means the data was successfully un-base64 encoded
->
it means the base64 encoded string in the data was successfully decoded