### PR TITLE
Add content/es/docs/reference/glossary/container-runtime.md

### DIFF
--- a/content/es/docs/reference/glossary/container-runtime.md
+++ b/content/es/docs/reference/glossary/container-runtime.md
@@ -1,0 +1,21 @@
+---
+title: Container Runtime
+id: container-runtime
+date: 2019-06-05
+full_link: /es/docs/reference/generated/container-runtime
+short_description: >
+  El _Container Runtime_, entorno de ejecución de un contenedor, es el software responsable de ejecutar contenedores.
+
+aka:
+tags:
+- fundamental
+- workload
+---
+El _Container Runtime_ es el software responsable de ejecutar contenedores.
+
+<!--more-->
+
+Kubernetes soporta varios _Container Runtimes_: [Docker](http://www.docker.com),
+[containerd](https://containerd.io), [cri-o](https://cri-o.io/),
+[rktlet](https://github.com/kubernetes-incubator/rktlet) y cualquier implementación de 
+[Kubernetes CRI (Container Runtime Interface)](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/container-runtime-interface.md).


### PR DESCRIPTION
He optado por no traducir `Container Runtime` a pesar de que Runtime lo he visto en el spanish style guide-glossary, no me sonaba bien