### PR TITLE
fix broken apply command due to update

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/web-ui-dashboard.md
+++ b/content/en/docs/tasks/access-application-cluster/web-ui-dashboard.md
@@ -30,7 +30,7 @@ Dashboard also provides information on the state of Kubernetes resources in your
 The Dashboard UI is not deployed by default. To deploy it, run the following command:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/master/aio/deploy/recommended/kubernetes-dashboard.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v1.10.1/src/deploy/recommended/kubernetes-dashboard.yaml
 ```
 
 ## Accessing the Dashboard UI


### PR DESCRIPTION
The kubernetes dashboard repo has restructured their yaml files so this command no longer works. 
I have changed the command to the recommended apply command found in the kubernetes/dashboard repository.
This should probably stay locked at v1.10.1 until v2 is out of beta.

The offending commit which broke the apply command: https://github.com/kubernetes/dashboard/commit/4fa3253c9e9efd5162597accab01aa1c716421ed

And the missing yaml file: https://raw.githubusercontent.com/kubernetes/dashboard/master/aio/deploy/recommended/kubernetes-dashboard.yaml
