### PR TITLE
Adding content for allowVolumeExpansion field in StorageClass

### DIFF
--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -53,6 +53,7 @@ provisioner: kubernetes.io/aws-ebs
 parameters:
   type: gp2
 reclaimPolicy: Retain
+allowVolumeExpansion: true
 mountOptions:
   - debug
 volumeBindingMode: Immediate
@@ -109,6 +110,31 @@ either `Delete` or `Retain`. If no `reclaimPolicy` is specified when a
 
 Persistent Volumes that are created manually and managed via a storage class will have
 whatever reclaim policy they were assigned at creation.
+
+### Allow Volume Expansion
+
+{{< feature-state for_k8s_version="v1.11" state="beta" >}}
+
+Persistent Volumes can be configured to be expandable. This feature when set to `true`, 
+allows the users to resize the volume by editing the corresponding PVC object. 
+
+The following types of volumes support volume expansion, when the underlying
+Storage Class has the field `allowVolumeExpansion` set to true.
+
+* gcePersistentDisk
+* awsElasticBlockStore
+* Cinder
+* glusterfs
+* rbd
+* Azure File
+* Azure Disk
+* Portworx
+* FlexVolumes
+* CSI  {{< feature-state for_k8s_version="v1.14" state="alpha" >}}
+
+{{< note >}}
+This feature cannot be used to shrink volumes.
+{{< /note >}}
 
 ### Mount Options
 


### PR DESCRIPTION
This PR is in reference to issue - https://github.com/kubernetes/website/issues/15587. I have added allowVolumeExpansion in the example and have written a paragraph to explain what it is. I have added supported types and a note telling that it cannot be used to shrink volumes. Please review and help me correct if any of the content is not up-to date and if anything else is missing. Thanks!