### PR TITLE
Removing vi command from text

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -17,8 +17,7 @@ weight: 10
 {{< glossary_definition term_id="service" length="short" >}}
 
 No need to modify your application to use an unfamiliar service discovery mechanism.
-Kubernetes gives pods their own IP addresses and a single DNS name for a set of pods,
-:wqaand can load-balance across them.
+Kubernetes gives pods their own IP addresses and a single DNS name for a set of pods, and can load-balance across them.
 
 {{% /capture %}}
 


### PR DESCRIPTION

Simple change to remove the `:wqa` (`vi`) command from the text. 