### PR TITLE
Fix broken link in CSI glossary entry

### DIFF
--- a/content/en/docs/reference/glossary/csi.md
+++ b/content/en/docs/reference/glossary/csi.md
@@ -18,4 +18,4 @@ tags:
 CSI allows vendors to create custom storage plugins for Kubernetes without adding them to the Kubernetes repository (out-of-tree plugins). To use a CSI driver from a storage provider, you must first [deploy it to your cluster](https://kubernetes-csi.github.io/docs/Setup.html). You will then be able to create a {{< glossary_tooltip text="Storage Class" term_id="storage-class" >}} that uses that CSI driver.
 
 * [CSI in the Kubernetes documentation](https://kubernetes.io/docs/concepts/storage/volumes/#csi)
-* [List of available CSI drivers](https://kubernetes-csi.github.io/docs/Drivers.html)
+* [List of available CSI drivers](https://kubernetes-csi.github.io/docs/drivers.html)


### PR DESCRIPTION
Fix broken link in https://kubernetes.io/docs/reference/glossary/?all=true
(from “Container Storage Interface” to list of drivers)

Also, fix a writing style nit.

Resolves #12713