### PR TITLE
kubeadm: update the setup documentation for 1.15

### DIFF
--- a/content/en/docs/setup/independent/ha-topology.md
+++ b/content/en/docs/setup/independent/ha-topology.md
@@ -34,7 +34,7 @@ Each control plane node creates a local etcd member and this etcd member communi
 the `kube-apiserver` of this node. The same applies to the local `kube-controller-manager`
 and `kube-scheduler` instances.
 
-This topology couples the control planes and etcd members on the same nodes. It is simpler to set up than a cluster 
+This topology couples the control planes and etcd members on the same nodes. It is simpler to set up than a cluster
 with external etcd nodes, and simpler to manage for replication.
 
 However, a stacked cluster runs the risk of failed coupling. If one node goes down, both an etcd member and a control
@@ -43,7 +43,7 @@ plane instance are lost, and redundancy is compromised. You can mitigate this ri
 You should therefore run a minimum of three stacked control plane nodes for an HA cluster.
 
 This is the default topology in kubeadm. A local etcd member is created automatically
-on control plane nodes when using `kubeadm init` and `kubeadm join --experimental-control-plane`.
+on control plane nodes when using `kubeadm init` and `kubeadm join --control-plane`.
 
 ![Stacked etcd topology](/images/kubeadm/kubeadm-ha-topology-stacked-etcd.svg)
 

--- a/content/en/docs/setup/independent/install-kubeadm.md
+++ b/content/en/docs/setup/independent/install-kubeadm.md
@@ -54,7 +54,7 @@ route, we recommend you add IP route(s) so Kubernetes cluster addresses go via t
 
 ## Check required ports
 
-### Master node(s)
+### Control-plane node(s)
 
 | Protocol | Direction | Port Range | Purpose                 | Used By                   |
 |----------|-----------|------------|-------------------------|---------------------------|
@@ -76,7 +76,7 @@ route, we recommend you add IP route(s) so Kubernetes cluster addresses go via t
 Any port numbers marked with * are overridable, so you will need to ensure any
 custom ports you provide are also open.
 
-Although etcd ports are included in master nodes, you can also host your own
+Although etcd ports are included in control-plane nodes, you can also host your own
 etcd cluster externally or on custom ports.
 
 The pod network plugin you use (see below) may also require certain ports to be
@@ -201,7 +201,7 @@ systemctl enable --now kubelet
 Install CNI plugins (required for most pod network):
 
 ```bash
-CNI_VERSION="v0.6.0"
+CNI_VERSION="v0.7.5"
 mkdir -p /opt/cni/bin
 curl -L "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-amd64-${CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz
 ```
@@ -209,7 +209,7 @@ curl -L "https://github.com/containernetworking/plugins/releases/download/${CNI_
 Install crictl (required for kubeadm / Kubelet Container Runtime Interface (CRI))
 
 ```bash
-CRICTL_VERSION="v1.11.1"
+CRICTL_VERSION="v1.12.0"
 mkdir -p /opt/bin
 curl -L "https://github.com/kubernetes-incubator/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz" | tar -C /opt/bin -xz
 ```
@@ -241,7 +241,7 @@ systemctl enable --now kubelet
 The kubelet is now restarting every few seconds, as it waits in a crashloop for
 kubeadm to tell it what to do.
 
-## Configure cgroup driver used by kubelet on Master Node
+## Configure cgroup driver used by kubelet on control-plane node
 
 When using Docker, kubeadm will automatically detect the cgroup driver for the kubelet
 and set it in the `/var/lib/kubelet/kubeadm-flags.env` file during runtime.
@@ -265,6 +265,9 @@ Restarting the kubelet is required:
 systemctl daemon-reload
 systemctl restart kubelet
 ```
+
+The automatic detection of cgroup driver for other container runtimes
+like CRI-O and containerd is work in progress.
 
 ## Troubleshooting
 

--- a/content/en/docs/setup/independent/troubleshooting-kubeadm.md
+++ b/content/en/docs/setup/independent/troubleshooting-kubeadm.md
@@ -60,7 +60,7 @@ This may be caused by a number of problems. The most common are:
  1. Install Docker again following instructions
   [here](/docs/setup/independent/install-kubeadm/#installing-docker).
  1. Change the kubelet config to match the Docker cgroup driver manually, you can refer to
-    [Configure cgroup driver used by kubelet on Master Node](/docs/setup/independent/install-kubeadm/#configure-cgroup-driver-used-by-kubelet-on-master-node)
+    [Configure cgroup driver used by kubelet on control-plane node](/docs/setup/independent/install-kubeadm/#configure-cgroup-driver-used-by-kubelet-on-master-node)
     for detailed instructions.
 
 - control plane Docker containers are crashlooping or hanging. You can check this by running `docker ps` and investigating each container by running `docker logs`.
@@ -100,7 +100,7 @@ Right after `kubeadm init` there should not be any pods in these states.
   until you have deployed the network solution.
 - If you see Pods in the `RunContainerError`, `CrashLoopBackOff` or `Error` state
   after deploying the network solution and nothing happens to `coredns` (or `kube-dns`),
-  it's very likely that the Pod Network solution that you installed is somehow broken. 
+  it's very likely that the Pod Network solution that you installed is somehow broken.
   You might have to grant it more RBAC privileges or use a newer version. Please file
   an issue in the Pod Network providers' issue tracker and get the issue triaged there.
 - If you install a version of Docker older than 1.12.1, remove the `MountFlags=slave` option


### PR DESCRIPTION
placeholder for 1.15

should hold changes under /setup/independent/...

xref https://github.com/kubernetes/kubeadm/issues/1577

@kubernetes/sig-cluster-lifecycle-pr-reviews 
/cc @fabriziopandini 
/sig cluster-lifecycle
/milestone v1.15
