### PR TITLE
For CentOS/RHEL 7.4+, Enable containerd to start at every restart

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -276,6 +276,9 @@ containerd config default > /etc/containerd/config.toml
 
 # Restart containerd
 systemctl restart containerd
+
+# Enable containerd to start at every restart
+systemctl enable containerd
 {{< /tab >}}
 {{< /tabs >}}
 


### PR DESCRIPTION
Added below lines

# Enable containerd to start at every restart
systemctl enable containerd
