### PR TITLE
Fix orders of yaml of custom-resource-definitions

### DIFF
--- a/content/en/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions.md
+++ b/content/en/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions.md
@@ -142,6 +142,7 @@ from the yaml you used to create it:
 
 ```console
 apiVersion: v1
+kind: List
 items:
 - apiVersion: stable.example.com/v1
   kind: CronTab
@@ -156,7 +157,6 @@ items:
   spec:
     cronSpec: '* * * * */5'
     image: my-awesome-cron-image
-kind: List
 metadata:
   resourceVersion: ""
   selfLink: ""


### PR DESCRIPTION
The orders of kind and metadata were inconsistent, and that made the
doc unreadable.
This fixes the orders in consistent way.

ref: https://github.com/kubernetes/website/issues/13862