### PR TITLE
Make secret-pod.yaml indentation consistent

### DIFF
--- a/content/en/examples/pods/inject/secret-pod.yaml
+++ b/content/en/examples/pods/inject/secret-pod.yaml
@@ -7,9 +7,9 @@ spec:
     - name: test-container
       image: nginx
       volumeMounts:
-          # name must match the volume name below
-          - name: secret-volume
-            mountPath: /etc/secret-volume
+        # name must match the volume name below
+        - name: secret-volume
+          mountPath: /etc/secret-volume
   # The secret data is exposed to Containers in the Pod through a Volume.
   volumes:
     - name: secret-volume


### PR DESCRIPTION
The `secret-pod.yaml` example used on the page *Distribute Credentials Securely Using Secrets* is indented inconsistently.  All of the lists in this yaml file use 2-space indent while the children of `volumeMounts` have extra indentation.

This PR makes it consistent.

Fixes #15117.