### PR TITLE
Add kubeadm_init_phase_kubeconfig_controller-manager.md and kubeadm_init_phase_mark-control-plane.md in zh doc.

### DIFF
--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_kubeconfig_controller-manager.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_kubeconfig_controller-manager.md
@@ -1,0 +1,137 @@
+
+<!-- Generates a kubeconfig file for the controller manager to use -->
+为 controller manager 生成要使用的 kubeconfig 文件
+
+<!-- ### Synopsis -->
+### 概要
+
+
+<!-- Generates the kubeconfig file for the controller manager to use and saves it to controller-manager.conf file -->
+生成 controller manager 要使用的的 kubeconfig ，并保存到 controller-manager.conf 文件中
+
+```
+kubeadm init phase kubeconfig controller-manager [flags]
+```
+
+<!-- ### Options -->
+### 选项
+
+<table style="width: 100%; table-layout: fixed;">
+  <colgroup>
+    <col span="1" style="width: 10px;" />
+    <col span="1" />
+  </colgroup>
+  <tbody>
+
+<!--     <tr>
+      <td colspan="2">--apiserver-advertise-address string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;">The IP address the API Server will advertise it's listening on. Specify '0.0.0.0' to use the address of the default network interface.</td>
+    </tr> -->
+    <tr>
+      <td colspan="2">--apiserver-advertise-address 字符串</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;"> API Server 将 advertise listening 设置的IP地址为当前监听的地址。“0.0.0.0”以使用默认指定的网络接口地址。</td>
+    </tr>
+
+<!--     <tr>
+      <td colspan="2">--apiserver-bind-port int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 6443</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;">Port for the API Server to bind to.</td>
+    </tr> -->
+    <tr>
+      <td colspan="2">--apiserver-bind-port int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 6443</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;">要绑定到 API Server 的端口。</td>
+    </tr>
+
+
+<!--     <tr>
+      <td colspan="2">--cert-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/etc/kubernetes/pki"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;">The path where to save and store the certificates.</td>
+    </tr> -->
+    <tr>
+      <td colspan="2">--cert-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/etc/kubernetes/pki"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;">保存和存储证书的路径。</td>
+    </tr>
+
+<!--     <tr>
+      <td colspan="2">--config string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;">Path to kubeadm config file. WARNING: Usage of a configuration file is experimental.</td>
+    </tr> -->
+    <tr>
+      <td colspan="2">--config string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;"> kubeadm 配置文件的路径。警告：配置文件的使用是实验性的。</td>
+    </tr>
+
+<!--     <tr>
+      <td colspan="2">-h, --help</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;">help for controller-manager</td>
+    </tr> -->
+    <tr>
+      <td colspan="2">-h, --help</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;"> controller-manager 的帮助</td>
+    </tr>
+
+<!--     <tr>
+      <td colspan="2">--kubeconfig-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/etc/kubernetes"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;">The path where to save the kubeconfig file.</td>
+    </tr> -->
+    <tr>
+      <td colspan="2">--kubeconfig-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/etc/kubernetes"</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;">保存 kubeconfig 的路径。</td>
+    </tr>
+
+  </tbody>
+</table>
+
+
+
+<!-- ### Options inherited from parent commands -->
+### 从父命令继承的选项
+
+<table style="width: 100%; table-layout: fixed;">
+  <colgroup>
+    <col span="1" style="width: 10px;" />
+    <col span="1" />
+  </colgroup>
+  <tbody>
+
+<!--     <tr>
+      <td colspan="2">--rootfs string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;">[EXPERIMENTAL] The path to the 'real' host root filesystem.</td>
+    </tr> -->
+    <tr>
+      <td colspan="2">--rootfs 字符串</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;">[实验] “真正的”主机 Rootfs 的路径。</td>
+    </tr>
+
+  </tbody>
+</table>
+
+
+

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_kubeconfig_controller-manager.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_kubeconfig_controller-manager.md
@@ -58,7 +58,7 @@ kubeadm init phase kubeconfig controller-manager [flags]
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The path where to save and store the certificates.</td>
     </tr> -->
     <tr>
-      <td colspan="2">--cert-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/etc/kubernetes/pki"</td>
+      <td colspan="2">--cert-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值: "/etc/kubernetes/pki"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">保存和存储证书的路径。</td>

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_kubeconfig_controller-manager.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_kubeconfig_controller-manager.md
@@ -33,7 +33,7 @@ kubeadm init phase kubeconfig controller-manager [flags]
       <td colspan="2">--apiserver-advertise-address 字符串</td>
     </tr>
     <tr>
-      <td></td><td style="line-height: 130%; word-wrap: break-word;"> API Server 将 advertise listening 设置的IP地址为当前监听的地址。“0.0.0.0”以使用默认指定的网络接口地址。</td>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;"> API Server 对外发布的当前监听地址。设置此值为 “0.0.0.0” 以使用默认网络接口的 IP 地址。</td>
     </tr>
 
 <!--     <tr>
@@ -127,7 +127,7 @@ kubeadm init phase kubeconfig controller-manager [flags]
       <td colspan="2">--rootfs 字符串</td>
     </tr>
     <tr>
-      <td></td><td style="line-height: 130%; word-wrap: break-word;">[实验] “真正的”主机 Rootfs 的路径。</td>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;">[实验] 主机根文件系统的“真实”路径。</td>
     </tr>
 
   </tbody>

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_kubeconfig_controller-manager.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_kubeconfig_controller-manager.md
@@ -1,13 +1,13 @@
 
 <!-- Generates a kubeconfig file for the controller manager to use -->
-为 controller manager 生成要使用的 kubeconfig 文件
+为控制器管理器生成要使用的 kubeconfig 文件
 
 <!-- ### Synopsis -->
 ### 概要
 
 
 <!-- Generates the kubeconfig file for the controller manager to use and saves it to controller-manager.conf file -->
-生成 controller manager 要使用的的 kubeconfig ，并保存到 controller-manager.conf 文件中
+生成控制器管理器要使用的 kubeconfig ，并保存到 controller-manager.conf 文件中
 
 ```
 kubeadm init phase kubeconfig controller-manager [flags]
@@ -43,7 +43,8 @@ kubeadm init phase kubeconfig controller-manager [flags]
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Port for the API Server to bind to.</td>
     </tr> -->
     <tr>
-      <td colspan="2">--apiserver-bind-port int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 6443</td>
+      <td colspan="2">--apiserver-bind-port int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+      默认值: 6443</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">要绑定到 API Server 的端口。</td>
@@ -86,7 +87,7 @@ kubeadm init phase kubeconfig controller-manager [flags]
       <td colspan="2">-h, --help</td>
     </tr>
     <tr>
-      <td></td><td style="line-height: 130%; word-wrap: break-word;"> controller-manager 的帮助</td>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;"> controller-manager 命令的帮助</td>
     </tr>
 
 <!--     <tr>
@@ -96,7 +97,8 @@ kubeadm init phase kubeconfig controller-manager [flags]
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The path where to save the kubeconfig file.</td>
     </tr> -->
     <tr>
-      <td colspan="2">--kubeconfig-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/etc/kubernetes"</td>
+      <td colspan="2">--kubeconfig-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+      默认值: "/etc/kubernetes"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">保存 kubeconfig 的路径。</td>

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_mark-control-plane.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_mark-control-plane.md
@@ -17,11 +17,9 @@ kubeadm init phase mark-control-plane [flags]
 ### 例子
 
 ```
-  # Applies control-plane label and taint to the current node, functionally equivalent to what executed by kubeadm init.
   # 将控制平面的标签和污点应用于当前节点，功能上等同于 kubeadm init 执行的操作。
   kubeadm init phase mark-control-plane --config config.yml
 
-  # Applies control-plane label and taint to a specific node
   # 将控制平面的标签和污点应用于特定节点
   kubeadm init phase mark-control-plane --node-name myNode
 ```
@@ -60,7 +58,7 @@ kubeadm init phase mark-control-plane [flags]
       <td colspan="2">-h, --help</td>
     </tr>
     <tr>
-      <td></td><td style="line-height: 130%; word-wrap: break-word;">标记控制平面的帮助</td>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;"> mark-control-plane 命令的帮助</td>
     </tr>
 
 <!--     <tr>
@@ -103,7 +101,7 @@ kubeadm init phase mark-control-plane [flags]
       <td colspan="2">--rootfs 字符串</td>
     </tr>
     <tr>
-      <td></td><td style="line-height: 130%; word-wrap: break-word;">[实验] “真正的”主机 Rootfs 的路径。</td>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;">主机根文件系统的“真实”路径。</td>
     </tr>
 
   </tbody>

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_mark-control-plane.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_mark-control-plane.md
@@ -1,0 +1,113 @@
+
+<!-- Mark a node as a control-plane -->
+将节点标记为控制平面
+
+<!-- ### Synopsis -->
+### 概要
+
+
+<!-- Mark a node as a control-plane -->
+将节点标记为控制平面
+
+```
+kubeadm init phase mark-control-plane [flags]
+```
+
+<!-- ### Examples -->
+### 例子
+
+```
+  # Applies control-plane label and taint to the current node, functionally equivalent to what executed by kubeadm init.
+  # 将控制平面的标签和污点应用于当前节点，功能上等同于 kubeadm init 执行的操作。
+  kubeadm init phase mark-control-plane --config config.yml
+
+  # Applies control-plane label and taint to a specific node
+  # 将控制平面的标签和污点应用于特定节点
+  kubeadm init phase mark-control-plane --node-name myNode
+```
+
+<!-- ### Options -->
+### 选项
+
+<table style="width: 100%; table-layout: fixed;">
+  <colgroup>
+    <col span="1" style="width: 10px;" />
+    <col span="1" />
+  </colgroup>
+  <tbody>
+
+<!--     <tr>
+      <td colspan="2">--config string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;">Path to kubeadm config file. WARNING: Usage of a configuration file is experimental.</td>
+    </tr> -->
+    <tr>
+      <td colspan="2">--config string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;"> kubeadm 配置文件的路径。 警告：配置文件的使用是实验性的。</td>
+    </tr>
+
+<!--     <tr>
+      <td colspan="2">-h, --help</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;">help for mark-control-plane</td>
+    </tr> -->
+
+    <tr>
+      <td colspan="2">-h, --help</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;">标记控制平面的帮助</td>
+    </tr>
+
+<!--     <tr>
+      <td colspan="2">--node-name string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;">Specify the node name.</td>
+    </tr> -->
+
+    <tr>
+      <td colspan="2">--node-name string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;">指定节点名称。</td>
+    </tr>
+
+  </tbody>
+</table>
+
+
+
+<!-- ### Options inherited from parent commands -->
+<!-- ### Options inherited from parent commands -->
+### 从父命令继承的选项
+
+<table style="width: 100%; table-layout: fixed;">
+  <colgroup>
+    <col span="1" style="width: 10px;" />
+    <col span="1" />
+  </colgroup>
+  <tbody>
+
+<!--     <tr>
+      <td colspan="2">--rootfs string</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;">[EXPERIMENTAL] The path to the 'real' host root filesystem.</td>
+    </tr> -->
+    <tr>
+      <td colspan="2">--rootfs 字符串</td>
+    </tr>
+    <tr>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;">[实验] “真正的”主机 Rootfs 的路径。</td>
+    </tr>
+
+  </tbody>
+</table>
+
+
+


### PR DESCRIPTION
> For Chinese localization, base branch to release-1.14.
Add kubeadm_init_phase_kubeconfig_controller-manager.md and kubeadm_init_phase_mark-control-plane.md in zh doc.

