### PR TITLE
Update high-availability.md

### DIFF
--- a/content/en/docs/setup/independent/high-availability.md
+++ b/content/en/docs/setup/independent/high-availability.md
@@ -160,9 +160,6 @@ SSH is required if you want to control all nodes from a single machine.
         apiVersion: kubeadm.k8s.io/v1beta1
         kind: ClusterConfiguration
         kubernetesVersion: stable
-        apiServer:
-          certSANs:
-          - "LOAD_BALANCER_DNS"
         controlPlaneEndpoint: "LOAD_BALANCER_DNS:LOAD_BALANCER_PORT"
 
     - `kubernetesVersion` should be set to the Kubernetes version to use. This


### PR DESCRIPTION
Remove `certSANs` setting, it is not needed because kubeadm
automatically adds the `controlPlaneEndpoint` to the SAN:
https://github.com/kubernetes/kubernetes/blob/v1.13.4/cmd/kubeadm/app/util/pkiutil/pki_helpers.go#L364