### PR TITLE
Correction on command: kubeadm config print join-defaults

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
@@ -250,7 +250,7 @@ contain a `JoinConfiguration` structure.
 To print the default values of `JoinConfiguration` run the following command:
 
 ```shell
-kubeadm config print-default --api-objects=JoinConfiguration
+kubeadm config print join-defaults
 ```
 
 For details on individual fields in `JoinConfiguration` see [the godoc](https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm#JoinConfiguration).


### PR DESCRIPTION
`kubeadm config print join-defaults` since kubeadm 1.13
https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-config/#cmd-config-print-join-defaults