### PR TITLE
Fix alignment in examples/pods/storage/pv-pod.yaml

### DIFF
--- a/content/en/examples/pods/storage/pv-pod.yaml
+++ b/content/en/examples/pods/storage/pv-pod.yaml
@@ -6,7 +6,7 @@ spec:
   volumes:
     - name: task-pv-storage
       persistentVolumeClaim:
-       claimName: task-pv-claim
+        claimName: task-pv-claim
   containers:
     - name: task-pv-container
       image: nginx

--- a/content/ja/examples/pods/storage/pv-pod.yaml
+++ b/content/ja/examples/pods/storage/pv-pod.yaml
@@ -6,7 +6,7 @@ spec:
   volumes:
     - name: task-pv-storage
       persistentVolumeClaim:
-       claimName: task-pv-claim
+        claimName: task-pv-claim
   containers:
     - name: task-pv-container
       image: nginx


### PR DESCRIPTION
Fix alignment in examples/pods/storage/pv-pod.yaml

The whole file should be aligned with 2 spaces. Fixing minor issue in examples