### PR TITLE
Minikube IP Address fixup for ingress demonstration

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -178,7 +178,7 @@ The following file is an Ingress resource that sends traffic to your Service via
 
 1. Add the following line to the bottom of the `/etc/hosts` file. 
 
-    {{< note >}}If you are running Minikube locally, use `minikube ip` to get the external IP. The IP displayed within the ingress list will be the internal cluster ip.{{< /note >}}
+    {{< note >}}If you are running Minikube locally, use `minikube ip` to get the external IP. The IP address displayed within the ingress list will be the internal IP.{{< /note >}}
 
     ```
     172.17.0.15 hello-world.info

--- a/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -178,6 +178,8 @@ The following file is an Ingress resource that sends traffic to your Service via
 
 1. Add the following line to the bottom of the `/etc/hosts` file. 
 
+    {{< note >}}If you are running Minikube locally, use `minikube ip` to get the external IP. The IP displayed within the ingress list will be the internal cluster ip.{{< /note >}}
+
     ```
     172.17.0.15 hello-world.info
     ```


### PR DESCRIPTION
Tested on Minikube for macOS.

When using Minikube, the IP address listed in `kubectl get ingress` is the internal Minikube IP address and is not available on the web browser.

Added advice to the user that when using Minikube, add the Minikube IP address to the Hosts file instead of the IP address displayed in `kubectl get ingress`.