### PR TITLE
Clarified step of getting Kubernetes cluster name; fixed quoting in c…

### DIFF
--- a/content/en/docs/tasks/administer-cluster/access-cluster-api.md
+++ b/content/en/docs/tasks/administer-cluster/access-cluster-api.md
@@ -87,7 +87,7 @@ directly to the API server, like this:
 
 Using `grep/cut` approach:
 
-``` shell
+```shell
 # Check all possible clusters, as you .KUBECONFIG may have multiple contexts:
 kubectl config view -o jsonpath='{"Cluster name\tServer\n"}{range .clusters[*]}{.name}{"\t"}{.cluster.server}{"\n"}{end}'
 

--- a/content/en/docs/tasks/administer-cluster/access-cluster-api.md
+++ b/content/en/docs/tasks/administer-cluster/access-cluster-api.md
@@ -88,11 +88,14 @@ directly to the API server, like this:
 Using `grep/cut` approach:
 
 ``` shell
-# Check all possible clusters, as you .KUBECONFIG may have multiple contexts
-kubectl config view -o jsonpath='{range .clusters[*]}{.name}{"\t"}{.cluster.server}{"\n"}{end}'
+# Check all possible clusters, as you .KUBECONFIG may have multiple contexts:
+kubectl config view -o jsonpath='{"Cluster name\tServer\n"}{range .clusters[*]}{.name}{"\t"}{.cluster.server}{"\n"}{end}'
+
+# Select name of cluster you want to interact with from above output:
+export CLUSTER_NAME="some_server_name"
 
 # Point to the API server refering the cluster name
-APISERVER=$(kubectl config view -o jsonpath='{.clusters[?(@.name=="$CLUSTER_NAME")].cluster.server}')
+APISERVER=$(kubectl config view -o jsonpath="{.clusters[?(@.name==\"$CLUSTER_NAME\")].cluster.server}")
 
 # Gets the token value
 TOKEN=$(kubectl get secrets -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='default')].data.token}"|base64 -d)


### PR DESCRIPTION
…ommand that sets `APISERVER`.

Need to set `CLUSTER_NAME` before using it.
The single quote in the `APISERVER` command prevented the expansion of the `CLUSTER_NAME` variable.