### PR TITLE
Add info on "no opinion" response

### DIFF
--- a/content/en/docs/reference/access-authn-authz/webhook.md
+++ b/content/en/docs/reference/access-authn-authz/webhook.md
@@ -108,7 +108,13 @@ the request and respond to either allow or disallow access. The response body's
 }
 ```
 
-To disallow access, the remote service would return:
+For disallowing access there are two methods.
+
+The first method is preferred in most cases, and indicates the authorization
+webhook does not allow, or has "no opinion" about the request, but if other 
+authorizers are configured, they are given a chance to allow the request. 
+If there are no other authorizers, or none of them allow the request, the 
+request is forbidden. The webhook would return:
 
 ```json
 {
@@ -116,6 +122,23 @@ To disallow access, the remote service would return:
   "kind": "SubjectAccessReview",
   "status": {
     "allowed": false,
+    "reason": "user does not have read access to the namespace"
+  }
+}
+```
+
+The second method denies immediately, short-circuiting evaluation by other 
+configured authorizers. This should only be used by webhooks that have 
+detailed knowledge of the full authorizer configuration of the cluster. 
+The webhook would return:
+
+```json
+{
+  "apiVersion": "authorization.k8s.io/v1beta1",
+  "kind": "SubjectAccessReview",
+  "status": {
+    "allowed": false,
+    "denied": true,
     "reason": "user does not have read access to the namespace"
   }
 }


### PR DESCRIPTION
While "chained" authorizers are mentioned elsewhere in the docs, nowhere is it mentioned how to delegate authorization calls to the next in line. Took me on a journey across both [StackOverflow](https://stackoverflow.com/questions/57248927/multiple-kubernetes-authorization-modules-checked-in-sequence-how) and the [kubernetes source code](https://github.com/kubernetes/kubernetes/blob/74618928c25302943a3a5e903bf9a3626bc1e84a/pkg/apis/authorization/types.go#L134) before figuring this one out - hoping the next one researching this may be helped by this.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> Remember to delete this note before submitting your pull request.
>
> For pull requests on 1.15 Features: set Milestone to 1.15 and Base Branch to dev-1.15
> 
> For pull requests on Chinese localization, set Base Branch to release-1.14
>
> For pull requests on Korean Localization: set Base Branch to dev-1.14-ko.\<latest team milestone>
>
> If you need Help on editing and submitting pull requests, visit:
> https://kubernetes.io/docs/contribute/start/#improve-existing-content.
>
> If you need Help on choosing which branch to use, visit:
> https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use.
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
