### PR TITLE
Update PR template's base branch for zh-trans

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,8 +2,8 @@
 > Remember to delete this note before submitting your pull request.
 >
 > For pull requests on 1.17 Features: set Milestone to 1.17 and Base Branch to dev-1.17
-> 
-> For pull requests on Chinese localization, set Base Branch to release-1.15
+>
+> For pull requests on Chinese localization, set Base Branch to release-1.16
 >
 > For pull requests on Korean Localization: set Base Branch to dev-1.16-ko.\<latest team milestone>
 >

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,7 @@
 > For pull requests on 1.17 Features: set Milestone to 1.17 and Base Branch to dev-1.17
 >
 > For pull requests on Chinese localization, set Base Branch to release-1.16
+> Feel free to ask questions in #kubernetes-docs-zh
 >
 > For pull requests on Korean Localization: set Base Branch to dev-1.16-ko.\<latest team milestone>
 >


### PR DESCRIPTION
Update base branch per recent release.

Relates to https://github.com/kubernetes/website/pull/16755, https://github.com/kubernetes/website/pull/16805

Communicate into #kubernetes-docs-zh channel
https://kubernetes.slack.com/archives/CE3LNFYJ1/p1571191499007300

/cc @markthink @SataQiu @zhangxiaoyu-zidif  @xichengliudui @AdamDang  
/cc @kubernetes/sig-docs-zh-reviews 