### PR TITLE
Fix webhook admission example

### DIFF
--- a/content/en/docs/reference/access-authn-authz/extensible-admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/extensible-admission-controllers.md
@@ -766,7 +766,7 @@ Use the object selector only if the webhook is opt-in, because end users may ski
 
 This example shows a mutating webhook that would match a `CREATE` of any resource with the label `foo: bar`:
 
-{{< tabs name="ValidatingWebhookConfiguration_example_1" >}}
+{{< tabs name="objectSelector_example" >}}
 {{% tab name="admissionregistration.k8s.io/v1" %}}
 ```yaml
 apiVersion: admissionregistration.k8s.io/v1


### PR DESCRIPTION
Fix the example code tabs at https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-objectselector

/cc @jpbetz 