### PR TITLE
Fix SSH tunnel links

### DIFF
--- a/content/en/docs/concepts/architecture/master-node-communication.md
+++ b/content/en/docs/concepts/architecture/master-node-communication.md
@@ -104,6 +104,6 @@ all traffic destined for a kubelet, node, pod, or service through the tunnel.
 This tunnel ensures that the traffic is not exposed outside of the network in
 which the nodes are running.
 
-SSH tunnels are deprecated, but a replacement is being designed.
+SSH tunnels are currently deprecated so you shouldn't opt to use them unless you know what you are doing. A replacement for this communication channel is being designed.
 
 {{% /capture %}}

--- a/content/en/docs/concepts/architecture/master-node-communication.md
+++ b/content/en/docs/concepts/architecture/master-node-communication.md
@@ -77,7 +77,7 @@ To verify this connection, use the `--kubelet-certificate-authority` flag to
 provide the apiserver with a root certificate bundle to use to verify the
 kubelet's serving certificate.
 
-If that is not possible, use [SSH tunneling](/docs/tasks/access-application-cluster/port-forward-access-application-cluster/)
+If that is not possible, use [SSH tunneling](/docs/concepts/architecture/master-node-communication/#ssh-tunnels)
 between the apiserver and kubelet if required to avoid connecting over an
 untrusted or public network.
 
@@ -94,5 +94,16 @@ provided by the HTTPS endpoint nor provide client credentials so while the
 connection will be encrypted, it will not provide any guarantees of integrity.
 These connections **are not currently safe** to run over untrusted and/or
 public networks.
+
+### SSH Tunnels
+
+Kubernetes supports SSH tunnels to protect the Master -> Cluster communication
+paths. In this configuration, the apiserver initiates an SSH tunnel to each node
+in the cluster (connecting to the ssh server listening on port 22) and passes
+all traffic destined for a kubelet, node, pod, or service through the tunnel.
+This tunnel ensures that the traffic is not exposed outside of the network in
+which the nodes are running.
+
+SSH tunnels are deprecated, but a replacement is being designed.
 
 {{% /capture %}}


### PR DESCRIPTION
* Removed reference to GKE, which seemed to prompt the initial removal.
* Fixed the link to refer back to the correct paragraph now that it exists again.
* Noted deprecation of SSH tunnels but work to create a replacement.

Fix #8262

This reverts commit 1da65603afa74f8491f9940314ad7eb597c7e2b6.

This reverts commit b8b71b6845a88989184e17d9939312398c3a044f.