### PR TITLE
Fix orders of yaml for tasks/administer-cluster/[a-k]*.go

### DIFF
--- a/content/en/docs/tasks/administer-cluster/declare-network-policy.md
+++ b/content/en/docs/tasks/administer-cluster/declare-network-policy.md
@@ -90,8 +90,8 @@ Connecting to nginx (10.100.0.16:80)
 Let's say you want to limit access to the `nginx` service so that only pods with the label `access: true` can query it. To do that, create a `NetworkPolicy` that allows connections only from those pods:
 
 ```yaml
-kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
 metadata:
   name: access-nginx
 spec:

--- a/content/en/docs/tasks/administer-cluster/encrypt-data.md
+++ b/content/en/docs/tasks/administer-cluster/encrypt-data.md
@@ -33,8 +33,8 @@ The alpha version of the encryption feature prior to 1.13 used the `--experiment
 ## Understanding the encryption at rest configuration.
 
 ```yaml
-kind: EncryptionConfiguration
 apiVersion: apiserver.config.k8s.io/v1
+kind: EncryptionConfiguration
 resources:
   - resources:
     - secrets
@@ -97,8 +97,8 @@ is the first provider, the first key is used for encryption.
 Create a new encryption config file:
 
 ```yaml
-kind: EncryptionConfiguration
 apiVersion: apiserver.config.k8s.io/v1
+kind: EncryptionConfiguration
 resources:
   - resources:
     - secrets
@@ -190,8 +190,8 @@ With a single `kube-apiserver`, step 2 may be skipped.
 To disable encryption at rest place the `identity` provider as the first entry in the config:
 
 ```yaml
-kind: EncryptionConfiguration
 apiVersion: apiserver.config.k8s.io/v1
+kind: EncryptionConfiguration
 resources:
   - resources:
     - secrets

--- a/content/en/docs/tasks/administer-cluster/kms-provider.md
+++ b/content/en/docs/tasks/administer-cluster/kms-provider.md
@@ -80,8 +80,8 @@ To encrypt the data:
 1. Create a new encryption configuration file using the appropriate properties for the `kms` provider:
 
 ```yaml
-kind: EncryptionConfiguration
 apiVersion: apiserver.config.k8s.io/v1
+kind: EncryptionConfiguration
 resources:
   - resources:
     - secrets
@@ -136,8 +136,8 @@ To switch from a local encryption provider to the `kms` provider and re-encrypt 
 1. Add the `kms` provider as the first entry in the configuration file as shown in the following example.
 
 ```yaml
-kind: EncryptionConfiguration
 apiVersion: apiserver.config.k8s.io/v1
+kind: EncryptionConfiguration
 resources:
   - resources:
     - secrets
@@ -166,8 +166,8 @@ To disable encryption at rest:
 1. Place the `identity` provider as the first entry in the configuration file: 
 
 ```yaml
-kind: EncryptionConfiguration
 apiVersion: apiserver.config.k8s.io/v1
+kind: EncryptionConfiguration
 resources:
   - resources:
     - secrets

--- a/content/en/docs/tasks/administer-cluster/kubelet-config-file.md
+++ b/content/en/docs/tasks/administer-cluster/kubelet-config-file.md
@@ -37,8 +37,8 @@ in this struct. Make sure the Kubelet has read permissions on the file.
 
 Here is an example of what this file might look like:
 ```
-kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
 evictionHard:
     memory.available:  "200Mi"
 ```

--- a/content/en/examples/admin/sched/my-scheduler.yaml
+++ b/content/en/examples/admin/sched/my-scheduler.yaml
@@ -4,8 +4,8 @@ metadata:
   name: my-scheduler
   namespace: kube-system
 ---
-kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
   name: my-scheduler-as-kube-scheduler
 subjects:


### PR DESCRIPTION
The orders of kind were inconsistent, and that made the doc unreadable.
This fixes the orders in consistent way in the following files.

- configure-multiple-schedulers.md (admin/sched/my-scheduler.yaml)
- declare-network-policy.md
- encrypt-data.md
- kms-provider.md
- kubelet-config-file.md

ref: #13862