### PR TITLE
Fix bad for in short options

### DIFF
--- a/content/en/docs/reference/kubectl/overview.md
+++ b/content/en/docs/reference/kubectl/overview.md
@@ -166,48 +166,48 @@ The default output format for all `kubectl` commands is the human readable plain
 #### Syntax
 
 ```shell
-kubectl [command] [TYPE] [NAME] -o=<output_format>
+kubectl [command] [TYPE] [NAME] -o <output_format>
 ```
 
 Depending on the `kubectl` operation, the following output formats are supported:
 
 Output format | Description
 --------------| -----------
-`-o=custom-columns=<spec>` | Print a table using a comma separated list of [custom columns](#custom-columns).
-`-o=custom-columns-file=<filename>` | Print a table using the [custom columns](#custom-columns) template in the `<filename>` file.
-`-o=json`     | Output a JSON formatted API object.
-`-o=jsonpath=<template>` | Print the fields defined in a [jsonpath](/docs/reference/kubectl/jsonpath/) expression.
-`-o=jsonpath-file=<filename>` | Print the fields defined by the [jsonpath](/docs/reference/kubectl/jsonpath/) expression in the `<filename>` file.
-`-o=name`     | Print only the resource name and nothing else.
-`-o=wide`     | Output in the plain-text format with any additional information. For pods, the node name is included.
-`-o=yaml`     | Output a YAML formatted API object.
+`-o custom-columns=<spec>` | Print a table using a comma separated list of [custom columns](#custom-columns).
+`-o custom-columns-file=<filename>` | Print a table using the [custom columns](#custom-columns) template in the `<filename>` file.
+`-o json`     | Output a JSON formatted API object.
+`-o jsonpath=<template>` | Print the fields defined in a [jsonpath](/docs/reference/kubectl/jsonpath/) expression.
+`-o jsonpath-file=<filename>` | Print the fields defined by the [jsonpath](/docs/reference/kubectl/jsonpath/) expression in the `<filename>` file.
+`-o name`     | Print only the resource name and nothing else.
+`-o wide`     | Output in the plain-text format with any additional information. For pods, the node name is included.
+`-o yaml`     | Output a YAML formatted API object.
 
 ##### Example
 
 In this example, the following command outputs the details for a single pod as a YAML formatted object:
 
 ```shell
-kubectl get pod web-pod-13je7 -o=yaml
+kubectl get pod web-pod-13je7 -o yaml
 ```
 
 Remember: See the [kubectl](/docs/user-guide/kubectl/) reference documentation for details about which output format is supported by each command.
 
 #### Custom columns
 
-To define custom columns and output only the details that you want into a table, you can use the `custom-columns` option. You can choose to define the custom columns inline or use a template file: `-o=custom-columns=<spec>` or `-o=custom-columns-file=<filename>`.
+To define custom columns and output only the details that you want into a table, you can use the `custom-columns` option. You can choose to define the custom columns inline or use a template file: `-o custom-columns=<spec>` or `-o custom-columns-file=<filename>`.
 
 ##### Examples
 
 Inline:
 
 ```shell
-kubectl get pods <pod-name> -o=custom-columns=NAME:.metadata.name,RSRC:.metadata.resourceVersion
+kubectl get pods <pod-name> -o custom-columns=NAME:.metadata.name,RSRC:.metadata.resourceVersion
 ```
 
 Template file:
 
 ```shell
-kubectl get pods <pod-name> -o=custom-columns-file=template.txt
+kubectl get pods <pod-name> -o custom-columns-file=template.txt
 ```
 
 where the `template.txt` file contains:


### PR DESCRIPTION
This one fixes issue #14211.

I just replaced `-o=parameter` instances with `-o parameter`.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> Please delete this note before submitting the pull request.
>
> For 1.15 Features: set Milestone to 1.15 and Base Branch to dev-1.15
> 
> For Chinese localization, base branch to release-1.12
>
> For Korean Localization: set Base Branch to dev-1.14-ko.\<latest team milestone>
>
> Help editing and submitting pull requests:
> https://kubernetes.io/docs/contribute/start/#improve-existing-content.
>
> Help choosing which branch to use:
> https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use.
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
