### PR TITLE
Fix codeblock in update deployment section

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/deployment.md
+++ b/content/en/docs/concepts/workloads/controllers/deployment.md
@@ -172,10 +172,9 @@ Suppose that you now want to update the nginx Pods to use the `nginx:1.9.1` imag
 instead of the `nginx:1.7.9` image.
 
 ```shell
-kubectl --record deployment.apps/nginx-deployment set image deployment.v1.apps/nginx-deployment 
+kubectl --record deployment.apps/nginx-deployment set image deployment.v1.apps/nginx-deployment nginx=nginx:1.9.1
 ```
 ```
-nginx=nginx:1.9.1 
 image updated
 ```
 


### PR DESCRIPTION
The trailing portion of the command (`nginx=nginx:1.9.1`):
```
kubectl --record deployment.apps/nginx-deployment set image deployment.v1.apps/nginx-deployment nginx=nginx:1.9.1
``` 
Was accidentally included in the output codeblock instead of the command codeblock. This PR corrects it.