### PR TITLE
fix wrong variable name

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -183,7 +183,7 @@ Use the option `--from-env-file` to create a ConfigMap from an env-file, for exa
 #   Each line in an env file has to be in VAR=VAL format.
 #   Lines beginning with # (i.e. comments) are ignored.
 #   Blank lines are ignored.
-#   There is no special handling of quotation marks (i.e. they will be part of the ConfigMap value)).
+#   There is no special handling of quotation marks (i.e. they will be part of the ConfigMap value).
 
 # Download the sample files into `configure-pod-container/configmap/` directory
 wget https://k8s.io/examples/configmap/game-env-file.properties -O configure-pod-container/configmap/game-env-file.properties

--- a/content/en/examples/pods/pod-configmap-volume-specific-key.yaml
+++ b/content/en/examples/pods/pod-configmap-volume-specific-key.yaml
@@ -15,6 +15,6 @@ spec:
       configMap:
         name: special-config
         items:
-        - key: special.level
+        - key: SPECIAL_LEVEL
           path: keys
   restartPolicy: Never


### PR DESCRIPTION
the configmap be defined in configmap-multikeys.yaml, the content is below:

[renyl@localhost configmap]$ cat configmap-multikeys.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: special-config
  namespace: default
data:
  SPECIAL_LEVEL: very
  SPECIAL_TYPE: charm
[renyl@localhost configmap]$

refer to  https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/
