### PR TITLE
Fix orders of yaml of concepts/storage/*

### DIFF
--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -198,8 +198,8 @@ the following types of volumes:
 You can only expand a PVC if its storage class's `allowVolumeExpansion` field is set to true.
 
 ``` yaml
-kind: StorageClass
 apiVersion: storage.k8s.io/v1
+kind: StorageClass
 metadata:
   name: gluster-vol-default
 provisioner: kubernetes.io/glusterfs
@@ -442,8 +442,8 @@ The CLI will show the name of the PVC bound to the PV.
 Each PVC contains a spec and status, which is the specification and status of the claim.
 
 ```yaml
-kind: PersistentVolumeClaim
 apiVersion: v1
+kind: PersistentVolumeClaim
 metadata:
   name: myclaim
 spec:
@@ -531,8 +531,8 @@ it won't be supported in a future Kubernetes release.
 Pods access storage by using the claim as a volume.  Claims must exist in the same namespace as the pod using the claim.  The cluster finds the claim in the pod's namespace and uses it to get the `PersistentVolume` backing the claim.  The volume is then mounted to the host and into the pod.
 
 ```yaml
-kind: Pod
 apiVersion: v1
+kind: Pod
 metadata:
   name: mypod
 spec:

--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -45,8 +45,8 @@ request any particular class to bind to: see the
 for details.
 
 ```yaml
-kind: StorageClass
 apiVersion: storage.k8s.io/v1
+kind: StorageClass
 metadata:
   name: standard
 provisioner: kubernetes.io/aws-ebs
@@ -167,8 +167,8 @@ zones and should be used as a replacement for the `zone` and `zones` parameters 
 supported plugins.
 
 ```yaml
-kind: StorageClass
 apiVersion: storage.k8s.io/v1
+kind: StorageClass
 metadata:
   name: standard
 provisioner: kubernetes.io/gce-pd
@@ -194,8 +194,8 @@ used.
 ### AWS EBS
 
 ```yaml
-kind: StorageClass
 apiVersion: storage.k8s.io/v1
+kind: StorageClass
 metadata:
   name: slow
 provisioner: kubernetes.io/aws-ebs
@@ -236,8 +236,8 @@ parameters:
 ### GCE PD
 
 ```yaml
-kind: StorageClass
 apiVersion: storage.k8s.io/v1
+kind: StorageClass
 metadata:
   name: slow
 provisioner: kubernetes.io/gce-pd
@@ -356,8 +356,8 @@ parameters:
 ### OpenStack Cinder
 
 ```yaml
-kind: StorageClass
 apiVersion: storage.k8s.io/v1
+kind: StorageClass
 metadata:
   name: gold
 provisioner: kubernetes.io/cinder
@@ -378,8 +378,8 @@ This internal provisioner of OpenStack is deprecated. Please use [the external c
 1. Create a StorageClass with a user specified disk format.
 
     ```yaml
-    kind: StorageClass
     apiVersion: storage.k8s.io/v1
+    kind: StorageClass
     metadata:
       name: fast
     provisioner: kubernetes.io/vsphere-volume
@@ -392,8 +392,8 @@ This internal provisioner of OpenStack is deprecated. Please use [the external c
 2. Create a StorageClass with a disk format on a user specified datastore.
 
     ```yaml
-    kind: StorageClass
     apiVersion: storage.k8s.io/v1
+    kind: StorageClass
     metadata:
       name: fast
     provisioner: kubernetes.io/vsphere-volume
@@ -446,8 +446,8 @@ which you try out for persistent volume management inside Kubernetes for vSphere
 ### Ceph RBD
 
 ```yaml
-kind: StorageClass
 apiVersion: storage.k8s.io/v1
+kind: StorageClass
 metadata:
   name: fast
 provisioner: kubernetes.io/rbd
@@ -544,8 +544,8 @@ parameters:
 #### Azure Unmanaged Disk Storage Class
 
 ```yaml
-kind: StorageClass
 apiVersion: storage.k8s.io/v1
+kind: StorageClass
 metadata:
   name: slow
 provisioner: kubernetes.io/azure-disk
@@ -565,8 +565,8 @@ parameters:
 #### New Azure Disk Storage Class (starting from v1.7.2)
 
 ```yaml
-kind: StorageClass
 apiVersion: storage.k8s.io/v1
+kind: StorageClass
 metadata:
   name: slow
 provisioner: kubernetes.io/azure-disk
@@ -592,8 +592,8 @@ parameters:
 ### Azure File
 
 ```yaml
-kind: StorageClass
 apiVersion: storage.k8s.io/v1
+kind: StorageClass
 metadata:
   name: azurefile
 provisioner: kubernetes.io/azure-file
@@ -620,8 +620,8 @@ add the `create` permission of resource `secret` for clusterrole
 ### Portworx Volume
 
 ```yaml
-kind: StorageClass
 apiVersion: storage.k8s.io/v1
+kind: StorageClass
 metadata:
   name: portworx-io-priority-high
 provisioner: kubernetes.io/portworx-volume
@@ -655,8 +655,8 @@ parameters:
 ### ScaleIO
 
 ```yaml
-kind: StorageClass
 apiVersion: storage.k8s.io/v1
+kind: StorageClass
 metadata:
   name: slow
 provisioner: kubernetes.io/scaleio
@@ -696,8 +696,8 @@ kubectl create secret generic sio-secret --type="kubernetes.io/scaleio" \
 ### StorageOS
 
 ```yaml
-kind: StorageClass
 apiVersion: storage.k8s.io/v1
+kind: StorageClass
 metadata:
   name: fast
 provisioner: kubernetes.io/storageos
@@ -747,8 +747,8 @@ references it.
 {{< feature-state for_k8s_version="v1.14" state="stable" >}}
 
 ```yaml
-kind: StorageClass
 apiVersion: storage.k8s.io/v1
+kind: StorageClass
 metadata:
   name: local-storage
 provisioner: kubernetes.io/no-provisioner


### PR DESCRIPTION
The orders of kind and metadata were inconsistent, and that made the
doc unreadable.
This fixes the orders in consistent way under concepts/storage/.

ref: https://github.com/kubernetes/website/issues/13862