### PR TITLE
Fix troubleshooting instruction at troubleshooting-kubeadm.md

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
@@ -170,6 +170,7 @@ Unable to connect to the server: x509: certificate signed by unknown authority (
 
   ```sh
   mv  $HOME/.kube $HOME/.kube.bak
+  mkdir $HOME/.kube
   sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
   sudo chown $(id -u):$(id -g) $HOME/.kube/config
   ```


### PR DESCRIPTION
## Issue

**Section**: *Another workaround is to overwrite the existing `kubeconfig` for the "admin" user*
**Line**: 173

`sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config` fails, since the directory `$HOME/.kube` doesn't exist.

## Fix

`mkdir $HOME/.kube` added prior to `sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config`.