### PR TITLE
Override deprecation warning for Chinese localization

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -144,6 +144,7 @@ contentDir = "content/zh"
 [languages.zh.params]
 time_format_blog = "2006.01.02"
 language_alternatives = ["en"]
+deprecated = false
 
 [languages.ko]
 title = "Kubernetes"


### PR DESCRIPTION
The Chinese (zh) localization will always fall behind the English main
site by one minor version. This means the 1.14 version at this stage is
the "current" version.

This PR attempts to fix the incorrect "deprecation" warning which is set
globally for release-1.14.


