### PR TITLE
Fix HPA metrics Resource from "kind" to "type" 

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -288,7 +288,7 @@ spec:
     resource:
       name: cpu
       target:
-        kind: AverageUtilization
+        type: AverageUtilization
         averageUtilization: 50
   - type: Pods
     pods:


### PR DESCRIPTION
**What this PR does / why we need it:**
Fix HPA metrics Resource from "kind" to "type" 

See: 
https://github.com/kubernetes/kubernetes/blob/9e4f8d6fae3a43833dbe9edcefd9170aa97496d7/staging/src/k8s.io/api/autoscaling/v2beta2/types.go#L201
```golang
// MetricTarget defines the target value, average value, or average utilization of a specific metric
type MetricTarget struct {
	// type represents whether the metric type is Utilization, Value, or AverageValue
	Type MetricTargetType `json:"type" protobuf:"bytes,1,name=type"`
	// value is the target value of the metric (as a quantity).
	// +optional
	Value *resource.Quantity `json:"value,omitempty" protobuf:"bytes,2,opt,name=value"`
	// averageValue is the target value of the average of the
	// metric across all relevant pods (as a quantity)
	// +optional
	AverageValue *resource.Quantity `json:"averageValue,omitempty" protobuf:"bytes,3,opt,name=averageValue"`
	// averageUtilization is the target value of the average of the
	// resource metric across all relevant pods, represented as a percentage of
	// the requested value of the resource for the pods.
	// Currently only valid for Resource metric source type
	// +optional
	AverageUtilization *int32 `json:"averageUtilization,omitempty" protobuf:"bytes,4,opt,name=averageUtilization"`
}
```