### PR TITLE
Fix links to locate Korean docs

### DIFF
--- a/content/ko/docs/home/_index.md
+++ b/content/ko/docs/home/_index.md
@@ -21,32 +21,32 @@ cards:
   title: "기초 이해하기"
   description: "쿠버네티스와 쿠버네티스의 기본 개념을 배운다."
   button: "개념 배우기"
-  button_path: "/docs/concepts"
+  button_path: "/ko/docs/concepts"
 - name: tutorials
   title: "쿠버네티스 사용해보기"
   description: "쿠버네티스에 애플리케이션을 배포하는 방법을 튜토리얼을 따라하며 배운다."
   button: "튜토리얼 보기"
-  button_path: "/docs/tutorials"
+  button_path: "/ko/docs/tutorials"
 - name: setup
   title: "클러스터 구축하기"
   description: "보유한 자원과 요구에 맞게 동작하는 쿠버네티스를 구축한다."
   button: "쿠버네티스 구축하기"
-  button_path: "/docs/setup"
+  button_path: "/ko/docs/setup"
 - name: tasks
   title: "쿠버네티스 사용법 배우기"
   description: "일반적인 태스크와 이를 수행하는 방법을 여러 단계로 구성된 짧은 시퀀스를 통해 살펴본다."
   button: "태스크 보기"
-  button_path: "/docs/tasks"
+  button_path: "/ko/docs/tasks"
 - name: reference
   title: 레퍼런스 정보 찾기
   description: 용어, 커맨드 라인 구문, API 자원 종류, 그리고 설치 툴 문서를 살펴본다.
   button: 레퍼런스 보기
-  button_path: /docs/reference
+  button_path: "/ko/docs/reference"
 - name: contribute
   title: 문서에 기여하기
   description: 이 프로젝트가 처음인 사람이든, 오래 활동한 사람이든 상관없이 누구나 기여할 수 있다.
   button: 문서에 기여하기
-  button_path: /docs/contribute
+  button_path: "/ko/docs/contribute"
 - name: download
   title: 쿠버네티스 내려받기
   description: 쿠버네티스를 설치하거나 최신의 버전으로 업그레이드하는 경우, 현재 릴리스 노트를 참고한다.

--- a/content/ko/docs/tasks/tools/install-minikube.md
+++ b/content/ko/docs/tasks/tools/install-minikube.md
@@ -9,7 +9,7 @@ card:
 
 {{% capture overview %}}
 
-이 페이지는 단일 노드 쿠버네티스 클러스터를 노트북의 가상 머신에서 구동하는 도구인 [Minikube](/docs/tutorials/hello-minikube)의 설치 방법을 설명한다.
+이 페이지는 단일 노드 쿠버네티스 클러스터를 노트북의 가상 머신에서 구동하는 도구인 [Minikube](/ko/docs/tutorials/hello-minikube)의 설치 방법을 설명한다.
 
 {{% /capture %}}
 

--- a/content/ko/docs/tutorials/_index.md
+++ b/content/ko/docs/tutorials/_index.md
@@ -8,11 +8,11 @@ content_template: templates/concept
 {{% capture overview %}}
 
 쿠버네티스 문서의 본 섹션은 튜토리얼을 포함하고 있다.
-튜토리얼은 개별 [작업](/docs/tasks) 단위보다 더 큰 목표를 달성하기
+튜토리얼은 개별 [작업](/ko/docs/tasks) 단위보다 더 큰 목표를 달성하기
 위한 방법을 보여준다. 일반적으로 튜토리얼은 각각 순차적 단계가 있는 여러
 섹션으로 구성된다.
 각 튜토리얼을 따라하기 전에, 나중에 참조할 수 있도록
-[표준 용어집](/docs/reference/glossary/) 페이지를 북마크하기를 권한다.
+[표준 용어집](/ko/docs/reference/glossary/) 페이지를 북마크하기를 권한다.
 
 {{% /capture %}}
 
@@ -30,23 +30,23 @@ content_template: templates/concept
 
 ## 구성
 
-* [Configuring Redis Using a ConfigMap](/docs/tutorials/configuration/configure-redis-using-configmap/)
+* [컨피그 맵을 사용해서 Redis 설정휴ㅏ기](/ko/docs/tutorials/configuration/configure-redis-using-configmap/)
 
 ## 상태 유지를 하지 않는(stateless) 애플리케이션
 
-* [Exposing an External IP Address to Access an Application in a Cluster](/docs/tutorials/stateless-application/expose-external-ip-address/)
+* [외부 IP 주소를 노출하여 클러스터의 애플리케이션에 접속하기](/ko/docs/tutorials/stateless-application/expose-external-ip-address/)
 
-* [Example: Deploying PHP Guestbook application with Redis](/docs/tutorials/stateless-application/guestbook/)
+* [예시: Redis를 사용한 PHP 방명록 애플리케이션 배포하기](/ko/docs/tutorials/stateless-application/guestbook/)
 
 ## 상태 유지가 필요한(stateful) 애플리케이션
 
-* [스테이트풀셋 기본](/docs/tutorials/stateful-application/basic-stateful-set/)
+* [스테이트풀셋 기본](/ko/docs/tutorials/stateful-application/basic-stateful-set/)
 
-* [Example: WordPress and MySQL with Persistent Volumes](/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/)
+* [예시: WordPress와 MySQL을 퍼시스턴트 볼륨에 배포하기](/ko/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/)
 
-* [Example: Deploying Cassandra with Stateful Sets](/docs/tutorials/stateful-application/cassandra/)
+* [예시: 카산드라를 스테이트풀셋으로 배포하기](/ko/docs/tutorials/stateful-application/cassandra/)
 
-* [Running ZooKeeper, A CP Distributed System](/docs/tutorials/stateful-application/zookeeper/)
+* [분산 시스템 코디네이터 ZooKeeper 실행하기](/ko/docs/tutorials/stateful-application/zookeeper/)
 
 ## CI/CD 파이프라인
 
@@ -60,11 +60,11 @@ content_template: templates/concept
 
 ## 클러스터
 
-* [AppArmor](/docs/tutorials/clusters/apparmor/)
+* [AppArmor](/ko/docs/tutorials/clusters/apparmor/)
 
 ## 서비스
 
-* [Using Source IP](/docs/tutorials/services/source-ip/)
+* [소스 IP 주소 이용하기](/ko/docs/tutorials/services/source-ip/)
 
 {{% /capture %}}
 

--- a/content/ko/docs/tutorials/_index.md
+++ b/content/ko/docs/tutorials/_index.md
@@ -30,7 +30,7 @@ content_template: templates/concept
 
 ## 구성
 
-* [컨피그 맵을 사용해서 Redis 설정휴ㅏ기](/ko/docs/tutorials/configuration/configure-redis-using-configmap/)
+* [컨피그 맵을 사용해서 Redis 설정하기](/ko/docs/tutorials/configuration/configure-redis-using-configmap/)
 
 ## 상태 유지를 하지 않는(stateless) 애플리케이션
 

--- a/content/ko/docs/tutorials/kubernetes-basics/expose/expose-intro.html
+++ b/content/ko/docs/tutorials/kubernetes-basics/expose/expose-intro.html
@@ -28,9 +28,9 @@ weight: 10
 			<div class="col-md-8">
 			<h3>쿠버네티스 서비스들에 대한 개요</h3>
 
-			<p>쿠버네티스 <a href="/ko/docs/concepts/workloads/pods/pod-overview/">파드들</a> 은 언젠가는 죽게된다. 실제 파드들은  <a href="/docs/concepts/workloads/pods/pod-lifecycle/">생명주기</a>를 갖는다. 워커 노드가 죽으면, 노드 상에서 동작하는 파드들 또한 종료된다. <a href="/docs/concepts/workloads/controllers/replicaset/">레플리카 셋</a>은 여러분의 애플리케이션이 지속적으로 동작할 수 있도록 새로운 파드들의 생성을 통해 동적으로 클러스터를 미리 지정해 둔 상태로 되돌려 줄 수도 있다. 또 다른 예시로서, 3개의 복제본을 갖는 이미지 처리용 백엔드를 고려해 보자. 그 복제본들은 교체 가능한 상태이다. 그래서 프론트엔드 시스템은 하나의 파드가 소멸되어 재생성이 되더라도, 백엔드 복제본들에 의한 영향을 받아서는 안된다. 즉, 동일 노드 상의 파드들이라 할지라도, 쿠버네티스 클러스터 내 각 파드는 유일한 IP 주소를 가지며, 여러분의 애플리케이션들이 지속적으로 기능할 수 있도록 파드들 속에서 발생하는 변화에 대해 자동으로 조정해 줄 방법이 있어야 한다.</p>
+			<p>쿠버네티스 <a href="/ko/docs/concepts/workloads/pods/pod-overview/">파드들</a> 은 언젠가는 죽게된다. 실제 파드들은  <a href="/ko/docs/concepts/workloads/pods/pod-lifecycle/">생명주기</a>를 갖는다. 워커 노드가 죽으면, 노드 상에서 동작하는 파드들 또한 종료된다. <a href="/ko/docs/concepts/workloads/controllers/replicaset/">레플리카 셋</a>은 여러분의 애플리케이션이 지속적으로 동작할 수 있도록 새로운 파드들의 생성을 통해 동적으로 클러스터를 미리 지정해 둔 상태로 되돌려 줄 수도 있다. 또 다른 예시로서, 3개의 복제본을 갖는 이미지 처리용 백엔드를 고려해 보자. 그 복제본들은 교체 가능한 상태이다. 그래서 프론트엔드 시스템은 하나의 파드가 소멸되어 재생성이 되더라도, 백엔드 복제본들에 의한 영향을 받아서는 안된다. 즉, 동일 노드 상의 파드들이라 할지라도, 쿠버네티스 클러스터 내 각 파드는 유일한 IP 주소를 가지며, 여러분의 애플리케이션들이 지속적으로 기능할 수 있도록 파드들 속에서 발생하는 변화에 대해 자동으로 조정해 줄 방법이 있어야 한다.</p>
 
-			<p>쿠버네티스에서 서비스는 하나의 논리적인 파드 셋과 그 파드들에 접근할 수 있는 정책을 정의하는 추상적 개념이다. 서비스는 종속적인 파드들 사이를 느슨하게 결합되도록 해준다. 서비스는 모든 쿠버네티스 오브젝트들과 같이 YAML <a href="/docs/concepts/configuration/overview/#general-configuration-tips">(보다 선호하는)</a> 또는 JSON을 이용하여 정의된다. 서비스가 대상으로 하는 파드 셋은 보통 <i>LabelSelector</i>에 의해 결정된다 (여러분이 왜 스펙에 <code>selector</code>가 포함되지 않은 서비스를 필요로 하게 될 수도 있는지에 대해 아래에서 확인해 보자).</p>
+			<p>쿠버네티스에서 서비스는 하나의 논리적인 파드 셋과 그 파드들에 접근할 수 있는 정책을 정의하는 추상적 개념이다. 서비스는 종속적인 파드들 사이를 느슨하게 결합되도록 해준다. 서비스는 모든 쿠버네티스 오브젝트들과 같이 YAML <a href="/ko/docs/concepts/configuration/overview/#일반적인-구성-팁">(보다 선호하는)</a> 또는 JSON을 이용하여 정의된다. 서비스가 대상으로 하는 파드 셋은 보통 <i>LabelSelector</i>에 의해 결정된다 (여러분이 왜 스펙에 <code>selector</code>가 포함되지 않은 서비스를 필요로 하게 될 수도 있는지에 대해 아래에서 확인해 보자).</p>
 
 			<p>비록 각 파드들이 고유의 IP를 갖고 있기는 하지만, 그 IP들은 서비스의 도움없이 클러스터 외부로 노출되어질 수 없다. 서비스들은 여러분의 애플리케이션들에게 트래픽이 실릴 수 있도록 허용해준다. 서비스들은 ServiceSpec에서 <code>type</code>을 지정함으로써 다양한 방식들로 노출시킬 수 있다:</p>
 			<ul>
@@ -39,7 +39,7 @@ weight: 10
 				<li><i>LoadBalancer</i> - (지원 가능한 경우) 기존 클라우드에서 외부용 로드밸런서를 생성하고 서비스에 고정된 공인 IP를 할당해준다. NodePort의 상위 집합이다. </li>
 				<li><i>ExternalName</i> - 이름으로 CNAME 레코드를 반환함으로써 임의의 이름(스펙에서 <code>externalName</code>으로 명시)을 이용하여 서비스를 노출시켜준다. 프록시는 사용되지 않는다. 이 방식은 <code>kube-dns</code> 버전 1.7 이상에서 지원 가능하다.</li>
 			</ul>
-			<p>다른 서비스 타입들에 대한 추가 정보는 <a href="/docs/tutorials/services/source-ip/">소스 IP 이용하기</a>  튜토리얼에서 확인 가능하다. 또한 <a href="/docs/concepts/services-networking/connect-applications-service">서비스들로 애플리케이션에 접속하기</a>도 참고해 보자.</p>
+			<p>다른 서비스 타입들에 대한 추가 정보는 <a href="/ko/docs/tutorials/services/source-ip/">소스 IP 이용하기</a>  튜토리얼에서 확인 가능하다. 또한 <a href="/docs/concepts/services-networking/connect-applications-service">서비스들로 애플리케이션에 접속하기</a>도 참고해 보자.</p>
 			<p>부가적으로, spec에 <code>selector</code>를 정의하지 않고 말아넣은 서비스들의 몇 가지 유즈케이스들이 있음을 주의하자. <code>selector</code> 없이 생성된 서비스는 상응하는 엔드포인트 오브젝트들 또한 생성하지 않는다. 이로써 사용자들로 하여금 하나의 서비스를 특정한 엔드포인트에 매핑 시킬수 있도록 해준다. selector를 생략하게 되는 또 다른 가능성은 여러분이 <code>type: ExternalName</code>을 이용하겠다고 확고하게 의도하는 경우이다.</p>
 			</div>
 			<div class="col-md-4">
@@ -73,7 +73,7 @@ weight: 10
 		<div class="row">
 			<div class="col-md-8">
 				<p>서비스는 파드 셋에 걸쳐서 트래픽을 라우트한다. 여러분의 애플리케이션에 영향을 주지 않으면서 쿠버네티스에서 파드들이 죽게도 하고, 복제가 되게도 해주는 추상적 개념이다. 종속적인 파드들 사이에서의 디스커버리와 라우팅은 (하나의 애플리케이션에서 프로트엔드와 백엔드 컴포넌트와 같은) 쿠버네티스 서비스들에 의해 처리된다.</p>
-				<p>서비스는 쿠버네티스의 객체들에 대해 논리 연산을 허용해주는 기본 그룹핑 단위인, <a href="/docs/concepts/overview/working-with-objects/labels">레이블과 셀렉터</a>를 이용하여 파드 셋과 매치시킨다. 레이블은 오브젝트들에 붙여진 키/밸류 쌍으로 다양한 방식으로 이용 가능하다:</p>
+				<p>서비스는 쿠버네티스의 객체들에 대해 논리 연산을 허용해주는 기본 그룹핑 단위인, <a href="/ko/docs/concepts/overview/working-with-objects/labels">레이블과 셀렉터</a>를 이용하여 파드 셋과 매치시킨다. 레이블은 오브젝트들에 붙여진 키/밸류 쌍으로 다양한 방식으로 이용 가능하다:</p>
 				<ul>
 					<li>개발, 테스트, 그리고 상용환경에 대한 객체들의 지정</li>
 					<li>임베디드된 버전 태그들</li>

--- a/content/ko/docs/tutorials/kubernetes-basics/scale/scale-intro.html
+++ b/content/ko/docs/tutorials/kubernetes-basics/scale/scale-intro.html
@@ -27,7 +27,7 @@ weight: 10
             <div class="col-md-8">
                 <h3>애플리케이션을 스케일하기</h3>
                 
-                <p>지난 모듈에서 <a href="/docs/concepts/workloads/controllers/deployment/"> 디플로이먼트</a>를 만들고,
+                <p>지난 모듈에서 <a href="/ko/docs/concepts/workloads/controllers/deployment/"> 디플로이먼트</a>를 만들고,
                     <a href="/docs/concepts/services-networking/service/">서비스</a>를
                     통해서 디플로이먼트를 외부에 노출시켜 봤다. 해당 디플로이먼트는 애플리케이션을 구동하기 위해 단
                     하나의 파드(Pod)만을 생성했었다. 트래픽이 증가하면, 사용자 요청에 맞추어 애플리케이션의 규모를

--- a/content/ko/docs/tutorials/stateless-application/guestbook.md
+++ b/content/ko/docs/tutorials/stateless-application/guestbook.md
@@ -359,9 +359,9 @@ Google Compute Engine 또는 Google Kubernetes Engine과 같은 일부 클라우
 {{% /capture %}}
 
 {{% capture whatsnext %}}
-* [ELK 로깅과 모니터링](/docs/tutorials/stateless-application/guestbook-logs-metrics-with-elk/)을 방명록 애플리케이션에 추가하기
-* [쿠버네티스 기초](/docs/tutorials/kubernetes-basics/) 튜토리얼을 완료
-* [MySQL과 Wordpress을 위한 퍼시스턴트 볼륨](/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/#visit-your-new-wordpress-blog)을 사용하여 블로그 생성하는데 쿠버네티스 이용하기
+* [ELK 로깅과 모니터링](/ko/docs/tutorials/stateless-application/guestbook-logs-metrics-with-elk/)을 방명록 애플리케이션에 추가하기
+* [쿠버네티스 기초](/ko/docs/tutorials/kubernetes-basics/) 튜토리얼을 완료
+* [MySQL과 Wordpress을 위한 퍼시스턴트 볼륨](/ko/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/#visit-your-new-wordpress-blog)을 사용하여 블로그 생성하는데 쿠버네티스 이용하기
 * [애플리케이션 접속](/docs/concepts/services-networking/connect-applications-service/)에 대해 더 알아보기
 * [자원 관리](/docs/concepts/cluster-administration/manage-deployment/#using-labels-effectively)에 대해 더 알아보기
 {{% /capture %}}


### PR DESCRIPTION
한글 문서 내 몇몇 링크의 페이지가 이미 한글 번역이 완료 되었음에도 영문 페이지를 가리키는 것을 발견했습니다.
이에 작은 pr을 드립니다 😃