### PR TITLE
add /etc/sysconfig/kubelet info for CentOS/RHEL/Fedora Distributions

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -247,7 +247,7 @@ When using Docker, kubeadm will automatically detect the cgroup driver for the k
 and set it in the `/var/lib/kubelet/kubeadm-flags.env` file during runtime.
 
 If you are using a different CRI, you have to modify the file
-`/etc/default/kubelet` with your `cgroup-driver` value, like so:
+`/etc/default/kubelet` (`/etc/sysconfig/kubelet` for CentOS, RHEL, Fedora) with your `cgroup-driver` value, like so:
 
 ```bash
 KUBELET_EXTRA_ARGS=--cgroup-driver=<value>


### PR DESCRIPTION
Add the info about putting KUBELET_EXTRA_ARGS into /etc/sysconfig/kubelet for CentOS, RHEL and Fedora Distributions.