### PR TITLE
Modifying adding label to node steps

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/assign-pods-nodes.md
+++ b/content/en/docs/tasks/configure-pod-container/assign-pods-nodes.md
@@ -19,19 +19,19 @@ Kubernetes cluster.
 
 ## Add a label to a node
 
-1. List the nodes in your cluster:
+1. List the nodes with labels in your cluster:
 
     ```shell
-    kubectl get nodes
+    kubectl get nodes --show-labels
     ```
 
     The output is similar to this:
 
     ```shell
-    NAME      STATUS    ROLES     AGE     VERSION
-    worker0   Ready     <none>    1d      v1.13.0
-    worker1   Ready     <none>    1d      v1.13.0
-    worker2   Ready     <none>    1d      v1.13.0
+    NAME      STATUS    ROLES    AGE     VERSION        LABELS
+    worker0   Ready     <none>   1d      v1.13.0        ...,kubernetes.io/hostname=worker0
+    worker1   Ready     <none>   1d      v1.13.0        ...,kubernetes.io/hostname=worker1
+    worker2   Ready     <none>   1d      v1.13.0        ...,kubernetes.io/hostname=worker2
     ```
 1. Chose one of your nodes, and add a label to it:
 

--- a/content/en/docs/tasks/configure-pod-container/assign-pods-nodes.md
+++ b/content/en/docs/tasks/configure-pod-container/assign-pods-nodes.md
@@ -19,7 +19,7 @@ Kubernetes cluster.
 
 ## Add a label to a node
 
-1. List the nodes with labels in your cluster:
+1. List the nodes in your cluster, along with their labels:
 
     ```shell
     kubectl get nodes --show-labels


### PR DESCRIPTION
Existing steps do not show what labels the node has before adding a new label. So I have changed the command to list out node along with their labels before adding any new label. This will help first-time readers to understand existing labels and then how we can add a new label and display it.