### PR TITLE
Update podManagementPolicy of StatefulSet object

### DIFF
--- a/content/en/examples/application/zookeeper/zookeeper.yaml
+++ b/content/en/examples/application/zookeeper/zookeeper.yaml
@@ -49,7 +49,7 @@ spec:
   replicas: 3
   updateStrategy:
     type: RollingUpdate
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   template:
     metadata:
       labels:


### PR DESCRIPTION
In given manifest, podManagementPolicy is set as Parallel, but in later section of page, the console logs of "kubectl get pods -w -l app=zk" command displays ordered behavior, which is not the actual result in case of Parallel option.

Sample logs from doc : 
NAME      READY     STATUS    RESTARTS   AGE
zk-0      0/1       Pending   0          0s
zk-0      0/1       Pending   0         0s
zk-0      0/1       ContainerCreating   0         0s
zk-0      0/1       Running   0         19s
zk-0      1/1       Running   0         40s
zk-1      0/1       Pending   0         0s
zk-1      0/1       Pending   0         0s
zk-1      0/1       ContainerCreating   0         0s
zk-1      0/1       Running   0         18s
zk-1      1/1       Running   0         40s
zk-2      0/1       Pending   0         0s
zk-2      0/1       Pending   0         0s
zk-2      0/1       ContainerCreating   0         0s
zk-2      0/1       Running   0         19s
zk-2      1/1       Running   0         40s

-- here pods are created in order

Actual results after applying the given manifest : 
[taher@kubernetes-docker ~]$ kubectl apply -f zookeeper.yaml
service/zk-hs created
service/zk-cs created
poddisruptionbudget.policy/zk-pdb created
statefulset.apps/zk created
[taher@kubernetes-docker ~]$ kubectl get pods -w -l app=zk
NAME   READY   STATUS              RESTARTS   AGE
zk-0   0/1     Pending             0          3s
zk-1   0/1     Pending             0          3s
zk-2   0/1     ContainerCreating   0          3s
zk-1   0/1   Pending   0     4s
zk-0   0/1   Pending   0     4s
zk-1   0/1   Pending   0     5s
zk-0   0/1   Pending   0     5s
zk-1   0/1   Pending   0     5s
zk-1   0/1   ContainerCreating   0     5s
zk-0   0/1   Pending   0     5s
zk-2   0/1   Running   0     19s
zk-1   0/1   Running   0     24s
zk-2   1/1   Running   0     35s
zk-1   1/1   Running   0     37s

-- here pods are created in parallel

Resolution :
Either change the value of podManagementPolicy option to OrderedReady or remove that option, so that StatefulSet will take it's default behavior.