### PR TITLE
Update code of conduct based on upstream changes

### DIFF
--- a/content/en/community/code-of-conduct.md
+++ b/content/en/community/code-of-conduct.md
@@ -11,7 +11,7 @@ css: /css/community.css
 Kubernetes follows the
 <a href="https://github.com/cncf/foundation/blob/master/code-of-conduct.md">CNCF Code of Conduct</a>.
 The text of the CNCF CoC is replicated below, as of
-<a href="https://github.com/cncf/foundation/blob/0ce4694e5103c0c24ca90c189da81e5408a46632/code-of-conduct.md">commit 0ce4694</a>.
+<a href="https://github.com/cncf/foundation/blob/214585e24aab747fb85c2ea44fbf4a2442e30de6/code-of-conduct.md">commit 214585e</a>.
 If you notice that this is out of date, please
 <a href="https://github.com/kubernetes/website/issues/new">file an issue</a>.
 

--- a/content/en/community/static/cncf-code-of-conduct.md
+++ b/content/en/community/static/cncf-code-of-conduct.md
@@ -34,8 +34,7 @@ Conduct may be permanently removed from the project team.
 This code of conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting
-the [Kubernetes Code of Conduct Committee](https://github.com/kubernetes/community/tree/master/committee-code-of-conduct) <conduct@kubernetes.io>.
+Instances of abusive, harassing, or otherwise unacceptable behavior in Kubernetes may be reported by contacting the [Kubernetes Code of Conduct Committee](https://git.k8s.io/community/committee-code-of-conduct) via <conduct@kubernetes.io>. For other projects, please contact a CNCF project maintainer or our mediator, Mishi Choudhary <mishi@linux.com>.
 
 This Code of Conduct is adapted from the Contributor Covenant
 (http://contributor-covenant.org), version 1.2.0, available at
@@ -43,4 +42,4 @@ http://contributor-covenant.org/version/1/2/0/
 
 ### CNCF Events Code of Conduct
 
-CNCF events are governed by the Linux Foundation [Code of Conduct](http://events.linuxfoundation.org/events/cloudnativecon/attend/code-of-conduct) available on the event page. This is designed to be compatible with the above policy and also includes more details on responding to incidents.
+CNCF events are governed by the Linux Foundation [Code of Conduct](https://events.linuxfoundation.org/code-of-conduct/) available on the event page. This is designed to be compatible with the above policy and also includes more details on responding to incidents.


### PR DESCRIPTION
Make the code of conduct on the website be level with https://github.com/cncf/foundation/commit/214585e24aab747fb85c2ea44fbf4a2442e30de6

The upstream code of conduct is now localized. I expect that website localizations should use the upstream localization (and not provide own translation). Does this seem OK?

Relevant to issue #14611