### PR TITLE
Check all commits in branch for examples (to trigger testing)

### DIFF
--- a/scripts/test_examples.sh
+++ b/scripts/test_examples.sh
@@ -13,8 +13,8 @@ if printf -- '%s\n' "${FILES[@]}" | grep -qE '^"?content/[^/]+/examples/'; then
 fi
 
 function install() {
-  if [[ $TEST_EXAMPLES == No ]]; then
-    echo "PR not touching examples, skipping example tests install"
+  if ! [[ $TEST_EXAMPLES == Yes ]]; then
+    echo "PR not touching examples, skipping example tests install" 1>&2
     exit 0
   fi
 
@@ -39,8 +39,8 @@ function install() {
 }
 
 function run_test() {
-  if [[ $TEST_EXAMPLES == No ]]; then
-    echo "PR not touching examples, skipping example tests execution"
+  if ! [[ $TEST_EXAMPLES == Yes ]]; then
+    echo "PR not touching examples, skipping example tests execution" 1>&2
     exit 0
   fi
   go test -v k8s.io/website/content/en/examples

--- a/scripts/test_examples.sh
+++ b/scripts/test_examples.sh
@@ -3,17 +3,14 @@
 set -e
 
 # List files changed in the commit to check
-FILES=`git log -n 2 --name-only --format=""`
+FILES=($( git diff "$( git merge-base --fork-point master )" --name-only ))
 
 TEST_EXAMPLES=No
 
-# Currently examine en directory only, can extend to other lang when neded
-for f in $FILES; do
-  if [[ $f =~ "content/en/examples/" ]]; then
+# Check if examples folders (all locales) change in this branch
+if printf -- '%s\n' "${FILES[@]}" | grep -qE '^"?content/[^/]+/examples/'; then
     TEST_EXAMPLES=Yes
-    break
-  fi
-done
+fi
 
 function install() {
   if [[ $TEST_EXAMPLES == No ]]; then


### PR DESCRIPTION
In #14147 @tengqm pointing out that that PR should have _failed_ CI testing for not adding the changed examples to a list of test cases. It didn't.

This currently-draft PR is my take on a partial fix: it looks at the list of files changed on the current branch (since it diverged `master`) and checks if any of those are in any locale's `examples` folder.

At least, that's what I think it does.

/sig testing