### PR TITLE
fix: typo: extra whitespace indentation

### DIFF
--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -1339,7 +1339,7 @@ spec:
       csi:
         driver: inline.storage.kubernetes.io
         volumeAttributes:
-              foo: bar
+          foo: bar
 ```
 
 This feature requires CSIInlineVolume feature gate to be enabled. It


### PR DESCRIPTION
I noticed that this was indented 6 additional spaces instead of 2, so I corrected it.