### PR TITLE
Fix unexpected line breaks for localized glossary tooltips

### DIFF
--- a/layouts/partials/docs/glossary-terms.html
+++ b/layouts/partials/docs/glossary-terms.html
@@ -3,9 +3,7 @@
   {{ $pages := $glossaryBundle.Resources.ByType "page" }}
   {{- range site.Params.language_alternatives -}}
     {{- with (where $glossaryBundle.Translations ".Lang" . ) -}}
-    {{ $p := (index . 0) }}
-    {{ $pages = $pages | lang.Merge ($p.Resources.ByType "page") }}
-    {{ end }}
+    {{ $p := (index . 0) }}{{ $pages = $pages | lang.Merge ($p.Resources.ByType "page") }}{{ end }}
   {{ end }}
   {{- $.Scratch.Set "glossary_items"  $pages -}}
 {{- else -}}


### PR DESCRIPTION
As described in #15390, there is an issue with line breaks and glossary tooltips.

In English, the tooltip is displayed correctly : 

![image](https://user-images.githubusercontent.com/1558361/63228388-4c6d7900-c1f2-11e9-9dbb-c681ac2d4ad8.png)

However, in another language, say French, there is a line break issue : 

![image](https://user-images.githubusercontent.com/1558361/63228392-627b3980-c1f2-11e9-9a50-c3fb46ed606a.png)

This is kind of a workaround, but it seems that removing the line breaks in `layouts/partials/docs/glossary-terms.html` fixes the issue...