### PR TITLE
fix visible scroll at vendorStrip in desktop

### DIFF
--- a/sass/_base.sass
+++ b/sass/_base.sass
@@ -584,6 +584,8 @@ section
     line-height: 44px
     max-width: 100%
     overflow-x: auto
+    overflow-y: hidden
+    z-index: 0
     -webkit-overflow-scrolling: touch
 
     ul


### PR DESCRIPTION
There is currently a useless scroll in `vendorstrip` component at https://kubernetes.io/docs/home/ for Google Chrome users:
![image](https://user-images.githubusercontent.com/18168330/58367180-c5ae4600-7ef9-11e9-8a6f-b01a286057b2.png)
This PR is supposed to fix the issue by doing little CSS tweaks and optimization 

Signed-off-by: harshvkarn <harshvardhan.karn@mayadata.io>

