### PR TITLE
incorrect command for sort-by operation on pod

### DIFF
--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -162,7 +162,7 @@ kubectl get pods --sort-by='.status.containerStatuses[0].restartCount'
 
 # List pods in test namespace sorted by capacity
 
-kubectl get pods -n test --sort-by=.spec.capacity.storage
+kubectl get pv -n test --sort-by=.spec.capacity.storage
 
 # Get the version label of all pods with label app=cassandra
 kubectl get pods --selector=app=cassandra -o \

--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -160,7 +160,7 @@ kubectl get services --sort-by=.metadata.name
 # List pods Sorted by Restart Count
 kubectl get pods --sort-by='.status.containerStatuses[0].restartCount'
 
-# List pods in test namespace sorted by capacity
+# List PersistentVolumes in test namespace sorted by capacity
 
 kubectl get pv -n test --sort-by=.spec.capacity.storage
 


### PR DESCRIPTION
kubectl get pods -n test --sort-by=.spec.capacity.storage, is incorrect for pod as pods will not have capacity.storage under .spec, rather it should be for PersistentVolume.

So change the command  

kubectl get pv -n test --sort-by=.spec.capacity.storage

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> Remember to delete this note before submitting your pull request.
>
> For pull requests on 1.17 Features: set Milestone to 1.17 and Base Branch to dev-1.17
>
> For pull requests on Chinese localization, set Base Branch to release-1.16
> Feel free to ask questions in #kubernetes-docs-zh
>
> For pull requests on Korean Localization: set Base Branch to dev-1.16-ko.\<latest team milestone>
>
> If you need Help on editing and submitting pull requests, visit:
> https://kubernetes.io/docs/contribute/start/#improve-existing-content.
>
> If you need Help on choosing which branch to use, visit:
> https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use.
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
