### PR TITLE
Fix link to Kubernetes Community Values doc

### DIFF
--- a/content/en/blog/_posts/2018-06-06-4-years-of-k8s.md
+++ b/content/en/blog/_posts/2018-06-06-4-years-of-k8s.md
@@ -23,6 +23,6 @@ The version of Kubernetes at that point was really just a shadow of what it was 
 <center><iframe width="560" height="315" src="https://www.youtube.com/embed/YrxnVKZeqK8" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe></center>
 
 
-But, however raw, that modest start was enough to pique the interest of a community that started strong and has only gotten stronger.  Over the past four years Kubernetes has exceeded the expectations of all of us that were there early on. We owe the Kubernetes community a huge debt.  The success the project has seen is based not just on code and technology but also the way that an amazing group of people have come together to create something special.  The best expression of this is the [set of Kubernetes values](https://github.com/kubernetes/steering/blob/master/values.md) that Sarah Novotny helped curate.
+But, however raw, that modest start was enough to pique the interest of a community that started strong and has only gotten stronger.  Over the past four years Kubernetes has exceeded the expectations of all of us that were there early on. We owe the Kubernetes community a huge debt.  The success the project has seen is based not just on code and technology but also the way that an amazing group of people have come together to create something special.  The best expression of this is the [set of Kubernetes values](https://git.k8s.io/community/values.md) that Sarah Novotny helped curate.
 
 Here is to another 4 years and beyond! 🎉🎉🎉

--- a/content/en/blog/_posts/2018-08-29-kubernetes-testing-ci-automating-contributor-experience.md
+++ b/content/en/blog/_posts/2018-08-29-kubernetes-testing-ci-automating-contributor-experience.md
@@ -6,7 +6,7 @@ date:   2018-08-29
 
 **Author**: Aaron Crickenberger (Google) and Benjamin Elder (Google)
 
-_“Large projects have a lot of less exciting, yet, hard work. We value time spent automating repetitive work more highly than toil. Where that work cannot be automated, it is our culture to recognize and reward all types of contributions. However, heroism is not sustainable.”_ - [Kubernetes Community Values](https://github.com/kubernetes/steering/blob/master/values.md#automation-over-process)
+_“Large projects have a lot of less exciting, yet, hard work. We value time spent automating repetitive work more highly than toil. Where that work cannot be automated, it is our culture to recognize and reward all types of contributions. However, heroism is not sustainable.”_ - [Kubernetes Community Values](https://git.k8s.io/community/values.md#automation-over-process)
 
 Like many open source projects, Kubernetes is hosted on GitHub. We felt the barrier to participation would be lowest if the project lived where developers already worked, using tools and processes developers already knew. Thus the project embraced the service fully: it was the basis of our workflow, our issue tracker, our documentation, our blog platform, our team structure, and more.
 

--- a/content/en/blog/_posts/2018-10-04-non-code-contributors-guide.md
+++ b/content/en/blog/_posts/2018-10-04-non-code-contributors-guide.md
@@ -10,7 +10,7 @@ It was May 2018 in Copenhagen, and the Kubernetes community was enjoying the con
 
 **This all led to an effort called the [Non-Code Contributor’s Guide](https://github.com/kubernetes/community/blob/master/contributors/guide/non-code-contributions.md).**
 
-Now, it’s important to note that Kubernetes is rare, if not unique, in the open source world, in that it was defined very early on as both a project and a community. While the project itself is focused on the codebase, it is the community of people driving it forward that makes the project successful. The community works together with an explicit set of [community values](https://github.com/kubernetes/steering/blob/master/values.md), guiding the day-to-day behavior of contributors whether on GitHub, Slack, Discourse, or sitting together over tea or coffee.
+Now, it’s important to note that Kubernetes is rare, if not unique, in the open source world, in that it was defined very early on as both a project and a community. While the project itself is focused on the codebase, it is the community of people driving it forward that makes the project successful. The community works together with an explicit set of [community values](https://git.k8s.io/community/values.md), guiding the day-to-day behavior of contributors whether on GitHub, Slack, Discourse, or sitting together over tea or coffee.
 
 By having a community that values people first, and explicitly values a diversity of people, the Kubernetes project is building a product to serve people with diverse needs. The different backgrounds of the contributors bring different approaches to the problem solving, with different methods of collaboration, and all those different viewpoints ultimately create a better project.
 


### PR DESCRIPTION
The doc has been migrated from the steering repo to the community repo: https://git.k8s.io/community/values.md.

Ref: 
- https://github.com/kubernetes/steering/pull/88
- https://github.com/kubernetes/community/pull/3103
- https://github.com/kubernetes/steering/pull/100
