### PR TITLE
Illustrate negative-exists selector in cheat sheet

### DIFF
--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -139,6 +139,10 @@ kubectl get pods --sort-by='.status.containerStatuses[0].restartCount'
 kubectl get pods --selector=app=cassandra rc -o \
   jsonpath='{.items[*].metadata.labels.version}'
 
+# Get all worker nodes (use a selector to exclude results that have a label
+# named 'node-role.kubernetes.io/master')
+kubectl get node --selector='!node-role.kubernetes.io/master'
+
 # Get all running pods in the namespace
 kubectl get pods --field-selector=status.phase=Running
 


### PR DESCRIPTION
Add
```bash
kubectl get node --selector='!node-role.kubernetes.io/master'
```
to the cheat-sheet. This shows how to select resources without a particular label. It also gives a strong hint about what a positive-exists selector looks like.