### PR TITLE
Fix windows download link

### DIFF
--- a/content/fr/docs/tasks/tools/install-kubectl.md
+++ b/content/fr/docs/tasks/tools/install-kubectl.md
@@ -169,7 +169,7 @@ Si vous êtes sur MacOS et que vous utilisez le gestionnaire de paquets [Macport
 
 ### Installer le binaire kubectl avec curl sur Windows
 
-1. Téléchargez la dernière release {{< param "fullversion" >}} depuis [ce lien](https://storage.googleapis.com/kubernetes-release/release/{{{< param "fullversion" >}}/bin/windows/amd64/kubectl.exe).
+1. Téléchargez la dernière release {{< param "fullversion" >}} depuis [ce lien](https://storage.googleapis.com/kubernetes-release/release/{{< param "fullversion" >}}/bin/windows/amd64/kubectl.exe).
 
     Ou si vous avez `curl` installé, utilisez cette commande:
 


### PR DESCRIPTION
I found an error on the French documentation of kubernetes.
The `kubectl` windows download link has errors.

- **Actually** : https://storage.googleapis.com/kubernetes-release/release/{v1.15.0/bin/windows/amd64/kubectl.exe
- **To** : https://storage.googleapis.com/kubernetes-release/release/v1.15.0/bin/windows/amd64/kubectl.exe
