### PR TITLE
remove unknown command

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/namespaces.md
+++ b/content/en/docs/concepts/overview/working-with-objects/namespaces.md
@@ -101,16 +101,6 @@ in some namespaces.  However namespace resources are not themselves in a namespa
 And low-level resources, such as [nodes](/docs/admin/node) and
 persistentVolumes, are not in any namespace.
 
-To see which Kubernetes resources are and aren't in a namespace:
-
-```shell
-# In a namespace
-kubectl api-resources --namespaced=true
-
-# Not in a namespace
-kubectl api-resources --namespaced=false
-```
-
 {{% /capture %}}
 
 {{% capture whatsnext %}}


### PR DESCRIPTION
Test with `v1.10.12`:
```
# kubectl api-resources 
Error: unknown command "api-resources" for "kubectl"
Run 'kubectl --help' for usage.
unknown command "api-resources" for "kubectl"
# kubectl version
Client Version: version.Info{Major:"1", Minor:"10", GitVersion:"v1.10.12", GitCommit:"c757b93cf034d49af3a3b8ecee3b9639a7a11df7", GitTreeState:"clean", BuildDate:"2018-12-19T11:16:52Z", GoVersion:"go1.9.3", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"10", GitVersion:"v1.10.12", GitCommit:"c757b93cf034d49af3a3b8ecee3b9639a7a11df7", GitTreeState:"clean", BuildDate:"2018-12-19T11:04:29Z", GoVersion:"go1.9.3", Compiler:"gc", Platform:"linux/amd64"}
```
