### PR TITLE
Fix apiversion for apiVersion

### DIFF
--- a/content/en/docs/concepts/cluster-administration/manage-deployment.md
+++ b/content/en/docs/concepts/cluster-administration/manage-deployment.md
@@ -307,7 +307,7 @@ kubectl annotate pods my-nginx-v4-9gw19 description='my frontend running nginx'
 kubectl get pods my-nginx-v4-9gw19 -o yaml
 ```
 ```shell
-apiversion: v1
+apiVersion: v1
 kind: pod
 metadata:
   annotations:


### PR DESCRIPTION
There is a typo on sample of yaml output.
This fixes it by replacing apiversion with apiVersion.

ref: https://github.com/kubernetes/website/issues/13862
