### PR TITLE
Fix kubectl kustomize typo

### DIFF
--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -865,7 +865,7 @@ EOF
 Apply all those objects on the Apiserver by
 
 ```shell
-kubectl apply --k .
+kubectl apply -k .
 ```
 
 Both containers will have the following files present on their filesystems with the values for each container's environment:


### PR DESCRIPTION
Write `kubectl -k` instead, fixing a typo in https://kubernetes.io/docs/concepts/configuration/secret/

Fixes #15546