### PR TITLE
add link to default admission controllers

### DIFF
--- a/content/en/docs/reference/access-authn-authz/admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/admission-controllers.md
@@ -622,9 +622,7 @@ versions 1.9 and later).
 
 ## Is there a recommended set of admission controllers to use?
 
-Yes.
-
-For Kubernetes version 1.10 and later, the recommended admission controllers are enabled by default, so you do not need to explicitly specify them. You can enable additional admission controllers beyond the default set using the `--enable-admission-plugins` flag (**order doesn't matter**).
+Yes. For Kubernetes version 1.10 and later, the recommended admission controllers are enabled by default (shown [here](/docs/reference/command-line-tools-reference/kube-apiserver/#options)), so you do not need to explicitly specify them. You can enable additional admission controllers beyond the default set using the `--enable-admission-plugins` flag (**order doesn't matter**).
 
 {{< note >}}
 `--admission-control` was deprecated in 1.10 and replaced with `--enable-admission-plugins`.


### PR DESCRIPTION
This link will help readers refer to the kube-apiserver documentation  to see which admission controllers are enabled by default.