### PR TITLE
move podresources endpoint to beta

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
+++ b/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
@@ -164,7 +164,7 @@ DaemonSet, `/var/lib/kubelet/pod-resources` must be mounted as a
 in the plugin's
 [PodSpec](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#podspec-v1-core).
 
-Support for the "PodResources service" is still in alpha.
+Support for the "PodResources service" is in beta, and is enabled by default.
 
 ## Examples
 


### PR DESCRIPTION
/milestone 1.15
Related Enhancement: https://github.com/kubernetes/enhancements/issues/606
The feature is moving to beta in 1.15