### PR TITLE
Explain how to cleanup the created pod

### DIFF
--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -99,6 +99,11 @@ kubectl exec -it redis redis-cli
 2) "allkeys-lru"
 ```
 
+Delete the created pod with the following command
+```shell
+kubectl delete pod redis
+```
+
 {{% /capture %}}
 
 {{% capture whatsnext %}}

--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -99,7 +99,7 @@ kubectl exec -it redis redis-cli
 2) "allkeys-lru"
 ```
 
-Delete the created pod with the following command
+Delete the created pod:
 ```shell
 kubectl delete pod redis
 ```


### PR DESCRIPTION
Added a `kubectl` command for deleting the redis pod created in this example.