### PR TITLE
Correcting minikube quickstart steps

### DIFF
--- a/content/en/docs/setup/minikube.md
+++ b/content/en/docs/setup/minikube.md
@@ -45,103 +45,132 @@ Note that the IP below is dynamic and can change. It can be retrieved with `mini
 * vmware ([driver installation](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#vmware-unified-driver)) (VMware unified driver)
 * none (Runs the Kubernetes components on the host and not in a VM. Using this driver requires Docker ([docker install](https://docs.docker.com/install/linux/docker-ce/ubuntu/)) and a Linux environment)
 
-```shell
-minikube start
-```
-```
-Starting local Kubernetes cluster...
-Running pre-create checks...
-Creating machine...
-Starting local Kubernetes cluster...
-```
-```shell
-kubectl run hello-minikube --image=k8s.gcr.io/echoserver:1.10 --port=8080
-```
-```
-deployment.apps/hello-minikube created
-```
+1. Start a minikube 
 
-```shell
-kubectl expose deployment hello-minikube --type=NodePort
-```
-```
-service/hello-minikube exposed
-```
+        ```shell
+        minikube start
+        ```
+    
+   The output displays the kubernetes cluster is started:
+   
+        ```
+        Starting local Kubernetes cluster...
+        Running pre-create checks...
+        Creating machine...
+        Starting local Kubernetes cluster...
+        ```
+        
+2. Create a echoserver deployment
 
-We have now launched an echoserver pod but we have to wait until the pod is up before curling/accessing it
-via the exposed service.
-To check whether the pod is up and running we can use the following:
+        ```shell
+        kubectl run hello-minikube --image=k8s.gcr.io/echoserver:1.10 --port=8080
+        ```
+        
+   The output of a successful command verifies that the deployment is created:
+   
+        ```
+        deployment.apps/hello-minikube created
+        ```
+        
+3. Expose a echoserver deployment to create service       
 
-```
-kubectl get pod
-```
-```
-NAME                              READY     STATUS              RESTARTS   AGE
-hello-minikube-3383150820-vctvh   0/1       ContainerCreating   0          3s
-```
+        ```shell
+        kubectl expose deployment hello-minikube --type=NodePort
+        ```
+   The output of a successful command verifies that the service is created:
+   
+        ```
+        service/hello-minikube exposed
+        ```
 
-We can see that the pod is still being created from the ContainerCreating status
-kubectl get pod
+4. Check whether the pod is up and running
 
-```
-NAME                              READY     STATUS    RESTARTS   AGE
-hello-minikube-3383150820-vctvh   1/1       Running   0          13s
-```
+        ```
+        kubectl get pod
+        ```
+   The output displays the pod is still being created:     
+         
+        ```
+        NAME                              READY     STATUS              RESTARTS   AGE
+        hello-minikube-3383150820-vctvh   0/1       ContainerCreating   0          3s
+        ```
 
-We can see that the pod is now Running and we will now be able to curl it:
+5. Wait for while and then check again, whether the pod is up and running using same command
 
-```
-curl $(minikube service hello-minikube --url)
-```
-```
+         ```
+          kubectl get pod
+         ```
+   Now the output displays the pod is created and it is running:     
+   
+        ```
+        NAME                              READY     STATUS    RESTARTS   AGE
+        hello-minikube-3383150820-vctvh   1/1       Running   0          13s
+        ```
 
-Hostname: hello-minikube-7c77b68cff-8wdzq
+6. Curl service which we have created
 
-Pod Information:
-	-no pod information available-
+        ```
+        curl $(minikube service hello-minikube --url)
+        ```        
+   Output looks similer to this:
+   
+        ```
+        Hostname: hello-minikube-7c77b68cff-8wdzq
 
-Server values:
-	server_version=nginx: 1.13.3 - lua: 10008
+        Pod Information:
+          -no pod information available-
 
-Request Information:
-	client_address=172.17.0.1
-	method=GET
-	real path=/
-	query=
-	request_version=1.1
-	request_scheme=http
-	request_uri=http://192.168.99.100:8080/
+        Server values:
+          server_version=nginx: 1.13.3 - lua: 10008
 
-Request Headers:
-	accept=*/*
-	host=192.168.99.100:30674
-	user-agent=curl/7.47.0
+        Request Information:
+          client_address=172.17.0.1
+          method=GET
+          real path=/
+          query=
+          request_version=1.1
+          request_scheme=http
+          request_uri=http://192.168.99.100:8080/
 
-Request Body:
-	-no body in request-
-```
+        Request Headers:
+          accept=*/*
+          host=192.168.99.100:30674
+          user-agent=curl/7.47.0
 
-```shell
-kubectl delete services hello-minikube
-```
-```
-service "hello-minikube" deleted
-```
+        Request Body:
+          -no body in request-
+        ```
+7. Delete the service which we have created
 
-```shell
-kubectl delete deployment hello-minikube
-```
-```
-deployment.extensions "hello-minikube" deleted
-```
+        ```shell
+        kubectl delete services hello-minikube
+        ```
+   The output of a successful command verifies that the service is deleted:  
+   
+        ```
+        service "hello-minikube" deleted
+        ```
+8. Delete the deployment which we have created
 
-```shell
-minikube stop
-```
-```
-Stopping local Kubernetes cluster...
-Stopping "minikube"...
-```
+        ```shell
+        kubectl delete deployment hello-minikube
+        ```
+   The output of a successful command verifies that the deployment is deleted:
+   
+        ```
+        deployment.extensions "hello-minikube" deleted
+        ```
+9. Stop a minikube
+
+        ```shell
+        minikube stop
+        ```
+   The output displays the kubernetes cluster is stopping:
+   
+        ```
+        Stopping local Kubernetes cluster...
+        Stopping "minikube"...
+        ```
 
 ### Alternative Container Runtimes
 

--- a/content/en/docs/setup/minikube.md
+++ b/content/en/docs/setup/minikube.md
@@ -50,7 +50,7 @@ Note that the IP below is dynamic and can change. It can be retrieved with `mini
         ```shell        
         minikube start
         ```    
-   The output displays the kubernetes cluster is started:
+   The output shows that the kubernetes cluster is started:
    
         ```
         Starting local Kubernetes cluster...

--- a/content/en/docs/setup/minikube.md
+++ b/content/en/docs/setup/minikube.md
@@ -59,7 +59,7 @@ Note that the IP below is dynamic and can change. It can be retrieved with `mini
         Starting local Kubernetes cluster...
         ```
         
-1. Create a echoserver deployment
+1. Create an echo server deployment
 
         ```shell        
         kubectl run hello-minikube --image=k8s.gcr.io/echoserver:1.10 --port=8080

--- a/content/en/docs/setup/minikube.md
+++ b/content/en/docs/setup/minikube.md
@@ -47,72 +47,72 @@ Note that the IP below is dynamic and can change. It can be retrieved with `mini
 
 1. Start a minikube 
 
-        ```shell        
-        minikube start
-        ```    
+   ```        
+     minikube start
+   ```    
    The output shows that the kubernetes cluster is started:
    
-        ```
-        Starting local Kubernetes cluster...
-        Running pre-create checks...
-        Creating machine...
-        Starting local Kubernetes cluster...
-        ```
+   ```
+     Starting local Kubernetes cluster...
+     Running pre-create checks...
+     Creating machine...
+     Starting local Kubernetes cluster...
+   ```
         
 1. Create an echo server deployment
 
-        ```shell        
-        kubectl run hello-minikube --image=k8s.gcr.io/echoserver:1.10 --port=8080
-        ```        
+   ```
+     kubectl run hello-minikube --image=k8s.gcr.io/echoserver:1.10 --port=8080
+   ```        
    The output of a successful command verifies that the deployment is created:
    
-        ```
-        deployment.apps/hello-minikube created
-        ```
+   ```
+     deployment.apps/hello-minikube created
+   ```
         
 1. Expose an echo server deployment to create service       
 
-        ```shell        
-        kubectl expose deployment hello-minikube --type=NodePort
-        ```
+   ```
+     kubectl expose deployment hello-minikube --type=NodePort
+   ```
    The output of a successful command verifies that the service is created:
    
-        ```
-        service/hello-minikube exposed
-        ```
+   ```
+     service/hello-minikube exposed
+   ```
 
 1. Check whether the pod is up and running
 
-        ```shell
-        kubectl get pod
-        ```
+   ```
+     kubectl get pod
+   ```
    The output displays the pod is still being created:     
          
-        ```
-        NAME                              READY     STATUS              RESTARTS   AGE
-        hello-minikube-3383150820-vctvh   0/1       ContainerCreating   0          3s
-        ```
+   ```
+     NAME                              READY     STATUS              RESTARTS   AGE
+     hello-minikube-3383150820-vctvh   0/1       ContainerCreating   0          3s
+   ```
 
 1. Wait for while and then check again, whether the pod is up and running using same command
 
-         ```shell
-          kubectl get pod
-         ```
+   ```
+     kubectl get pod
+   ```
    Now the output displays the pod is created and it is running:     
    
-        ```
-        NAME                              READY     STATUS    RESTARTS   AGE
-        hello-minikube-3383150820-vctvh   1/1       Running   0          13s
-        ```
+   ```
+     NAME                              READY     STATUS    RESTARTS   AGE
+     hello-minikube-3383150820-vctvh   1/1       Running   0          13s
+   ```
 
 1. Curl service which we have created
 
-        ```shell
-        curl $(minikube service hello-minikube --url)
-        ```        
+   ```
+     curl $(minikube service hello-minikube --url)
+   ```        
    Output looks similer to this:
    
-        ```
+    ```
         Hostname: hello-minikube-7c77b68cff-8wdzq
 
         Pod Information:
@@ -137,38 +137,38 @@ Note that the IP below is dynamic and can change. It can be retrieved with `mini
 
         Request Body:
           -no body in request-
-        ```
+    ```
 1. Delete the service which we have created
 
-        ```shell
-        kubectl delete services hello-minikube
-        ```
+    ```
+      kubectl delete services hello-minikube
+    ```
    The output of a successful command verifies that the service is deleted:  
    
-        ```
-        service "hello-minikube" deleted
-        ```
+    ```
+      service "hello-minikube" deleted
+    ```
 1. Delete the deployment which we have created
 
-        ```shell
-        kubectl delete deployment hello-minikube
-        ```
+    ```
+      kubectl delete deployment hello-minikube
+    ```
    The output of a successful command verifies that the deployment is deleted:
    
-        ```
-        deployment.extensions "hello-minikube" deleted
-        ```
+   ```
+     deployment.extensions "hello-minikube" deleted
+   ```
 1. Stop a minikube
 
-        ```shell
-        minikube stop
-        ```
+   ```
+     minikube stop
+   ```
    The output displays the kubernetes cluster is stopping:
    
-        ```
-        Stopping local Kubernetes cluster...
-        Stopping "minikube"...
-        ```
+   ```
+     Stopping local Kubernetes cluster...
+     Stopping "minikube"...
+   ```
 
 ### Alternative Container Runtimes
 

--- a/content/en/docs/setup/minikube.md
+++ b/content/en/docs/setup/minikube.md
@@ -47,38 +47,32 @@ Note that the IP below is dynamic and can change. It can be retrieved with `mini
 
 1. Start a minikube 
 
-        ```shell
-        
+        ```shell        
         minikube start
-        ```
-    
+        ```    
    The output displays the kubernetes cluster is started:
    
         ```
-        
         Starting local Kubernetes cluster...
         Running pre-create checks...
         Creating machine...
         Starting local Kubernetes cluster...
         ```
         
-2. Create a echoserver deployment
+1. Create a echoserver deployment
 
-        ```shell
-        
+        ```shell        
         kubectl run hello-minikube --image=k8s.gcr.io/echoserver:1.10 --port=8080
-        ```
-        
+        ```        
    The output of a successful command verifies that the deployment is created:
    
         ```
         deployment.apps/hello-minikube created
         ```
         
-3. Expose a echoserver deployment to create service       
+1. Expose a echoserver deployment to create service       
 
-        ```shell
-        
+        ```shell        
         kubectl expose deployment hello-minikube --type=NodePort
         ```
    The output of a successful command verifies that the service is created:
@@ -87,9 +81,9 @@ Note that the IP below is dynamic and can change. It can be retrieved with `mini
         service/hello-minikube exposed
         ```
 
-4. Check whether the pod is up and running
+1. Check whether the pod is up and running
 
-        ```
+        ```shell
         kubectl get pod
         ```
    The output displays the pod is still being created:     
@@ -99,9 +93,9 @@ Note that the IP below is dynamic and can change. It can be retrieved with `mini
         hello-minikube-3383150820-vctvh   0/1       ContainerCreating   0          3s
         ```
 
-5. Wait for while and then check again, whether the pod is up and running using same command
+1. Wait for while and then check again, whether the pod is up and running using same command
 
-         ```
+         ```shell
           kubectl get pod
          ```
    Now the output displays the pod is created and it is running:     
@@ -111,9 +105,9 @@ Note that the IP below is dynamic and can change. It can be retrieved with `mini
         hello-minikube-3383150820-vctvh   1/1       Running   0          13s
         ```
 
-6. Curl service which we have created
+1. Curl service which we have created
 
-        ```
+        ```shell
         curl $(minikube service hello-minikube --url)
         ```        
    Output looks similer to this:
@@ -144,7 +138,7 @@ Note that the IP below is dynamic and can change. It can be retrieved with `mini
         Request Body:
           -no body in request-
         ```
-7. Delete the service which we have created
+1. Delete the service which we have created
 
         ```shell
         kubectl delete services hello-minikube
@@ -154,7 +148,7 @@ Note that the IP below is dynamic and can change. It can be retrieved with `mini
         ```
         service "hello-minikube" deleted
         ```
-8. Delete the deployment which we have created
+1. Delete the deployment which we have created
 
         ```shell
         kubectl delete deployment hello-minikube
@@ -164,7 +158,7 @@ Note that the IP below is dynamic and can change. It can be retrieved with `mini
         ```
         deployment.extensions "hello-minikube" deleted
         ```
-9. Stop a minikube
+1. Stop a minikube
 
         ```shell
         minikube stop

--- a/content/en/docs/setup/minikube.md
+++ b/content/en/docs/setup/minikube.md
@@ -48,12 +48,14 @@ Note that the IP below is dynamic and can change. It can be retrieved with `mini
 1. Start a minikube 
 
         ```shell
+        
         minikube start
         ```
     
    The output displays the kubernetes cluster is started:
    
         ```
+        
         Starting local Kubernetes cluster...
         Running pre-create checks...
         Creating machine...
@@ -63,6 +65,7 @@ Note that the IP below is dynamic and can change. It can be retrieved with `mini
 2. Create a echoserver deployment
 
         ```shell
+        
         kubectl run hello-minikube --image=k8s.gcr.io/echoserver:1.10 --port=8080
         ```
         
@@ -75,6 +78,7 @@ Note that the IP below is dynamic and can change. It can be retrieved with `mini
 3. Expose a echoserver deployment to create service       
 
         ```shell
+        
         kubectl expose deployment hello-minikube --type=NodePort
         ```
    The output of a successful command verifies that the service is created:

--- a/content/en/docs/setup/minikube.md
+++ b/content/en/docs/setup/minikube.md
@@ -47,127 +47,127 @@ Note that the IP below is dynamic and can change. It can be retrieved with `mini
 
 1. Start a minikube 
 
-   ```        
-     minikube start
-   ```    
-   The output shows that the kubernetes cluster is started:
+    ```        
+    minikube start
+    ```    
+    The output shows that the kubernetes cluster is started:
    
-   ```
-     Starting local Kubernetes cluster...
-     Running pre-create checks...
-     Creating machine...
-     Starting local Kubernetes cluster...
-   ```
+    ```
+    Starting local Kubernetes cluster...
+    Running pre-create checks...
+    Creating machine...
+    Starting local Kubernetes cluster...
+    ```
         
-1. Create an echo server deployment
+2. Create an echo server deployment
 
-   ```
-     kubectl run hello-minikube --image=k8s.gcr.io/echoserver:1.10 --port=8080
-   ```        
-   The output of a successful command verifies that the deployment is created:
+    ```
+    kubectl run hello-minikube --image=k8s.gcr.io/echoserver:1.10 --port=8080
+    ```        
+    The output of a successful command verifies that the deployment is created:
    
-   ```
-     deployment.apps/hello-minikube created
-   ```
+    ```
+    deployment.apps/hello-minikube created
+    ```
         
-1. Expose an echo server deployment to create service       
+3. Expose an echo server deployment to create service       
 
-   ```
-     kubectl expose deployment hello-minikube --type=NodePort
-   ```
-   The output of a successful command verifies that the service is created:
+    ```
+    kubectl expose deployment hello-minikube --type=NodePort
+    ```
+    The output of a successful command verifies that the service is created:
    
-   ```
-     service/hello-minikube exposed
-   ```
+    ```
+    service/hello-minikube exposed
+    ```
 
-1. Check whether the pod is up and running
+4. Check whether the pod is up and running
 
-   ```
-     kubectl get pod
-   ```
-   The output displays the pod is still being created:     
+    ```
+    kubectl get pod
+    ```
+    The output displays the pod is still being created:     
          
-   ```
-     NAME                              READY     STATUS              RESTARTS   AGE
-     hello-minikube-3383150820-vctvh   0/1       ContainerCreating   0          3s
-   ```
+    ```
+    NAME                              READY     STATUS              RESTARTS   AGE
+    hello-minikube-3383150820-vctvh   0/1       ContainerCreating   0          3s
+    ```
 
-1. Wait for while and then check again, whether the pod is up and running using same command
+5. Wait for while and then check again, whether the pod is up and running using same command
 
-   ```
-     kubectl get pod
-   ```
-   Now the output displays the pod is created and it is running:     
-   
-   ```
-     NAME                              READY     STATUS    RESTARTS   AGE
-     hello-minikube-3383150820-vctvh   1/1       Running   0          13s
-   ```
-
-1. Curl service which we have created
-
-   ```
-     curl $(minikube service hello-minikube --url)
-   ```        
-   Output looks similer to this:
+    ```
+    kubectl get pod
+    ```
+    Now the output displays the pod is created and it is running:     
    
     ```
-        Hostname: hello-minikube-7c77b68cff-8wdzq
-
-        Pod Information:
-          -no pod information available-
-
-        Server values:
-          server_version=nginx: 1.13.3 - lua: 10008
-
-        Request Information:
-          client_address=172.17.0.1
-          method=GET
-          real path=/
-          query=
-          request_version=1.1
-          request_scheme=http
-          request_uri=http://192.168.99.100:8080/
-
-        Request Headers:
-          accept=*/*
-          host=192.168.99.100:30674
-          user-agent=curl/7.47.0
-
-        Request Body:
-          -no body in request-
+    NAME                              READY     STATUS    RESTARTS   AGE
+    hello-minikube-3383150820-vctvh   1/1       Running   0          13s
     ```
-1. Delete the service which we have created
+
+6. Curl service which we have created
 
     ```
-      kubectl delete services hello-minikube
-    ```
-   The output of a successful command verifies that the service is deleted:  
+    curl $(minikube service hello-minikube --url)
+    ```        
+    Output looks similer to this:
    
     ```
-      service "hello-minikube" deleted
+    Hostname: hello-minikube-7c77b68cff-8wdzq
+
+    Pod Information:
+      -no pod information available-
+
+    Server values:
+      server_version=nginx: 1.13.3 - lua: 10008
+
+    Request Information:
+      client_address=172.17.0.1
+      method=GET
+      real path=/
+      query=
+      request_version=1.1
+      request_scheme=http
+      request_uri=http://192.168.99.100:8080/
+
+    Request Headers:
+      accept=*/*
+      host=192.168.99.100:30674
+      user-agent=curl/7.47.0
+
+    Request Body:
+      -no body in request-
     ```
-1. Delete the deployment which we have created
+7. Delete the service which we have created
 
     ```
-      kubectl delete deployment hello-minikube
+    kubectl delete services hello-minikube
     ```
-   The output of a successful command verifies that the deployment is deleted:
+    The output of a successful command verifies that the service is deleted:  
    
-   ```
-     deployment.extensions "hello-minikube" deleted
-   ```
-1. Stop a minikube
+    ```
+    service "hello-minikube" deleted
+    ```
+8. Delete the deployment which we have created
 
-   ```
-     minikube stop
+    ```
+    kubectl delete deployment hello-minikube
+    ```
+    The output of a successful command verifies that the deployment is deleted:
+   
+    ```
+    deployment.extensions "hello-minikube" deleted
+    ```
+9. Stop a minikube
+
+    ```
+    minikube stop
    ```
    The output displays the kubernetes cluster is stopping:
    
    ```
-     Stopping local Kubernetes cluster...
-     Stopping "minikube"...
+   Stopping local Kubernetes cluster...
+   Stopping "minikube"...
    ```
 
 ### Alternative Container Runtimes

--- a/content/en/docs/setup/minikube.md
+++ b/content/en/docs/setup/minikube.md
@@ -70,7 +70,7 @@ Note that the IP below is dynamic and can change. It can be retrieved with `mini
         deployment.apps/hello-minikube created
         ```
         
-1. Expose a echoserver deployment to create service       
+1. Expose an echo server deployment to create service       
 
         ```shell        
         kubectl expose deployment hello-minikube --type=NodePort


### PR DESCRIPTION
In minikube quickstart section , it was difficult to differentiate between command and its output. Also, There was no details given for each steps and its expected output. This PR fixes these issues.
