### PR TITLE
Update k8s.io/docs/concepts/overview/working-with-objects/names/

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/names.md
+++ b/content/en/docs/concepts/overview/working-with-objects/names.md
@@ -9,11 +9,13 @@ weight: 20
 
 {{% capture overview %}}
 
-All objects in the Kubernetes REST API are unambiguously identified by a Name and a UID.
+Each object in your cluster has a [_Name_](#names) that is unique for that type of resource.
+Every Kubernetes object also has a [_UID_](#uids) that is unique across your whole cluster.
 
-For non-unique user-provided attributes, Kubernetes provides [labels](/docs/user-guide/labels) and [annotations](/docs/concepts/overview/working-with-objects/annotations/).
+For example, you can only have one Pod named “myapp-1234”, but you can have one Pod
+and one Deployment that are each named “myapp-1234”.
 
-See the [identifiers design doc](https://git.k8s.io/community/contributors/design-proposals/architecture/identifiers.md) for the precise syntax rules for Names and UIDs.
+For non-unique user-provided attributes, Kubernetes provides [labels](/docs/concepts/overview/working-with-objects/labels/) and [annotations](/docs/concepts/overview/working-with-objects/annotations/).
 
 {{% /capture %}}
 
@@ -24,9 +26,9 @@ See the [identifiers design doc](https://git.k8s.io/community/contributors/desig
 
 {{< glossary_definition term_id="name" length="all" >}}
 
-By convention, the names of Kubernetes resources should be up to maximum length of 253 characters and consist of lower case alphanumeric characters, `-`, and `.`, but certain resources have more specific restrictions.
+Kubernetes resources can have names up to 253 characters long. The characters allowed in names are: digits (0-9), lower case letters (a-z), `-`, and `.`.
 
-For example, here’s the configuration file with a Pod name as `nginx-demo` and a Container name as `nginx`:
+Here’s an example manifest for a Pod named `nginx-demo`.
 
 ```yaml
 apiVersion: v1
@@ -41,8 +43,19 @@ spec:
     - containerPort: 80
 ```
 
+{{< note >}}
+Some resource types have additional restrictions on their names.
+{{< /note >}}
+
 ## UIDs
 
 {{< glossary_definition term_id="uid" length="all" >}}
 
+Kubernetes UIDs are universally unique identifiers (also known as UUIDs).
+UUIDs are standardized as ISO/IEC 9834-8 and as ITU-T X.667.
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+* Read about [labels](/docs/concepts/overview/working-with-objects/labels/) in Kubernetes.
+* See the [Identifiers and Names in Kubernetes](https://git.k8s.io/community/contributors/design-proposals/architecture/identifiers.md) design document.
 {{% /capture %}}


### PR DESCRIPTION
Tweaks to https://k8s.io/docs/concepts/overview/working-with-objects/names/ ([preview](https://deploy-preview-16202--kubernetes-io-master-staging.netlify.com/docs/concepts/overview/working-with-objects/names/))

- explain that Kubernetes used the term “UID” to mean a UUID
- clarify page overview
- drop some wording about container names that could distract from explaining resource names

Fixes #16141