### PR TITLE
Remove command prompts 

### DIFF
--- a/content/en/docs/tasks/debug-application-cluster/audit.md
+++ b/content/en/docs/tasks/debug-application-cluster/audit.md
@@ -275,8 +275,8 @@ Fluent-plugin-forest and fluent-plugin-rewrite-tag-filter are plugins for fluent
 
 1. create a config file for fluentd
 
-    ```none
-    $ cat <<'EOF' > /etc/fluentd/config
+    ```
+    cat <<'EOF' > /etc/fluentd/config
     # fluentd conf runs in the same host with kube-apiserver
     <source>
         @type tail
@@ -331,7 +331,7 @@ Fluent-plugin-forest and fluent-plugin-rewrite-tag-filter are plugins for fluent
 1. start fluentd
 
     ```shell
-    $ fluentd -c /etc/fluentd/config  -vv
+    fluentd -c /etc/fluentd/config  -vv
     ```
 
 1. start kube-apiserver with the following options:
@@ -349,10 +349,11 @@ we will use logstash to collect audit events from webhook backend, and save even
 different users into different files.
 
 1. install [logstash][logstash_install_doc]
+
 1. create config file for logstash
 
-    ```none
-    $ cat <<EOF > /etc/logstash/config
+    ```
+    cat <<EOF > /etc/logstash/config
     input{
         http{
             #TODO, figure out a way to use kubeconfig file to authenticate to logstash
@@ -384,12 +385,12 @@ different users into different files.
 1. start logstash
 
     ```shell
-    $ bin/logstash -f /etc/logstash/config --path.settings /etc/logstash/
+    bin/logstash -f /etc/logstash/config --path.settings /etc/logstash/
     ```
 
 1. create a [kubeconfig file](/docs/tasks/access-application-cluster/authenticate-across-clusters-kubeconfig/) for kube-apiserver webhook audit backend
 
-        $ cat <<EOF > /etc/kubernetes/audit-webhook-kubeconfig
+        cat <<EOF > /etc/kubernetes/audit-webhook-kubeconfig
         apiVersion: v1
         clusters:
         - cluster:


### PR DESCRIPTION
- follow the style guide
- In `create a kubeconfig file for kube-apiserver webhook audit backend` section, hugo(blackfriday) can not generate outputs correctly with bucktick code snippets. So I keep original style.