### PR TITLE
Add Federation to glossary page.

### DIFF
--- a/content/en/docs/reference/glossary/federation.md
+++ b/content/en/docs/reference/glossary/federation.md
@@ -1,0 +1,13 @@
+title: Federation
+id: federation
+full-link: /docs/concepts/workloads/pods/federation/
+tags:
+ - architecture
+ - operation
+ - workload
+short_description: >
+  The ability to distribute Kubernetes resources to multiple {% glossary_tooltip text="Clusters" term_id="cluster" %} using a single API.
+
+long-description: >  
+  All {% glossary_tooltip text="Clusters" term_id="cluster" %} managed using [Federation](https://kubernetes.io/docs/concepts/cluster-administration/federation/) are maintained in a {% glossary_tooltip text="Cluster Registry" term_id="cluster registry" %}. {% glossary_tooltip text="Clusters" term_id="cluster" %} within the registry are then managed using a Federation controller along with external DNS resource records for [Ingress](/docs/concepts/services-networking/ingress/) and [Service](/docs/concepts/services-networking/service/) objects.  
+  


### PR DESCRIPTION
I attempted to tackle Federation. However, the only page to link was for v1. But I used information for V2, for it's new architecture, located in the github repo. Please let me know if I should remove that reference to the deprecated v1 page. Associated with #5993