### PR TITLE
Update release-1.15 to Hugo version 0.57.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DOCKER       = docker
-HUGO_VERSION = 0.53
+HUGO_VERSION = 0.57.2
 DOCKER_IMAGE = kubernetes-hugo
 DOCKER_RUN   = $(DOCKER) run --rm --interactive --tty --volume $(CURDIR):/src
 NODE_BIN     = node_modules/.bin

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@ functions = "functions"
 command = "make non-production-build"
 
 [build.environment]
-HUGO_VERSION = "0.53"
+HUGO_VERSION = "0.57.2"
 
 [context.production.environment]
 HUGO_BASEURL = "https://kubernetes.io/"


### PR DESCRIPTION
This PR reintroduces #16094, which replicates #16104 and #16151 for `release-1.15`.

Fixes #16066

### Context

#16066 exhibits behavior characteristic of gohugoio/hugo#5615. To resolve the issue, we need to upgrade Hugo to a version that includes the solution.

Because #16094 got lost in the release timing shuffle, this PR didn't make it into `release-1.15` before 1.16 was released. This PR also needs to be introduced into `master` in a separate PR.

/sig docs
/priority important-soon

/assign @aimeeu 