### PR TITLE
Fix func name PodResourcesLister

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
+++ b/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
@@ -148,7 +148,7 @@ The kubelet provides a gRPC service to enable discovery of in-use devices, and t
 for these devices:
 
 ```gRPC
-// PodResources is a service provided by the kubelet that provides information about the
+// PodResourcesLister is a service provided by the kubelet that provides information about the
 // node resources consumed by pods and containers on the node
 service PodResourcesLister {
     rpc List(ListPodResourcesRequest) returns (ListPodResourcesResponse) {}

--- a/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
+++ b/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
@@ -150,7 +150,7 @@ for these devices:
 ```gRPC
 // PodResources is a service provided by the kubelet that provides information about the
 // node resources consumed by pods and containers on the node
-service PodResources {
+service PodResourcesLister {
     rpc List(ListPodResourcesRequest) returns (ListPodResourcesResponse) {}
 }
 ```


### PR DESCRIPTION
The func PodResources is change to PodResourcesLister.
See this https://github.com/kubernetes/kubernetes/blob/release-1.14/pkg/kubelet/apis/podresources/v1alpha1/api.proto#L19
Please check.