### PR TITLE
Fixes `runAsGroup` security context example (#13535)

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/security-context.md
+++ b/content/en/docs/tasks/configure-pod-container/security-context.md
@@ -79,15 +79,15 @@ kubectl exec -it security-context-demo -- sh
 In your shell, list the running processes:
 
 ```shell
-ps aux
+ps
 ```
 
 The output shows that the processes are running as user 1000, which is the value of `runAsUser`:
 
 ```shell
-USER   PID %CPU %MEM    VSZ   RSS TTY   STAT START   TIME COMMAND
-1000     1  0.0  0.0   4336   724 ?     Ss   18:16   0:00 /bin/sh -c node server.js
-1000     5  0.2  0.6 772124 22768 ?     Sl   18:16   0:00 node server.js
+PID   USER     TIME  COMMAND
+    1 1000      0:00 sleep 1h
+    6 1000      0:00 sh
 ...
 ```
 

--- a/content/en/examples/pods/security/security-context.yaml
+++ b/content/en/examples/pods/security/security-context.yaml
@@ -5,13 +5,15 @@ metadata:
 spec:
   securityContext:
     runAsUser: 1000
+    runAsGroup: 3000
     fsGroup: 2000
   volumes:
   - name: sec-ctx-vol
     emptyDir: {}
   containers:
   - name: sec-ctx-demo
-    image: gcr.io/google-samples/node-hello:1.0
+    image: busybox
+    command: [ "sh", "-c", "sleep 1h" ]
     volumeMounts:
     - name: sec-ctx-vol
       mountPath: /data/demo


### PR DESCRIPTION
Fixes #13535 by publishing a new example and refreshing the command outputs.

The new example is required, because it is not possible to demonstrate `runAsGroup: 3000`'s use with the `gcr.io/google-samples/node-hello:1.0` image as the `/server.js` file is only readable to `root`'s user and group.
  
```
$ ls -l /server.js
-rw-r----- 1 root root 861 Apr  4  2016 /server.js
```

Attempting to run the current example results in the the `sec-ctx-demo` container crashing as shown below:


```
$ kubectl get pods
NAME                    READY   STATUS             RESTARTS   AGE
security-context-demo   0/1     CrashLoopBackOff   4          2m37s

$ kubectl logs security-context-demo -c sec-ctx-demo
fs.js:549
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^

Error: EACCES: permission denied, open '/server.js'
    at Error (native)
    at Object.fs.openSync (fs.js:549:18)
    at Object.fs.readFileSync (fs.js:397:15)
    at Object.Module._extensions..js (module.js:415:20)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Function.Module.runMain (module.js:441:10)
    at startup (node.js:139:18)
    at node.js:968:3
```

As an alternative, I changed the example to use the `busybox` image and updated the ps output accordingly.
