### PR TITLE
Rename architecture section

### DIFF
--- a/content/en/docs/concepts/architecture/_index.md
+++ b/content/en/docs/concepts/architecture/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Kubernetes Architecture"
+title: "Cluster Architecture"
 weight: 30
 ---
 

--- a/content/en/docs/concepts/overview/components.md
+++ b/content/en/docs/concepts/overview/components.md
@@ -10,8 +10,11 @@ card:
 ---
 
 {{% capture overview %}}
-This document outlines the various binary components needed to
-deliver a functioning Kubernetes cluster.
+When you deploy Kubernetes, you get a cluster.
+{{< glossary_definition term_id="cluster" length="all" prepend="A cluster is">}}
+
+This document outlines the various components you need to have
+a complete and working Kubernetes cluster.
 {{% /capture %}}
 
 {{% capture body %}}
@@ -109,7 +112,7 @@ about containers in a central database, and provides a UI for browsing that data
 
 ### Cluster-level Logging
 
-A [Cluster-level logging](/docs/concepts/cluster-administration/logging/) mechanism is responsible for
+A [cluster-level logging](/docs/concepts/cluster-administration/logging/) mechanism is responsible for
 saving container logs to a central log store with search/browsing interface.
 
 {{% /capture %}}

--- a/content/en/docs/concepts/overview/what-is-kubernetes.md
+++ b/content/en/docs/concepts/overview/what-is-kubernetes.md
@@ -29,13 +29,13 @@ Early on, organizations ran applications on physical servers. There was no way t
 
 **Virtualized deployment era:**  As a solution, virtualization was introduced. It allows you to run multiple Virtual Machines (VMs) on a single physical server's CPU. Virtualization allows applications to be isolated between VMs and provides a level of security as the information of one application cannot be freely accessed by another application.
 
-Virtualization allows better utilization of resources in a physical server and allows better scalability because an application can be added or updated easily, reduces hardware costs, and much more.
+Virtualization allows better utilization of resources in a physical server and allows better scalability because an application can be added or updated easily, reduces hardware costs, and much more. With virtualization you can present a set of physical resources as a cluster of disposable virtual machines.
 
 Each VM is a full machine running all the components, including its own operating system, on top of the virtualized hardware.
 
 **Container deployment era:** Containers are similar to VMs, but they have relaxed isolation properties to share the Operating System (OS) among the applications. Therefore, containers are considered lightweight. Similar to a VM, a container has its own filesystem, CPU, memory, process space, and more. As they are decoupled from the underlying infrastructure, they are portable across clouds and OS distributions.
 
-Containers are becoming popular because they have many benefits. Some of the container benefits are listed below:
+Containers have become popular because they provide extra benefits, such as:
 
 * Agile application creation and deployment: increased ease and efficiency of container image creation compared to VM image use.
 * Continuous development, integration, and deployment: provides for reliable and frequent container image build and deployment with quick and easy rollbacks (due to image immutability).
@@ -52,7 +52,7 @@ Containers are becoming popular because they have many benefits. Some of the con
 
 Containers are a good way to bundle and run your applications. In a production environment, you need to manage the containers that run the applications and ensure that there is no downtime. For example, if a container goes down, another container needs to start. Wouldn't it be easier if this behavior was handled by a system?
 
-That's how Kubernetes comes to the rescue! Kubernetes provides you with a framework to run distributed systems resiliently. It takes care of your scaling requirements, failover, deployment patterns, and more. For example, Kubernetes can easily manage a canary deployment for your system.
+That's how Kubernetes comes to the rescue! Kubernetes provides you with a framework to run distributed systems resiliently. It takes care of scaling and failover for your application, provides deployment patterns, and more. For example, Kubernetes can easily manage a canary deployment for your system.
 
 Kubernetes provides you with:
 
@@ -63,7 +63,7 @@ Kubernetes allows you to automatically mount a storage system of your choice, su
 * **Automated rollouts and rollbacks**  
 You can describe the desired state for your deployed containers using Kubernetes, and it can change the actual state to the desired state at a controlled rate. For example, you can automate Kubernetes to create new containers for your deployment, remove existing containers and adopt all their resources to the new container.
 * **Automatic bin packing**  
-Kubernetes allows you to specify how much CPU and memory (RAM) each container needs. When containers have resource requests specified, Kubernetes can make better decisions to manage the resources for containers.
+You provide Kubernetes with a cluster of nodes that it can use to run containerized tasks. You tell Kubernetes how much CPU and memory (RAM) each container needs. Kubernetes can fit containers onto your nodes to make the best use of your resources.
 * **Self-healing**  
 Kubernetes restarts containers that fail, replaces containers, kills containers that don’t respond to your user-defined health check, and doesn’t advertise them to clients until they are ready to serve.
 * **Secret and configuration management**  


### PR DESCRIPTION
New title for https://kubernetes.io/docs/concepts/architecture/

“Kubernetes” goes without saying. This section is mainly talking about cluster architecture (control plane, nodes, etc), so make the title match that.

[Preview](https://deploy-preview-16286--kubernetes-io-master-staging.netlify.com/docs/concepts/architecture/)