### PR TITLE
Fix syntax broken highlighting

### DIFF
--- a/content/en/examples/admin/cloud/ccm-example.yaml
+++ b/content/en/examples/admin/cloud/ccm-example.yaml
@@ -47,7 +47,7 @@ spec:
         image: k8s.gcr.io/cloud-controller-manager:v1.8.0
         command:
         - /usr/local/bin/cloud-controller-manager
-        - --cloud-provider=<YOUR_CLOUD_PROVIDER>   # Add your own cloud provider here!
+        - --cloud-provider=[YOUR_CLOUD_PROVIDER]  # Add your own cloud provider here!
         - --leader-elect=true
         - --use-service-account-credentials
         # these flags will vary for every cloud provider


### PR DESCRIPTION
Hugo's highlighter does not understand a variable name with angle
brackets, and breaks the coloring.

This is a fix for  #15829