### PR TITLE
Correct 'print default' command in kubeadm-config.md

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-config.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-config.md
@@ -16,7 +16,7 @@ You can execute `kubeadm config view` to view the ConfigMap. If you initialized 
 kubeadm v1.7.x or lower, you must use `kubeadm config upload` to create the ConfigMap before you
 may use `kubeadm upgrade`.
 
-In Kubernetes v1.11.0, some new commands were added. You can use `kubeadm config print-default`
+In Kubernetes v1.11.0, some new commands were added. You can use `kubeadm config print`
 to print the default configuration and `kubeadm config migrate` to convert your old configuration
 files to a newer version. `kubeadm config images list` and `kubeadm config images pull` can be used
 to list and pull the images that kubeadm requires.

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-config.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-config.md
@@ -16,10 +16,9 @@ You can execute `kubeadm config view` to view the ConfigMap. If you initialized 
 kubeadm v1.7.x or lower, you must use `kubeadm config upload` to create the ConfigMap before you
 may use `kubeadm upgrade`.
 
-In Kubernetes v1.11.0, some new commands were added. You can use `kubeadm config print`
-to print the default configuration and `kubeadm config migrate` to convert your old configuration
-files to a newer version. `kubeadm config images list` and `kubeadm config images pull` can be used
-to list and pull the images that kubeadm requires.
+You can use `kubeadm config print` to print the default configuration and `kubeadm config migrate` to
+convert your old configuration files to a newer version. `kubeadm config images list` and
+`kubeadm config images pull` can be used to list and pull the images that kubeadm requires.
 
 In Kubernetes v1.13.0 and later to list/pull kube-dns images instead of the CoreDNS image
 the `--config` method described [here](/docs/reference/setup-tools/kubeadm/kubeadm-init-phase/#cmd-phase-addon)


### PR DESCRIPTION
`kubeadm config print-default` command doesn't exist in v1.15.0.
It's now `kubeadm config print init-defaults` and `kubeadm config print join-defaults`.