### PR TITLE
Translate concept and related glossaries to Japanese

### DIFF
--- a/content/ja/docs/concepts/overview/components.md
+++ b/content/ja/docs/concepts/overview/components.md
@@ -1,0 +1,112 @@
+---
+title: Kubernetesのコンポーネント
+content_template: templates/concept
+weight: 20
+card: 
+  name: concepts
+  weight: 20
+---
+
+{{% capture overview %}}
+このドキュメントでは、Kubernetesクラスターが機能するために必要となるさまざまなコンポーネントの概要を説明します。
+{{% /capture %}}
+
+{{% capture body %}}
+
+## Masterコンポーネント
+
+Masterコンポーネントは、クラスターのコントロールプレーンを提供します。
+Masterコンポーネントは、クラスターに関する(スケジューリングなどの)グローバルな決定を行います。また、クラスターイベントの検出および応答を行います(たとえば、deploymentの`replica`フィールドが満たされていない場合に、新しい {{< glossary_tooltip text="pod" term_id="pod">}} を起動する等)。
+
+Masterコンポーネントはクラスター内のどのマシンでも実行できますが、シンプルにするため、セットアップスクリプトは通常、すべてのMasterコンポーネントを同じマシンで起動し、そのマシンではユーザーコンテナを実行しません。
+マルチMaster VMセットアップの例については、[高可用性クラスターの構築](/docs/admin/high-availability/) を参照してください。
+
+### kube-apiserver
+
+{{< glossary_definition term_id="kube-apiserver" length="all" >}}
+
+### etcd
+
+{{< glossary_definition term_id="etcd" length="all" >}}
+
+### kube-scheduler
+
+{{< glossary_definition term_id="kube-scheduler" length="all" >}}
+
+### kube-controller-manager
+
+{{< glossary_definition term_id="kube-controller-manager" length="all" >}}
+
+コントローラーには以下が含まれます。
+
+  * ノードコントローラー：ノードがダウンした場合の通知と対応を担当します。
+  * レプリケーションコントローラー：システム内の全レプリケーションコントローラーオブジェクトについて、Podの数を正しく保つ役割を持ちます。
+  * エンドポイントコントローラー：エンドポイントオブジェクトを注入します(つまり、ServiceとPodを紐付けます)。
+  * サービスアカウントとトークンコントローラー：新規の名前空間に対して、デフォルトアカウントとAPIアクセストークンを作成します。
+
+### cloud-controller-manager
+
+[cloud-controller-manager](/docs/tasks/administer-cluster/running-cloud-controller/) は、基盤であるクラウドプロバイダーと対話するコントローラーを実行します。
+cloud-controller-managerバイナリは、Kubernetesリリース1.6で導入された機能です。
+
+cloud-controller-managerは、クラウドプロバイダー固有のコントローラーループのみを実行します。これらのコントローラーループはkube-controller-managerで無効にする必要があります。 kube-controller-managerの起動時に `--cloud-provider` フラグを `external` に設定することで、コントローラーループを無効にできます。
+
+cloud-controller-managerを使用すると、クラウドベンダーのコードとKubernetesコードを互いに独立して進化させることができます。以前のリリースでは、コアKubernetesコードは、機能的にクラウドプロバイダー固有のコードに依存していました。将来のリリースでは、クラウドベンダーに固有のコードはクラウドベンダー自身で管理し、Kubernetesの実行中にcloud-controller-managerにリンクする必要があります。
+
+次のコントローラーには、クラウドプロバイダーへの依存関係があります。
+
+  * ノードコントローラー：ノードが応答を停止した後、クラウドで削除されたかどうかを判断するため、クラウドプロバイダーをチェックします。
+  * ルーティングコントローラー：基盤であるクラウドインフラでルーティングを設定します。
+  * Serviceコントローラー：クラウドプロバイダーのロードバランサーの作成、更新、削除を行います。
+  * Volumeコントローラー：Volumeを作成、アタッチ、マウントしたり、クラウドプロバイダーとやり取りしてVolumeを調整したりします。
+
+## ノードコンポーネント
+
+ノードコンポーネントはすべてのノードで実行され、実行中PodのメンテナンスおよびKubernetesランタイム環境の提供を行います。
+
+### kubelet
+
+{{< glossary_definition term_id="kubelet" length="all" >}}
+
+### kube-proxy
+
+{{< glossary_definition term_id="kube-proxy" length="all" >}}
+
+### コンテナランタイム
+
+{{< glossary_definition term_id="container-runtime" length="all" >}}
+
+## アドオン
+
+アドオンはクラスター機能を実装するためにKubernetesリソース({{< glossary_tooltip term_id="daemonset" >}}、{{< glossary_tooltip term_id="deployment" >}}など)を使用します。
+アドオンはクラスターレベルの機能を提供しているため、アドオンのリソースで名前空間が必要なものは`kube-system`名前空間に属します。
+
+いくつかのアドオンについて以下で説明します。より多くの利用可能なアドオンのリストは、[アドオン](/docs/concepts/cluster-administration/addons/) をご覧ください。
+
+### DNS
+
+クラスターDNS以外のアドオンは必須ではありませんが、すべてのKubernetesクラスターは[クラスターDNS](/docs/concepts/services-networking/dns-pod-service/)を持つべきです。多くの使用例がクラスターDNSを前提としています。
+
+クラスターDNSは、環境内の他のDNSサーバーに加えて、KubernetesサービスのDNSレコードを提供するDNSサーバーです。
+
+Kubernetesによって開始されたコンテナは、DNS検索にこのDNSサーバーを自動的に含めます。
+
+
+### Web UI (ダッシュボード)
+
+[ダッシュボード](/docs/tasks/access-application-cluster/web-ui-dashboard/)は、Kubernetesクラスター用の汎用WebベースUIです。これによりユーザーはクラスターおよびクラスター内で実行されているアプリケーションについて、管理およびトラブルシューティングを行うことができます。
+
+### コンテナリソース監視
+
+[コンテナリソース監視](/docs/tasks/debug-application-cluster/resource-usage-monitoring/)は、コンテナに関する一般的な時系列メトリックを中央データベースに記録します。また、そのデータを閲覧するためのUIを提供します。
+
+### クラスターレベルログ
+
+[クラスターレベルログ](/docs/concepts/cluster-administration/logging/)メカニズムは、コンテナのログを、検索／参照インターフェイスを備えた中央ログストアに保存します。
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+* [ノード](/docs/concepts/architecture/nodes/) について学ぶ
+* [kube-scheduler](/docs/concepts/scheduling/kube-scheduler/) について学ぶ
+* etcdの公式 [ドキュメント](https://etcd.io/docs/) を読む
+{{% /capture %}}

--- a/content/ja/docs/reference/glossary/container-runtime.md
+++ b/content/ja/docs/reference/glossary/container-runtime.md
@@ -1,0 +1,22 @@
+---
+title: コンテナランタイム
+id: container-runtime
+date: 2019-06-05
+full_link: /docs/reference/generated/container-runtime
+short_description: >
+ コンテナランタイムは、コンテナの実行を担当するソフトウェアです。
+
+aka:
+tags:
+- fundamental
+- workload
+---
+ コンテナランタイムは、コンテナの実行を担当するソフトウェアです。
+
+<!--more-->
+
+Kubernetesは次の複数のコンテナランタイムをサポートします。
+[Docker](http://www.docker.com), [containerd](https://containerd.io), [cri-o](https://cri-o.io/),
+[rktlet](https://github.com/kubernetes-incubator/rktlet) および全ての
+[Kubernetes CRI (Container Runtime Interface)](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/container-runtime-interface.md)
+実装。

--- a/content/ja/docs/reference/glossary/controller.md
+++ b/content/ja/docs/reference/glossary/controller.md
@@ -1,0 +1,20 @@
+---
+title: Controller
+id: controller
+date: 2018-04-12
+full_link: /docs/admin/kube-controller-manager/
+short_description: >
+  apiserverを介してクラスターの共有された状態を監視し、現在の状態をdesired state (望ましい状態)に向けて変更しようとする制御ループ。
+
+aka: 
+tags:
+- architecture
+- fundamental
+---
+ {{< glossary_tooltip text="apiserver" term_id="kube-apiserver" >}}を介してクラスターの共有された状態を監視し、現在の状態をdesired state (望ましい状態)に向けて変更しようとする制御ループ。
+
+<!--more--> 
+
+現在Kubernetesに同梱されているコントローラーの例には、レプリケーションコントローラー、エンドポイントコントローラー、名前空間コントローラー、およびサービスアカウントコントローラーがあります。
+
+

--- a/content/ja/docs/reference/glossary/daemonset.md
+++ b/content/ja/docs/reference/glossary/daemonset.md
@@ -1,0 +1,20 @@
+---
+title: DaemonSet
+id: daemonset
+date: 2018-04-12
+full_link: /docs/concepts/workloads/controllers/daemonset
+short_description: >
+  Podのコピーがクラスター内の一連のNodeに渡って実行されることを保証します。
+
+aka: 
+tags:
+- fundamental
+- core-object
+- workload
+---
+  {{< glossary_tooltip text="Pod" term_id="pod" >}}のコピーが{{< glossary_tooltip text="クラスター" term_id="cluster" >}}内の一連のNodeに渡って実行されることを保証します。
+
+<!--more--> 
+
+通常{{< glossary_tooltip term_id="node" >}}で実行する必要があるログコレクターや監視エージェントなどのシステムデーモンをデプロイするために使用します。
+

--- a/content/ja/docs/reference/glossary/deployment.md
+++ b/content/ja/docs/reference/glossary/deployment.md
@@ -1,0 +1,19 @@
+---
+title: Deployment
+id: deployment
+date: 2018-04-12
+full_link: /docs/concepts/workloads/controllers/deployment/
+short_description: >
+  複製されたアプリケーションを管理するAPIオブジェクト。
+
+aka: 
+tags:
+- fundamental
+- core-object
+- workload
+---
+ 複製されたアプリケーションを管理するAPIオブジェクト。
+
+<!--more--> 
+
+各レプリカは{{< glossary_tooltip term_id="pod" >}}で表され、ポッドはクラスターのノード間で分散されます。

--- a/content/ja/docs/reference/glossary/etcd.md
+++ b/content/ja/docs/reference/glossary/etcd.md
@@ -1,0 +1,20 @@
+---
+title: etcd
+id: etcd
+date: 2018-04-12
+full_link: /docs/tasks/administer-cluster/configure-upgrade-etcd/
+short_description: >
+  一貫性があり高い可用性を持つキーバリューストア。Kubernetesのデータストアとして使用され、すべてのクラスタデータを保持します。
+
+aka: 
+tags:
+- architecture
+- storage
+---
+ 一貫性があり高い可用性を持つキーバリューストア。Kubernetesのデータストアとして使用され、すべてのクラスタデータを保持します。
+
+<!--more-->
+
+etcdをKubernetesのデータストアとして使用する場合、必ずデータの[バックアップ](/docs/tasks/administer-cluster/configure-upgrade-etcd/#backing-up-an-etcd-cluster)計画を作成して下さい。
+
+公式[ドキュメント](https://etcd.io/docs/)でetcdに関する詳細な情報を見つけることができます。

--- a/content/ja/docs/reference/glossary/kube-apiserver.md
+++ b/content/ja/docs/reference/glossary/kube-apiserver.md
@@ -1,0 +1,19 @@
+---
+title: kube-apiserver
+id: kube-apiserver
+date: 2018-04-12
+full_link: /docs/reference/generated/kube-apiserver/
+short_description: >
+  Master上で、Kubernetes APIを公開するコンポーネント。このコンポーネントがKubernetesコントロールプレーンのフロントエンドです。
+
+aka: 
+tags:
+- architecture
+- fundamental
+---
+ Master上でKubernetes APIを公開するコンポーネント。このコンポーネントがKubernetesコントロールプレーンのフロントエンドです。
+
+<!--more--> 
+
+このコンポーネントは、水平にスケーリングする ―― つまり、より多くのインスタンスをデプロイすることでスケーリングする ―― ように計設されています。[高可用性クラスタの構築](/docs/admin/high-availability/) を参照して下さい。
+

--- a/content/ja/docs/reference/glossary/kube-controller-manager.md
+++ b/content/ja/docs/reference/glossary/kube-controller-manager.md
@@ -1,0 +1,20 @@
+---
+title: kube-controller-manager
+id: kube-controller-manager
+date: 2018-04-12
+full_link: /docs/reference/generated/kube-controller-manager/
+short_description: >
+  Master上に存在し、コントローラーを実行するコンポーネント。
+
+aka: 
+tags:
+- architecture
+- fundamental
+---
+ Master上に存在し、{{< glossary_tooltip text="コントローラー" term_id="controller" >}}を実行するコンポーネント。
+
+<!--more--> 
+
+論理的には各{{< glossary_tooltip text="コントローラー" term_id="controller" >}}は個別のプロセスですが、複雑さを軽減するために、すべて単一のバイナリにコンパイルされ、単一のプロセスで実行されます。
+
+

--- a/content/ja/docs/reference/glossary/kube-proxy.md
+++ b/content/ja/docs/reference/glossary/kube-proxy.md
@@ -1,0 +1,20 @@
+---
+title: kube-proxy
+id: kube-proxy
+date: 2018-04-12
+full_link: /docs/reference/command-line-tools-reference/kube-proxy/
+short_description: >
+  `kube-proxy`はクラスター内の各Nodeで動作しているネットワークプロキシです。
+
+aka:
+tags:
+- fundamental
+- networking
+---
+ [kube-proxy](/docs/reference/command-line-tools-reference/kube-proxy/) はクラスター内の各Nodeで動作しているネットワークプロキシで、Kubernetesの{{< glossary_tooltip term_id="service">}}コンセプトの一部を実装しています。
+
+<!--more-->
+
+kube-proxyは、Nodeのネットワークルールをメンテナンスします。これらのネットワークルールにより、クラスターの内部または外部のネットワークセッションからPodへのネットワーク通信が可能になります。
+
+kube-proxyは、オペレーティングシステムにパケットフィルタリング層があり、かつ使用可能な場合、パケットフィルタリング層を使用します。それ以外の場合は自身でトラフィックを転送します。

--- a/content/ja/docs/reference/glossary/kube-scheduler.md
+++ b/content/ja/docs/reference/glossary/kube-scheduler.md
@@ -1,0 +1,18 @@
+---
+title: kube-scheduler
+id: kube-scheduler
+date: 2018-04-12
+full_link: /docs/reference/generated/kube-scheduler/
+short_description: >
+  新しく作られたPodにノードが割り当てられているか監視し、割り当てられていなかった場合に、そのPodを実行するノードを選択するコンポーネント。Master上に存在します。
+
+aka: 
+tags:
+- architecture
+---
+  新しく作られたPodにノードが割り当てられているか監視し、割り当てられていなかった場合に、そのPodを実行するノードを選択するコンポーネント。Master上に存在します。
+
+<!--more--> 
+
+スケジューリング決定で考慮される因子には、個々および集団のリソース要件、ハードウェア/ソフトウェア/ポリシーの制約、アフィニティおよびアンチアフィニティの指定、データの局所性、ワークロード間の干渉と有効期限が含まれます。
+

--- a/content/ja/docs/reference/glossary/kubelet.md
+++ b/content/ja/docs/reference/glossary/kubelet.md
@@ -1,0 +1,20 @@
+---
+title: Kubelet
+id: kubelet
+date: 2018-04-12
+full_link: /docs/reference/generated/kubelet
+short_description: >
+  クラスター内の全ノードで実行されるエージェント。各コンテナがPodで実行されていることを保証します。
+
+aka: 
+tags:
+- fundamental
+- core-object
+---
+ クラスター内の全ノードで実行されるエージェント。各コンテナがPodで実行されていることを保証します。
+
+<!--more--> 
+
+kubeletは、さまざまなメカニズムを通じて提供されるPodSpecのセットを取得し、それらのPodSpecに記述されているコンテナが正常に実行されている状態に保ちます。kubeletは、Kubernetesが作成したものではないコンテナは管理しません。
+
+

--- a/content/ja/docs/reference/glossary/pod.md
+++ b/content/ja/docs/reference/glossary/pod.md
@@ -1,0 +1,19 @@
+---
+title: Pod
+id: pod
+date: 2018-04-12
+full_link: /docs/concepts/workloads/pods/pod-overview/
+short_description: >
+  一番小さく一番シンプルな Kubernetes のオブジェクト。Pod とはクラスターで動作しているいくつかのコンテナのまとまりです。
+
+aka: 
+tags:
+- core-object
+- fundamental
+---
+  一番小さく一番シンプルなKubernetesのオブジェクト。Podとはクラスターで動作しているいくつかの{{< glossary_tooltip text="コンテナ" term_id="container" >}}のまとまりです。
+
+<!--more--> 
+
+通常、Pod は一つの主コンテナを実行するように設定されます。ロギングなどの補足機能を付加する、取り外し可能なサイドカーコンテナを実行することもできます。Pod は通常 {{< glossary_tooltip term_id="deployment" >}} によって管理されます。
+

--- a/content/ja/docs/reference/glossary/service.md
+++ b/content/ja/docs/reference/glossary/service.md
@@ -1,0 +1,20 @@
+---
+title: Service
+id: service
+date: 2018-04-12
+full_link: /docs/concepts/services-networking/service/
+short_description: >
+  Podの集合で実行されているアプリケーションをネットワークサービスとして公開する方法。
+
+aka:
+tags:
+- fundamental
+- core-object
+---
+{{< glossary_tooltip text="Pods" term_id="pod" >}}の集合で実行されているアプリケーションをネットワークサービスとして公開する抽象的な方法。
+
+<!--more-->
+
+Serviceが対象とするPodの集合は、(通常){{< glossary_tooltip text="セレクター" term_id="selector" >}}によって決定されます。
+Podを追加または削除するとセレクターにマッチしているPodの集合は変更されます。
+Serviceは、ネットワークトラフィックが現在そのワークロードを処理するPodの集合に向かうことを保証します。


### PR DESCRIPTION
concept / components と、そこからリンクされている glossaries を日本語訳しました。
gloassary はディレクトリ一式追加してしまいましたが、日本語訳しているのは以下12ファイルです。
* container-runtime.md
* controller.md
* daemonset.md
* deployment.md
* etcd.md
* kube-apiserver.md
* kube-controller-manager.md
* kube-proxy.md
* kube-scheduler.md
* kubelet.md
* pod.md
* service.md

