### PR TITLE
Add content/es/docs/reference/glossary/rkt.md

### DIFF
--- a/content/es/docs/reference/glossary/rkt.md
+++ b/content/es/docs/reference/glossary/rkt.md
@@ -11,7 +11,7 @@ tags:
 - security
 - tool
 ---
- Un motor de contennedores basado en el estandar y centrado en la seguridad.
+ Un motor de contenedores basado en el estándar y centrado en la seguridad.
 
 <!--more--> .
 

--- a/content/es/docs/reference/glossary/rkt.md
+++ b/content/es/docs/reference/glossary/rkt.md
@@ -4,7 +4,7 @@ id: rkt
 date: 2019-05-16
 full_link: https://coreos.com/rkt/
 short_description: >
-  Un motor de contennedores basado en el estandar y centrado en la seguridad.
+  Un motor de contenedores basado en el estándar y centrado en la seguridad.
 
 aka:
 tags:

--- a/content/es/docs/reference/glossary/rkt.md
+++ b/content/es/docs/reference/glossary/rkt.md
@@ -1,0 +1,18 @@
+---
+title: rkt
+id: rkt
+date: 2019-05-16
+full_link: https://coreos.com/rkt/
+short_description: >
+  Un motor de contennedores basado en el estandar y centrado en la seguridad.
+
+aka:
+tags:
+- security
+- tool
+---
+ Un motor de contennedores basado en el estandar y centrado en la seguridad.
+
+<!--more--> .
+
+rkt es un motor de {{< glossary_tooltip text="contenedores" term_id="container" >}} ofreciendo un enfoque a un {{< glossary_tooltip text="pod" term_id="pod" >}}-nativo, un entorno de ejecución extensible y una area superficial bien definida. rkt permite a los usuarios aplicar diferentes configuraciones a nivel de Pod y aplicación. Cada Pod se ejecuta directamente en el modelo clásico de Unix, en un entorno independiente y aislado.

--- a/content/es/docs/reference/glossary/rkt.md
+++ b/content/es/docs/reference/glossary/rkt.md
@@ -15,4 +15,4 @@ tags:
 
 <!--more--> .
 
-rkt es un motor de {{< glossary_tooltip text="contenedores" term_id="container" >}} ofreciendo un enfoque a un {{< glossary_tooltip text="pod" term_id="pod" >}}-nativo, un entorno de ejecución extensible y una area superficial bien definida. rkt permite a los usuarios aplicar diferentes configuraciones a nivel de Pod y aplicación. Cada Pod se ejecuta directamente en el modelo clásico de Unix, en un entorno independiente y aislado.
+rkt es un motor de {{< glossary_tooltip text="contenedores" term_id="container" >}} cuya unidad mínima de computación es el pod, que representa una colección de contenedores igual que el {{< glossary_tooltip text="Pod" term_id="pod" >}} de la API de Kubernetes. rkt permite a los usuarios aplicar diferentes configuraciones a nivel de Pod y aplicación. Cada Pod se ejecuta directamente en el modelo clásico de Unix, en un entorno independiente y aislado.


### PR DESCRIPTION
Add the Spanish localization for the _rkt_ glossary term.