### PR TITLE
Fix Prev/Next navigation buttons when viewing article

### DIFF
--- a/layouts/blog/pager.html
+++ b/layouts/blog/pager.html
@@ -1,7 +1,7 @@
 <div class="PageNavigation">
 	 {{ if .PrevInSection }}
     <div class="pagerButton left">
-        <h4><a class=" button" href="{{ .PrevInSection.RelPermalink }}"> {{ T "layouts_blog_pager_next" }} </a></h4>
+        <h4><a class=" button" href="{{ .PrevInSection.RelPermalink }}"> {{ T "layouts_blog_pager_prev" }} </a></h4>
     </div>
     {{ end }}
     {{ if .NextInSection }}


### PR DESCRIPTION
Earlier both the on the left and right buttons had the text `Next>>` now
the left one will have the text `<< Prev`

fixes: https://github.com/kubernetes/website/issues/15438

Signed-off-by: Harsh Vardhan <harsh.vardhan@mayadata.io>