### PR TITLE
Changing k8s -> K8s on homepage

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -8,7 +8,7 @@ cid: home
 
 {{< blocks/section id="oceanNodes" >}}
 {{% blocks/feature image="flower" %}}
-### [Kubernetes (k8s)]({{< relref "/docs/concepts/overview/what-is-kubernetes" >}}) is an open-source system for automating deployment, scaling, and management of containerized applications.
+### [Kubernetes (K8s)]({{< relref "/docs/concepts/overview/what-is-kubernetes" >}}) is an open-source system for automating deployment, scaling, and management of containerized applications.
 
 It groups containers that make up an application into logical units for easy management and discovery. Kubernetes builds upon [15 years of experience of running production workloads at Google](http://queue.acm.org/detail.cfm?id=2898444), combined with best-of-breed ideas and practices from the community.
 {{% /blocks/feature %}}


### PR DESCRIPTION
Mirroring the [style guide](https://github.com/cncf/foundation/blob/master/style-guide.md), as Kubernetes is a proper noun.  