### PR TITLE
update tutorial not to use ‘kubectl run’ for creating deployment

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/service-access-application-cluster.md
+++ b/content/en/docs/tasks/access-application-cluster/service-access-application-cluster.md
@@ -34,21 +34,21 @@ provides load balancing for an application that has two running instances.
 ## Creating a service for an application running in two pods
 
 1. Run a Hello World application in your cluster:
-    Here is the configuration file for the application Deployment:
+   Here is the configuration file for the application Deployment:
 
-    {{< codenew file="service/access/hello-application.yaml" >}}
+   {{< codenew file="service/access/hello-application.yaml" >}}
 
-    Create the application Deployment:
+   Create the application Deployment:
     
-        kubectl apply -f https://k8s.io/examples/service/access/hello-application.yaml
+       kubectl apply -f https://k8s.io/examples/service/access/hello-application.yaml
 
-    The preceding command creates a
-    [Deployment](/docs/concepts/workloads/controllers/deployment/)
-    object and an associated
-    [ReplicaSet](/docs/concepts/workloads/controllers/replicaset/)
-    object. The ReplicaSet has two
-    [Pods](/docs/concepts/workloads/pods/pod/),
-    each of which runs the Hello World application.
+   The preceding command creates a
+   [Deployment](/docs/concepts/workloads/controllers/deployment/)
+   object and an associated
+   [ReplicaSet](/docs/concepts/workloads/controllers/replicaset/)
+   object. The ReplicaSet has two
+   [Pods](/docs/concepts/workloads/pods/pod/),
+   each of which runs the Hello World application.
 
 1. Display information about the Deployment:
    ```shell

--- a/content/en/docs/tasks/access-application-cluster/service-access-application-cluster.md
+++ b/content/en/docs/tasks/access-application-cluster/service-access-application-cluster.md
@@ -42,7 +42,6 @@ Here is the configuration file for the application Deployment:
    ```shell
    kubectl apply -f https://k8s.io/examples/service/access/hello-application.yaml
    ```
-
    The preceding command creates a
    [Deployment](/docs/concepts/workloads/controllers/deployment/)
    object and an associated

--- a/content/en/docs/tasks/access-application-cluster/service-access-application-cluster.md
+++ b/content/en/docs/tasks/access-application-cluster/service-access-application-cluster.md
@@ -39,10 +39,8 @@ provides load balancing for an application that has two running instances.
     {{< codenew file="service/access/hello-application.yaml" >}}
 
     Create the application Deployment:
-
-    ```shell
-    kubectl apply -f https://k8s.io/examples/service/access/hello-application.yaml
-    ```
+    
+        kubectl apply -f https://k8s.io/examples/service/access/hello-application.yaml
 
     The preceding command creates a
     [Deployment](/docs/concepts/workloads/controllers/deployment/)

--- a/content/en/docs/tasks/access-application-cluster/service-access-application-cluster.md
+++ b/content/en/docs/tasks/access-application-cluster/service-access-application-cluster.md
@@ -33,14 +33,15 @@ provides load balancing for an application that has two running instances.
 
 ## Creating a service for an application running in two pods
 
+Here is the configuration file for the application Deployment:
+
+{{< codenew file="service/access/hello-application.yaml" >}}
+
 1. Run a Hello World application in your cluster:
-   Here is the configuration file for the application Deployment:
-
-   {{< codenew file="service/access/hello-application.yaml" >}}
-
-   Create the application Deployment:
-    
-       kubectl apply -f https://k8s.io/examples/service/access/hello-application.yaml
+   Create the application Deployment using the file above:
+   ```shell
+   kubectl apply -f https://k8s.io/examples/service/access/hello-application.yaml
+   ```
 
    The preceding command creates a
    [Deployment](/docs/concepts/workloads/controllers/deployment/)

--- a/content/en/docs/tasks/access-application-cluster/service-access-application-cluster.md
+++ b/content/en/docs/tasks/access-application-cluster/service-access-application-cluster.md
@@ -34,9 +34,16 @@ provides load balancing for an application that has two running instances.
 ## Creating a service for an application running in two pods
 
 1. Run a Hello World application in your cluster:
-   ```shell
-   kubectl run hello-world --replicas=2 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
-   ```   
+    Here is the configuration file for the application Deployment:
+
+    {{< codenew file="service/access/hello-application.yaml" >}}
+
+    Create the application Deployment:
+
+    ```shell
+    kubectl apply -f https://k8s.io/examples/service/access/hello-application.yaml
+    ```
+
     The preceding command creates a
     [Deployment](/docs/concepts/workloads/controllers/deployment/)
     object and an associated

--- a/content/en/examples/service/access/hello-application.yaml
+++ b/content/en/examples/service/access/hello-application.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-world
+spec:
+  selector:
+    matchLabels:
+      run: load-balancer-example
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        run: load-balancer-example
+    spec:
+      containers:
+        - name: hello-world
+          image: gcr.io/google-samples/node-hello:1.0
+          ports:
+            - containerPort: 8080
+              protocol: TCP


### PR DESCRIPTION
When I use the command in the tutorial which is as followed:

"kubectl run hello-world --replicas=2 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080"

kubectl gives me the response which is as followed:

"kubectl run --generator=deployment/apps.v1 is DEPRECATED and will be removed in a future version. Use kubectl run --generator=run-pod/v1 or kubectl create instead."

So, I changed the tutorial to use yaml file for creating deployment.