### PR TITLE
Document the enableServiceLinks flag

### DIFF
--- a/content/en/docs/concepts/services-networking/connect-applications-service.md
+++ b/content/en/docs/concepts/services-networking/connect-applications-service.md
@@ -135,7 +135,9 @@ Kubernetes supports 2 primary modes of finding a Service - environment variables
 and DNS. The former works out of the box while the latter requires the
 [CoreDNS cluster addon](http://releases.k8s.io/{{< param "githubbranch" >}}/cluster/addons/dns/coredns).
 {{< note >}}
-If the service environment variables are not desired (because possible clashing with expected program ones, too many variables to process, only using DNS, etc) this mode can be disabled setting the `enableServiceLinks` flag to `false` on the [pod spec](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#pod-v1-core). 
+If the service environment variables are not desired (because possible clashing with expected program ones,
+too many variables to process, only using DNS, etc) this mode can be disabled by setting the `enableServiceLinks` 
+flag to `false` on the [pod spec](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#pod-v1-core). 
 {{< /note >}}
 
 

--- a/content/en/docs/concepts/services-networking/connect-applications-service.md
+++ b/content/en/docs/concepts/services-networking/connect-applications-service.md
@@ -136,7 +136,7 @@ and DNS. The former works out of the box while the latter requires the
 [CoreDNS cluster addon](http://releases.k8s.io/{{< param "githubbranch" >}}/cluster/addons/dns/coredns).
 {{< note >}}
 If the service environment variables are not desired (because possible clashing with expected program ones,
-too many variables to process, only using DNS, etc) this mode can be disabled by setting the `enableServiceLinks` 
+too many variables to process, only using DNS, etc) you can disable this mode by setting the `enableServiceLinks` 
 flag to `false` on the [pod spec](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#pod-v1-core). 
 {{< /note >}}
 

--- a/content/en/docs/concepts/services-networking/connect-applications-service.md
+++ b/content/en/docs/concepts/services-networking/connect-applications-service.md
@@ -135,7 +135,7 @@ Kubernetes supports 2 primary modes of finding a Service - environment variables
 and DNS. The former works out of the box while the latter requires the
 [CoreDNS cluster addon](http://releases.k8s.io/{{< param "githubbranch" >}}/cluster/addons/dns/coredns).
 {{< note >}}
-Environment variables mode can be disabled using the `enableServiceLinks` flag on the [pod spec](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#pod-v1-core). 
+If the service environment variables are not desired (because possible clashing with expected program ones, too many variables to process, only using DNS, etc) this mode can be disabled setting the `enableServiceLinks` flag to `false` on the [pod spec](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#pod-v1-core). 
 {{< /note >}}
 
 

--- a/content/en/docs/concepts/services-networking/connect-applications-service.md
+++ b/content/en/docs/concepts/services-networking/connect-applications-service.md
@@ -134,6 +134,10 @@ about the [service proxy](/docs/concepts/services-networking/service/#virtual-ip
 Kubernetes supports 2 primary modes of finding a Service - environment variables
 and DNS. The former works out of the box while the latter requires the
 [CoreDNS cluster addon](http://releases.k8s.io/{{< param "githubbranch" >}}/cluster/addons/dns/coredns).
+{{< note >}}
+Environment variables mode can be disabled using the `enableServiceLinks` flag on the [pod spec](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#pod-v1-core). 
+{{< /note >}}
+
 
 ### Environment Variables
 


### PR DESCRIPTION
There are many cases of service discovery environment variables clashing with env vars expected by programs, causing  hard to debug problems. The enableServiceLinks flag added in 1.13 should be mentioned here and not only on the API reference.
