### PR TITLE
Typo in San Diego city name

### DIFF
--- a/content/en/blog/_posts/2019-10-10-contributor-summit-san-diego-schedule.md
+++ b/content/en/blog/_posts/2019-10-10-contributor-summit-san-diego-schedule.md
@@ -55,7 +55,7 @@ and there will be a huge Meet & Greet for new contributors to find their SIG
 Monday.
 
 Hope to see you all there, and [make sure you register!][reg]
-[San Deigo team][team]
+[San Diego team][team]
 
 [reg]: https://events19.linuxfoundation.org/events/kubernetes-contributor-summit-north-america-2019/register/
 [schedule]: https://events19.linuxfoundation.org/events/kubernetes-contributor-summit-north-america-2019/program/schedule/


### PR DESCRIPTION
Minor typo fix in the Contributor Summit San Diego blog post.