### PR TITLE
Removed lledru from OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -52,7 +52,6 @@ aliases:
     - sieben
     - perriea
     - rekcah78
-    - lledru
     - yastij
     - smana
     - rbenzair
@@ -65,7 +64,6 @@ aliases:
     - sieben
     - perriea
     - rekcah78
-    - lledru
     - yastij
     - smana
     - rbenzair
@@ -76,11 +74,9 @@ aliases:
     - oussemos
   sig-docs-it-owners: # Admins for Italian content
     - rlenferink
-    - lledru
     - micheleberardi
   sig-docs-it-reviews: # PR reviews for Italian content
     - rlenferink
-    - lledru
     - micheleberardi
   sig-docs-ja-owners: # Admins for Japanese content 
     - cstoku


### PR DESCRIPTION
Due to time constraints @lledru asked to be removed from the OWNERS_ALIASES for sig-docs.

/cc @lledru 
/assign @ryanmcginnis
as PR wrangler