### PR TITLE
Make it compatible with Hugo 0.55

### DIFF
--- a/layouts/case-studies/list.html
+++ b/layouts/case-studies/list.html
@@ -48,7 +48,7 @@
 			{{ $logo := .Resources.GetMatch "**logo*.png" }}
 			{{ $p := . }}
 			<a target="_blank" href="{{ with $p.Params.content_url }}{{ . | safeURL }}{{ else }}{{ .RelPermalink }}{{ end }}">{{ with $logo }}<img src="{{ .RelPermalink }}" alt="{{ $p.LinkTitle }}">{{ else }}
-				{{ errorf "Case Studies: Missing logo for %s. Put a PNG with the word 'logo' in the filename into %q" $p.LinkTitle $p.Dir }}
+				{{ errorf "Case Studies: Missing logo for %s. Put a PNG with the word 'logo' in the filename into %q" $p.LinkTitle $p.File.Dir }}
 			{{ end }}</a>
 			{{ end }}
 			<a target="_blank" href="https://docs.google.com/a/google.com/forms/d/e/1FAIpQLScuI7Ye3VQHQTwBASrgkjQDSS5TP0g3AXfFhwSM9YpHgxRKFA/viewform" class="tell-your-story"><img src="/images/case_studies/story.png" alt="Tell your story"></a>

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -1,5 +1,11 @@
 {{ define "content" }}
-	 {{ with .Content }}
+    {{ $hasContent := false }}
+    {{ with .File }}
+    {{ if ne .Filename "" }}
+    {{ $hasContent =  (ge (len $.RawContent) 100) }}
+    {{ end }}
+    {{ end }}
+	 {{ if $hasContent }}
 	 {{ partial "docs/content-page" (dict "ctx" $ "page" $ ) }}
 	 {{ else }}
     {{ if ge (len .Pages) 1 }}

--- a/layouts/partials/docs/top-menu.html
+++ b/layouts/partials/docs/top-menu.html
@@ -4,7 +4,7 @@
 {{ $menuSections := (where $docs.Sections ".Params.main_menu" true) }}
 {{ range $menuSections }}
 {{ if $p.IsDescendant . }}
-<h1>{{ if not (strings.Contains .Dir "home")}}{{ .Params.bigheader | default .Title }}{{ end }}</h1>
+<h1>{{ if not (strings.Contains .Path "home")}}{{ .Params.bigheader | default .Title }}{{ end }}</h1>
 <h5>{{ .Params.abstract }}</h5>
 {{ end }}
 {{ end }}

--- a/layouts/partials/git-info.html
+++ b/layouts/partials/git-info.html
@@ -19,7 +19,7 @@
     {{ end }}
     {{ end }}
     {{ if not .Params.noedit }}
-    <a href="https://github.com/kubernetes/website/edit/master/content/{{ site.Language.Lang }}/{{ .File.Path }}" class="button issue">{{ T "main_edit_this_page" }}</a>
+    {{ if .File }}<a href="https://github.com/kubernetes/website/edit/master/content/{{ site.Language.Lang }}/{{ .File.Path }}" class="button issue">{{ T "main_edit_this_page" }}</a>{{ end }}
     {{ end }}
   </div>
   {{ if and (not .Params.showcommit) $.GitInfo }}

--- a/layouts/partials/templates/blocks.html
+++ b/layouts/partials/templates/blocks.html
@@ -1,10 +1,10 @@
 {{ .ctx.Scratch.Set "sections" slice }}
 <ul id="markdown-toc">
 {{ range .ctx.Scratch.Get "blocks" }}
-{{ if .content }}
-{{ $.ctx.Scratch.Set "section" .content }}
-{{ else}}
+{{ if .block }}
 {{ $.ctx.Scratch.Set "section" (partial "templates/block" .) }}
+{{ else}}
+{{ $.ctx.Scratch.Set "section" .content }}
 {{ end }}
 {{ $section := $.ctx.Scratch.Get "section" }}
 {{ $headers := findRE "<h2.*?>(.|\n)*?</h2>" $section }}

--- a/layouts/shortcodes/capture.html
+++ b/layouts/shortcodes/capture.html
@@ -1,3 +1,4 @@
+{{ $_hugo_config := `{ "version": 1 }`}}
 {{- $id := .Get 0 -}}
 {{- if not $id -}}
 {{- errorf "missing id in capture" -}}

--- a/layouts/shortcodes/code.html
+++ b/layouts/shortcodes/code.html
@@ -2,8 +2,8 @@
 {{ $file := .Get "file" }}
 {{ $codelang := .Get "language" | default (path.Ext $file | strings.TrimPrefix ".") }} 
 {{ $fileDir := path.Split $file }}
-{{ $bundlePath := path.Join .Page.Dir $fileDir.Dir }}
-{{ $filename := path.Join $p.Dir $file }}
+{{ $bundlePath := path.Join .Page.File.Dir $fileDir.Dir }}
+{{ $filename := path.Join $p.File.Dir $file }}
 {{ $ghlink := printf "https://%s/blob/master/content/%s/%s" site.Params.githubwebsiterepo .Page.Lang $filename | safeURL }}
 {{/* First assume this is a bundle and the file is inside it. */}}
 {{ $resource := $p.Resources.GetMatch (printf "%s*" $file ) }}

--- a/layouts/shortcodes/codenew.html
+++ b/layouts/shortcodes/codenew.html
@@ -2,7 +2,7 @@
 {{ $file := .Get "file" }}
 {{ $codelang := .Get "language" | default (path.Ext $file | strings.TrimPrefix ".") }} 
 {{ $fileDir := path.Split $file }}
-{{ $bundlePath := path.Join .Page.Dir $fileDir.Dir }}
+{{ $bundlePath := path.Join .Page.File.Dir $fileDir.Dir }}
 {{ $filename := printf "/content/%s/examples/%s" .Page.Lang $file | safeURL }}
 {{ $ghlink := printf "https://%s/master%s" site.Params.githubwebsiteraw $filename | safeURL }}
 {{/* First assume this is a bundle and the file is inside it. */}}

--- a/layouts/shortcodes/include.html
+++ b/layouts/shortcodes/include.html
@@ -11,7 +11,7 @@
 	{{- .Content | safeHTML -}}
 	{{- else -}}
 	{{/* It is not a resource in the includes bundle. Try to find the page relative to the current. */}}
-	{{- $path := path.Join $.Page.Dir $name -}}
+	{{- $path := path.Join $.Page.File.Dir $name -}}
 	{{- $page := site.GetPage "page" $path -}}
 	{{- with $page }}
 	{{ .Content }}

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -27,7 +27,7 @@
 				{{ end }}
 			{{ end }}
 		{{ else}}
-		{{ $path := path.Join $.Page.Dir .include }}
+		{{ $path := path.Join $.Page.File.Dir .include }}
 		{{ $page := site.GetPage "page" $path }}
 		{{ with $page }}
 			{{ .Content }}


### PR DESCRIPTION
This commit adds two backwards compatible changes to prepare for the next Hugo version, most notable:

* All the `File` methods on `Page` has been deprecated and will give a warning in the next Hugo version. Adjust this by changing `.Dir` to ´.File.Dir` and similar.
* Version the capture shortcode to use the old behaviour for markdown rendering of shortcode inner content.

Note that there are several fixes in this version of Hugo that makes it worth-while for this site, esp. one bugfix re. merging of languages.