### PR TITLE
Fix orders of yaml of services-networking/ingress

### DIFF
--- a/content/en/docs/concepts/services-networking/ingress.md
+++ b/content/en/docs/concepts/services-networking/ingress.md
@@ -305,13 +305,13 @@ and private key to use for TLS, e.g.:
 
 ```yaml
 apiVersion: v1
-data:
-  tls.crt: base64 encoded cert
-  tls.key: base64 encoded key
 kind: Secret
 metadata:
   name: testsecret-tls
   namespace: default
+data:
+  tls.crt: base64 encoded cert
+  tls.key: base64 encoded key
 type: kubernetes.io/tls
 ```
 


### PR DESCRIPTION
The order of kind and metadata were inconsistent, and that made the
doc unreadable.
This fixes the orders in consistent way in ingress.md

ref: https://github.com/kubernetes/website/issues/13862