### PR TITLE
Clarifying that you cannot mix Windows and Linux containers in a single pod

### DIFF
--- a/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
+++ b/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
@@ -58,7 +58,7 @@ Key Kubernetes elements work the same way in Windows as they do in Linux. In thi
 
 * [Pods](/docs/concepts/workloads/pods/pod-overview/)
 
-    A Pod is the basic building block of Kubernetes–the smallest and simplest unit in the Kubernetes object model that you create or deploy. The following Pod capabilities, properties and events are supported with Windows containers:
+    A Pod is the basic building block of Kubernetes–the smallest and simplest unit in the Kubernetes object model that you create or deploy. You may not deploy Windows and Linux containers in the same Pod. All containers in a Pod are scheduled onto a single Node where each Node represents a specific platform and architecture. The following Pod capabilities, properties and events are supported with Windows containers:
 
   * Single or multiple containers per Pod with process isolation and volume sharing
   * Pod status fields


### PR DESCRIPTION
This seems to be implied by [another page](https://kubernetes.io/docs/setup/production-environment/windows/user-guide-windows-containers/#ensuring-os-specific-workloads-land-on-the-appropriate-container-host) as well as the comment

> Windows containers have to be scheduled on Windows nodes and Linux containers on Linux nodes.

on this page, but if true it would be better to be explicit rather than leaving the corollary to the reader’s imagination.

CC @richbg