### PR TITLE
docs: note that kubectl port-forward supported in 1.15 on Windows

### DIFF
--- a/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
+++ b/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
@@ -235,7 +235,6 @@ The following networking functionality is not supported on Windows nodes
 * Local NodePort access from the node itself fails (works for other nodes or external clients)
 * Accessing service VIPs from nodes will be available with a future release of Windows Server
 * Overlay networking support in kube-proxy is an alpha release. In addition, it requires [KB4482887](https://support.microsoft.com/en-us/help/4482887/windows-10-update-kb4482887) to be installed on Windows Server 2019
-* `kubectl port-forward`
 * Local Traffic Policy and DSR mode
 * Windows containers connected to l2bridge, l2tunnel, or overlay networks do not support communicating over the IPv6 stack. There is outstanding Windows platform work required to enable these network drivers to consume IPv6 addresses and subsequent Kubernetes work in kubelet, kube-proxy, and CNI plugins.
 * Outbound communication using the ICMP protocol via the win-overlay, win-bridge, and Azure-CNI plugin. Specifically, the Windows data plane ([VFP](https://www.microsoft.com/en-us/research/project/azure-virtual-filtering-platform/)) doesn't support ICMP packet transpositions. This means:
@@ -243,6 +242,10 @@ The following networking functionality is not supported on Windows nodes
   * TCP/UDP packets work as expected and without any limitations
   * ICMP packets directed to pass through a remote network (e.g. pod to external internet communication via ping) cannot be transposed and thus will not be routed back to their source
   * Since TCP/UDP packets can still be transposed, one can substitute `ping <destination>` with `curl <destination>` to be able to debug connectivity to the outside world.
+
+These features were added in Kubernetes v1.15:
+
+* `kubectl port-forward`
 
 ##### CNI Plugins
 


### PR DESCRIPTION
I missed one reference that said `kubectl port-forward` was unsupported. I moved it to a section saying it's supported as of 1.15.


related to PR #15345 