### PR TITLE
Fix code block

### DIFF
--- a/content/en/docs/contribute/style/style-guide.md
+++ b/content/en/docs/contribute/style/style-guide.md
@@ -62,7 +62,7 @@ represents.
 
 1. Display information about a Pod:
 
-       kubectl describe pod <pod-name>
+        kubectl describe pod <pod-name>
 
     where `<pod-name>` is the name of one of your Pods.
 


### PR DESCRIPTION
This code block isn’t recognized by the Markdown engine for the site. GitHub Markdown implementation is more tolerant than the one used by the k8s site.