### PR TITLE
Update cloning docs to reflect beta for 1.16

### DIFF
--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -98,7 +98,7 @@ Name:          hostpath
 Namespace:     default
 StorageClass:  example-hostpath
 Status:        Terminating
-Volume:        
+Volume:
 Labels:        <none>
 Annotations:   volume.beta.kubernetes.io/storage-class=example-hostpath
                volume.beta.kubernetes.io/storage-provisioner=example.com/hostpath
@@ -116,15 +116,15 @@ Annotations:     <none>
 Finalizers:      [kubernetes.io/pv-protection]
 StorageClass:    standard
 Status:          Available
-Claim:           
+Claim:
 Reclaim Policy:  Delete
 Access Modes:    RWO
 Capacity:        1Gi
-Message:         
+Message:
 Source:
     Type:          HostPath (bare host directory volume)
     Path:          /tmp/data
-    HostPathType:  
+    HostPathType:
 Events:            <none>
 ```
 
@@ -228,10 +228,10 @@ You can only resize volumes containing a file system if the file system is XFS, 
 
 When a volume contains a file system, the file system is only resized when a new Pod is using
 the `PersistentVolumeClaim` in ReadWrite mode. File system expansion is either done when Pod is starting up
-or is done when Pod is running and underlying file system supports online expansion. 
+or is done when Pod is running and underlying file system supports online expansion.
 
-FlexVolumes allow resize if the driver is set with the `RequiresFSResize` capability to true. 
-The FlexVolume can be resized on pod restart. 
+FlexVolumes allow resize if the driver is set with the `RequiresFSResize` capability to true.
+The FlexVolume can be resized on pod restart.
 
 #### Resizing an in-use PersistentVolumeClaim
 
@@ -682,7 +682,7 @@ spec:
 
 ## Volume Cloning
 
-{{< feature-state for_k8s_version="v1.15" state="alpha" >}}
+{{< feature-state for_k8s_version="v1.16" state="beta" >}}
 
 Volume clone feature was added to support CSI Volume Plugins only. For details, see [volume cloning](/docs/concepts/storage/volume-pvc-datasource/).
 

--- a/content/en/docs/concepts/storage/volume-pvc-datasource.md
+++ b/content/en/docs/concepts/storage/volume-pvc-datasource.md
@@ -11,7 +11,7 @@ weight: 30
 
 {{% capture overview %}}
 
-{{< feature-state for_k8s_version="v1.15" state="alpha" >}} 
+{{< feature-state for_k8s_version="v1.16" state="beta" >}}
 This document describes the concept of cloning existing CSI Volumes in Kubernetes.  Familiarity with [Volumes](/docs/concepts/storage/volumes) is suggested.
 
 This feature requires VolumePVCDataSource feature gate to be enabled:
@@ -32,7 +32,7 @@ The {{< glossary_tooltip text="CSI" term_id="csi" >}} Volume Cloning feature add
 
 A Clone is defined as a duplicate of an existing Kubernetes Volume that can be consumed as any standard Volume would be.  The only difference is that upon provisioning, rather than creating a "new" empty Volume, the back end device creates an exact duplicate of the specified Volume.
 
-The implementation of cloning, from the perspective of the Kubernetes API simply adds the ability to specify an existing unbound PVC as a dataSource during new pvc creation. 
+The implementation of cloning, from the perspective of the Kubernetes API simply adds the ability to specify an existing unbound PVC as a dataSource during new pvc creation.
 
 Users need to be aware of the following when using this feature:
 
@@ -40,6 +40,10 @@ Users need to be aware of the following when using this feature:
 * Cloning support is only available for dynamic provisioners.
 * CSI drivers may or may not have implemented the volume cloning functionality.
 * You can only clone a PVC when it exists in the same namespace as the destination PVC (source and destination must be in the same namespace).
+* Cloning is only supported within the same Storage Class.
+    - Destination volume must be the same storage class as the source
+    - Default storage class can be used and storageClassName omitted in the spec
+
 
 ## Provisioning
 
@@ -54,6 +58,7 @@ metadata:
 spec:
   accessModes:
   - ReadWriteOnce
+  storageClassName: cloning
   resources:
     requests:
       storage: 5Gi

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -174,7 +174,8 @@ different Kubernetes components.
 | `TokenRequestProjection` | `false` | Alpha | 1.11 | 1.11 |
 | `TokenRequestProjection` | `true` | Beta | 1.12 | |
 | `TTLAfterFinished` | `false` | Alpha | 1.12 | |
-| `VolumePVCDataSource` | `false` | Alpha | 1.15 | |
+| `VolumePVCDataSource` | `false` | Alpha | 1.15 | 1.15 |
+| `VolumePVCDataSource` | `true` | Beta | 1.16 | |
 | `VolumeScheduling` | `false` | Alpha | 1.9 | 1.9 |
 | `VolumeScheduling` | `true` | Beta | 1.10 | 1.12 |
 | `VolumeScheduling` | `true` | GA | 1.13 | |
@@ -308,7 +309,7 @@ Each feature gate is designed for enabling/disabling a specific feature:
 - `MountPropagation`: Enable sharing volume mounted by one container to other containers or pods.
   For more details, please see [mount propagation](/docs/concepts/storage/volumes/#mount-propagation).
 - `NodeLease`: Enable the new Lease API to report node heartbeats, which could be used as a node health signal.
-- `NonPreemptingPriority`: Enable NonPreempting option for PriorityClass and Pod. 
+- `NonPreemptingPriority`: Enable NonPreempting option for PriorityClass and Pod.
 - `PersistentLocalVolumes`: Enable the usage of `local` volume type in Pods.
   Pod affinity has to be specified if requesting a `local` volume.
 - `PodPriority`: Enable the descheduling and preemption of Pods based on their [priorities](/docs/concepts/configuration/pod-priority-preemption/).


### PR DESCRIPTION
Updates the feature status for VolumePVCDataSource to 1.16/beta in the
docs.

Associated KEP update:  https://github.com/kubernetes/enhancements/pull/1147