### PR TITLE
Update typo in "New issue" page on k/website issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -1,6 +1,6 @@
 ---
 name: Support Request
-about: Support request or question relating to Kubernetes Dashboard project
+about: Support request or question relating to Kubernetes Website project
 labels:
 - triage/support
 ---


### PR DESCRIPTION
There is a "Kubernetes Dashboard project" in "about" at ".github/ISSUE_TEMPLATE/support.md"
This PR changes "Kubernetes Dashboard project" with "Kubernetes Website project".

Fixes: #16563 

