### PR TITLE
Removing some tiny redundant parts of the EndpointSlice documentation

### DIFF
--- a/content/en/docs/concepts/services-networking/endpoint-slices.md
+++ b/content/en/docs/concepts/services-networking/endpoint-slices.md
@@ -15,7 +15,6 @@ weight: 10
 {{% capture overview %}}
 
 {{< feature-state for_k8s_version="v1.16" state="alpha" >}}
-{{< glossary_definition term_id="endpoint-slice" length="short" >}}
 
 _Endpoint Slices_ provide a simple way to track network endpoints within a
 Kubernetes cluster. They offer a more scalable and extensible alternative to

--- a/content/en/docs/reference/glossary/endpoint-slice.md
+++ b/content/en/docs/reference/glossary/endpoint-slice.md
@@ -15,5 +15,5 @@ tags:
 <!--more-->
 
 A scalable and extensible way to group network endpoints together. These can be
-used as by {{< glossary_tooltip text="kube-proxy" term_id="kube-proxy" >}} to
+used by {{< glossary_tooltip text="kube-proxy" term_id="kube-proxy" >}} to
 establish network routes on each {{< glossary_tooltip text="node" term_id="node" >}}.

--- a/content/en/docs/tasks/administer-cluster/enabling-endpoint-slices.md
+++ b/content/en/docs/tasks/administer-cluster/enabling-endpoint-slices.md
@@ -49,7 +49,3 @@ EndpointSlice resources for each Endpoints resource. In addition to supporting
 existing Endpoints functionality, Endpoint Slices should include new bits of
 information such as topology. They will allow for greater scalability and
 extensibility of network endpoints in your cluster.
-
-### Feature availability
-
-Kubernetes 1.16 or newer is required to use Endpoint Slices.


### PR DESCRIPTION
This is a bit of cleanup from https://github.com/kubernetes/website/pull/16018 to help address some issues @kbhawkey found after the original PR was merged.

/cc @kbhawkey @simplytunde 