### PR TITLE
Update install-kubectl.md: Docker for Windows -> Docker Desktop for Windows

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl.md
+++ b/content/en/docs/tasks/tools/install-kubectl.md
@@ -189,8 +189,8 @@ If you are on macOS and using [Macports](https://macports.org/) package manager,
     kubectl version
     ```
 {{< note >}}
-[Docker for Windows](https://docs.docker.com/docker-for-windows/#kubernetes) adds its own version of `kubectl` to PATH.
-If you have installed Docker before, you may need to place your PATH entry before the one added by Docker installer or remove the Docker's `kubectl`.
+[Docker Desktop for Windows](https://docs.docker.com/docker-for-windows/#kubernetes) adds its own version of `kubectl` to PATH.
+If you have installed Docker Desktop before, you may need to place your PATH entry before the one added by the Docker Desktop installer or remove the Docker Desktop's `kubectl`.
 {{< /note >}}
 
 ### Install with Powershell from PSGallery


### PR DESCRIPTION
Docker for Windows is now called Docker Desktop for windows, to prevent confusion with Docker on Windows server.