### PR TITLE
client-go: use docs version param

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/access-cluster.md
+++ b/content/en/docs/tasks/access-application-cluster/access-cluster.md
@@ -142,8 +142,8 @@ client libraries.
 
 ### Go client
 
-* To get the library, run the following command: `go get k8s.io/client-go/<version number>/kubernetes`, see [INSTALL.md](https://github.com/kubernetes/client-go/blob/master/INSTALL.md#for-the-casual-user) for detailed installation instructions. See [https://github.com/kubernetes/client-go](https://github.com/kubernetes/client-go#compatibility-matrix) to see which versions are supported.
-* Write an application atop of the client-go clients. Note that client-go defines its own API objects, so if needed, please import API definitions from client-go rather than from the main repository, e.g., `import "k8s.io/client-go/1.4/pkg/api/v1"` is correct.
+* To get the library, run the following command: `go get k8s.io/client-go/{{< param "version" >}}/kubernetes`, see [INSTALL.md](https://github.com/kubernetes/client-go/blob/master/INSTALL.md#for-the-casual-user) for detailed installation instructions. If you want support for a different Kubernetes version, change `{{< param "version" >}}` to the version you want to use.
+* Write an application atop of the client-go clients. Note that client-go defines its own API objects, so if needed, please import API definitions from client-go rather than from the main repository, e.g., `import "k8s.io/client-go/{{< param "version" >}}/pkg/api/v1"` is correct.
 
 The Go client can use the same [kubeconfig file](/docs/concepts/cluster-administration/authenticate-across-clusters-kubeconfig/)
 as the kubectl CLI does to locate and authenticate to the apiserver. See this [example](https://git.k8s.io/client-go/examples/out-of-cluster-client-configuration/main.go).

--- a/content/en/docs/tasks/access-application-cluster/access-cluster.md
+++ b/content/en/docs/tasks/access-application-cluster/access-cluster.md
@@ -142,7 +142,10 @@ client libraries.
 
 ### Go client
 
-* To get the library, run the following command: `go get k8s.io/client-go/{{< param "version" >}}/kubernetes`, see [INSTALL.md](https://github.com/kubernetes/client-go/blob/master/INSTALL.md#for-the-casual-user) for detailed installation instructions. If you want support for a different Kubernetes version, change `{{< param "version" >}}` to the version you want to use.
+* To get the library, run:
+  `go get k8s.io/client-go/{{< param "version" >}}/kubernetes`
+  (see [INSTALL](https://github.com/kubernetes/client-go/blob/master/INSTALL.md#for-the-casual-user) for detailed installation instructions).
+  If you want support for a different Kubernetes version, change `{{< param "version" >}}` to the version you want to use.
 * Write an application atop of the client-go clients. Note that client-go defines its own API objects, so if needed, please import API definitions from client-go rather than from the main repository, e.g., `import "k8s.io/client-go/{{< param "version" >}}/pkg/api/v1"` is correct.
 
 The Go client can use the same [kubeconfig file](/docs/concepts/cluster-administration/authenticate-across-clusters-kubeconfig/)

--- a/content/en/docs/tasks/administer-cluster/access-cluster-api.md
+++ b/content/en/docs/tasks/administer-cluster/access-cluster-api.md
@@ -158,7 +158,10 @@ Kubernetes officially supports client libraries for [Go](#go-client) and
 
 #### Go client
 
-* To get the library, run the following command: `go get k8s.io/client-go/{{< param "version" >}}/kubernetes`, see [INSTALL.md](https://github.com/kubernetes/client-go/blob/master/INSTALL.md#for-the-casual-user) for detailed installation instructions. If you want support for a different Kubernetes version, change `{{< param "version" >}}` to the version you want to use.
+* To get the library, run:
+  `go get k8s.io/client-go/{{< param "version" >}}/kubernetes`
+  (see [INSTALL](https://github.com/kubernetes/client-go/blob/master/INSTALL.md#for-the-casual-user) for detailed installation instructions).
+  If you want support for a different Kubernetes version, change `{{< param "version" >}}` to the version you want to use.
 * Write an application atop of the client-go clients. Note that client-go defines its own API objects, so if needed, please import API definitions from client-go rather than from the main repository, e.g., `import "k8s.io/client-go/{{< param "version" >}}/pkg/api/v1"` is correct.
 
 The Go client can use the same [kubeconfig file](/docs/concepts/cluster-administration/authenticate-across-clusters-kubeconfig/)

--- a/content/en/docs/tasks/administer-cluster/access-cluster-api.md
+++ b/content/en/docs/tasks/administer-cluster/access-cluster-api.md
@@ -158,8 +158,8 @@ Kubernetes officially supports client libraries for [Go](#go-client) and
 
 #### Go client
 
-* To get the library, run the following command: `go get k8s.io/client-go/<version number>/kubernetes` See [https://github.com/kubernetes/client-go](https://github.com/kubernetes/client-go) to see which versions are supported.
-* Write an application atop of the client-go clients. Note that client-go defines its own API objects, so if needed, please import API definitions from client-go rather than from the main repository, e.g., `import "k8s.io/client-go/1.4/pkg/api/v1"` is correct.
+* To get the library, run the following command: `go get k8s.io/client-go/{{< param "version" >}}/kubernetes`, see [INSTALL.md](https://github.com/kubernetes/client-go/blob/master/INSTALL.md#for-the-casual-user) for detailed installation instructions. If you want support for a different Kubernetes version, change `{{< param "version" >}}` to the version you want to use.
+* Write an application atop of the client-go clients. Note that client-go defines its own API objects, so if needed, please import API definitions from client-go rather than from the main repository, e.g., `import "k8s.io/client-go/{{< param "version" >}}/pkg/api/v1"` is correct.
 
 The Go client can use the same [kubeconfig file](/docs/concepts/cluster-administration/authenticate-across-clusters-kubeconfig/)
 as the kubectl CLI does to locate and authenticate to the API server. See this [example](https://git.k8s.io/client-go/examples/out-of-cluster-client-configuration/main.go):


### PR DESCRIPTION
Change https://kubernetes.io/docs/tasks/administer-cluster/access-cluster-api/ and https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/ to direct people to use the `client-go` version matching the docs they're viewing.

Drop a strong hint about how to get a different client version.

Associated with #12662