### PR TITLE
fix yaml in examples emptydir-pod.yaml

### DIFF
--- a/content/en/examples/windows/emptydir-pod.yaml
+++ b/content/en/examples/windows/emptydir-pod.yaml
@@ -1,20 +1,20 @@
- apiVersion: v1
- kind: Pod
- metadata:
-   name: my-empty-dir-pod
- spec:
-   containers:
-   - image: microsoft/windowsservercore:1709
-     name: my-empty-dir-pod
-     volumeMounts:
-     - mountPath: /cache
-       name: cache-volume
-     - mountPath: C:/scratch
-       name: scratch-volume
-   volumes:
-   - name: cache-volume
-     emptyDir: {}
-   - name: scratch-volume
-     emptyDir: {}
-   nodeSelector:
-     beta.kubernetes.io/os: windows
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-empty-dir-pod
+spec:
+  containers:
+  - image: microsoft/windowsservercore:1709
+    name: my-empty-dir-pod
+    volumeMounts:
+    - mountPath: /cache
+      name: cache-volume
+    - mountPath: C:/scratch
+      name: scratch-volume
+  volumes:
+  - name: cache-volume
+    emptyDir: {}
+  - name: scratch-volume
+    emptyDir: {}
+  nodeSelector:
+    beta.kubernetes.io/os: windows

--- a/content/ja/examples/windows/emptydir-pod.yaml
+++ b/content/ja/examples/windows/emptydir-pod.yaml
@@ -1,20 +1,20 @@
- apiVersion: v1
- kind: Pod
- metadata:
-   name: my-empty-dir-pod
- spec:
-   containers:
-   - image: microsoft/windowsservercore:1709
-     name: my-empty-dir-pod
-     volumeMounts:
-     - mountPath: /cache
-       name: cache-volume
-     - mountPath: C:/scratch
-       name: scratch-volume
-   volumes:
-   - name: cache-volume
-     emptyDir: {}
-   - name: scratch-volume
-     emptyDir: {}
-   nodeSelector:
-     beta.kubernetes.io/os: windows
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-empty-dir-pod
+spec:
+  containers:
+  - image: microsoft/windowsservercore:1709
+    name: my-empty-dir-pod
+    volumeMounts:
+    - mountPath: /cache
+      name: cache-volume
+    - mountPath: C:/scratch
+      name: scratch-volume
+  volumes:
+  - name: cache-volume
+    emptyDir: {}
+  - name: scratch-volume
+    emptyDir: {}
+  nodeSelector:
+    beta.kubernetes.io/os: windows


### PR DESCRIPTION
Example yaml file has wrong indentation.
Removing unwanted space to make it valid yaml file.