### PR TITLE
upgrade ubuntu docker image 14.04 → 18.04

### DIFF
--- a/content/en/examples/application/job/rabbitmq/Dockerfile
+++ b/content/en/examples/application/job/rabbitmq/Dockerfile
@@ -1,5 +1,5 @@
 # Specify BROKER_URL and QUEUE when running
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y curl ca-certificates amqp-tools python \

--- a/content/ja/examples/application/job/rabbitmq/Dockerfile
+++ b/content/ja/examples/application/job/rabbitmq/Dockerfile
@@ -1,5 +1,5 @@
 # Specify BROKER_URL and QUEUE when running
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y curl ca-certificates amqp-tools python \


### PR DESCRIPTION
1. I do the exercise: [Coarse Parallel Processing Using a Work Queue - Kubernetes](https://kubernetes.io/docs/tasks/job/coarse-parallel-processing-work-queue/). **The 18.04 is OK, but the 14.04 returns an error message**: `logging in to AMQP server: a socket error occurred`.
1. In the [Coarse Parallel Processing Using a Work Queue - Kubernetes](https://kubernetes.io/docs/tasks/job/coarse-parallel-processing-work-queue/), **the 18.04 is used in the content.** So, I think it is best to be consistent.
1. The 14.04 exceeds the support time.