### PR TITLE
Update managing-tls-in-a-cluster.md

### DIFF
--- a/content/en/docs/tasks/tls/managing-tls-in-a-cluster.md
+++ b/content/en/docs/tasks/tls/managing-tls-in-a-cluster.md
@@ -36,7 +36,7 @@ Trusting the cluster root CA from an application running as a pod usually
 requires some extra application configuration. You will need to add the CA
 certificate bundle to the list of CA certificates that the TLS client or server
 trusts. For example, you would do this with a golang TLS config by parsing the
-certificate chain and adding the parsed certificates to the `Certificates` field
+certificate chain and adding the parsed certificates to the `RootCAs` field
 in the [`tls.Config`](https://godoc.org/crypto/tls#Config) struct.
 
 The CA certificate bundle is automatically mounted into pods using the default


### PR DESCRIPTION
per the godocs:
 // RootCAs defines the set of root certificate authorities
 // that clients use when verifying server certificates.
// If RootCAs is nil, TLS uses the host's root CA set.
