### PR TITLE
Remove index.md from workloads path

### DIFF
--- a/content/en/docs/concepts/workloads/_index.md
+++ b/content/en/docs/concepts/workloads/_index.md
@@ -1,5 +1,0 @@
----
-title: "Workloads"
-weight: 50
----
-

--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -81,9 +81,9 @@ NAME        READY   STATUS    RESTARTS   AGE
 pod/redis   1/1     Running   0          52s
 ```
 
-In the example, the config volume is mounted at `/redis-master`.
+In the example, the config volume is mounted at `/usr/local/etc/redis`.
 It uses `path` to add the `redis-config` key to a file named `redis.conf`.
-The file path for the redis config, therefore, is `/redis-master/redis.conf`.
+The file path for the redis config, therefore, is `/usr/local/etc/redis/redis.conf`.
 This is where the image will look for the config file for the redis master.
 
 Use `kubectl exec` to enter the pod and run the `redis-cli` tool to verify that

--- a/content/en/examples/pods/config/redis-pod.yaml
+++ b/content/en/examples/pods/config/redis-pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: redis
-    image: kubernetes/redis:v1
+    image: redis:5
     env:
     - name: MASTER
       value: "true"
@@ -15,10 +15,12 @@ spec:
       limits:
         cpu: "0.1"
     volumeMounts:
-    - mountPath: /redis-master-data
+    - mountPath: /data
       name: data
-    - mountPath: /redis-master
+    - mountPath: /usr/local/etc/redis
       name: config
+    args:
+    - /usr/loca/etc/redis/redis.conf
   volumes:
     - name: data
       emptyDir: {}


### PR DESCRIPTION
The top level for the workloads link does not need an _index.md, and can potentially just cause confusion. 

See link:

https://kubernetes.io/docs/concepts/workloads/

Removing _index.md so it doesnt return an empty page. 