### PR TITLE
Switched to using GNU standard

### DIFF
--- a/content/en/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases.md
+++ b/content/en/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases.md
@@ -82,7 +82,7 @@ pod/hostaliases-pod created
 Examine a Pod IP and status:
 
 ```shell
-kubectl get pod -o=wide
+kubectl get pod --output=wide
 ```
 
 ```shell


### PR DESCRIPTION
Extra fix for #14211, This PR is to make sure the whole page at https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/ follows the GNU standard.