### PR TITLE
[WIP] testing restyled kubectl ref

### DIFF
--- a/content/en/docs/reference/kubectl/kubectl-reference/_index.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/_index.md
@@ -1,5 +1,5 @@
 ---
 title: "kubectl command reference"
-weight: 10
+weight: 80
 ---
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/_index.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/_index.md
@@ -1,0 +1,5 @@
+---
+title: "kubectl command reference"
+weight: 10
+---
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/alpha.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/alpha.md
@@ -1,0 +1,17 @@
+---
+title: alpha
+content_template: templates/tool-reference
+---
+
+### Overview
+These commands correspond to alpha features that are not enabled in Kubernetes clusters by default.
+
+### Usage
+
+`$ alpha`
+
+
+
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/alpha.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/alpha.md
@@ -8,10 +8,20 @@ These commands correspond to alpha features that are not enabled in Kubernetes c
 
 ### Usage
 
-`$ alpha`
+`alpha`
 
 
 
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/alpha.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/alpha.md
@@ -1,6 +1,7 @@
 ---
 title: alpha
-content_template: templates/tool-reference
+noedit: true
+layout: kuberef
 ---
 
 ### Overview

--- a/content/en/docs/reference/kubectl/kubectl-reference/alpha.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/alpha.md
@@ -20,8 +20,11 @@ These commands correspond to alpha features that are not enabled in Kubernetes c
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/annotate.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/annotate.md
@@ -1,0 +1,123 @@
+---
+title: annotate
+content_template: templates/tool-reference
+---
+
+### Overview
+Update the annotations on one or more resources
+
+ All Kubernetes objects support the ability to store additional data with the object as annotations. Annotations are key/value pairs that can be larger than labels and include arbitrary string values such as structured JSON. Tools and system extensions may use annotations to store their own data.
+
+ Attempting to set an annotation that already exists will fail unless --overwrite is set. If --resource-version is specified and does not match the current resource version on the server the command will fail.
+
+Use "kubectl api-resources" for a complete list of supported resources.
+
+### Usage
+
+`$ annotate [--overwrite] (-f FILENAME | TYPE NAME) KEY_1=VAL_1 ... KEY_N=VAL_N [--resource-version=version]`
+
+
+### Example
+
+ Update pod 'foo' with the annotation 'description' and the value 'my frontend'. # If the same annotation is set multiple times, only the last value will be applied
+
+```shell
+kubectl annotate pods foo description='my frontend'
+```
+
+ Update a pod identified by type and name in "pod.json"
+
+```shell
+kubectl annotate -f pod.json description='my frontend'
+```
+
+ Update pod 'foo' with the annotation 'description' and the value 'my frontend running nginx', overwriting any existing value.
+
+```shell
+kubectl annotate --overwrite pods foo description='my frontend running nginx'
+```
+
+ Update all pods in the namespace
+
+```shell
+kubectl annotate pods --all description='my frontend running nginx'
+```
+
+ Update pod 'foo' only if the resource is unchanged from version 1.
+
+```shell
+kubectl annotate pods foo description='my frontend running nginx' --resource-version=1
+```
+
+ Update pod 'foo' by removing an annotation named 'description' if it exists. # Does not require the --overwrite flag.
+
+```shell
+kubectl annotate pods foo description-
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>all</td><td></td><td>false</td><td>Select all resources, including uninitialized ones, in the namespace of the specified resource types.</td>
+    </tr>
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>field-selector</td><td></td><td></td><td>Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>Filename, directory, or URL to files identifying the resource to update the annotation</td>
+    </tr>
+    <tr>
+    <td>include-uninitialized</td><td></td><td>false</td><td>If true, the kubectl command applies to uninitialized objects. If explicitly set to false, this flag overrides other flags that make the kubectl commands apply to uninitialized objects, e.g., "--all". Objects with empty metadata.initializers are regarded as initialized.</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process the kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>local</td><td></td><td>false</td><td>If true, annotation will NOT contact api-server but run locally.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>overwrite</td><td></td><td>false</td><td>If true, allow annotations to be overwritten, otherwise reject annotation updates that overwrite existing annotations.</td>
+    </tr>
+    <tr>
+    <td>record</td><td></td><td>false</td><td>Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>resource-version</td><td></td><td></td><td>If non-empty, the annotation update will only succeed if this is the current resource-version for the object. Only valid when specifying a single resource.</td>
+    </tr>
+    <tr>
+    <td>selector</td><td>l</td><td></td><td>Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2).</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/annotate.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/annotate.md
@@ -14,7 +14,7 @@ Use "kubectl api-resources" for a complete list of supported resources.
 
 ### Usage
 
-`$ annotate [--overwrite] (-f FILENAME | TYPE NAME) KEY_1=VAL_1 ... KEY_N=VAL_N [--resource-version=version]`
+`annotate [--overwrite] (-f FILENAME | TYPE NAME) KEY_1=VAL_1 ... KEY_N=VAL_N [--resource-version=version]`
 
 
 ### Example
@@ -120,4 +120,14 @@ kubectl annotate pods foo description-
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/annotate.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/annotate.md
@@ -1,6 +1,7 @@
 ---
 title: annotate
-content_template: templates/tool-reference
+noedit: true
+layout: kuberef
 ---
 
 ### Overview

--- a/content/en/docs/reference/kubectl/kubectl-reference/annotate.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/annotate.md
@@ -126,8 +126,11 @@ kubectl annotate pods foo description-
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/api-resources.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/api-resources.md
@@ -1,6 +1,7 @@
 ---
 title: api-resources
-content_template: templates/tool-reference
+noedit: true
+layout: kuberef
 ---
 
 ### Overview

--- a/content/en/docs/reference/kubectl/kubectl-reference/api-resources.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/api-resources.md
@@ -1,0 +1,84 @@
+---
+title: api-resources
+content_template: templates/tool-reference
+---
+
+### Overview
+Print the supported API resources on the server
+
+### Usage
+
+`$ api-resources`
+
+
+### Example
+
+ Print the supported API Resources
+
+```shell
+kubectl api-resources
+```
+
+ Print the supported API Resources with more information
+
+```shell
+kubectl api-resources -o wide
+```
+
+ Print the supported namespaced resources
+
+```shell
+kubectl api-resources --namespaced=true
+```
+
+ Print the supported non-namespaced resources
+
+```shell
+kubectl api-resources --namespaced=false
+```
+
+ Print the supported API Resources with specific APIGroup
+
+```shell
+kubectl api-resources --api-group=extensions
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>api-group</td><td></td><td></td><td>Limit to resources in the specified API group.</td>
+    </tr>
+    <tr>
+    <td>cached</td><td></td><td>false</td><td>Use the cached list of resources if available.</td>
+    </tr>
+    <tr>
+    <td>namespaced</td><td></td><td>true</td><td>If false, non-namespaced resources will be returned, otherwise returning namespaced resources by default.</td>
+    </tr>
+    <tr>
+    <td>no-headers</td><td></td><td>false</td><td>When using the default or custom-column output format, don't print headers (default print headers).</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: wide&#124;name.</td>
+    </tr>
+    <tr>
+    <td>verbs</td><td></td><td>[]</td><td>Limit to resources that support the specified verbs.</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/api-resources.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/api-resources.md
@@ -87,8 +87,11 @@ kubectl api-resources --api-group=extensions
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/api-resources.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/api-resources.md
@@ -8,7 +8,7 @@ Print the supported API resources on the server
 
 ### Usage
 
-`$ api-resources`
+`api-resources`
 
 
 ### Example
@@ -81,4 +81,14 @@ kubectl api-resources --api-group=extensions
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/api-versions.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/api-versions.md
@@ -1,0 +1,26 @@
+---
+title: api-versions
+content_template: templates/tool-reference
+---
+
+### Overview
+Print the supported API versions on the server, in the form of "group/version"
+
+### Usage
+
+`$ api-versions`
+
+
+### Example
+
+ Print the supported API versions
+
+```shell
+kubectl api-versions
+```
+
+
+
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/api-versions.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/api-versions.md
@@ -1,6 +1,7 @@
 ---
 title: api-versions
-content_template: templates/tool-reference
+noedit: true
+layout: kuberef
 ---
 
 ### Overview

--- a/content/en/docs/reference/kubectl/kubectl-reference/api-versions.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/api-versions.md
@@ -8,7 +8,7 @@ Print the supported API versions on the server, in the form of "group/version"
 
 ### Usage
 
-`$ api-versions`
+`api-versions`
 
 
 ### Example
@@ -23,4 +23,14 @@ kubectl api-versions
 
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/api-versions.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/api-versions.md
@@ -29,8 +29,11 @@ kubectl api-versions
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/apply.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/apply.md
@@ -1,6 +1,7 @@
 ---
 title: apply
-content_template: templates/tool-reference
+noedit: true
+layout: kuberef
 ---
 
 ### Overview

--- a/content/en/docs/reference/kubectl/kubectl-reference/apply.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/apply.md
@@ -368,8 +368,11 @@ kubectl apply view-last-applied -f deploy.yaml -o json
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/apply.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/apply.md
@@ -12,7 +12,7 @@ Apply a configuration to a resource by filename or stdin. The resource name must
 
 ### Usage
 
-`$ apply (-f FILENAME | -k DIRECTORY)`
+`apply (-f FILENAME | -k DIRECTORY)`
 
 
 ### Example
@@ -161,7 +161,7 @@ Edit the latest last-applied-configuration annotations of resources from the def
 
 ### Usage
 
-`$ edit-last-applied (RESOURCE/NAME | -f FILENAME)`
+`edit-last-applied (RESOURCE/NAME | -f FILENAME)`
 
 
 ### Example
@@ -182,7 +182,7 @@ kubectl apply edit-last-applied -f deploy.yaml -o json
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -235,7 +235,7 @@ Set the latest last-applied-configuration annotations by setting it to match the
 
 ### Usage
 
-`$ set-last-applied -f FILENAME`
+`set-last-applied -f FILENAME`
 
 
 ### Example
@@ -262,7 +262,7 @@ kubectl apply set-last-applied -f deploy.yaml --create-annotation=true
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -308,7 +308,7 @@ View the latest last-applied-configuration annotations by type/name or file.
 
 ### Usage
 
-`$ view-last-applied (TYPE [NAME | -l label] | TYPE/NAME | -f FILENAME)`
+`view-last-applied (TYPE [NAME | -l label] | TYPE/NAME | -f FILENAME)`
 
 
 ### Example
@@ -329,7 +329,7 @@ kubectl apply view-last-applied -f deploy.yaml -o json
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -362,4 +362,14 @@ kubectl apply view-last-applied -f deploy.yaml -o json
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/apply.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/apply.md
@@ -1,0 +1,365 @@
+---
+title: apply
+content_template: templates/tool-reference
+---
+
+### Overview
+Apply a configuration to a resource by filename or stdin. The resource name must be specified. This resource will be created if it doesn't exist yet. To use 'apply', always create the resource initially with either 'apply' or 'create --save-config'.
+
+ JSON and YAML formats are accepted.
+
+ Alpha Disclaimer: the --prune functionality is not yet complete. Do not use unless you are aware of what the current state is. See https://issues.k8s.io/34274.
+
+### Usage
+
+`$ apply (-f FILENAME | -k DIRECTORY)`
+
+
+### Example
+
+ Apply the configuration in pod.json to a pod.
+
+```shell
+kubectl apply -f ./pod.json
+```
+
+ Apply resources from a directory containing kustomization.yaml - e.g. dir/kustomization.yaml.
+
+```shell
+kubectl apply -k dir/
+```
+
+ Apply the JSON passed into stdin to a pod.
+
+```shell
+cat pod.json | kubectl apply -f -
+```
+
+ Note: --prune is still in Alpha # Apply the configuration in manifest.yaml that matches label app=nginx and delete all the other resources that are not in the file and match label app=nginx.
+
+```shell
+kubectl apply --prune -f manifest.yaml -l app=nginx
+```
+
+ Apply the configuration in manifest.yaml and delete all the other configmaps that are not in the file.
+
+```shell
+kubectl apply --prune -f manifest.yaml --all --prune-whitelist=core/v1/ConfigMap
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>all</td><td></td><td>false</td><td>Select all resources in the namespace of the specified resource types.</td>
+    </tr>
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>cascade</td><td></td><td>true</td><td>If true, cascade the deletion of the resources managed by this resource (e.g. Pods created by a ReplicationController).  Default true.</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it. Warning: --dry-run cannot accurately output the result of merging the local manifest and the server-side data. Use --server-dry-run to get the merged result instead.</td>
+    </tr>
+    <tr>
+    <td>experimental-field-manager</td><td></td><td>kubectl</td><td>Name of the manager used to track field ownership. This is an alpha feature and flag.</td>
+    </tr>
+    <tr>
+    <td>experimental-force-conflicts</td><td></td><td>false</td><td>If true, server-side apply will force the changes against conflicts. This is an alpha feature and flag.</td>
+    </tr>
+    <tr>
+    <td>experimental-server-side</td><td></td><td>false</td><td>If true, apply runs in the server instead of the client. This is an alpha feature and flag.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>that contains the configuration to apply</td>
+    </tr>
+    <tr>
+    <td>force</td><td></td><td>false</td><td>Only used when grace-period=0. If true, immediately remove resources from API and bypass graceful deletion. Note that immediate deletion of some resources may result in inconsistency or data loss and requires confirmation.</td>
+    </tr>
+    <tr>
+    <td>grace-period</td><td></td><td>-1</td><td>Period of time in seconds given to the resource to terminate gracefully. Ignored if negative. Set to 1 for immediate shutdown. Can only be set to 0 when --force is true (force deletion).</td>
+    </tr>
+    <tr>
+    <td>include-uninitialized</td><td></td><td>false</td><td>If true, the kubectl command applies to uninitialized objects. If explicitly set to false, this flag overrides other flags that make the kubectl commands apply to uninitialized objects, e.g., "--all". Objects with empty metadata.initializers are regarded as initialized.</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process a kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>openapi-patch</td><td></td><td>true</td><td>If true, use openapi to calculate diff when the openapi presents and the resource can be found in the openapi spec. Otherwise, fall back to use baked-in types.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>overwrite</td><td></td><td>true</td><td>Automatically resolve conflicts between the modified and live configuration by using values from the modified configuration</td>
+    </tr>
+    <tr>
+    <td>prune</td><td></td><td>false</td><td>Automatically delete resource objects, including the uninitialized ones, that do not appear in the configs and are created by either apply or create --save-config. Should be used with either -l or --all.</td>
+    </tr>
+    <tr>
+    <td>prune-whitelist</td><td></td><td>[]</td><td>Overwrite the default whitelist with <group/version/kind> for --prune</td>
+    </tr>
+    <tr>
+    <td>record</td><td></td><td>false</td><td>Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>selector</td><td>l</td><td></td><td>Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)</td>
+    </tr>
+    <tr>
+    <td>server-dry-run</td><td></td><td>false</td><td>If true, request will be sent to server with dry-run flag, which means the modifications won't be persisted. This is an alpha feature and flag.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>timeout</td><td></td><td>0s</td><td>The length of time to wait before giving up on a delete, zero means determine a timeout from the size of the object</td>
+    </tr>
+    <tr>
+    <td>validate</td><td></td><td>true</td><td>If true, use a schema to validate the input before sending it</td>
+    </tr>
+    <tr>
+    <td>wait</td><td></td><td>false</td><td>If true, wait for resources to be gone before returning. This waits for finalizers.</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## edit-last-applied
+
+
+### Overview
+Edit the latest last-applied-configuration annotations of resources from the default editor.
+
+ The edit-last-applied command allows you to directly edit any API resource you can retrieve via the command line tools. It will open the editor defined by your KUBE_EDITOR, or EDITOR environment variables, or fall back to 'vi' for Linux or 'notepad' for Windows. You can edit multiple objects, although changes are applied one at a time. The command accepts filenames as well as command line arguments, although the files you point to must be previously saved versions of resources.
+
+ The default format is YAML. To edit in JSON, specify "-o json".
+
+ The flag --windows-line-endings can be used to force Windows line endings, otherwise the default for your operating system will be used.
+
+ In the event an error occurs while updating, a temporary file will be created on disk that contains your unapplied changes. The most common error when updating a resource is another editor changing the resource on the server. When this occurs, you will have to apply your changes to the newer version of the resource, or update your temporary saved copy to include the latest resource version.
+
+### Usage
+
+`$ edit-last-applied (RESOURCE/NAME | -f FILENAME)`
+
+
+### Example
+ Edit the last-applied-configuration annotations by type/name in YAML.
+
+```shell
+kubectl apply edit-last-applied deployment/nginx
+```
+
+ Edit the last-applied-configuration annotations by file in JSON.
+
+```shell
+kubectl apply edit-last-applied -f deploy.yaml -o json
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>Filename, directory, or URL to files to use to edit the resource</td>
+    </tr>
+    <tr>
+    <td>include-uninitialized</td><td></td><td>false</td><td>If true, the kubectl command applies to uninitialized objects. If explicitly set to false, this flag overrides other flags that make the kubectl commands apply to uninitialized objects, e.g., "--all". Objects with empty metadata.initializers are regarded as initialized.</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process the kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>record</td><td></td><td>false</td><td>Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>windows-line-endings</td><td></td><td>false</td><td>Defaults to the line ending native to your platform.</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## set-last-applied
+
+
+### Overview
+Set the latest last-applied-configuration annotations by setting it to match the contents of a file. This results in the last-applied-configuration being updated as though 'kubectl apply -f<file> ' was run, without updating any other parts of the object.
+
+### Usage
+
+`$ set-last-applied -f FILENAME`
+
+
+### Example
+ Set the last-applied-configuration of a resource to match the contents of a file.
+
+```shell
+kubectl apply set-last-applied -f deploy.yaml
+```
+
+ Execute set-last-applied against each configuration file in a directory.
+
+```shell
+kubectl apply set-last-applied -f path/
+```
+
+ Set the last-applied-configuration of a resource to match the contents of a file, will create the annotation if it does not already exist.
+
+```shell
+kubectl apply set-last-applied -f deploy.yaml --create-annotation=true
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>create-annotation</td><td></td><td>false</td><td>Will create 'last-applied-configuration' annotations if current objects doesn't have one</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>Filename, directory, or URL to files that contains the last-applied-configuration annotations</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## view-last-applied
+
+
+### Overview
+View the latest last-applied-configuration annotations by type/name or file.
+
+ The default output will be printed to stdout in YAML format. One can use -o option to change output format.
+
+### Usage
+
+`$ view-last-applied (TYPE [NAME | -l label] | TYPE/NAME | -f FILENAME)`
+
+
+### Example
+ View the last-applied-configuration annotations by type/name in YAML.
+
+```shell
+kubectl apply view-last-applied deployment/nginx
+```
+
+ View the last-applied-configuration annotations by file in JSON
+
+```shell
+kubectl apply view-last-applied -f deploy.yaml -o json
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>all</td><td></td><td>false</td><td>Select all resources in the namespace of the specified resource types</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>Filename, directory, or URL to files that contains the last-applied-configuration annotations</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process the kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td>yaml</td><td>Output format. Must be one of yaml&#124;json</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>selector</td><td>l</td><td></td><td>Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/attach.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/attach.md
@@ -75,8 +75,11 @@ kubectl attach rs/nginx
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/attach.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/attach.md
@@ -8,7 +8,7 @@ Attach to a process that is already running inside an existing container.
 
 ### Usage
 
-`$ attach (POD | TYPE/NAME) -c CONTAINER`
+`attach (POD | TYPE/NAME) -c CONTAINER`
 
 
 ### Example
@@ -69,4 +69,14 @@ kubectl attach rs/nginx
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/attach.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/attach.md
@@ -1,0 +1,72 @@
+---
+title: attach
+content_template: templates/tool-reference
+---
+
+### Overview
+Attach to a process that is already running inside an existing container.
+
+### Usage
+
+`$ attach (POD | TYPE/NAME) -c CONTAINER`
+
+
+### Example
+
+ Get output from running pod 123456-7890, using the first container by default
+
+```shell
+kubectl attach 123456-7890
+```
+
+ Get output from ruby-container from pod 123456-7890
+
+```shell
+kubectl attach 123456-7890 -c ruby-container
+```
+
+ Switch to raw terminal mode, sends stdin to 'bash' in ruby-container from pod 123456-7890 # and sends stdout/stderr from 'bash' back to the client
+
+```shell
+kubectl attach 123456-7890 -c ruby-container -i -t
+```
+
+ Get output from the first pod of a ReplicaSet named nginx
+
+```shell
+kubectl attach rs/nginx
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>container</td><td>c</td><td></td><td>Container name. If omitted, the first container in the pod will be chosen</td>
+    </tr>
+    <tr>
+    <td>pod-running-timeout</td><td></td><td>1m0s</td><td>The length of time (like 5s, 2m, or 3h, higher than zero) to wait until at least one pod is running</td>
+    </tr>
+    <tr>
+    <td>stdin</td><td>i</td><td>false</td><td>Pass stdin to the container</td>
+    </tr>
+    <tr>
+    <td>tty</td><td>t</td><td>false</td><td>Stdin is a TTY</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/attach.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/attach.md
@@ -1,6 +1,7 @@
 ---
 title: attach
-content_template: templates/tool-reference
+noedit: true
+layout: kuberef
 ---
 
 ### Overview

--- a/content/en/docs/reference/kubectl/kubectl-reference/auth.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/auth.md
@@ -1,0 +1,187 @@
+---
+title: auth
+content_template: templates/tool-reference
+---
+
+### Overview
+Inspect authorization
+
+### Usage
+
+`$ auth`
+
+
+
+
+
+
+<hr>
+
+## can-i
+
+
+### Overview
+Check whether an action is allowed.
+
+ VERB is a logical Kubernetes API verb like 'get', 'list', 'watch', 'delete', etc. TYPE is a Kubernetes resource. Shortcuts and groups will be resolved. NONRESOURCEURL is a partial URL starts with "/". NAME is the name of a particular Kubernetes resource.
+
+### Usage
+
+`$ can-i VERB [TYPE | TYPE/NAME | NONRESOURCEURL]`
+
+
+### Example
+ Check to see if I can create pods in any namespace
+
+```shell
+kubectl auth can-i create pods --all-namespaces
+```
+
+ Check to see if I can list deployments in my current namespace
+
+```shell
+kubectl auth can-i list deployments.extensions
+```
+
+ Check to see if I can do everything in my current namespace ("*" means all)
+
+```shell
+kubectl auth can-i '*' '*'
+```
+
+ Check to see if I can get the job named "bar" in namespace "foo"
+
+```shell
+kubectl auth can-i list jobs.batch/bar -n foo
+```
+
+ Check to see if I can read pod logs
+
+```shell
+kubectl auth can-i get pods --subresource=log
+```
+
+ Check to see if I can access the URL /logs/
+
+```shell
+kubectl auth can-i get /logs/
+```
+
+ List all allowed actions in namespace "foo"
+
+```shell
+kubectl auth can-i --list --namespace=foo
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>all-namespaces</td><td>A</td><td>false</td><td>If true, check the specified action in all namespaces.</td>
+    </tr>
+    <tr>
+    <td>list</td><td></td><td>false</td><td>If true, prints all allowed actions.</td>
+    </tr>
+    <tr>
+    <td>no-headers</td><td></td><td>false</td><td>If true, prints allowed actions without headers</td>
+    </tr>
+    <tr>
+    <td>quiet</td><td>q</td><td>false</td><td>If true, suppress output and just return the exit code.</td>
+    </tr>
+    <tr>
+    <td>subresource</td><td></td><td></td><td>SubResource such as pod/log or deployment/scale</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## reconcile
+
+
+### Overview
+Reconciles rules for RBAC Role, RoleBinding, ClusterRole, and ClusterRole binding objects.
+
+ Missing objects are created, and the containing namespace is created for namespaced objects, if required.
+
+ Existing roles are updated to include the permissions in the input objects, and remove extra permissions if --remove-extra-permissions is specified.
+
+ Existing bindings are updated to include the subjects in the input objects, and remove extra subjects if --remove-extra-subjects is specified.
+
+ This is preferred to 'apply' for RBAC resources so that semantically-aware merging of rules and subjects is done.
+
+### Usage
+
+`$ reconcile -f FILENAME`
+
+
+### Example
+ Reconcile rbac resources from a file
+
+```shell
+kubectl auth reconcile -f my-rbac-rules.yaml
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, display results but do not submit changes</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>Filename, directory, or URL to files identifying the resource to reconcile.</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process the kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>remove-extra-permissions</td><td></td><td>false</td><td>If true, removes extra permissions added to roles</td>
+    </tr>
+    <tr>
+    <td>remove-extra-subjects</td><td></td><td>false</td><td>If true, removes extra subjects added to rolebindings</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/auth.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/auth.md
@@ -190,8 +190,11 @@ kubectl auth reconcile -f my-rbac-rules.yaml
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/auth.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/auth.md
@@ -8,7 +8,7 @@ Inspect authorization
 
 ### Usage
 
-`$ auth`
+`auth`
 
 
 
@@ -27,7 +27,7 @@ Check whether an action is allowed.
 
 ### Usage
 
-`$ can-i VERB [TYPE | TYPE/NAME | NONRESOURCEURL]`
+`can-i VERB [TYPE | TYPE/NAME | NONRESOURCEURL]`
 
 
 ### Example
@@ -78,7 +78,7 @@ kubectl auth can-i --list --namespace=foo
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -127,7 +127,7 @@ Reconciles rules for RBAC Role, RoleBinding, ClusterRole, and ClusterRole bindin
 
 ### Usage
 
-`$ reconcile -f FILENAME`
+`reconcile -f FILENAME`
 
 
 ### Example
@@ -142,7 +142,7 @@ kubectl auth reconcile -f my-rbac-rules.yaml
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -184,4 +184,14 @@ kubectl auth reconcile -f my-rbac-rules.yaml
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/auth.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/auth.md
@@ -1,6 +1,7 @@
 ---
 title: auth
-content_template: templates/tool-reference
+noedit: true
+layout: kuberef
 ---
 
 ### Overview

--- a/content/en/docs/reference/kubectl/kubectl-reference/autoscale.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/autoscale.md
@@ -1,6 +1,7 @@
 ---
 title: autoscale
-content_template: templates/tool-reference
+noedit: true
+layout: kuberef
 ---
 
 ### Overview

--- a/content/en/docs/reference/kubectl/kubectl-reference/autoscale.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/autoscale.md
@@ -1,0 +1,92 @@
+---
+title: autoscale
+content_template: templates/tool-reference
+---
+
+### Overview
+Creates an autoscaler that automatically chooses and sets the number of pods that run in a kubernetes cluster.
+
+ Looks up a Deployment, ReplicaSet, StatefulSet, or ReplicationController by name and creates an autoscaler that uses the given resource as a reference. An autoscaler can automatically increase or decrease number of pods deployed within the system as needed.
+
+### Usage
+
+`$ autoscale (-f FILENAME | TYPE NAME | TYPE/NAME) [--min=MINPODS] --max=MAXPODS [--cpu-percent=CPU]`
+
+
+### Example
+
+ Auto scale a deployment "foo", with the number of pods between 2 and 10, no target CPU utilization specified so a default autoscaling policy will be used:
+
+```shell
+kubectl autoscale deployment foo --min=2 --max=10
+```
+
+ Auto scale a replication controller "foo", with the number of pods between 1 and 5, target CPU utilization at 80%:
+
+```shell
+kubectl autoscale rc foo --max=5 --cpu-percent=80
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>cpu-percent</td><td></td><td>-1</td><td>The target average CPU utilization (represented as a percent of requested CPU) over all the pods. If it's not specified or negative, a default autoscaling policy will be used.</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>Filename, directory, or URL to files identifying the resource to autoscale.</td>
+    </tr>
+    <tr>
+    <td>generator</td><td></td><td>horizontalpodautoscaler/v1</td><td>The name of the API generator to use. Currently there is only 1 generator.</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process the kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>max</td><td></td><td>-1</td><td>The upper limit for the number of pods that can be set by the autoscaler. Required.</td>
+    </tr>
+    <tr>
+    <td>min</td><td></td><td>-1</td><td>The lower limit for the number of pods that can be set by the autoscaler. If it's not specified or negative, the server will apply a default value.</td>
+    </tr>
+    <tr>
+    <td>name</td><td></td><td></td><td>The name for the newly created object. If not specified, the name of the input resource will be used.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>record</td><td></td><td>false</td><td>Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>save-config</td><td></td><td>false</td><td>If true, the configuration of current object will be saved in its annotation. Otherwise, the annotation will be unchanged. This flag is useful when you want to perform kubectl apply on this object in the future.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/autoscale.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/autoscale.md
@@ -95,8 +95,11 @@ kubectl autoscale rc foo --max=5 --cpu-percent=80
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/autoscale.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/autoscale.md
@@ -10,7 +10,7 @@ Creates an autoscaler that automatically chooses and sets the number of pods tha
 
 ### Usage
 
-`$ autoscale (-f FILENAME | TYPE NAME | TYPE/NAME) [--min=MINPODS] --max=MAXPODS [--cpu-percent=CPU]`
+`autoscale (-f FILENAME | TYPE NAME | TYPE/NAME) [--min=MINPODS] --max=MAXPODS [--cpu-percent=CPU]`
 
 
 ### Example
@@ -89,4 +89,14 @@ kubectl autoscale rc foo --max=5 --cpu-percent=80
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/certificate.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/certificate.md
@@ -8,7 +8,7 @@ Modify certificate resources.
 
 ### Usage
 
-`$ certificate SUBCOMMAND`
+`certificate SUBCOMMAND`
 
 
 
@@ -29,14 +29,14 @@ Approve a certificate signing request.
 
 ### Usage
 
-`$ approve (-f FILENAME | NAME)`
+`approve (-f FILENAME | NAME)`
 
 
 
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -85,14 +85,14 @@ Deny a certificate signing request.
 
 ### Usage
 
-`$ deny (-f FILENAME | NAME)`
+`deny (-f FILENAME | NAME)`
 
 
 
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -128,4 +128,14 @@ Deny a certificate signing request.
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/certificate.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/certificate.md
@@ -1,6 +1,7 @@
 ---
 title: certificate
-content_template: templates/tool-reference
+noedit: true
+layout: kuberef
 ---
 
 ### Overview

--- a/content/en/docs/reference/kubectl/kubectl-reference/certificate.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/certificate.md
@@ -134,8 +134,11 @@ Deny a certificate signing request.
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/certificate.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/certificate.md
@@ -1,0 +1,131 @@
+---
+title: certificate
+content_template: templates/tool-reference
+---
+
+### Overview
+Modify certificate resources.
+
+### Usage
+
+`$ certificate SUBCOMMAND`
+
+
+
+
+
+
+<hr>
+
+## approve
+
+
+### Overview
+Approve a certificate signing request.
+
+ kubectl certificate approve allows a cluster admin to approve a certificate signing request (CSR). This action tells a certificate signing controller to issue a certificate to the requestor with the attributes requested in the CSR.
+
+ SECURITY NOTICE: Depending on the requested attributes, the issued certificate can potentially grant a requester access to cluster resources or to authenticate as a requested identity. Before approving a CSR, ensure you understand what the signed certificate can do.
+
+### Usage
+
+`$ approve (-f FILENAME | NAME)`
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>Filename, directory, or URL to files identifying the resource to update</td>
+    </tr>
+    <tr>
+    <td>force</td><td></td><td>false</td><td>Update the CSR even if it is already approved.</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process the kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## deny
+
+
+### Overview
+Deny a certificate signing request.
+
+ kubectl certificate deny allows a cluster admin to deny a certificate signing request (CSR). This action tells a certificate signing controller to not to issue a certificate to the requestor.
+
+### Usage
+
+`$ deny (-f FILENAME | NAME)`
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>Filename, directory, or URL to files identifying the resource to update</td>
+    </tr>
+    <tr>
+    <td>force</td><td></td><td>false</td><td>Update the CSR even if it is already denied.</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process the kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/cluster-info.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/cluster-info.md
@@ -111,8 +111,11 @@ kubectl cluster-info dump --namespaces default,kube-system --output-directory=/p
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/cluster-info.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/cluster-info.md
@@ -8,7 +8,7 @@ Display addresses of the master and services with label kubernetes.io/cluster-se
 
 ### Usage
 
-`$ cluster-info`
+`cluster-info`
 
 
 ### Example
@@ -36,7 +36,7 @@ Dumps cluster info out suitable for debugging and diagnosing cluster problems.  
 
 ### Usage
 
-`$ dump`
+`dump`
 
 
 ### Example
@@ -69,7 +69,7 @@ kubectl cluster-info dump --namespaces default,kube-system --output-directory=/p
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -105,4 +105,14 @@ kubectl cluster-info dump --namespaces default,kube-system --output-directory=/p
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/cluster-info.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/cluster-info.md
@@ -1,0 +1,108 @@
+---
+title: cluster-info
+content_template: templates/tool-reference
+---
+
+### Overview
+Display addresses of the master and services with label kubernetes.io/cluster-service=true To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
+
+### Usage
+
+`$ cluster-info`
+
+
+### Example
+
+ Print the address of the master and cluster services
+
+```shell
+kubectl cluster-info
+```
+
+
+
+
+
+
+<hr>
+
+## dump
+
+
+### Overview
+Dumps cluster info out suitable for debugging and diagnosing cluster problems.  By default, dumps everything to stdout. You can optionally specify a directory with --output-directory.  If you specify a directory, kubernetes will build a set of files in that directory.  By default only dumps things in the 'kube-system' namespace, but you can switch to a different namespace with the --namespaces flag, or specify --all-namespaces to dump all namespaces.
+
+ The command also dumps the logs of all of the pods in the cluster, these logs are dumped into different directories based on namespace and pod name.
+
+### Usage
+
+`$ dump`
+
+
+### Example
+ Dump current cluster state to stdout
+
+```shell
+kubectl cluster-info dump
+```
+
+ Dump current cluster state to /path/to/cluster-state
+
+```shell
+kubectl cluster-info dump --output-directory=/path/to/cluster-state
+```
+
+ Dump all namespaces to stdout
+
+```shell
+kubectl cluster-info dump --all-namespaces
+```
+
+ Dump a set of namespaces to /path/to/cluster-state
+
+```shell
+kubectl cluster-info dump --namespaces default,kube-system --output-directory=/path/to/cluster-state
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>all-namespaces</td><td>A</td><td>false</td><td>If true, dump all namespaces.  If true, --namespaces is ignored.</td>
+    </tr>
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>namespaces</td><td></td><td>[]</td><td>A comma separated list of namespaces to dump.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td>json</td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>output-directory</td><td></td><td></td><td>Where to output the files.  If empty or '-' uses stdout, otherwise creates a directory hierarchy in that directory</td>
+    </tr>
+    <tr>
+    <td>pod-running-timeout</td><td></td><td>20s</td><td>The length of time (like 5s, 2m, or 3h, higher than zero) to wait until at least one pod is running</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/completion.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/completion.md
@@ -1,0 +1,75 @@
+---
+title: completion
+content_template: templates/tool-reference
+---
+
+### Overview
+Output shell completion code for the specified shell (bash or zsh). The shell code must be evaluated to provide interactive completion of kubectl commands.  This can be done by sourcing it from the .bash_profile.
+
+ Detailed instructions on how to do this are available here: https://kubernetes.io/docs/tasks/tools/install-kubectl/#enabling-shell-autocompletion
+
+ Note for zsh users: [1] zsh completions are only supported in versions of zsh >= 5.2
+
+### Usage
+
+`$ completion SHELL`
+
+
+### Example
+
+ Installing bash completion on macOS using homebrew ## If running Bash 3.2 included with macOS
+
+```shell
+brew install bash-completion
+```
+
+# or, if running Bash 4.1+
+
+```shell
+brew install bash-completion@2
+```
+
+# If kubectl is installed via homebrew, this should start working immediately. ## If you've installed via other means, you may need add the completion to your completion directory
+
+```shell
+kubectl completion bash > $(brew --prefix)/etc/bash_completion.d/kubectl
+```
+
+ Installing bash completion on Linux ## If bash-completion is not installed on Linux, please install the 'bash-completion' package ## via your distribution's package manager. ## Load the kubectl completion code for bash into the current shell
+
+```shell
+source <(kubectl completion bash)
+```
+
+# Write bash completion code to a file and source if from .bash_profile
+
+```shell
+kubectl completion bash > ~/.kube/completion.bash.inc
+printf "
+```
+
+ Kubectl shell completion
+
+```shell
+source '$HOME/.kube/completion.bash.inc'
+" >> $HOME/.bash_profile
+source $HOME/.bash_profile
+```
+
+ Load the kubectl completion code for zsh[1] into the current shell
+
+```shell
+source <(kubectl completion zsh)
+```
+
+ Set the kubectl completion code for zsh[1] to autoload on startup
+
+```shell
+kubectl completion zsh > "${fpath[1]}/_kubectl"
+```
+
+
+
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/completion.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/completion.md
@@ -78,8 +78,11 @@ kubectl completion zsh > "${fpath[1]}/_kubectl"
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/completion.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/completion.md
@@ -12,7 +12,7 @@ Output shell completion code for the specified shell (bash or zsh). The shell co
 
 ### Usage
 
-`$ completion SHELL`
+`completion SHELL`
 
 
 ### Example
@@ -72,4 +72,14 @@ kubectl completion zsh > "${fpath[1]}/_kubectl"
 
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/config.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/config.md
@@ -1,6 +1,7 @@
 ---
 title: config
-content_template: templates/tool-reference
+noedit: true
+layout: kuberef
 ---
 
 ### Overview

--- a/content/en/docs/reference/kubectl/kubectl-reference/config.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/config.md
@@ -14,7 +14,7 @@ Modify kubeconfig files using subcommands like "kubectl config set current-conte
 
 ### Usage
 
-`$ config SUBCOMMAND`
+`config SUBCOMMAND`
 
 
 
@@ -31,7 +31,7 @@ Displays the current-context
 
 ### Usage
 
-`$ current-context`
+`current-context`
 
 
 ### Example
@@ -56,7 +56,7 @@ Delete the specified cluster from the kubeconfig
 
 ### Usage
 
-`$ delete-cluster NAME`
+`delete-cluster NAME`
 
 
 ### Example
@@ -81,7 +81,7 @@ Delete the specified context from the kubeconfig
 
 ### Usage
 
-`$ delete-context NAME`
+`delete-context NAME`
 
 
 ### Example
@@ -106,7 +106,7 @@ Display clusters defined in the kubeconfig.
 
 ### Usage
 
-`$ get-clusters`
+`get-clusters`
 
 
 ### Example
@@ -131,7 +131,7 @@ Displays one or many contexts from the kubeconfig file.
 
 ### Usage
 
-`$ get-contexts [(-o|--output=)name)]`
+`get-contexts [(-o|--output=)name)]`
 
 
 ### Example
@@ -152,7 +152,7 @@ kubectl config get-contexts my-context
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -190,7 +190,7 @@ Renames a context from the kubeconfig file.
 
 ### Usage
 
-`$ rename-context CONTEXT_NAME NEW_NAME`
+`rename-context CONTEXT_NAME NEW_NAME`
 
 
 ### Example
@@ -221,7 +221,7 @@ Sets an individual value in a kubeconfig file
 
 ### Usage
 
-`$ set PROPERTY_NAME PROPERTY_VALUE`
+`set PROPERTY_NAME PROPERTY_VALUE`
 
 
 ### Example
@@ -254,7 +254,7 @@ kubectl config set users.cluster-admin.client-key-data cert_data_here --set-raw-
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -285,7 +285,7 @@ Sets a cluster entry in kubeconfig.
 
 ### Usage
 
-`$ set-cluster NAME [--server=server] [--certificate-authority=path/to/certificate/authority] [--insecure-skip-tls-verify=true]`
+`set-cluster NAME [--server=server] [--certificate-authority=path/to/certificate/authority] [--insecure-skip-tls-verify=true]`
 
 
 ### Example
@@ -312,7 +312,7 @@ kubectl config set-cluster e2e --insecure-skip-tls-verify=true
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -343,7 +343,7 @@ Sets a context entry in kubeconfig
 
 ### Usage
 
-`$ set-context [NAME | --current] [--cluster=cluster_nickname] [--user=user_nickname] [--namespace=namespace]`
+`set-context [NAME | --current] [--cluster=cluster_nickname] [--user=user_nickname] [--namespace=namespace]`
 
 
 ### Example
@@ -358,7 +358,7 @@ kubectl config set-context gce --user=cluster-admin
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -400,7 +400,7 @@ Sets a user entry in kubeconfig
 
 ### Usage
 
-`$ set-credentials NAME [--client-certificate=path/to/certfile] [--client-key=path/to/keyfile] [--token=bearer_token] [--username=basic_user] [--password=basic_password] [--auth-provider=provider_name] [--auth-provider-arg=key=value] [--exec-command=exec_command] [--exec-api-version=exec_api_version] [--exec-arg=arg] [--exec-env=key=value]`
+`set-credentials NAME [--client-certificate=path/to/certfile] [--client-key=path/to/keyfile] [--token=bearer_token] [--username=basic_user] [--password=basic_password] [--auth-provider=provider_name] [--auth-provider-arg=key=value] [--exec-command=exec_command] [--exec-api-version=exec_api_version] [--exec-arg=arg] [--exec-env=key=value]`
 
 
 ### Example
@@ -469,7 +469,7 @@ kubectl config set-credentials cluster-admin --exec-env=var-to-remove-
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -518,7 +518,7 @@ Unsets an individual value in a kubeconfig file
 
 ### Usage
 
-`$ unset PROPERTY_NAME`
+`unset PROPERTY_NAME`
 
 
 ### Example
@@ -549,7 +549,7 @@ Sets the current-context in a kubeconfig file
 
 ### Usage
 
-`$ use-context CONTEXT_NAME`
+`use-context CONTEXT_NAME`
 
 
 ### Example
@@ -576,7 +576,7 @@ Display merged kubeconfig settings or a specified kubeconfig file.
 
 ### Usage
 
-`$ view`
+`view`
 
 
 ### Example
@@ -603,7 +603,7 @@ kubectl config view -o jsonpath='{.users[?(@.name == "e2e")].user.password}'
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -639,4 +639,14 @@ kubectl config view -o jsonpath='{.users[?(@.name == "e2e")].user.password}'
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/config.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/config.md
@@ -1,0 +1,642 @@
+---
+title: config
+content_template: templates/tool-reference
+---
+
+### Overview
+Modify kubeconfig files using subcommands like "kubectl config set current-context my-context"
+
+ The loading order follows these rules:
+
+  1.  If the --kubeconfig flag is set, then only that file is loaded. The flag may only be set once and no merging takes place.
+  2.  If $KUBECONFIG environment variable is set, then it is used as a list of paths (normal path delimiting rules for your system). These paths are merged. When a value is modified, it is modified in the file that defines the stanza. When a value is created, it is created in the first file that exists. If no files in the chain exist, then it creates the last file in the list.
+  3.  Otherwise, ${HOME}/.kube/config is used and no merging takes place.
+
+### Usage
+
+`$ config SUBCOMMAND`
+
+
+
+
+
+
+<hr>
+
+## current-context
+
+
+### Overview
+Displays the current-context
+
+### Usage
+
+`$ current-context`
+
+
+### Example
+ Display the current-context
+
+```shell
+kubectl config current-context
+```
+
+
+
+
+
+
+<hr>
+
+## delete-cluster
+
+
+### Overview
+Delete the specified cluster from the kubeconfig
+
+### Usage
+
+`$ delete-cluster NAME`
+
+
+### Example
+ Delete the minikube cluster
+
+```shell
+kubectl config delete-cluster minikube
+```
+
+
+
+
+
+
+<hr>
+
+## delete-context
+
+
+### Overview
+Delete the specified context from the kubeconfig
+
+### Usage
+
+`$ delete-context NAME`
+
+
+### Example
+ Delete the context for the minikube cluster
+
+```shell
+kubectl config delete-context minikube
+```
+
+
+
+
+
+
+<hr>
+
+## get-clusters
+
+
+### Overview
+Display clusters defined in the kubeconfig.
+
+### Usage
+
+`$ get-clusters`
+
+
+### Example
+ List the clusters kubectl knows about
+
+```shell
+kubectl config get-clusters
+```
+
+
+
+
+
+
+<hr>
+
+## get-contexts
+
+
+### Overview
+Displays one or many contexts from the kubeconfig file.
+
+### Usage
+
+`$ get-contexts [(-o|--output=)name)]`
+
+
+### Example
+ List all the contexts in your kubeconfig file
+
+```shell
+kubectl config get-contexts
+```
+
+ Describe one context in your kubeconfig file.
+
+```shell
+kubectl config get-contexts my-context
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>no-headers</td><td></td><td>false</td><td>When using the default or custom-column output format, don't print headers (default print headers).</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: name</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## rename-context
+
+
+### Overview
+Renames a context from the kubeconfig file.
+
+ CONTEXT_NAME is the context name that you wish to change.
+
+ NEW_NAME is the new name you wish to set.
+
+ Note: In case the context being renamed is the 'current-context', this field will also be updated.
+
+### Usage
+
+`$ rename-context CONTEXT_NAME NEW_NAME`
+
+
+### Example
+ Rename the context 'old-name' to 'new-name' in your kubeconfig file
+
+```shell
+kubectl config rename-context old-name new-name
+```
+
+
+
+
+
+
+<hr>
+
+## set
+
+
+### Overview
+Sets an individual value in a kubeconfig file
+
+ PROPERTY_NAME is a dot delimited name where each token represents either an attribute name or a map key.  Map keys may not contain dots.
+
+ PROPERTY_VALUE is the new value you wish to set. Binary fields such as 'certificate-authority-data' expect a base64 encoded string unless the --set-raw-bytes flag is used.
+
+ Specifying a attribute name that already exists will merge new fields on top of existing values.
+
+### Usage
+
+`$ set PROPERTY_NAME PROPERTY_VALUE`
+
+
+### Example
+ Set server field on the my-cluster cluster to https://1.2.3.4
+
+```shell
+kubectl config set clusters.my-cluster.server https://1.2.3.4
+```
+
+ Set certificate-authority-data field on the my-cluster cluster.
+
+```shell
+kubectl config set clusters.my-cluster.certificate-authority-data $(echo "cert_data_here" | base64 -i -)
+```
+
+ Set cluster field in the my-context context to my-cluster.
+
+```shell
+kubectl config set contexts.my-context.cluster my-cluster
+```
+
+ Set client-key-data field in the cluster-admin user using --set-raw-bytes option.
+
+```shell
+kubectl config set users.cluster-admin.client-key-data cert_data_here --set-raw-bytes=true
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>set-raw-bytes</td><td></td><td>false</td><td>When writing a []byte PROPERTY_VALUE, write the given string directly without base64 decoding.</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## set-cluster
+
+
+### Overview
+Sets a cluster entry in kubeconfig.
+
+ Specifying a name that already exists will merge new fields on top of existing values for those fields.
+
+### Usage
+
+`$ set-cluster NAME [--server=server] [--certificate-authority=path/to/certificate/authority] [--insecure-skip-tls-verify=true]`
+
+
+### Example
+ Set only the server field on the e2e cluster entry without touching other values.
+
+```shell
+kubectl config set-cluster e2e --server=https://1.2.3.4
+```
+
+ Embed certificate authority data for the e2e cluster entry
+
+```shell
+kubectl config set-cluster e2e --certificate-authority=~/.kube/e2e/kubernetes.ca.crt
+```
+
+ Disable cert checking for the dev cluster entry
+
+```shell
+kubectl config set-cluster e2e --insecure-skip-tls-verify=true
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>embed-certs</td><td></td><td>false</td><td>embed-certs for the cluster entry in kubeconfig</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## set-context
+
+
+### Overview
+Sets a context entry in kubeconfig
+
+ Specifying a name that already exists will merge new fields on top of existing values for those fields.
+
+### Usage
+
+`$ set-context [NAME | --current] [--cluster=cluster_nickname] [--user=user_nickname] [--namespace=namespace]`
+
+
+### Example
+ Set the user field on the gce context entry without touching other values
+
+```shell
+kubectl config set-context gce --user=cluster-admin
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>current</td><td></td><td>false</td><td>Modify the current context</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## set-credentials
+
+
+### Overview
+Sets a user entry in kubeconfig
+
+ Specifying a name that already exists will merge new fields on top of existing values.
+
+  Client-certificate flags:
+  --client-certificate=certfile --client-key=keyfile
+  
+  Bearer token flags:
+  --token=bearer_token
+  
+  Basic auth flags:
+  --username=basic_user --password=basic_password
+  
+ Bearer token and basic auth are mutually exclusive.
+
+### Usage
+
+`$ set-credentials NAME [--client-certificate=path/to/certfile] [--client-key=path/to/keyfile] [--token=bearer_token] [--username=basic_user] [--password=basic_password] [--auth-provider=provider_name] [--auth-provider-arg=key=value] [--exec-command=exec_command] [--exec-api-version=exec_api_version] [--exec-arg=arg] [--exec-env=key=value]`
+
+
+### Example
+ Set only the "client-key" field on the "cluster-admin" # entry, without touching other values:
+
+```shell
+kubectl config set-credentials cluster-admin --client-key=~/.kube/admin.key
+```
+
+ Set basic auth for the "cluster-admin" entry
+
+```shell
+kubectl config set-credentials cluster-admin --username=admin --password=uXFGweU9l35qcif
+```
+
+ Embed client certificate data in the "cluster-admin" entry
+
+```shell
+kubectl config set-credentials cluster-admin --client-certificate=~/.kube/admin.crt --embed-certs=true
+```
+
+ Enable the Google Compute Platform auth provider for the "cluster-admin" entry
+
+```shell
+kubectl config set-credentials cluster-admin --auth-provider=gcp
+```
+
+ Enable the OpenID Connect auth provider for the "cluster-admin" entry with additional args
+
+```shell
+kubectl config set-credentials cluster-admin --auth-provider=oidc --auth-provider-arg=client-id=foo --auth-provider-arg=client-secret=bar
+```
+
+ Remove the "client-secret" config value for the OpenID Connect auth provider for the "cluster-admin" entry
+
+```shell
+kubectl config set-credentials cluster-admin --auth-provider=oidc --auth-provider-arg=client-secret-
+```
+
+ Enable new exec auth plugin for the "cluster-admin" entry
+
+```shell
+kubectl config set-credentials cluster-admin --exec-command=/path/to/the/executable --exec-api-version=client.authentication.k8s.io/v1beta
+```
+
+ Define new exec auth plugin args for the "cluster-admin" entry
+
+```shell
+kubectl config set-credentials cluster-admin --exec-arg=arg1 --exec-arg=arg2
+```
+
+ Create or update exec auth plugin environment variables for the "cluster-admin" entry
+
+```shell
+kubectl config set-credentials cluster-admin --exec-env=key1=val1 --exec-env=key2=val2
+```
+
+ Remove exec auth plugin environment variables for the "cluster-admin" entry
+
+```shell
+kubectl config set-credentials cluster-admin --exec-env=var-to-remove-
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>auth-provider</td><td></td><td></td><td>Auth provider for the user entry in kubeconfig</td>
+    </tr>
+    <tr>
+    <td>auth-provider-arg</td><td></td><td>[]</td><td>'key=value' arguments for the auth provider</td>
+    </tr>
+    <tr>
+    <td>embed-certs</td><td></td><td>false</td><td>Embed client cert/key for the user entry in kubeconfig</td>
+    </tr>
+    <tr>
+    <td>exec-api-version</td><td></td><td></td><td>API version of the exec credential plugin for the user entry in kubeconfig</td>
+    </tr>
+    <tr>
+    <td>exec-arg</td><td></td><td>[]</td><td>New arguments for the exec credential plugin command for the user entry in kubeconfig</td>
+    </tr>
+    <tr>
+    <td>exec-command</td><td></td><td></td><td>Command for the exec credential plugin for the user entry in kubeconfig</td>
+    </tr>
+    <tr>
+    <td>exec-env</td><td></td><td>[]</td><td>'key=value' environment values for the exec credential plugin</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## unset
+
+
+### Overview
+Unsets an individual value in a kubeconfig file
+
+ PROPERTY_NAME is a dot delimited name where each token represents either an attribute name or a map key.  Map keys may not contain dots.
+
+### Usage
+
+`$ unset PROPERTY_NAME`
+
+
+### Example
+ Unset the current-context.
+
+```shell
+kubectl config unset current-context
+```
+
+ Unset namespace in foo context.
+
+```shell
+kubectl config unset contexts.foo.namespace
+```
+
+
+
+
+
+
+<hr>
+
+## use-context
+
+
+### Overview
+Sets the current-context in a kubeconfig file
+
+### Usage
+
+`$ use-context CONTEXT_NAME`
+
+
+### Example
+ Use the context for the minikube cluster
+
+```shell
+kubectl config use-context minikube
+```
+
+
+
+
+
+
+<hr>
+
+## view
+
+
+### Overview
+Display merged kubeconfig settings or a specified kubeconfig file.
+
+ You can use --output jsonpath={...} to extract specific values using a jsonpath expression.
+
+### Usage
+
+`$ view`
+
+
+### Example
+ Show merged kubeconfig settings.
+
+```shell
+kubectl config view
+```
+
+ Show merged kubeconfig settings and raw certificate data.
+
+```shell
+kubectl config view --raw
+```
+
+ Get the password for the e2e user
+
+```shell
+kubectl config view -o jsonpath='{.users[?(@.name == "e2e")].user.password}'
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>flatten</td><td></td><td>false</td><td>Flatten the resulting kubeconfig file into self-contained output (useful for creating portable kubeconfig files)</td>
+    </tr>
+    <tr>
+    <td>merge</td><td></td><td>true</td><td>Merge the full hierarchy of kubeconfig files</td>
+    </tr>
+    <tr>
+    <td>minify</td><td></td><td>false</td><td>Remove all information not used by current-context from the output</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td>yaml</td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>raw</td><td></td><td>false</td><td>Display raw byte data</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/config.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/config.md
@@ -645,8 +645,11 @@ kubectl config view -o jsonpath='{.users[?(@.name == "e2e")].user.password}'
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/convert.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/convert.md
@@ -12,7 +12,7 @@ Convert config files between different API versions. Both YAML and JSON formats 
 
 ### Usage
 
-`$ convert -f FILENAME`
+`convert -f FILENAME`
 
 
 ### Example
@@ -82,4 +82,14 @@ kubectl convert -f . | kubectl create -f -
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/convert.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/convert.md
@@ -88,8 +88,11 @@ kubectl convert -f . | kubectl create -f -
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/convert.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/convert.md
@@ -1,0 +1,85 @@
+---
+title: convert
+content_template: templates/tool-reference
+---
+
+### Overview
+Convert config files between different API versions. Both YAML and JSON formats are accepted.
+
+ The command takes filename, directory, or URL as input, and convert it into format of version specified by --output-version flag. If target version is not specified or not supported, convert to latest version.
+
+ The default output will be printed to stdout in YAML format. One can use -o option to change to output destination.
+
+### Usage
+
+`$ convert -f FILENAME`
+
+
+### Example
+
+ Convert 'pod.yaml' to latest version and print to stdout.
+
+```shell
+kubectl convert -f pod.yaml
+```
+
+ Convert the live state of the resource specified by 'pod.yaml' to the latest version # and print to stdout in JSON format.
+
+```shell
+kubectl convert -f pod.yaml --local -o json
+```
+
+ Convert all files under current directory to latest version and create them all.
+
+```shell
+kubectl convert -f . | kubectl create -f -
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>Filename, directory, or URL to files to need to get converted.</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process the kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>local</td><td></td><td>true</td><td>If true, convert will NOT try to contact api-server but run locally.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td>yaml</td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>output-version</td><td></td><td></td><td>Output the formatted object with the given group version (for ex: 'extensions/v1beta1').</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>validate</td><td></td><td>true</td><td>If true, use a schema to validate the input before sending it</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/cordon.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/cordon.md
@@ -8,7 +8,7 @@ Mark node as unschedulable.
 
 ### Usage
 
-`$ cordon NODE`
+`cordon NODE`
 
 
 ### Example
@@ -45,4 +45,14 @@ kubectl cordon foo
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/cordon.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/cordon.md
@@ -51,8 +51,11 @@ kubectl cordon foo
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/cordon.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/cordon.md
@@ -1,0 +1,48 @@
+---
+title: cordon
+content_template: templates/tool-reference
+---
+
+### Overview
+Mark node as unschedulable.
+
+### Usage
+
+`$ cordon NODE`
+
+
+### Example
+
+ Mark node "foo" as unschedulable.
+
+```shell
+kubectl cordon foo
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>selector</td><td>l</td><td></td><td>Selector (label query) to filter on</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/cp.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/cp.md
@@ -8,7 +8,7 @@ Copy files and directories to and from containers.
 
 ### Usage
 
-`$ cp <file-spec-src> <file-spec-dest>`
+`cp <file-spec-src> <file-spec-dest>`
 
 
 ### Example
@@ -63,4 +63,14 @@ kubectl cp <some-namespace>/<some-pod>:/tmp/foo /tmp/bar
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/cp.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/cp.md
@@ -1,6 +1,7 @@
 ---
 title: cp
-content_template: templates/tool-reference
+noedit: true
+layout: kuberef
 ---
 
 ### Overview

--- a/content/en/docs/reference/kubectl/kubectl-reference/cp.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/cp.md
@@ -69,8 +69,11 @@ kubectl cp <some-namespace>/<some-pod>:/tmp/foo /tmp/bar
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/cp.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/cp.md
@@ -1,0 +1,66 @@
+---
+title: cp
+content_template: templates/tool-reference
+---
+
+### Overview
+Copy files and directories to and from containers.
+
+### Usage
+
+`$ cp <file-spec-src> <file-spec-dest>`
+
+
+### Example
+
+ !!!Important Note!!! # Requires that the 'tar' binary is present in your container # image.  If 'tar' is not present, 'kubectl cp' will fail. # Copy /tmp/foo_dir local directory to /tmp/bar_dir in a remote pod in the default namespace
+
+```shell
+kubectl cp /tmp/foo_dir <some-pod>:/tmp/bar_dir
+```
+
+ Copy /tmp/foo local file to /tmp/bar in a remote pod in a specific container
+
+```shell
+kubectl cp /tmp/foo <some-pod>:/tmp/bar -c <specific-container>
+```
+
+ Copy /tmp/foo local file to /tmp/bar in a remote pod in namespace <some-namespace>
+
+```shell
+kubectl cp /tmp/foo <some-namespace>/<some-pod>:/tmp/bar
+```
+
+ Copy /tmp/foo from a remote pod to /tmp/bar locally
+
+```shell
+kubectl cp <some-namespace>/<some-pod>:/tmp/foo /tmp/bar
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>container</td><td>c</td><td></td><td>Container name. If omitted, the first container in the pod will be chosen</td>
+    </tr>
+    <tr>
+    <td>no-preserve</td><td></td><td>false</td><td>The copied file/directory's ownership and permissions will not be preserved in the container</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/create.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/create.md
@@ -1,0 +1,1702 @@
+---
+title: create
+content_template: templates/tool-reference
+---
+
+### Overview
+Create a resource from a file or from stdin.
+
+ JSON and YAML formats are accepted.
+
+### Usage
+
+`$ create -f FILENAME`
+
+
+### Example
+
+ Create a pod using the data in pod.json.
+
+```shell
+kubectl create -f ./pod.json
+```
+
+ Create a pod based on the JSON passed into stdin.
+
+```shell
+cat pod.json | kubectl create -f -
+```
+
+ Edit the data in docker-registry.yaml in JSON then create the resource using the edited data.
+
+```shell
+kubectl create -f docker-registry.yaml --edit -o json
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>edit</td><td></td><td>false</td><td>Edit the API resource before creating</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>Filename, directory, or URL to files to use to create the resource</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process the kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>raw</td><td></td><td></td><td>Raw URI to POST to the server.  Uses the transport specified by the kubeconfig file.</td>
+    </tr>
+    <tr>
+    <td>record</td><td></td><td>false</td><td>Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>save-config</td><td></td><td>false</td><td>If true, the configuration of current object will be saved in its annotation. Otherwise, the annotation will be unchanged. This flag is useful when you want to perform kubectl apply on this object in the future.</td>
+    </tr>
+    <tr>
+    <td>selector</td><td>l</td><td></td><td>Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>validate</td><td></td><td>true</td><td>If true, use a schema to validate the input before sending it</td>
+    </tr>
+    <tr>
+    <td>windows-line-endings</td><td></td><td>false</td><td>Only relevant if --edit=true. Defaults to the line ending native to your platform.</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## clusterrole
+
+
+### Overview
+Create a ClusterRole.
+
+### Usage
+
+`$ clusterrole NAME --verb=verb --resource=resource.group [--resource-name=resourcename] [--dry-run]`
+
+
+### Example
+ Create a ClusterRole named "pod-reader" that allows user to perform "get", "watch" and "list" on pods
+
+```shell
+kubectl create clusterrole pod-reader --verb=get,list,watch --resource=pods
+```
+
+ Create a ClusterRole named "pod-reader" with ResourceName specified
+
+```shell
+kubectl create clusterrole pod-reader --verb=get --resource=pods --resource-name=readablepod --resource-name=anotherpod
+```
+
+ Create a ClusterRole named "foo" with API Group specified
+
+```shell
+kubectl create clusterrole foo --verb=get,list,watch --resource=rs.extensions
+```
+
+ Create a ClusterRole named "foo" with SubResource specified
+
+```shell
+kubectl create clusterrole foo --verb=get,list,watch --resource=pods,pods/status
+```
+
+ Create a ClusterRole name "foo" with NonResourceURL specified
+
+```shell
+kubectl create clusterrole "foo" --verb=get --non-resource-url=/logs/*
+```
+
+ Create a ClusterRole name "monitoring" with AggregationRule specified
+
+```shell
+kubectl create clusterrole monitoring --aggregation-rule="rbac.example.com/aggregate-to-monitoring=true"
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>aggregation-rule</td><td></td><td></td><td>An aggregation label selector for combining ClusterRoles.</td>
+    </tr>
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>non-resource-url</td><td></td><td>[]</td><td>A partial url that user should have access to.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>resource</td><td></td><td>[]</td><td>Resource that the rule applies to</td>
+    </tr>
+    <tr>
+    <td>resource-name</td><td></td><td>[]</td><td>Resource in the white list that the rule applies to, repeat this flag for multiple items</td>
+    </tr>
+    <tr>
+    <td>save-config</td><td></td><td>false</td><td>If true, the configuration of current object will be saved in its annotation. Otherwise, the annotation will be unchanged. This flag is useful when you want to perform kubectl apply on this object in the future.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>validate</td><td></td><td>true</td><td>If true, use a schema to validate the input before sending it</td>
+    </tr>
+    <tr>
+    <td>verb</td><td></td><td>[]</td><td>Verb that applies to the resources contained in the rule</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## clusterrolebinding
+
+
+### Overview
+Create a ClusterRoleBinding for a particular ClusterRole.
+
+### Usage
+
+`$ clusterrolebinding NAME --clusterrole=NAME [--user=username] [--group=groupname] [--serviceaccount=namespace:serviceaccountname] [--dry-run]`
+
+
+### Example
+ Create a ClusterRoleBinding for user1, user2, and group1 using the cluster-admin ClusterRole
+
+```shell
+kubectl create clusterrolebinding cluster-admin --clusterrole=cluster-admin --user=user1 --user=user2 --group=group1
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>clusterrole</td><td></td><td></td><td>ClusterRole this ClusterRoleBinding should reference</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>generator</td><td></td><td>clusterrolebinding.rbac.authorization.k8s.io/v1alpha1</td><td>The name of the API generator to use.</td>
+    </tr>
+    <tr>
+    <td>group</td><td></td><td>[]</td><td>Groups to bind to the clusterrole</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>save-config</td><td></td><td>false</td><td>If true, the configuration of current object will be saved in its annotation. Otherwise, the annotation will be unchanged. This flag is useful when you want to perform kubectl apply on this object in the future.</td>
+    </tr>
+    <tr>
+    <td>serviceaccount</td><td></td><td>[]</td><td>Service accounts to bind to the clusterrole, in the format <namespace>:<name></td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>validate</td><td></td><td>true</td><td>If true, use a schema to validate the input before sending it</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## configmap
+
+
+### Overview
+Create a configmap based on a file, directory, or specified literal value.
+
+ A single configmap may package one or more key/value pairs.
+
+ When creating a configmap based on a file, the key will default to the basename of the file, and the value will default to the file content.  If the basename is an invalid key, you may specify an alternate key.
+
+ When creating a configmap based on a directory, each file whose basename is a valid key in the directory will be packaged into the configmap.  Any directory entries except regular files are ignored (e.g. subdirectories, symlinks, devices, pipes, etc).
+
+### Usage
+
+`$ configmap NAME [--from-file=[key=]source] [--from-literal=key1=value1] [--dry-run]`
+
+
+### Example
+ Create a new configmap named my-config based on folder bar
+
+```shell
+kubectl create configmap my-config --from-file=path/to/bar
+```
+
+ Create a new configmap named my-config with specified keys instead of file basenames on disk
+
+```shell
+kubectl create configmap my-config --from-file=key1=/path/to/bar/file1.txt --from-file=key2=/path/to/bar/file2.txt
+```
+
+ Create a new configmap named my-config with key1=config1 and key2=config2
+
+```shell
+kubectl create configmap my-config --from-literal=key1=config1 --from-literal=key2=config2
+```
+
+ Create a new configmap named my-config from the key=value pairs in the file
+
+```shell
+kubectl create configmap my-config --from-file=path/to/bar
+```
+
+ Create a new configmap named my-config from an env file
+
+```shell
+kubectl create configmap my-config --from-env-file=path/to/bar.env
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>append-hash</td><td></td><td>false</td><td>Append a hash of the configmap to its name.</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>from-env-file</td><td></td><td></td><td>Specify the path to a file to read lines of key=val pairs to create a configmap (i.e. a Docker .env file).</td>
+    </tr>
+    <tr>
+    <td>from-file</td><td></td><td>[]</td><td>Key file can be specified using its file path, in which case file basename will be used as configmap key, or optionally with a key and file path, in which case the given key will be used.  Specifying a directory will iterate each named file in the directory whose basename is a valid configmap key.</td>
+    </tr>
+    <tr>
+    <td>from-literal</td><td></td><td>[]</td><td>Specify a key and literal value to insert in configmap (i.e. mykey=somevalue)</td>
+    </tr>
+    <tr>
+    <td>generator</td><td></td><td>configmap/v1</td><td>The name of the API generator to use.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>save-config</td><td></td><td>false</td><td>If true, the configuration of current object will be saved in its annotation. Otherwise, the annotation will be unchanged. This flag is useful when you want to perform kubectl apply on this object in the future.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>validate</td><td></td><td>true</td><td>If true, use a schema to validate the input before sending it</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## cronjob
+
+
+### Overview
+Create a cronjob with the specified name.
+
+### Usage
+
+`$ cronjob NAME --image=image --schedule='0/5 * * * ?' -- [COMMAND] [args...]`
+
+
+### Example
+ Create a cronjob
+
+```shell
+kubectl create cronjob my-job --image=busybox
+```
+
+ Create a cronjob with command
+
+```shell
+kubectl create cronjob my-job --image=busybox -- date
+```
+
+ Create a cronjob with schedule
+
+```shell
+kubectl create cronjob test-job --image=busybox --schedule="*/1 * * * *"
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>image</td><td></td><td></td><td>Image name to run.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>restart</td><td></td><td></td><td>job's restart policy. supported values: OnFailure, Never</td>
+    </tr>
+    <tr>
+    <td>save-config</td><td></td><td>false</td><td>If true, the configuration of current object will be saved in its annotation. Otherwise, the annotation will be unchanged. This flag is useful when you want to perform kubectl apply on this object in the future.</td>
+    </tr>
+    <tr>
+    <td>schedule</td><td></td><td></td><td>A schedule in the Cron format the job should be run with.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>validate</td><td></td><td>true</td><td>If true, use a schema to validate the input before sending it</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## deployment
+
+
+### Overview
+Create a deployment with the specified name.
+
+### Usage
+
+`$ deployment NAME --image=image [--dry-run]`
+
+
+### Example
+ Create a new deployment named my-dep that runs the busybox image.
+
+```shell
+kubectl create deployment my-dep --image=busybox
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>generator</td><td></td><td></td><td>The name of the API generator to use.</td>
+    </tr>
+    <tr>
+    <td>image</td><td></td><td>[]</td><td>Image name to run.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>save-config</td><td></td><td>false</td><td>If true, the configuration of current object will be saved in its annotation. Otherwise, the annotation will be unchanged. This flag is useful when you want to perform kubectl apply on this object in the future.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>validate</td><td></td><td>true</td><td>If true, use a schema to validate the input before sending it</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## job
+
+
+### Overview
+Create a job with the specified name.
+
+### Usage
+
+`$ job NAME --image=image [--from=cronjob/name] -- [COMMAND] [args...]`
+
+
+### Example
+ Create a job
+
+```shell
+kubectl create job my-job --image=busybox
+```
+
+ Create a job with command
+
+```shell
+kubectl create job my-job --image=busybox -- date
+```
+
+ Create a job from a CronJob named "a-cronjob"
+
+```shell
+kubectl create job test-job --from=cronjob/a-cronjob
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>from</td><td></td><td></td><td>The name of the resource to create a Job from (only cronjob is supported).</td>
+    </tr>
+    <tr>
+    <td>image</td><td></td><td></td><td>Image name to run.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>save-config</td><td></td><td>false</td><td>If true, the configuration of current object will be saved in its annotation. Otherwise, the annotation will be unchanged. This flag is useful when you want to perform kubectl apply on this object in the future.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>validate</td><td></td><td>true</td><td>If true, use a schema to validate the input before sending it</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## namespace
+
+
+### Overview
+Create a namespace with the specified name.
+
+### Usage
+
+`$ namespace NAME [--dry-run]`
+
+
+### Example
+ Create a new namespace named my-namespace
+
+```shell
+kubectl create namespace my-namespace
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>generator</td><td></td><td>namespace/v1</td><td>The name of the API generator to use.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>save-config</td><td></td><td>false</td><td>If true, the configuration of current object will be saved in its annotation. Otherwise, the annotation will be unchanged. This flag is useful when you want to perform kubectl apply on this object in the future.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>validate</td><td></td><td>true</td><td>If true, use a schema to validate the input before sending it</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## poddisruptionbudget
+
+
+### Overview
+Create a pod disruption budget with the specified name, selector, and desired minimum available pods
+
+### Usage
+
+`$ poddisruptionbudget NAME --selector=SELECTOR --min-available=N [--dry-run]`
+
+
+### Example
+ Create a pod disruption budget named my-pdb that will select all pods with the app=rails label # and require at least one of them being available at any point in time.
+
+```shell
+kubectl create poddisruptionbudget my-pdb --selector=app=rails --min-available=1
+```
+
+ Create a pod disruption budget named my-pdb that will select all pods with the app=nginx label # and require at least half of the pods selected to be available at any point in time.
+
+```shell
+kubectl create pdb my-pdb --selector=app=nginx --min-available=50%
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>generator</td><td></td><td>poddisruptionbudget/v1beta1/v2</td><td>The name of the API generator to use.</td>
+    </tr>
+    <tr>
+    <td>max-unavailable</td><td></td><td></td><td>The maximum number or percentage of unavailable pods this budget requires.</td>
+    </tr>
+    <tr>
+    <td>min-available</td><td></td><td></td><td>The minimum number or percentage of available pods this budget requires.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>save-config</td><td></td><td>false</td><td>If true, the configuration of current object will be saved in its annotation. Otherwise, the annotation will be unchanged. This flag is useful when you want to perform kubectl apply on this object in the future.</td>
+    </tr>
+    <tr>
+    <td>selector</td><td></td><td></td><td>A label selector to use for this budget. Only equality-based selector requirements are supported.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>validate</td><td></td><td>true</td><td>If true, use a schema to validate the input before sending it</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## priorityclass
+
+
+### Overview
+Create a priorityclass with the specified name, value, globalDefault and description
+
+### Usage
+
+`$ priorityclass NAME --value=VALUE --global-default=BOOL [--dry-run]`
+
+
+### Example
+ Create a priorityclass named high-priority
+
+```shell
+kubectl create priorityclass high-priority --value=1000 --description="high priority"
+```
+
+ Create a priorityclass named default-priority that considered as the global default priority
+
+```shell
+kubectl create priorityclass default-priority --value=1000 --global-default=true --description="default priority"
+```
+
+ Create a priorityclass named high-priority that can not preempt pods with lower priority
+
+```shell
+kubectl create priorityclass high-priority --value=1000 --description="high priority" --preemption-policy="Never"
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>description</td><td></td><td></td><td>description is an arbitrary string that usually provides guidelines on when this priority class should be used.</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>generator</td><td></td><td>priorityclass/v1</td><td>The name of the API generator to use.</td>
+    </tr>
+    <tr>
+    <td>global-default</td><td></td><td>false</td><td>global-default specifies whether this PriorityClass should be considered as the default priority.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>preemption-policy</td><td></td><td></td><td>preemption-policy is the policy for preempting pods with lower priority.</td>
+    </tr>
+    <tr>
+    <td>save-config</td><td></td><td>false</td><td>If true, the configuration of current object will be saved in its annotation. Otherwise, the annotation will be unchanged. This flag is useful when you want to perform kubectl apply on this object in the future.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>validate</td><td></td><td>true</td><td>If true, use a schema to validate the input before sending it</td>
+    </tr>
+    <tr>
+    <td>value</td><td></td><td>0</td><td>the value of this priority class.</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## quota
+
+
+### Overview
+Create a resourcequota with the specified name, hard limits and optional scopes
+
+### Usage
+
+`$ quota NAME [--hard=key1=value1,key2=value2] [--scopes=Scope1,Scope2] [--dry-run=bool]`
+
+
+### Example
+ Create a new resourcequota named my-quota
+
+```shell
+kubectl create quota my-quota --hard=cpu=1,memory=1G,pods=2,services=3,replicationcontrollers=2,resourcequotas=1,secrets=5,persistentvolumeclaims=10
+```
+
+ Create a new resourcequota named best-effort
+
+```shell
+kubectl create quota best-effort --hard=pods=100 --scopes=BestEffort
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>generator</td><td></td><td>resourcequotas/v1</td><td>The name of the API generator to use.</td>
+    </tr>
+    <tr>
+    <td>hard</td><td></td><td></td><td>A comma-delimited set of resource=quantity pairs that define a hard limit.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>save-config</td><td></td><td>false</td><td>If true, the configuration of current object will be saved in its annotation. Otherwise, the annotation will be unchanged. This flag is useful when you want to perform kubectl apply on this object in the future.</td>
+    </tr>
+    <tr>
+    <td>scopes</td><td></td><td></td><td>A comma-delimited set of quota scopes that must all match each object tracked by the quota.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>validate</td><td></td><td>true</td><td>If true, use a schema to validate the input before sending it</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## role
+
+
+### Overview
+Create a role with single rule.
+
+### Usage
+
+`$ role NAME --verb=verb --resource=resource.group/subresource [--resource-name=resourcename] [--dry-run]`
+
+
+### Example
+ Create a Role named "pod-reader" that allows user to perform "get", "watch" and "list" on pods
+
+```shell
+kubectl create role pod-reader --verb=get --verb=list --verb=watch --resource=pods
+```
+
+ Create a Role named "pod-reader" with ResourceName specified
+
+```shell
+kubectl create role pod-reader --verb=get --resource=pods --resource-name=readablepod --resource-name=anotherpod
+```
+
+ Create a Role named "foo" with API Group specified
+
+```shell
+kubectl create role foo --verb=get,list,watch --resource=rs.extensions
+```
+
+ Create a Role named "foo" with SubResource specified
+
+```shell
+kubectl create role foo --verb=get,list,watch --resource=pods,pods/status
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>resource</td><td></td><td>[]</td><td>Resource that the rule applies to</td>
+    </tr>
+    <tr>
+    <td>resource-name</td><td></td><td>[]</td><td>Resource in the white list that the rule applies to, repeat this flag for multiple items</td>
+    </tr>
+    <tr>
+    <td>save-config</td><td></td><td>false</td><td>If true, the configuration of current object will be saved in its annotation. Otherwise, the annotation will be unchanged. This flag is useful when you want to perform kubectl apply on this object in the future.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>validate</td><td></td><td>true</td><td>If true, use a schema to validate the input before sending it</td>
+    </tr>
+    <tr>
+    <td>verb</td><td></td><td>[]</td><td>Verb that applies to the resources contained in the rule</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## rolebinding
+
+
+### Overview
+Create a RoleBinding for a particular Role or ClusterRole.
+
+### Usage
+
+`$ rolebinding NAME --clusterrole=NAME|--role=NAME [--user=username] [--group=groupname] [--serviceaccount=namespace:serviceaccountname] [--dry-run]`
+
+
+### Example
+ Create a RoleBinding for user1, user2, and group1 using the admin ClusterRole
+
+```shell
+kubectl create rolebinding admin --clusterrole=admin --user=user1 --user=user2 --group=group1
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>clusterrole</td><td></td><td></td><td>ClusterRole this RoleBinding should reference</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>generator</td><td></td><td>rolebinding.rbac.authorization.k8s.io/v1alpha1</td><td>The name of the API generator to use.</td>
+    </tr>
+    <tr>
+    <td>group</td><td></td><td>[]</td><td>Groups to bind to the role</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>role</td><td></td><td></td><td>Role this RoleBinding should reference</td>
+    </tr>
+    <tr>
+    <td>save-config</td><td></td><td>false</td><td>If true, the configuration of current object will be saved in its annotation. Otherwise, the annotation will be unchanged. This flag is useful when you want to perform kubectl apply on this object in the future.</td>
+    </tr>
+    <tr>
+    <td>serviceaccount</td><td></td><td>[]</td><td>Service accounts to bind to the role, in the format <namespace>:<name></td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>validate</td><td></td><td>true</td><td>If true, use a schema to validate the input before sending it</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## secret
+
+
+### Overview
+Create a secret using specified subcommand.
+
+### Usage
+
+`$ secret`
+
+
+
+
+
+
+<hr>
+
+## secret docker-registry
+
+
+### Overview
+Create a new secret for use with Docker registries.
+  
+  Dockercfg secrets are used to authenticate against Docker registries.
+  
+  When using the Docker command line to push images, you can authenticate to a given registry by running:
+    '$ docker login DOCKER_REGISTRY_SERVER --username=DOCKER_USER --password=DOCKER_PASSWORD --email=DOCKER_EMAIL'.
+  
+ That produces a ~/.dockercfg file that is used by subsequent 'docker push' and 'docker pull' commands to authenticate to the registry. The email address is optional.
+
+  When creating applications, you may have a Docker registry that requires authentication.  In order for the
+  nodes to pull images on your behalf, they have to have the credentials.  You can provide this information
+  by creating a dockercfg secret and attaching it to your service account.
+
+### Usage
+
+`$ docker-registry NAME --docker-username=user --docker-password=password --docker-email=email [--docker-server=string] [--from-literal=key1=value1] [--dry-run]`
+
+
+### Example
+ If you don't already have a .dockercfg file, you can create a dockercfg secret directly by using:
+
+```shell
+kubectl create secret docker-registry my-secret --docker-server=DOCKER_REGISTRY_SERVER --docker-username=DOCKER_USER --docker-password=DOCKER_PASSWORD --docker-email=DOCKER_EMAIL
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>append-hash</td><td></td><td>false</td><td>Append a hash of the secret to its name.</td>
+    </tr>
+    <tr>
+    <td>docker-email</td><td></td><td></td><td>Email for Docker registry</td>
+    </tr>
+    <tr>
+    <td>docker-password</td><td></td><td></td><td>Password for Docker registry authentication</td>
+    </tr>
+    <tr>
+    <td>docker-server</td><td></td><td>https://index.docker.io/v1/</td><td>Server location for Docker registry</td>
+    </tr>
+    <tr>
+    <td>docker-username</td><td></td><td></td><td>Username for Docker registry authentication</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>from-file</td><td></td><td>[]</td><td>Key files can be specified using their file path, in which case a default name will be given to them, or optionally with a name and file path, in which case the given name will be used.  Specifying a directory will iterate each named file in the directory that is a valid secret key.</td>
+    </tr>
+    <tr>
+    <td>generator</td><td></td><td>secret-for-docker-registry/v1</td><td>The name of the API generator to use.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>save-config</td><td></td><td>false</td><td>If true, the configuration of current object will be saved in its annotation. Otherwise, the annotation will be unchanged. This flag is useful when you want to perform kubectl apply on this object in the future.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>validate</td><td></td><td>true</td><td>If true, use a schema to validate the input before sending it</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## secret generic
+
+
+### Overview
+Create a secret based on a file, directory, or specified literal value.
+
+ A single secret may package one or more key/value pairs.
+
+ When creating a secret based on a file, the key will default to the basename of the file, and the value will default to the file content. If the basename is an invalid key or you wish to chose your own, you may specify an alternate key.
+
+ When creating a secret based on a directory, each file whose basename is a valid key in the directory will be packaged into the secret. Any directory entries except regular files are ignored (e.g. subdirectories, symlinks, devices, pipes, etc).
+
+### Usage
+
+`$ generic NAME [--type=string] [--from-file=[key=]source] [--from-literal=key1=value1] [--dry-run]`
+
+
+### Example
+ Create a new secret named my-secret with keys for each file in folder bar
+
+```shell
+kubectl create secret generic my-secret --from-file=path/to/bar
+```
+
+ Create a new secret named my-secret with specified keys instead of names on disk
+
+```shell
+kubectl create secret generic my-secret --from-file=ssh-privatekey=path/to/id_rsa --from-file=ssh-publickey=path/to/id_rsa.pub
+```
+
+ Create a new secret named my-secret with key1=supersecret and key2=topsecret
+
+```shell
+kubectl create secret generic my-secret --from-literal=key1=supersecret --from-literal=key2=topsecret
+```
+
+ Create a new secret named my-secret using a combination of a file and a literal
+
+```shell
+kubectl create secret generic my-secret --from-file=ssh-privatekey=path/to/id_rsa --from-literal=passphrase=topsecret
+```
+
+ Create a new secret named my-secret from an env file
+
+```shell
+kubectl create secret generic my-secret --from-env-file=path/to/bar.env
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>append-hash</td><td></td><td>false</td><td>Append a hash of the secret to its name.</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>from-env-file</td><td></td><td></td><td>Specify the path to a file to read lines of key=val pairs to create a secret (i.e. a Docker .env file).</td>
+    </tr>
+    <tr>
+    <td>from-file</td><td></td><td>[]</td><td>Key files can be specified using their file path, in which case a default name will be given to them, or optionally with a name and file path, in which case the given name will be used.  Specifying a directory will iterate each named file in the directory that is a valid secret key.</td>
+    </tr>
+    <tr>
+    <td>from-literal</td><td></td><td>[]</td><td>Specify a key and literal value to insert in secret (i.e. mykey=somevalue)</td>
+    </tr>
+    <tr>
+    <td>generator</td><td></td><td>secret/v1</td><td>The name of the API generator to use.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>save-config</td><td></td><td>false</td><td>If true, the configuration of current object will be saved in its annotation. Otherwise, the annotation will be unchanged. This flag is useful when you want to perform kubectl apply on this object in the future.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>type</td><td></td><td></td><td>The type of secret to create</td>
+    </tr>
+    <tr>
+    <td>validate</td><td></td><td>true</td><td>If true, use a schema to validate the input before sending it</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## secret tls
+
+
+### Overview
+Create a TLS secret from the given public/private key pair.
+
+ The public/private key pair must exist before hand. The public key certificate must be .PEM encoded and match the given private key.
+
+### Usage
+
+`$ tls NAME --cert=path/to/cert/file --key=path/to/key/file [--dry-run]`
+
+
+### Example
+ Create a new TLS secret named tls-secret with the given key pair:
+
+```shell
+kubectl create secret tls tls-secret --cert=path/to/tls.cert --key=path/to/tls.key
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>append-hash</td><td></td><td>false</td><td>Append a hash of the secret to its name.</td>
+    </tr>
+    <tr>
+    <td>cert</td><td></td><td></td><td>Path to PEM encoded public key certificate.</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>generator</td><td></td><td>secret-for-tls/v1</td><td>The name of the API generator to use.</td>
+    </tr>
+    <tr>
+    <td>key</td><td></td><td></td><td>Path to private key associated with given certificate.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>save-config</td><td></td><td>false</td><td>If true, the configuration of current object will be saved in its annotation. Otherwise, the annotation will be unchanged. This flag is useful when you want to perform kubectl apply on this object in the future.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>validate</td><td></td><td>true</td><td>If true, use a schema to validate the input before sending it</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## service
+
+
+### Overview
+Create a service using specified subcommand.
+
+### Usage
+
+`$ service`
+
+
+
+
+
+
+<hr>
+
+## service clusterip
+
+
+### Overview
+Create a ClusterIP service with the specified name.
+
+### Usage
+
+`$ clusterip NAME [--tcp=<port>:<targetPort>] [--dry-run]`
+
+
+### Example
+ Create a new ClusterIP service named my-cs
+
+```shell
+kubectl create service clusterip my-cs --tcp=5678:8080
+```
+
+ Create a new ClusterIP service named my-cs (in headless mode)
+
+```shell
+kubectl create service clusterip my-cs --clusterip="None"
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>clusterip</td><td></td><td></td><td>Assign your own ClusterIP or set to 'None' for a 'headless' service (no loadbalancing).</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>generator</td><td></td><td>service-clusterip/v1</td><td>The name of the API generator to use.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>save-config</td><td></td><td>false</td><td>If true, the configuration of current object will be saved in its annotation. Otherwise, the annotation will be unchanged. This flag is useful when you want to perform kubectl apply on this object in the future.</td>
+    </tr>
+    <tr>
+    <td>tcp</td><td></td><td>[]</td><td>Port pairs can be specified as '<port>:<targetPort>'.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>validate</td><td></td><td>true</td><td>If true, use a schema to validate the input before sending it</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## service externalname
+
+
+### Overview
+Create an ExternalName service with the specified name.
+
+ ExternalName service references to an external DNS address instead of only pods, which will allow application authors to reference services that exist off platform, on other clusters, or locally.
+
+### Usage
+
+`$ externalname NAME --external-name external.name [--dry-run]`
+
+
+### Example
+ Create a new ExternalName service named my-ns
+
+```shell
+kubectl create service externalname my-ns --external-name bar.com
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>external-name</td><td></td><td></td><td>External name of service</td>
+    </tr>
+    <tr>
+    <td>generator</td><td></td><td>service-externalname/v1</td><td>The name of the API generator to use.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>save-config</td><td></td><td>false</td><td>If true, the configuration of current object will be saved in its annotation. Otherwise, the annotation will be unchanged. This flag is useful when you want to perform kubectl apply on this object in the future.</td>
+    </tr>
+    <tr>
+    <td>tcp</td><td></td><td>[]</td><td>Port pairs can be specified as '<port>:<targetPort>'.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>validate</td><td></td><td>true</td><td>If true, use a schema to validate the input before sending it</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## service loadbalancer
+
+
+### Overview
+Create a LoadBalancer service with the specified name.
+
+### Usage
+
+`$ loadbalancer NAME [--tcp=port:targetPort] [--dry-run]`
+
+
+### Example
+ Create a new LoadBalancer service named my-lbs
+
+```shell
+kubectl create service loadbalancer my-lbs --tcp=5678:8080
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>generator</td><td></td><td>service-loadbalancer/v1</td><td>The name of the API generator to use.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>save-config</td><td></td><td>false</td><td>If true, the configuration of current object will be saved in its annotation. Otherwise, the annotation will be unchanged. This flag is useful when you want to perform kubectl apply on this object in the future.</td>
+    </tr>
+    <tr>
+    <td>tcp</td><td></td><td>[]</td><td>Port pairs can be specified as '<port>:<targetPort>'.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>validate</td><td></td><td>true</td><td>If true, use a schema to validate the input before sending it</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## service nodeport
+
+
+### Overview
+Create a NodePort service with the specified name.
+
+### Usage
+
+`$ nodeport NAME [--tcp=port:targetPort] [--dry-run]`
+
+
+### Example
+ Create a new NodePort service named my-ns
+
+```shell
+kubectl create service nodeport my-ns --tcp=5678:8080
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>generator</td><td></td><td>service-nodeport/v1</td><td>The name of the API generator to use.</td>
+    </tr>
+    <tr>
+    <td>node-port</td><td></td><td>0</td><td>Port used to expose the service on each node in a cluster.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>save-config</td><td></td><td>false</td><td>If true, the configuration of current object will be saved in its annotation. Otherwise, the annotation will be unchanged. This flag is useful when you want to perform kubectl apply on this object in the future.</td>
+    </tr>
+    <tr>
+    <td>tcp</td><td></td><td>[]</td><td>Port pairs can be specified as '<port>:<targetPort>'.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>validate</td><td></td><td>true</td><td>If true, use a schema to validate the input before sending it</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## serviceaccount
+
+
+### Overview
+Create a service account with the specified name.
+
+### Usage
+
+`$ serviceaccount NAME [--dry-run]`
+
+
+### Example
+ Create a new service account named my-service-account
+
+```shell
+kubectl create serviceaccount my-service-account
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>generator</td><td></td><td>serviceaccount/v1</td><td>The name of the API generator to use.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>save-config</td><td></td><td>false</td><td>If true, the configuration of current object will be saved in its annotation. Otherwise, the annotation will be unchanged. This flag is useful when you want to perform kubectl apply on this object in the future.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>validate</td><td></td><td>true</td><td>If true, use a schema to validate the input before sending it</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/create.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/create.md
@@ -1705,8 +1705,11 @@ kubectl create serviceaccount my-service-account
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/create.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/create.md
@@ -10,7 +10,7 @@ Create a resource from a file or from stdin.
 
 ### Usage
 
-`$ create -f FILENAME`
+`create -f FILENAME`
 
 
 ### Example
@@ -106,7 +106,7 @@ Create a ClusterRole.
 
 ### Usage
 
-`$ clusterrole NAME --verb=verb --resource=resource.group [--resource-name=resourcename] [--dry-run]`
+`clusterrole NAME --verb=verb --resource=resource.group [--resource-name=resourcename] [--dry-run]`
 
 
 ### Example
@@ -151,7 +151,7 @@ kubectl create clusterrole monitoring --aggregation-rule="rbac.example.com/aggre
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -210,7 +210,7 @@ Create a ClusterRoleBinding for a particular ClusterRole.
 
 ### Usage
 
-`$ clusterrolebinding NAME --clusterrole=NAME [--user=username] [--group=groupname] [--serviceaccount=namespace:serviceaccountname] [--dry-run]`
+`clusterrolebinding NAME --clusterrole=NAME [--user=username] [--group=groupname] [--serviceaccount=namespace:serviceaccountname] [--dry-run]`
 
 
 ### Example
@@ -225,7 +225,7 @@ kubectl create clusterrolebinding cluster-admin --clusterrole=cluster-admin --us
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -287,7 +287,7 @@ Create a configmap based on a file, directory, or specified literal value.
 
 ### Usage
 
-`$ configmap NAME [--from-file=[key=]source] [--from-literal=key1=value1] [--dry-run]`
+`configmap NAME [--from-file=[key=]source] [--from-literal=key1=value1] [--dry-run]`
 
 
 ### Example
@@ -326,7 +326,7 @@ kubectl create configmap my-config --from-env-file=path/to/bar.env
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -385,7 +385,7 @@ Create a cronjob with the specified name.
 
 ### Usage
 
-`$ cronjob NAME --image=image --schedule='0/5 * * * ?' -- [COMMAND] [args...]`
+`cronjob NAME --image=image --schedule='0/5 * * * ?' -- [COMMAND] [args...]`
 
 
 ### Example
@@ -412,7 +412,7 @@ kubectl create cronjob test-job --image=busybox --schedule="*/1 * * * *"
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -465,7 +465,7 @@ Create a deployment with the specified name.
 
 ### Usage
 
-`$ deployment NAME --image=image [--dry-run]`
+`deployment NAME --image=image [--dry-run]`
 
 
 ### Example
@@ -480,7 +480,7 @@ kubectl create deployment my-dep --image=busybox
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -530,7 +530,7 @@ Create a job with the specified name.
 
 ### Usage
 
-`$ job NAME --image=image [--from=cronjob/name] -- [COMMAND] [args...]`
+`job NAME --image=image [--from=cronjob/name] -- [COMMAND] [args...]`
 
 
 ### Example
@@ -557,7 +557,7 @@ kubectl create job test-job --from=cronjob/a-cronjob
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -607,7 +607,7 @@ Create a namespace with the specified name.
 
 ### Usage
 
-`$ namespace NAME [--dry-run]`
+`namespace NAME [--dry-run]`
 
 
 ### Example
@@ -622,7 +622,7 @@ kubectl create namespace my-namespace
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -669,7 +669,7 @@ Create a pod disruption budget with the specified name, selector, and desired mi
 
 ### Usage
 
-`$ poddisruptionbudget NAME --selector=SELECTOR --min-available=N [--dry-run]`
+`poddisruptionbudget NAME --selector=SELECTOR --min-available=N [--dry-run]`
 
 
 ### Example
@@ -690,7 +690,7 @@ kubectl create pdb my-pdb --selector=app=nginx --min-available=50%
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -746,7 +746,7 @@ Create a priorityclass with the specified name, value, globalDefault and descrip
 
 ### Usage
 
-`$ priorityclass NAME --value=VALUE --global-default=BOOL [--dry-run]`
+`priorityclass NAME --value=VALUE --global-default=BOOL [--dry-run]`
 
 
 ### Example
@@ -773,7 +773,7 @@ kubectl create priorityclass high-priority --value=1000 --description="high prio
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -832,7 +832,7 @@ Create a resourcequota with the specified name, hard limits and optional scopes
 
 ### Usage
 
-`$ quota NAME [--hard=key1=value1,key2=value2] [--scopes=Scope1,Scope2] [--dry-run=bool]`
+`quota NAME [--hard=key1=value1,key2=value2] [--scopes=Scope1,Scope2] [--dry-run=bool]`
 
 
 ### Example
@@ -853,7 +853,7 @@ kubectl create quota best-effort --hard=pods=100 --scopes=BestEffort
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -906,7 +906,7 @@ Create a role with single rule.
 
 ### Usage
 
-`$ role NAME --verb=verb --resource=resource.group/subresource [--resource-name=resourcename] [--dry-run]`
+`role NAME --verb=verb --resource=resource.group/subresource [--resource-name=resourcename] [--dry-run]`
 
 
 ### Example
@@ -939,7 +939,7 @@ kubectl create role foo --verb=get,list,watch --resource=pods,pods/status
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -992,7 +992,7 @@ Create a RoleBinding for a particular Role or ClusterRole.
 
 ### Usage
 
-`$ rolebinding NAME --clusterrole=NAME|--role=NAME [--user=username] [--group=groupname] [--serviceaccount=namespace:serviceaccountname] [--dry-run]`
+`rolebinding NAME --clusterrole=NAME|--role=NAME [--user=username] [--group=groupname] [--serviceaccount=namespace:serviceaccountname] [--dry-run]`
 
 
 ### Example
@@ -1007,7 +1007,7 @@ kubectl create rolebinding admin --clusterrole=admin --user=user1 --user=user2 -
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -1066,7 +1066,7 @@ Create a secret using specified subcommand.
 
 ### Usage
 
-`$ secret`
+`secret`
 
 
 
@@ -1094,7 +1094,7 @@ Create a new secret for use with Docker registries.
 
 ### Usage
 
-`$ docker-registry NAME --docker-username=user --docker-password=password --docker-email=email [--docker-server=string] [--from-literal=key1=value1] [--dry-run]`
+`docker-registry NAME --docker-username=user --docker-password=password --docker-email=email [--docker-server=string] [--from-literal=key1=value1] [--dry-run]`
 
 
 ### Example
@@ -1109,7 +1109,7 @@ kubectl create secret docker-registry my-secret --docker-server=DOCKER_REGISTRY_
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -1180,7 +1180,7 @@ Create a secret based on a file, directory, or specified literal value.
 
 ### Usage
 
-`$ generic NAME [--type=string] [--from-file=[key=]source] [--from-literal=key1=value1] [--dry-run]`
+`generic NAME [--type=string] [--from-file=[key=]source] [--from-literal=key1=value1] [--dry-run]`
 
 
 ### Example
@@ -1219,7 +1219,7 @@ kubectl create secret generic my-secret --from-env-file=path/to/bar.env
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -1283,7 +1283,7 @@ Create a TLS secret from the given public/private key pair.
 
 ### Usage
 
-`$ tls NAME --cert=path/to/cert/file --key=path/to/key/file [--dry-run]`
+`tls NAME --cert=path/to/cert/file --key=path/to/key/file [--dry-run]`
 
 
 ### Example
@@ -1298,7 +1298,7 @@ kubectl create secret tls tls-secret --cert=path/to/tls.cert --key=path/to/tls.k
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -1354,7 +1354,7 @@ Create a service using specified subcommand.
 
 ### Usage
 
-`$ service`
+`service`
 
 
 
@@ -1371,7 +1371,7 @@ Create a ClusterIP service with the specified name.
 
 ### Usage
 
-`$ clusterip NAME [--tcp=<port>:<targetPort>] [--dry-run]`
+`clusterip NAME [--tcp=<port>:<targetPort>] [--dry-run]`
 
 
 ### Example
@@ -1392,7 +1392,7 @@ kubectl create service clusterip my-cs --clusterip="None"
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -1447,7 +1447,7 @@ Create an ExternalName service with the specified name.
 
 ### Usage
 
-`$ externalname NAME --external-name external.name [--dry-run]`
+`externalname NAME --external-name external.name [--dry-run]`
 
 
 ### Example
@@ -1462,7 +1462,7 @@ kubectl create service externalname my-ns --external-name bar.com
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -1515,7 +1515,7 @@ Create a LoadBalancer service with the specified name.
 
 ### Usage
 
-`$ loadbalancer NAME [--tcp=port:targetPort] [--dry-run]`
+`loadbalancer NAME [--tcp=port:targetPort] [--dry-run]`
 
 
 ### Example
@@ -1530,7 +1530,7 @@ kubectl create service loadbalancer my-lbs --tcp=5678:8080
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -1580,7 +1580,7 @@ Create a NodePort service with the specified name.
 
 ### Usage
 
-`$ nodeport NAME [--tcp=port:targetPort] [--dry-run]`
+`nodeport NAME [--tcp=port:targetPort] [--dry-run]`
 
 
 ### Example
@@ -1595,7 +1595,7 @@ kubectl create service nodeport my-ns --tcp=5678:8080
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -1648,7 +1648,7 @@ Create a service account with the specified name.
 
 ### Usage
 
-`$ serviceaccount NAME [--dry-run]`
+`serviceaccount NAME [--dry-run]`
 
 
 ### Example
@@ -1663,7 +1663,7 @@ kubectl create serviceaccount my-service-account
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -1699,4 +1699,14 @@ kubectl create serviceaccount my-service-account
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/create.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/create.md
@@ -1,6 +1,7 @@
 ---
 title: create
-content_template: templates/tool-reference
+noedit: true
+layout: kuberef
 ---
 
 ### Overview

--- a/content/en/docs/reference/kubectl/kubectl-reference/delete.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/delete.md
@@ -1,0 +1,140 @@
+---
+title: delete
+content_template: templates/tool-reference
+---
+
+### Overview
+Delete resources by filenames, stdin, resources and names, or by resources and label selector.
+
+ JSON and YAML formats are accepted. Only one type of the arguments may be specified: filenames, resources and names, or resources and label selector.
+
+ Some resources, such as pods, support graceful deletion. These resources define a default period before they are forcibly terminated (the grace period) but you may override that value with the --grace-period flag, or pass --now to set a grace-period of 1. Because these resources often represent entities in the cluster, deletion may not be acknowledged immediately. If the node hosting a pod is down or cannot reach the API server, termination may take significantly longer than the grace period. To force delete a resource, you must pass a grace period of 0 and specify the --force flag.
+
+ IMPORTANT: Force deleting pods does not wait for confirmation that the pod's processes have been terminated, which can leave those processes running until the node detects the deletion and completes graceful deletion. If your processes use shared storage or talk to a remote API and depend on the name of the pod to identify themselves, force deleting those pods may result in multiple processes running on different machines using the same identification which may lead to data corruption or inconsistency. Only force delete pods when you are sure the pod is terminated, or if your application can tolerate multiple copies of the same pod running at once. Also, if you force delete pods the scheduler may place new pods on those nodes before the node has released those resources and causing those pods to be evicted immediately.
+
+ Note that the delete command does NOT do resource version checks, so if someone submits an update to a resource right when you submit a delete, their update will be lost along with the rest of the resource.
+
+### Usage
+
+`$ delete ([-f FILENAME] | [-k DIRECTORY] | TYPE [(NAME | -l label | --all)])`
+
+
+### Example
+
+ Delete a pod using the type and name specified in pod.json.
+
+```shell
+kubectl delete -f ./pod.json
+```
+
+ Delete resources from a directory containing kustomization.yaml - e.g. dir/kustomization.yaml.
+
+```shell
+kubectl delete -k dir
+```
+
+ Delete a pod based on the type and name in the JSON passed into stdin.
+
+```shell
+cat pod.json | kubectl delete -f -
+```
+
+ Delete pods and services with same names "baz" and "foo"
+
+```shell
+kubectl delete pod,service baz foo
+```
+
+ Delete pods and services with label name=myLabel.
+
+```shell
+kubectl delete pods,services -l name=myLabel
+```
+
+ Delete a pod with minimal delay
+
+```shell
+kubectl delete pod foo --now
+```
+
+ Force delete a pod on a dead node
+
+```shell
+kubectl delete pod foo --grace-period=0 --force
+```
+
+ Delete all pods
+
+```shell
+kubectl delete pods --all
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>all</td><td></td><td>false</td><td>Delete all resources, including uninitialized ones, in the namespace of the specified resource types.</td>
+    </tr>
+    <tr>
+    <td>all-namespaces</td><td>A</td><td>false</td><td>If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.</td>
+    </tr>
+    <tr>
+    <td>cascade</td><td></td><td>true</td><td>If true, cascade the deletion of the resources managed by this resource (e.g. Pods created by a ReplicationController).  Default true.</td>
+    </tr>
+    <tr>
+    <td>field-selector</td><td></td><td></td><td>Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>containing the resource to delete.</td>
+    </tr>
+    <tr>
+    <td>force</td><td></td><td>false</td><td>Only used when grace-period=0. If true, immediately remove resources from API and bypass graceful deletion. Note that immediate deletion of some resources may result in inconsistency or data loss and requires confirmation.</td>
+    </tr>
+    <tr>
+    <td>grace-period</td><td></td><td>-1</td><td>Period of time in seconds given to the resource to terminate gracefully. Ignored if negative. Set to 1 for immediate shutdown. Can only be set to 0 when --force is true (force deletion).</td>
+    </tr>
+    <tr>
+    <td>ignore-not-found</td><td></td><td>false</td><td>Treat "resource not found" as a successful delete. Defaults to "true" when --all is specified.</td>
+    </tr>
+    <tr>
+    <td>include-uninitialized</td><td></td><td>false</td><td>If true, the kubectl command applies to uninitialized objects. If explicitly set to false, this flag overrides other flags that make the kubectl commands apply to uninitialized objects, e.g., "--all". Objects with empty metadata.initializers are regarded as initialized.</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process a kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>now</td><td></td><td>false</td><td>If true, resources are signaled for immediate shutdown (same as --grace-period=1).</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output mode. Use "-o name" for shorter output (resource/name).</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>selector</td><td>l</td><td></td><td>Selector (label query) to filter on, not including uninitialized ones.</td>
+    </tr>
+    <tr>
+    <td>timeout</td><td></td><td>0s</td><td>The length of time to wait before giving up on a delete, zero means determine a timeout from the size of the object</td>
+    </tr>
+    <tr>
+    <td>wait</td><td></td><td>true</td><td>If true, wait for resources to be gone before returning. This waits for finalizers.</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/delete.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/delete.md
@@ -143,8 +143,11 @@ kubectl delete pods --all
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/delete.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/delete.md
@@ -1,6 +1,7 @@
 ---
 title: delete
-content_template: templates/tool-reference
+noedit: true
+layout: kuberef
 ---
 
 ### Overview

--- a/content/en/docs/reference/kubectl/kubectl-reference/delete.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/delete.md
@@ -16,7 +16,7 @@ Delete resources by filenames, stdin, resources and names, or by resources and l
 
 ### Usage
 
-`$ delete ([-f FILENAME] | [-k DIRECTORY] | TYPE [(NAME | -l label | --all)])`
+`delete ([-f FILENAME] | [-k DIRECTORY] | TYPE [(NAME | -l label | --all)])`
 
 
 ### Example
@@ -137,4 +137,14 @@ kubectl delete pods --all
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/describe.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/describe.md
@@ -104,8 +104,11 @@ kubectl describe pods frontend
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/describe.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/describe.md
@@ -16,7 +16,7 @@ Use "kubectl api-resources" for a complete list of supported resources.
 
 ### Usage
 
-`$ describe (-f FILENAME | TYPE [NAME_PREFIX | -l label] | TYPE/NAME)`
+`describe (-f FILENAME | TYPE [NAME_PREFIX | -l label] | TYPE/NAME)`
 
 
 ### Example
@@ -98,4 +98,14 @@ kubectl describe pods frontend
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/describe.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/describe.md
@@ -1,0 +1,101 @@
+---
+title: describe
+content_template: templates/tool-reference
+---
+
+### Overview
+Show details of a specific resource or group of resources
+
+ Print a detailed description of the selected resources, including related resources such as events or controllers. You may select a single object by name, all objects of that type, provide a name prefix, or label selector. For example:
+
+  $ kubectl describe TYPE NAME_PREFIX
+  
+ will first check for an exact match on TYPE and NAME_PREFIX. If no such resource exists, it will output details for every resource that has a name prefixed with NAME_PREFIX.
+
+Use "kubectl api-resources" for a complete list of supported resources.
+
+### Usage
+
+`$ describe (-f FILENAME | TYPE [NAME_PREFIX | -l label] | TYPE/NAME)`
+
+
+### Example
+
+ Describe a node
+
+```shell
+kubectl describe nodes kubernetes-node-emt8.c.myproject.internal
+```
+
+ Describe a pod
+
+```shell
+kubectl describe pods/nginx
+```
+
+ Describe a pod identified by type and name in "pod.json"
+
+```shell
+kubectl describe -f pod.json
+```
+
+ Describe all pods
+
+```shell
+kubectl describe pods
+```
+
+ Describe pods by label name=myLabel
+
+```shell
+kubectl describe po -l name=myLabel
+```
+
+ Describe all pods managed by the 'frontend' replication controller (rc-created pods # get the name of the rc as a prefix in the pod the name).
+
+```shell
+kubectl describe pods frontend
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>all-namespaces</td><td>A</td><td>false</td><td>If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>Filename, directory, or URL to files containing the resource to describe</td>
+    </tr>
+    <tr>
+    <td>include-uninitialized</td><td></td><td>false</td><td>If true, the kubectl command applies to uninitialized objects. If explicitly set to false, this flag overrides other flags that make the kubectl commands apply to uninitialized objects, e.g., "--all". Objects with empty metadata.initializers are regarded as initialized.</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process the kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>selector</td><td>l</td><td></td><td>Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)</td>
+    </tr>
+    <tr>
+    <td>show-events</td><td></td><td>true</td><td>If true, display events related to the described object.</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/diff.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/diff.md
@@ -73,8 +73,11 @@ cat service.yaml | kubectl diff -f -
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/diff.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/diff.md
@@ -1,0 +1,70 @@
+---
+title: diff
+content_template: templates/tool-reference
+---
+
+### Overview
+Diff configurations specified by filename or stdin between the current online configuration, and the configuration as it would be if applied.
+
+ Output is always YAML.
+
+ KUBECTL_EXTERNAL_DIFF environment variable can be used to select your own diff command. By default, the "diff" command available in your path will be run with "-u" (unicode) and "-N" (treat new files as empty) options.
+
+### Usage
+
+`$ diff -f FILENAME`
+
+
+### Example
+
+ Diff resources included in pod.json.
+
+```shell
+kubectl diff -f pod.json
+```
+
+ Diff file read from stdin
+
+```shell
+cat service.yaml | kubectl diff -f -
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>experimental-field-manager</td><td></td><td>kubectl</td><td>Name of the manager used to track field ownership. This is an alpha feature and flag.</td>
+    </tr>
+    <tr>
+    <td>experimental-force-conflicts</td><td></td><td>false</td><td>If true, server-side apply will force the changes against conflicts. This is an alpha feature and flag.</td>
+    </tr>
+    <tr>
+    <td>experimental-server-side</td><td></td><td>false</td><td>If true, apply runs in the server instead of the client. This is an alpha feature and flag.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>Filename, directory, or URL to files contains the configuration to diff</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process the kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/diff.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/diff.md
@@ -12,7 +12,7 @@ Diff configurations specified by filename or stdin between the current online co
 
 ### Usage
 
-`$ diff -f FILENAME`
+`diff -f FILENAME`
 
 
 ### Example
@@ -67,4 +67,14 @@ cat service.yaml | kubectl diff -f -
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/drain.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/drain.md
@@ -1,0 +1,80 @@
+---
+title: drain
+content_template: templates/tool-reference
+---
+
+### Overview
+Drain node in preparation for maintenance.
+
+ The given node will be marked unschedulable to prevent new pods from arriving. 'drain' evicts the pods if the APIServer supportshttp://kubernetes.io/docs/admin/disruptions/ . Otherwise, it will use normal DELETE to delete the pods. The 'drain' evicts or deletes all pods except mirror pods (which cannot be deleted through the API server).  If there are DaemonSet-managed pods, drain will not proceed without --ignore-daemonsets, and regardless it will not delete any DaemonSet-managed pods, because those pods would be immediately replaced by the DaemonSet controller, which ignores unschedulable markings.  If there are any pods that are neither mirror pods nor managed by ReplicationController, ReplicaSet, DaemonSet, StatefulSet or Job, then drain will not delete any pods unless you use --force.  --force will also allow deletion to proceed if the managing resource of one or more pods is missing.
+
+ 'drain' waits for graceful termination. You should not operate on the machine until the command completes.
+
+ When you are ready to put the node back into service, use kubectl uncordon, which will make the node schedulable again.
+
+ http://kubernetes.io/images/docs/kubectl_drain.svg
+
+### Usage
+
+`$ drain NODE`
+
+
+### Example
+
+ Drain node "foo", even if there are pods not managed by a ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet on it.
+
+```shell
+$ kubectl drain foo --force
+```
+
+ As above, but abort if there are pods not managed by a ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet, and use a grace period of 15 minutes.
+
+```shell
+$ kubectl drain foo --grace-period=900
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>delete-local-data</td><td></td><td>false</td><td>Continue even if there are pods using emptyDir (local data that will be deleted when the node is drained).</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>force</td><td></td><td>false</td><td>Continue even if there are pods not managed by a ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet.</td>
+    </tr>
+    <tr>
+    <td>grace-period</td><td></td><td>-1</td><td>Period of time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used.</td>
+    </tr>
+    <tr>
+    <td>ignore-daemonsets</td><td></td><td>false</td><td>Ignore DaemonSet-managed pods.</td>
+    </tr>
+    <tr>
+    <td>pod-selector</td><td></td><td></td><td>Label selector to filter pods on the node</td>
+    </tr>
+    <tr>
+    <td>selector</td><td>l</td><td></td><td>Selector (label query) to filter on</td>
+    </tr>
+    <tr>
+    <td>timeout</td><td></td><td>0s</td><td>The length of time to wait before giving up, zero means infinite</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/drain.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/drain.md
@@ -16,7 +16,7 @@ Drain node in preparation for maintenance.
 
 ### Usage
 
-`$ drain NODE`
+`drain NODE`
 
 
 ### Example
@@ -77,4 +77,14 @@ $ kubectl drain foo --grace-period=900
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/drain.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/drain.md
@@ -83,8 +83,11 @@ $ kubectl drain foo --grace-period=900
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/edit.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/edit.md
@@ -18,7 +18,7 @@ Edit a resource from the default editor.
 
 ### Usage
 
-`$ edit (RESOURCE/NAME | -f FILENAME)`
+`edit (RESOURCE/NAME | -f FILENAME)`
 
 
 ### Example
@@ -103,4 +103,14 @@ kubectl edit deployment/mydeployment -o yaml --save-config
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/edit.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/edit.md
@@ -109,8 +109,11 @@ kubectl edit deployment/mydeployment -o yaml --save-config
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/edit.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/edit.md
@@ -1,0 +1,106 @@
+---
+title: edit
+content_template: templates/tool-reference
+---
+
+### Overview
+Edit a resource from the default editor.
+
+ The edit command allows you to directly edit any API resource you can retrieve via the command line tools. It will open the editor defined by your KUBE_EDITOR, or EDITOR environment variables, or fall back to 'vi' for Linux or 'notepad' for Windows. You can edit multiple objects, although changes are applied one at a time. The command accepts filenames as well as command line arguments, although the files you point to must be previously saved versions of resources.
+
+ Editing is done with the API version used to fetch the resource. To edit using a specific API version, fully-qualify the resource, version, and group.
+
+ The default format is YAML. To edit in JSON, specify "-o json".
+
+ The flag --windows-line-endings can be used to force Windows line endings, otherwise the default for your operating system will be used.
+
+ In the event an error occurs while updating, a temporary file will be created on disk that contains your unapplied changes. The most common error when updating a resource is another editor changing the resource on the server. When this occurs, you will have to apply your changes to the newer version of the resource, or update your temporary saved copy to include the latest resource version.
+
+### Usage
+
+`$ edit (RESOURCE/NAME | -f FILENAME)`
+
+
+### Example
+
+ Edit the service named 'docker-registry':
+
+```shell
+kubectl edit svc/docker-registry
+```
+
+ Use an alternative editor
+
+```shell
+KUBE_EDITOR="nano" kubectl edit svc/docker-registry
+```
+
+ Edit the job 'myjob' in JSON using the v1 API format:
+
+```shell
+kubectl edit job.v1.batch/myjob -o json
+```
+
+ Edit the deployment 'mydeployment' in YAML and save the modified config in its annotation:
+
+```shell
+kubectl edit deployment/mydeployment -o yaml --save-config
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>Filename, directory, or URL to files to use to edit the resource</td>
+    </tr>
+    <tr>
+    <td>include-uninitialized</td><td></td><td>false</td><td>If true, the kubectl command applies to uninitialized objects. If explicitly set to false, this flag overrides other flags that make the kubectl commands apply to uninitialized objects, e.g., "--all". Objects with empty metadata.initializers are regarded as initialized.</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process the kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>output-patch</td><td></td><td>false</td><td>Output the patch if the resource is edited.</td>
+    </tr>
+    <tr>
+    <td>record</td><td></td><td>false</td><td>Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>save-config</td><td></td><td>false</td><td>If true, the configuration of current object will be saved in its annotation. Otherwise, the annotation will be unchanged. This flag is useful when you want to perform kubectl apply on this object in the future.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>validate</td><td></td><td>true</td><td>If true, use a schema to validate the input before sending it</td>
+    </tr>
+    <tr>
+    <td>windows-line-endings</td><td></td><td>false</td><td>Defaults to the line ending native to your platform.</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/exec.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/exec.md
@@ -8,7 +8,7 @@ Execute a command in a container.
 
 ### Usage
 
-`$ exec (POD | TYPE/NAME) [-c CONTAINER] [flags] -- COMMAND [args...]`
+`exec (POD | TYPE/NAME) [-c CONTAINER] [flags] -- COMMAND [args...]`
 
 
 ### Example
@@ -81,4 +81,14 @@ kubectl exec svc/myservice date
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/exec.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/exec.md
@@ -87,8 +87,11 @@ kubectl exec svc/myservice date
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/exec.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/exec.md
@@ -1,0 +1,84 @@
+---
+title: exec
+content_template: templates/tool-reference
+---
+
+### Overview
+Execute a command in a container.
+
+### Usage
+
+`$ exec (POD | TYPE/NAME) [-c CONTAINER] [flags] -- COMMAND [args...]`
+
+
+### Example
+
+ Get output from running 'date' command from pod mypod, using the first container by default
+
+```shell
+kubectl exec mypod date
+```
+
+ Get output from running 'date' command in ruby-container from pod mypod
+
+```shell
+kubectl exec mypod -c ruby-container date
+```
+
+ Switch to raw terminal mode, sends stdin to 'bash' in ruby-container from pod mypod # and sends stdout/stderr from 'bash' back to the client
+
+```shell
+kubectl exec mypod -c ruby-container -i -t -- bash -il
+```
+
+ List contents of /usr from the first container of pod mypod and sort by modification time. # If the command you want to execute in the pod has any flags in common (e.g. -i), # you must use two dashes (--) to separate your command's flags/arguments. # Also note, do not surround your command and its flags/arguments with quotes # unless that is how you would execute it normally (i.e., do ls -t /usr, not "ls -t /usr").
+
+```shell
+kubectl exec mypod -i -t -- ls -t /usr
+```
+
+ Get output from running 'date' command from the first pod of the deployment mydeployment, using the first container by default
+
+```shell
+kubectl exec deploy/mydeployment date
+```
+
+ Get output from running 'date' command from the first pod of the service myservice, using the first container by default
+
+```shell
+kubectl exec svc/myservice date
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>container</td><td>c</td><td></td><td>Container name. If omitted, the first container in the pod will be chosen</td>
+    </tr>
+    <tr>
+    <td>pod-running-timeout</td><td></td><td>1m0s</td><td>The length of time (like 5s, 2m, or 3h, higher than zero) to wait until at least one pod is running</td>
+    </tr>
+    <tr>
+    <td>stdin</td><td>i</td><td>false</td><td>Pass stdin to the container</td>
+    </tr>
+    <tr>
+    <td>tty</td><td>t</td><td>false</td><td>Stdin is a TTY</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/explain.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/explain.md
@@ -65,8 +65,11 @@ kubectl explain pods.spec.containers
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/explain.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/explain.md
@@ -1,6 +1,7 @@
 ---
 title: explain
-content_template: templates/tool-reference
+noedit: true
+layout: kuberef
 ---
 
 ### Overview

--- a/content/en/docs/reference/kubectl/kubectl-reference/explain.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/explain.md
@@ -1,0 +1,62 @@
+---
+title: explain
+content_template: templates/tool-reference
+---
+
+### Overview
+List the fields for supported resources
+
+ This command describes the fields associated with each supported API resource. Fields are identified via a simple JSONPath identifier:
+
+  <type>.<fieldName>[.<fieldName>]
+  
+ Add the --recursive flag to display all of the fields at once without descriptions. Information about each field is retrieved from the server in OpenAPI format.
+
+Use "kubectl api-resources" for a complete list of supported resources.
+
+### Usage
+
+`$ explain RESOURCE`
+
+
+### Example
+
+ Get the documentation of the resource and its fields
+
+```shell
+kubectl explain pods
+```
+
+ Get the documentation of a specific field of a resource
+
+```shell
+kubectl explain pods.spec.containers
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>api-version</td><td></td><td></td><td>Get different explanations for particular API version</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td></td><td>false</td><td>Print the fields of fields (Currently only 1 level deep)</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/explain.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/explain.md
@@ -16,7 +16,7 @@ Use "kubectl api-resources" for a complete list of supported resources.
 
 ### Usage
 
-`$ explain RESOURCE`
+`explain RESOURCE`
 
 
 ### Example
@@ -59,4 +59,14 @@ kubectl explain pods.spec.containers
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/expose.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/expose.md
@@ -14,7 +14,7 @@ Expose a resource as a new Kubernetes service.
 
 ### Usage
 
-`$ expose (-f FILENAME | TYPE NAME) [--port=port] [--protocol=TCP|UDP|SCTP] [--target-port=number-or-name] [--name=name] [--external-ip=external-ip-of-service] [--type=type]`
+`expose (-f FILENAME | TYPE NAME) [--port=port] [--protocol=TCP|UDP|SCTP] [--target-port=number-or-name] [--name=name] [--external-ip=external-ip-of-service] [--type=type]`
 
 
 ### Example
@@ -150,4 +150,14 @@ kubectl expose deployment nginx --port=80 --target-port=8000
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/expose.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/expose.md
@@ -1,0 +1,153 @@
+---
+title: expose
+content_template: templates/tool-reference
+---
+
+### Overview
+Expose a resource as a new Kubernetes service.
+
+ Looks up a deployment, service, replica set, replication controller or pod by name and uses the selector for that resource as the selector for a new service on the specified port. A deployment or replica set will be exposed as a service only if its selector is convertible to a selector that service supports, i.e. when the selector contains only the matchLabels component. Note that if no port is specified via --port and the exposed resource has multiple ports, all will be re-used by the new service. Also if no labels are specified, the new service will re-use the labels from the resource it exposes.
+
+ Possible resources include (case insensitive):
+
+ pod (po), service (svc), replicationcontroller (rc), deployment (deploy), replicaset (rs)
+
+### Usage
+
+`$ expose (-f FILENAME | TYPE NAME) [--port=port] [--protocol=TCP|UDP|SCTP] [--target-port=number-or-name] [--name=name] [--external-ip=external-ip-of-service] [--type=type]`
+
+
+### Example
+
+ Create a service for a replicated nginx, which serves on port 80 and connects to the containers on port 8000.
+
+```shell
+kubectl expose rc nginx --port=80 --target-port=8000
+```
+
+ Create a service for a replication controller identified by type and name specified in "nginx-controller.yaml", which serves on port 80 and connects to the containers on port 8000.
+
+```shell
+kubectl expose -f nginx-controller.yaml --port=80 --target-port=8000
+```
+
+ Create a service for a pod valid-pod, which serves on port 444 with the name "frontend"
+
+```shell
+kubectl expose pod valid-pod --port=444 --name=frontend
+```
+
+ Create a second service based on the above service, exposing the container port 8443 as port 443 with the name "nginx-https"
+
+```shell
+kubectl expose service nginx --port=443 --target-port=8443 --name=nginx-https
+```
+
+ Create a service for a replicated streaming application on port 4100 balancing UDP traffic and named 'video-stream'.
+
+```shell
+kubectl expose rc streamer --port=4100 --protocol=UDP --name=video-stream
+```
+
+ Create a service for a replicated nginx using replica set, which serves on port 80 and connects to the containers on port 8000.
+
+```shell
+kubectl expose rs nginx --port=80 --target-port=8000
+```
+
+ Create a service for an nginx deployment, which serves on port 80 and connects to the containers on port 8000.
+
+```shell
+kubectl expose deployment nginx --port=80 --target-port=8000
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>cluster-ip</td><td></td><td></td><td>ClusterIP to be assigned to the service. Leave empty to auto-allocate, or set to 'None' to create a headless service.</td>
+    </tr>
+    <tr>
+    <td>container-port</td><td></td><td></td><td>Synonym for --target-port</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>external-ip</td><td></td><td></td><td>Additional external IP address (not managed by Kubernetes) to accept for the service. If this IP is routed to a node, the service can be accessed by this IP in addition to its generated service IP.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>Filename, directory, or URL to files identifying the resource to expose a service</td>
+    </tr>
+    <tr>
+    <td>generator</td><td></td><td>service/v2</td><td>The name of the API generator to use. There are 2 generators: 'service/v1' and 'service/v2'. The only difference between them is that service port in v1 is named 'default', while it is left unnamed in v2. Default is 'service/v2'.</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process the kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>labels</td><td>l</td><td></td><td>Labels to apply to the service created by this call.</td>
+    </tr>
+    <tr>
+    <td>load-balancer-ip</td><td></td><td></td><td>IP to assign to the LoadBalancer. If empty, an ephemeral IP will be created and used (cloud-provider specific).</td>
+    </tr>
+    <tr>
+    <td>name</td><td></td><td></td><td>The name for the newly created object.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>overrides</td><td></td><td></td><td>An inline JSON override for the generated object. If this is non-empty, it is used to override the generated object. Requires that the object supply a valid apiVersion field.</td>
+    </tr>
+    <tr>
+    <td>port</td><td></td><td></td><td>The port that the service should serve on. Copied from the resource being exposed, if unspecified</td>
+    </tr>
+    <tr>
+    <td>protocol</td><td></td><td></td><td>The network protocol for the service to be created. Default is 'TCP'.</td>
+    </tr>
+    <tr>
+    <td>record</td><td></td><td>false</td><td>Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>save-config</td><td></td><td>false</td><td>If true, the configuration of current object will be saved in its annotation. Otherwise, the annotation will be unchanged. This flag is useful when you want to perform kubectl apply on this object in the future.</td>
+    </tr>
+    <tr>
+    <td>selector</td><td></td><td></td><td>A label selector to use for this service. Only equality-based selector requirements are supported. If empty (the default) infer the selector from the replication controller or replica set.)</td>
+    </tr>
+    <tr>
+    <td>session-affinity</td><td></td><td></td><td>If non-empty, set the session affinity for the service to this; legal values: 'None', 'ClientIP'</td>
+    </tr>
+    <tr>
+    <td>target-port</td><td></td><td></td><td>Name or number for the port on the container that the service should direct traffic to. Optional.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>type</td><td></td><td></td><td>Type for this service: ClusterIP, NodePort, LoadBalancer, or ExternalName. Default is 'ClusterIP'.</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/expose.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/expose.md
@@ -156,8 +156,11 @@ kubectl expose deployment nginx --port=80 --target-port=8000
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/get.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/get.md
@@ -1,0 +1,179 @@
+---
+title: get
+content_template: templates/tool-reference
+---
+
+### Overview
+Display one or many resources
+
+ Prints a table of the most important information about the specified resources. You can filter the list using a label selector and the --selector flag. If the desired resource type is namespaced you will only see results in your current namespace unless you pass --all-namespaces.
+
+ Uninitialized objects are not shown unless --include-uninitialized is passed.
+
+ By specifying the output as 'template' and providing a Go template as the value of the --template flag, you can filter the attributes of the fetched resources.
+
+Use "kubectl api-resources" for a complete list of supported resources.
+
+### Usage
+
+`$ get [(-o|--output=)json|yaml|wide|custom-columns=...|custom-columns-file=...|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=...] (TYPE[.VERSION][.GROUP] [NAME | -l label] | TYPE[.VERSION][.GROUP]/NAME ...) [flags]`
+
+
+### Example
+
+ List all pods in ps output format.
+
+```shell
+kubectl get pods
+```
+
+ List all pods in ps output format with more information (such as node name).
+
+```shell
+kubectl get pods -o wide
+```
+
+ List a single replication controller with specified NAME in ps output format.
+
+```shell
+kubectl get replicationcontroller web
+```
+
+ List deployments in JSON output format, in the "v1" version of the "apps" API group:
+
+```shell
+kubectl get deployments.v1.apps -o json
+```
+
+ List a single pod in JSON output format.
+
+```shell
+kubectl get -o json pod web-pod-13je7
+```
+
+ List a pod identified by type and name specified in "pod.yaml" in JSON output format.
+
+```shell
+kubectl get -f pod.yaml -o json
+```
+
+ List resources from a directory with kustomization.yaml - e.g. dir/kustomization.yaml.
+
+```shell
+kubectl get -k dir/
+```
+
+ Return only the phase value of the specified pod.
+
+```shell
+kubectl get -o template pod/web-pod-13je7 --template={{.status.phase}}
+```
+
+ List resource information in custom columns.
+
+```shell
+kubectl get pod test-pod -o custom-columns=CONTAINER:.spec.containers[0].name,IMAGE:.spec.containers[0].image
+```
+
+ List all replication controllers and services together in ps output format.
+
+```shell
+kubectl get rc,services
+```
+
+ List one or more resources by their type and names.
+
+```shell
+kubectl get rc/web service/frontend pods/web-pod-13je7
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>all-namespaces</td><td>A</td><td>false</td><td>If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.</td>
+    </tr>
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>chunk-size</td><td></td><td>500</td><td>Return large lists in chunks rather than all at once. Pass 0 to disable. This flag is beta and may change in the future.</td>
+    </tr>
+    <tr>
+    <td>export</td><td></td><td>false</td><td>If true, use 'export' for the resources.  Exported resources are stripped of cluster-specific information.</td>
+    </tr>
+    <tr>
+    <td>field-selector</td><td></td><td></td><td>Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>Filename, directory, or URL to files identifying the resource to get from a server.</td>
+    </tr>
+    <tr>
+    <td>ignore-not-found</td><td></td><td>false</td><td>If the requested object does not exist the command will return exit code 0.</td>
+    </tr>
+    <tr>
+    <td>include-uninitialized</td><td></td><td>false</td><td>If true, the kubectl command applies to uninitialized objects. If explicitly set to false, this flag overrides other flags that make the kubectl commands apply to uninitialized objects, e.g., "--all". Objects with empty metadata.initializers are regarded as initialized.</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process the kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>label-columns</td><td>L</td><td>[]</td><td>Accepts a comma separated list of labels that are going to be presented as columns. Names are case-sensitive. You can also use multiple flag options like -L label1 -L label2...</td>
+    </tr>
+    <tr>
+    <td>no-headers</td><td></td><td>false</td><td>When using the default or custom-column output format, don't print headers (default print headers).</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;wide&#124;name&#124;custom-columns=...&#124;custom-columns-file=...&#124;go-template=...&#124;go-template-file=...&#124;jsonpath=...&#124;jsonpath-file=... See custom columns [http://kubernetes.io/docs/user-guide/kubectl-overview/#custom-columns], golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [http://kubernetes.io/docs/user-guide/jsonpath].</td>
+    </tr>
+    <tr>
+    <td>raw</td><td></td><td></td><td>Raw URI to request from the server.  Uses the transport specified by the kubeconfig file.</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>selector</td><td>l</td><td></td><td>Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)</td>
+    </tr>
+    <tr>
+    <td>server-print</td><td></td><td>true</td><td>If true, have the server return the appropriate table output. Supports extension APIs and CRDs.</td>
+    </tr>
+    <tr>
+    <td>show-kind</td><td></td><td>false</td><td>If present, list the resource type for the requested object(s).</td>
+    </tr>
+    <tr>
+    <td>show-labels</td><td></td><td>false</td><td>When printing, show all labels as the last column (default hide labels column)</td>
+    </tr>
+    <tr>
+    <td>sort-by</td><td></td><td></td><td>If non-empty, sort list types using this field specification.  The field specification is expressed as a JSONPath expression (e.g. '{.metadata.name}'). The field in the API resource specified by this JSONPath expression must be an integer or a string.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>use-openapi-print-columns</td><td></td><td>false</td><td>If true, use x-kubernetes-print-column metadata (if present) from the OpenAPI schema for displaying a resource.</td>
+    </tr>
+    <tr>
+    <td>watch</td><td>w</td><td>false</td><td>After listing/getting the requested object, watch for changes. Uninitialized objects are excluded if no object name is provided.</td>
+    </tr>
+    <tr>
+    <td>watch-only</td><td></td><td>false</td><td>Watch for changes to the requested object(s), without listing/getting first.</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/get.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/get.md
@@ -182,8 +182,11 @@ kubectl get rc/web service/frontend pods/web-pod-13je7
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/get.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/get.md
@@ -1,6 +1,7 @@
 ---
 title: get
-content_template: templates/tool-reference
+noedit: true
+layout: kuberef
 ---
 
 ### Overview

--- a/content/en/docs/reference/kubectl/kubectl-reference/get.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/get.md
@@ -16,7 +16,7 @@ Use "kubectl api-resources" for a complete list of supported resources.
 
 ### Usage
 
-`$ get [(-o|--output=)json|yaml|wide|custom-columns=...|custom-columns-file=...|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=...] (TYPE[.VERSION][.GROUP] [NAME | -l label] | TYPE[.VERSION][.GROUP]/NAME ...) [flags]`
+`get [(-o|--output=)json|yaml|wide|custom-columns=...|custom-columns-file=...|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=...] (TYPE[.VERSION][.GROUP] [NAME | -l label] | TYPE[.VERSION][.GROUP]/NAME ...) [flags]`
 
 
 ### Example
@@ -176,4 +176,14 @@ kubectl get rc/web service/frontend pods/web-pod-13je7
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/kustomize.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/kustomize.md
@@ -45,8 +45,11 @@ kubectl kustomize github.com/kubernetes-sigs/kustomize.git/examples/helloWorld?r
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/kustomize.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/kustomize.md
@@ -12,7 +12,7 @@ Print a set of API resources generated from instructions in a kustomization.yaml
 
 ### Usage
 
-`$ kustomize <dir>`
+`kustomize <dir>`
 
 
 ### Example
@@ -39,4 +39,14 @@ kubectl kustomize github.com/kubernetes-sigs/kustomize.git/examples/helloWorld?r
 
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/kustomize.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/kustomize.md
@@ -1,0 +1,42 @@
+---
+title: kustomize
+content_template: templates/tool-reference
+---
+
+### Overview
+Print a set of API resources generated from instructions in a kustomization.yaml file.
+
+ The argument must be the path to the directory containing the file, or a git repository URL with a path suffix specifying same with respect to the repository root.
+
+ kubectl kustomize somedir
+
+### Usage
+
+`$ kustomize <dir>`
+
+
+### Example
+
+ Use the current working directory
+
+```shell
+kubectl kustomize .
+```
+
+ Use some shared configuration directory
+
+```shell
+kubectl kustomize /home/configuration/production
+```
+
+ Use a URL
+
+```shell
+kubectl kustomize github.com/kubernetes-sigs/kustomize.git/examples/helloWorld?ref=v1.0.6
+```
+
+
+
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/label.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/label.md
@@ -1,6 +1,7 @@
 ---
 title: label
-content_template: templates/tool-reference
+noedit: true
+layout: kuberef
 ---
 
 ### Overview

--- a/content/en/docs/reference/kubectl/kubectl-reference/label.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/label.md
@@ -128,8 +128,11 @@ kubectl label pods foo bar-
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/label.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/label.md
@@ -1,0 +1,125 @@
+---
+title: label
+content_template: templates/tool-reference
+---
+
+### Overview
+Update the labels on a resource.
+
+  *  A label key and value must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores, up to  63 characters each.
+  *  Optionally, the key can begin with a DNS subdomain prefix and a single '/', like example.com/my-app
+  *  If --overwrite is true, then existing labels can be overwritten, otherwise attempting to overwrite a label will result in an error.
+  *  If --resource-version is specified, then updates will use this resource version, otherwise the existing resource-version will be used.
+
+### Usage
+
+`$ label [--overwrite] (-f FILENAME | TYPE NAME) KEY_1=VAL_1 ... KEY_N=VAL_N [--resource-version=version]`
+
+
+### Example
+
+ Update pod 'foo' with the label 'unhealthy' and the value 'true'.
+
+```shell
+kubectl label pods foo unhealthy=true
+```
+
+ Update pod 'foo' with the label 'status' and the value 'unhealthy', overwriting any existing value.
+
+```shell
+kubectl label --overwrite pods foo status=unhealthy
+```
+
+ Update all pods in the namespace
+
+```shell
+kubectl label pods --all status=unhealthy
+```
+
+ Update a pod identified by the type and name in "pod.json"
+
+```shell
+kubectl label -f pod.json status=unhealthy
+```
+
+ Update pod 'foo' only if the resource is unchanged from version 1.
+
+```shell
+kubectl label pods foo status=unhealthy --resource-version=1
+```
+
+ Update pod 'foo' by removing a label named 'bar' if it exists. # Does not require the --overwrite flag.
+
+```shell
+kubectl label pods foo bar-
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>all</td><td></td><td>false</td><td>Select all resources, including uninitialized ones, in the namespace of the specified resource types</td>
+    </tr>
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>field-selector</td><td></td><td></td><td>Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>Filename, directory, or URL to files identifying the resource to update the labels</td>
+    </tr>
+    <tr>
+    <td>include-uninitialized</td><td></td><td>false</td><td>If true, the kubectl command applies to uninitialized objects. If explicitly set to false, this flag overrides other flags that make the kubectl commands apply to uninitialized objects, e.g., "--all". Objects with empty metadata.initializers are regarded as initialized.</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process the kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>list</td><td></td><td>false</td><td>If true, display the labels for a given resource.</td>
+    </tr>
+    <tr>
+    <td>local</td><td></td><td>false</td><td>If true, label will NOT contact api-server but run locally.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>overwrite</td><td></td><td>false</td><td>If true, allow labels to be overwritten, otherwise reject label updates that overwrite existing labels.</td>
+    </tr>
+    <tr>
+    <td>record</td><td></td><td>false</td><td>Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>resource-version</td><td></td><td></td><td>If non-empty, the labels update will only succeed if this is the current resource-version for the object. Only valid when specifying a single resource.</td>
+    </tr>
+    <tr>
+    <td>selector</td><td>l</td><td></td><td>Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2).</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/label.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/label.md
@@ -13,7 +13,7 @@ Update the labels on a resource.
 
 ### Usage
 
-`$ label [--overwrite] (-f FILENAME | TYPE NAME) KEY_1=VAL_1 ... KEY_N=VAL_N [--resource-version=version]`
+`label [--overwrite] (-f FILENAME | TYPE NAME) KEY_1=VAL_1 ... KEY_N=VAL_N [--resource-version=version]`
 
 
 ### Example
@@ -122,4 +122,14 @@ kubectl label pods foo bar-
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/logs.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/logs.md
@@ -1,0 +1,135 @@
+---
+title: logs
+content_template: templates/tool-reference
+---
+
+### Overview
+Print the logs for a container in a pod or specified resource. If the pod has only one container, the container name is optional.
+
+### Usage
+
+`$ logs [-f] [-p] (POD | TYPE/NAME) [-c CONTAINER]`
+
+
+### Example
+
+ Return snapshot logs from pod nginx with only one container
+
+```shell
+kubectl logs nginx
+```
+
+ Return snapshot logs from pod nginx with multi containers
+
+```shell
+kubectl logs nginx --all-containers=true
+```
+
+ Return snapshot logs from all containers in pods defined by label app=nginx
+
+```shell
+kubectl logs -lapp=nginx --all-containers=true
+```
+
+ Return snapshot of previous terminated ruby container logs from pod web-1
+
+```shell
+kubectl logs -p -c ruby web-1
+```
+
+ Begin streaming the logs of the ruby container in pod web-1
+
+```shell
+kubectl logs -f -c ruby web-1
+```
+
+ Begin streaming the logs from all containers in pods defined by label app=nginx
+
+```shell
+kubectl logs -f -lapp=nginx --all-containers=true
+```
+
+ Display only the most recent 20 lines of output in pod nginx
+
+```shell
+kubectl logs --tail=20 nginx
+```
+
+ Show all logs from pod nginx written in the last hour
+
+```shell
+kubectl logs --since=1h nginx
+```
+
+ Return snapshot logs from first container of a job named hello
+
+```shell
+kubectl logs job/hello
+```
+
+ Return snapshot logs from container nginx-1 of a deployment named nginx
+
+```shell
+kubectl logs deployment/nginx -c nginx-1
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>all-containers</td><td></td><td>false</td><td>Get all containers' logs in the pod(s).</td>
+    </tr>
+    <tr>
+    <td>container</td><td>c</td><td></td><td>Print the logs of this container</td>
+    </tr>
+    <tr>
+    <td>follow</td><td>f</td><td>false</td><td>Specify if the logs should be streamed.</td>
+    </tr>
+    <tr>
+    <td>ignore-errors</td><td></td><td>false</td><td>If watching / following pod logs, allow for any errors that occur to be non-fatal</td>
+    </tr>
+    <tr>
+    <td>limit-bytes</td><td></td><td>0</td><td>Maximum bytes of logs to return. Defaults to no limit.</td>
+    </tr>
+    <tr>
+    <td>max-log-requests</td><td></td><td>5</td><td>Specify maximum number of concurrent logs to follow when using by a selector. Defaults to 5.</td>
+    </tr>
+    <tr>
+    <td>pod-running-timeout</td><td></td><td>20s</td><td>The length of time (like 5s, 2m, or 3h, higher than zero) to wait until at least one pod is running</td>
+    </tr>
+    <tr>
+    <td>previous</td><td>p</td><td>false</td><td>If true, print the logs for the previous instance of the container in a pod if it exists.</td>
+    </tr>
+    <tr>
+    <td>selector</td><td>l</td><td></td><td>Selector (label query) to filter on.</td>
+    </tr>
+    <tr>
+    <td>since</td><td></td><td>0s</td><td>Only return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to all logs. Only one of since-time / since may be used.</td>
+    </tr>
+    <tr>
+    <td>since-time</td><td></td><td></td><td>Only return logs after a specific date (RFC3339). Defaults to all logs. Only one of since-time / since may be used.</td>
+    </tr>
+    <tr>
+    <td>tail</td><td></td><td>-1</td><td>Lines of recent log file to display. Defaults to -1 with no selector, showing all log lines otherwise 10, if a selector is provided.</td>
+    </tr>
+    <tr>
+    <td>timestamps</td><td></td><td>false</td><td>Include timestamps on each line in the log output</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/logs.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/logs.md
@@ -138,8 +138,11 @@ kubectl logs deployment/nginx -c nginx-1
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/logs.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/logs.md
@@ -8,7 +8,7 @@ Print the logs for a container in a pod or specified resource. If the pod has on
 
 ### Usage
 
-`$ logs [-f] [-p] (POD | TYPE/NAME) [-c CONTAINER]`
+`logs [-f] [-p] (POD | TYPE/NAME) [-c CONTAINER]`
 
 
 ### Example
@@ -132,4 +132,14 @@ kubectl logs deployment/nginx -c nginx-1
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/options.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/options.md
@@ -1,0 +1,26 @@
+---
+title: options
+content_template: templates/tool-reference
+---
+
+### Overview
+Print the list of flags inherited by all commands
+
+### Usage
+
+`$ options`
+
+
+### Example
+
+ Print flags inherited by all commands
+
+```shell
+kubectl options
+```
+
+
+
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/options.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/options.md
@@ -29,8 +29,11 @@ kubectl options
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/options.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/options.md
@@ -8,7 +8,7 @@ Print the list of flags inherited by all commands
 
 ### Usage
 
-`$ options`
+`options`
 
 
 ### Example
@@ -23,4 +23,14 @@ kubectl options
 
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/options.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/options.md
@@ -1,6 +1,7 @@
 ---
 title: options
-content_template: templates/tool-reference
+noedit: true
+layout: kuberef
 ---
 
 ### Overview

--- a/content/en/docs/reference/kubectl/kubectl-reference/patch.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/patch.md
@@ -10,7 +10,7 @@ Update field(s) of a resource using strategic merge patch, a JSON merge patch, o
 
 ### Usage
 
-`$ patch (-f FILENAME | TYPE NAME) -p PATCH`
+`patch (-f FILENAME | TYPE NAME) -p PATCH`
 
 
 ### Example
@@ -98,4 +98,14 @@ kubectl patch pod valid-pod --type='json' -p='[{"op": "replace", "path": "/spec/
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/patch.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/patch.md
@@ -104,8 +104,11 @@ kubectl patch pod valid-pod --type='json' -p='[{"op": "replace", "path": "/spec/
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/patch.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/patch.md
@@ -1,0 +1,101 @@
+---
+title: patch
+content_template: templates/tool-reference
+---
+
+### Overview
+Update field(s) of a resource using strategic merge patch, a JSON merge patch, or a JSON patch.
+
+ JSON and YAML formats are accepted.
+
+### Usage
+
+`$ patch (-f FILENAME | TYPE NAME) -p PATCH`
+
+
+### Example
+
+ Partially update a node using a strategic merge patch. Specify the patch as JSON.
+
+```shell
+kubectl patch node k8s-node-1 -p '{"spec":{"unschedulable":true}}'
+```
+
+ Partially update a node using a strategic merge patch. Specify the patch as YAML.
+
+```shell
+kubectl patch node k8s-node-1 -p $'spec:\n unschedulable: true'
+```
+
+ Partially update a node identified by the type and name specified in "node.json" using strategic merge patch.
+
+```shell
+kubectl patch -f node.json -p '{"spec":{"unschedulable":true}}'
+```
+
+ Update a container's image; spec.containers[*].name is required because it's a merge key.
+
+```shell
+kubectl patch pod valid-pod -p '{"spec":{"containers":[{"name":"kubernetes-serve-hostname","image":"new image"}]}}'
+```
+
+ Update a container's image using a json patch with positional arrays.
+
+```shell
+kubectl patch pod valid-pod --type='json' -p='[{"op": "replace", "path": "/spec/containers/0/image", "value":"new image"}]'
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>Filename, directory, or URL to files identifying the resource to update</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process the kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>local</td><td></td><td>false</td><td>If true, patch will operate on the content of the file, not the server-side resource.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>patch</td><td>p</td><td></td><td>The patch to be applied to the resource JSON file.</td>
+    </tr>
+    <tr>
+    <td>record</td><td></td><td>false</td><td>Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>type</td><td></td><td>strategic</td><td>The type of patch being provided; one of [json merge strategic]</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/patch.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/patch.md
@@ -1,6 +1,7 @@
 ---
 title: patch
-content_template: templates/tool-reference
+noedit: true
+layout: kuberef
 ---
 
 ### Overview

--- a/content/en/docs/reference/kubectl/kubectl-reference/plugin.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/plugin.md
@@ -60,8 +60,11 @@ List all available plugin files on a user's PATH.
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/plugin.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/plugin.md
@@ -1,0 +1,57 @@
+---
+title: plugin
+content_template: templates/tool-reference
+---
+
+### Overview
+Provides utilities for interacting with plugins.
+
+ Plugins provide extended functionality that is not part of the major command-line distribution. Please refer to the documentation and examples for more information about how write your own plugins.
+
+### Usage
+
+`$ plugin [flags]`
+
+
+
+
+
+
+<hr>
+
+## list
+
+
+### Overview
+List all available plugin files on a user's PATH.
+
+ Available plugin files are those that are: - executable - anywhere on the user's PATH - begin with "kubectl-"
+
+### Usage
+
+`$ list`
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>name-only</td><td></td><td>false</td><td>If true, display only the binary name of each plugin, rather than its full path</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/plugin.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/plugin.md
@@ -1,6 +1,7 @@
 ---
 title: plugin
-content_template: templates/tool-reference
+noedit: true
+layout: kuberef
 ---
 
 ### Overview

--- a/content/en/docs/reference/kubectl/kubectl-reference/plugin.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/plugin.md
@@ -10,7 +10,7 @@ Provides utilities for interacting with plugins.
 
 ### Usage
 
-`$ plugin [flags]`
+`plugin [flags]`
 
 
 
@@ -29,14 +29,14 @@ List all available plugin files on a user's PATH.
 
 ### Usage
 
-`$ list`
+`list`
 
 
 
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -54,4 +54,14 @@ List all available plugin files on a user's PATH.
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/port-forward.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/port-forward.md
@@ -1,0 +1,88 @@
+---
+title: port-forward
+content_template: templates/tool-reference
+---
+
+### Overview
+Forward one or more local ports to a pod. This command requires the node to have 'socat' installed.
+
+ Use resource type/name such as deployment/mydeployment to select a pod. Resource type defaults to 'pod' if omitted.
+
+ If there are multiple pods matching the criteria, a pod will be selected automatically. The forwarding session ends when the selected pod terminates, and rerun of the command is needed to resume forwarding.
+
+### Usage
+
+`$ port-forward TYPE/NAME [options] [LOCAL_PORT:]REMOTE_PORT [...[LOCAL_PORT_N:]REMOTE_PORT_N]`
+
+
+### Example
+
+ Listen on ports 5000 and 6000 locally, forwarding data to/from ports 5000 and 6000 in the pod
+
+```shell
+kubectl port-forward pod/mypod 5000 6000
+```
+
+ Listen on ports 5000 and 6000 locally, forwarding data to/from ports 5000 and 6000 in a pod selected by the deployment
+
+```shell
+kubectl port-forward deployment/mydeployment 5000 6000
+```
+
+ Listen on ports 5000 and 6000 locally, forwarding data to/from ports 5000 and 6000 in a pod selected by the service
+
+```shell
+kubectl port-forward service/myservice 5000 6000
+```
+
+ Listen on port 8888 locally, forwarding to 5000 in the pod
+
+```shell
+kubectl port-forward pod/mypod 8888:5000
+```
+
+ Listen on port 8888 on all addresses, forwarding to 5000 in the pod
+
+```shell
+kubectl port-forward --address 0.0.0.0 pod/mypod 8888:5000
+```
+
+ Listen on port 8888 on localhost and selected IP, forwarding to 5000 in the pod
+
+```shell
+kubectl port-forward --address localhost,10.19.21.23 pod/mypod 8888:5000
+```
+
+ Listen on a random port locally, forwarding to 5000 in the pod
+
+```shell
+kubectl port-forward pod/mypod :5000
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>address</td><td></td><td>[localhost]</td><td>Addresses to listen on (comma separated). Only accepts IP addresses or localhost as a value. When localhost is supplied, kubectl will try to bind on both 127.0.0.1 and ::1 and will fail if neither of these addresses are available to bind.</td>
+    </tr>
+    <tr>
+    <td>pod-running-timeout</td><td></td><td>1m0s</td><td>The length of time (like 5s, 2m, or 3h, higher than zero) to wait until at least one pod is running</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/port-forward.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/port-forward.md
@@ -91,8 +91,11 @@ kubectl port-forward pod/mypod :5000
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/port-forward.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/port-forward.md
@@ -12,7 +12,7 @@ Forward one or more local ports to a pod. This command requires the node to have
 
 ### Usage
 
-`$ port-forward TYPE/NAME [options] [LOCAL_PORT:]REMOTE_PORT [...[LOCAL_PORT_N:]REMOTE_PORT_N]`
+`port-forward TYPE/NAME [options] [LOCAL_PORT:]REMOTE_PORT [...[LOCAL_PORT_N:]REMOTE_PORT_N]`
 
 
 ### Example
@@ -85,4 +85,14 @@ kubectl port-forward pod/mypod :5000
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/proxy.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/proxy.md
@@ -8,7 +8,7 @@ Creates a proxy server or application-level gateway between localhost and the Ku
 
 ### Usage
 
-`$ proxy [--port=PORT] [--www=static-dir] [--www-prefix=prefix] [--api-prefix=prefix]`
+`proxy [--port=PORT] [--www=static-dir] [--www-prefix=prefix] [--api-prefix=prefix]`
 
 
 ### Example
@@ -105,4 +105,14 @@ kubectl proxy --api-prefix=/k8s-api
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/proxy.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/proxy.md
@@ -1,6 +1,7 @@
 ---
 title: proxy
-content_template: templates/tool-reference
+noedit: true
+layout: kuberef
 ---
 
 ### Overview

--- a/content/en/docs/reference/kubectl/kubectl-reference/proxy.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/proxy.md
@@ -1,0 +1,108 @@
+---
+title: proxy
+content_template: templates/tool-reference
+---
+
+### Overview
+Creates a proxy server or application-level gateway between localhost and the Kubernetes API Server. It also allows serving static content over specified HTTP path. All incoming data enters through one port and gets forwarded to the remote kubernetes API Server port, except for the path matching the static content path.
+
+### Usage
+
+`$ proxy [--port=PORT] [--www=static-dir] [--www-prefix=prefix] [--api-prefix=prefix]`
+
+
+### Example
+
+ To proxy all of the kubernetes api and nothing else, use:
+
+```shell
+$ kubectl proxy --api-prefix=/
+```
+
+ To proxy only part of the kubernetes api and also some static files:
+
+```shell
+$ kubectl proxy --www=/my/files --www-prefix=/static/ --api-prefix=/api/
+```
+
+ The above lets you 'curl localhost:8001/api/v1/pods'. # To proxy the entire kubernetes api at a different root, use:
+
+```shell
+$ kubectl proxy --api-prefix=/custom/
+```
+
+ The above lets you 'curl localhost:8001/custom/api/v1/pods' # Run a proxy to kubernetes apiserver on port 8011, serving static content from ./local/www/
+
+```shell
+kubectl proxy --port=8011 --www=./local/www/
+```
+
+ Run a proxy to kubernetes apiserver on an arbitrary local port. # The chosen port for the server will be output to stdout.
+
+```shell
+kubectl proxy --port=0
+```
+
+ Run a proxy to kubernetes apiserver, changing the api prefix to k8s-api # This makes e.g. the pods api available at localhost:8001/k8s-api/v1/pods/
+
+```shell
+kubectl proxy --api-prefix=/k8s-api
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>accept-hosts</td><td></td><td>^localhost$,^127\.0\.0\.1$,^\[::1\]$</td><td>Regular expression for hosts that the proxy should accept.</td>
+    </tr>
+    <tr>
+    <td>accept-paths</td><td></td><td>^.*</td><td>Regular expression for paths that the proxy should accept.</td>
+    </tr>
+    <tr>
+    <td>address</td><td></td><td>127.0.0.1</td><td>The IP address on which to serve on.</td>
+    </tr>
+    <tr>
+    <td>api-prefix</td><td></td><td>/</td><td>Prefix to serve the proxied API under.</td>
+    </tr>
+    <tr>
+    <td>disable-filter</td><td></td><td>false</td><td>If true, disable request filtering in the proxy. This is dangerous, and can leave you vulnerable to XSRF attacks, when used with an accessible port.</td>
+    </tr>
+    <tr>
+    <td>keepalive</td><td></td><td>0s</td><td>keepalive specifies the keep-alive period for an active network connection. Set to 0 to disable keepalive.</td>
+    </tr>
+    <tr>
+    <td>port</td><td>p</td><td>8001</td><td>The port on which to run the proxy. Set to 0 to pick a random port.</td>
+    </tr>
+    <tr>
+    <td>reject-methods</td><td></td><td>^$</td><td>Regular expression for HTTP methods that the proxy should reject (example --reject-methods='POST,PUT,PATCH'). </td>
+    </tr>
+    <tr>
+    <td>reject-paths</td><td></td><td>^/api/.*/pods/.*/exec,^/api/.*/pods/.*/attach</td><td>Regular expression for paths that the proxy should reject. Paths specified here will be rejected even accepted by --accept-paths.</td>
+    </tr>
+    <tr>
+    <td>unix-socket</td><td>u</td><td></td><td>Unix socket on which to run the proxy.</td>
+    </tr>
+    <tr>
+    <td>www</td><td>w</td><td></td><td>Also serve static files from the given directory under the specified prefix.</td>
+    </tr>
+    <tr>
+    <td>www-prefix</td><td>P</td><td>/static/</td><td>Prefix to serve static files under, if static file directory is specified.</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/proxy.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/proxy.md
@@ -111,8 +111,11 @@ kubectl proxy --api-prefix=/k8s-api
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/replace.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/replace.md
@@ -1,0 +1,103 @@
+---
+title: replace
+content_template: templates/tool-reference
+---
+
+### Overview
+Replace a resource by filename or stdin.
+
+ JSON and YAML formats are accepted. If replacing an existing resource, the complete resource spec must be provided. This can be obtained by
+
+  $ kubectl get TYPE NAME -o yaml
+
+### Usage
+
+`$ replace -f FILENAME`
+
+
+### Example
+
+ Replace a pod using the data in pod.json.
+
+```shell
+kubectl replace -f ./pod.json
+```
+
+ Replace a pod based on the JSON passed into stdin.
+
+```shell
+cat pod.json | kubectl replace -f -
+```
+
+ Update a single-container pod's image version (tag) to v4
+
+```shell
+kubectl get pod mypod -o yaml | sed 's/\(image: myimage\):.*$/\1:v4/' | kubectl replace -f -
+```
+
+ Force replace, delete and then re-create the resource
+
+```shell
+kubectl replace --force -f ./pod.json
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>cascade</td><td></td><td>true</td><td>If true, cascade the deletion of the resources managed by this resource (e.g. Pods created by a ReplicationController).  Default true.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>to use to replace the resource.</td>
+    </tr>
+    <tr>
+    <td>force</td><td></td><td>false</td><td>Only used when grace-period=0. If true, immediately remove resources from API and bypass graceful deletion. Note that immediate deletion of some resources may result in inconsistency or data loss and requires confirmation.</td>
+    </tr>
+    <tr>
+    <td>grace-period</td><td></td><td>-1</td><td>Period of time in seconds given to the resource to terminate gracefully. Ignored if negative. Set to 1 for immediate shutdown. Can only be set to 0 when --force is true (force deletion).</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process a kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>save-config</td><td></td><td>false</td><td>If true, the configuration of current object will be saved in its annotation. Otherwise, the annotation will be unchanged. This flag is useful when you want to perform kubectl apply on this object in the future.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>timeout</td><td></td><td>0s</td><td>The length of time to wait before giving up on a delete, zero means determine a timeout from the size of the object</td>
+    </tr>
+    <tr>
+    <td>validate</td><td></td><td>true</td><td>If true, use a schema to validate the input before sending it</td>
+    </tr>
+    <tr>
+    <td>wait</td><td></td><td>false</td><td>If true, wait for resources to be gone before returning. This waits for finalizers.</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/replace.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/replace.md
@@ -106,8 +106,11 @@ kubectl replace --force -f ./pod.json
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/replace.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/replace.md
@@ -12,7 +12,7 @@ Replace a resource by filename or stdin.
 
 ### Usage
 
-`$ replace -f FILENAME`
+`replace -f FILENAME`
 
 
 ### Example
@@ -100,4 +100,14 @@ kubectl replace --force -f ./pod.json
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/rolling-update.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/rolling-update.md
@@ -115,8 +115,11 @@ kubectl rolling-update frontend-v1 frontend-v2 --rollback
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/rolling-update.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/rolling-update.md
@@ -1,6 +1,7 @@
 ---
 title: rolling-update
-content_template: templates/tool-reference
+noedit: true
+layout: kuberef
 ---
 
 ### Overview

--- a/content/en/docs/reference/kubectl/kubectl-reference/rolling-update.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/rolling-update.md
@@ -12,7 +12,7 @@ Perform a rolling update of the given ReplicationController.
 
 ### Usage
 
-`$ rolling-update OLD_CONTROLLER_NAME ([NEW_CONTROLLER_NAME] --image=NEW_CONTAINER_IMAGE | -f NEW_CONTROLLER_SPEC)`
+`rolling-update OLD_CONTROLLER_NAME ([NEW_CONTROLLER_NAME] --image=NEW_CONTAINER_IMAGE | -f NEW_CONTROLLER_SPEC)`
 
 
 ### Example
@@ -109,4 +109,14 @@ kubectl rolling-update frontend-v1 frontend-v2 --rollback
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/rolling-update.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/rolling-update.md
@@ -1,0 +1,112 @@
+---
+title: rolling-update
+content_template: templates/tool-reference
+---
+
+### Overview
+Perform a rolling update of the given ReplicationController.
+
+ Replaces the specified replication controller with a new replication controller by updating one pod at a time to use the new PodTemplate. The new-controller.json must specify the same namespace as the existing replication controller and overwrite at least one (common) label in its replicaSelector.
+
+ http://kubernetes.io/images/docs/kubectl_rollingupdate.svg
+
+### Usage
+
+`$ rolling-update OLD_CONTROLLER_NAME ([NEW_CONTROLLER_NAME] --image=NEW_CONTAINER_IMAGE | -f NEW_CONTROLLER_SPEC)`
+
+
+### Example
+
+ Update pods of frontend-v1 using new replication controller data in frontend-v2.json.
+
+```shell
+kubectl rolling-update frontend-v1 -f frontend-v2.json
+```
+
+ Update pods of frontend-v1 using JSON data passed into stdin.
+
+```shell
+cat frontend-v2.json | kubectl rolling-update frontend-v1 -f -
+```
+
+ Update the pods of frontend-v1 to frontend-v2 by just changing the image, and switching the # name of the replication controller.
+
+```shell
+kubectl rolling-update frontend-v1 frontend-v2 --image=image:v2
+```
+
+ Update the pods of frontend by just changing the image, and keeping the old name.
+
+```shell
+kubectl rolling-update frontend --image=image:v2
+```
+
+ Abort and reverse an existing rollout in progress (from frontend-v1 to frontend-v2).
+
+```shell
+kubectl rolling-update frontend-v1 frontend-v2 --rollback
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>container</td><td></td><td></td><td>Container name which will have its image upgraded. Only relevant when --image is specified, ignored otherwise. Required when using --image on a multi-container pod</td>
+    </tr>
+    <tr>
+    <td>deployment-label-key</td><td></td><td>deployment</td><td>The key to use to differentiate between two different controllers, default 'deployment'.  Only relevant when --image is specified, ignored otherwise</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>Filename or URL to file to use to create the new replication controller.</td>
+    </tr>
+    <tr>
+    <td>image</td><td></td><td></td><td>Image to use for upgrading the replication controller. Must be distinct from the existing image (either new image or new image tag).  Can not be used with --filename/-f</td>
+    </tr>
+    <tr>
+    <td>image-pull-policy</td><td></td><td></td><td>Explicit policy for when to pull container images. Required when --image is same as existing image, ignored otherwise.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>poll-interval</td><td></td><td>3s</td><td>Time delay between polling for replication controller status after the update. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".</td>
+    </tr>
+    <tr>
+    <td>rollback</td><td></td><td>false</td><td>If true, this is a request to abort an existing rollout that is partially rolled out. It effectively reverses current and next and runs a rollout</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>timeout</td><td></td><td>5m0s</td><td>Max time to wait for a replication controller to update before giving up. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".</td>
+    </tr>
+    <tr>
+    <td>update-period</td><td></td><td>1m0s</td><td>Time to wait between updating pods. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".</td>
+    </tr>
+    <tr>
+    <td>validate</td><td></td><td>true</td><td>If true, use a schema to validate the input before sending it</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/rollout.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/rollout.md
@@ -14,7 +14,7 @@ Manage the rollout of a resource.
 
 ### Usage
 
-`$ rollout SUBCOMMAND`
+`rollout SUBCOMMAND`
 
 
 ### Example
@@ -46,7 +46,7 @@ View previous rollout revisions and configurations.
 
 ### Usage
 
-`$ history (TYPE NAME | TYPE/NAME) [flags]`
+`history (TYPE NAME | TYPE/NAME) [flags]`
 
 
 ### Example
@@ -67,7 +67,7 @@ kubectl rollout history daemonset/abc --revision=3
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -116,7 +116,7 @@ Mark the provided resource as paused
 
 ### Usage
 
-`$ pause RESOURCE`
+`pause RESOURCE`
 
 
 ### Example
@@ -131,7 +131,7 @@ kubectl rollout pause deployment/nginx
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -177,7 +177,7 @@ Restart a resource.
 
 ### Usage
 
-`$ restart RESOURCE`
+`restart RESOURCE`
 
 
 ### Example
@@ -198,7 +198,7 @@ kubectl rollout restart daemonset/abc
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -244,7 +244,7 @@ Resume a paused resource
 
 ### Usage
 
-`$ resume RESOURCE`
+`resume RESOURCE`
 
 
 ### Example
@@ -259,7 +259,7 @@ kubectl rollout resume deployment/nginx
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -305,7 +305,7 @@ Show the status of the rollout.
 
 ### Usage
 
-`$ status (TYPE NAME | TYPE/NAME) [flags]`
+`status (TYPE NAME | TYPE/NAME) [flags]`
 
 
 ### Example
@@ -320,7 +320,7 @@ kubectl rollout status deployment/nginx
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -364,7 +364,7 @@ Rollback to a previous rollout.
 
 ### Usage
 
-`$ undo (TYPE NAME | TYPE/NAME) [flags]`
+`undo (TYPE NAME | TYPE/NAME) [flags]`
 
 
 ### Example
@@ -391,7 +391,7 @@ kubectl rollout undo --dry-run=true deployment/abc
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -430,4 +430,14 @@ kubectl rollout undo --dry-run=true deployment/abc
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/rollout.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/rollout.md
@@ -1,0 +1,433 @@
+---
+title: rollout
+content_template: templates/tool-reference
+---
+
+### Overview
+Manage the rollout of a resource.
+  
+ Valid resource types include:
+
+  *  deployments
+  *  daemonsets
+  *  statefulsets
+
+### Usage
+
+`$ rollout SUBCOMMAND`
+
+
+### Example
+
+ Rollback to the previous deployment
+
+```shell
+kubectl rollout undo deployment/abc
+```
+
+ Check the rollout status of a daemonset
+
+```shell
+kubectl rollout status daemonset/foo
+```
+
+
+
+
+
+
+<hr>
+
+## history
+
+
+### Overview
+View previous rollout revisions and configurations.
+
+### Usage
+
+`$ history (TYPE NAME | TYPE/NAME) [flags]`
+
+
+### Example
+ View the rollout history of a deployment
+
+```shell
+kubectl rollout history deployment/abc
+```
+
+ View the details of daemonset revision 3
+
+```shell
+kubectl rollout history daemonset/abc --revision=3
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>Filename, directory, or URL to files identifying the resource to get from a server.</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process the kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>revision</td><td></td><td>0</td><td>See the details, including podTemplate of the revision specified</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## pause
+
+
+### Overview
+Mark the provided resource as paused
+
+ Paused resources will not be reconciled by a controller. Use "kubectl rollout resume" to resume a paused resource. Currently only deployments support being paused.
+
+### Usage
+
+`$ pause RESOURCE`
+
+
+### Example
+ Mark the nginx deployment as paused. Any current state of # the deployment will continue its function, new updates to the deployment will not # have an effect as long as the deployment is paused.
+
+```shell
+kubectl rollout pause deployment/nginx
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>Filename, directory, or URL to files identifying the resource to get from a server.</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process the kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## restart
+
+
+### Overview
+Restart a resource.
+
+   Resource will be rollout restarted.
+
+### Usage
+
+`$ restart RESOURCE`
+
+
+### Example
+ Restart a deployment
+
+```shell
+kubectl rollout restart deployment/nginx
+```
+
+ Restart a daemonset
+
+```shell
+kubectl rollout restart daemonset/abc
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>Filename, directory, or URL to files identifying the resource to get from a server.</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process the kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## resume
+
+
+### Overview
+Resume a paused resource
+
+ Paused resources will not be reconciled by a controller. By resuming a resource, we allow it to be reconciled again. Currently only deployments support being resumed.
+
+### Usage
+
+`$ resume RESOURCE`
+
+
+### Example
+ Resume an already paused deployment
+
+```shell
+kubectl rollout resume deployment/nginx
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>Filename, directory, or URL to files identifying the resource to get from a server.</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process the kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## status
+
+
+### Overview
+Show the status of the rollout.
+
+ By default 'rollout status' will watch the status of the latest rollout until it's done. If you don't want to wait for the rollout to finish then you can use --watch=false. Note that if a new rollout starts in-between, then 'rollout status' will continue watching the latest revision. If you want to pin to a specific revision and abort if it is rolled over by another revision, use --revision=N where N is the revision you need to watch for.
+
+### Usage
+
+`$ status (TYPE NAME | TYPE/NAME) [flags]`
+
+
+### Example
+ Watch the rollout status of a deployment
+
+```shell
+kubectl rollout status deployment/nginx
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>Filename, directory, or URL to files identifying the resource to get from a server.</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process the kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>revision</td><td></td><td>0</td><td>Pin to a specific revision for showing its status. Defaults to 0 (last revision).</td>
+    </tr>
+    <tr>
+    <td>timeout</td><td></td><td>0s</td><td>The length of time to wait before ending watch, zero means never. Any other values should contain a corresponding time unit (e.g. 1s, 2m, 3h).</td>
+    </tr>
+    <tr>
+    <td>watch</td><td>w</td><td>true</td><td>Watch the status of the rollout until it's done.</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## undo
+
+
+### Overview
+Rollback to a previous rollout.
+
+### Usage
+
+`$ undo (TYPE NAME | TYPE/NAME) [flags]`
+
+
+### Example
+ Rollback to the previous deployment
+
+```shell
+kubectl rollout undo deployment/abc
+```
+
+ Rollback to daemonset revision 3
+
+```shell
+kubectl rollout undo daemonset/abc --to-revision=3
+```
+
+ Rollback to the previous deployment with dry-run
+
+```shell
+kubectl rollout undo --dry-run=true deployment/abc
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>Filename, directory, or URL to files identifying the resource to get from a server.</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process the kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>to-revision</td><td></td><td>0</td><td>The revision to rollback to. Default to 0 (last revision).</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/rollout.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/rollout.md
@@ -436,8 +436,11 @@ kubectl rollout undo --dry-run=true deployment/abc
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/run.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/run.md
@@ -1,0 +1,227 @@
+---
+title: run
+content_template: templates/tool-reference
+---
+
+### Overview
+Create and run a particular image, possibly replicated.
+
+ Creates a deployment or job to manage the created container(s).
+
+### Usage
+
+`$ run NAME --image=image [--env="key=value"] [--port=port] [--replicas=replicas] [--dry-run=bool] [--overrides=inline-json] [--command] -- [COMMAND] [args...]`
+
+
+### Example
+
+ Start a single instance of nginx.
+
+```shell
+kubectl run nginx --image=nginx
+```
+
+ Start a single instance of hazelcast and let the container expose port 5701 .
+
+```shell
+kubectl run hazelcast --image=hazelcast --port=5701
+```
+
+ Start a single instance of hazelcast and set environment variables "DNS_DOMAIN=cluster" and "POD_NAMESPACE=default" in the container.
+
+```shell
+kubectl run hazelcast --image=hazelcast --env="DNS_DOMAIN=cluster" --env="POD_NAMESPACE=default"
+```
+
+ Start a single instance of hazelcast and set labels "app=hazelcast" and "env=prod" in the container.
+
+```shell
+kubectl run hazelcast --image=hazelcast --labels="app=hazelcast,env=prod"
+```
+
+ Start a replicated instance of nginx.
+
+```shell
+kubectl run nginx --image=nginx --replicas=5
+```
+
+ Dry run. Print the corresponding API objects without creating them.
+
+```shell
+kubectl run nginx --image=nginx --dry-run
+```
+
+ Start a single instance of nginx, but overload the spec of the deployment with a partial set of values parsed from JSON.
+
+```shell
+kubectl run nginx --image=nginx --overrides='{ "apiVersion": "v1", "spec": { ... } }'
+```
+
+ Start a pod of busybox and keep it in the foreground, don't restart it if it exits.
+
+```shell
+kubectl run -i -t busybox --image=busybox --restart=Never
+```
+
+ Start the nginx container using the default command, but use custom arguments (arg1 .. argN) for that command.
+
+```shell
+kubectl run nginx --image=nginx -- <arg1> <arg2> ... <argN>
+```
+
+ Start the nginx container using a different command and custom arguments.
+
+```shell
+kubectl run nginx --image=nginx --command -- <cmd> <arg1> ... <argN>
+```
+
+ Start the perl container to compute π to 2000 places and print it out.
+
+```shell
+kubectl run pi --image=perl --restart=OnFailure -- perl -Mbignum=bpi -wle 'print bpi(2000)'
+```
+
+ Start the cron job to compute π to 2000 places and print it out every 5 minutes.
+
+```shell
+kubectl run pi --schedule="0/5 * * * ?" --image=perl --restart=OnFailure -- perl -Mbignum=bpi -wle 'print bpi(2000)'
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>attach</td><td></td><td>false</td><td>If true, wait for the Pod to start running, and then attach to the Pod as if 'kubectl attach ...' were called.  Default false, unless '-i/--stdin' is set, in which case the default is true. With '--restart=Never' the exit code of the container process is returned.</td>
+    </tr>
+    <tr>
+    <td>cascade</td><td></td><td>true</td><td>If true, cascade the deletion of the resources managed by this resource (e.g. Pods created by a ReplicationController).  Default true.</td>
+    </tr>
+    <tr>
+    <td>command</td><td></td><td>false</td><td>If true and extra arguments are present, use them as the 'command' field in the container, rather than the 'args' field which is the default.</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>env</td><td></td><td>[]</td><td>Environment variables to set in the container</td>
+    </tr>
+    <tr>
+    <td>expose</td><td></td><td>false</td><td>If true, a public, external service is created for the container(s) which are run</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>to use to replace the resource.</td>
+    </tr>
+    <tr>
+    <td>force</td><td></td><td>false</td><td>Only used when grace-period=0. If true, immediately remove resources from API and bypass graceful deletion. Note that immediate deletion of some resources may result in inconsistency or data loss and requires confirmation.</td>
+    </tr>
+    <tr>
+    <td>generator</td><td></td><td></td><td>The name of the API generator to use, see http://kubernetes.io/docs/user-guide/kubectl-conventions/#generators for a list.</td>
+    </tr>
+    <tr>
+    <td>grace-period</td><td></td><td>-1</td><td>Period of time in seconds given to the resource to terminate gracefully. Ignored if negative. Set to 1 for immediate shutdown. Can only be set to 0 when --force is true (force deletion).</td>
+    </tr>
+    <tr>
+    <td>hostport</td><td></td><td>-1</td><td>The host port mapping for the container port. To demonstrate a single-machine container.</td>
+    </tr>
+    <tr>
+    <td>image</td><td></td><td></td><td>The image for the container to run.</td>
+    </tr>
+    <tr>
+    <td>image-pull-policy</td><td></td><td></td><td>The image pull policy for the container. If left empty, this value will not be specified by the client and defaulted by the server</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process a kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>labels</td><td>l</td><td></td><td>Comma separated labels to apply to the pod(s). Will override previous values.</td>
+    </tr>
+    <tr>
+    <td>leave-stdin-open</td><td></td><td>false</td><td>If the pod is started in interactive mode or with stdin, leave stdin open after the first attach completes. By default, stdin will be closed after the first attach completes.</td>
+    </tr>
+    <tr>
+    <td>limits</td><td></td><td></td><td>The resource requirement limits for this container.  For example, 'cpu=200m,memory=512Mi'.  Note that server side components may assign limits depending on the server configuration, such as limit ranges.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>overrides</td><td></td><td></td><td>An inline JSON override for the generated object. If this is non-empty, it is used to override the generated object. Requires that the object supply a valid apiVersion field.</td>
+    </tr>
+    <tr>
+    <td>pod-running-timeout</td><td></td><td>1m0s</td><td>The length of time (like 5s, 2m, or 3h, higher than zero) to wait until at least one pod is running</td>
+    </tr>
+    <tr>
+    <td>port</td><td></td><td></td><td>The port that this container exposes.  If --expose is true, this is also the port used by the service that is created.</td>
+    </tr>
+    <tr>
+    <td>quiet</td><td></td><td>false</td><td>If true, suppress prompt messages.</td>
+    </tr>
+    <tr>
+    <td>record</td><td></td><td>false</td><td>Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>replicas</td><td>r</td><td>1</td><td>Number of replicas to create for this container. Default is 1.</td>
+    </tr>
+    <tr>
+    <td>requests</td><td></td><td></td><td>The resource requirement requests for this container.  For example, 'cpu=100m,memory=256Mi'.  Note that server side components may assign requests depending on the server configuration, such as limit ranges.</td>
+    </tr>
+    <tr>
+    <td>restart</td><td></td><td>Always</td><td>The restart policy for this Pod.  Legal values [Always, OnFailure, Never].  If set to 'Always' a deployment is created, if set to 'OnFailure' a job is created, if set to 'Never', a regular pod is created. For the latter two --replicas must be 1.  Default 'Always', for CronJobs `Never`.</td>
+    </tr>
+    <tr>
+    <td>rm</td><td></td><td>false</td><td>If true, delete resources created in this command for attached containers.</td>
+    </tr>
+    <tr>
+    <td>save-config</td><td></td><td>false</td><td>If true, the configuration of current object will be saved in its annotation. Otherwise, the annotation will be unchanged. This flag is useful when you want to perform kubectl apply on this object in the future.</td>
+    </tr>
+    <tr>
+    <td>schedule</td><td></td><td></td><td>A schedule in the Cron format the job should be run with.</td>
+    </tr>
+    <tr>
+    <td>service-generator</td><td></td><td>service/v2</td><td>The name of the generator to use for creating a service.  Only used if --expose is true</td>
+    </tr>
+    <tr>
+    <td>service-overrides</td><td></td><td></td><td>An inline JSON override for the generated service object. If this is non-empty, it is used to override the generated object. Requires that the object supply a valid apiVersion field.  Only used if --expose is true.</td>
+    </tr>
+    <tr>
+    <td>serviceaccount</td><td></td><td></td><td>Service account to set in the pod spec</td>
+    </tr>
+    <tr>
+    <td>stdin</td><td>i</td><td>false</td><td>Keep stdin open on the container(s) in the pod, even if nothing is attached.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>timeout</td><td></td><td>0s</td><td>The length of time to wait before giving up on a delete, zero means determine a timeout from the size of the object</td>
+    </tr>
+    <tr>
+    <td>tty</td><td>t</td><td>false</td><td>Allocated a TTY for each container in the pod.</td>
+    </tr>
+    <tr>
+    <td>wait</td><td></td><td>false</td><td>If true, wait for resources to be gone before returning. This waits for finalizers.</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/run.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/run.md
@@ -1,6 +1,7 @@
 ---
 title: run
-content_template: templates/tool-reference
+noedit: true
+layout: kuberef
 ---
 
 ### Overview

--- a/content/en/docs/reference/kubectl/kubectl-reference/run.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/run.md
@@ -230,8 +230,11 @@ kubectl run pi --schedule="0/5 * * * ?" --image=perl --restart=OnFailure -- perl
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/run.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/run.md
@@ -10,7 +10,7 @@ Create and run a particular image, possibly replicated.
 
 ### Usage
 
-`$ run NAME --image=image [--env="key=value"] [--port=port] [--replicas=replicas] [--dry-run=bool] [--overrides=inline-json] [--command] -- [COMMAND] [args...]`
+`run NAME --image=image [--env="key=value"] [--port=port] [--replicas=replicas] [--dry-run=bool] [--overrides=inline-json] [--command] -- [COMMAND] [args...]`
 
 
 ### Example
@@ -224,4 +224,14 @@ kubectl run pi --schedule="0/5 * * * ?" --image=perl --restart=OnFailure -- perl
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/scale.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/scale.md
@@ -12,7 +12,7 @@ Set a new size for a Deployment, ReplicaSet, Replication Controller, or Stateful
 
 ### Usage
 
-`$ scale [--resource-version=version] [--current-replicas=count] --replicas=COUNT (-f FILENAME | TYPE NAME)`
+`scale [--resource-version=version] [--current-replicas=count] --replicas=COUNT (-f FILENAME | TYPE NAME)`
 
 
 ### Example
@@ -106,4 +106,14 @@ kubectl scale --replicas=3 statefulset/web
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/scale.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/scale.md
@@ -112,8 +112,11 @@ kubectl scale --replicas=3 statefulset/web
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/scale.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/scale.md
@@ -1,0 +1,109 @@
+---
+title: scale
+content_template: templates/tool-reference
+---
+
+### Overview
+Set a new size for a Deployment, ReplicaSet, Replication Controller, or StatefulSet.
+
+ Scale also allows users to specify one or more preconditions for the scale action.
+
+ If --current-replicas or --resource-version is specified, it is validated before the scale is attempted, and it is guaranteed that the precondition holds true when the scale is sent to the server.
+
+### Usage
+
+`$ scale [--resource-version=version] [--current-replicas=count] --replicas=COUNT (-f FILENAME | TYPE NAME)`
+
+
+### Example
+
+ Scale a replicaset named 'foo' to 3.
+
+```shell
+kubectl scale --replicas=3 rs/foo
+```
+
+ Scale a resource identified by type and name specified in "foo.yaml" to 3.
+
+```shell
+kubectl scale --replicas=3 -f foo.yaml
+```
+
+ If the deployment named mysql's current size is 2, scale mysql to 3.
+
+```shell
+kubectl scale --current-replicas=2 --replicas=3 deployment/mysql
+```
+
+ Scale multiple replication controllers.
+
+```shell
+kubectl scale --replicas=5 rc/foo rc/bar rc/baz
+```
+
+ Scale statefulset named 'web' to 3.
+
+```shell
+kubectl scale --replicas=3 statefulset/web
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>all</td><td></td><td>false</td><td>Select all resources in the namespace of the specified resource types</td>
+    </tr>
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>current-replicas</td><td></td><td>-1</td><td>Precondition for current size. Requires that the current size of the resource match this value in order to scale.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>Filename, directory, or URL to files identifying the resource to set a new size</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process the kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>record</td><td></td><td>false</td><td>Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>replicas</td><td></td><td>0</td><td>The new desired number of replicas. Required.</td>
+    </tr>
+    <tr>
+    <td>resource-version</td><td></td><td></td><td>Precondition for resource version. Requires that the current resource version match this value in order to scale.</td>
+    </tr>
+    <tr>
+    <td>selector</td><td>l</td><td></td><td>Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>timeout</td><td></td><td>0s</td><td>The length of time to wait before giving up on a scale operation, zero means don't wait. Any other values should contain a corresponding time unit (e.g. 1s, 2m, 3h).</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/set.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/set.md
@@ -642,8 +642,11 @@ kubectl create rolebinding admin --role=admin --user=admin -o yaml --dry-run | k
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/set.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/set.md
@@ -10,7 +10,7 @@ Configure application resources
 
 ### Usage
 
-`$ set SUBCOMMAND`
+`set SUBCOMMAND`
 
 
 
@@ -35,7 +35,7 @@ Update environment variables on a pod template.
 
 ### Usage
 
-`$ env RESOURCE/NAME KEY_1=VAL_1 ... KEY_N=VAL_N`
+`env RESOURCE/NAME KEY_1=VAL_1 ... KEY_N=VAL_N`
 
 
 ### Example
@@ -110,7 +110,7 @@ env | grep RAILS_ | kubectl set env -e - deployment/registry
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -194,7 +194,7 @@ Update existing container image(s) of resources.
 
 ### Usage
 
-`$ image (-f FILENAME | TYPE NAME) CONTAINER_NAME_1=CONTAINER_IMAGE_1 ... CONTAINER_NAME_N=CONTAINER_IMAGE_N`
+`image (-f FILENAME | TYPE NAME) CONTAINER_NAME_1=CONTAINER_IMAGE_1 ... CONTAINER_NAME_N=CONTAINER_IMAGE_N`
 
 
 ### Example
@@ -227,7 +227,7 @@ kubectl set image -f path/to/file.yaml nginx=nginx:1.9.1 --local -o yaml
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -293,7 +293,7 @@ Specify compute resource requirements (cpu, memory) for any resource that define
 
 ### Usage
 
-`$ resources (-f FILENAME | TYPE NAME)  ([--limits=LIMITS & --requests=REQUESTS]`
+`resources (-f FILENAME | TYPE NAME)  ([--limits=LIMITS & --requests=REQUESTS]`
 
 
 ### Example
@@ -326,7 +326,7 @@ kubectl set resources -f path/to/file.yaml --limits=cpu=200m,memory=512Mi --loca
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -399,7 +399,7 @@ Set the selector on a resource. Note that the new selector will overwrite the ol
 
 ### Usage
 
-`$ selector (-f FILENAME | TYPE NAME) EXPRESSIONS [--resource-version=version]`
+`selector (-f FILENAME | TYPE NAME) EXPRESSIONS [--resource-version=version]`
 
 
 ### Example
@@ -415,7 +415,7 @@ kubectl create deployment my-dep -o yaml --dry-run | kubectl label --local -f - 
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -475,7 +475,7 @@ Update ServiceAccount of pod template resources.
 
 ### Usage
 
-`$ serviceaccount (-f FILENAME | TYPE NAME) SERVICE_ACCOUNT`
+`serviceaccount (-f FILENAME | TYPE NAME) SERVICE_ACCOUNT`
 
 
 ### Example
@@ -496,7 +496,7 @@ kubectl set sa -f nginx-deployment.yaml serviceaccount1 --local --dry-run -o yam
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -555,7 +555,7 @@ Update User, Group or ServiceAccount in a RoleBinding/ClusterRoleBinding.
 
 ### Usage
 
-`$ subject (-f FILENAME | TYPE NAME) [--user=username] [--group=groupname] [--serviceaccount=namespace:serviceaccountname] [--dry-run]`
+`subject (-f FILENAME | TYPE NAME) [--user=username] [--group=groupname] [--serviceaccount=namespace:serviceaccountname] [--dry-run]`
 
 
 ### Example
@@ -582,7 +582,7 @@ kubectl create rolebinding admin --role=admin --user=admin -o yaml --dry-run | k
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -636,4 +636,14 @@ kubectl create rolebinding admin --role=admin --user=admin -o yaml --dry-run | k
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/set.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/set.md
@@ -1,0 +1,639 @@
+---
+title: set
+content_template: templates/tool-reference
+---
+
+### Overview
+Configure application resources
+
+ These commands help you make changes to existing application resources.
+
+### Usage
+
+`$ set SUBCOMMAND`
+
+
+
+
+
+
+<hr>
+
+## env
+
+
+### Overview
+Update environment variables on a pod template.
+
+ List environment variable definitions in one or more pods, pod templates. Add, update, or remove container environment variable definitions in one or more pod templates (within replication controllers or deployment configurations). View or modify the environment variable definitions on all containers in the specified pods or pod templates, or just those that match a wildcard.
+
+ If "--env -" is passed, environment variables can be read from STDIN using the standard env syntax.
+
+ Possible resources include (case insensitive):
+
+  pod (po), replicationcontroller (rc), deployment (deploy), daemonset (ds), job, replicaset (rs)
+
+### Usage
+
+`$ env RESOURCE/NAME KEY_1=VAL_1 ... KEY_N=VAL_N`
+
+
+### Example
+ Update deployment 'registry' with a new environment variable
+
+```shell
+kubectl set env deployment/registry STORAGE_DIR=/local
+```
+
+ List the environment variables defined on a deployments 'sample-build'
+
+```shell
+kubectl set env deployment/sample-build --list
+```
+
+ List the environment variables defined on all pods
+
+```shell
+kubectl set env pods --all --list
+```
+
+ Output modified deployment in YAML, and does not alter the object on the server
+
+```shell
+kubectl set env deployment/sample-build STORAGE_DIR=/data -o yaml
+```
+
+ Update all containers in all replication controllers in the project to have ENV=prod
+
+```shell
+kubectl set env rc --all ENV=prod
+```
+
+ Import environment from a secret
+
+```shell
+kubectl set env --from=secret/mysecret deployment/myapp
+```
+
+ Import environment from a config map with a prefix
+
+```shell
+kubectl set env --from=configmap/myconfigmap --prefix=MYSQL_ deployment/myapp
+```
+
+ Import specific keys from a config map
+
+```shell
+kubectl set env --keys=my-example-key --from=configmap/myconfigmap deployment/myapp
+```
+
+ Remove the environment variable ENV from container 'c1' in all deployment configs
+
+```shell
+kubectl set env deployments --all --containers="c1" ENV-
+```
+
+ Remove the environment variable ENV from a deployment definition on disk and # update the deployment config on the server
+
+```shell
+kubectl set env -f deploy.json ENV-
+```
+
+ Set some of the local shell environment into a deployment config on the server
+
+```shell
+env | grep RAILS_ | kubectl set env -e - deployment/registry
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>all</td><td></td><td>false</td><td>If true, select all resources in the namespace of the specified resource types</td>
+    </tr>
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>containers</td><td>c</td><td>*</td><td>The names of containers in the selected pod templates to change - may use wildcards</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>env</td><td>e</td><td>[]</td><td>Specify a key-value pair for an environment variable to set into each container.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>Filename, directory, or URL to files the resource to update the env</td>
+    </tr>
+    <tr>
+    <td>from</td><td></td><td></td><td>The name of a resource from which to inject environment variables</td>
+    </tr>
+    <tr>
+    <td>keys</td><td></td><td>[]</td><td>Comma-separated list of keys to import from specified resource</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process the kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>list</td><td></td><td>false</td><td>If true, display the environment and any changes in the standard format. this flag will removed when we have kubectl view env.</td>
+    </tr>
+    <tr>
+    <td>local</td><td></td><td>false</td><td>If true, set env will NOT contact api-server but run locally.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>overwrite</td><td></td><td>true</td><td>If true, allow environment to be overwritten, otherwise reject updates that overwrite existing environment.</td>
+    </tr>
+    <tr>
+    <td>prefix</td><td></td><td></td><td>Prefix to append to variable names</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>resolve</td><td></td><td>false</td><td>If true, show secret or configmap references when listing variables</td>
+    </tr>
+    <tr>
+    <td>selector</td><td>l</td><td></td><td>Selector (label query) to filter on</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## image
+
+
+### Overview
+Update existing container image(s) of resources.
+
+ Possible resources include (case insensitive):
+
+  pod (po), replicationcontroller (rc), deployment (deploy), daemonset (ds), replicaset (rs)
+
+### Usage
+
+`$ image (-f FILENAME | TYPE NAME) CONTAINER_NAME_1=CONTAINER_IMAGE_1 ... CONTAINER_NAME_N=CONTAINER_IMAGE_N`
+
+
+### Example
+ Set a deployment's nginx container image to 'nginx:1.9.1', and its busybox container image to 'busybox'.
+
+```shell
+kubectl set image deployment/nginx busybox=busybox nginx=nginx:1.9.1
+```
+
+ Update all deployments' and rc's nginx container's image to 'nginx:1.9.1'
+
+```shell
+kubectl set image deployments,rc nginx=nginx:1.9.1 --all
+```
+
+ Update image of all containers of daemonset abc to 'nginx:1.9.1'
+
+```shell
+kubectl set image daemonset abc *=nginx:1.9.1
+```
+
+ Print result (in yaml format) of updating nginx container image from local file, without hitting the server
+
+```shell
+kubectl set image -f path/to/file.yaml nginx=nginx:1.9.1 --local -o yaml
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>all</td><td></td><td>false</td><td>Select all resources, including uninitialized ones, in the namespace of the specified resource types</td>
+    </tr>
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>Filename, directory, or URL to files identifying the resource to get from a server.</td>
+    </tr>
+    <tr>
+    <td>include-uninitialized</td><td></td><td>false</td><td>If true, the kubectl command applies to uninitialized objects. If explicitly set to false, this flag overrides other flags that make the kubectl commands apply to uninitialized objects, e.g., "--all". Objects with empty metadata.initializers are regarded as initialized.</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process the kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>local</td><td></td><td>false</td><td>If true, set image will NOT contact api-server but run locally.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>record</td><td></td><td>false</td><td>Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>selector</td><td>l</td><td></td><td>Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## resources
+
+
+### Overview
+Specify compute resource requirements (cpu, memory) for any resource that defines a pod template.  If a pod is successfully scheduled, it is guaranteed the amount of resource requested, but may burst up to its specified limits.
+
+ for each compute resource, if a limit is specified and a request is omitted, the request will default to the limit.
+
+ Possible resources include (case insensitive): Use "kubectl api-resources" for a complete list of supported resources..
+
+### Usage
+
+`$ resources (-f FILENAME | TYPE NAME)  ([--limits=LIMITS & --requests=REQUESTS]`
+
+
+### Example
+ Set a deployments nginx container cpu limits to "200m" and memory to "512Mi"
+
+```shell
+kubectl set resources deployment nginx -c=nginx --limits=cpu=200m,memory=512Mi
+```
+
+ Set the resource request and limits for all containers in nginx
+
+```shell
+kubectl set resources deployment nginx --limits=cpu=200m,memory=512Mi --requests=cpu=100m,memory=256Mi
+```
+
+ Remove the resource requests for resources on containers in nginx
+
+```shell
+kubectl set resources deployment nginx --limits=cpu=0,memory=0 --requests=cpu=0,memory=0
+```
+
+ Print the result (in yaml format) of updating nginx container limits from a local, without hitting the server
+
+```shell
+kubectl set resources -f path/to/file.yaml --limits=cpu=200m,memory=512Mi --local -o yaml
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>all</td><td></td><td>false</td><td>Select all resources, including uninitialized ones, in the namespace of the specified resource types</td>
+    </tr>
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>containers</td><td>c</td><td>*</td><td>The names of containers in the selected pod templates to change, all containers are selected by default - may use wildcards</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>Filename, directory, or URL to files identifying the resource to get from a server.</td>
+    </tr>
+    <tr>
+    <td>include-uninitialized</td><td></td><td>false</td><td>If true, the kubectl command applies to uninitialized objects. If explicitly set to false, this flag overrides other flags that make the kubectl commands apply to uninitialized objects, e.g., "--all". Objects with empty metadata.initializers are regarded as initialized.</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process the kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>limits</td><td></td><td></td><td>The resource requirement requests for this container.  For example, 'cpu=100m,memory=256Mi'.  Note that server side components may assign requests depending on the server configuration, such as limit ranges.</td>
+    </tr>
+    <tr>
+    <td>local</td><td></td><td>false</td><td>If true, set resources will NOT contact api-server but run locally.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>record</td><td></td><td>false</td><td>Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>requests</td><td></td><td></td><td>The resource requirement requests for this container.  For example, 'cpu=100m,memory=256Mi'.  Note that server side components may assign requests depending on the server configuration, such as limit ranges.</td>
+    </tr>
+    <tr>
+    <td>selector</td><td>l</td><td></td><td>Selector (label query) to filter on, not including uninitialized ones,supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## selector
+
+
+### Overview
+Set the selector on a resource. Note that the new selector will overwrite the old selector if the resource had one prior to the invocation of 'set selector'.
+
+ A selector must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores, up to  63 characters. If --resource-version is specified, then updates will use this resource version, otherwise the existing resource-version will be used. Note: currently selectors can only be set on Service objects.
+
+### Usage
+
+`$ selector (-f FILENAME | TYPE NAME) EXPRESSIONS [--resource-version=version]`
+
+
+### Example
+ set the labels and selector before creating a deployment/service pair.
+
+```shell
+kubectl create service clusterip my-svc --clusterip="None" -o yaml --dry-run | kubectl set selector --local -f - 'environment=qa' -o yaml | kubectl create -f -
+kubectl create deployment my-dep -o yaml --dry-run | kubectl label --local -f - environment=qa -o yaml | kubectl create -f -
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>all</td><td></td><td>false</td><td>Select all resources in the namespace of the specified resource types</td>
+    </tr>
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>identifying the resource.</td>
+    </tr>
+    <tr>
+    <td>local</td><td></td><td>false</td><td>If true, annotation will NOT contact api-server but run locally.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>record</td><td></td><td>false</td><td>Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>true</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>resource-version</td><td></td><td></td><td>If non-empty, the selectors update will only succeed if this is the current resource-version for the object. Only valid when specifying a single resource.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## serviceaccount
+
+
+### Overview
+Update ServiceAccount of pod template resources.
+
+ Possible resources (case insensitive) can be:
+
+ replicationcontroller (rc), deployment (deploy), daemonset (ds), job, replicaset (rs), statefulset
+
+### Usage
+
+`$ serviceaccount (-f FILENAME | TYPE NAME) SERVICE_ACCOUNT`
+
+
+### Example
+ Set Deployment nginx-deployment's ServiceAccount to serviceaccount1
+
+```shell
+kubectl set serviceaccount deployment nginx-deployment serviceaccount1
+```
+
+ Print the result (in yaml format) of updated nginx deployment with serviceaccount from local file, without hitting apiserver
+
+```shell
+kubectl set sa -f nginx-deployment.yaml serviceaccount1 --local --dry-run -o yaml
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>all</td><td></td><td>false</td><td>Select all resources, including uninitialized ones, in the namespace of the specified resource types</td>
+    </tr>
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>Filename, directory, or URL to files identifying the resource to get from a server.</td>
+    </tr>
+    <tr>
+    <td>include-uninitialized</td><td></td><td>false</td><td>If true, the kubectl command applies to uninitialized objects. If explicitly set to false, this flag overrides other flags that make the kubectl commands apply to uninitialized objects, e.g., "--all". Objects with empty metadata.initializers are regarded as initialized.</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process the kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>local</td><td></td><td>false</td><td>If true, set serviceaccount will NOT contact api-server but run locally.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>record</td><td></td><td>false</td><td>Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## subject
+
+
+### Overview
+Update User, Group or ServiceAccount in a RoleBinding/ClusterRoleBinding.
+
+### Usage
+
+`$ subject (-f FILENAME | TYPE NAME) [--user=username] [--group=groupname] [--serviceaccount=namespace:serviceaccountname] [--dry-run]`
+
+
+### Example
+ Update a ClusterRoleBinding for serviceaccount1
+
+```shell
+kubectl set subject clusterrolebinding admin --serviceaccount=namespace:serviceaccount1
+```
+
+ Update a RoleBinding for user1, user2, and group1
+
+```shell
+kubectl set subject rolebinding admin --user=user1 --user=user2 --group=group1
+```
+
+ Print the result (in yaml format) of updating rolebinding subjects from a local, without hitting the server
+
+```shell
+kubectl create rolebinding admin --role=admin --user=admin -o yaml --dry-run | kubectl set subject --local -f - --user=foo -o yaml
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>all</td><td></td><td>false</td><td>Select all resources, including uninitialized ones, in the namespace of the specified resource types</td>
+    </tr>
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>Filename, directory, or URL to files the resource to update the subjects</td>
+    </tr>
+    <tr>
+    <td>group</td><td></td><td>[]</td><td>Groups to bind to the role</td>
+    </tr>
+    <tr>
+    <td>include-uninitialized</td><td></td><td>false</td><td>If true, the kubectl command applies to uninitialized objects. If explicitly set to false, this flag overrides other flags that make the kubectl commands apply to uninitialized objects, e.g., "--all". Objects with empty metadata.initializers are regarded as initialized.</td>
+    </tr>
+    <tr>
+    <td>kustomize</td><td>k</td><td></td><td>Process the kustomization directory. This flag can't be used together with -f or -R.</td>
+    </tr>
+    <tr>
+    <td>local</td><td></td><td>false</td><td>If true, set subject will NOT contact api-server but run locally.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>false</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>selector</td><td>l</td><td></td><td>Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)</td>
+    </tr>
+    <tr>
+    <td>serviceaccount</td><td></td><td>[]</td><td>Service accounts to bind to the role</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/set.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/set.md
@@ -1,6 +1,7 @@
 ---
 title: set
-content_template: templates/tool-reference
+noedit: true
+layout: kuberef
 ---
 
 ### Overview

--- a/content/en/docs/reference/kubectl/kubectl-reference/taint.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/taint.md
@@ -15,7 +15,7 @@ Update the taints on one or more nodes.
 
 ### Usage
 
-`$ taint NODE NAME KEY_1=VAL_1:TAINT_EFFECT_1 ... KEY_N=VAL_N:TAINT_EFFECT_N`
+`taint NODE NAME KEY_1=VAL_1:TAINT_EFFECT_1 ... KEY_N=VAL_N:TAINT_EFFECT_N`
 
 
 ### Example
@@ -91,4 +91,14 @@ kubectl taint nodes foo bar:NoSchedule
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/taint.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/taint.md
@@ -97,8 +97,11 @@ kubectl taint nodes foo bar:NoSchedule
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/taint.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/taint.md
@@ -1,0 +1,94 @@
+---
+title: taint
+content_template: templates/tool-reference
+---
+
+### Overview
+Update the taints on one or more nodes.
+
+  *  A taint consists of a key, value, and effect. As an argument here, it is expressed as key=value:effect.
+  *  The key must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores, up to  253 characters.
+  *  Optionally, the key can begin with a DNS subdomain prefix and a single '/', like example.com/my-app
+  *  The value is optional. If given, it must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores, up to  63 characters.
+  *  The effect must be NoSchedule, PreferNoSchedule or NoExecute.
+  *  Currently taint can only apply to node.
+
+### Usage
+
+`$ taint NODE NAME KEY_1=VAL_1:TAINT_EFFECT_1 ... KEY_N=VAL_N:TAINT_EFFECT_N`
+
+
+### Example
+
+ Update node 'foo' with a taint with key 'dedicated' and value 'special-user' and effect 'NoSchedule'. # If a taint with that key and effect already exists, its value is replaced as specified.
+
+```shell
+kubectl taint nodes foo dedicated=special-user:NoSchedule
+```
+
+ Remove from node 'foo' the taint with key 'dedicated' and effect 'NoSchedule' if one exists.
+
+```shell
+kubectl taint nodes foo dedicated:NoSchedule-
+```
+
+ Remove from node 'foo' all the taints with key 'dedicated'
+
+```shell
+kubectl taint nodes foo dedicated-
+```
+
+ Add a taint with key 'dedicated' on nodes having label mylabel=X
+
+```shell
+kubectl taint node -l myLabel=X  dedicated=foo:PreferNoSchedule
+```
+
+ Add to node 'foo' a taint with key 'bar' and no value
+
+```shell
+kubectl taint nodes foo bar:NoSchedule
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>all</td><td></td><td>false</td><td>Select all nodes in the cluster</td>
+    </tr>
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>overwrite</td><td></td><td>false</td><td>If true, allow taints to be overwritten, otherwise reject taint updates that overwrite existing taints.</td>
+    </tr>
+    <tr>
+    <td>selector</td><td>l</td><td></td><td>Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>validate</td><td></td><td>true</td><td>If true, use a schema to validate the input before sending it</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/taint.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/taint.md
@@ -1,6 +1,7 @@
 ---
 title: taint
-content_template: templates/tool-reference
+noedit: true
+layout: kuberef
 ---
 
 ### Overview

--- a/content/en/docs/reference/kubectl/kubectl-reference/top.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/top.md
@@ -184,8 +184,11 @@ kubectl top pod -l name=myLabel
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/top.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/top.md
@@ -1,6 +1,7 @@
 ---
 title: top
-content_template: templates/tool-reference
+noedit: true
+layout: kuberef
 ---
 
 ### Overview

--- a/content/en/docs/reference/kubectl/kubectl-reference/top.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/top.md
@@ -1,0 +1,181 @@
+---
+title: top
+content_template: templates/tool-reference
+---
+
+### Overview
+Display Resource (CPU/Memory/Storage) usage.
+
+ The top command allows you to see the resource consumption for nodes or pods.
+
+ This command requires Heapster to be correctly configured and working on the server.
+
+### Usage
+
+`$ top`
+
+
+
+
+
+
+<hr>
+
+## node
+
+
+### Overview
+Display Resource (CPU/Memory/Storage) usage of nodes.
+
+ The top-node command allows you to see the resource consumption of nodes.
+
+### Usage
+
+`$ node [NAME | -l label]`
+
+
+### Example
+ Show metrics for all nodes
+
+```shell
+kubectl top node
+```
+
+ Show metrics for a given node
+
+```shell
+kubectl top node NODE_NAME
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>heapster-namespace</td><td></td><td>kube-system</td><td>Namespace Heapster service is located in</td>
+    </tr>
+    <tr>
+    <td>heapster-port</td><td></td><td></td><td>Port name in service to use</td>
+    </tr>
+    <tr>
+    <td>heapster-scheme</td><td></td><td>http</td><td>Scheme (http or https) to connect to Heapster as</td>
+    </tr>
+    <tr>
+    <td>heapster-service</td><td></td><td>heapster</td><td>Name of Heapster service</td>
+    </tr>
+    <tr>
+    <td>no-headers</td><td></td><td>false</td><td>If present, print output without headers</td>
+    </tr>
+    <tr>
+    <td>selector</td><td>l</td><td></td><td>Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)</td>
+    </tr>
+    <tr>
+    <td>sort-by</td><td></td><td></td><td>If non-empty, sort nodes list using specified field. The field can be either 'cpu' or 'memory'.</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+
+<hr>
+
+## pod
+
+
+### Overview
+Display Resource (CPU/Memory/Storage) usage of pods.
+
+ The 'top pod' command allows you to see the resource consumption of pods.
+
+ Due to the metrics pipeline delay, they may be unavailable for a few minutes since pod creation.
+
+### Usage
+
+`$ pod [NAME | -l label]`
+
+
+### Example
+ Show metrics for all pods in the default namespace
+
+```shell
+kubectl top pod
+```
+
+ Show metrics for all pods in the given namespace
+
+```shell
+kubectl top pod --namespace=NAMESPACE
+```
+
+ Show metrics for a given pod and its containers
+
+```shell
+kubectl top pod POD_NAME --containers
+```
+
+ Show metrics for the pods defined by label name=myLabel
+
+```shell
+kubectl top pod -l name=myLabel
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>all-namespaces</td><td>A</td><td>false</td><td>If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.</td>
+    </tr>
+    <tr>
+    <td>containers</td><td></td><td>false</td><td>If present, print usage of containers within a pod.</td>
+    </tr>
+    <tr>
+    <td>heapster-namespace</td><td></td><td>kube-system</td><td>Namespace Heapster service is located in</td>
+    </tr>
+    <tr>
+    <td>heapster-port</td><td></td><td></td><td>Port name in service to use</td>
+    </tr>
+    <tr>
+    <td>heapster-scheme</td><td></td><td>http</td><td>Scheme (http or https) to connect to Heapster as</td>
+    </tr>
+    <tr>
+    <td>heapster-service</td><td></td><td>heapster</td><td>Name of Heapster service</td>
+    </tr>
+    <tr>
+    <td>no-headers</td><td></td><td>false</td><td>If present, print output without headers.</td>
+    </tr>
+    <tr>
+    <td>selector</td><td>l</td><td></td><td>Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)</td>
+    </tr>
+    <tr>
+    <td>sort-by</td><td></td><td></td><td>If non-empty, sort pods list using specified field. The field can be either 'cpu' or 'memory'.</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/top.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/top.md
@@ -12,7 +12,7 @@ Display Resource (CPU/Memory/Storage) usage.
 
 ### Usage
 
-`$ top`
+`top`
 
 
 
@@ -31,7 +31,7 @@ Display Resource (CPU/Memory/Storage) usage of nodes.
 
 ### Usage
 
-`$ node [NAME | -l label]`
+`node [NAME | -l label]`
 
 
 ### Example
@@ -52,7 +52,7 @@ kubectl top node NODE_NAME
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -103,7 +103,7 @@ Display Resource (CPU/Memory/Storage) usage of pods.
 
 ### Usage
 
-`$ pod [NAME | -l label]`
+`pod [NAME | -l label]`
 
 
 ### Example
@@ -136,7 +136,7 @@ kubectl top pod -l name=myLabel
 
 ### Flags
 
-<div class="table-responsive"><table class="table table-bordered">
+<div class="table-responsive kubectl-flags-table"><table class="table table-bordered">
 <thead class="thead-light">
 <tr>
             <th>Name</th>
@@ -178,4 +178,14 @@ kubectl top pod -l name=myLabel
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/uncordon.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/uncordon.md
@@ -8,7 +8,7 @@ Mark node as schedulable.
 
 ### Usage
 
-`$ uncordon NODE`
+`uncordon NODE`
 
 
 ### Example
@@ -45,4 +45,14 @@ $ kubectl uncordon foo
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/uncordon.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/uncordon.md
@@ -1,6 +1,7 @@
 ---
 title: uncordon
-content_template: templates/tool-reference
+noedit: true
+layout: kuberef
 ---
 
 ### Overview

--- a/content/en/docs/reference/kubectl/kubectl-reference/uncordon.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/uncordon.md
@@ -51,8 +51,11 @@ $ kubectl uncordon foo
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/uncordon.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/uncordon.md
@@ -1,0 +1,48 @@
+---
+title: uncordon
+content_template: templates/tool-reference
+---
+
+### Overview
+Mark node as schedulable.
+
+### Usage
+
+`$ uncordon NODE`
+
+
+### Example
+
+ Mark node "foo" as schedulable.
+
+```shell
+$ kubectl uncordon foo
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>dry-run</td><td></td><td>false</td><td>If true, only print the object that would be sent, without sending it.</td>
+    </tr>
+    <tr>
+    <td>selector</td><td>l</td><td></td><td>Selector (label query) to filter on</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/version.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/version.md
@@ -54,8 +54,11 @@ kubectl version
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/version.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/version.md
@@ -1,0 +1,51 @@
+---
+title: version
+content_template: templates/tool-reference
+---
+
+### Overview
+Print the client and server version information for the current context
+
+### Usage
+
+`$ version`
+
+
+### Example
+
+ Print the client and server versions for the current context
+
+```shell
+kubectl version
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>client</td><td></td><td>false</td><td>Client version only (no server required).</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>One of 'yaml' or 'json'.</td>
+    </tr>
+    <tr>
+    <td>short</td><td></td><td>false</td><td>Print just the version number.</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/version.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/version.md
@@ -8,7 +8,7 @@ Print the client and server version information for the current context
 
 ### Usage
 
-`$ version`
+`version`
 
 
 ### Example
@@ -48,4 +48,14 @@ kubectl version
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/wait.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/wait.md
@@ -94,8 +94,11 @@ kubectl wait --for=delete pod/busybox1 --timeout=60s
 
 
 ### Version
+
 <div class="kubectl-reference-copyright">
 
-<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs  
+{{< param "fullversion" >}}   &#xa9;Copyright 2019 The Kubernetes Authors</a>
+
 </div>
 

--- a/content/en/docs/reference/kubectl/kubectl-reference/wait.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/wait.md
@@ -1,0 +1,91 @@
+---
+title: wait
+content_template: templates/tool-reference
+---
+
+### Overview
+Experimental: Wait for a specific condition on one or many resources.
+
+ The command takes multiple resources and waits until the specified condition is seen in the Status field of every given resource.
+
+ Alternatively, the command can wait for the given set of resources to be deleted by providing the "delete" keyword as the value to the --for flag.
+
+ A successful message will be printed to stdout indicating when the specified condition has been met. One can use -o option to change to output destination.
+
+### Usage
+
+`$ wait ([-f FILENAME] | resource.group/resource.name | resource.group [(-l label | --all)]) [--for=delete|--for condition=available]`
+
+
+### Example
+
+ Wait for the pod "busybox1" to contain the status condition of type "Ready".
+
+```shell
+kubectl wait --for=condition=Ready pod/busybox1
+```
+
+ Wait for the pod "busybox1" to be deleted, with a timeout of 60s, after having issued the "delete" command.
+
+```shell
+kubectl delete pod/busybox1
+kubectl wait --for=delete pod/busybox1 --timeout=60s
+```
+
+
+
+
+### Flags
+
+<div class="table-responsive"><table class="table table-bordered">
+<thead class="thead-light">
+<tr>
+            <th>Name</th>
+            <th>Shorthand</th>
+            <th>Default</th>
+            <th>Usage</th>
+        </tr>
+    </thead>
+    <tbody>
+    
+    <tr>
+    <td>all</td><td></td><td>false</td><td>Select all resources in the namespace of the specified resource types</td>
+    </tr>
+    <tr>
+    <td>all-namespaces</td><td>A</td><td>false</td><td>If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.</td>
+    </tr>
+    <tr>
+    <td>allow-missing-template-keys</td><td></td><td>true</td><td>If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.</td>
+    </tr>
+    <tr>
+    <td>field-selector</td><td></td><td></td><td>Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.</td>
+    </tr>
+    <tr>
+    <td>filename</td><td>f</td><td>[]</td><td>identifying the resource.</td>
+    </tr>
+    <tr>
+    <td>for</td><td></td><td></td><td>The condition to wait on: [delete&#124;condition=condition-name].</td>
+    </tr>
+    <tr>
+    <td>local</td><td></td><td>false</td><td>If true, annotation will NOT contact api-server but run locally.</td>
+    </tr>
+    <tr>
+    <td>output</td><td>o</td><td></td><td>Output format. One of: json&#124;yaml&#124;name&#124;go-template&#124;go-template-file&#124;template&#124;templatefile&#124;jsonpath&#124;jsonpath-file.</td>
+    </tr>
+    <tr>
+    <td>recursive</td><td>R</td><td>true</td><td>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</td>
+    </tr>
+    <tr>
+    <td>selector</td><td>l</td><td></td><td>Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)</td>
+    </tr>
+    <tr>
+    <td>template</td><td></td><td></td><td>Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].</td>
+    </tr>
+    <tr>
+    <td>timeout</td><td></td><td>30s</td><td>The length of time to wait before giving up.  Zero means check once and don't wait, negative means wait for a week.</td>
+    </tr>
+</tbody>
+</table></div>
+
+
+

--- a/content/en/docs/reference/kubectl/kubectl-reference/wait.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/wait.md
@@ -1,6 +1,7 @@
 ---
 title: wait
-content_template: templates/tool-reference
+noedit: true
+layout: kuberef
 ---
 
 ### Overview

--- a/content/en/docs/reference/kubectl/kubectl-reference/wait.md
+++ b/content/en/docs/reference/kubectl/kubectl-reference/wait.md
@@ -14,7 +14,7 @@ Experimental: Wait for a specific condition on one or many resources.
 
 ### Usage
 
-`$ wait ([-f FILENAME] | resource.group/resource.name | resource.group [(-l label | --all)]) [--for=delete|--for condition=available]`
+`wait ([-f FILENAME] | resource.group/resource.name | resource.group [(-l label | --all)]) [--for=delete|--for condition=available]`
 
 
 ### Example
@@ -88,4 +88,14 @@ kubectl wait --for=delete pod/busybox1 --timeout=60s
 </table></div>
 
 
+
+
+<hr>
+
+
+### Version
+<div class="kubectl-reference-copyright">
+
+<a href="https://github.com/kubernetes/kubernetes">Kubectl Reference Docs version 1.15 &#xa9;Copyright 2019 The Kubernetes Authors</a>
+</div>
 

--- a/layouts/docs/kuberef.html
+++ b/layouts/docs/kuberef.html
@@ -1,0 +1,22 @@
+{{ define "content" }}
+
+<div class="container-fluid td-outer flex-1" style="display:flex">
+<!-- content -->
+<div class="col-12 col-md-9 col-xl-8 pl-md-5 td-content" style="flex-grow:1;max-width:66.66%;top:4rem;float:left;min-height:1px;order:1">
+
+{{ partial "ref-content-page.html" (dict "ctx" . "page" .) }}
+</div>
+
+<!-- inner toc-->
+<div class="order-2 col-12 col-md-9 col-xl-8 pl-md-5 td-toc" style="overflow-y:bottom:100px;list-style-type:none;font-size:.875rem;width:20%;right:0;position:fixed;border:1;top:265px;order:2;padding-left:1rem;padding-right:1rem;border-left-style:solid;border-left-width:1px;border-color:#ccc">
+{{ .TableOfContents }}
+</div>
+</div>
+{{ end }}
+
+
+{{ define "side-menu" }}
+<div class="td-sidebar" style="display:block;width:20%;order:0"> 
+    {{ partial "docs/side-menu.html" . }}
+</div>
+{{ end }}

--- a/layouts/partials/ref-content-page.html
+++ b/layouts/partials/ref-content-page.html
@@ -1,0 +1,16 @@
+{{ if not .page.Params.noedit }}
+{{- $filepath := .page.File.Path }}
+{{- $editLink := printf "https://github.com/kubernetes/website/edit/master/content/%s/%s" .page.Language.Lang $filepath }}
+<p>
+  <a href="{{ $editLink }}" id="editPageButton" target="_blank">
+    Edit This Page
+  </a>
+</p>
+{{ end }}
+
+{{ if not .page.Params.notitle }}
+<h1>{{ .page.Title }}</h1>
+{{ end }}
+
+{{ .page.Content }}
+

--- a/layouts/partials/templates/tool-reference.html
+++ b/layouts/partials/templates/tool-reference.html
@@ -2,8 +2,8 @@
 {{ partial "templates/block" (dict "page" .page "block" "overview" "purpose" "provides an overview" "optional" true) }}
 
 {{ .ctx.Scratch.Set "blocks" slice }}
-{{ .ctx.Scratch.Add "blocks" (dict "page" .page "block" "synopsis" "heading" "Synopsis" "purpose" "describes the component") }}
-{{ .ctx.Scratch.Add "blocks" (dict "page" .page "block" "options" "heading" "Options" "purpose" "lists the options for the component") }}
+{{ .ctx.Scratch.Add "blocks" (dict "page" .page "block" "synopsis" "heading" "Synopsis" "purpose" "describes the component" "optional" true) }}
+{{ .ctx.Scratch.Add "blocks" (dict "page" .page "block" "options" "heading" "Options" "purpose" "lists the options for the component" "optional" true) }}
 {{ .ctx.Scratch.Add "blocks" (dict "page" .page "block" "parentoptions" "heading" "Options from Parent Commands" "optional" true ) }}
 {{ .ctx.Scratch.Add "blocks" (dict "page" .page "block" "examples" "heading" "Examples" "optional" true ) }}
 {{ .ctx.Scratch.Add "blocks" (dict "page" .page "block" "body" "purpose" "the body of the page content" "optional" true) }}


### PR DESCRIPTION
- Testing an initial, cleaned up, simple generation of kubectl reference docs
- Needs further styling; needs navigation improvement; uses hugo to generate html and better integration with k8s/docs
- I have been separately testing a 3 column layout for reference docs that reuses the base docs layout and sidebar, but adds the inline page toc to the right hand side of the page. Ideas taken from the docsy theme.
- Also envision a new shortcode to create the version/copyright info.
- Comments welcome 