### PR TITLE
Update fluentd 0.12 to 1.0 in the example

### DIFF
--- a/content/en/docs/tasks/debug-application-cluster/audit.md
+++ b/content/en/docs/tasks/debug-application-cluster/audit.md
@@ -301,7 +301,11 @@ Fluent-plugin-forest and fluent-plugin-rewrite-tag-filter are plugins for fluent
     <match audit>
         # route audit according to namespace element in context
         @type rewrite_tag_filter
-        rewriterule1 namespace ^(.+) ${tag}.$1
+        <rule>
+            key namespace
+            pattern /^(.+)/
+            tag ${tag}.$1
+        </rule>
     </match>
 
     <filter audit.**>
@@ -420,8 +424,8 @@ plugin which supports full-text search and analytics.
 [gce-audit-profile]: https://github.com/kubernetes/kubernetes/blob/{{< param "githubbranch" >}}/cluster/gce/gci/configure-helper.sh#L735
 [kubeconfig]: /docs/tasks/access-application-cluster/configure-access-multiple-clusters/
 [fluentd]: http://www.fluentd.org/
-[fluentd_install_doc]: http://docs.fluentd.org/v0.12/articles/quickstart#step1-installing-fluentd
-[fluentd_plugin_management_doc]: https://docs.fluentd.org/v0.12/articles/plugin-management
+[fluentd_install_doc]: https://docs.fluentd.org/v1.0/articles/quickstart#step-1:-installing-fluentd
+[fluentd_plugin_management_doc]: https://docs.fluentd.org/v1.0/articles/plugin-management
 [logstash]: https://www.elastic.co/products/logstash
 [logstash_install_doc]: https://www.elastic.co/guide/en/logstash/current/installing-logstash.html
 [kube-aggregator]: /docs/concepts/api-extension/apiserver-aggregation

--- a/content/en/docs/tasks/debug-application-cluster/audit.md
+++ b/content/en/docs/tasks/debug-application-cluster/audit.md
@@ -207,13 +207,13 @@ By default truncate is disabled in both `webhook` and `log`, a cluster administr
 
 {{< feature-state for_k8s_version="v1.13" state="alpha" >}}
 
-In Kubernetes version 1.13, you can configure dynamic audit webhook backends AuditSink API objects. 
+In Kubernetes version 1.13, you can configure dynamic audit webhook backends AuditSink API objects.
 
 To enable dynamic auditing you must set the following apiserver flags:
 
-- `--audit-dynamic-configuration`: the primary switch. When the feature is at GA, the only required flag.   
-- `--feature-gates=DynamicAuditing=true`: feature gate at alpha and beta.   
-- `--runtime-config=auditregistration.k8s.io/v1alpha1=true`: enable API.   
+- `--audit-dynamic-configuration`: the primary switch. When the feature is at GA, the only required flag.
+- `--feature-gates=DynamicAuditing=true`: feature gate at alpha and beta.
+- `--runtime-config=auditregistration.k8s.io/v1alpha1=true`: enable API.
 
 When enabled, an AuditSink object can be provisioned:
 


### PR DESCRIPTION
[Log Collector Examples](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#log-collector-examples) was really helpful, but I suggest fluentd be updated to current stable version 1.0. I modified 2 documentation links, and syntax in the example.

syntax references:
- https://docs.fluentd.org/v0.12/articles/out_rewrite_tag_filter
- https://docs.fluentd.org/v1.0/articles/out_rewrite_tag_filter