### PR TITLE
Cloud Providers - Openstack [Route] vs [Router]

### DIFF
--- a/content/en/docs/concepts/cluster-administration/cloud-providers.md
+++ b/content/en/docs/concepts/cluster-administration/cloud-providers.md
@@ -336,10 +336,10 @@ should appear in the `[Metadata]` section of the `cloud.conf` file:
   both configuration drive and metadata service though and only one or the other
   may be available which is why the default is to check both.
 
-##### Router
+##### Route
 
 These configuration options for the OpenStack provider pertain to the [kubenet]
-Kubernetes network plugin and should appear in the `[Router]` section of the
+Kubernetes network plugin and should appear in the `[Route]` section of the
 `cloud.conf` file:
 
 * `router-id` (Optional): If the underlying cloud's Neutron deployment supports


### PR DESCRIPTION
Using the solution found at https://github.com/rancher/rke/issues/689#issuecomment-397016756 I was able to avoid the error `can't store data at section "Router"`

Additionally, reference commit https://github.com/kubernetes/kubernetes/commit/0b57371ffab5b32dc991ff5fe60c3d58f7c2f9cc to confirm this.