### PR TITLE
Fix CCM implementation link error

### DIFF
--- a/content/zh/docs/concepts/architecture/cloud-controller.md
+++ b/content/zh/docs/concepts/architecture/cloud-controller.md
@@ -237,11 +237,12 @@ rules:
 
 以下云服务供应商为自己的云部署了CCM。
 
-* [Digital Ocean]()
-* [Oracle]()
-* [Azure]()
-* [GCE]()
-* [AWS]()
+* [Digital Ocean](https://github.com/digitalocean/digitalocean-cloud-controller-manager)
+* [Oracle](https://github.com/oracle/oci-cloud-controller-manager)
+* [Azure](https://github.com/kubernetes/kubernetes/tree/master/pkg/cloudprovider/providers/azure)
+* [GCE](https://github.com/kubernetes/kubernetes/tree/master/pkg/cloudprovider/providers/gce)
+* [AWS](https://github.com/kubernetes/kubernetes/tree/master/pkg/cloudprovider/providers/aws)
+* [BaiduCloud](https://github.com/baidu/cloud-provider-baiducloud)
 
 ## 群集管理
 


### PR DESCRIPTION
**What this PR does / why we need it:**
This pr fix CCM implementation link error according to https://github.com/kubernetes/website/blob/master/content/en/docs/concepts/architecture/cloud-controller.md
```
## Vendor Implementations

The following cloud providers have implemented CCMs:

* [Digital Ocean](https://github.com/digitalocean/digitalocean-cloud-controller-manager)
* [Oracle](https://github.com/oracle/oci-cloud-controller-manager)
* [Azure](https://github.com/kubernetes/kubernetes/tree/master/pkg/cloudprovider/providers/azure)
* [GCE](https://github.com/kubernetes/kubernetes/tree/master/pkg/cloudprovider/providers/gce)
* [AWS](https://github.com/kubernetes/kubernetes/tree/master/pkg/cloudprovider/providers/aws)
* [BaiduCloud](https://github.com/baidu/cloud-provider-baiducloud)
```