### PR TITLE
Update console output as per configmap data

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -555,8 +555,8 @@ kubectl create -f https://k8s.io/examples/pods/pod-configmap-volume.yaml
 When the pod runs, the command `ls /etc/config/` produces the output below:
 
 ```shell
-special.level
-special.type
+SPECIAL_LEVEL
+SPECIAL_TYPE
 ```
 
 {{< caution >}}
@@ -566,7 +566,7 @@ If there are some files in the `/etc/config/` directory, they will be deleted.
 ### Add ConfigMap data to a specific path in the Volume
 
 Use the `path` field to specify the desired file path for specific ConfigMap items. 
-In this case, the `special.level` item will be mounted in the `config-volume` volume at `/etc/config/keys`.
+In this case, the `SPECIAL_LEVEL` item will be mounted in the `config-volume` volume at `/etc/config/keys`.
 
 {{< codenew file="pods/pod-configmap-volume-specific-key.yaml" >}}
 


### PR DESCRIPTION
Actual Console Output :
root@ubuntu:~/practice1$ kubectl create -f https://k8s.io/examples/configmap/configmap-multikeys.yaml
configmap/special-config created
root@ubuntu:~/practice1$ kubectl get configmaps special-config
NAME             DATA   AGE
special-config   2      17s
root@ubuntu:~/practice1$ kubectl get configmaps special-config -o yaml
apiVersion: v1
data:
  SPECIAL_LEVEL: very
  SPECIAL_TYPE: charm
kind: ConfigMap
metadata:
  creationTimestamp: "2019-03-30T06:52:22Z"
  name: special-config
  namespace: default
  resourceVersion: "1404079"
  selfLink: /api/v1/namespaces/default/configmaps/special-config
  uid: 5ec833dd-52b8-11e9-b4c7-005056ad4679
root@ubuntu:~/practice1$ kubectl create -f https://k8s.io/examples/pods/pod-configmap-volume.yaml
pod/dapi-test-pod created
root@ubuntu:~/practice1$ kubectl logs dapi-test-pod
SPECIAL_LEVEL
SPECIAL_TYPE

Need to update this manfiest as well : pods/pod-configmap-volume-specific-key.yaml