### PR TITLE
Add new section to reference contributor cheatsheet in `contribute` page

### DIFF
--- a/content/en/docs/contribute/_index.md
+++ b/content/en/docs/contribute/_index.md
@@ -13,7 +13,7 @@ we're happy to have your help! Anyone can contribute, whether you're new to the
 project or you've been around a long time, and whether you self-identify as a
 developer, an end user, or someone who just can't stand seeing typos.
 
-For more ways to get involved in the Kubernetes community or to learn about us, visit the [Kubernetes community site](/community/). 
+For more ways to get involved in the Kubernetes community or to learn about us, visit the [Kubernetes community site](/community/).
 For information on the Kubernetes documentation style guide, see the [style guide](/docs/contribute/style/style-guide/).
 
 {{% capture body %}}
@@ -69,5 +69,10 @@ documentation, but it should help you get started.
   - Propose improvements to the style guide
   - Propose improvements to docs tests
   - Propose improvements to the Kubernetes website or other tooling
+
+### Feature development
+
+You can also contribute to Kubernetes feature development.
+The [contributor cheatsheet](https://github.com/kubernetes/community/tree/master/contributors/guide/contributor-cheatsheet) can help you get started.
 
 {{% /capture %}}


### PR DESCRIPTION
Add new section to reference contributor cheatsheet.

relates to: https://github.com/kubernetes/website/issues/13989