### PR TITLE
ko: Change the full link in the document to an inline link.

### DIFF
--- a/content/ko/docs/concepts/workloads/pods/pod-overview.md
+++ b/content/ko/docs/concepts/workloads/pods/pod-overview.md
@@ -19,7 +19,7 @@ card:
 
 파드는 애플리케이션 컨테이너(또는, 몇몇의 경우, 다중 컨테이너), 저장소 리소스, 특정 네트워크 IP 그리고, {{< glossary_tooltip text="container" term_id="container" >}} 가 동작하기 위해 만들어진 옵션들을 캡슐화 한다. 파드는 배포의 단위를 말한다. 아마 단일 컨테이너로 구성되어 있거나, 강하게 결합되어 리소스를 공유하는 소수의 컨테이너로 구성되어 있는 *쿠버네티스에서의 애플리케이션 단일 인스턴스* 를 의미함.
 
-[도커](https://www.docker.com)는 쿠버네티스 파드에서 사용되는 가장 대표적인 컨테이너 런타임이지만, 파드는 다른 [컨테이너 런타임](https://kubernetes.io/ko/docs/setup/production-environment/container-runtimes/) 역시 지원한다.
+[도커](https://www.docker.com)는 쿠버네티스 파드에서 사용되는 가장 대표적인 컨테이너 런타임이지만, 파드는 다른 [컨테이너 런타임](/ko/docs/setup/production-environment/container-runtimes/) 역시 지원한다.
 
 
 쿠버네티스 클러스터 내부의 파드는 주로 두 가지 방법으로 사용된다.

--- a/content/ko/docs/reference/glossary/cri.md
+++ b/content/ko/docs/reference/glossary/cri.md
@@ -2,7 +2,7 @@
 title: 컨테이너 런타임 인터페이스(Container runtime interface, CRI)
 id: cri
 date: 2019-03-07
-full_link: https://kubernetes.io/docs/concepts/overview/components/#container-runtime
+full_link: /docs/concepts/overview/components/#container-runtime
 short_description: >
   Kubelet과 컨테이너 런타임을 통합시키기 위한 API
 

--- a/content/ko/docs/setup/production-environment/windows/user-guide-windows-nodes.md
+++ b/content/ko/docs/setup/production-environment/windows/user-guide-windows-nodes.md
@@ -334,7 +334,7 @@ kubectl get nodes
 1. 등록된 모든 쿠버네티스 서비스(flanneld, kubelet, kube-proxy)를 해지한다.
 1. 쿠버네티스 바이너리(kube-proxy.exe, kubelet.exe, flanneld.exe, kubeadm.exe)를 모두 삭제한다.
 1. CNI 네트워크 플러그인 바이너리를 모두 삭제한다.
-1. 쿠버네티스 클러스터에 접근하기 위한 [Kubeconfig 파일](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/)을 삭제한다.
+1. 쿠버네티스 클러스터에 접근하기 위한 [Kubeconfig 파일](/docs/concepts/configuration/organize-cluster-access-kubeconfig/)을 삭제한다.
 
 
 ### 퍼블릭 클라우드 제공자

--- a/content/ko/docs/tutorials/stateless-application/guestbook-logs-metrics-with-elk.md
+++ b/content/ko/docs/tutorials/stateless-application/guestbook-logs-metrics-with-elk.md
@@ -47,7 +47,7 @@ card:
 이 튜토리얼은 [Redis를 이용한 PHP 방명록](../guestbook)을 기반으로 한다. 방명록 애플리케이션을 실행 중이라면, 이를 모니터링할 수 있다. 실행되지 않은 경우라면 지침을 따라 방명록을 배포하고 **정리하기** 단계는 수행하지 말자. 방명록을 실행할 때 이 페이지로 돌아오자.
 
 ## 클러스터 롤 바인딩 추가
-[클러스터 단위 롤 바인딩](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding)을 생성하여, 클러스터 수준(kube-system 안에)으로 kube-state-metrics와 Beats를 배포할 수 있게 한다.
+[클러스터 단위 롤 바인딩](/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding)을 생성하여, 클러스터 수준(kube-system 안에)으로 kube-state-metrics와 Beats를 배포할 수 있게 한다.
 
 ```shell
 kubectl create clusterrolebinding cluster-admin-binding \


### PR DESCRIPTION
### Change to inline URL for inconsistent full URLs and inline URLs.

### following command
`grep -r "https \: \ / \ / kubernetes \ .io" content/ko/docs`

### Changed to inline link except the following list.
- URLs are mentioned directly in the body
- release note
- url to blog
- url to community
- Url to be redirected

### Changed docs list.
- [x] /ko/docs/concepts/architecture/nodes
> Submitted in PR #16876.
- [x] /ko/docs/concepts/workloads/pods/pod-overview
- [x] /ko/docs/reference/glossary/cri
- [x] /ko/docs/setup/production-environment/windows/user-guide-windows-nodes
- [x] /ko/docs/tutorials/stateless-application/guestbook-logs-metrics-with-elk

### reference
/language ko
from #17058