### PR TITLE
Update “Autoscale the DNS Service in a Cluster”

### DIFF
--- a/content/en/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
+++ b/content/en/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
@@ -22,7 +22,8 @@ Kubernetes cluster.
 
 ## Determining whether DNS horizontal autoscaling is already enabled
 
-List the Deployments in your cluster in the kube-system namespace:
+List the {{< glossary_tooltip text="Deployments" term_id="deployment" >}}
+in your cluster in the kube-system namespace:
 
 ```shell
 kubectl get deployment --namespace=kube-system
@@ -116,7 +117,7 @@ DNS horizontal autoscaling is now enabled.
 
 ## Tuning autoscaling parameters
 
-Verify that the dns-autoscaler ConfigMap exists:
+Verify that the dns-autoscaler {{< glossary_tooltip text="ConfigMap" term_id="configmap" >}} exists:
 
 ```shell
 kubectl get configmap --namespace=kube-system

--- a/content/en/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
+++ b/content/en/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
@@ -12,6 +12,8 @@ Kubernetes cluster.
 
 * {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
 
+* This guide assumes your nodes use the AMD64 or Intel 64 CPU architecture
+
 * Make sure the [DNS feature](/docs/concepts/services-networking/dns-pod-service/) itself is enabled.
 
 * Kubernetes version 1.4.0 or later is recommended.

--- a/content/en/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
+++ b/content/en/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
@@ -203,7 +203,7 @@ The output is:
 
 ### Option 3: Delete the dns-autoscaler manifest file from the master node
 
-This option works if dns-autoscaler is under control of the
+This option works if dns-autoscaler is under control of the (deprecated)
 [Addon Manager](https://git.k8s.io/kubernetes/cluster/addons/README.md),
 and you have write access to the master node.
 
@@ -256,6 +256,6 @@ is under consideration as a future development.
 {{% /capture %}}
 
 {{% capture whatsnext %}}
-Learn more about the
+* Learn more about the
 [implementation of cluster-proportional-autoscaler](https://github.com/kubernetes-incubator/cluster-proportional-autoscaler).
 {{% /capture %}}

--- a/content/en/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
+++ b/content/en/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
@@ -24,7 +24,9 @@ Kubernetes cluster.
 
 List the Deployments in your cluster in the kube-system namespace:
 
-    kubectl get deployment --namespace=kube-system
+```shell
+kubectl get deployment --namespace=kube-system
+```
 
 The output is similar to this:
 
@@ -41,7 +43,9 @@ already enabled, and you can skip to
 
 List the Deployments in your cluster in the kube-system namespace:
 
-    kubectl get deployment --namespace=kube-system
+```shell
+kubectl get deployment --namespace=kube-system
+```
 
 The output is similar to this:
 
@@ -58,7 +62,9 @@ ReplicationController instead of a Deployment. So if you don't see kube-dns,
 or a similar name, in the preceding output, list the ReplicationControllers in
 your cluster in the kube-system namespace:
 
-    kubectl get rc --namespace=kube-system
+```shell
+kubectl get rc --namespace=kube-system
+```
 
 The output is similar to this:
 
@@ -98,7 +104,9 @@ In the file, replace `<SCALE_TARGET>` with your scale target.
 Go to the directory that contains your configuration file, and enter this
 command to create the Deployment:
 
-    kubectl apply -f dns-horizontal-autoscaler.yaml
+```shell
+kubectl apply -f dns-horizontal-autoscaler.yaml
+```
 
 The output of a successful command is:
 
@@ -110,7 +118,9 @@ DNS horizontal autoscaling is now enabled.
 
 Verify that the dns-autoscaler ConfigMap exists:
 
-    kubectl get configmap --namespace=kube-system
+```shell
+kubectl get configmap --namespace=kube-system
+```
 
 The output is similar to this:
 
@@ -121,11 +131,15 @@ The output is similar to this:
 
 Modify the data in the ConfigMap:
 
-    kubectl edit configmap dns-autoscaler --namespace=kube-system
+```shell
+kubectl edit configmap dns-autoscaler --namespace=kube-system
+```
 
 Look for this line:
 
-    linear: '{"coresPerReplica":256,"min":1,"nodesPerReplica":16}'
+```yaml
+linear: '{"coresPerReplica":256,"min":1,"nodesPerReplica":16}'
+```
 
 Modify the fields according to your needs. The "min" field indicates the
 minimal number of DNS backends. The actual number of backends number is
@@ -152,7 +166,9 @@ use depends on different conditions.
 
 This option works for all situations. Enter this command:
 
-    kubectl scale deployment --replicas=0 dns-autoscaler --namespace=kube-system
+```shell
+kubectl scale deployment --replicas=0 dns-autoscaler --namespace=kube-system
+```
 
 The output is:
 
@@ -160,7 +176,9 @@ The output is:
 
 Verify that the replica count is zero:
 
-    kubectl get deployment --namespace=kube-system
+```shell
+kubectl get deployment --namespace=kube-system
+```
 
 The output displays 0 in the DESIRED and CURRENT columns:
 
@@ -174,7 +192,9 @@ The output displays 0 in the DESIRED and CURRENT columns:
 This option works if dns-autoscaler is under your own control, which means
 no one will re-create it:
 
-    kubectl delete deployment dns-autoscaler --namespace=kube-system
+```shell
+kubectl delete deployment dns-autoscaler --namespace=kube-system
+```
 
 The output is:
 

--- a/content/en/examples/admin/dns/dns-horizontal-autoscaler.yaml
+++ b/content/en/examples/admin/dns/dns-horizontal-autoscaler.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: autoscaler
-        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.1.1
+        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.6.0
         resources:
           requests:
             cpu: 20m


### PR DESCRIPTION
Update https://kubernetes.io/docs/tasks/administer-cluster/dns-horizontal-autoscaling/

- use code block highlighting
- add glossary tooltips where appropriate
- switch to a more recent cluster-proportional-autoscaler image
  - untested; I'm relying on the image having its own release process and the project using semantic versioning
- mention that addons manager is deprecated
- note that this guide assumes cluster nodes are AMD64