### PR TITLE
Update UAA, Dex links in setup instructions for specific systems

### DIFF
--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -347,8 +347,8 @@ Or you can use [this similar script](https://raw.githubusercontent.com/TremoloSe
 
 Setup instructions for specific systems:
 
-- [UAA](http://apigee.com/about/blog/engineering/kubernetes-authentication-enterprise)
-- [Dex](https://speakerdeck.com/ericchiang/kubernetes-access-control-with-dex)
+- [UAA](https://docs.cloudfoundry.org/concepts/architecture/uaa.html)
+- [Dex](https://github.com/dexidp/dex/blob/master/Documentation/kubernetes.md)
 - [OpenUnison](https://www.tremolosecurity.com/orchestra-k8s/)
 
 #### Using kubectl


### PR DESCRIPTION
Update UAA, Dex links in _setup instructions for specific systems_ in  https://kubernetes.io/docs/reference/access-authn-authz/authentication/#configuring-the-api-server

Fixing the links. This page may or may not be a candidate for third-party content review once the KEP is finalized.

Fixes #16916 

Page Preview:   https://deploy-preview-16945--kubernetes-io-master-staging.netlify.com/docs/reference/access-authn-authz/authentication/#configuring-the-api-server

Signed-off-by: Aimee Ukasick <aimeeu.opensource@gmail.com>


