### PR TITLE
removes extra /configmap from ui.properties path

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -52,7 +52,7 @@ mkdir -p configure-pod-container/configmap/
 
 # Download the sample files into `configure-pod-container/configmap/` directory
 wget https://k8s.io/examples/configmap/game.properties -O configure-pod-container/configmap/game.properties
-wget https://k8s.io/examples/configmap/configmap/ui.properties -O configure-pod-container/configmap/ui.properties
+wget https://k8s.io/examples/configmap/ui.properties -O configure-pod-container/configmap/ui.properties
 
 # Create the configmap
 kubectl create configmap game-config --from-file=configure-pod-container/configmap/


### PR DESCRIPTION
This file path `https://k8s.io/examples/configmap/configmap/ui.properties` has extra `/configmap`.

This PR removes extra `/configmap` path from ui.properties file path.