### PR TITLE
FR | Add "building a release" link in docs home

### DIFF
--- a/content/fr/docs/setup/release/building-from-source.md
+++ b/content/fr/docs/setup/release/building-from-source.md
@@ -1,6 +1,10 @@
 ---
 title: Construire une release
 content_template: templates/concept
+card:
+  name: download
+  weight: 20
+  title: Construire une release
 ---
 {{% capture overview %}}
 Vous pouvez soit compiler une version à partir des sources, soit télécharger une version pré-compilée.  Si vous ne 


### PR DESCRIPTION
C'est pour ajouter le lien "Construire une release" sur la page https://kubernetes.io/fr/docs/home/