### PR TITLE
Fix "Basic Working Knowledge of Kubernetes" links and standardize wording

### DIFF
--- a/content/en/docs/tasks/federation/administer-federation/cluster.md
+++ b/content/en/docs/tasks/federation/administer-federation/cluster.md
@@ -20,7 +20,7 @@ federation api-server.
 {{% capture prerequisites %}}
 
 * {{< include "federated-task-tutorial-prereqs.md" >}}
-* You should also have a basic [working knowledge of Kubernetes](/docs/setup/) in
+* You should also have a basic [working knowledge of Kubernetes](/docs/tutorials/kubernetes-basics/) in
 general.
 
 {{% /capture %}}

--- a/content/en/docs/tasks/federation/administer-federation/configmap.md
+++ b/content/en/docs/tasks/federation/administer-federation/configmap.md
@@ -22,7 +22,7 @@ across all the clusters in federation.
 
 * {{< include "federated-task-tutorial-prereqs.md" >}}
 * You should also have a basic
-[working knowledge of Kubernetes](/docs/setup/) in
+[working knowledge of Kubernetes](/docs/tutorials/kubernetes-basics/) in
 general and [ConfigMaps](/docs/tasks/configure-pod-container/configure-pod-configmap/) in particular.
 
 {{% /capture %}}

--- a/content/en/docs/tasks/federation/administer-federation/daemonset.md
+++ b/content/en/docs/tasks/federation/administer-federation/daemonset.md
@@ -21,8 +21,8 @@ across all the clusters in federation.
 {{% capture prerequisites %}}
 
 * {{< include "federated-task-tutorial-prereqs.md" >}}
-* You are also expected to have a basic
-[working knowledge of Kubernetes](/docs/setup/) in
+* You should also have a basic
+[working knowledge of Kubernetes](/docs/tutorials/kubernetes-basics/) in
 general and [DaemonSets](/docs/concepts/workloads/controllers/daemonset/) in particular.
 
 {{% /capture %}}

--- a/content/en/docs/tasks/federation/administer-federation/deployment.md
+++ b/content/en/docs/tasks/federation/administer-federation/deployment.md
@@ -27,7 +27,7 @@ Some features
 
 * {{< include "federated-task-tutorial-prereqs.md" >}}
 * You should also have a basic
-[working knowledge of Kubernetes](/docs/setup/) in
+[working knowledge of Kubernetes](/docs/tutorials/kubernetes-basics/) in
 general and [Deployments](/docs/concepts/workloads/controllers/deployment/) in particular.
 
 {{% /capture %}}

--- a/content/en/docs/tasks/federation/administer-federation/events.md
+++ b/content/en/docs/tasks/federation/administer-federation/events.md
@@ -26,8 +26,8 @@ this for you). Other tutorials, for example
 [this one](https://github.com/kelseyhightower/kubernetes-cluster-federation)
 by Kelsey Hightower, are also available to help you.
 
-You are also expected to have a basic
-[working knowledge of Kubernetes](/docs/setup/) in
+You should also have a basic
+[working knowledge of Kubernetes](/docs/tutorials/kubernetes-basics/) in
 general.
 
 ## View federation events

--- a/content/en/docs/tasks/federation/administer-federation/hpa.md
+++ b/content/en/docs/tasks/federation/administer-federation/hpa.md
@@ -25,8 +25,8 @@ needed most by manipulating the min and max limits of the HPA objects in the fed
 {{% capture prerequisites %}}
 
 * {{< include "federated-task-tutorial-prereqs.md" >}}
-* You are also expected to have a basic
-[working knowledge of Kubernetes](/docs/setup/) in
+* You should also have a basic
+[working knowledge of Kubernetes](/docs/tutorials/kubernetes-basics/) in
 general and [HPAs](/docs/tasks/run-application/horizontal-pod-autoscale/) in particular.
 
 The federated HPA is an alpha feature. The API is not enabled by default on the

--- a/content/en/docs/tasks/federation/administer-federation/ingress.md
+++ b/content/en/docs/tasks/federation/administer-federation/ingress.md
@@ -71,8 +71,8 @@ this for you). Other tutorials, for example
 [this one](https://github.com/kelseyhightower/kubernetes-cluster-federation)
 by Kelsey Hightower, are also available to help you.
 
-You must also have a basic
-[working knowledge of Kubernetes](/docs/setup/) in
+You should also have a basic
+[working knowledge of Kubernetes](/docs/tutorials/kubernetes-basics/) in
 general, and [Ingress](/docs/concepts/services-networking/ingress/) in particular.
 {{% /capture %}}
 

--- a/content/en/docs/tasks/federation/administer-federation/job.md
+++ b/content/en/docs/tasks/federation/administer-federation/job.md
@@ -21,8 +21,8 @@ parallelism and completions exist across the registered clusters.
 {{% capture prerequisites %}}
 
 * {{< include "federated-task-tutorial-prereqs.md" >}}
-* You are also expected to have a basic
-[working knowledge of Kubernetes](/docs/setup/) in
+* You should also have a basic
+[working knowledge of Kubernetes](/docs/tutorials/kubernetes-basics/) in
 general and [jobs](/docs/concepts/workloads/controllers/jobs-run-to-completion/) in particular.
 {{% /capture %}}
 

--- a/content/en/docs/tasks/federation/administer-federation/namespaces.md
+++ b/content/en/docs/tasks/federation/administer-federation/namespaces.md
@@ -22,7 +22,7 @@ across all the clusters in federation.
 
 * {{< include "federated-task-tutorial-prereqs.md" >}}
 * You are also expected to have a basic
-[working knowledge of Kubernetes](/docs/setup/) in
+[working knowledge of Kubernetes](/docs/tutorials/kubernetes-basics/) in
 general and [Namespaces](/docs/concepts/overview/working-with-objects/namespaces/) in particular.
 
 {{% /capture %}}

--- a/content/en/docs/tasks/federation/administer-federation/replicaset.md
+++ b/content/en/docs/tasks/federation/administer-federation/replicaset.md
@@ -21,8 +21,8 @@ replicas exist across the registered clusters.
 {{% capture prerequisites %}}
 
 * {{< include "federated-task-tutorial-prereqs.md" >}}
-* You are also expected to have a basic
-[working knowledge of Kubernetes](/docs/setup/) in
+* You should also have a basic
+[working knowledge of Kubernetes](/docs/tutorials/kubernetes-basics/) in
 general and [ReplicaSets](/docs/concepts/workloads/controllers/replicaset/) in particular.
 {{% /capture %}}
 

--- a/content/en/docs/tasks/federation/administer-federation/secret.md
+++ b/content/en/docs/tasks/federation/administer-federation/secret.md
@@ -31,8 +31,8 @@ this for you). Other tutorials, for example
 [this one](https://github.com/kelseyhightower/kubernetes-cluster-federation)
 by Kelsey Hightower, are also available to help you.
 
-You are also expected to have a basic
-[working knowledge of Kubernetes](/docs/setup/) in
+You should also have a basic
+[working knowledge of Kubernetes](/docs/tutorials/kubernetes-basics/) in
 general and [Secrets](/docs/concepts/configuration/secret/) in particular.
 
 ## Creating a Federated Secret

--- a/content/en/docs/tasks/federation/federation-service-discovery.md
+++ b/content/en/docs/tasks/federation/federation-service-discovery.md
@@ -62,8 +62,8 @@ this for you). Other tutorials, for example
 [this one](https://github.com/kelseyhightower/kubernetes-cluster-federation)
 by Kelsey Hightower, are also available to help you.
 
-You are also expected to have a basic
-[working knowledge of Kubernetes](/docs/setup/) in
+You should also have a basic
+[working knowledge of Kubernetes](/docs/tutorials/kubernetes-basics/) in
 general, and [Services](/docs/concepts/services-networking/service/) in particular.
 
 ## Hybrid cloud capabilities


### PR DESCRIPTION
Multiple references to the same link in the Federation docs were dead, PR #14468 fixed that and redirected to `/setup` but @sftim (FYI BTW) mentioned that perhaps routing to `/docs/tutorials/kubernetes-basics/` might be a better idea. 

Many pages under the federation section shared a similar prerequisites setup, this PR fixes those links to route to a better location (basics vs setup) and standardizes the wording. 


