### PR TITLE
Clarify behavior of parallel pod management policy of stateful sets

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/en/docs/concepts/workloads/controllers/statefulset.md
@@ -209,7 +209,8 @@ described [above](#deployment-and-scaling-guarantees).
 `Parallel` pod management tells the StatefulSet controller to launch or
 terminate all Pods in parallel, and to not wait for Pods to become Running
 and Ready or completely terminated prior to launching or terminating another
-Pod.
+Pod. This option only affects the behavior for scaling operations. Updates are not
+affected.
 
 ## Update Strategies
 


### PR DESCRIPTION
When specifying the `podManagementPolicy` on a stateful set, we observed that the option only affects the behavior for scaling operations and we saw that the behavior of the rolling updates remains the same, i.e. the pods are updated one by one and each respective subsequent pod is only updated after the one before was ready. This PR improves the clarity of the docs about this behavior.

Observed on Kubernetes 1.11