### PR TITLE
Correct the link of #sig-docs

### DIFF
--- a/content/en/docs/contribute/start.md
+++ b/content/en/docs/contribute/start.md
@@ -50,7 +50,7 @@ The SIG Docs community created guidelines about what kind of content is allowed
 in the Kubernetes documentation. Look over the [Documentation Content 
 Guide](/docs/contribute/style/content-guide/) to determine if the content 
 contribution you want to make is allowed. You can ask questions about allowed 
-content in the [#sig-docs]((#participate-in-sig-docs-discussions)) Slack 
+content in the [#sig-docs](#participate-in-sig-docs-discussions) Slack
 channel.
 
 ### Style guidelines


### PR DESCRIPTION
The link of #sig-docs in https://kubernetes.io/docs/contribute/start/ can't be access.