### PR TITLE
Change link to official CloudStack cloud provider

### DIFF
--- a/content/en/docs/concepts/cluster-administration/cloud-providers.md
+++ b/content/en/docs/concepts/cluster-administration/cloud-providers.md
@@ -117,7 +117,7 @@ Note that the Kubernetes Node name must match the Azure VM name.
 
 ## CloudStack
 
-If you wish to use the external cloud provider, its repository is [kubernetes/cloud-provider-openstack](https://github.com/kubernetes/cloud-provider-openstack#readme)
+The Apache project releases their own cloud provider, which is available from [apache/cloudstack-kubernetes-provider](https://github.com/apache/cloudstack-kubernetes-provider)
 
 ### Node Name
 


### PR DESCRIPTION
Fixes #14817

The Kubernetes has incorrectly referred to the OpenStack cloud provider as suitable for CloudStack for quite some time.

As the CloudStack developers have now started to work on an official cloud provider, the docs should link to this provider instead.