### PR TITLE
ImagePolicyWebhook: config can be embedded

### DIFF
--- a/content/en/docs/reference/access-authn-authz/admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/admission-controllers.md
@@ -249,6 +249,22 @@ plugins:
 ...
 ```
 
+Alternatively, you can embed the configuration directly in the file:
+
+```yaml
+apiVersion: apiserver.k8s.io/v1alpha1
+kind: AdmissionConfiguration
+plugins:
+- name: ImagePolicyWebhook
+  configuration:
+    imagePolicy:
+      kubeConfigFile: /path/to/file
+      allowTTL: 50
+      denyTTL: 50
+      retryBackoff: 500
+      defaultAllow: true
+```
+
 The ImagePolicyWebhook config file must reference a [kubeconfig](/docs/concepts/cluster-administration/authenticate-across-clusters-kubeconfig/) formatted file which sets up the connection to the backend. It is required that the backend communicate over TLS.
 
 The kubeconfig file's cluster field must point to the remote service, and the user field must contain the returned authorizer.


### PR DESCRIPTION
All admission control plugins support two modes for specifying their configuration: linking to an external file using the `path` key in the shared admission configuration file, or directly embedding the configuration using the `configuration` key in the shared admission configuration file.

This commit makes the ImagePolicyWebhook documentation mention the embedded configuration option.
