### PR TITLE
en/glossary: use title for all Pod occurrences

### DIFF
--- a/content/en/docs/reference/glossary/rkt.md
+++ b/content/en/docs/reference/glossary/rkt.md
@@ -15,4 +15,4 @@ tags:
 
 <!--more--> 
 
-rkt is an application {{< glossary_tooltip text="container" term_id="container" >}} engine featuring a {{< glossary_tooltip text="pod" term_id="pod" >}}-native approach, a pluggable execution environment, and a well-defined surface area. rkt allows users to apply different configurations at both the pod and application level. Each Pod executes directly in the classic Unix process model, in a self-contained, isolated environment.
+rkt is an application {{< glossary_tooltip text="container" term_id="container" >}} engine featuring a {{< glossary_tooltip text="Pod" term_id="pod" >}}-native approach, a pluggable execution environment, and a well-defined surface area. rkt allows users to apply different configurations at both the Pod and application level. Each Pod executes directly in the classic Unix process model, in a self-contained, isolated environment.


### PR DESCRIPTION
Use title case for all the Pod occurrences which appear in the English localization of the _rkt_ glossary term.