### PR TITLE
Update Cilium version in installation guide

### DIFF
--- a/content/en/docs/setup/independent/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/independent/create-cluster-kubeadm.md
@@ -320,7 +320,7 @@ kubectl taint nodes <node-name> node-role.kubernetes.io/master:NoSchedule-
 To deploy Cilium you just need to run:
 
 ```shell
-kubectl create -f https://raw.githubusercontent.com/cilium/cilium/v1.4/examples/kubernetes/1.13/cilium.yaml
+kubectl create -f https://raw.githubusercontent.com/cilium/cilium/v1.5/examples/kubernetes/1.14/cilium.yaml
 ```
 
 Once all Cilium pods are marked as `READY`, you start using your cluster.


### PR DESCRIPTION
This PR updates Cilium to v1.5 which was released eight days ago.

Also, it updates k8s manifests version to v1.14, as the latest kubeadm installs k8s v1.14.

The Cilium v1.5 changelog:
- https://github.com/cilium/cilium/releases/tag/v1.5.0
- https://cilium.io/blog/2019/04/24/cilium-15