### PR TITLE
Note to limit changes in PR to one language

### DIFF
--- a/content/en/docs/contribute/start.md
+++ b/content/en/docs/contribute/start.md
@@ -243,7 +243,11 @@ your fork's repository. The GitHub website will prompt you to create the
 pull request if it detects that you pushed a new branch to your fork.
 {{< /note >}}
     
-5.  The **Open a pull request** screen appears. The subject of the pull request
+5.  {{< note >}}
+    Please limit pull requests to one language per PR. For example, if you need to make an identical change to the same code sample in multiple languages, open a separate PR for each language. 
+    {{< /note >}}
+
+    The **Open a pull request** screen appears. The subject of the pull request
     is the same as the commit summary, but you can change it if needed. The
     body is populated by your extended commit message (if present) and some
     template text. Read the template text and fill out the details it asks for,

--- a/content/en/docs/contribute/start.md
+++ b/content/en/docs/contribute/start.md
@@ -243,11 +243,7 @@ your fork's repository. The GitHub website will prompt you to create the
 pull request if it detects that you pushed a new branch to your fork.
 {{< /note >}}
     
-5.  {{< note >}}
-    Please limit pull requests to one language per PR. For example, if you need to make an identical change to the same code sample in multiple languages, open a separate PR for each language. 
-    {{< /note >}}
-
-    The **Open a pull request** screen appears. The subject of the pull request
+5.  The **Open a pull request** screen appears. The subject of the pull request
     is the same as the commit summary, but you can change it if needed. The
     body is populated by your extended commit message (if present) and some
     template text. Read the template text and fill out the details it asks for,
@@ -264,6 +260,10 @@ pull request if it detects that you pushed a new branch to your fork.
     applied. Go to the **Conversation** tab of your PR and click the **Details**
     link for the `deploy/netlify` test, near the bottom of the page. It opens in
     the same browser window by default.
+
+    {{< note >}}
+    Please limit pull requests to one language per PR. For example, if you need to make an identical change to the same code sample in multiple languages, open a separate PR for each language. 
+    {{< /note >}}
 
 6.  Wait for review. Generally, reviewers are suggested by the `k8s-ci-robot`.
     If a reviewer asks you to make changes, you can go to the **Files changed**


### PR DESCRIPTION
Closes #15762

Updated step 5 in https://kubernetes.io/docs/contribute/start/#submit-a-pull-request with a note asking to limit changes in each PR to one language. 

I was initially going to put the note at the bottom of step 5, but it was easy to miss the note. I think the note will be more noticeable at the beginning of the step, especially since step 5 begins with creating a pull request and this is something they should know before they start creating it.
