### PR TITLE
Missing "Manifest" from glossary k8s.io/docs/reference/glossary/ #13546

### DIFF
--- a/content/en/docs/concepts/cluster-administration/manage-deployment.md
+++ b/content/en/docs/concepts/cluster-administration/manage-deployment.md
@@ -107,7 +107,7 @@ With the above commands, we first create resources under `examples/application/n
 
 If you happen to organize your resources across several subdirectories within a particular directory, you can recursively perform the operations on the subdirectories also, by specifying `--recursive` or `-R` alongside the `--filename,-f` flag.
 
-For instance, assume there is a directory `project/k8s/development` that holds all of the manifests needed for the development environment, organized by resource type:
+For instance, assume there is a directory `project/k8s/development` that holds all of the {{< glossary_tooltip text="manifests" term_id="manifest" >}} needed for the development environment, organized by resource type:
 
 ```
 project/k8s/development

--- a/content/en/docs/reference/glossary/manifest.md
+++ b/content/en/docs/reference/glossary/manifest.md
@@ -1,0 +1,15 @@
+---
+title: Manifest
+id: manifest
+date: 2019-06-28
+short_description: >
+  A serialized specification of one or more Kubernetes API objects.
+
+aka:
+tags:
+- fundamental
+---
+ Specification of a Kubernetes API object in JSON or YAML format.
+
+<!--more-->
+A manifest specifies the desired state of an object that Kubernetes will maintain when you apply the manifest. Each configuration file can contain multiple manifests.


### PR DESCRIPTION
This PR resolves #13546
Added manifest glossary term.

