### PR TITLE
docs: CRD pruning to GA and defaulting to beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # The Kubernetes documentation
 
+
 [![Build Status](https://api.travis-ci.org/kubernetes/website.svg?branch=master)](https://travis-ci.org/kubernetes/website)
 [![GitHub release](https://img.shields.io/github/release/kubernetes/website.svg)](https://github.com/kubernetes/website/releases/latest)
 


### PR DESCRIPTION
Replaced by https://github.com/kubernetes/website/pull/15983.