### PR TITLE
Fix yaml sample order of /debug-application-cluster

### DIFF
--- a/content/en/docs/tasks/debug-application-cluster/audit.md
+++ b/content/en/docs/tasks/debug-application-cluster/audit.md
@@ -392,6 +392,7 @@ different users into different files.
 
         cat <<EOF > /etc/kubernetes/audit-webhook-kubeconfig
         apiVersion: v1
+        kind: Config
         clusters:
         - cluster:
             server: http://<ip_of_logstash>:8888
@@ -402,7 +403,6 @@ different users into different files.
             user: ""
           name: default-context
         current-context: default-context
-        kind: Config
         preferences: {}
         users: []
         EOF


### PR DESCRIPTION
The orders of kind and metadata were inconsistent, and that made the
doc unreadable.
This fixes the orders in consistent way.

ref: https://github.com/kubernetes/website/issues/13862