### PR TITLE
Update content on kube-dns to coredns configmap translation

### DIFF
--- a/content/en/docs/tasks/administer-cluster/dns-custom-nameservers.md
+++ b/content/en/docs/tasks/administer-cluster/dns-custom-nameservers.md
@@ -82,7 +82,7 @@ data:
            fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153
-        proxy . /etc/resolv.conf
+        forward . /etc/resolv.conf
         cache 30
         loop
         reload
@@ -100,7 +100,7 @@ The Corefile configuration includes the following [plugins](https://coredns.io/p
 > `Upstream` is used for resolving services that point to external hosts (External Services).
 
 * [prometheus](https://coredns.io/plugins/prometheus/): Metrics of CoreDNS are available at http://localhost:9153/metrics in [Prometheus](https://prometheus.io/) format.
-* [proxy](https://coredns.io/plugins/proxy/): Any queries that are not within the cluster domain of Kubernetes will be forwarded to predefined resolvers (/etc/resolv.conf).
+* [forward](https://coredns.io/plugins/forward/): Any queries that are not within the cluster domain of Kubernetes will be forwarded to predefined resolvers (/etc/resolv.conf).
 * [cache](https://coredns.io/plugins/cache/): This enables a frontend cache.
 * [loop](https://coredns.io/plugins/loop/): Detects simple forwarding loops and halts the CoreDNS process if a loop is found.
 * [reload](https://coredns.io/plugins/reload): Allows automatic reload of a changed Corefile. After you edit the ConfigMap configuration, allow two minutes for your changes to take effect.
@@ -110,7 +110,7 @@ You can modify the default CoreDNS behavior by modifying the ConfigMap.
 
 ### Configuration of Stub-domain and upstream nameserver using CoreDNS
 
-CoreDNS has the ability to configure stubdomains and upstream nameservers using the [proxy plugin](https://coredns.io/plugins/proxy/). 
+CoreDNS has the ability to configure stubdomains and upstream nameservers using the [forward plugin](https://coredns.io/plugins/forward/).
 
 #### Example
 If a cluster operator has a [Consul](https://www.consul.io/) domain server located at 10.150.0.1, and all Consul names have the suffix .consul.local. To configure it in CoreDNS, the cluster administrator creates the following stanza in the CoreDNS ConfigMap.
@@ -119,18 +119,15 @@ If a cluster operator has a [Consul](https://www.consul.io/) domain server locat
 consul.local:53 {
         errors
         cache 30
-        proxy . 10.150.0.1
+        forward . 10.150.0.1
     }
 ```
 
-To explicitly force all non-cluster DNS lookups to go through a specific nameserver at 172.16.0.1, point the `proxy` and `upstream` to the nameserver instead of `/etc/resolv.conf`
+To explicitly force all non-cluster DNS lookups to go through a specific nameserver at 172.16.0.1, point the `forward` to the nameserver instead of `/etc/resolv.conf`
 
 ```
-proxy .  172.16.0.1
+forward .  172.16.0.1
 ``` 
-```
-upstream 172.16.0.1
-```
 
 The final ConfigMap along with the default `Corefile` configuration looks like:
 
@@ -147,11 +144,11 @@ data:
         health
         kubernetes cluster.local in-addr.arpa ip6.arpa {
            pods insecure
-           upstream 172.16.0.1
+           upstream
            fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153
-        proxy . 172.16.0.1
+        forward . 172.16.0.1
         cache 30
         loop
         reload
@@ -160,10 +157,12 @@ data:
     consul.local:53 {
         errors
         cache 30
-        proxy . 10.150.0.1
+        forward . 10.150.0.1
     }
 ```
 In Kubernetes version 1.10 and later, kubeadm supports automatic translation of the CoreDNS ConfigMap from the kube-dns ConfigMap.
+***Note: While kube-dns accepts a service name (eg: ns.foo.com) for stubdomain and nameserver, CoreDNS does not support this feature. 
+During translation, if a service name is detected, it will be omitted while translating to the equivalent CoreDNS config.***
 
 ## Kube-dns
 
@@ -308,7 +307,7 @@ data:
 ## CoreDNS configuration equivalent to kube-dns
 
 CoreDNS supports the features of kube-dns and more.
-A ConfigMap created for kube-dns to support `StubDomains`and `upstreamNameservers` translates to the `proxy` plugin in CoreDNS.
+A ConfigMap created for kube-dns to support `StubDomains`and `upstreamNameservers` translates to the `forward` plugin in CoreDNS.
 Similarly, the `Federations` plugin in kube-dns translates to the `federation` plugin in CoreDNS.
 
 ### Example
@@ -341,12 +340,12 @@ federation cluster.local {
 abc.com:53 {
         errors
         cache 30
-        proxy . 1.2.3.4
+        forward . 1.2.3.4
     }
     my.cluster.local:53 {
         errors
         cache 30
-        proxy . 2.3.4.5
+        forward . 2.3.4.5
     }
 ```
 
@@ -357,7 +356,7 @@ The complete Corefile with the default plugins:
         errors
         health
         kubernetes cluster.local in-addr.arpa ip6.arpa {
-           upstream  8.8.8.8 8.8.4.4
+           upstream
            pods insecure
            fallthrough in-addr.arpa ip6.arpa
         }
@@ -365,18 +364,18 @@ The complete Corefile with the default plugins:
            foo foo.feddomain.com
         }
         prometheus :9153
-        proxy .  8.8.8.8 8.8.4.4
+        forward .  8.8.8.8 8.8.4.4
         cache 30
     }
     abc.com:53 {
         errors
         cache 30
-        proxy . 1.2.3.4
+        forward . 1.2.3.4
     }
     my.cluster.local:53 {
         errors
         cache 30
-        proxy . 2.3.4.5
+        forward . 2.3.4.5
     }
 ```
 

--- a/content/en/docs/tasks/administer-cluster/dns-custom-nameservers.md
+++ b/content/en/docs/tasks/administer-cluster/dns-custom-nameservers.md
@@ -162,7 +162,7 @@ data:
 ```
 In Kubernetes version 1.10 and later, kubeadm supports automatic translation of the CoreDNS ConfigMap from the kube-dns ConfigMap.
 ***Note: While kube-dns accepts an FQDN for stubdomain and nameserver (eg: ns.foo.com), CoreDNS does not support this feature. 
-During translation, if a service name is detected, it will be omitted while translating to the equivalent CoreDNS config.***
+During translation, all FQDN nameservers will be omitted from the CoreDNS config.***
 
 ## Kube-dns
 

--- a/content/en/docs/tasks/administer-cluster/dns-custom-nameservers.md
+++ b/content/en/docs/tasks/administer-cluster/dns-custom-nameservers.md
@@ -78,7 +78,6 @@ data:
         health
         kubernetes cluster.local in-addr.arpa ip6.arpa {
            pods insecure
-           upstream
            fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153
@@ -96,8 +95,6 @@ The Corefile configuration includes the following [plugins](https://coredns.io/p
 * [kubernetes](https://coredns.io/plugins/kubernetes/): CoreDNS will reply to DNS queries based on IP of the services and pods of Kubernetes. You can find more details [here](https://coredns.io/plugins/kubernetes/). 
 
 > The `pods insecure` option is provided for backward compatibility with kube-dns. You can use the `pods verified` option, which returns an A record only if there exists a pod in same namespace with matching IP. The `pods disabled` option can be used if you don't use pod records.
-
-> `Upstream` is used for resolving services that point to external hosts (External Services).
 
 * [prometheus](https://coredns.io/plugins/prometheus/): Metrics of CoreDNS are available at http://localhost:9153/metrics in [Prometheus](https://prometheus.io/) format.
 * [forward](https://coredns.io/plugins/forward/): Any queries that are not within the cluster domain of Kubernetes will be forwarded to predefined resolvers (/etc/resolv.conf).
@@ -144,7 +141,6 @@ data:
         health
         kubernetes cluster.local in-addr.arpa ip6.arpa {
            pods insecure
-           upstream
            fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153
@@ -356,7 +352,6 @@ The complete Corefile with the default plugins:
         errors
         health
         kubernetes cluster.local in-addr.arpa ip6.arpa {
-           upstream
            pods insecure
            fallthrough in-addr.arpa ip6.arpa
         }

--- a/content/en/docs/tasks/administer-cluster/dns-custom-nameservers.md
+++ b/content/en/docs/tasks/administer-cluster/dns-custom-nameservers.md
@@ -161,7 +161,7 @@ data:
     }
 ```
 In Kubernetes version 1.10 and later, kubeadm supports automatic translation of the CoreDNS ConfigMap from the kube-dns ConfigMap.
-***Note: While kube-dns accepts a service name (eg: ns.foo.com) for stubdomain and nameserver, CoreDNS does not support this feature. 
+***Note: While kube-dns accepts an FQDN for stubdomain and nameserver (eg: ns.foo.com), CoreDNS does not support this feature. 
 During translation, if a service name is detected, it will be omitted while translating to the equivalent CoreDNS config.***
 
 ## Kube-dns


### PR DESCRIPTION
Updates and corrects the part of configmap for CoreDNS