### PR TITLE
use glossary defs in overview/components.md

### DIFF
--- a/content/en/docs/concepts/overview/components.md
+++ b/content/en/docs/concepts/overview/components.md
@@ -74,13 +74,11 @@ Node components run on every node, maintaining running pods and providing the Ku
 
 ### kube-proxy
 
-[kube-proxy](/docs/admin/kube-proxy/) enables the Kubernetes service abstraction by maintaining
-network rules on the host and performing connection forwarding.
+{{< glossary_definition term_id="kube-proxy" length="all" >}}
 
 ### Container Runtime
 
-The container runtime is the software that is responsible for running containers.
-Kubernetes supports several runtimes: [Docker](http://www.docker.com), [containerd](https://containerd.io), [cri-o](https://cri-o.io/), [rktlet](https://github.com/kubernetes-incubator/rktlet) and any implementation of the [Kubernetes CRI (Container Runtime Interface)](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/container-runtime-interface.md).
+{{< glossary_definition term_id="container-runtime" length="all" >}}
 
 ## Addons
 

--- a/content/en/docs/reference/glossary/container-runtime.md
+++ b/content/en/docs/reference/glossary/container-runtime.md
@@ -1,0 +1,21 @@
+---
+title: Container Runtime
+id: container-runtime
+date: 2019-06-05
+full_link: /docs/reference/generated/container-runtime
+short_description: >
+ The container runtime is the software that is responsible for running containers.
+
+aka:
+tags:
+- fundamental
+- workload
+---
+ The container runtime is the software that is responsible for running containers.
+
+<!--more-->
+
+Kubernetes supports several container runtimes: [Docker](http://www.docker.com),
+[containerd](https://containerd.io), [cri-o](https://cri-o.io/),
+[rktlet](https://github.com/kubernetes-incubator/rktlet) and any implementation of
+the [Kubernetes CRI (Container Runtime Interface)](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/container-runtime-interface.md).

--- a/content/en/docs/reference/glossary/kube-proxy.md
+++ b/content/en/docs/reference/glossary/kube-proxy.md
@@ -13,6 +13,9 @@ tags:
 ---
  `kube-proxy` is a network proxy that runs on each node in the cluster.
 
+It enables the Kubernetes service abstraction by maintaining network rules on
+the host and performing connection forwarding.
+
 <!--more--> 
 
 `kube-proxy` is responsible for request forwarding. `kube-proxy` allows TCP and UDP stream forwarding or round robin TCP and UDP forwarding across a set of backend functions.


### PR DESCRIPTION
This patch promotes re-use of the existing kube-proxy glossary
definition by referencing it from overview/components.md. Similarly, we
move the definition of Container Runtime into a new glossary definition
so that other pages may refer to it.