### PR TITLE
delete unnecessary space and character in sample yaml

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/configure-access-multiple-clusters.md
+++ b/content/en/docs/tasks/access-application-cluster/configure-access-multiple-clusters.md
@@ -262,12 +262,12 @@ For example:
 
 ### Linux
 ```shell
-export  KUBECONFIG_SAVED=$KUBECONFIG
+export KUBECONFIG_SAVED=$KUBECONFIG
 ```
 ### Windows PowerShell
 ```shell
- $Env:KUBECONFIG_SAVED=$ENV:KUBECONFIG
- ```
+$Env:KUBECONFIG_SAVED=$ENV:KUBECONFIG
+```
  The `KUBECONFIG` environment variable is a list of paths to configuration files. The list is
 colon-delimited for Linux and Mac, and semicolon-delimited for Windows. If you have
 a `KUBECONFIG` environment variable, familiarize yourself with the configuration files
@@ -277,7 +277,7 @@ Temporarily append two paths to your `KUBECONFIG` environment variable. For exam
 
 ### Linux
 ```shell
-export  KUBECONFIG=$KUBECONFIG:config-demo:config-demo-2
+export KUBECONFIG=$KUBECONFIG:config-demo:config-demo-2
 ```
 ### Windows PowerShell
 ```shell
@@ -344,7 +344,7 @@ export KUBECONFIG=$KUBECONFIG:$HOME/.kube/config
 ```
 ### Windows Powershell
 ```shell
- $Env:KUBECONFIG=($Env:KUBECONFIG;$HOME/.kube/config)
+$Env:KUBECONFIG=($Env:KUBECONFIG;$HOME/.kube/config)
 ```
 
 View configuration information merged from all the files that are now listed
@@ -363,7 +363,7 @@ export KUBECONFIG=$KUBECONFIG_SAVED
 ```
 Windows PowerShell
 ```shell
- $Env:KUBECONFIG=$ENV:KUBECONFIG_SAVED
+$Env:KUBECONFIG=$ENV:KUBECONFIG_SAVED
 ```
 
 {{% /capture %}}

--- a/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -135,24 +135,23 @@ The following file is an Ingress resource that sends traffic to your Service via
 
 1. Create `example-ingress.yaml` from the following file:
 
-      ```yaml    
-        ---
-        apiVersion: networking.k8s.io/v1beta1
-        kind: Ingress
-        metadata:
-          name: example-ingress
-          annotations:
-            nginx.ingress.kubernetes.io/rewrite-target: /
-        spec:
-         rules:
-         - host: hello-world.info
-           http:
-             paths:
-             - path: /*
-               backend:
-                 serviceName: web
-                 servicePort: 8080
-      ```
+    ```yaml
+    apiVersion: networking.k8s.io/v1beta1
+    kind: Ingress
+    metadata:
+      name: example-ingress
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: /
+    spec:
+     rules:
+     - host: hello-world.info
+       http:
+         paths:
+         - path: /*
+           backend:
+             serviceName: web
+             servicePort: 8080
+    ```
 
 1. Create the Ingress resource by running the following command:
     
@@ -232,12 +231,12 @@ The following file is an Ingress resource that sends traffic to your Service via
 
 1. Edit the existing `example-ingress.yaml` and add the following lines:  
 
-      ```yaml
-        - path: /v2/*
-          backend:
-            serviceName: web2
-            servicePort: 8080
-      ```
+    ```yaml
+         - path: /v2/*
+           backend:
+             serviceName: web2
+             servicePort: 8080
+    ```
 
 1. Apply the changes:
 


### PR DESCRIPTION
Some sample yaml and command line included unnecessary space and character, and that made the doc unreadable and kubectl apply failure.
This PR deletes that in tasks/access-application-cluster/*.

ref: #13862
