### PR TITLE
Page configure-liveness-readiness-probes the server.go link is broken

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-probes.md
@@ -138,7 +138,7 @@ Any code greater than or equal to 200 and less than 400 indicates success. Any
 other code indicates failure.
 
 You can see the source code for the server in
-[server.go](https://github.com/kubernetes/kubernetes/blob/master/test/images/liveness/server.go).
+[server.go](https://github.com/kubernetes/kubernetes/blob/master/test/images/agnhost/liveness/server.go).
 
 For the first 10 seconds that the Container is alive, the `/healthz` handler
 returns a status of 200. After that, the handler returns a status of 500.


### PR DESCRIPTION
The link from the source code of the server.go is broken.

Signed-off-by: André R. de Miranda andre@miranda.work