### PR TITLE
recommended admission controllers are already enabled by default

### DIFF
--- a/content/en/docs/reference/access-authn-authz/admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/admission-controllers.md
@@ -624,15 +624,11 @@ versions 1.9 and later).
 
 Yes.
 
-For Kubernetes version 1.10 and later, we recommend running the following set of admission controllers using the `--enable-admission-plugins` flag (**order doesn't matter**).
+For Kubernetes version 1.10 and later, the recommended admission controllers are enabled by default, so you do not need to explicitly specify them. You can enable additional admission controllers beyond the default set using the `--enable-admission-plugins` flag (**order doesn't matter**).
 
 {{< note >}}
 `--admission-control` was deprecated in 1.10 and replaced with `--enable-admission-plugins`.
 {{< /note >}}
-
-```shell
---enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,Priority,ResourceQuota
-```
 
 For Kubernetes 1.9 and earlier, we recommend running the following set of admission controllers using the `--admission-control` flag (**order matters**).
 


### PR DESCRIPTION
The documentation was misleading because it implied that the recommended ones need to be listed using the --enable-admission-plugins flag in order to be enabled:
"we recommend running the following set of admission controllers using the --enable-admission-plugins flag"

However that does not appear to be the case, according to https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/ , the purpose of --enable-admission-plugins is to enable additional plugins *beyond* the default, so it is not necessary to explicitly list them. 

According to https://github.com/kubernetes/website/blob/release-1.10/content/en/docs/reference/command-line-tools-reference/kube-apiserver.md  this has been the case since 1.10:

"admission plugins that should be enabled in addition to default enabled ones."

Therefore the administrator does not need to do anything in order to use the recommended (default) admission controllers.