### PR TITLE
Removed junk character from the output

### DIFF
--- a/content/en/docs/concepts/policy/pod-security-policy.md
+++ b/content/en/docs/concepts/policy/pod-security-policy.md
@@ -336,7 +336,6 @@ pause-7774d79b5-qrgcb   0/1       Pending   0         1s
 pause-7774d79b5-qrgcb   0/1       Pending   0         1s
 pause-7774d79b5-qrgcb   0/1       ContainerCreating   0         1s
 pause-7774d79b5-qrgcb   1/1       Running   0         2s
-^C
 ```
 
 ### Clean up


### PR DESCRIPTION
Removed a junk character from the output on this page: 

https://kubernetes.io/docs/concepts/policy/pod-security-policy/

For output of this command:

`
kubectl-user get pods --watch
`