### PR TITLE
Add English-Korean translation glossary

### DIFF
--- a/content/ko/docs/contribute/localization_ko.md
+++ b/content/ko/docs/contribute/localization_ko.md
@@ -79,8 +79,7 @@ weight: 10
 * 한영 병기 (예: 훅(hook))
 * 영어 단어 (예: Kubelet)
 
-단, 자연스러움을 판단하는 기준은 주관적이므로 문서 한글화팀이 공동으로 관리하는 
-[한글화팀 용어집](https://goo.gl/BDNeJ1)과 기존에 번역된 문서를 참고한다.
+단, 자연스러움을 판단하는 기준은 주관적이므로 다음의 [용어집](#용어집)과 기존에 번역된 문서를 참고한다.
 
 {{% note %}}
 API 오브젝트는 원 단어를 
@@ -102,6 +101,206 @@ API 오브젝트의 필드 이름, 파일 이름, 경로 이름과 같은 내용
 {{% note %}}
 한영 병기는 페이지 내에서 해당 용어가 처음 사용되는 경우에만 적용하고 이후 부터는 한글만 표기한다.
 {{% /note %}}
+
+### 용어집
+
+English | 한글 | 비고
+--- | --- | ---
+Access | 접근 | 
+Active | Active | 잡의 상태 
+Active Job | 액티브 잡 | 
+Addons | 애드온 | 
+admission controller | 어드미션 컨트롤러 | 
+Age | 기간 | 
+Allocation | 할당량 
+Annotation | 어노테이션 | 
+App | 앱 | 
+Appendix | 부록 | 
+Application | 애플리케이션 | 
+Args | Args | 약어의 형태이므로 한글화하지 않고 영문 표기
+array | 배열 | 
+autoscaler | 오토스케일러  
+availability zone | 가용성 영역(availability zone) |
+bare pod | 베어(bare) 파드 | 
+beta | 베타 |
+boilerplate | 상용구 | 
+Boot | 부트 | 
+Build | 빌드 |
+Cache | 캐시 | 
+canary | 카나리(canary) | 릴리스 방식에 관련한 용어인 경우에 한함
+cascading | 캐스케이딩(cascading) |
+character set | 캐릭터 셋 |
+Charts | 차트 |
+checkpoint | 체크포인트 |
+CLI | CLI | 
+Cluster | 클러스터 | 
+Command Line Tool | 커맨드라인 툴 |
+Config Map | 컨피그 맵 | 
+configuration | 구성, 설정 |
+Connection | 연결 | 
+containerized | 컨테이너화 된 |
+Context | 컨텍스트  | 
+Control Plane | 컨트롤 플레인 | 
+controller | 컨트롤러 |
+Cron Job | 크론 잡 | 
+custom metrics | 사용자 정의 메트릭 | 
+Custom resource | 사용자 정의 리소스 |
+CustomResourceDefinition | 커스텀 리소스 데피니션 | 
+Daemon | 데몬 |
+Daemon Set | 데몬 셋 |
+Dashboard | 대시보드 | 
+Data Plane | 데이터 플레인 | 
+Default Limit | 기본 상한 | 
+Default Request | 기본 요청량 | 
+Deployment | 디플로이먼트 | 
+deprecated | 사용 중단(deprecated) |
+descriptor | 디스크립터, 식별자 |
+Desired number of pods | 의도한 파드의 수 | 
+Desired State | 의도한 상태 | 
+disruption | 중단(disruption) | 
+distros | 배포판 |
+Docker | 도커 |
+Dockerfile | Dockerfile | 
+Downward API | 다운워드(Downward) API |
+Endpoint | 엔드포인트 |
+entry point | 진입점 | 
+Event | 이벤트 | 
+Exec | Exec |
+expose | 노출시키다 |
+extension | 익스텐션(extension) |
+Failed | Failed | 파드의 상태에 한함 
+Federation | 페더레이션 |
+field | 필드 | 
+Flannel | Flannel |
+form | 형식 |
+Google Compute Engine | Google Compute Engine | 
+hash | 해시 |
+headless | 헤드리스 |
+health check | 헬스 체크 |
+Heapster | 힙스터(Heapster) |
+Heartbeat | 하트비트 |
+Homebrew | Homebrew | 
+hook | 훅(hook) | 
+Horizontal Pod Autoscaler | Horizontal Pod Autoscaler | 예외적으로 API 오브젝트에 대해 외래어 표기법 적용하지 않고 원문 그대로 표기
+hosted zone | 호스팅 영역 | 
+hostname | 호스트네임 |
+Huge page | Huge page |
+Hypervisor | 하이퍼바이저 |
+idempotent | 멱등성 |
+Image | 이미지 | 
+Image Pull Secrets | 이미지 풀(Pull) 시크릿 | 
+Ingress | 인그레스 | 
+Init Container | 초기화 컨테이너 | 
+Instance group | 인스턴스 그룹 |
+introspection | 인트로스펙션(introspection) |
+Istio | 이스티오(Istio) |
+Job | 잡 |
+Kubelet | Kubelet |
+Kubernetes | 쿠버네티스 |
+label | 레이블 | 
+lifecycle | 라이프사이클 |
+Linux | 리눅스 | 
+load | 부하 | 
+Log | 로그 | 
+Lost | Lost | 클레임의 상태에 한함 
+Machine | 머신 | 
+manifest | 매니페스트 | 
+Master | 마스터 | 
+max limit/request ratio | 최대 상한/요청량 비율 | 
+metadata | 메타데이터 |
+metric | 메트릭 |
+Minikube | Minikube | 
+Mirror pod | 미러 파드(mirror pod) |
+monitoring | 모니터링 | 
+naked pod | 네이키드(naked) 파드 |
+Namespace | 네임스페이스 | 
+Network Policy | 네트워크 폴리시 |
+Node | 노드 | 
+node lease | 노드 리스(lease)
+Object | 오브젝트 | 
+Orchestrate | 오케스트레이션하다 |
+Output | 출력 | 
+parameter | 파라미터 |
+patch | 패치 |
+Pending | Pending | 파드, 클레임의 상태에 한함 
+Persistent Volume | 퍼시스턴트 볼륨 | 
+Persistent Volume Claim | 퍼시스턴트 볼륨 클레임 | 
+pipeline | 파이프라인 | 
+placeholder pod | 플레이스홀더(placeholder) 파드 | 
+Pod(파드) | 파드 |
+Pod Preset | 파드 프리셋 | 
+PodAntiAffinity | 파드안티어피니티(PodAntiAffinity) | 
+PodDisruptionBudget | PodDisruptionBudget |
+postfix | 접미사 | 
+prefix | 접두사 |
+Previleged | 특권을 가진(previleged) |
+Prometheus | 프로메테우스 |
+proof of concept | 개념 증명 | 
+Pull Request | 풀 리퀘스트 |
+Pull Secret Credentials | 풀(Pull) 시크릿 자격증명 |
+QoS Class | QoS 클래스 | 
+Quota | 쿼터 | 
+Ready | Ready |
+Reclaim Policy | 반환 정책 | 
+Registry | 레지스트리 | 
+Release | 릴리스 | 
+Replica Set | 레플리카 셋 | 
+replicas | 레플리카 |
+Replication Controller | 레플리케이션 컨트롤러 | 
+repository | 리포지터리 |
+resource | 리소스 | 
+Resource Limit | 리소스 상한 |
+Resource Quota | 리소스 쿼터 |
+return | 반환하다 | 
+revision | 리비전 |
+Role | 롤 |  
+rollback | 롤백 | 
+rolling update | 롤링 업데이트 |
+rollout | 롤아웃 |
+Running | Running | 파드의 상태에 한함 
+runtime | 런타임 |
+Scale | 스케일 | 
+Secret | 시크릿 | 
+segment | 세그먼트 |
+Selector | 셀렉터 | 
+Self-healing | 자가 치유 |
+Service | 서비스 | 
+Service Account | 서비스 어카운트 | 
+service discovery | 서비스 디스커버리 | 
+service mesh | 서비스 메쉬 |
+Session | 세션 | 
+Session Affinity | 세션 어피니티(Affinity) |
+Setting | 세팅 | 
+Shell | 셸 |
+Sign In | 로그인 | 
+Sign Out | 로그아웃 | 
+Stateful Set | 스테이트풀 셋 | 
+stateless | 스테이트리스 | 
+Static pod | 스태틱 파드(static pod) |
+Storage Class | 스토리지 클래스 | 
+Sub-Object | 서브-오브젝트 | 
+support | 지원 |
+Surge | 증가율 | 롤링업데이트 전략에 한함
+System | 시스템 | 
+taint | 테인트(taint) |
+Task | 태스크 |
+Terminated | Terminated | 파드의 상태에 한함 
+tolerations | 톨러레이션(toleration) |
+Tools  | 도구
+traffic | 트래픽 |
+Type | 타입 | 
+ubuntu | 우분투 | 
+use case | 유스케이스 | 
+Utilization | 사용량, 사용률 |
+verbosity | 로그 상세 레벨(verbosity) |
+virtualization | 가상화 |
+Volume | 볼륨 | 
+Waiting | Waiting | 파드의 상태에 한함 
+Walkthrough | 연습 | 
+Windows | 윈도우 | 
+Worker | 워커 | 노드의 형태에 한함 
+Workload | 워크로드 | 
+YAML | YAML | 
 
 {{% /capture %}}
 


### PR DESCRIPTION
Contents are migrated from [한글화팀 용어집](https://docs.google.com/spreadsheets/d/1BWKq_HYmt_p1RKzQJoPfCb4ZgBgxH_q3_mf9ujCmniw)
