### PR TITLE
Typo: Remove duplicate reference to awsElasticBlockStore

### DIFF
--- a/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
+++ b/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
@@ -113,7 +113,6 @@ Code associated with in-tree volume plugins ship as part of the core Kubernetes 
 * [azureDisk](/docs/concepts/storage/volumes/#azuredisk)
 * [azureFile](/docs/concepts/storage/volumes/#azurefile)
 * [gcePersistentDisk](/docs/concepts/storage/volumes/#gcepersistentdisk)
-* [awsElasticBlockStore](/docs/concepts/storage/volumes/#awselasticblockstore)
 * [vsphereVolume](/docs/concepts/storage/volumes/#vspherevolume)
 
 ##### FlexVolume Plugins


### PR DESCRIPTION
In the list of in-tree volume plugins awsElasticBlockStore is listed twice, this PR removes the duplicate.