### PR TITLE
Fix glossary tooltip mismatch

### DIFF
--- a/layouts/shortcodes/glossary_tooltip.html
+++ b/layouts/shortcodes/glossary_tooltip.html
@@ -5,7 +5,7 @@
 {{- if not $glossary_items -}}
 {{- errorf "[%s] No glossary items found" site.Language.Lang -}}
 {{- else -}}
-{{- $term_info := $glossary_items.GetMatch (printf "%s*" $id ) -}}
+{{- $term_info := $glossary_items.GetMatch (printf "%s.md" $id ) -}}
 {{- if not $term_info -}}
 {{- errorf "[%s] %q: %q is not a valid glossary term_id, see ./docs/reference/glossary/* for a full list" site.Language.Lang .Page.Path $id -}}
 {{- end }}


### PR DESCRIPTION
To fix #14226. (I found #12608 is related too)

I modified 

https://github.com/kubernetes/website/blob/0fe73a189015e20d826341ed7bd5d214612ecfdc/layouts/shortcodes/glossary_tooltip.html#L8 

from not exact match ("%s*") to exact match ("%s.md").


