### PR TITLE
Adding clarification that Endpoints are still required when EndpointSlices are enabled.

### DIFF
--- a/content/en/docs/tasks/administer-cluster/enabling-endpoint-slices.md
+++ b/content/en/docs/tasks/administer-cluster/enabling-endpoint-slices.md
@@ -26,6 +26,15 @@ network endpoints, they will be split into multiple smaller Endpoint Slice
 resources instead of a single large Endpoints resource.
 
 ## Enabling Endpoint Slices
+
+{{< feature-state for_k8s_version="v1.16" state="alpha" >}}
+
+{{< note >}}
+Although Endpoint Slices may eventually replace Endpoints, many Kubernetes
+components still rely on Endpoints. For now, enabling Endpoint Slices should be
+seen as an addition to Endpoints in a cluster, not a replacement for them.
+{{< /note >}}
+
 As an alpha feature, Endpoint Slices are not enabled by default in Kubernetes.
 Enabling Endpoint Slices requires as many as 3 changes to Kubernetes cluster
 configuration.


### PR DESCRIPTION
This is meant to help clarify that Endpoints should not be disabled when Endpoint Slices are enabled. This came up in https://github.com/kubernetes/kubernetes/issues/83212 and I think this update to the docs could help prevent similar confusion in the future.