### PR TITLE
Add more language specific slack channels

### DIFF
--- a/content/en/docs/tasks/debug-application-cluster/troubleshooting.md
+++ b/content/en/docs/tasks/debug-application-cluster/troubleshooting.md
@@ -70,7 +70,7 @@ There are also many country specific/local language channels. Feel free to join
 these channels for localized support and info:
 
 - China: `#cn-users`, `#cn-events`
-- Finland: `fi-users`
+- Finland: `#fi-users`
 - France: `#fr-users`, `#fr-events`
 - Germany: `#de-users`, `#de-events`
 - India: `#in-users`, `#in-events`

--- a/content/en/docs/tasks/debug-application-cluster/troubleshooting.md
+++ b/content/en/docs/tasks/debug-application-cluster/troubleshooting.md
@@ -70,6 +70,7 @@ There are also many country specific/local language channels. Feel free to join
 these channels for localized support and info:
 
 - China: `#cn-users`, `#cn-events`
+- Finland: `fi-users`
 - France: `#fr-users`, `#fr-events`
 - Germany: `#de-users`, `#de-events`
 - India: `#in-users`, `#in-events`
@@ -81,6 +82,7 @@ these channels for localized support and info:
 - Poland: `#pl-users`
 - Russia: `#ru-users`
 - Spain: `#es-users`
+- Sweden: `#se-users`
 - Turkey: `#tr-users`, `#tr-events`
 
 ### Forum


### PR DESCRIPTION
This simply adds the Swedish and Finnish slack channels to the list of localized channels.