### PR TITLE
need to add minikube ip in host file

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -182,7 +182,7 @@ The following file is an Ingress resource that sends traffic to your Service via
 1. Add the following line to the bottom of the `/etc/hosts` file. 
 
     ```
-    172.17.0.15 hello-world.info
+    <minikube-IP> hello-world.info
     ```
 
     This sends requests from hello-world.info to Minikube.


### PR DESCRIPTION
need to add minikube ip in host file instead of ingress ip
example: 192.168.99.100 hello-world.info

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> Please delete this note before submitting the pull request.
>
> For 1.15 Features: set Milestone to 1.15 and Base Branch to dev-1.15
> 
> For Chinese localization, base branch to release-1.12
>
> For Korean Localization: set Base Branch to dev-1.14-ko.\<latest team milestone>
>
> Help editing and submitting pull requests:
> https://kubernetes.io/docs/contribute/start/#improve-existing-content.
>
> Help choosing which branch to use:
> https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use.
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
