### PR TITLE
extend documentation on server-side apply

### DIFF
--- a/content/en/docs/reference/using-api/api-concepts.md
+++ b/content/en/docs/reference/using-api/api-concepts.md
@@ -430,3 +430,17 @@ Another difference is that an applier using Client Side Apply is unable to chang
 ### Custom Resources
 
 Server Side Apply currently treats all custom resources as unstructured data. All keys are treated the same as struct fields, and all lists are considered atomic. In the future, it will use the validation field in Custom Resource Definitions to allow Custom Resource authors to define how to how to merge their own objects.
+
+### Clearing ManagedFields
+
+It is possible to strip all managedFields from an object by overwriting them using `MergePatch`.
+This can be done via a `POST` request with content type `application/merge-patch+json` on the targeted object and the following data:
+
+```json
+POST /api/v1/namespaces/default/configmaps/example-cm
+Content-Type: application/json
+Accept: application/json
+Data: {"metadata":{"managedFields": [{}]}}
+```
+
+This will overwrite the managedFields with a list containing a single empty entry that then results in the managedFields being stripped entirely from the object.

--- a/content/en/docs/reference/using-api/api-concepts.md
+++ b/content/en/docs/reference/using-api/api-concepts.md
@@ -433,14 +433,21 @@ Server Side Apply currently treats all custom resources as unstructured data. Al
 
 ### Clearing ManagedFields
 
-It is possible to strip all managedFields from an object by overwriting them using `MergePatch`.
-This can be done via a `POST` request with content type `application/merge-patch+json` on the targeted object and the following data:
+It is possible to strip all managedFields from an object by overwriting them using `MergePatch` or `JSONPatch`.
+This can be done via a `PATCH` request with the respective content type on the targeted object. Two examples are:
 
 ```json
-POST /api/v1/namespaces/default/configmaps/example-cm
-Content-Type: application/json
+PATCH /api/v1/namespaces/default/configmaps/example-cm
+Content-Type: application/merge-patch+json
 Accept: application/json
 Data: {"metadata":{"managedFields": [{}]}}
+```
+
+```json
+PATCH /api/v1/namespaces/default/configmaps/example-cm
+Content-Type: application/json-patch+json
+Accept: application/json
+Data: [{"op": "replace", "path": "/metadata/managedFields", "value": [{}]}]
 ```
 
 This will overwrite the managedFields with a list containing a single empty entry that then results in the managedFields being stripped entirely from the object.

--- a/content/en/docs/reference/using-api/api-concepts.md
+++ b/content/en/docs/reference/using-api/api-concepts.md
@@ -433,8 +433,8 @@ Server Side Apply currently treats all custom resources as unstructured data. Al
 
 ### Clearing ManagedFields
 
-It is possible to strip all managedFields from an object by overwriting them using `MergePatch` or `JSONPatch`.
-This can be done via a `PATCH` request with the respective content type on the targeted object. Two examples are:
+It is possible to strip all managedFields from an object by overwriting them using `MergePatch`, `StrategicMergePatch`, `JSONPatch` or `Update`, so every non-apply operation.
+This can be done by overwriting the managedFields field with an empty entry. Two examples are:
 
 ```json
 PATCH /api/v1/namespaces/default/configmaps/example-cm
@@ -450,4 +450,4 @@ Accept: application/json
 Data: [{"op": "replace", "path": "/metadata/managedFields", "value": [{}]}]
 ```
 
-This will overwrite the managedFields with a list containing a single empty entry that then results in the managedFields being stripped entirely from the object.
+This will overwrite the managedFields with a list containing a single empty entry that then results in the managedFields being stripped entirely from the object. Note that just setting the managedFields to an empty list will not reset the field. This is on purpose, so managedFields never get stripped by clients not aware of the field.


### PR DESCRIPTION
This PR adds more documentation for server-side apply and serves as the placeholder for potential other additions that are targeted for 1.15.

Current additions:
- Documentation on how to clear the managedFields object manually.

/milestone 1.15
/sig api-machinery
/wg apply
/cc @apelisse @jennybuckley @simplytunde