### PR TITLE
Tidy & reword “Configure a Pod to Use a Projected Volume for Storage”

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-projected-volume-storage.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-projected-volume-storage.md
@@ -53,7 +53,7 @@ the Pod:
     kubectl get --watch pod test-projected-volume
     ```
     The output looks like this:
-    ```shell
+    ```
     NAME                    READY     STATUS    RESTARTS   AGE
     test-projected-volume   1/1       Running   0          14s
     ```

--- a/content/en/docs/tasks/configure-pod-container/configure-projected-volume-storage.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-projected-volume-storage.md
@@ -24,7 +24,7 @@ and `serviceAccountToken` volumes can be projected.
 {{% capture steps %}}
 ## Configure a projected volume for a pod
 
-In this exercise, you create username and password Secrets from local files. You then create a Pod that runs one Container, using a [`projected`](/docs/concepts/storage/volumes/#projected) Volume to mount the Secrets into the same shared directory.
+In this exercise, you create username and password {{< glossary_tooltip text="Secrets" term_id="secret" >}} from local files. You then create a Pod that runs one Container, using a [`projected`](/docs/concepts/storage/volumes/#projected) Volume to mount the Secrets into the same shared directory.
 
 Here is the configuration file for the Pod:
 

--- a/content/en/docs/tasks/configure-pod-container/configure-projected-volume-storage.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-projected-volume-storage.md
@@ -8,7 +8,7 @@ weight: 70
 ---
 
 {{% capture overview %}}
-This page shows how to use a [`projected`](/docs/concepts/storage/volumes/#projected) volume to mount
+This page shows how to use a [`projected`](/docs/concepts/storage/volumes/#projected) Volume to mount
 several existing volume sources into the same directory. Currently, `secret`, `configMap`, `downwardAPI`,
 and `serviceAccountToken` volumes can be projected.
 
@@ -24,7 +24,7 @@ and `serviceAccountToken` volumes can be projected.
 {{% capture steps %}}
 ## Configure a projected volume for a pod
 
-In this exercise, you create username and password {{< glossary_tooltip text="Secrets" term_id="secret" >}} from local files. You then create a Pod that runs one Container, using a [`projected`](/docs/concepts/storage/volumes/#projected) Volume to mount the Secrets into the same shared directory.
+In this exercise, you create username and password {{< glossary_tooltip text="Secrets" term_id="secret" >}} from local files. You then create a Pod that runs one container, using a [`projected`](/docs/concepts/storage/volumes/#projected) Volume to mount the Secrets into the same shared directory.
 
 Here is the configuration file for the Pod:
 
@@ -46,7 +46,7 @@ Here is the configuration file for the Pod:
     ```shell
     kubectl apply -f https://k8s.io/examples/pods/storage/projected.yaml
     ```
-1. Verify that the Pod's Container is running, and then watch for changes to
+1. Verify that the Pod's container is running, and then watch for changes to
 the Pod:
 
     ```shell
@@ -57,7 +57,7 @@ the Pod:
     NAME                    READY     STATUS    RESTARTS   AGE
     test-projected-volume   1/1       Running   0          14s
     ```
-1. In another terminal, get a shell to the running Container:
+1. In another terminal, get a shell to the running container:
 
     ```shell
     kubectl exec -it test-projected-volume -- /bin/sh
@@ -73,5 +73,3 @@ the Pod:
 * Learn more about [`projected`](/docs/concepts/storage/volumes/#projected) volumes.
 * Read the [all-in-one volume](https://github.com/kubernetes/community/blob/{{< param "githubbranch" >}}/contributors/design-proposals/node/all-in-one-volume.md) design document.
 {{% /capture %}}
-
-


### PR DESCRIPTION
Tidy & reword “[Configure a Pod to Use a Projected Volume for Storage](https://kubernetes.io/docs/tasks/configure-pod-container/configure-projected-volume-storage/)” 

- reference the glossary entry for Secret
- write Volume in initial-caps
- write container in lowercase
- fix sample output marked as Bourne shell code

/kind cleanup
