### PR TITLE
Correction: sysctl entries aren't annotations

### DIFF
--- a/content/en/docs/concepts/policy/pod-security-policy.md
+++ b/content/en/docs/concepts/policy/pod-security-policy.md
@@ -610,8 +610,8 @@ default cannot be changed.
 
 By default, all safe sysctls are allowed. 
 
-- *forbiddenSysctls* - excludes specific sysctls. You can forbid a combination of safe and unsafe sysctls in the list. To forbid setting any sysctls, use * on its own
-- *allowedUnsafeSysctls* - allows specific sysctls that had been disallowed by the default list, so long as these are not listed in forbiddenSysctls.
+- `forbiddenSysctls` - excludes specific sysctls. You can forbid a combination of safe and unsafe sysctls in the list. To forbid setting any sysctls, use `*` on its own.
+- `allowedUnsafeSysctls` - allows specific sysctls that had been disallowed by the default list, so long as these are not listed in `forbiddenSysctls`.
 
 Refer to the [Sysctl documentation](
 /docs/concepts/cluster-administration/sysctl-cluster/#podsecuritypolicy).

--- a/content/en/docs/concepts/policy/pod-security-policy.md
+++ b/content/en/docs/concepts/policy/pod-security-policy.md
@@ -44,7 +44,7 @@ administrator to control the following:
 | The Allowed Proc Mount types for the container      | [`allowedProcMountTypes`](#allowedprocmounttypes) |
 | The AppArmor profile used by containers             | [annotations](#apparmor)                    |
 | The seccomp profile used by containers              | [annotations](#seccomp)                     |
-| The sysctl profile used by containers               | [annotations](#sysctl)                      |
+| The sysctl profile used by containers               | [`forbiddenSysctls`,`allowedUnsafeSysctls`](#sysctl)                      |
 
 
 ## Enabling Pod Security Policies
@@ -608,7 +608,12 @@ default cannot be changed.
 
 ### Sysctl
 
-Controlled via annotations on the PodSecurityPolicy. Refer to the [Sysctl documentation](
+By default, all safe sysctls are allowed. 
+
+- *forbiddenSysctls* - excludes specific sysctls. You can forbid a combination of safe and unsafe sysctls in the list. To forbid setting any sysctls, use * on its own
+- *allowedUnsafeSysctls* - allows specific sysctls that had been disallowed by the default list, so long as these are not listed in forbiddenSysctls.
+
+Refer to the [Sysctl documentation](
 /docs/concepts/cluster-administration/sysctl-cluster/#podsecuritypolicy).
 
 {{% /capture %}}


### PR DESCRIPTION
First, thank you for your work on this documentation. It means so much to so many users. I found that the sysctl documentation linked here explains that sysctl pod security policy entries are in the spec field, not done via annotation. This corrects it, using as much of the original language as possible from the linked sysctl documentation.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> Remember to delete this note before submitting your pull request.
>
> For pull requests on 1.15 Features: set Milestone to 1.15 and Base Branch to dev-1.15
> 
> For pull requests on Chinese localization, set Base Branch to release-1.14
>
> For pull requests on Korean Localization: set Base Branch to dev-1.14-ko.\<latest team milestone>
>
> If you need Help on editing and submitting pull requests, visit:
> https://kubernetes.io/docs/contribute/start/#improve-existing-content.
>
> If you need Help on choosing which branch to use, visit:
> https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use.
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
