### PR TITLE
Fix typo in https://kubernetes.io/docs/setup/certificates/

### DIFF
--- a/content/en/docs/setup/certificates.md
+++ b/content/en/docs/setup/certificates.md
@@ -84,7 +84,7 @@ where `kind` maps to one or more of the [x509 key usage][usage] types:
 
 Certificates should be placed in a recommended path (as used by [kubeadm][kubeadm]). Paths should be specified using the given argument regardless of location.
 
-| Default CN                   | recommend key path           | recommended cert path       | command        | key argument                 | cert argument                             |
+| Default CN                   | recommended key path         | recommended cert path       | command        | key argument                 | cert argument                             |
 |------------------------------|------------------------------|-----------------------------|----------------|------------------------------|-------------------------------------------|
 | etcd-ca                      |                              | etcd/ca.crt                 | kube-apiserver |                              | --etcd-cafile                             |
 | etcd-client                  | apiserver-etcd-client.key    | apiserver-etcd-client.crt   | kube-apiserver | --etcd-keyfile               | --etcd-certfile                           |


### PR DESCRIPTION
Replace “recommend” with “recommended” to suit English grammar

Might need a rebase if #13895 is merged first.