### PR TITLE
Validate namespace preference in current context with --minify option

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/namespaces.md
+++ b/content/en/docs/concepts/overview/working-with-objects/namespaces.md
@@ -82,7 +82,7 @@ context.
 ```shell
 kubectl config set-context --current --namespace=<insert-namespace-name-here>
 # Validate it
-kubectl config view | grep namespace:
+kubectl config view --minify | grep namespace:
 ```
 
 ## Namespaces and DNS


### PR DESCRIPTION
It's easier to validate preferred namespace for current context when other contexts are ignored.