### PR TITLE
Remove a space previous a tooltip text

### DIFF
--- a/layouts/partials/docs/glossary-terms.html
+++ b/layouts/partials/docs/glossary-terms.html
@@ -1,10 +1,7 @@
 {{ $glossaryBundle := site.GetPage "page" "docs/reference/glossary" }}
 {{- if $glossaryBundle -}}
   {{ $pages := $glossaryBundle.Resources.ByType "page" }}
-  {{- range site.Params.language_alternatives -}}
-    {{- with (where $glossaryBundle.Translations ".Lang" . ) -}}
-    {{ $p := (index . 0) }}{{ $pages = $pages | lang.Merge ($p.Resources.ByType "page") }}{{ end }}
-  {{ end }}
+  {{- range site.Params.language_alternatives -}}{{- with (where $glossaryBundle.Translations ".Lang" . ) -}}{{ $p := (index . 0) }}{{ $pages = $pages | lang.Merge ($p.Resources.ByType "page") }}{{ end }}{{ end }}
   {{- $.Scratch.Set "glossary_items"  $pages -}}
 {{- else -}}
 {{- errorf "[%s] Glossary Bundle not found for language. Create at least an index.md file inside docs/reference/glossary" site.Language.Lang -}}

--- a/layouts/partials/docs/glossary-terms.html
+++ b/layouts/partials/docs/glossary-terms.html
@@ -1,7 +1,12 @@
 {{ $glossaryBundle := site.GetPage "page" "docs/reference/glossary" }}
 {{- if $glossaryBundle -}}
   {{ $pages := $glossaryBundle.Resources.ByType "page" }}
-  {{- range site.Params.language_alternatives -}}{{- with (where $glossaryBundle.Translations ".Lang" . ) -}}{{ $p := (index . 0) }}{{ $pages = $pages | lang.Merge ($p.Resources.ByType "page") }}{{ end }}{{ end }}
+  {{- range site.Params.language_alternatives -}}
+    {{- with (where $glossaryBundle.Translations ".Lang" . ) -}}
+      {{- $p := (index . 0) -}}
+      {{- $pages = $pages | lang.Merge ($p.Resources.ByType "page") -}}
+    {{- end -}}
+  {{ end }}
   {{- $.Scratch.Set "glossary_items"  $pages -}}
 {{- else -}}
 {{- errorf "[%s] Glossary Bundle not found for language. Create at least an index.md file inside docs/reference/glossary" site.Language.Lang -}}


### PR DESCRIPTION
#15920 fixed unexpected line breaks for localized glossary tooltips.
But an unexpected space previous a tooltip text exists.

<img width="766" alt="12132131Kubernetesコンポーネント_-_Kubernetes" src="https://user-images.githubusercontent.com/2158863/67594902-54243d80-f7a0-11e9-811a-cbdbecc827a6.png">

So I trimmed a space.

<img width="772" alt="123131スクリーンショット_2019_10_26_3_19" src="https://user-images.githubusercontent.com/2158863/67595079-bf6e0f80-f7a0-11e9-88da-414dfdfcf392.png">

