### PR TITLE
Fixing one word typo in OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -97,7 +97,7 @@ aliases:
     - nasa9084
     - tnir
     - zacharysarah
-  sig-docs-ja-reviews: # PR reviews for Italian content 
+  sig-docs-ja-reviews: # PR reviews for Japanese content 
     - cstoku
     - makocchi-git
     - MasayaAoyama


### PR DESCRIPTION
Fixing one word typo in OWNERS_ALIASES file.

Comment on 'sig-docs-ja-reviews' says "PR reviews for _Italian_ content".
But 'sig-docs-ja-reviews' must point to "PR reviews for **Japanese** content".