### PR TITLE
Update CVE-2019-5736 blog post with kops fixes

### DIFF
--- a/content/en/blog/_posts/2019-02-11-runc-CVE-2019-5736.md
+++ b/content/en/blog/_posts/2019-02-11-runc-CVE-2019-5736.md
@@ -62,7 +62,7 @@ Upgrading runc can generally be accomplished by upgrading the package `runc` for
 * RedHat Enterprise Linux - [`docker 1.13.1-91.git07f3374.el7`](https://access.redhat.com/security/vulnerabilities/runcescape) (if SELinux is disabled)
 * Amazon Linux - [`docker 18.06.1ce-7.25.amzn1.x86_64`](https://alas.aws.amazon.com/ALAS-2019-1156.html)
 * CoreOS - Stable: [`1967.5.0`](https://coreos.com/releases/#1967.5.0) / Beta: [`2023.2.0`](https://coreos.com/releases/#2023.2.0) / Alpha: [`2051.0.0`](https://coreos.com/releases/#2051.0.0)
-* Kops Debian - [in progress](https://github.com/kubernetes/kops/pull/6460)
+* Kops Debian - [in progress](https://github.com/kubernetes/kops/pull/6460) (see [advisory](https://github.com/kubernetes/kops/blob/master/docs/advisories/cve_2019_5736.md) for how to address until Kops Debian is patched)
 * Docker - [`18.09.2`](https://github.com/docker/docker-ce/releases/tag/v18.09.2)
 
 Some platforms have also posted more specific instructions:
@@ -78,6 +78,10 @@ Amazon has also issued a [security bulletin](https://aws.amazon.com/security/sec
 #### Azure Kubernetes Service (AKS)
 
 Microsoft has issued a [security bulletin](https://azure.microsoft.com/en-us/updates/cve-2019-5736-and-runc-vulnerability/) with detailed information on mitigating the issue. Microsoft recommends all AKS users to upgrade their cluster to mitigate the issue.
+
+#### Kops
+
+Kops has issued an [advisory](https://github.com/kubernetes/kops/blob/master/docs/advisories/cve_2019_5736.md) with detailed information on mitigating this issue.
 
 ### Docker
 


### PR DESCRIPTION
Update the blog post to link to
https://github.com/kubernetes/kops/blob/master/docs/advisories/cve_2019_5736.md.