### PR TITLE
add daminisatya as en owner

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -39,6 +39,7 @@ aliases:
     - bradtopol
     - chenopis
     - cody-clark
+    - daminisatya
     - gochist
     - jaredbhatti
     - jimangel


### PR DESCRIPTION
This is to add 1.17 docs lead, @daminisatya, to the list of en owners as required by the [role handbook](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/docs).

