### PR TITLE
Replace CRI-O incubator links.

### DIFF
--- a/content/de/docs/setup/minikube.md
+++ b/content/de/docs/setup/minikube.md
@@ -18,7 +18,7 @@ Minikube ist ein Tool, mit dem Kubernetes lokal einfach ausgeführt werden kann.
   * NodePorts
   * ConfigMaps and Secrets
   * Dashboards
-  * Container Laufzeiumgebungen: Docker, [rkt](https://github.com/rkt/rkt), [CRI-O](https://github.com/kubernetes-incubator/cri-o) und [containerd](https://github.com/containerd/containerd)
+  * Container Laufzeiumgebungen: Docker, [rkt](https://github.com/rkt/rkt), [CRI-O](https://cri-o.io/) und [containerd](https://github.com/containerd/containerd)
   * Unterstützung von CNI (Container Network Interface)
   * Ingress
 
@@ -164,7 +164,7 @@ minikube start \
 
 #### CRI-O
 
-Um [CRI-O](https://github.com/kubernetes-incubator/cri-o) als Containerlaufzeitumgebung zu verwenden, führen Sie den folgenden Befehl aus:
+Um [CRI-O](https://cri-o.io/) als Containerlaufzeitumgebung zu verwenden, führen Sie den folgenden Befehl aus:
 
 ```bash
 minikube start \

--- a/content/en/blog/_posts/2016-12-00-Container-Runtime-Interface-Cri-In-Kubernetes.md
+++ b/content/en/blog/_posts/2016-12-00-Container-Runtime-Interface-Cri-In-Kubernetes.md
@@ -100,7 +100,7 @@ Although CRI is still in its early stages, there are already several projects un
 
 
 
-- [cri-o](https://github.com/kubernetes-incubator/cri-o): OCI conformant runtimes.
+- [cri-o](https://cri-o.io/): OCI conformant runtimes.
 - [rktlet](https://github.com/kubernetes-incubator/rktlet): the rkt container runtime.
 - [frakti](https://github.com/kubernetes/frakti): hypervisor-based container runtimes.
 - [docker CRI shim](https://github.com/kubernetes/kubernetes/tree/release-1.5/pkg/kubelet/dockershim).

--- a/content/en/docs/setup/learning-environment/minikube.md
+++ b/content/en/docs/setup/learning-environment/minikube.md
@@ -23,7 +23,7 @@ Minikube supports the following Kubernetes features:
 * NodePorts
 * ConfigMaps and Secrets
 * Dashboards
-* Container Runtime: Docker, [CRI-O](https://github.com/kubernetes-incubator/cri-o), and [containerd](https://github.com/containerd/containerd)
+* Container Runtime: Docker, [CRI-O](https://cri-o.io/), and [containerd](https://github.com/containerd/containerd)
 * Enabling CNI (Container Network Interface)
 * Ingress
 
@@ -232,7 +232,7 @@ minikube start \
 ```
 {{% /tab %}}
 {{% tab name="CRI-O" %}}
-To use [CRI-O](https://github.com/kubernetes-incubator/cri-o) as the container runtime, run:
+To use [CRI-O](https://cri-o.io/) as the container runtime, run:
 ```bash
 minikube start \
     --network-plugin=cni \

--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -137,7 +137,7 @@ If the container runtime of choice is Docker, it is used through the built-in
 Other CRI-based runtimes include:
 
 - [containerd](https://github.com/containerd/cri) (CRI plugin built into containerd)
-- [cri-o](https://github.com/kubernetes-incubator/cri-o)
+- [cri-o](https://cri-o.io/)
 - [frakti](https://github.com/kubernetes/frakti)
 
 Refer to the [CRI installation instructions](/docs/setup/cri) for more information.

--- a/content/fr/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/fr/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -180,7 +180,7 @@ Le runtime utilisé par défaut est Docker, activé à travers l'adaptateur four
 Parmi les autres runtimes CRI, on retrouvera :
 
 - [cri-containerd](https://github.com/containerd/cri-containerd)
-- [cri-o](https://github.com/kubernetes-incubator/cri-o)
+- [cri-o](https://cri-o.io/)
 - [frakti](https://github.com/kubernetes/frakti)
 - [rkt](https://github.com/kubernetes-incubator/rktlet)
 

--- a/content/fr/docs/setup/independent/install-kubeadm.md
+++ b/content/fr/docs/setup/independent/install-kubeadm.md
@@ -90,7 +90,7 @@ Le moteur de runtime de conteneur utilisé par défaut est Docker, activé par l
 Les autres runtimes basés sur la CRI incluent:
 
 - [containerd](https://github.com/containerd/cri) (plugin CRI construit dans containerd)
-- [cri-o](https://github.com/kubernetes-incubator/cri-o)
+- [cri-o](https://cri-o.io/)
 - [frakti](https://github.com/kubernetes/frakti)
 
 Reportez-vous aux [instructions d'installation de la CRI](/docs/setup/cri) pour plus d'informations.

--- a/content/ja/docs/setup/independent/install-kubeadm.md
+++ b/content/ja/docs/setup/independent/install-kubeadm.md
@@ -92,7 +92,7 @@ The container runtime used by default is Docker, which is enabled through the bu
 Other CRI-based runtimes include:
 
 - [containerd](https://github.com/containerd/cri) (CRI plugin built into containerd)
-- [cri-o](https://github.com/kubernetes-incubator/cri-o)
+- [cri-o](https://cri-o.io/)
 - [frakti](https://github.com/kubernetes/frakti)
 
 Refer to the [CRI installation instructions](/docs/setup/cri) for more information.

--- a/content/ja/docs/setup/minikube.md
+++ b/content/ja/docs/setup/minikube.md
@@ -18,7 +18,7 @@ Minikubeはローカル環境でKubernetesを簡単に実行するためのツ�
   * NodePorts
   * ConfigMapsとSecrets
   * ダッシュボード
-  * コンテナランタイム: Docker, [rkt](https://github.com/rkt/rkt), [CRI-O](https://github.com/kubernetes-incubator/cri-o), [containerd](https://github.com/containerd/containerd)
+  * コンテナランタイム: Docker, [rkt](https://github.com/rkt/rkt), [CRI-O](https://cri-o.io/), [containerd](https://github.com/containerd/containerd)
   * CNI (Container Network Interface) の有効化
   * Ingress
 

--- a/content/ko/docs/setup/learning-environment/minikube.md
+++ b/content/ko/docs/setup/learning-environment/minikube.md
@@ -19,7 +19,7 @@ Minikube는 다음과 같은 쿠버네티스의 기능을 제공한다.
 * 노드 포트
 * 컨피그 맵과 시크릿
 * 대시보드
-* 컨테이너 런타임: Docker, [CRI-O](https://github.com/kubernetes-incubator/cri-o) 와 [containerd](https://github.com/containerd/containerd)
+* 컨테이너 런타임: Docker, [CRI-O](https://cri-o.io/) 와 [containerd](https://github.com/containerd/containerd)
 * CNI(Container Network Interface) 사용
 * 인그레스
 

--- a/content/zh/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -300,7 +300,7 @@ The container runtime used by default is Docker, which is enabled through the bu
 其它的基于 CRI 的运行时包括:
 
 - [cri-containerd](https://github.com/containerd/cri-containerd)
-- [cri-o](https://github.com/kubernetes-incubator/cri-o)
+- [cri-o](https://cri-o.io/)
 - [frakti](https://github.com/kubernetes/frakti)
 - [rkt](https://github.com/kubernetes-incubator/rktlet)
 

--- a/content/zh/docs/setup/independent/install-kubeadm.md
+++ b/content/zh/docs/setup/independent/install-kubeadm.md
@@ -160,7 +160,7 @@ The container runtime used by default is Docker, which is enabled through the bu
 Other CRI-based runtimes include:
 
 - [containerd](https://github.com/containerd/cri) (CRI plugin built into containerd)
-- [cri-o](https://github.com/kubernetes-incubator/cri-o)
+- [cri-o](https://cri-o.io/)
 - [frakti](https://github.com/kubernetes/frakti)
 - [rkt](https://github.com/kubernetes-incubator/rktlet) 
 -->


### PR DESCRIPTION
Update CRI-O links from Kubernetes incubator to the official CRI-O
homepage. Most links were already updated, but there were a few
stragglers in minikube documentation and old blog posts.
