### PR TITLE
Applied title case to page title

### DIFF
--- a/content/en/docs/concepts/architecture/master-node-communication.md
+++ b/content/en/docs/concepts/architecture/master-node-communication.md
@@ -3,7 +3,7 @@ reviewers:
 - dchen1107
 - roberthbailey
 - liggitt
-title: Master-Node communication
+title: Master-Node Communication
 content_template: templates/concept
 weight: 20
 ---


### PR DESCRIPTION
Page titles throughout the doc set typically use title case. This one uses sentence case. I've added capitalization to match the common style.

I'm re-creating https://github.com/kubernetes/website/pull/15543 after having signed the CLA.