### PR TITLE
Update URL in /docs/tasks/federation/administer-federation/cluster

### DIFF
--- a/content/en/docs/tasks/federation/administer-federation/cluster.md
+++ b/content/en/docs/tasks/federation/administer-federation/cluster.md
@@ -20,7 +20,7 @@ federation api-server.
 {{% capture prerequisites %}}
 
 * {{< include "federated-task-tutorial-prereqs.md" >}}
-* You should also have a basic [working knowledge of Kubernetes](/docs/setup/pick-right-solution/) in
+* You should also have a basic [working knowledge of Kubernetes](/docs/setup/) in
 general.
 
 {{% /capture %}}


### PR DESCRIPTION
Reference URL: https://kubernetes.io/docs/tasks/federation/administer-federation/cluster/#before-you-begin
"working knowledge of Kubernetes" redirects to a URL which doesnot exist