### PR TITLE
added missing backquote

### DIFF
--- a/content/en/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions.md
+++ b/content/en/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions.md
@@ -383,7 +383,7 @@ For CustomResourceDefinitions created in `apiextensions.k8s.io/v1beta1`, if a [s
 
 If pruning is enabled, unspecified fields in CustomResources on creation and on update are dropped.
 
-Compare the CustomResourceDefinition `crontabs.stable.example.com` above. It has pruning enabled (both in `apiextensions.k8s.io/v1` and `apiextensions.k8s.io/v1beta1). Hence, if you save the following YAML to `my-crontab.yaml`:
+Compare the CustomResourceDefinition `crontabs.stable.example.com` above. It has pruning enabled (both in `apiextensions.k8s.io/v1` and `apiextensions.k8s.io/v1beta1`). Hence, if you save the following YAML to `my-crontab.yaml`:
 
 ```yaml
 apiVersion: "stable.example.com/v1"


### PR DESCRIPTION
The document lacks of a backquote, and so, code block format is broken.

before
![crd_before](https://user-images.githubusercontent.com/4710215/65811933-11039880-e1fb-11e9-8d4b-b3133c909e90.png)
after
![crd_after](https://user-images.githubusercontent.com/4710215/65811939-17921000-e1fb-11e9-8147-4a437c443704.png)
