### PR TITLE
Add “API group” to glossary #15906

### DIFF
--- a/content/en/docs/reference/access-authn-authz/authorization.md
+++ b/content/en/docs/reference/access-authn-authz/authorization.md
@@ -52,7 +52,7 @@ Kubernetes reviews only the following API request attributes:
  * **Resource** - The ID or name of the resource that is being accessed (for resource requests only) -- For resource requests using `get`, `update`, `patch`, and `delete` verbs, you must provide the resource name.
  * **Subresource** - The subresource that is being accessed (for resource requests only).
  * **Namespace** - The namespace of the object that is being accessed (for namespaced resource requests only).
- * **API group** - The API group being accessed (for resource requests only). An empty string designates the [core API group](/docs/concepts/overview/kubernetes-api/).
+ * **API group** - The {{< glossary_tooltip text="API Group" term_id="api-group" >}} being accessed (for resource requests only). An empty string designates the [core API group](/docs/concepts/overview/kubernetes-api/).
 
 ## Determine the Request Verb
 

--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -13,7 +13,7 @@ Role-based access control (RBAC) is a method of regulating access to computer or
 {{% /capture %}}
 
 {{% capture body %}}
-`RBAC` uses the `rbac.authorization.k8s.io` API group
+`RBAC` uses the `rbac.authorization.k8s.io` {{< glossary_tooltip text="API Group" term_id="api-group" >}}
 to drive authorization decisions, allowing admins to dynamically configure policies
 through the Kubernetes API.
 
@@ -286,7 +286,7 @@ rules:
 
 Only the `rules` section is shown in the following examples.
 
-Allow reading the resource "pods" in the core API group:
+Allow reading the resource "pods" in the core {{< glossary_tooltip text="API Group" term_id="api-group" >}}:
 
 ```yaml
 rules:

--- a/content/en/docs/reference/glossary/api-group.md
+++ b/content/en/docs/reference/glossary/api-group.md
@@ -1,0 +1,19 @@
+---
+title: API Group
+id: api-group
+date: 2019-09-02
+full_link: /docs/concepts/overview/kubernetes-api/#api-groups
+short_description: >
+  A set of related paths in the Kubernetes API.
+
+aka:
+tags:
+- fundamental
+- architecture
+---
+A set of related paths in Kubernetes API. 
+
+<!--more-->
+You can enable or disable each API group by changing the configuration of your API server. You can also disable or enable paths to specific resources. API group makes it easier to extend the Kubernetes API. The API group is specified in a REST path and in the `apiVersion` field of a serialized object.
+
+* Read [API Group](/docs/concepts/overview/kubernetes-api/#api-groups) for more information.


### PR DESCRIPTION
This PR resolves #15906

Created API Group glossary term
Linked glossary term to applicable pages

