### PR TITLE
Adding command to display node details

### DIFF
--- a/content/en/docs/concepts/architecture/nodes.md
+++ b/content/en/docs/concepts/architecture/nodes.md
@@ -30,6 +30,10 @@ A node's status contains the following information:
 * [Capacity and Allocatable](#capacity)
 * [Info](#info)
 
+Node status and other details about a node can be displayed using below command:
+```shell
+kubectl describe node <insert-node-name-here>
+```
 Each section is described in detail below.
 
 ### Addresses


### PR DESCRIPTION
Details of a node are already described on this page but the command used to get those details were missing. So with this PR adding that command.