### PR TITLE
trim redundant leading spaces

### DIFF
--- a/content/en/docs/tutorials/stateless-application/expose-external-ip-address.md
+++ b/content/en/docs/tutorials/stateless-application/expose-external-ip-address.md
@@ -146,12 +146,12 @@ The preceding command creates a
 
 To delete the Service, enter this command:
 
-        kubectl delete services my-service
+    kubectl delete services my-service
 
 To delete the Deployment, the ReplicaSet, and the Pods that are running
 the Hello World application, enter this command:
 
-        kubectl delete deployment hello-world
+    kubectl delete deployment hello-world
 
 {{% /capture %}}
 


### PR DESCRIPTION
There is too much indent for code blocks. I removed leading spaces.

![ss_ 2019-08-17 21 36 17](https://user-images.githubusercontent.com/4710215/63211815-541c1780-c137-11e9-9272-8cc4fe5be097.png)
