### PR TITLE
Init Indonesian translation

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -80,6 +80,12 @@ aliases:
     - jygastaud
     - awkif
     - oussemos
+  sig-docs-id-owners: # Admins for Indonesian content
+    - girikuncoro
+    - irfiva
+  sig-docs-id-reviews: # PR reviews for Indonesian content
+    - girikuncoro
+    - irfiva
   sig-docs-it-owners: # Admins for Italian content
     - rlenferink
     - micheleberardi

--- a/README-id.md
+++ b/README-id.md
@@ -3,71 +3,70 @@
 [![Build Status](https://api.travis-ci.org/kubernetes/website.svg?branch=master)](https://travis-ci.org/kubernetes/website)
 [![GitHub release](https://img.shields.io/github/release/kubernetes/website.svg)](https://github.com/kubernetes/website/releases/latest)
 
-Selamat datang! Repositori ini merupakan wadah bagi semua komponen yang dibutuhkan untuk membuat [dokumentasi Kubernetes](https://kubernetes.io/). Kami merasa sangat senang apabila Anda berminat untuk menjadi kontributor!
+Selamat datang! Repositori ini merupakan wadah bagi semua komponen yang dibutuhkan untuk membuat [dokumentasi Kubernetes](https://kubernetes.io/). Kami merasa sangat senang apabila kamu berminat untuk menjadi kontributor!
 
 ## Kontribusi pada dokumentasi
 
-Pertama Anda dapat menekan tombol **Fork** yang berada pada bagian atas layar Anda untuk menyalin repositori pada akun Github Anda. Salinan ini disebut sebagai **fork**. Anda dapat menambahkan konten pada **fork** yang Anda miliki, setelah Anda meraca cukup untuk menambahkan konten yang Anda miliki dan ingin memberikan konten tersebut pada kami, Anda dapat melihat **fork** yang telah Anda buat dan membuat **pull request** untuk memberi tahu kami bahwa Anda ingin menambahkan konten yang telah Anda buat.
+Pertama, kamu dapat menekan tombol **Fork** yang berada pada bagian atas layar, untuk menyalin repositori pada akun Github-mu. Salinan ini disebut sebagai **fork**. Kamu dapat menambahkan konten pada **fork** yang kamu miliki, setelah kamu merasa cukup untuk menambahkan konten yang kamu miliki dan ingin memberikan konten tersebut pada kami, kamu dapat melihat **fork** yang telah kamu buat dan membuat **pull request** untuk memberi tahu kami bahwa kamu ingin menambahkan konten yang telah kamu buat.
 
-Setelah Anda membuat sebuah **pull request**, seorang **reviewer** akan memberikan masukan terhadap konten yang Anda sediakan serta beberapa hal yang dapat Anda lakukan apabila perbaikan diperlukan terhadap konten yang telah Anda sediakan. Sebagai seorang yang membuat **pull request**, **sudah menjadi kewajiban bagi Anda untuk melakukan modifikasi terhadap konten yang Anda berikan sesuai dengan masukan yang diberikan oleh seorang reviewer Kubernetes**. Perlu Anda ketahui bahwa Anda dapat saja memilki lebih dari satu orang **reviewer Kubernetes** atau dalam kasus Anda bisa saja mendapatkan **reviewer Kubernetes** yang berbeda dengan **reviewer Kubernetes** awal yang ditugaskan untuk memberikan masukan terhadap konten yang Anda sediakan. Selain itu, seorang **reviewer Kubernetes** bisa saja meminta masukan teknikanl dari [reviewer tekninal Kubernetes](https://github.com/kubernetes/website/wiki/Tech-reviewers) jika diperlukan. 
+Setelah kamu membuat sebuah **pull request**, seorang **reviewer** akan memberikan masukan terhadap konten yang kamu sediakan serta beberapa hal yang dapat kamu lakukan apabila perbaikan diperlukan terhadap konten yang telah kamu sediakan. Sebagai seorang yang membuat **pull request**, **sudah menjadi kewajiban kamu untuk melakukan modifikasi terhadap konten yang kamu berikan sesuai dengan masukan yang diberikan oleh seorang reviewer Kubernetes**. Perlu kamu ketahui bahwa kamu dapat saja memiliki lebih dari satu orang **reviewer Kubernetes** atau dalam kasus kamu bisa saja mendapatkan **reviewer Kubernetes** yang berbeda dengan **reviewer Kubernetes** awal yang ditugaskan untuk memberikan masukan terhadap konten yang kamu sediakan. Selain itu, seorang **reviewer Kubernetes** bisa saja meminta masukan teknis dari [reviewer teknis Kubernetes](https://github.com/kubernetes/website/wiki/Tech-reviewers) jika diperlukan. 
 
-Untuk informasi lebih lanjut mengenai tata cara melakukan kontribusi, Anda dapat melihat tautan di bawah ini:
+Untuk informasi lebih lanjut mengenai tata cara melakukan kontribusi, kamu dapat melihat tautan di bawah ini:
 
 * [Petunjuk Melakukan Kontribusi](https://kubernetes.io/docs/contribute/start/)
-* [Melakukan Tahap Staging pada Konten Dokumentasi yang telah Anda Sediakan](http://kubernetes.io/docs/contribute/intermediate#view-your-changes-locally)
+* [Melakukan Tahap Staging pada Konten Dokumentasi yang telah Kamu Sediakan](http://kubernetes.io/docs/contribute/intermediate#view-your-changes-locally)
 * [Petunjuk Menggunakan Page Templates](http://kubernetes.io/docs/contribute/style/page-templates/)
 * [Petunjuk untuk Documentation Style](http://kubernetes.io/docs/contribute/style/style-guide/)
 * [Petunjuk untuk Melakukan Lokalisasi Dokumentasi Kubernetes](https://kubernetes.io/docs/contribute/localization/)
 
-## Menjalankan Dokumentasi Kubernetes pada Mesin Lokal Anda
+## Menjalankan Dokumentasi Kubernetes pada Mesin Lokal Kamu
 
-Petunjuk yang disarankan untuk menjalankan Dokumentasi Kubernetes pada mesin lokal Anda adalah dengan menggunakan [Docker](https://docker.com) **image** yang memiliki **package** [Hugo](https://gohugo.io), **Hugo** sendiri merupakan generator website statis. 
+Petunjuk yang disarankan untuk menjalankan Dokumentasi Kubernetes pada mesin lokal kamus adalah dengan menggunakan [Docker](https://docker.com) **image** yang memiliki **package** [Hugo](https://gohugo.io), **Hugo** sendiri merupakan generator website statis. 
 
-> Jika Anda menggunakan Windows, Anda mungkin membutuhkan beberapa langkah tambahan untuk melakukan instalasi perangkat lunak yang dibutuhkan. Instalasi ini dapat dilakukan dengan menggukanan [Chocolatey](https://chocolatey.org). `choco install make`
+> Jika kamu menggunakan Windows, kamu mungkin membutuhkan beberapa langkah tambahan untuk melakukan instalasi perangkat lunak yang dibutuhkan. Instalasi ini dapat dilakukan dengan menggunakan [Chocolatey](https://chocolatey.org). `choco install make`
 
-> Jika Anda ingin menjalankan **website** tanpa menggukana **Docker**, Anda dapat emlihat tautan berikut [Petunjuk untuk menjalankan website pada mesin lokal dengan menggunakan Hugo](#petunjuk-untuk-menjalankan-website-pada-mesin-lokal-denga-menggunakan-hugo) di bagian bawah.
+> Jika kamu ingin menjalankan **website** tanpa menggunakan **Docker**, kamu dapat melihat tautan berikut [Petunjuk untuk menjalankan website pada mesin lokal dengan menggunakan Hugo](#petunjuk-untuk-menjalankan-website-pada-mesin-lokal-denga-menggunakan-hugo) di bagian bawah.
 
-Jika Anda sudah memiliki **Docker** [yang sudah dapat digunakan](https://www.docker.com/get-started), Anda dapat melakukan **build** `kubernetes-hugo` **Docker image** secraa lokal:
+Jika kamu sudah memiliki **Docker** [yang sudah dapat digunakan](https://www.docker.com/get-started), kamu dapat melakukan **build** `kubernetes-hugo` **Docker image** secara lokal:
 
 ```bash
 make docker-image
 ```
 
-Setelah **image** berhasil di-**build**, Anda dapat menjalankan website tersebut pada mesin lokal Anda:
+Setelah **image** berhasil di-**build**, kamu dapat menjalankan website tersebut pada mesin lokal-mu:
 
 ```bash
 make docker-serve
 ```
 
-Buka **browser** Anda ke http://localhost:1313 untuk melihat laman dokumentasi. Selama Anda melakukan penambahan konten, **Hugo** akan secara otomatis melakukan perubahan terhadap laman dokumentasi apabila **browser** melakukan proses **refresh**.
+Buka **browser** kamu ke http://localhost:1313 untuk melihat laman dokumentasi. Selama kamu melakukan penambahan konten, **Hugo** akan secara otomatis melakukan perubahan terhadap laman dokumentasi apabila **browser** melakukan proses **refresh**.
 
 
 ## Petunjuk untuk menjalankan website pada mesin lokal dengan menggunakan Hugo
 
-Anda dapat melihat [dokumentasi resmi Hugo](https://gohugo.io/getting-started/installing/) untuk mengetahui langhak yang diperlukan untuk melakukan instalasi **Hugo**. Pastikan Anda melakukan instalasi versi **Hugo** sesuai dengan versi yang tersedia pada **environment variable** `HUGO_VERSION` pada **file**[`netlify.toml`](netlify.toml#L9). 
+Kamu dapat melihat [dokumentasi resmi Hugo](https://gohugo.io/getting-started/installing/) untuk mengetahui langkah yang diperlukan untuk melakukan instalasi **Hugo**. Pastikan kamu melakukan instalasi versi **Hugo** sesuai dengan versi yang tersedia pada **environment variable** `HUGO_VERSION` pada **file**[`netlify.toml`](netlify.toml#L9). 
 
-Untuk menjalankan laman pada mesin lokal Anda setelah Anda melakukan instalasi **Hugo**, anda dapat menjalankan perintah berikut:
+Untuk menjalankan laman pada mesin lokal setelah instalasi **Hugo**, kamu dapat menjalankan perintah berikut:
 
-```baseh
-rang  
+```bash
 make serve
 ```
 
-Buka **browser** Anda ke http://localhost:1313 untuk melihat laman dokumentasi. Selama Anda melakukan penambahan konten, **Hugo** akan secara otomatis melakukan perubahan terhadap laman dokumentasi apabila **browser** melakukan proses **refresh**.
+Buka **browser** kamu ke http://localhost:1313 untuk melihat laman dokumentasi. Selama kamu melakukan penambahan konten, **Hugo** akan secara otomatis melakukan perubahan terhadap laman dokumentasi apabila **browser** melakukan proses **refresh**.
 
 ## Komunitas, Diskusi, Kontribusi, dan Bantuan
 
-Anda dapat belajar bagaimana tata cara untuk ikut terlibat dalam komunitas Kubernetes melalui [laman komunitas](http://kubernetes.io/community/).
+Kamu dapat belajar bagaimana tata cara untuk ikut terlibat dalam komunitas Kubernetes melalui [laman komunitas](http://kubernetes.io/community/).
 
-Anda dapat berinteraksi dengan **maintainers** project ini melalui:
+Kamu dapat berinteraksi dengan **maintainers** project ini melalui:
 
 - [Slack](https://kubernetes.slack.com/messages/sig-docs)
 - [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-sig-docs)
 
 ### Etika dalam Berkontribusi
 
-Partisipasi dalam komunitas Kubernetes diatul dalam [Etika dalam Berkontribusi pada Kubernetes](code-of-conduct.md).
+Partisipasi dalam komunitas Kubernetes diatur dalam [Etika dalam Berkontribusi pada Kubernetes](code-of-conduct.md).
 
 ## Terima Kasih!
 
-Kubernetes sangat menjunjung tinggi partisipas dari komunitas, dan kami sangat mengapresiasi kontribusi Anda pada laman dan dokumentasi kamu!
+Kubernetes sangat menjunjung tinggi partisipasi dari komunitas, dan kami sangat mengapresiasi kontribusi kamu pada laman dan dokumentasi kami!

--- a/README-id.md
+++ b/README-id.md
@@ -1,0 +1,73 @@
+# Dokumentasi Kubernetes
+
+[![Build Status](https://api.travis-ci.org/kubernetes/website.svg?branch=master)](https://travis-ci.org/kubernetes/website)
+[![GitHub release](https://img.shields.io/github/release/kubernetes/website.svg)](https://github.com/kubernetes/website/releases/latest)
+
+Selamat datang! Repositori ini merupakan wadah bagi semua komponen yang dibutuhkan untuk membuat [dokumentasi Kubernetes](https://kubernetes.io/). Kami merasa sangat senang apabila Anda berminat untuk menjadi kontributor!
+
+## Kontribusi pada dokumentasi
+
+Pertama Anda dapat menekan tombol **Fork** yang berada pada bagian atas layar Anda untuk menyalin repositori pada akun Github Anda. Salinan ini disebut sebagai **fork**. Anda dapat menambahkan konten pada **fork** yang Anda miliki, setelah Anda meraca cukup untuk menambahkan konten yang Anda miliki dan ingin memberikan konten tersebut pada kami, Anda dapat melihat **fork** yang telah Anda buat dan membuat **pull request** untuk memberi tahu kami bahwa Anda ingin menambahkan konten yang telah Anda buat.
+
+Setelah Anda membuat sebuah **pull request**, seorang **reviewer** akan memberikan masukan terhadap konten yang Anda sediakan serta beberapa hal yang dapat Anda lakukan apabila perbaikan diperlukan terhadap konten yang telah Anda sediakan. Sebagai seorang yang membuat **pull request**, **sudah menjadi kewajiban bagi Anda untuk melakukan modifikasi terhadap konten yang Anda berikan sesuai dengan masukan yang diberikan oleh seorang reviewer Kubernetes**. Perlu Anda ketahui bahwa Anda dapat saja memilki lebih dari satu orang **reviewer Kubernetes** atau dalam kasus Anda bisa saja mendapatkan **reviewer Kubernetes** yang berbeda dengan **reviewer Kubernetes** awal yang ditugaskan untuk memberikan masukan terhadap konten yang Anda sediakan. Selain itu, seorang **reviewer Kubernetes** bisa saja meminta masukan teknikanl dari [reviewer tekninal Kubernetes](https://github.com/kubernetes/website/wiki/Tech-reviewers) jika diperlukan. 
+
+Untuk informasi lebih lanjut mengenai tata cara melakukan kontribusi, Anda dapat melihat tautan di bawah ini:
+
+* [Petunjuk Melakukan Kontribusi](https://kubernetes.io/docs/contribute/start/)
+* [Melakukan Tahap Staging pada Konten Dokumentasi yang telah Anda Sediakan](http://kubernetes.io/docs/contribute/intermediate#view-your-changes-locally)
+* [Petunjuk Menggunakan Page Templates](http://kubernetes.io/docs/contribute/style/page-templates/)
+* [Petunjuk untuk Documentation Style](http://kubernetes.io/docs/contribute/style/style-guide/)
+* [Petunjuk untuk Melakukan Lokalisasi Dokumentasi Kubernetes](https://kubernetes.io/docs/contribute/localization/)
+
+## Menjalankan Dokumentasi Kubernetes pada Mesin Lokal Anda
+
+Petunjuk yang disarankan untuk menjalankan Dokumentasi Kubernetes pada mesin lokal Anda adalah dengan menggunakan [Docker](https://docker.com) **image** yang memiliki **package** [Hugo](https://gohugo.io), **Hugo** sendiri merupakan generator website statis. 
+
+> Jika Anda menggunakan Windows, Anda mungkin membutuhkan beberapa langkah tambahan untuk melakukan instalasi perangkat lunak yang dibutuhkan. Instalasi ini dapat dilakukan dengan menggukanan [Chocolatey](https://chocolatey.org). `choco install make`
+
+> Jika Anda ingin menjalankan **website** tanpa menggukana **Docker**, Anda dapat emlihat tautan berikut [Petunjuk untuk menjalankan website pada mesin lokal dengan menggunakan Hugo](#petunjuk-untuk-menjalankan-website-pada-mesin-lokal-denga-menggunakan-hugo) di bagian bawah.
+
+Jika Anda sudah memiliki **Docker** [yang sudah dapat digunakan](https://www.docker.com/get-started), Anda dapat melakukan **build** `kubernetes-hugo` **Docker image** secraa lokal:
+
+```bash
+make docker-image
+```
+
+Setelah **image** berhasil di-**build**, Anda dapat menjalankan website tersebut pada mesin lokal Anda:
+
+```bash
+make docker-serve
+```
+
+Buka **browser** Anda ke http://localhost:1313 untuk melihat laman dokumentasi. Selama Anda melakukan penambahan konten, **Hugo** akan secara otomatis melakukan perubahan terhadap laman dokumentasi apabila **browser** melakukan proses **refresh**.
+
+
+## Petunjuk untuk menjalankan website pada mesin lokal dengan menggunakan Hugo
+
+Anda dapat melihat [dokumentasi resmi Hugo](https://gohugo.io/getting-started/installing/) untuk mengetahui langhak yang diperlukan untuk melakukan instalasi **Hugo**. Pastikan Anda melakukan instalasi versi **Hugo** sesuai dengan versi yang tersedia pada **environment variable** `HUGO_VERSION` pada **file**[`netlify.toml`](netlify.toml#L9). 
+
+Untuk menjalankan laman pada mesin lokal Anda setelah Anda melakukan instalasi **Hugo**, anda dapat menjalankan perintah berikut:
+
+```baseh
+rang  
+make serve
+```
+
+Buka **browser** Anda ke http://localhost:1313 untuk melihat laman dokumentasi. Selama Anda melakukan penambahan konten, **Hugo** akan secara otomatis melakukan perubahan terhadap laman dokumentasi apabila **browser** melakukan proses **refresh**.
+
+## Komunitas, Diskusi, Kontribusi, dan Bantuan
+
+Anda dapat belajar bagaimana tata cara untuk ikut terlibat dalam komunitas Kubernetes melalui [laman komunitas](http://kubernetes.io/community/).
+
+Anda dapat berinteraksi dengan **maintainers** project ini melalui:
+
+- [Slack](https://kubernetes.slack.com/messages/sig-docs)
+- [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-sig-docs)
+
+### Etika dalam Berkontribusi
+
+Partisipasi dalam komunitas Kubernetes diatul dalam [Etika dalam Berkontribusi pada Kubernetes](code-of-conduct.md).
+
+## Terima Kasih!
+
+Kubernetes sangat menjunjung tinggi partisipas dari komunitas, dan kami sangat mengapresiasi kontribusi Anda pada laman dan dokumentasi kamu!

--- a/config.toml
+++ b/config.toml
@@ -224,3 +224,15 @@ contentDir = "content/es"
 time_format_blog = "02.01.2006"
 # A list of language codes to look for untranslated content, ordered from left to right.
 language_alternatives = ["en"]
+
+[languages.id]
+title = "Kubernetes"
+description = "Production-Grade Container Orchestration"
+languageName ="Bahasa Indonesia"
+weight = 10
+contentDir = "content/id"
+
+[languages.id.params]
+time_format_blog = "02.01.2006"
+# A list of language codes to look for untranslated content, ordered from left to right.
+language_alternatives = ["en"]

--- a/content/id/OWNERS
+++ b/content/id/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# This is the localization project for Indonesian.
+# Teams and members are visible at https://github.com/orgs/kubernetes/teams.
+
+reviewers:
+- sig-docs-id-reviews
+
+approvers:
+- sig-docs-id-owners
+
+labels:
+- language/id

--- a/content/id/OWNERS
+++ b/content/id/OWNERS
@@ -1,6 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
-# This is the localization project for Indonesian.
+# This is the localization project for Spanish.
 # Teams and members are visible at https://github.com/orgs/kubernetes/teams.
 
 reviewers:

--- a/content/id/OWNERS
+++ b/content/id/OWNERS
@@ -1,6 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
-# This is the localization project for Spanish.
+# This is the localization project for Bahasa.
 # Teams and members are visible at https://github.com/orgs/kubernetes/teams.
 
 reviewers:

--- a/content/id/_common-resources/index.md
+++ b/content/id/_common-resources/index.md
@@ -1,0 +1,3 @@
+---
+headless: true
+---

--- a/content/id/_index.html
+++ b/content/id/_index.html
@@ -1,0 +1,63 @@
+---
+title: "Orkestrasi Container dengan Skala Production"
+abstract: "Otomatisasi container deployment, scaling, dan management"
+cid: home
+---
+
+{{< deprecationwarning >}}
+
+{{< blocks/section id="oceanNodes" >}}
+{{% blocks/feature image="flower" %}}
+### Kubernetes (K8s)
+Kubernetes mengelompokkan container yang membentuk suatu aplikasi dalam bentuk unit logis yang memudahkan proses manajemen dan discovery. Kubernetes dibuat berdasarkan [pengalaman operasional workloads skala production yang dilakukan oleh Google](http://queue.acm.org/detail.cfm?id=2898444), yang digabungkan dengan ide-ide terbaik dan best practices yang diberikan oleh komunitas.
+{{% /blocks/feature %}}
+
+{{% blocks/feature image="scalable" %}}
+#### Skala Besar
+
+Didesain berdasarkan landasan yang digunakan Google untuk menjalankan milyaran container dalam waktu seminggu, Kubernetes secara dinamis dapat menyesuaikan workloads tanpa membutuhkan peningkatan tim operasional.
+
+{{% /blocks/feature %}}
+
+{{% blocks/feature image="blocks" %}}
+#### Fleksibel
+
+Baik digunakan untuk melakukan testing di mesin lokal maupun dijalankan sebagai sistem enterprise global, fleksibilitas yang disediakan oleh Kubernetes memungkinkan Anda untuk menghasilkan aplikasi secara konsisten dan mudah, tidak peduli seberapa kompleks kebutuhan yang Anda miliki.
+
+
+{{% /blocks/feature %}}
+
+{{% blocks/feature image="suitcase" %}}
+#### Dapat Dijalankan di Berbagai Platform
+
+Kubernetes sebagai open source memberikan Anda kebebasan untuk menggunakan on-premise, hybrid, atau public cloud infrastructure, memberikan anda kemudahan untuk memindahkan workloads yang Anda miliki.
+
+
+{{% /blocks/feature %}}
+
+{{< /blocks/section >}}
+
+{{< blocks/section id="video" background-image="kub_video_banner_homepage" >}}
+<div class="light-text">
+<h2>Tantangan yang Dihadapi untuk Melakukan Migrasi 150+ Microservices ke Kubernetes</h2>
+        <p>Oleh Sarah Wells, Technical Director for Operations and Reliability, Financial Times</p>
+        <button id="desktopShowVideoButton" onclick="kub.showVideo()">Watch Video</button>
+        <br>
+        <br>
+        <br>
+        <a href="https://events.linuxfoundation.org/events/kubecon-cloudnativecon-europe-2019" button id="desktopKCButton">Hadiri Acara di Barcelona pada Tanggal 20-23 Mei 2019</a>
+        <br>
+        <br>
+        <br>
+        <br>
+        <a href="https://www.lfasiallc.com/events/kubecon-cloudnativecon-china-2019" button id="desktopKCButton">Hadiri Acara KubeCon di Shanghai pada Tanggal  24-26 Juni 2019</a>
+</div>
+<div id="videoPlayer">
+    <iframe data-url="https://www.youtube.com/embed/H06qrNmGqyE?autoplay=1" frameborder="0" allowfullscreen></iframe>
+    <button id="closeButton"></button>
+</div>
+{{< /blocks/section >}}
+
+{{< blocks/kubernetes-features >}}
+
+{{< blocks/case-studies >}}

--- a/content/id/_index.html
+++ b/content/id/_index.html
@@ -1,6 +1,6 @@
 ---
-title: "Orkestrasi Container dengan Skala Production"
-abstract: "Otomatisasi container deployment, scaling, dan management"
+title: "Orkestrasi Kontainer dengan Skala Produksi"
+abstract: "Otomatisasi Kontainer deployment, scaling, dan management"
 cid: home
 ---
 
@@ -9,13 +9,13 @@ cid: home
 {{< blocks/section id="oceanNodes" >}}
 {{% blocks/feature image="flower" %}}
 ### Kubernetes (K8s)
-Kubernetes mengelompokkan container yang membentuk suatu aplikasi dalam bentuk unit logis yang memudahkan proses manajemen dan discovery. Kubernetes dibuat berdasarkan [pengalaman operasional workloads skala production yang dilakukan oleh Google](http://queue.acm.org/detail.cfm?id=2898444), yang digabungkan dengan ide-ide terbaik dan best practices yang diberikan oleh komunitas.
+Kubernetes mengelompokkan kontainer yang membentuk suatu aplikasi dalam bentuk unit logis yang memudahkan proses manajemen dan discovery. Kubernetes dibuat berdasarkan [pengalaman operasional workloads skala production yang dilakukan oleh Google](http://queue.acm.org/detail.cfm?id=2898444), yang digabungkan dengan ide-ide terbaik dan best practices yang diberikan oleh komunitas.
 {{% /blocks/feature %}}
 
 {{% blocks/feature image="scalable" %}}
 #### Skala Besar
 
-Didesain berdasarkan landasan yang digunakan Google untuk menjalankan milyaran container dalam waktu seminggu, Kubernetes secara dinamis dapat menyesuaikan workloads tanpa membutuhkan peningkatan tim operasional.
+Didesain berdasarkan landasan yang digunakan Google untuk menjalankan milyaran kontainer dalam waktu seminggu, Kubernetes secara dinamis dapat menyesuaikan workloads tanpa membutuhkan peningkatan tim operasional.
 
 {{% /blocks/feature %}}
 

--- a/content/id/case-studies/_index.html
+++ b/content/id/case-studies/_index.html
@@ -1,0 +1,10 @@
+---
+title: Studi kasus
+linkTitle: Studi kasus
+bigheader: Studi kasus penggunaan Kubernetes
+abstract: Studi kasus penggunaan Kubernetes pada environment production.
+layout: basic
+class: gridPage
+cid: caseStudies
+---
+

--- a/content/id/docs/_index.md
+++ b/content/id/docs/_index.md
@@ -1,0 +1,3 @@
+---
+title: Dokumentasi
+---

--- a/content/id/docs/home/_index.md
+++ b/content/id/docs/home/_index.md
@@ -1,0 +1,56 @@
+---
+title: Dokumentasi Kubernetes
+noedit: true
+cid: docsHome
+layout: docsportal_home
+class: gridPage
+linkTitle: "Home"
+main_menu: true
+weight: 10
+hide_feedback: true
+menu:
+  main:
+    title: "Dokumentasi"
+    weight: 20
+    post: >
+      <p>Mengerti penggunaan Kubernetes dengan belajar konsep, tutorial, dan referensinya. Kamupun bisa <a href="/editdocs/" data-auto-burger-exclude>bantu kami perbaiki dan lengkapi dokumentasinya</a>, yuk kontribusi!</p>
+overview: >
+  Kubernetes adalah sebuah orkestrator kontainer open source, yang mengotomasi deployment, replikasi, dan pengaturan aplikasi kontainer dengan mudah. Cloud Native Computing Foundation (<a href="https://www.cncf.io/about">CNCF</a>) mewadahi proyek open source ini.
+cards:
+- name: concepts
+  title: "Konsep dasar Kubernetes"
+  description: "Pelajari tentang Kubernetes dan segala konsep dasarnya."
+  button: "Pelajari konsep"
+  button_path: "/docs/concepts"
+- name: tutorials
+  title: "Coba Kubernetes"
+  description: "Ikuti tutorial untuk belajar cara deploy aplikasi di Kubernetes."
+  button: "Lihat tutorial"
+  button_path: "/docs/tutorials"
+- name: setup
+  title: "Menyiapkan sebuah kluster"
+  description: "Dapatkan kluster Kubernetes sesuai dengan kapasitas dan kebutuhanmu."
+  button: "Menyiapkan Kubernetes"
+  button_path: "/docs/setup"
+- name: tasks
+  title: "Pelajari penggunaan Kubernetes"
+  description: "Lihat penggunaan Kubernetes secara umum dan bagaimana langkah-langkahnya secara singkat."
+  button: "Lihat penggunaan"
+  button_path: "/docs/tasks"
+- name: reference
+  title: Lihat referensi
+  description: Lihat-lihat istilah, sintaks command line, ragam API, dan dokumentasi tool.
+  button: Lihat referensi
+  button_path: /docs/reference
+- name: contribute
+  title: Kontribusi ke dokumentasi
+  description: Siapapun bisa kontribusi, buat kamu yang baru di proyek ini maupun sudah lama.
+  button: Kontribusi ke dokumentasi
+  button_path: /docs/contribute
+- name: download
+  title: Unduh Kubernetes
+  description: Untuk instalasi atau pembaharuan Kubernetes ke versi paling baru, lihat catatan rilis saat ini.
+- name: about
+  title: Tentang dokumentasi
+  description: Situs ini merupakan dokumentasi dari Kubernetes versi saat ini dan 4 versi sebelumnya.
+---

--- a/content/id/docs/home/supported-doc-versions.md
+++ b/content/id/docs/home/supported-doc-versions.md
@@ -1,0 +1,29 @@
+---
+title: Versi Kubernetes yang Termasuk dalam Dokumentasi
+content_template: templates/concept
+card:
+  name: about
+  weight: 10
+  title: Versi Kubernetes yang Termasuk dalam Dokumentasi
+---
+
+{{% capture overview %}}
+
+Situs ini merupakan dokumentasi dari Kubernetes versi saat ini dan 4 versi sebelumnya.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+## Versi saat ini
+
+Versi saat ini adalah
+[{{< param "version" >}}](/).
+
+## Versi sebelumnya
+
+{{< versions-other >}}
+
+{{% /capture %}}
+
+

--- a/content/id/docs/setup/_index.md
+++ b/content/id/docs/setup/_index.md
@@ -1,0 +1,81 @@
+---
+no_issue: true
+title: Persiapan
+main_menu: true
+weight: 30
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+Gunakan halaman ini untuk mencari solusi yang paling sesuai dengan kebutuhan kamu.
+
+Menentukan dimana sebaiknya Kubernetes dijalankan sangat tergantung pada kapasitas yang kamu punya dan seberapa fleksibel kluster yang kamu inginkan. 
+Kamu dapat menjalankan Kubernetes hampir dimana saja, mulai dari laptop, VM di penyedia cloud, sampai pada rak-rak berisi server <i>baremetal</i>.
+Kamu juga bisa menyiapkan kluster yang diatur sepenuhnya (<i>fully-managed</i>), dengan hanya menjalankan satu perintah, ataupun membuat kluster dengan solusi <i>custom</i> kamu sendiri pada server <i>baremetal</i>.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+## Solusi pada Mesin Lokal
+
+Memulai Kubernetes bisa dilakukan dengan mudah melalui solusi pada mesin lokal.
+Kamu bisa membuat dan mengevaluasi kluster Kubernetes tanpa perlu takut menghabiskan <i>resource</i> dan kuota penyedia cloud.
+
+Sebaiknya kamu memilih solusi lokal jika kamu ingin:
+
+* Mulai belajar atau mencoba Kubernetes
+* Mengembangkan dan melakukan evaluasi kluster secara lokal
+
+Pilih [solusi lokal](/docs/setup/pick-right-solution/#local-machine-solutions).
+
+## Solusi Tersediakan (<i>Hosted Solution</i>)
+
+Solusi tersediakan adalah cara yang nyaman untuk membuat dan memelihara kluster Kubernetes. Kamu tidak perlu repot, karena para penyedia solusi mengatur dan mengoperasikan kluster milikmu.
+
+Sebaiknya kamu memilih solusi tersediakan ini jika kamu:
+
+* Ingin punya solusi yang diatur sepenuhnya
+* Fokus pada pengembangan aplikasi atau servis saja
+* Tidak mau punya tim SRE (<i>Site Reliability Engineering</i>) yang mendedikasikan waktunya untukmu, tapi ingin HA (<i>High Availability</i>)
+* Tidak punya <i>resource</i> untuk menjalankan dan memonitor kluster.
+
+Pilih [solusi tersediakan](/docs/setup/pick-right-solution/#hosted-solutions).
+
+## Turnkey – Solusi Cloud
+
+Solusi-solusi ini memudahkan kamu untuk mempunyai kluster Kubernetes hanya dengan beberapa perintah. Lalu, solusi-solusi ini juga masih terus berkembang dan memiliki pendukung komunitas yang aktif.
+Mereka juga bisa berjalan pada berbagai macam penyedia Cloud IaaS, tapi mereka menawarkan kebebasan dan fleksibilitas sebagai pengganti dari usaha.
+
+Sebaiknya kamu memilih solusi cloud <i>turnkey</i>, jika kamu:
+
+* Ingin punya kontrol yang lebih daripada yang ditawarkan oleh solusi tersediakan (<i>hosted solution</i>)
+* Ingin memiliki porsi dalam mengoperasikan kluster
+
+Pilih [solusi cloud turnkey](/docs/setup/pick-right-solution/#turnkey-cloud-solutions)
+
+## Turnkey – Solusi On-Premise
+
+Solusi-solusi ini menyediakan cara untuk membuat kluster Kubernetes di dalam jaringan cloud internal kamu yang aman, hanya dengan beberapa perintah.
+
+Sebaiknya kamu memilih solusi cloud on-premise turnkey, jika kamu:
+
+* Ingin membuat kluster di jaringan cloud yang privat (<i>private cloud network</i>)
+* Punya tim SRE yang mendedikasikan waktunya
+* Punya <i>resource</i> untuk menjalankan dan memonitor kluster
+
+Pilih [solusi cloud on-prem turnkey](/docs/setup/pick-right-solution/#on-premises-turnkey-cloud-solutions).
+
+## Solusi <i>Custom</i>
+
+Solusi <i>custom</i> adalah solusi yang paling memberikan kebebasan dalam menjalankan kluster kamu, tapi perlu keahlian.
+Solusi-solusi ini cukup beragam, mulai dari bare-metal sampai ke penyedia cloud, berjalan pada sistem operasi yang berbeda-beda.
+
+Pilih [solusi <i>custom</i>](/docs/setup/pick-right-solution/#custom-solutions).
+
+{{% /capture %}}
+
+{{% capture whatsnext %}}
+Lihat [Memilih Solusi Terbaik](/docs/setup/pick-right-solution/) untuk daftar solusi yang lengkap.
+{{% /capture %}}

--- a/content/id/docs/tutorials/_index.md
+++ b/content/id/docs/tutorials/_index.md
@@ -1,0 +1,75 @@
+---
+title: Tutorials
+main_menu: true
+weight: 60
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+Bagian ini membahas tentang tutorial Kubernetes.
+Tutorial berfungsi untuk memperlihatkan bagaimana caranya mencapai suatu tujuan yang lebih dari sekedar [task](/docs/tasks/) sederhana. 
+Biasanya, sebuah tutorial punya beberapa bagian, masing-masing bagian terdiri dari langkah-langkah yang berurutan.
+Sebelum melangkah lebih lanjut ke tutorial, sebaiknya tandai dulu halaman [Kamus Istilah](/docs/reference/glossary/) untuk referensi nanti.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+## Prinsip Dasar
+
+* [Prinsip Dasar Kubernetes](/docs/tutorials/kubernetes-basics/) merupakan tutorial yang sangat interaktif, membantu kamu mengerti apa itu sistem Kubernetes dan beberapa fitur Kubernetes yang umum digunakan.
+
+* [Mikroservis yang Scalable dengan Kubernetes (Udacity)](https://www.udacity.com/course/scalable-microservices-with-kubernetes--ud615)
+
+* [Pengenalan Kubernetes (edX)](https://www.edx.org/course/introduction-kubernetes-linuxfoundationx-lfs158x#)
+
+* [Halo Minikube](/docs/tutorials/hello-minikube/)
+
+## Konfigurasi
+
+* [Konfigurasi Redis menggunakan sebuah ConfigMap](/docs/tutorials/configuration/configure-redis-using-configmap/)
+
+## Aplikasi Stateless
+
+* [Memberi Akses Aplikasi di dalam Kluster melalui IP Eksternal](/docs/tutorials/stateless-application/expose-external-ip-address/)
+
+* [Contoh: Deploy aplikasi Guestbook PHP dengan Redis](/docs/tutorials/stateless-application/guestbook/)
+
+## Aplikasi Stateful
+
+* [Prinsip Dasar StatefulSet](/docs/tutorials/stateful-application/basic-stateful-set/)
+
+* [Contoh: WordPress dan MySQL dengan Persistent Volumes](/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/)
+
+* [Contoh: Deploy Cassandra dengan Stateful Sets](/docs/tutorials/stateful-application/cassandra/)
+
+* [Menjalankan ZooKeeper, sebuah sistem terdistribusi yang berbasis CP](/docs/tutorials/stateful-application/zookeeper/)
+
+## Pipeline CI/CD
+
+* [Menyiapkan Pipeline CI/CD dengan Kubernetes Bagian 1: Ringkasan](https://www.linux.com/blog/learn/chapter/Intro-to-Kubernetes/2017/5/set-cicd-pipeline-kubernetes-part-1-overview)
+
+* [Menyiapkan Pipeline CI/CD dengan Jenkins Pod di Kubernetes (Part 2)](https://www.linux.com/blog/learn/chapter/Intro-to-Kubernetes/2017/6/set-cicd-pipeline-jenkins-pod-kubernetes-part-2)
+
+* [Menjalankan dan Mereplikasi Aplikasi Teka-Teki Terdistribusi dengan CI/CD pada Kubernetes (Bagian 3)](https://www.linux.com/blog/learn/chapter/intro-to-kubernetes/2017/6/run-and-scale-distributed-crossword-puzzle-app-cicd-kubernetes-part-3)
+
+* [Menyiapkan CI/CD  untuk Aplikasi Teka-Teki Terdistribusi pada Kubernetes (Bagian 4)](https://www.linux.com/blog/learn/chapter/intro-to-kubernetes/2017/6/set-cicd-distributed-crossword-puzzle-app-kubernetes-part-4)
+
+## Kluster
+
+* [AppArmor](/docs/tutorials/clusters/apparmor/)
+
+## Servis
+
+* [Menggunakan Source IP](/docs/tutorials/services/source-ip/)
+
+{{% /capture %}}
+
+{{% capture whatsnext %}}
+
+Tertarik menulis tutorial? Lihat 
+[Menggunakan Template Halaman](/docs/home/contribute/page-templates/)
+untuk info mengenai template dan ragam halaman tutorial.
+
+{{% /capture %}}

--- a/content/id/docs/tutorials/hello-minikube.md
+++ b/content/id/docs/tutorials/hello-minikube.md
@@ -1,0 +1,270 @@
+---
+title: Halo Minikube
+content_template: templates/tutorial
+weight: 5
+menu:
+  main:
+    title: "Mulai"
+    weight: 10
+    post: >
+      <p>Siap untuk mengotori tanganmu? Yuk kita buat kluster Kubernetes sederhana yang menjalankan Node.js aplikasi "Halo Dunia".</p>
+card: 
+  name: tutorials
+  weight: 10
+---
+
+{{% capture overview %}}
+
+Tutorial ini menunjukkan bagaimana caranya menjalankan aplikasi sederhana Node.js Halo Dunia di Kubernetes, dengan [Minikube](/docs/getting-started-guides/minikube) dan Katacoda.
+Katacoda menyediakan <i>environment</i> Kubernetes secara gratis di dalam browser.
+
+{{< note >}}
+Kamupun bisa mengikuti tutorial ini kalau sudah instalasi [Minikube di lokal](/docs/tasks/tools/install-minikube/) kamu.
+{{< /note >}}
+
+{{% /capture %}}
+
+{{% capture objectives %}}
+
+* Deploy aplikasi halo dunia pada Minikube.
+* Jalankan aplikasinya.
+* Melihat log aplikasi.
+
+{{% /capture %}}
+
+{{% capture prerequisites %}}
+
+Tutorial ini menyediakan image Kontainer yang dibuat melalui barisan kode berikut:
+
+{{< codenew language="js" file="minikube/server.js" >}}
+
+{{< codenew language="conf" file="minikube/Dockerfile" >}}
+
+Untuk info lebih lanjut tentang perintah `docker build`, baca [dokumentasi Docker](https://docs.docker.com/engine/reference/commandline/build/).
+
+{{% /capture %}}
+
+{{% capture lessoncontent %}}
+
+## Membuat sebuah kluster Minikube
+
+1. Tekan **Launch Terminal** 
+
+    {{< kat-button >}}
+
+    {{< note >}}Kalau kamu memilih instalasi Minikube secara lokal,  jalankan `minikube start`.{{< /note >}}
+
+2. Buka dasbor Kubernetes di dalam browser:
+
+    ```shell
+    minikube dashboard
+    ```
+
+3. Hanya untuk <i>environment</i> Katacoda: Di layar terminal paling atas, tekan tombol plus, lalu lanjut tekan **Select port to view on Host 1**.
+
+4. Hanya untuk <i>environment</i> Katacoda: Ketik `30000`, lalu lanjut tekan **Display Port**. 
+
+## Membuat sebuah Deployment
+
+Sebuah Kubernetes [*Pod*](/docs/concepts/workloads/pods/pod/) adalah kumpulan dari satu atau banyak Kontainer,
+saling terhubung untuk kebutuhan administrasi dan jaringan. Pod dalam tutorial ini hanya punya satu Kontainer. Sebuah Kubernetes
+[*Deployment*](/docs/concepts/workloads/controllers/deployment/) selalu memeriksa kesehatan
+Pod kamu dan melakukan <i>restart</i> saat Kontainer di dalam Pod tersebut mati. Deployment adalah cara jitu untuk membuat dan mereplikasi Pod.
+
+1. Gunakan perintah `kubectl create` untuk membuat Deployment yang dapat mengatur Pod.
+Pod menjalankan Kontainer sesuai dengan image Docker yang telah diberikan. 
+
+    ```shell
+    kubectl create deployment hello-node --image=gcr.io/hello-minikube-zero-install/hello-node
+    ```
+
+2. Lihat Deployment:
+
+    ```shell
+    kubectl get deployments
+    ```
+
+    Keluaran:
+
+    ```shell
+    NAME         DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
+    hello-node   1         1         1            1           1m
+    ```
+
+3. Lihat Pod:
+
+    ```shell
+    kubectl get pods
+    ```
+    Keluaran:
+
+    ```shell
+    NAME                          READY     STATUS    RESTARTS   AGE
+    hello-node-5f76cf6ccf-br9b5   1/1       Running   0          1m
+    ```
+
+4. Lihat <i>event</i> kluster:
+
+    ```shell
+    kubectl get events
+    ```
+
+5. Lihat konfigurasi `kubectl`:
+
+    ```shell
+    kubectl config view
+    ```
+  
+    {{< note >}}Untuk info lebih lanjut tentang perintah `kubectl`, lihat [ringkasan kubectl](/docs/user-guide/kubectl-overview/).{{< /note >}}
+
+## Membuat sebuah Servis
+
+Secara <i>default</i>, Pod hanya bisa diakses melalui alamat IP internal di dalam kluster Kubernetes.
+Supaya Kontainer `hello-node` bisa diakses dari luar jaringan virtual Kubernetes, kamu harus ekspos Pod sebagai [*Servis*](/docs/concepts/services-networking/service/) Kubernetes.
+
+1. Ekspos Pod pada internet publik menggunakan perintah `kubectl expose`:
+
+    ```shell
+    kubectl expose deployment hello-node --type=LoadBalancer --port=8080
+    ```
+    
+    Tanda `--type=LoadBalancer` menunjukkan bahwa kamu ingin ekspos Servis keluar dari kluster.
+
+2. Lihat Servis yang baru kamu buat:
+
+    ```shell
+    kubectl get services
+    ```
+
+    Keluaran:
+
+    ```shell
+    NAME         TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
+    hello-node   LoadBalancer   10.108.144.78   <pending>     8080:30369/TCP   21s
+    kubernetes   ClusterIP      10.96.0.1       <none>        443/TCP          23m
+    ```
+
+    Untuk penyedia cloud yang memiliki <i>load balancer</i>, sebuah alamat IP eksternal akan disediakan untuk mengakses Servis tersebut. 
+    Pada Minikube, tipe `LoadBalancer` membuat Servis tersebut dapat diakses melalui perintah `minikube service`.
+
+3. Jalankan perintah berikut:
+
+    ```shell
+    minikube service hello-node
+    ```
+
+4. Hanya untuk <i>environment</i> Katacoda: Tekan tombol plus, lalu lanjut tekan **Select port to view on Host 1**.
+
+5. Hanya untuk <i>environment</i> Katacoda: Ketik `30369` (lihat port di samping `8080` pada keluaran servis), lalu lanjut tekan
+
+    Ini akan membuka jendela browser yang menjalankan aplikasimu dan memperlihatkan pesan "Halo Dunia".
+
+## Aktifkan addons
+
+Minikube punya beberapa <i>addons</i> yang bisa diaktifkan, dinon-aktifkan, maupun dibuka di dalam <i>environment</i> Kubernetes lokal.
+
+1. Daftar <i>addons</i> yang ada saat ini:
+
+    ```shell
+    minikube addons list
+    ```
+
+    Keluaran:
+
+    ```shell
+    addon-manager: enabled
+    coredns: disabled
+    dashboard: enabled
+    default-storageclass: enabled
+    efk: disabled
+    freshpod: disabled
+    heapster: disabled
+    ingress: disabled
+    kube-dns: enabled
+    metrics-server: disabled
+    nvidia-driver-installer: disabled
+    nvidia-gpu-device-plugin: disabled
+    registry: disabled
+    registry-creds: disabled
+    storage-provisioner: enabled
+    ```
+   
+2. Aktifkan sebuah <i>addon</i>, misalnya `heapster`:
+
+    ```shell
+    minikube addons enable heapster
+    ```
+  
+    Keluaran:
+
+    ```shell
+    heapster was successfully enabled
+    ```
+
+3. Lihat Pod dan Servis yang baru saja kamu buat:
+
+    ```shell
+    kubectl get pod,svc -n kube-system
+    ```
+
+    Keluaran:
+
+    ```shell
+    NAME                                        READY     STATUS    RESTARTS   AGE
+    pod/heapster-9jttx                          1/1       Running   0          26s
+    pod/influxdb-grafana-b29w8                  2/2       Running   0          26s
+    pod/kube-addon-manager-minikube             1/1       Running   0          34m
+    pod/kube-dns-6dcb57bcc8-gv7mw               3/3       Running   0          34m
+    pod/kubernetes-dashboard-5498ccf677-cgspw   1/1       Running   0          34m
+    pod/storage-provisioner                     1/1       Running   0          34m
+
+    NAME                           TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)             AGE
+    service/heapster               ClusterIP   10.96.241.45    <none>        80/TCP              26s
+    service/kube-dns               ClusterIP   10.96.0.10      <none>        53/UDP,53/TCP       34m
+    service/kubernetes-dashboard   NodePort    10.109.29.1     <none>        80:30000/TCP        34m
+    service/monitoring-grafana     NodePort    10.99.24.54     <none>        80:30002/TCP        26s
+    service/monitoring-influxdb    ClusterIP   10.111.169.94   <none>        8083/TCP,8086/TCP   26s
+    ```
+
+4. Non-aktifkan `heapster`:
+
+    ```shell
+    minikube addons disable heapster
+    ```
+  
+    Keluaran:
+
+    ```shell
+    heapster was successfully disabled
+    ```
+
+## Bersih-bersih
+
+Sekarang, mari kita bersihkan semua <i>resource</i> yang kamu buat di kluster:
+
+```shell
+kubectl delete service hello-node
+kubectl delete deployment hello-node
+```
+
+Kamu juga boleh mematikan mesin virtual (VM) untuk Minikube:
+
+```shell
+minikube stop
+```
+
+Kamu juga boleh menghapus Minikube VM:
+
+```shell
+minikube delete
+```
+
+{{% /capture %}}
+
+{{% capture whatsnext %}}
+
+* Pelajari lebih lanjut tentang [Deployment](/docs/concepts/workloads/controllers/deployment/).
+* Pelajari lebih lanjut tentang [Deploy aplikasi](/docs/user-guide/deploying-applications/).
+* Pelajari lebih lanjut tentang [Servis](/docs/concepts/services-networking/service/).
+
+{{% /capture %}}

--- a/content/id/docs/tutorials/kubernetes-basics/_index.html
+++ b/content/id/docs/tutorials/kubernetes-basics/_index.html
@@ -21,15 +21,15 @@ card:
     <div class="row">
       <div class="col-md-9">
         <h2>Panduan Dasar Kubernetes</h2>
-        <p>Tutorial ini menyediakan panduan dasar mekanisme orkestrasi <i>cluster</i> Kubernetes. Setiap modul memliki beberapa informasi mengenai latar belakang bagi konsep mendasar dan <i>feature</i> Kubernetes, termasuk mode interaktif yang dapat digunakan sebagai metode pembelajaran <i>online</i>. Mode tutorial interaktif ini memberikan kesempatan pengguna untuk melakukan manajemen <i>cluster</i> sederhana beserta aplikasi dalam kontainer yang Anda miliki.</p>
+        <p>Tutorial ini menyediakan panduan dasar mekanisme orkestrasi <i>cluster</i> Kubernetes. Setiap modul memliki beberapa informasi mengenai latar belakang bagi konsep mendasar dan <i>feature</i> Kubernetes, termasuk mode interaktif yang dapat digunakan sebagai metode pembelajaran <i>online</i>. Mode tutorial interaktif ini memberikan kesempatan pengguna untuk melakukan manajemen <i>cluster</i> sederhana beserta aplikasi dalam kontainer yang kamu miliki.</p>
         <p>Dengan menggunakan mode tutorial interaktif ini, pengguna diharapkan dapat memahami:</p>
         <ul>
         <li><i>Deploy</i>i> sebuah aplikasi yang sudah dikontainerisasi pada <i>cluster</i></li>
         <li>Melakukan <i>scale</i> <i>deployment</i></li>
-        <li>Meng-update aplikasi yang sudah dikontenairisasi dengan menggunakan versi aplikasi terbaru</li>
-        <li>Men-debug aplikasi yang sudah dikontenairisasi</li>
+        <li>Meng-update aplikasi yang sudah dikontainerisasi dengan menggunakan versi aplikasi terbaru</li>
+        <li>Men-debug aplikasi yang sudah dikontainerisasi</li>
         </ul>
-        <p>Tutorial ini menggunakan Katakoda untuk menjalankan terminal virtual diatas Minikube pada <i>web browser</i> Anda. Dengan demikian, Anda tidak perlu melakukan instalasi perangkat lunak apa pun, segala modul yang ada dijalankan secara langsung melalui <i>web browser</i> yang Anda miliki.</p>
+        <p>Tutorial ini menggunakan Katakoda untuk menjalankan terminal virtual diatas Minikube pada <i>web browser</i> kamu. Dengan demikian, kamu tidak perlu melakukan instalasi perangkat lunak apa pun, segala modul yang ada dijalankan secara langsung melalui <i>web browser</i> yang kamu miliki.</p>
       </div>
     </div>
 
@@ -37,8 +37,8 @@ card:
 
     <div class="row">
       <div class="col-md-9">
-        <h2>Apa yang dapat dilakukan oleh Kubernetes untuk Anda?</h2>
-        <p>Seiring berkembangnya web servis modern, pengguna memiliki ekspektasi agar aplikasi selalu dapat diakses 24/7, selain itu <i>developers</i> juga memiliki harapan agar mereka dapat melakukan <i>deployment</i> aplikasi dengan versi terbaru yang mereka miliki berulang per hari. Mekanisme kontainerisasi mengepak perangkat lunak agar memenuhi kebutuhan yang ada, memudahkan serta mempercepat proses rilis dan pembaharuan aplikasi tanpa adanya <i>downtime</i> proses ini dapat dilakukan berulang per hari. Kubernetes membantu Anda menjaga aplikasi yang Anda buat untuk dapat dijalankan dimana pun dan kapan pun Anda menginginkannya, serta menjamin segala kebutuhan dan peralatan yang dibutuhkan oleh aplikasi anda tersedia. Kubernetes merupakan platform <i>open source</i> yang sudah matang yang didesain berdasarkan pengalaman Google serta ide yang brilian dari komunitas yang ada. </p>
+        <h2>Apa yang dapat dilakukan oleh Kubernetes untuk kamu?</h2>
+        <p>Seiring berkembangnya web servis modern, pengguna memiliki ekspektasi agar aplikasi selalu dapat diakses 24/7, selain itu <i>developers</i> juga memiliki harapan agar mereka dapat melakukan <i>deployment</i> aplikasi dengan versi terbaru yang mereka miliki berulang per hari. Mekanisme kontainerisasi mengepak perangkat lunak agar memenuhi kebutuhan yang ada, memudahkan serta mempercepat proses rilis dan pembaharuan aplikasi tanpa adanya <i>downtime</i> proses ini dapat dilakukan berulang per hari. Kubernetes membantu kamu menjaga aplikasi yang kamu buat untuk dapat dijalankan dimana pun dan kapan pun kamu menginginkannya, serta menjamin segala kebutuhan dan peralatan yang dibutuhkan oleh aplikasi kamu tersedia. Kubernetes merupakan platform <i>open source</i> yang sudah matang yang didesain berdasarkan pengalaman Google serta ide yang brilian dari komunitas yang ada. </p>
       </div>
     </div>
 

--- a/content/id/docs/tutorials/kubernetes-basics/_index.html
+++ b/content/id/docs/tutorials/kubernetes-basics/_index.html
@@ -1,0 +1,92 @@
+---
+title: Mempelajari Panduan Dasar Kubernetes
+linkTitle: Mempelajari Panduan Dasar Kubernetes
+weight: 10
+card:
+  name: tutorials
+  weight: 20
+  title: Panduan dasar
+---
+
+<!DOCTYPE html>
+
+<html lang="en">
+
+<body>
+
+<div class="layout" id="top">
+
+  <main class="content">
+
+    <div class="row">
+      <div class="col-md-9">
+        <h2>Panduan Dasar Kubernetes</h2>
+        <p>Tutorial ini menyediakan panduan dasar mekanisme orkestrasi <i>cluster</i> Kubernetes. Setiap modul memliki beberapa informasi mengenai latar belakang bagi konsep mendasar dan <i>feature</i> Kubernetes, termasuk mode interaktif yang dapat digunakan sebagai metode pembelajaran <i>online</i>. Mode tutorial interaktif ini memberikan kesempatan pengguna untuk melakukan manajemen <i>cluster</i> sederhana beserta aplikasi dalam kontainer yang Anda miliki.</p>
+        <p>Dengan menggunakan mode tutorial interaktif ini, pengguna diharapkan dapat memahami:</p>
+        <ul>
+        <li><i>Deploy</i>i> sebuah aplikasi yang sudah dikontainerisasi pada <i>cluster</i></li>
+        <li>Melakukan <i>scale</i> <i>deployment</i></li>
+        <li>Meng-update aplikasi yang sudah dikontenairisasi dengan menggunakan versi aplikasi terbaru</li>
+        <li>Men-debug aplikasi yang sudah dikontenairisasi</li>
+        </ul>
+        <p>Tutorial ini menggunakan Katakoda untuk menjalankan terminal virtual diatas Minikube pada <i>web browser</i> Anda. Dengan demikian, Anda tidak perlu melakukan instalasi perangkat lunak apa pun, segala modul yang ada dijalankan secara langsung melalui <i>web browser</i> yang Anda miliki.</p>
+      </div>
+    </div>
+
+    <br>
+
+    <div class="row">
+      <div class="col-md-9">
+        <h2>Apa yang dapat dilakukan oleh Kubernetes untuk Anda?</h2>
+        <p>Seiring berkembangnya web servis modern, pengguna memiliki ekspektasi agar aplikasi selalu dapat diakses 24/7, selain itu <i>developers</i> juga memiliki harapan agar mereka dapat melakukan <i>deployment</i> aplikasi dengan versi terbaru yang mereka miliki berulang per hari. Mekanisme kontainerisasi mengepak perangkat lunak agar memenuhi kebutuhan yang ada, memudahkan serta mempercepat proses rilis dan pembaharuan aplikasi tanpa adanya <i>downtime</i> proses ini dapat dilakukan berulang per hari. Kubernetes membantu Anda menjaga aplikasi yang Anda buat untuk dapat dijalankan dimana pun dan kapan pun Anda menginginkannya, serta menjamin segala kebutuhan dan peralatan yang dibutuhkan oleh aplikasi anda tersedia. Kubernetes merupakan platform <i>open source</i> yang sudah matang yang didesain berdasarkan pengalaman Google serta ide yang brilian dari komunitas yang ada. </p>
+      </div>
+    </div>
+
+    <div id="basics-modules" class="content__modules">
+      <h2>Kubernetes Basics Modules</h2>
+      <div class="row">
+        <div class="col-md-12">
+          <div class="row">
+            <div class="col-md-4">
+              <div class="thumbnail">
+                <a href="/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_01.svg?v=1469803628347" alt=""></a>
+                <div class="caption">
+                  <a href="/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro/"><h5>1. Create a Kubernetes cluster</h5></a>
+                </div>
+              </div>
+            </div>
+            <div class="col-md-4">
+              <div class="thumbnail">
+                <a href="/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_02.svg?v=1469803628347" alt=""></a>
+                <div class="caption">
+                  <a href="/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/"><h5>2. Deploy an app</h5></a>
+                </div>
+              </div>
+            </div>
+            <div class="col-md-4">
+              <div class="thumbnail">
+                <a href="/docs/tutorials/kubernetes-basics/explore/explore-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_03.svg?v=1469803628347" alt=""></a>
+                <div class="caption">
+                  <a href="/docs/tutorials/kubernetes-basics/explore/explore-intro/"><h5>3. Explore your app</h5></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-12">
+          <div class="row">
+            <div class="col-md-4">
+              <div class="thumbnail">
+                <a href="/docs/tutorials/kubernetes-basics/expose/expose-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_04.svg?v=1469803628347" alt=""></a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
+
+</div>
+
+</body>
+</html>

--- a/content/id/examples/minikube/Dockerfile
+++ b/content/id/examples/minikube/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:6.14.2
+EXPOSE 8080
+COPY server.js .
+CMD node server.js

--- a/content/id/examples/minikube/server.js
+++ b/content/id/examples/minikube/server.js
@@ -1,0 +1,9 @@
+var http = require('http');
+
+var handleRequest = function(request, response) {
+  console.log('Received request for URL: ' + request.url);
+  response.writeHead(200);
+  response.end('Hello World!');
+};
+var www = http.createServer(handleRequest);
+www.listen(8080);

--- a/i18n/id.toml
+++ b/i18n/id.toml
@@ -1,0 +1,139 @@
+# i18n strings for the Indonesian (main) site.
+
+[deprecation_warning]
+other = " dokumentasi sudah tidak dirawat lagi. Versi yang kamu lihat ini hanyalah snapshot statis. Untuk dokumentasi terkini, lihat "
+
+[deprecation_file_warning]
+other = "Sudah usang"
+
+[objectives_heading]
+other = "Tujuan"
+
+[cleanup_heading]
+other = "Bersihkan"
+
+[prerequisites_heading]
+other = "Sebelum mulai"
+
+[whatsnext_heading]
+other = "Selanjutnya"
+
+[feedback_heading]
+other = "Masukan"
+
+[feedback_question]
+other = "Apakah halaman ini berguna?"
+
+[feedback_yes]
+other = "Ya"
+
+[feedback_no]
+other = "Tidak"
+
+[latest_version]
+other = "versi terkini."
+
+[version_check_mustbe]
+other = "Kubernetes servermu harus ada di versi "
+
+[version_check_mustbeorlater]
+other = "Kubernetes servermu harus ada di versi yang sama atau lebih baru "
+
+[version_check_tocheck]
+other = "Untuk melihat versi, tekan "
+
+[caution]
+other = "Perhatian:"
+
+[note]
+other = "Catatan:"
+
+[warning]
+other = "Peringatan:"
+
+[main_read_about]
+other = "Baca tentang"
+
+[main_read_more]
+other = "Baca lebih lanjut"
+
+[main_github_invite]
+other = "Tertarik untuk ulik kode dari Kubernetes?"
+
+[main_github_view_on]
+other = "Lihat di GitHub"
+
+[main_github_create_an_issue]
+other = "Buat isu"
+
+[main_community_explore]
+other = "Jelajahi komunitasnya"
+
+[main_kubernetes_features]
+other = "Fitur kubernetes"
+
+[main_cncf_project]
+other = """Kami merupakan proyek yang lulus dari <a href="https://cncf.io/">CNCF</a></p>"""
+
+[main_kubeweekly_baseline]
+other = "Tertarik untuk dapatkan info terkini tentang Kubernetes? Daftarkan dirimu di buletin KubeWeekly."
+
+[main_kubernetes_past_link]
+other = "Lihat buletin edisi sebelumnya"
+
+[main_kubeweekly_signup]
+other = "Langganan"
+
+[main_contribute]
+other = "Kontribusi"
+
+[main_edit_this_page]
+other = "Ubah halaman ini"
+
+[main_page_history]
+other ="Riwayat halaman"
+
+[main_page_last_modified_on]
+other = "Halaman diubah terakhir kali pada"
+
+[main_by]
+other = "oleh"
+
+[main_documentation_license]
+other = """Para Pencipta Kubernetes | Dokumentasi didistribusikan melalui <a href="https://git.k8s.io/website/LICENSE" class="light-text">CC BY 4.0</a>"""
+
+[main_copyright_notice]
+other = """Linux Foundation &reg;. Hak cipta dilindungi. Linux Foundation telah mendaftarkan merek dagang dan pengunaannya. Perinciannya bisa dilihat pada <a href="https://www.linuxfoundation.org/trademark-usage" class="light-text">halaman penggunaan merek dagang</a>"""
+
+# Labels for the docs portal home page.
+[docs_label_browse]
+other = "Lihat-lihat dokumentasi"
+
+[docs_label_contributors]
+other = "Para kontributor"
+
+[docs_label_users]
+other = "Para pengguna"
+
+[docs_label_i_am]
+other = "AKU ADALAH..."
+
+
+
+# Community links
+[community_twitter_name]
+other = "Twitter"
+[community_github_name]
+other = "GitHub"
+[community_slack_name]
+other = "Slack"
+[community_stack_overflow_name]
+other = "Stack Overflow"
+[community_forum_name]
+other = "Forum"
+[community_events_calendar]
+other = "Kalender acara"
+
+# UI elements
+[ui_search_placeholder]
+other = "Cari"


### PR DESCRIPTION
Init Indonesian translation for Kubernetes docs, which includes minimal requirement as per [L10n doc](https://kubernetes.io/docs/contribute/localization/). 

- [x] Home : [All heading and subheading URLs](https://kubernetes.io/docs/home/)
- [x] Setup : [All heading and subheading URLs](https://kubernetes.io/docs/setup/)
- [x] Tutorials : [Kubernetes Basics](https://kubernetes.io/docs/tutorials/kubernetes-basics/)
- [x] Tutorials : [Hello Minikube](https://kubernetes.io/docs/tutorials/hello-minikube/)

Some expressions might not be best and not that easy to understand, as Indonesian language for tech is always not straight forward, but refinement can be done as we go. We will also discuss and debate (a long one) correct terms and glossary in Indonesian language for Kubernetes world, and iterate accordingly on the docs. For now, we want to focus on getting the init in, and involve more local community to translate the entire doc. 

Co-authored-by: Giri Kuncoro <girikuncoro@gmail.com>
Co-authored-by: Irvi Firqotul Aini <irvifa@gmail.com>