### PR TITLE
Only one word typo fix

### DIFF
--- a/content/en/docs/concepts/containers/images.md
+++ b/content/en/docs/concepts/containers/images.md
@@ -243,7 +243,7 @@ template needs to include the `.docker/config.json` or mount a drive that contai
 All pods will have read access to images in any private registry once private
 registry keys are added to the `.docker/config.json`.
 
-### Pre-pulling Images
+### Pre-pulled Images
 
 {{< note >}}
 If you are running on Google Kubernetes Engine, there will already be a `.dockercfg` on each node with credentials for Google Container Registry.  You cannot use this approach.

--- a/content/en/docs/concepts/containers/images.md
+++ b/content/en/docs/concepts/containers/images.md
@@ -70,7 +70,7 @@ Credentials can be provided in several ways:
   - Configuring Nodes to Authenticate to a Private Registry
     - all pods can read any configured private registries
     - requires node configuration by cluster administrator
-  - Pre-pulling Images
+  - Pre-pulled Images
     - all pods can use any images cached on a node
     - requires root access to all nodes to setup
   - Specifying ImagePullSecrets on a Pod
@@ -103,7 +103,7 @@ in the Pod definition.
 All users of the cluster who can create pods will be able to run pods that use any of the
 images in the ECR registry.
 
-The kubelet will fetch and periodically refresh ECR credentials.  It needs the following permissions to do this:
+The kubelet eill fetch and periodically refresh ECR credentials.  It needs the following permissions to do this:
 
 - `ecr:GetAuthorizationToken`
 - `ecr:BatchCheckLayerAvailability`

--- a/content/en/docs/concepts/containers/images.md
+++ b/content/en/docs/concepts/containers/images.md
@@ -103,7 +103,7 @@ in the Pod definition.
 All users of the cluster who can create pods will be able to run pods that use any of the
 images in the ECR registry.
 
-The kubelet eill fetch and periodically refresh ECR credentials.  It needs the following permissions to do this:
+The kubelet will fetch and periodically refresh ECR credentials.  It needs the following permissions to do this:
 
 - `ecr:GetAuthorizationToken`
 - `ecr:BatchCheckLayerAvailability`


### PR DESCRIPTION
This commit fixes `Pre-pulling` to `Pre-pulled` in docs/concepts/containers/images.md .