### PR TITLE
Fix orders of yaml for tasks/administer-cluster/[l-z]*.go

### DIFF
--- a/content/en/docs/tasks/administer-cluster/reconfigure-kubelet.md
+++ b/content/en/docs/tasks/administer-cluster/reconfigure-kubelet.md
@@ -149,9 +149,6 @@ This is an example of a valid response:
 
 ```none
 apiVersion: v1
-data:
-  kubelet: |
-    {...}
 kind: ConfigMap
 metadata:
   creationTimestamp: 2017-09-14T20:23:33Z
@@ -160,6 +157,9 @@ metadata:
   resourceVersion: "119980"
   selfLink: /api/v1/namespaces/kube-system/configmaps/my-node-config-gkt4c2m4b2
   uid: 946d785e-998a-11e7-a8dd-42010a800006
+data:
+  kubelet: |
+    {...}
 ```
 
 The ConfigMap is created in the `kube-system` namespace because this

--- a/content/en/examples/admin/cloud/ccm-example.yaml
+++ b/content/en/examples/admin/cloud/ccm-example.yaml
@@ -10,8 +10,8 @@ metadata:
   name: cloud-controller-manager
   namespace: kube-system
 ---
-kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
   name: system:cloud-controller-manager
 roleRef:

--- a/content/en/examples/admin/namespace-dev.json
+++ b/content/en/examples/admin/namespace-dev.json
@@ -1,6 +1,6 @@
 {
-  "kind": "Namespace",
   "apiVersion": "v1",
+  "kind": "Namespace",
   "metadata": {
     "name": "development",
     "labels": {

--- a/content/en/examples/admin/namespace-prod.json
+++ b/content/en/examples/admin/namespace-prod.json
@@ -1,6 +1,6 @@
 {
-  "kind": "Namespace",
   "apiVersion": "v1",
+  "kind": "Namespace",
   "metadata": {
     "name": "production",
     "labels": {

--- a/content/en/examples/admin/resource/quota-objects-pvc-2.yaml
+++ b/content/en/examples/admin/resource/quota-objects-pvc-2.yaml
@@ -1,5 +1,5 @@
-kind: PersistentVolumeClaim
 apiVersion: v1
+kind: PersistentVolumeClaim
 metadata:
   name: pvc-quota-demo-2
 spec:

--- a/content/en/examples/admin/resource/quota-objects-pvc.yaml
+++ b/content/en/examples/admin/resource/quota-objects-pvc.yaml
@@ -1,5 +1,5 @@
-kind: PersistentVolumeClaim
 apiVersion: v1
+kind: PersistentVolumeClaim
 metadata:
   name: pvc-quota-demo
 spec:


### PR DESCRIPTION
The orders of kind and metadata were inconsistent, and that made the doc unreadable.
This fixes the orders in consistent way in the following files.

- namespaces.md (admin/namespace-dev.json)
- namespaces-walkthrough.md (admin/namespace-dev.json, admin/namespace-prod.json)
- quota-api-object.md (admin/resource/quota-objects-pvc.yaml, admin/resource/quota-objects-pvc-2.yaml)
- reconfigure-kubelet.md
- running-cloud-controller.md (admin/cloud/ccm-example.yaml)

ref: #13862