### PR TITLE
Reworked a sentence for clarity and tone.

### DIFF
--- a/content/en/docs/concepts/services-networking/ingress.md
+++ b/content/en/docs/concepts/services-networking/ingress.md
@@ -15,7 +15,7 @@ weight: 40
 
 ## Terminology
 
-For the sake of clarity, this guide defines the following terms:
+For clarity, this guide defines the following terms:
 
 Node
 : A worker machine in Kubernetes, part of a cluster.


### PR DESCRIPTION
I reworked the sentence:

`For the sake of clarity, this guide defines the following terms:`
to
`For clarity, this guide defines the following terms:`

The tone is in this case less condescending and the colloquial nature of `for the sake of` is confusing to non-native English speakers. 