### PR TITLE
Update Interactive Terminal button

### DIFF
--- a/layouts/shortcodes/kat-button
+++ b/layouts/shortcodes/kat-button
@@ -1,3 +1,3 @@
-<div id="my-panel" data-katacoda-ondemand="true" data-katacoda-env="minikube" data-katacoda-command="minikube version; minikube start" data-katacoda-ui="panel"></div>
+<div id="my-panel" data-katacoda-ondemand="true" data-katacoda-port="30000" data-katacoda-env="minikube" data-katacoda-command="start.sh" data-katacoda-ui="panel"></div>
 <script src="https://katacoda.com/embed.js"></script>
 <button class="button" onclick="window.katacoda.init(); ">Launch Terminal</button>


### PR DESCRIPTION
Based on the feedback in #15212

When the terminal now starts, it will use `start.sh`. This is a wrapper script we created that will deploy `minikube` with the new `wait=false` flag so that it starts faster for users. The abstraction will make it easier to keep up-to-date with future changes and optimisations that can be done.

Secondly, we added a "Preview Port 30000" button to the terminal making it easier for people to access the dashboard.