### PR TITLE
Using hugo extended version when locally using Hugo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Open up your browser to http://localhost:1313 to view the website. As you make c
 
 ## Running the website locally using Hugo
 
-See the [official Hugo documentation](https://gohugo.io/getting-started/installing/) for Hugo installation instructions. Make sure to install the Hugo version specified by the `HUGO_VERSION` environment variable in the [`netlify.toml`](netlify.toml#L9) file.
+See the [official Hugo documentation](https://gohugo.io/getting-started/installing/) for Hugo installation instructions. Make sure to install the Hugo extended version specified by the `HUGO_VERSION` environment variable in the [`netlify.toml`](netlify.toml#L9) file.
 
 To run the website locally when you have Hugo installed:
 


### PR DESCRIPTION
I follow the [running-the-website-locally-using-hugo](https://github.com/kubernetes/website#running-the-website-locally-using-hugo) document, this document not specify which hugo binary file should installed.

I download and install `hugo_0.53_Linux-64bit.tar.gz`, it not work, below is error log:

```sh
hugo server --buildFuture
Building sites … ERROR 2019/06/21 15:53:11 error: failed to transform resource: TOCSS: failed to transform "sass/style.sass" (text/x-sass): this feature is not available in your current Hugo version
```

I donwload and install hugo extended version, `make serve` works well, so i think we should explain which hugo should installed.
