### PR TITLE
correct typo in home directory name

### DIFF
--- a/content/en/docs/setup/independent/high-availability.md
+++ b/content/en/docs/setup/independent/high-availability.md
@@ -357,7 +357,7 @@ the creation of additional nodes could fail due to a lack of required SANs.
 {{< /caution >}}
 
 1. Then on each joining control plane node you have to run the following script before running `kubeadm join`.
-   This script will move the previously copied certificates from the home directory to `/etc/kuberentes/pki`:
+   This script will move the previously copied certificates from the home directory to `/etc/kubernetes/pki`:
 
     ```sh
     USER=ubuntu # customizable


### PR DESCRIPTION
home directory given as /etc/kuberentes/pki
should be /etc/kubernetes/pki

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> Remember to delete this note before submitting your pull request.
>
> For pull requests on 1.15 Features: set Milestone to 1.15 and Base Branch to dev-1.15
> 
> For pull requests on Chinese localization, set Base Branch to release-1.14
>
> For pull requests on Korean Localization: set Base Branch to dev-1.14-ko.\<latest team milestone>
>
> If you need Help on editing and submitting pull requests, visit:
> https://kubernetes.io/docs/contribute/start/#improve-existing-content.
>
> If you need Help on choosing which branch to use, visit:
> https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use.
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
