### PR TITLE
Fix shell code indentation / markdown formatting

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/deployment.md
+++ b/content/en/docs/concepts/workloads/controllers/deployment.md
@@ -658,26 +658,26 @@ In our example above, 3 replicas are added to the old ReplicaSet and 2 replicas 
 new ReplicaSet. The rollout process should eventually move all replicas to the new ReplicaSet, assuming
 the new replicas become healthy. To confirm this, run:  
 
-    ```shell
-    kubectl get deploy
-    ```
+```shell
+kubectl get deploy
+```
 
-    The output is similar to this:
-    ```
-    NAME                 DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
-    nginx-deployment     15        18        7            8           7m
-    ```
-   The rollout status confirms how the replicas were added to each ReplicaSet.
-    ```shell
-    kubectl get rs
-    ```
+The output is similar to this: 
+```
+NAME                 DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
+nginx-deployment     15        18        7            8           7m
+```
+The rollout status confirms how the replicas were added to each ReplicaSet.
+```shell
+kubectl get rs
+```
 
-    The output is similar to this:
-    ```
-    NAME                          DESIRED   CURRENT   READY     AGE
-    nginx-deployment-1989198191   7         7         0         7m
-    nginx-deployment-618515232    11        11        11        7m
-    ```
+The output is similar to this:
+```
+NAME                          DESIRED   CURRENT   READY     AGE
+nginx-deployment-1989198191   7         7         0         7m
+nginx-deployment-618515232    11        11        11        7m
+```
 
 ## Pausing and Resuming a Deployment
 


### PR DESCRIPTION
The backticks were visible in the generated documentation, removing the indentation hides it once more.