### PR TITLE
Update DaemonSet deletion documentation

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/daemonset.md
+++ b/content/en/docs/concepts/workloads/controllers/daemonset.md
@@ -194,12 +194,9 @@ You can modify the Pods that a DaemonSet creates.  However, Pods do not allow al
 fields to be updated.  Also, the DaemonSet controller will use the original template the next
 time a node (even with the same name) is created.
 
-
 You can delete a DaemonSet.  If you specify `--cascade=false` with `kubectl`, then the Pods
-will be left on the nodes.  You can then create a new DaemonSet with a different template.
-The new DaemonSet with the different template will recognize all the existing Pods as having
-matching labels.  It will not modify or delete them despite a mismatch in the Pod template.
-You will need to force new Pod creation by deleting the Pod or deleting the node.
+will be left on the nodes.  If you subsequently create a new DaemonSet with the same selector,
+the existing pods will be adopted by the new DaemonSet and replaced according to its `updateStrategy`.
 
 In Kubernetes version 1.6 and later, you can [perform a rolling update](/docs/tasks/manage-daemon/update-daemon-set/) on a DaemonSet.
 


### PR DESCRIPTION
The "Updating a DaemonSet" section referred to pre-1.6 behavior, where rolling updates of DaemonSets were not supported and thus orphaned pods from deleted DaemonSets would not be replaced by a new DaemonSet.

Describe the new behavior, where orphaned pods can be adopted by a new DaemonSet and may be replaced depending on the update strategy in use.