### PR TITLE
Fix HTML typo (“stylsheet” → “stylesheet”) for case studies

### DIFF
--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -1,7 +1,7 @@
 <link rel="stylesheet" href="/css/base_fonts.css">
 <link rel="stylesheet" href="/css/styles.css">
 {{- if .Params.case_study_styles }}
-<link rel="stylsheet" href="/css/case-study-styles.css">
+<link rel="stylesheet" href="/css/case-study-styles.css">
 {{- end }}
 <link rel="stylesheet" href="{{ "css/jquery-ui.min.css" | relURL }}">
 <link rel="stylesheet" href="{{ "css/sweetalert.min.css" | relURL }}">


### PR DESCRIPTION
This makes the [case studies](https://kubernetes.io/case-studies/) cascading stylesheet take effect. It doesn't seem to have a negative impact when I try the fix.