### PR TITLE
Fix #12574: update link to SSH tunneling

### DIFF
--- a/content/zh/docs/concepts/architecture/master-node-communication.md
+++ b/content/zh/docs/concepts/architecture/master-node-communication.md
@@ -52,7 +52,7 @@ Master 组件通过非安全（没有加密或认证）端口和集群的 apiser
 为了对这个连接进行认证，请使用 `--kubelet-certificate-authority` 标记给 apiserver 提供一个根证书捆绑，用于 kubelet 的服务证书。
 
 
-如果这样不可能，又要求避免在不可信的或公共的网络上进行连接，请在 apiserver 和 kubelet 之间使用 [SSH 隧道](/docs/concepts/architecture/master-node-communication/#ssh-tunnels)。
+如果这样不可能，又要求避免在不可信的或公共的网络上进行连接，请在 apiserver 和 kubelet 之间使用 [SSH 隧道](/docs/tasks/access-application-cluster/port-forward-access-application-cluster/)。
 
 
 最后，应该启用[Kubelet 用户认证和/或权限认证](/docs/admin/kubelet-authentication-authorization/)来保护 kubelet API。


### PR DESCRIPTION
The link to SSH tunneling is mistake.

Fix #12574