### PR TITLE
Disable Italian localization

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -24,7 +24,9 @@ pygmentsStyle = "emacs"
 enableGitInfo = true
 
 # Norwegian ("no") is sometimes but not currently used for testing.
-disableLanguages = ["hi", "no"]
+# Hindi is disabled because it's currently in development.
+# Italian is disabled until it meets minimum standards for quality.
+disableLanguages = ["hi", "it", "no"]
 
 [blackfriday]
 hrefTargetBlank = true


### PR DESCRIPTION
This PR disables the Italian localization until it meets minimum standards of quality.

Context: [sig-docs Slack](https://kubernetes.slack.com/archives/C1J0BPD2M/p1561571907154900)

/sig docs
/assign @rlenferink 