### PR TITLE
Fix wrong name for CRDs in Operators concept

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/operator.md
+++ b/content/en/docs/concepts/extend-kubernetes/operator.md
@@ -6,8 +6,9 @@ weight: 30
 
 {{% capture overview %}}
 
-Operators are software extensions to Kubernetes that make use of third-party
-resources to manage applications and their components. Operators follow
+Operators are software extensions to Kubernetes that make use of [custom
+resources](/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
+to manage applications and their components. Operators follow
 Kubernetes principles, notably the [control loop](/docs/concepts/#kubernetes-control-plane).
 
 {{% /capture %}}


### PR DESCRIPTION
In the [Operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) concept, call a custom resource a custom resource:
```diff
-Operators are software extensions to Kubernetes that make use of third-party
-resources to manage applications and their components. Operators follow
+Operators are software extensions to Kubernetes that make use of [custom
+resources](/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
+to manage applications and their components. Operators follow
```
as per #15469.