### PR TITLE
Make CRD w/ webhook conversion strategy example usable

### DIFF
--- a/content/en/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning.md
+++ b/content/en/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning.md
@@ -217,6 +217,8 @@ metadata:
 spec:
   # group name to use for REST API: /apis/<group>/<version>
   group: example.com
+  # prunes object fields that are not specified in OpenAPI schemas below.
+  preserveUnknownFields: false
   # list of versions supported by this CustomResourceDefinition
   versions:
   - name: v1beta1
@@ -228,6 +230,7 @@ spec:
     # schema is defined.
     schema:
       openAPIV3Schema:
+        type: object
         properties:
           hostPort:
             type: string
@@ -236,6 +239,7 @@ spec:
     storage: false
     schema:
       openAPIV3Schema:
+        type: object
         properties:
           host:
             type: string


### PR DESCRIPTION
- Sample CRD will not work due to `apiextensions.k8s.io/v1beta1` setting `preserveUnknownFields` to `true` by default. Set to `false`.
- Provide required `type: object` at `openAPIV3Schema` root for both versions to avoid the following error: `schema.openAPIV3Schema.type: Required value: must not be empty at the root`.
