### PR TITLE
Add `get all` to kubectl cheatsheet

### DIFF
--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -142,6 +142,7 @@ EOF
 
 ```bash
 # Get commands with basic output
+kubectl get all                               # List all Kubernetes objects in the namespace
 kubectl get services                          # List all services in the namespace
 kubectl get pods --all-namespaces             # List all pods in all namespaces
 kubectl get pods -o wide                      # List all pods in the namespace, with more details


### PR DESCRIPTION
`kubectl get all` command is extremely useful when trying to navigate the waters of Kubernetes and/or debugging things in the unknown namespace. Interestingly this command is not listed on `kubectl get --help` page.

TODO: check if this change needs localization.
I see cheatsheet page has been translated to

- German: https://github.com/kubernetes/website/blob/master/content/de/docs/reference/kubectl/cheatsheet.md
- Korean: https://github.com/kubernetes/website/blob/master/content/ko/docs/reference/kubectl/cheatsheet.md
- French: https://github.com/kubernetes/website/blob/master/content/fr/docs/reference/kubectl/cheatsheet.md

But I don't know those languages well enough to make localization changes.
