### PR TITLE
Documentation for Kubelet Resource Metrics Endpoint

### DIFF
--- a/content/en/docs/tasks/debug-application-cluster/resource-metrics-pipeline.md
+++ b/content/en/docs/tasks/debug-application-cluster/resource-metrics-pipeline.md
@@ -2,7 +2,7 @@
 reviewers:
 - fgrzadkowski
 - piosz
-title: Core metrics pipeline
+title: Resource metrics pipeline
 content_template: templates/concept
 ---
 

--- a/content/en/docs/tasks/debug-application-cluster/resource-usage-monitoring.md
+++ b/content/en/docs/tasks/debug-application-cluster/resource-usage-monitoring.md
@@ -46,7 +46,7 @@ monitoring statistics by default:
 
 ### Kubelet
 
-The Kubelet acts as a bridge between the Kubernetes master and the nodes. It manages the pods and containers running on a machine. Kubelet translates each pod into its constituent containers and fetches individual container usage statistics from cAdvisor. It then exposes the aggregated pod resource usage statistics via a REST API.
+The Kubelet acts as a bridge between the Kubernetes master and the nodes. It manages the pods and containers running on a machine. Kubelet translates each pod into its constituent containers and fetches individual container usage statistics from the container runtime, through the container runtime interface. For the legacy docker integration, it fetches this information from cAdvisor.  It then exposes the aggregated pod resource usage statistics through the kubelet resource metrics api.  This api is served at `/metrics/resource/v1alpha1` on the kubelet's authenticated and read-only ports.
 
 ### cAdvisor
 

--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -71,7 +71,7 @@ or the custom metrics API (for all other metrics).
 The HorizontalPodAutoscaler normally fetches metrics from a series of aggregated APIs (`metrics.k8s.io`,
 `custom.metrics.k8s.io`, and `external.metrics.k8s.io`).  The `metrics.k8s.io` API is usually provided by
 metrics-server, which needs to be launched separately. See
-[metrics-server](https://kubernetes.io/docs/tasks/debug-application-cluster/core-metrics-pipeline/#metrics-server)
+[metrics-server](https://kubernetes.io/docs/tasks/debug-application-cluster/resource-metrics-pipeline/#metrics-server)
 for instructions. The HorizontalPodAutoscaler can also fetch metrics directly from Heapster.
 
 {{< note >}}

--- a/content/en/docs/user-journeys/users/cluster-operator/foundational.md
+++ b/content/en/docs/user-journeys/users/cluster-operator/foundational.md
@@ -80,7 +80,7 @@ You can see the status of the core of kubernetes with the command `kubectl get c
 Some additional resources for getting information about your cluster and how it is operating include:
 
 * [Tools for Monitoring Compute, Storage, and Network Resources](/docs/tasks/debug-application-cluster/resource-usage-monitoring/)
-* [Core metrics pipeline](/docs/tasks/debug-application-cluster/core-metrics-pipeline/)
+* [Resource metrics pipeline](/docs/tasks/debug-application-cluster/resource-metrics-pipeline/)
   * [Metrics](/docs/concepts/cluster-administration/controller-metrics/)
 
 ## Explore additional resources

--- a/content/en/docs/user-journeys/users/cluster-operator/intermediate.md
+++ b/content/en/docs/user-journeys/users/cluster-operator/intermediate.md
@@ -82,7 +82,7 @@ Start with the [basics on Kubernetes logging](/docs/concepts/cluster-administrat
 * [Logging Using Stackdriver](/docs/tasks/debug-application-cluster/logging-stackdriver/)
 
 Like log aggregation, many clusters utilize additional software to help capture metrics and display them. There is an overview of tools at [Tools for Monitoring Compute, Storage, and Network Resources](/docs/tasks/debug-application-cluster/resource-usage-monitoring/).
-Kubernetes also supports a [core metrics pipeline](/docs/tasks/debug-application-cluster/core-metrics-pipeline/) which can be used by Horizontal Pod Autoscaler with custom metrics.
+Kubernetes also supports a [resource metrics pipeline](/docs/tasks/debug-application-cluster/resource-metrics-pipeline/) which can be used by Horizontal Pod Autoscaler with custom metrics.
 
 [Prometheus](https://prometheus.io/), which is another CNCF project, is a common choice to support capture and temporary collection of metrics. There are several options for installing Prometheus, including using the [stable/prometheus](https://github.com/kubernetes/charts/tree/master/stable/prometheus) [helm](https://helm.sh/) chart, and CoreOS provides a [prometheus operator](https://github.com/coreos/prometheus-operator) and [kube-prometheus](https://github.com/coreos/prometheus-operator/tree/master/contrib/kube-prometheus), which adds on Grafana dashboards and common configurations.
 

--- a/data/tasks.yml
+++ b/data/tasks.yml
@@ -89,7 +89,7 @@ toc:
 - title: Monitor, Log, and Debug
   landing_page: /docs/tasks/debug-application-cluster/resource-usage-monitoring/
   section:
-  - docs/tasks/debug-application-cluster/core-metrics-pipeline.md
+  - docs/tasks/debug-application-cluster/resource-metrics-pipeline.md
   - docs/tasks/debug-application-cluster/resource-usage-monitoring.md
   - docs/tasks/debug-application-cluster/get-shell-running-container.md
   - docs/tasks/debug-application-cluster/monitor-node-health.md


### PR DESCRIPTION
Documentation for https://github.com/kubernetes/enhancements/issues/727.  Apparrently we don't have any monitoring documentation, so this will be more broad than just the new kubelet endpoint.

/milestone 1.14
