### PR TITLE
Fix French translation of hello-minikube.md

### DIFF
--- a/content/fr/docs/tutorials/hello-minikube.md
+++ b/content/fr/docs/tutorials/hello-minikube.md
@@ -78,7 +78,7 @@ Pod utilise un conteneur basé sur l'image Docker fournie.
 2. Affichez le déploiement :
 
     ```shell
-    Déploiements de kubectl
+    kubectl get deployments
     ```
 
     Sortie :


### PR DESCRIPTION
In the French translation, the command "kubectl get deployments" has been translated into "Déploiements de kubectl", so it does not work.
This PR replaces the translated command by the original.