### PR TITLE
Use sudo(8) to create directory and hosted file

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
@@ -41,11 +41,11 @@ shell to your Node by entering `minikube ssh`.
 
 In your shell, create a `/mnt/data` directory:
 
-    mkdir /mnt/data
+    sudo mkdir /mnt/data
 
 In the `/mnt/data` directory, create an `index.html` file:
 
-    echo 'Hello from Kubernetes storage' > /mnt/data/index.html
+    sudo sh -c "echo 'Hello from Kubernetes storage' > /mnt/data/index.html"
 
 ## Create a PersistentVolume
 


### PR DESCRIPTION
*minikube ssh* logs into the cluster as user 'docker'. The user 'docker' (uid=1000) does not have write permissions in /mnt to create a new directory and/or the example's HTML file. Use sudo(8) to create the directory as well as the HTML file nginx will ultimately serves.