### PR TITLE
allow-privileged was deprecated and removed in 1.15.0

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/kube-apiserver.md
+++ b/content/en/docs/reference/command-line-tools-reference/kube-apiserver.md
@@ -42,13 +42,6 @@ kube-apiserver [flags]
     </tr>
 
     <tr>
-      <td colspan="2">--allow-privileged</td>
-    </tr>
-    <tr>
-      <td></td><td style="line-height: 130%; word-wrap: break-word;">If true, allow privileged containers. [default=false]</td>
-    </tr>
-
-    <tr>
       <td colspan="2">--alsologtostderr</td>
     </tr>
     <tr>


### PR DESCRIPTION
--allow-privileged was deprecated and removed in 1.15.0

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> Remember to delete this note before submitting your pull request.
>
> For pull requests on 1.15 Features: set Milestone to 1.15 and Base Branch to dev-1.15
> 
> For pull requests on Chinese localization, set Base Branch to release-1.14
>
> For pull requests on Korean Localization: set Base Branch to dev-1.14-ko.\<latest team milestone>
>
> If you need Help on editing and submitting pull requests, visit:
> https://kubernetes.io/docs/contribute/start/#improve-existing-content.
>
> If you need Help on choosing which branch to use, visit:
> https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use.
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
