### PR TITLE
Fix fluentd image

### DIFF
--- a/content/en/examples/controllers/daemonset.yaml
+++ b/content/en/examples/controllers/daemonset.yaml
@@ -19,7 +19,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: fluentd-elasticsearch
-        image: gcr.io/fluentd-elasticsearch/fluentd:v2.5.1
+        image: quay.io/fluentd_elasticsearch/fluentd:v2.5.2
         resources:
           limits:
             memory: 200Mi

--- a/content/ja/examples/controllers/daemonset.yaml
+++ b/content/ja/examples/controllers/daemonset.yaml
@@ -19,7 +19,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: fluentd-elasticsearch
-        image: gcr.io/fluentd-elasticsearch/fluentd:v2.5.1
+        image: quay.io/fluentd_elasticsearch/fluentd:v2.5.2
         resources:
           limits:
             memory: 200Mi

--- a/content/ko/examples/controllers/daemonset.yaml
+++ b/content/ko/examples/controllers/daemonset.yaml
@@ -19,7 +19,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: fluentd-elasticsearch
-        image: gcr.io/fluentd-elasticsearch/fluentd:v2.5.1
+        image: quay.io/fluentd_elasticsearch/fluentd:v2.5.2
         resources:
           limits:
             memory: 200Mi

--- a/content/zh/docs/concepts/workloads/controllers/daemonset.yaml
+++ b/content/zh/docs/concepts/workloads/controllers/daemonset.yaml
@@ -6,14 +6,20 @@ metadata:
   labels:
     k8s-app: fluentd-logging
 spec:
+  selector:
+    matchLabels:
+      name: fluentd-elasticsearch
   template:
     metadata:
       labels:
         name: fluentd-elasticsearch
     spec:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       containers:
       - name: fluentd-elasticsearch
-        image: gcr.io/fluentd-elasticsearch/fluentd:v2.5.1
+        image: quay.io/fluentd_elasticsearch/fluentd:v2.5.2
         resources:
           limits:
             memory: 200Mi


### PR DESCRIPTION
fluentd image was moved from gcr.io to quay.io - ref kubernetes/kubernetes#79390.
Currently the image pull fails:
```bash
docker pull gcr.io/fluentd-elasticsearch/fluentd:v2.5.1
Error response from daemon: pull access denied for gcr.io/fluentd-elasticsearch/fluentd, repository does not exist or may require 'docker login': denied: Permission denied for "v2.5.1" from request "/v2/fluentd-elasticsearch/fluentd/manifests/v2.5.1".
```

/kind bug