### PR TITLE
📰 fix the scheduling framework figure link

### DIFF
--- a/content/en/docs/concepts/configuration/scheduling-framework.md
+++ b/content/en/docs/concepts/configuration/scheduling-framework.md
@@ -54,7 +54,7 @@ equivalent to "Predicate" and "Scoring" is equivalent to "Priority function".
 One plugin may register at multiple extension points to perform more complex or
 stateful tasks.
 
-{{< figure src="/images/docs/scheduling-framework.png" title="scheduling framework extension points" >}}
+{{< figure src="/images/docs/scheduling-framework-extensions.png" title="scheduling framework extension points" >}}
 
 ### Queue sort
 
@@ -238,7 +238,7 @@ decode and process the configuration.
 
 The following example shows a scheduler configuration that enables some
 plugins at `reserve` and `preBind` extension points and disables a plugin. It
-also provides a configuration to plugin `foo`. 
+also provides a configuration to plugin `foo`.
 
 ```yaml
 apiVersion: kubescheduler.config.k8s.io/v1alpha1


### PR DESCRIPTION
📰 fix the scheduling framework figure link

![image](https://user-images.githubusercontent.com/13084624/60262818-b3b52e00-9911-11e9-8ff9-ad785bf04e7d.png)

Should be "static/images/docs/**scheduling-framework-extensions**.png".