### PR TITLE
Fix glossary entry for Docker

### DIFF
--- a/content/en/docs/reference/glossary/docker.md
+++ b/content/en/docs/reference/glossary/docker.md
@@ -1,18 +1,17 @@
 ---
-title: docker
+title: Docker
 id: docker
 date: 2018-04-12
-full_link: /docs/reference/kubectl/docker-cli-to-kubectl/
+full_link: https://docs.docker.com/engine/
 short_description: >
   Docker is a software technology providing operating-system-level virtualization also known as containers.
 
-aka: 
+aka:
 tags:
 - fundamental
 ---
- Docker is a software technology providing operating-system-level virtualization also known as containers.
+Docker (specifically, Docker Engine) is a software technology providing operating-system-level virtualization also known as {{< glossary_tooltip text="containers" term_id="container" >}}.
 
-<!--more--> 
+<!--more-->
 
-Docker uses the resource isolation features of the Linux kernel such as cgroups and kernel namespaces, and a union-capable file system such as OverlayFS and others to allow independent "containers" to run within a single Linux instance, avoiding the overhead of starting and maintaining virtual machines (VMs).
-
+Docker uses the resource isolation features of the Linux kernel such as cgroups and kernel namespaces, and a union-capable file system such as OverlayFS and others to allow independent containers to run within a single Linux instance, avoiding the overhead of starting and maintaining virtual machines (VMs).


### PR DESCRIPTION
Also mention Docker Engine. Docker as a brand covers several technologies.

Resolves #14279 

I'm not sure which bit of the changes makes it show up, but this seems to fix it.