### PR TITLE
Fix broken link to Documentation style overview from Contribute page

### DIFF
--- a/content/en/docs/contribute/_index.md
+++ b/content/en/docs/contribute/_index.md
@@ -15,7 +15,7 @@ developer, an end user, or someone who just can't stand seeing typos.
 
 For information on the Kubernetes documentation
  content and style, see the 
- [Documentation style overview](/docs/contribute/style/style/).
+ [Documentation style overview](/docs/contribute/style/).
 
 {{% capture body %}}
 


### PR DESCRIPTION
On the [Contribute to Kubernetes docs](https://kubernetes.io/docs/contribute/) page the link to [Documentation style overview](https://kubernetes.io/docs/contribute/style/) is broken. This fixes the link.

Deeplink preview: https://deploy-preview-16667--kubernetes-io-master-staging.netlify.com/docs/contribute/