### PR TITLE
Add cross-references to glossary

### DIFF
--- a/content/en/docs/reference/glossary/annotation.md
+++ b/content/en/docs/reference/glossary/annotation.md
@@ -14,5 +14,5 @@ tags:
 
 <!--more--> 
 
-The metadata in an annotation can be small or large, structured or unstructured, and can include characters not permitted by labels. Clients such as tools and libraries can retrieve this metadata.
+The metadata in an annotation can be small or large, structured or unstructured, and can include characters not permitted by {{< glossary_tooltip text="labels" term_id="label" >}}. Clients such as tools and libraries can retrieve this metadata.
 

--- a/content/en/docs/reference/glossary/cluster.md
+++ b/content/en/docs/reference/glossary/cluster.md
@@ -15,5 +15,4 @@ tags:
 
 <!--more--> 
 
-A cluster has several worker nodes and at least one master node.
-
+A cluster has several {{< glossary_tooltip text="worker nodes" term_id="node" >}} and at least one master node.

--- a/content/en/docs/reference/glossary/container-env-variables.md
+++ b/content/en/docs/reference/glossary/container-env-variables.md
@@ -10,8 +10,8 @@ aka:
 tags:
 - fundamental
 ---
- Container environment variables are name=value pairs that provide useful information into containers running in a Pod.
+ Container environment variables are name=value pairs that provide useful information into containers running in a {{< glossary_tooltip text="pod" term_id="pod" >}}
 
 <!--more-->
 
-Container environment variables provide information that is required by the running containerized applications along with information about important resources to the {{< glossary_tooltip text="Containers" term_id="container" >}}. For example, file system details, information about the container itself, and other cluster resources such as service endpoints.
+Container environment variables provide information that is required by the running containerized applications along with information about important resources to the {{< glossary_tooltip text="containers" term_id="container" >}}. For example, file system details, information about the container itself, and other cluster resources such as service endpoints.

--- a/content/en/docs/reference/glossary/deployment.md
+++ b/content/en/docs/reference/glossary/deployment.md
@@ -16,5 +16,5 @@ tags:
 
 <!--more--> 
 
-Each replica is represented by a {{< glossary_tooltip term_id="pod" >}}, and the Pods are distributed among the nodes of a cluster.
+Each replica is represented by a {{< glossary_tooltip term_id="pod" >}}, and the Pods are distributed among the {{< glossary_tooltip text="nodes" term_id="node" >}} of a cluster.
 

--- a/content/en/docs/reference/glossary/docker.md
+++ b/content/en/docs/reference/glossary/docker.md
@@ -10,7 +10,7 @@ aka:
 tags:
 - fundamental
 ---
- Docker is a software technology providing operating-system-level virtualization also known as containers.
+ Docker is a software technology providing operating-system-level virtualization also known as {{< glossary_tooltip text="containers" term_id="container" >}}.
 
 <!--more--> 
 

--- a/content/en/docs/reference/glossary/host-aliases.md
+++ b/content/en/docs/reference/glossary/host-aliases.md
@@ -10,7 +10,7 @@ aka:
 tags:
 - operation
 ---
- A HostAliases is a mapping between the IP address and hostname to be injected into a Pod's hosts file.
+ A HostAliases is a mapping between the IP address and hostname to be injected into a {{< glossary_tooltip text="Pod" term_id="pod" >}}'s hosts file.
 
 <!--more-->
 

--- a/content/en/docs/reference/glossary/image.md
+++ b/content/en/docs/reference/glossary/image.md
@@ -10,9 +10,9 @@ aka:
 tags:
 - fundamental
 ---
- Stored instance of a container that holds a set of software needed to run an application.
+ Stored instance of a {{< glossary_tooltip term_id="container" >}} that holds a set of software needed to run an application.
 
-<!--more--> 
+<!--more-->
 
 A way of packaging software that allows it to be stored in a container registry, pulled to a local system, and run as an application. Meta data is included in the image that can indicate what executable to run, who built it, and other information.
 

--- a/content/en/docs/reference/glossary/init-container.md
+++ b/content/en/docs/reference/glossary/init-container.md
@@ -4,15 +4,14 @@ id: init-container
 date: 2018-04-12
 full_link: 
 short_description: >
-  One or more initialization containers that must run to completion before any app containers run. 
+  One or more initialization containers that must run to completion before any app containers run.
 
 aka: 
 tags:
 - fundamental
 ---
- One or more initialization containers that must run to completion before any app containers run. 
+ One or more initialization {{< glossary_tooltip text="containers" term_id="container" >}} that must run to completion before any app containers run.
 
 <!--more--> 
 
-Initialization (init) containers are like regular app containers, with one difference: init containers must run to completion before any app containers can start. Init containers run in series: each init container must run to completion before the next init container begins.  
-
+Initialization (init) containers are like regular app containers, with one difference: init containers must run to completion before any app containers can start. Init containers run in series: each init container must run to completion before the next init container begins.

--- a/content/en/docs/reference/glossary/kube-proxy.md
+++ b/content/en/docs/reference/glossary/kube-proxy.md
@@ -11,7 +11,7 @@ tags:
 - fundamental
 - core-object
 ---
- `kube-proxy` is a network proxy that runs on each node in the cluster.
+ `kube-proxy` is a network proxy that runs on each {{< glossary_tooltip text="node" term_id="node" >}} in the cluster.
 
 <!--more--> 
 

--- a/content/en/docs/reference/glossary/kube-scheduler.md
+++ b/content/en/docs/reference/glossary/kube-scheduler.md
@@ -10,7 +10,7 @@ aka:
 tags:
 - architecture
 ---
- Component on the master that watches newly created pods that have no node assigned, and selects a node for them to run on.
+ Component on the master that watches newly created {{< glossary_tooltip text="pods" term_id="pod" >}} that have no {{< glossary_tooltip term_id="node" >}} assigned, and selects a node for them to run on.
 
 <!--more--> 
 

--- a/content/en/docs/reference/glossary/kubeadm.md
+++ b/content/en/docs/reference/glossary/kubeadm.md
@@ -15,5 +15,5 @@ tags:
 
 <!--more--> 
 
-You can use kubeadm to install both the control plane and the worker node components.
+You can use kubeadm to install both the control plane and the {{< glossary_tooltip text="worker node" term_id="node" >}} components.
 

--- a/content/en/docs/reference/glossary/kubelet.md
+++ b/content/en/docs/reference/glossary/kubelet.md
@@ -11,9 +11,8 @@ tags:
 - fundamental
 - core-object
 ---
- An agent that runs on each node in the cluster. It makes sure that containers are running in a pod.
+ An agent that runs on each {{< glossary_tooltip text="node" term_id="node" >}} in the cluster. It makes sure that {{< glossary_tooltip text="containers" term_id="container" >}} are running in a {{< glossary_tooltip text="pod" term_id="pod" >}}.
 
 <!--more--> 
 
 The kubelet takes a set of PodSpecs that are provided through various mechanisms and ensures that the containers described in those PodSpecs are running and healthy. The kubelet doesn’t manage containers which were not created by Kubernetes.
-

--- a/content/en/docs/reference/glossary/persistent-volume-claim.md
+++ b/content/en/docs/reference/glossary/persistent-volume-claim.md
@@ -11,7 +11,7 @@ tags:
 - core-object
 - storage
 ---
- Claims storage resources defined in a PersistentVolume so that it can be mounted as a volume in a container.
+ Claims storage resources defined in a PersistentVolume so that it can be mounted as a volume in a {{< glossary_tooltip text="container" term_id="container" >}}.
 
 <!--more--> 
 

--- a/content/en/docs/reference/glossary/pod-priority.md
+++ b/content/en/docs/reference/glossary/pod-priority.md
@@ -10,7 +10,7 @@ aka:
 tags:
 - operation
 ---
- Pod Priority indicates the importance of a Pod relative to other Pods.
+ Pod Priority indicates the importance of a {{< glossary_tooltip term_id="pod" >}} relative to other Pods.
 
 <!--more-->
 

--- a/content/en/docs/reference/glossary/podpreset.md
+++ b/content/en/docs/reference/glossary/podpreset.md
@@ -10,7 +10,7 @@ aka:
 tags:
 - operation
 ---
- An API object that injects information such as secrets, volume mounts, and environment variables into pods at creation time.
+ An API object that injects information such as secrets, volume mounts, and environment variables into {{< glossary_tooltip text="pods" term_id="pod" >}} at creation time.
 
 <!--more--> 
 

--- a/content/en/docs/reference/glossary/preemption.md
+++ b/content/en/docs/reference/glossary/preemption.md
@@ -10,7 +10,7 @@ aka:
 tags:
 - operation
 ---
- Preemption logic in Kubernetes helps a pending Pod to find a suitable Node by evicting low priority Pods existing on that Node.
+ Preemption logic in Kubernetes helps a pending {{< glossary_tooltip term_id="pod" >}} to find a suitable {{< glossary_tooltip term_id="node" >}} by evicting low priority Pods existing on that Node.
 
 <!--more-->
 

--- a/content/en/docs/reference/glossary/replica-set.md
+++ b/content/en/docs/reference/glossary/replica-set.md
@@ -16,5 +16,5 @@ tags:
 
 <!--more--> 
 
-ReplicaSet, like ReplicationController, ensures that a specified number of pods replicas are running at one time. ReplicaSet supports the new set-based selector requirements as described in the labels user guide, whereas a Replication Controller only supports equality-based selector requirements.
+ReplicaSet, like ReplicationController, ensures that a specified number of pods replicas are running at one time. ReplicaSet supports the new set-based {{< glossary_tooltip text="selector" term_id="selector" >}} requirements as described in the labels user guide, whereas a Replication Controller only supports equality-based selector requirements.
 

--- a/content/en/docs/reference/glossary/replication-controller.md
+++ b/content/en/docs/reference/glossary/replication-controller.md
@@ -11,7 +11,7 @@ tags:
 - workload
 - core-object
 ---
- Kubernetes service that ensures a specific number of instances of a pod are always running.
+ Kubernetes service that ensures a specific number of instances of a {{< glossary_tooltip text="Pod" term_id="pod" >}} are always running.
 
 <!--more--> 
 

--- a/content/en/docs/reference/glossary/security-context.md
+++ b/content/en/docs/reference/glossary/security-context.md
@@ -10,9 +10,9 @@ aka:
 tags:
 - security
 ---
- The securityContext field defines privilege and access control settings for a Pod or Container, including the runtime UID and GID.
+ The securityContext field defines privilege and access control settings for a {{< glossary_tooltip text="Pod" term_id="container" >}} or {{< glossary_tooltip text="Containers" term_id="container" >}}, including the runtime UID and GID.
 
-<!--more--> 
+<!--more-->
 
-The securityContext field in a {{< glossary_tooltip term_id="pod" >}} (applying to all containers) or container is used to set the user (runAsUser) and group (fsGroup), capabilities, privilege settings, and security policies (SELinux/AppArmor/Seccomp) that container processes use.
+The securityContext field in a Pod (applying to all containers) or container is used to set the user (runAsUser) and group (fsGroup), capabilities, privilege settings, and security policies (SELinux/AppArmor/Seccomp) that container processes use.
 

--- a/content/en/docs/reference/glossary/selector.md
+++ b/content/en/docs/reference/glossary/selector.md
@@ -10,9 +10,9 @@ aka:
 tags:
 - fundamental
 ---
- Allows users to filter a list of resources based on labels.
+ Allows users to filter a list of resources based on {{< glossary_tooltip text="labels" term_id="label" >}}.
 
 <!--more--> 
 
-Selectors are applied when querying lists of resources to filter them by {{< glossary_tooltip text="Labels" term_id="label" >}}.
+Selectors are applied when querying lists of resources to filter them by labels.
 

--- a/content/en/docs/reference/glossary/service-account.md
+++ b/content/en/docs/reference/glossary/service-account.md
@@ -15,5 +15,4 @@ tags:
 
 <!--more--> 
 
-When processes inside Pods access the cluster, they are authenticated by the API server as a particular service account, for example, `default`. When you create a Pod, if you do not specify a service account, it is automatically assigned the default service account in the same namespace {{< glossary_tooltip text="Namespace" term_id="namespace" >}}.
-
+When processes inside Pods access the cluster, they are authenticated by the API server as a particular service account, for example, `default`. When you create a Pod, if you do not specify a service account, it is automatically assigned the default service account in the same {{< glossary_tooltip text="namespace" term_id="namespace" >}}.

--- a/content/en/docs/reference/glossary/taint.md
+++ b/content/en/docs/reference/glossary/taint.md
@@ -11,7 +11,7 @@ tags:
 - core-object
 - fundamental
 ---
- A key-value pair and an effect to prevent the scheduling of pods on nodes or node groups.
+ A key-value pair and an effect to prevent the scheduling of {{< glossary_tooltip text="pods" term_id="pod" >}} on {{< glossary_tooltip text="nodes" term_id="node" >}} or node groups.
 
 <!--more-->
 

--- a/content/en/docs/reference/glossary/volume.md
+++ b/content/en/docs/reference/glossary/volume.md
@@ -11,9 +11,8 @@ tags:
 - core-object
 - fundamental
 ---
- A directory containing data, accessible to the containers in a {{< glossary_tooltip text="pod" term_id="pod" >}}.
+ A directory containing data, accessible to the {{< glossary_tooltip text="containers" term_id="container" >}} in a {{< glossary_tooltip term_id="pod" >}}.
 
 <!--more--> 
 
-A Kubernetes volume lives as long as the {{< glossary_tooltip text="pod" term_id="pod" >}} that encloses it. Consequently, a volume outlives any {{< glossary_tooltip text="containers" term_id="container" >}} that run within the {{< glossary_tooltip text="pod" term_id="pod" >}}, and data is preserved across {{< glossary_tooltip text="container" term_id="container" >}} restarts. 
-
+A Kubernetes volume lives as long as the pod that encloses it. Consequently, a volume outlives any containers that run within the pod, and data is preserved across container restarts.


### PR DESCRIPTION
Tangentially relevant to #5993

Where a glossary term uses another term in its definition, reference it.
For example: [kubelet](https://github.com/kubernetes/website/pull/12610/files#diff-5a06695e50dc585cca05032a68f3703eR14)