### PR TITLE
streamline `grep` usage in minikube_before_you_begin

### DIFF
--- a/content/en/docs/tasks/tools/install-minikube.md
+++ b/content/en/docs/tasks/tools/install-minikube.md
@@ -21,15 +21,15 @@ VT-x or AMD-v virtualization must be enabled in your computer's BIOS.
 {{% tab name="Linux" %}}
 To check if virtualization is supported on Linux, run the following command and verify that the output is non-empty:
 ```
-egrep --color 'vmx|svm' /proc/cpuinfo
+grep -E --color 'vmx|svm' /proc/cpuinfo
 ```
 {{% /tab %}}
 {{% tab name="macOS" %}}
 To check if virtualization is supported on macOS, run the following command on your terminal.
 ```
-sysctl -a | grep machdep.cpu.features
+sysctl -a | grep -E --color 'machdep.cpu.features|VMX' 
 ```
-If you see `VMX` in the output, the VT-x feature is supported on your OS.
+If you see `VMX` in the output (should be colored), the VT-x feature is enabled in your machine.
 {{% /tab %}}
 {{% tab name="Windows" %}}
 To check if virtualization is supported on Windows 8 and above, run the following command on your Windows terminal or command prompt. 


### PR DESCRIPTION
- tested on macOS with BSD's grep and GNU's. same flags, same output.
- there are some 55 CPU flags on mac, so highlighting VMX makes it
  easier to grasp
- using `egrep` on linux and `grep` on mac, not necessary
- precision: the VT-x feature is NOT an OS feature...

