### PR TITLE
Added missing --rotate-server-certificates flag to kubelet cli reference

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/kubelet.md
+++ b/content/en/docs/reference/command-line-tools-reference/kubelet.md
@@ -977,6 +977,13 @@ kubelet [flags]
     </tr>
 
      <tr>
+       <td colspan="2">--rotate-server-certificates</td> 
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;"><Warning: Beta feature> Auto-request and rotate the kubelet serving certificates by requesting new certificates from the kube-apiserver when the certificate expiration approaches. Requires the RotateKubeletServerCertificate feature gate to be enabled, and approval of the submitted CertificateSigningRequest objects.</td>
+    </tr>
+    
+     <tr>
        <td colspan="2">--runonce</td> 
     </tr>
     <tr>


### PR DESCRIPTION
 [TLS bootstrapping](https://v1-12.docs.kubernetes.io/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/#certificate-rotation) documentation specifies about "--rotate-server-certificates" flag, but when we check it in kubelet flags reference section it is missing [Kubelet cli reference](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/)

How this might be helpful:
- We had written a custom csr approver to approve kubelet serving certs. But from kubernetes 1.11 we need to enable both ServerTLSBootstrap and RotateKubeletServerCertificate [feature](https://github.com/kubernetes/kubernetes/issues/63878)  flag to use the feature and there is no reference to this ServerTLSBootstrap flag in kubelet flags section. We were able to correlate ServerTLSBootstrap can be set via --rotate-server-certificates by looking at the [code](https://github.com/kubernetes/kubernetes/blob/master/cmd/kubelet/app/options/options.go#L516). Not sure why this flag is missed but having this flag in cli reference will be helpful.