### PR TITLE
pod-network to be done only on master node

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
@@ -255,6 +255,7 @@ This section contains important information about installation and deployment or
 
 You must install a pod network add-on so that your pods can communicate with
 each other.
+#Note - This need to be done only on the Control-Plane / on the Master Node
 
 **The network must be deployed before any applications. Also, CoreDNS will not start up before a network is installed.
 kubeadm only supports Container Network Interface (CNI) based networks (and does not support kubenet).**

--- a/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
@@ -255,7 +255,6 @@ This section contains important information about installation and deployment or
 
 You must install a pod network add-on so that your pods can communicate with
 each other.
-#Note - This need to be done only on the Control-Plane / on the Master Node
 
 **The network must be deployed before any applications. Also, CoreDNS will not start up before a network is installed.
 kubeadm only supports Container Network Interface (CNI) based networks (and does not support kubenet).**
@@ -271,7 +270,7 @@ Make sure that your network manifest supports RBAC.
 Also, beware, that your Pod network must not overlap with any of the host networks as this can cause issues.
 If you find a collision between your network plugin’s preferred Pod network and some of your host networks, you should think of a suitable CIDR replacement and use that during `kubeadm init` with `--pod-network-cidr` and as a replacement in your network plugin’s YAML.
 
-You can install a pod network add-on with the following command:
+You can install a pod network add-on with the following command on the control-plane node or a node that has the kubeconfig credentials:
 
 ```bash
 kubectl apply -f <add-on.yaml>


### PR DESCRIPTION
added a note saying that Install a pod-network add on need to be done only on the master node

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> Remember to delete this note before submitting your pull request.
>
> For pull requests on 1.15 Features: set Milestone to 1.15 and Base Branch to dev-1.15
> 
> For pull requests on Chinese localization, set Base Branch to release-1.14
>
> For pull requests on Korean Localization: set Base Branch to dev-1.14-ko.\<latest team milestone>
>
> If you need Help on editing and submitting pull requests, visit:
> https://kubernetes.io/docs/contribute/start/#improve-existing-content.
>
> If you need Help on choosing which branch to use, visit:
> https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use.
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
