### PR TITLE
Add KubeOne as AWS turnkey solution

### DIFF
--- a/content/en/docs/setup/turnkey/aws.md
+++ b/content/en/docs/setup/turnkey/aws.md
@@ -26,6 +26,8 @@ To create a Kubernetes cluster on AWS, you will need an Access Key ID and a Secr
 
 * CoreOS originated and the Kubernetes Incubator maintains [a CLI tool, kube-aws](https://github.com/kubernetes-incubator/kube-aws), that creates and manages Kubernetes clusters with [Container Linux](https://coreos.com/why/) nodes, using AWS tools: EC2, CloudFormation and Autoscaling.
 
+* [KubeOne](https://github.com/kubermatic/kubeone) is an open source cluster lifecycle management tool that creates, upgrades and manages Kubernetes Highly-Available clusters.
+
 {{% /capture %}}
 
 {{% capture steps %}}
@@ -81,7 +83,7 @@ IaaS Provider        | Config. Mgmt | OS            | Networking  | Docs        
 AWS                  | kops         | Debian        | k8s (VPC)   | [docs](https://github.com/kubernetes/kops)    |          | Community ([@justinsb](https://github.com/justinsb))
 AWS                  | CoreOS       | CoreOS        | flannel     | [docs](/docs/getting-started-guides/aws)      |          | Community
 AWS                  | Juju         | Ubuntu        | flannel, calico, canal     | [docs](/docs/getting-started-guides/ubuntu)      | 100%     | Commercial, Community
-
+AWS                  | KubeOne         | Ubuntu, CoreOS, CentOS   | canal, weavenet     | [docs](https://github.com/kubermatic/kubeone)      | 100%    | Commercial, Community
 
 ## Further reading
 


### PR DESCRIPTION
This PR proposes to add [KubeOne](https://github.com/kubermatic/kubeone) as an AWS turnkey solution.

I'm not sure is it needed to propose the change somewhere else before creating a PR, so sorry if I skipped any step.

We should eventually consider removing CoreOS Tectonic from the document at some point as it's deprecated.
