### PR TITLE
Fix orders of yaml of pods/init-containers.md

### DIFF
--- a/content/en/docs/concepts/workloads/pods/init-containers.md
+++ b/content/en/docs/concepts/workloads/pods/init-containers.md
@@ -156,8 +156,8 @@ spec:
 Yaml file below outlines the `mydb` and `myservice` services:
 
 ```yaml
-kind: Service
 apiVersion: v1
+kind: Service
 metadata:
   name: myservice
 spec:
@@ -166,8 +166,8 @@ spec:
     port: 80
     targetPort: 9376
 ---
-kind: Service
 apiVersion: v1
+kind: Service
 metadata:
   name: mydb
 spec:


### PR DESCRIPTION
The orders of kind and metadata were inconsistent, and that made the
doc unreadable.
This fixes the orders in consistent way under pods/init-containers.md.

ref: https://github.com/kubernetes/website/issues/13862
