### PR TITLE
kubelet-integration: Update kubeadm config command

### DIFF
--- a/content/en/docs/setup/independent/kubelet-integration.md
+++ b/content/en/docs/setup/independent/kubelet-integration.md
@@ -96,7 +96,7 @@ such as systemd.
 It is possible to configure the kubelet that kubeadm will start if a custom `KubeletConfiguration`
 API object is passed with a configuration file like so `kubeadm ... --config some-config-file.yaml`.
 
-By calling `kubeadm config print-default --api-objects KubeletConfiguration` you can
+By calling `kubeadm config print init-defaults --component-configs KubeletConfiguration` you can
 see all the default values for this structure.
 
 Also have a look at the [API reference for the


### PR DESCRIPTION
print-default subcommand got removed in 1.14

See: https://github.com/kubernetes/kubernetes/pull/71467

Signed-off-by: Manuel Rüger <manuel@rueg.eu>

