### PR TITLE
Remove "LoadBalancer" limitation from Minikube

### DIFF
--- a/content/en/docs/setup/learning-environment/minikube.md
+++ b/content/en/docs/setup/learning-environment/minikube.md
@@ -455,8 +455,7 @@ export no_proxy=$no_proxy,$(minikube ip)
 ```
 
 ## Known Issues
-* Features that require a Cloud Provider will not work in Minikube. These include:
-  * LoadBalancers
+
 * Features that require multiple nodes. These include:
   * Advanced scheduling policies
 

--- a/content/en/docs/setup/learning-environment/minikube.md
+++ b/content/en/docs/setup/learning-environment/minikube.md
@@ -456,8 +456,7 @@ export no_proxy=$no_proxy,$(minikube ip)
 
 ## Known Issues
 
-* Features that require multiple nodes. These include:
-  * Advanced scheduling policies
+Features that require multiple nodes will not work in Minikube.
 
 ## Design
 


### PR DESCRIPTION
Hi dear maintainers, thanks for taking care of this docuemntation!

This PR proposes the following change: 

* Removing the "LoadBalancer" limitation from Minikube's "known issues".

Why this change? Beginners starting to learn Kubernetes are often feeling that they cannot use a lot of Kubernetes-related tools, as default Services are really often "LoadBalancer" types.
Since Minikube "kinda supports" this type with the command `minikube tunnel` (Ref. <https://github.com/kubernetes/minikube/blob/master/docs/tunnel.md>), this can be removed to allows beginner to start their journey gently  with minikube.

What do you think? Should we also improve the tutoriel by mentioning `minikube tunnel` explicitely on the example?