### PR TITLE
removed longer version to fetch labels for pods #14778

### DIFF
--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -185,7 +185,12 @@ echo $(kubectl get pods --selector=$sel --output=jsonpath={.items..metadata.name
 # Also uses "jq"
 for item in $( kubectl get pod --output=name); do printf "Labels for %s\n" "$item" | grep --color -E '[^/]+$' && kubectl get "$item" --output=json | jq -r -S '.metadata.labels | to_entries | .[] | " \(.key)=\(.value)"' 2>/dev/null; printf "\n"; done
 
+<<<<<<< HEAD
 # Or this command can be used as well to get all the labels associated with pods
+=======
+# OR
+
+>>>>>>> updated OR comments
 kubectl get pods --show-labels
 
 # Check which nodes are ready

--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -182,15 +182,6 @@ sel=${$(kubectl get rc my-rc --output=json | jq -j '.spec.selector | to_entries 
 echo $(kubectl get pods --selector=$sel --output=jsonpath={.items..metadata.name})
 
 # Show labels for all pods (or any other Kubernetes object that supports labelling)
-# Also uses "jq"
-for item in $( kubectl get pod --output=name); do printf "Labels for %s\n" "$item" | grep --color -E '[^/]+$' && kubectl get "$item" --output=json | jq -r -S '.metadata.labels | to_entries | .[] | " \(.key)=\(.value)"' 2>/dev/null; printf "\n"; done
-
-<<<<<<< HEAD
-# Or this command can be used as well to get all the labels associated with pods
-=======
-# OR
-
->>>>>>> updated OR comments
 kubectl get pods --show-labels
 
 # Check which nodes are ready


### PR DESCRIPTION
removed longer version to fetch labels for pods to use only kubectl get pods --show-labels #14778