### PR TITLE
Adding example to show labels in POD yaml

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/labels.md
+++ b/content/en/docs/concepts/overview/working-with-objects/labels.md
@@ -55,6 +55,24 @@ The `kubernetes.io/` and `k8s.io/` prefixes are reserved for Kubernetes core com
 
 Valid label values must be 63 characters or less and must be empty or begin and end with an alphanumeric character (`[a-z0-9A-Z]`) with dashes (`-`), underscores (`_`), dots (`.`), and alphanumerics between.
 
+For example, the sample Pod with the labels `environment: production` and `tier: frontend`:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cuda-test
+  labels:
+    environment: production
+    tier: frontend
+spec:
+  containers:
+    - name: cuda-test
+      image: "k8s.gcr.io/cuda-vector-add:v0.1"
+      resources:
+        limits:
+          nvidia.com/gpu: 1
+```
 ## Label selectors
 
 Unlike [names and UIDs](/docs/user-guide/identifiers), labels do not provide uniqueness. In general, we expect many objects to carry the same label(s).

--- a/content/en/docs/concepts/overview/working-with-objects/labels.md
+++ b/content/en/docs/concepts/overview/working-with-objects/labels.md
@@ -55,24 +55,26 @@ The `kubernetes.io/` and `k8s.io/` prefixes are reserved for Kubernetes core com
 
 Valid label values must be 63 characters or less and must be empty or begin and end with an alphanumeric character (`[a-z0-9A-Z]`) with dashes (`-`), underscores (`_`), dots (`.`), and alphanumerics between.
 
-For example, the sample Pod with the labels `environment: production` and `tier: frontend`:
+For example, here’s the configuration file for a Pod that has two labels `environment: production` and `app: nginx` :
 
 ```yaml
+
 apiVersion: v1
 kind: Pod
 metadata:
-  name: cuda-test
+  name: label-demo
   labels:
     environment: production
-    tier: frontend
+    app: nginx
 spec:
   containers:
-    - name: cuda-test
-      image: "k8s.gcr.io/cuda-vector-add:v0.1"
-      resources:
-        limits:
-          nvidia.com/gpu: 1
+  - name: nginx
+    image: nginx:1.7.9
+    ports:
+    - containerPort: 80
+    
 ```
+
 ## Label selectors
 
 Unlike [names and UIDs](/docs/user-guide/identifiers), labels do not provide uniqueness. In general, we expect many objects to carry the same label(s).


### PR DESCRIPTION
This page talk about labels and its syntax. But it does not show how we can have labels in resource manifest. So with this PR I am adding example which shows that how we can have labels in pod manifest.