### PR TITLE
Update pod-lifecycle.md

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -209,7 +209,7 @@ spec:
 status:
   conditions:
     - type: Ready  # this is a builtin PodCondition
-      status: "True"
+      status: "False"
       lastProbeTime: null
       lastTransitionTime: 2018-01-01T00:00:00Z
     - type: "www.example.com/feature-1"   # an extra PodCondition


### PR DESCRIPTION
if condition type "www.example.com/feature-1" is False, the type "Ready" should be False also, like "https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/0007-pod-ready%2B%2B.md#pod-readiness" says.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> Please delete this note before submitting the pull request.
>
> For 1.15 Features: set Milestone to 1.15 and Base Branch to dev-1.15
> 
> For Chinese localization, base branch to release-1.12
>
> For Korean Localization: set Base Branch to dev-1.14-ko.\<latest team milestone>
>
> Help editing and submitting pull requests:
> https://kubernetes.io/docs/contribute/start/#improve-existing-content.
>
> Help choosing which branch to use:
> https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use.
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
