### PR TITLE
Fixed CRD schema - missing root type

### DIFF
--- a/content/en/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning.md
+++ b/content/en/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning.md
@@ -228,6 +228,7 @@ spec:
     # schema is defined.
     schema:
       openAPIV3Schema:
+        type: object
         properties:
           hostPort:
             type: string
@@ -236,6 +237,7 @@ spec:
     storage: false
     schema:
       openAPIV3Schema:
+        type: object
         properties:
           host:
             type: string


### PR DESCRIPTION
When testing the conversion webhook, I got an error when creating the CRD:
```
The CustomResourceDefinition "kamussecrets.soluto.com" is invalid: 
* spec.versions[0].schema.openAPIV3Schema.type: Required value: must not be empty at the root
* spec.versions[1].schema.openAPIV3Schema.type: Required value: must not be empty at the root
```
After adding root `type`, I was able to apply it. Added the fix also to the docs.