### PR TITLE
Documentation corrected

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -542,7 +542,7 @@ kubectl create -f https://kubernetes.io/examples/configmap/configmap-multikeys.y
 
 Add the ConfigMap name under the `volumes` section of the Pod specification.
 This adds the ConfigMap data to the directory specified as `volumeMounts.mountPath` (in this case, `/etc/config`).
-The `command` section references the `special.level` item stored in the ConfigMap.
+The `command` section lists the contents of the directory which got populated with the files having names as same as the keys in configMap.
 
 {{< codenew file="pods/pod-configmap-volume.yaml" >}}
 

--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -542,7 +542,7 @@ kubectl create -f https://kubernetes.io/examples/configmap/configmap-multikeys.y
 
 Add the ConfigMap name under the `volumes` section of the Pod specification.
 This adds the ConfigMap data to the directory specified as `volumeMounts.mountPath` (in this case, `/etc/config`).
-The `command` section lists the contents of the directory which got populated with the files having names as same as the keys in configMap.
+The `command` section lists directory files with names that match the keys in ConfigMap.
 
 {{< codenew file="pods/pod-configmap-volume.yaml" >}}
 


### PR DESCRIPTION
The description for the `command` section was wrong. Same is corrected.

