### PR TITLE
Add divisor to Downward API example

### DIFF
--- a/content/en/docs/tasks/inject-data-application/environment-variable-expose-pod-information.md
+++ b/content/en/docs/tasks/inject-data-application/environment-variable-expose-pod-information.md
@@ -148,8 +148,8 @@ kubectl logs dapi-envars-resourcefieldref
 The output shows the values of selected environment variables:
 
 ```
-1
-1
+125
+250
 33554432
 67108864
 ```

--- a/content/en/examples/pods/inject/dapi-envars-container.yaml
+++ b/content/en/examples/pods/inject/dapi-envars-container.yaml
@@ -27,11 +27,13 @@ spec:
             resourceFieldRef:
               containerName: test-container
               resource: requests.cpu
+              divisor: "1m"
         - name: MY_CPU_LIMIT
           valueFrom:
             resourceFieldRef:
               containerName: test-container
               resource: limits.cpu
+              divisor: "1m"
         - name: MY_MEM_REQUEST
           valueFrom:
             resourceFieldRef:

--- a/content/ja/examples/pods/inject/dapi-envars-container.yaml
+++ b/content/ja/examples/pods/inject/dapi-envars-container.yaml
@@ -27,11 +27,13 @@ spec:
             resourceFieldRef:
               containerName: test-container
               resource: requests.cpu
+              divisor: "1m"
         - name: MY_CPU_LIMIT
           valueFrom:
             resourceFieldRef:
               containerName: test-container
               resource: limits.cpu
+              divisor: "1m"
         - name: MY_MEM_REQUEST
           valueFrom:
             resourceFieldRef:

--- a/content/zh/docs/tasks/inject-data-application/dapi-envars-container.yaml
+++ b/content/zh/docs/tasks/inject-data-application/dapi-envars-container.yaml
@@ -27,11 +27,13 @@ spec:
             resourceFieldRef:
               containerName: test-container
               resource: requests.cpu
+              divisor: "1m"
         - name: MY_CPU_LIMIT
           valueFrom:
             resourceFieldRef:
               containerName: test-container
               resource: limits.cpu
+              divisor: "1m"
         - name: MY_MEM_REQUEST
           valueFrom:
             resourceFieldRef:

--- a/content/zh/docs/tasks/inject-data-application/environment-variable-expose-pod-information.md
+++ b/content/zh/docs/tasks/inject-data-application/environment-variable-expose-pod-information.md
@@ -131,8 +131,8 @@ kubectl logs dapi-envars-resourcefieldref
 输出信息显示了所选择的环境变量的值：
 
 ```
-1
-1
+125
+250
 33554432
 67108864
 ```


### PR DESCRIPTION
Without the divisor both 125m and 250m show up as 1, which is confusing