### PR TITLE
[DE] Removed unneeded de/index.md

### DIFF
--- a/content/de/index.md
+++ b/content/de/index.md
@@ -1,3 +1,0 @@
----
-headless: true
----


### PR DESCRIPTION
Removed unneeded index.md for the German translation.
Keeping the  `index.md` results in a generated website without the German homepage: https://kubernetes.io/de/

/cc @bene2k1 
/assign @bene2k1 