### PR TITLE
Update vuln reporting language to match reality

### DIFF
--- a/content/en/docs/reference/issues-security/security.md
+++ b/content/en/docs/reference/issues-security/security.md
@@ -33,7 +33,9 @@ You may encrypt your email to this list using the GPG keys of the [Product Secur
 
 - You think you discovered a potential security vulnerability in Kubernetes
 - You are unsure how a vulnerability affects Kubernetes
-- You think you discovered a vulnerability in another project that Kubernetes depends on (e.g. docker, rkt, etcd)
+- You think you discovered a vulnerability in another project that Kubernetes depends on
+  - For projects with their own vulnerability reporting and disclosure process, please report it directly there
+
 
 ### When Should I NOT Report a Vulnerability?
 
@@ -51,5 +53,5 @@ As the security issue moves from triage, to identified fix, to release planning 
 
 ## Public Disclosure Timing
 
-A public disclosure date is negotiated by the Kubernetes Product Security Committee and the bug submitter. We prefer to fully disclose the bug as soon as possible once a user mitigation is available. It is reasonable to delay disclosure when the bug or the fix is not yet fully understood, the solution is not well-tested, or for vendor coordination. The timeframe for disclosure is from immediate (especially if it's already publicly known) to a few weeks. As a basic default, we expect report date to disclosure date to be on the order of 7 days. The Kubernetes Product Security Committee holds the final say when setting a disclosure date.
+A public disclosure date is negotiated by the Kubernetes Product Security Committee and the bug submitter. We prefer to fully disclose the bug as soon as possible once a user mitigation is available. It is reasonable to delay disclosure when the bug or the fix is not yet fully understood, the solution is not well-tested, or for vendor coordination. The timeframe for disclosure is from immediate (especially if it's already publicly known) to a few weeks. For a vulnerability with a straightforward mitigation, we expect report date to disclosure date to be on the order of 7 days. The Kubernetes Product Security Committee holds the final say when setting a disclosure date.
 {{% /capture %}}


### PR DESCRIPTION
We don't need to be the dispatch for all vulns, now that other projects are starting to have their own processes. But we don't want to discourage reports about stuff that isn't directly in k/k either.

Saying that we usually disclose vuln reports in 7 days is just not true. But, I think it's still good to aim for 7 days when we aren't blocked on and coordinating release of patches.