### PR TITLE
Updates kubernetes-basics

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/_index.html
+++ b/content/en/docs/tutorials/kubernetes-basics/_index.html
@@ -24,10 +24,10 @@ card:
         <p>This tutorial provides a walkthrough of the basics of the Kubernetes cluster orchestration system. Each module contains some background information on major Kubernetes features and concepts, and includes an interactive online tutorial. These interactive tutorials let you manage a simple cluster and its containerized applications for yourself.</p>
         <p>Using the interactive tutorials, you can learn to:</p>
         <ul>
-        <li>Deploy a containerized application on a cluster</li>
-        <li>Scale the deployment</li>
-        <li>Update the containerized application with a new software version</li>
-        <li>Debug the containerized application</li>
+        <li>Deploy a containerized application on a cluster.</li>
+        <li>Scale the deployment.</li>
+        <li>Update the containerized application with a new software version.</li>
+        <li>Debug the containerized application.</li>
         </ul>
         <p>The tutorials use Katacoda to run a virtual terminal in your web browser that runs Minikube, a small-scale local deployment of Kubernetes that can run anywhere. There's no need to install any software or configure anything; each interactive tutorial runs directly out of your web browser itself.</p>
       </div>
@@ -101,12 +101,6 @@ card:
             </div>
           </div>
         </div>
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="col-md-12">
-        <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro/" role="button">Start the tutorial<span class="btn__next">›</span></a>
       </div>
     </div>
 


### PR DESCRIPTION
Minor updates:
- Add a full stop.
- Removed the 'Start the tutorial›' section. The sections are already linked from 1 to 6 and this section doe not add any value after point 6.