### PR TITLE
Fix link to Storage Classes doc

### DIFF
--- a/content/en/docs/concepts/storage/dynamic-provisioning.md
+++ b/content/en/docs/concepts/storage/dynamic-provisioning.md
@@ -38,7 +38,7 @@ about the complexity and nuances of how storage is provisioned, but still
 have the ability to select from multiple storage options.
 
 More information on storage classes can be found
-[here](/docs/concepts/storage/persistent-volumes/#storageclasses).
+[here](/docs/concepts/storage/storage-classes/).
 
 ## Enabling Dynamic Provisioning
 


### PR DESCRIPTION
Existing link does not lead to the expected doc/section, it probably moved. Fixed link points to correct content.