### PR TITLE
fix: incorrect path

### DIFF
--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -51,7 +51,7 @@ volume type used.
 To use a volume, a Pod specifies what volumes to provide for the Pod (the
 `.spec.volumes`
 field) and where to mount those into Containers (the
-`.spec.containers.volumeMounts`
+`.spec.containers[*].volumeMounts`
 field).
 
 A process in a container sees a filesystem view composed from their Docker


### PR DESCRIPTION
the path in question is not under an object `containers`, but rather under an array `containers`, which means that `.spec.containers.volumeMounts` is invalid.  The `[*]` syntax is used throughout the site, so I went with that to denote selecting an item from the `containers` array.