### PR TITLE
Capitalize Pod, style guide edits

### DIFF
--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -25,21 +25,21 @@ This document describes the current state of `PersistentVolumes` in Kubernetes. 
 
 ## Introduction
 
-Managing storage is a distinct problem from managing compute. The `PersistentVolume` subsystem provides an API for users and administrators that abstracts details of how storage is provided from how it is consumed. To do this we introduce two new API resources:  `PersistentVolume` and `PersistentVolumeClaim`.
+Managing storage is a distinct problem from managing compute. The `PersistentVolume` subsystem provides an API for users and administrators that abstracts details of how storage is provided from how it is consumed. To do this, we introduce two new API resources:  `PersistentVolume` and `PersistentVolumeClaim`.
 
-A `PersistentVolume` (PV) is a piece of storage in the cluster that has been provisioned by an administrator or dynamically provisioned using [Storage Classes](/docs/concepts/storage/storage-classes/). It is a resource in the cluster just like a node is a cluster resource. PVs are volume plugins like Volumes, but have a lifecycle independent of any individual pod that uses the PV. This API object captures the details of the implementation of the storage, be that NFS, iSCSI, or a cloud-provider-specific storage system.
+A `PersistentVolume` (PV) is a piece of storage in the cluster that has been provisioned by an administrator or dynamically provisioned using [Storage Classes](/docs/concepts/storage/storage-classes/). It is a resource in the cluster just like a node is a cluster resource. PVs are volume plugins like Volumes, but have a lifecycle independent of any individual Pod that uses the PV. This API object captures the details of the implementation of the storage, be that NFS, iSCSI, or a cloud-provider-specific storage system.
 
-A `PersistentVolumeClaim` (PVC) is a request for storage by a user. It is similar to a pod. Pods consume node resources and PVCs consume PV resources. Pods can request specific levels of resources (CPU and Memory).  Claims can request specific size and access modes (e.g., can be mounted once read/write or many times read-only).
+A `PersistentVolumeClaim` (PVC) is a request for storage by a user. It is similar to a Pod. Pods consume node resources and PVCs consume PV resources. Pods can request specific levels of resources (CPU and Memory).  Claims can request specific size and access modes (e.g., they can be mounted once read/write or many times read-only).
 
 While `PersistentVolumeClaims` allow a user to consume abstract storage
 resources, it is common that users need `PersistentVolumes` with varying
 properties, such as performance, for different problems. Cluster administrators
 need to be able to offer a variety of `PersistentVolumes` that differ in more
 ways than just size and access modes, without exposing users to the details of
-how those volumes are implemented. For these needs there is the `StorageClass`
+how those volumes are implemented. For these needs, there is the `StorageClass`
 resource.
 
-Please see the [detailed walkthrough with working examples](/docs/tasks/configure-pod-container/configure-persistent-volume-storage/).
+See the [detailed walkthrough with working examples](/docs/tasks/configure-pod-container/configure-persistent-volume-storage/).
 
 
 ## Lifecycle of a volume and claim
@@ -51,14 +51,14 @@ PVs are resources in the cluster. PVCs are requests for those resources and also
 There are two ways PVs may be provisioned: statically or dynamically.
 
 #### Static
-A cluster administrator creates a number of PVs. They carry the details of the real storage which is available for use by cluster users. They exist in the Kubernetes API and are available for consumption.
+A cluster administrator creates a number of PVs. They carry the details of the real storage, which is available for use by cluster users. They exist in the Kubernetes API and are available for consumption.
 
 #### Dynamic
-When none of the static PVs the administrator created matches a user's `PersistentVolumeClaim`,
+When none of the static PVs the administrator created match a user's `PersistentVolumeClaim`,
 the cluster may try to dynamically provision a volume specially for the PVC.
 This provisioning is based on `StorageClasses`: the PVC must request a
 [storage class](/docs/concepts/storage/storage-classes/) and
-the administrator must have created and configured that class in order for dynamic
+the administrator must have created and configured that class for dynamic
 provisioning to occur. Claims that request the class `""` effectively disable
 dynamic provisioning for themselves.
 
@@ -66,29 +66,29 @@ To enable dynamic storage provisioning based on storage class, the cluster admin
 needs to enable the `DefaultStorageClass` [admission controller](/docs/reference/access-authn-authz/admission-controllers/#defaultstorageclass)
 on the API server. This can be done, for example, by ensuring that `DefaultStorageClass` is
 among the comma-delimited, ordered list of values for the `--enable-admission-plugins` flag of
-the API server component. For more information on API server command line flags,
-please check [kube-apiserver](/docs/admin/kube-apiserver/) documentation.
+the API server component. For more information on API server command-line flags,
+check [kube-apiserver](/docs/admin/kube-apiserver/) documentation.
 
 ### Binding
 
-A user creates, or has already created in the case of dynamic provisioning, a `PersistentVolumeClaim` with a specific amount of storage requested and with certain access modes. A control loop in the master watches for new PVCs, finds a matching PV (if possible), and binds them together. If a PV was dynamically provisioned for a new PVC, the loop will always bind that PV to the PVC. Otherwise, the user will always get at least what they asked for, but the volume may be in excess of what was requested. Once bound, `PersistentVolumeClaim` binds are exclusive, regardless of how they were bound. A PVC to PV binding is a one-to-one mapping.
+A user creates, or in the case of dynamic provisioning, has already created, a `PersistentVolumeClaim` with a specific amount of storage requested and with certain access modes. A control loop in the master watches for new PVCs, finds a matching PV (if possible), and binds them together. If a PV was dynamically provisioned for a new PVC, the loop will always bind that PV to the PVC. Otherwise, the user will always get at least what they asked for, but the volume may be in excess of what was requested. Once bound, `PersistentVolumeClaim` binds are exclusive, regardless of how they were bound. A PVC to PV binding is a one-to-one mapping.
 
 Claims will remain unbound indefinitely if a matching volume does not exist. Claims will be bound as matching volumes become available. For example, a cluster provisioned with many 50Gi PVs would not match a PVC requesting 100Gi. The PVC can be bound when a 100Gi PV is added to the cluster.
 
 ### Using
 
-Pods use claims as volumes. The cluster inspects the claim to find the bound volume and mounts that volume for a pod. For volumes which support multiple access modes, the user specifies which mode is desired when using their claim as a volume in a pod.
+Pods use claims as volumes. The cluster inspects the claim to find the bound volume and mounts that volume for a Pod. For volumes that support multiple access modes, the user specifies which mode is desired when using their claim as a volume in a Pod.
 
 Once a user has a claim and that claim is bound, the bound PV belongs to the user for as long as they need it. Users schedule Pods and access their claimed PVs by including a `persistentVolumeClaim` in their Pod's volumes block. [See below for syntax details](#claims-as-volumes).
 
 ### Storage Object in Use Protection
-The purpose of the Storage Object in Use Protection feature is to ensure that Persistent Volume Claims (PVCs) in active use by a pod and Persistent Volume (PVs) that are bound to PVCs are not removed from the system as this may result in data loss.
+The purpose of the Storage Object in Use Protection feature is to ensure that Persistent Volume Claims (PVCs) in active use by a Pod and Persistent Volume (PVs) that are bound to PVCs are not removed from the system, as this may result in data loss.
 
 {{< note >}}
-PVC is in active use by a pod when a pod object exists that is using the PVC.
+PVC is in active use by a Pod when a Pod object exists that is using the PVC.
 {{< /note >}}
 
-If a user deletes a PVC in active use by a pod, the PVC is not removed immediately. PVC removal is postponed until the PVC is no longer actively used by any pods, and also if admin deletes a PV that is bound to a PVC, the PV is not removed immediately. PV removal is postponed until the PV is no longer bound to a PVC.
+If a user deletes a PVC in active use by a Pod, the PVC is not removed immediately. PVC removal is postponed until the PVC is no longer actively used by any Pods. Also, if an admin deletes a PV that is bound to a PVC, the PV is not removed immediately. PV removal is postponed until the PV is no longer bound to a PVC.
 
 You can see that a PVC is protected when the PVC's status is `Terminating` and the `Finalizers` list includes `kubernetes.io/pvc-protection`:
 
@@ -130,7 +130,7 @@ Events:            <none>
 
 ### Reclaiming
 
-When a user is done with their volume, they can delete the PVC objects from the API which allows reclamation of the resource. The reclaim policy for a `PersistentVolume` tells the cluster what to do with the volume after it has been released of its claim. Currently, volumes can either be Retained, Recycled or Deleted.
+When a user is done with their volume, they can delete the PVC objects from the API that allows reclamation of the resource. The reclaim policy for a `PersistentVolume` tells the cluster what to do with the volume after it has been released of its claim. Currently, volumes can either be Retained, Recycled, or Deleted.
 
 #### Retain
 
@@ -142,7 +142,7 @@ The `Retain` reclaim policy allows for manual reclamation of the resource. When 
 
 #### Delete
 
-For volume plugins that support the `Delete` reclaim policy, deletion removes both the `PersistentVolume` object from Kubernetes, as well as the associated storage asset in the external infrastructure, such as an AWS EBS, GCE PD, Azure Disk, or Cinder volume. Volumes that were dynamically provisioned inherit the [reclaim policy of their `StorageClass`](#reclaim-policy), which defaults to `Delete`. The administrator should configure the `StorageClass` according to users' expectations, otherwise the PV must be edited or patched after it is created. See [Change the Reclaim Policy of a PersistentVolume](/docs/tasks/administer-cluster/change-pv-reclaim-policy/).
+For volume plugins that support the `Delete` reclaim policy, deletion removes both the `PersistentVolume` object from Kubernetes, as well as the associated storage asset in the external infrastructure, such as an AWS EBS, GCE PD, Azure Disk, or Cinder volume. Volumes that were dynamically provisioned inherit the [reclaim policy of their `StorageClass`](#reclaim-policy), which defaults to `Delete`. The administrator should configure the `StorageClass` according to users' expectations; otherwise, the PV must be edited or patched after it is created. See [Change the Reclaim Policy of a PersistentVolume](/docs/tasks/administer-cluster/change-pv-reclaim-policy/).
 
 #### Recycle
 
@@ -152,7 +152,7 @@ The `Recycle` reclaim policy is deprecated. Instead, the recommended approach is
 
 If supported by the underlying volume plugin, the `Recycle` reclaim policy performs a basic scrub (`rm -rf /thevolume/*`) on the volume and makes it available again for a new claim.
 
-However, an administrator can configure a custom recycler pod template using the Kubernetes controller manager command line arguments as described [here](/docs/admin/kube-controller-manager/). The custom recycler pod template must contain a `volumes` specification, as shown in the example below:
+However, an administrator can configure a custom recycler Pod template using the Kubernetes controller manager command line arguments as described [here](/docs/admin/kube-controller-manager/). The custom recycler Pod template must contain a `volumes` specification, as shown in the example below:
 
 ```yaml
 apiVersion: v1
@@ -175,7 +175,7 @@ spec:
       mountPath: /scrub
 ```
 
-However, the particular path specified in the custom recycler pod template in the `volumes` part is replaced with the particular path of the volume that is being recycled.
+However, the particular path specified in the custom recycler Pod template in the `volumes` part is replaced with the particular path of the volume that is being recycled.
 
 ### Expanding Persistent Volumes Claims
 
@@ -219,7 +219,7 @@ new `PersistentVolume` is never created to satisfy the claim. Instead, an existi
 
 {{< feature-state for_k8s_version="v1.16" state="beta" >}}
 
-Support for expanding CSI volumes is enabled by default but it also requires specific CSI driver to support volume expansion. Please refer to documentation of specific CSI driver for more information.
+Support for expanding CSI volumes is enabled by default but it also requires a specific CSI driver to support volume expansion. Refer to documentation of the specific CSI driver for more information.
 
 
 #### Resizing a volume containing a file system
@@ -227,34 +227,34 @@ Support for expanding CSI volumes is enabled by default but it also requires spe
 You can only resize volumes containing a file system if the file system is XFS, Ext3, or Ext4.
 
 When a volume contains a file system, the file system is only resized when a new Pod is using
-the `PersistentVolumeClaim` in ReadWrite mode. File system expansion is either done when Pod is starting up
-or is done when Pod is running and underlying file system supports online expansion.
+the `PersistentVolumeClaim` in ReadWrite mode. File system expansion is either done when a Pod is starting up
+or when a Pod is running and the underlying file system supports online expansion.
 
-FlexVolumes allow resize if the driver is set with the `RequiresFSResize` capability to true.
-The FlexVolume can be resized on pod restart.
+FlexVolumes allow resize if the driver is set with the `RequiresFSResize` capability to `true`.
+The FlexVolume can be resized on Pod restart.
 
 #### Resizing an in-use PersistentVolumeClaim
 
 {{< feature-state for_k8s_version="v1.15" state="beta" >}}
 
 {{< note >}}
-Expanding in-use PVCs is available as beta since 1.15, and as alpha since Kubernetes 1.11. The `ExpandInUsePersistentVolumes` feature must be enabled, which is the case automatically for many clusters for beta features. Please refer to the [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) documentation for more information.
+Expanding in-use PVCs is available as beta since Kubernetes 1.15, and as alpha since 1.11. The `ExpandInUsePersistentVolumes` feature must be enabled, which is the case automatically for many clusters for beta features. Refer to the [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) documentation for more information.
 {{< /note >}}
 
 In this case, you don't need to delete and recreate a Pod or deployment that is using an existing PVC.
 Any in-use PVC automatically becomes available to its Pod as soon as its file system has been expanded.
-This feature has no effect on PVCs that are not in use by a Pod or deployment. You must create a Pod which
+This feature has no effect on PVCs that are not in use by a Pod or deployment. You must create a Pod that
 uses the PVC before the expansion can complete.
 
 
-Similar to other volume types - FlexVolume volumes can also be expanded when in-use by a pod.
+Similar to other volume types - FlexVolume volumes can also be expanded when in-use by a Pod.
 
 {{< note >}}
 FlexVolume resize is possible only when the underlying driver supports resize.
 {{< /note >}}
 
 {{< note >}}
-Expanding EBS volumes is a time consuming operation. Also, there is a per-volume quota of one modification every 6 hours.
+Expanding EBS volumes is a time-consuming operation. Also, there is a per-volume quota of one modification every 6 hours.
 {{< /note >}}
 
 
@@ -325,7 +325,7 @@ parameter.
 
 ### Access Modes
 
-A `PersistentVolume` can be mounted on a host in any way supported by the resource provider.  As shown in the table below, providers will have different capabilities and each PV's access modes are set to the specific modes supported by that particular volume.  For example, NFS can support multiple read/write clients, but a specific NFS PV might be exported on the server as read-only.  Each PV gets its own set of access modes describing that specific PV's capabilities.
+A `PersistentVolume` can be mounted on a host in any way supported by the resource provider. As shown in the table below, providers will have different capabilities and each PV's access modes are set to the specific modes supported by that particular volume.  For example, NFS can support multiple read/write clients, but a specific NFS PV might be exported on the server as read-only. Each PV gets its own set of access modes describing that specific PV's capabilities.
 
 The access modes are:
 
@@ -360,7 +360,7 @@ In the CLI, the access modes are abbreviated to:
 | Quobyte              | &#x2713;               | &#x2713;              | &#x2713;     |
 | NFS                  | &#x2713;               | &#x2713;              | &#x2713;     |
 | RBD                  | &#x2713;               | &#x2713;              | -            |
-| VsphereVolume        | &#x2713;               | -                     | - (works when pods are collocated)  |
+| VsphereVolume        | &#x2713;               | -                     | - (works when Pods are collocated)  |
 | PortworxVolume       | &#x2713;               | -                     | &#x2713;     |
 | ScaleIO              | &#x2713;               | &#x2713;              | -            |
 | StorageOS            | &#x2713;               | -                     | -            |
@@ -375,7 +375,7 @@ that class. A PV with no `storageClassName` has no class and can only be bound
 to PVCs that request no particular class.
 
 In the past, the annotation `volume.beta.kubernetes.io/storage-class` was used instead
-of the `storageClassName` attribute. This annotation is still working, however
+of the `storageClassName` attribute. This annotation is still working; however,
 it will become fully deprecated in a future Kubernetes release.
 
 ### Reclaim Policy
@@ -393,7 +393,7 @@ Currently, only NFS and HostPath support recycling. AWS EBS, GCE PD, Azure Disk,
 A Kubernetes administrator can specify additional mount options for when a Persistent Volume is mounted on a node.
 
 {{< note >}}
-Not all Persistent volume types support mount options.
+Not all Persistent Volume types support mount options.
 {{< /note >}}
 
 The following volume types support mount options:
@@ -415,7 +415,7 @@ The following volume types support mount options:
 Mount options are not validated, so mount will simply fail if one is invalid.
 
 In the past, the annotation `volume.beta.kubernetes.io/mount-options` was used instead
-of the `mountOptions` attribute. This annotation is still working, however
+of the `mountOptions` attribute. This annotation is still working; however,
 it will become fully deprecated in a future Kubernetes release.
 
 ### Node Affinity
@@ -471,7 +471,7 @@ Claims use the same convention as volumes to indicate the consumption of the vol
 
 ### Resources
 
-Claims, like pods, can request specific quantities of a resource.  In this case, the request is for storage.  The same [resource model](https://git.k8s.io/community/contributors/design-proposals/scheduling/resources.md) applies to both volumes and claims.
+Claims, like Pods, can request specific quantities of a resource. In this case, the request is for storage. The same [resource model](https://git.k8s.io/community/contributors/design-proposals/scheduling/resources.md) applies to both volumes and claims.
 
 ### Selector
 
@@ -480,7 +480,7 @@ Claims can specify a [label selector](/docs/concepts/overview/working-with-objec
 * `matchLabels` - the volume must have a label with this value
 * `matchExpressions` - a list of requirements made by specifying key, list of values, and operator that relates the key and values. Valid operators include In, NotIn, Exists, and DoesNotExist.
 
-All of the requirements, from both `matchLabels` and `matchExpressions` are ANDed together – they must all be satisfied in order to match.
+All of the requirements, from both `matchLabels` and `matchExpressions`, are ANDed together – they must all be satisfied in order to match.
 
 ### Class
 
@@ -494,14 +494,14 @@ PVCs don't necessarily have to request a class. A PVC with its `storageClassName
 equal to `""` is always interpreted to be requesting a PV with no class, so it
 can only be bound to PVs with no class (no annotation or one set equal to
 `""`). A PVC with no `storageClassName` is not quite the same and is treated differently
-by the cluster depending on whether the
+by the cluster, depending on whether the
 [`DefaultStorageClass` admission plugin](/docs/reference/access-authn-authz/admission-controllers/#defaultstorageclass)
 is turned on.
 
 * If the admission plugin is turned on, the administrator may specify a
   default `StorageClass`. All PVCs that have no `storageClassName` can be bound only to
   PVs of that default. Specifying a default `StorageClass` is done by setting the
-  annotation `storageclass.kubernetes.io/is-default-class` equal to "true" in
+  annotation `storageclass.kubernetes.io/is-default-class` equal to `true` in
   a `StorageClass` object. If the administrator does not specify a default, the
   cluster responds to PVC creation as if the admission plugin were turned off. If
   more than one default is specified, the admission plugin forbids the creation of
@@ -512,7 +512,7 @@ is turned on.
   same way as PVCs that have their `storageClassName` set to `""`.
 
 Depending on installation method, a default StorageClass may be deployed
-to Kubernetes cluster by addon manager during installation.
+to a Kubernetes cluster by addon manager during installation.
 
 When a PVC specifies a `selector` in addition to requesting a `StorageClass`,
 the requirements are ANDed together: only a PV of the requested class and with
@@ -523,12 +523,12 @@ Currently, a PVC with a non-empty `selector` can't have a PV dynamically provisi
 {{< /note >}}
 
 In the past, the annotation `volume.beta.kubernetes.io/storage-class` was used instead
-of `storageClassName` attribute. This annotation is still working, however
+of `storageClassName` attribute. This annotation is still working; however,
 it won't be supported in a future Kubernetes release.
 
 ## Claims As Volumes
 
-Pods access storage by using the claim as a volume.  Claims must exist in the same namespace as the pod using the claim.  The cluster finds the claim in the pod's namespace and uses it to get the `PersistentVolume` backing the claim.  The volume is then mounted to the host and into the pod.
+Pods access storage by using the claim as a volume. Claims must exist in the same namespace as the Pod using the claim. The cluster finds the claim in the Pod's namespace and uses it to get the `PersistentVolume` backing the claim. The volume is then mounted to the host and into the Pod.
 
 ```yaml
 apiVersion: v1
@@ -557,7 +557,7 @@ spec:
 {{< feature-state for_k8s_version="v1.13" state="beta" >}}
 
 The following volume plugins support raw block volumes, including dynamic provisioning where
-applicable.
+applicable:
 
 * AWSElasticBlockStore
 * AzureDisk
@@ -627,7 +627,7 @@ spec:
 ```
 
 {{< note >}}
-When adding a raw block device for a Pod, we specify the device path in the container instead of a mount path.
+When adding a raw block device for a Pod, you specify the device path in the container instead of a mount path.
 {{< /note >}}
 
 ### Binding Block Volumes
@@ -686,7 +686,7 @@ spec:
 
 Volume clone feature was added to support CSI Volume Plugins only. For details, see [volume cloning](/docs/concepts/storage/volume-pvc-datasource/).
 
-To enable support for cloning a volume from a pvc data source, enable the
+To enable support for cloning a volume from a PVC data source, enable the
 `VolumePVCDataSource` feature gate on the apiserver and controller-manager.
 
 ### Create Persistent Volume Claim from an existing pvc
@@ -710,9 +710,9 @@ spec:
 ## Writing Portable Configuration
 
 If you're writing configuration templates or examples that run on a wide range of clusters
-and need persistent storage, we recommend that you use the following pattern:
+and need persistent storage, it is recommended that you use the following pattern:
 
-- Do include PersistentVolumeClaim objects in your bundle of config (alongside
+- Include PersistentVolumeClaim objects in your bundle of config (alongside
   Deployments, ConfigMaps, etc).
 - Do not include PersistentVolume objects in the config, since the user instantiating
   the config may not have permission to create PersistentVolumes.
@@ -725,10 +725,10 @@ and need persistent storage, we recommend that you use the following pattern:
   - If the user does not provide a storage class name, leave the
     `persistentVolumeClaim.storageClassName` field as nil.
     - This will cause a PV to be automatically provisioned for the user with
-      the default StorageClass in the cluster.  Many cluster environments have
+      the default StorageClass in the cluster. Many cluster environments have
       a default StorageClass installed, or administrators can create their own
       default StorageClass.
-- In your tooling, do watch for PVCs that are not getting bound after some time
+- In your tooling, watch for PVCs that are not getting bound after some time
   and surface this to the user, as this may indicate that the cluster has no
   dynamic storage support (in which case the user should create a matching PV)
   or the cluster has no storage system (in which case the user cannot deploy


### PR DESCRIPTION
Capitalize instances of Pod and other minor edits (for example, change instances of "we") to conform with the [Documentation style guide](https://kubernetes.io/docs/contribute/style/style-guide) and for improved readability.