### PR TITLE
Update building-from-source.md

### DIFF
--- a/content/en/docs/setup/release/building-from-source.md
+++ b/content/en/docs/setup/release/building-from-source.md
@@ -3,6 +3,7 @@ reviewers:
 - david-mcmahon
 - jbeda
 title: Building a release
+content_template: templates/concept
 card:
   name: download
   weight: 20


### PR DESCRIPTION
Added the attribute: content_template: templates/concept

Because the content was not appearing in: https://kubernetes.io/docs/setup/release/building-from-source/

