### PR TITLE
Fix glossary entry for rkt

### DIFF
--- a/content/en/docs/reference/glossary/rkt.md
+++ b/content/en/docs/reference/glossary/rkt.md
@@ -15,4 +15,4 @@ tags:
 
 <!--more--> 
 
-rkt is an application {% glossary_tooltip text="container" term_id="container" %} engine featuring a {% glossary_tooltip text="pod" term_id="pod" %}-native approach, a pluggable execution environment, and a well-defined surface area. rkt allows users to apply different configurations  at both the pod and application level and each pod executes directly in the classic Unix process model, in a self-contained, isolated environment.
+rkt is an application {{< glossary_tooltip text="container" term_id="container" >}} engine featuring a {{< glossary_tooltip text="pod" term_id="pod" >}}-native approach, a pluggable execution environment, and a well-defined surface area. rkt allows users to apply different configurations at both the pod and application level and each pod executes directly in the classic Unix process model, in a self-contained, isolated environment.

--- a/content/en/docs/reference/glossary/rkt.md
+++ b/content/en/docs/reference/glossary/rkt.md
@@ -15,4 +15,4 @@ tags:
 
 <!--more--> 
 
-rkt is an application {{< glossary_tooltip text="container" term_id="container" >}} engine featuring a {{< glossary_tooltip text="pod" term_id="pod" >}}-native approach, a pluggable execution environment, and a well-defined surface area. rkt allows users to apply different configurations at both the pod and application level and each pod executes directly in the classic Unix process model, in a self-contained, isolated environment.
+rkt is an application {{< glossary_tooltip text="container" term_id="container" >}} engine featuring a {{< glossary_tooltip text="pod" term_id="pod" >}}-native approach, a pluggable execution environment, and a well-defined surface area. rkt allows users to apply different configurations at both the pod and application level. Each Pod executes directly in the classic Unix process model, in a self-contained, isolated environment.


### PR DESCRIPTION
Currently, https://kubernetes.io/docs/reference/glossary/?all=true#term-rkt contains incorrect formatting.

- fix that
- also tweak the wording slightly