### PR TITLE
Changes service name to 'foo' to match env vars

### DIFF
--- a/content/en/docs/concepts/containers/container-environment-variables.md
+++ b/content/en/docs/concepts/containers/container-environment-variables.md
@@ -42,7 +42,7 @@ as are any environment variables specified statically in the Docker image.
 A list of all services that were running when a Container was created is available to that Container as environment variables.
 Those environment variables match the syntax of Docker links.
 
-For a service named *foo* that maps to a Container named *bar*,
+For a service named *foo* that maps to a Container named *foo*,
 the following variables are defined:
 
 ```shell


### PR DESCRIPTION
Previously the docs said the service was named _bar_, but the environment variables use the name _foo_