### PR TITLE
Add “webhook” to glossary

### DIFF
--- a/content/en/docs/reference/glossary/webhook.md
+++ b/content/en/docs/reference/glossary/webhook.md
@@ -1,0 +1,27 @@
+---
+title: Webhook
+id: webhook
+date: 2019-02-13
+full_link: /docs/reference/access-authn-authz/webhook/
+short_description: >
+  A way for one component to notify another component in real time, via HTTP.
+
+aka:
+tags:
+- networking
+---
+ A notification message sent from one component to another component's unique URL,
+ via HTTP.
+
+<!--more-->
+
+The two components need not be related, and often are not. The sender need only
+know the URL of the recipient side. Typically, a webhook makes a `POST` request
+that includes a payload in JSON format. On the recipient side, the webhook can
+trigger further processing such as invalidating a cache and refetching.
+
+In Kubernetes, “webhook mode” refers to calling an external service via HTTP.
+You can configure Kubernetes so that its API server makes a `POST` to an
+external service when processing certain requests. The API server waits for
+a response to that `POST` so that it can continue processing the original
+request.

--- a/content/en/docs/reference/glossary/webhook.md
+++ b/content/en/docs/reference/glossary/webhook.md
@@ -21,7 +21,7 @@ that includes a payload in JSON format. On the recipient side, the webhook can
 trigger further processing such as invalidating a cache and refetching.
 
 In Kubernetes, “webhook mode” refers to calling an external service via HTTP.
-You can configure Kubernetes so that its API server makes a `POST` to an
-external service when processing certain requests. The API server waits for
-a response to that `POST` so that it can continue processing the original
-request.
+For example, there are [admission controllers](/docs/reference/access-authn-authz/admission-controllers/)
+that intercept requests to the Kubernetes API server and send these to an
+external service. These admission controllers stall the original request
+until the external service has responded.

--- a/content/en/docs/reference/glossary/webhook.md
+++ b/content/en/docs/reference/glossary/webhook.md
@@ -4,21 +4,22 @@ id: webhook
 date: 2019-02-13
 full_link: /docs/reference/access-authn-authz/webhook/
 short_description: >
-  A way for one component to notify another component in real time, via HTTP.
+  A way to notify a web service via HTTP, in real time.
 
 aka:
 tags:
 - networking
 ---
- A notification message sent from one component to another component's unique URL,
- via HTTP.
+ A de facto mechanism for sending event notifications to an external web service.
 
 <!--more-->
 
 The two components need not be related, and often are not. The sender need only
-know the URL of the recipient side. Typically, a webhook makes a `POST` request
-that includes a payload in JSON format. On the recipient side, the webhook can
-trigger further processing such as invalidating a cache and refetching.
+know the URL of the recipient side. Typically, the sending side makes a `POST`
+request to a pre-arranged URL on the recipient component. The body of that `POST`
+is either empty, or consists of machine-readable data such as JSON.
+On the receiving side, the webhook's arrival can trigger further processing such
+as invalidating a cache and refetching.
 
 In Kubernetes, “webhook mode” refers to calling an external service via HTTP.
 For example, there are [admission controllers](/docs/reference/access-authn-authz/admission-controllers/)

--- a/content/en/docs/reference/glossary/webhook.md
+++ b/content/en/docs/reference/glossary/webhook.md
@@ -25,3 +25,5 @@ For example, there are [admission controllers](/docs/reference/access-authn-auth
 that intercept requests to the Kubernetes API server and send these to an
 external service. These admission controllers stall the original request
 until the external service has responded.
+
+For more on webhooks in general, see [What Webhooks Are And Why You Should Care](http://timothyfitz.com/2009/02/09/what-webhooks-are-and-why-you-should-care/).


### PR DESCRIPTION
Relevant to #5993 

I'm aiming to make it clear that, in Kubernetes, a “webhook” is an HTTP request where the response is waited for and acted upon.

If someone is coming to Kubernetes from outside and is accustomed to treating Webhooks as asynchronous and one-way, this extra detail is there to help explain what's going on.