### PR TITLE
azure-file storage class: add missing parameter for multi tenancy #14762

### DIFF
--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -610,12 +610,23 @@ parameters:
   group are searched to find one that matches `skuName` and `location`. If a
   storage account is provided, it must reside in the same resource group as the
   cluster, and `skuName` and `location` are ignored.
+* `secretNamespace`: the namespace of the secret that contains Azure Storage 
+  Account Name and Key default is the same as the Pod
+* `secretName`: the name of secret that contains Azure Storage Account Name and
+  Key. Default is `azure-storage-account-" + accountName + "-secret`
+* `readOnly`: Defaults to false (read/write). ReadOnly here will force the 
+  ReadOnly setting in VolumeMounts.
 
-During provision, a secret is created for mounting credentials. If the cluster
-has enabled both [RBAC](/docs/reference/access-authn-authz/rbac/) and
+During provision, a secret (defined by parameter secretName)is created for 
+mounting credentials. If the cluster has enabled both 
+[RBAC](/docs/reference/access-authn-authz/rbac/) and 
 [Controller Roles](/docs/reference/access-authn-authz/rbac/#controller-roles),
 add the `create` permission of resource `secret` for clusterrole
 `system:controller:persistent-volume-binder`.
+
+In a multi tenancy context is strongly recommended to set the value of 
+`secretNamespace` otherwise customer can access to the credentials of storage
+account.
 
 ### Portworx Volume
 

--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -610,23 +610,24 @@ parameters:
   group are searched to find one that matches `skuName` and `location`. If a
   storage account is provided, it must reside in the same resource group as the
   cluster, and `skuName` and `location` are ignored.
-* `secretNamespace`: the namespace of the secret that contains Azure Storage 
-  Account Name and Key default is the same as the Pod
-* `secretName`: the name of secret that contains Azure Storage Account Name and
-  Key. Default is `azure-storage-account-" + accountName + "-secret`
-* `readOnly`: Defaults to false (read/write). ReadOnly here will force the 
-  ReadOnly setting in VolumeMounts.
+* `secretNamespace`: the namespace of the secret that contains the Azure Storage 
+  Account Name and Key. Default is the same as the Pod.
+* `secretName`: the name of the secret that contains the Azure Storage Account Name and
+  Key. Default is `azure-storage-account-<accountName>-secret`
+* `readOnly`: a flag indicating whether the storage will be mounted as read only.
+  Defaults to false which means a read/write mount. This setting will impact the 
+  `ReadOnly` setting in VolumeMounts as well.
 
-During provision, a secret (defined by parameter secretName)is created for 
+During storage provisioning, a secret named by `secretName` is created for the 
 mounting credentials. If the cluster has enabled both 
 [RBAC](/docs/reference/access-authn-authz/rbac/) and 
 [Controller Roles](/docs/reference/access-authn-authz/rbac/#controller-roles),
 add the `create` permission of resource `secret` for clusterrole
 `system:controller:persistent-volume-binder`.
 
-In a multi tenancy context is strongly recommended to set the value of 
-`secretNamespace` otherwise customer can access to the credentials of storage
-account.
+In a multi-tenancy context, it is strongly recommended to set the value for 
+`secretNamespace` explicitly, otherwise the storage account credentials may
+be read by other users.
 
 ### Portworx Volume
 


### PR DESCRIPTION
# Description
Currently theses parameter of  the  are missing:
* `secretNamespace`: the namespace of the secret that contains Azure Storage 
  Account Name and Key default is the same as the Pod
* `secretName`: the name of secret that contains Azure Storage Account Name and
  Key. Default is `azure-storage-account-" + accountName + "-secret`
* `readOnly`: Defaults to false (read/write). ReadOnly here will force the 
  ReadOnly setting in VolumeMounts.


# Why is this needed
In multi tenancy context it's preferable to set the `secretNamespace` otherwise user can access to credentials of the azure storage account.

More over in every context if you don't set the  `secretNamespace`, the secret is create in the namespace of the PVC. When you delete the namespace, the secret may be deleted before the PV resulting in a pv in a failed state.

# Additional  Informations:
I have extracted the description of the field from [api/openapi-spec/swagger.json](https://github.com/kubernetes/kubernetes/blob/master/api/openapi-spec/swagger.json) in section `"io.k8s.api.core.v1.AzureFilePersistentVolumeSource`

the default value of `secretName` can be found [here](https://github.com/kubernetes/kubernetes/blob/ef7808fec57284582c7bf3fc834570e5769df83e/pkg/volume/azure_file/azure_util.go#L77)

fix #14762 
/milestone 1.15


