### PR TITLE
an offense against the style guide.

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/kubernetes-objects.md
+++ b/content/en/docs/concepts/overview/working-with-objects/kubernetes-objects.md
@@ -61,7 +61,7 @@ In the `.yaml` file for the Kubernetes object you want to create, you'll need to
 
 * `apiVersion` - Which version of the Kubernetes API you're using to create this object
 * `kind` - What kind of object you want to create
-* `metadata` - Data that helps uniquely identify the object, including a `name` string, UID, and optional `namespace`
+* `metadata` - Data that helps uniquely identify the object, including a `name` string, `UID`, and optional `namespace`
 
 You'll also need to provide the object `spec` field. The precise format of the object `spec` is different for every Kubernetes object, and contains nested fields specific to that object. The [Kubernetes API Reference](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/) can help you find the spec format for all of the objects you can create using Kubernetes.
 For example, the `spec` format for a `Pod` can be found


### PR DESCRIPTION
Evidence:
> Use code style for object field names