### PR TITLE
Update dns-pod-service.md

### DIFF
--- a/content/en/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/en/docs/concepts/services-networking/dns-pod-service.md
@@ -76,7 +76,7 @@ the hostname of the pod. For example, given a Pod with `hostname` set to
 The Pod spec also has an optional `subdomain` field which can be used to specify
 its subdomain. For example, a Pod with `hostname` set to "`foo`", and `subdomain`
 set to "`bar`", in namespace "`my-namespace`", will have the fully qualified
-domain name (FQDN) "`foo.bar.my-namespace.svc.cluster-domain.example`".
+domain name (FQDN) "`foo.bar.my-namespace.pod.cluster-domain.example`".
 
 Example:
 


### PR DESCRIPTION
The more I read that change, the less I'm sure that it's correct...

Either way, I think it would be really helpful to explain why a pod FQDN would have a `.svc` somewhere in its name, as it sounds a bit misleading (at least to me).

Also, this makes me wonder even more:

> Note: Because A records are not created for Pod names, hostname is required for the Pod’s A record to be created. A Pod with no hostname but with subdomain will only create the A record for the headless service (default-subdomain.my-namespace.svc.cluster-domain.example), pointing to the Pod’s IP address.

From what I read, a pod with a `hostname` set should have his own DNS `A record`. I would have liked to see what that FQDN would look like here (`.pod` or `.svc`), maybe it would have cleared my initial question :).

Looking forward to reading your thoughts on the matter.