### PR TITLE
Explain interaction between secret, optional, and PodPreset

### DIFF
--- a/content/en/docs/concepts/workloads/pods/podpreset.md
+++ b/content/en/docs/concepts/workloads/pods/podpreset.md
@@ -39,7 +39,9 @@ When a pod creation request occurs, the system does the following:
 1. Attempt to merge the various resources defined by the `PodPreset` into the
    Pod being created.
 1. On error, throw an event documenting the merge error on the pod, and create
-   the pod _without_ any injected resources from the `PodPreset`.
+   the pod _without_ any injected resources from the `PodPreset`. This rule does
+   not work for environment which from secret, since as default, the `optional`
+   key for secret is `false` which would stop pod creatation.
 1. Annotate the resulting modified Pod spec to indicate that it has been
    modified by a `PodPreset`. The annotation is of the form
    `podpreset.admission.kubernetes.io/podpreset-<pod-preset name>: "<resource version>"`.

--- a/content/en/docs/concepts/workloads/pods/podpreset.md
+++ b/content/en/docs/concepts/workloads/pods/podpreset.md
@@ -76,11 +76,11 @@ In order to use Pod Presets in your cluster you must ensure the following:
 1.  You have enabled the admission controller `PodPreset`. One way to doing this
     is to include `PodPreset` in the `--enable-admission-plugins` option value specified
     for the API server. In minikube add this flag
-    
+
     ```shell
     --extra-config=apiserver.enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,PodPreset
     ```
-    
+
     while starting the cluster.
 1.  You have defined your Pod Presets by creating `PodPreset` objects in the
     namespace you will use.


### PR DESCRIPTION
Test with following config:
```
apiVersion: settings.k8s.io/v1alpha1
kind: PodPreset
metadata:
  name: test-podpreset
spec:
  env:
  - name: test_env
    valueFrom:
      secretKeyRef:
        key: test_env
        name: test-secret
  selector:
    matchLabels:
      test/podpreset: "true"
---
apiVersion: v1
kind: Pod
metadata:
  labels:
    test/podpreset: "true"
  name: test-pod
spec:
  containers:
  - args:
    - /bin/bash
    image: nicolaka/netshoot
    imagePullPolicy: IfNotPresent
    name: tmp-shell
```

The test-pod failed to create:
```
  Warning  Failed  3m19s (x4485 over 16h)  kubelet, test.localdomain  Error: secret "test-secret" not found
```

The reason is that when use env from secret, the default value for `optional` is `false` which check the secret must be created.

After add `optiional: true` for env in podpreset, and re-apply, test-pod run as expected.

refer to:

- https://stackoverflow.com/questions/48208705/how-to-mark-secret-as-optional-in-kubernetes
- https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/types.go#L1827