### PR TITLE
Added Instana to tools

### DIFF
--- a/content/zh/docs/concepts/workloads/controllers/daemonset.md
+++ b/content/zh/docs/concepts/workloads/controllers/daemonset.md
@@ -22,7 +22,7 @@ redirect_from:
 
 - 运行集群存储 daemon，例如在每个节点上运行 `glusterd`、`ceph`。
 - 在每个节点上运行日志收集 daemon，例如`fluentd`、`logstash`。
-- 在每个节点上运行监控 daemon，例如 [Prometheus Node Exporter](https://github.com/prometheus/node_exporter)、`collectd`、Datadog 代理、New Relic 代理，或 Ganglia `gmond`。
+- 在每个节点上运行监控 daemon，例如 [Prometheus Node Exporter](https://github.com/prometheus/node_exporter)、`collectd`、Datadog 代理、New Relic 代理, Ganglia `gmond`, 或 [Instana Agent](https://www.instana.com/supported-integrations/kubernetes-monitoring/)。
 
 一个简单的用法是在所有的节点上都启动一个 DaemonSet，将被作为每种类型的 daemon 使用。
 一个稍微复杂的用法是单独对每种 daemon 类型使用多个 DaemonSet，但具有不同的标志，和/或对不同硬件类型具有不同的内存、CPU要求。


### PR DESCRIPTION
Added Instana (incl link) to the Chinese version of the daemonset documentation to make it easier for people to find the Instana integration which can monitor kubernetes orchestrated containers automatically. I hope my language skills were good enough to make the sentence still correct :-)

I also hope the selected branch is correct, was a bit confused by the message which branch to use.