### PR TITLE
promote AWS-NLB Support from alpha to beta

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -700,15 +700,11 @@ There are other annotations to manage Classic Elastic Load Balancers that are de
         # A list of additional security groups to be added to ELB
 ```
 
-#### Network Load Balancer support on AWS [alpha]
+#### Network Load Balancer support on AWS
 
-{{< warning >}}
-This is an alpha feature and not recommended for production clusters yet.
-{{< /warning >}}
+{{< feature-state for_k8s_version="v1.15" state="beta" >}}
 
-Starting in version 1.9.0, Kubernetes supports Network Load Balancer (NLB). To
-use a Network Load Balancer on AWS, use the annotation `service.beta.kubernetes.io/aws-load-balancer-type`
-with the value set to `nlb`.
+To use a Network Load Balancer on AWS, use the annotation `service.beta.kubernetes.io/aws-load-balancer-type` with the value set to `nlb`.
 
 ```yaml
     metadata:


### PR DESCRIPTION
Promote AWS-NLB support from alpha to beta

Note:
This is just for updating the AWS-NLB feature status.
There should be future PR to enhance the doc structure. e.g. SSL support is available on both NLB & CLB, we should reorganize it to make it cleaner.