### PR TITLE
Fix typos

### DIFF
--- a/content/en/docs/concepts/policy/limit-range.md
+++ b/content/en/docs/concepts/policy/limit-range.md
@@ -58,7 +58,7 @@ Neither contention nor changes to limitrange will affect already created resourc
 
 The following section discusses the creation of a LimitRange acting at Container Level.
 A Pod with 04 containers is first created; each container within the Pod has a specific `spec.resource` configuration  
-each containerwithin the pod is handled differently by the LimitRanger admission controller.
+each container within the pod is handled differently by the LimitRanger admission controller.
 
  Create a namespace `limitrange-demo` using the following kubectl command
 
@@ -107,7 +107,7 @@ kubectl apply -f https://k8s.io/examples/admin/resource/limit-range-pod-1.yaml -
 ```
 
 ### Container spec with  valid CPU/Memory requests and limits
-View the the `busybox-cnt01` resource configuration
+View the `busybox-cnt01` resource configuration
 
 ```shell 
 kubectl get  po/busybox1 -n limitrange-demo -o json | jq ".spec.containers[0].resources"

--- a/content/en/docs/concepts/scheduling/kube-scheduler.md
+++ b/content/en/docs/concepts/scheduling/kube-scheduler.md
@@ -86,7 +86,7 @@ kube-scheduler has a default set of scheduling policies.
 ### Filtering
 
 - `PodFitsHostPorts`: Checks if a Node has free ports (the network protocol kind)
-  for the Pod ports the the Pod is requesting.
+  for the Pod ports the Pod is requesting.
 
 - `PodFitsHost`: Checks if a Pod specifies a specific Node by it hostname.
 


### PR DESCRIPTION
Fix a typo in https://kubernetes.io/docs/concepts/policy/limit-range/ and https://kubernetes.io/docs/concepts/scheduling/kube-scheduler/.
