### PR TITLE
remove zacharyzarah from sig-docs-ja-owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -117,7 +117,6 @@ aliases:
   sig-docs-ja-owners: # Admins for Japanese content
     - cstoku
     - nasa9084
-    - zacharysarah
   sig-docs-ja-reviews: # PR reviews for Japanese content
     - cstoku
     - inductor


### PR DESCRIPTION
zach is not an reviewer/approver of docs-ja, and his name is in sig-docs-en-owners, which is defined as the top-level approvers of this repository

related conversation on slack: https://kubernetes.slack.com/archives/CAG2M83S8/p1571808221036500