### PR TITLE
Update Link to .spec details

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/jobs-run-to-completion.md
+++ b/content/en/docs/concepts/workloads/controllers/jobs-run-to-completion.md
@@ -102,7 +102,7 @@ $ kubectl logs $pods
 
 As with all other Kubernetes config, a Job needs `apiVersion`, `kind`, and `metadata` fields.
 
-A Job also needs a [`.spec` section](https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status).
+A Job also needs a [`.spec` section](https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status).
 
 ### Pod Template
 


### PR DESCRIPTION
The [old URL](https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status) now consists of a page that says the new URL is https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status, so let's just go ahead and link to the new URL directly :)
