### PR TITLE
Update deployment.md

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/deployment.md
+++ b/content/en/docs/concepts/workloads/controllers/deployment.md
@@ -997,7 +997,7 @@ allowed, which is the default if not specified.
 
 ### Selector
 
-`.spec.selector` is an optional field that specifies a [label selector](/docs/concepts/overview/working-with-objects/labels/)
+`.spec.selector` is an required field that specifies a [label selector](/docs/concepts/overview/working-with-objects/labels/)
 for the Pods targeted by this deployment.
 
 `.spec.selector` must match `.spec.template.metadata.labels`, or it will be rejected by the API.


### PR DESCRIPTION
https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#pod-template  

Current is:

> The .spec.template and .spec.selector are the only **required** field of the .spec.

> .spec.selector is an **optional** field that specifies a label selector for the Pods targeted by this deployment.


