### PR TITLE
storage: CSI inline volumes in beta

### DIFF
--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -1316,6 +1316,7 @@ Learn how to
 #### CSI ephemeral volumes
 
 {{< feature-state for_k8s_version="v1.15" state="alpha" >}}
+{{< feature-state for_k8s_version="v1.16" state="beta" >}}
 
 This feature allows CSI volumes to be directly embedded in the Pod specification instead of a PersistentVolume. Volumes specified in this way are ephemeral and do not persist across Pod restarts.
 
@@ -1342,7 +1343,9 @@ spec:
               foo: bar
 ```
 
-This feature requires CSIInlineVolume feature gate to be enabled:
+This feature requires CSIInlineVolume feature gate to be enabled. It
+is enabled by default in Kubernetes >= 1.16. In Kubernetes v1.15, it
+has to be enabled explicitly:
 
 ```
 --feature-gates=CSIInlineVolume=true

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -1315,7 +1315,6 @@ Learn how to
 
 #### CSI ephemeral volumes
 
-{{< feature-state for_k8s_version="v1.15" state="alpha" >}}
 {{< feature-state for_k8s_version="v1.16" state="beta" >}}
 
 This feature allows CSI volumes to be directly embedded in the Pod specification instead of a PersistentVolume. Volumes specified in this way are ephemeral and do not persist across Pod restarts.
@@ -1344,12 +1343,7 @@ spec:
 ```
 
 This feature requires CSIInlineVolume feature gate to be enabled. It
-is enabled by default in Kubernetes >= 1.16. In Kubernetes v1.15, it
-has to be enabled explicitly:
-
-```
---feature-gates=CSIInlineVolume=true
-```
+is enabled by default starting with Kubernetes 1.16.
 
 CSI ephemeral volumes are only supported by a subset of CSI drivers. Please see the list of CSI drivers [here](https://kubernetes-csi.github.io/docs/drivers.html).
 

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -58,7 +58,8 @@ different Kubernetes components.
 | `CSIBlockVolume` | `true` | Beta | 1.14 | |
 | `CSIDriverRegistry` | `false` | Alpha | 1.12 | 1.13 |
 | `CSIDriverRegistry` | `true` | Beta | 1.14 | |
-| `CSIInlineVolume` | `false` | Alpha | 1.15 | - |
+| `CSIInlineVolume` | `false` | Alpha | 1.15 | 1.15 |
+| `CSIInlineVolume` | `true` | Beta | 1.16 | - |
 | `CSIMigration` | `false` | Alpha | 1.14 | |
 | `CSIMigrationAWS` | `false` | Alpha | 1.14 | |
 | `CSIMigrationAzureDisk` | `false` | Alpha | 1.15 | |


### PR DESCRIPTION
Kubernetes 1.16 graduates this feature to beta.

Related-to: https://github.com/kubernetes/website/pull/14704, 
https://github.com/kubernetes/enhancements/issues/596
