### PR TITLE
Remove inactive approver

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -57,7 +57,6 @@ aliases:
     - tengqm
     - tfogo
     - zacharysarah
-    - zhangxiaoyu-zidif
     - zparnold
   sig-docs-en-reviews: # PR reviews for English content
     - jimangel


### PR DESCRIPTION
This PR removes @zhangxiaoyu-zidif from English approvers. 

With only [one PR in the past year](https://github.com/kubernetes/website/pulls?q=is%3Apr+author%3Azhangxiaoyu-zidif+is%3Aclosed) and with no response to [PR wrangling](https://github.com/kubernetes/website/wiki/PR-Wranglers) responsibilities, it looks like @zhangxiaoyu-zidif may have moved on from K8s docs.

Tim, we wish you well! Thanks for all of your contributions, and best wishes for all your future endeavors. 🙇