### PR TITLE
Pods count should be part of object-count's spec.

### DIFF
--- a/content/en/docs/concepts/policy/resource-quotas.md
+++ b/content/en/docs/concepts/policy/resource-quotas.md
@@ -401,7 +401,6 @@ metadata:
   name: compute-resources
 spec:
   hard:
-    pods: "4"
     requests.cpu: "1"
     requests.memory: 1Gi
     limits.cpu: "2"
@@ -424,6 +423,7 @@ spec:
   hard:
     configmaps: "10"
     persistentvolumeclaims: "4"
+    pods: "4"
     replicationcontrollers: "20"
     secrets: "10"
     services: "10"
@@ -456,7 +456,6 @@ Resource                 Used  Hard
 --------                 ----  ----
 limits.cpu               0     2
 limits.memory            0     2Gi
-pods                     0     4
 requests.cpu             0     1
 requests.memory          0     1Gi
 requests.nvidia.com/gpu  0     4
@@ -473,6 +472,7 @@ Resource                Used    Hard
 --------                ----    ----
 configmaps              0       10
 persistentvolumeclaims  0       4
+pods                    0       4
 replicationcontrollers  0       20
 secrets                 1       10
 services                0       10


### PR DESCRIPTION
Pods count was added in compute-resources spec which should be in objects-count spec as we're passing count of pods in the definition.

