### PR TITLE
Update to 0.57.2 via fixing Chinese content (see #16531)

### DIFF
--- a/content/zh/docs/tutorials/clusters/apparmor.md
+++ b/content/zh/docs/tutorials/clusters/apparmor.md
@@ -246,7 +246,15 @@ k8s-apparmor-example-deny-write (enforce)
 denies all file writes: -->
 首先，我们需要将要使用的配置文件加载到节点上。我们将使用的配置文件仅拒绝所有文件写入：
 
-{{< code language="text" file="deny-write.profile" >}}
+```shell
+#include <tunables/global>
+profile k8s-apparmor-example-deny-write flags=(attach_disconnected) {
+  #include <abstractions/base>
+  file,
+  # Deny all file writes.
+  deny /** w,
+}
+```
 
 <!-- Since we don't know where the Pod will be scheduled, we'll need to load the profile on all our
 nodes. For this example we'll just use SSH to install the profiles, but other approaches are


### PR DESCRIPTION
This PR extends the fix in #16531 to Chinese docs.

### Some background

I accidentally [YOLO'd a commit](76028716007b61ddc7c7e27fd750b555b4dd9dd8) directly to `release-1.14`. In the process of trying to revert it, the last stable commit began to fail. After initially mistaking it for a stealthy work-in-test-but-fail-in-production build on the part of #16647, I realized that netlify was now failing for a [similar but unrelated error](16652#issuecomment-537283252) in Chinese content.

Rather than revert the original commit, apply the fix to Chinese content, then resubmit the original commit in the form of a PR, this PR threads the needle by politely ignoring my earlier commit, fixing Chinese content, and calling it a day.

![razzledazzle](https://user-images.githubusercontent.com/3210446/66010541-318a5780-e474-11e9-887f-ad58de652bea.gif)

### Preview link

https://deploy-preview-16653--k8s-v1-14.netlify.com/zh/docs/tutorials/clusters/apparmor/#%E4%B8%BE%E4%BE%8B


