### PR TITLE
Only use CNCF logo style on home page

### DIFF
--- a/assets/sass/_base.sass
+++ b/assets/sass/_base.sass
@@ -1121,6 +1121,16 @@ $feature-box-div-margin-bottom: 40px
     #vendorStrip
       display: none
 
+  // Add logo to CNCF section
+  section#cncf
+    padding-top: 60px
+    padding-bottom: 140px
+    background-image: url(/images/cncf-color.png)
+    background-position: center 100px
+    background-repeat: no-repeat
+    background-size: 300px
+
+
 
 // OCEAN NODES
 #oceanNodes
@@ -1264,15 +1274,6 @@ $feature-box-div-margin-bottom: 40px
 
     &:hover
       border-color: white
-
-// CNCF
-#cncf
-  padding-top: 60px
-  padding-bottom: 140px
-  background-image: url(/images/cncf-color.png)
-  background-position: center 100px
-  background-repeat: no-repeat
-  background-size: 300px
 
 // KubeWeekly
 #kubeweekly


### PR DESCRIPTION
There's some SASS that adds a logo to the CNCF section of the page at
https://kubernetes.io/ (and its localizations).

Narrow this styling to apply only to the home page.

Unless I've missed something, this fixes #14575 (thanks to @praseodym for diagnosis).