### PR TITLE
ingress: Use networking.k8s.io/v1beta1 in Ingress examples

### DIFF
--- a/content/en/docs/concepts/services-networking/ingress.md
+++ b/content/en/docs/concepts/services-networking/ingress.md
@@ -73,7 +73,7 @@ Make sure you review your ingress controller's documentation to understand the c
 A minimal ingress resource example:
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: test-ingress
@@ -169,7 +169,7 @@ foo.bar.com -> 178.91.123.132 -> / foo    service1:4200
 would require an Ingress such as:
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: simple-fanout-example
@@ -239,7 +239,7 @@ The following Ingress tells the backing loadbalancer to route requests based on
 the [Host header](https://tools.ietf.org/html/rfc7230#section-5.4).
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: name-virtual-host-ingress
@@ -267,7 +267,7 @@ to the IP address without a hostname defined in request (that is, without a requ
 presented) to `service3`.
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: name-virtual-host-ingress
@@ -321,7 +321,7 @@ sure the TLS secret you created came from a certificate that contains a CN
 for `sslexample.foo.com`.
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: tls-example-ingress

--- a/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -137,7 +137,7 @@ The following file is an Ingress resource that sends traffic to your Service via
 
       ```yaml    
         ---
-        apiVersion: extensions/v1beta1
+        apiVersion: networking.k8s.io/v1beta1
         kind: Ingress
         metadata:
           name: example-ingress

--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -271,7 +271,7 @@ object:
   metric:
     name: requests-per-second
   describedObject:
-    apiVersion: extensions/v1beta1
+    apiVersion: networking.k8s.io/v1beta1
     kind: Ingress
     name: main-route
   target:
@@ -316,7 +316,7 @@ spec:
       metric:
         name: requests-per-second
       describedObject:
-        apiVersion: extensions/v1beta1
+        apiVersion: networking.k8s.io/v1beta1
         kind: Ingress
         name: main-route
       target:
@@ -339,7 +339,7 @@ status:
       metric:
         name: requests-per-second
       describedObject:
-        apiVersion: extensions/v1beta1
+        apiVersion: networking.k8s.io/v1beta1
         kind: Ingress
         name: main-route
       current:

--- a/content/en/examples/service/networking/ingress.yaml
+++ b/content/en/examples/service/networking/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: test-ingress

--- a/content/id/docs/concepts/services-networking/ingress.md
+++ b/content/id/docs/concepts/services-networking/ingress.md
@@ -72,7 +72,7 @@ Pastikan kamu sudah terlebih dahulu memahami dokumentasi kontroler Ingress yang 
 Berikut ini merupakan salah satu contoh konfigurasi Ingress yang minimum:
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: test-ingress
@@ -167,7 +167,7 @@ foo.bar.com -> 178.91.123.132 -> / foo    service1:4200
 akan memerlukan konfigurasi Ingress seperti:
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: simple-fanout-example
@@ -236,7 +236,7 @@ Ingress di bawah ini memberikan perintah pada *loadbalancer* untuk melakukan mek
 [header host](https://tools.ietf.org/html/rfc7230#section-5.4).
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: name-virtual-host-ingress
@@ -264,7 +264,7 @@ dari `first.bar.com` ke `service1`, `second.foo.com` ke `service2`, dan trafik l
 ke alamat IP tanpa *host name* yang didefinisikan di dalam *request* (yang tidak memiliki *request header*) ke `service3`.
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: name-virtual-host-ingress
@@ -317,7 +317,7 @@ Kamu harus memastikan *secret* TLS yang digunakan memiliki sertifikat yang menga
 CN untuk `sslexample.foo.com`.
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: tls-example-ingress

--- a/content/id/examples/service/networking/ingress.yaml
+++ b/content/id/examples/service/networking/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: test-ingress

--- a/content/ja/examples/service/networking/ingress.yaml
+++ b/content/ja/examples/service/networking/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: test-ingress

--- a/content/ko/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/ko/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -231,7 +231,7 @@ object:
   metric:
     name: requests-per-second
   describedObject:
-    apiVersion: extensions/v1beta1
+    apiVersion: networking.k8s.io/v1beta1
     kind: Ingress
     name: main-route
   target:
@@ -273,7 +273,7 @@ spec:
       metric:
         name: requests-per-second
       describedObject:
-        apiVersion: extensions/v1beta1
+        apiVersion: networking.k8s.io/v1beta1
         kind: Ingress
         name: main-route
       target:
@@ -296,7 +296,7 @@ status:
       metric:
         name: requests-per-second
       describedObject:
-        apiVersion: extensions/v1beta1
+        apiVersion: networking.k8s.io/v1beta1
         kind: Ingress
         name: main-route
       current:

--- a/content/zh/docs/concepts/services-networking/ingress.yaml
+++ b/content/zh/docs/concepts/services-networking/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: test-ingress

--- a/content/zh/docs/user-guide/ingress.yaml
+++ b/content/zh/docs/user-guide/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: test-ingress


### PR DESCRIPTION
This patch swaps all uses with extensions/v1beta1 with the new
networking.k8s.io/v1beta1 apiVersion for the Ingress resource.

Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

**Notes for Reviewer**
- This flip already happened in 1.14
- I did not update any of the blog post pages, but I can if needed

Related: kubernetes/enhancements#758
