### PR TITLE
Correcting sequence of tasks for manage cluster daemon

### DIFF
--- a/content/en/docs/tasks/manage-daemon/rollback-daemon-set.md
+++ b/content/en/docs/tasks/manage-daemon/rollback-daemon-set.md
@@ -3,6 +3,7 @@ reviewers:
 - janetkuo
 title: Perform a Rollback on a DaemonSet
 content_template: templates/task
+weight: 20
 ---
 
 {{% capture overview %}}

--- a/content/en/docs/tasks/manage-daemon/update-daemon-set.md
+++ b/content/en/docs/tasks/manage-daemon/update-daemon-set.md
@@ -3,6 +3,7 @@ reviewers:
 - janetkuo
 title: Perform a Rolling Update on a DaemonSet
 content_template: templates/task
+weight: 10
 ---
 
 {{% capture overview %}}


### PR DESCRIPTION
Corrected sequence of tasks using the `weight`: front-matter key as below
1. Perform a Rolling Update on a DaemonSet
2. Perform a Rollback on a DaemonSet

