### PR TITLE
Add a blog label, update blog OWNERS

### DIFF
--- a/content/en/blog/OWNERS
+++ b/content/en/blog/OWNERS
@@ -1,11 +1,17 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
-# Owned by Kubernetes Blog reviewers.
+# Owned by Kubernetes Blog reviewers
+
 options:
   no_parent_owners: false
-reviewers:
-  - kbarnard10
+  
 approvers:
+  - kbarnard10
+
+reviewers:
   - bobsky
   - natekartchner
   - sarahkconway
+  
+labels:
+  - area/blog


### PR DESCRIPTION
The K8s blog [is now an official subproject](https://github.com/kubernetes/community/issues/3524#issuecomment-480445006) of SIG Docs. This PR configures tooling in support of the blog as a distinct subproject.

This PR specifies an automatic label for PRs opened against blog content: `area/blog` (https://github.com/kubernetes/test-infra/pull/12098).

This PR also updates the blog-specific OWNERS file, with the understanding that additional changes are coming.

/assign @kbarnard10 
/cc @parispittman @jaredbhatti @Bradamant3 