### PR TITLE
Remove unneeded "groups" from CSR yaml example

### DIFF
--- a/content/en/docs/tasks/tls/managing-tls-in-a-cluster.md
+++ b/content/en/docs/tasks/tls/managing-tls-in-a-cluster.md
@@ -110,8 +110,6 @@ kind: CertificateSigningRequest
 metadata:
   name: my-svc.my-namespace
 spec:
-  groups:
-  - system:authenticated
   request: $(cat server.csr | base64 | tr -d '\n')
   usages:
   - digital signature


### PR DESCRIPTION
This bit in the docs confused me for a minute because it makes it seem like you can influence the groups added to a cert via the CSR yaml (rather then the contents of the certificate itself). If you look in the CSR handling code, it actually discards anything put into the "groups" or "user" field on creation (because it's actually used for recording which kubernetes user  is requesting signing). 
