### PR TITLE
Update link to Minikube from glossary

### DIFF
--- a/content/en/docs/reference/glossary/minikube.md
+++ b/content/en/docs/reference/glossary/minikube.md
@@ -2,7 +2,7 @@
 title: Minikube
 id: minikube
 date: 2018-04-12
-full_link: /docs/getting-started-guides/minikube/
+full_link: /docs/setup/learning-environment/minikube/
 short_description: >
   A tool for running Kubernetes locally.
 
@@ -16,4 +16,5 @@ tags:
 <!--more--> 
 
 Minikube runs a single-node cluster inside a VM on your computer.
-
+You can use Minikube to
+[try Kubernetes in a learning environment](/docs/setup/learning-environment/).


### PR DESCRIPTION
Update https://kubernetes.io/docs/reference/glossary/?all=true#term-minikube to link to the new URI of the [page about Minikube](https://kubernetes.io/docs/setup/learning-environment/minikube/).