### PR TITLE
kubeadm: update setup docs for 1.16

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/control-plane-flags.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/control-plane-flags.md
@@ -42,7 +42,7 @@ Example usage:
 ```yaml
 apiVersion: kubeadm.k8s.io/v1beta2
 kind: ClusterConfiguration
-kubernetesVersion: v1.13.0
+kubernetesVersion: v1.16.0
 apiServer:
   extraArgs:
     advertise-address: 192.168.0.103
@@ -59,7 +59,7 @@ Example usage:
 ```yaml
 apiVersion: kubeadm.k8s.io/v1beta2
 kind: ClusterConfiguration
-kubernetesVersion: v1.13.0
+kubernetesVersion: v1.16.0
 controllerManager:
   extraArgs:
     cluster-signing-key-file: /home/johndoe/keys/ca.key
@@ -75,7 +75,7 @@ Example usage:
 ```yaml
 apiVersion: kubeadm.k8s.io/v1beta2
 kind: ClusterConfiguration
-kubernetesVersion: v1.13.0
+kubernetesVersion: v1.16.0
 scheduler:
   extraArgs:
     address: 0.0.0.0

--- a/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
@@ -35,17 +35,6 @@ but you may also build them from source for other OSes.
 
 ### kubeadm maturity
 
-| Area                      | Maturity Level |
-|---------------------------|--------------- |
-| Command line UX           | GA             |
-| Implementation            | GA             |
-| Config file API           | Beta           |
-| CoreDNS                   | GA             |
-| kubeadm alpha subcommands | Alpha          |
-| High availability         | Beta           |
-| DynamicKubeletConfig      | Alpha          |
-
-
 kubeadm's overall feature state is **GA**. Some sub-features, like the configuration
 file API are still under active development. The implementation of creating the cluster
 may change slightly as the tool evolves, but the overall implementation should be pretty stable.
@@ -61,16 +50,10 @@ timeframe; which also applies to `kubeadm`.
 
 | Kubernetes version | Release month  | End-of-life-month |
 |--------------------|----------------|-------------------|
-| v1.6.x             | March 2017     | December 2017     |
-| v1.7.x             | June 2017      | March 2018        |
-| v1.8.x             | September 2017 | June 2018         |
-| v1.9.x             | December 2017  | September 2018    |
-| v1.10.x            | March 2018     | December 2018     |
-| v1.11.x            | June 2018      | March 2019        |
-| v1.12.x            | September 2018 | June 2019         |
 | v1.13.x            | December 2018  | September 2019    |
 | v1.14.x            | March 2019     | December 2019     |
 | v1.15.x            | June 2019      | March 2020        |
+| v1.16.x            | September 2019 | June 2020         |
 
 {{% /capture %}}
 

--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -201,17 +201,17 @@ systemctl enable --now kubelet
 Install CNI plugins (required for most pod network):
 
 ```bash
-CNI_VERSION="v0.7.5"
+CNI_VERSION="v0.8.2"
 mkdir -p /opt/cni/bin
-curl -L "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-amd64-${CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz
+curl -L "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-amd64-${CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz
 ```
 
 Install crictl (required for kubeadm / Kubelet Container Runtime Interface (CRI))
 
 ```bash
-CRICTL_VERSION="v1.12.0"
+CRICTL_VERSION="v1.16.0"
 mkdir -p /opt/bin
-curl -L "https://github.com/kubernetes-incubator/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz" | tar -C /opt/bin -xz
+curl -L "https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz" | tar -C /opt/bin -xz
 ```
 
 Install `kubeadm`, `kubelet`, `kubectl` and add a `kubelet` systemd service:

--- a/content/en/docs/setup/production-environment/tools/kubeadm/self-hosting.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/self-hosting.md
@@ -10,7 +10,7 @@ weight: 100
 
 ### Self-hosting the Kubernetes control plane {#self-hosting}
 
-As of 1.8, you can experimentally create a _self-hosted_ Kubernetes control
+kubeadm allows you to experimentally create a _self-hosted_ Kubernetes control
 plane. This means that key components such as the API server, controller
 manager, and scheduler run as [DaemonSet pods](/docs/concepts/workloads/controllers/daemonset/)
 configured via the Kubernetes API instead of [static pods](/docs/tasks/administer-cluster/static-pod/)


### PR DESCRIPTION
- minor fix for control-plane-flags
- cleanup tables from "kubeadm maturity" in create-cluster
- update install guide for container linux guide in install-kubeadm
- minor fixes in self-hosting

/sig cluster-lifecycle
/priority important-soon

tracked at:
kubernetes/kubeadm#1739
