### PR TITLE
Fixes PDB rounding docs (percentage as string instead of float)

### DIFF
--- a/content/en/docs/tasks/run-application/configure-pdb.md
+++ b/content/en/docs/tasks/run-application/configure-pdb.md
@@ -83,12 +83,12 @@ Values for `minAvailable` or `maxUnavailable` can be expressed as integers or as
 
 - When you specify an integer, it represents a number of Pods. For instance, if you set `minAvailable` to 10, then 10
   Pods must always be available, even during a disruption.
-- When you specify a percentage by setting the value to a floating-point value between 0 and 1, it represents a percentage of
+- When you specify a percentage by setting the value to a string representation of a percentage (eg. `"50%"`), it represents a percentage of
   total Pods. For instance, if you set `minUnavailable` to `"50%"`, then only 50% of the Pods can be unavailable during a
   disruption.
 
 When you specify the value as a percentage, it may not map to an exact number of Pods. For example, if you have 7 Pods and
-you set `minAvailable` to `.5`, it's not immediately obvious whether that means 3 Pods or 4 Pods must be available.
+you set `minAvailable` to `"50%"`, it's not immediately obvious whether that means 3 Pods or 4 Pods must be available.
 Kubernetes rounds up to the nearest integer, so in this case, 4 Pods must be available. You can examine the
 [code](https://github.com/kubernetes/kubernetes/blob/23be9587a0f8677eb8091464098881df939c44a9/pkg/controller/disruption/disruption.go#L539)
 that controls this behavior.

--- a/content/en/docs/tasks/run-application/configure-pdb.md
+++ b/content/en/docs/tasks/run-application/configure-pdb.md
@@ -84,7 +84,7 @@ Values for `minAvailable` or `maxUnavailable` can be expressed as integers or as
 - When you specify an integer, it represents a number of Pods. For instance, if you set `minAvailable` to 10, then 10
   Pods must always be available, even during a disruption.
 - When you specify a percentage by setting the value to a floating-point value between 0 and 1, it represents a percentage of
-  total Pods. For instance, if you set `minUnavailable` to `.5`, then only 50% of the Pods can be unavailable during a
+  total Pods. For instance, if you set `minUnavailable` to `"50%"`, then only 50% of the Pods can be unavailable during a
   disruption.
 
 When you specify the value as a percentage, it may not map to an exact number of Pods. For example, if you have 7 Pods and


### PR DESCRIPTION
Closes https://github.com/kubernetes/website/issues/14682

Details of the problem are in the linked issue ^

TLDR: the way to specify a percentage in a PodDisruptionBudget spec is as a string percentage (ie `”50%”`, not a float (ie `0.5`).