### PR TITLE
Document how to init cluster from a development-branch packages

### DIFF
--- a/content/en/docs/setup/independent/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/independent/create-cluster-kubeadm.md
@@ -131,6 +131,11 @@ Now run:
 kubeadm init <args> 
 ```
 
+{{< note >}}
+If you have installed kubeadm from development packages (e.g., deb or rpm) of version X,
+the arguments should include: `--kubernetes-version=latest-X`.
+{{< /note >}}
+
 ### More information
 
 For more information about `kubeadm init` arguments, see the [kubeadm reference guide](/docs/reference/setup-tools/kubeadm/kubeadm/).


### PR DESCRIPTION
I've spent some time investigating a version mismatch between several nodes that was caused by not specifying `--kubernetes-version=latest-1` when initializing a cluster using packages that were built from the master branch so documenting this as it may be helpful for others.