### PR TITLE
Adding link to About Hugo page

### DIFF
--- a/content/en/docs/contribute/style/_index.md
+++ b/content/en/docs/contribute/style/_index.md
@@ -5,5 +5,5 @@ weight: 80
 ---
 
 The topics in this section provide guidance on writing style, content formatting
-and organization, and using Hugo customizations specific to Kubernetes
+and organization, and using [Hugo](https://gohugo.io/about/what-is-hugo/) customizations specific to Kubernetes
 documentation.


### PR DESCRIPTION
It's nice to provide a link for more information about things that might not be well down. You don't have to explain it. That creates clutter for folks who know. But it's a nice device that doesn't cost much and helps readers continue on with your content.
