### PR TITLE
Correcting statement about Service ports

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -84,7 +84,9 @@ number that pods expose in the next version of your backend software, without
 breaking clients.
 
 `TCP` is the default protocol for services, and you can also use any other
-[supported protocol](#protocol-support). As many `Services` need to expose more than one port, Kubernetes supports multiple port definitions on a `Service` object. Each port definition can have the same or a different `protocol`.
+[supported protocol](#protocol-support). As many Services need to expose more than
+one port, Kubernetes supports multiple port definitions on a `Service` object.
+Each port definition can have the same or a different `protocol`.
 
 ### Services without selectors
 

--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -84,8 +84,7 @@ number that pods expose in the next version of your backend software, without
 breaking clients.
 
 `TCP` is the default protocol for services, and you can also use any other
-[supported protocol](#protocol-support). At the moment, you can only set a
-single `port` and `protocol` for a Service.
+[supported protocol](#protocol-support). As many `Services` need to expose more than one port, Kubernetes supports multiple port definitions on a `Service` object. Each port definition can have the same or a different `protocol`.
 
 ### Services without selectors
 


### PR DESCRIPTION
Correcting details about service ports and protocol. Removed statement saying Service supports single port definition only and added details about multiport support.

This also fixes #13034 
