### PR TITLE
Add Linux Foundation's K8s Online Training to Online Training List

### DIFF
--- a/content/en/docs/tutorials/online-training/overview.md
+++ b/content/en/docs/tutorials/online-training/overview.md
@@ -43,6 +43,8 @@ Here are some of the sites that offer online training for Kubernetes:
 
 * [Kubernetes for the Absolute Beginners with Hands-on Labs (KodeKloud)](https://kodekloud.com/p/kubernetes-for-the-absolute-beginners-hands-on)
 
+* [Kubernetes Fundamentals (LFS258) (The Linux Foundation)](https://training.linuxfoundation.org/training/kubernetes-fundamentals/)
+
 * [Kubernetes Quick Start with Hands-On Labs (Linux Academy)] (https://linuxacademy.com/linux/training/course/name/kubernetes-quick-start)
 
 * [Kubernetes the Hard Way with Hands-On Labs (Linux Academy)](https://linuxacademy.com/linux/training/course/name/kubernetes-the-hard-way)


### PR DESCRIPTION
This PR adds The Linux Foundation's K8s online training ( [Kubernetes Fundamentals (LFS258)](https://training.linuxfoundation.org/training/kubernetes-fundamentals/) ) to online training list of K8s website