### PR TITLE
Add comprehensive CRD versioning flow to documentation

### DIFF
--- a/content/en/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning.md
+++ b/content/en/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning.md
@@ -55,9 +55,9 @@ Adding a new version:
    webhook should be used. If there are no schema changes, the default `None`
    conversion strategy may be used and only the `apiVersion` field will be
    modified when serving different versions.
-2. If using conversion webhooks, create and deploy the conversion webhook. See
+1. If using conversion webhooks, create and deploy the conversion webhook. See
    the [Webhook conversion](#webhook-conversion) for more details.
-3. Update the CustomResourceDefinition to include the new version in the
+1. Update the CustomResourceDefinition to include the new version in the
    `spec.versions` list with `served:true`.  Also, set `spec.conversion` field
    to the selected conversion strategy. If using a conversion webhook, configure
    `spec.conversion.webhookClientConfig` field to call the webhook.
@@ -82,8 +82,8 @@ Removing an old version:
    If this occurs, set `served` to `true`, migrate the clients to the new version and
    repeat this step.
 1. Ensure the [upgrade existing objects to a new stored version](#upgrade-existing-objects-to-a-new-stored-version) step has been completed.
-  1. Verify that the `stored` is set to `true` for the new version in the `spec.versions` list in the CustomResourceDefinition.
-  1. Verify that the old version is no longer listed in the CustomResourceDefinition `status.storedVersions`.
+    1. Verify that the `stored` is set to `true` for the new version in the `spec.versions` list in the CustomResourceDefinition.
+    1. Verify that the old version is no longer listed in the CustomResourceDefinition `status.storedVersions`.
 1. Remove the old version from the CustomResourceDefinition `spec.versions` list.
 1. Drop conversion support for the old version in conversion webhooks.
 

--- a/content/en/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning.md
+++ b/content/en/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning.md
@@ -82,9 +82,9 @@ Removing an old version:
 1. Set `served` to `false` for the old version in the `spec.versions` list. If
    any clients are still unexpectedly using the old version they may begin reporting
    errors attempting to access the custom resource objects at the old version.
-   If this occurs, set `served` to `true`, migrate the clients to the new version and
-   repeat this step.
-1. Ensure the [upgrade existing objects to a new stored version](#upgrade-existing-objects-to-a-new-stored-version) step has been completed.
+   If this occurs, switch back to using `served:true` on the old version, migrate the 
+   remaining clients to the new version and repeat this step.
+1. Ensure the [upgrade of existing objects to the new stored version](#upgrade-existing-objects-to-a-new-stored-version) step has been completed.
     1. Verify that the `stored` is set to `true` for the new version in the `spec.versions` list in the CustomResourceDefinition.
     1. Verify that the old version is no longer listed in the CustomResourceDefinition `status.storedVersions`.
 1. Remove the old version from the CustomResourceDefinition `spec.versions` list.

--- a/content/en/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning.md
+++ b/content/en/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning.md
@@ -46,6 +46,7 @@ Once the CustomResourceDefinition is created, clients may begin using the
 Later it might be necessary to add new version such as `v1`.
 
 Adding a new version:
+
 1. Pick a conversion strategy. Since custom resource objects need to be able to
    be served at both versions, that means they will sometimes be served at a
    different version than their storage version. In order for this to be
@@ -67,12 +68,14 @@ version. It is perfectly safe for some clients to use the old version while
 others use the new version.
 
 Migrate stored objects to the new version:
+
 1. See the [upgrade existing objects to a new stored version](#upgrade-existing-objects-to-a-new-stored-version) section.
 
 It is safe for clients to use both the old and new version before, during and
 after upgrading the objects to a new stored version.
 
 Removing an old version:
+
 1. Ensure all clients are fully migrated to the new version. The kube-apiserver
    logs can reviewed to help identify any clients that are still accessing via
    the old version.


### PR DESCRIPTION
This is a doc improvement for https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20180415-crds-to-ga.md

- [x] Provide custom resource definition authors with a comprehensive explanation of the lifecycle of a CRD version
- [x] Provide a breakdown of individual steps
- [ ] ~Link to a sample crd conversion project for reference~ (we will do this post-GA as as sample project similar to the aggregated-apiserver sample)