### PR TITLE
Link will be broken when deprecation is false

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,7 +1,7 @@
 # i18n strings for the English (main) site.
 
 [deprecation_warning]
-other = " documentation is no longer actively maintained. The version you are currently viewing is a static snapshot. For up-to-date documentation, see "
+other = " documentation is no longer actively maintained. The version you are currently viewing is a static snapshot. For up-to-date documentation, see the "
 
 [deprecation_file_warning]
 other = "Deprecated"

--- a/layouts/shortcodes/deprecationwarning.html
+++ b/layouts/shortcodes/deprecationwarning.html
@@ -3,9 +3,9 @@
   <main>
     <div class="content deprecation-warning">
       <h3>
-	 Kubernetes {{ .Param "version" }}
+	 Kubernetes {{ .Page.Param "version" }}
 	 {{ T "deprecation_warning" }}
-	 <a href="{{ site.Params.currentUrl }}">{{ T "latest_version" }}</a>
+	 <a href="{{ .Site.Params.currentUrl }}">{{ T "latest_version" }}</a>
       </h3>
     </div>
   </main>


### PR DESCRIPTION
Link to the latest docs will be broker when deprecation set to false when do the next release
This issue solved for v1.13 with PR #13649
