### PR TITLE
Add content/fr/docs/tutorials/_index.md

### DIFF
--- a/content/fr/docs/tutorials/_index.md
+++ b/content/fr/docs/tutorials/_index.md
@@ -37,7 +37,7 @@ Avant d'explorer chacun des tutoriels, il peut-être utile de garder un signet p
 
 * [Exemple: Déployer l'application PHP Guestbook avec Redis (EN)](/docs/tutorials/stateless-application/guestbook/)
 
-## Applications Sans États (stateful applications)
+## Applications Avec États (stateful applications)
 
 * [StatefulSet Élémentaire (EN)](/docs/tutorials/stateful-application/basic-stateful-set/)
 

--- a/content/fr/docs/tutorials/_index.md
+++ b/content/fr/docs/tutorials/_index.md
@@ -1,0 +1,75 @@
+---
+title: Tutoriels
+main_menu: true
+weight: 60
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+Cette section de la documentation de Kubernetes contient des tutoriels.
+
+Un tutoriel montre comment atteindre un objectif qui est plus grand qu'une simple [tâche](/docs/tasks/). Il contient différentes sections, et une section contient différentes étapes.
+
+Avant d'explorer chacun des tutoriels, il peut-être utile de garder un signet pour le [Glossaire standardisé](/docs/reference/glossary/) pour pouvoir le consulter plus facilement par la suite.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+## Elémentaires
+
+* [Kubernetes Élémentaire (EN)](/docs/tutorials/kubernetes-basics/) est un tutoriel interactif en profondeur qui vous aidera à comprendre le système de Kubernetes et de commencer avec des fonctionnalités élémentaires de Kubernetes.
+
+* [Microservices Evolutifs avec Kubernetes (Udacity) (EN)](https://www.udacity.com/course/scalable-microservices-with-kubernetes--ud615)
+
+* [Introduction à Kubernetes (edX) (EN)](https://www.edx.org/course/introduction-kubernetes-linuxfoundationx-lfs158x#)
+
+* [Bonjour Minikube!(FR)](/fr/docs/tutorials/hello-minikube/)
+
+## Configuration
+
+* [Configurer Redis en utilisant un ConfigMap (EN)](/docs/tutorials/configuration/configure-redis-using-configmap/)
+
+## Applications Sans États (stateless applications)
+
+* [Exposer une adresse IP externe pour accéder a une application dans un cluster (EN)](/docs/tutorials/stateless-application/expose-external-ip-address/)
+
+* [Exemple: Déployer l'application PHP Guestbook avec Redis (EN)](/docs/tutorials/stateless-application/guestbook/)
+
+## Applications Sans États (stateful applications)
+
+* [StatefulSet Élémentaire (EN)](/docs/tutorials/stateful-application/basic-stateful-set/)
+
+* [Exemple: WordPress et MySQL avec des Persistent Volumes (volumes persistants) (EN)](/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/)
+
+* [Exemple: Déployer Cassandra avec un StatefulSet (EN)](/docs/tutorials/stateful-application/cassandra/)
+
+* [Exécuter ZooKeeper, un système distribué CP (EN)](/docs/tutorials/stateful-application/zookeeper/)
+
+## Pipeline d'Intégration continue et de déploiement continu (CI/CD)
+
+* Mettre en place un pipeline CI/CD avec Kubernetes:
+ * [1ère partie: Vue d'ensemble (EN)](https://www.linux.com/blog/learn/chapter/Intro-to-Kubernetes/2017/5/set-cicd-pipeline-kubernetes-part-1-overview)
+
+ * [2ème partie: avec un Pod Jenkins (EN)](https://www.linux.com/blog/learn/chapter/Intro-to-Kubernetes/2017/6/set-cicd-pipeline-jenkins-pod-kubernetes-part-2)
+
+ * [3ème partie: Exécuter et mettre à l'échelle une application distribuée de mots croisés (EN)](https://www.linux.com/blog/learn/chapter/intro-to-kubernetes/2017/6/run-and-scale-distributed-crossword-puzzle-app-cicd-kubernetes-part-3)
+
+ * [4ème partie: mettre en place un pipeline CI/CD pour une application distribuée de mots croisés avec Kubernetes (EN)](https://www.linux.com/blog/learn/chapter/intro-to-kubernetes/2017/6/set-cicd-distributed-crossword-puzzle-app-kubernetes-part-4)
+
+## Clusters
+
+* [AppArmor (EN)](/docs/tutorials/clusters/apparmor/)
+
+## Services
+
+* [Utiliser Source IP (EN)](/docs/tutorials/services/source-ip/)
+
+{{% /capture %}}
+
+{{% capture whatsnext %}}
+
+Si vous voulez écrire un tutoriel, regardez la section des modèles de page de tutoriel dans l'[Utilisation des modèles de pages ](/docs/home/contribute/page-templates/).
+
+{{% /capture %}}


### PR DESCRIPTION
* The navigation menu was broken without it.
* Translation from `content/en/docs/tutorials/_index.md`
