### PR TITLE
Fix orders of yaml for examples/*

### DIFF
--- a/content/en/examples/admin/resource/pvc-limit-greater.yaml
+++ b/content/en/examples/admin/resource/pvc-limit-greater.yaml
@@ -1,5 +1,5 @@
-kind: PersistentVolumeClaim
 apiVersion: v1
+kind: PersistentVolumeClaim
 metadata:
   name: pvc-limit-greater
 spec:

--- a/content/en/examples/admin/resource/pvc-limit-lower.yaml
+++ b/content/en/examples/admin/resource/pvc-limit-lower.yaml
@@ -1,5 +1,5 @@
-kind: PersistentVolumeClaim
 apiVersion: v1
+kind: PersistentVolumeClaim
 metadata:
   name: pvc-limit-lower
 spec:

--- a/content/en/examples/application/mysql/mysql-pv.yaml
+++ b/content/en/examples/application/mysql/mysql-pv.yaml
@@ -1,5 +1,5 @@
-kind: PersistentVolume
 apiVersion: v1
+kind: PersistentVolume
 metadata:
   name: mysql-pv-volume
   labels:

--- a/content/en/examples/debug/fluentd-gcp-configmap.yaml
+++ b/content/en/examples/debug/fluentd-gcp-configmap.yaml
@@ -1,5 +1,5 @@
-kind: ConfigMap
 apiVersion: v1
+kind: ConfigMap
 data:
   containers.input.conf: |-
     # This configuration file for Fluentd is used

--- a/content/en/examples/federation/policy-engine-service.yaml
+++ b/content/en/examples/federation/policy-engine-service.yaml
@@ -1,5 +1,5 @@
-kind: Service
 apiVersion: v1
+kind: Service
 metadata:
   name: opa
   namespace: federation-system

--- a/content/en/examples/pods/pod-projected-svc-token.yaml
+++ b/content/en/examples/pods/pod-projected-svc-token.yaml
@@ -1,5 +1,5 @@
-kind: Pod
 apiVersion: v1
+kind: Pod
 metadata:
   name: nginx
 spec:

--- a/content/en/examples/pods/storage/pv-claim.yaml
+++ b/content/en/examples/pods/storage/pv-claim.yaml
@@ -1,5 +1,5 @@
-kind: PersistentVolumeClaim
 apiVersion: v1
+kind: PersistentVolumeClaim
 metadata:
   name: task-pv-claim
 spec:

--- a/content/en/examples/pods/storage/pv-pod.yaml
+++ b/content/en/examples/pods/storage/pv-pod.yaml
@@ -1,5 +1,5 @@
-kind: Pod
 apiVersion: v1
+kind: Pod
 metadata:
   name: task-pv-pod
 spec:

--- a/content/en/examples/pods/storage/pv-volume.yaml
+++ b/content/en/examples/pods/storage/pv-volume.yaml
@@ -1,5 +1,5 @@
-kind: PersistentVolume
 apiVersion: v1
+kind: PersistentVolume
 metadata:
   name: task-pv-volume
   labels:

--- a/content/en/examples/service/access/hello-service.yaml
+++ b/content/en/examples/service/access/hello-service.yaml
@@ -1,5 +1,5 @@
-kind: Service
 apiVersion: v1
+kind: Service
 metadata:
   name: hello
 spec:


### PR DESCRIPTION
The order of kind and apiVersion were inconsistent, and that made the doc unreadable.
This fixes the orders in consistent way in examples/*.

ref: #13862