### PR TITLE
Fix possible copy paste issue for label name for sample deployment

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/common-labels.md
+++ b/content/en/docs/concepts/overview/working-with-objects/common-labels.md
@@ -82,8 +82,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/name: myservice
-    app.kubernetes.io/instance: myservice-abcxzy
+    app.kubernetes.io/name: mydeployment
+    app.kubernetes.io/instance: mydeployment-abcxzy
 ...
 ```
 


### PR DESCRIPTION
I found a copy paste issue in the docs for explaining how to use common labels. There are two examples one for a `Deployment` and one for a `Service` an both have the same `app.kubernetes.io/name`