### PR TITLE
Issue #15098- Update hello-minikube.md for Gateway error

### DIFF
--- a/content/en/docs/tutorials/hello-minikube.md
+++ b/content/en/docs/tutorials/hello-minikube.md
@@ -61,7 +61,7 @@ For more information on the `docker build` command, read the [Docker documentati
     minikube dashboard
     ```
 
-3. Katacoda environment only: At the top of the terminal pane, click the plus sign, and then click **Select port to view on Host 1**.
+3. Katacoda environment only: At the top of the terminal pane, click the plus sign, and then click **View HTTP port 80 on Host 1**.
 
 4. Katacoda environment only: Type `30000`, and then click **Display Port**. 
 


### PR DESCRIPTION
update the tutorial instructions to use the [View HTTP port 80 on Host 1] selection option in the the Katacoda pane list (instead of the "Select port" option) since it leads to 502 Gateway error. 
This successfully opened a new browser tab to a functional URL, similar to: https://[random_number]-80-cykoria04.environments.katacoda.com/.