### PR TITLE
Blog related fixes

### DIFF
--- a/content/en/blog/_posts/2018-04-11-migrating-the-kubernetes-blog.md
+++ b/content/en/blog/_posts/2018-04-11-migrating-the-kubernetes-blog.md
@@ -35,4 +35,4 @@ Our workflow hasn't changed for confidential advance drafts. Additionally, we'll
 
 ### Call for reviewers
 
-The Kubernetes Blog needs more reviewers! If you're interested in contributing to the Kubernetes project and can participate on a regular, weekly basis, send an introductory email to [k8sblog@linuxfoundation.org](k8sblog@linuxfoundation.org).
+The Kubernetes Blog needs more reviewers! If you're interested in contributing to the Kubernetes project and can participate on a regular, weekly basis, send an introductory email to [k8sblog@linuxfoundation.org](mailto:k8sblog@linuxfoundation.org).

--- a/content/en/blog/_posts/2018-07-16-kubernetes-1-11-release-interview.md
+++ b/content/en/blog/_posts/2018-07-16-kubernetes-1-11-release-interview.md
@@ -267,7 +267,7 @@ TIM PEPPER: Also, I would maybe argue in a way that a portion of that wasn't jus
 
 <i>Thanks to Josh Berkus and Tim Pepper for talking to the Kubernetes Podcast from Google.
 
-[Josh Berkus](https://github.com/jberkus) hangs out in #sig-release on the [Kubernetes Slack](slack.k8s.io). He maintains a newsletter called "[Last Week in Kubernetes Development](http://lwkd.info/)", with Noah Kantrowitz. You can read him on Twitter at [@fuzzychef](https://twitter.com/fuzzychef), but he does warn you that there's a lot of politics there as well.
+[Josh Berkus](https://github.com/jberkus) hangs out in #sig-release on the [Kubernetes Slack](https://slack.k8s.io). He maintains a newsletter called "[Last Week in Kubernetes Development](http://lwkd.info/)", with Noah Kantrowitz. You can read him on Twitter at [@fuzzychef](https://twitter.com/fuzzychef), but he does warn you that there's a lot of politics there as well.
 
 
 [Tim Pepper](https://github.com/tpepper) is also on Slack - he's always open to folks reaching out with a question, looking for help or advice.  On Twitter you'll find him at [@pythomit](https://twitter.com/pythomit), which is "Timothy P" backwards. Tim is an avid soccer fan and season ticket holder for the [Portland Timbers](https://portlandtimbers.com/) and the [Portland Thorns](https://portlandthorns.com/), so you'll get all sorts of opinions on soccer in addition to technology!

--- a/content/en/blog/_posts/2019-02-12-building-a-kubernetes-edge-control-plane-for-envoy-v2.md
+++ b/content/en/blog/_posts/2019-02-12-building-a-kubernetes-edge-control-plane-for-envoy-v2.md
@@ -59,7 +59,7 @@ More crucially, though, the first implementation of the IR allowed rapid prototy
 
 ## Ambassador >= v0.50: Envoy v2 APIs (ADS), Testing with KAT, and Golang
 
-In consultation with the [Ambassador community](http://d6e.co/slack), the [Datawire](www.datawire.io) team undertook a redesign of the internals of Ambassador in 2018. This was driven by two key goals. First, we wanted to integrate Envoy's v2 configuration format, which would enable the support of features such as [SNI](https://www.getambassador.io/user-guide/sni/), [rate limiting](https://www.getambassador.io/user-guide/rate-limiting) and [gRPC authentication APIs](https://www.getambassador.io/user-guide/auth-tutorial). Second, we also wanted to do much more robust semantic validation of Envoy configuration due to its increasing complexity (particularly when operating with large-scale application deployments).
+In consultation with the [Ambassador community](http://d6e.co/slack), the [Datawire](https://www.datawire.io) team undertook a redesign of the internals of Ambassador in 2018. This was driven by two key goals. First, we wanted to integrate Envoy's v2 configuration format, which would enable the support of features such as [SNI](https://www.getambassador.io/user-guide/sni/), [rate limiting](https://www.getambassador.io/user-guide/rate-limiting) and [gRPC authentication APIs](https://www.getambassador.io/user-guide/auth-tutorial). Second, we also wanted to do much more robust semantic validation of Envoy configuration due to its increasing complexity (particularly when operating with large-scale application deployments).
 
 
 ### Initial stages

--- a/content/en/blog/_posts/2019-03-20-A-Look-Back-And-Whats-In-Store-For-Kubernetes-Contributor-Summits.md
+++ b/content/en/blog/_posts/2019-03-20-A-Look-Back-And-Whats-In-Store-For-Kubernetes-Contributor-Summits.md
@@ -19,7 +19,7 @@ We build the contributor summits around you:
   * docs
   * code
   * community management
-* [Subproject OWNERs] (aka maintainers in other OSS circles)
+* [Subproject OWNERs] - aka maintainers in other OSS circles.
 * Special Interest Group (SIG) / Working Group (WG) [Chair or Tech Lead]
 * Active Contributors
 * Casual Contributors
@@ -57,17 +57,17 @@ Jonas Rosland, Josh Berkus, Paris Pittman, Jorge Castro, Bob Killen, Deb Giles, 
 
 ## Relive Seattle Contributor Summit 
 
-📈 80% growth rate since the Austin 2017 December event  
-📜 Event waiting list: 103  
-🎓 76 contributors were on-boarded through the New Contributor Workshop  
-🎉 92% of the current contributors RSVPs attended and of those:  
-👩🏻‍🚒 25% were [Special Interest Group] or Working Group Chairs or Tech Leads  
-🗳 70% were eligible to vote in the last [steering committee election] (more than 50 contributions in 2018)   
-📹 20+ [Sessions]  
-👀 Most watched to date: Technical Vision, Security, API Code Base Tour  
-🌟 Top 3 according to survey: Live API Code Review, Deflaking Unconference, Technical Vision  
-🎱 🎳 160 attendees for the social at [Garage] on Sunday night where we sunk eight balls and recorded strikes (out in some cases)  
-🏆 Special recognition: SIG Storage, @dims, and @jordan  
+📈 80% growth rate since the Austin 2017 December event
+📜 Event waiting list: 103
+🎓 76 contributors were on-boarded through the New Contributor Workshop
+🎉 92% of the current contributors RSVPs attended and of those:
+👩🏻‍🚒 25% were [Special Interest Group] or Working Group Chairs or Tech Leads
+🗳 70% were eligible to vote in the last [steering committee election] - more than 50 contributions in 2018
+📹 20+ [Sessions]
+👀 Most watched to date: Technical Vision, Security, API Code Base Tour
+🌟 Top 3 according to survey: Live API Code Review, Deflaking Unconference, Technical Vision
+🎱 🎳 160 attendees for the social at [Garage] on Sunday night where we sunk eight balls and recorded strikes (out in some cases)
+🏆 Special recognition: SIG Storage, @dims, and @jordan
 📸 Pictures (special thanks to [rdodev])
 Garage Pic
 Reg Desk

--- a/content/en/blog/_posts/2019-03-20-A-Look-Back-And-Whats-In-Store-For-Kubernetes-Contributor-Summits.md
+++ b/content/en/blog/_posts/2019-03-20-A-Look-Back-And-Whats-In-Store-For-Kubernetes-Contributor-Summits.md
@@ -58,17 +58,29 @@ Jonas Rosland, Josh Berkus, Paris Pittman, Jorge Castro, Bob Killen, Deb Giles, 
 ## Relive Seattle Contributor Summit 
 
 📈 80% growth rate since the Austin 2017 December event
+
 📜 Event waiting list: 103
+
 🎓 76 contributors were on-boarded through the New Contributor Workshop
+
 🎉 92% of the current contributors RSVPs attended and of those:
+
 👩🏻‍🚒 25% were [Special Interest Group] or Working Group Chairs or Tech Leads
+
 🗳 70% were eligible to vote in the last [steering committee election] - more than 50 contributions in 2018
+
 📹 20+ [Sessions]
+
 👀 Most watched to date: Technical Vision, Security, API Code Base Tour
+
 🌟 Top 3 according to survey: Live API Code Review, Deflaking Unconference, Technical Vision
+
 🎱 🎳 160 attendees for the social at [Garage] on Sunday night where we sunk eight balls and recorded strikes (out in some cases)
+
 🏆 Special recognition: SIG Storage, @dims, and @jordan
+
 📸 Pictures (special thanks to [rdodev])
+
 Garage Pic
 Reg Desk
 

--- a/content/en/blog/_posts/2019-03-29-kube-proxy-subtleties-debugging-an-intermittent-connection-resets.md
+++ b/content/en/blog/_posts/2019-03-29-kube-proxy-subtleties-debugging-an-intermittent-connection-resets.md
@@ -3,7 +3,7 @@ title: 'kube-proxy Subtleties: Debugging an Intermittent Connection Reset'
 date: 2019-03-29
 ---
 
-**Author:** [Yongkun Gui](ygui@google.com), Google
+**Author:** [Yongkun Gui](mailto:ygui@google.com), Google
 
 I recently came across a bug that causes intermittent connection resets.  After
 some digging, I found it was caused by a subtle combination of several different


### PR DESCRIPTION
+ these fixes mostly covers forgotten scheme (like https: or mailto:)
+ fix for markdown parsing, which trigger to generate broken html (see [2019-03-20 post](https://kubernetes.io/blog/2019/03/20/a-look-back-and-whats-in-store-for-kubernetes-contributor-summits/))
 