### PR TITLE
Fix#13372 - Issue template for bug, support, feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,13 +1,15 @@
+---
+name: Bug Report
+about: Report a bug encountered with Kubernetes Website
+labels: kind/bug
+
+---
+**This is a Bug Report**
+
 <!-- Thanks for filing an issue! Before submitting, please fill in the following information. -->
 <!-- See https://kubernetes.io/docs/contribute/start/ for guidance on writing an actionable issue description. -->
 
 <!--Required Information-->
-
-**This is a...** 
-<!-- choose one by changing [ ] to [x] -->
-- [ ] Feature Request
-- [ ] Bug Report
-
 **Problem:**
 
 

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,18 @@
+---
+name: Feature Request
+about: Suggest a/an feature/enhancement to the Kubernetes Website project
+labels: kind/feature
+
+---
+**This is a Feature Request**
+
+<!-- Please only use this template for submitting feature/enhancement requests -->
+<!-- See https://kubernetes.io/docs/contribute/start/ for guidance on writing an actionable issue description. -->
+
+**What would you like to be added**
+<!-- Describe as precisely as possible how this feature/enhancement should work from the user perspective. What should be changed, etc. -->
+
+**Why is this needed**
+
+**Comments**
+<!-- Any additional related comments that might help. Drawings/mockups would be extremely helpful (if required). -->

--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -1,0 +1,18 @@
+---
+name: Support Request
+about: Support request or question relating to Kubernetes Dashboard project
+labels: triage/support
+
+---
+**This is Support**
+<!--
+STOP -- PLEASE READ!
+
+GitHub is not the right place for support requests.
+
+If you're looking for help, check [Stack Overflow](https://stackoverflow.com/questions/tagged/kubernetes)
+
+You can also post your question on the [Kubernetes Slack](http://slack.k8s.io/) or the [Discuss Kubernetes](https://discuss.kubernetes.io/) forum.
+
+If the matter is security related, please disclose it privately via https://kubernetes.io/security/.
+-->

--- a/layouts/partials/git-info.html
+++ b/layouts/partials/git-info.html
@@ -14,7 +14,7 @@
     };
     (function(d,c,j){if(!document.getElementById(j)){var pd=d.createElement(c),s;pd.id=j;pd.src=('https:'==document.location.protocol)?'https://polldaddy.com/js/rating/rating.js':'http://i0.poll.fm/js/rating/rating.js';s=document.getElementsByTagName(c)[0];s.parentNode.insertBefore(pd,s);}}(document,'script','pd-rating-js'));
     </script>
-    <a href="" onclick="window.open('https://github.com/kubernetes/website/issues/new?title=Issue%20with%20' +
+    <a href="" onclick="window.open('https://github.com/kubernetes/website/issues/new?template=bug-report.md&title=Issue%20with%20' +
     'k8s.io'+window.location.pathname)" class="button issue">{{ T "main_github_create_an_issue" }}</a>
     {{ end }}
     {{ end }}


### PR DESCRIPTION
#13372 

Every bug report from pre footer on the website is pointed to the bug template. 

<img width="1141" alt="Screen Shot 1941-01-04 at 9 12 36 AM" src="https://user-images.githubusercontent.com/6227784/54893937-46db6380-4ede-11e9-82e1-fdad82ea1359.png">
