### PR TITLE
Add a example for union operator in the shell env

### DIFF
--- a/content/en/docs/reference/kubectl/jsonpath.md
+++ b/content/en/docs/reference/kubectl/jsonpath.md
@@ -72,7 +72,7 @@ Function            | Description               | Example                       
 `.` or `[]`         | child operator            | `{.kind}` or `{['kind']}`                                       | `List`
 `..`                | recursive descent         | `{..name}`                                                      | `127.0.0.1 127.0.0.2 myself e2e`
 `*`                 | wildcard. Get all objects | `{.items[*].metadata.name}`                                     | `[127.0.0.1 127.0.0.2]`
-`[start:end :step]` | subscript operator        | `{.users[0].name}`                                              | `myself`
+`[start:end:step]` | subscript operator        | `{.users[0].name}`                                              | `myself`
 `[,]`               | union operator            | `{.items[*]['metadata.name', 'status.capacity']}`               | `127.0.0.1 127.0.0.2 map[cpu:4] map[cpu:8]`
 `?()`               | filter                    | `{.users[?(@.name=="e2e")].user.password}`                      | `secret`
 `range`, `end`      | iterate list              | `{range .items[*]}[{.metadata.name}, {.status.capacity}] {end}` | `[127.0.0.1, map[cpu:4]] [127.0.0.2, map[cpu:8]]`
@@ -85,6 +85,7 @@ kubectl get pods -o json
 kubectl get pods -o=jsonpath='{@}'
 kubectl get pods -o=jsonpath='{.items[0]}'
 kubectl get pods -o=jsonpath='{.items[0].metadata.name}'
+kubectl get pods -o=jsonpath="{.items[*]['metadata.name', 'status.capacity']}"
 kubectl get pods -o=jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.startTime}{"\n"}{end}'
 ```
 


### PR DESCRIPTION
In the current example, single quotes are used, but the **union operator** can be confusing.

**Incorrect**
`kubectl get pod -o=jsonpath='{.items[*]['metadata.name','spec.nodeName']}'`

**Correct:**
`kubectl get pods -o=jsonpath="{.items[*]['metadata.name', 'status.capacity']}"`