### PR TITLE
Fix CRD namespace explanation

### DIFF
--- a/content/en/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions.md
+++ b/content/en/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions.md
@@ -29,11 +29,11 @@ into the Kubernetes API by creating a
 ## Create a CustomResourceDefinition
 
 When you create a new CustomResourceDefinition (CRD), the Kubernetes API Server
-creates a new RESTful resource path for each version you specify. The CRD can be
-either namespaced or cluster-scoped, as specified in the CRD's `scope` field. As
-with existing built-in objects, deleting a namespace deletes all custom objects
-in that namespace. CustomResourceDefinitions themselves are non-namespaced and
-are available to all namespaces.
+creates a new RESTful resource path for each version you specify.
+The custom objects can be either namespaced or cluster-scoped, as specified in
+the CRD's `scope` field. As with existing built-in objects, deleting a
+namespace deletes all custom objects in that namespace.
+CustomResourceDefinitions themselves are non-namespaced.
 
 For example, if you save the following CustomResourceDefinition to `resourcedefinition.yaml`:
 


### PR DESCRIPTION
CRDs are non-namespaced but custom objects can be namespaced or cluster-scoped.

This recently came up on Slack...

/assign @sttts 
