### PR TITLE
Correct minor typo `Cronjob` -> `CronJob`.

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/en/docs/concepts/workloads/controllers/cron-jobs.md
@@ -54,7 +54,7 @@ To illustrate this concept further, suppose a CronJob is set to schedule a new J
 `startingDeadlineSeconds` is set to 200 seconds. If the CronJob controller happens to
 be down for the same period as the previous example (`08:29:00` to `10:21:00`,) the Job will still start at 10:22:00. This happens as the controller now checks how many missed schedules happened in the last 200 seconds (ie, 3 missed schedules), rather than from the last scheduled time until now.
 
-The Cronjob is only responsible for creating Jobs that match its schedule, and
+The CronJob is only responsible for creating Jobs that match its schedule, and
 the Job in turn is responsible for the management of the Pods it represents.
 
 {{% /capture %}}


### PR DESCRIPTION
Typo is in the last paragraph on the controller concept page: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/.