### PR TITLE
Rework glossary definition of Workloads

### DIFF
--- a/content/en/docs/reference/glossary/workload.md
+++ b/content/en/docs/reference/glossary/workload.md
@@ -1,28 +1,22 @@
 ---
-title: Workloads
+title: Workload
 id: workloads
 date: 2019-02-13
 full_link: /docs/concepts/workloads/
 short_description: >
-   Workloads are objects you use to manage and run your containers on the cluster.
+   A workload is an application running on Kubernetes.
 
 aka: 
 tags:
 - fundamental
-- core-object
-- workload
 ---
-  Workloads are objects you use to manage and run your containers on the cluster.
+   A workload is an application running on Kubernetes.
 
 <!--more--> 
 
-Kubernetes performs the 
-deployment and updates the workload with the current state of the application.
-Workloads include the DaemonSet, Deployments, Jobs, Pods, ReplicaSet, ReplicationController, and StatefulSet objects.
+Various core objects that represent different types or parts of a workload
+include the DaemonSet, Deployment, Job, ReplicaSet, and StatefulSet objects.
 
-For example, a workload that has a web element and a database element might run the
-database in one {{< glossary_tooltip term_id="StatefulSet" >}} of
-{{< glossary_tooltip text="pods" term_id="pod" >}} and the webserver via
-a {{< glossary_tooltip term_id="Deployment" >}} that consists of many web app
-{{< glossary_tooltip text="pods" term_id="pod" >}}, all alike.
-
+For example, a workload that has a web server and a database might run the
+database in one {{< glossary_tooltip term_id="StatefulSet" >}} and the web server
+in a {{< glossary_tooltip term_id="Deployment" >}}.


### PR DESCRIPTION
This patch turns the glossary entry for "workloads" into "workload" in
order to be consistent with other terms in the glossary. In addition,
the definition is modified to match what the overlay tip for the
"Workload" tag at the top of the glossary page says, which is
"Applications running on Kubernetes".

A workload is *not* a core object itself. Rather, it is a general
concept. Various other core objects describe different types of
workloads, and the glossary definition is appropriately modified to make
that clear.

Fixes Issue #14107