### PR TITLE
minor link update with the migration of conventions in the community repo

### DIFF
--- a/content/en/docs/concepts/overview/kubernetes-api.md
+++ b/content/en/docs/concepts/overview/kubernetes-api.md
@@ -11,7 +11,7 @@ card:
 
 {{% capture overview %}}
 
-Overall API conventions are described in the [API conventions doc](https://git.k8s.io/community/contributors/devel/api-conventions.md).
+Overall API conventions are described in the [API conventions doc](https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md).
 
 API endpoints, resource types and samples are described in [API Reference](/docs/reference).
 


### PR DESCRIPTION
Good morning docs-folk!

I was wandering through the Kubernetes API docs and noticed this slight URL update - there's a holding-place page in the community repo, but I thought it worthwhile to update to the end state they point to.

- joe