### PR TITLE
The page was displaying as ```shell

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/deployment.md
+++ b/content/en/docs/concepts/workloads/controllers/deployment.md
@@ -736,6 +736,7 @@ deployment.apps/nginx-deployment resumed
 ```shell
 kubectl get rs -w
 ```
+```
 NAME               DESIRED   CURRENT   READY     AGE
 nginx-2142116321   2         2         2         2m
 nginx-3926361531   2         2         0         6s
@@ -751,7 +752,6 @@ nginx-2142116321   0         1         1         2m
 nginx-2142116321   0         1         1         2m
 nginx-2142116321   0         0         0         2m
 nginx-3926361531   3         3         3         20s
-
 ```
 ```shell
 kubectl get rs

--- a/content/en/docs/concepts/workloads/controllers/deployment.md
+++ b/content/en/docs/concepts/workloads/controllers/deployment.md
@@ -732,10 +732,9 @@ Eventually, resume the Deployment and observe a new ReplicaSet coming up with al
 kubectl rollout resume deployment.v1.apps/nginx-deployment
 ```
 deployment.apps/nginx-deployment resumed
-```
+
 ```shell
 kubectl get rs -w
-```
 ```
 NAME               DESIRED   CURRENT   READY     AGE
 nginx-2142116321   2         2         2         2m


### PR DESCRIPTION
The page was displaying as ```shell  as we had an additional wrapper on top of it.


