### PR TITLE
Tidy assign-cpu-resource page

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/assign-cpu-resource.md
+++ b/content/en/docs/tasks/configure-pod-container/assign-cpu-resource.md
@@ -7,7 +7,7 @@ weight: 20
 {{% capture overview %}}
 
 This page shows how to assign a CPU *request* and a CPU *limit* to
-a dontainer. Containers cannot use more CPU than the configured limit.
+a container. Containers cannot use more CPU than the configured limit.
 Provided the system has CPU time free, a container is guaranteed to be
 allocated as much CPU as it requests.
 

--- a/content/en/docs/tasks/configure-pod-container/assign-cpu-resource.md
+++ b/content/en/docs/tasks/configure-pod-container/assign-cpu-resource.md
@@ -7,9 +7,9 @@ weight: 20
 {{% capture overview %}}
 
 This page shows how to assign a CPU *request* and a CPU *limit* to
-a Container. A Container is guaranteed to have as much CPU as it requests,
-but is not allowed to use more CPU than its limit.
-
+a dontainer. Containers cannot use more CPU than the configured limit.
+Provided the system has CPU time free, a container is guaranteed to be
+allocated as much CPU as it requests.
 
 {{% /capture %}}
 
@@ -25,8 +25,8 @@ A few of the steps on this page require you to run the
 service in your cluster. If you have the metrics-server
 running, you can skip those steps.
 
-If you are running minikube, run the following command to enable
-metrics-server:
+If you are running {{< glossary_tooltip term_id="minikube" >}}, run the
+following command to enable metrics-server:
 
 ```shell
 minikube addons enable metrics-server
@@ -43,8 +43,8 @@ If the resource metrics API is available, the output will include a
 reference to `metrics.k8s.io`.
 
 
-```shell
-NAME      
+```
+NAME
 v1beta1.metrics.k8s.io
 ```
 
@@ -55,8 +55,8 @@ v1beta1.metrics.k8s.io
 
 ## Create a namespace
 
-Create a namespace so that the resources you create in this exercise are
-isolated from the rest of your cluster.
+Create a {{< glossary_tooltip term_id="namespace" >}} so that the resources you
+create in this exercise are isolated from the rest of your cluster.
 
 ```shell
 kubectl create namespace cpu-example
@@ -64,14 +64,15 @@ kubectl create namespace cpu-example
 
 ## Specify a CPU request and a CPU limit
 
-To specify a CPU request for a Container, include the `resources:requests` field
+To specify a CPU request for a container, include the `resources:requests` field
 in the Container resource manifest. To specify a CPU limit, include `resources:limits`.
 
-In this exercise, you create a Pod that has one Container. The Container has a request of 0.5 CPU and a limit of 1 CPU. Here is the configuration file for the Pod:
+In this exercise, you create a Pod that has one container. The container has a request
+of 0.5 CPU and a limit of 1 CPU. Here is the configuration file for the Pod:
 
 {{< codenew file="pods/resource/cpu-request-limit.yaml" >}}
 
-The `args` section of the configuration file provides arguments for the Container when it starts.
+The `args` section of the configuration file provides arguments for the container when it starts.
 The `-cpus "2"` argument tells the Container to attempt to use 2 CPUs.
 
 Create the Pod:
@@ -80,7 +81,7 @@ Create the Pod:
 kubectl apply -f https://k8s.io/examples/pods/resource/cpu-request-limit.yaml --namespace=cpu-example
 ```
 
-Verify that the Pod Container is running:
+Verify that the Pod is running:
 
 ```shell
 kubectl get pod cpu-demo --namespace=cpu-example
@@ -92,7 +93,7 @@ View detailed information about the Pod:
 kubectl get pod cpu-demo --output=yaml --namespace=cpu-example
 ```
 
-The output shows that the one Container in the Pod has a CPU request of 500 milliCPU
+The output shows that the one container in the Pod has a CPU request of 500 milliCPU
 and a CPU limit of 1 CPU.
 
 ```yaml
@@ -109,18 +110,18 @@ Use `kubectl top` to fetch the metrics for the pod:
 kubectl top pod cpu-demo --namespace=cpu-example
 ```
 
-The output shows that the Pod is using 974 milliCPU, which is just a bit less than
-the limit of 1 CPU specified in the Pod configuration file.
+This example output shows that the Pod is using 974 milliCPU, which is
+just a bit less than the limit of 1 CPU specified in the Pod configuration.
 
 ```
 NAME                        CPU(cores)   MEMORY(bytes)
 cpu-demo                    974m         <something>
 ```
 
-Recall that by setting `-cpu "2"`, you configured the Container to attempt to use 2 CPUs, but the Container is only being allowed to use about 1 CPU. The Container CPU use is being throttled, because the Container is attempting to use more CPU resources than its limit.
+Recall that by setting `-cpu "2"`, you configured the Container to attempt to use 2 CPUs, but the Container is only being allowed to use about 1 CPU. The container's CPU use is being throttled, because the container is attempting to use more CPU resources than its limit.
 
 {{< note >}}
-Another possible explanation for the CPU throttling is that the Node might not have
+Another possible explanation for the CPU use being below 1.0 is that the Node might not have
 enough CPU resources available. Recall that the prerequisites for this exercise require each of
 your Nodes to have at least 1 CPU. If your Container runs on a Node that has only 1 CPU, the Container
 cannot use more than 1 CPU regardless of the CPU limit specified for the Container.
@@ -183,6 +184,8 @@ scheduled to run on any Node, and it will remain in the Pending state indefinite
 
 ```shell
 kubectl get pod cpu-demo-2 --namespace=cpu-example
+```
+```
 NAME         READY     STATUS    RESTARTS   AGE
 cpu-demo-2   0/1       Pending   0          7m
 ```
@@ -198,11 +201,11 @@ The output shows that the Container cannot be scheduled because of insufficient
 CPU resources on the Nodes:
 
 
-```shell
+```
 Events:
-  Reason			Message
-  ------			-------
-  FailedScheduling	No nodes are available that match all of the following predicates:: Insufficient cpu (3).
+  Reason                        Message
+  ------                        -------
+  FailedScheduling      No nodes are available that match all of the following predicates:: Insufficient cpu (3).
 ```
 
 Delete your Pod:
@@ -269,6 +272,3 @@ kubectl delete namespace cpu-example
 * [Configure Quotas for API Objects](/docs/tasks/administer-cluster/quota-api-object/)
 
 {{% /capture %}}
-
-
-


### PR DESCRIPTION
- Write container in lower case, except where discussing part of the Kubernetes API
- Add a couple of glossary tooltips
- Fix code block language / highlighting
- Convert tabs to spaces in sample output
- Some rewording

CPU use might be below 1000milli not because of “throttling” but because the Node only has 1 physical CPU and that one CPU has to multiplex the Pod / container against other tasks.