### PR TITLE
fixes offline dependencies

### DIFF
--- a/content/en/blog/_posts/2018-10-18-tips-for-first-kubecon-presentation-part-1.md
+++ b/content/en/blog/_posts/2018-10-18-tips-for-first-kubecon-presentation-part-1.md
@@ -8,7 +8,7 @@ date: 2018-10-18
 
 First of all, let me congratulate you to this outstanding achievement. Speaking at KubeCon, especially if it's your first time, is a tremendous honor and experience. Well done!
 
-<center>{{< tweet 1044345018490662912 >}}</center>
+<center><blockquote class="twitter-tweet"><p lang="en" dir="ltr">Congrats to everyone who got Kubecon talks accepted! 👏👏👏<br><br>To everyone who got a rejection don&#39;t feel bad. Only 13% could be accepted. Keep trying. There will be other opportunities.</p>&mdash; Justin Garrison (@rothgar) <a href="https://twitter.com/rothgar/status/1044345018490662912?ref_src=twsrc%5Etfw">September 24, 2018</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script></center>
 
 When I was informed that my [KubeCon talk about Kubernetes Resource Management](https://www.youtube.com/watch?v=8-apJyr2gi0) was accepted for KubeCon EU in Denmark (2018), I really could not believe it. By then, the chances to get your talk accepted were around 10% (or less, don't really remember the exact number). There were over a 1,000 submissions just for that KubeCon (recall that we now have **three KubeCon events during the year** - US, EU and Asia region). The popularity of Kubernetes is ever increasing and so is the number of people trying to get a talk accepted. Once again, **outstanding achievement to get your talk in**!
 

--- a/content/en/blog/_posts/2018-10-26-tips-for-first-kubecon-presentation-part-2.md
+++ b/content/en/blog/_posts/2018-10-26-tips-for-first-kubecon-presentation-part-2.md
@@ -52,4 +52,4 @@ I hope some of these tips are useful for you as well. And I wish you all the bes
 
 Besides my fantastic reviewers and the speaker support team already mentioned above, I also would like to thank the people who supported me along this KubeCon journey: Bjoern, Timo, Emad and Steve!
 
-{{< tweet 992409364467200000 >}}
+<blockquote class="twitter-tweet"><p lang="en" dir="ltr"><a href="https://twitter.com/hashtag/KubeCon?src=hash&amp;ref_src=twsrc%5Etfw">#KubeCon</a> <a href="https://twitter.com/embano1?ref_src=twsrc%5Etfw">@embano1</a> is laying down an homage to an earlier <a href="https://twitter.com/thockin?ref_src=twsrc%5Etfw">@thockin</a> presentation in his &quot;Inside K8S Resource Management&quot; session, if you didn&#39;t make it in the door, check out the deck here <a href="https://t.co/4xQq5CQ3aZ">https://t.co/4xQq5CQ3aZ</a> <a href="https://t.co/ObFEuKskhB">pic.twitter.com/ObFEuKskhB</a></p>&mdash; Steve Wong (@cantbewong) <a href="https://twitter.com/cantbewong/status/992400932968288256?ref_src=twsrc%5Etfw">May 4, 2018</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script> 

--- a/content/en/blog/_posts/2019-03-28-running-kubernetes-locally-on-linux-with-minikube.md
+++ b/content/en/blog/_posts/2019-03-28-running-kubernetes-locally-on-linux-with-minikube.md
@@ -12,7 +12,7 @@ Kubernetes is a real winner (and a de facto standard) in the world of distribute
 
 A few weeks ago I ran a poll on Twitter asking the community to specify their preferred option for running Kubernetes locally on Linux:
 
-<center>{{< tweet 1093154369040773120 >}}</center>
+<center><blockquote class="twitter-tweet"><p lang="en" dir="ltr">Ok, Twitter ✋<br><br>Your local Kubernetes cluster on Linux is deployed by:</p>&mdash; ihor dvoretskyi (@idvoretskyi) <a href="https://twitter.com/idvoretskyi/status/1093154369040773120?ref_src=twsrc%5Etfw">February 6, 2019</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script></center>
 
 This is post #1 in a series about the local deployment options on Linux, and it will cover Minikube, the most popular community-built solution for running Kubernetes on a local machine.
 

--- a/layouts/shortcodes/upcoming-events.html
+++ b/layouts/shortcodes/upcoming-events.html
@@ -1,4 +1,10 @@
 {{ $date := now.Format "2006-01-02T15:04:05Z07:00" | querify "timeMin" }}
+
+
+{{/* Setting external resource based on whether hugo is running locally or public */}}
+{{ if .Site.IsServer }}
+{{ $jurl := printf "" $date }}
+{{ else }}
 {{ $jurl := printf "https://www.googleapis.com/calendar/v3/calendars/nt2tcnbtbied3l6gi2h29slvc0%%40group.calendar.google.com/events?orderBy=startTime&singleEvents=true&%s&key=AIzaSyAST-sCyPJzMQJSl6_vRPW9r4DNLPaDIyM" $date }}
 {{ $dataJ := getJSON $jurl }}
 
@@ -8,4 +14,4 @@
   <div class="event"><a href="{{ safeHTML $url }}">{{ .summary }}</a> - {{ .location }} - {{ .start.date }}</div>
 {{ end }}
 
-    
+{{ end }}    


### PR DESCRIPTION
**Fixes:** https://github.com/kubernetes/website/issues/15245

**Test:**
```
# https://gohugo.io/getting-started/installing/
git clone https://github.com/kubernetes/website.git
cd website
hugo server --ignoreCache
```

**Note:** It appears that hugo doesn't like building offline with the '{{ < tweet 123456 > }}' shortcode. It could most likely be modified in the themes but I noticed other blogs used the embedded tweets which works around this issue (most likely unintentionally).