### PR TITLE
Use literals in jsonpath examples

### DIFF
--- a/content/en/docs/reference/kubectl/jsonpath.md
+++ b/content/en/docs/reference/kubectl/jsonpath.md
@@ -65,18 +65,18 @@ Given the JSON input:
 }
 ```
 
-Function          | Description               | Example                                                       | Result
-------------------|---------------------------|---------------------------------------------------------------|------------------
-text              | the plain text            | kind is {.kind}                                               | kind is List
-@                 | the current object        | {@}                                                           | the same as input
-. or []           | child operator            | {.kind} or {['kind']}                                         | List
-..                | recursive descent         | {..name}                                                      | 127.0.0.1 127.0.0.2 myself e2e
-\*                | wildcard. Get all objects | {.items[*].metadata.name}                                     | [127.0.0.1 127.0.0.2]
-[start:end :step] | subscript operator        | {.users[0].name}                                              | myself
-[,]               | union operator            | {.items[*]['metadata.name', 'status.capacity']}               | 127.0.0.1 127.0.0.2 map[cpu:4] map[cpu:8]
-?()               | filter                    | {.users[?(@.name=="e2e")].user.password}                      | secret
-range, end        | iterate list              | {range .items[*]}[{.metadata.name}, {.status.capacity}] {end} | [127.0.0.1, map[cpu:4]] [127.0.0.2, map[cpu:8]]
-''                | quote interpreted string  | {range .items[*]}{.metadata.name}{'\t'}{end}                  | 127.0.0.1    127.0.0.2
+Function            | Description               | Example                                                         | Result
+--------------------|---------------------------|-----------------------------------------------------------------|------------------
+`text`              | the plain text            | `kind is {.kind}`                                               | `kind is List`
+`@`                 | the current object        | `{@}`                                                           | the same as input
+`.` or `[]`         | child operator            | `{.kind}` or `{['kind']}`                                       | `List`
+`..`                | recursive descent         | `{..name}`                                                      | `127.0.0.1 127.0.0.2 myself e2e`
+`*`                 | wildcard. Get all objects | `{.items[*].metadata.name}`                                     | `[127.0.0.1 127.0.0.2]`
+`[start:end :step]` | subscript operator        | `{.users[0].name}`                                              | `myself`
+`[,]`               | union operator            | `{.items[*]['metadata.name', 'status.capacity']}`               | `127.0.0.1 127.0.0.2 map[cpu:4] map[cpu:8]`
+`?()`               | filter                    | `{.users[?(@.name=="e2e")].user.password}`                      | `secret`
+`range`, `end`      | iterate list              | `{range .items[*]}[{.metadata.name}, {.status.capacity}] {end}` | `[127.0.0.1, map[cpu:4]] [127.0.0.2, map[cpu:8]]`
+`''`                | quote interpreted string  | `{range .items[*]}{.metadata.name}{'\t'}{end}`                  | `127.0.0.1      127.0.0.2`
 
 Examples using `kubectl` and JSONPath expressions:
 

--- a/content/fr/docs/reference/kubectl/jsonpath.md
+++ b/content/fr/docs/reference/kubectl/jsonpath.md
@@ -67,18 +67,18 @@ En plus de la syntaxe de modèle JSONPath originale, les fonctions et syntaxes s
 }
 ```
 
-Fonction          | Description                | Exemple                                                       | Résultat
-------------------|----------------------------|---------------------------------------------------------------|------------------
-text              | le texte en clair          | le type est {.kind}                                           | le type est List
-@                 | l'objet courant            | {@}                                                           | identique à l'entrée
-. or []           | opérateur fils             | {.kind} ou {['kind']}                                         | List
-..                | descente récursive         | {..name}                                                      | 127.0.0.1 127.0.0.2 myself e2e
-\*                | joker. Tous les objets     | {.items[*].metadata.name}                                     | [127.0.0.1 127.0.0.2]
-[start:end :step] | opérateur d'indice         | {.users[0].name}                                              | myself
-[,]               | opérateur d'union          | {.items[*]['metadata.name', 'status.capacity']}               | 127.0.0.1 127.0.0.2 map[cpu:4] map[cpu:8]
-?()               | filtre                     | {.users[?(@.name=="e2e")].user.password}                      | secret
-range, end        | itération de liste         | {range .items[*]}[{.metadata.name}, {.status.capacity}] {end} | [127.0.0.1, map[cpu:4]] [127.0.0.2, map[cpu:8]]
-''                | protège chaîne interprétée | {range .items[*]}{.metadata.name}{'\t'}{end}                  | 127.0.0.1    127.0.0.2
+Fonction            | Description                | Exemple                                                         | Résultat
+--------------------|----------------------------|-----------------------------------------------------------------|------------------
+`text`              | le texte en clair          | `le type est {.kind}`                                           | `le type est List`
+`@`                 | l'objet courant            | `{@}`                                                           | identique à l'entrée
+`.` ou `[]`         | opérateur fils             | `{.kind}` ou `{['kind']}`                                       | `List`
+`..`                | descente récursive         | `{..name}`                                                      | `127.0.0.1 127.0.0.2 myself e2e`
+`*`                 | joker. Tous les objets     | `{.items[*].metadata.name}`                                     | `[127.0.0.1 127.0.0.2]`
+`[start:end :step]` | opérateur d'indice         | `{.users[0].name}`                                              | `myself`
+`[,]`               | opérateur d'union          | `{.items[*]['metadata.name', 'status.capacity']}`               | `127.0.0.1 127.0.0.2 map[cpu:4] map[cpu:8]`
+`?()`               | filtre                     | `{.users[?(@.name=="e2e")].user.password}`                      | `secret`
+`range`, `end`      | itération de liste         | `{range .items[*]}[{.metadata.name}, {.status.capacity}] {end}` | `[127.0.0.1, map[cpu:4]] [127.0.0.2, map[cpu:8]]`
+`''`                | protège chaîne interprétée | `{range .items[*]}{.metadata.name}{'\t'}{end}`                  | `127.0.0.1    127.0.0.2`
 
 Exemples utilisant `kubectl` et des expressions JSONPath :
 

--- a/content/zh/docs/reference/kubectl/jsonpath.md
+++ b/content/zh/docs/reference/kubectl/jsonpath.md
@@ -49,15 +49,15 @@ JSONPath 模板由 {} 包起来的 JSONPath 表达式组成。
   ]
 }
 ```
-| 函数                | 描述         | 示例                                       | 结果                                       |
-| ----------------- | ---------- | ---------------------------------------- | ---------------------------------------- |
-| text              | 纯文本        | kind is {.kind}                          | kind is List                             |
-| @                 | 当前对象       | {@}                                      | 与输入相同                                    |
-| . or []           | 子运算符       | {.kind} 或者 {['kind']}                    | List                                     |
-| ..                | 递归下降       | {..name}                                 | 127.0.0.1 127.0.0.2 myself e2e           |
-| *                 | 通配符，获取所有对象 | {.items[*].metadata.name}                | [127.0.0.1 127.0.0.2]                    |
-| [start:end :step] | 下标运算符      | {.users[0].name}                         | myself                                   |
-| [,]               | 并集运算符      | {.items[*]['metadata.name', 'status.capacity']} | 127.0.0.1 127.0.0.2 map[cpu:4] map[cpu:8] |
-| ?()               | 过滤         | {.users[?(@.name=="e2e")].user.password} | secret                                   |
-| range, end        | 迭代列表       | {range .items[*]}[{.metadata.name}, {.status.capacity}] {end} | [127.0.0.1, map[cpu:4]] [127.0.0.2, map[cpu:8]] |
-| ""                | 引用解释执行字符串  | {range .items[*]}{.metadata.name}{"\t"}{end} | 127.0.0.1    127.0.0.2                   |
+| 函数                  | 描述         | 示例                                         | 结果                                         |
+| ------------------- | ---------- | ------------------------------------------ | ------------------------------------------ |
+| `text`              | 纯文本        | `kind is {.kind}`                          | `kind is List`                             |
+| `@`                 | 当前对象       | `{@}`                                      | 与输入相同                                    |
+| `.` 或者 `[]`         | 子运算符       | `{.kind}` 或者 `{['kind']}`                  | `List`                                     |
+| `..`                | 递归下降       | `{..name}`                                 | `127.0.0.1 127.0.0.2 myself e2e`           |
+| `*`                 | 通配符，获取所有对象 | `{.items[*].metadata.name}`                | `[127.0.0.1 127.0.0.2]`                    |
+| `[start:end :step]` | 下标运算符      | `{.users[0].name}`                         | `myself`                                   |
+| `[,]`               | 并集运算符      | `{.items[*]['metadata.name', 'status.capacity']}` | `127.0.0.1 127.0.0.2 map[cpu:4] map[cpu:8]` |
+| `?()`               | 过滤         | `{.users[?(@.name=="e2e")].user.password}` | `secret`                                   |
+| `range`, `end`      | 迭代列表       | `{range .items[*]}[{.metadata.name}, {.status.capacity}] {end}` | `[127.0.0.1, map[cpu:4]] [127.0.0.2, map[cpu:8]]` |
+| `''`                | 引用解释执行字符串  | `{range .items[*]}{.metadata.name}{'\t'}{end}` | `127.0.0.1    127.0.0.2`                   |


### PR DESCRIPTION
It's very difficult to figure out e.g. the correct quotes to use from
regular text that is subject to being converted for typographers quotes.
Use code literals instead to ensure that nothing is modified, and to
distinguish literals from accompanying text.