### PR TITLE
Update Cilium version

### DIFF
--- a/content/en/docs/tasks/administer-cluster/network-policy-provider/cilium-network-policy.md
+++ b/content/en/docs/tasks/administer-cluster/network-policy-provider/cilium-network-policy.md
@@ -45,7 +45,7 @@ DaemonSet configurations for Cilium, and the necessary configurations to connect
 to the etcd instance deployed in minikube as well as appropriate RBAC settings:
 
 ```shell
-kubectl create -f  https://raw.githubusercontent.com/cilium/cilium/v1.4/examples/kubernetes/1.13/cilium-minikube.yaml
+kubectl create -f  https://raw.githubusercontent.com/cilium/cilium/v1.5/examples/kubernetes/1.14/cilium-minikube.yaml
 ```
 ```
 configmap/cilium-config created


### PR DESCRIPTION
This commit updates Cilium to v1.5 which was released
eight days ago.

The v1.5 changelog:
- https://github.com/cilium/cilium/releases/tag/v1.5.0
- https://cilium.io/blog/2019/04/24/cilium-15