### PR TITLE
Add Ref to shared process namespaces

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/communicate-containers-same-pod-shared-volume.md
+++ b/content/en/docs/tasks/access-application-cluster/communicate-containers-same-pod-shared-volume.md
@@ -7,7 +7,7 @@ weight: 110
 {{% capture overview %}}
 
 This page shows how to use a Volume to communicate between two Containers running
-in the same Pod.
+in the same Pod. See also how to allow processes to communicate by [sharing process namespace](/docs/tasks/configure-pod-container/share-process-namespace/) between containers (Kubernetes server must be at or later than version v1.10).
 
 {{% /capture %}}
 
@@ -140,6 +140,8 @@ the shared Volume is lost.
 
 * See
 [Configuring a Pod to Use a Volume for Storage](/docs/tasks/configure-pod-container/configure-volume-storage/).
+
+* See [Configure a Pod to share process namespace between containers in a Pod](/docs/tasks/configure-pod-container/share-process-namespace/)
 
 * See [Volume](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#volume-v1-core).
 

--- a/content/en/docs/tasks/access-application-cluster/communicate-containers-same-pod-shared-volume.md
+++ b/content/en/docs/tasks/access-application-cluster/communicate-containers-same-pod-shared-volume.md
@@ -7,7 +7,7 @@ weight: 110
 {{% capture overview %}}
 
 This page shows how to use a Volume to communicate between two Containers running
-in the same Pod. See also how to allow processes to communicate by [sharing process namespace](/docs/tasks/configure-pod-container/share-process-namespace/) between containers (Kubernetes server must be at or later than version v1.10).
+in the same Pod. See also how to allow processes to communicate by [sharing process namespace](/docs/tasks/configure-pod-container/share-process-namespace/) between containers.
 
 {{% /capture %}}
 


### PR DESCRIPTION
The documentation talking about ways containers can talk to each other within a pod should include shared process namespace as a method and refer to the documentation talking about sharing process namespace

