### PR TITLE
Fix inconsistency of note on command example

### DIFF
--- a/content/en/docs/tasks/manage-kubernetes-objects/declarative-config.md
+++ b/content/en/docs/tasks/manage-kubernetes-objects/declarative-config.md
@@ -764,7 +764,7 @@ spec:
     rollingUpdate: # defaulted by apiserver - derived from strategy.type
       maxSurge: 1
       maxUnavailable: 1
-    type: RollingUpdate # defaulted apiserver
+    type: RollingUpdate # defaulted by apiserver
   template:
     metadata:
       creationTimestamp: null


### PR DESCRIPTION
In doc on Declarative Management of K8s object, there is explanation of 'Default field values of K8s object set by K8s apiserver'. In this explanation, there is examples of resource of K8s object.

And in this example, there is notes on what field value is set by apiserver by default. But there is lack of a word in one of these notes.
This commit fixes it.