### PR TITLE
ko: Add the Localization Korean page's link

### DIFF
--- a/README-ko.md
+++ b/README-ko.md
@@ -20,9 +20,9 @@
 
 ### 한국어
 
-`README.md` 번역 및 한국어 기여자를 위한 보다 자세한 가이드를 [한국어 README](README-ko.md) 페이지에서 살펴봅니다.
+`README.md` 번역 및 한국어 기여자를 위한 보다 자세한 가이드를 [한국어 README](README-ko.md) 페이지 혹은 [쿠버네티스 문서 한글화 가이드](https://kubernetes.io/ko/docs/contribute/localization_ko/)에서 살펴봅니다.
 
-한국어 번역 메인테이너에게 다음을 통해 연락 가능합니다:
+한국어 번역 메인테이너에게 다음을 통해 연락 가능합니다.
 
 * 이덕준 ([GitHub - @gochist](https://github.com/gochist))
 * [Slack channel](https://kubernetes.slack.com/messages/kubernetes-docs-ko)


### PR DESCRIPTION
Add the [Localization Korean page](https://kubernetes.io/ko/docs/contribute/localization_ko/)'s link in [README-ko.md](https://github.com/kubernetes/website/blob/master/README-ko.md).
