### PR TITLE
kubeadm: recommend installing calico 3.8

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
@@ -295,7 +295,7 @@ For more information about using Calico, see [Quickstart for Calico on Kubernete
 For Calico to work correctly, you need to pass `--pod-network-cidr=192.168.0.0/16` to `kubeadm init` or update the `calico.yml` file to match your Pod network. Note that Calico works on `amd64`, `arm64`, and `ppc64le` only.
 
 ```shell
-kubectl apply -f https://docs.projectcalico.org/v3.7/manifests/calico.yaml
+kubectl apply -f https://docs.projectcalico.org/v3.8/manifests/calico.yaml
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
This change is required since the 3.8 manifest moves to using
apps/v1 instead of extensions/v1beta1 for types like DaemonSet
and Deployment.

See PR 70672 of k/k.

/kind feature
/priority important-longterm
/sig cluster-lifecycle
