### PR TITLE
Add announcement shortcode and partial so the docs can display an announcement

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -78,6 +78,11 @@ nextUrl = "https://kubernetes-io-vnext-staging.netlify.com/"
 githubWebsiteRepo = "github.com/kubernetes/website"
 githubWebsiteRaw = "raw.githubusercontent.com/kubernetes/website"
 
+# param for displaying an announcement block on every page; see PR #16210
+announcement = false
+# announcement_message is only displayed when announcement = true; update with your specific message
+announcement_message = "The Kubernetes Documentation team would like your feedback!  Please take a <a href='https://www.surveymonkey.com/r/8R237FN' target='_blank'>short survey</a> so we can improve the Kubernetes online documentation."
+
 [[params.versions]]
 fullversion = "v1.15.0"
 version = "v1.15"

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -3,6 +3,7 @@ title: "Production-Grade Container Orchestration"
 abstract: "Automated container deployment, scaling, and management"
 cid: home
 ---
+{{< announcement >}}
 
 {{< deprecationwarning >}}
 

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -11,12 +11,13 @@
 			{{ partial "docs/top-menu.html" . }}
 		</section>
 		{{ end }}
+    {{ block "announcement" . }}{{ partial "announcement.html" . }}{{ end }}
 		{{ block "deprecation" . }}{{ partial "deprecation-warning.html" . }}{{ end }}
 		<section id="encyclopedia">
 			{{ block "side-menu" . }}<div id="docsToc" style="display:none;"></div>{{ end }}
 			<div id="{{ block "content-id" . }}docsContent{{ end }}">
         {{ block "content" . }}{{ end }}
-        
+
         {{ partial "feedback.html" . }}
 
         {{ partial "git-info.html" . }}

--- a/layouts/partials/announcement.html
+++ b/layouts/partials/announcement.html
@@ -1,0 +1,11 @@
+{{ if .Param "announcement"}}
+  <section id="announcement">
+    <main>
+      <div class="content announcement">
+        <h3>
+          {{ .Param "announcement_message" | markdownify }}
+        </h3>
+      </div>
+    </main>
+  </section>
+{{ end }}

--- a/layouts/shortcodes/announcement.html
+++ b/layouts/shortcodes/announcement.html
@@ -1,0 +1,11 @@
+{{ if .Page.Param "announcement" }}
+<section id="announcement">
+  <main>
+    <div class="content announcement">
+      <h3>
+          {{ .Page.Param "announcement_message" | markdownify }}
+      </h3>
+    </div>
+  </main>
+</section>
+{{ end }}

--- a/static/css/announcement.css
+++ b/static/css/announcement.css
@@ -1,0 +1,6 @@
+.announcement {
+    padding: 20px;
+    margin: 20px 0;
+    border-radius: 3px;
+    background-color: #eeeeee;
+}


### PR DESCRIPTION
Add shortcode so we can display a link to the SIG Docs survey

I can get the notice to appear on the website home page but not on other pages. Yep, I really don't know what I'm doing... yet. Appreciate feedback!

/cc @zacharysarah 