### PR TITLE
Tweak glossary entry for Static Pod

### DIFF
--- a/content/en/docs/reference/glossary/static-pod.md
+++ b/content/en/docs/reference/glossary/static-pod.md
@@ -1,8 +1,8 @@
 ---
 title: Static Pod
 id: static-pod
-date: 2091-02-12
-full_link: /docs/tasks/administer-cluster/static-pod/
+date: 2019-02-12
+full_link: /docs/tasks/configure-pod-container/static-pod/
 short_description: >
   A pod managed directly by kubelet daemon on a specific node
 
@@ -10,5 +10,4 @@ aka:
 tags:
 - fundamental
 ---
- A {{< glossary_tooltip text="pod" term_id="pod" >}} managed directly by the kubelet
- daemon on a specific node, without the API server observing it.
+ A Pod managed directly by the kubelet on a specific node, without the API server controlling it.


### PR DESCRIPTION
Prompted by a [comment](https://github.com/kubernetes/website/pull/14831#issuecomment-519317833) on #13831, I wonder if this change will help the glossary entry come out right.

- fix date of entry
- fix link to page
- drop Hugo shortcodes

Using glossary tooltips in glossary entries seems both:
- helpful to readers
- a bit fragile, because I have seen some implementation snags that surprised me