### PR TITLE
modify example error about hpa of autoscaling/v2beta2 HorizontalPodAu…

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -310,7 +310,9 @@ spec:
     pods:
       metric:
         name: packets-per-second
-      targetAverageValue: 1k
+      target:
+        type: AverageValue
+        averageValue: 1k
   - type: Object
     object:
       metric:


### PR DESCRIPTION
HorizontalPodAutoscaler.spec.metrics.pods.target has no attibute of targetAverageValue

KIND:     HorizontalPodAutoscaler
VERSION:  autoscaling/v2beta2

```shell
kubectl explain --api-version=autoscaling/v2beta2 HorizontalPodAutoscaler.spec.metrics.pods.target
FIELDS:
   averageUtilization   <integer>
     averageUtilization is the target value of the average of the resource
     metric across all relevant pods, represented as a percentage of the
     requested value of the resource for the pods. Currently only valid for
     Resource metric source type

   averageValue <string>
     averageValue is the target value of the average of the metric across all
     relevant pods (as a quantity)

   type <string> -required-
     type represents whether the metric type is Utilization, Value, or
     AverageValue

   value        <string>
     value is the target value of the metric (as a quantity).

```

fixed #16759
