### PR TITLE
Add localization support for layouts

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -118,7 +118,63 @@ other = "Users"
 [docs_label_i_am]
 other = "I AM..."
 
+# layouts > blog > pager
 
+[layouts_blog_pager_prev]
+other = "<< Prev"
+
+[layouts_blog_pager_next]
+other = "Next >>"
+
+# layouts > blog > list
+
+[layouts_case_studies_list_tell]
+other = "Tell your story"
+
+# layouts > docs > glossary
+
+[layouts_docs_glossary_description]
+other = "This glossary is intended to be a comprehensive, standardized list of Kubernetes terminology. It includes technical terms that are specific to K8s, as well as more general terms that provide useful context."
+
+[layouts_docs_glossary_filter]
+other = "Filter terms according to their tags"
+
+[layouts_docs_glossary_select_all]
+other = "Select all"
+
+[layouts_docs_glossary_deselect_all]
+other = "Deselect all"
+
+[layouts_docs_glossary_aka]
+other = "Also known as"
+
+[layouts_docs_glossary_click_details_before]
+other = "Click on the"
+
+[layouts_docs_glossary_click_details_after]
+other = "indicators below to get a longer explanation for any particular term."
+
+# layouts > docs > search
+
+[layouts_docs_search_fetching]
+other = "Fetching results.."
+
+# layouts > partial > feedback
+
+[layouts_docs_partials_feedback_thanks]
+other = "Thanks for the feedback. If you have a specific, answerable question about how to use Kubernetes, ask it on"
+
+[layouts_docs_partials_feedback_issue]
+other = "Open an issue in the GitHub repo if you want to "
+
+[layouts_docs_partials_feedback_problem]
+other = "report a problem"
+
+[layouts_docs_partials_feedback_or]
+other = "or"
+
+[layouts_docs_partials_feedback_improvement]
+other = "suggest an improvement"
 
 # Community links
 [community_twitter_name]

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -118,7 +118,63 @@ other = "Usuarios"
 [docs_label_i_am]
 other = "Yo soy..."
 
+# layouts > blog > pager
 
+[layouts_blog_pager_prev]
+other = "<< Anterior"
+
+[layouts_blog_pager_next]
+other = "Siguiente >>"
+
+# layouts > blog > list
+
+[layouts_case_studies_list_tell]
+other = "Cuéntanos tu historia"
+
+# layouts > docs > glossary
+
+[layouts_docs_glossary_description]
+other = "Este glosario tiene la intención de ser una lista completa y estandarizada de la terminología de Kubernetes. Incluye términos técnicos que son específicos de k8s, así como términos más generales que proporcionan un contexto."
+
+[layouts_docs_glossary_filter]
+other = "Filtrar terminos por categoría:"
+
+[layouts_docs_glossary_select_all]
+other = "Seleccionar todos"
+
+[layouts_docs_glossary_deselect_all]
+other = "Elmininar selección"
+
+[layouts_docs_glossary_aka]
+other = "Also known as"
+
+[layouts_docs_glossary_click_details_before]
+other = "Haz click en el símbolo"
+
+[layouts_docs_glossary_click_details_after]
+other = "para obtener información detallada sobre el término."
+
+# layouts > docs > search
+
+[layouts_docs_search_fetching]
+other = "Obteniendo resultados.."
+
+# layouts > partial > feedback
+
+[layouts_docs_partials_feedback_thanks]
+other = "Muchas gracias por el feedback. Si tienes alguna pregunta específica sobre como usar Kubernetes, puedes preguntar en"
+
+[layouts_docs_partials_feedback_issue]
+other = "Abre un issue en el repositorio de GitHub si quieres"
+
+[layouts_docs_partials_feedback_problem]
+other = "reportar un problema"
+
+[layouts_docs_partials_feedback_or]
+other = "o"
+
+[layouts_docs_partials_feedback_improvement]
+other = "sugerir alguna mejora"
 
 # Community links
 [community_twitter_name]

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html id="{{ .Params.cid }}" lang="en" class="{{ .Params.class }}">
+<html id="{{ .Params.cid }}" lang="{{ .Language }}" class="{{ .Params.class }}">
 	<head>
 		{{ partial "head.html" . }}
 	</head>

--- a/layouts/blog/baseof.html
+++ b/layouts/blog/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html id="blog" lang="en" class="gr__kubernetes_io fontawesome-i2svg-active fontawesome-i2svg-complete">
+<html id="blog" lang="{{ .Language }}" class="gr__kubernetes_io fontawesome-i2svg-active fontawesome-i2svg-complete">
 	<head>
 		{{ partial "head.html" . }}
 		<link rel='stylesheet' type='text/css' href='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css'>

--- a/layouts/blog/pager.html
+++ b/layouts/blog/pager.html
@@ -1,12 +1,12 @@
 <div class="PageNavigation">
 	 {{ if .PrevInSection }}
     <div class="pagerButton left">
-        <h4><a class=" button" href="{{ .PrevInSection.RelPermalink }}"> « Prev </a></h4>
+        <h4><a class=" button" href="{{ .PrevInSection.RelPermalink }}"> {{ T "layouts_blog_pager_next" }} </a></h4>
     </div>
     {{ end }}
     {{ if .NextInSection }}
     <div class="pagerButton right">
-        <h4><a class=" button" href="{{ .NextInSection.RelPermalink }}"> Next >></a></h4>
+        <h4><a class=" button" href="{{ .NextInSection.RelPermalink }}"> {{ T "layouts_blog_pager_next" }} </a></h4>
     </div>
     {{ end }}
  </div>

--- a/layouts/case-studies/list.html
+++ b/layouts/case-studies/list.html
@@ -51,7 +51,7 @@
 				{{ errorf "Case Studies: Missing logo for %s. Put a PNG with the word 'logo' in the filename into %q" $p.LinkTitle $p.File.Dir }}
 			{{ end }}</a>
 			{{ end }}
-			<a target="_blank" href="https://docs.google.com/a/google.com/forms/d/e/1FAIpQLScuI7Ye3VQHQTwBASrgkjQDSS5TP0g3AXfFhwSM9YpHgxRKFA/viewform" class="tell-your-story"><img src="/images/case_studies/story.png" alt="Tell your story"></a>
+			<a target="_blank" href="https://docs.google.com/a/google.com/forms/d/e/1FAIpQLScuI7Ye3VQHQTwBASrgkjQDSS5TP0g3AXfFhwSM9YpHgxRKFA/viewform" class="tell-your-story"><img src="/images/case_studies/story.png" alt="{{ T "layouts_case_studies_list_tell" }}"></a>
 		</div>
 	</main>
 </section>

--- a/layouts/case-studies/single-baseof.html
+++ b/layouts/case-studies/single-baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html id="{{ .Params.cid }}" lang="en" class="{{ .Params.class }}">
+<html id="{{ .Params.cid }}" lang="{{ .Language }}" class="{{ .Params.class }}">
 	<head>
 		{{ partial "head.html" . }}
 	</head>

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html id="docs" lang="en" class="{{ .Params.class }}">
+<html id="docs" lang="{{ .Language }}" class="{{ .Params.class }}">
 	<head>
 	{{ partial "head.html" . }}
 	</head>

--- a/layouts/docs/glossary.html
+++ b/layouts/docs/glossary.html
@@ -6,9 +6,9 @@
 <h1>{{ .Title }}</h1>
 <link href="{{ "css/glossary.css" | relURL }}" rel="stylesheet">
 <script src="{{ "js/glossary.js" | relURL }}"></script>
-<p>This glossary is intended to be a comprehensive, standardized list of Kubernetes terminology. It includes technical terms that are specific to K8s, as well as more general terms that provide useful context.</p>
+<p>{{ T "layouts_docs_glossary_description" }}</p>
 <div id="tag-container">
-	<p>Filter terms according to their tags:</p>
+	<p>{{ T "layouts_docs_glossary_filter" }}</p>
 	<div class="tag-description invisible" id="placeholder">.</div>
 	{{ range (index site.Data "canonical-tags") }}
 	<div class="tag-description hide" id="{{ printf "tag-%s-description" .id  }}">
@@ -22,10 +22,10 @@
 		<a href="javascript:void(0)">{{  .name  }}</a>
 	</span>
 	{{ end }}
-	<span class="tag-option"><a id="select-all-tags" href="javascript:void(0)">Select all</a></span>
-	<span class="tag-option"><a id="deselect-all-tags" href="javascript:void(0)">Deselect all</a></span>
+	<span class="tag-option"><a id="select-all-tags" href="javascript:void(0)">{{ T "layouts_docs_glossary_select_all" }}</a></span>
+	<span class="tag-option"><a id="deselect-all-tags" href="javascript:void(0)">{{ T "layouts_docs_glossary_deselect_all" }}</a></span>
 </div>
-<p>Click on the <a href="javascript:void(0)" class="no-underline">[+]</a> indicators below to get a longer explanation for any particular term.</p>
+<p>{{ T "layouts_docs_glossary_click_details_before" }} <a href="javascript:void(0)" class="no-underline">[+]</a> {{ T "layouts_docs_glossary_click_details_after" }}</p>
 {{ partial "docs/glossary-terms.html" . }}
 {{ $glossary_items := $.Scratch.Get "glossary_items" }}
 {{ with $glossary_items }}
@@ -43,7 +43,7 @@
 		<div>
 			<div class="term-name"><b>{{ .Title }}</b><a href="{{ printf "#%s" $term_identifier }}" class="permalink hide">LINK</a></div>
 			{{ with .Params.aka }}
-			Also known as: <i>{{ delimit . ", " }}</i>
+			{{ T "layouts_docs_glossary_aka" }}:<i>{{ delimit . ", " }}</i>
 			<br>
 			{{ end }}
 			<span class="preview-text">{{ .Summary }} <a href="javascript:void(0)" class="click-controller no-underline" data-target="{{ .Params.id }}">[+]</a></span>

--- a/layouts/docs/search.html
+++ b/layouts/docs/search.html
@@ -2,7 +2,7 @@
 <h1>{{ .Title }}</h1>
 
 <gcse:searchresults-only linktarget="_parent">
-    <div id="bing-results-container">Fetching results..</div>
+    <div id="bing-results-container">{{ T "layouts_docs_search_fetching" }}</div>
     <div id="bing-pagination-container"></div>
 </gcse:searchresults-only>
 

--- a/layouts/partials/feedback.html
+++ b/layouts/partials/feedback.html
@@ -4,13 +4,18 @@
   <button class="button feedback--yes">{{ T "feedback_yes" }}</button>
   <button class="button feedback--no">{{ T "feedback_no" }}</button>
   <p class="feedback--response feedback--response__hidden">
-    Thanks for the feedback. If you have a specific, answerable question about how to use Kubernetes,
-    ask it on <a target="_blank" rel="noopener"
-    href="https://stackoverflow.com/questions/tagged/kubernetes">Stack Overflow</a>. Open
-    an issue in the GitHub repo if you want to <a class="feedback--link" target="_blank" rel="noopener"
-    href="https://github.com/kubernetes/website/issues/new?title=Issue%20with%20k8s.io">report a problem</a> or
+    {{ T "layouts_docs_partials_feedback_thanks" }}
+    <a target="_blank" rel="noopener"
+      href="https://stackoverflow.com/questions/tagged/kubernetes">
+      Stack Overflow</a>.
+    {{ T "layouts_docs_partials_feedback_issue" }}
     <a class="feedback--link" target="_blank" rel="noopener"
-    href="https://github.com/kubernetes/website/issues/new?title=Improvement%20for%20k8s.io">suggest an improvement</a>.
+      href="https://github.com/kubernetes/website/issues/new?title=Issue%20with%20k8s.io">
+      {{ T "layouts_docs_partials_feedback_problem" }}</a>
+    {{ T "layouts_docs_partials_feedback_or" }}
+    <a class="feedback--link" target="_blank" rel="noopener"
+      href="https://github.com/kubernetes/website/issues/new?title=Improvement%20for%20k8s.io">
+      {{ T "layouts_docs_partials_feedback_improvement" }}</a>.
   </p>
   <script>
     const yes = document.querySelector('.feedback--yes');


### PR DESCRIPTION
This PR adds support to localized templates by extracting all hardcoded string to i18n strings.

Also sets the `html` `lang` attribute to the current page language using `{{ .Language }}` as suggested by @remyleone in https://github.com/kubernetes/website/pull/13799/ > [layouts/docs/baseof.html](https://github.com/kubernetes/website/pull/13799/files#diff-94990944772498e35cecc79f68198cee).

cc @kubernetes/sig-docs-l10n-admins @zacharysarah @remyleone 