### PR TITLE
kubeadm: Add optional step to disable kube-proxy

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
@@ -127,6 +127,10 @@ with the default gateway to advertise the master's IP. To use a different
 network interface, specify the `--apiserver-advertise-address=<ip-address>` argument
 to `kubeadm init`. To deploy an IPv6 Kubernetes cluster using IPv6 addressing, you
 must specify an IPv6 address, for example `--apiserver-advertise-address=fd00::101`
+1. (Optional) To disable kube-proxy, specify the `--skip-phases=addon/kube-proxy`
+argument to `kubeadm init`. At [Installing a pod network add-on](#pod-network),
+you will need to choose a pod network add-on which provides the kube-proxy
+functionality.
 1. (Optional) Run `kubeadm config images pull` prior to `kubeadm init` to verify
 connectivity to gcr.io registries.   
 


### PR DESCRIPTION
Considering that https://github.com/kubernetes/kubernetes/pull/82248 has been merged, we can run k8s without kube-proxy with kubeadm.