### PR TITLE
Improve pod concept docs

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-overview.md
+++ b/content/en/docs/concepts/workloads/pods/pod-overview.md
@@ -104,6 +104,7 @@ Rather than specifying the current desired state of all replicas, pod templates 
 {{% /capture %}}
 
 {{% capture whatsnext %}}
+* Learn more about [Pods](/docs/concepts/workloads/pods/pod/)
 * Learn more about Pod behavior:
   * [Pod Termination](/docs/concepts/workloads/pods/pod/#termination-of-pods)
   * [Pod Lifecycle](/docs/concepts/workloads/pods/pod-lifecycle/)

--- a/content/en/docs/concepts/workloads/pods/pod-overview.md
+++ b/content/en/docs/concepts/workloads/pods/pod-overview.md
@@ -21,17 +21,17 @@ A *Pod* is the basic building block of Kubernetes--the smallest and simplest uni
 
 A Pod encapsulates an application's container (or, in some cases, multiple containers), storage resources, a unique network IP, and options that govern how the container(s) should run. A Pod represents a unit of deployment: *a single instance of an application in Kubernetes*, which might consist of either a single {{< glossary_tooltip text="container" term_id="container" >}} or a small number of containers that are tightly coupled and that share resources.
 
-> [Docker](https://www.docker.com) is the most common container runtime used in a Kubernetes Pod, but Pods support other container runtimes as well.
+[Docker](https://www.docker.com) is the most common container runtime used in a Kubernetes Pod, but Pods support other container runtimes as well.
+
 
 Pods in a Kubernetes cluster can be used in two main ways:
 
 * **Pods that run a single container**. The "one-container-per-Pod" model is the most common Kubernetes use case; in this case, you can think of a Pod as a wrapper around a single container, and Kubernetes manages the Pods rather than the containers directly.
 * **Pods that run multiple containers that need to work together**. A Pod might encapsulate an application composed of multiple co-located containers that are tightly coupled and need to share resources. These co-located containers might form a single cohesive unit of service--one container serving files from a shared volume to the public, while a separate "sidecar" container refreshes or updates those files. The Pod wraps these containers and storage resources together as a single manageable entity.
-
 The [Kubernetes Blog](http://kubernetes.io/blog) has some additional information on Pod use cases. For more information, see:
 
-* [The Distributed System Toolkit: Patterns for Composite Containers](https://kubernetes.io/blog/2015/06/the-distributed-system-toolkit-patterns)
-* [Container Design Patterns](https://kubernetes.io/blog/2016/06/container-design-patterns)
+  * [The Distributed System Toolkit: Patterns for Composite Containers](https://kubernetes.io/blog/2015/06/the-distributed-system-toolkit-patterns)
+  * [Container Design Patterns](https://kubernetes.io/blog/2016/06/container-design-patterns)
 
 Each Pod is meant to run a single instance of a given application. If you want to scale your application horizontally (e.g., run multiple instances), you should use multiple Pods, one for each instance. In Kubernetes, this is generally referred to as _replication_. Replicated Pods are usually created and managed as a group by an abstraction called a Controller. See [Pods and Controllers](#pods-and-controllers) for more information.
 
@@ -41,7 +41,7 @@ Pods are designed to support multiple cooperating processes (as containers) that
 
 Note that grouping multiple co-located and co-managed containers in a single Pod is a relatively advanced use case. You should use this pattern only in specific instances in which your containers are tightly coupled. For example, you might have a container that acts as a web server for files in a shared volume, and a separate "sidecar" container that updates those files from a remote source, as in the following diagram:
 
-{{< figure src="/images/docs/pod.svg" title="pod diagram" width="50%" >}}
+{{< figure src="/images/docs/pod.svg" alt="example pod diagram" width="50%" >}}
 
 Some Pods have {{< glossary_tooltip text="init containers" term_id="init-container" >}} as well as {{< glossary_tooltip text="app containers" term_id="app-container" >}}. Init containers run and complete before the app containers are started.
 

--- a/content/en/docs/concepts/workloads/pods/pod-overview.md
+++ b/content/en/docs/concepts/workloads/pods/pod-overview.md
@@ -17,9 +17,9 @@ This page provides an overview of `Pod`, the smallest deployable object in the K
 {{% capture body %}}
 ## Understanding Pods
 
-A *Pod* is the basic building block of Kubernetes--the smallest and simplest unit in the Kubernetes object model that you create or deploy. A Pod represents a running process on your cluster.
+A *Pod* is the basic building block of Kubernetes--the smallest and simplest unit in the Kubernetes object model that you create or deploy. A Pod represents processes running on your {{< glossary_tooltip term_id="cluster" >}}.
 
-A Pod encapsulates an application container (or, in some cases, multiple containers), storage resources, a unique network IP, and options that govern how the container(s) should run. A Pod represents a unit of deployment: *a single instance of an application in Kubernetes*, which might consist of either a single container or a small number of containers that are tightly coupled and that share resources.
+A Pod encapsulates an application's container (or, in some cases, multiple containers), storage resources, a unique network IP, and options that govern how the container(s) should run. A Pod represents a unit of deployment: *a single instance of an application in Kubernetes*, which might consist of either a single {{< glossary_tooltip text="container" term_id="container" >}} or a small number of containers that are tightly coupled and that share resources.
 
 > [Docker](https://www.docker.com) is the most common container runtime used in a Kubernetes Pod, but Pods support other container runtimes as well.
 
@@ -43,6 +43,8 @@ Note that grouping multiple co-located and co-managed containers in a single Pod
 
 {{< figure src="/images/docs/pod.svg" title="pod diagram" width="50%" >}}
 
+Some Pods have {{< glossary_tooltip text="init containers" term_id="init-container" >}} as well as {{< glossary_tooltip text="app containers" term_id="app-container" >}}. Init containers run and complete before the app containers are started.
+
 Pods provide two kinds of shared resources for their constituent containers: *networking* and *storage*.
 
 #### Networking
@@ -51,11 +53,11 @@ Each Pod is assigned a unique IP address. Every container in a Pod shares the ne
 
 #### Storage
 
-A Pod can specify a set of shared storage *volumes*. All containers in the Pod can access the shared volumes, allowing those containers to share data. Volumes also allow persistent data in a Pod to survive in case one of the containers within needs to be restarted. See [Volumes](/docs/concepts/storage/volumes/) for more information on how Kubernetes implements shared storage in a Pod.
+A Pod can specify a set of shared storage {{< glossary_tooltip text="Volumes" term_id="volume" >}}. All containers in the Pod can access the shared volumes, allowing those containers to share data. Volumes also allow persistent data in a Pod to survive in case one of the containers within needs to be restarted. See [Volumes](/docs/concepts/storage/volumes/) for more information on how Kubernetes implements shared storage in a Pod.
 
 ## Working with Pods
 
-You'll rarely create individual Pods directly in Kubernetes--even singleton Pods. This is because Pods are designed as relatively ephemeral, disposable entities. When a Pod gets created (directly by you, or indirectly by a Controller), it is scheduled to run on a Node in your cluster. The Pod remains on that Node until the process is terminated, the pod object is deleted, the pod is *evicted* for lack of resources, or the Node fails.
+You'll rarely create individual Pods directly in Kubernetes--even singleton Pods. This is because Pods are designed as relatively ephemeral, disposable entities. When a Pod gets created (directly by you, or indirectly by a Controller), it is scheduled to run on a {{< glossary_tooltip term_id="node" >}} in your cluster. The Pod remains on that Node until the process is terminated, the pod object is deleted, the Pod is *evicted* for lack of resources, or the Node fails.
 
 {{< note >}}
 Restarting a container in a Pod should not be confused with restarting the Pod. The Pod itself does not run, but is an environment the containers run in and persists until it is deleted.

--- a/content/en/docs/concepts/workloads/pods/pod.md
+++ b/content/en/docs/concepts/workloads/pods/pod.md
@@ -17,61 +17,61 @@ managed in Kubernetes.
 
 ## What is a Pod?
 
-A _pod_ (as in a pod of whales or pea pod) is a group of one or more
+A _Pod_ (as in a pod of whales or pea pod) is a group of one or more
 {{< glossary_tooltip text="containers" term_id="container" >}} (such as
 Docker containers), with shared storage/network, and a specification
-for how to run the containers.  A pod's contents are always co-located and
-co-scheduled, and run in a shared context.  A pod models an
+for how to run the containers.  A Pod's contents are always co-located and
+co-scheduled, and run in a shared context.  A Pod models an
 application-specific "logical host" - it contains one or more application
 containers which are relatively tightly coupled &mdash; in a pre-container
 world, being executed on the same physical or virtual machine would mean being
 executed on the same logical host.
 
 While Kubernetes supports more container runtimes than just Docker, Docker is
-the most commonly known runtime, and it helps to describe pods in Docker terms.
+the most commonly known runtime, and it helps to describe Pods in Docker terms.
 
-The shared context of a pod is a set of Linux namespaces, cgroups, and
+The shared context of a Pod is a set of Linux namespaces, cgroups, and
 potentially other facets of isolation - the same things that isolate a Docker
-container.  Within a pod's context, the individual applications may have
+container.  Within a Pod's context, the individual applications may have
 further sub-isolations applied.
 
-Containers within a pod share an IP address and port space, and
+Containers within a Pod share an IP address and port space, and
 can find each other via `localhost`. They can also communicate with each
 other using standard inter-process communications like SystemV semaphores or
-POSIX shared memory.  Containers in different pods have distinct IP addresses
+POSIX shared memory.  Containers in different Pods have distinct IP addresses
 and can not communicate by IPC without
 [special configuration](/docs/concepts/policy/pod-security-policy/).
 These containers usually communicate with each other via Pod IP addresses.
 
-Applications within a pod also have access to shared {{< glossary_tooltip text="volumes" term_id="volume" >}}, which are defined
-as part of a pod and are made available to be mounted into each application's
+Applications within a Pod also have access to shared {{< glossary_tooltip text="volumes" term_id="volume" >}}, which are defined
+as part of a Pod and are made available to be mounted into each application's
 filesystem.
 
-In terms of [Docker](https://www.docker.com/) constructs, a pod is modelled as
+In terms of [Docker](https://www.docker.com/) constructs, a Pod is modelled as
 a group of Docker containers with shared namespaces and shared filesystem
 volumes.
 
-Like individual application containers, pods are considered to be relatively
-ephemeral (rather than durable) entities. As discussed in [life of a
-pod](/docs/concepts/workloads/pods/pod-lifecycle/), pods are created, assigned a unique ID (UID), and
+Like individual application containers, Pods are considered to be relatively
+ephemeral (rather than durable) entities. As discussed in
+[pod lifecycle](/docs/concepts/workloads/pods/pod-lifecycle/), Pods are created, assigned a unique ID (UID), and
 scheduled to nodes where they remain until termination (according to restart
-policy) or deletion. If a {{< glossary_tooltip term_id="node" >}} dies, the pods scheduled to that node are
-scheduled for deletion, after a timeout period. A given pod (as defined by a UID) is not
-"rescheduled" to a new node; instead, it can be replaced by an identical pod,
+policy) or deletion. If a {{< glossary_tooltip term_id="node" >}} dies, the Pods scheduled to that node are
+scheduled for deletion, after a timeout period. A given Pod (as defined by a UID) is not
+"rescheduled" to a new node; instead, it can be replaced by an identical Pod,
 with even the same name if desired, but with a new UID (see [replication
 controller](/docs/concepts/workloads/controllers/replicationcontroller/) for more details).
 
-When something is said to have the same lifetime as a pod, such as a volume,
-that means that it exists as long as that pod (with that UID) exists. If that
-pod is deleted for any reason, even if an identical replacement is created, the
+When something is said to have the same lifetime as a Pod, such as a volume,
+that means that it exists as long as that Pod (with that UID) exists. If that
+Pod is deleted for any reason, even if an identical replacement is created, the
 related thing (e.g. volume) is also destroyed and created anew.
 
-{{< figure src="/images/docs/pod.svg" title="pod diagram" width="50%" >}}
+{{< figure src="/images/docs/pod.svg" title="Pod diagram" width="50%" >}}
 
-*A multi-container pod that contains a file puller and a
+*A multi-container Pod that contains a file puller and a
 web server that uses a persistent volume for shared storage between the containers.*
 
-## Motivation for pods
+## Motivation for Pods
 
 ### Management
 
@@ -81,24 +81,25 @@ by providing a higher-level abstraction than the set of their constituent
 applications. Pods serve as unit of deployment, horizontal scaling, and
 replication. Colocation (co-scheduling), shared fate (e.g. termination),
 coordinated replication, resource sharing, and dependency management are
-handled automatically for containers in a pod.
+handled automatically for containers in a Pod.
 
 ### Resource sharing and communication
 
 Pods enable data sharing and communication among their constituents.
 
-The applications in a pod all use the same network namespace (same IP and port
+The applications in a Pod all use the same network namespace (same IP and port
 space), and can thus "find" each other and communicate using `localhost`.
-Because of this, applications in a pod must coordinate their usage of ports.
-Each pod has an IP address in a flat shared networking space that has full
-communication with other physical computers and pods across the network.
+Because of this, applications in a Pod must coordinate their usage of ports.
+Each Pod has an IP address in a flat shared networking space that has full
+communication with other physical computers and Pods across the network.
 
-The hostname is set to the pod's Name for the application containers within the
-pod. [More details on networking](/docs/concepts/cluster-administration/networking/).
+Containers within the Pod see the system hostname as being the same as the configured
+`name` for the Pod. There's more about this in the [networking](/docs/concepts/cluster-administration/networking/)
+section.
 
-In addition to defining the application containers that run in the pod, the pod
+In addition to defining the application containers that run in the Pod, the Pod
 specifies a set of shared storage volumes. Volumes enable data to survive
-container restarts and to be shared among the applications within the pod.
+container restarts and to be shared among the applications within the Pod.
 
 ## Uses of pods
 
@@ -112,7 +113,7 @@ programs, such as:
 * proxies, bridges, and adapters
 * controllers, managers, configurators, and updaters
 
-Individual pods are not intended to run multiple instances of the same
+Individual Pods are not intended to run multiple instances of the same
 application, in general.
 
 For a longer explanation, see [The Distributed System ToolKit: Patterns for
@@ -123,7 +124,7 @@ Containers](https://kubernetes.io/blog/2015/06/the-distributed-system-toolkit-pa
 
 _Why not just run multiple programs in a single (Docker) container?_
 
-1. Transparency. Making the containers within the pod visible to the
+1. Transparency. Making the containers within the Pod visible to the
    infrastructure enables the infrastructure to provide services to those
    containers, such as process management and resource monitoring. This
    facilitates a number of conveniences for users.
@@ -138,20 +139,20 @@ _Why not just run multiple programs in a single (Docker) container?_
 _Why not support affinity-based co-scheduling of containers?_
 
 That approach would provide co-location, but would not provide most of the
-benefits of pods, such as resource sharing, IPC, guaranteed fate sharing, and
+benefits of Pods, such as resource sharing, IPC, guaranteed fate sharing, and
 simplified management.
 
 ## Durability of pods (or lack thereof)
 
 Pods aren't intended to be treated as durable entities. They won't survive scheduling failures, node failures, or other evictions, such as due to lack of resources, or in the case of node maintenance.
 
-In general, users shouldn't need to create pods directly. They should almost
+In general, users shouldn't need to create Pods directly. They should almost
 always use controllers even for singletons, for example,
 [Deployments](/docs/concepts/workloads/controllers/deployment/).
 Controllers provide self-healing with a cluster scope, as well as replication
 and rollout management.
 Controllers like [StatefulSet](/docs/concepts/workloads/controllers/statefulset.md)
-can also provide support to stateful pods.
+can also provide support to stateful Pods.
 
 The use of collective APIs as the primary user-facing primitive is relatively common among cluster scheduling systems, including [Borg](https://research.google.com/pubs/pub43438.html), [Marathon](https://mesosphere.github.io/marathon/docs/rest-api.html), [Aurora](http://aurora.apache.org/documentation/latest/reference/configuration/#job-schema), and [Tupperware](http://www.slideshare.net/Docker/aravindnarayanan-facebook140613153626phpapp02-37588997).
 
@@ -159,38 +160,39 @@ Pod is exposed as a primitive in order to facilitate:
 
 * scheduler and controller pluggability
 * support for pod-level operations without the need to "proxy" them via controller APIs
-* decoupling of pod lifetime from controller lifetime, such as for bootstrapping
-* decoupling of controllers and services &mdash; the endpoint controller just watches pods
+* decoupling of Pod lifetime from controller lifetime, such as for bootstrapping
+* decoupling of controllers and services &mdash; the endpoint controller just watches Pods
 * clean composition of Kubelet-level functionality with cluster-level functionality &mdash; Kubelet is effectively the "pod controller"
-* high-availability applications, which will expect pods to be replaced in advance of their termination and certainly in advance of deletion, such as in the case of planned evictions or image prefetching.
+* high-availability applications, which will expect Pods to be replaced in advance of their termination and certainly in advance of deletion, such as in the case of planned evictions or image prefetching.
 
 ## Termination of Pods
 
-Because pods represent running processes on nodes in the cluster, it is important to allow those processes to gracefully terminate when they are no longer needed (vs being violently killed with a KILL signal and having no chance to clean up). Users should be able to request deletion and know when processes terminate, but also be able to ensure that deletes eventually complete. When a user requests deletion of a pod, the system records the intended grace period before the pod is allowed to be forcefully killed, and a TERM signal is sent to the main process in each container. Once the grace period has expired, the KILL signal is sent to those processes, and the pod is then deleted from the API server. If the Kubelet or the container manager is restarted while waiting for processes to terminate, the termination will be retried with the full grace period.
+Because Pods represent running processes on nodes in the cluster, it is important to allow those processes to gracefully terminate when they are no longer needed (vs being violently killed with a KILL signal and having no chance to clean up). Users should be able to request deletion and know when processes terminate, but also be able to ensure that deletes eventually complete. When a user requests deletion of a Pod, the system records the intended grace period before the Pod is allowed to be forcefully killed, and a TERM signal is sent to the main process in each container. Once the grace period has expired, the KILL signal is sent to those processes, and the Pod is then deleted from the API server. If the Kubelet or the container manager is restarted while waiting for processes to terminate, the termination will be retried with the full grace period.
 
 An example flow:
 
 1. User sends command to delete Pod, with default grace period (30s)
 1. The Pod in the API server is updated with the time beyond which the Pod is considered "dead" along with the grace period.
 1. Pod shows up as "Terminating" when listed in client commands
-1. (simultaneous with 3) When the Kubelet sees that a Pod has been marked as terminating because the time in 2 has been set, it begins the pod shutdown process.
+1. (simultaneous with 3) When the Kubelet sees that a Pod has been marked as terminating because the time in 2 has been set, it begins the Pod shutdown process.
     1. If one of the Pod's containers has defined a [preStop hook](/docs/concepts/containers/container-lifecycle-hooks/#hook-details), it is invoked inside of the container. If the `preStop` hook is still running after the grace period expires, step 2 is then invoked with a small (2 second) extended grace period.
     1. The container is sent the TERM signal. Note that not all containers in the Pod will receive the TERM signal at the same time and may each require a `preStop` hook if the order in which they shut down matters.
-1. (simultaneous with 3) Pod is removed from endpoints list for service, and are no longer considered part of the set of running pods for replication controllers. Pods that shutdown slowly cannot continue to serve traffic as load balancers (like the service proxy) remove them from their rotations.
+1. (simultaneous with 3) Pod is removed from endpoints list for service, and are no longer considered part of the set of running Pods for replication controllers. Pods that shutdown slowly cannot continue to serve traffic as load balancers (like the service proxy) remove them from their rotations.
 1. When the grace period expires, any processes still running in the Pod are killed with SIGKILL.
 1. The Kubelet will finish deleting the Pod on the API server by setting grace period 0 (immediate deletion). The Pod disappears from the API and is no longer visible from the client.
 
-By default, all deletes are graceful within 30 seconds. The `kubectl delete` command supports the `--grace-period=<seconds>` option which allows a user to override the default and specify their own value. The value `0` [force deletes](/docs/concepts/workloads/pods/pod/#force-deletion-of-pods) the pod. In kubectl version >= 1.5, you must specify an additional flag `--force` along with `--grace-period=0` in order to perform force deletions.
+By default, all deletes are graceful within 30 seconds. The `kubectl delete` command supports the `--grace-period=<seconds>` option which allows a user to override the default and specify their own value. The value `0` [force deletes](/docs/concepts/workloads/pods/pod/#force-deletion-of-pods) the Pod.
+You must specify an additional flag `--force` along with `--grace-period=0` in order to perform force deletions.
 
 ### Force deletion of pods
 
-Force deletion of a pod is defined as deletion of a pod from the cluster state and etcd immediately. When a force deletion is performed, the apiserver does not wait for confirmation from the kubelet that the pod has been terminated on the node it was running on. It removes the pod in the API immediately so a new pod can be created with the same name. On the node, pods that are set to terminate immediately will still be given a small grace period before being force killed.
+Force deletion of a Pod is defined as deletion of a Pod from the cluster state and etcd immediately. When a force deletion is performed, the apiserver does not wait for confirmation from the kubelet that the Pod has been terminated on the node it was running on. It removes the Pod in the API immediately so a new Pod can be created with the same name. On the node, Pods that are set to terminate immediately will still be given a small grace period before being force killed.
 
-Force deletions can be potentially dangerous for some pods and should be performed with caution. In case of StatefulSet pods, please refer to the task documentation for [deleting Pods from a StatefulSet](/docs/tasks/run-application/force-delete-stateful-set-pod/).
+Force deletions can be potentially dangerous for some Pods and should be performed with caution. In case of StatefulSet Pods, please refer to the task documentation for [deleting Pods from a StatefulSet](/docs/tasks/run-application/force-delete-stateful-set-pod/).
 
 ## Privileged mode for pod containers
 
-Any container in a pod can enable privileged mode, using the `privileged` flag on the [security context](/docs/tasks/configure-pod-container/security-context/) of the container spec. This is useful for containers that want to use Linux capabilities like manipulating the network stack and accessing devices. Processes within the container get almost the same privileges that are available to processes outside a container. With privileged mode, it should be easier to write network and volume plugins as separate pods that don't need to be compiled into the kubelet.
+Any container in a Pod can enable privileged mode, using the `privileged` flag on the [security context](/docs/tasks/configure-pod-container/security-context/) of the container spec. This is useful for containers that want to use Linux capabilities like manipulating the network stack and accessing devices. Processes within the container get almost the same privileges that are available to processes outside a container. With privileged mode, it should be easier to write network and volume plugins as separate Pods that don't need to be compiled into the kubelet.
 
 {{< note >}}
 Your container runtime must support the concept of a privileged container for this setting to be relevant.

--- a/content/en/docs/concepts/workloads/pods/pod.md
+++ b/content/en/docs/concepts/workloads/pods/pod.md
@@ -190,16 +190,11 @@ Force deletions can be potentially dangerous for some pods and should be perform
 
 ## Privileged mode for pod containers
 
-From Kubernetes v1.1, any container in a pod can enable privileged mode, using the `privileged` flag on the `SecurityContext` of the container spec. This is useful for containers that want to use linux capabilities like manipulating the network stack and accessing devices. Processes within the container get almost the same privileges that are available to processes outside a container. With privileged mode, it should be easier to write network and volume plugins as separate pods that don't need to be compiled into the kubelet.
+Any container in a pod can enable privileged mode, using the `privileged` flag on the `SecurityContext` of the container spec. This is useful for containers that want to use Linux capabilities like manipulating the network stack and accessing devices. Processes within the container get almost the same privileges that are available to processes outside a container. With privileged mode, it should be easier to write network and volume plugins as separate pods that don't need to be compiled into the kubelet.
 
-If the master is running Kubernetes v1.1 or higher, and the nodes are running a version lower than v1.1, then new privileged pods will be accepted by api-server, but will not be launched. They will be in pending state.
-If user calls `kubectl describe pod FooPodName`, user can see the reason why the pod is in pending state. The events table in the describe command output will say:
-`Error validating pod "FooPodName"."FooPodNamespace" from api, ignoring: spec.containers[0].securityContext.privileged: forbidden '<*>(0xc2089d3248)true'`
-
-
-If the master is running a version lower than v1.1, then privileged pods cannot be created. If user attempts to create a pod, that has a privileged container, the user will get the following error:
-`The Pod "FooPodName" is invalid.
-spec.containers[0].securityContext.privileged: forbidden '<*>(0xc20b222db0)true'`
+{{< note >}}
+Your container runtime must support the concept of a privileged container for this setting to be relevant.
+{{< /note >}}
 
 ## API Object
 

--- a/content/en/docs/concepts/workloads/pods/pod.md
+++ b/content/en/docs/concepts/workloads/pods/pod.md
@@ -17,8 +17,9 @@ managed in Kubernetes.
 
 ## What is a Pod?
 
-A _pod_ (as in a pod of whales or pea pod) is a group of one or more containers
-(such as Docker containers), with shared storage/network, and a specification
+A _pod_ (as in a pod of whales or pea pod) is a group of one or more
+{{< glossary_tooltip text="containers" term_id="container" >}} (such as
+Docker containers), with shared storage/network, and a specification
 for how to run the containers.  A pod's contents are always co-located and
 co-scheduled, and run in a shared context.  A pod models an
 application-specific "logical host" - it contains one or more application
@@ -42,19 +43,19 @@ and can not communicate by IPC without
 [special configuration](/docs/concepts/policy/pod-security-policy/).
 These containers usually communicate with each other via Pod IP addresses.
 
-Applications within a pod also have access to shared volumes, which are defined
+Applications within a pod also have access to shared {{< glossary_tooltip text="volumes" term_id="volume" >}}, which are defined
 as part of a pod and are made available to be mounted into each application's
 filesystem.
 
 In terms of [Docker](https://www.docker.com/) constructs, a pod is modelled as
-a group of Docker containers with shared namespaces and shared
-[volumes](/docs/concepts/storage/volumes/).
+a group of Docker containers with shared namespaces and shared filesystem
+volumes.
 
 Like individual application containers, pods are considered to be relatively
 ephemeral (rather than durable) entities. As discussed in [life of a
 pod](/docs/concepts/workloads/pods/pod-lifecycle/), pods are created, assigned a unique ID (UID), and
 scheduled to nodes where they remain until termination (according to restart
-policy) or deletion. If a node dies, the pods scheduled to that node are
+policy) or deletion. If a {{< glossary_tooltip term_id="node" >}} dies, the pods scheduled to that node are
 scheduled for deletion, after a timeout period. A given pod (as defined by a UID) is not
 "rescheduled" to a new node; instead, it can be replaced by an identical pod,
 with even the same name if desired, but with a new UID (see [replication

--- a/content/en/docs/concepts/workloads/pods/pod.md
+++ b/content/en/docs/concepts/workloads/pods/pod.md
@@ -190,7 +190,7 @@ Force deletions can be potentially dangerous for some pods and should be perform
 
 ## Privileged mode for pod containers
 
-Any container in a pod can enable privileged mode, using the `privileged` flag on the `SecurityContext` of the container spec. This is useful for containers that want to use Linux capabilities like manipulating the network stack and accessing devices. Processes within the container get almost the same privileges that are available to processes outside a container. With privileged mode, it should be easier to write network and volume plugins as separate pods that don't need to be compiled into the kubelet.
+Any container in a pod can enable privileged mode, using the `privileged` flag on the [security context](/docs/tasks/configure-pod-container/security-context/) of the container spec. This is useful for containers that want to use Linux capabilities like manipulating the network stack and accessing devices. Processes within the container get almost the same privileges that are available to processes outside a container. With privileged mode, it should be easier to write network and volume plugins as separate pods that don't need to be compiled into the kubelet.
 
 {{< note >}}
 Your container runtime must support the concept of a privileged container for this setting to be relevant.
@@ -198,8 +198,8 @@ Your container runtime must support the concept of a privileged container for th
 
 ## API Object
 
-Pod is a top-level resource in the Kubernetes REST API. More details about the
-API object can be found at:
-[Pod API object](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#pod-v1-core).
+Pod is a top-level resource in the Kubernetes REST API.
+The [Pod API object](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#pod-v1-core) definition
+describes the object in detail.
 
 {{% /capture %}}


### PR DESCRIPTION
Improve wording of:
- https://kubernetes.io/docs/concepts/workloads/pods/pod/
- https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/

by adding relevant glossary references & tweaking some wording.
Also, we're well past Kubernetes v1.1 so we can assume that there's support for privileged containers.

It feels like there's room for further improvement; however, this is a step in the right direction.