### PR TITLE
JSON to YAML for external LoadBalancer

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/create-external-load-balancer.md
+++ b/content/en/docs/tasks/access-application-cluster/create-external-load-balancer.md
@@ -35,30 +35,24 @@ documentation.
 To create an external load balancer, add the following line to your
 [service configuration file](/docs/concepts/services-networking/service/#loadbalancer):
 
-```json
-    "type": "LoadBalancer"
+```yaml
+    type: LoadBalancer
 ```
 
 Your configuration file might look like:
 
-```json
-    {
-      "kind": "Service",
-      "apiVersion": "v1",
-      "metadata": {
-        "name": "example-service"
-      },
-      "spec": {
-        "ports": [{
-          "port": 8765,
-          "targetPort": 9376
-        }],
-        "selector": {
-          "app": "example"
-        },
-        "type": "LoadBalancer"
-      }
-    }
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-service
+spec:
+  selector:
+    app: example
+  ports:
+    - port: 8765
+      targetPort: 9376
+  type: LoadBalancer
 ```
 
 ## Using kubectl
@@ -139,25 +133,19 @@ to "Local".
 This feature can be activated by setting `externalTrafficPolicy` to "Local" in the
 Service Configuration file.
 
-```json
-    {
-      "kind": "Service",
-      "apiVersion": "v1",
-      "metadata": {
-        "name": "example-service"
-      },
-      "spec": {
-        "ports": [{
-          "port": 8765,
-          "targetPort": 9376
-        }],
-        "selector": {
-          "app": "example"
-        },
-        "type": "LoadBalancer",
-        "externalTrafficPolicy": "Local"
-      }
-    }
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-service
+spec:
+  selector:
+    app: example
+  ports:
+    - port: 8765
+      targetPort: 9376
+  externalTrafficPolicy: Local
+  type: LoadBalancer
 ```
 
 ### Feature availability
@@ -238,5 +226,3 @@ Once the external load balancers provide weights, this functionality can be adde
 Internal pod to pod traffic should behave similar to ClusterIP services, with equal probability across all pods.
 
 {{% /capture %}}
-
-

--- a/content/en/docs/tasks/access-application-cluster/create-external-load-balancer.md
+++ b/content/en/docs/tasks/access-application-cluster/create-external-load-balancer.md
@@ -112,7 +112,7 @@ minikube service example-service --url
 ## Preserving the client source IP
 
 Due to the implementation of this feature, the source IP seen in the target
-container will *not be the original source IP* of the client. To enable
+container is *not the original source IP* of the client. To enable
 preservation of the client IP, the following fields can be configured in the
 service spec (supported in GCE/Google Kubernetes Engine environments):
 
@@ -123,15 +123,15 @@ IP and may cause a second hop to another node, but should have good overall
 load-spreading. Local preserves the client source IP and avoids a second hop
 for LoadBalancer and NodePort type services, but risks potentially imbalanced
 traffic spreading.
-* `service.spec.healthCheckNodePort` - specifies the healthcheck nodePort
+* `service.spec.healthCheckNodePort` - specifies the health check nodePort
 (numeric port number) for the service. If not specified, `healthCheckNodePort` is
 created by the service API backend with the allocated `nodePort`. It will use the
 user-specified `nodePort` value if specified by the client. It only has an
-effect when type is set to LoadBalancer and `externalTrafficPolicy` is set
+effect when `type` is set to LoadBalancer and `externalTrafficPolicy` is set
 to Local.
 
-This feature can be activated by setting `externalTrafficPolicy` to Local in the
-Service Configuration file.
+Setting `externalTrafficPolicy` to Local in the Service configuration file
+activates this feature.
 
 ```yaml
 apiVersion: v1
@@ -191,7 +191,7 @@ associated Service is deleted. Finalizer Protection for Service LoadBalancers wa
 introduced to prevent this from happening. By using finalizers, a Service resource
 will never be deleted until the correlating load balancer resources are also deleted.
 
-Specifically, if a Service has Type=LoadBalancer, the service controller will attach
+Specifically, if a Service has `type` LoadBalancer, the service controller will attach
 a finalizer named `service.kubernetes.io/load-balancer-cleanup`.
 The finalizer will only be removed after the load balancer resource is cleaned up.
 This prevents dangling load balancer resources even in corner cases such as the
@@ -205,14 +205,18 @@ enabling the [feature gate](/docs/reference/command-line-tools-reference/feature
 
 It is important to note that the datapath for this functionality is provided by a load balancer external to the Kubernetes cluster.
 
-When the service type is set to LoadBalancer, Kubernetes provides functionality equivalent to `type=<ClusterIP>` to pods within the cluster and extends it by programming the (external to Kubernetes) load balancer with entries for the Kubernetes pods. The Kubernetes service controller automates the creation of the external load balancer, health checks (if needed), firewall rules (if needed) and retrieves the external IP allocated by the cloud provider and populates it in the service object.
+When the Service `type` is set to LoadBalancer, Kubernetes provides functionality equivalent to `type` equals ClusterIP to pods
+within the cluster and extends it by programming the (external to Kubernetes) load balancer with entries for the Kubernetes
+pods. The Kubernetes service controller automates the creation of the external load balancer, health checks (if needed),
+firewall rules (if needed) and retrieves the external IP allocated by the cloud provider and populates it in the service
+object.
 
 ## Caveats and Limitations when preserving source IPs
 
 GCE/AWS load balancers do not provide weights for their target pools. This was not an issue with the old LB
 kube-proxy rules which would correctly balance across all endpoints.
 
-With the new functionality, the external traffic will not be equally load balanced across pods, but rather
+With the new functionality, the external traffic is not equally load balanced across pods, but rather
 equally balanced at the node level (because GCE/AWS and other external LB implementations do not have the ability
 for specifying the weight per node, they balance equally across all target nodes, disregarding the number of
 pods on each node).

--- a/content/en/docs/tasks/access-application-cluster/create-external-load-balancer.md
+++ b/content/en/docs/tasks/access-application-cluster/create-external-load-balancer.md
@@ -118,19 +118,19 @@ service spec (supported in GCE/Google Kubernetes Engine environments):
 
 * `service.spec.externalTrafficPolicy` - denotes if this Service desires to route
 external traffic to node-local or cluster-wide endpoints. There are two available
-options: "Cluster" (default) and "Local". "Cluster" obscures the client source
+options: Cluster (default) and Local. Cluster obscures the client source
 IP and may cause a second hop to another node, but should have good overall
-load-spreading. "Local" preserves the client source IP and avoids a second hop
+load-spreading. Local preserves the client source IP and avoids a second hop
 for LoadBalancer and NodePort type services, but risks potentially imbalanced
 traffic spreading.
 * `service.spec.healthCheckNodePort` - specifies the healthcheck nodePort
-(numeric port number) for the service. If not specified, healthCheckNodePort is
-created by the service API backend with the allocated nodePort. It will use the
-user-specified nodePort value if specified by the client. It only has an
-effect when type is set to "LoadBalancer" and externalTrafficPolicy is set
-to "Local".
+(numeric port number) for the service. If not specified, `healthCheckNodePort` is
+created by the service API backend with the allocated `nodePort`. It will use the
+user-specified `nodePort` value if specified by the client. It only has an
+effect when type is set to LoadBalancer and `externalTrafficPolicy` is set
+to Local.
 
-This feature can be activated by setting `externalTrafficPolicy` to "Local" in the
+This feature can be activated by setting `externalTrafficPolicy` to Local in the
 Service Configuration file.
 
 ```yaml
@@ -166,8 +166,8 @@ after v1.7. Please update existing applications to use the fields directly.
 `service.beta.kubernetes.io/external-traffic` annotation has a different set of values
 compared to the `service.spec.externalTrafficPolicy` field. The values match as follows:
 
-* "OnlyLocal" for annotation <-> "Local" for field
-* "Global" for annotation <-> "Cluster" for field
+* OnlyLocal for annotation <-> Local for field
+* Global for annotation <-> Cluster for field
 
 {{< note >}}
 This feature is not currently implemented for all cloudproviders/environments.
@@ -205,7 +205,7 @@ enabling the [feature gate](/docs/reference/command-line-tools-reference/feature
 
 It is important to note that the datapath for this functionality is provided by a load balancer external to the Kubernetes cluster.
 
-When the service type is set to `LoadBalancer`, Kubernetes provides functionality equivalent to `type=<ClusterIP>` to pods within the cluster and extends it by programming the (external to Kubernetes) load balancer with entries for the Kubernetes pods. The Kubernetes service controller automates the creation of the external load balancer, health checks (if needed), firewall rules (if needed) and retrieves the external IP allocated by the cloud provider and populates it in the service object.
+When the service type is set to LoadBalancer, Kubernetes provides functionality equivalent to `type=<ClusterIP>` to pods within the cluster and extends it by programming the (external to Kubernetes) load balancer with entries for the Kubernetes pods. The Kubernetes service controller automates the creation of the external load balancer, health checks (if needed), firewall rules (if needed) and retrieves the external IP allocated by the cloud provider and populates it in the service object.
 
 ## Caveats and Limitations when preserving source IPs
 

--- a/content/en/docs/tasks/access-application-cluster/create-external-load-balancer.md
+++ b/content/en/docs/tasks/access-application-cluster/create-external-load-balancer.md
@@ -9,6 +9,10 @@ weight: 80
 
 This page shows how to create an External Load Balancer.
 
+{{< note >}}
+This feature is only available for cloud providers or environments which support external load balancers.
+{{< /note >}}
+
 When creating a service, you have the option of automatically creating a
 cloud network load balancer. This provides an externally-accessible IP address
 that sends traffic to the correct port on your cluster nodes
@@ -147,40 +151,6 @@ spec:
   externalTrafficPolicy: Local
   type: LoadBalancer
 ```
-
-### Feature availability
-
-| K8s version | Feature support |
-| :---------: |:-----------:|
-| 1.7+ | Supports the full API fields |
-| 1.5 - 1.6 | Supports Beta Annotations |
-| <1.5 | Unsupported |
-
-Below you could find the deprecated Beta annotations used to enable this feature
-prior to its stable version. Newer Kubernetes versions may stop supporting these
-after v1.7. Please update existing applications to use the fields directly.
-
-* `service.beta.kubernetes.io/external-traffic` annotation <-> `service.spec.externalTrafficPolicy` field
-* `service.beta.kubernetes.io/healthcheck-nodeport` annotation <-> `service.spec.healthCheckNodePort` field
-
-`service.beta.kubernetes.io/external-traffic` annotation has a different set of values
-compared to the `service.spec.externalTrafficPolicy` field. The values match as follows:
-
-* OnlyLocal for annotation <-> Local for field
-* Global for annotation <-> Cluster for field
-
-{{< note >}}
-This feature is not currently implemented for all cloudproviders/environments.
-{{< /note >}}
-
-Known issues:
-
-* AWS: [kubernetes/kubernetes#35758](https://github.com/kubernetes/kubernetes/issues/35758)
-* Weave-Net: [weaveworks/weave/#2924](https://github.com/weaveworks/weave/issues/2924)
-
-{{% /capture %}}
-
-{{% capture discussion %}}
 
 ## Garbage Collecting Load Balancers
 


### PR DESCRIPTION
Make this page consistent:
- YAML definitions for an object instead of JSON,
- apply style guide rules,
- remove obsolete fragments.