### PR TITLE
Update Corefile to conform to coredns 1.5.0

### DIFF
--- a/content/en/docs/tasks/administer-cluster/dns-custom-nameservers.md
+++ b/content/en/docs/tasks/administer-cluster/dns-custom-nameservers.md
@@ -82,7 +82,7 @@ data:
            fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153
-        proxy . /etc/resolv.conf
+        forward . /etc/resolv.conf
         cache 30
         loop
         reload


### PR DESCRIPTION
`proxy` is not supported anymore, use `forward`

See https://github.com/kubernetes/website/pull/13826/files
