### PR TITLE
Updated links on kubectl documentation page

### DIFF
--- a/content/en/docs/reference/kubectl/kubectl.md
+++ b/content/en/docs/reference/kubectl/kubectl.md
@@ -487,46 +487,46 @@ kubectl [flags]
 
 
 ### SEE ALSO
-* [kubectl annotate](kubectl_annotate.md)	 - Update the annotations on a resource
-* [kubectl api-resources](kubectl_api-resources.md)	 - Print the supported API resources on the server
-* [kubectl api-versions](kubectl_api-versions.md)	 - Print the supported API versions on the server, in the form of "group/version"
-* [kubectl apply](kubectl_apply.md)	 - Apply a configuration to a resource by filename or stdin
-* [kubectl attach](kubectl_attach.md)	 - Attach to a running container
-* [kubectl auth](kubectl_auth.md)	 - Inspect authorization
-* [kubectl autoscale](kubectl_autoscale.md)	 - Auto-scale a Deployment, ReplicaSet, or ReplicationController
-* [kubectl certificate](kubectl_certificate.md)	 - Modify certificate resources.
-* [kubectl cluster-info](kubectl_cluster-info.md)	 - Display cluster info
-* [kubectl completion](kubectl_completion.md)	 - Output shell completion code for the specified shell (bash or zsh)
-* [kubectl config](kubectl_config.md)	 - Modify kubeconfig files
-* [kubectl convert](kubectl_convert.md)	 - Convert config files between different API versions
-* [kubectl cordon](kubectl_cordon.md)	 - Mark node as unschedulable
-* [kubectl cp](kubectl_cp.md)	 - Copy files and directories to and from containers.
-* [kubectl create](kubectl_create.md)	 - Create a resource from a file or from stdin.
-* [kubectl delete](kubectl_delete.md)	 - Delete resources by filenames, stdin, resources and names, or by resources and label selector
-* [kubectl describe](kubectl_describe.md)	 - Show details of a specific resource or group of resources
-* [kubectl diff](kubectl_diff.md)	 - Diff live version against would-be applied version
-* [kubectl drain](kubectl_drain.md)	 - Drain node in preparation for maintenance
-* [kubectl edit](kubectl_edit.md)	 - Edit a resource on the server
-* [kubectl exec](kubectl_exec.md)	 - Execute a command in a container
-* [kubectl explain](kubectl_explain.md)	 - Documentation of resources
-* [kubectl expose](kubectl_expose.md)	 - Take a replication controller, service, deployment or pod and expose it as a new Kubernetes Service
-* [kubectl get](kubectl_get.md)	 - Display one or many resources
-* [kubectl kustomize](kubectl_kustomize.md)	 - Build a kustomization target from a directory or a remote url.
-* [kubectl label](kubectl_label.md)	 - Update the labels on a resource
-* [kubectl logs](kubectl_logs.md)	 - Print the logs for a container in a pod
-* [kubectl options](kubectl_options.md)	 - Print the list of flags inherited by all commands
-* [kubectl patch](kubectl_patch.md)	 - Update field(s) of a resource using strategic merge patch
-* [kubectl plugin](kubectl_plugin.md)	 - Provides utilities for interacting with plugins.
-* [kubectl port-forward](kubectl_port-forward.md)	 - Forward one or more local ports to a pod
-* [kubectl proxy](kubectl_proxy.md)	 - Run a proxy to the Kubernetes API server
-* [kubectl replace](kubectl_replace.md)	 - Replace a resource by filename or stdin
-* [kubectl rollout](kubectl_rollout.md)	 - Manage the rollout of a resource
-* [kubectl run](kubectl_run.md)	 - Run a particular image on the cluster
-* [kubectl scale](kubectl_scale.md)	 - Set a new size for a Deployment, ReplicaSet, Replication Controller, or Job
-* [kubectl set](kubectl_set.md)	 - Set specific features on objects
-* [kubectl taint](kubectl_taint.md)	 - Update the taints on one or more nodes
-* [kubectl top](kubectl_top.md)	 - Display Resource (CPU/Memory/Storage) usage.
-* [kubectl uncordon](kubectl_uncordon.md)	 - Mark node as schedulable
-* [kubectl version](kubectl_version.md)	 - Print the client and server version information
-* [kubectl wait](kubectl_wait.md)	 - Experimental: Wait for a specific condition on one or many resources.
+* [kubectl annotate](/docs/reference/generated/kubectl/kubectl-commands.html#annotate) - Update the annotations on a resource
+* [kubectl api-resources](/docs/reference/generated/kubectl/kubectl-commands.html#api-resources) - Print the supported API resources on the server
+* [kubectl api-versions](/docs/reference/generated/kubectl/kubectl-commands.html#api-versions) - Print the supported API versions on the server, in the form of "group/version"
+* [kubectl apply](/docs/reference/generated/kubectl/kubectl-commands.html#apply) - Apply a configuration to a resource by filename or stdin
+* [kubectl attach](/docs/reference/generated/kubectl/kubectl-commands.html#attach) - Attach to a running container
+* [kubectl auth](/docs/reference/generated/kubectl/kubectl-commands.html#auth) - Inspect authorization
+* [kubectl autoscale](/docs/reference/generated/kubectl/kubectl-commands.html#autoscale) - Auto-scale a Deployment, ReplicaSet, or ReplicationController
+* [kubectl certificate](/docs/reference/generated/kubectl/kubectl-commands.html#certificate) - Modify certificate resources.
+* [kubectl cluster-info](/docs/reference/generated/kubectl/kubectl-commands.html#cluster-info) - Display cluster info
+* [kubectl completion](/docs/reference/generated/kubectl/kubectl-commands.html#completion) - Output shell completion code for the specified shell (bash or zsh)
+* [kubectl config](/docs/reference/generated/kubectl/kubectl-commands.html#config) - Modify kubeconfig files
+* [kubectl convert](/docs/reference/generated/kubectl/kubectl-commands.html#convert) - Convert config files between different API versions
+* [kubectl cordon](/docs/reference/generated/kubectl/kubectl-commands.html#cordon) - Mark node as unschedulable
+* [kubectl cp](/docs/reference/generated/kubectl/kubectl-commands.html#cp) - Copy files and directories to and from containers.
+* [kubectl create](/docs/reference/generated/kubectl/kubectl-commands.html#create) - Create a resource from a file or from stdin.
+* [kubectl delete](/docs/reference/generated/kubectl/kubectl-commands.html#delete) - Delete resources by filenames, stdin, resources and names, or by resources and label selector
+* [kubectl describe](/docs/reference/generated/kubectl/kubectl-commands.html#describe) - Show details of a specific resource or group of resources
+* [kubectl diff](/docs/reference/generated/kubectl/kubectl-commands.html#diff) - Diff live version against would-be applied version
+* [kubectl drain](/docs/reference/generated/kubectl/kubectl-commands.html#drain) - Drain node in preparation for maintenance
+* [kubectl edit](/docs/reference/generated/kubectl/kubectl-commands.html#edit) - Edit a resource on the server
+* [kubectl exec](/docs/reference/generated/kubectl/kubectl-commands.html#exec) - Execute a command in a container
+* [kubectl explain](/docs/reference/generated/kubectl/kubectl-commands.html#explain) - Documentation of resources
+* [kubectl expose](/docs/reference/generated/kubectl/kubectl-commands.html#expose) - Take a replication controller, service, deployment or pod and expose it as a new Kubernetes Service
+* [kubectl get](/docs/reference/generated/kubectl/kubectl-commands.html#get) - Display one or many resources
+* [kubectl kustomize](/docs/reference/generated/kubectl/kubectl-commands.html#kustomize) - Build a kustomization target from a directory or a remote url.
+* [kubectl label](/docs/reference/generated/kubectl/kubectl-commands.html#label) - Update the labels on a resource
+* [kubectl logs](/docs/reference/generated/kubectl/kubectl-commands.html#logs) - Print the logs for a container in a pod
+* [kubectl options](/docs/reference/generated/kubectl/kubectl-commands.html#options) - Print the list of flags inherited by all commands
+* [kubectl patch](/docs/reference/generated/kubectl/kubectl-commands.html#patch) - Update field(s) of a resource using strategic merge patch
+* [kubectl plugin](/docs/reference/generated/kubectl/kubectl-commands.html#plugin) - Provides utilities for interacting with plugins.
+* [kubectl port-forward](/docs/reference/generated/kubectl/kubectl-commands.html#port-forward) - Forward one or more local ports to a pod
+* [kubectl proxy](/docs/reference/generated/kubectl/kubectl-commands.html#proxy) - Run a proxy to the Kubernetes API server
+* [kubectl replace](/docs/reference/generated/kubectl/kubectl-commands.html#replace) - Replace a resource by filename or stdin
+* [kubectl rollout](/docs/reference/generated/kubectl/kubectl-commands.html#rollout) - Manage the rollout of a resource
+* [kubectl run](/docs/reference/generated/kubectl/kubectl-commands.html#run) - Run a particular image on the cluster
+* [kubectl scale](/docs/reference/generated/kubectl/kubectl-commands.html#scale) - Set a new size for a Deployment, ReplicaSet, Replication Controller, or Job
+* [kubectl set](/docs/reference/generated/kubectl/kubectl-commands.html#set) - Set specific features on objects
+* [kubectl taint](/docs/reference/generated/kubectl/kubectl-commands.html#taint) - Update the taints on one or more nodes
+* [kubectl top](/docs/reference/generated/kubectl/kubectl-commands.html#top) - Display Resource (CPU/Memory/Storage) usage.
+* [kubectl uncordon](/docs/reference/generated/kubectl/kubectl-commands.html#uncordon) - Mark node as schedulable
+* [kubectl version](/docs/reference/generated/kubectl/kubectl-commands.html#version) - Print the client and server version information
+* [kubectl wait](/docs/reference/generated/kubectl/kubectl-commands.html#wait) - Experimental: Wait for a specific condition on one or many resources.
 


### PR DESCRIPTION
Replaced all links to non-existing markdown files to point to the kubectl commands reference documentation.

fixes #13559 
fixes #13569 