### PR TITLE
Remove --allow-privileged as it is deprecated in latest 1.15.0

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/kubelet.md
+++ b/content/en/docs/reference/command-line-tools-reference/kubelet.md
@@ -60,13 +60,6 @@ kubelet [flags]
     </tr>
 
     <tr>
-      <td colspan="2">--allow-privileged</td>
-    </tr>
-    <tr>
-      <td></td><td style="line-height: 130%; word-wrap: break-word;">If true, allow containers to request privileged mode.</td>
-    </tr>
-
-    <tr>
       <td colspan="2">--alsologtostderr</td>
     </tr>
     <tr>


### PR DESCRIPTION
I meet the issue below after I upgrade my cluster to 1.15.0

> server.go:156] unknown flag: --allow-privileged

And the document here in https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options whose top bars show 1.15 document. However this is not updated. So I remove it. 