### PR TITLE
Fix bugs about kubeadm upgrading.

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-12.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-12.md
@@ -44,7 +44,8 @@ This page explains how to upgrade a Kubernetes cluster created with `kubeadm` fr
     apt-mark hold kubeadm
     {{% /tab %}}
     {{% tab name="CentOS, RHEL or Fedora" %}}
-    yum upgrade -y kubeadm-1.12.5 --disableexcludes=kubernetes
+    # replace "x" with the latest patch version
+    yum upgrade -y kubeadm-1.12.x --disableexcludes=kubernetes
     {{% /tab %}}
     {{< /tabs >}}
 

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-12.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-12.md
@@ -235,7 +235,8 @@ This page explains how to upgrade a Kubernetes cluster created with `kubeadm` fr
     apt-get upgrade -y kubelet kubeadm
     {{% /tab %}}
     {{% tab name="CentOS, RHEL or Fedora" %}}
-    yum upgrade -y kubelet kubeadm --disableexcludes=kubernetes
+    # replace "x" with the latest patch version
+    yum upgrade -y kubelet-1.12.x kubeadm-1.12.x --disableexcludes=kubernetes
     {{% /tab %}}
     {{< /tabs >}}
 

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-12.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-12.md
@@ -39,8 +39,9 @@ This page explains how to upgrade a Kubernetes cluster created with `kubeadm` fr
 
     {{< tabs name="k8s_install" >}}
     {{% tab name="Ubuntu, Debian or HypriotOS" %}}
+    # replace "x" with the latest patch version
     apt-mark unhold kubeadm && \
-    apt-get update && apt-get upgrade -y kubeadm && \
+    apt-get update && apt-get upgrade -y kubeadm=1.12.x-00 && \
     apt-mark hold kubeadm
     {{% /tab %}}
     {{% tab name="CentOS, RHEL or Fedora" %}}
@@ -231,8 +232,9 @@ This page explains how to upgrade a Kubernetes cluster created with `kubeadm` fr
 
     {{< tabs name="k8s_upgrade" >}}
     {{% tab name="Ubuntu, Debian or HypriotOS" %}}
+    # replace "x" with the latest patch version
     apt-get update
-    apt-get upgrade -y kubelet kubeadm
+    apt-get upgrade -y kubelet=1.12.x-00 kubeadm=1.12.x-00
     {{% /tab %}}
     {{% tab name="CentOS, RHEL or Fedora" %}}
     # replace "x" with the latest patch version

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-12.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-12.md
@@ -44,7 +44,7 @@ This page explains how to upgrade a Kubernetes cluster created with `kubeadm` fr
     apt-mark hold kubeadm
     {{% /tab %}}
     {{% tab name="CentOS, RHEL or Fedora" %}}
-    yum upgrade -y kubeadm --disableexcludes=kubernetes
+    yum upgrade -y kubeadm-1.12.5 --disableexcludes=kubernetes
     {{% /tab %}}
     {{< /tabs >}}
 


### PR DESCRIPTION
It will lead to the following error if using `yum upgrade -y kubeadm --disableexcludes=kubernetes` command:
<https://serverfault.com/questions/943696/fatal-unexpected-error-when-reading-kubeadm-config-configmap-clusterconfigurat>

Running `yum upgrade -y kubeadm --disableexcludes=kubernetes` command will upgrade the kubeadm to v1.13, but kubeadm v1.13 could not upgrade the v1.11 kubeadm cluster.

