### PR TITLE
Fix local build errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DOCKER       = docker
-HUGO_VERSION = 0.53
+HUGO_VERSION = 0.58.3
 DOCKER_IMAGE = kubernetes-hugo
 DOCKER_RUN   = $(DOCKER) run --rm --interactive --tty --volume $(CURDIR):/src
 NODE_BIN     = node_modules/.bin

--- a/layouts/shortcodes/code.html
+++ b/layouts/shortcodes/code.html
@@ -3,7 +3,7 @@
 {{ $codelang := .Get "language" | default (path.Ext $file | strings.TrimPrefix ".") }} 
 {{ $fileDir := path.Split $file }}
 {{ $bundlePath := path.Join .Page.File.Dir $fileDir.Dir }}
-{{ $filename := path.Join $p.File.Dir $file }}
+{{ $filename := printf "/content/%s/%s/%s" .Page.Lang $p.File.Dir $file | safeURL }}
 {{ $ghlink := printf "https://%s/blob/master/content/%s/%s" site.Params.githubwebsiterepo .Page.Lang $filename | safeURL }}
 {{/* First assume this is a bundle and the file is inside it. */}}
 {{ $resource := $p.Resources.GetMatch (printf "%s*" $file ) }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,10 @@ functions = "functions"
 command = "make non-production-build"
 
 [build.environment]
-HUGO_VERSION = "0.53"
+# https://gitmemory.com/kubernetes/website
+# https://www.gitmemory.com/zacharysarah
+# https://github.com/kubernetes/website/pull/16151/files
+HUGO_VERSION = "0.58.3"
 
 [context.production.environment]
 HUGO_BASEURL = "https://kubernetes.io/"


### PR DESCRIPTION
Fix the following compilation error

```bash
$ make docker-serve
docker run --rm --interactive --tty --volume /Users/dxwsker/works/github/issueflow/errbot-plugin/errbot/repository/website:/src -p 1313:1313 kubernetes-hugo hugo server --buildFuture --bind 0.0.0.0
Building sites … WARN 2019/10/06 15:01:27 Content directory "/src/content/en/docs/reference/kubernetes-api" have both index.* and _index.* files, pick one.
WARN 2019/10/06 15:01:27 Content directory "/src/content/en/docs/reference/kubernetes-api" have both index.* and _index.* files, pick one.
WARN 2019/10/06 15:01:27 Content directory "/src/content/en/docs/reference/kubernetes-api" have both index.* and _index.* files, pick one.
Total in 37702 ms
Error: Error building site: "/src/content/en/docs/tutorials/clusters/apparmor.md:126:1": failed to render shortcode "capture": failed to process shortcode: "/src/layouts/shortcodes/code.html:14:16": execute of template failed: template: shortcodes/code.html:14:16: executing "shortcodes/code.html" at <readFile $filename>: error calling readFile: runtime error: invalid memory address or nil pointer dereference
make: *** [docker-serve] Error 255
```