### PR TITLE
update kubectl documentation

### DIFF
--- a/content/en/docs/concepts/cluster-administration/logging.md
+++ b/content/en/docs/concepts/cluster-administration/logging.md
@@ -35,7 +35,7 @@ a container that writes some text to standard output once per second.
 To run this pod, use the following command:
 
 ```shell
-$ kubectl create -f https://k8s.io/examples/debug/counter-pod.yaml
+$ kubectl apply -f https://k8s.io/examples/debug/counter-pod.yaml
 pod/counter created
 ```
 

--- a/content/en/docs/concepts/cluster-administration/logging.md
+++ b/content/en/docs/concepts/cluster-administration/logging.md
@@ -35,7 +35,7 @@ a container that writes some text to standard output once per second.
 To run this pod, use the following command:
 
 ```shell
-$ kubectl apply -f https://k8s.io/examples/debug/counter-pod.yaml
+kubectl apply -f https://k8s.io/examples/debug/counter-pod.yaml
 pod/counter created
 ```
 

--- a/content/en/docs/concepts/cluster-administration/manage-deployment.md
+++ b/content/en/docs/concepts/cluster-administration/manage-deployment.md
@@ -36,13 +36,13 @@ The resources will be created in the order they appear in the file. Therefore, i
 `kubectl apply` also accepts multiple `-f` arguments:
 
 ```shell
-$ kubectl apply -f https://k8s.io/examples/application/nginx/nginx-svc.yaml -f https://k8s.io/examples/application/nginx/nginx-deployment.yaml
+kubectl apply -f https://k8s.io/examples/application/nginx/nginx-svc.yaml -f https://k8s.io/examples/application/nginx/nginx-deployment.yaml
 ```
 
 And a directory can be specified rather than or in addition to individual files:
 
 ```shell
-$ kubectl apply -f https://k8s.io/examples/application/nginx/
+kubectl apply -f https://k8s.io/examples/application/nginx/
 ```
 
 `kubectl` will read any files with suffixes `.yaml`, `.yml`, or `.json`.
@@ -52,7 +52,7 @@ It is a recommended practice to put resources related to the same microservice o
 A URL can also be specified as a configuration source, which is handy for deploying directly from configuration files checked into github:
 
 ```shell
-$ kubectl apply -f https://raw.githubusercontent.com/kubernetes/website/master/content/en/examples/application/nginx/nginx-deployment.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/website/master/content/en/examples/application/nginx/nginx-deployment.yaml
 deployment.apps/my-nginx created
 ```
 
@@ -83,7 +83,7 @@ service "my-nginx-svc" deleted
 Because `kubectl` outputs resource names in the same syntax it accepts, it's easy to chain operations using `$()` or `xargs`:
 
 ```shell
-$ kubectl get $(kubectl apply -f docs/concepts/cluster-administration/nginx/ -o name | grep service)
+kubectl get $(kubectl apply -f docs/concepts/cluster-administration/nginx/ -o name | grep service)
 NAME           TYPE           CLUSTER-IP   EXTERNAL-IP   PORT(S)      AGE
 my-nginx-svc   LoadBalancer   10.0.0.208   <pending>     80/TCP       0s
 ```
@@ -108,14 +108,14 @@ project/k8s/development
 By default, performing a bulk operation on `project/k8s/development` will stop at the first level of the directory, not processing any subdirectories. If we had tried to create the resources in this directory using the following command, we would have encountered an error:
 
 ```shell
-$ kubectl apply -f project/k8s/development
+kubectl apply -f project/k8s/development
 error: you must provide one or more resources by argument or filename (.json|.yaml|.yml|stdin)
 ```
 
 Instead, specify the `--recursive` or `-R` flag with the `--filename,-f` flag as such:
 
 ```shell
-$ kubectl apply -f project/k8s/development --recursive
+kubectl apply -f project/k8s/development --recursive
 configmap/my-config created
 deployment.apps/my-deployment created
 persistentvolumeclaim/my-pvc created
@@ -320,7 +320,7 @@ Then, you can use [`kubectl apply`](/docs/reference/generated/kubectl/kubectl-co
 This command will compare the version of the configuration that you're pushing with the previous version and apply the changes you've made, without overwriting any automated changes to properties you haven't specified.
 
 ```shell
-$ kubectl apply -f https://k8s.io/examples/application/nginx/nginx-deployment.yaml
+kubectl apply -f https://k8s.io/examples/application/nginx/nginx-deployment.yaml
 deployment.apps/my-nginx configured
 ```
 
@@ -329,10 +329,6 @@ Note that `kubectl apply` attaches an annotation to the resource in order to det
 Currently, resources are created without this annotation, so the first invocation of `kubectl apply` will fall back to a two-way diff between the provided input and the current configuration of the resource. During this first invocation, it cannot detect the deletion of properties set when the resource was created. For this reason, it will not remove them.
 
 All subsequent calls to `kubectl apply`, and other commands that modify the configuration, such as `kubectl replace` and `kubectl edit`, will update the annotation, allowing subsequent calls to `kubectl apply` to detect and perform deletions using a three-way diff.
-
-{{< note >}}
-To use apply, always create resource initially with either `kubectl apply`.
-{{< /note >}}
 
 ### kubectl edit
 

--- a/content/en/docs/concepts/cluster-administration/manage-deployment.md
+++ b/content/en/docs/concepts/cluster-administration/manage-deployment.md
@@ -26,23 +26,23 @@ Many applications require multiple resources to be created, such as a Deployment
 Multiple resources can be created the same way as a single resource:
 
 ```shell
-$ kubectl create -f https://k8s.io/examples/application/nginx-app.yaml
+$ kubectl apply -f https://k8s.io/examples/application/nginx-app.yaml
 service/my-nginx-svc created
 deployment.apps/my-nginx created
 ```
 
 The resources will be created in the order they appear in the file. Therefore, it's best to specify the service first, since that will ensure the scheduler can spread the pods associated with the service as they are created by the controller(s), such as Deployment.
 
-`kubectl create` also accepts multiple `-f` arguments:
+`kubectl apply` also accepts multiple `-f` arguments:
 
 ```shell
-$ kubectl create -f https://k8s.io/examples/application/nginx/nginx-svc.yaml -f https://k8s.io/examples/application/nginx/nginx-deployment.yaml
+$ kubectl apply -f https://k8s.io/examples/application/nginx/nginx-svc.yaml -f https://k8s.io/examples/application/nginx/nginx-deployment.yaml
 ```
 
 And a directory can be specified rather than or in addition to individual files:
 
 ```shell
-$ kubectl create -f https://k8s.io/examples/application/nginx/
+$ kubectl apply -f https://k8s.io/examples/application/nginx/
 ```
 
 `kubectl` will read any files with suffixes `.yaml`, `.yml`, or `.json`.
@@ -52,7 +52,7 @@ It is a recommended practice to put resources related to the same microservice o
 A URL can also be specified as a configuration source, which is handy for deploying directly from configuration files checked into github:
 
 ```shell
-$ kubectl create -f https://raw.githubusercontent.com/kubernetes/website/master/content/en/examples/application/nginx/nginx-deployment.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/kubernetes/website/master/content/en/examples/application/nginx/nginx-deployment.yaml
 deployment.apps/my-nginx created
 ```
 
@@ -83,7 +83,7 @@ service "my-nginx-svc" deleted
 Because `kubectl` outputs resource names in the same syntax it accepts, it's easy to chain operations using `$()` or `xargs`:
 
 ```shell
-$ kubectl get $(kubectl create -f docs/concepts/cluster-administration/nginx/ -o name | grep service)
+$ kubectl get $(kubectl apply -f docs/concepts/cluster-administration/nginx/ -o name | grep service)
 NAME           TYPE           CLUSTER-IP   EXTERNAL-IP   PORT(S)      AGE
 my-nginx-svc   LoadBalancer   10.0.0.208   <pending>     80/TCP       0s
 ```
@@ -108,14 +108,14 @@ project/k8s/development
 By default, performing a bulk operation on `project/k8s/development` will stop at the first level of the directory, not processing any subdirectories. If we had tried to create the resources in this directory using the following command, we would have encountered an error:
 
 ```shell
-$ kubectl create -f project/k8s/development
+$ kubectl apply -f project/k8s/development
 error: you must provide one or more resources by argument or filename (.json|.yaml|.yml|stdin)
 ```
 
 Instead, specify the `--recursive` or `-R` flag with the `--filename,-f` flag as such:
 
 ```shell
-$ kubectl create -f project/k8s/development --recursive
+$ kubectl apply -f project/k8s/development --recursive
 configmap/my-config created
 deployment.apps/my-deployment created
 persistentvolumeclaim/my-pvc created
@@ -126,7 +126,7 @@ The `--recursive` flag works with any operation that accepts the `--filename,-f`
 The `--recursive` flag also works when multiple `-f` arguments are provided:
 
 ```shell
-$ kubectl create -f project/k8s/namespaces -f project/k8s/development --recursive
+$ kubectl apply -f project/k8s/namespaces -f project/k8s/development --recursive
 namespace/development created
 namespace/staging created
 configmap/my-config created
@@ -169,7 +169,7 @@ and
 The labels allow us to slice and dice our resources along any dimension specified by a label:
 
 ```shell
-$ kubectl create -f examples/guestbook/all-in-one/guestbook-all-in-one.yaml
+$ kubectl apply -f examples/guestbook/all-in-one/guestbook-all-in-one.yaml
 $ kubectl get pods -Lapp -Ltier -Lrole
 NAME                           READY     STATUS    RESTARTS   AGE       APP         TIER       ROLE
 guestbook-fe-4nlpb             1/1       Running   0          1m        guestbook   frontend   <none>
@@ -331,7 +331,7 @@ Currently, resources are created without this annotation, so the first invocatio
 All subsequent calls to `kubectl apply`, and other commands that modify the configuration, such as `kubectl replace` and `kubectl edit`, will update the annotation, allowing subsequent calls to `kubectl apply` to detect and perform deletions using a three-way diff.
 
 {{< note >}}
-To use apply, always create resource initially with either `kubectl apply` or `kubectl create --save-config`.
+To use apply, always create resource initially with either `kubectl apply`.
 {{< /note >}}
 
 ### kubectl edit
@@ -379,8 +379,7 @@ deployment.apps/my-nginx replaced
 
 At some point, you'll eventually need to update your deployed application, typically by specifying a new image or image tag, as in the canary deployment scenario above. `kubectl` supports several update operations, each of which is applicable to different scenarios.
 
-We'll guide you through how to create and update applications with Deployments. If your deployed application is managed by Replication Controllers,
-you should read [how to use `kubectl rolling-update`](/docs/tasks/run-application/rolling-update-replication-controller/) instead.
+We'll guide you through how to create and update applications with Deployments.
 
 Let's say you were running version 1.7.9 of nginx:
 

--- a/content/en/docs/concepts/configuration/assign-pod-node.md
+++ b/content/en/docs/concepts/configuration/assign-pod-node.md
@@ -69,7 +69,7 @@ Then add a nodeSelector like so:
 
 {{< codenew file="pods/pod-nginx.yaml" >}}
 
-When you then run `kubectl create -f https://k8s.io/examples/pods/pod-nginx.yaml`,
+When you then run `kubectl apply -f https://k8s.io/examples/pods/pod-nginx.yaml`,
 the Pod will get scheduled on the node that you attached the label to. You can
 verify that it worked by running `kubectl get pods -o wide` and looking at the
 "NODE" that the Pod was assigned to.

--- a/content/en/docs/concepts/configuration/overview.md
+++ b/content/en/docs/concepts/configuration/overview.md
@@ -23,7 +23,7 @@ This is a living document. If you think of something that is not on this list bu
 
 - Group related objects into a single file whenever it makes sense. One file is often easier to manage than several. See the [guestbook-all-in-one.yaml](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/guestbook/all-in-one/guestbook-all-in-one.yaml) file as an example of this syntax.
 
-- Note also that many `kubectl` commands can be called on a directory. For example, you can call `kubectl create` on a directory of config files.
+- Note also that many `kubectl` commands can be called on a directory. For example, you can call `kubectl apply` on a directory of config files.
 
 - Don't specify default values unnecessarily: simple, minimal configuration will make errors less likely.
 
@@ -97,7 +97,7 @@ The caching semantics of the underlying image provider make even `imagePullPolic
 
 ## Using kubectl
 
-- Use `kubectl apply -f <directory>` or `kubectl create -f <directory>`. This looks for Kubernetes configuration in all `.yaml`, `.yml`, and `.json` files in `<directory>` and passes it to `apply` or `create`.
+- Use `kubectl apply -f <directory>`. This looks for Kubernetes configuration in all `.yaml`, `.yml`, and `.json` files in `<directory>` and passes it to `apply`.
 
 - Use label selectors for `get` and `delete` operations instead of specific object names. See the sections on [label selectors](/docs/concepts/overview/working-with-objects/labels/#label-selectors) and [using labels effectively](/docs/concepts/cluster-administration/manage-deployment/#using-labels-effectively).
 

--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -72,6 +72,12 @@ the object on the Apiserver.
 $ kubectl create secret generic db-user-pass --from-file=./username.txt --from-file=./password.txt
 secret "db-user-pass" created
 ```
+{{< note >}}	
+Special characters such as `$`, `\*`, and `!` require escaping.	
+If the password you are using has special characters, you need to escape them using the `\\` character. For example, if your actual password is `S!B\*d$zDsb`, you should execute the command this way:	
+     kubectl create secret generic dev-db-secret --from-literal=username=devuser --from-literal=password=S\\!B\\\*d\\$zDsb	
+ You do not need to escape special characters in passwords from files (`--from-file`).	
+{{< /note >}}
 
 You can check that the secret was created like this:
 
@@ -135,7 +141,7 @@ data:
 Now create the Secret using [`kubectl apply`](/docs/reference/generated/kubectl/kubectl-commands#apply):
 
 ```shell
-$ kubectl apply -f ./secret.yaml
+kubectl apply -f ./secret.yaml
 secret "mysecret" created
 ```
 
@@ -242,14 +248,16 @@ the option `-w 0` to `base64` commands or the pipeline `base64 | tr -d '\n'` if
 `-w` option is not available.
 
 #### Creating a Secret from Generator
-You can also create a Secret from generators and then apply it to create the object on 
+Kubectl supports [managing objects using Kustomize](/docs/concepts/overview/object-management-kubectl/kustomization/)
+since 1.14. With this new feature,
+you can also create a Secret from generators and then apply it to create the object on 
 the Apiserver. The generators
 should be specified in a `kustomization.yaml` inside a directory.
 
 For example, to generate a Secret from files `./username.txt` and `./password.txt`
 ```shell
 # Create a kustomization.yaml file with SecretGenerator
-$ cat <<EOF >./kustomization.yaml
+cat <<EOF >./kustomization.yaml
 secretGenerator:
 - name: db-user-pass
   files:
@@ -296,13 +304,15 @@ secretGenerator:
   - password=secret
 EOF
 ```
-Apply the kustomization directory to create the Secert object.
+Apply the kustomization directory to create the Secret object.
 ```shell
 $ kubectl apply -k .
 secret/db-user-pass-dddghtt9b5 created
 ```
-Note that the generated Secrets name has a suffix appended by hashing the contents. This ensures that a new
+{{< note >}}
+The generated Secrets name has a suffix appended by hashing the contents. This ensures that a new
 Secret is generated each time the contents is modified.
+{{< /note >}}
 
 #### Decoding a Secret
 

--- a/content/en/docs/concepts/containers/images.md
+++ b/content/en/docs/concepts/containers/images.md
@@ -205,7 +205,7 @@ example, run these on your desktop/laptop:
 Verify by creating a pod that uses a private image, e.g.:
 
 ```yaml
-kubectl create -f - <<EOF
+kubectl apply -f - <<EOF
 apiVersion: v1
 kind: Pod
 metadata:
@@ -279,8 +279,19 @@ Kubernetes supports specifying registry keys on a pod.
 Run the following command, substituting the appropriate uppercase values:
 
 ```shell
-kubectl create secret docker-registry myregistrykey --docker-server=DOCKER_REGISTRY_SERVER --docker-username=DOCKER_USER --docker-password=DOCKER_PASSWORD --docker-email=DOCKER_EMAIL
-secret/myregistrykey created.
+$ cat <<EOF > ./kustomization.yaml
+secretGenerator:
+- name: myregistrykey
+  type: docker-registry
+  literals:
+  - docker-server=DOCKER_REGISTRY_SERVER
+  - docker-username=DOCKER_USER
+  - docker-password=DOCKER_PASSWORD
+  - docker-email=DOCKER_EMAIL
+EOF
+
+$ kubectl apply -k .
+secret/myregistrykey-66h7d4d986 created
 ```
 
 If you need access to multiple registries, you can create one secret for each registry.
@@ -290,42 +301,13 @@ when pulling images for your Pods.
 Pods can only reference image pull secrets in their own namespace,
 so this process needs to be done one time per namespace.
 
-##### Bypassing kubectl create secrets
-
-If for some reason you need multiple items in a single `.docker/config.json` or need
-control not given by the above command, then you can [create a secret using
-json or yaml](/docs/user-guide/secrets/#creating-a-secret-manually).
-
-Be sure to:
-
-- set the name of the data item to `.dockerconfigjson`
-- base64 encode the docker file and paste that string, unbroken
-  as the value for field `data[".dockerconfigjson"]`
-- set `type` to `kubernetes.io/dockerconfigjson`
-
-Example:
-
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: myregistrykey
-  namespace: awesomeapps
-data:
-  .dockerconfigjson: UmVhbGx5IHJlYWxseSByZWVlZWVlZWVlZWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGx5eXl5eXl5eXl5eXl5eXl5eXl5eSBsbGxsbGxsbGxsbGxsbG9vb29vb29vb29vb29vb29vb29vb29vb29vb25ubm5ubm5ubm5ubm5ubm5ubm5ubm5ubmdnZ2dnZ2dnZ2dnZ2dnZ2dnZ2cgYXV0aCBrZXlzCg==
-type: kubernetes.io/dockerconfigjson
-```
-
-If you get the error message `error: no objects passed to create`, it may mean the base64 encoded string is invalid.
-If you get an error message like `Secret "myregistrykey" is invalid: data[.dockerconfigjson]: invalid value ...`, it means
-the data was successfully un-base64 encoded, but could not be parsed as a `.docker/config.json` file.
-
 #### Referring to an imagePullSecrets on a Pod
 
 Now, you can create pods which reference that secret by adding an `imagePullSecrets`
 section to a pod definition.
 
-```yaml
+```shell
+$ cat <<EOF > pod.yaml
 apiVersion: v1
 kind: Pod
 metadata:
@@ -337,6 +319,12 @@ spec:
       image: janedoe/awesomeapp:v1
   imagePullSecrets:
     - name: myregistrykey
+EOF
+
+$ cat <<EOF >> ./kustomization.yaml
+resources:
+- pod.yaml
+EOF
 ```
 
 This needs to be done for each pod that is using a private registry.

--- a/content/en/docs/concepts/containers/images.md
+++ b/content/en/docs/concepts/containers/images.md
@@ -279,7 +279,7 @@ Kubernetes supports specifying registry keys on a pod.
 Run the following command, substituting the appropriate uppercase values:
 
 ```shell
-$ cat <<EOF > ./kustomization.yaml
+cat <<EOF > ./kustomization.yaml
 secretGenerator:
 - name: myregistrykey
   type: docker-registry
@@ -290,7 +290,7 @@ secretGenerator:
   - docker-email=DOCKER_EMAIL
 EOF
 
-$ kubectl apply -k .
+kubectl apply -k .
 secret/myregistrykey-66h7d4d986 created
 ```
 
@@ -307,7 +307,7 @@ Now, you can create pods which reference that secret by adding an `imagePullSecr
 section to a pod definition.
 
 ```shell
-$ cat <<EOF > pod.yaml
+cat <<EOF > pod.yaml
 apiVersion: v1
 kind: Pod
 metadata:
@@ -321,7 +321,7 @@ spec:
     - name: myregistrykey
 EOF
 
-$ cat <<EOF >> ./kustomization.yaml
+cat <<EOF >> ./kustomization.yaml
 resources:
 - pod.yaml
 EOF

--- a/content/en/docs/concepts/overview/object-management-kubectl/declarative-config.md
+++ b/content/en/docs/concepts/overview/object-management-kubectl/declarative-config.md
@@ -55,6 +55,10 @@ defined by configuration files in a specified directory:
 ```shell
 kubectl apply -f <directory>/
 ```
+or
+```shell
+kubectl apply -k <kustomization_directory>/
+```
 
 This sets the `kubectl.kubernetes.io/last-applied-configuration: '{...}'`
 annotation on each object. The annotation contains the contents of the object

--- a/content/en/docs/concepts/overview/object-management-kubectl/declarative-config.md
+++ b/content/en/docs/concepts/overview/object-management-kubectl/declarative-config.md
@@ -55,10 +55,6 @@ defined by configuration files in a specified directory:
 ```shell
 kubectl apply -f <directory>/
 ```
-or
-```shell
-kubectl apply -k <kustomization_directory>/
-```
 
 This sets the `kubectl.kubernetes.io/last-applied-configuration: '{...}'`
 annotation on each object. The annotation contains the contents of the object

--- a/content/en/docs/concepts/overview/object-management-kubectl/kustomization.md
+++ b/content/en/docs/concepts/overview/object-management-kubectl/kustomization.md
@@ -1,5 +1,5 @@
 ---
-title: Declarative Management of Kubernetes Objects Using Kustomization
+title: Declarative Management of Kubernetes Objects Using Kustomize
 content_template: templates/concept
 weight: 40
 ---
@@ -7,26 +7,32 @@ weight: 40
 {{% capture overview %}}
 [Kustomize](https://github.com/kubernetes-sigs/kustomize) is a standalone tool
 to customize Kubernetes objects
-through a [kusotmization file](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/kustomization.yaml). 
+through a [kustomization file](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/kustomization.yaml). 
 Since 1.14, Kubectl also
 supports the management of Kubernetes objects using a kustomization file.
-When dealing with Resources or objects from kustomization, the flag
-`--kusotmize` or `-k` need to be used in Kubectl commands.
+To view Resources found in a directory containing a kustomization file, run the following command:
+```shell
+kubectl kustomize <kustomization_directory>
+``` 
+To apply those Resources, run `kubectl apply` with `--kustomize` or `-k` flag:
+```shell
+kubectl apply -k <kustomization_directory>
+``` 
 {{% /capture %}}
 
 {{% capture body %}}
 
 ## Overview of Kustomize
-Kustomize is a tool for customizing Kubernetes configuration. 
-It offers simple tooling to manage configuration files for your applications with features from aspects as
+Kustomize is a tool for customizing Kubernetes configurations. It has the following features to manage application configuration files:
+
 * generating resources from other sources
 * setting cross-cutting fields for resources
 * composing and customizing collections of resources
 
 ### Generating Resources
-ConfigMap and Secrets hold config or sensitive data that are used by other Kubernetes objects, such as Pods. The source
-of truth of ConfigMap or Secrets are usually from somewhere else, such as a `.properties` file or a ssh key file.
-Kustomize has `secretGenerator` and `configMapGenerator`, which generate Secrets and ConfigMaps from files or literals.
+ConfigMap and Secret hold config or sensitive data that are used by other Kubernetes objects, such as Pods. The source
+of truth of ConfigMap or Secret are usually from somewhere else, such as a `.properties` file or a ssh key file.
+Kustomize has `secretGenerator` and `configMapGenerator`, which generate Secret and ConfigMap from files or literals.
 
 
 #### configMapGenerator
@@ -44,7 +50,7 @@ configMapGenerator:
   - application.properties
 EOF
 ```
-The generated ConfigMap can be checked by following command
+The generated ConfigMap can be checked by the following command:
 ```shell
 kubectl kustomize ./
 ```
@@ -59,7 +65,7 @@ metadata:
   name: example-configmap-1-8mbdf7882g
 ```
 
-ConfigMap can also be generated from literal key-value pairs. To generate a ConfigMap from a literal key-value pair, add an entry to `literal` list in configMapGenerator. Here is an example of generating a ConfigMap with a data item from a key-value pair.
+ConfigMap can also be generated from literal key-value pairs. To generate a ConfigMap from a literal key-value pair, add an entry to `literals` list in configMapGenerator. Here is an example of generating a ConfigMap with a data item from a key-value pair.
 ```shell
 cat <<EOF >./kustomization.yaml
 configMapGenerator:
@@ -68,7 +74,7 @@ configMapGenerator:
   - FOO=Bar
 EOF
 ```
-The generated ConfigMap can be checked by following command
+The generated ConfigMap can be checked by the following command:
 ```shell
 kubectl kustomize ./
 ```
@@ -83,7 +89,7 @@ metadata:
 ```
 
 #### secretGenerator
-Secrets can also be generated from files or literal key-value paris. To generate a Secret from a file, add an entry to `files` list in `secretGenerator`. Here is an example of generating a Secret with a data item from a file.
+Secret can also be generated from files or literal key-value pairs. To generate a Secret from a file, add an entry to `files` list in `secretGenerator`. Here is an example of generating a Secret with a data item from a file.
 ```shell
 # Create a password.txt file
 cat <<EOF >./password.txt
@@ -98,7 +104,7 @@ secretGenerator:
   - password.txt
 EOF
 ```
-The generated Secret is as following:
+The generated Secret is as follows:
 ```yaml
 apiVersion: v1
 data:
@@ -108,7 +114,7 @@ metadata:
   name: example-secret-1-t2kt65hgtb
 type: Opaque
 ```
-To generate a secret from a literal key-value pair, add an entry to `literals` list in `secretGenerator`. Here is an example of generating a Secret with a data item from a key-value pair.
+To generate a Secret from a literal key-value pair, add an entry to `literals` list in `secretGenerator`. Here is an example of generating a Secret with a data item from a key-value pair.
 ```shell
 cat <<EOF >./kustomization.yaml
 secretGenerator:
@@ -118,7 +124,7 @@ secretGenerator:
   - password=secert 
 EOF
 ```
-The generated Secret is as following:
+The generated Secret is as follows:
 ```yaml
 apiVersion: v1
 data:
@@ -131,7 +137,7 @@ type: Opaque
 ```
 
 #### generatorOptions
-The generated ConfigMaps and Secrets hvae a suffix appended by hashing the contents. This ensures that a new ConfigMap or Secret is generated when the content is changed. To disable the behavior of appending a suffix, one can use `generatorOptions`. Besides that, it is also possible to specify cross-cutting options for generated ConfigMaps and Secrets.
+The generated ConfigMaps and Secrets have a suffix appended by hashing the contents. This ensures that a new ConfigMap or Secret is generated when the content is changed. To disable the behavior of appending a suffix, one can use `generatorOptions`. Besides that, it is also possible to specify cross-cutting options for generated ConfigMaps and Secrets.
 ```shell
 cat <<EOF >./kustomization.yaml
 configMapGenerator:
@@ -146,7 +152,7 @@ generatorOptions:
     note: generated
 EOF
 ```
-By `kubectl kustomize ./`, you can see the generated ConfigMap as
+Run`kubectl kustomize ./` to view the generated ConfigMap:
 ```yaml
 apiVersion: v1
 data:
@@ -161,8 +167,9 @@ metadata:
 ```
 
 ### Setting cross-cutting fields
-It is quite common to set some cross-cutting fields at the same time for all
-Kubernetes Resources that are in the same project
+It is quite common to set cross-cutting fields for all Kubernetes resources in a project. 
+Some use cases for setting cross-cutting fields:
+
 * setting the same namespace for all Resource
 * adding the same name prefix or suffix
 * adding the same set of labels
@@ -204,7 +211,7 @@ resources:
 - deployment.yaml
 EOF
 ```
-By `kubectl kustomize ./`, you can see those fields are all set in the Deployment Resource.
+Run `kubectl kustomize ./` to view those fields are all set in the Deployment Resource:
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -232,12 +239,12 @@ spec:
 ```
 
 ### Composing and Customizing Resources
-It is common to compose a set of Resources in a project and management them inside
+It is common to compose a set of Resources in a project and manage them inside
 the same file or directory. 
 Kustomize offers composing Resources from different files and applying patches or other customization to them. 
 
 #### Composing
-To compose different Resource files in `kustomization.yaml`, one need to add those files to the `resources` list.
+Kustomize supports composition of different resources. The `resources` field, in the `kustomization.yaml` file, defines the list of resources to include in a configuration. Set the path to a resource's configuration file in the `resources` list.
 Here is an example for an nginx application with a Deployment and a Service.
 ```shell
 # Create a deployment.yaml file
@@ -289,7 +296,7 @@ EOF
 The Resources from `kubectl kustomize ./` contains both the Deployment and the Service objects.
 
 #### Customizing
-On top of Resources, one can apply different customization by applying patches. Kustomize supports different patching
+On top of Resources, one can apply different customizations by applying patches. Kustomize supports different patching
 mechanisms through `patchesStrategicMerge` and `patchesJson6902`. `patchesStrategicMerge` is a list of file paths. Each file should be resolved to a [strategic merge patch](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-api-machinery/strategic-merge-patch.md). The names inside the patches must match Resource names that are already loaded. Small patches that do one thing are recommended. For example, create one patch for increasing the deployment replica number and another patch for setting the memory limit.
 ```shell
 # Create a deployment.yaml file
@@ -349,7 +356,7 @@ patchesStrategicMerge:
 - set_memory.yaml
 EOF
 ```
-By `kubectl kustomize ./`, you can see that the Deployment object is as
+Run `kubectl kustomize ./` to view the Deployment:
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -423,7 +430,7 @@ patchesJson6902:
   path: patch.yaml  
 EOF
 ```
-By `kubectl kustomize ./`, you can see that the `replicas` field is updated.
+Run `kubectl kustomize ./` to see the `replicas` field is updated:
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -479,7 +486,7 @@ images:
   newTag: 1.4.0
 EOF
 ```
-By `kubectl kustomize ./`, you can see that the image being used is updated.
+Run `kubectl kustomize ./` to see that the image being used is updated:
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -501,11 +508,10 @@ spec:
         ports:
         - containerPort: 80
 ```
-Sometimes, the application running in Pods may need to know configuration from other objects. For example,
+Sometimes, the application running in a Pod may need to use configuration values from other objects. For example,
 a Pod from a Deployment object need to read the corresponding Service name from Env or as a command argument.
-Since the Service name may change as namePrefix or nameSuffix is added in the `kustomization.yaml` file. It is
-not recommended to hard code the Service name in the command argument. For this usage, Kustomize can inject
-the Service name dynamically into containers through `vars`.
+Since the Service name may change as `namePrefix` or `nameSuffix` is added in the `kustomization.yaml` file. It is
+not recommended to hard code the Service name in the command argument. For this usage, Kustomize can inject the Service name into containers through `vars`.
 
 ```shell
 # Create a deployment.yaml file
@@ -562,7 +568,7 @@ vars:
     apiVersion: v1
 EOF
 ```
-By `kubectl kustomize ./`, you can see that the Service name injected into containers is `dev-my-nginx-001`.
+Run `kubectl kustomize ./` to see that the Service name injected into containers is `dev-my-nginx-001`:
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -588,10 +594,10 @@ spec:
 ```
 
 ## Bases and Overlays
-Kustomize has concepts **bases** and **overlays**. A **base** is a directory with a `kustomization.yaml`, which contains a
+Kustomize has the concepts of **bases** and **overlays**. A **base** is a directory with a `kustomization.yaml`, which contains a
 set of resources and associated customization. A base could be either a local directory or a directory from a remote repo,
-as long sa a `kustomization.yaml` is present inside. An **overlay** is a directory with a `kustomization.yaml` that refers to other
-kustomization directories as its `bases`. A **base** has no knowledge of an overlay and can be used in multiple overlay.
+as long as a `kustomization.yaml` is present inside. An **overlay** is a directory with a `kustomization.yaml` that refers to other
+kustomization directories as its `bases`. A **base** has no knowledge of an overlay and can be used in multiple overlays.
 An overlay may have multiple bases and it composes all resources
 from bases and may also have customization on top of them.
 
@@ -600,7 +606,7 @@ Here is an example of a base.
 # Create a directory to hold the base
 mkdir base
 # Create a base/deployment.yaml
-at <<EOF > base/deployment.yaml
+cat <<EOF > base/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -618,7 +624,6 @@ spec:
       containers:
       - name: my-nginx
         image: nginx
-        command: ["start", "--host", "\$(MY_SERVICE_NAME)"]
 EOF
 
 # Create a base/service.yaml file
@@ -642,7 +647,7 @@ resources:
 - deployment.yaml
 - service.yaml
 ```
-This base can be used in multiple overlays. You can add different namePrefix or other cross-cutting fields
+This base can be used in multiple overlays. You can add different `namePrefix` or other cross-cutting fields
 in different overlays. Here are two overlays using the same base.
 ```shell
 mkdir dev
@@ -660,14 +665,14 @@ namePrefix: prod-
 EOF
 ```
 
-## How to apply/view/delete objects from Kustomization
-Use `--kustomize` or `-k` in kubectl commands to recognize Resources managed by `kustomization.yaml`. 
+## How to apply/view/delete objects using Kustomize
+Use `--kustomize` or `-k` in `kubectl` commands to recognize Resources managed by `kustomization.yaml`. 
 Note that `-k` should point to a kustomization directory, such as
 
 ```shell
 kubectl apply -k <kustomization directory>/
 ```
-Given following `kustomization.yaml` file and associated Resource files,
+Given the following `kustomization.yaml`,
 ```shell
 # Create a deployment.yaml file
 cat <<EOF > deployment.yaml
@@ -701,12 +706,12 @@ resources:
 - deployment.yaml
 EOF
 ```
-Running following command will apply the Deployment object `dev-my-nginx`
+Running the following command will apply the Deployment object `dev-my-nginx`:
 ```shell
 > kubectl apply -k ./
 deployment.apps/dev-my-nginx created
 ```
-Run following command to view the Deployment object
+Running the following command will get he Deployment object `dev-my-nginx`:
 ```shell
 kubectl get -k ./
 ```
@@ -714,7 +719,7 @@ or
 ```shell
 kubectl describe -k ./
 ```
-Run following command to delete the Deployment object
+Running the following command will delete the Deployment object `dev-my-nginx`:
 ```shell
 > kubectl delete -k ./
 deployment.apps "dev-my-nginx" deleted
@@ -724,7 +729,7 @@ deployment.apps "dev-my-nginx" deleted
 ## Kustomize Feature List
 Here is a list of all the features in Kustomize.
 
-| Field                 | Type                                                                                                         | Explanation                                                                        |  
+| Field                 | Type                                                                                                         | Explanation                                                                        |
 |-----------------------|--------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------|
 | namespace             | string                                                                                                       | add namespace to all resources                                                     |
 | namePrefix            | string                                                                                                       | value of this field is prepended to the names of all resources                     |
@@ -747,6 +752,7 @@ Here is a list of all the features in Kustomize.
 
 {{% capture whatsnext %}}
 - [Kustomize](https://github.com/kubernetes-sigs/kustomize)
+- [Kubectl Book](https://kubectl.docs.kubernetes.io)
 - [Kubectl Command Reference](/docs/reference/generated/kubectl/kubectl/)
 - [Kubernetes API Reference](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/)
 {{% /capture %}}

--- a/content/en/docs/concepts/overview/object-management-kubectl/kustomization.md
+++ b/content/en/docs/concepts/overview/object-management-kubectl/kustomization.md
@@ -1,0 +1,752 @@
+---
+title: Declarative Management of Kubernetes Objects Using Kustomization
+content_template: templates/concept
+weight: 40
+---
+
+{{% capture overview %}}
+[Kustomize](https://github.com/kubernetes-sigs/kustomize) is a standalone tool
+to customize Kubernetes objects
+through a [kusotmization file](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/kustomization.yaml). 
+Since 1.14, Kubectl also
+supports the management of Kubernetes objects using a kustomization file.
+When dealing with Resources or objects from kustomization, the flag
+`--kusotmize` or `-k` need to be used in Kubectl commands.
+{{% /capture %}}
+
+{{% capture body %}}
+
+## Overview of Kustomize
+Kustomize is a tool for customizing Kubernetes configuration. 
+It offers simple tooling to manage configuration files for your applications with features from aspects as
+* generating resources from other sources
+* setting cross-cutting fields for resources
+* composing and customizing collections of resources
+
+### Generating Resources
+ConfigMap and Secrets hold config or sensitive data that are used by other Kubernetes objects, such as Pods. The source
+of truth of ConfigMap or Secrets are usually from somewhere else, such as a `.properties` file or a ssh key file.
+Kustomize has `secretGenerator` and `configMapGenerator`, which generate Secrets and ConfigMaps from files or literals.
+
+
+#### configMapGenerator
+To generate a ConfigMap from a file, add an entry to `files` list in `configMapGenerator`. Here is an example of generating a ConfigMap with a data item from a file content.
+```shell
+# Create a application.properties file
+cat <<EOF >application.properties
+FOO=Bar
+EOF
+
+cat <<EOF >./kustomization.yaml
+configMapGenerator:
+- name: example-configmap-1
+  files:
+  - application.properties
+EOF
+```
+The generated ConfigMap can be checked by following command
+```shell
+kubectl kustomize ./
+```
+The generated ConfigMap is
+```yaml
+apiVersion: v1
+data:
+  application.properties: |
+    FOO=Bar
+kind: ConfigMap
+metadata:
+  name: example-configmap-1-8mbdf7882g
+```
+
+ConfigMap can also be generated from literal key-value pairs. To generate a ConfigMap from a literal key-value pair, add an entry to `literal` list in configMapGenerator. Here is an example of generating a ConfigMap with a data item from a key-value pair.
+```shell
+cat <<EOF >./kustomization.yaml
+configMapGenerator:
+- name: example-configmap-2
+  literals:
+  - FOO=Bar
+EOF
+```
+The generated ConfigMap can be checked by following command
+```shell
+kubectl kustomize ./
+```
+The generated ConfigMap is
+```yaml
+apiVersion: v1
+data:
+  FOO: Bar
+kind: ConfigMap
+metadata:
+  name: example-configmap-2-g2hdhfc6tk
+```
+
+#### secretGenerator
+Secrets can also be generated from files or literal key-value paris. To generate a Secret from a file, add an entry to `files` list in `secretGenerator`. Here is an example of generating a Secret with a data item from a file.
+```shell
+# Create a password.txt file
+cat <<EOF >./password.txt
+username=admin
+password=secret
+EOF
+
+cat <<EOF >./kustomization.yaml
+secretGenerator:
+- name: example-secret-1
+  files:
+  - password.txt
+EOF
+```
+The generated Secret is as following:
+```yaml
+apiVersion: v1
+data:
+  password.txt: dXNlcm5hbWU9YWRtaW4KcGFzc3dvcmQ9c2VjcmV0Cg==
+kind: Secret
+metadata:
+  name: example-secret-1-t2kt65hgtb
+type: Opaque
+```
+To generate a secret from a literal key-value pair, add an entry to `literals` list in `secretGenerator`. Here is an example of generating a Secret with a data item from a key-value pair.
+```shell
+cat <<EOF >./kustomization.yaml
+secretGenerator:
+- name: example-secret-2
+  literals:
+  - username=admin
+  - password=secert 
+EOF
+```
+The generated Secret is as following:
+```yaml
+apiVersion: v1
+data:
+  password: c2VjZXJ0
+  username: YWRtaW4=
+kind: Secret
+metadata:
+  name: example-secret-2-t52t6g96d8
+type: Opaque
+```
+
+#### generatorOptions
+The generated ConfigMaps and Secrets hvae a suffix appended by hashing the contents. This ensures that a new ConfigMap or Secret is generated when the content is changed. To disable the behavior of appending a suffix, one can use `generatorOptions`. Besides that, it is also possible to specify cross-cutting options for generated ConfigMaps and Secrets.
+```shell
+cat <<EOF >./kustomization.yaml
+configMapGenerator:
+- name: example-configmap-3
+  literals:
+  - FOO=Bar
+generatorOptions:
+  disableNameSuffixHash: true
+  labels:
+    type: generated
+  annotations:
+    note: generated
+EOF
+```
+By `kubectl kustomize ./`, you can see the generated ConfigMap as
+```yaml
+apiVersion: v1
+data:
+  FOO: Bar
+kind: ConfigMap
+metadata:
+  annotations:
+    note: generated
+  labels:
+    type: generated
+  name: example-configmap-3
+```
+
+### Setting cross-cutting fields
+It is quite common to set some cross-cutting fields at the same time for all
+Kubernetes Resources that are in the same project
+* setting the same namespace for all Resource
+* adding the same name prefix or suffix
+* adding the same set of labels
+* adding the same set of annotations
+
+Here is an example:
+```shell
+# Create a deployment.yaml
+cat <<EOF >./deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+EOF
+
+cat <<EOF >./kustomization.yaml
+namespace: my-namespace
+namePrefix: dev-
+nameSuffix: "-001"
+commonLabels:
+  app: bingo
+commonAnnotations:
+  oncallPager: 800-555-1212
+resources:
+- deployment.yaml
+EOF
+```
+By `kubectl kustomize ./`, you can see those fields are all set in the Deployment Resource.
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    oncallPager: 800-555-1212
+  labels:
+    app: bingo
+  name: dev-nginx-deployment-001
+  namespace: my-namespace
+spec:
+  selector:
+    matchLabels:
+      app: bingo
+  template:
+    metadata:
+      annotations:
+        oncallPager: 800-555-1212
+      labels:
+        app: bingo
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+```
+
+### Composing and Customizing Resources
+It is common to compose a set of Resources in a project and management them inside
+the same file or directory. 
+Kustomize offers composing Resources from different files and applying patches or other customization to them. 
+
+#### Composing
+To compose different Resource files in `kustomization.yaml`, one need to add those files to the `resources` list.
+Here is an example for an nginx application with a Deployment and a Service.
+```shell
+# Create a deployment.yaml file
+cat <<EOF > deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-nginx
+spec:
+  selector:
+    matchLabels:
+      run: my-nginx
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        run: my-nginx
+    spec:
+      containers:
+      - name: my-nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+EOF
+
+# Create a service.yaml file
+cat <<EOF > service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-nginx
+  labels:
+    run: my-nginx
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+  selector:
+    run: my-nginx
+EOF
+
+# Create a kustomization.yaml composing them
+cat <<EOF >./kustomization.yaml
+resources:
+- deployment.yaml
+- service.yaml
+EOF
+```
+The Resources from `kubectl kustomize ./` contains both the Deployment and the Service objects.
+
+#### Customizing
+On top of Resources, one can apply different customization by applying patches. Kustomize supports different patching
+mechanisms through `patchesStrategicMerge` and `patchesJson6902`. `patchesStrategicMerge` is a list of file paths. Each file should be resolved to a [strategic merge patch](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-api-machinery/strategic-merge-patch.md). The names inside the patches must match Resource names that are already loaded. Small patches that do one thing are recommended. For example, create one patch for increasing the deployment replica number and another patch for setting the memory limit.
+```shell
+# Create a deployment.yaml file
+cat <<EOF > deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-nginx
+spec:
+  selector:
+    matchLabels:
+      run: my-nginx
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        run: my-nginx
+    spec:
+      containers:
+      - name: my-nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+EOF
+
+# Create a patch increase_replicas.yaml
+cat <<EOF > increase_replicas.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-nginx
+spec:
+  replicas: 3
+EOF
+
+# Create another patch set_memory.yaml
+cat <<EOF > set_memory.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-nginx
+spec:
+  template:
+    spec:
+      containers:
+      - name: my-nginx
+        resources:
+        limits:
+          memory: 512Mi
+EOF
+
+cat <<EOF >./kustomization.yaml
+resources:
+- deployment.yaml
+patchesStrategicMerge:
+- increase_replicas.yaml
+- set_memory.yaml
+EOF
+```
+By `kubectl kustomize ./`, you can see that the Deployment object is as
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      run: my-nginx
+  template:
+    metadata:
+      labels:
+        run: my-nginx
+    spec:
+      containers:
+      - image: nginx
+        limits:
+          memory: 512Mi
+        name: my-nginx
+        ports:
+        - containerPort: 80
+```
+Not all Resources or fields support strategic merge patches. To support modifying arbitrary fields in arbitrary Resources,
+Kustomize offers applying [JSON patch](https://tools.ietf.org/html/rfc6902) through `patchesJson6902`.
+To find the correct Resource for a Json patch, the group, version, kind and name of that Resource need to be
+specified in `kustomization.yaml`. For example, increasing the replica number of a Deployment object can also be done
+through `patchesJson6902`.
+```shell
+# Create a deployment.yaml file
+cat <<EOF > deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-nginx
+spec:
+  selector:
+    matchLabels:
+      run: my-nginx
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        run: my-nginx
+    spec:
+      containers:
+      - name: my-nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+EOF
+
+# Create a json patch
+cat <<EOF > patch.yaml
+- op: replace
+  path: /spec/replicas
+  value: 3 
+EOF
+
+# Create a kustomization.yaml
+cat <<EOF >./kustomization.yaml
+resources:
+- deployment.yaml
+
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: my-nginx
+  path: patch.yaml  
+EOF
+```
+By `kubectl kustomize ./`, you can see that the `replicas` field is updated.
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      run: my-nginx
+  template:
+    metadata:
+      labels:
+        run: my-nginx
+    spec:
+      containers:
+      - image: nginx
+        name: my-nginx
+        ports:
+        - containerPort: 80
+```
+In addition to patches, Kustomize also offers customizing container images or injecting field values from other objects into containers
+without creating patches. For example, you can change the image used inside containers by specifying the new image in `images` field in `kustomization.yaml`.
+```shell
+cat <<EOF > deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-nginx
+spec:
+  selector:
+    matchLabels:
+      run: my-nginx
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        run: my-nginx
+    spec:
+      containers:
+      - name: my-nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+EOF
+
+cat <<EOF >./kustomization.yaml
+resources:
+- deployment.yaml
+images:
+- name: nginx
+  newName: my.image.registry/nginx
+  newTag: 1.4.0
+EOF
+```
+By `kubectl kustomize ./`, you can see that the image being used is updated.
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-nginx
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      run: my-nginx
+  template:
+    metadata:
+      labels:
+        run: my-nginx
+    spec:
+      containers:
+      - image: my.image.registry/nginx:1.4.0
+        name: my-nginx
+        ports:
+        - containerPort: 80
+```
+Sometimes, the application running in Pods may need to know configuration from other objects. For example,
+a Pod from a Deployment object need to read the corresponding Service name from Env or as a command argument.
+Since the Service name may change as namePrefix or nameSuffix is added in the `kustomization.yaml` file. It is
+not recommended to hard code the Service name in the command argument. For this usage, Kustomize can inject
+the Service name dynamically into containers through `vars`.
+
+```shell
+# Create a deployment.yaml file
+cat <<EOF > deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-nginx
+spec:
+  selector:
+    matchLabels:
+      run: my-nginx
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        run: my-nginx
+    spec:
+      containers:
+      - name: my-nginx
+        image: nginx
+        command: ["start", "--host", "\$(MY_SERVICE_NAME)"]
+EOF
+
+# Create a service.yaml file
+cat <<EOF > service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-nginx
+  labels:
+    run: my-nginx
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+  selector:
+    run: my-nginx
+EOF
+
+cat <<EOF >./kustomization.yaml
+namePrefix: dev-
+nameSuffix: "-001"
+
+resources:
+- deployment.yaml
+- service.yaml
+
+vars:
+- name: MY_SERVICE_NAME
+  objref:
+    kind: Service
+    name: my-nginx
+    apiVersion: v1
+EOF
+```
+By `kubectl kustomize ./`, you can see that the Service name injected into containers is `dev-my-nginx-001`.
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dev-my-nginx-001
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      run: my-nginx
+  template:
+    metadata:
+      labels:
+        run: my-nginx
+    spec:
+      containers:
+      - command:
+        - start
+        - --host
+        - dev-my-nginx-001
+        image: nginx
+        name: my-nginx
+```
+
+## Bases and Overlays
+Kustomize has concepts **bases** and **overlays**. A **base** is a directory with a `kustomization.yaml`, which contains a
+set of resources and associated customization. A base could be either a local directory or a directory from a remote repo,
+as long sa a `kustomization.yaml` is present inside. An **overlay** is a directory with a `kustomization.yaml` that refers to other
+kustomization directories as its `bases`. A **base** has no knowledge of an overlay and can be used in multiple overlay.
+An overlay may have multiple bases and it composes all resources
+from bases and may also have customization on top of them.
+
+Here is an example of a base.
+```shell
+# Create a directory to hold the base
+mkdir base
+# Create a base/deployment.yaml
+at <<EOF > base/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-nginx
+spec:
+  selector:
+    matchLabels:
+      run: my-nginx
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        run: my-nginx
+    spec:
+      containers:
+      - name: my-nginx
+        image: nginx
+        command: ["start", "--host", "\$(MY_SERVICE_NAME)"]
+EOF
+
+# Create a base/service.yaml file
+cat <<EOF > base/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-nginx
+  labels:
+    run: my-nginx
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+  selector:
+    run: my-nginx
+EOF
+# Create a base/kustomization.yaml
+cat <<EOF > base/kustomization.yaml
+resources:
+- deployment.yaml
+- service.yaml
+```
+This base can be used in multiple overlays. You can add different namePrefix or other cross-cutting fields
+in different overlays. Here are two overlays using the same base.
+```shell
+mkdir dev
+cat <<EOF > dev/kustomization.yaml
+bases:
+- ../base
+namePrefix: dev-
+EOF
+
+mkdir prod
+cat <<EOF > prod/kustomization.yaml
+bases:
+- ../base
+namePrefix: prod-
+EOF
+```
+
+## How to apply/view/delete objects from Kustomization
+Use `--kustomize` or `-k` in kubectl commands to recognize Resources managed by `kustomization.yaml`. 
+Note that `-k` should point to a kustomization directory, such as
+
+```shell
+kubectl apply -k <kustomization directory>/
+```
+Given following `kustomization.yaml` file and associated Resource files,
+```shell
+# Create a deployment.yaml file
+cat <<EOF > deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-nginx
+spec:
+  selector:
+    matchLabels:
+      run: my-nginx
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        run: my-nginx
+    spec:
+      containers:
+      - name: my-nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+EOF
+
+# Create a kustomization.yaml
+cat <<EOF >./kustomization.yaml
+namePrefix: dev-
+commonLabels:
+  app: my-nginx
+resources:
+- deployment.yaml
+EOF
+```
+Running following command will apply the Deployment object `dev-my-nginx`
+```shell
+> kubectl apply -k ./
+deployment.apps/dev-my-nginx created
+```
+Run following command to view the Deployment object
+```shell
+kubectl get -k ./
+```
+or 
+```shell
+kubectl describe -k ./
+```
+Run following command to delete the Deployment object
+```shell
+> kubectl delete -k ./
+deployment.apps "dev-my-nginx" deleted
+```
+
+
+## Kustomize Feature List
+Here is a list of all the features in Kustomize.
+
+| Field                 | Type                                                                                                         | Explanation                                                                        |  
+|-----------------------|--------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------|
+| namespace             | string                                                                                                       | add namespace to all resources                                                     |
+| namePrefix            | string                                                                                                       | value of this field is prepended to the names of all resources                     |
+| nameSuffix            | string                                                                                                       | value of this field is appended to the names of all resources                      |
+| commonlabels          | map[string]string                                                                                            | labels to add to all resources and selectors                                       |
+| commonAnnotations     | map[string]string                                                                                            | annotations to add to all resources                                                |
+| resources             | []string                                                                                                     | each entry in this list must resolve to an existing resource configuration file    |
+| configmapGenerator    | [][ConfigMapArgs](https://github.com/kubernetes-sigs/kustomize/blob/master/pkg/types/kustomization.go#L195)  | Each entry in this list generates a ConfigMap                                      |
+| secretGenerator       | [][SecretArgs](https://github.com/kubernetes-sigs/kustomize/blob/master/pkg/types/kustomization.go#L201)     | Each entry in this list generates a Secret                                         |
+| generatorOptions      | [GeneratorOptions](https://github.com/kubernetes-sigs/kustomize/blob/master/pkg/types/kustomization.go#L239) | Modify behaviors of all ConfigMap and Secret generatos                             |
+| bases                 | []string                                                                                                     | Each entry in this list should resolve to a directory containing a kustomization.yaml file |
+| patchesStrategicMerge | []string                                                                                                     | Each entry in this list should resolve a strategic merge patch of a Kubernetes object |
+| patchesJson6902       | [][Json6902](https://github.com/kubernetes-sigs/kustomize/blob/master/pkg/patch/json6902.go#L23)             | Each entry in this list should resolve to a Kubernetes object and a Json Patch     |
+| vars                  | [][Var](https://github.com/kubernetes-sigs/kustomize/blob/master/pkg/types/var.go#L31)                       | Each entry is to capture text from one resource's field                            |
+| images                | [][Image](https://github.com/kubernetes-sigs/kustomize/blob/master/pkg/image/image.go#L23)                   | Each entry is to modify the name, tags and/or digest for one image without creating patches |
+| configurations        | []string                                                                                                     | Each entry in this list should resolve to a file containing [Kustomize transformer configurations](https://github.com/kubernetes-sigs/kustomize/tree/master/examples/transformerconfigs) |
+| crds                  | []string                                                                                                     | Each entry in this list should resolve to an OpenAPI definition file for Kubernetes types |
+
+
+
+{{% capture whatsnext %}}
+- [Kustomize](https://github.com/kubernetes-sigs/kustomize)
+- [Kubectl Command Reference](/docs/reference/generated/kubectl/kubectl/)
+- [Kubernetes API Reference](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/)
+{{% /capture %}}

--- a/content/en/docs/concepts/overview/object-management-kubectl/overview.md
+++ b/content/en/docs/concepts/overview/object-management-kubectl/overview.md
@@ -7,7 +7,8 @@ weight: 10
 {{% capture overview %}}
 The `kubectl` command-line tool supports several different ways to create and manage
 Kubernetes objects. This document provides an overview of the different
-approaches.
+approaches. Read the [Kubectl book](https://kubectl.docs.kubernetes.io) for
+details of managing objects by Kubectl.
 {{% /capture %}}
 
 {{% capture body %}}
@@ -179,6 +180,7 @@ Disadvantages compared to imperative object configuration:
 - [Managing Kubernetes Objects Using Object Configuration (Imperative)](/docs/concepts/overview/object-management-kubectl/imperative-config/)
 - [Managing Kubernetes Objects Using Object Configuration (Declarative)](/docs/concepts/overview/object-management-kubectl/declarative-config/)
 - [Kubectl Command Reference](/docs/reference/generated/kubectl/kubectl-commands/)
+- [Kubectl Book](https://kubectl.docs.kubernetes.io)
 - [Kubernetes API Reference](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/)
 
 {{< comment >}}

--- a/content/en/docs/concepts/overview/working-with-objects/kubernetes-objects.md
+++ b/content/en/docs/concepts/overview/working-with-objects/kubernetes-objects.md
@@ -43,7 +43,7 @@ One way to create a Deployment using a `.yaml` file like the one above is to use
 in the `kubectl` command-line interface, passing the `.yaml` file as an argument. Here's an example:
 
 ```shell
-$ kubectl apply -f https://k8s.io/examples/application/deployment.yaml --record
+$ kubectl apply -f https://k8s.io/examples/application/deployment.yaml
 ```
 
 The output is similar to this:

--- a/content/en/docs/concepts/overview/working-with-objects/kubernetes-objects.md
+++ b/content/en/docs/concepts/overview/working-with-objects/kubernetes-objects.md
@@ -39,11 +39,11 @@ Here's an example `.yaml` file that shows the required fields and object spec fo
 {{< codenew file="application/deployment.yaml" >}}
 
 One way to create a Deployment using a `.yaml` file like the one above is to use the
-[`kubectl create`](/docs/reference/generated/kubectl/kubectl-commands#create) command
+[`kubectl apply`](/docs/reference/generated/kubectl/kubectl-commands#apply) command
 in the `kubectl` command-line interface, passing the `.yaml` file as an argument. Here's an example:
 
 ```shell
-$ kubectl create -f https://k8s.io/examples/application/deployment.yaml --record
+$ kubectl apply -f https://k8s.io/examples/application/deployment.yaml --record
 ```
 
 The output is similar to this:

--- a/content/en/docs/concepts/services-networking/connect-applications-service.md
+++ b/content/en/docs/concepts/services-networking/connect-applications-service.md
@@ -35,7 +35,7 @@ Create an nginx Pod, and note that it has a container port specification:
 This makes it accessible from any node in your cluster. Check the nodes the Pod is running on:
 
 ```shell
-$ kubectl create -f ./run-my-nginx.yaml
+$ kubectl apply -f ./run-my-nginx.yaml
 $ kubectl get pods -l run=my-nginx -o wide
 NAME                        READY     STATUS    RESTARTS   AGE       IP            NODE
 my-nginx-3800858182-jr4a2   1/1       Running   0          13s       10.244.3.4    kubernetes-minion-905m
@@ -67,7 +67,7 @@ $ kubectl expose deployment/my-nginx
 service/my-nginx exposed
 ```
 
-This is equivalent to `kubectl create -f` the following yaml:
+This is equivalent to `kubectl apply -f` the following yaml:
 
 {{< codenew file="service/networking/nginx-svc.yaml" >}}
 
@@ -211,7 +211,7 @@ You can acquire all these from the [nginx https example](https://github.com/kube
 
 ```shell
 $ make keys secret KEY=/tmp/nginx.key CERT=/tmp/nginx.crt SECRET=/tmp/secret.json
-$ kubectl create -f /tmp/secret.json
+$ kubectl apply -f /tmp/secret.json
 secret/nginxsecret created
 $ kubectl get secrets
 NAME                  TYPE                                  DATA      AGE
@@ -242,7 +242,7 @@ data:
 Now create the secrets using the file:
 
 ```shell
-$ kubectl create -f nginxsecrets.yaml
+$ kubectl apply -f nginxsecrets.yaml
 $ kubectl get secrets
 NAME                  TYPE                                  DATA      AGE
 default-token-il9rc   kubernetes.io/service-account-token   1         1d
@@ -263,7 +263,7 @@ Noteworthy points about the nginx-secure-app manifest:
   This is setup *before* the nginx server is started.
 
 ```shell
-$ kubectl delete deployments,svc my-nginx; kubectl create -f ./nginx-secure-app.yaml
+$ kubectl delete deployments,svc my-nginx; kubectl apply -f ./nginx-secure-app.yaml
 ```
 
 At this point you can reach the nginx server from any node.
@@ -283,7 +283,7 @@ Let's test this from a pod (the same secret is being reused for simplicity, the 
 {{< codenew file="service/networking/curlpod.yaml" >}}
 
 ```shell
-$ kubectl create -f ./curlpod.yaml
+$ kubectl apply -f ./curlpod.yaml
 $ kubectl get pods -l app=curlpod
 NAME                               READY     STATUS    RESTARTS   AGE
 curl-deployment-1515033274-1410r   1/1       Running   0          1m

--- a/content/en/docs/concepts/services-networking/ingress.md
+++ b/content/en/docs/concepts/services-networking/ingress.md
@@ -170,7 +170,7 @@ There are existing Kubernetes concepts that allow you to expose a single Service
 
 {{< codenew file="service/networking/ingress.yaml" >}}
 
-If you create it using `kubectl create -f` you should see:
+If you create it using `kubectl apply -f` you should see:
 
 ```shell
 kubectl get ingress test-ingress
@@ -224,7 +224,7 @@ spec:
           servicePort: 8080
 ```
 
-When you create the ingress with `kubectl create -f`:
+When you create the ingress with `kubectl apply -f`:
 
 ```shell
 kubectl describe ingress simple-fanout-example

--- a/content/en/docs/concepts/workloads/controllers/daemonset.md
+++ b/content/en/docs/concepts/workloads/controllers/daemonset.md
@@ -42,7 +42,7 @@ You can describe a DaemonSet in a YAML file. For example, the `daemonset.yaml` f
 
 * Create a DaemonSet based on the YAML file:
 ```
-kubectl create -f https://k8s.io/examples/controllers/daemonset.yaml
+kubectl apply -f https://k8s.io/examples/controllers/daemonset.yaml
 ```
 
 ### Required Fields

--- a/content/en/docs/concepts/workloads/controllers/deployment.md
+++ b/content/en/docs/concepts/workloads/controllers/deployment.md
@@ -74,7 +74,7 @@ In this example:
 To create this Deployment, run the following command:
 
 ```shell
-kubectl create -f https://k8s.io/examples/controllers/nginx-deployment.yaml
+kubectl apply -f https://k8s.io/examples/controllers/nginx-deployment.yaml
 ```
 
 {{< note >}}
@@ -429,7 +429,7 @@ First, check the revisions of this deployment:
 $ kubectl rollout history deployment.v1.apps/nginx-deployment
 deployments "nginx-deployment"
 REVISION    CHANGE-CAUSE
-1           kubectl create --filename=https://k8s.io/examples/controllers/nginx-deployment.yaml --record=true
+1           kubectl apply --filename=https://k8s.io/examples/controllers/nginx-deployment.yaml --record=true
 2           kubectl set image deployment.v1.apps/nginx-deployment nginx=nginx:1.9.1 --record=true
 3           kubectl set image deployment.v1.apps/nginx-deployment nginx=nginx:1.91 --record=true
 ```

--- a/content/en/docs/concepts/workloads/controllers/garbage-collection.md
+++ b/content/en/docs/concepts/workloads/controllers/garbage-collection.md
@@ -39,7 +39,7 @@ If you create the ReplicaSet and then view the Pod metadata, you can see
 OwnerReferences field:
 
 ```shell
-kubectl create -f https://k8s.io/examples/controllers/replicaset.yaml
+kubectl apply -f https://k8s.io/examples/controllers/replicaset.yaml
 kubectl get pods --output=yaml
 ```
 

--- a/content/en/docs/concepts/workloads/controllers/jobs-run-to-completion.md
+++ b/content/en/docs/concepts/workloads/controllers/jobs-run-to-completion.md
@@ -39,7 +39,7 @@ It takes around 10s to complete.
 Run the example job by downloading the example file and then running this command:
 
 ```shell
-$ kubectl create -f https://k8s.io/examples/controllers/job.yaml
+$ kubectl apply -f https://k8s.io/examples/controllers/job.yaml
 job "pi" created
 ```
 

--- a/content/en/docs/concepts/workloads/controllers/replicaset.md
+++ b/content/en/docs/concepts/workloads/controllers/replicaset.md
@@ -54,7 +54,7 @@ Saving this manifest into `frontend.yaml` and submitting it to a Kubernetes clus
 create the defined ReplicaSet and the Pods that it manages.
 
 ```shell
-kubectl create -f http://k8s.io/examples/controllers/frontend.yaml
+kubectl apply -f http://k8s.io/examples/controllers/frontend.yaml
 ```
 
 You can then get the current ReplicaSets deployed:
@@ -162,7 +162,7 @@ Suppose you create the Pods after the frontend ReplicaSet has been deployed and 
 fulfill its replica count requirement:
 
 ```shell
-kubectl create -f http://k8s.io/examples/pods/pod-rs.yaml
+kubectl apply -f http://k8s.io/examples/pods/pod-rs.yaml
 ```
 
 The new Pods will be acquired by the ReplicaSet, and then immediately terminated as the ReplicaSet would be over
@@ -184,12 +184,12 @@ pod2             0/1     Terminating   0          4s
 
 If you create the Pods first:
 ```shell
-kubectl create -f http://k8s.io/examples/pods/pod-rs.yaml
+kubectl apply -f http://k8s.io/examples/pods/pod-rs.yaml
 ```
 
 And then create the ReplicaSet however:
 ```shell
-kubectl create -f http://k8s.io/examples/controllers/frontend.yaml
+kubectl apply -f http://k8s.io/examples/controllers/frontend.yaml
 ```
 
 You shall see that the ReplicaSet has acquired the Pods and has only created new ones according to its spec until the
@@ -304,7 +304,7 @@ create the defined HPA that autoscales the target ReplicaSet depending on the CP
 of the replicated Pods.
 
 ```shell
-kubectl create -f https://k8s.io/examples/controllers/hpa-rs.yaml
+kubectl apply -f https://k8s.io/examples/controllers/hpa-rs.yaml
 ```
 
 Alternatively, you can use the `kubectl autoscale` command to accomplish the same

--- a/content/en/docs/concepts/workloads/controllers/replicationcontroller.md
+++ b/content/en/docs/concepts/workloads/controllers/replicationcontroller.md
@@ -55,7 +55,7 @@ This example ReplicationController config runs three copies of the nginx web ser
 Run the example job by downloading the example file and then running this command:
 
 ```shell
-$ kubectl create -f https://k8s.io/examples/controllers/replication.yaml
+$ kubectl apply -f https://k8s.io/examples/controllers/replication.yaml
 replicationcontroller/nginx created
 ```
 

--- a/content/en/docs/concepts/workloads/pods/init-containers.md
+++ b/content/en/docs/concepts/workloads/pods/init-containers.md
@@ -180,7 +180,7 @@ spec:
 This Pod can be started and debugged with the following commands:
 
 ```shell
-$ kubectl create -f myapp.yaml
+$ kubectl apply -f myapp.yaml
 pod/myapp-pod created
 $ kubectl get -f myapp.yaml
 NAME        READY     STATUS     RESTARTS   AGE
@@ -226,7 +226,7 @@ Once we start the `mydb` and `myservice` services, we can see the Init Container
 complete and the `myapp-pod` is created:
 
 ```shell
-$ kubectl create -f services.yaml
+$ kubectl apply -f services.yaml
 service/myservice created
 service/mydb created
 $ kubectl get -f myapp.yaml

--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -26,7 +26,7 @@ To enable RBAC, start the apiserver with `--authorization-mode=RBAC`.
 The RBAC API declares four top-level types which will be covered in this
 section. Users can interact with these resources as they would with any other
 API resource (via `kubectl`, API calls, etc.). For instance,
-`kubectl create -f (resource).yml` can be used with any of these examples,
+`kubectl apply -f (resource).yml` can be used with any of these examples,
 though readers who wish to follow along should review the section on
 bootstrapping first.
 

--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -68,15 +68,15 @@ Kubernetes manifests can be defined in json or yaml. The file extension `.yaml`,
 `.yml`, and `.json` can be used.
 
 ```bash
-kubectl create -f ./my-manifest.yaml           # create resource(s)
-kubectl create -f ./my1.yaml -f ./my2.yaml     # create from multiple files
-kubectl create -f ./dir                        # create resource(s) in all manifest files in dir
-kubectl create -f https://git.io/vPieo         # create resource(s) from url
+kubectl apply -f ./my-manifest.yaml           # create resource(s)
+kubectl apply -f ./my1.yaml -f ./my2.yaml     # create from multiple files
+kubectl apply -f ./dir                        # create resource(s) in all manifest files in dir
+kubectl apply -f https://git.io/vPieo         # create resource(s) from url
 kubectl create deployment nginx --image=nginx  # start a single instance of nginx
 kubectl explain pods,svc                       # get the documentation for pod and svc manifests
 
 # Create multiple YAML objects from stdin
-cat <<EOF | kubectl create -f -
+cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: Pod
 metadata:
@@ -103,7 +103,7 @@ spec:
 EOF
 
 # Create a secret with several keys
-cat <<EOF | kubectl create -f -
+cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: Secret
 metadata:

--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -62,6 +62,9 @@ kubectl config set-context gce --user=cluster-admin --namespace=foo \
   && kubectl config use-context gce
 ```
 
+## Apply
+`apply` manages applications through files defining Kubernetes resources. It creates and updates resources in a cluster through running `kubectl apply`. This is the recommended way of managing Kubernetes applications on production. See [Kubectl Book](https://kubectl.docs.kubernetes.io).
+
 ## Creating Objects
 
 Kubernetes manifests can be defined in json or yaml. The file extension `.yaml`,

--- a/content/en/docs/reference/kubectl/conventions.md
+++ b/content/en/docs/reference/kubectl/conventions.md
@@ -77,6 +77,6 @@ flag, which provides the object to be submitted to the cluster.
 
 ### `kubectl apply`
 
-* You can use `kubectl apply` to create or update resources. However, to update a resource you should have created the resource by using `kubectl apply` or `kubectl create --save-config`. For more information about using kubectl apply to update resources, see [Managing Resources](/docs/concepts/cluster-administration/manage-deployment/#kubectl-apply).
+* You can use `kubectl apply` to create or update resources. However, to update a resource you should have created the resource by using `kubectl apply`. For more information about using kubectl apply to update resources, see [Managing Resources](/docs/concepts/cluster-administration/manage-deployment/#kubectl-apply).
 
 {{% /capture %}}

--- a/content/en/docs/reference/kubectl/conventions.md
+++ b/content/en/docs/reference/kubectl/conventions.md
@@ -77,6 +77,6 @@ flag, which provides the object to be submitted to the cluster.
 
 ### `kubectl apply`
 
-* You can use `kubectl apply` to create or update resources. However, to update a resource you should have created the resource by using `kubectl apply`. For more information about using kubectl apply to update resources, see [Managing Resources](/docs/concepts/cluster-administration/manage-deployment/#kubectl-apply).
+* You can use `kubectl apply` to create or update resources. For more information about using kubectl apply to update resources, see [Kubectl Book](https://kubectl.docs.kubernetes.io).
 
 {{% /capture %}}

--- a/content/en/docs/reference/kubectl/overview.md
+++ b/content/en/docs/reference/kubectl/overview.md
@@ -255,17 +255,17 @@ $ kubectl get pods --sort-by=.metadata.name
 
 Use the following set of examples to help you familiarize yourself with running the commonly used `kubectl` operations:
 
-`kubectl create` - Create a resource from a file or stdin.
+`kubectl apply` - Apply or Update a resource from a file or stdin.
 
 ```shell
 // Create a service using the definition in example-service.yaml.
-$ kubectl create -f example-service.yaml
+$ kubectl apply -f example-service.yaml
 
 // Create a replication controller using the definition in example-controller.yaml.
-$ kubectl create -f example-controller.yaml
+$ kubectl apply -f example-controller.yaml
 
 // Create the objects that are defined in any .yaml, .yml, or .json file within the <directory> directory.
-$ kubectl create -f <directory>
+$ kubectl apply -f <directory>
 ```
 
 `kubectl get` - List one or more resources.

--- a/content/en/docs/setup/independent/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/independent/create-cluster-kubeadm.md
@@ -326,7 +326,7 @@ tls/deploy-certs.sh
 # Label kube-dns with fixed identity label
 kubectl label -n kube-system pod $(kubectl -n kube-system get pods -l k8s-app=kube-dns -o jsonpath='{range .items[]}{.metadata.name}{" "}{end}') io.cilium.fixed-identity=kube-dns
 
-kubectl create -f ./
+kubectl apply -f ./
 
 # Wait several minutes for Cilium, coredns and etcd pods to converge to a working state
 ```

--- a/content/en/docs/setup/multiple-zones.md
+++ b/content/en/docs/setup/multiple-zones.md
@@ -175,7 +175,7 @@ kubernetes-minion-wf8i   Ready                      <none>   2m    v1.13.0      
 Create a volume using the dynamic volume creation (only PersistentVolumes are supported for zone affinity):
 
 ```json
-kubectl create -f - <<EOF
+kubectl apply -f - <<EOF
 {
   "kind": "PersistentVolumeClaim",
   "apiVersion": "v1",
@@ -221,7 +221,7 @@ Because GCE PDs / AWS EBS volumes cannot be attached across zones,
 this means that this pod can only be created in the same zone as the volume:
 
 ```yaml
-kubectl create -f - <<EOF
+kubectl apply -f - <<EOF
 kind: Pod
 apiVersion: v1
 metadata:
@@ -277,7 +277,7 @@ kubectl get nodes --show-labels
 Create the guestbook-go example, which includes an RC of size 3, running a simple web app:
 
 ```shell
-find kubernetes/examples/guestbook-go/ -name '*.json' | xargs -I {} kubectl create -f {}
+find kubernetes/examples/guestbook-go/ -name '*.json' | xargs -I {} kubectl apply -f {}
 ```
 
 The pods should be spread across all 3 zones:

--- a/content/en/docs/tasks/access-application-cluster/communicate-containers-same-pod-shared-volume.md
+++ b/content/en/docs/tasks/access-application-cluster/communicate-containers-same-pod-shared-volume.md
@@ -44,7 +44,7 @@ directory of the nginx server.
 
 Create the Pod and the two Containers:
 
-    kubectl create -f https://k8s.io/examples/pods/two-container-pod.yaml
+    kubectl apply -f https://k8s.io/examples/pods/two-container-pod.yaml
 
 View information about the Pod and the Containers:
 

--- a/content/en/docs/tasks/access-application-cluster/connecting-frontend-backend.md
+++ b/content/en/docs/tasks/access-application-cluster/connecting-frontend-backend.md
@@ -48,7 +48,7 @@ file for the backend Deployment:
 Create the backend Deployment:
 
 ```
-kubectl create -f https://k8s.io/examples/service/access/hello.yaml
+kubectl apply -f https://k8s.io/examples/service/access/hello.yaml
 ```
 
 View information about the backend Deployment:
@@ -111,7 +111,7 @@ that have the labels `app: hello` and `tier: backend`.
 Create the `hello` Service:
 
 ```
-kubectl create -f https://k8s.io/examples/service/access/hello-service.yaml
+kubectl apply -f https://k8s.io/examples/service/access/hello-service.yaml
 ```
 
 At this point, you have a backend Deployment running, and you have a
@@ -138,7 +138,7 @@ the Service uses the default load balancer of your cloud provider.
 Create the frontend Deployment and Service:
 
 ```
-kubectl create -f https://k8s.io/examples/service/access/frontend.yaml
+kubectl apply -f https://k8s.io/examples/service/access/frontend.yaml
 ```
 
 The output verifies that both resources were created:

--- a/content/en/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
+++ b/content/en/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
@@ -28,7 +28,7 @@ for database debugging.
 
 1. Create a Redis deployment:
 
-        kubectl create -f https://k8s.io/examples/application/guestbook/redis-master-deployment.yaml
+        kubectl apply -f https://k8s.io/examples/application/guestbook/redis-master-deployment.yaml
 
     The output of a successful command verifies that the deployment was created:
 
@@ -64,7 +64,7 @@ for database debugging.
 
 2. Create a Redis service:
 
-        kubectl create -f https://k8s.io/examples/application/guestbook/redis-master-service.yaml
+        kubectl apply -f https://k8s.io/examples/application/guestbook/redis-master-service.yaml
 
     The output of a successful command verifies that the service was created:
 

--- a/content/en/docs/tasks/access-application-cluster/web-ui-dashboard.md
+++ b/content/en/docs/tasks/access-application-cluster/web-ui-dashboard.md
@@ -26,7 +26,7 @@ Dashboard also provides information on the state of Kubernetes resources in your
 The Dashboard UI is not deployed by default. To deploy it, run the following command:
 
 ```
-kubectl create -f https://raw.githubusercontent.com/kubernetes/dashboard/master/aio/deploy/recommended/kubernetes-dashboard.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/master/aio/deploy/recommended/kubernetes-dashboard.yaml
 ```
 
 ## Accessing the Dashboard UI

--- a/content/en/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning.md
+++ b/content/en/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning.md
@@ -87,10 +87,10 @@ spec:
 ```
 
 You can save the CustomResourceDefinition in a YAML file, then use
-`kubectl create` to create it.
+`kubectl apply` to create it.
 
 ```shell
-kubectl create -f my-versioned-crontab.yaml
+kubectl apply -f my-versioned-crontab.yaml
 ```
 
 After creation, the API server starts to serve each enabled version at an HTTP

--- a/content/en/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions.md
+++ b/content/en/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions.md
@@ -70,7 +70,7 @@ spec:
 And create it:
 
 ```shell
-kubectl create -f resourcedefinition.yaml
+kubectl apply -f resourcedefinition.yaml
 ```
 
 Then a new namespaced RESTful API endpoint is created at:
@@ -112,7 +112,7 @@ spec:
 and create it:
 
 ```shell
-kubectl create -f my-crontab.yaml
+kubectl apply -f my-crontab.yaml
 ```
 
 You can then manage your CronTab objects using kubectl. For example:
@@ -288,7 +288,7 @@ spec:
 And create it:
 
 ```shell
-kubectl create -f resourcedefinition.yaml
+kubectl apply -f resourcedefinition.yaml
 ```
 
 A request to create a custom object of kind `CronTab` will be rejected if there are invalid values in its fields.
@@ -313,7 +313,7 @@ spec:
 and create it:
 
 ```shell
-kubectl create -f my-crontab.yaml
+kubectl apply -f my-crontab.yaml
 ```
 
 you will get an error:
@@ -343,7 +343,7 @@ spec:
 And create it:
 
 ```shell
-kubectl create -f my-crontab.yaml
+kubectl apply -f my-crontab.yaml
 crontab "my-new-cron-object" created
 ```
 
@@ -387,7 +387,7 @@ columns.
 2.  Create the CustomResourceDefinition:
 
       ```shell
-      kubectl create -f resourcedefinition.yaml
+      kubectl apply -f resourcedefinition.yaml
       ```
 
 3.  Create an instance using the `my-crontab.yaml` from the previous section.
@@ -560,7 +560,7 @@ spec:
 And create it:
 
 ```shell
-kubectl create -f resourcedefinition.yaml
+kubectl apply -f resourcedefinition.yaml
 ```
 
 After the CustomResourceDefinition object has been created, you can create custom objects.
@@ -581,7 +581,7 @@ spec:
 and create it:
 
 ```shell
-kubectl create -f my-crontab.yaml
+kubectl apply -f my-crontab.yaml
 ```
 
 Then new namespaced RESTful API endpoints are created at:
@@ -645,7 +645,7 @@ spec:
 And create it:
 
 ```shell
-kubectl create -f resourcedefinition.yaml
+kubectl apply -f resourcedefinition.yaml
 ```
 
 After the CustomResourceDefinition object has been created, you can create custom objects.
@@ -665,7 +665,7 @@ spec:
 and create it:
 
 ```shell
-kubectl create -f my-crontab.yaml
+kubectl apply -f my-crontab.yaml
 ```
 
 You can specify the category using `kubectl get`:

--- a/content/en/docs/tasks/administer-cluster/declare-network-policy.md
+++ b/content/en/docs/tasks/administer-cluster/declare-network-policy.md
@@ -110,7 +110,7 @@ spec:
 Use kubectl to create a NetworkPolicy from the above nginx-policy.yaml file:
 
 ```console
-kubectl create -f nginx-policy.yaml
+kubectl apply -f nginx-policy.yaml
 ```
 
 ```none

--- a/content/en/docs/tasks/administer-cluster/dns-debugging-resolution.md
+++ b/content/en/docs/tasks/administer-cluster/dns-debugging-resolution.md
@@ -27,7 +27,7 @@ Create a file named busybox.yaml with the following contents:
 Then create a pod using this file and verify its status:
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/dns/busybox.yaml
+kubectl apply -f https://k8s.io/examples/admin/dns/busybox.yaml
 pod/busybox created
 
 kubectl get pods busybox

--- a/content/en/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
+++ b/content/en/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
@@ -98,7 +98,7 @@ In the file, replace `<SCALE_TARGET>` with your scale target.
 Go to the directory that contains your configuration file, and enter this
 command to create the Deployment:
 
-    kubectl create -f dns-horizontal-autoscaler.yaml
+    kubectl apply -f dns-horizontal-autoscaler.yaml
 
 The output of a successful command is:
 

--- a/content/en/docs/tasks/administer-cluster/ip-masq-agent.md
+++ b/content/en/docs/tasks/administer-cluster/ip-masq-agent.md
@@ -61,7 +61,7 @@ By default, in GCE/Google Kubernetes Engine starting with Kubernetes version 1.7
 To create an ip-masq-agent, run the following kubectl command:
 
 `
-kubectl create -f https://raw.githubusercontent.com/kubernetes-incubator/ip-masq-agent/master/ip-masq-agent.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-incubator/ip-masq-agent/master/ip-masq-agent.yaml
 `
 
 You must also apply the appropriate node label to any nodes in your cluster that you want the agent to run on.

--- a/content/en/docs/tasks/administer-cluster/manage-resources/cpu-constraint-namespace.md
+++ b/content/en/docs/tasks/administer-cluster/manage-resources/cpu-constraint-namespace.md
@@ -45,7 +45,7 @@ Here's the configuration file for a LimitRange:
 Create the LimitRange:
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/resource/cpu-constraints.yaml --namespace=constraints-cpu-example
+kubectl apply -f https://k8s.io/examples/admin/resource/cpu-constraints.yaml --namespace=constraints-cpu-example
 ```
 
 View detailed information about the LimitRange:
@@ -96,7 +96,7 @@ minimum and maximum CPU constraints imposed by the LimitRange.
 Create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/resource/cpu-constraints-pod.yaml --namespace=constraints-cpu-example
+kubectl apply -f https://k8s.io/examples/admin/resource/cpu-constraints-pod.yaml --namespace=constraints-cpu-example
 ```
 
 Verify that the Pod's Container is running:
@@ -138,7 +138,7 @@ CPU request of 500 millicpu and a cpu limit of 1.5 cpu.
 Attempt to create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/resource/cpu-constraints-pod-2.yaml --namespace=constraints-cpu-example
+kubectl apply -f https://k8s.io/examples/admin/resource/cpu-constraints-pod-2.yaml --namespace=constraints-cpu-example
 ```
 
 The output shows that the Pod does not get created, because the Container specifies a CPU limit that is
@@ -159,7 +159,7 @@ CPU request of 100 millicpu and a CPU limit of 800 millicpu.
 Attempt to create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/resource/cpu-constraints-pod-3.yaml --namespace=constraints-cpu-example
+kubectl apply -f https://k8s.io/examples/admin/resource/cpu-constraints-pod-3.yaml --namespace=constraints-cpu-example
 ```
 
 The output shows that the Pod does not get created, because the Container specifies a CPU
@@ -180,7 +180,7 @@ specify a CPU request, and it does not specify a CPU limit.
 Create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/resource/cpu-constraints-pod-4.yaml --namespace=constraints-cpu-example
+kubectl apply -f https://k8s.io/examples/admin/resource/cpu-constraints-pod-4.yaml --namespace=constraints-cpu-example
 ```
 
 View detailed information about the Pod:

--- a/content/en/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace.md
+++ b/content/en/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace.md
@@ -40,7 +40,7 @@ a default CPU request and a default CPU limit.
 Create the LimitRange in the default-cpu-example namespace:
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/resource/cpu-defaults.yaml --namespace=default-cpu-example
+kubectl apply -f https://k8s.io/examples/admin/resource/cpu-defaults.yaml --namespace=default-cpu-example
 ```
 
 Now if a Container is created in the default-cpu-example namespace, and the
@@ -56,7 +56,7 @@ does not specify a CPU request and limit.
 Create the Pod.
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/resource/cpu-defaults-pod.yaml --namespace=default-cpu-example
+kubectl apply -f https://k8s.io/examples/admin/resource/cpu-defaults-pod.yaml --namespace=default-cpu-example
 ```
 
 View the Pod's specification:
@@ -91,7 +91,7 @@ Create the Pod:
 
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/resource/cpu-defaults-pod-2.yaml --namespace=default-cpu-example
+kubectl apply -f https://k8s.io/examples/admin/resource/cpu-defaults-pod-2.yaml --namespace=default-cpu-example
 ```
 
 View the Pod specification:
@@ -121,7 +121,7 @@ specifies a CPU request, but not a limit:
 Create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/resource/cpu-defaults-pod-3.yaml --namespace=default-cpu-example
+kubectl apply -f https://k8s.io/examples/admin/resource/cpu-defaults-pod-3.yaml --namespace=default-cpu-example
 ```
 
 View the Pod specification:

--- a/content/en/docs/tasks/administer-cluster/manage-resources/memory-constraint-namespace.md
+++ b/content/en/docs/tasks/administer-cluster/manage-resources/memory-constraint-namespace.md
@@ -45,7 +45,7 @@ Here's the configuration file for a LimitRange:
 Create the LimitRange:
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/resource/memory-constraints.yaml --namespace=constraints-mem-example
+kubectl apply -f https://k8s.io/examples/admin/resource/memory-constraints.yaml --namespace=constraints-mem-example
 ```
 
 View detailed information about the LimitRange:
@@ -90,7 +90,7 @@ minimum and maximum memory constraints imposed by the LimitRange.
 Create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/resource/memory-constraints-pod.yaml --namespace=constraints-mem-example
+kubectl apply -f https://k8s.io/examples/admin/resource/memory-constraints-pod.yaml --namespace=constraints-mem-example
 ```
 
 Verify that the Pod's Container is running:
@@ -132,7 +132,7 @@ memory request of 800 MiB and a memory limit of 1.5 GiB.
 Attempt to create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/resource/memory-constraints-pod-2.yaml --namespace=constraints-mem-example
+kubectl apply -f https://k8s.io/examples/admin/resource/memory-constraints-pod-2.yaml --namespace=constraints-mem-example
 ```
 
 The output shows that the Pod does not get created, because the Container specifies a memory limit that is
@@ -153,7 +153,7 @@ memory request of 100 MiB and a memory limit of 800 MiB.
 Attempt to create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/resource/memory-constraints-pod-3.yaml --namespace=constraints-mem-example
+kubectl apply -f https://k8s.io/examples/admin/resource/memory-constraints-pod-3.yaml --namespace=constraints-mem-example
 ```
 
 The output shows that the Pod does not get created, because the Container specifies a memory
@@ -176,7 +176,7 @@ specify a memory request, and it does not specify a memory limit.
 Create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/resource/memory-constraints-pod-4.yaml --namespace=constraints-mem-example
+kubectl apply -f https://k8s.io/examples/admin/resource/memory-constraints-pod-4.yaml --namespace=constraints-mem-example
 ```
 
 View detailed information about the Pod:

--- a/content/en/docs/tasks/administer-cluster/manage-resources/memory-default-namespace.md
+++ b/content/en/docs/tasks/administer-cluster/manage-resources/memory-default-namespace.md
@@ -42,7 +42,7 @@ a default memory request and a default memory limit.
 Create the LimitRange in the default-mem-example namespace:
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/resource/memory-defaults.yaml --namespace=default-mem-example
+kubectl apply -f https://k8s.io/examples/admin/resource/memory-defaults.yaml --namespace=default-mem-example
 ```
 
 Now if a Container is created in the default-mem-example namespace, and the
@@ -58,7 +58,7 @@ does not specify a memory request and limit.
 Create the Pod.
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/resource/memory-defaults-pod.yaml --namespace=default-mem-example
+kubectl apply -f https://k8s.io/examples/admin/resource/memory-defaults-pod.yaml --namespace=default-mem-example
 ```
 
 View detailed information about the Pod:
@@ -99,7 +99,7 @@ Create the Pod:
 
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/resource/memory-defaults-pod-2.yaml --namespace=default-mem-example
+kubectl apply -f https://k8s.io/examples/admin/resource/memory-defaults-pod-2.yaml --namespace=default-mem-example
 ```
 
 View detailed information about the Pod:
@@ -129,7 +129,7 @@ specifies a memory request, but not a limit:
 Create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/resource/memory-defaults-pod-3.yaml --namespace=default-mem-example
+kubectl apply -f https://k8s.io/examples/admin/resource/memory-defaults-pod-3.yaml --namespace=default-mem-example
 ```
 
 View the Pod's specification:

--- a/content/en/docs/tasks/administer-cluster/manage-resources/quota-memory-cpu-namespace.md
+++ b/content/en/docs/tasks/administer-cluster/manage-resources/quota-memory-cpu-namespace.md
@@ -44,7 +44,7 @@ Here is the configuration file for a ResourceQuota object:
 Create the ResourceQuota:
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/resource/quota-mem-cpu.yaml --namespace=quota-mem-cpu-example
+kubectl apply -f https://k8s.io/examples/admin/resource/quota-mem-cpu.yaml --namespace=quota-mem-cpu-example
 ```
 
 View detailed information about the ResourceQuota:
@@ -71,7 +71,7 @@ Here is the configuration file for a Pod:
 Create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/resource/quota-mem-cpu-pod.yaml --namespace=quota-mem-cpu-example
+kubectl apply -f https://k8s.io/examples/admin/resource/quota-mem-cpu-pod.yaml --namespace=quota-mem-cpu-example
 ```
 
 Verify that the Pod's Container is running:
@@ -117,7 +117,7 @@ request exceeds the memory request quota. 600 MiB + 700 MiB > 1 GiB.
 Attempt to create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/resource/quota-mem-cpu-pod-2.yaml --namespace=quota-mem-cpu-example
+kubectl apply -f https://k8s.io/examples/admin/resource/quota-mem-cpu-pod-2.yaml --namespace=quota-mem-cpu-example
 ```
 
 The second Pod does not get created. The output shows that creating the second Pod

--- a/content/en/docs/tasks/administer-cluster/manage-resources/quota-pod-namespace.md
+++ b/content/en/docs/tasks/administer-cluster/manage-resources/quota-pod-namespace.md
@@ -42,7 +42,7 @@ Here is the configuration file for a ResourceQuota object:
 Create the ResourceQuota:
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/resource/quota-pod.yaml --namespace=quota-pod-example
+kubectl apply -f https://k8s.io/examples/admin/resource/quota-pod.yaml --namespace=quota-pod-example
 ```
 
 View detailed information about the ResourceQuota:
@@ -74,7 +74,7 @@ In the configuration file, `replicas: 3` tells Kubernetes to attempt to create t
 Create the Deployment:
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/resource/quota-pod-deployment.yaml --namespace=quota-pod-example
+kubectl apply -f https://k8s.io/examples/admin/resource/quota-pod-deployment.yaml --namespace=quota-pod-example
 ```
 
 View detailed information about the Deployment:

--- a/content/en/docs/tasks/administer-cluster/namespaces-walkthrough.md
+++ b/content/en/docs/tasks/administer-cluster/namespaces-walkthrough.md
@@ -73,7 +73,7 @@ Use the file [`namespace-dev.json`](/examples/admin/namespace-dev.json) which de
 Create the development namespace using kubectl.
 
 ```shell
-$ kubectl create -f https://k8s.io/examples/admin/namespace-dev.json
+$ kubectl apply -f https://k8s.io/examples/admin/namespace-dev.json
 ```
 
 Save the following contents into file [`namespace-prod.json`](/examples/admin/namespace-prod.json) which describes a production namespace:
@@ -83,7 +83,7 @@ Save the following contents into file [`namespace-prod.json`](/examples/admin/na
 And then let's create the production namespace using kubectl.
 
 ```shell
-$ kubectl create -f https://k8s.io/examples/admin/namespace-prod.json
+$ kubectl apply -f https://k8s.io/examples/admin/namespace-prod.json
 ```
 
 To be sure things are right, let's list all of the namespaces in our cluster.

--- a/content/en/docs/tasks/administer-cluster/namespaces.md
+++ b/content/en/docs/tasks/administer-cluster/namespaces.md
@@ -89,7 +89,7 @@ metadata:
 Then run:
 
 ```shell
-$ kubectl create -f ./my-namespace.yaml
+$ kubectl apply -f ./my-namespace.yaml
 ```
 
 Note that the name of your namespace must be a DNS compatible label.
@@ -151,13 +151,13 @@ Use the file [`namespace-dev.json`](/examples/admin/namespace-dev.json) which de
 Create the development namespace using kubectl.
 
 ```shell
-$ kubectl create -f https://k8s.io/examples/admin/namespace-dev.json
+$ kubectl apply -f https://k8s.io/examples/admin/namespace-dev.json
 ```
 
 And then let's create the production namespace using kubectl.
 
 ```shell
-$ kubectl create -f https://k8s.io/examples/admin/namespace-prod.json
+$ kubectl apply -f https://k8s.io/examples/admin/namespace-prod.json
 ```
 
 To be sure things are right, list all of the namespaces in our cluster.

--- a/content/en/docs/tasks/administer-cluster/network-policy-provider/cilium-network-policy.md
+++ b/content/en/docs/tasks/administer-cluster/network-policy-provider/cilium-network-policy.md
@@ -30,7 +30,7 @@ As Cilium requires a standalone etcd instance, for minikube you can deploy it
 by running:
 
 ```shell
-kubectl create -n kube-system -f https://raw.githubusercontent.com/cilium/cilium/v1.3/examples/kubernetes/addons/etcd/standalone-etcd.yaml
+kubectl apply -n kube-system -f https://raw.githubusercontent.com/cilium/cilium/v1.3/examples/kubernetes/addons/etcd/standalone-etcd.yaml
 ```
 
 After etcd is up and running you can deploy Cilium Kubernetes descriptor which
@@ -39,7 +39,7 @@ Cilium, to connect to the etcd instance previously deployed as well as
 appropriate RBAC settings:
 
 ```shell
-$ kubectl create -f https://raw.githubusercontent.com/cilium/cilium/v1.3/examples/kubernetes/1.12/cilium.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/cilium/cilium/v1.3/examples/kubernetes/1.12/cilium.yaml
 configmap/cilium-config created
 daemonset.apps/cilium created
 clusterrolebinding.rbac.authorization.k8s.io/cilium created

--- a/content/en/docs/tasks/administer-cluster/quota-api-object.md
+++ b/content/en/docs/tasks/administer-cluster/quota-api-object.md
@@ -43,7 +43,7 @@ Here is the configuration file for a ResourceQuota object:
 Create the ResourceQuota:
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/resource/quota-objects.yaml --namespace=quota-object-example
+kubectl apply -f https://k8s.io/examples/admin/resource/quota-objects.yaml --namespace=quota-object-example
 ```
 
 View detailed information about the ResourceQuota:
@@ -77,7 +77,7 @@ Here is the configuration file for a PersistentVolumeClaim object:
 Create the PersistentVolumeClaim:
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/resource/quota-objects-pvc.yaml --namespace=quota-object-example
+kubectl apply -f https://k8s.io/examples/admin/resource/quota-objects-pvc.yaml --namespace=quota-object-example
 ```
 
 Verify that the PersistentVolumeClaim was created:
@@ -102,7 +102,7 @@ Here is the configuration file for a second PersistentVolumeClaim:
 Attempt to create the second PersistentVolumeClaim:
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/resource/quota-objects-pvc-2.yaml --namespace=quota-object-example
+kubectl apply -f https://k8s.io/examples/admin/resource/quota-objects-pvc-2.yaml --namespace=quota-object-example
 ```
 
 The output shows that the second PersistentVolumeClaim was not created,

--- a/content/en/docs/tasks/configure-pod-container/assign-cpu-resource.md
+++ b/content/en/docs/tasks/configure-pod-container/assign-cpu-resource.md
@@ -77,7 +77,7 @@ The `-cpus "2"` argument tells the Container to attempt to use 2 CPUs.
 Create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/pods/resource/cpu-request-limit.yaml --namespace=cpu-example
+kubectl apply -f https://k8s.io/examples/pods/resource/cpu-request-limit.yaml --namespace=cpu-example
 ```
 
 Verify that the Pod Container is running:
@@ -168,7 +168,7 @@ capacity of any Node in your cluster.
 Create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/pods/resource/cpu-request-limit-2.yaml --namespace=cpu-example
+kubectl apply -f https://k8s.io/examples/pods/resource/cpu-request-limit-2.yaml --namespace=cpu-example
 ```
 
 View the Pod status:

--- a/content/en/docs/tasks/configure-pod-container/assign-memory-resource.md
+++ b/content/en/docs/tasks/configure-pod-container/assign-memory-resource.md
@@ -76,7 +76,7 @@ The `"--vm-bytes", "150M"` arguments tell the Container to attempt to allocate 1
 Create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/pods/resource/memory-request-limit.yaml --namespace=mem-example
+kubectl apply -f https://k8s.io/examples/pods/resource/memory-request-limit.yaml --namespace=mem-example
 ```
 
 Verify that the Pod Container is running:
@@ -146,7 +146,7 @@ will attempt to allocate 250 MiB of memory, which is well above the 100 MiB limi
 Create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/pods/resource/memory-request-limit-2.yaml --namespace=mem-example
+kubectl apply -f https://k8s.io/examples/pods/resource/memory-request-limit-2.yaml --namespace=mem-example
 ```
 
 View detailed information about the Pod:
@@ -252,7 +252,7 @@ of any Node in your cluster.
 Create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/pods/resource/memory-request-limit-3.yaml --namespace=mem-example
+kubectl apply -f https://k8s.io/examples/pods/resource/memory-request-limit-3.yaml --namespace=mem-example
 ```
 
 View the Pod status:

--- a/content/en/docs/tasks/configure-pod-container/assign-pods-nodes.md
+++ b/content/en/docs/tasks/configure-pod-container/assign-pods-nodes.md
@@ -71,7 +71,7 @@ a `disktype=ssd` label.
    chosen node:
     
     ```shell
-    kubectl create -f https://k8s.io/examples/pods/pod-nginx.yaml
+    kubectl apply -f https://k8s.io/examples/pods/pod-nginx.yaml
     ```
 
 1. Verify that the pod is running on your chosen node:

--- a/content/en/docs/tasks/configure-pod-container/attach-handler-lifecycle-event.md
+++ b/content/en/docs/tasks/configure-pod-container/attach-handler-lifecycle-event.md
@@ -38,7 +38,7 @@ nginx gracefully. This is helpful if the Container is being terminated because o
 
 Create the Pod:
 
-    kubectl create -f https://k8s.io/examples/pods/lifecycle-events.yaml
+    kubectl apply -f https://k8s.io/examples/pods/lifecycle-events.yaml
 
 Verify that the Container in the Pod is running:
 

--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-probes.md
@@ -62,7 +62,7 @@ code. After 30 seconds, `cat /tmp/healthy` returns a failure code.
 Create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/pods/probe/exec-liveness.yaml
+kubectl apply -f https://k8s.io/examples/pods/probe/exec-liveness.yaml
 ```
 
 Within 30 seconds, view the Pod events:
@@ -163,7 +163,7 @@ checks will fail, and the kubelet will kill and restart the Container.
 To try the HTTP liveness check, create a Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/pods/probe/http-liveness.yaml
+kubectl apply -f https://k8s.io/examples/pods/probe/http-liveness.yaml
 ```
 
 After 10 seconds, view Pod events to verify that liveness probes have failed and
@@ -204,7 +204,7 @@ will be restarted.
 To try the TCP liveness check, create a Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/pods/probe/tcp-liveness-readiness.yaml
+kubectl apply -f https://k8s.io/examples/pods/probe/tcp-liveness-readiness.yaml
 ```
 
 After 15 seconds, view Pod events to verify that liveness probes:

--- a/content/en/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
@@ -73,7 +73,7 @@ PersistentVolumeClaim requests to this PersistentVolume.
 
 Create the PersistentVolume:
 
-    kubectl create -f https://k8s.io/examples/pods/storage/pv-volume.yaml
+    kubectl apply -f https://k8s.io/examples/pods/storage/pv-volume.yaml
 
 View information about the PersistentVolume:
 
@@ -98,7 +98,7 @@ Here is the configuration file for the PersistentVolumeClaim:
 
 Create the PersistentVolumeClaim:
 
-    kubectl create -f https://k8s.io/examples/pods/storage/pv-claim.yaml
+    kubectl apply -f https://k8s.io/examples/pods/storage/pv-claim.yaml
 
 After you create the PersistentVolumeClaim, the Kubernetes control plane looks
 for a PersistentVolume that satisfies the claim's requirements. If the control
@@ -138,7 +138,7 @@ is a volume.
 
 Create the Pod:
 
-    kubectl create -f https://k8s.io/examples/pods/storage/pv-pod.yaml
+    kubectl apply -f https://k8s.io/examples/pods/storage/pv-pod.yaml
 
 Verify that the Container in the Pod is running;
 

--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -19,7 +19,7 @@ ConfigMaps allow you to decouple configuration artifacts from image content to k
 
 
 ## Create a ConfigMap
-You can use either `kubectl create configmap` or a ConfigMap generator in `kustomization.yaml` to create a ConfigMap.
+You can use either `kubectl create configmap` or a ConfigMap generator in `kustomization.yaml` to create a ConfigMap. Note that `kubectl` starts to support `kustomization.yaml` since 1.14. 
 
 ### Create a ConfigMap Using kubectl create configmap
 
@@ -296,6 +296,7 @@ metadata:
 ```
 
 ### Create a ConfigMap from generator
+`kubectl` supports `kustomization.yaml` since 1.14.
 You can also create a ConfigMap from generators and then apply it to create the object on
 the Apiserver. The generators
 should be specified in a `kustomization.yaml` inside a directory.
@@ -304,7 +305,7 @@ should be specified in a `kustomization.yaml` inside a directory.
 For example, to generate a ConfigMap from files `configure-pod-container/configmap/kubectl/game.properties`
 ```shell
 # Create a kustomization.yaml file with ConfigMapGenerator
-$ cat <<EOF >./kustomization.yaml
+cat <<EOF >./kustomization.yaml
 configMapGenerator:
 - name: game-config-4
   files:
@@ -314,19 +315,19 @@ EOF
 
 Apply the kustomization directory to create the ConfigMap object.
 ```shell
-$ kubectl apply -k .
+kubectl apply -k .
 configmap/game-config-4-m9dm2f92bt created
 ```
 
 You can check that the ConfigMap was created like this:
 
 ```shell
-$ kubectl get configmap
+kubectl get configmap
 NAME                       DATA   AGE
 game-config-4-m9dm2f92bt   1      37s
 
 
-$ kubectl describe configmaps/game-config-4-m9dm2f92bt
+kubectl describe configmaps/game-config-4-m9dm2f92bt
 Name:         game-config-4-m9dm2f92bt
 Namespace:    default
 Labels:       <none>
@@ -347,8 +348,8 @@ secret.code.lives=30
 Events:  <none>
 ```
 
-Note that the generated ConfigMaps name has a suffix appended by hashing the contents. This ensures that a
-new ConfigMap is generated each time the contents is modified.
+Note that the generated ConfigMap name has a suffix appended by hashing the contents. This ensures that a
+new ConfigMap is generated each time the content is modified.
 
 #### Define the key to use when generating a ConfigMap from a file
 You can define a key other than the file name to use in the ConfigMap generator.
@@ -357,7 +358,7 @@ with the key `game-special-key`
 
 ```shell
 # Create a kustomization.yaml file with ConfigMapGenerator
-$ cat <<EOF >./kustomization.yaml
+cat <<EOF >./kustomization.yaml
 configMapGenerator:
 - name: game-config-5
   files:
@@ -367,7 +368,7 @@ EOF
 
 Apply the kustomization directory to create the ConfigMap object.
 ```shell
-$ kubectl apply -k .
+kubectl apply -k .
 configmap/game-config-5-m67dt67794 created
 ```
 
@@ -376,7 +377,7 @@ To generate a ConfigMap from literals `special.type=charm` and `special.how=very
 you can specify the ConfigMap generator in `kusotmization.yaml` as
 ```shell
 # Create a kustomization.yaml file with ConfigMapGenerator
-$ cat <<EOF >./kustomization.yaml
+cat <<EOF >./kustomization.yaml
 configMapGenerator:
 - name: special-config-2
   literals:
@@ -386,7 +387,7 @@ EOF
 ```
 Apply the kustomization directory to create the ConfigMap object.
 ```shell
-$ kubectl apply -k .
+kubectl apply -k .
 configmap/special-config-2-c92b5mmcf2 created
 ```
 

--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -18,7 +18,10 @@ ConfigMaps allow you to decouple configuration artifacts from image content to k
 {{% capture steps %}}
 
 
-## Create a ConfigMap 
+## Create a ConfigMap
+You can use either `kubectl create configmap` or a ConfigMap generator in `kustomization.yaml` to create a ConfigMap.
+
+### Create a ConfigMap Using kubectl create configmap
 
 Use the `kubectl create configmap` command to create configmaps from [directories](#create-configmaps-from-directories), [files](#create-configmaps-from-files), or [literal values](#create-configmaps-from-literal-values):
 
@@ -37,7 +40,7 @@ You can use [`kubectl describe`](/docs/reference/generated/kubectl/kubectl-comma
 [`kubectl get`](/docs/reference/generated/kubectl/kubectl-commands/#get) to retrieve information
 about a ConfigMap.
 
-### Create ConfigMaps from directories
+#### Create ConfigMaps from directories
 
 You can use `kubectl create configmap` to create a ConfigMap from multiple files in the same directory.
 
@@ -105,7 +108,7 @@ metadata:
   uid: b4952dc3-d670-11e5-8cd0-68f728db1985
 ```
 
-### Create ConfigMaps from files
+#### Create ConfigMaps from files
 
 You can use `kubectl create configmap` to create a ConfigMap from an individual file, or from multiple files.
 
@@ -263,7 +266,7 @@ metadata:
   uid: 05f8da22-d671-11e5-8cd0-68f728db1985
 ```
 
-### Create ConfigMaps from literal values
+#### Create ConfigMaps from literal values
 
 You can use `kubectl create configmap` with the `--from-literal` argument to define a literal value from the command line:
 
@@ -292,6 +295,100 @@ metadata:
   uid: dadce046-d673-11e5-8cd0-68f728db1985
 ```
 
+### Create a ConfigMap from generator
+You can also create a ConfigMap from generators and then apply it to create the object on
+the Apiserver. The generators
+should be specified in a `kustomization.yaml` inside a directory.
+
+#### Generate ConfigMaps from files
+For example, to generate a ConfigMap from files `configure-pod-container/configmap/kubectl/game.properties`
+```shell
+# Create a kustomization.yaml file with ConfigMapGenerator
+$ cat <<EOF >./kustomization.yaml
+configMapGenerator:
+- name: game-config-4
+  files:
+  - configure-pod-container/configmap/kubectl/game.properties
+EOF
+```
+
+Apply the kustomization directory to create the ConfigMap object.
+```shell
+$ kubectl apply -k .
+configmap/game-config-4-m9dm2f92bt created
+```
+
+You can check that the ConfigMap was created like this:
+
+```shell
+$ kubectl get configmap
+NAME                       DATA   AGE
+game-config-4-m9dm2f92bt   1      37s
+
+
+$ kubectl describe configmaps/game-config-4-m9dm2f92bt
+Name:         game-config-4-m9dm2f92bt
+Namespace:    default
+Labels:       <none>
+Annotations:  kubectl.kubernetes.io/last-applied-configuration:
+                {"apiVersion":"v1","data":{"game.properties":"enemies=aliens\nlives=3\nenemies.cheat=true\nenemies.cheat.level=noGoodRotten\nsecret.code.p...
+
+Data
+====
+game.properties:
+----
+enemies=aliens
+lives=3
+enemies.cheat=true
+enemies.cheat.level=noGoodRotten
+secret.code.passphrase=UUDDLRLRBABAS
+secret.code.allowed=true
+secret.code.lives=30
+Events:  <none>
+```
+
+Note that the generated ConfigMaps name has a suffix appended by hashing the contents. This ensures that a
+new ConfigMap is generated each time the contents is modified.
+
+#### Define the key to use when generating a ConfigMap from a file
+You can define a key other than the file name to use in the ConfigMap generator.
+For example, to generate a ConfigMap from files `configure-pod-container/configmap/kubectl/game.properties`
+with the key `game-special-key`
+
+```shell
+# Create a kustomization.yaml file with ConfigMapGenerator
+$ cat <<EOF >./kustomization.yaml
+configMapGenerator:
+- name: game-config-5
+  files:
+  - game-special-key=configure-pod-container/configmap/kubectl/game.properties
+EOF
+```
+
+Apply the kustomization directory to create the ConfigMap object.
+```shell
+$ kubectl apply -k .
+configmap/game-config-5-m67dt67794 created
+```
+
+#### Generate ConfigMaps from Literals
+To generate a ConfigMap from literals `special.type=charm` and `special.how=very`,
+you can specify the ConfigMap generator in `kusotmization.yaml` as
+```shell
+# Create a kustomization.yaml file with ConfigMapGenerator
+$ cat <<EOF >./kustomization.yaml
+configMapGenerator:
+- name: special-config-2
+  literals:
+  - special.how=very
+  - special.type=charm
+EOF
+```
+Apply the kustomization directory to create the ConfigMap object.
+```shell
+$ kubectl apply -k .
+configmap/special-config-2-c92b5mmcf2 created
+```
 
 ## Define container environment variables using ConfigMap data
 

--- a/content/en/docs/tasks/configure-pod-container/configure-pod-initialization.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-initialization.md
@@ -43,7 +43,7 @@ of the nginx server.
 
 Create the Pod:
 
-    kubectl create -f https://k8s.io/examples/pods/init-containers.yaml
+    kubectl apply -f https://k8s.io/examples/pods/init-containers.yaml
 
 Verify that the nginx container is running:
 

--- a/content/en/docs/tasks/configure-pod-container/configure-projected-volume-storage.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-projected-volume-storage.md
@@ -42,7 +42,7 @@ Here is the configuration file for the Pod:
 ```
 1. Create the Pod:
 ```shell
-       kubectl create -f https://k8s.io/examples/pods/storage/projected.yaml
+       kubectl apply -f https://k8s.io/examples/pods/storage/projected.yaml
 ```
 1. Verify that the Pod's Container is running, and then watch for changes to
 the Pod:

--- a/content/en/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-service-account.md
@@ -92,7 +92,7 @@ default   1          1d
 You can create additional ServiceAccount objects like this:
 
 ```shell
-kubectl create -f - <<EOF
+kubectl apply -f - <<EOF
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -141,7 +141,7 @@ Suppose we have an existing service account named "build-robot" as mentioned abo
 a new secret manually.
 
 ```shell
-kubectl create -f - <<EOF
+kubectl apply -f - <<EOF
 apiVersion: v1
 kind: Secret
 metadata:

--- a/content/en/docs/tasks/configure-pod-container/configure-volume-storage.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-volume-storage.md
@@ -37,7 +37,7 @@ restarts. Here is the configuration file for the Pod:
 1. Create the Pod:
 
     ```shell
-    kubectl create -f https://k8s.io/examples/pods/storage/redis.yaml
+    kubectl apply -f https://k8s.io/examples/pods/storage/redis.yaml
     ```
 
 1. Verify that the Pod's Container is running, and then watch for changes to

--- a/content/en/docs/tasks/configure-pod-container/extended-resource.md
+++ b/content/en/docs/tasks/configure-pod-container/extended-resource.md
@@ -43,7 +43,7 @@ In the configuration file, you can see that the Container requests 3 dongles.
 Create a Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/pods/resource/extended-resource-pod.yaml
+kubectl apply -f https://k8s.io/examples/pods/resource/extended-resource-pod.yaml
 ```
 
 Verify that the Pod is running:
@@ -80,7 +80,7 @@ used three of the four available dongles.
 Attempt to create a Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/pods/resource/extended-resource-pod-2.yaml
+kubectl apply -f https://k8s.io/examples/pods/resource/extended-resource-pod-2.yaml
 ```
 
 Describe the Pod

--- a/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
+++ b/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
@@ -152,7 +152,7 @@ The `imagePullSecrets` field in the configuration file specifies that Kubernetes
 Create a Pod that uses your Secret, and verify that the Pod is running:
 
 ```shell
-kubectl create -f my-private-reg-pod.yaml
+kubectl apply -f my-private-reg-pod.yaml
 kubectl get pod private-reg
 ```
 

--- a/content/en/docs/tasks/configure-pod-container/quality-service-pod.md
+++ b/content/en/docs/tasks/configure-pod-container/quality-service-pod.md
@@ -55,7 +55,7 @@ memory request, both equal to 200 MiB. The Container has a CPU limit and a CPU r
 Create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/pods/qos/qos-pod.yaml --namespace=qos-example
+kubectl apply -f https://k8s.io/examples/pods/qos/qos-pod.yaml --namespace=qos-example
 ```
 
 View detailed information about the Pod:
@@ -111,7 +111,7 @@ and a memory request of 100 MiB.
 Create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/pods/qos/qos-pod-2.yaml --namespace=qos-example
+kubectl apply -f https://k8s.io/examples/pods/qos/qos-pod-2.yaml --namespace=qos-example
 ```
 
 View detailed information about the Pod:
@@ -156,7 +156,7 @@ limits or requests:
 Create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/pods/qos/qos-pod-3.yaml --namespace=qos-example
+kubectl apply -f https://k8s.io/examples/pods/qos/qos-pod-3.yaml --namespace=qos-example
 ```
 
 View detailed information about the Pod:
@@ -195,7 +195,7 @@ criteria for QoS class Guaranteed, and one of its Containers has a memory reques
 Create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/pods/qos/qos-pod-4.yaml --namespace=qos-example
+kubectl apply -f https://k8s.io/examples/pods/qos/qos-pod-4.yaml --namespace=qos-example
 ```
 
 View detailed information about the Pod:

--- a/content/en/docs/tasks/configure-pod-container/security-context.md
+++ b/content/en/docs/tasks/configure-pod-container/security-context.md
@@ -60,7 +60,7 @@ volume.
 Create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/pods/security/security-context.yaml
+kubectl apply -f https://k8s.io/examples/pods/security/security-context.yaml
 ```
 
 Verify that the Pod's Container is running:
@@ -146,7 +146,7 @@ and the Container have a `securityContext` field:
 Create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/pods/security/security-context-2.yaml
+kubectl apply -f https://k8s.io/examples/pods/security/security-context-2.yaml
 ```
 
 Verify that the Pod's Container is running:
@@ -199,7 +199,7 @@ Here is configuration file that does not add or remove any Container capabilitie
 Create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/pods/security/security-context-3.yaml
+kubectl apply -f https://k8s.io/examples/pods/security/security-context-3.yaml
 ```
 
 Verify that the Pod's Container is running:
@@ -261,7 +261,7 @@ adds the `CAP_NET_ADMIN` and `CAP_SYS_TIME` capabilities:
 Create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/pods/security/security-context-4.yaml
+kubectl apply -f https://k8s.io/examples/pods/security/security-context-4.yaml
 ```
 
 Get a shell into the running Container:

--- a/content/en/docs/tasks/configure-pod-container/share-process-namespace.md
+++ b/content/en/docs/tasks/configure-pod-container/share-process-namespace.md
@@ -43,7 +43,7 @@ Process Namespace Sharing is enabled using the `ShareProcessNamespace` field of
 
 1. Create the pod `nginx` on your cluster:
 
-        kubectl create -f https://k8s.io/examples/pods/share-process-namespace.yaml
+        kubectl apply -f https://k8s.io/examples/pods/share-process-namespace.yaml
 
 1. Attach to the `shell` container and run `ps`:
 

--- a/content/en/docs/tasks/configure-pod-container/translate-compose-kubernetes.md
+++ b/content/en/docs/tasks/configure-pod-container/translate-compose-kubernetes.md
@@ -124,7 +124,7 @@ you need is an existing `docker-compose.yml` file.
       ```bash
       $ kompose up
       We are going to create Kubernetes Deployments, Services and PersistentVolumeClaims for your Dockerized application.
-      If you need different kind of resources, use the 'kompose convert' and 'kubectl create -f' commands instead.
+      If you need different kind of resources, use the 'kompose convert' and 'kubectl apply -f' commands instead.
 
       INFO Successfully created Service: redis          
       INFO Successfully created Service: web            
@@ -135,7 +135,7 @@ you need is an existing `docker-compose.yml` file.
       ```
 
 3.  To convert the `docker-compose.yml` file to files that you can use with
-    `kubectl`, run `kompose convert` and then `kubectl create -f <output file>`.
+    `kubectl`, run `kompose convert` and then `kubectl apply -f <output file>`.
 
       ```bash
       $ kompose convert                           
@@ -148,7 +148,7 @@ you need is an existing `docker-compose.yml` file.
       ```
 
       ```bash
-      $ kubectl create -f frontend-service.yaml,redis-master-service.yaml,redis-slave-service.yaml,frontend-deployment.yaml,redis-master-deployment.yaml,redis-slave-deployment.yaml
+      $ kubectl apply -f frontend-service.yaml,redis-master-service.yaml,redis-slave-service.yaml,frontend-deployment.yaml,redis-master-deployment.yaml,redis-slave-deployment.yaml
       service/frontend created
       service/redis-master created
       service/redis-slave created
@@ -309,7 +309,7 @@ Kompose supports a straightforward way to deploy your "composed" application to 
 ```sh
 $ kompose --file ./examples/docker-guestbook.yml up
 We are going to create Kubernetes deployments and services for your Dockerized application.
-If you need different kind of resources, use the 'kompose convert' and 'kubectl create -f' commands instead.
+If you need different kind of resources, use the 'kompose convert' and 'kubectl apply -f' commands instead.
 
 INFO Successfully created service: redis-master   
 INFO Successfully created service: redis-slave    
@@ -341,7 +341,7 @@ pod/redis-slave-2504961300-nve7b    1/1           Running       0            4m
 **Note**:
 
 - You must have a running Kubernetes cluster with a pre-configured kubectl context.
-- Only deployments and services are generated and deployed to Kubernetes. If you need different kind of resources, use the `kompose convert` and `kubectl create -f` commands instead.
+- Only deployments and services are generated and deployed to Kubernetes. If you need different kind of resources, use the `kompose convert` and `kubectl apply -f` commands instead.
 
 ### OpenShift
 ```sh
@@ -426,7 +426,7 @@ INFO Image 'docker.io/foo/bar' from directory 'build' built successfully
 INFO Pushing image 'foo/bar:latest' to registry 'docker.io'
 INFO Attempting authentication credentials 'https://index.docker.io/v1/
 INFO Successfully pushed image 'foo/bar:latest' to registry 'docker.io'
-INFO We are going to create Kubernetes Deployments, Services and PersistentVolumeClaims for your Dockerized application. If you need different kind of resources, use the 'kompose convert' and 'kubectl create -f' commands instead.
+INFO We are going to create Kubernetes Deployments, Services and PersistentVolumeClaims for your Dockerized application. If you need different kind of resources, use the 'kompose convert' and 'kubectl apply -f' commands instead.
 
 INFO Deploying application in "default" namespace
 INFO Successfully created Service: foo            

--- a/content/en/docs/tasks/debug-application-cluster/debug-application-introspection.md
+++ b/content/en/docs/tasks/debug-application-cluster/debug-application-introspection.md
@@ -26,7 +26,7 @@ For this example we'll use a Deployment to create two pods, similar to the earli
 Create deployment by running following command:
 
 ```shell
-kubectl create -f https://k8s.io/examples/application/nginx-with-request.yaml
+kubectl apply -f https://k8s.io/examples/application/nginx-with-request.yaml
 ```
 
 ```none

--- a/content/en/docs/tasks/debug-application-cluster/debug-application.md
+++ b/content/en/docs/tasks/debug-application-cluster/debug-application.md
@@ -107,7 +107,7 @@ For example, if you misspelled `command` as `commnd` then the pod will be create
 will not use the command line you intended it to use.
 
 The first thing to do is to delete your pod and try creating it again with the `--validate` option.
-For example, run `kubectl create --validate -f mypod.yaml`.
+For example, run `kubectl apply --validate -f mypod.yaml`.
 If you misspelled `command` as `commnd` then will give an error like this:
 
 ```shell

--- a/content/en/docs/tasks/debug-application-cluster/determine-reason-pod-failure.md
+++ b/content/en/docs/tasks/debug-application-cluster/determine-reason-pod-failure.md
@@ -38,7 +38,7 @@ the container starts.
 
 1. Create a Pod based on the YAML configuration file:
 
-        kubectl create -f https://k8s.io/examples/debug/termination.yaml
+        kubectl apply -f https://k8s.io/examples/debug/termination.yaml
 
     In the YAML file, in the `cmd` and `args` fields, you can see that the
     container sleeps for 10 seconds and then writes "Sleep expired" to

--- a/content/en/docs/tasks/debug-application-cluster/events-stackdriver.md
+++ b/content/en/docs/tasks/debug-application-cluster/events-stackdriver.md
@@ -59,7 +59,7 @@ average, approximately 100Mb RAM and 100m CPU is needed.
 Deploy event exporter to your cluster using the following command:
 
 ```shell
-kubectl create -f https://k8s.io/examples/debug/event-exporter.yaml
+kubectl apply -f https://k8s.io/examples/debug/event-exporter.yaml
 ```
 
 Since event exporter accesses the Kubernetes API, it requires permissions to

--- a/content/en/docs/tasks/debug-application-cluster/get-shell-running-container.md
+++ b/content/en/docs/tasks/debug-application-cluster/get-shell-running-container.md
@@ -33,7 +33,7 @@ runs the nginx image. Here is the configuration file for the Pod:
 Create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/application/shell-demo.yaml
+kubectl apply -f https://k8s.io/examples/application/shell-demo.yaml
 ```
 
 Verify that the Container is running:

--- a/content/en/docs/tasks/debug-application-cluster/logging-stackdriver.md
+++ b/content/en/docs/tasks/debug-application-cluster/logging-stackdriver.md
@@ -97,7 +97,7 @@ than Google Kubernetes Engine. Proceed at your own risk.
 1. Deploy a `ConfigMap` with the logging agent configuration by running the following command:
 
     ```
-    kubectl create -f https://k8s.io/examples/debug/fluentd-gcp-configmap.yaml
+    kubectl apply -f https://k8s.io/examples/debug/fluentd-gcp-configmap.yaml
     ```
 
     The command creates the `ConfigMap` in the `default` namespace. You can download the file
@@ -106,7 +106,7 @@ than Google Kubernetes Engine. Proceed at your own risk.
 1. Deploy the logging agent `DaemonSet` by running the following command:
 
     ```
-    kubectl create -f https://k8s.io/examples/debug/fluentd-gcp-ds.yaml
+    kubectl apply -f https://k8s.io/examples/debug/fluentd-gcp-ds.yaml
     ```
 
     You can download and edit this file before using it as well.
@@ -139,7 +139,7 @@ that writes out the value of a counter and the date once per
 second, and runs indefinitely. Let's create this pod in the default namespace.
 
 ```shell
-kubectl create -f https://k8s.io/examples/debug/counter-pod.yaml
+kubectl apply -f https://k8s.io/examples/debug/counter-pod.yaml
 ```
 
 You can observe the running pod:
@@ -176,7 +176,7 @@ pod "counter" deleted
 and then recreating it:
 
 ```shell
-$ kubectl create -f https://k8s.io/examples/debug/counter-pod.yaml
+$ kubectl apply -f https://k8s.io/examples/debug/counter-pod.yaml
 pod/counter created
 ```
 

--- a/content/en/docs/tasks/debug-application-cluster/monitor-node-health.md
+++ b/content/en/docs/tasks/debug-application-cluster/monitor-node-health.md
@@ -73,7 +73,7 @@ OS distro.***
 * **Step 2:** Start node problem detector with `kubectl`:
 
 ```shell
- kubectl create -f https://k8s.io/examples/debug/node-problem-detector.yaml
+ kubectl apply -f https://k8s.io/examples/debug/node-problem-detector.yaml
 ```
 
 ### Addon Pod
@@ -105,7 +105,7 @@ node-problem-detector-config --from-file=config/`.
 
 ```shell
  kubectl delete -f https://k8s.io/examples/debug/node-problem-detector.yaml # If you have a node-problem-detector running
- kubectl create -f https://k8s.io/examples/debug/node-problem-detector-configmap.yaml
+ kubectl apply -f https://k8s.io/examples/debug/node-problem-detector-configmap.yaml
 ```
 
 ***Notice that this approach only applies to node problem detector started with `kubectl`.***

--- a/content/en/docs/tasks/federation/set-up-placement-policies-federation.md
+++ b/content/en/docs/tasks/federation/set-up-placement-policies-federation.md
@@ -32,7 +32,7 @@ After deploying the Federation control plane, you must configure an Admission
 Controller in the Federation API server that enforces placement decisions
 received from the external policy engine.
 
-    kubectl create -f scheduling-policy-admission.yaml
+    kubectl apply -f scheduling-policy-admission.yaml
 
 Shown below is an example ConfigMap for the Admission Controller:
 
@@ -82,7 +82,7 @@ decisions in the Federation control plane.
 
 Create a Service in the host cluster to contact the external policy engine:
 
-    kubectl create -f policy-engine-service.yaml
+    kubectl apply -f policy-engine-service.yaml
 
 Shown below is an example Service for OPA.
 
@@ -90,7 +90,7 @@ Shown below is an example Service for OPA.
 
 Create a Deployment in the host cluster with the Federation control plane:
 
-    kubectl create -f policy-engine-deployment.yaml
+    kubectl apply -f policy-engine-deployment.yaml
 
 Shown below is an example Deployment for OPA.
 

--- a/content/en/docs/tasks/inject-data-application/define-command-argument-container.md
+++ b/content/en/docs/tasks/inject-data-application/define-command-argument-container.md
@@ -47,7 +47,7 @@ file for the Pod defines a command and two arguments:
 1. Create a Pod based on the YAML configuration file:
 
     ```shell
-    kubectl create -f https://k8s.io/examples/pods/commands.yaml
+    kubectl apply -f https://k8s.io/examples/pods/commands.yaml
     ```
 
 1. List the running Pods:

--- a/content/en/docs/tasks/inject-data-application/define-environment-variable-container.md
+++ b/content/en/docs/tasks/inject-data-application/define-environment-variable-container.md
@@ -37,7 +37,7 @@ Pod:
 1. Create a Pod based on the YAML configuration file:
 
     ```shell
-    kubectl create -f https://k8s.io/examples/pods/inject/envars.yaml
+    kubectl apply -f https://k8s.io/examples/pods/inject/envars.yaml
     ```
 
 1. List the running Pods:

--- a/content/en/docs/tasks/inject-data-application/distribute-credentials-secure.md
+++ b/content/en/docs/tasks/inject-data-application/distribute-credentials-secure.md
@@ -42,7 +42,7 @@ username and password:
 1. Create the Secret
 
     ```shell
-    kubectl create -f https://k8s.io/examples/pods/inject/secret.yaml
+    kubectl apply -f https://k8s.io/examples/pods/inject/secret.yaml
     ```
 
 1. View information about the Secret:
@@ -98,7 +98,7 @@ Here is a configuration file you can use to create a Pod:
 1. Create the Pod:
 
     ```shell
-    kubectl create -f https://k8s.io/examples/pods/inject/secret-pod.yaml
+    kubectl apply -f https://k8s.io/examples/pods/inject/secret-pod.yaml
     ```
 
 1. Verify that your Pod is running:
@@ -153,7 +153,7 @@ Here is a configuration file you can use to create a Pod:
 1. Create the Pod:
 
     ```shell
-    kubectl create -f https://k8s.io/examples/pods/inject/secret-envars-pod.yaml
+    kubectl apply -f https://k8s.io/examples/pods/inject/secret-envars-pod.yaml
     ```
 
 1. Verify that your Pod is running:

--- a/content/en/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
+++ b/content/en/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
@@ -56,7 +56,7 @@ fields of the Container in the Pod.
 Create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/pods/inject/dapi-volume.yaml
+kubectl apply -f https://k8s.io/examples/pods/inject/dapi-volume.yaml
 ```
 
 Verify that Container in the Pod is running:
@@ -172,7 +172,7 @@ default value of `1` which means cores for cpu and bytes for memory.
 Create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/pods/inject/dapi-volume-resources.yaml
+kubectl apply -f https://k8s.io/examples/pods/inject/dapi-volume-resources.yaml
 ```
 
 Get a shell into the Container that is running in your Pod:

--- a/content/en/docs/tasks/inject-data-application/environment-variable-expose-pod-information.md
+++ b/content/en/docs/tasks/inject-data-application/environment-variable-expose-pod-information.md
@@ -55,7 +55,7 @@ Container in the Pod.
 Create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/pods/inject/dapi-envars-pod.yaml
+kubectl apply -f https://k8s.io/examples/pods/inject/dapi-envars-pod.yaml
 ```
 
 Verify that the Container in the Pod is running:
@@ -130,7 +130,7 @@ from Container fields.
 Create the Pod:
 
 ```shell
-kubectl create -f https://k8s.io/examples/pods/inject/dapi-envars-container.yaml
+kubectl apply -f https://k8s.io/examples/pods/inject/dapi-envars-container.yaml
 ```
 
 Verify that the Container in the Pod is running:

--- a/content/en/docs/tasks/inject-data-application/podpreset.md
+++ b/content/en/docs/tasks/inject-data-application/podpreset.md
@@ -36,7 +36,7 @@ Preset.
 Create the PodPreset:
 
 ```shell
-kubectl create -f https://k8s.io/examples/podpreset/preset.yaml
+kubectl apply -f https://k8s.io/examples/podpreset/preset.yaml
 ```
 
 Examine the created PodPreset:
@@ -54,7 +54,7 @@ The new PodPreset will act upon any pod that has label `role: frontend`.
 Create a pod:
 
 ```shell
-$ kubectl create -f https://k8s.io/examples/podpreset/pod.yaml
+$ kubectl apply -f https://k8s.io/examples/podpreset/pod.yaml
 ```
 
 List the running Pods:

--- a/content/en/docs/tasks/job/automated-tasks-with-cron-jobs.md
+++ b/content/en/docs/tasks/job/automated-tasks-with-cron-jobs.md
@@ -50,7 +50,7 @@ This example cron job config `.spec` file prints the current time and a hello me
 Run the example cron job by downloading the example file and then running this command:
 
 ```shell
-$ kubectl create -f ./cronjob.yaml
+$ kubectl apply -f ./cronjob.yaml
 cronjob "hello" created
 ```
 

--- a/content/en/docs/tasks/job/coarse-parallel-processing-work-queue.md
+++ b/content/en/docs/tasks/job/coarse-parallel-processing-work-queue.md
@@ -46,9 +46,9 @@ cluster and reuse it for many jobs, as well as for long-running services.
 Start RabbitMQ as follows:
 
 ```shell
-$ kubectl create -f examples/celery-rabbitmq/rabbitmq-service.yaml
+$ kubectl apply -f examples/celery-rabbitmq/rabbitmq-service.yaml
 service "rabbitmq-service" created
-$ kubectl create -f examples/celery-rabbitmq/rabbitmq-controller.yaml
+$ kubectl apply -f examples/celery-rabbitmq/rabbitmq-controller.yaml
 replicationcontroller "rabbitmq-controller" created
 ```
 
@@ -234,7 +234,7 @@ done.  So we set, `.spec.completions: 8` for the example, since we put 8 items i
 So, now run the Job:
 
 ```shell
-kubectl create -f ./job.yaml
+kubectl apply -f ./job.yaml
 ```
 
 Now wait a bit, then check on the job.

--- a/content/en/docs/tasks/job/fine-parallel-processing-work-queue.md
+++ b/content/en/docs/tasks/job/fine-parallel-processing-work-queue.md
@@ -53,9 +53,9 @@ directory and start a temporary Pod running Redis and a service so we can find i
 
 ```shell
 $ cd content/en/examples/application/job/redis
-$ kubectl create -f ./redis-pod.yaml
+$ kubectl apply -f ./redis-pod.yaml
 pod/redis-master created
-$ kubectl create -f ./redis-service.yaml
+$ kubectl apply -f ./redis-service.yaml
 service/redis created
 ```
 
@@ -196,7 +196,7 @@ too.
 So, now run the Job:
 
 ```shell
-kubectl create -f ./job.yaml
+kubectl apply -f ./job.yaml
 ```
 
 Now wait a bit, then check on the job.

--- a/content/en/docs/tasks/job/parallel-processing-expansion.md
+++ b/content/en/docs/tasks/job/parallel-processing-expansion.md
@@ -66,7 +66,7 @@ to generate the Job objects.
 Next, create all the jobs with one kubectl command:
 
 ```shell
-$ kubectl create -f ./jobs
+$ kubectl apply -f ./jobs
 job "process-item-apple" created
 job "process-item-banana" created
 job "process-item-cherry" created
@@ -178,7 +178,7 @@ cat job.yaml.jinja2 | render_template > jobs.yaml
 Or sent directly to kubectl, like this:
 
 ```shell
-cat job.yaml.jinja2 | render_template | kubectl create -f -
+cat job.yaml.jinja2 | render_template | kubectl apply -f -
 ```
 
 ## Alternatives

--- a/content/en/docs/tasks/manage-daemon/update-daemon-set.md
+++ b/content/en/docs/tasks/manage-daemon/update-daemon-set.md
@@ -56,7 +56,7 @@ If you haven't created the DaemonSet in the system, check your DaemonSet
 manifest with the following command instead:
 
 ```shell
-kubectl create -f ds.yaml --dry-run -o go-template='{{.spec.updateStrategy.type}}{{"\n"}}'
+kubectl apply -f ds.yaml --dry-run -o go-template='{{.spec.updateStrategy.type}}{{"\n"}}'
 ```
 
 The output from both commands should be:
@@ -76,7 +76,7 @@ step 3.
 After verifying the update strategy of the DaemonSet manifest, create the DaemonSet:
 
 ```shell
-kubectl create -f ds.yaml
+kubectl apply -f ds.yaml
 ```
 
 Alternatively, use `kubectl apply` to create the same DaemonSet if you plan to

--- a/content/en/docs/tasks/run-application/configure-pdb.md
+++ b/content/en/docs/tasks/run-application/configure-pdb.md
@@ -167,7 +167,7 @@ automatically responds to changes in the number of replicas of the corresponding
 
 ## Create the PDB object
 
-You can create the PDB object with a command like `kubectl create -f mypdb.yaml`.
+You can create the PDB object with a command like `kubectl apply -f mypdb.yaml`.
 
 You cannot update PDB objects.  They must be deleted and re-created.
 

--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -454,7 +454,7 @@ can use the following file to create it declaratively:
 We will create the autoscaler by executing the following command:
 
 ```shell
-$ kubectl create -f https://k8s.io/examples/application/hpa/php-apache.yaml
+$ kubectl apply -f https://k8s.io/examples/application/hpa/php-apache.yaml
 horizontalpodautoscaler.autoscaling/php-apache created
 ```
 

--- a/content/en/docs/tasks/run-application/run-replicated-stateful-application.md
+++ b/content/en/docs/tasks/run-application/run-replicated-stateful-application.md
@@ -60,7 +60,7 @@ and a StatefulSet.
 Create the ConfigMap from the following YAML configuration file:
 
 ```shell
-kubectl create -f https://k8s.io/examples/application/mysql/mysql-configmap.yaml
+kubectl apply -f https://k8s.io/examples/application/mysql/mysql-configmap.yaml
 ```
 
 {{< codenew file="application/mysql/mysql-configmap.yaml" >}}
@@ -80,7 +80,7 @@ based on information provided by the StatefulSet controller.
 Create the Services from the following YAML configuration file:
 
 ```shell
-kubectl create -f https://k8s.io/examples/application/mysql/mysql-services.yaml
+kubectl apply -f https://k8s.io/examples/application/mysql/mysql-services.yaml
 ```
 
 {{< codenew file="application/mysql/mysql-services.yaml" >}}
@@ -106,7 +106,7 @@ writes.
 Finally, create the StatefulSet from the following YAML configuration file:
 
 ```shell
-kubectl create -f https://k8s.io/examples/application/mysql/mysql-statefulset.yaml
+kubectl apply -f https://k8s.io/examples/application/mysql/mysql-statefulset.yaml
 ```
 
 {{< codenew file="application/mysql/mysql-statefulset.yaml" >}}

--- a/content/en/docs/tasks/run-application/run-single-instance-stateful-application.md
+++ b/content/en/docs/tasks/run-application/run-single-instance-stateful-application.md
@@ -53,11 +53,11 @@ for a secure solution.
 
 1. Deploy the PV and PVC of the YAML file:
 
-        kubectl create -f https://k8s.io/examples/application/mysql/mysql-pv.yaml
+        kubectl apply -f https://k8s.io/examples/application/mysql/mysql-pv.yaml
 
 1. Deploy the contents of the YAML file:
 
-        kubectl create -f https://k8s.io/examples/application/mysql/mysql-deployment.yaml
+        kubectl apply -f https://k8s.io/examples/application/mysql/mysql-deployment.yaml
 
 1. Display information about the Deployment:
 

--- a/content/en/docs/tasks/run-application/scale-stateful-set.md
+++ b/content/en/docs/tasks/run-application/scale-stateful-set.md
@@ -50,7 +50,7 @@ kubectl scale statefulsets <stateful-set-name> --replicas=<new-replicas>
 
 Alternatively, you can do [in-place updates](/docs/concepts/cluster-administration/manage-deployment/#in-place-updates-of-resources) on your StatefulSets.
 
-If your StatefulSet was initially created with `kubectl apply` or `kubectl create --save-config`,
+If your StatefulSet was initially created with `kubectl apply`,
 update `.spec.replicas` of the StatefulSet manifests, and then do a `kubectl apply`:
 
 ```shell

--- a/content/en/docs/tasks/run-application/update-api-object-kubectl-patch.md
+++ b/content/en/docs/tasks/run-application/update-api-object-kubectl-patch.md
@@ -31,7 +31,7 @@ is a Pod that has one container:
 Create the Deployment:
 
 ```shell
-kubectl create -f https://k8s.io/examples/application/deployment-patch.yaml
+kubectl apply -f https://k8s.io/examples/application/deployment-patch.yaml
 ```
 
 View the Pods associated with your Deployment:

--- a/content/en/docs/tasks/tls/managing-tls-in-a-cluster.md
+++ b/content/en/docs/tasks/tls/managing-tls-in-a-cluster.md
@@ -104,7 +104,7 @@ Generate a CSR yaml blob and send it to the apiserver by running the following
 command:
 
 ```shell
-cat <<EOF | kubectl create -f -
+cat <<EOF | kubectl apply -f -
 apiVersion: certificates.k8s.io/v1beta1
 kind: CertificateSigningRequest
 metadata:

--- a/content/en/docs/tutorials/clusters/apparmor.md
+++ b/content/en/docs/tutorials/clusters/apparmor.md
@@ -198,7 +198,7 @@ Next, we'll run a simple "Hello AppArmor" pod with the deny-write profile:
 {{< codenew file="pods/security/hello-apparmor.yaml" >}}
 
 ```shell
-$ kubectl create -f ./hello-apparmor.yaml
+$ kubectl apply -f ./hello-apparmor.yaml
 ```
 
 If we look at the pod events, we can see that the Pod container was created with the AppArmor
@@ -231,7 +231,7 @@ error: error executing remote command: command terminated with non-zero exit cod
 To wrap up, let's look at what happens if we try to specify a profile that hasn't been loaded:
 
 ```shell
-$ kubectl create -f /dev/stdin <<EOF
+$ kubectl apply -f /dev/stdin <<EOF
 apiVersion: v1
 kind: Pod
 metadata:

--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -14,9 +14,10 @@ This page provides a real world example of how to configure Redis using a Config
 
 {{% capture objectives %}}
 
-* Create a ConfigMap.
-* Create a pod specification using the ConfigMap.
-* Create the pod.
+* Create a kustomization.yaml with
+  * a ConfigMap generator
+  * a Pod resource config using the ConfigMap
+* Apply the directory by `kubectl apply -k ./`
 * Verify that the configuration was correctly applied.
 
 {{% /capture %}}
@@ -35,49 +36,48 @@ This page provides a real world example of how to configure Redis using a Config
 
 You can follow the steps below to configure a Redis cache using data stored in a ConfigMap.
 
-First create a ConfigMap from the `redis-config` file:
+First create a `kustomization.yaml` with a ConfigMap from the `redis-config` file:
 
 {{< codenew file="pods/config/redis-config" >}}
 
 ```shell
 curl -OL https://k8s.io/examples/pods/config/redis-config
-kubectl create configmap example-redis-config --from-file=redis-config
+
+cat <<EOF >./kustomization.yaml
+configMapGenerator:
+- name: example-redis-config
+  files:
+  - redis-config
+EOF
 ```
 
-```shell
-configmap/example-redis-config created
-```
-
-Examine the created ConfigMap:
-
-```shell
-kubectl get configmap example-redis-config -o yaml
-```
-
-```yaml
-apiVersion: v1
-data:
-  redis-config: |
-    maxmemory 2mb
-    maxmemory-policy allkeys-lru
-kind: ConfigMap
-metadata:
-  creationTimestamp: 2016-03-30T18:14:41Z
-  name: example-redis-config
-  namespace: default
-  resourceVersion: "24686"
-  selfLink: /api/v1/namespaces/default/configmaps/example-redis-config
-  uid: 460a2b6e-f6a3-11e5-8ae5-42010af00002
-```
-
-Now create a pod specification that uses the config data stored in the ConfigMap:
+Add the pod resource config to the `kustomization.yaml`:
 
 {{< codenew file="pods/config/redis-pod.yaml" >}}
 
-Create the pod:
+```shell
+curl -OL https://k8s.io/examples/pods/config/redis-pod.yaml
+
+cat <<EOF >>./kustomization.yaml
+resources:
+- redis-pod.yaml
+EOF
+```
+
+Apply the kustomization directory to create both the ConfigMap and Pod objects:
 
 ```shell
-kubectl create -f https://k8s.io/examples/pods/config/redis-pod.yaml
+kubectl apply -k .
+```
+
+Examine the created objects by
+```shell
+> kubectl get -k .
+NAME                                        DATA   AGE
+configmap/example-redis-config-dgh9dg555m   1      52s
+
+NAME        READY   STATUS    RESTARTS   AGE
+pod/redis   1/1     Running   0          52s
 ```
 
 In the example, the config volume is mounted at `/redis-master`.

--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -14,10 +14,10 @@ This page provides a real world example of how to configure Redis using a Config
 
 {{% capture objectives %}}
 
-* Create a kustomization.yaml with
+* Create a `kustomization.yaml` file containing:
   * a ConfigMap generator
   * a Pod resource config using the ConfigMap
-* Apply the directory by `kubectl apply -k ./`
+* Apply the directory by running `kubectl apply -k ./`
 * Verify that the configuration was correctly applied.
 
 {{% /capture %}}
@@ -25,6 +25,7 @@ This page provides a real world example of how to configure Redis using a Config
 {{% capture prerequisites %}}
 
 * {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+* The example shown on this page works with `kubectl` 1.14 and above.
 * Understand [Configure Containers Using a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/).
 
 {{% /capture %}}
@@ -36,7 +37,7 @@ This page provides a real world example of how to configure Redis using a Config
 
 You can follow the steps below to configure a Redis cache using data stored in a ConfigMap.
 
-First create a `kustomization.yaml` with a ConfigMap from the `redis-config` file:
+First create a `kustomization.yaml` containing a ConfigMap from the `redis-config` file:
 
 {{< codenew file="pods/config/redis-config" >}}
 

--- a/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -73,11 +73,11 @@ kubectl get pods -w -l app=nginx
 ```
 
 In the second terminal, use 
-[`kubectl create`](/docs/reference/generated/kubectl/kubectl-commands/#create) to create the 
+[`kubectl apply`](/docs/reference/generated/kubectl/kubectl-commands/#apply) to create the
 Headless Service and StatefulSet defined in `web.yaml`.
 
 ```shell
-kubectl create -f web.yaml 
+kubectl apply -f web.yaml
 service/nginx created
 statefulset.apps/web created
 ```
@@ -783,7 +783,7 @@ you deleted the `nginx` Service ( which you should not have ), you will see
 an error indicating that the Service already exists.
 
 ```shell
-kubectl create -f web.yaml 
+kubectl apply -f web.yaml
 statefulset.apps/web created
 Error from server (AlreadyExists): error when creating "web.yaml": services "nginx" already exists
 ```
@@ -883,7 +883,7 @@ service "nginx" deleted
 Recreate the StatefulSet and Headless Service one more time.
 
 ```shell
-kubectl create -f web.yaml 
+kubectl apply -f web.yaml
 service/nginx created
 statefulset.apps/web created
 ```
@@ -947,7 +947,7 @@ kubectl get po -l app=nginx -w
 In another terminal, create the StatefulSet and Service in the manifest.
 
 ```shell
-kubectl create -f web-parallel.yaml 
+kubectl apply -f web-parallel.yaml
 service/nginx created
 statefulset.apps/web created
 ```

--- a/content/en/docs/tutorials/stateful-application/cassandra.md
+++ b/content/en/docs/tutorials/stateful-application/cassandra.md
@@ -76,7 +76,7 @@ The following `Service` is used for DNS lookups between Cassandra Pods and clien
 1. Create a Service to track all Cassandra StatefulSet nodes from the `cassandra-service.yaml` file:
 
     ```shell
-    kubectl create -f https://k8s.io/examples/application/cassandra/cassandra-service.yaml
+    kubectl apply -f https://k8s.io/examples/application/cassandra/cassandra-service.yaml
     ```
 
 ### Validating (optional)
@@ -110,7 +110,7 @@ This example uses the default provisioner for Minikube. Please update the follow
 1. Create the Cassandra StatefulSet from the `cassandra-statefulset.yaml` file:
 
     ```shell
-    kubectl create -f https://k8s.io/examples/application/cassandra/cassandra-statefulset.yaml
+    kubectl apply -f https://k8s.io/examples/application/cassandra/cassandra-statefulset.yaml
     ```
 
 ## Validating The Cassandra StatefulSet

--- a/content/en/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
+++ b/content/en/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
@@ -34,7 +34,8 @@ The files provided in this tutorial are using GA Deployment APIs and are specifi
 
 {{% capture prerequisites %}}
 
-{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}} 
+{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+The example shown on this page works with `kubectl` 1.14 and above.
 
 Download the following configuration files:
 
@@ -69,19 +70,18 @@ If you have a Kubernetes cluster running on Google Kubernetes Engine, please fol
 ## Create a kustomization.yaml
 
 ### Add a Secret generator
-A [Secret](/docs/concepts/configuration/secret/) is an object that stores a piece of sensitive data like a password or key. You can create a Secret by generators in `kustomization.yaml`
+A [Secret](/docs/concepts/configuration/secret/) is an object that stores a piece of sensitive data like a password or key. Since 1.14, `kubectl` supports the management of Kubernetes objects using a kustomization file. You can create a Secret by generators in `kustomization.yaml`.
 
-1. Add a Secret generator in `kustomization.yaml` from the following command. You will need to replace
-   `YOUR_PASSWORD` with the password you want to use.
+Add a Secret generator in `kustomization.yaml` from the following command. You will need to replace `YOUR_PASSWORD` with the password you want to use.
 
-      ```shell
-      cat <<EOF >./kustomization.yaml
-      secretGenerator:
-      - name: mysql-pass
-        literals:
-        - password=YOUR_PASSWORD
-      EOF
-      ```
+```shell
+cat <<EOF >./kustomization.yaml
+secretGenerator:
+- name: mysql-pass
+  literals:
+  - password=YOUR_PASSWORD
+EOF
+```
 
 ## Add resource configs for MySQL and WordPress
 
@@ -89,25 +89,27 @@ The following manifest describes a single-instance MySQL Deployment. The MySQL c
 
 {{< codenew file="application/wordpress/mysql-deployment.yaml" >}}
 
-1. Download the MySQL deployment configuration file
+1. Download the MySQL deployment configuration file.
 
       ```shell
       curl -LO https://k8s.io/examples/application/wordpress/mysql-deployment.yaml
       ```
-2. Download the WordPress configuration file
+            
+2. Download the WordPress configuration file.
 
       ```shell
       curl -LO https://k8s.io/examples/application/wordpress/wordpress-deployment.yaml
       ```
-3. Add them to `kustomization.yaml`
+      
+3. Add them to `kustomization.yaml` file.
 
-     ```shell
-     cat <<EOF >>./kustomization.yaml
-     resources:
-     - mysql-deployment.yaml
-     - wordpress-deployment.yaml
-     EOF
-     ```
+      ```shell
+      cat <<EOF >>./kustomization.yaml
+      resources:
+        - mysql-deployment.yaml
+        - wordpress-deployment.yaml
+      EOF
+      ```
 
 ## Apply and Verify
 The `kustomization.yaml` contains all the resources for deploying a WordPress site and a 
@@ -115,20 +117,21 @@ MySQL database. You can apply the directory by
 ```shell
 kubectl apply -k ./
 ```
+
 Now you can verify that all objects exist.
+
 1. Verify that the Secret exists by running the following command:
 
-     ```shell
+      ```shell
       kubectl get secrets
       ```
 
       The response should be like this:
 
-      ```
+      ```shell
       NAME                    TYPE                                  DATA   AGE
       mysql-pass-c57bb4t7mf   Opaque                                1      9s
       ```
-
 
 2. Verify that a PersistentVolume got dynamically provisioned. Note that it can
    It can take up to a few minutes for the PVs to be provisioned and bound.
@@ -139,7 +142,7 @@ Now you can verify that all objects exist.
 
       The response should be like this:
 
-      ```
+      ```shell
       NAME             STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS       AGE
       mysql-pv-claim   Bound     pvc-8cbd7b2e-4044-11e9-b2bb-42010a800002   20Gi       RWO            standard           77s
       wp-pv-claim      Bound     pvc-8cd0df54-4044-11e9-b2bb-42010a800002   20Gi       RWO            standard           77s
@@ -205,23 +208,10 @@ Do not leave your WordPress installation on this page. If another user finds it,
 
 {{% capture cleanup %}}
 
-1. Run the following command to delete your Secret:
+1. Run the following command to delete your Secret, Deployments, Services and PersistentVolumeClaims:
 
       ```shell
-      kubectl delete secret mysql-pass
-      ```
-
-2. Run the following commands to delete all Deployments and Services:
-
-      ```shell
-      kubectl delete deployment -l app=wordpress
-      kubectl delete service -l app=wordpress
-      ```
-
-3. Run the following commands to delete the PersistentVolumeClaims.  The dynamically provisioned PersistentVolumes will be automatically deleted.
-
-      ```shell
-      kubectl delete pvc -l app=wordpress
+      kubectl delete -k ./
       ```
 
 {{% /capture %}}

--- a/content/en/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
+++ b/content/en/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
@@ -23,9 +23,11 @@ The files provided in this tutorial are using GA Deployment APIs and are specifi
 
 {{% capture objectives %}}
 * Create PersistentVolumeClaims and PersistentVolumes
-* Create a Secret
-* Deploy MySQL
-* Deploy WordPress
+* Create a `kustomization.yaml` with
+  * a Secret generator
+  * MySQL resource configs
+  * WordPress resource configs
+* Apply the kustomization directory by `kubectl apply -k ./`
 * Clean up
 
 {{% /capture %}}
@@ -64,45 +66,69 @@ If you are bringing up a cluster that needs to use the `hostPath` provisioner, t
 If you have a Kubernetes cluster running on Google Kubernetes Engine, please follow [this guide](https://cloud.google.com/kubernetes-engine/docs/tutorials/persistent-disk).
 {{< /note >}}
 
-## Create a Secret for MySQL Password
+## Create a kustomization.yaml
 
-A [Secret](/docs/concepts/configuration/secret/) is an object that stores a piece of sensitive data like a password or key. The manifest files are already configured to use a Secret, but you have to create your own Secret.
+### Add a Secret generator
+A [Secret](/docs/concepts/configuration/secret/) is an object that stores a piece of sensitive data like a password or key. You can create a Secret by generators in `kustomization.yaml`
 
-1. Create the Secret object from the following command. You will need to replace
+1. Add a Secret generator in `kustomization.yaml` from the following command. You will need to replace
    `YOUR_PASSWORD` with the password you want to use.
 
       ```shell
-      kubectl create secret generic mysql-pass --from-literal=password=YOUR_PASSWORD
+      cat <<EOF >./kustomization.yaml
+      secretGenerator:
+      - name: mysql-pass
+        literals:
+        - password=YOUR_PASSWORD
+      EOF
       ```
-       
-2. Verify that the Secret exists by running the following command:
+
+## Add resource configs for MySQL and WordPress
+
+The following manifest describes a single-instance MySQL Deployment. The MySQL container mounts the PersistentVolume at /var/lib/mysql. The `MYSQL_ROOT_PASSWORD` environment variable sets the database password from the Secret. 
+
+{{< codenew file="application/wordpress/mysql-deployment.yaml" >}}
+
+1. Download the MySQL deployment configuration file
 
       ```shell
+      curl -LO https://k8s.io/examples/application/wordpress/mysql-deployment.yaml
+      ```
+2. Download the WordPress configuration file
+
+      ```shell
+      curl -LO https://k8s.io/examples/application/wordpress/wordpress-deployment.yaml
+      ```
+3. Add them to `kustomization.yaml`
+
+     ```shell
+     cat <<EOF >>./kustomization.yaml
+     resources:
+     - mysql-deployment.yaml
+     - wordpress-deployment.yaml
+     EOF
+     ```
+
+## Apply and Verify
+The `kustomization.yaml` contains all the resources for deploying a WordPress site and a 
+MySQL database. You can apply the directory by
+```shell
+kubectl apply -k ./
+```
+Now you can verify that all objects exist.
+1. Verify that the Secret exists by running the following command:
+
+     ```shell
       kubectl get secrets
       ```
 
       The response should be like this:
 
       ```
-      NAME                  TYPE                    DATA      AGE
-      mysql-pass            Opaque                  1         42s
+      NAME                    TYPE                                  DATA   AGE
+      mysql-pass-c57bb4t7mf   Opaque                                1      9s
       ```
 
-{{< note >}}
-To protect the Secret from exposure, neither `get` nor `describe` show its contents. 
-{{< /note >}}
-
-## Deploy MySQL
-
-The following manifest describes a single-instance MySQL Deployment. The MySQL container mounts the PersistentVolume at /var/lib/mysql. The `MYSQL_ROOT_PASSWORD` environment variable sets the database password from the Secret. 
-
-{{< codenew file="application/wordpress/mysql-deployment.yaml" >}}
-
-1. Deploy MySQL from the `mysql-deployment.yaml` file:
-
-      ```shell
-      kubectl create -f https://k8s.io/examples/application/wordpress/mysql-deployment.yaml
-      ```
 
 2. Verify that a PersistentVolume got dynamically provisioned. Note that it can
    It can take up to a few minutes for the PVs to be provisioned and bound.
@@ -114,8 +140,9 @@ The following manifest describes a single-instance MySQL Deployment. The MySQL c
       The response should be like this:
 
       ```
-      NAME             STATUS    VOLUME                                     CAPACITY ACCESS MODES   STORAGECLASS   AGE
-      mysql-pv-claim   Bound     pvc-91e44fbf-d477-11e7-ac6a-42010a800002   20Gi     RWO            standard       29s
+      NAME             STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS       AGE
+      mysql-pv-claim   Bound     pvc-8cbd7b2e-4044-11e9-b2bb-42010a800002   20Gi       RWO            standard           77s
+      wp-pv-claim      Bound     pvc-8cd0df54-4044-11e9-b2bb-42010a800002   20Gi       RWO            standard           77s
       ```
 
 3. Verify that the Pod is running by running the following command:
@@ -135,36 +162,7 @@ The following manifest describes a single-instance MySQL Deployment. The MySQL c
       wordpress-mysql-1894417608-x5dzt   1/1       Running   0          40s
       ```
 
-## Deploy WordPress
-
-The following manifest describes a single-instance WordPress Deployment and Service. It uses many of the same features like a PVC for persistent storage and a Secret for the password. But it also uses a different setting: `type: LoadBalancer`. This setting exposes WordPress to traffic from outside of the cluster.
-
-{{< codenew file="application/wordpress/wordpress-deployment.yaml" >}}
-
-1. Create a WordPress Service and Deployment from the `wordpress-deployment.yaml` file:
-
-      ```shell
-      kubectl create -f https://k8s.io/examples/application/wordpress/wordpress-deployment.yaml
-      ```
-
-2. Verify that a PersistentVolume got dynamically provisioned:
-
-      ```shell
-      kubectl get pvc
-      ```
-
-      {{< note >}}
-      It can take up to a few minutes for the PVs to be provisioned and bound.
-      {{< /note >}}
-
-      The response should be like this:
-
-      ```
-      NAME             STATUS    VOLUME                                     CAPACITY ACCESS MODES   STORAGECLASS   AGE
-      wp-pv-claim      Bound     pvc-e69d834d-d477-11e7-ac6a-42010a800002   20Gi     RWO            standard       7s
-      ```
-
-3. Verify that the Service is running by running the following command:
+4. Verify that the Service is running by running the following command:
 
       ```shell
       kubectl get services wordpress
@@ -181,7 +179,7 @@ The following manifest describes a single-instance WordPress Deployment and Serv
       Minikube can only expose Services through `NodePort`. The EXTERNAL-IP is always pending.
       {{< /note >}}
 
-4. Run the following command to get the IP Address for the WordPress Service:
+5. Run the following command to get the IP Address for the WordPress Service:
 
       ```shell
       minikube service wordpress --url
@@ -193,7 +191,7 @@ The following manifest describes a single-instance WordPress Deployment and Serv
       http://1.2.3.4:32406
       ```
 
-5. Copy the IP address, and load the page in your browser to view your site.
+6. Copy the IP address, and load the page in your browser to view your site.
 
    You should see the WordPress set up page similar to the following screenshot.
 


### PR DESCRIPTION
update the kubectl docs after kustomize is integrated. https://github.com/kubernetes/enhancements/issues/633
- Add examples for Secret/ConfigMap generators in docs for Secret/ConfigMap
- replace `kubectl create -f` by `kubectl apply -f`
- Add a page for kustomize support in `kubectl`.