### PR TITLE
Add a new Korean l10n owner to OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -122,6 +122,7 @@ aliases:
     - ClaudiaJKang
     - gochist
     - ianychoi
+    - seokho-son
     - zacharysarah
   sig-docs-ko-reviews: # PR reviews for Korean content
     - ClaudiaJKang


### PR DESCRIPTION
This PR updates OWNERS_ALIASES 
to add @seokho-son to sig-docs-ko-owners. (Korean l10n team owner)

@seokho-son is qulified  to be an approver according to the following [requirements](https://github.com/kubernetes/community/blob/master/community-membership.md#requirements-2)
- Reviewer of the codebase for at least 3 months
[The first primary review on 19 Feb, 2019](https://github.com/kubernetes/website/pull/12565)

- Primary reviewer for at least 10 substantial PRs to the codebase
[is:pr reviewed-by:seokho-son](https://github.com/kubernetes/website/pulls?utf8=%E2%9C%93&q=is%3Apr+reviewed-by%3Aseokho-son+)

- Reviewed or merged at least 30 PRs to the codebase
[is:merged reviewed-by:seokho-son](https://github.com/kubernetes/website/pulls?utf8=%E2%9C%93&q=is%3Amerged+author%3Aseokho-son+)
[is:merged author:seokho-son](https://github.com/kubernetes/website/pulls?utf8=%E2%9C%93&q=is%3Amerged+is%3Apr+reviewed-by%3Aseokho-son)

- Nominated by a subproject owner
/cc @kubernetes/sig-docs-ko-owners

Thank you !!