### PR TITLE
Clean up https://kubernetes.io/docs/reference/kubectl/docker-cli-to-kubectl/

### DIFF
--- a/content/en/docs/reference/kubectl/docker-cli-to-kubectl.md
+++ b/content/en/docs/reference/kubectl/docker-cli-to-kubectl.md
@@ -354,11 +354,11 @@ kubectl:
 kubectl cluster-info
 ```
 ```
-Kubernetes master is running at https://108.59.85.141
-KubeDNS is running at https://108.59.85.141/api/v1/namespaces/kube-system/services/kube-dns/proxy
-kubernetes-dashboard is running at https://108.59.85.141/api/v1/namespaces/kube-system/services/kubernetes-dashboard/proxy
-Grafana is running at https://108.59.85.141/api/v1/namespaces/kube-system/services/monitoring-grafana/proxy
-Heapster is running at https://108.59.85.141/api/v1/namespaces/kube-system/services/monitoring-heapster/proxy
-InfluxDB is running at https://108.59.85.141/api/v1/namespaces/kube-system/services/monitoring-influxdb/proxy
+Kubernetes master is running at https://203.0.113.141
+KubeDNS is running at https://203.0.113.141/api/v1/namespaces/kube-system/services/kube-dns/proxy
+kubernetes-dashboard is running at https://203.0.113.141/api/v1/namespaces/kube-system/services/kubernetes-dashboard/proxy
+Grafana is running at https://203.0.113.141/api/v1/namespaces/kube-system/services/monitoring-grafana/proxy
+Heapster is running at https://203.0.113.141/api/v1/namespaces/kube-system/services/monitoring-heapster/proxy
+InfluxDB is running at https://203.0.113.141/api/v1/namespaces/kube-system/services/monitoring-influxdb/proxy
 ```
 {{% /capture %}}


### PR DESCRIPTION
108.59.85.141 is a genuine IPv4 address; at the time of writing it's assigned to Google LLC / Google Cloud Platform. Use a [documentation IPv4 address](https://tools.ietf.org/html/rfc5737) instead.

[Preview](https://deploy-preview-16867--kubernetes-io-master-staging.netlify.com/docs/reference/kubectl/docker-cli-to-kubectl/#docker-info)

/kind cleanup