### PR TITLE
correct conjure-up link

### DIFF
--- a/content/en/docs/setup/production-environment/turnkey/aws.md
+++ b/content/en/docs/setup/production-environment/turnkey/aws.md
@@ -18,7 +18,7 @@ To create a Kubernetes cluster on AWS, you will need an Access Key ID and a Secr
 
 ### Supported Production Grade Tools
 
-* [conjure-up](/docs/getting-started-guides/ubuntu/) is an open-source installer for Kubernetes that creates Kubernetes clusters with native AWS integrations on Ubuntu.
+* [conjure-up](https://docs.conjure-up.io/stable/en/spellbooks/kubernetes) is an open-source installer for Kubernetes that creates Kubernetes clusters with native AWS integrations on Ubuntu.
 
 * [Kubernetes Operations](https://github.com/kubernetes/kops) - Production Grade K8s Installation, Upgrades, and Management. Supports running Debian, Ubuntu, CentOS, and RHEL in AWS.
 


### PR DESCRIPTION
conjure-up link currently links to k8s "getting started" docs as opposed to conjure-up docs

