### PR TITLE
Fix inconsistent style of pod-lifecycle.md in glossary

### DIFF
--- a/content/en/docs/reference/glossary/pod-lifecycle.md
+++ b/content/en/docs/reference/glossary/pod-lifecycle.md
@@ -9,8 +9,11 @@ related:
 tags:
  - fundamental
 short_description: >
- A high-level summary of what phase the Pod is in within its lifecyle.
+  A high-level summary of what phase the Pod is in within its lifecyle.
  
 ---
+ A high-level summary of what phase the Pod is in within its lifecyle.
+
+<!--more--> 
 
 The [Pod Lifecycle](/docs/concepts/workloads/pods/pod-lifecycle/) is a high level summary of where a Pod is in its lifecyle.  A Pod’s `status` field is a [PodStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#podstatus-v1-core) object, which has a `phase` field that displays one of the following phases: Running, Pending, Succeeded, Failed, Unknown, Completed, or CrashLoopBackOff.


### PR DESCRIPTION
This PR fixes inconsistent style of pod-lifecycle.md in glossary.
The pod-lifecycle.md in docs/reference/glossary has inconsistent style with other glossary items.

For instance, glossary item for "Pod Lifecycle" does not show a short description. Also, it shows duplicated detail descriptions when we push the [+] button.

[Pod](https://kubernetes.io/docs/reference/glossary/?fundamental=true#term-pod)

> The smallest and simplest Kubernetes object. A Pod represents a set of running containers on your cluster.[-]
> A Pod is typically set up to run a single primary container. It can also run optional sidecar containers that add supplementary features like logging. Pods are commonly managed by a Deployment .

[Pod Lifecycle](https://kubernetes.io/docs/reference/glossary/?fundamental=true#term-pod-lifecycle)

> The Pod Lifecycle is a high level summary of where a Pod is in its lifecyle. A Pod’s status field is a PodStatus object, which has a phase field that displays one of the following phases: Running, Pending, Succeeded, Failed, Unknown, Completed, or CrashLoopBackOff. [-]
> The Pod Lifecycle is a high level summary of where a Pod is in its lifecyle. A Pod’s status field is a PodStatus object, which has a phase field that displays one of the following phases: Running, Pending, Succeeded, Failed, Unknown, Completed, or CrashLoopBackOff
