### PR TITLE
Added logo change for blog site

### DIFF
--- a/assets/sass/_base.sass
+++ b/assets/sass/_base.sass
@@ -131,7 +131,6 @@ header
     .logo
       background-image: url(../images/nav_logo2.svg)
 
-
 // Blog post tables
 .blog-content
   table

--- a/assets/sass/_base.sass
+++ b/assets/sass/_base.sass
@@ -125,6 +125,11 @@ header
   background-size: contain
   background-position: center center
   background-repeat: no-repeat
+  
+#blog
+  &.flip-nav, &.open-nav
+    .logo
+      background-image: url(../images/nav_logo2.svg)
 
 
 // Blog post tables


### PR DESCRIPTION
Currently on blog site (https://kubernetes.io/blog/) if you scroll down the page, logo (top left corner) disappears because the background is being changed to white. On the main page, this is fixed by changing the logo to the blue version on scroll down but it wasn't working on blog site. Added the same behaviour.