### PR TITLE
WIP - CRD v1 docs

### DIFF
--- a/content/en/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions.md
+++ b/content/en/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions.md
@@ -8,6 +8,8 @@ content_template: templates/task
 weight: 20
 ---
 
+TODO: Update CRD documentation to include CRD v1 API and promote usage of v1 over v1beta1.
+
 {{% capture overview %}}
 This page shows how to install a
 [custom resource](/docs/concepts/extend-kubernetes/api-extension/custom-resources/)


### PR DESCRIPTION
Placeholder PR for CRD v1 API . This API is being promoted from v1beta1 to v1 in 1.16.

Key changes:

- [ ] CRD v1: promote to v1
- [ ] CRD v1: require validation schemas
- [ ] CRD v1: structural schema: require structural schema
- [ ] CRD v1: prevent invalid type attributes in schema
- [ ] CRD v1: only allow default attributes in schema via v1
- [ ] ConversionReview: promote types to v1
- [ ] ConversionReview: allow dispatcher to speak v1
- [ ] ConversionReview: in v1, verify response.uid, kind, apiVersion are set in responses

