### PR TITLE
Fix orders of yaml of reference/kube*

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping.md
+++ b/content/en/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping.md
@@ -191,8 +191,8 @@ To do this, you just need to create a `ClusterRoleBinding` that binds the `syste
 
 ```
 # enable bootstrapping nodes to create CSR
-kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
   name: create-csrs-for-bootstrapping
 subjects:
@@ -259,8 +259,8 @@ To enable the kubelet to request and receive a new certificate, create a `Cluste
 
 ```yml
 # Approve all CSRs for the group "system:bootstrappers"
-kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
   name: auto-approve-csrs-for-group
 subjects:
@@ -278,8 +278,8 @@ grants it permission, `system:certificates.k8s.io:certificatesigningrequests:sel
 
 ```yml
 # Approve renewal CSRs for the group "system:nodes"
-kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
   name: auto-approve-renewals-for-nodes
 subjects:
@@ -299,8 +299,8 @@ To create the `ClusterRole`s:
 ```yml
 # A ClusterRole which instructs the CSR approver to approve a user requesting
 # node client credentials.
-kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
   name: system:certificates.k8s.io:certificatesigningrequests:nodeclient
 rules:
@@ -310,8 +310,8 @@ rules:
 ---
 # A ClusterRole which instructs the CSR approver to approve a node renewing its
 # own client credentials.
-kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
   name: system:certificates.k8s.io:certificatesigningrequests:selfnodeclient
 rules:
@@ -348,6 +348,7 @@ Its format is identical to a normal `kubeconfig` file. A sample file might look 
 
 ```yml
 apiVersion: v1
+kind: Config
 clusters:
 - cluster:
     certificate-authority: /var/lib/kubernetes/ca.pem
@@ -359,7 +360,6 @@ contexts:
     user: kubelet-bootstrap
   name: bootstrap
 current-context: bootstrap
-kind: Config
 preferences: {}
 users:
 - name: kubelet-bootstrap

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
@@ -214,6 +214,7 @@ it off regardless. Doing so will disable the ability to use the `--discovery-tok
 ```shell
 kubectl -n kube-public get cm cluster-info -o yaml | grep "kubeconfig:" -A11 | grep "apiVersion" -A10 | sed "s/    //" | tee cluster-info.yaml
 apiVersion: v1
+kind: Config
 clusters:
 - cluster:
     certificate-authority-data: <ca-cert>
@@ -221,7 +222,6 @@ clusters:
   name: ""
 contexts: []
 current-context: ""
-kind: Config
 preferences: {}
 users: []
 ```


### PR DESCRIPTION
The orders of kind and metadata were inconsistent, and that made the
doc unreadable.
This fixes the orders in consistent way.

ref: https://github.com/kubernetes/website/issues/13862