### PR TITLE
remove invalid pod phases

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -39,9 +39,6 @@ Value | Description
 `Succeeded` | All Containers in the Pod have terminated in success, and will not be restarted.
 `Failed` | All Containers in the Pod have terminated, and at least one Container has terminated in failure. That is, the Container either exited with non-zero status or was terminated by the system.
 `Unknown` | For some reason the state of the Pod could not be obtained, typically due to an error in communicating with the host of the Pod.
-`Completed` | The pod has run to completion as there's nothing to keep it running eg. Completed Jobs.
-`CrashLoopBackOff` | This means that one of the containers in the pod has exited unexpectedly, and perhaps with a non-zero error code even after restarting due to [restart policy](#restart-policy).
-
 
 ## Pod conditions
 


### PR DESCRIPTION
`Completed` and `CrashLoopBackOff` are incorrectly listed as being a valid Pod Phase, these are container state reasons, not pod phases. Valid pod phases can be found here: https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/types.go#L2160.

This can cause some confusion e.g https://github.com/kubernetes/kubernetes/issues/76619
