### PR TITLE
remove extra space character between the end of the "Applications" de…

### DIFF
--- a/content/en/docs/reference/glossary/applications.md
+++ b/content/en/docs/reference/glossary/applications.md
@@ -5,7 +5,6 @@ date: 2019-05-12
 full_link:
 short_description: >
   The layer where various containerized applications run.
-
 aka:
 tags:
 - fundamental


### PR DESCRIPTION
remove extra space character between the end of the "Applications" definition
fixes https://github.com/kubernetes/website/issues/15529