### PR TITLE
Remove trailing spaces from 'no' documents(#16742)

### DIFF
--- a/content/no/docs/reference/glossary/container.md
+++ b/content/no/docs/reference/glossary/container.md
@@ -6,14 +6,14 @@ full_link: /docs/concepts/overview/what-is-kubernetes/#why-containers
 short_description: >
   En lett-vekts kontainer med alle avhengigheter.
 
-aka: 
+aka:
 tags:
 - fundamental
 - workload
 ---
  En lett-vekts kontainer med alle avhengigheter.
 
-<!--more--> 
+<!--more-->
 
 Mer tekst her.
 


### PR DESCRIPTION
This PR removes trailing spaces from "no" doc.  Following command are used.
```
sed -i 's/[ ]*$//' $(find content/no -type f -not -name "*.png" -not -name "*.jpg" -not -name "*.svg" -not -name "*.gif")
```
