### PR TITLE
revert on a name translation of card made by mistake

### DIFF
--- a/content/fr/docs/home/_index.md
+++ b/content/fr/docs/home/_index.md
@@ -25,17 +25,17 @@ cards:
   description: "En savoir plus sur Kubernetes et ses concepts fondamentaux."
   button: "Apprendre les concepts"
   button_path: "/docs/concepts"
-- name: tutoriels
+- name: tutorials
   title: "Essayez Kubernetes"
   description: "Suivez les tutoriels pour apprendre à déployer des applications dans Kubernetes."
   button: "Voir les tutoriels"
   button_path: "/docs/tutorials"
-- name: installer
+- name: setup
   title: "Mettre en place un cluster"
   description: "Faites fonctionner Kubernetes en fonction de vos ressources et de vos besoins."
   button: "Installer Kubernetes"
   button_path: "/docs/setup"
-- name: Tâches
+- name: tasks
   title: "Apprenez à utiliser Kubernetes"
   description: "Recherchez des tâches courantes et leur exécution en suivant une courte séquence d'étapes."
   button: "Voir les tâches"

--- a/content/fr/docs/tutorials/hello-minikube.md
+++ b/content/fr/docs/tutorials/hello-minikube.md
@@ -10,7 +10,7 @@ menu:
     post: >
       <p>Prêt à vous salir les mains ? Créez un cluster Kubernetes simple qui exécute "Hello World" pour Node.js.</p>>.
 card: 
-  name: tutoriels
+  name: tutorials
   weight: 10
 ---
 


### PR DESCRIPTION
we have mistakenly translated the "anchors" that allows link block generation automatically