### PR TITLE
Add documentation about kernel module autoloading security

### DIFF
--- a/content/en/docs/tasks/administer-cluster/securing-a-cluster.md
+++ b/content/en/docs/tasks/administer-cluster/securing-a-cluster.md
@@ -114,6 +114,36 @@ client applications from escaping their containers should use a restrictive pod 
 policy.
 
 
+### Preventing containers from loading unwanted kernel modules
+
+The Linux kernel automatically loads kernel modules from disk if needed in certain
+circumstances, such as when a piece of hardware is attached or a filesystem is mounted. Of
+particular relevance to Kubernetes, even unprivileged processes can cause certain
+network-protocol-related kernel modules to be loaded, just by creating a socket of the
+appropriate type. This may allow an attacker to exploit a security hole in a kernel module
+that the administrator assumed was not in use.
+
+To prevent specific modules from being automatically loaded, you can uninstall them from
+the node, or add rules to block them. On most Linux distributions, you can do that by
+creating a file such as `/etc/modprobe.d/kubernetes-blacklist.conf` with contents like:
+
+```
+# DCCP is unlikely to be needed, has had multiple serious
+# vulnerabilities, and is not well-maintained.
+blacklist dccp
+
+# SCTP is not used in most Kubernetes clusters, and has also had
+# vulnerabilities in the past.
+blacklist sctp
+```
+
+To block module loading more generically, you can use a Linux Security Module (such as
+SELinux) to completely deny the `module_request` permission to containers, preventing the
+kernel from loading modules for containers under any circumstances. (Pods would still be
+able to use modules that had been loaded manually, or modules that were loaded by the
+kernel on behalf of some more-privileged process.)
+
+
 ### Restricting network access
 
 The [network policies](/docs/tasks/administer-cluster/declare-network-policy/) for a namespace 


### PR DESCRIPTION
This came out of a discussion of moving the SCTP KEP forward in sig-network; some people might be thinking that since Kubernetes doesn't (currently) support SCTP, that this means they are protected from CVEs involving the SCTP kernel module, but that's not true at all. (See also https://discuss.kubernetes.io/t/kubernetes-security-announcement-linux-kernel-memory-cgroups-escape-via-sctp-cve-2019-3874/5594.)

I'm not sure how specific we should get about recommendations here... People should definitely be blacklisting dccp if their distro still ships it, and a lot of people will want to blacklist sctp. But like, you could make a good argument for blacklisting bluetooth too; it's not like pods are going to need to be talking to Bluetooth devices... I think the answer probably comes down to "if you spend more than 5 minutes thinking about it, you should probably just run selinux". (Or maybe someone should improve the cgroups APIs so that Kubernetes can control whether module loading is available or blocked via PodSecurityPolicy. But that's way outside the scope of this PR...)