### PR TITLE
Document rounding behavior for PDBs

### DIFF
--- a/content/en/docs/tasks/run-application/configure-pdb.md
+++ b/content/en/docs/tasks/run-application/configure-pdb.md
@@ -77,6 +77,22 @@ due to a voluntary disruption.
   - Concern: Job needs to complete in case of voluntary disruption.
     - Possible solution: Do not create a PDB.  The Job controller will create a replacement pod.
 
+### Rounding logic when specifying percentages
+
+Values for `minAvailable` or `maxUnavailable` can be expressed as integers or as a percentage.
+
+- When you specify an integer, it represents a number of Pods. For instance, if you set `minAvailable` to 10, then 10
+  Pods must always be available, even during a disruption.
+- When you specify a percentage by setting the value to a floating-point value between 0 and 1, it represents a percentage of
+  total Pods. For instance, if you set `minUnavailable` to `.5`, then only 50% of the Pods can be unavailable during a
+  disruption.
+
+When you specify a the value as a percentage, it may not map to an exact number of Pods. For example, if you have 7 Pods and
+you set `minAvailable` to `.5`, it's not immediately obvious whether that means 3 Pods or 4 Pods must be available.
+Kubernetes rounds up to the nearest integer, so in this case, 4 Pods must be available. You can examine the
+[code](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/disruption/disruption.go#L539)
+that controls this behavior.
+
 ## Specifying a PodDisruptionBudget
 
 A `PodDisruptionBudget` has three fields: 

--- a/content/en/docs/tasks/run-application/configure-pdb.md
+++ b/content/en/docs/tasks/run-application/configure-pdb.md
@@ -87,7 +87,7 @@ Values for `minAvailable` or `maxUnavailable` can be expressed as integers or as
   total Pods. For instance, if you set `minUnavailable` to `.5`, then only 50% of the Pods can be unavailable during a
   disruption.
 
-When you specify a the value as a percentage, it may not map to an exact number of Pods. For example, if you have 7 Pods and
+When you specify the value as a percentage, it may not map to an exact number of Pods. For example, if you have 7 Pods and
 you set `minAvailable` to `.5`, it's not immediately obvious whether that means 3 Pods or 4 Pods must be available.
 Kubernetes rounds up to the nearest integer, so in this case, 4 Pods must be available. You can examine the
 [code](https://github.com/kubernetes/kubernetes/blob/23be9587a0f8677eb8091464098881df939c44a9/pkg/controller/disruption/disruption.go#L539)

--- a/content/en/docs/tasks/run-application/configure-pdb.md
+++ b/content/en/docs/tasks/run-application/configure-pdb.md
@@ -90,7 +90,7 @@ Values for `minAvailable` or `maxUnavailable` can be expressed as integers or as
 When you specify a the value as a percentage, it may not map to an exact number of Pods. For example, if you have 7 Pods and
 you set `minAvailable` to `.5`, it's not immediately obvious whether that means 3 Pods or 4 Pods must be available.
 Kubernetes rounds up to the nearest integer, so in this case, 4 Pods must be available. You can examine the
-[code](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/disruption/disruption.go#L539)
+[code](https://github.com/kubernetes/kubernetes/blob/23be9587a0f8677eb8091464098881df939c44a9/pkg/controller/disruption/disruption.go#L539)
 that controls this behavior.
 
 ## Specifying a PodDisruptionBudget


### PR DESCRIPTION
Fixes #7581

Document that we round up when a percentage for minAvailable or maxUnavailable

/assign @erictune 