### PR TITLE
Update the kubectl config command in cheatsheet.md

### DIFF
--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -62,7 +62,7 @@ kubectl config view
 # get the password for the e2e user
 kubectl config view -o jsonpath='{.users[?(@.name == "e2e")].user.password}'
 
-kubectl config view -o jsonpath='{.users[].name}'    # get a list of users
+kubectl config view -o jsonpath='{.users[*].name}'    # get a list of users
 kubectl config get-contexts                          # display list of contexts 
 kubectl config current-context			               # display the current-context
 kubectl config use-context my-cluster-name           # set the default context to my-cluster-name


### PR DESCRIPTION
`kubectl config view -o jsonpath='{.users[].name}'` in the doc doesn't get the list of users as described in the comment. It returns the first user actually.

To get the list of users, the json path should be `'{.users[*].name}' `