### PR TITLE
Add content/es/docs/tutorials/kubernetes-basics/create-cluster, deploy-app

### DIFF
--- a/content/es/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive.html
+++ b/content/es/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive.html
@@ -1,0 +1,37 @@
+---
+title: Tutorial interactivo - Crear un clúster
+weight: 20
+---
+
+<!DOCTYPE html>
+
+<html lang="en">
+
+<body>
+
+<link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
+<link href="/docs/tutorials/kubernetes-basics/public/css/overrides.css" rel="stylesheet">
+<script src="https://katacoda.com/embed.js"></script>
+
+<div class="layout" id="top">
+
+    <main class="content katacoda-content">
+
+        <div class="katacoda">
+            <div class="katacoda__alert">
+                Para interactuar con la Terminal, use la versión de escritorio / tableta
+            </div>
+            <div class="katacoda__box" id="inline-terminal-1" data-katacoda-lang="es" data-katacoda-id="kubernetes-bootcamp/1" data-katacoda-color="326de6" data-katacoda-secondary="273d6d" data-katacoda-hideintro="false" data-katacoda-font="Roboto" data-katacoda-fontheader="Roboto Slab" data-katacoda-prompt="Kubernetes Bootcamp Terminal" style="height: 600px;"></div>
+        </div>
+        <div class="row">
+            <div class="col-md-12">
+                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/" role="button">Continuar con el Módulo 2<span class="btn__next">›</span></a>
+            </div>
+        </div>
+
+    </main>
+
+</div>
+
+</body>
+</html>

--- a/content/es/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive.html
+++ b/content/es/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive.html
@@ -1,0 +1,41 @@
+---
+title: Tutorial interactivo - Implementando una aplicación
+weight: 20
+---
+
+<!DOCTYPE html>
+
+<html lang="en">
+
+<body>
+
+<link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
+<link href="/docs/tutorials/kubernetes-basics/public/css/overrides.css" rel="stylesheet">
+<script src="https://katacoda.com/embed.js"></script>
+
+<div class="layout" id="top">
+
+    <main class="content katacoda-content">
+
+        <br>
+        <div class="katacoda">
+            <div class="katacoda__alert">
+                Para interactuar con la Terminal, use la versión de escritorio / tableta
+            </div>
+
+            <div class="katacoda__box" id="inline-terminal-1" data-katacoda-lang="es" data-katacoda-id="kubernetes-bootcamp/7" data-katacoda-color="326de6" data-katacoda-secondary="273d6d" data-katacoda-hideintro="false" data-katacoda-font="Roboto" data-katacoda-fontheader="Roboto Slab" data-katacoda-prompt="Kubernetes Bootcamp Terminal" style="height: 600px;">
+            </div>
+
+        </div>
+        <div class="row">
+            <div class="col-md-12">
+                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/explore/explore-intro/" role="button">Continuar con el Módulo 3<span class="btn__next">›</span></a>
+            </div>
+        </div>
+
+    </main>
+
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
Katacoda now supports the ability to translate the website elements.

In celebration of Kubecon EU, we have put live the Spanish translation. Other translations and languages are also supported once the content has been created.

Here is a screenshot of what it looks like:

![Screenshot 2019-05-20 16 21 30](https://user-images.githubusercontent.com/82614/58029055-b56e2380-7b13-11e9-9777-5a1a1ff03bf0.png)

Thanks to a combined effort from @gsoria and @raelga. Once the rest of the scenarios are live then I'll submit the completed PR.

Creating a draft to produce netlify URL and gather feedback.