### PR TITLE
Branch language-id tracker that will be raised against upstream k/website

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -80,6 +80,12 @@ aliases:
     - jygastaud
     - awkif
     - oussemos
+  sig-docs-id-owners: # Admins for Indonesian content
+    - girikuncoro
+    - irfiva
+  sig-docs-id-reviews: # PR reviews for Indonesian content
+    - girikuncoro
+    - irfiva
   sig-docs-it-owners: # Admins for Italian content
     - rlenferink
     - micheleberardi

--- a/content/id/OWNERS
+++ b/content/id/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# This is the localization project for Indonesian.
+# Teams and members are visible at https://github.com/orgs/kubernetes/teams.
+
+reviewers:
+- sig-docs-id-reviews
+
+approvers:
+- sig-docs-id-owners
+
+labels:
+- language/id


### PR DESCRIPTION
This is for our main development branch of Bahasa Indonesia translation work, that will be raised against upstream `k/website` when we are done during init phase. All translation works in this fork should be merged into this branch. This will help in Bahasa Indonesia doc review, and will help when we finally raise PR into `k/website`.

Refer to init spanish works that k folks have recently merged.
https://github.com/kubernetes/website/pull/13543/commits
