### PR TITLE
Added missing --rotate-server-certificates flag to kubelet cli reference

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/kubelet.md
+++ b/content/en/docs/reference/command-line-tools-reference/kubelet.md
@@ -975,6 +975,13 @@ kubelet [flags]
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;"><Warning: Beta feature> Auto rotate the kubelet client certificates by requesting new certificates from the kube-apiserver when the certificate expiration approaches.</td>
     </tr>
+    
+     <tr>
+       <td colspan="2">--rotate-server-certificates</td> 
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;"><Warning: Beta feature> Auto-request and rotate the kubelet serving certificates by requesting new certificates from the kube-apiserver when the certificate expiration approaches. Requires the RotateKubeletServerCertificate feature gate to be enabled, and approval of the submitted CertificateSigningRequest objects.</td>
+    </tr>
 
      <tr>
        <td colspan="2">--runonce</td> 


### PR DESCRIPTION
 [TLS bootstrapping](https://v1-12.docs.kubernetes.io/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/#certificate-rotation) documentation specifies about "--rotate-server-certificates" flag, but when we check it in kubelet flags reference section it is missing [Kubelet cli reference](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/)