### PR TITLE
Add content/es/docs/templates

### DIFF
--- a/content/es/docs/templates/feature-state-alpha.txt
+++ b/content/es/docs/templates/feature-state-alpha.txt
@@ -1,0 +1,7 @@
+La funcionalidad está actualmente en *alpha*:
+
+* El nombre de la versión contiene alpha (por ejemplo, v1alpha1)
+* No está completamente testeada, por lo que habilitar la funcionalidad puede exponer problemas. Se encuentra deshabilitada por defecto.
+* El soporte de la funcionalidad puede desestimarse en cualquier momento sin previo aviso.
+* La API puede romper la compatibilidad en releases posteriores sin previo aviso.
+* Se recomienda utilizar este tipo de funcionalidades únicamente en clústeres efímeros para testing, dado el elevado riesgo de problemas que puede provocar y la falta de soporte a larga plazo.

--- a/content/es/docs/templates/feature-state-beta.txt
+++ b/content/es/docs/templates/feature-state-beta.txt
@@ -1,0 +1,9 @@
+La funcionalidad está actualmente en *beta*:
+
+* El nombre de la versión contiene beta (por ejemplo, v2beta3)
+* El código está bien testeado y la funcionalidad se puede habilitar de forma segura. Se encuentra habilitada por defecto.
+* Se mantendrá el soporte sobre esta nueva funcionalidad, aunque algunos detalles pueden cambiar.
+* El esquema o la semántica de los objetos puede cambiar rompiendo la compatibilidad en futuras versiones. Cuando esto ocurre, se proporcionarán instrucciones para migrar a la siguiente versión. La migración puede implicar el borrado, edición o recreación de algunos objetos de la API. Este proceso puede conllevar la necesidad de planificar el cambio para aplicarlo de forma controlada y puede suponer una afectación del servicio en aplicaciones que utilicen la nueva funcionalidad.
+* Recomendado para usos que no sean críticos dado el riesgo de incompatibilidad con futuras versiones. Si tienes más de un clúster que puedas actualizar de forma independiente, se podría llegar a aplicar el proceso de migración sin que haya una pérdida de servicio.
+
+* **Por favor, prueba las funcionalidades en beta y reporta tu experiencia! Una vez salen de Beta, es posible que sea más difícil cambiar el comportamiento de la funcionalidad. **

--- a/content/es/docs/templates/feature-state-deprecated.txt
+++ b/content/es/docs/templates/feature-state-deprecated.txt
@@ -1,0 +1,1 @@
+La funcionalidad está *obsoleta*. Para más información sobre este estado, consulta la [Política de Obsolescencia en Kubernetes](/docs/reference/deprecation-policy/).

--- a/content/es/docs/templates/feature-state-stable.txt
+++ b/content/es/docs/templates/feature-state-stable.txt
@@ -1,0 +1,4 @@
+La funcionalidad es *estable*:
+
+* La versión es vX, donde X es un entero.
+* La versión estable de las funcionalidades estarán disponibles en el software distribuido por muchas versiones posteriores.

--- a/content/es/docs/templates/index.md
+++ b/content/es/docs/templates/index.md
@@ -1,0 +1,13 @@
+---
+headless: true
+
+resources:
+- src: "*alpha*"
+  title: "alpha"
+- src: "*beta*"
+  title: "beta"
+- src: "*deprecated*"
+  title: "obsoleta"
+- src: "*stable*"
+  title: "estable"
+---


### PR DESCRIPTION
This PR adds the feature state templates used in several documents across the site.

![image](https://user-images.githubusercontent.com/795289/57096962-c0a11100-6d16-11e9-80b8-cece587dbda5.png)

/cc @emedina 