### PR TITLE
Fix: typo in assign-pods-nodes.md (Chinese version)

### DIFF
--- a/content/zh/docs/tasks/configure-pod-container/assign-pods-nodes.md
+++ b/content/zh/docs/tasks/configure-pod-container/assign-pods-nodes.md
@@ -66,7 +66,7 @@ Kubernetes cluster.
 -->
 1. 验证你选择的节点是否有 `disktype=ssd` 标签：
 
-       kubectl get nodes --show-labels
+        kubectl get nodes --show-labels
 
 
     <!--

--- a/content/zh/includes/task-tutorial-prereqs.md
+++ b/content/zh/includes/task-tutorial-prereqs.md
@@ -13,4 +13,3 @@ or you can use one of these Kubernetes playgrounds:
 
 * [Katacoda](https://www.katacoda.com/courses/kubernetes/playground)
 * [Play with Kubernetes](http://labs.play-with-k8s.com/)
--->

--- a/i18n/zh.toml
+++ b/i18n/zh.toml
@@ -30,6 +30,15 @@ other = "否"
 [latest_version]
 other = "最新版本。"
 
+[version_check_mustbe]
+other = "您的 Kubernetes 服务器必须是版本 "
+
+[version_check_mustbeorlater]
+other = "您的 Kubernetes 服务器必须等于或高于版本 "
+
+[version_check_tocheck]
+other = "为了检查版本, 输入 "
+
 [main_read_about]
 other = "Read about"
 


### PR DESCRIPTION
An omitted space is making the web page look abnormal. 

For example:
https://kubernetes.io/zh/docs/tasks/configure-pod-container/assign-pods-nodes/
https://v1-14.docs.kubernetes.io/zh/docs/tasks/configure-pod-container/assign-pods-nodes/
