### PR TITLE
Drop vestigial note about StatefulSet stability

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/en/docs/concepts/workloads/controllers/statefulset.md
@@ -15,10 +15,6 @@ weight: 40
 
 StatefulSet is the workload API object used to manage stateful applications.
 
-{{< note >}}
-StatefulSets are stable (GA) in 1.9.
-{{< /note >}}
-
 {{< glossary_definition term_id="statefulset" length="all" >}}
 {{% /capture %}}
 
@@ -43,7 +39,6 @@ provides a set of stateless replicas. Controllers such as
 
 ## Limitations
 
-* StatefulSet was a beta resource prior to 1.9 and not available in any Kubernetes release prior to 1.5.
 * The storage for a given Pod must either be provisioned by a [PersistentVolume Provisioner](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/persistent-volume-provisioning/README.md) based on the requested `storage class`, or pre-provisioned by an admin.
 * Deleting and/or scaling a StatefulSet down will *not* delete the volumes associated with the StatefulSet. This is done to ensure data safety, which is generally more valuable than an automatic purge of all related StatefulSet resources.
 * StatefulSets currently require a [Headless Service](/docs/concepts/services-networking/service/#headless-services) to be responsible for the network identity of the Pods. You are responsible for creating this Service.


### PR DESCRIPTION
No need to mention that [StatefulSet](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/) is stable: it has been for quite some time.