### PR TITLE
Correcting API version in example

### DIFF
--- a/content/en/docs/concepts/configuration/scheduler-perf-tuning.md
+++ b/content/en/docs/concepts/configuration/scheduler-perf-tuning.md
@@ -43,7 +43,7 @@ smaller than 5.
 Below is an example configuration that sets `percentageOfNodesToScore` to 50%.
 
 ```yaml
-apiVersion: componentconfig/v1alpha1
+apiVersion: kubescheduler.config.k8s.io/v1alpha1
 kind: KubeSchedulerConfiguration
 algorithmSource:
   provider: DefaultProvider


### PR DESCRIPTION
API version of KubeSchedulerConfiguration is corrected to kubescheduler.config.k8s.io

This fixes issue #13653 