### PR TITLE
Remove APT hold for kubectl during kubeadm upgrade

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-15.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-15.md
@@ -225,9 +225,9 @@ The upgrade workflow at high level is the following:
     {{< tabs name="k8s_install_kubelet" >}}
     {{% tab name="Ubuntu, Debian or HypriotOS" %}}
     # replace x in 1.15.x-00 with the latest patch version
-    apt-mark unhold kubelet && \
+    apt-mark unhold kubelet kubectl && \
     apt-get update && apt-get install -y kubelet=1.15.x-00 kubectl=1.15.x-00 && \
-    apt-mark hold kubelet
+    apt-mark hold kubelet kubectl
     {{% /tab %}}
     {{% tab name="CentOS, RHEL or Fedora" %}}
     # replace x in 1.15.x-0 with the latest patch version


### PR DESCRIPTION
 lose apt-mark unhold kubectl when apt-get install kubectl. If not unhold kubectl, it would return the error follows:(It tells that kubectl will be hold in upgrade from 1.13.x to 1.14.x in the [doc](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-14/), as a result, if we donot unhold kubectl, install kubectl for a high version will leads to an error in my opinion)
``` shell
root@ecs-k8s-master:~# apt-mark unhold kubelet && apt-get update && apt-get install -y kubelet=1.15.0-00 kubectl=1.15.0-00 && apt-mark hold kubelet 
kubelet was already not hold.
Hit:1 https://download.docker.com/linux/ubuntu xenial InRelease
Hit:2 https://mirrors.tuna.tsinghua.edu.cn/ubuntu xenial InRelease
Hit:3 https://mirrors.tuna.tsinghua.edu.cn/ubuntu xenial-updates InRelease
Get:4 https://mirrors.tuna.tsinghua.edu.cn/ubuntu xenial-backports InRelease [107 kB]
Hit:4 https://mirrors.tuna.tsinghua.edu.cn/ubuntu xenial-backports InRelease
Hit:5 https://mirrors.tuna.tsinghua.edu.cn/ubuntu xenial-security InRelease
Hit:6 https://packages.cloud.google.com/apt kubernetes-xenial InRelease                                                                                                                     
Reading package lists... Done
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following packages were automatically installed and are no longer required:
  linux-headers-4.4.0-145 linux-headers-4.4.0-145-generic linux-image-4.4.0-145-generic linux-modules-4.4.0-145-generic
Use 'apt autoremove' to remove them.
The following held packages will be changed:
  kubectl
The following packages will be upgraded:
  kubectl kubelet
2 upgraded, 0 newly installed, 0 to remove and 9 not upgraded.
E: Held packages were changed and -y was used without --allow-change-held-packages.
```

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> Remember to delete this note before submitting your pull request.
>
> For pull requests on 1.15 Features: set Milestone to 1.15 and Base Branch to dev-1.15
> 
> For pull requests on Chinese localization, set Base Branch to release-1.14
>
> For pull requests on Korean Localization: set Base Branch to dev-1.14-ko.\<latest team milestone>
>
> If you need Help on editing and submitting pull requests, visit:
> https://kubernetes.io/docs/contribute/start/#improve-existing-content.
>
> If you need Help on choosing which branch to use, visit:
> https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use.
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
