### PR TITLE
Travis performance improvement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+env:
+  global:
+    - KUBE_VERSION: 1.13
 language: go
 go:
   - 1.11.5
@@ -8,22 +11,10 @@ jobs:
       cache:
         directories:
           - $HOME/.cache/go-build
-      # Don't want default ./... here:
       install:
-      - export PATH=$GOPATH/bin:$PATH
-      - mkdir -p $HOME/gopath/src/k8s.io
-      - mv $TRAVIS_BUILD_DIR $HOME/gopath/src/k8s.io/website && cd $HOME/gopath/src/k8s.io/website
-
-      # Make sure we are testing against the correct branch
-      - pushd $GOPATH/src/k8s.io && git clone https://github.com/kubernetes/kubernetes && popd
-      - pushd $GOPATH/src/k8s.io/kubernetes && git checkout release-1.13 && make generated_files && popd
-      - cp -L -R $GOPATH/src/k8s.io/kubernetes/vendor/ $GOPATH/src/
-      - rm -r $GOPATH/src/k8s.io/kubernetes/vendor/
-
-      # Fetch additional dependencies to run the tests in examples/examples_test.go
-      - go get -t -v k8s.io/website/content/en/examples
+      - bash scripts/test_examples.sh install
       script:
-      - go test -v k8s.io/website/content/en/examples
+      - bash scripts/test_examples.sh run
     - name: "Hugo build"
       install:
       - make travis-hugo-build

--- a/scripts/test_examples.sh
+++ b/scripts/test_examples.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -e
+
+# List files changed in the commit to check
+FILES=`git log -n 2 --name-only --format=""`
+
+TEST_EXAMPLES=No
+
+# Currently examine en directory only, can extend to other lang when neded
+for f in $FILES; do
+  if [[ $f =~ "content/en/examples/" ]]; then
+    TEST_EXAMPLES=Yes
+    break
+  fi
+  if [[ $f =~ ".travis.yml" ]]; then
+    TEST_EXAMPLES=Yes
+    break
+  fi
+done
+
+function install() {
+  if [[ $TEST_EXAMPLES == No ]]; then
+    echo "PR not touching examples, skipping example tests install"
+    exit 0
+  fi
+
+  export PATH=$GOPATH/bin:$PATH
+  mkdir -p $HOME/gopath/src/k8s.io
+  mv $TRAVIS_BUILD_DIR $HOME/gopath/src/k8s.io/website && cd $HOME/gopath/src/k8s.io/website
+
+  # Make sure we are testing against the correct branch
+  wget https://github.com/kubernetes/kubernetes/archive/v${KUBE_VERSION}.0.tar.gz -P $GOPATH/src/k8s.io
+
+  pushd $GOPATH/src/k8s.io
+  tar xzf v${KUBE_VERSION}.0.tar.gz
+  mv kubernetes-${KUBE_VERSION}.0 kubernetes
+  cd kubernetes
+  make generated_files
+  cp -L -R vendor $GOPATH/src/
+  rm -r vendor
+  popd
+
+  # Fetch additional dependencies to run the tests in examples/examples_test.go
+  go get -t -v k8s.io/website/content/en/examples
+}
+
+function run_test() {
+  if [[ $TEST_EXAMPLES == No ]]; then
+    echo "PR not touching examples, skipping example tests execution"
+    exit 0
+  fi
+  go test -v k8s.io/website/content/en/examples
+}
+
+if [[ $1 == install ]]; then
+  install
+  exit 0
+elif [[ $1 == "run" ]]; then
+  run_test
+fi


### PR DESCRIPTION
Three optimizations:
- move example testing logic into a bash script to save travis specifics;
- use kubernetes release package (about 20MB) instead of git repo (about 800 MB 
  at the moment); this cuts the example testing time from ~7 minutes to ~3 minutes;
- detect whether a PR contains changes to examples and skip examples testing if not.
  This further reduces the example testing job from ~3 minutes to ~1 minute for most PRs.
    
Closes: #13140
