### PR TITLE
Improve Restrictions section of https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -647,13 +647,9 @@ data:
    0s       0s        1     dapi-test-pod Pod              Warning   InvalidEnvironmentVariableNames   {kubelet, 127.0.0.1}  Keys [1badkey, 2alsobad] from the EnvFrom configMap default/myconfig were skipped since they are considered invalid environment variable names.
    ```
 
-- ConfigMaps reside in a specific [namespace](/docs/concepts/overview/working-with-objects/namespaces/). A ConfigMap can only be referenced by pods residing in the same namespace.
+- ConfigMaps reside in a specific {{< glossary_tooltip term_id="namespace" >}}. A ConfigMap can only be referenced by pods residing in the same namespace.
 
-- Kubelet doesn't support the use of ConfigMaps for pods not found on the API server. This includes pods created via the Kubelet's `--manifest-url` flag, `--config` flag, or the Kubelet REST API.
-
-   {{< note >}}
-   These are not commonly-used ways to create pods.
-   {{< /note >}}
+- You can't use ConfigMaps for {{< glossary_tooltip text="static pods" term_id="static-pod" >}}, because the Kubelet does not support this.
 
 {{% /capture %}}
 


### PR DESCRIPTION
Use glossary shortcodes in https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/

(needs tech review to check on the change to line 652).

[Preview](https://deploy-preview-16086--kubernetes-io-master-staging.netlify.com/docs/tasks/configure-pod-container/configure-pod-configmap/)