### PR TITLE
FR | Add Supported Versions of the Documentation link in docs home

### DIFF
--- a/content/fr/docs/home/supported-doc-versions.md
+++ b/content/fr/docs/home/supported-doc-versions.md
@@ -1,6 +1,10 @@
 ---
 title: Versions supportées de la documentation Kubernetes
 content_template: templates/concept
+card:
+  name: about
+  weight: 10
+  title: Versions supportées de la documentation
 ---
 
 {{% capture overview %}}


### PR DESCRIPTION
"Supported Versions of the Documentation" Link missing below "About the documentation" in https://kubernetes.io/fr/docs/home/