### PR TITLE
Update cheatsheet based on deprecation

### DIFF
--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -145,7 +145,6 @@ kubectl get services                          # List all services in the namespa
 kubectl get pods --all-namespaces             # List all pods in all namespaces
 kubectl get pods -o wide                      # List all pods in the namespace, with more details
 kubectl get deployment my-dep                 # List a particular deployment
-kubectl get pods --include-uninitialized      # List all pods in the namespace, including uninitialized ones
 kubectl get pod my-pod -o yaml                # Get a pod's YAML
 kubectl get pod my-pod -o yaml --export       # Get a pod's YAML without cluster specific information
 


### PR DESCRIPTION
Flag --include-uninitialized has been deprecated, yet it still appears in the cheatsheet.

I'm open to updating this PR to fit standards or to make a more comprehensive update. 
Just quickly raising this for review.