### PR TITLE
Use correct kubelet config name

### DIFF
--- a/content/en/docs/tasks/administer-cluster/sysctl-cluster.md
+++ b/content/en/docs/tasks/administer-cluster/sysctl-cluster.md
@@ -83,7 +83,7 @@ kubelet --allowed-unsafe-sysctls \
 For minikube, this can be done via the `extra-config` flag:
 
 ```shell
-minikube start --extra-config="kubelet.AllowedUnsafeSysctls=kernel.msg*,net.ipv4.route.min_pmtu"...
+minikube start --extra-config="kubelet.allowed-unsafe-sysctls=kernel.msg*,net.ipv4.route.min_pmtu"...
 ```
 
 Only _namespaced_ sysctls can be enabled this way.


### PR DESCRIPTION
At its current form minikube fails to start with following error:

    unknown flag: --AllowedUnsafeSysctls

Renaming it to `allowed-unsafe-sysctls` works as expected.
