### PR TITLE
Issue with tutorial  update/update-intro/ carousel not working

### DIFF
--- a/content/de/docs/tutorials/kubernetes-basics/update/update-intro.html
+++ b/content/de/docs/tutorials/kubernetes-basics/update/update-intro.html
@@ -64,19 +64,19 @@ weight: 10
                         <li data-target="#myCarousel" data-slide-to="3"></li>
                     </ol>
                       <div class="carousel-inner" role="listbox">
-                        <div class="item active">
+                        <div class="item carousel-item active">
                           <img src="/docs/tutorials/kubernetes-basics/public/images/module_06_rollingupdates1.svg" >
                         </div>
 
-                        <div class="item">
+                        <div class="item carousel-item">
                           <img src="/docs/tutorials/kubernetes-basics/public/images/module_06_rollingupdates2.svg">
                         </div>
 
-                        <div class="item">
+                        <div class="item carousel-item">
                           <img src="/docs/tutorials/kubernetes-basics/public/images/module_06_rollingupdates3.svg">
                         </div>
 
-                        <div class="item">
+                        <div class="item carousel-item">
                           <img src="/docs/tutorials/kubernetes-basics/public/images/module_06_rollingupdates4.svg">
                         </div>
                       </div>

--- a/content/en/docs/tutorials/kubernetes-basics/update/update-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/update/update-intro.html
@@ -64,19 +64,19 @@ weight: 10
                         <li data-target="#myCarousel" data-slide-to="3"></li>
                     </ol>
                       <div class="carousel-inner" role="listbox">
-                        <div class="item active">
+                        <div class="item carousel-item active">
                           <img src="/docs/tutorials/kubernetes-basics/public/images/module_06_rollingupdates1.svg" >
                         </div>
 
-                        <div class="item">
+                        <div class="item carousel-item">
                           <img src="/docs/tutorials/kubernetes-basics/public/images/module_06_rollingupdates2.svg">
                         </div>
 
-                        <div class="item">
+                        <div class="item carousel-item">
                           <img src="/docs/tutorials/kubernetes-basics/public/images/module_06_rollingupdates3.svg">
                         </div>
 
-                        <div class="item">
+                        <div class="item carousel-item">
                           <img src="/docs/tutorials/kubernetes-basics/public/images/module_06_rollingupdates4.svg">
                         </div>
                       </div>

--- a/content/ja/docs/tutorials/kubernetes-basics/update/update-intro.html
+++ b/content/ja/docs/tutorials/kubernetes-basics/update/update-intro.html
@@ -63,19 +63,19 @@ weight: 10
                         <li data-target="#myCarousel" data-slide-to="3"></li>
                     </ol>
                       <div class="carousel-inner" role="listbox">
-                        <div class="item active">
+                        <div class="item carousel-item active">
                           <img src="/docs/tutorials/kubernetes-basics/public/images/module_06_rollingupdates1.svg" >
                         </div>
 
-                        <div class="item">
+                        <div class="item carousel-item">
                           <img src="/docs/tutorials/kubernetes-basics/public/images/module_06_rollingupdates2.svg">
                         </div>
 
-                        <div class="item">
+                        <div class="item carousel-item">
                           <img src="/docs/tutorials/kubernetes-basics/public/images/module_06_rollingupdates3.svg">
                         </div>
 
-                        <div class="item">
+                        <div class="item carousel-item">
                           <img src="/docs/tutorials/kubernetes-basics/public/images/module_06_rollingupdates4.svg">
                         </div>
                       </div>

--- a/content/ko/docs/tutorials/kubernetes-basics/update/update-intro.html
+++ b/content/ko/docs/tutorials/kubernetes-basics/update/update-intro.html
@@ -68,19 +68,19 @@ weight: 10
                         <li data-target="#myCarousel" data-slide-to="3"></li>
                     </ol>
                     <div class="carousel-inner" role="listbox">
-                        <div class="item active">
+                        <div class="item carousel-item active">
                             <img src="/docs/tutorials/kubernetes-basics/public/images/module_06_rollingupdates1.svg">
                         </div>
 
-                        <div class="item">
+                        <div class="item carousel-item">
                             <img src="/docs/tutorials/kubernetes-basics/public/images/module_06_rollingupdates2.svg">
                         </div>
 
-                        <div class="item">
+                        <div class="item carousel-item">
                             <img src="/docs/tutorials/kubernetes-basics/public/images/module_06_rollingupdates3.svg">
                         </div>
 
-                        <div class="item">
+                        <div class="item carousel-item">
                             <img src="/docs/tutorials/kubernetes-basics/public/images/module_06_rollingupdates4.svg">
                         </div>
                     </div>


### PR DESCRIPTION
i discovered that bootstrap is upgraded, so i decided to add the specific class to ensure design did not change.

Pages affected:
en: [original](https://kubernetes.io/docs/tutorials/kubernetes-basics/update/update-intro/) | [updated](https://deploy-preview-14895--kubernetes-io-master-staging.netlify.com/docs/tutorials/kubernetes-basics/update/update-intro/)
de: [original](https://kubernetes.io/de/docs/tutorials/kubernetes-basics/update/update-intro/) | [updated](https://deploy-preview-14895--kubernetes-io-master-staging.netlify.com/de/docs/tutorials/kubernetes-basics/update/update-intro/)
ja: [original](https://kubernetes.io/ja/docs/tutorials/kubernetes-basics/update/update-intro/) | [updated](https://deploy-preview-14895--kubernetes-io-master-staging.netlify.com/ja/docs/tutorials/kubernetes-basics/update/update-intro/)
ko: [original](https://kubernetes.io/ko/docs/tutorials/kubernetes-basics/update/update-intro/) | [updated](https://deploy-preview-14895--kubernetes-io-master-staging.netlify.com/ko/docs/tutorials/kubernetes-basics/update/update-intro/)

Fixes #14882  
Fixes #14809