### PR TITLE
Temp fix for more reliable builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ functions-build:
 check-headers-file:
 	scripts/check-headers-file.sh
 
-production-build: test-examples check-hugo-versions build check-headers-file ## Build the production site and ensure that noindex headers aren't added
+production-build: check-hugo-versions build check-headers-file ## Build the production site and ensure that noindex headers aren't added
 
 non-production-build: test-examples check-hugo-versions ## Build the non-production site, which adds noindex headers to prevent indexing
 	hugo --enableGitInfo


### PR DESCRIPTION
We have a test in our makefile that has been preventing builds if any files in `content/en/examples` are changed. This is mainly due to our deprecation of Travis and missing variables.

This PR removes the test to allow more reliable builds, however it doesn't fix the root problem and reduces the testing surface on k/website.

I'm looking for @lucperkins to suggest a long term fix.

/cc @zacharysarah