### PR TITLE
Update config option for openstack block storage

### DIFF
--- a/content/en/docs/concepts/cluster-administration/cloud-providers.md
+++ b/content/en/docs/concepts/cluster-administration/cloud-providers.md
@@ -294,6 +294,8 @@ and should appear in the `[BlockStorage]` section of the `cloud.conf` file:
   there are many Nova availability zones but only one Cinder availability zone.
   The default value is `false` to preserve the behavior used in earlier
   releases, but may change in the future.
+* `node-volume-attach-limit` (Optional): Maximum Number of Volumes that can be
+  attached to the node, default is 256 for cinder.
 
 If deploying Kubernetes versions <= 1.8 on an OpenStack deployment that uses
 paths rather than ports to differentiate between endpoints it may be necessary

--- a/content/en/docs/concepts/cluster-administration/cloud-providers.md
+++ b/content/en/docs/concepts/cluster-administration/cloud-providers.md
@@ -294,7 +294,7 @@ and should appear in the `[BlockStorage]` section of the `cloud.conf` file:
   there are many Nova availability zones but only one Cinder availability zone.
   The default value is `false` to preserve the behavior used in earlier
   releases, but may change in the future.
-* `node-volume-attach-limit` (Optional): Maximum Number of Volumes that can be
+* `node-volume-attach-limit` (Optional): Maximum number of Volumes that can be
   attached to the node, default is 256 for cinder.
 
 If deploying Kubernetes versions <= 1.8 on an OpenStack deployment that uses


### PR DESCRIPTION
node-volume-attach-limit for cinder added in the last cycle, updating the doc for the same
https://github.com/kubernetes/kubernetes/pull/74542
