### PR TITLE
Fix dead links related to Kubernetes object management

### DIFF
--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -75,11 +75,11 @@ kubectl create secret generic db-user-pass --from-file=./username.txt --from-fil
 ```
 secret "db-user-pass" created
 ```
-{{< note >}}	
-Special characters such as `$`, `\*`, and `!` require escaping.	
-If the password you are using has special characters, you need to escape them using the `\\` character. For example, if your actual password is `S!B\*d$zDsb`, you should execute the command this way:	
-     kubectl create secret generic dev-db-secret --from-literal=username=devuser --from-literal=password=S\\!B\\\\*d\\$zDsb	
- You do not need to escape special characters in passwords from files (`--from-file`).	
+{{< note >}}
+Special characters such as `$`, `\*`, and `!` require escaping.
+If the password you are using has special characters, you need to escape them using the `\\` character. For example, if your actual password is `S!B\*d$zDsb`, you should execute the command this way:
+     kubectl create secret generic dev-db-secret --from-literal=username=devuser --from-literal=password=S\\!B\\\\*d\\$zDsb
+ You do not need to escape special characters in passwords from files (`--from-file`).
 {{< /note >}}
 
 You can check that the secret was created like this:
@@ -261,9 +261,9 @@ the option `-w 0` to `base64` commands or the pipeline `base64 | tr -d '\n'` if
 `-w` option is not available.
 
 #### Creating a Secret from Generator
-Kubectl supports [managing objects using Kustomize](/docs/concepts/overview/object-management-kubectl/kustomization/)
+Kubectl supports [managing objects using Kustomize](/docs/tasks/manage-kubernetes-objects/kustomization/)
 since 1.14. With this new feature,
-you can also create a Secret from generators and then apply it to create the object on 
+you can also create a Secret from generators and then apply it to create the object on
 the Apiserver. The generators
 should be specified in a `kustomization.yaml` inside a directory.
 

--- a/content/en/docs/concepts/services-networking/network-policies.md
+++ b/content/en/docs/concepts/services-networking/network-policies.md
@@ -77,7 +77,7 @@ __Mandatory Fields__: As with all other Kubernetes config, a `NetworkPolicy`
 needs `apiVersion`, `kind`, and `metadata` fields.  For general information
 about working with config files, see
 [Configure Containers Using a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/),
-and [Object Management](/docs/concepts/overview/object-management-kubectl/overview/).
+and [Object Management](/docs/concepts/overview/working-with-objects/object-management).
 
 __spec__: `NetworkPolicy` [spec](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status) has all the information needed to define a particular network policy in the given namespace.
 

--- a/content/en/docs/concepts/workloads/controllers/daemonset.md
+++ b/content/en/docs/concepts/workloads/controllers/daemonset.md
@@ -49,7 +49,7 @@ kubectl apply -f https://k8s.io/examples/controllers/daemonset.yaml
 
 As with all other Kubernetes config, a DaemonSet needs `apiVersion`, `kind`, and `metadata` fields.  For
 general information about working with config files, see [deploying applications](/docs/user-guide/deploying-applications/),
-[configuring containers](/docs/tasks/), and [object management using kubectl](/docs/concepts/overview/object-management-kubectl/overview/) documents.
+[configuring containers](/docs/tasks/), and [object management using kubectl](/docs/concepts/overview/working-with-objects/object-management/) documents.
 
 A DaemonSet also needs a [`.spec`](https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status) section.
 

--- a/content/en/docs/concepts/workloads/controllers/deployment.md
+++ b/content/en/docs/concepts/workloads/controllers/deployment.md
@@ -974,7 +974,7 @@ can create multiple Deployments, one for each release, following the canary patt
 
 As with all other Kubernetes configs, a Deployment needs `apiVersion`, `kind`, and `metadata` fields.
 For general information about working with config files, see [deploying applications](/docs/tutorials/stateless-application/run-stateless-application-deployment/),
-configuring containers, and [using kubectl to manage resources](/docs/concepts/overview/object-management-kubectl/overview/) documents.
+configuring containers, and [using kubectl to manage resources](/docs/concepts/overview/working-with-objects/object-management/) documents.
 
 A Deployment also needs a [`.spec` section](https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status).
 

--- a/content/en/docs/concepts/workloads/controllers/replicationcontroller.md
+++ b/content/en/docs/concepts/workloads/controllers/replicationcontroller.md
@@ -3,7 +3,7 @@ reviewers:
 - bprashanth
 - janetkuo
 title: ReplicationController
-feature: 
+feature:
   title: Self-healing
   anchor: How a ReplicationController Works
   description: >
@@ -116,7 +116,7 @@ specifies an expression that just gets the name from each pod in the returned li
 ## Writing a ReplicationController Spec
 
 As with all other Kubernetes config, a ReplicationController needs `apiVersion`, `kind`, and `metadata` fields.
-For general information about working with config files, see [object management ](/docs/concepts/overview/object-management-kubectl/overview/).
+For general information about working with config files, see [object management ](/docs/concepts/overview/working-with-objects/object-management/).
 
 A ReplicationController also needs a [`.spec` section](https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status).
 
@@ -152,7 +152,7 @@ If specified, the `.spec.template.metadata.labels` must be equal to the `.spec.s
 be rejected by the API.  If `.spec.selector` is unspecified, it will be defaulted to
 `.spec.template.metadata.labels`.
 
-Also you should not normally create any pods whose labels match this selector, either directly, with 
+Also you should not normally create any pods whose labels match this selector, either directly, with
 another ReplicationController, or with another controller such as Job. If you do so, the
 ReplicationController thinks that it created the other pods.  Kubernetes does not stop you
 from doing this.
@@ -289,5 +289,3 @@ safe to terminate when the machine is otherwise ready to be rebooted/shutdown.
 Read [Run Stateless AP Replication Controller](/docs/tutorials/stateless-application/run-stateless-ap-replication-controller/).
 
 {{% /capture %}}
-
-

--- a/content/en/docs/tasks/manage-daemon/update-daemon-set.md
+++ b/content/en/docs/tasks/manage-daemon/update-daemon-set.md
@@ -95,7 +95,7 @@ update. This can be done with several different `kubectl` commands.
 #### Declarative commands
 
 If you update DaemonSets using
-[configuration files](/docs/concepts/overview/object-management-kubectl/declarative-config/),
+[configuration files](/docs/tasks/manage-kubernetes-objects/declarative-config/),
 use `kubectl apply`:
 
 ```shell
@@ -105,7 +105,7 @@ kubectl apply -f ds-v2.yaml
 #### Imperative commands
 
 If you update DaemonSets using
-[imperative commands](/docs/concepts/overview/object-management-kubectl/imperative-command/),
+[imperative commands](/docs/tasks/manage-kubernetes-objects/imperative-command/),
 use `kubectl edit` or `kubectl patch`:
 
 ```shell

--- a/content/en/docs/tasks/manage-kubernetes-objects/declarative-config.md
+++ b/content/en/docs/tasks/manage-kubernetes-objects/declarative-config.md
@@ -31,7 +31,7 @@ The `kubectl` tool supports three kinds of object management:
 * Imperative object configuration
 * Declarative object configuration
 
-See [Kubernetes Object Management](/docs/concepts/overview/object-management-kubectl/overview/)
+See [Kubernetes Object Management](/docs/concepts/overview/working-with-objects/object-management/)
 for a discussion of the advantages and disadvantage of each kind of object management.
 
 ## Overview

--- a/content/en/docs/tasks/run-application/update-api-object-kubectl-patch.md
+++ b/content/en/docs/tasks/run-application/update-api-object-kubectl-patch.md
@@ -330,11 +330,9 @@ and
 
 {{% capture whatsnext %}}
 
-* [Kubernetes Object Management](/docs/concepts/overview/object-management-kubectl/overview/)
-* [Managing Kubernetes Objects Using Imperative Commands](/docs/concepts/overview/object-management-kubectl/imperative-command/)
-* [Imperative Management of Kubernetes Objects Using Configuration Files](/docs/concepts/overview/object-management-kubectl/imperative-config/)
-* [Declarative Management of Kubernetes Objects Using Configuration Files](/docs/concepts/overview/object-management-kubectl/declarative-config/)
+* [Kubernetes Object Management](/docs/concepts/overview/working-with-objects/object-management/)
+* [Managing Kubernetes Objects Using Imperative Commands](/docs/tasks/manage-kubernetes-objects/imperative-command/)
+* [Imperative Management of Kubernetes Objects Using Configuration Files](/docs/tasks/manage-kubernetes-objects/imperative-config/)
+* [Declarative Management of Kubernetes Objects Using Configuration Files](/docs/tasks/manage-kubernetes-objects/declarative-config/)
 
 {{% /capture %}}
-
-


### PR DESCRIPTION
Kubernetes object management related documentation was moved from the old path `/docs/concepts/overview/object-management-kubectl`. In all places that referenced `overview.md`, I changed it to `/docs/concepts/overview/working-with-objects/object-management/`. All of the old `object-management-kubectl/*.md` files (_except_ `overview.md`) were moved to `/docs/tasks/manage-kubernetes-objects`, so all links referencing specific concepts were pointed to the tasks path.

Addresses #14453 