### PR TITLE
Better example of a preStop hook for nginx

### DIFF
--- a/content/en/examples/pods/lifecycle-events.yaml
+++ b/content/en/examples/pods/lifecycle-events.yaml
@@ -12,5 +12,5 @@ spec:
           command: ["/bin/sh", "-c", "echo Hello from the postStart handler > /usr/share/message"]
       preStop:
         exec:
-          command: ["/usr/sbin/nginx","-s","quit"]
+          command: ["/bin/sh","-c","nginx -s quit; while killall -0 nginx; do sleep 1; done"]
 


### PR DESCRIPTION
It looks like `nginx -s quit` returns immediately rather than blocking until nginx has finished gracefully shutting down. As a result, just running `nginx -s quit` in the preStop hook won't work very well for high load and/or long running requests; nginx will get a TERM signal (and do a hard shutdown) immediately after `nginx -s quit` returns.

(I was getting connection errors while terminating pods, and adding a sleep-until-done to the preStop hook seemed to make them go away.)
