### PR TITLE
Add containerd and CRI-O to glossary

### DIFF
--- a/content/en/docs/reference/glossary/containerd.md
+++ b/content/en/docs/reference/glossary/containerd.md
@@ -1,0 +1,19 @@
+---
+title: containerd
+id: containerd
+date: 2019-05-14
+full_link: https://containerd.io/docs/
+short_description: >
+  A container runtime with an emphasis on simplicity, robustness and portability
+
+aka:
+tags:
+- tool
+---
+ A container runtime with an emphasis on simplicity, robustness and portability
+
+<!--more-->
+
+containerd is a {{< glossary_tooltip text="container" term_id="container" >}} runtime
+that runs as a daemon on Linux or Windows. containerd takes care of fetching and
+storing container images, executing containers, providing network access, and more.

--- a/content/en/docs/reference/glossary/cri-o.md
+++ b/content/en/docs/reference/glossary/cri-o.md
@@ -1,0 +1,24 @@
+---
+title: CRI-O
+id: cri-o
+date: 2019-05-14
+full_link: https://cri-o.io/docs/
+short_description: >
+  A lightweight container runtime specifically for Kubernetes
+
+aka:
+tags:
+- tool
+---
+A tool that lets you use OCI container runtimes witk Kubernetes CRI.
+
+<!--more-->
+
+CRI-O is an implementation of the {{< glossary_tooltip term_id="cri" >}}
+to enable using {{< glossary_tooltip text="container" term_id="container" >}}
+runtimes that are compatible with the Open Container Initiative (OCI)
+[runtime spec](http://www.github.com/opencontainers/runtime-spec).
+
+Deploying CRI-O allows Kubernetes to use any OCI-compliant runtime as the container
+runtime for running {{< glossary_tooltip text="Pods" term_id="pod" >}}, and to fetch
+OCI container images from remote registries.


### PR DESCRIPTION
2 new glossary entries:
 - containerd
 - CRI-O

Relevant to #5993. Could help with a [suggestion](https://github.com/kubernetes/website/pull/14255#discussion_r283097009) I made for PR #14255.