### PR TITLE
Add Quobyte's CSI plug-in reference in place of in-tree plug-in

### DIFF
--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -837,7 +837,7 @@ created before you can use it.
 
 Quobyte supports the {{< glossary_tooltip text="Container Storage Interface" term_id="csi" >}}.
 CSI is the recommended plugin to use Quobyte volumes inside Kubernetes. Quobyte's
-CSI deployment instructions and examples can be found [here](https://github.com/quobyte/quobyte-csi).
+GitHub project has [instructions](https://github.com/quobyte/quobyte-csi#quobyte-csi) for deploying Quobyte using CSI, along with examples.
 
 ### rbd {#rbd}
 

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -835,7 +835,9 @@ You must have your own Quobyte setup running with the volumes
 created before you can use it.
 {{< /caution >}}
 
-See the [Quobyte example](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/quobyte) for more details.
+Quobyte supports [Container Storage Interface](https://kubernetes.io/blog/2018/01/introducing-container-storage-interface/).
+CSI is the recommended plugin to use Quobyte volumes inside Kubernetes. Quobyte's
+CSI deployment instructions and examples can be found [here](https://github.com/quobyte/quobyte-csi).
 
 ### rbd {#rbd}
 

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -835,7 +835,7 @@ You must have your own Quobyte setup running with the volumes
 created before you can use it.
 {{< /caution >}}
 
-Quobyte supports [Container Storage Interface](https://kubernetes.io/blog/2018/01/introducing-container-storage-interface/).
+Quobyte supports the {{< glossary_tooltip text="Container Storage Interface" term_id="csi" >}}.
 CSI is the recommended plugin to use Quobyte volumes inside Kubernetes. Quobyte's
 CSI deployment instructions and examples can be found [here](https://github.com/quobyte/quobyte-csi).
 


### PR DESCRIPTION
Added new reference link for Quobyte CSI in place of old in-tree plug-in.
Quobyte supports CSI plug-in and is the recommended plug-in to access the volumes.
