### PR TITLE
Add recap blog post for Contributor Summit Barcelona 2019

### DIFF
--- a/content/en/blog/_posts/2019-06-25-recap-of-contributor-summit-bcn-2019.md
+++ b/content/en/blog/_posts/2019-06-25-recap-of-contributor-summit-bcn-2019.md
@@ -1,0 +1,58 @@
+---
+layout: blog
+title: 'Recap of Kubernetes Contributor Summit Barcelona 2019'
+date: 2019-06-25
+---
+
+**Author**: Jonas Rosland (VMware)
+
+First of all, **THANK YOU** to everyone who made the Kubernetes Contributor Summit in Barcelona possible. We had an amazing team of volunteers tasked with planning and executing the event, and it was so much fun meeting and talking to all new and current contributors during the main event and the pre-event celebration.
+
+Contributor Summit in Barcelona kicked off KubeCon + CloudNativeCon in a big way as it was the **largest contributor summit** to date with 331 people signed up, and only 9 didn't pick up their badges!
+
+## Contributor Celebration
+
+Sunday evening before the main event we held a **Contributor Celebration**, which was very well attended. We hope that all new and current contributors felt welcome and enjoyed the food, the music, and the company.
+
+![contributor-celebration2](https://live.staticflickr.com/65535/46981485515_561bb324b2_z.jpg)
+![contributor-celebration](https://live.staticflickr.com/65535/46981484655_8122564557_z.jpg)
+
+## New Contributor Workshops
+
+We had over **130 people registered** for the New Contributor Workshops. This year the workshops were divided into _101-level content_ for people who were not familiar with contributing to an open source project, and _201-level content_ for those who were.
+
+The workshops contained overviews of what SIGs are, deep-dives into the codebase, test builds of the Kubernetes project, and real contributions.
+
+Did you miss something during the workshops? We now have them [published on YouTube](https://www.youtube.com/playlist?list=PL69nYSiGNLP2WTJ6P8sQenhf0RY-JqF5L), with added closed captioning!
+
+![img](https://live.staticflickr.com/65535/47897543541_a57d3b9ac9_z.jpg)
+![img](https://live.staticflickr.com/65535/47108247174_5d60b60846_z.jpg)
+
+## SIG Face-to-Face
+
+We also tried a new thing for Barcelona, the SIG Face-to-Face meetings. We had **over 170 people** registered to attend the 11 SIG and one subproject meetings throughout the day, going over what they're working on and what they want to do in the near future.
+
+![img](https://live.staticflickr.com/65535/47108254124_248a80ef1a_z.jpg)
+![img](https://live.staticflickr.com/65535/47108250434_88afdf930a_z.jpg)
+
+## SIG Meet and Greet
+
+At the end of the summit, both new and current contributors had a chance to sit down with SIG chairs and members. The goal of this was to make sure that contributors got to know even more individuals in the project, hear what some of the SIGs actually do, and sign up to be a part of them and learn more.
+
+![img](https://live.staticflickr.com/65535/47108248464_97eb2bbbb6_k.jpg)
+![img](https://live.staticflickr.com/65535/47845452032_a3d478beb9_k.jpg)
+
+
+## Join us!
+
+Interested in attending the Contributor Summit in San Diego? [You can get more information on our event page](https://events.linuxfoundation.org/events/contributor-summit-north-america-2019/), sign up and we will notify you when registration opens.
+
+## Thanks!
+
+Again, thank you to everyone for making this an amazing event, and we're looking forward to seeing you next time!
+
+To our Barcelona crew, you ROCK! 🥁
+
+Paris Pittman, Bob Killen, Guinevere Saenger, Tim Pepper, Deb Giles, Ihor Dvoretskyi, Jorge Castro, Noah Kantrowitz, Dawn Foster, Ruben Orduz, Josh Berkus, Kiran Mova, Bart Smykla, Rostislav Georgiev, Jeffrey Sica, Rael Garcia, Silvia Moura Pina, Arnaud Meukam, Jason DeTiberius, Andy Goldstein, Suzanne Ambiel, Jonas Rosland
+
+You can see many more pictures from the event [over on CNCF's Flickr](https://www.flickr.com/photos/143247548@N03/sets/72157680323974628).


### PR DESCRIPTION
This will add a recap blog post of Contributor Summit Barcelona.

Signed-off-by: jonasrosland <jrosland@vmware.com>