### PR TITLE
Set stewart-yu to emeritus approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,6 +9,8 @@ approvers:
 emeritus_approvers:
 - chenopis
 - jaredbhatti
+# stewart-yu, you're welcome to return when you're ready to resume PR wrangling
+- stewart-yu 
 
 labels:
 - sig/docs

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -50,7 +50,6 @@ aliases:
     - ryanmcginnis
     - simplytunde
     - steveperry-53
-    - stewart-yu
     - tengqm
     - tfogo
     - xiangpengzhao
@@ -59,7 +58,6 @@ aliases:
   sig-docs-en-reviews: # PR reviews for English content
     - rajakavitha1
     - sftim
-    - stewart-yu
   sig-docs-es-owners: # Admins for Spanish content
     - raelga
     - alexbrand


### PR DESCRIPTION
This PR removes @stewart-yu as an approver for k/website.

@stewart-yu missed his [PR wrangler shift](https://github.com/kubernetes/website/wiki/PR-Wranglers) last week and doesn't have a [Kubernetes Slack ID](https://app.slack.com/client/T09NY5SBT/C1J0BPD2M) or clearly associated email to respond to queries. We [haven't been able to reach him](https://github.com/kubernetes/community/blob/master/contributors/guide/expectations.md#expectations-of-reviewers-review-latency) in over a week.

@stewart-yu We hope you're OK! 💜 Please let us know if you're on vacation or need a break. Also, please sign up for [K8s slack](https://slack.k8s.io) and let a SIG Docs chair (myself, @jimangel, @Bradamant3) know how to contact you by email.

### Update (15 Oct 2019)

@stewart-yu reached out to me on Slack (`@Yu Chianjian`) to provide his email address to let me know that he's busy with work and will be returning in a month's time.

I recommend we assign him status as an emeritus approver (no ability to approve PRs, no auto assignments, can return later at their discretion).

### Lazy consensus

This PR should merge unless these three conditions are true by 5:30pm Pacific on Thursday, October 10, 2019 (~48 hours from now):
- [ ] @stewart-yu replies to this PR
- [x] @stewart-yu signs up for Kubernetes Slack
- [x] @stewart-yu shares an email address with at least one chair of SIG Docs via Slack

### Dependency

If this PR merges, it requires a followup PR in [k/org](https://github.com/kubernetes/org/blob/master/config/kubernetes/sig-docs/teams.yaml).

/assign @Bradamant3 @jimangel 
