### PR TITLE
Use HTTPS for links in header and footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -11,10 +11,10 @@
             <div>
                 <a href="https://twitter.com/kubernetesio" class="twitter"><span>{{ T "community_twitter_name" }}</span></a>
                 <a href="https://github.com/kubernetes/kubernetes" class="github"><span>{{ T "community_github_name" }}</span></a>
-                <a href="http://slack.k8s.io/" class="slack"><span>Slack</span></a>
+                <a href="https://slack.k8s.io/" class="slack"><span>Slack</span></a>
             </div>
             <div>
-                <a href="http://stackoverflow.com/questions/tagged/kubernetes" class="stack-overflow"><span>{{ T "community_stack_overflow_name" }}</span></a>
+                <a href="https://stackoverflow.com/questions/tagged/kubernetes" class="stack-overflow"><span>{{ T "community_stack_overflow_name" }}</span></a>
                 <a href="https://discuss.kubernetes.io" class="mailing-list"><span>{{ T "community_forum_name" }}</span></a>
                 <a href="https://calendar.google.com/calendar/embed?src=nt2tcnbtbied3l6gi2h29slvc0%40group.calendar.google.com" class="calendar"><span>{{ T "community_events_calendar" }}</span></a>
             </div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -21,7 +21,7 @@
                 {{ end }}
                 </ul>
             </li>
-         
+
             <li>
                 <a href="#">
                     {{ site.Params.version }} <span class="ui-icon ui-icon-carat-1-s"></span>
@@ -60,7 +60,7 @@
             <div class="social">
                 <a href="https://twitter.com/kubernetesio" class="twitter"><span>{{ T "community_twitter_name" }}</span></a>
                 <a href="https://github.com/kubernetes/kubernetes" class="github"><span>{{ T "community_github_name" }}</span></a>
-                <a href="http://slack.k8s.io/" class="slack"><span>{{ T "community_slack_name" }} Slack</span></a>
+                <a href="https://slack.k8s.io/" class="slack"><span>{{ T "community_slack_name" }} Slack</span></a>
                 <a href="https://stackoverflow.com/questions/tagged/kubernetes" class="stack-overflow"><span>{{ T "community_stack_overflow_name" }}</span></a>
                 <a href="https://discuss.kubernetes.io" class="mailing-list"><span>{{ T "community_forum_name" }}</span></a>
                 <a href="https://calendar.google.com/calendar/embed?src=nt2tcnbtbied3l6gi2h29slvc0%40group.calendar.google.com" class="calendar"><span>{{ T "community_events_calendar" }}</span></a>


### PR DESCRIPTION
Use HTTPS instead of HTTP for the social links in the header and footer. slack.k8s.io is especially bad without HTTPS since it doesn't encrypt the subsequent request containing the email.