### PR TITLE
Remove enable resource quota note

### DIFF
--- a/content/en/docs/concepts/policy/resource-quotas.md
+++ b/content/en/docs/concepts/policy/resource-quotas.md
@@ -201,11 +201,6 @@ field in the quota spec.
 
 A quota is matched and consumed only if `scopeSelector` in the quota spec selects the pod.
 
-{{< note >}}
-You need to enable the feature gate `ResourceQuotaScopeSelectors`before using resource quotas
-per PriorityClass.
-{{< /note >}}
-
 This example creates a quota object and matches it with pods at specific priorities. The example
 works as follows:
 
@@ -537,7 +532,7 @@ restrictions around nodes: pods from several namespaces may run on the same node
 
 It may be desired that pods at a particular priority, eg. "cluster-services", should be allowed in a namespace, if and only if, a matching quota object exists.
 
-With this mechanism, operators will be able to restrict usage of certain high priority classes to a limited number of namespaces and not every namespace will be able to consume these priority classes by default.
+With this mechanism, operators will be able to restrict usage of certain high priority classes to a limited number of namespaces and not every namespaces will be able to consume these priority classes by default.
 
 To enforce this, kube-apiserver flag `--admission-control-config-file` should be used to pass path to the following configuration file:
 

--- a/content/en/docs/concepts/policy/resource-quotas.md
+++ b/content/en/docs/concepts/policy/resource-quotas.md
@@ -532,7 +532,7 @@ restrictions around nodes: pods from several namespaces may run on the same node
 
 It may be desired that pods at a particular priority, eg. "cluster-services", should be allowed in a namespace, if and only if, a matching quota object exists.
 
-With this mechanism, operators will be able to restrict usage of certain high priority classes to a limited number of namespaces and not every namespaces will be able to consume these priority classes by default.
+With this mechanism, operators will be able to restrict usage of certain high priority classes to a limited number of namespaces and not every namespace will be able to consume these priority classes by default.
 
 To enforce this, kube-apiserver flag `--admission-control-config-file` should be used to pass path to the following configuration file:
 


### PR DESCRIPTION
As of now, `ResourceQuotaScopeSelectors` is enabled by default, since it's in beta. So, let's remove it.

/cc @bsalamat @vikaschoudhary16 