### PR TITLE
Fix password example for kubectl create secret

### DIFF
--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -78,7 +78,7 @@ secret "db-user-pass" created
 {{< note >}}	
 Special characters such as `$`, `\*`, and `!` require escaping.	
 If the password you are using has special characters, you need to escape them using the `\\` character. For example, if your actual password is `S!B\*d$zDsb`, you should execute the command this way:	
-     kubectl create secret generic dev-db-secret --from-literal=username=devuser --from-literal=password=S\\!B\\\*d\\$zDsb	
+     kubectl create secret generic dev-db-secret --from-literal=username=devuser --from-literal=password=S\\!B\\\\*d\\$zDsb	
  You do not need to escape special characters in passwords from files (`--from-file`).	
 {{< /note >}}
 


### PR DESCRIPTION
Add extra '\\' to properly escape '\\' for --from-literal example.
