### PR TITLE
Re-adding content_template for building-from-source

### DIFF
--- a/content/en/docs/setup/release/building-from-source.md
+++ b/content/en/docs/setup/release/building-from-source.md
@@ -7,6 +7,7 @@ card:
   name: download
   weight: 20
   title: Building a release
+content_template: templates/concept
 ---
 {{% capture overview %}}
 You can either build a release from source or download a pre-built release.  If you do not plan on developing Kubernetes itself, we suggest using a pre-built version of the current release, which can be found in the [Release Notes](/docs/setup/release/notes/).


### PR DESCRIPTION
Fixes https://github.com/kubernetes/website/issues/12959

In commit https://github.com/kubernetes/website/commit/8e5d7e482999957fa64152a2490df1a9350ec112/ the `content_template` was removed and this broke the https://kubernetes.io/docs/setup/release/building-from-source/ page.