### PR TITLE
[WIP] Add controller reference pages

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/garbage-collection.md
+++ b/content/en/docs/concepts/workloads/controllers/garbage-collection.md
@@ -17,16 +17,15 @@ that once had an owner, but no longer have an owner.
 ## Owners and dependents
 
 Some Kubernetes objects are owners of other objects. For example, a ReplicaSet
-is the owner of a set of Pods. The owned objects are called *dependents* of the
+owns a set of Pods. The owned objects are called *dependents* of the
 owner object. Every dependent object has a `metadata.ownerReferences` field that
 points to the owning object.
 
 Sometimes, Kubernetes sets the value of `ownerReference` automatically. For
 example, when you create a ReplicaSet, Kubernetes automatically sets the
-`ownerReference` field of each Pod in the ReplicaSet. In 1.8, Kubernetes
+`ownerReference` field of each Pod in the ReplicaSet. Kubernetes
 automatically sets the value of `ownerReference` for objects created or adopted
-by ReplicationController, ReplicaSet, StatefulSet, DaemonSet, Deployment, Job
-and CronJob.
+by workload resources such as {{< glossary_tooltip term_id="deployment" >}}.
 
 You can also specify relationships between owners and dependents by manually
 setting the `ownerReference` field.
@@ -164,20 +163,12 @@ to delete not only the ReplicaSets created, but also their Pods. If this type of
 is not used, only the ReplicaSets will be deleted, and the Pods will be orphaned.
 See [kubeadm/#149](https://github.com/kubernetes/kubeadm/issues/149#issuecomment-284766613) for more information.
 
-## Known issues
-
-Tracked at [#26120](https://github.com/kubernetes/kubernetes/issues/26120)
-
 {{% /capture %}}
-
 
 {{% capture whatsnext %}}
 
-[Design Doc 1](https://git.k8s.io/community/contributors/design-proposals/api-machinery/garbage-collection.md)
-
-[Design Doc 2](https://git.k8s.io/community/contributors/design-proposals/api-machinery/synchronous-garbage-collection.md)
+* Read the reference documentation for the [garbage collector](/docs/reference/controllers/garbage-collector/)
+* Read [Garbage collection design document 1](https://git.k8s.io/community/contributors/design-proposals/api-machinery/garbage-collection.md)
+* Read [Garbage collection design document 2](https://git.k8s.io/community/contributors/design-proposals/api-machinery/synchronous-garbage-collection.md)
 
 {{% /capture %}}
-
-
-

--- a/content/en/docs/reference/controllers/_index.md
+++ b/content/en/docs/reference/controllers/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Controllers reference"
+weight: 40
+---
+

--- a/content/en/docs/reference/controllers/admission-pod-preset.md
+++ b/content/en/docs/reference/controllers/admission-pod-preset.md
@@ -1,0 +1,59 @@
+---
+toc_hide: true
+toc_hide: true
+title: PodPreset controller
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+The PodPreset admission controller injects configuration data into
+{{< glossary_tooltip text="pods" term_id="pod" >}} when they are created.
+
+The configuration data can include {{< glossary_tooltip text="Secrets" term_id="secret" >}},
+{{< glossary_tooltip text="Volumes" term_id="volume" >}}, volume mounts,
+and {{< glossary_tooltip text="environment variables" term_id="container-env-variables" >}}.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+## Controller behavior
+
+This is a mutating
+[admission controller](/docs/reference/access-authn-authz/admission-controllers/#what-are-they)
+that acts on Pod creation requests.
+
+When a pod creation request arrives for processing, the controller:
+
+1. Retrieves all `PodPresets` available for use.
+1. Checks if the label selectors of any `PodPreset` match the labels on the
+   Pod being created.
+1. Attempts to merge the various resources defined by the `PodPreset` into the
+   Pod being created.
+1. On error, throws an event documenting the merge error on the Pod, and then
+   allows creation of the the Pod _without_ any injected resources from the `PodPreset`.
+1. Annotates the resulting modified Pod spec to indicate that it has been
+   modified by a `PodPreset`. The annotation is of the form
+   `podpreset.admission.kubernetes.io/podpreset-<pod-preset name>: "<resource version>"`.
+
+Each Pod can be matched by zero or more Pod Presets; and each `PodPreset` can be
+applied to zero or more pods. When a `PodPreset` is applied to one or more
+Pods, Kubernetes modifies the Pod Spec. For changes to `Env`, `EnvFrom`, and
+`VolumeMounts`, Kubernetes modifies the container spec for all containers in
+the Pod; for changes to `Volume`, Kubernetes modifies the Pod Spec.
+
+{{< note >}}
+A Pod Preset is capable of modifying the following fields in a Pod spec when appropriate:
+- The `.spec.containers` field.
+- The `initContainers` field (requires Kubernetes version 1.14.0 or later).
+{{< /note >}}
+
+{{% /capture %}}
+
+{{% capture whatsnext %}}
+
+* Learn how to [enable PodPreset](/docs/concepts/workloads/pods/podpreset/#enable-pod-preset)
+* Try to [inject information into Pods Using a PodPreset](/docs/tasks/inject-data-application/podpreset/)
+
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/built-in.md
+++ b/content/en/docs/reference/controllers/built-in.md
@@ -1,0 +1,49 @@
+---
+title: Built-in controllers
+content_template: templates/concept
+weight: 10
+---
+
+{{% capture overview %}}
+
+Kubernetes comes with a number of built-in 
+{{< glossary_tooltip text="controllers" term_id="controller" >}} that run as
+part of the {{< glossary_tooltip term_id="kube-controller-manager" >}}.
+
+This page summarizes the types of controller that come as part of Kubernetes
+itself.
+
+{{% /capture %}}
+
+{{% capture body %}}
+ 
+The built-in {{< glossary_tooltip term_id="kube-scheduler" >}}
+is itself a specialized controller. [Scheduling](/docs/concepts/scheduling/)
+means matching the desired set of running
+{{< glossary_tooltip text="Pods" term_id="pod" >}} against the available
+{{< glossary_tooltip text="Nodes" term_id="node" >}}.
+
+The kube-scheduler runs separately from the kube-controller-manager. This
+separation helps with control plane performance.
+
+{{< note >}}
+If your cluster is deployed against a cloud service provider, you can
+use the
+[cloud-controller-manager](/docs/reference/command-line-tools-reference/cloud-controller-manager/)
+to run additional provider-specific controllers such as
+[Route](/docs/concepts/architecture/cloud-controller/#route-controller).
+{{< /note >}}
+
+
+## Controllers grouped by purpose
+
+* [Workload controllers](/docs/reference/controllers/workload-controllers/)
+* [Pod management controllers](/docs/reference/controllers/workload-controllers/)
+* [Resource management controllers](/docs/reference/controllers/resource-management-controllers/)
+* [Certificate controllers](/docs/reference/controllers/certificate-controllers/)
+* [Storage controllers](/docs/reference/controllers/storage-controllers/)
+* [Networking controllers](/docs/reference/controllers/network-controllers/)
+* [Cluster orchestration controllers](/docs/reference/controllers/cluster-orchestration-controllers/)
+* [Resource clean-up controllers](/docs/reference/controllers/resource-cleanup-controllers/)
+
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/certificate-approver.md
+++ b/content/en/docs/reference/controllers/certificate-approver.md
@@ -1,0 +1,42 @@
+---
+toc_hide: true
+title: Certificate signature approver
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+The CertificateSigningRequest approver
+{{< glossary_tooltip term_id="controller" text="controller">}}
+(aka CSR approver) is part of a set of built-in controllers for certificate management.
+
+{{% /capture %}}
+
+
+{{% capture body %}}
+The CSR approver is built in to the {{< glossary_tooltip term_id="kube-controller-manager" >}}.
+
+## Controller behavior
+
+This controller acts specifically on CertificateSigningRequests (CSR) that come from
+the kubelet (or that purport to come from kubelet).
+
+When the kubelet is setting up on a new node, the kubelet generates a CSR and submits
+it to the Kubernetes API server using
+[bootstrap](/docs/reference/access-authn-authz/bootstrap-tokens/)
+authentication and authorization.
+
+This controller watches for CertificateSigningRequests from a kubelet. For each
+submitted CertificateSigningRequest, this controller creates a
+SubjectAccessReview object to verify whether this Node's kubelet is allowed to
+have its certificate signed.
+
+If the request is authentic and the SubjectAccessReview passes, the controller marks the
+CSR as approved. This approval allows the
+[certificate signer](/docs/reference/controllers/certificate-signer) to issue a certificate.
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+* Read about the [certificate signer](/docs/reference/controllers/certificate-signer/)
+* Read about other [certificate controllers](/docs/reference/controllers/certificate-controllers/)
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/certificate-cleaner.md
+++ b/content/en/docs/reference/controllers/certificate-cleaner.md
@@ -1,0 +1,30 @@
+---
+toc_hide: true
+title: Certificate signing request cleaner
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+This {{< glossary_tooltip term_id="controller" >}} removes certificate signing
+requests (CSRs) that have expired without being approved.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+The CSR cleaner is built in to the {{< glossary_tooltip term_id="kube-controller-manager" >}}.
+
+## Controller behavior
+
+This controller watches for CertificateSigningRequest objects and their approvals.
+
+After a CSR has been in the system for a certain amount of time without being approved,
+this controller deletes it.
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+* Read about the [certificate approver](/docs/reference/controllers/certificate-approver/)
+* Read about the [certificate signer](/docs/reference/controllers/certificate-signer/)
+* Learn about other [resource clean-up controllers](/docs/reference/controllers/resource-cleanup-controllers/)
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/certificate-controllers.md
+++ b/content/en/docs/reference/controllers/certificate-controllers.md
@@ -1,0 +1,64 @@
+---
+title: Certificate controllers
+content_template: templates/concept
+weight: 50
+---
+
+{{% capture overview %}}
+
+This page lists the
+{{< glossary_tooltip term_id="certificate" text="certificate" >}}
+{{< glossary_tooltip text="controllers" term_id="controller" >}}
+that come as part of Kubernetes itself.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+## Root certificate publisher
+
+The [root certificate publisher](/docs/reference/controllers/certificate-root-ca-publisher/)
+manages a {{< glossary_tooltip term_id="configmap" >}} in every configured Namespace, so that Pods in that
+namespace have access to the cluster's root certificate. Pods can load that
+ConfigMap and use the cluster root certificate to validate other components'
+identities.
+
+## Certificate signing controllers
+
+There are a set of three controllers that work together to provide signed
+certificates on demand, for use within your cluster:
+
+### Certificate signature approver
+
+The [certificate signature approver](/docs/reference/controllers/certificate-approver/)
+automates approval of certificate signing requests made by a Node within your
+cluster.
+
+{{< note >}}
+If you want to enable something that isn't a Node to use a CertificateSigningRequest and
+obtain valid cluster certificates, you can implement that in a new
+[custom controller](/docs/concepts/extend-kubernetes/extend-cluster/#extension-patterns).
+
+The built-in certificate signature approver only reacts to certificate signing
+requests that come from cluster nodes.
+{{< /note >}}
+
+### CertificateSigningRequest signer
+
+The [certificate signer](/docs/reference/controllers/certificate-signer/) is a
+controller that signs certificates based on a certificate signing request (CSR),
+once approved. The issued certificates will have a signing chain back to the
+root CA.
+
+### CSR cleaner
+
+Within your cluster, CertificateSigningRequests (CSRs) stay valid only for a
+limited time.
+The [CSR cleaner](/docs/reference/controllers/certificate-cleaner/)
+removes CertificateSigningRequests that have expired without being approved.
+
+{{% /capture %}}
+
+{{% capture whatsnext %}}
+* Read about [storage controllers](/docs/reference/controllers/storage-controllers/)
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/certificate-root-ca-publisher.md
+++ b/content/en/docs/reference/controllers/certificate-root-ca-publisher.md
@@ -1,0 +1,32 @@
+---
+toc_hide: true
+title: Root CA controller
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+Kubernetes clusters have a [certificate authority](/docs/concepts/cluster-administration/certificates/)
+(CA) that the control plane uses to authenticate different components.
+
+This {{< glossary_tooltip term_id="controller" text="controller" >}} manages a
+{{< glossary_tooltip term_id="configmap" >}} in every configured
+{{< glossary_tooltip term_id="namespace" >}}, so that Pods
+in that Namespace have access to the cluster's root CA and can validate other
+components' identity.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+The root CA controller is built in to the {{< glossary_tooltip term_id="kube-controller-manager" >}}.
+
+## Controller behavior
+
+This controller watches for Namespaces. For every new Namespace, the
+controller adds a ConfigMap containing the cluster's root certificate.
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+* Read about other [certificate controllers](/docs/reference/controllers/certificate-controllers/)
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/certificate-signer.md
+++ b/content/en/docs/reference/controllers/certificate-signer.md
@@ -1,0 +1,35 @@
+---
+toc_hide: true
+title: Certificate signer controller
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+A {{< glossary_tooltip term_id="controller" text="controller" >}} that signs
+{{< glossary_tooltip text="certificates" term_id="certificate" >}},
+based on a certificate signing request (CSR), once approved. The issued
+certificates will have a signing chain back to the cluster's root CA.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+The certificate signer is built in to the {{< glossary_tooltip term_id="kube-controller-manager" >}}.
+You can add your own controller, either to work alongside this built-in
+controller, or to work in its place.
+
+## Controller behavior
+
+This controller watches for CertificateSigningRequest (CSR) objects and their approvals.
+When the certificate signer sees an approved request, it signs the request using the
+configured certificate and key (typically, this will be the cluster root CA).
+
+The controller stores the issued certificate in the `status.certificate` field of the
+CertificateSigningRequest object.
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+* Read about the [certificate approver](/docs/reference/controllers/certificate-approver/)
+* Read about other [certificate controllers](/docs/reference/controllers/certificate-controllers/)
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/cluster-orchestration-controllers.md
+++ b/content/en/docs/reference/controllers/cluster-orchestration-controllers.md
@@ -1,0 +1,48 @@
+---
+title: Cluster orchestration controllers
+content_template: templates/concept
+weight: 80
+---
+
+{{% capture overview %}}
+
+A _cluster_ is a set of machines, called
+{{< glossary_tooltip text="Nodes" term_id="node" >}}, that run containerized
+applications.
+
+This page lists the cluster orchestration
+{{< glossary_tooltip text="controllers" term_id="controller" >}}
+that come as part of Kubernetes itself.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+## ClusterRole aggregation controller
+
+The [ClusterRole aggregation controller](/docs/reference/controllers/clusterrole-aggregation/)
+manages the permissions of aggregated ClusterRoles.
+
+## Node lifecycle controller {#controller-node-lifecycle}
+
+The [Node lifecycle controller](/docs/reference/controllers/node-lifecycle/)
+observes the status of the {{< glossary_tooltip text="kubelet" term_id="kubelet" >}}
+on each node, and manages {{< glossary_tooltip text="taints" term_id="taint" >}}
+on Nodes based on its findings.
+
+## ServiceAccount controller
+
+The [ServiceAccount controller](/docs/reference/controllers/serviceaccount/)
+ensures that each Namespace contains a default ServiceAccount.
+
+## ServiceAccount token controller
+
+The [ServiceAccount token controller](/docs/reference/controllers/serviceaccount-token/)
+issues API access tokens for each ServiceAccount.
+
+
+{{% /capture %}}
+
+{{% capture whatsnext %}}
+* Read about [resource clean-up controllers](/docs/reference/controllers/resource-cleanup-controllers/)
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/clusterrole-aggregation.md
+++ b/content/en/docs/reference/controllers/clusterrole-aggregation.md
@@ -1,0 +1,37 @@
+---
+toc_hide: true
+title: ClusterRole aggregation controller
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+This {{< glossary_tooltip term_id="controller" text="controller" >}}
+implements the `aggregationRule` property for
+[ClusterRoles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole),
+which are used in connection with
+{{< glossary_tooltip text="Role-Based Access Control" term_id="rbac" >}} (RBAC).
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+The ClusterRole aggregation controller is built in to the {{< glossary_tooltip term_id="kube-controller-manager" >}}.
+
+## Controller behavior
+
+This controller manages the permissions of aggregated ClusterRoles. The controller
+watches (all) ClusterRoles for changes.
+
+If the controller sees changes (add / remove / update) to a ClusterRole that matches
+the clusterRoleSelectors for any existing ClusterRole, it will calcluate the rules
+for the ClusterRole that had clusterRoleSelectors set.
+
+See [Aggregated ClusterRoles](/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles)
+for more information on this.
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+* Read about [ClusterRoles](/docs/reference/access-authn-authz/rbac/#role-and-clusterrole)
+* Read about other [cluster orchestration controllers](/docs/reference/controllers/cluster-orchestration-controllers/)
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/cronjob.md
+++ b/content/en/docs/reference/controllers/cronjob.md
@@ -1,0 +1,48 @@
+---
+toc_hide: true
+title: Cron job controller
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+The CronJob {{< glossary_tooltip term_id="controller" text="controller" >}} creates
+{{< glossary_tooltip text="Jobs" term_id="job" >}} for a
+{{< glossary_tooltip term_id="cronjob" >}} on a time-based schedule.
+
+
+{{% /capture %}}
+
+
+{{% capture body %}}
+
+The CronJob controller is built in to the {{< glossary_tooltip term_id="kube-controller-manager" >}}.
+
+## Controller behavior
+
+The cron job controller creates a Job object _about_ once per execution time
+of its schedule. In certain circumstances, the controller might create one
+job, or none.
+
+For every CronJob, the CronJob controller checks how many schedules it
+missed in the duration from its last scheduled time until now. If there
+are too many, then it does not start the Job and instead records an Event
+to log the error.
+
+The CronJob controller is only responsible for creating Jobs that match a
+CronJob's schedule. The [Job controller](/docs/reference/controllers/job/)
+takes care of running Jobs by creating Pods.
+
+{{< note >}}
+All `schedule:` times for CronJobs are based on the timezone of the Kubernetes control plane.
+{{< /note >}}
+
+{{% /capture %}}
+
+{{% capture whatsnext %}}
+
+* Read about [CronJobs](/docs/concepts/workloads/controllers/cron-jobs/)
+* Learn about [running automated tasks with cron jobs](/docs/tasks/job/automated-tasks-with-cron-jobs).
+* Read about other [workload controllers](/docs/reference/controllers/workload-controllers/)
+
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/daemonset.md
+++ b/content/en/docs/reference/controllers/daemonset.md
@@ -1,0 +1,86 @@
+---
+toc_hide: true
+title: DaemonSet controller
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+The DaemonSet {{< glossary_tooltip term_id="controller" text="controller" >}} manages
+{{< glossary_tooltip term_id="pod" text="Pods">}} configured via a
+{{< glossary_tooltip term_id="daemonset" >}} object. A DaemonSet makes
+sure that, for Nodes meeting some condition you specify, they are
+all running a copy of a Pod.
+
+{{< note >}}
+If you don't specify any selector for a DaemonSet, this controller runs it on every node.
+{{< /note >}}
+
+{{% /capture %}}
+
+
+{{% capture body %}}
+
+The DaemonSet controller is built into the {{< glossary_tooltip term_id="kube-controller-manager" >}}.
+
+## Controller behavior
+
+The DaemonSet controller ensures that all eligible nodes run a copy of a Pod,
+by creating Pods with a Node assignment (one Pod for each eligible Node).
+
+This controller creates one Pod for each Node that the DaemonSet matches.
+It creates new Pods in batches, doubling the batch size each time a request
+succeeds. This helps to avoid sending a very large number of API requests that
+will ultimately all fail with the same error.
+
+To track changes efficiently, this controller labels new Pods using a hash
+of the the DaemonSet the Pod belongs to.
+
+If this controller is managing a Pod on a Node that no longer matches
+the DaemonSet, or where the Node no longer exists, the controller will remove
+that Pod.
+
+If a DaemonSet's Pods fail the controller recreates them, applying a rate
+limit to avoid a hot loop of killing and then recreating broken Pods.
+
+## How DaemonSet Pods are scheduled
+
+A DaemonSet ensures that all eligible nodes run a copy of a Pod. Normally, the
+Kubernetes scheduler selects the node that a Pod runs on. However, this controller
+ceates Pods for DaemonSets with the aim of having each Pod run on a specific Node.
+That would introduce the following issues:
+
+ * Inconsistent Pod behavior: Normal Pods waiting to be scheduled are created
+   and in `Pending` state, but DaemonSet pods are not created in `Pending`
+   state. This is confusing to the user.
+ * [Pod preemption](/docs/concepts/configuration/pod-priority-preemption/)
+   is handled by the default scheduler. When preemption is enabled, the DaemonSet
+   controller would take scheduling decisions without considering pod priority or
+   preemption.
+
+The DaemonSet controller sets
+[node affinity](/docs/concepts/configuration/assign-pod-node/#node-affinity)
+so that the Pods it creates are scheduled onto the correct Node.
+
+This controller creates Pods with a
+`RequiredDuringSchedulingIgnoredDuringExecution` node affinity, so that the
+`nodeName` matches the target Node where the DaemonSet controller intends to
+place a particular Pod.
+
+If the DaemonSet controller is handling an existing Pod for a DaemonSet, it
+makes sure that `nodeAffinity` matches the Node where the Pod is executing,
+and that there is only ever one Pod running on a Node for a given DaemonSet.
+
+### Taints and Tolerations
+
+This controller automatically adds
+{{< glossary_tooltip text="tolerations" term_id="toleration" >}} to every
+Pod that it creates, so that the scheduler is able to place the DaemonSet's
+Pods onto Nodes that are not yet ready to accept Pods for application workloads.
+
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+* Read about [DaemonSets](/docs/concepts/workloads/daemonset)
+* Read about other [workload controllers](/docs/reference/controllers/workload-controllers/)
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/deployment.md
+++ b/content/en/docs/reference/controllers/deployment.md
@@ -1,0 +1,91 @@
+---
+toc_hide: true
+title: Deployment controller
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+The {{< glossary_tooltip term_id="deployment" >}}
+{{< glossary_tooltip term_id="controller" text="controller" >}}
+enables declarative definitions for [Pods](/docs/concepts/workloads/pods/pod/) and
+[ReplicaSets](/docs/concepts/workloads/controllers/replicaset/) to run an application
+using stateless containers.
+
+You describe a _desired state_ in the spec of a Deployment object, and this
+controller drives actual state towards the desired state at a
+constrained rate. You can define Deployments to create new ReplicaSets, or to
+remove existing ReplicaSets and adopt all their resources with new ReplicaSets.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+The Deployment controller is built in to the {{< glossary_tooltip term_id="kube-controller-manager" >}}.
+
+## Controller behavior
+
+The Deployment controller creates and manages a
+{{< glossary_tooltip term_id="replica-set" >}} that in turn,
+via the [ReplicaSet controller](/docs/reference/controllers/replicaset/),
+manages a set of Pods to run a containerized application.
+Each time the Deployment controller observes a new Deployment object,
+it creates a new ReplicaSet to bring up the desired Pods, unless there is
+already a ReplicaSet doing just that.
+
+The Deployment controller gives each ReplicaSet a name that it derives from
+the name of the Pod in the Deployment's replicaset template. The Deployment
+controller creates the ReplicaSet's Pod spec with a
+{{< glossary_tooltip term_id="label" >}}
+for those Pods, based on a hash of the pod template part of the Deployment spec.
+
+The Deployment controller adds this `pod-template-hash` label to every
+ReplicaSet that it is managing.
+
+When you update a Deployment's Pod template, this triggers an update.
+The Deployment controller tracks revisions to the Deployment object,
+up to a configurable number of history revisions.
+
+The Deployment controller creates a new ReplicaSet and switches to it
+(see [Deployment](/docs/concepts/workloads/deployment/): either gradually
+or all-at-once.
+
+### Tracking progress
+
+The Deployment controller marks a Deployment as _progressing_ based
+on [defined criteria](
+
+* The Deployment creates a new ReplicaSet.
+* The Deployment is scaling up its newest ReplicaSet.
+* The Deployment is scaling down its older ReplicaSet(s).
+* New Pods, relevant to the Deployment but not previously known to the controller, become ready or available (ready for at least [MinReadySeconds](#min-ready-seconds)).
+
+The deployment controller marks a Deployment as _complete_ when it has the following characteristics:
+
+* All of the replicas associated with the Deployment have been updated to the latest version you've specified, meaning any
+updates you've requested have been completed.
+* All of the replicas associated with the Deployment are available.
+* No old replicas for the Deployment are running.
+
+When processing a Deployment with `spec.paused` set, the controller adds a condition
+with `Reason=DeploymentPaused`. The Deployment controller skips progress
+checking for Deployments with that condition set.
+
+### Tracking failure(s) {#tracking-failure}
+
+If a rollout creates only bad (failing) Pods, the Deployment controller detects
+this and aborts the rollout: it ceases scaling up the new ReplicaSet.
+
+The Deployment controller keeps track of whether its newest ReplicaSet is
+deploying OK. If you set `.spec.progressDeadlineSeconds` for a Deployment,
+and the ReplicaSet does not come up OK within that interval, the Deployment
+controller adds a Condition to the Deployment, with
+condition `Type=Progressing, Status=False` and
+`Reason=ProgressDeadlineExceeded`.
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+* Read about [Deployments](/docs/concepts/workloads/controllers/deployment/)
+* Read about [ReplicaSets](/docs/concepts/workloads/controllers/replicaset/)
+* Read about other [workload controllers](/docs/reference/controllers/workload-controllers/)
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/endpoint-slice.md
+++ b/content/en/docs/reference/controllers/endpoint-slice.md
@@ -1,0 +1,41 @@
+---
+toc_hide: true
+title: EndpointSlice controller
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+{{< feature-state for_k8s_version="v1.17" state="beta" >}}
+
+This {{< glossary_tooltip term_id="controller" text="controller" >}} makes
+complements the [Endpoint controller](/docs/reference/controllers/endpoint/)
+with a higher-performance API object, EndpointSlice.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+The EndpointSlice controller is built in to the {{< glossary_tooltip term_id="kube-controller-manager" >}}.
+
+## Controller behavior
+
+Endpoint Slices group network endpoints together by unique Service and Port combinations.
+
+This controller watches for Service and Pod objects. For each Service that has
+a {{< glossary_tooltip term_id="selector" >}}, this
+controller adds, removes or amends EndpointSlices so that each Pod has an endpoint in the
+relevant EndpointSlice.
+
+{{< note >}}
+If you define a Service without a selector, this controller will not create
+EndpointSlices for that Service.
+{{< /note >}}
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+
+* Read about [endpoint slices](/docs/concepts/services-networking/endpoint-slices/)
+* Read about the [Endpoint controller](/docs/reference/controllers/endpoint/)
+* Read about the [Service controller](/docs/reference/controllers/service/)
+
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/endpoint.md
+++ b/content/en/docs/reference/controllers/endpoint.md
@@ -1,0 +1,37 @@
+---
+toc_hide: true
+title: Endpoint controller
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+This {{< glossary_tooltip term_id="controller" text="controller" >}} makes
+sure that {{< glossary_tooltip text="Services" term_id="service" >}}
+have an Endpoint for each Pod that matches the Service's
+{{< glossary_tooltip term_id="label" >}} selector.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+The Endpoint controller is built in to the {{< glossary_tooltip term_id="kube-controller-manager" >}}.
+
+## Controller behavior
+
+This controller watches for Service and Pod objects. For each Service that has
+a {{< glossary_tooltip term_id="selector" >}}, this
+controller adds or removes Endpoints so that each Pod has a matching Endpoint.
+
+{{< note >}}
+If you define a Service without a selector, this controller will not create
+Endpoints for that Service.
+{{< /note >}}
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+
+* Read about the [Service controller](/docs/reference/controllers/service/)
+* Read about the [EndpointSlice controller](/docs/reference/controllers/endpoint-slice/)
+
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/garbage-collector.md
+++ b/content/en/docs/reference/controllers/garbage-collector.md
@@ -1,0 +1,39 @@
+---
+toc_hide: true
+title: Garbage Collector
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+The Kubernetes garbage collector is a built-in controller. It deletes certain
+objects that once had an owner, but no longer have an owner.
+
+{{% /capture %}}
+
+
+{{% capture body %}}
+
+## Controller behavior
+
+This controller watches for changes to objects that have dependencies, and
+spots objects that are eligible for garbage collection. Once identified these
+are queued for (attempts at) deletion.
+
+Other controllers can rely on this behavior to take care of cascading deletion
+of objects via parent-child relationships.
+
+For example: if you remove a {{< glossary_tooltip term_id="deployment" >}}
+that relies on a {{< glossary_tooltip term_id="replica-set" >}} to ensure
+the right number of {{< glossary_tooltip text="Pods" term_id="pod" >}} are
+running, removing that Deployment will schedule removal of the ReplicaSet.
+
+{{% /capture %}}
+
+{{% capture whatsnext %}}
+
+* Learn about other [resource clean-up controllers](/docs/reference/controllers/resource-cleanup-controllers/)
+* Read [Garbage collection design document 1](https://git.k8s.io/community/contributors/design-proposals/api-machinery/garbage-collection.md)
+* Read [Garbage collection design document 2](https://git.k8s.io/community/contributors/design-proposals/api-machinery/synchronous-garbage-collection.md)
+
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/horizontal-pod-autoscaler.md
+++ b/content/en/docs/reference/controllers/horizontal-pod-autoscaler.md
@@ -1,0 +1,86 @@
+---
+toc_hide: true
+title: Horizontal Pod Autoscaler
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+A HorizontalPodAutoscaler automatically scales the number of
+{{< glossary_tooltip text="Pods" term_id="pod" >}}
+in a {{< glossary_tooltip text="Deployment," term_id="deployment" >}}
+{{< glossary_tooltip text="StatefulSet," term_id="statefulset" >}} or other scalable resource.
+
+This {{< glossary_tooltip term_id="controller" text="controller" >}} scales the
+number of Pods based on observed metrics.
+
+{{% /capture %}}
+{{% capture body %}}
+
+The HorizontalPodAutoscaler controller is built in to the {{< glossary_tooltip term_id="kube-controller-manager" >}}.
+
+The controller periodically adjusts the number of replicas for a workload resource,
+so as to to match the observed average resource utilization to the target you specified.
+
+## Controller behavior
+
+This controller runs as an continuous control loop that takes measurements over a period
+controlled by kube-controller-manager's `--horizontal-pod-autoscaler-sync-period` flag.
+The default synchronization period is 15 seconds.
+
+During each period, the Horizontal Pod Autoscaler queries the resource utilization against the
+metrics specified in each HorizontalPodAutoscaler resource. The controller
+obtains the metrics from either the resource metrics API (for per-Pod resource metrics),
+or the custom metrics API (for all other metrics).
+
+* For per-Pod resource metrics, like CPU, this controller fetches the metrics
+  from the resource metrics API for each Pod that the HorizontalPodAutoscaler object
+  targets.
+  Then, if a target utilization value is set, the controller calculates the utilization
+  value as a percentage of the equivalent resource request on the containers in
+  each pod.  If a target raw value is set, the raw metric values are used directly.
+  This controller takes the mean of the utilization or the raw value (depending on the type
+  of target specified) across all targeted Pods, and produces a ratio used to scale
+  the number of desired replicas.
+
+  If some of the Pod's containers do not have the relevant resource request set,
+  CPU utilization for the Pod will not be defined and the autoscaler will
+  not take any action for that metric. See
+  [algorithm details](/docs/tasks/run-application/horizontal-pod-autoscale/#algorithm-details) for
+  more information about autoscaling works.
+
+* For per-Pod custom metrics, this controller functions similarly to per-Pod resource metrics,
+  except that it works with raw values, not utilization values.
+
+* For object metrics and external metrics, this controller fetches a single metric that
+  describes the object in question. Optionally (based on the HorizontalPodAutoscaler spec),
+  this controller divides the fetched value by the number of Pods. Next, the controller compares
+  the processed metric value against its configured target.
+
+The HorizontalPodAutoscaler conteoller accesses corresponding scalable resources
+(such as Deployments and ReplicaSets) by using their `scale` sub-resource.
+
+## Multiple metrics
+
+If multiple metrics are specified in a HorizontalPodAutoscaler, the controller
+calculates scaling for each metric and then combines those scale values,
+choosing the largest. If the controller cannot determine a desired replica
+count based on any metric, it skips scaling.
+For example, this could be due to an error fetching a single metric.
+
+## Smoothing
+
+Before this controller updates the target's scale, it records a
+_scale recommendation_ is recorded.  The controller considers all scale
+ recommendations within a window, choosing the highest scale recommendation
+from within that window.
+
+This windowing smooths out the impact of rapidly fluctuating metric values.
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+
+* Read about other [Pod management controllers](/docs/reference/controllers/pod-management-controllers/)
+* Read the design proposal for [scale subresources](https://git.k8s.io/community/contributors/design-proposals/autoscaling/horizontal-pod-autoscaler.md#scale-subresource)
+
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/ingress.md
+++ b/content/en/docs/reference/controllers/ingress.md
@@ -1,0 +1,74 @@
+---
+toc_hide: true
+title: Ingress controllers
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+{{< feature-state for_k8s_version="v1.1" state="beta" >}}
+
+In order for the Ingress resource to work, the cluster must have at least
+one ingress {{< glossary_tooltip term_id="controller" text="controller">}} running.
+
+Unlike the controllers which run as part of the `kube-controller-manager` binary, Ingress controllers
+are not started automatically with a cluster. Use this page to choose the ingress controller implementation(s)
+that best fit your cluster.
+
+The Kubernetes project currently supports and maintains [GCE](https://git.k8s.io/ingress-gce/README.md) and
+  [nginx](https://git.k8s.io/ingress-nginx/README.md) controllers.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+## Third-party ingress controllers {#additional-controllers}
+
+* [Ambassador](https://www.getambassador.io/) API Gateway is an [Envoy](https://www.envoyproxy.io)-based ingress
+  controller with [community](https://www.getambassador.io/docs) or
+  [commercial](https://www.getambassador.io/pro/) support from [Datawire](https://www.datawire.io/).
+* [Citrix Kubernetes Ingress Controller](https://github.com/citrix/citrix-k8s-ingress-controller) for use with with Citrix hardware (MPX), virtualized (VPX) and free [containerized (CPX) ADC](https://www.citrix.com/products/citrix-adc/cpx-express.html). You can use it for [bare metal](https://github.com/citrix/citrix-k8s-ingress-controller/tree/master/deployment/baremetal) or [cloud](https://github.com/citrix/citrix-k8s-ingress-controller/tree/master/deployment) deployments.
+* [Contour](https://github.com/heptio/contour) is an [Envoy](https://www.envoyproxy.io) based ingress controller.
+* [F5 BIG-IP Controller for Kubernetes](http://clouddocs.f5.com/products/connectors/k8s-bigip-ctlr/latest) from
+  [F5 Networks](https://f5.com/).
+* [Gloo](https://gloo.solo.io) is an open-source ingress controller based on [Envoy](https://www.envoyproxy.io) which offers API Gateway functionality. You can get enterprise support for Gloo from [solo.io](https://www.solo.io).
+* [HAProxy Technologies](https://www.haproxy.com/) offers support and maintenance for
+  the [HAProxy Ingress Controller for
+Kubernetes](https://github.com/haproxytech/kubernetes-ingress).
+  See the [official documentation](https://www.haproxy.com/documentation/hapee/1-9r1/traffic-management/kubernetes-ingress-controller/).
+* [Kong Ingress Controller for Kubernetes](https://github.com/Kong/kubernetes-ingress-controller). You can choose
+  either the [community](https://discuss.konghq.com/c/kubernetes) or
+  [commercial](https://konghq.com/kong-enterprise/) support and maintenance.
+* [NGINX Ingress Controller for Kubernetes](https://www.nginx.com/products/nginx/kubernetes-ingress-controller).
+  from [NGINX, Inc.](https://www.nginx.com/)
+* [Traefik](https://traefik.io/) is a fully featured ingress controller
+  ([Let's Encrypt](https://letsencrypt.org), secrets, http2, WebSockets). You can use a [community edition](https://traefik.io/#community) or choose commercial support from by [Containous](https://containo.us/services).
+* [Voyager](https://appscode.com/products/voyager/) is based on [HAProxy](http://www.haproxy.org/). You can get support from [AppsCode Inc.](https://appscode.com)
+
+If you use Istio, you can use it to [control ingress traffic](https://istio.io/docs/tasks/traffic-management/ingress/) via Istio's custom resources.
+The outcome you'll get is broadly equivalent to deploying a suitable Ingress controller.
+
+## Using multiple Ingress controllers
+
+You may deploy [any number of ingress controllers](https://git.k8s.io/ingress-nginx/docs/user-guide/multiple-ingress.md#multiple-ingress-controllers)
+within a cluster. When you create an ingress, you should annotate each ingress with the appropriate
+[`ingress.class`](https://git.k8s.io/ingress-gce/docs/faq/README.md#how-do-i-run-multiple-ingress-controllers-in-the-same-cluster)
+to indicate which ingress controller should be used if more than one exists within your cluster.
+
+If you do not define a class, your cloud provider may use a default ingress provider.
+
+Ideally, all ingress controllers should fulfill this specification, but the various ingress
+controllers operate slightly differently.
+
+{{< note >}}
+Make sure you review your ingress controller's documentation to understand the caveats of choosing it.
+{{< /note >}}
+
+{{% /capture %}}
+
+{{% capture whatsnext %}}
+
+* Learn more about [Ingress](/docs/concepts/services-networking/ingress/).
+* [Set up Ingress on Minikube with the NGINX Controller](/docs/tasks/access-application-cluster/ingress-minikube).
+
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/job.md
+++ b/content/en/docs/reference/controllers/job.md
@@ -1,0 +1,30 @@
+---
+toc_hide: true
+title: Job controller
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+The {{< glossary_tooltip term_id="job" >}}
+{{< glossary_tooltip term_id="controller" text="controller" >}}$
+creates {{< glossary_tooltip term_id="pod" text="Pods" >}} to run each
+Job to completion.
+
+As its pods successfully complete, the controller tracks successful completions.
+When a specified number of successful completions is reached, the Job
+controller updates the Job object to mark it complete.
+
+{{% /capture %}}
+
+
+{{% capture body %}}
+
+The Job controller is built in to the {{< glossary_tooltip term_id="kube-controller-manager" >}}.
+It creates one or more Pods to run each Job to completion.
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+* Read about [Jobs](/docs/concepts/workloads/controllers/job-run-to-completion/)
+* Read about other [workload controllers](/docs/reference/controllers/workload-controllers/)
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/namespace.md
+++ b/content/en/docs/reference/controllers/namespace.md
@@ -1,0 +1,28 @@
+---
+toc_hide: true
+title: Namespace controller
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+The {{< glossary_tooltip term_id="namespace" >}} controller is a built-in
+controller that handles cleanup when a Namespace is removed.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+## Controller behavior
+
+When you (or any Kubernetes API client) remove a namespace, this
+controller makes sure that objects in that namespace are removed before
+the namespace itself is removed.
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+
+* Read about [Namespaces](/docs/concepts/overview/working-with-objects/namespaces/)
+* Learn about other [resource clean-up controllers](/docs/reference/controllers/resource-cleanup-controllers/)
+
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/network-controllers.md
+++ b/content/en/docs/reference/controllers/network-controllers.md
@@ -1,0 +1,48 @@
+---
+title: Networking controllers
+content_template: templates/concept
+weight: 70
+---
+
+{{% capture overview %}}
+
+This page lists the networking
+{{< glossary_tooltip text="controllers" term_id="controller" >}}
+that come as part of Kubernetes itself.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+## Endpoint controller
+
+The [Endpoint controller](/docs/reference/controllers/endpoint/) makes sure
+that there is an Endpoint for each {{< glossary_tooltip term_id="pod" >}} in a
+{{< glossary_tooltip term_id="service" >}}.
+
+## EndpointSlice controller
+
+The [EndpointSlice controller](/docs/reference/controllers/endpoint-slice/)
+manages EndpointSlice objects rather than Endpoints, providing a different way
+to map Services to Pods.
+
+## Service controller
+
+The [Service controller](/docs/reference/controllers/service/) tracks the Pods
+in a Service and implements access to that Service; for example, via a load
+balancer outside your cluster.
+
+## Node IPAM controller
+
+When active, the
+[Node IP address management (IPAM) controller](/docs/reference/controllers/node-ip-address-management/)
+manages the blocks of IP addresses assigned to
+{{< glossary_tooltip text="Nodes" term_id="node" >}}.
+
+{{% /capture %}}
+
+{{% capture whatsnext %}}
+* Read about the [Service](/docs/concepts/services-networking/service/) concept
+* Read about the [Ingress](/docs/concepts/services-networking/ingress/) concept
+* Read about [cluster orchestration controllers](/docs/reference/controllers/cluster-orchestration-controllers/)
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/node-ip-address-management.md
+++ b/content/en/docs/reference/controllers/node-ip-address-management.md
@@ -1,0 +1,29 @@
+---
+toc_hide: true
+title: Node IPAM controller
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+This {{< glossary_tooltip text="controller" term_id="controller" >}}
+implements IP address management to ensure that
+{{< glossary_tooltip text="Nodes" term_id="node" >}}
+have blocks of IP addresses available to be assigned
+to Pods.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+{{< note >}}
+The network configuration for your cluster, and the choice of
+{{< glossary_tooltip text="CNI" term_id="cni" >}} plugin(s) will
+determine whether and how this controller sets `podCIDR` for Nodes in
+the cluster.
+{{< /note >}}
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+* Read about [cluster networking](/docs/concepts/cluster-administration/networking/)
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/node-lifecycle.md
+++ b/content/en/docs/reference/controllers/node-lifecycle.md
@@ -1,0 +1,42 @@
+---
+toc_hide: true
+title: Node lifecycle controller
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+The Node lifecycle {{< glossary_tooltip term_id="controller" text="controller" >}}
+automates managing {{< glossary_tooltip text="taints" term_id="taint" >}} on
+cluster nodes.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+The Node lifecycle controller is built in to the {{< glossary_tooltip term_id="kube-controller-manager" >}}.
+
+## Controller behavior
+
+This controller observes the behavior of the {{< glossary_tooltip term_id="kubelet" >}}
+on a cluster node, and sets (potentially also removes)
+{{< glossary_tooltip text="taints" term_id="taint" >}} on Nodes
+to match its findings.
+
+For example: if a kubelet stops reporting that a worker node is healthy, the
+controller can apply a taint to prevent scheduling new Pods there.
+
+If there is a significant problem&mdash;maybe the entire node has crashed&mdash;then
+this controller triggers evictions for the Pods on the affected node.
+
+If you're using taint-based evictions, this controller takes care to limit the rate at
+which it adds taints to nodes. If many nodes get the same taint at once, that rate limit
+reduces the impact of evictions that would otherwise happen as soon as the API server
+registered the relevant taints.
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+* Read about other [cluster orchestration controllers](/docs/reference/controllers/cluster-orchestration-controllers/)
+* Read about [Taint based evictions](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/#taint-based-evictions)
+{{% /capture %}}
+

--- a/content/en/docs/reference/controllers/node.md
+++ b/content/en/docs/reference/controllers/node.md
@@ -1,0 +1,51 @@
+---
+toc_hide: true
+title: Node controller
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+The node controller is a Kubernetes master component which manages various
+aspects of nodes.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+## Controller behavior
+
+The node controller has multiple roles in a node's life.
+
+### Roles
+
+1.  If CIDR assignment is enabled, this controller assigns a CIDR block to each
+    new Node when it is registered.
+2.  This controller tracks and caches the cloud provider's list of available machines.
+    When running in a cloud environment, and a node becomes unhealthy, the node
+    controller queries the cloud provider's API to discover whether the server
+    representing the unhealthy Node is still available. If the cloud provider API
+    shows the server is gone / missing, the node controller stops tracking the Node.
+3.  This controller watches running Nodes and updates the
+    [conditions](/docs/concepts/architecture/nodes/#condition) field if the kubelet on
+    a server stops sending heartbeats.
+    Heartbeats come in 2 kinds:
+    - changes to the associated Lease resource in the `kube-node-lease` namespace
+    - updates to the Node's `.nodeStatus` field
+    
+    Either kind of heartbeat counts as a sign that the Node is still alive.
+    If a Node becomes unreachable (the node controller hasn't seen the heartbeats
+    for at least `--node-monitor-grace-period` seconds), this controller sets the Node's
+    condition to `Unknown`.
+4.  When something sets a condition on a Node, this controller additionally
+    {{< glossary_tooltip text="taints" term_id="taint" >}} the Node with taints inside
+    `node.kubernetes.io/`. For example, `node.kubernetes.io/unreachable` is the taint that
+    matches the `Unknown` condition.
+    
+    If / when the condition changes, this controller updates the taints to match.
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+* Read about [nodes](/docs/concepts/architecture/nodes/)
+* Read about the [Node API object](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#node-v1-core).
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/pod-disruption-budget.md
+++ b/content/en/docs/reference/controllers/pod-disruption-budget.md
@@ -1,0 +1,37 @@
+---
+toc_hide: true
+title: PodDisruptionBudget controller
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+The PodDisruptionBudget {{< glossary_tooltip term_id="controller" text="controller" >}}
+manages the level of disruption to workloads running on your cluster.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+The PodDisruptionBudget controller is built in to the {{< glossary_tooltip term_id="kube-controller-manager" >}}.
+
+## Controller behavior
+
+Where a PodDisruptionBudget matches a {{< glossary_tooltip term_id="label" >}}
+selector, the PodDisruptionBudget controller finds the resource that manages
+those Pods (eg a Deployment) and sets either `maxUnavailable` or `minAvailable`
+for the managing resource (for the example, that means the Deployment object).
+
+The PodDisruptionBudget controller has special behaviour if managing
+Deployment, ReplicationController, ReplicaSet, and StatefulSet, when the PDB
+selector matches the PodDisruptionBudget’s selector. See
+[Specifying a Disruption Budget for your Application](/docs/tasks/run-application/configure-pdb/)
+for more details.
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+
+* Read about [disruptions](/docs/concepts/workloads/pods/disruptions/)
+* Read about other [Pod management controllers](/docs/reference/controllers/pod-management-controllers/)
+
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/pod-garbage-collector.md
+++ b/content/en/docs/reference/controllers/pod-garbage-collector.md
@@ -1,0 +1,30 @@
+---
+toc_hide: true
+title: Pod garbage collector
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+The Pod garbage collector handles cleanup of
+terminated {{< glossary_tooltip text="Pods" term_id="pod" >}}.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+## Controller behavior
+
+This controller takes care of cleaning up Pods that are terminated, so
+that the resources for tracking those Pods can be reclaimed.
+
+The controller tracks the number of Pods eligible for cleanup and activates
+onces that number passes a defined threshold. This controller only ever removes Pods
+that are already terminated.
+
+{{% /capture %}}
+{{% capture whatsnext%}}
+
+* Learn about other [resource clean-up controllers](/docs/reference/controllers/resource-cleanup-controllers/)
+
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/pod-management-controllers.md
+++ b/content/en/docs/reference/controllers/pod-management-controllers.md
@@ -1,0 +1,38 @@
+---
+title: Pod management controllers
+content_template: templates/concept
+weight: 30
+---
+
+{{% capture overview %}}
+
+This page lists the {{< glossary_tooltip term_id="pod" >}} management
+{{< glossary_tooltip text="controllers" term_id="controller" >}}
+that come as part of Kubernetes itself.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+## HorizontalPodAutoscaler controller
+
+The [HorizontalPodAutoscaler](/docs/reference/controllers/horizontal-pod-autoscaler/)
+controller enacts the scaling rules from each HorizontalPodAutoscaler object.
+
+## PodDisruptionBudget controller
+
+The [PodDisruptionBudget controller](/docs/reference/controllers/poddisruptionbudget/)
+manages the amount of [disruption](/docs/concepts/workloads/pods/disruptions/) to workloads
+running on your cluster.
+
+## PodPreset controller
+
+The [PodPreset controller](/docs/reference/access-authn-authz/admission-controllers/#podpreset)
+is an admission controller that applies [Pod presets](/docs/concepts/workloads/pods/podpreset/)
+to incoming Pods.
+
+{{% /capture %}}
+
+{{% capture whatsnext %}}
+* Read about [Resource management controllers](/docs/reference/controllers/resource-management-controllers)
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/replicaset.md
+++ b/content/en/docs/reference/controllers/replicaset.md
@@ -1,0 +1,71 @@
+---
+toc_hide: true
+title: ReplicaSet controller
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+The ReplicaSet {{< glossary_tooltip term_id="controller" text="controller" >}}
+maintains a stable number of replica Pods for each
+{{< glossary_tooltip text="ReplicaSet" term_id="replica-set" >}}.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+The ReplicaSet controller is built in to the
+{{< glossary_tooltip term_id="kube-controller-manager" >}}.
+
+## Controller behavior
+
+The controller watches for ReplicaSet objects. For each ReplicaSet, this
+controller adds or removes Pods so that the right number of Pods are running
+for each ReplicaSet.
+
+When you define a ReplicaSet you provide fields including a desired number of
+replicas, a template for Pods that the controller should create, and a
+{{< glossary_tooltip term_id="selector" >}} that the controller can use to find
+the Pods it is managing.
+
+If there are more Pods running for a ReplicaSet than the desired count, the
+controller selects a Pod from the replica set and deletes it. If there are too
+few replicas, the controller will create a new Pod based on the Pod template
+for that ReplicaSet.
+
+Pods for a ReplicaSet must have a
+[restart policy](/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy)
+of `Always`.
+
+When the controller creates Pods, it sets the [metadata.ownerReferences](/docs/reference/controllers/garbage-collector/#owners-and-dependents) for each new Pod, so that the Pod is owned
+by the ReplicaSet that is responsible for it existing.
+
+The ReplicaSet controller uses the owner reference to track the Pods that it
+is managing on behalf of a given ReplicaSet. When the controller finds a Pod
+that matches the selector for a current ReplicaSet, and has no ownerReference,
+the ReplicaSet controller updates that Pod's ownerReference. The discovered
+Pod becomes owned by the ReplicaSet.
+
+If you update a ReplicaSet that has already created Pods with one template,
+and change the Pod template inside the ReplicaSet, existing Pods will stay
+running and will continue to match the ReplicaSet's selector. If / when the
+ReplicaSet controller creates new Pods, those new Pods will be based on the
+updated selector and may well be different from the older Pods.
+
+{{< note >}}
+The ReplicationController controller does not check readiness nor liveness of the Pods
+that it manages.
+{{< /note >}}
+
+If the ReplicSet's replica count is unset, the controller defaults to running
+a single Pod.
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+
+* Read about the [Deployment controller](/docs/reference/controllers/deployment/)
+* Read about the [ReplicationController controller](/docs/reference/controllers/replicationcontroller/)
+  (ReplicaSet and Deployment replaced the now-deprecated ReplicationController resource)
+* Read about other [workload controllers](/docs/reference/controllers/workload-controllers/)
+
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/replicationcontroller.md
+++ b/content/en/docs/reference/controllers/replicationcontroller.md
@@ -1,0 +1,52 @@
+---
+toc_hide: true
+title: Replication controller
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+The replication controller ensures that a specified number of Pod replicas are running at any one
+time.
+You can set up a ReplicationController object in order to make sure that a Pod or a homogeneous set
+of Pods is always up and available.
+
+{{< note >}}
+You should set up replication using a [Deployment](/docs/concepts/workloads/controllers/deployment/) that configures a [ReplicaSet](/docs/concepts/workloads/replicaset/). ReplicationController is available but deprecated.
+{{< /note >}}
+
+{{% /capture %}}
+
+
+{{% capture body %}}
+
+## ReplicationController objects
+
+Each controller in Kubernetes works with a particular set of objects. The _replication controller_
+is a {{< glossary_tooltip term_id="controller" text="controller" >}} that
+manages Pod objects based on its configuration object (_ReplicationController_).
+
+## Controller behavior
+
+The replication controller works similarly to the ReplicaSet controller. For a given
+replication configuration, the replication controller matches the running number of Pods to
+its desired state.
+If there are too many Pods, this controller selects surplus Pods and removes
+(terminates) them.
+If there are too few Pods running, this controller creates more. That means that if a
+Pod for the ReplicationController's label selector terminates unexpectedly, this
+controller will set up a replacement.
+
+{{< note >}}
+The ReplicationController controller does not check readiness nor liveness of the Pods
+that it manages.
+{{< /note >}}
+
+{{% /capture %}}
+
+{{% capture whatsnext %}}
+
+* Read about the [ReplicaSet controller](/docs/reference/controllers/replicaset/)
+* Read about other [workload controllers](/docs/reference/controllers/workload-controllers/)
+
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/resource-cleanup-controllers.md
+++ b/content/en/docs/reference/controllers/resource-cleanup-controllers.md
@@ -1,0 +1,58 @@
+---
+title: Resource clean-up controllers
+content_template: templates/concept
+weight: 90
+---
+
+{{% capture overview %}}
+
+This page lists the {{< glossary_tooltip text="controllers" term_id="controller" >}}
+for resource cleanup and garbage collection, that come as part of Kubernetes itself.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+### Time-to-live (TTL) controller {#controller-ttl}
+
+The [Time-to-live controller](/docs/reference/controllers/ttl/) sets TTL
+annotations on {{< glossary_tooltip text="Nodes" term_id="node" >}}
+based on the size of your cluster, so that the
+{{< glossary_tooltip text="kubelet" term_id="kubelet" >}} understands how long
+it can cache responses from the
+{{< glossary_tooltip text="API server" term_id="kube-apiserver" >}}.
+
+### TTL-after-finished controller {#controller-ttl-after-finished}
+
+The [TTL-after-finished controller](/docs/reference/controllers/ttl-after-finished/)
+cleans up finished tasks.
+
+### Garbage collector {#controller-garbagecollector}
+
+For objects that are created automatically, the
+[garbage collector](/docs/reference/controllers/garbage-collector/) makes sure
+that resources are removed when all the objects that depend on them are removed.
+
+### Pod garbage collector {#controller-pod-garbage-collector}
+
+The [Pod garbage collector](/docs/reference/controllers/pod-garbage-collector/)
+cleans up {{< glossary_tooltip text="Pods" term_id="pod" >}} that
+are terminated.
+
+### Certificate signing request (CSR) cleaner {#controller-csr-cleaner}
+
+The [CSR cleaner](/docs/reference/controllers/certificate-cleaner/)
+removes old certificate signing requests that haven't been approved and signed.
+
+### Namespace lifecycle controller {#controller-namespace}
+
+When you (or any Kubernetes API client) remove a
+{{< glossary_tooltip term_id="namespace" >}},
+the [namespace controller](/docs/reference/controllers/namespace/) makes sure
+the Namespace is empty (contains no objects) before that Namespace is removed.
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+* Read about [owners and dependents](/docs/concepts/workloads/controllers/garbage-collection/#owners-and-dependents)
+* Read about [admission controllers](/docs/reference/access-authn-authz/admission-controllers/)
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/resource-management-controllers.md
+++ b/content/en/docs/reference/controllers/resource-management-controllers.md
@@ -1,0 +1,27 @@
+---
+title: Resource management controllers
+content_template: templates/concept
+weight: 40
+---
+
+{{% capture overview %}}
+
+This page lists the resource management
+{{< glossary_tooltip text="controllers" term_id="controller" >}}
+that come as part of Kubernetes itself.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+## ResourceQuota controller
+
+The [ResourceQuota admission controller](/docs/reference/access-authn-authz/admission-controllers/#resourcequota)
+watches for ResourceQuota objects and uses that information to enforce those
+constraints on new Pods.
+
+{{% /capture %}}
+
+{{% capture whatsnext %}}
+* Read about [certificate controllers](/docs/reference/controllers/certificate-controllers)
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/resource-quota.md
+++ b/content/en/docs/reference/controllers/resource-quota.md
@@ -1,0 +1,30 @@
+---
+toc_hide: true
+title: Resource quota controller
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+This {{< glossary_tooltip term_id="controller" >}} limits the quantity of objects
+that can be created in a Namespace by object type, as well as the total amount of
+compute resources that may be consumed by resources in that Namespace.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+The ResourceQuota controller is built in to the {{< glossary_tooltip term_id="kube-controller-manager" >}}.
+
+## Controller behavior
+
+Acting as an [admission controller](/docs/reference/access-authn-authz/admission-controllers/),
+this component rejects requests that would take the amount of resource past
+any configured limit. The controller tracks (and caches) the actual amount of
+resource in real time, so that it can make an admission decision promptly.
+
+{{% /capture %}}
+
+{{% capture whatsnext %}}
+* Read about [resource quotas](/docs/concepts/policy/resource-quotas/) 
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/service.md
+++ b/content/en/docs/reference/controllers/service.md
@@ -1,0 +1,42 @@
+---
+toc_hide: true
+title: Service controller
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+The {{< glossary_tooltip term_id="service" >}}
+{{< glossary_tooltip term_id="controller" text="controller" >}} manages network
+access to a set of {{< glossary_tooltip text="Pods" term_id="pod" >}} via one or
+more Endpoints.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+## Controller behavior
+
+For each Service, the controller continuously scans for Pods that match that
+Service's {{< glossary_tooltip term_id="selector" >}}, and will then POST any
+updates to an Endpoint object with the same name as the Service.
+
+Unless the Service controller idenfifies a “headless” Service (with `.spec.clusterIP`
+explicitly set to `None`) then this controller will attempt to set up access to
+the Service. For example, the Service controller might assign an IP address for
+external access, or it might defer to another controller to ensure that an address
+gets assigned.
+
+Using a Service resource you can set up several different mechanisms to handle
+incoming network traffic to your application. Depending on your cluster and its
+environment, this may involve the cloud-controller-manager as well as cloud-specific
+controller behaviors.
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+
+* Read about the [Endpoint controller](/docs/reference/controllers/endpoint/)
+* Read about the [Service](/docs/concepts/services-networking/service/) concept
+* Read about the [Ingress](/docs/concepts/services-networking/ingress/) concept
+
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/serviceaccount-token.md
+++ b/content/en/docs/reference/controllers/serviceaccount-token.md
@@ -1,0 +1,28 @@
+---
+toc_hide: true
+title: ServiceAccount token controller
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+The ServiceAccount token {{< glossary_tooltip term_id="controller" >}} generates and
+assigns API access tokens for a ServiceAccount.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+The ServiceAccount token controller is built in to the {{< glossary_tooltip term_id="kube-controller-manager" >}}.
+
+## Controller behavior
+
+This controller issues API access tokens for each ServiceAccount and places them into
+an associated {{< glossary_tooltip term_id="secret" >}}. Pods that can access that Secret
+can use the token to identify as the relevant ServiceAccount.
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+* Read about the [ServiceAccount controller](/docs/reference/controllers/serviceaccount/)
+* Read about other [cluster orchestration controllers](/docs/reference/controllers/cluster-orchestration-controllers/)
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/serviceaccount.md
+++ b/content/en/docs/reference/controllers/serviceaccount.md
@@ -1,0 +1,27 @@
+---
+toc_hide: true
+title: ServiceAccount controller
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+One of a pair of {{< glossary_tooltip term_id="controller" text="controllers">}}
+for the {{< glossary_tooltip text="ServiceAccount" term_id="service-account" >}}
+resource.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+The ServiceAccount controller is built in to the {{< glossary_tooltip term_id="kube-controller-manager" >}}.
+
+## Controller behavior
+
+This controller ensures that each {{< glossary_tooltip term_id="namespace" >}}
+contains a default ServiceAccount.
+{{% /capture %}}
+{{% capture whatsnext %}}
+* Read about the [ServiceAccount token controller](/docs/reference/controllers/serviceaccount-token/)
+* Read about other [cluster orchestration controllers](/docs/reference/controllers/cluster-orchestration-controllers/)
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/statefulset.md
+++ b/content/en/docs/reference/controllers/statefulset.md
@@ -1,0 +1,44 @@
+---
+toc_hide: true
+title: StatefulSet controller
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+The StatefulSet {{< glossary_tooltip term_id="controller" text="controller" >}}
+ensures that a {{< glossary_tooltip term_id="StatefulSet" >}} is running on a
+suitable set of {{< glossary_tooltip term_id="node" text="Nodes" >}}.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+The StatefulSet controller is built in to the {{< glossary_tooltip term_id="kube-controller-manager" >}}.
+
+## Controller behavior
+
+The controller creates a number of Pods for each StatefulSet that it observes,
+based on the count of replicas configured for that StatefulSet.
+
+{{< note >}}
+The StatefulSet controller creates each Pod sequentially.
+{{< /note >}}
+
+As the StatefulSet controller creates a Pod, it adds a label, `statefulset.kubernetes.io/pod-name`,
+that is set to the name of the Pod. This label gives each Pod a durable, stable
+network identity, that allows you to attach a Service to a specific Pod in
+the StatefulSet.
+
+The controller constructs the name label's value based on a pattern:
+`$(statefulset_name)-$(ordinal)`.
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+
+* Read about the [StatefulSet](/docs/concepts/workloads/controllers/statefulset/) concept
+* Read about other [workload controllers](/docs/reference/controllers/workload-controllers/)
+
+{{% /capture %}}
+
+

--- a/content/en/docs/reference/controllers/storage-controllers.md
+++ b/content/en/docs/reference/controllers/storage-controllers.md
@@ -1,0 +1,49 @@
+---
+title: Storage controllers
+content_template: templates/concept
+weight: 60
+---
+
+{{% capture overview %}}
+
+This page lists the built-in
+{{< glossary_tooltip text="controllers" term_id="controller" >}}
+for storage management, that come as part of Kubernetes itself.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+## PersistentVolume controller
+
+The [PersistentVolume controller](/docs/reference/controllers/volume-persistentvolume/)
+controller ensures, where possible, that each PersistentVolumeClaim
+is [bound](/docs/concepts/storage/persistent-volumes/#binding)
+to a suitable PersistentVolume. This can include provisioning a new PersistentVolume,
+with help from other components such as a {{< glossary_tooltip text="CSI" term_id="csi" >}}
+driver.
+
+## PersistentVolume in-use protection controller
+
+The [PersistentVolume protection controller](/docs/reference/controllers/volume-persistentvolume-protection/)
+acts as a backstop for the related
+[admission controller](/docs/reference/access-authn-authz/admission-controllers/#storageobjectinuseprotection)
+and makes sure that all PersistentVolumes have a finalizer set.
+
+## PersistentVolumeClaim in-use protection controller
+
+The [PersistentVolumeClaim protection controller](/docs/reference/controllers/volume-persistentvolumeclaim-protection/)
+also acts as a backstop for the related
+[admission controller](/docs/reference/access-authn-authz/admission-controllers/#storageobjectinuseprotection)
+and makes sure that all PersistentVolumes have a finalizer set.
+
+## Volume attach / detach controller
+
+The [Volume attach / detach controller](/docs/reference/controllers/volume-attach-detach/)
+is responsible for attaching and detaching all Volumes across a cluster.
+
+{{% /capture %}}
+
+{{% capture whatsnext %}}
+* Read about [networking controllers](/docs/reference/controllers/network-controllers/)
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/ttl-after-finished.md
+++ b/content/en/docs/reference/controllers/ttl-after-finished.md
@@ -1,0 +1,39 @@
+---
+toc_hide: true
+title: TTL-after-finished controller
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+{{< feature-state for_k8s_version="v1.12" state="alpha" >}}
+
+The TTL-after-finished controller provides a Time-To-Live mechanism to limit the lifetime of resource
+objects that have finished execution.
+
+The TTL-after-finished controller cleans up {{< glossary_tooltip text="Jobs" term_id="job" >}}
+resources after they complete.
+
+You can use the TTL-after-finished controller by enabling the
+[feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
+`TTLAfterFinished`.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+## Controller behavior
+
+When this controller observes a Job that is finished (either `Complete` or `Failed`),
+and that Job has `.spec.ttlSecondsAfterFinished` set, this controller waits until
+the Job has been complete for that many seconds.
+
+After the timer has expired, this controller deletes the Job.
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+
+* Read about [Jobs](/docs/concepts/workloads/controllers/job-run-to-completion/#clean-up-finished-jobs-automatically)
+* Learn about other [resource clean-up controllers](/docs/reference/controllers/resource-cleanup-controllers/)
+
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/ttl-after-finished.md
+++ b/content/en/docs/reference/controllers/ttl-after-finished.md
@@ -30,6 +30,14 @@ the Job has been complete for that many seconds.
 
 After the timer has expired, this controller deletes the Job.
 
+{{< caution >}}
+This controller uses timestamps stored in the Kubernetes resources to
+determine whether the TTL has expired or not. Expiry checks are sensitive
+to clock skew in your cluster. If different parts of your control plane
+have unsynchronized clocks, the TTL-after-finished controller could
+clean up resources at the wrong time.
+{{< /caution >}}
+
 {{% /capture %}}
 {{% capture whatsnext %}}
 

--- a/content/en/docs/reference/controllers/ttl.md
+++ b/content/en/docs/reference/controllers/ttl.md
@@ -1,0 +1,33 @@
+---
+toc_hide: true
+title: Time-to-live (TTL) controller
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+The Time-to-live (TTL) controller sets sets TTL annotations on Nodes based on cluster size.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+## Controller behavior
+
+This controller sets sets TTL annotations on Nodes based on cluster size.
+The {{< glossary_tooltip term_id="kubelet" text="kubelet" >}} consumes these
+annotations as a hint about how long it can cache object data it has
+fetched from the {{< glossary_tooltip text="API server" term_id="kube-apiserver" >}}.
+
+{{< comment >}}
+This controller is an implementation detail; if the kubelet were able to
+subscribe to watch all resources related to Pods on that node,
+then the kubelet could use those notifications for cache invalidation instead.
+{{< /comment >}}
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+
+* Learn about other [resource clean-up controllers](/docs/reference/controllers/resource-cleanup-controllers/)
+
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/volume-attach-detach.md
+++ b/content/en/docs/reference/controllers/volume-attach-detach.md
@@ -1,0 +1,45 @@
+---
+toc_hide: true
+title: Volume attach / detach controller
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+The {{< glossary_tooltip text="Volume" term_id="volume" >}}
+attach / detach {{< glossary_tooltip text="controller" term_id="controller" >}}
+is part of a set of built-in controllers for storage management.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+## Controller behavior
+
+The volume attach / detach controller is responsible for attaching and detaching
+all Volumes across a cluster. This controller watches the API server for Pod
+creation and termination.
+
+Once a new pod is scheduled, the volume attach / detach controller works out what
+volumes need to be attached and signals this (via the API server) to kubelet and
+to storage services. The controller updates `.status.volumesAttached` on the
+Node where the Pod is scheduled, and kubelet updates `.status.volumesInUse` once
+it starts using the Volume (ie, mounting it for a container in a Pod).
+
+When a pod is terminated, the controller makes sure that the existing attached
+volumes are detached. After signalling for kubelet to unmount the volume, the
+volume attach / detach controller waits for graceful unmount before attempting
+to detach it.
+
+Different nodes might have different ways of attaching volumes, and different
+Volumes can have different values for VolumeNodeAffinity, so the decision
+around volume attachment happens after scheduling.
+
+To learn more about how Kubernetes manages storage and makes this storage
+available to Pods, refer to the [storage](/docs/concepts/storage/persistent-volumes/) documentation.
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+* Read about other [storage controllers](/docs/reference/controllers/storage-controllers/)
+{{% /capture %}}
+

--- a/content/en/docs/reference/controllers/volume-persistentvolume-protection.md
+++ b/content/en/docs/reference/controllers/volume-persistentvolume-protection.md
@@ -1,0 +1,34 @@
+---
+toc_hide: true
+title: PersistentVolume in-use protection controller
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+The {{< glossary_tooltip text="PersistentVolume" term_id="persistent-volume-claim" >}}
+protection {{< glossary_tooltip text="controller" term_id="controller" >}} is
+part of a set of built-in controllers for storage management.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+## Controller behavior
+
+The PersistentVolume (PV) protection controller watches for PersistentVolumes
+and Pods. This controller acts as a backstop for the related
+[admission controller](/docs/reference/access-authn-authz/admission-controllers/#storageobjectinuseprotection)
+and makes sure that all PVs have a finalizer set. The finalizer is there to block PV
+deletion for any PV that's used by a running Pod.
+
+When a PV becomes a candidate for deletion, the PV protection controller
+checks if the PV is still in use. If the PV is still in use then the finalizer
+stays in place. If / when the PV stops being used, this controller removes
+the storage object in-use protection finalizer, so that the PV can be deleted.
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+* Read about [storage object in-use protection](/docs/concepts/storage/persistent-volumes/#storage-object-in-use-protection)
+* Read about other [storage controllers](/docs/reference/controllers/storage-controllers/)
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/volume-persistentvolume.md
+++ b/content/en/docs/reference/controllers/volume-persistentvolume.md
@@ -1,0 +1,43 @@
+---
+toc_hide: true
+title: PersistentVolume controller
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+The {{< glossary_tooltip text="PersistentVolume" term_id="persistent-volume" >}}
+{{< glossary_tooltip text="controller" term_id="controller" >}} is part of a set
+of built-in controllers for storage management.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+```
+// ==================================================================
+// PLEASE DO NOT ATTEMPT TO SIMPLIFY THIS CODE.
+// KEEP THE SPACE SHUTTLE FLYING.
+// ==================================================================
+```
+
+## Controller behavior
+
+This controller ensures, where possible, that each PersistentVolumeClaim
+is [bound](/docs/concepts/storage/persistent-volumes/#binding)
+to a suitable PersistentVolume. This can include provisioning a new PersistentVolume,
+with help from other components such as a {{< glossary_tooltip text="CSI" term_id="csi" >}}
+driver.
+
+When PersistentVolumes become eligible for
+[reclamation](/docs/concepts/storage/persistent-volumes/#reclaiming), this
+controller takes part in ensuring that the appropriate reclaim action takes place.
+
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+* Read the [storage](/docs/concepts/storage/persistent-volumes/) documentation to
+  learn about how Kubernetes manages {{< glossary_tooltip text="volumes" term_id="volume" >}} and
+  related resources.
+* Read about other [storage controllers](/docs/reference/controllers/storage-controllers/)
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/volume-persistentvolumeclaim-protection.md
+++ b/content/en/docs/reference/controllers/volume-persistentvolumeclaim-protection.md
@@ -1,0 +1,34 @@
+---
+toc_hide: true
+title: PersistentVolumeClaim in-use protection controller
+content_template: templates/concept
+---
+
+{{% capture overview %}}
+
+The {{< glossary_tooltip text="PersistentVolumeClaim" term_id="persistent-volume-claim" >}}
+protection {{< glossary_tooltip text="controller" term_id="controller" >}} is
+part of a set of built-in controllers for storage management.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+## Controller behavior
+
+The PersistentVolumeClaim (PVC) protection controller watches for
+PersistentVolumeClaims and Pods. The controller acts as a backstop for the related
+[admission controller](/docs/reference/access-authn-authz/admission-controllers/#storageobjectinuseprotection)
+and makes sure that all PVCs have a finalizer set. The finalizer is there to block PVC
+deletion for any PVC that's used by a running Pod.
+
+When a PVC becomes a candidate for deletion, the PVC protection controller
+checks if the PVC is still in use. If the PVC is still in use then the finalizer
+stays in place. If / when the PVC stops being used, this controller removes
+the storage object in-use protection finalizer, so that the PVC can be deleted.
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+* Read about [storage object in-use protection](/docs/concepts/storage/persistent-volumes/#storage-object-in-use-protection)
+* Read about other [storage controllers](/docs/reference/controllers/storage-controllers/)
+{{% /capture %}}

--- a/content/en/docs/reference/controllers/workload-controllers.md
+++ b/content/en/docs/reference/controllers/workload-controllers.md
@@ -1,0 +1,66 @@
+---
+title: Workload controllers
+content_template: templates/concept
+weight: 20
+---
+
+{{% capture overview %}}
+
+This page lists the workload
+{{< glossary_tooltip text="controllers" term_id="controller" >}}
+that come as part of Kubernetes itself.
+{{< glossary_definition term_id="workload" length="short">}}
+
+{{% /capture %}}
+
+{{% capture body %}}
+## CronJob controller
+
+The [CronJob controller](/docs/reference/controllers/cronjob/) creates
+{{< glossary_tooltip text="Jobs" term_id="job" >}} for a
+{{< glossary_tooltip term_id="cronjob" >}} on a time-based schedule.
+
+## DaemonSet controller
+
+The [DaemonSet controller](/docs/reference/controllers/daemonset/) manages
+Pods configured via a
+{{< glossary_tooltip term_id="daemonset" >}} object, to make sure that some
+(or all) Nodes run a copy of a Pod.
+
+## Deployment controller
+
+The [Deployment controller](/docs/reference/controllers/deployment/)
+enables declarative definitions for [Pods](/docs/concepts/workloads/pods/pod/) and
+[ReplicaSets](/docs/concepts/workloads/controllers/replicaset/) to run an application
+using stateless containers.
+
+## Job controller
+
+The [Job controller](/docs/reference/controllers/job/) creates
+{{< glossary_tooltip term_id="pod" text="Pods" >}} to run each defined
+Job to completion.
+
+## ReplicaSet controller
+
+The [ReplicaSet controller](/docs/reference/controllers/replicaset/)
+maintains a stable number of replica Pods for each
+{{< glossary_tooltip text="ReplicaSet" term_id="replica-set" >}}.
+
+## ReplicationController
+
+The [controller for ReplicationController objects](/docs/reference/controllers/replicationcontroller/)
+is called “the replication controller”.
+This deprecated controller ensures that a specified number of Pod replicas are
+running at any one time, based on the spec in a ReplicationController object.
+
+## StatefulSet controller
+
+The [StatefulSet controller](/docs/reference/controllers/statefulset/)
+ensures that a {{< glossary_tooltip term_id="StatefulSet" >}} is ready to be
+scheduled onto a suitable set of Nodes.
+
+{{% /capture %}}
+
+{{% capture whatsnext %}}
+* Read about [Pod management controllers](/docs/reference/controllers/pod-management-controllers/)
+{{% /capture %}}


### PR DESCRIPTION
Relevant to issue #4135. Rework of PR #15374. [Preview](https://deploy-preview-16885--kubernetes-io-master-staging.netlify.com/docs/reference/controllers/).

Add a reference section that lists the built-in controllers and explains what each of them does.

This change fits in with an idea I have to restructure https://kubernetes.io/docs/concepts/workloads/

People developing things to deploy on Kubernetes need to understand that there is (eg) a Deployment resource; it doesn't matter as much _how_ the Deployment resource gets translated into API actions like creating or removing ReplicaSet objects. Some resources happen to involve more than one controller (eg Job with the Job controller and the TTL-after-finished controller).

If you are interested in looking behind the scenes, I think it helps to have all kube-controller-manager controllers listed in one place, no matter what kind of resource they interact with (Endpoint? ReplicaSet? Namespace?)

/sig apps

Credit to @lavalamp for the excellent [Kubecon talk](https://youtu.be/zCXiXKMqnuE) that helped me a lot with drafting these documents.