### PR TITLE
rewrite-target of nginx ingress controller, Version 0.22.0(onwards) changed- now uses /$1 as value

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -140,13 +140,13 @@ The following file is an Ingress resource that sends traffic to your Service via
         metadata:
           name: example-ingress
           annotations:
-            nginx.ingress.kubernetes.io/rewrite-target: /
+            nginx.ingress.kubernetes.io/rewrite-target: /$1
         spec:
          rules:
          - host: hello-world.info
            http:
              paths:
-             - path: /*
+             - path: /(.+)
                backend:
                  serviceName: web
                  servicePort: 8080


### PR DESCRIPTION

In nginx ingress controller Version 0.22.0 and beyond, any substrings within the request URI that need to be passed to the rewritten path must explicitly be defined in a capture group. Please refer doc here: 
* `https://kubernetes.github.io/ingress-nginx/examples/rewrite/#rewrite-target`
* `https://stackoverflow.com/a/55193468/5527839 `

Currently, what was mentioned in the docs, didnt work for me. I was using minikube version `1.2.0` which uses ingress above v0.21.0. After reading the docs provided in above two links, was able to figure out where it was lacking. Have mentioned the changes in the proposed file change.
