### PR TITLE
document pod downwardAPI fieldRef & resourceFiledRef values

### DIFF
--- a/content/en/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
+++ b/content/en/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
@@ -199,13 +199,9 @@ The following information is available to containers through environment
 variables and `downwardAPI` volumes:
 
 * Information available via `fieldRef`:
-  * `spec.nodeName` - the node’s name
-  * `status.hostIP` - the node's IP
   * `metadata.name` - the pod’s name
   * `metadata.namespace` - the pod’s namespace
-  * `status.podIP` - the pod’s IP address
-  * `spec.serviceAccountName` - the pod’s service account name
-  * `metadata.uid` - the pod’s UID
+  * `metadata.uid` - the pod’s UID, available in v1.8.0-alpha.2
   * `metadata.labels['<KEY>']` - the value of the pod’s label `<KEY>` (for example, `metadata.labels['mylabel']`); available in Kubernetes 1.9+
   * `metadata.annotations['<KEY>']` - the value of the pod’s annotation `<KEY>` (for example, `metadata.annotations['myannotation']`); available in Kubernetes 1.9+
 * Information available via `resourceFieldRef`:
@@ -213,12 +209,20 @@ variables and `downwardAPI` volumes:
   * A Container’s CPU request
   * A Container’s memory limit
   * A Container’s memory request
+  * A Container’s ephemeral-storage limit, available in v1.8.0-beta.0
+  * A Container’s ephemeral-storage request, available in v1.8.0-beta.0
 
 In addition, the following information is available through
 `downwardAPI` volume `fieldRef`:
 
 * `metadata.labels` - all of the pod’s labels, formatted as `label-key="escaped-label-value"` with one label per line
 * `metadata.annotations` - all of the pod’s annotations, formatted as `annotation-key="escaped-annotation-value"` with one annotation per line
+
+The following information is available through environment variables
+* `status.podIP` - the pod’s IP address
+* `spec.serviceAccountName` - the pod’s service account name, available in v1.4.0-alpha.3
+* `spec.nodeName` - the node’s name, available in v1.4.0-alpha.3
+* `status.hostIP` - the node's IP, available in v1.7.0-alpha.1
 
 {{< note >}}
 If CPU and memory limits are not specified for a Container, the

--- a/content/en/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
+++ b/content/en/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
@@ -201,7 +201,7 @@ variables and `downwardAPI` volumes:
 * Information available via `fieldRef`:
   * `metadata.name` - the pod’s name
   * `metadata.namespace` - the pod’s namespace
-  * `metadata.uid` - the pod’s UID, available in v1.8.0-alpha.2
+  * `metadata.uid` - the pod’s UID, available since v1.8.0-alpha.2
   * `metadata.labels['<KEY>']` - the value of the pod’s label `<KEY>` (for example, `metadata.labels['mylabel']`); available in Kubernetes 1.9+
   * `metadata.annotations['<KEY>']` - the value of the pod’s annotation `<KEY>` (for example, `metadata.annotations['myannotation']`); available in Kubernetes 1.9+
 * Information available via `resourceFieldRef`:
@@ -209,8 +209,8 @@ variables and `downwardAPI` volumes:
   * A Container’s CPU request
   * A Container’s memory limit
   * A Container’s memory request
-  * A Container’s ephemeral-storage limit, available in v1.8.0-beta.0
-  * A Container’s ephemeral-storage request, available in v1.8.0-beta.0
+  * A Container’s ephemeral-storage limit, available since v1.8.0-beta.0
+  * A Container’s ephemeral-storage request, available since v1.8.0-beta.0
 
 In addition, the following information is available through
 `downwardAPI` volume `fieldRef`:
@@ -218,11 +218,12 @@ In addition, the following information is available through
 * `metadata.labels` - all of the pod’s labels, formatted as `label-key="escaped-label-value"` with one label per line
 * `metadata.annotations` - all of the pod’s annotations, formatted as `annotation-key="escaped-annotation-value"` with one annotation per line
 
-The following information is available through environment variables
+The following information is available through environment variables:
+
 * `status.podIP` - the pod’s IP address
-* `spec.serviceAccountName` - the pod’s service account name, available in v1.4.0-alpha.3
-* `spec.nodeName` - the node’s name, available in v1.4.0-alpha.3
-* `status.hostIP` - the node's IP, available in v1.7.0-alpha.1
+* `spec.serviceAccountName` - the pod’s service account name, available since v1.4.0-alpha.3
+* `spec.nodeName` - the node’s name, available since v1.4.0-alpha.3
+* `status.hostIP` - the node's IP, available since v1.7.0-alpha.1
 
 {{< note >}}
 If CPU and memory limits are not specified for a Container, the

--- a/content/zh/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
+++ b/content/zh/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information.md
@@ -169,22 +169,34 @@ kubectl exec -it kubernetes-downwardapi-volume-example-2 -- sh
 
 下面这些信息可以通过环境变量和DownwardAPIVolumeFiles提供给容器：
 
-* 节点名称
-* 节点IP
-* Pod名称
-* Pod名字空间
-* Pod IP地址
-* Pod服务帐号名称
-* Pod的UID
-* 容器的CPU约束
-* 容器的CPU请求值
-* 容器的内存约束
-* 容器的内存请求值
+能通过`fieldRef`获得的：
+  * `metadata.name` - Pod名称
+  * `metadata.namespace` - Pod名字空间
+  * `metadata.uid` - Pod的UID, 版本要求 v1.8.0-alpha.2
+  * `metadata.labels['<KEY>']` - 单个 pod 标签值 `<KEY>` (例如, `metadata.labels['mylabel']`); 版本要求 Kubernetes 1.9+
+  * `metadata.annotations['<KEY>']` - 单个 pod 的标注值 `<KEY>` (例如, `metadata.annotations['myannotation']`); 版本要求 Kubernetes 1.9+
 
-此外，以下信息可通过DownwardAPIVolumeFiles获得：
+能通过`resourceFieldRef`获得的：
+  * 容器的CPU约束值
+  * 容器的CPU请求值
+  * 容器的内存约束值
+  * 容器的内存请求值
+  * 容器的临时存储约束值, 版本要求 v1.8.0-beta.0
+  * 容器的临时存储请求值, 版本要求 v1.8.0-beta.0
 
-* Pod的标签
-* Pod的注释
+此外，以下信息可通过DownwardAPIVolumeFiles从`fieldRef`获得：
+
+* `metadata.labels` - all of the pod’s labels, formatted as `label-key="escaped-label-value"` with one label per line
+* `metadata.annotations` - all of the pod’s annotations, formatted as `annotation-key="escaped-annotation-value"` with one annotation per line
+* `metadata.labels` - 所有Pod的标签，以`label-key="escaped-label-value"`格式显示，每行显示一个label
+* `metadata.annotations` - Pod的注释，以`annotation-key="escaped-annotation-value"`格式显示，每行显示一个标签
+
+以下信息可通过环境变量从`fieldRef`获得：
+
+* `status.podIP` - 节点IP
+* `spec.serviceAccountName` - Pod服务帐号名称, 版本要求 v1.4.0-alpha.3
+* `spec.nodeName` - 节点名称, 版本要求 v1.4.0-alpha.3
+* `status.hostIP` - 节点IP, 版本要求 v1.7.0-alpha.1
 
 {{< note >}}
 如果容器未指定CPU和memory limits，则Downward API默认为节点可分配值。


### PR DESCRIPTION
fixes #8136 

unless I am missing something, from here([pkg/apis/core/types.go +1162](https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/types.go#L1162) ) and here([pkg/apis/core/validation/validation.go +941](https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/validation/validation.go#L941)) I can see 
Information available via fieldRef through downwardAPI volumes support:
```
	"metadata.name",
	"metadata.namespace",
	"metadata.labels",
	"metadata.annotations",
	"metadata.uid"
        single value of annotation & label
```

Information available via fieldRef through env var support:
```
	"metadata.name",
	"metadata.namespace",
	"metadata.uid",
	"spec.nodeName",
	"spec.serviceAccountName",
	"status.hostIP",
	"status.podIP"
        single value of annotation & label
```
https://github.com/kubernetes/kubernetes/issues/43222 had done testing, exposing ephemeral-storage via resourceFieldRef is supported since v1.8.0-beta.0 by PR https://github.com/kubernetes/kubernetes/pull/50435