### PR TITLE
fix orders in yaml and json for multiple-zones.md

### DIFF
--- a/content/en/docs/setup/multiple-zones.md
+++ b/content/en/docs/setup/multiple-zones.md
@@ -191,8 +191,8 @@ Create a volume using the dynamic volume creation (only PersistentVolumes are su
 ```json
 kubectl apply -f - <<EOF
 {
-  "kind": "PersistentVolumeClaim",
   "apiVersion": "v1",
+  "kind": "PersistentVolumeClaim",
   "metadata": {
     "name": "claim1",
     "annotations": {
@@ -241,8 +241,8 @@ this means that this pod can only be created in the same zone as the volume:
 
 ```yaml
 kubectl apply -f - <<EOF
-kind: Pod
 apiVersion: v1
+kind: Pod
 metadata:
   name: mypod
 spec:


### PR DESCRIPTION
The order of kind and data were inconsistent, and that made the doc unreadable.
This fixes the orders in consistent way in setup/rmultiple-zones.md.

ref: #13862