### PR TITLE
Prefer "minikube delete" over "rm -rf ~/.minikube"

### DIFF
--- a/content/en/docs/tasks/tools/install-minikube.md
+++ b/content/en/docs/tasks/tools/install-minikube.md
@@ -141,7 +141,7 @@ To install Minikube manually on windows using [Windows Installer](https://docs.m
 
 {{% /capture %}}
 
-## Cleanup everything to start fresh
+## Cleanup local state
 
 If you have previously installed minikube, and run:
 ```shell
@@ -153,7 +153,7 @@ And this command returns an error:
 machine does not exist
 ```
 
-You need to wipe the configuration files:
+You need to clear minikube's local state:
 ```shell
-rm -rf ~/.minikube
+minikube delete
 ```


### PR DESCRIPTION
Using `rm -Rf ~/.minikube` is not necessary in modern (v1.x) versions of minikube, and is highly discouraged as may can leave dangling VM's running, which minikube will fail to recover from. 

Example issue: https://github.com/kubernetes/minikube/issues/4377