### PR TITLE
Fix bullet list output in CRD schema blog

### DIFF
--- a/content/en/blog/_posts/2019-06-20-Future-of-CRDs-Structural-Schemas.md
+++ b/content/en/blog/_posts/2019-06-20-Future-of-CRDs-Structural-Schemas.md
@@ -195,7 +195,8 @@ While most Kubernetes-like APIs can be expressed with a structural schema, there
 
 Because we want CRDs to make use of these types as well, we introduce the following OpenAPI vendor extensions to the permitted core constructs:
 
-* `x-kubernetes-embedded-resource: true` — specifies that this is an `runtime.RawExtensions-like field, with a Kubernetes resource with apiVersion, kind and metadata. The consequence is that those 3 fields are not pruned and are automatically validated.
+* `x-kubernetes-embedded-resource: true` — specifies that this is an `runtime.RawExtension`-like field, with a Kubernetes resource with apiVersion, kind and metadata. The consequence is that those 3 fields are not pruned and are automatically validated.
+
 * `x-kubernetes-int-or-string: true` — specifies that this is either an integer or a string. No types must be specified, but
   
   ```yaml
@@ -205,6 +206,7 @@ Because we want CRDs to make use of these types as well, we introduce the follow
   ```
 
   is permitted, though optional.
+
 * `x-kubernetes-preserve-unknown-fields: true` — specifies that the pruning algorithm should not prune any field. This can be combined with `x-kubernetes-embedded-resource`. Note that within a nested `properties` or `additionalProperties` OpenAPI schema the pruning starts again.
   
   One can use `x-kubernetes-preserve-unknown-fields: true` at the root of the schema (and inside any `properties`, `additionalProperties`) to get the traditional CRD behaviour that nothing is prune, despite being `spec.preserveUnknownProperties: false` is set.


### PR DESCRIPTION
Due to a couple missing newlines and missing closing fixed-width quote
delimiter, the bulleted list of extensions to core constructs was being
incorrectly displayed.