### PR TITLE
Removing broken hyperlink

### DIFF
--- a/content/en/docs/concepts/cluster-administration/logging.md
+++ b/content/en/docs/concepts/cluster-administration/logging.md
@@ -209,8 +209,7 @@ an application that writes to a single file, it's generally better to set
 container approach.
 
 Sidecar containers can also be used to rotate log files that cannot be
-rotated by the application itself. [An example](https://github.com/samsung-cnct/logrotate)
-of this approach is a small container running logrotate periodically.
+rotated by the application itself. An example of this approach is a small container running logrotate periodically.
 However, it's recommended to use `stdout` and `stderr` directly and leave rotation
 and retention policies to the kubelet.
 


### PR DESCRIPTION
removed hyperlink from "An example" in the statement An example of this approach is a small container running logrotate periodically. However, it's recommended to use stdout and stderr directly and leave rotation and retention policies to the kubelet.
This fix is for issue #13656 
