### PR TITLE
Add a Korean l10n reviewer to OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -124,6 +124,7 @@ aliases:
     - ClaudiaJKang
     - gochist
     - ianychoi
+    - seokho-son
   sig-docs-maintainers: # Website maintainers
     - bradamant3
     - chenopis


### PR DESCRIPTION
This PR updates OWNERS_ALIASES 
to add @seokho-son to sig-docs-ko-reviews. (Korean l10n team reviewer)

@seokho-son is a member of Kubernetes and a primary reviewer of following PRs.
https://github.com/kubernetes/website/pull/14115
https://github.com/kubernetes/website/pull/13938
https://github.com/kubernetes/website/pull/13812
https://github.com/kubernetes/website/pull/13549
https://github.com/kubernetes/website/pull/13076
...

/assign @zacharysarah

[Korean l10n team cc]
/cc @gochist 
/cc @ClaudiaJKang 