### PR TITLE
Add the -n for pod in kubectl command

### DIFF
--- a/content/en/docs/contribute/style/style-guide.md
+++ b/content/en/docs/contribute/style/style-guide.md
@@ -73,9 +73,9 @@ represents.
 
 1. Display information about a Pod:
 
-        kubectl describe pod <pod-name>
+        kubectl describe pod <pod-name> -n <namespace>
 
-    where `<pod-name>` is the name of one of your Pods.
+    If the namespace of the pod is `default`, you can omit the '-n' parameter.
 
 ### Use bold for user interface elements
 


### PR DESCRIPTION
'kubectl describe pod <pod-name>' is only valid for the default namespace. It should take ‘-n’ parameters and explain it.
