### PR TITLE
Use shortcode for note in Kops glossary entry

### DIFF
--- a/content/en/docs/reference/glossary/kops.md
+++ b/content/en/docs/reference/glossary/kops.md
@@ -4,16 +4,21 @@ id: kops
 date: 2018-04-12
 full_link: /docs/getting-started-guides/kops/
 short_description: >
-  A CLI tool that helps you create, destroy, upgrade and maintain production-grade, highly available, Kubernetes clusters. *NOTE&#58; Officially supports AWS only, with GCE and VMware vSphere in alpha*.
+  A CLI tool that helps you create, destroy, upgrade and maintain production-grade, highly available, Kubernetes clusters.
 
 aka: 
 tags:
 - tool
 - operation
 ---
- A CLI tool that helps you create, destroy, upgrade and maintain production-grade, highly available, Kubernetes clusters. *NOTE&#58; Officially supports AWS only, with GCE and VMware vSphere in alpha*.
+ A CLI tool that helps you create, destroy, upgrade and maintain production-grade, highly available, Kubernetes clusters.
 
 <!--more--> 
+
+{{< note >}}
+kops has general availability support only for AWS.
+Support for using kops with GCE and VMware vSphere are in alpha.
+{{< /note >}}
 
 `kops` provisions your cluster with&#58;
 

--- a/content/en/docs/reference/glossary/kops.md
+++ b/content/en/docs/reference/glossary/kops.md
@@ -27,7 +27,6 @@ Support for using kops with GCE and VMware vSphere are in alpha.
   * Self-healing&#58; everything runs in Auto-Scaling Groups
   * Limited OS support (Debian preferred, Ubuntu 16.04 supported, early support for CentOS & RHEL)
   * High availability (HA) support
-  * The ability to directly provision, or generate terraform manifests
+  * The ability to directly provision, or to generate Terraform manifests
 
 You can also build your own cluster using {{< glossary_tooltip term_id="kubeadm" >}} as a building block. `kops` builds on the kubeadm work.
-


### PR DESCRIPTION
- Use shortcode for note in Kops glossary entry
- also change “terraform” to “Terraform”