### PR TITLE
Typo in the deprecation warning and link is broken to latest docs (#13460)

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,7 +1,7 @@
 # i18n strings for the English (main) site.
 
 [deprecation_warning]
-other = " documentation is no longer actively maintained. The version you are currently viewing is a static snapshot. For up-to-date documentation, see "
+other = " documentation is no longer actively maintained. The version you are currently viewing is a static snapshot. For up-to-date documentation, see the "
 
 [deprecation_file_warning]
 other = "Deprecated"

--- a/layouts/shortcodes/deprecationwarning.html
+++ b/layouts/shortcodes/deprecationwarning.html
@@ -5,7 +5,7 @@
       <h3>
 	 Kubernetes {{ .Page.Param "version" }}
 	 {{ T "deprecation_warning" }}
-	 <a href="{{ site.Params.currentUrl }}">{{ T "latest_version" }}</a>
+	 <a href="{{ .Site.Params.currentUrl }}">{{ T "latest_version" }}</a>
       </h3>
     </div>
   </main>


### PR DESCRIPTION
v1.13 deprecation warning link to the latest docs was broken.This issue fixed the broken link as well as the typo in the deprecation warning

