### PR TITLE
pod spec.subdomain does not have to be headless service for DNS record to exist

### DIFF
--- a/content/en/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/en/docs/concepts/services-networking/dns-pod-service.md
@@ -127,11 +127,11 @@ spec:
     name: busybox
 ```
 
-If there exists a headless service in the same namespace as the pod and with
+If there exists a service in the same namespace as the pod and with
 the same name as the subdomain, the cluster's KubeDNS Server also returns an A
 record for the Pod's fully qualified hostname.
 For example, given a Pod with the hostname set to "`busybox-1`" and the subdomain set to
-"`default-subdomain`", and a headless Service named "`default-subdomain`" in
+"`default-subdomain`", and a Service named "`default-subdomain`" in
 the same namespace, the pod will see its own FQDN as
 "`busybox-1.default-subdomain.my-namespace.svc.cluster-domain.example`". DNS serves an
 A record at that name, pointing to the Pod's IP. Both pods "`busybox1`" and


### PR DESCRIPTION
I tested it with a service LoadBalancer type service as well, and pod-A was able to get IP address of pod-B using its canonical hostname .
Note: pod-B was "selected" by the selector spec in service. 