### PR TITLE
Fix field in PDB

### DIFF
--- a/content/en/docs/tasks/run-application/configure-pdb.md
+++ b/content/en/docs/tasks/run-application/configure-pdb.md
@@ -86,7 +86,7 @@ Values for `minAvailable` or `maxUnavailable` can be expressed as integers or as
 - When you specify an integer, it represents a number of Pods. For instance, if you set `minAvailable` to 10, then 10
   Pods must always be available, even during a disruption.
 - When you specify a percentage by setting the value to a string representation of a percentage (eg. `"50%"`), it represents a percentage of
-  total Pods. For instance, if you set `minUnavailable` to `"50%"`, then only 50% of the Pods can be unavailable during a
+  total Pods. For instance, if you set `maxUnavailable` to `"50%"`, then only 50% of the Pods can be unavailable during a
   disruption.
 
 When you specify the value as a percentage, it may not map to an exact number of Pods. For example, if you have 7 Pods and


### PR DESCRIPTION
Fixing typo in website PDB documentation.

Note: I have also found the `minUnavailable` term [here](https://github.com/kubernetes/website/blob/7b44b7a3df523284c9f3c4cb76021088111831d7/content/en/examples/examples_test.go#L532), shall I also correct it?