### PR TITLE
Define container environment variables using Secret data

### DIFF
--- a/content/en/docs/tasks/inject-data-application/distribute-credentials-secure.md
+++ b/content/en/docs/tasks/inject-data-application/distribute-credentials-secure.md
@@ -152,19 +152,19 @@ is exposed:
 
    ```shell
    kubectl create secret generic backend-user --from-literal=backend-username='backend-admin'
-    ```
+   ```
 
-2. Assign the username value defined in the Secret to the SECRET_USERNAME environment variable in the Pod specification.
+1. Assign the username value defined in the Secret to the SECRET_USERNAME environment variable in the Pod specification.
    
    {{< codenew file="pods/inject/pod-single-secret-env-variable.yaml" >}}
    
-3. Create the Pod:	
+1. Create the Pod:	
 
    ```shell
-   kubectl create -f https://k8s.io/examples/pods/pod-single-secret-env-variable.yaml
+   kubectl create -f https://k8s.io/examples/pods/inject/pod-single-secret-env-variable.yaml
    ```
    
-4. Now, the Pod’s output includes environment variable `SECRET_USERNAME=backend-admin`
+1. Now, the Pod’s output includes environment variable `SECRET_USERNAME=backend-admin`
 
 
 ### Define container environment variables with data from multiple Secrets
@@ -177,17 +177,17 @@ is exposed:
 	 kubectl create secret generic db-user --from-literal=db-username='db-admin' 
    ```
    
-2. Define the environment variables in the Pod specification.   
+1. Define the environment variables in the Pod specification.   
    
    {{< codenew file="pods/inject/pod-multiple-secret-env-variable.yaml" >}}
    
-3. Create the Pod:
+1. Create the Pod:
 
    ```shell
-   kubectl create -f https://k8s.io/examples/pods/pod-multiple-secret-env-variable.yaml 
+   kubectl create -f https://k8s.io/examples/pods/inject/pod-multiple-secret-env-variable.yaml 
    ```
    
-4. Now, the Pod’s output includes `BACKEND_USERNAME=backend-admin` and `DB_USERNAME=db-admin` environment variables. 	 
+1. Now, the Pod’s output includes `BACKEND_USERNAME=backend-admin` and `DB_USERNAME=db-admin` environment variables. 	 
 
 
 ## Configure all key-value pairs in a Secret as container environment variables
@@ -202,17 +202,17 @@ This functionality is available in Kubernetes v1.6 and later.
    kubectl create secret generic test-secret --from-literal=username='my-app' --from-literal=password='39528$vdg7Jb'
    ```
    
-2. Use envFrom to define all of the Secret’s data as container environment variables. The key from the Secret becomes the environment      variable name in the Pod.   
+1. Use envFrom to define all of the Secret’s data as container environment variables. The key from the Secret becomes the environment      variable name in the Pod.   
 
     {{< codenew file="pods/inject/pod-secret-envFrom.yaml" >}}
    
-3. Create the Pod:
+1. Create the Pod:
 
    ```shell
-   kubectl create -f https://k8s.io/examples/pods/pod-secret-envFrom.yaml
+   kubectl create -f https://k8s.io/examples/pods/inject/pod-secret-envFrom.yaml
    ```
  
-4. Now, the Pod’s output includes `username=my-app` and `password=39528$vdg7Jb` environment variables.  
+1. Now, the Pod’s output includes `username=my-app` and `password=39528$vdg7Jb` environment variables.  
    
      
 {{% /capture %}}

--- a/content/en/docs/tasks/inject-data-application/distribute-credentials-secure.md
+++ b/content/en/docs/tasks/inject-data-application/distribute-credentials-secure.md
@@ -151,7 +151,7 @@ is exposed:
 1. Define an environment variable as a key-value pair in a Secret:
 
    ```shell
-   kubectl create secret generic backend-user --from-literal=username='admin'
+   kubectl create secret generic backend-user --from-literal=backend-username='backend-admin'
     ```
 
 2. Assign the username value defined in the Secret to the SECRET_USERNAME environment variable in the Pod specification.
@@ -164,7 +164,7 @@ is exposed:
    kubectl create -f https://k8s.io/examples/pods/pod-single-secret-env-variable.yaml
    ```
    
-4. Now, the Pod’s output includes environment variable `SECRET_USERNAME=admin`
+4. Now, the Pod’s output includes environment variable `SECRET_USERNAME=backend-admin`
 
 
 ### Define container environment variables with data from multiple Secrets
@@ -174,7 +174,7 @@ is exposed:
    ```shell
    kubectl create secret generic backend-user --from-literal=backend-username='backend-admin' 
    
-	kubectl create secret generic db-user --from-literal=db-username='db-admin' 
+	 kubectl create secret generic db-user --from-literal=db-username='db-admin' 
    ```
    
 2. Define the environment variables in the Pod specification.   
@@ -187,50 +187,34 @@ is exposed:
    kubectl create -f https://k8s.io/examples/pods/pod-multiple-secret-env-variable.yaml 
    ```
    
-4. Now, the Pod’s output includes `BACKEND_USERNAME=backend-admin` and `DB_USERNAME=db-admin` environment variables. 	   
+4. Now, the Pod’s output includes `BACKEND_USERNAME=backend-admin` and `DB_USERNAME=db-admin` environment variables. 	 
+
+
+## Configure all key-value pairs in a Secret as container environment variables
+
+{{< note >}}
+This functionality is available in Kubernetes v1.6 and later.
+{{< /note >}}
+
+1. Create a Secret containing multiple key-value pairs
    
+   ```shell
+   kubectl create secret generic test-secret --from-literal=username='my-app' --from-literal=password='39528$vdg7Jb'
+   ```
    
-## Create a Pod that has access to the secret data through environment variables
+2. Use envFrom to define all of the Secret’s data as container environment variables. The key from the Secret becomes the environment      variable name in the Pod.   
 
-Here is a configuration file you can use to create a Pod:
+    {{< codenew file="pods/inject/pod-secret-envFrom.yaml" >}}
+   
+3. Create the Pod:
 
-{{< codenew file="pods/inject/secret-envars-pod.yaml" >}}
-
-1. Create the Pod:
-
-    ```shell
-    kubectl apply -f https://k8s.io/examples/pods/inject/secret-envars-pod.yaml
-    ```
-
-1. Verify that your Pod is running:
-    ```shell
-    kubectl get pod secret-envars-test-pod
-    ```
-
-    Output:
-    ```shell
-    NAME                     READY     STATUS    RESTARTS   AGE
-    secret-envars-test-pod   1/1       Running   0          4m
-    ```
-
-1. Get a shell into the Container that is running in your Pod:
-    ```shell
-    kubectl exec -it secret-envars-test-pod -- /bin/bash
-    ```
-
-1. In your shell, display the environment variables:
-    ```shell
-    root@secret-envars-test-pod:/# printenv
-    ```
-
-    The output includes your username and password:
-    ```shell
-    ...
-    SECRET_USERNAME=my-app
-    ...
-    SECRET_PASSWORD=39528$vdg7Jb
-    ```
-    
+   ```shell
+   kubectl create -f https://k8s.io/examples/pods/pod-secret-envFrom.yaml
+   ```
+ 
+4. Now, the Pod’s output includes `username=my-app` and `password=39528$vdg7Jb` environment variables.  
+   
+     
 {{% /capture %}}
 
 {{% capture whatsnext %}}

--- a/content/en/docs/tasks/inject-data-application/distribute-credentials-secure.md
+++ b/content/en/docs/tasks/inject-data-application/distribute-credentials-secure.md
@@ -148,46 +148,46 @@ is exposed:
 
 ### Define a container environment variable with data from a single Secret
 
-1. Define an environment variable as a key-value pair in a Secret:
+*  Define an environment variable as a key-value pair in a Secret:
 
    ```shell
    kubectl create secret generic backend-user --from-literal=backend-username='backend-admin'
    ```
 
-1. Assign the username value defined in the Secret to the SECRET_USERNAME environment variable in the Pod specification.
+*  Assign the `backend-username` value defined in the Secret to the `SECRET_USERNAME` environment variable in the Pod specification.   
    
    {{< codenew file="pods/inject/pod-single-secret-env-variable.yaml" >}}
    
-1. Create the Pod:	
+*  Create the Pod:	
 
    ```shell
    kubectl create -f https://k8s.io/examples/pods/inject/pod-single-secret-env-variable.yaml
    ```
    
-1. Now, the Pod’s output includes environment variable `SECRET_USERNAME=backend-admin`
+*  Now, the Pod’s output includes environment variable `SECRET_USERNAME=backend-admin`
 
 
 ### Define container environment variables with data from multiple Secrets
 
-1. As with the previous example, create the Secrets first.
+*  As with the previous example, create the Secrets first.
   
    ```shell
-   kubectl create secret generic backend-user --from-literal=backend-username='backend-admin' 
-   
+     kubectl create secret generic backend-user --from-literal=backend-username='backend-admin' 
+  
 	 kubectl create secret generic db-user --from-literal=db-username='db-admin' 
    ```
    
-1. Define the environment variables in the Pod specification.   
+*  Define the environment variables in the Pod specification.   
    
    {{< codenew file="pods/inject/pod-multiple-secret-env-variable.yaml" >}}
    
-1. Create the Pod:
+*  Create the Pod:
 
    ```shell
    kubectl create -f https://k8s.io/examples/pods/inject/pod-multiple-secret-env-variable.yaml 
    ```
    
-1. Now, the Pod’s output includes `BACKEND_USERNAME=backend-admin` and `DB_USERNAME=db-admin` environment variables. 	 
+*  Now, the Pod’s output includes `BACKEND_USERNAME=backend-admin` and `DB_USERNAME=db-admin` environment variables. 	 
 
 
 ## Configure all key-value pairs in a Secret as container environment variables
@@ -196,23 +196,23 @@ is exposed:
 This functionality is available in Kubernetes v1.6 and later.
 {{< /note >}}
 
-1. Create a Secret containing multiple key-value pairs
+*  Create a Secret containing multiple key-value pairs
    
    ```shell
    kubectl create secret generic test-secret --from-literal=username='my-app' --from-literal=password='39528$vdg7Jb'
    ```
    
-1. Use envFrom to define all of the Secret’s data as container environment variables. The key from the Secret becomes the environment      variable name in the Pod.   
+*  Use envFrom to define all of the Secret’s data as container environment variables. The key from the Secret becomes the environment      variable name in the Pod.   
 
     {{< codenew file="pods/inject/pod-secret-envFrom.yaml" >}}
    
-1. Create the Pod:
+*  Create the Pod:
 
    ```shell
    kubectl create -f https://k8s.io/examples/pods/inject/pod-secret-envFrom.yaml
    ```
  
-1. Now, the Pod’s output includes `username=my-app` and `password=39528$vdg7Jb` environment variables.  
+*  Now, the Pod’s output includes `username=my-app` and `password=39528$vdg7Jb` environment variables.  
    
      
 {{% /capture %}}

--- a/content/en/docs/tasks/inject-data-application/distribute-credentials-secure.md
+++ b/content/en/docs/tasks/inject-data-application/distribute-credentials-secure.md
@@ -143,7 +143,53 @@ is exposed:
     my-app
     39528$vdg7Jb
     ```
+    
+## Define container environment variables using Secret data
 
+### Define a container environment variable with data from a single Secret
+
+1. Define an environment variable as a key-value pair in a Secret:
+
+   ```shell
+   kubectl create secret generic backend-user --from-literal=username='admin'
+    ```
+
+2. Assign the username value defined in the Secret to the SECRET_USERNAME environment variable in the Pod specification.
+   
+   {{< codenew file="pods/inject/pod-single-secret-env-variable.yaml" >}}
+   
+3. Create the Pod:	
+
+   ```shell
+   kubectl create -f https://k8s.io/examples/pods/pod-single-secret-env-variable.yaml
+   ```
+   
+4. Now, the Pod’s output includes environment variable `SECRET_USERNAME=admin`
+
+
+### Define container environment variables with data from multiple Secrets
+
+1. As with the previous example, create the Secrets first.
+  
+   ```shell
+   kubectl create secret generic backend-user --from-literal=backend-username='backend-admin' 
+   
+	kubectl create secret generic db-user --from-literal=db-username='db-admin' 
+   ```
+   
+2. Define the environment variables in the Pod specification.   
+   
+   {{< codenew file="pods/inject/pod-multiple-secret-env-variable.yaml" >}}
+   
+3. Create the Pod:
+
+   ```shell
+   kubectl create -f https://k8s.io/examples/pods/pod-multiple-secret-env-variable.yaml 
+   ```
+   
+4. Now, the Pod’s output includes `BACKEND_USERNAME=backend-admin` and `DB_USERNAME=db-admin` environment variables. 	   
+   
+   
 ## Create a Pod that has access to the secret data through environment variables
 
 Here is a configuration file you can use to create a Pod:

--- a/content/en/examples/pods/inject/pod-multiple-secret-env-variable.yaml
+++ b/content/en/examples/pods/inject/pod-multiple-secret-env-variable.yaml
@@ -12,7 +12,7 @@ spec:
         secretKeyRef:
           name: backend-user
           key: backend_username
-	env:
+	  env:
     - name: DB_USERNAME
       valueFrom:
         secretKeyRef:

--- a/content/en/examples/pods/inject/pod-multiple-secret-env-variable.yaml
+++ b/content/en/examples/pods/inject/pod-multiple-secret-env-variable.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: secret-envars-test-pod
+  name: secret-multiple-envars
 spec:
   containers:
   - name: envars-test-container
@@ -12,7 +12,6 @@ spec:
         secretKeyRef:
           name: backend-user
           key: backend_username
-	  env:
     - name: DB_USERNAME
       valueFrom:
         secretKeyRef:

--- a/content/en/examples/pods/inject/pod-multiple-secret-env-variable.yaml
+++ b/content/en/examples/pods/inject/pod-multiple-secret-env-variable.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: secret-multiple-envars
+  name: envvars-multiple-secrets
 spec:
   containers:
   - name: envars-test-container

--- a/content/en/examples/pods/inject/pod-multiple-secret-env-variable.yaml
+++ b/content/en/examples/pods/inject/pod-multiple-secret-env-variable.yaml
@@ -11,9 +11,9 @@ spec:
       valueFrom:
         secretKeyRef:
           name: backend-user
-          key: backend_username
+          key: backend-username
     - name: DB_USERNAME
       valueFrom:
         secretKeyRef:
           name: db-user
-          key: db_username
+          key: db-username

--- a/content/en/examples/pods/inject/pod-multiple-secret-env-variable.yaml
+++ b/content/en/examples/pods/inject/pod-multiple-secret-env-variable.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: secret-envars-test-pod
+spec:
+  containers:
+  - name: envars-test-container
+    image: nginx
+    env:
+    - name: BACKEND_USERNAME
+      valueFrom:
+        secretKeyRef:
+          name: backend-user
+          key: backend_username
+	env:
+    - name: DB_USERNAME
+      valueFrom:
+        secretKeyRef:
+          name: db-user
+          key: db_username

--- a/content/en/examples/pods/inject/pod-secret-envFrom.yaml
+++ b/content/en/examples/pods/inject/pod-secret-envFrom.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: envfrom-secret
+spec:
+  containers:
+  - name: envars-test-container
+    image: nginx
+    envFrom:
+    - secretRef:
+        name: test-secret

--- a/content/en/examples/pods/inject/pod-single-secret-env-variable.yaml
+++ b/content/en/examples/pods/inject/pod-single-secret-env-variable.yaml
@@ -10,4 +10,4 @@ spec:
       valueFrom:
         secretKeyRef:
           name: backend-user
-          key: username
+          key: backend_username

--- a/content/en/examples/pods/inject/pod-single-secret-env-variable.yaml
+++ b/content/en/examples/pods/inject/pod-single-secret-env-variable.yaml
@@ -1,6 +1,6 @@
 kind: Pod
 metadata:
-  name: secret-envars-test-pod
+  name: env-single-secret
 spec:
   containers:
   - name: envars-test-container
@@ -10,4 +10,4 @@ spec:
       valueFrom:
         secretKeyRef:
           name: backend-user
-          key: backend_username
+          key: backend-username

--- a/content/en/examples/pods/inject/pod-single-secret-env-variable.yaml
+++ b/content/en/examples/pods/inject/pod-single-secret-env-variable.yaml
@@ -1,0 +1,13 @@
+kind: Pod
+metadata:
+  name: secret-envars-test-pod
+spec:
+  containers:
+  - name: envars-test-container
+    image: nginx
+    env:
+    - name: SECRET_USERNAME
+      valueFrom:
+        secretKeyRef:
+          name: backend-user
+          key: username

--- a/content/en/examples/pods/inject/pod-single-secret-env-variable.yaml
+++ b/content/en/examples/pods/inject/pod-single-secret-env-variable.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 kind: Pod
 metadata:
   name: env-single-secret


### PR DESCRIPTION
The existing document didn't show different ways to inject secret as environment variables.  So with this PR I have split existing heading into two headings with more specific and appropriate details:
Added below new headings:

1. Define container environment variables using Secret data
   Under this heading, I have added two examples. First one explains adding environment variable to the container using a single secret and second explains adding environment variables to the container from two different secrets.

2. Configure all key-value pairs in a ConfigMap as container environment variables
  Under this heading, I have documented 'envFrom' option to add environment variables. As this option is supported from kubernetes v1.6 , a note is also added under this heading. 
