### PR TITLE
Fix local build errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DOCKER       = docker
-HUGO_VERSION = 0.53
+HUGO_VERSION = 0.58.3
 DOCKER_IMAGE = kubernetes-hugo
 DOCKER_RUN   = $(DOCKER) run --rm --interactive --tty --volume $(CURDIR):/src
 NODE_BIN     = node_modules/.bin

--- a/content/zh/docs/tasks/federation/policy.rego
+++ b/content/zh/docs/tasks/federation/policy.rego
@@ -1,0 +1,74 @@
+# OPA supports a high-level declarative language named Rego for authoring and
+# enforcing policies. For more information on Rego, visit
+# http://openpolicyagent.org.
+
+# Rego policies are namespaced by the "package" directive.
+package kubernetes.placement
+
+# Imports provide aliases for data inside the policy engine. In this case, the
+# policy simply refers to "clusters" below.
+import data.kubernetes.clusters
+
+# The "annotations" rule generates a JSON object containing the key
+# "federation.kubernetes.io/replica-set-preferences" mapped to <preferences>.
+# The preferences values is generated dynamically by OPA when it evaluates the
+# rule.
+#
+# The SchedulingPolicy Admission Controller running inside the Federation API
+# server will merge these annotations into incoming Federated resources. By
+# setting replica-set-preferences, we can control the placement of Federated
+# ReplicaSets.
+#
+# Rules are defined to generate JSON values (booleans, strings, objects, etc.)
+# When OPA evaluates a rule, it generates a value IF all of the expressions in
+# the body evaluate successfully. All rules can be understood intuitively as
+# <head> if <body> where <body> is true if <expr-1> AND <expr-2> AND ...
+# <expr-N> is true (for some set of data.)
+annotations["federation.kubernetes.io/replica-set-preferences"] = preferences {
+    input.kind = "ReplicaSet"
+    value = {"clusters": cluster_map, "rebalance": true}
+    json.marshal(value, preferences)
+}
+
+# This "annotations" rule generates a value for the "federation.alpha.kubernetes.io/cluster-selector"
+# annotation.
+#
+# In English, the policy asserts that resources in the "production" namespace
+# that are not annotated with "criticality=low" MUST be placed on clusters
+# labelled with "on-premises=true".
+annotations["federation.alpha.kubernetes.io/cluster-selector"] = selector {
+    input.metadata.namespace = "production"
+    not input.metadata.annotations.criticality = "low"
+    json.marshal([{
+        "operator": "=",
+        "key": "on-premises",
+        "values": "[true]",
+    }], selector)
+}
+
+# Generates a set of cluster names that satisfy the incoming Federated
+# ReplicaSet's requirements. In this case, just PCI compliance.
+replica_set_clusters[cluster_name] {
+    clusters[cluster_name]
+    not insufficient_pci[cluster_name]
+}
+
+# Generates a set of clusters that must not be used for Federated ReplicaSets
+# that request PCI compliance.
+insufficient_pci[cluster_name] {
+    clusters[cluster_name]
+    input.metadata.annotations["requires-pci"] = "true"
+    not pci_clusters[cluster_name]
+}
+
+# Generates a set of clusters that are PCI certified. In this case, we assume
+# clusters are annotated to indicate if they have passed PCI compliance audits.
+pci_clusters[cluster_name] {
+    clusters[cluster_name].metadata.annotations["pci-certified"] = "true"
+}
+
+# Helper rule to generate a mapping of desired clusters to weights. In this
+# case, weights are static.
+cluster_map[cluster_name] = {"weight": 1} {
+    replica_set_clusters[cluster_name]
+}

--- a/layouts/shortcodes/code.html
+++ b/layouts/shortcodes/code.html
@@ -3,7 +3,7 @@
 {{ $codelang := .Get "language" | default (path.Ext $file | strings.TrimPrefix ".") }} 
 {{ $fileDir := path.Split $file }}
 {{ $bundlePath := path.Join .Page.File.Dir $fileDir.Dir }}
-{{ $filename := path.Join $p.File.Dir $file }}
+{{ $filename := printf "/content/%s/%s/%s" .Page.Lang $p.File.Dir $file | safeURL }}
 {{ $ghlink := printf "https://%s/blob/master/content/%s/%s" site.Params.githubwebsiterepo .Page.Lang $filename | safeURL }}
 {{/* First assume this is a bundle and the file is inside it. */}}
 {{ $resource := $p.Resources.GetMatch (printf "%s*" $file ) }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@ functions = "functions"
 command = "make non-production-build"
 
 [build.environment]
-HUGO_VERSION = "0.57.2"
+HUGO_VERSION = "0.58.3"
 
 [context.production.environment]
 HUGO_BASEURL = "https://kubernetes.io/"


### PR DESCRIPTION
Fix the following compilation error

```bash
$ make docker-serve
docker run --rm --interactive --tty --volume /Users/dxwsker/works/github/issueflow/errbot-plugin/errbot/repository/website:/src -p 1313:1313 kubernetes-hugo hugo server --buildFuture --bind 0.0.0.0
Building sites … WARN 2019/10/06 15:01:27 Content directory "/src/content/en/docs/reference/kubernetes-api" have both index.* and _index.* files, pick one.
WARN 2019/10/06 15:01:27 Content directory "/src/content/en/docs/reference/kubernetes-api" have both index.* and _index.* files, pick one.
WARN 2019/10/06 15:01:27 Content directory "/src/content/en/docs/reference/kubernetes-api" have both index.* and _index.* files, pick one.
Total in 37702 ms
Error: Error building site: "/src/content/en/docs/tutorials/clusters/apparmor.md:126:1": failed to render shortcode "capture": failed to process shortcode: "/src/layouts/shortcodes/code.html:14:16": execute of template failed: template: shortcodes/code.html:14:16: executing "shortcodes/code.html" at <readFile $filename>: error calling readFile: runtime error: invalid memory address or nil pointer dereference
make: *** [docker-serve] Error 255
```