### PR TITLE
Tweaks to write K8s as proper noun

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/create-external-load-balancer.md
+++ b/content/en/docs/tasks/access-application-cluster/create-external-load-balancer.md
@@ -162,7 +162,7 @@ Service Configuration file.
 
 ### Feature availability
 
-| k8s version | Feature support |
+| K8s version | Feature support |
 | :---------: |:-----------:|
 | 1.7+ | Supports the full API fields |
 | 1.5 - 1.6 | Supports Beta Annotations |

--- a/content/en/docs/tasks/federation/set-up-cluster-federation-kubefed.md
+++ b/content/en/docs/tasks/federation/set-up-cluster-federation-kubefed.md
@@ -52,7 +52,7 @@ now maintained. Consequently, the federation release information is available on
 [release page](https://github.com/kubernetes/federation/releases).
 {{< /note >}}
 
-### For k8s versions 1.8.x and earlier:
+### For Kubernetes versions 1.8.x and earlier:
 
 ```shell
 curl -LO https://storage.googleapis.com/kubernetes-release/release/${RELEASE-VERSION}/kubernetes-client-linux-amd64.tar.gz
@@ -70,7 +70,7 @@ sudo cp kubernetes/client/bin/kubefed /usr/local/bin
 sudo chmod +x /usr/local/bin/kubefed
 ```
 
-### For k8s versions 1.9.x and above:
+### For Kubernetes versions 1.9.x and above:
 
 ```shell
 curl -LO https://storage.cloud.google.com/kubernetes-federation-release/release/${RELEASE-VERSION}/federation-client-linux-amd64.tar.gz


### PR DESCRIPTION
I saw #12969 and wondered if the same change applied elsewhere. Here's where I think it does.