### PR TITLE
duplicated "Note: "

### DIFF
--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -252,7 +252,7 @@ uses the PVC before the expansion can complete.
 Expanding in-use PVCs for FlexVolumes is added in release 1.13. To enable this feature use  `ExpandInUsePersistentVolumes` and `ExpandPersistentVolumes` feature gates. The `ExpandPersistentVolumes` feature gate is already enabled by default. If the `ExpandInUsePersistentVolumes` is set, FlexVolume can be resized online without pod restart. 
  
 {{< note >}}
-**Note:** FlexVolume resize is possible only when the underlying driver supports resize.
+FlexVolume resize is possible only when the underlying driver supports resize.
 {{< /note >}}
 
 {{< note >}}


### PR DESCRIPTION
check current website [here](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#resizing-an-in-use-persistentvolumeclaim)

```
Note: Note: FlexVolume resize is possible only when the underlying driver supports resize.
```

There is a "Note: " already.
