### PR TITLE
Update fluentd image

### DIFF
--- a/content/en/examples/controllers/daemonset.yaml
+++ b/content/en/examples/controllers/daemonset.yaml
@@ -19,7 +19,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: fluentd-elasticsearch
-        image: k8s.gcr.io/fluentd-elasticsearch:1.20
+        image: gcr.io/fluentd-elasticsearch/fluentd:v2.5.1
         resources:
           limits:
             memory: 200Mi

--- a/content/ja/examples/controllers/daemonset.yaml
+++ b/content/ja/examples/controllers/daemonset.yaml
@@ -19,7 +19,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: fluentd-elasticsearch
-        image: k8s.gcr.io/fluentd-elasticsearch:1.20
+        image: gcr.io/fluentd-elasticsearch/fluentd:v2.5.1
         resources:
           limits:
             memory: 200Mi

--- a/content/zh/docs/concepts/workloads/controllers/daemonset.yaml
+++ b/content/zh/docs/concepts/workloads/controllers/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluentd-elasticsearch
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: fluentd-elasticsearch
-        image: k8s.gcr.io/fluentd-elasticsearch:1.20
+        image: gcr.io/fluentd-elasticsearch/fluentd:v2.5.1
         resources:
           limits:
             memory: 200Mi


### PR DESCRIPTION
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> Please delete this note before submitting the pull request.
>
> For 1.15 Features: set Milestone to 1.15 and Base Branch to dev-1.15
> 
> For Chinese localization, base branch to release-1.12
>
> For Korean Localization: set Base Branch to dev-1.13-ko.<latest team milestone>
>
> Help editing and submitting pull requests:
> https://kubernetes.io/docs/contribute/start/#improve-existing-content.
>
> Help choosing which branch to use:
> https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use.
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>

With kubernetes/kubernetes#73819 fluentd-elasticsearch image is moved to community controller location. This PR updates the examples with the latest image in the new location.

