### PR TITLE
Tweak glossary entry for kube-apiserver

### DIFF
--- a/content/en/docs/reference/glossary/kube-apiserver.md
+++ b/content/en/docs/reference/glossary/kube-apiserver.md
@@ -1,12 +1,13 @@
 ---
-title: kube-apiserver
+title: API server
 id: kube-apiserver
 date: 2018-04-12
 full_link: /docs/reference/generated/kube-apiserver/
 short_description: >
   Component on the master that exposes the Kubernetes API. It is the front-end for the Kubernetes control plane. 
 
-aka: 
+aka:
+- kube-apiserver
 tags:
 - architecture
 - fundamental

--- a/content/en/docs/reference/glossary/kube-apiserver.md
+++ b/content/en/docs/reference/glossary/kube-apiserver.md
@@ -4,7 +4,7 @@ id: kube-apiserver
 date: 2018-04-12
 full_link: /docs/reference/generated/kube-apiserver/
 short_description: >
-  Component on the master that exposes the Kubernetes API. It is the front-end for the Kubernetes control plane. 
+  Control plane component that serves the Kubernetes API.
 
 aka:
 - kube-apiserver
@@ -12,9 +12,12 @@ tags:
 - architecture
 - fundamental
 ---
- Component on the master that exposes the Kubernetes API. It is the front-end for the Kubernetes control plane. 
+ The API server is a component of the Kubernetes
+{{< glossary_tooltip text="control plane" term_id="control-plane" >}} that exposes the Kubernetes API.
+The API server is the front end for the Kubernetes control plane.
 
-<!--more--> 
+<!--more-->
 
-It is designed to scale horizontally -- that is, it scales by deploying more instances. See [Building High-Availability Clusters](/docs/admin/high-availability/).
-
+The main implementation of a Kubernetes API server is [kube-apiserver](/docs/reference/generated/kube-apiserver/).
+kube-apiserver is designed to scale horizontally&mdash;that is, it scales by deploying more instances.
+You can run several instances of kube-apiserver and balance traffic between those instances.


### PR DESCRIPTION
Tweak https://kubernetes.io/docs/reference/glossary/?all=true#term-kube-apiserver

- Change title to “API server” with “kube-apiserver” listed as an AKA
 - the title change also puts the entry under “A” in the glossary, rather than after “Z”
- use “control plane” rather than “master”
- other rewording

*NB* Every existing reference to this glossary entry uses the term “API server” or a variant.
[Preview](https://deploy-preview-16294--kubernetes-io-master-staging.netlify.com/docs/reference/glossary/?all=true#term-kube-apiserver)