### PR TITLE
Redis ConfigMap Tutorial - Pod YAML command and change pod curl

### DIFF
--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -57,7 +57,7 @@ Add the pod resource config to the `kustomization.yaml`:
 {{< codenew file="pods/config/redis-pod.yaml" >}}
 
 ```shell
-curl -OL https://k8s.io/examples/pods/config/redis-pod.yaml
+curl -OL https://raw.githubusercontent.com/kubernetes/website/master/content/en/examples/pods/config/redis-pod.yaml
 
 cat <<EOF >>./kustomization.yaml
 resources:

--- a/content/en/examples/pods/config/redis-pod.yaml
+++ b/content/en/examples/pods/config/redis-pod.yaml
@@ -6,6 +6,9 @@ spec:
   containers:
   - name: redis
     image: redis:5.0.4
+    command:
+      - redis-server
+      - "/redis-master/redis.conf"
     env:
     - name: MASTER
       value: "true"


### PR DESCRIPTION
This PR addresses both #14401 and #14428. 

Although there may be a better way to fix #14428 as it has a friendly DNS name for the for the `curl` command, (`curl -OLhttps://k8s.io/examples/pods/config/redis-pod.yaml`) and replacing is with
`curl -OL https://raw.githubusercontent.com/kubernetes/website/master/content/en/examples/pods/config/redis-pod.yaml` might be less ideal. I'm not sure how the `k8s.io` DNS name from above would be updated. 

Second issue (#14428) - redis Pod needed a `command` to use the provided config map. 
