### PR TITLE
corrected example for private image string format

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
+++ b/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
@@ -187,7 +187,7 @@ wget -O my-private-reg-pod.yaml https://k8s.io/examples/pods/private-reg-pod.yam
 In file `my-private-reg-pod.yaml`, replace `<your-private-image>` with the path to an image in a private registry such as:
 
 ```none
-janedoe/jdoe-private:v1
+yourprivateregistry.com/janedoe/jdoe-private:v1
 ```
 
 To pull the image from the private registry, Kubernetes needs credentials.


### PR DESCRIPTION
without specifying registry details for `image` value, You will get following error if you are using a private registry even when your private images are hosted in docker.hub and you have valid credentials configured for the same.

Failed to pull image "xxx/xxx-app:0.0.1": rpc error: code = Unknown desc = Error response from daemon: pull access denied for xxx/xxx-app, repository does not exist or may require 'docker login'