### PR TITLE
Remove kubelet --allow-privileged flag when setup ha etcd with kubeadm

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
@@ -53,7 +53,7 @@ this example.
     cat << EOF > /etc/systemd/system/kubelet.service.d/20-etcd-service-manager.conf
     [Service]
     ExecStart=
-    ExecStart=/usr/bin/kubelet --address=127.0.0.1 --pod-manifest-path=/etc/kubernetes/manifests --allow-privileged=true
+    ExecStart=/usr/bin/kubelet --address=127.0.0.1 --pod-manifest-path=/etc/kubernetes/manifests
     Restart=always
     EOF
 


### PR DESCRIPTION
Now the setup ha etcd cluster with kubeadm document use the kubelet have been removed flag `--allow-privileged`, it make kubelet can not work. So change this document.

## Related issues

issue https://github.com/kubernetes/kubeadm/issues/1630