### PR TITLE
Update flannel_multi_node_cluster.md

### DIFF
--- a/content/en/docs/getting-started-guides/fedora/flannel_multi_node_cluster.md
+++ b/content/en/docs/getting-started-guides/fedora/flannel_multi_node_cluster.md
@@ -38,7 +38,8 @@ Choose an IP range that is *NOT* part of the public IP address range.
 Add the configuration to the etcd server on fed-master.
 
 ```shell
-etcdctl set /coreos.com/network/config < flannel-config.json
+if the etcd server version 3.x, and as flanneld does not supoort etcd v3.x yet
+ETCDCTL_API=2 etcdctl set /coreos.com/network/config < flannel-config.json
 ```
 
 * Verify that the key exists in the etcd server on fed-master.


### PR DESCRIPTION
flannel support only etcd v2 and latest installation of etcd by default creates key:value in v3.x format.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> Remember to delete this note before submitting your pull request.
>
> For pull requests on 1.15 Features: set Milestone to 1.15 and Base Branch to dev-1.15
> 
> For pull requests on Chinese localization, set Base Branch to release-1.14
>
> For pull requests on Korean Localization: set Base Branch to dev-1.14-ko.\<latest team milestone>
>
> If you need Help on editing and submitting pull requests, visit:
> https://kubernetes.io/docs/contribute/start/#improve-existing-content.
>
> If you need Help on choosing which branch to use, visit:
> https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use.
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
