### PR TITLE
Powershell note for kubectl patch command

### DIFF
--- a/content/en/docs/tasks/run-application/update-api-object-kubectl-patch.md
+++ b/content/en/docs/tasks/run-application/update-api-object-kubectl-patch.md
@@ -69,13 +69,17 @@ spec:
 
 Patch your Deployment:
 
-```shell
+{{< tabs name="kubectl_patch_example" >}}
+{{{< tab name="Bash" codelang="bash" >}}
 kubectl patch deployment patch-demo --patch "$(cat patch-file-containers.yaml)"
-```
-
+{{< /tab >}}
+{{< tab name="PowerShell" codelang="posh" >}}
+kubectl patch deployment patch-demo --patch $(cat patch-file-containers.yaml)
 {{< note >}}
-In case you are using `PowerShell`, do not add quotes around command substitution. `kubectl patch deployment patch-demo --patch $(cat patch-file-containers.yaml)`. Else, `PowerShell` will remove new lines from yaml file and `kubectl` will not be able to convert the yaml into json at runtime. 
+Kindly note the missing quotes around command substitution. These need to be removed else `PowerShell` will remove new lines from yaml file and `kubectl` will not be able to convert the yaml into json at runtime.
 {{< /note >}}
+{{< /tab >}}}
+{{< /tabs >}}
 
 View the patched Deployment:
 

--- a/content/en/docs/tasks/run-application/update-api-object-kubectl-patch.md
+++ b/content/en/docs/tasks/run-application/update-api-object-kubectl-patch.md
@@ -75,9 +75,6 @@ kubectl patch deployment patch-demo --patch "$(cat patch-file-containers.yaml)"
 {{< /tab >}}
 {{< tab name="PowerShell" codelang="posh" >}}
 kubectl patch deployment patch-demo --patch $(cat patch-file-containers.yaml)
-{{< note >}}
-Kindly note the missing quotes around command substitution. These need to be removed else `PowerShell` will remove new lines from yaml file and `kubectl` will not be able to convert the yaml into json at runtime.
-{{< /note >}}
 {{< /tab >}}}
 {{< /tabs >}}
 

--- a/content/en/docs/tasks/run-application/update-api-object-kubectl-patch.md
+++ b/content/en/docs/tasks/run-application/update-api-object-kubectl-patch.md
@@ -73,6 +73,10 @@ Patch your Deployment:
 kubectl patch deployment patch-demo --patch "$(cat patch-file-containers.yaml)"
 ```
 
+{{< note >}}
+In case you are using `PowerShell`, do not add quotes around command substitution. `kubectl patch deployment patch-demo --patch $(cat patch-file-containers.yaml)`. Else, `PowerShell` will remove new lines from yaml file and `kubectl` will not be able to convert the yaml into json at runtime. 
+{{< /note >}}
+
 View the patched Deployment:
 
 ```shell


### PR DESCRIPTION
This command does not work in Powershell. A specific note would help the developers to take care of the same.


