### PR TITLE
change CSIVolumeSnapshotSource to csi

### DIFF
--- a/content/en/blog/_posts/2018-10-09-volume-snapshot-alpha.md
+++ b/content/en/blog/_posts/2018-10-09-volume-snapshot-alpha.md
@@ -155,7 +155,7 @@ You can always import an existing snapshot to Kubernetes by manually creating a 
 
 A `VolumeSnapshotContent` object should be created with the following fields to represent a pre-provisioned snapshot:
 
-* `csiVolumeSnapshotSource` - Snapshot identifying information.
+* `csi` - Snapshot identifying information.
   * `snapshotHandle` - name/identifier of the snapshot. This field is required.
   * `driver` - CSI driver used to handle this volume. This field is required. It must match the snapshotter name in the snapshot controller.
   * `creationTime` and `restoreSize` - these fields are not required for pre-provisioned volumes. The external-snapshotter controller will automatically update them after creation.
@@ -170,7 +170,7 @@ kind: VolumeSnapshotContent
 metadata:
   name: static-snapshot-content
 spec:
-  csiVolumeSnapshotSource:
+  csi:
     driver: com.example.csi-driver
     snapshotHandle: snapshotcontent-example-id
   volumeSnapshotRef:


### PR DESCRIPTION
```CSIVolumeSnapshotSource``` is Type, the key name should be  ```csi```
See type defination [here](https://github.com/kubernetes-csi/external-snapshotter/blob/ffee5f487d7c3f9193433900f8c9b7ff435f9669/pkg/apis/volumesnapshot/v1alpha1/types.go#L214)
```
// VolumeSnapshotSource represents the actual location and type of the snapshot. Only one of its members may be specified.
type VolumeSnapshotSource struct {
	// CSI (Container Storage Interface) represents storage that handled by an external CSI Volume Driver (Alpha feature).
	// +optional
	CSI *CSIVolumeSnapshotSource `json:"csiVolumeSnapshotSource,omitempty"`xing-yang, 1 year ago: • Add Snapshot APIs
}
```

and related issue here https://github.com/kubernetes-csi/external-snapshotter/issues/163