### PR TITLE
fix: removes dead link

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -602,8 +602,6 @@ metadata:
         cloud.google.com/load-balancer-type: "Internal"
 [...]
 ```
-Use `cloud.google.com/load-balancer-type: "internal"` for masters with version 1.7.0 to 1.7.3.
-For more information, see the [docs](https://cloud.google.com/kubernetes-engine/docs/internal-load-balancing).
 {{% /tab %}}
 {{% tab name="AWS" %}}
 ```yaml


### PR DESCRIPTION
The link in question to here no longer contains a caveat for kubernetes 1.7.0 to 1.7.3.  Also, this version of kubernetes is neither supported by kubernetes itself or by GCP, so far as I'm aware.