### PR TITLE
Fix busybox `nslookup` example

### DIFF
--- a/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -160,7 +160,7 @@ Using `nslookup` on the Pods' hostnames, you can examine their in-cluster DNS
 addresses.
 
 ```shell
-kubectl run -i --tty --image busybox dns-test --restart=Never --rm /bin/sh 
+kubectl run -i --tty --image busybox:1.28 dns-test --restart=Never --rm  
 nslookup web-0.nginx
 Server:    10.0.0.10
 Address 1: 10.0.0.10 kube-dns.kube-system.svc.cluster.local


### PR DESCRIPTION
* Similarly to https://github.com/kubernetes/website/pull/9901 pin busybox image to 1.28. Although https://bugs.busybox.net/show_bug.cgi?id=11161 is closed, this still doesn't work on images > 1.28
* remove `/bin/sh` from the command to be executed on busybox, this leads to `/bin/sh: can't open 'nslookup': No such file or directory`

