### PR TITLE
Correct Debian version in runc post, link to other CoreOS channels

### DIFF
--- a/content/en/blog/_posts/2019-02-11-runc-CVE-2019-5736.md
+++ b/content/en/blog/_posts/2019-02-11-runc-CVE-2019-5736.md
@@ -58,10 +58,10 @@ Another potential mitigation is to ensure all your container images are vetted a
 Upgrading runc can generally be accomplished by upgrading the package `runc` for your distribution or by upgrading your OS image if using immutable images. This is a list of known safe versions for various distributions and platforms:
 
 * Ubuntu - [`runc 1.0.0~rc4+dfsg1-6ubuntu0.18.10.1`](https://people.canonical.com/~ubuntu-security/cve/2019/CVE-2019-5736.html)
-* Debian - [`runc 0.1.1+dfsg1-2`](https://security-tracker.debian.org/tracker/CVE-2019-5736)
+* Debian - [`runc 1.0.0~rc6+dfsg1-2`](https://security-tracker.debian.org/tracker/CVE-2019-5736)
 * RedHat Enterprise Linux - [`docker 1.13.1-91.git07f3374.el7`](https://access.redhat.com/security/vulnerabilities/runcescape) (if SELinux is disabled)
 * Amazon Linux - [`docker 18.06.1ce-7.25.amzn1.x86_64`](https://alas.aws.amazon.com/ALAS-2019-1156.html)
-* CoreOS - [`2051.0.0`](https://coreos.com/releases/#2051.0.0)
+* CoreOS - Stable: [`1967.5.0`](https://coreos.com/releases/#1967.5.0) / Beta: [`2023.2.0`](https://coreos.com/releases/#2023.2.0) / Alpha: [`2051.0.0`](https://coreos.com/releases/#2051.0.0)
 * Kops Debian - [in progress](https://github.com/kubernetes/kops/pull/6460)
 * Docker - [`18.09.2`](https://github.com/docker/docker-ce/releases/tag/v18.09.2)
 


### PR DESCRIPTION
The specific version referenced for the Debian release was a vulnerable version, however the linked page listed the correct versions.

Added links to the fixed releases for all of the CoreOS channels.