### PR TITLE
Fixes path in first ingress resource yaml

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -146,7 +146,7 @@ The following file is an Ingress resource that sends traffic to your Service via
           - host: hello-world.info
             http:
               paths:
-              - path: /|/(.+)
+              - path: /
                 backend:
                   serviceName: web
                   servicePort: 8080


### PR DESCRIPTION
When the second path is attached to `example-ingress` for `/v2` it doesn't work because the first path captures all paths. Solution is the make the `/` capture everything except `/v2` (also captures `/v2/<anything else>`)
