### PR TITLE
use log_path busybox.log instead of busybox/0.log in crictl.md

### DIFF
--- a/content/en/docs/tasks/debug-application-cluster/crictl.md
+++ b/content/en/docs/tasks/debug-application-cluster/crictl.md
@@ -295,7 +295,7 @@ deleted by the Kubelet.
         "command": [
             "top"
         ],
-        "log_path":"busybox/0.log",
+        "log_path":"busybox.log",
         "linux": {
         }
       }


### PR DESCRIPTION
because with busybox/0.log it fails as shown below (unless you mkdir busybox, with the correct permission, which is an extra step we can avoid for a tutorial like this)

FATA[0000] Starting the container "3c71f8c3abfcac0f8357fa25be896062f05f88e1d9acbd7a033afeee9a54f3c4" failed: rpc error: code = Unknown desc = failed to create containerd task: failed to create container loggers: failed to create and open log file: open busybox/0.log: no such file or directory