### PR TITLE
Fix missing curly bracket in content/ja/docs/tasks/debug-application-cluster/debug-pod-replication-controller.md

### DIFF
--- a/content/ja/docs/tasks/debug-application-cluster/debug-pod-replication-controller.md
+++ b/content/ja/docs/tasks/debug-application-cluster/debug-pod-replication-controller.md
@@ -103,7 +103,7 @@ kubectl logs --previous ${POD_NAME} ${CONTAINER_NAME}
 kubectl exec ${POD_NAME} -c ${CONTAINER_NAME} -- ${CMD} ${ARG1} ${ARG2} ... ${ARGN}
 ```
 
-{{< note >}
+{{< note >}}
 `-c ${CONTAINER_NAME}`はオプションです。単一のコンテナのみを含むPodの場合は省略できます。
 {{< /note >}}
 


### PR DESCRIPTION
The following error occurred when running `make docker-serve`.

```
Error: Error building site: "/src/content/ja/docs/tasks/debug-application-cluster/debug-pod-replication-controller.md:106:10": unrecognized character in shortcode action: U+003E '>'. Note: Parameters with non-alphanumeric args must be quoted
```

https://github.com/kubernetes/website/pull/15883