### PR TITLE
Use networking.k8s.io/v1beta1 for ingress apiVersion

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -135,7 +135,7 @@ The following file is an Ingress resource that sends traffic to your Service via
 
 1. Create `example-ingress.yaml` from the following file:
 
-        apiVersion: extensions/v1beta1
+        apiVersion: networking.k8s.io/v1beta1 # for versions before 1.14 use extensions/v1beta1
         kind: Ingress
         metadata:
           name: example-ingress
@@ -160,7 +160,7 @@ The following file is an Ingress resource that sends traffic to your Service via
     Output:
     
     ```shell
-    ingress.extensions/example-ingress created
+    ingress.networking.k8s.io/example-ingress created
     ```
 
 1. Verify the IP address is set: 

--- a/content/fr/docs/concepts/services-networking/ingress.md
+++ b/content/fr/docs/concepts/services-networking/ingress.md
@@ -72,7 +72,7 @@ Assurez-vous de consulter la documentation de votre contrôleur d’Ingress pour
 Exemple de ressource Ingress minimale :
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: test-ingress
@@ -126,7 +126,7 @@ Il existe des concepts Kubernetes qui vous permettent d’exposer un seul servic
 
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: test-ingress
@@ -166,7 +166,7 @@ foo.bar.com -> 178.91.123.132 -> / foo    service1:4200
 ceci nécessitera un Ingress défini comme suit :
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: simple-fanout-example
@@ -233,7 +233,7 @@ bar.foo.com --|                 |-> bar.foo.com s2:80
 L’ingress suivant indique au load-balancer de router les requêtes en fonction de [En-tête du hôte](https://tools.ietf.org/html/rfc7230#section-5.4).
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: name-virtual-host-ingress
@@ -256,7 +256,7 @@ spec:
 Si vous créez une ressource Ingress sans aucun hôte défini dans les règles, tout trafic Web à destination de l'adresse IP de votre contrôleur d'Ingress peut être mis en correspondance sans qu'un hôte virtuel basé sur le nom ne soit requis. Par exemple, la ressource Ingress suivante acheminera le trafic demandé pour `first.bar.com` au `service1` `second.foo.com` au `service2`, et à tout trafic à l'adresse IP sans nom d'hôte défini dans la demande (c'est-à-dire sans en-tête de requête présenté) au `service3`.
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: name-virtual-host-ingress
@@ -300,7 +300,7 @@ type: kubernetes.io/tls
 Référencer ce secret dans un ingress indiquera au contrôleur d'ingress de sécuriser le canal du client au load-balancer à l'aide de TLS. Vous devez vous assurer que le secret TLS que vous avez créé provenait d'un certificat contenant un CN pour `sslexample.foo.com`.
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: tls-example-ingress


### PR DESCRIPTION
Starting from 1.14 Ingress resources are available via `networking.k8s.io/v1beta1`. Ingress resources in `extensions/v1beta1` are deprecated and will no longer be served in v1.18. Existing persisted data is available via the new API group/version (#74057, @liggitt)