### PR TITLE
Update install-minikube.md

### DIFF
--- a/content/en/docs/tasks/tools/install-minikube.md
+++ b/content/en/docs/tasks/tools/install-minikube.md
@@ -95,7 +95,7 @@ sudo mv minikube /usr/local/bin
 ### Linux
 
 {{< note >}}
-This document shows you how to install Minikube on Linux using a static binary. For alternative Linux installation methods, see [Other Ways to Install](https://github.com/kubernetes/minikube#other-ways-to-install) in the official Minikube GitHub repository.
+This document shows you how to install Minikube on Linux using a static binary.
 {{< /note >}}
 
 You can install Minikube on Linux by downloading a static binary:


### PR DESCRIPTION
The link https://github.com/kubernetes/minikube#other-ways-to-install doesn't exist anymore.
So either we remove the link to it or we fix the minikube README and add a new section for alternative ways to install minikube.
What do you think?
