### PR TITLE
Removed extra "```shell" from the output box

### DIFF
--- a/content/en/docs/concepts/cluster-administration/manage-deployment.md
+++ b/content/en/docs/concepts/cluster-administration/manage-deployment.md
@@ -366,7 +366,6 @@ This command will compare the version of the configuration that you're pushing w
 
 ```shell
 kubectl apply -f https://k8s.io/examples/application/nginx/nginx-deployment.yaml
-```shell
 deployment.apps/my-nginx configured
 ```
 


### PR DESCRIPTION
On the [manage-deployment](https://kubernetes.io/docs/concepts/cluster-administration/manage-deployment/#in-place-updates-of-resources) page, under "In-place updates of resources", there is an extra `shell` tag in the output box. 

This PR removes this extra tag. 