### PR TITLE
Cycle KubeCon info on landing page

### DIFF
--- a/assets/sass/_base.sass
+++ b/assets/sass/_base.sass
@@ -1184,7 +1184,7 @@ $feature-box-div-margin-bottom: 40px
     position: absolute
     top: 50%
     left: 75%
-    width: 525px
+    width: 575px
     padding-right: 80px
     transform: translate(-50%, -50%)
     color: white

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -44,12 +44,12 @@ Kubernetes is open source giving you the freedom to take advantage of on-premise
         <br>
         <br>
         <br>
-        <a href="https://www.lfasiallc.com/events/kubecon-cloudnativecon-china-2019" button id="desktopKCButton">Attend KubeCon in Shanghai on June 24-26, 2019</a>
-        <br>
-        <br>
-        <br>
-        <br>
         <a href="https://events.linuxfoundation.org/events/kubecon-cloudnativecon-north-america-2019" button id="desktopKCButton">Attend KubeCon in San Diego on Nov. 18-21, 2019</a>
+        <br>
+        <br>
+        <br>
+        <br>
+        <a href="https://events.linuxfoundation.org/events/kubecon-cloudnativecon-europe-2020/" button id="desktopKCButton">Attend KubeCon in Amsterdam on Mar. 30-Apr. 2, 2020</a>
 </div>
 <div id="videoPlayer">
     <iframe data-url="https://www.youtube.com/embed/H06qrNmGqyE?autoplay=1" frameborder="0" allowfullscreen></iframe>


### PR DESCRIPTION
This PR updates:
- KubeCon dates/locations in the buttons on the main page
- button width to accommodate longer text strings for Amsterdam

/sig docs
/assign @idvoretskyi 