### PR TITLE
Remove non-member approver from PT content

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -180,8 +180,6 @@ aliases:
   sig-docs-pt-owners: # Admins for Portuguese content
     - femrtnz
     - jcjesus
-    - devlware
   sig-docs-pt-reviews: # PR reviews for Portugese content
     - femrtnz
     - jcjesus
-    - devlware


### PR DESCRIPTION
This PR removes @devlware as an approver for Portuguese content. 

See https://github.com/kubernetes/website/pull/15131#issuecomment-518402761 for context, which also specifies conditions for re-adding @devlware. 

TLDR: @devlware needs to be an org member first.

This PR needs fast approval because it's blocking the 1.16 release cycle. #15656 
EDIT: It's also blocking the Portuguese l10n cycle: #15655

/sig docs
/priority critical-urgent
/assign @jimangel 