### PR TITLE
[WIP] Added OWNERS for localization projects

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -112,6 +112,28 @@ aliases:
     - ClaudiaJKang
     - gochist
     - ianychoi
+  sig-docs-l10n-owners: # Owners for localization projects
+    - alexbrand # Spanish
+    - bene2k1 # German
+    - bradamant3 # English
+    - chenrui # Chinese
+    - ClaudiaJKang # Korean
+    - cstoku # Japanese
+    - daminisatya # Hindi
+    - femrtnz # Portuguese
+    - girikuncoro # Indonesian
+    - gochist # Korean
+    - hanjiayao # Chinese
+    - irvifa # Indonesian
+    - jaredbhatti # English
+    - jcjesus # Portuguese
+    - micheleberardi # Italian
+    - raelga # Spanish
+    - remyleone # French
+    - Rajakavitha1 # Hindi
+    - rlenferink # German, Italian
+    - tnir # Japanese
+    - zacharysarah # English
   sig-docs-maintainers: # Website maintainers
     - bradamant3
     - chenopis

--- a/i18n/OWNERS
+++ b/i18n/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+- sig-docs-l10n-owners
+
+approvers:
+- sig-docs-l10n-owners
+
+labels:
+- sig/docs


### PR DESCRIPTION
Added sig-docs-l10n-owners to the OWNERS_ALIASES and added a new OWNERS file to the i18n directory. This will enable localization teams to approve changes for content in the `/i18n/` directory.

xref. #14048 
/cc @zacharysarah 
/cc @kubernetes/sig-docs-l10n-admins 