### PR TITLE
Add gochist to sig-docs-en-owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -41,6 +41,7 @@ aliases:
     - bradtopol
     - chenopis
     - cody-clark
+    - gochist
     - jaredbhatti
     - jimangel
     - kbarnard10


### PR DESCRIPTION
This is a workaround for #14008. The power will be used only for the `i18n/` and `README-ko.md`.
