### PR TITLE
modify the file name to increase the contrast

### DIFF
--- a/content/en/docs/tasks/run-application/update-api-object-kubectl-patch.md
+++ b/content/en/docs/tasks/run-application/update-api-object-kubectl-patch.md
@@ -56,7 +56,7 @@ get terminated and replaced by new ones.
 At this point, each Pod has one Container that runs the nginx image. Now suppose
 you want each Pod to have two containers: one that runs nginx and one that runs redis.
 
-Create a file named `patch-file-containers.yaml` that has this content:
+Create a file named `patch-file.yaml` that has this content:
 
 ```yaml
 spec:
@@ -71,10 +71,10 @@ Patch your Deployment:
 
 {{< tabs name="kubectl_patch_example" >}}
 {{{< tab name="Bash" codelang="bash" >}}
-kubectl patch deployment patch-demo --patch "$(cat patch-file-containers.yaml)"
+kubectl patch deployment patch-demo --patch "$(cat patch-file.yaml)"
 {{< /tab >}}
 {{< tab name="PowerShell" codelang="posh" >}}
-kubectl patch deployment patch-demo --patch $(cat patch-file-containers.yaml)
+kubectl patch deployment patch-demo --patch $(cat patch-file.yaml)
 {{< /tab >}}}
 {{< /tabs >}}
 
@@ -311,7 +311,7 @@ The following commands are equivalent:
 
 
 ```shell
-kubectl patch deployment patch-demo --patch "$(cat patch-file.json)"
+kubectl patch deployment patch-demo --patch "$(cat patch-file.yaml)"
 kubectl patch deployment patch-demo --patch 'spec:\n template:\n  spec:\n   containers:\n   - name: patch-demo-ctr-2\n     image: redis'
 
 kubectl patch deployment patch-demo --patch "$(cat patch-file.json)"


### PR DESCRIPTION
Modify the file name to increase the contrast.

The above content of the last update command is `The following commands are equivalent:`. But there are two same commands. **The context shows that the `kubectl patch` command can use both YAML content and JSON content. There is only a JSON file, not a YAML file.**

In my opinion, the parameter of the first command should be a YAML file. So, combined with the context, I modified the file name.