### PR TITLE
upgrade Node.js version for examples

### DIFF
--- a/content/de/examples/minikube/Dockerfile
+++ b/content/de/examples/minikube/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.14.2
+FROM node:10.16.3
 EXPOSE 8080
 COPY server.js .
 CMD node server.js

--- a/content/en/examples/minikube/Dockerfile
+++ b/content/en/examples/minikube/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.14.2
+FROM node:10.16.3
 EXPOSE 8080
 COPY server.js .
 CMD node server.js

--- a/content/fr/examples/minikube/Dockerfile
+++ b/content/fr/examples/minikube/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.14.2
+FROM node:10.16.3
 EXPOSE 8080
 COPY server.js .
 CMD node server.js

--- a/content/id/examples/minikube/Dockerfile
+++ b/content/id/examples/minikube/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.14.2
+FROM node:10.16.3
 EXPOSE 8080
 COPY server.js .
 CMD node server.js

--- a/content/ja/examples/minikube/Dockerfile
+++ b/content/ja/examples/minikube/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.14.2
+FROM node:10.16.3
 EXPOSE 8080
 COPY server.js .
 CMD node server.js

--- a/content/ko/examples/minikube/Dockerfile
+++ b/content/ko/examples/minikube/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.14.2
+FROM node:10.16.3
 EXPOSE 8080
 COPY server.js .
 CMD node server.js


### PR DESCRIPTION
Node version 6 has been deprecated since a long time ago