### PR TITLE
Fix download bug for manual macOS kubectl binary install docs

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl.md
+++ b/content/en/docs/tasks/tools/install-kubectl.md
@@ -30,7 +30,7 @@ You must use a kubectl version that is within one minor version difference of yo
     curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
     ```
 
-    To download a specific version, replace the `$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)` portion of the command with the specific version.
+    To download a specific version, replace the `curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt` portion of the command with the specific version.
 
     For example, to download version {{< param "fullversion" >}} on Linux, type:
     
@@ -102,10 +102,10 @@ If you are on Ubuntu or another Linux distribution that support [snap](https://s
 1. Download the latest release:
 
     ```		 
-    curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/darwin/amd64/kubectl
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/darwin/amd64/kubectl
     ```
 
-    To download a specific version, replace the `$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)` portion of the command with the specific version.
+    To download a specific version, replace the ``curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`` portion of the command with the specific version.
 
     For example, to download version {{< param "fullversion" >}} on macOS, type:
 		  

--- a/content/en/docs/tasks/tools/install-kubectl.md
+++ b/content/en/docs/tasks/tools/install-kubectl.md
@@ -105,7 +105,7 @@ If you are on Ubuntu or another Linux distribution that support [snap](https://s
     curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/darwin/amd64/kubectl
     ```
 
-    To download a specific version, replace the ``curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`` portion of the command with the specific version.
+    To download a specific version, replace the `curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt` portion of the command with the specific version.
 
     For example, to download version {{< param "fullversion" >}} on macOS, type:
 		  


### PR DESCRIPTION
The issue #15264 Fixed a bug on downloading kubectl in linux #15264 by changing the `$` to just a regular `

**Fixed Linux instructions**
```
// Download the Linux release
➜  kuctl_mac git:(master) ✗ curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl    

// File is dowloaded correctly
➜  kuctl_mac git:(master) ✗ ls
kubectl
```

**Current macOS docs 404**
```
// Download the macOS Darwin release - Broken
➜  kuctl_mac git:(master) ✗ curl -LO https://storage.googleapis.com/kubernetes-release/release/$\(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt\)/bin/darwin/amd64/kubectl

// Error unable to find the key
<?xml version='1.0' encoding='UTF-8'?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Details>No such object: kubernetes-release/release/stable.txt)/bin/darwin/amd64/kubectl</Details></Error>%              
```

**Updated macOS docs**

```
// Download the macOS Darwin release - Works
curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/darwin/amd64/kubectl

// File is dowloaded correctly
➜  kuctl_mac git:(master) ✗ ls
kubectl
```

**Updates in the PR:**
1. Install kubectl binary with curl on Linux - Update directions to get a specific version. Remove last reference to $ that was fixed in #15264
2. Install kubectl binary with curl on macOS - Fix the download URLs to use ` and not $ with escaping as in #15264 where the linux docs were updated
3. Install kubectl binary with curl on macOS  - Update directions to get a specific version. Remove last reference of $ that was fixed in #15264