### PR TITLE
Add description when a PDB is needed

### DIFF
--- a/content/en/docs/concepts/workloads/pods/disruptions.md
+++ b/content/en/docs/concepts/workloads/pods/disruptions.md
@@ -16,6 +16,13 @@ what types of Disruptions can happen to Pods.
 It is also for Cluster Administrators who want to perform automated
 cluster actions, like upgrading and autoscaling clusters.
 
+It is most useful if your Pod has special requirements to run and not all your
+nodes provide this environment, eg. some are Linux and some are Windows. In this
+case, even though the cluster has resources left, the constraints for your Pod
+does not allow it to be scheduled on the other node pool. If all your nodes
+provide the same environment, you generally don't need Pod Disruption Budgets, as
+Kubernetes will try to keep your given amount of Pods available.
+
 {{% /capture %}}
 
 


### PR DESCRIPTION
In generally from my perspective you don't need a PDB defined as Kubernetes will try to do that job already as good as it can.

I see people use the PDB wrongly where they should rather raise the amount of pods the run, as a unforseen event for cause disruption for them anyways.

Most people that run Kubernetes run with nodes there are completely identical, meaning that in a Node Pool migration, all modes evicted would easily be able to fit on another node pool.

I want to include something on this page to tell that most people don't need to define it, as I think this also causes people to believe that Kubernetes requires more YAML than necessary and will begin to include it even for simple Kubernetes yaml deployments.

PodDisruptionBudgets are a super cool feature, but I think it is more of a advance feature than a feature beginners need to care about.

It is also used sometimes to run only 1-2 pod of a application than in a unforseen event would take out the application, which is never what you want anyways, therefore the page could also encourage people to run 3 pods/replicas instead to both cover for unforseen and forseen events.