### PR TITLE
Replace tabs by spaces in glossary-terms partials

### DIFF
--- a/layouts/partials/docs/glossary-terms.html
+++ b/layouts/partials/docs/glossary-terms.html
@@ -1,13 +1,13 @@
 {{ $glossaryBundle := site.GetPage "page" "docs/reference/glossary" }}
 {{- if $glossaryBundle -}}
-	{{ $pages := $glossaryBundle.Resources.ByType "page" }}
-	{{- range site.Params.language_alternatives -}}
-		{{- with (where $glossaryBundle.Translations ".Lang" . ) -}}
-		{{ $p := (index . 0) }}
-		{{ $pages = $pages | lang.Merge ($p.Resources.ByType "page") }}
-		{{ end }}
-	{{ end }}
-	{{- $.Scratch.Set "glossary_items"  $pages -}}
+  {{ $pages := $glossaryBundle.Resources.ByType "page" }}
+  {{- range site.Params.language_alternatives -}}
+    {{- with (where $glossaryBundle.Translations ".Lang" . ) -}}
+    {{ $p := (index . 0) }}
+    {{ $pages = $pages | lang.Merge ($p.Resources.ByType "page") }}
+    {{ end }}
+  {{ end }}
+  {{- $.Scratch.Set "glossary_items"  $pages -}}
 {{- else -}}
 {{- errorf "[%s] Glossary Bundle not found for language. Create at least an index.md file inside docs/reference/glossary" site.Language.Lang -}}
 {{- end -}}


### PR DESCRIPTION
Using tabs in this html-partial used in the glossary-tooltip shortcode seems to cause Hugo to parse the shortcode as a `<pre><code>` block instead of rendering the resulting HTML code.

Solves #14792 rendering issues:

* With tabs:

```
<pre><code>&lt;a class='glossary-tooltip' href='/docs/concepts/workloads/pods/pod-overview/' target='_blank'&gt;Pod&lt;span class='tooltip-text'&gt;Unit Kubernetes yang paling sederhana dan kecil. Sebuah Pod merepresentasikan sebuah set kontainer yang dijalankan pada kluster kamu.&lt;/span&gt;
</code></pre>
```

* With spaces:

```html
<p><a class='glossary-tooltip' href='/docs/concepts/workloads/pods/pod-overview/' target='_blank'>Pod<span class='tooltip-text'>Unit Kubernetes yang paling sederhana dan kecil. Sebuah Pod merepresentasikan sebuah set kontainer yang dijalankan pada kluster kamu.</span>
```

/cc @bep @zacharysarah @irvifa @sftim @girikuncoro