### PR TITLE
en: Change the full link in the document to an inline link.

### DIFF
--- a/content/en/docs/concepts/configuration/pod-overhead.md
+++ b/content/en/docs/concepts/configuration/pod-overhead.md
@@ -27,9 +27,9 @@ on top of the container requests & limits.
 ## Pod Overhead
 
 In Kubernetes, the pod's overhead is set at
-[admission](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#what-are-admission-webhooks)
+[admission](/docs/reference/access-authn-authz/extensible-admission-controllers/#what-are-admission-webhooks)
 time according to the overhead associated with the pod's
-[RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/).
+[RuntimeClass](/docs/concepts/containers/runtime-class/).
 
 When Pod Overhead is enabled, the overhead is considered in addition to the sum of container
 resource requests when scheduling a pod. Similarly, Kubelet will include the pod overhead when sizing

--- a/content/en/docs/concepts/configuration/pod-priority-preemption.md
+++ b/content/en/docs/concepts/configuration/pod-priority-preemption.md
@@ -156,7 +156,7 @@ description: "This priority class should be used for XYZ service pods only."
 
 1.15 adds the `PreemptionPolicy` field as an alpha feature.
 It is disabled by default in 1.15,
-and requires the `NonPreemptingPriority`[feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
+and requires the `NonPreemptingPriority`[feature gate](/docs/reference/command-line-tools-reference/feature-gates/
 ) to be enabled.
 
 Pods with `PreemptionPolicy: Never` will be placed in the scheduling queue

--- a/content/en/docs/concepts/scheduling/kube-scheduler.md
+++ b/content/en/docs/concepts/scheduling/kube-scheduler.md
@@ -174,7 +174,7 @@ kube-scheduler has a default set of scheduling policies.
   that the Service becomes more resilient to a single Node failure.
 
 - `CalculateAntiAffinityPriorityMap`: This policy helps implement
-  [pod anti-affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity).
+  [pod anti-affinity](/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity).
 
 - `EqualPriorityMap`: Gives an equal weight of one to all nodes.
 

--- a/content/en/docs/concepts/services-networking/dual-stack.md
+++ b/content/en/docs/concepts/services-networking/dual-stack.md
@@ -45,7 +45,7 @@ The following prerequisites are needed in order to utilize IPv4/IPv6 dual-stack 
 
 ## Enable IPv4/IPv6 dual-stack
 
-To enable IPv4/IPv6 dual-stack, enable the `IPv6DualStack` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) for the relevant components of your cluster, and set dual-stack cluster network assignments:
+To enable IPv4/IPv6 dual-stack, enable the `IPv6DualStack` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) for the relevant components of your cluster, and set dual-stack cluster network assignments:
 
    * kube-controller-manager:
       * `--feature-gates="IPv6DualStack=true"`

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -214,7 +214,7 @@ See the [CephFS example](https://github.com/kubernetes/examples/tree/{{< param "
 
 {{< note >}}
 Prerequisite: Kubernetes with OpenStack Cloud Provider configured. For cloudprovider
-configuration please refer [cloud provider openstack](https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#openstack).
+configuration please refer [cloud provider openstack](/docs/concepts/cluster-administration/cloud-providers/#openstack).
 {{< /note >}}
 
 `cinder` is used to mount OpenStack Cinder Volume into your Pod.

--- a/content/en/docs/concepts/workloads/pods/pod-overview.md
+++ b/content/en/docs/concepts/workloads/pods/pod-overview.md
@@ -21,7 +21,7 @@ A *Pod* is the basic execution unit of a Kubernetes application--the smallest an
 
 A Pod encapsulates an application's container (or, in some cases, multiple containers), storage resources, a unique network IP, and options that govern how the container(s) should run. A Pod represents a unit of deployment: *a single instance of an application in Kubernetes*, which might consist of either a single {{< glossary_tooltip text="container" term_id="container" >}} or a small number of containers that are tightly coupled and that share resources.
 
-[Docker](https://www.docker.com) is the most common container runtime used in a Kubernetes Pod, but Pods support other [container runtimes](https://kubernetes.io/docs/setup/production-environment/container-runtimes/) as well.
+[Docker](https://www.docker.com) is the most common container runtime used in a Kubernetes Pod, but Pods support other [container runtimes](docs/setup/production-environment/container-runtimes/) as well.
 
 
 Pods in a Kubernetes cluster can be used in two main ways:

--- a/content/en/docs/concepts/workloads/pods/pod-overview.md
+++ b/content/en/docs/concepts/workloads/pods/pod-overview.md
@@ -21,7 +21,7 @@ A *Pod* is the basic execution unit of a Kubernetes application--the smallest an
 
 A Pod encapsulates an application's container (or, in some cases, multiple containers), storage resources, a unique network IP, and options that govern how the container(s) should run. A Pod represents a unit of deployment: *a single instance of an application in Kubernetes*, which might consist of either a single {{< glossary_tooltip text="container" term_id="container" >}} or a small number of containers that are tightly coupled and that share resources.
 
-[Docker](https://www.docker.com) is the most common container runtime used in a Kubernetes Pod, but Pods support other [container runtimes](docs/setup/production-environment/container-runtimes/) as well.
+[Docker](https://www.docker.com) is the most common container runtime used in a Kubernetes Pod, but Pods support other [container runtimes](/docs/setup/production-environment/container-runtimes/) as well.
 
 
 Pods in a Kubernetes cluster can be used in two main ways:

--- a/content/en/docs/contribute/localization.md
+++ b/content/en/docs/contribute/localization.md
@@ -42,7 +42,7 @@ cd website
 
 ### Open a pull request
 
-Next, [open a pull request](https://kubernetes.io/docs/contribute/start/#submit-a-pull-request) (PR) to add a localization to the `kubernetes/website` repository. 
+Next, [open a pull request](/docs/contribute/start/#submit-a-pull-request) (PR) to add a localization to the `kubernetes/website` repository. 
 
 The PR must include all of the [minimum required content](#minimum-required-content) before it can be approved.
 

--- a/content/en/docs/contribute/style/style-guide.md
+++ b/content/en/docs/contribute/style/style-guide.md
@@ -34,7 +34,7 @@ and representing feature state.
 Kubernetes documentation has been translated into multiple languages
 (see [Localization READMEs](https://github.com/kubernetes/website/blob/master/README.md#localization-readmemds)).
 
-The way of localizing the docs for a different language is described in [Localizing Kubernetes Documentation](https://kubernetes.io/docs/contribute/localization/).
+The way of localizing the docs for a different language is described in [Localizing Kubernetes Documentation](/docs/contribute/localization/).
 
 The English-language documentation uses U.S. English spelling and grammar.
 

--- a/content/en/docs/reference/access-authn-authz/extensible-admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/extensible-admission-controllers.md
@@ -525,7 +525,7 @@ Example of a minimal response from a webhook to forbid a request:
 
 When rejecting a request, the webhook can customize the http code and message returned to the user using the `status` field.
 The specified status object is returned to the user.
-See the [API documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#status-v1-meta) for details about the status type.
+See the [API documentation](/docs/reference/generated/kubernetes-api/v1.14/#status-v1-meta) for details about the status type.
 Example of a response to forbid a request, customizing the HTTP status code and message presented to the user:
 {{< tabs name="AdmissionReview_response_forbid_details" >}}
 {{% tab name="admission.k8s.io/v1" %}}

--- a/content/en/docs/reference/glossary/cri.md
+++ b/content/en/docs/reference/glossary/cri.md
@@ -2,7 +2,7 @@
 title: Container runtime interface (CRI)
 id: cri
 date: 2019-03-07
-full_link: https://kubernetes.io/docs/concepts/overview/components/#container-runtime
+full_link: /docs/concepts/overview/components/#container-runtime
 short_description: >
     An API for container runtimes to integrate with kubelet
 

--- a/content/en/docs/reference/kubectl/overview.md
+++ b/content/en/docs/reference/kubectl/overview.md
@@ -10,7 +10,7 @@ card:
 ---
 
 {{% capture overview %}}
-Kubectl is a command line interface for running commands against Kubernetes clusters. `kubectl` looks for a file named config in the $HOME/.kube directory. You can specify other [kubeconfig](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) files by setting the KUBECONFIG environment variable or by setting the [`--kubeconfig`](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) flag.
+Kubectl is a command line interface for running commands against Kubernetes clusters. `kubectl` looks for a file named config in the $HOME/.kube directory. You can specify other [kubeconfig](/docs/concepts/configuration/organize-cluster-access-kubeconfig/) files by setting the KUBECONFIG environment variable or by setting the [`--kubeconfig`](/docs/concepts/configuration/organize-cluster-access-kubeconfig/) flag.
 
 This overview covers `kubectl` syntax, describes the command operations, and provides common examples. For details about each command, including all the supported flags and subcommands, see the [kubectl](/docs/reference/generated/kubectl/kubectl-commands/) reference documentation. For installation instructions see [installing kubectl](/docs/tasks/kubectl/install/).
 

--- a/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
@@ -313,7 +313,7 @@ the field will be omitted when marshalling. When the field is omitted, kubeadm a
 
 There are at least two workarounds:
 
-1. Use the `role.kubernetes.io/master:PreferNoSchedule` taint instead of an empty slice. [Pods will get scheduled on masters](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/), unless other nodes have capacity.
+1. Use the `role.kubernetes.io/master:PreferNoSchedule` taint instead of an empty slice. [Pods will get scheduled on masters](/docs/concepts/configuration/taint-and-toleration/), unless other nodes have capacity.
 
 2. Remove the taint after kubeadm init exits:
 ```bash

--- a/content/en/docs/setup/production-environment/windows/user-guide-windows-nodes.md
+++ b/content/en/docs/setup/production-environment/windows/user-guide-windows-nodes.md
@@ -336,7 +336,7 @@ This step will perform the following actions on the targeted Windows node:
 1. Unregister all Kubernetes services (flanneld, kubelet, kube-proxy)
 1. Delete all Kubernetes binaries (kube-proxy.exe, kubelet.exe, flanneld.exe, kubeadm.exe)
 1. Delete all CNI network plugins binaries
-1. Delete [Kubeconfig file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) used to access the Kubernetes cluster
+1. Delete [Kubeconfig file](/docs/concepts/configuration/organize-cluster-access-kubeconfig/) used to access the Kubernetes cluster
 
 
 ### Public Cloud Providers

--- a/content/en/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods.md
+++ b/content/en/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods.md
@@ -29,7 +29,7 @@ For static pods, this means it can't be evicted, but for non-static pods, it jus
 
 Prior to v1.11, critical pod has to run in the `kube-system` namespace, this restriction was removed after v1.11 and pod in any namespace can be configed as a critical pod by the following either way:
 
-* Ensure the PodPriority [feature gates](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) is enabled. Have the priorityClassName set as "system-cluster-critical" or "system-node-critical", the latter being the highest for entire cluster, the two priority class names available since v1.10+
+* Ensure the PodPriority [feature gates](/docs/reference/command-line-tools-reference/feature-gates/) is enabled. Have the priorityClassName set as "system-cluster-critical" or "system-node-critical", the latter being the highest for entire cluster, the two priority class names available since v1.10+
 
 * Alternatively, ensure both PodPriority and ExperimentalCriticalPodAnnotation feature gates are enabled, you could add an annotation `scheduler.alpha.kubernetes.io/critical-pod` as key and empty string as value to your pod, but this annotation is deprecated as of version 1.13 and will be removed in a future release.
 

--- a/content/en/docs/tasks/administer-cluster/topology-manager.md
+++ b/content/en/docs/tasks/administer-cluster/topology-manager.md
@@ -47,7 +47,7 @@ The hint is then stored in the Topology Manager for use by the *Hint Providers* 
 
 The Topology Manager currently:
 
- - Works on Nodes with the `static` CPU Manager Policy enabled. See [control CPU Management Policies](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/)
+ - Works on Nodes with the `static` CPU Manager Policy enabled. See [control CPU Management Policies](/docs/tasks/administer-cluster/cpu-management-policies/)
  - Works on Pods in the `Guaranteed` {{< glossary_tooltip text="QoS class" term_id="qos-class" >}}
 
 If these conditions are met, Topology Manager will align CPU and device requests.

--- a/content/en/docs/tasks/configure-pod-container/configure-runasusername.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-runasusername.md
@@ -23,7 +23,7 @@ You need to have a Kubernetes cluster and the kubectl command-line tool must be 
 
 ### Enable the WindowsRunAsUserName feature gate
 
-In the alpha state, the `WindowsRunAsUserName` feature gate needs to be enabled on the `kube-apiserver` service. Without it, the `runAsUserName` field will be dropped from the pod's, container's, and init container's SecurityContexts. See [Feature Gates](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) for an explanation of enabling feature gates. Please make sure `feature-gates=WindowsRunAsUserName=true` parameter exists in the `kube-apiserver` command line.
+In the alpha state, the `WindowsRunAsUserName` feature gate needs to be enabled on the `kube-apiserver` service. Without it, the `runAsUserName` field will be dropped from the pod's, container's, and init container's SecurityContexts. See [Feature Gates](/docs/reference/command-line-tools-reference/feature-gates/) for an explanation of enabling feature gates. Please make sure `feature-gates=WindowsRunAsUserName=true` parameter exists in the `kube-apiserver` command line.
 
 {{% /capture %}}
 

--- a/content/en/docs/tutorials/stateless-application/guestbook-logs-metrics-with-elk.md
+++ b/content/en/docs/tutorials/stateless-application/guestbook-logs-metrics-with-elk.md
@@ -48,7 +48,7 @@ Additionally you need:
 This tutorial builds on the [PHP Guestbook with Redis](../guestbook) tutorial.  If you have the guestbook application running, then you can monitor that.  If you do not have it running then follow the instructions to deploy the guestbook and do not perform the **Cleanup** steps.  Come back to this page when you have the guestbook running.
 
 ## Add a Cluster role binding
-Create a [cluster level role binding](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding) so that you can deploy kube-state-metrics and the Beats at the cluster level (in kube-system).
+Create a [cluster level role binding](/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding) so that you can deploy kube-state-metrics and the Beats at the cluster level (in kube-system).
 
 ```shell
 kubectl create clusterrolebinding cluster-admin-binding \


### PR DESCRIPTION
### Change to inline URL for inconsistent full URLs and inline URLs.

### following command
`grep -r "https \: \ / \ / kubernetes \ .io" content/en/docs`

### Changed to inline link except the following list.
- URLs are mentioned directly in the body
- release note
- url to blog
- url to community
- Url to be redirected

### Changed docs list.
- [x] /en/docs/concepts/architecture/nodes
> Submitted in PR #16909.
- [x] /en/docs/concepts/configuration/pod-overhead
- [x] /en/docs/concepts/configuration/pod-priority-preemption
- [x] /en/docs/concepts/scheduling/kube-scheduler
- [x] /en/docs/concepts/services-networking/dual-stack
- [x] /en/docs/concepts/storage/volumes
- [x] /en/docs/concepts/workloads/pods/pod-overview
- [x] /en/docs/contribute/localization
- [x] /en/docs/contribute/style/style-guide
- [x] /en/docs/reference/access-authn-authz/extensible-admission-controllers
- [x] /en/docs/reference/glossary/cri
- [x] /en/docs/reference/kubectl/overview
- [x] /en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm
- [x] /en/docs/setup/production-environment/windows/user-guide-windows-nodes
- [x] /en/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods
- [x] /en/docs/tasks/administer-cluster/topology-manager
- [x] /en/docs/tasks/configure-pod-container/configure-runasusername
- [x] /en/docs/tutorials/stateless-application/guestbook-logs-metrics-with-elk

### refirence
/from #17056 
/language en