### PR TITLE
Clarify that kubernetes docs uses US English as authoritative source.

### DIFF
--- a/content/en/docs/contribute/style/style-guide.md
+++ b/content/en/docs/contribute/style/style-guide.md
@@ -29,7 +29,7 @@ and representing feature state.
 
 ## Language
 
-Kubernetes documentation uses US English.
+Kubernetes documentations are available in multiple languages. US English is considered to be the authoritative source.
 
 ## Documentation formatting standards
 


### PR DESCRIPTION
Fixes #15093
