### PR TITLE
Fix MySQL slave node can not sync data with the master node in examples/application/mysql/mysql-statefulset.yaml

### DIFF
--- a/content/en/examples/application/mysql/mysql-statefulset.yaml
+++ b/content/en/examples/application/mysql/mysql-statefulset.yaml
@@ -106,16 +106,16 @@ spec:
           cd /var/lib/mysql
 
           # Determine binlog position of cloned data, if any.
-          if [[ -f xtrabackup_slave_info ]]; then
+          if [[ -f xtrabackup_slave_info && "x$(<xtrabackup_slave_info)" != "x" ]]; then
             # XtraBackup already generated a partial "CHANGE MASTER TO" query
-            # because we're cloning from an existing slave.
-            mv xtrabackup_slave_info change_master_to.sql.in
+            # because we're cloning from an existing slave. (Need to remove the tailing semicolon!)
+            cat xtrabackup_slave_info | sed -E 's/;$//g' > change_master_to.sql.in
             # Ignore xtrabackup_binlog_info in this case (it's useless).
-            rm -f xtrabackup_binlog_info
+            rm -f xtrabackup_slave_info xtrabackup_binlog_info
           elif [[ -f xtrabackup_binlog_info ]]; then
             # We're cloning directly from master. Parse binlog position.
             [[ `cat xtrabackup_binlog_info` =~ ^(.*?)[[:space:]]+(.*?)$ ]] || exit 1
-            rm xtrabackup_binlog_info
+            rm -f xtrabackup_binlog_info xtrabackup_slave_info
             echo "CHANGE MASTER TO MASTER_LOG_FILE='${BASH_REMATCH[1]}',\
                   MASTER_LOG_POS=${BASH_REMATCH[2]}" > change_master_to.sql.in
           fi
@@ -126,16 +126,15 @@ spec:
             until mysql -h 127.0.0.1 -e "SELECT 1"; do sleep 1; done
 
             echo "Initializing replication from clone position"
+            mysql -h 127.0.0.1 \
+                  -e "$(<change_master_to.sql.in), \
+                          MASTER_HOST='mysql-0.mysql', \
+                          MASTER_USER='root', \
+                          MASTER_PASSWORD='', \
+                          MASTER_CONNECT_RETRY=10; \
+                        START SLAVE;" || exit 1
             # In case of container restart, attempt this at-most-once.
             mv change_master_to.sql.in change_master_to.sql.orig
-            mysql -h 127.0.0.1 <<EOF
-          $(<change_master_to.sql.orig),
-            MASTER_HOST='mysql-0.mysql',
-            MASTER_USER='root',
-            MASTER_PASSWORD='',
-            MASTER_CONNECT_RETRY=10;
-          START SLAVE;
-          EOF
           fi
 
           # Start a server to send backups when requested by peers.

--- a/content/ja/examples/application/mysql/mysql-statefulset.yaml
+++ b/content/ja/examples/application/mysql/mysql-statefulset.yaml
@@ -106,16 +106,16 @@ spec:
           cd /var/lib/mysql
 
           # Determine binlog position of cloned data, if any.
-          if [[ -f xtrabackup_slave_info ]]; then
+          if [[ -f xtrabackup_slave_info && "x$(<xtrabackup_slave_info)" != "x" ]]; then
             # XtraBackup already generated a partial "CHANGE MASTER TO" query
-            # because we're cloning from an existing slave.
-            mv xtrabackup_slave_info change_master_to.sql.in
+            # because we're cloning from an existing slave. (Need to remove the tailing semicolon!)
+            cat xtrabackup_slave_info | sed -E 's/;$//g' > change_master_to.sql.in
             # Ignore xtrabackup_binlog_info in this case (it's useless).
-            rm -f xtrabackup_binlog_info
+            rm -f xtrabackup_slave_info xtrabackup_binlog_info
           elif [[ -f xtrabackup_binlog_info ]]; then
             # We're cloning directly from master. Parse binlog position.
             [[ `cat xtrabackup_binlog_info` =~ ^(.*?)[[:space:]]+(.*?)$ ]] || exit 1
-            rm xtrabackup_binlog_info
+            rm -f xtrabackup_binlog_info xtrabackup_slave_info
             echo "CHANGE MASTER TO MASTER_LOG_FILE='${BASH_REMATCH[1]}',\
                   MASTER_LOG_POS=${BASH_REMATCH[2]}" > change_master_to.sql.in
           fi
@@ -126,16 +126,15 @@ spec:
             until mysql -h 127.0.0.1 -e "SELECT 1"; do sleep 1; done
 
             echo "Initializing replication from clone position"
+            mysql -h 127.0.0.1 \
+                  -e "$(<change_master_to.sql.in), \
+                          MASTER_HOST='mysql-0.mysql', \
+                          MASTER_USER='root', \
+                          MASTER_PASSWORD='', \
+                          MASTER_CONNECT_RETRY=10; \
+                        START SLAVE;" || exit 1
             # In case of container restart, attempt this at-most-once.
             mv change_master_to.sql.in change_master_to.sql.orig
-            mysql -h 127.0.0.1 <<EOF
-          $(<change_master_to.sql.orig),
-            MASTER_HOST='mysql-0.mysql',
-            MASTER_USER='root',
-            MASTER_PASSWORD='',
-            MASTER_CONNECT_RETRY=10;
-          START SLAVE;
-          EOF
           fi
 
           # Start a server to send backups when requested by peers.

--- a/content/zh/docs/tasks/run-application/mysql-statefulset.yaml
+++ b/content/zh/docs/tasks/run-application/mysql-statefulset.yaml
@@ -100,16 +100,16 @@ spec:
           cd /var/lib/mysql
 
           # Determine binlog position of cloned data, if any.
-          if [[ -f xtrabackup_slave_info ]]; then
+          if [[ -f xtrabackup_slave_info && "x$(<xtrabackup_slave_info)" != "x" ]]; then
             # XtraBackup already generated a partial "CHANGE MASTER TO" query
-            # because we're cloning from an existing slave.
-            mv xtrabackup_slave_info change_master_to.sql.in
+            # because we're cloning from an existing slave. (Need to remove the tailing semicolon!)
+            cat xtrabackup_slave_info | sed -E 's/;$//g' > change_master_to.sql.in
             # Ignore xtrabackup_binlog_info in this case (it's useless).
-            rm -f xtrabackup_binlog_info
+            rm -f xtrabackup_slave_info xtrabackup_binlog_info
           elif [[ -f xtrabackup_binlog_info ]]; then
             # We're cloning directly from master. Parse binlog position.
             [[ `cat xtrabackup_binlog_info` =~ ^(.*?)[[:space:]]+(.*?)$ ]] || exit 1
-            rm xtrabackup_binlog_info
+            rm -f xtrabackup_binlog_info xtrabackup_slave_info
             echo "CHANGE MASTER TO MASTER_LOG_FILE='${BASH_REMATCH[1]}',\
                   MASTER_LOG_POS=${BASH_REMATCH[2]}" > change_master_to.sql.in
           fi
@@ -120,16 +120,15 @@ spec:
             until mysql -h 127.0.0.1 -e "SELECT 1"; do sleep 1; done
 
             echo "Initializing replication from clone position"
+            mysql -h 127.0.0.1 \
+                  -e "$(<change_master_to.sql.in), \
+                          MASTER_HOST='mysql-0.mysql', \
+                          MASTER_USER='root', \
+                          MASTER_PASSWORD='', \
+                          MASTER_CONNECT_RETRY=10; \
+                        START SLAVE;" || exit 1
             # In case of container restart, attempt this at-most-once.
             mv change_master_to.sql.in change_master_to.sql.orig
-            mysql -h 127.0.0.1 <<EOF
-          $(<change_master_to.sql.orig),
-            MASTER_HOST='mysql-0.mysql',
-            MASTER_USER='root',
-            MASTER_PASSWORD='',
-            MASTER_CONNECT_RETRY=10;
-          START SLAVE;
-          EOF
           fi
 
           # Start a server to send backups when requested by peers.


### PR DESCRIPTION
- Ignore 'xtrabackup_slave_info' if it is an empty file.
- Remove the tailing semicolon in 'xtrabackup_slave_info'.
- Stop script when 'CHANGE MASTER' is failed, then rename 'change_master_to.sql.in' only when changing master is successful.
