### PR TITLE
Remove trailing spaces from pt documents(#16742)

### DIFF
--- a/content/pt/community/_index.html
+++ b/content/pt/community/_index.html
@@ -8,8 +8,8 @@ cid: community
     <main>
         <div class="content">
             <h3>Garantir que o Kubernetes funcione bem em todos os lugares e para todos.</h3>
-            <p>Conecte-se à comunidade do Kubernetes no nosso canal <a href="http://slack.k8s.io/">canal do Slack</a>, <a href="https://discuss.kubernetes.io/"> no fórum de discussão</a>, ou participe do grupo <a href="https://groups.google.com/forum/#!forum/kubernetes-dev">Kubernetes-dev Google group</a>. 
-                Uma reunião semanal da comunidade é realizada por meio de videoconferência para discutir o estado das coisas. Veja essas 
+            <p>Conecte-se à comunidade do Kubernetes no nosso canal <a href="http://slack.k8s.io/">canal do Slack</a>, <a href="https://discuss.kubernetes.io/"> no fórum de discussão</a>, ou participe do grupo <a href="https://groups.google.com/forum/#!forum/kubernetes-dev">Kubernetes-dev Google group</a>.
+                Uma reunião semanal da comunidade é realizada por meio de videoconferência para discutir o estado das coisas. Veja essas
 		<a href="https://github.com/kubernetes/community/blob/master/events/community-meeting.md">instruções </a> para obter informações sobre como participar.</p>
             <p>Você também pode participar do Kubernetes em todo o mundo através de nossa
                 <a href="https://www.meetup.com/topics/kubernetes/">Comunidade Meetup de Kubernetes</a> e
@@ -17,7 +17,7 @@ cid: community
           </div>
         <div class="content">
             <h3>Grupos de Interesse Especial (SIGs)</h3>
-            <p>Tem um interesse especial em saber como o Kubernetes trabalha com outra tecnologia? 
+            <p>Tem um interesse especial em saber como o Kubernetes trabalha com outra tecnologia?
                 Veja nossas <a href="https://git.k8s.io/community/sig-list.md">listas</a>
                 cada vez maiores de SIGs,de AWS e Openstack ate Big Data e Escalabilidade, há um lugar para você contribuir e instruções para formar um novo SIG se o seu interesse especial não estiver coberto (ainda).
             </p>
@@ -30,12 +30,12 @@ cid: community
         <div class="content">
           <h3>Código de conduta</h3>
           <p>
-            A comunidade Kubernetes valoriza o respeito e a inclusão e aplica um 
+            A comunidade Kubernetes valoriza o respeito e a inclusão e aplica um
             <a href="code-of-conduct/"></a>Código de Conduta</a>
-            em todas as interações. Se você notar uma violação do Código de Conduta em um evento ou reunião, 
-            no Slack ou em outro mecanismo de comunicação, entre em contato com o 
+            em todas as interações. Se você notar uma violação do Código de Conduta em um evento ou reunião,
+            no Slack ou em outro mecanismo de comunicação, entre em contato com o
             <a href="https://github.com/kubernetes/community/tree/master/committee-code-of-conduct">Comitê de Código de Conduta da Kubernetes</a>
-            <a href="mailto:conduct@kubernetes.io">conduct@kubernetes.io</a>            
+            <a href="mailto:conduct@kubernetes.io">conduct@kubernetes.io</a>
             Seu anonimato será protegido.
           </p>
          </div>
@@ -45,7 +45,7 @@ cid: community
 <section id="talkToUs">
     <main>
         <h3>Fale Conosco</h3>
-        <h4>Gostaríamos muito de ouvir de você, como você está usando o Kubernetes<br> 
+        <h4>Gostaríamos muito de ouvir de você, como você está usando o Kubernetes<br>
                 e o que podemos fazer para torná-lo melhor.
         </h4>
         <div id="bigSocial">

--- a/content/pt/community/code-of-conduct.md
+++ b/content/pt/community/code-of-conduct.md
@@ -17,7 +17,7 @@ Se você perceber que isso está desatualizado, por favor
 
 Se você notar uma violação do Código de Conduta em um evento ou meetup,
 ou em outro meio de comunicação, entre em contato com
-<a href="https://git.k8s.io/community/committee-code-of-conduct">Comitê de Código de Conduta da Comunidade Kubernetes</a>. 
+<a href="https://git.k8s.io/community/committee-code-of-conduct">Comitê de Código de Conduta da Comunidade Kubernetes</a>.
 Você pode nos contatar por e-mail em<a href="mailto:conduct@kubernetes.io">conduct@kubernetes.io</a>.
 Seu anonimato será protegido.
 

--- a/content/pt/docs/concepts/cluster-administration/cluster-administration-overview.md
+++ b/content/pt/docs/concepts/cluster-administration/cluster-administration-overview.md
@@ -57,7 +57,7 @@ a permissão para usuários e contas de serviço.
 * [Usando Sysctls em um Cluster Kubernetes](/docs/concepts/cluster-administration/sysctl-cluster/) descreve a um administrador como usar a ferramenta de linha de comando `sysctl` para definir os parâmetros do kernel.
 
 
-* [Auditando](/docs/tasks/debug-application-cluster/audit/) 
+* [Auditando](/docs/tasks/debug-application-cluster/audit/)
 descreve como interagir com os logs de auditoria do Kubernetes.
 
 ### Protegendo o kubelet

--- a/content/pt/docs/home/_index.md
+++ b/content/pt/docs/home/_index.md
@@ -1,7 +1,7 @@
 ---
 approvers:
 - chenopis
-title: Kubernetes 
+title: Kubernetes
 noedit: true
 cid: docsHome
 layout: docsportal_home

--- a/content/pt/partners/_index.html
+++ b/content/pt/partners/_index.html
@@ -16,7 +16,7 @@ cid: parceiros
               <h5>
                 <b>Provedores de serviços certificados em Kubernetes</b>
               </h5>
-              <br>Provedores de serviços certificados, com profunda experiência em ajudar empresas a adotar Kubernetes com sucesso. 
+              <br>Provedores de serviços certificados, com profunda experiência em ajudar empresas a adotar Kubernetes com sucesso.
               <br><br><br>
               <button id="kcsp" class="button" onClick="updateSrc(this.id)">See KCSP Partners</button>
               <br><br>Interessado em se tornar um <a href="https://www.cncf.io/certification/kcsp/">KCSP</a>?
@@ -26,7 +26,7 @@ cid: parceiros
             <center>
               <h5>
                 <b>Distribuições certificadas do Kubernetes, plataformas hospedadas e instaladores                  </b>
-              </h5>A conformidade com o software garante que a versão de cada fornecedor do Kubernetes suporte as APIs necessárias. 
+              </h5>A conformidade com o software garante que a versão de cada fornecedor do Kubernetes suporte as APIs necessárias.
               <br><br><br>
               <button id="conformance" class="button" onClick="updateSrc(this.id)">See Conformance Partners</button>
               <br><br>Interessado em se tornar<a href="https://www.cncf.io/certification/software-conformance/">Certified Kubernetes</a>?
@@ -36,7 +36,7 @@ cid: parceiros
             <center>
               <h5><b>Parceiros de treinamento da Kubernetes
                 </b></h5>
-              <br>Provedores de treinamento certificados que têm profunda experiência em treinamento em tecnologia nativa em nuvem. 
+              <br>Provedores de treinamento certificados que têm profunda experiência em treinamento em tecnologia nativa em nuvem.
               <br><br><br><br>
               <button id="ktp" class="button" onClick="updateSrc(this.id)">Veja Parceiros KTP</button>
               <br><br>Interessado em se tornar um<a href="https://www.cncf.io/certification/training/">KTP</a>?


### PR DESCRIPTION
This PR removes trailing spaces from pt doc.  Following command are used.
```
sed -i 's/[ ]*$//' $(find content/pt -type f -not -name "*.png" -not -name "*.jpg" -not -name "*.svg" -not -name "*.gif")
```
