### PR TITLE
fix chinese display bug in page “Creating a single control-plane cluster with kubeadm”

### DIFF
--- a/content/zh/docs/setup/independent/create-cluster-kubeadm.md
+++ b/content/zh/docs/setup/independent/create-cluster-kubeadm.md
@@ -418,7 +418,9 @@ kubectl apply -f <add-on.yaml>
 {{< tabs name="tabs-Pod-install" >}}
 {{% tab name="Choose one..." %}}
 Please select one of the tabs to see installation instructions for the respective third-party Pod Network Provider.
-{{% /tab %}} -->
+{{% /tab %}}
+{{< /tabs >}} -->
+
 
 您仅可以给任何一个集群安装一个网络插件。
 


### PR DESCRIPTION
I want to explain that <!-- --> is html comment syntax, not markdown comment syntax, so all the code between <!-- -->will be compiled and only blocked by brower. So in this file, <tabs> don't have a end block and the rest of the file couldn't be compiled successfully.
这里需要解释一下，<!-- -->作为html注释语法，并不是markdown注释，所以它仅仅在最终浏览阶段被浏览器屏蔽，里面的所有内容仍然会被markdown进行编译。在这里<tabs>因为找不到对应的结束块</tabs>，会使后续内容编译失败无法展示。