### PR TITLE
Correcting details about current request namespace

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/namespaces.md
+++ b/content/en/docs/concepts/overview/working-with-objects/namespaces.md
@@ -65,13 +65,13 @@ Kubernetes starts with three initial namespaces:
 
 ### Setting the namespace for a request
 
-To temporarily set the namespace for a request, use the `--namespace` flag.
+To set the namespace for a current request, use the `--namespace` flag.
 
 For example:
 
 ```shell
-kubectl --namespace=<insert-namespace-name-here> run nginx --image=nginx
-kubectl --namespace=<insert-namespace-name-here> get pods
+kubectl run nginx --image=nginx --namespace=<insert-namespace-name-here>
+kubectl get pods --namespace=<insert-namespace-name-here>
 ```
 
 ### Setting the namespace preference


### PR DESCRIPTION
Removed ambiguous word 'temporarily', as namespace set using that method, is not temporary. It is permanent for a current resource and there is no concept of a temporary namespace in K8s. 
Also, for consistency '--namespace' flag added after the actual command.