### PR TITLE
Fix for Error: unknown flag: --current

### DIFF
--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -72,7 +72,7 @@ kubectl config use-context my-cluster-name           # set the default context t
 kubectl config set-credentials kubeuser/foo.kubernetes.com --username=kubeuser --password=kubepassword
 
 # permanently save the namespace for all subsequent kubectl commands in that context.
-kubectl config set-context --current --namespace=ggckad-s2
+kubectl config set-context $(kubectl config current-context) --namespace=ggckad-s2
 
 # set a context utilizing a specific username and namespace.
 kubectl config set-context gce --user=cluster-admin --namespace=foo \


### PR DESCRIPTION
`kubectl config set-context --current --namespace=myns` 

throws me the error:

````
Error: unknown flag: --current


Examples:
  # Set the user field on the gce context entry without touching other values
  kubectl config set-context gce --user=cluster-admin

Usage:
  kubectl config set-context NAME [--cluster=cluster_nickname] [--user=user_nickname] [--namespace=namespace] [options]

Use "kubectl options" for a list of global command-line options (applies to all commands).

unknown flag: --current
````

the proposed change works for me
