### PR TITLE
List & watch can be authorized on named resources

### DIFF
--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -193,9 +193,8 @@ rules:
 ```
 
 Resources can also be referred to by name for certain requests through the `resourceNames` list.
-When specified, requests using the "get", "delete", "update", and "patch" verbs can be restricted
-to individual instances of a resource. To restrict a subject to only "get" and "update" a single
-configmap, you would write:
+When specified, requests can be restricted to individual instances of a resource. To restrict a
+subject to only "get" and "update" a single configmap, you would write:
 
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -210,10 +209,8 @@ rules:
   verbs: ["update", "get"]
 ```
 
-Notably, if `resourceNames` are set, then the verb must not be list, watch, create, or deletecollection.
-Because resource names are not present in the URL for create, list, watch, and deletecollection API requests,
-those verbs would not be allowed by a rule with `resourceNames` set, since the `resourceNames` portion of the
-rule would not match the request.
+Note that `create` requests cannot be restricted by resourceName, as the object name is not known at
+authorization time. The other exception is `deletecollection`.
 
 ### Aggregated ClusterRoles
 


### PR DESCRIPTION
As of 1.11, resource names for list & watch requests are populated from a field selector on `metadata.name` [1]. Update the RBAC documentation to reflect this change.

[1] https://github.com/kubernetes/kubernetes/pull/63469

/assign @liggitt 
/cc @wojtek-t @haiyanmeng