### PR TITLE
fix url to ReplicationController

### DIFF
--- a/content/en/docs/tasks/run-application/rolling-update-replication-controller.md
+++ b/content/en/docs/tasks/run-application/rolling-update-replication-controller.md
@@ -67,7 +67,7 @@ The configuration file must:
 * Use the same `metadata.namespace`.
 
 Replication controller configuration files are described in
-[Creating Replication Controllers](/docs/tutorials/stateless-application/run-stateless-ap-replication-controller/).
+[Creating Replication Controllers](/docs/concepts/workloads/controllers/replicationcontroller/).
 
 ### Examples
 


### PR DESCRIPTION
Rolling update for ReplicationController. But the link is to "Run a Stateless Application Using a Deployment" which does not use ReplicationController.