### PR TITLE
Tiny typo fix

### DIFF
--- a/content/en/docs/contribute/style/style-guide.md
+++ b/content/en/docs/contribute/style/style-guide.md
@@ -216,7 +216,7 @@ Hugo [Shortcodes](https://gohugo.io/content-management/shortcodes) help create d
 
     ```
     {{</* note */>}}
-    No need to include a prefix; the shortcode automatically provides on (Note:, Caution:, etc.).
+    No need to include a prefix; the shortcode automatically provides one. (Note:, Caution:, etc.)
     {{</* /note */>}}
     ```
 


### PR DESCRIPTION
This PR fixes a tiny typo in the style guide.

/sig docs