### PR TITLE
Update file outdated korean docs in dev-1.16-ko.4

### DIFF
--- a/content/ko/docs/concepts/architecture/cloud-controller.md
+++ b/content/ko/docs/concepts/architecture/cloud-controller.md
@@ -226,7 +226,7 @@ rules:
 * [AWS](https://github.com/kubernetes/cloud-provider-aws)
 * [Azure](https://github.com/kubernetes/cloud-provider-azure)
 * [BaiduCloud](https://github.com/baidu/cloud-provider-baiducloud)
-* [Digital Ocean](https://github.com/digitalocean/digitalocean-cloud-controller-manager)
+* [DigitalOcean](https://github.com/digitalocean/digitalocean-cloud-controller-manager)
 * [GCP](https://github.com/kubernetes/cloud-provider-gcp)
 * [Linode](https://github.com/linode/linode-cloud-controller-manager)
 * [OpenStack](https://github.com/kubernetes/cloud-provider-openstack)

--- a/content/ko/docs/concepts/cluster-administration/federation.md
+++ b/content/ko/docs/concepts/cluster-administration/federation.md
@@ -88,17 +88,17 @@ weight: 80
 있다.
 다음의 가이드는 일부 리소스에 대해서 자세히 설명한다.
 
-* [클러스터](/docs/tasks/administer-federation/cluster/)
-* [컨피그 맵](/docs/tasks/administer-federation/configmap/)
-* [데몬 셋](/docs/tasks/administer-federation/daemonset/)
-* [디플로이먼트](/docs/tasks/administer-federation/deployment/)
-* [이벤트](/docs/tasks/administer-federation/events/)
-* [Hpa](/docs/tasks/administer-federation/hpa/)
-* [인그레스](/docs/tasks/administer-federation/ingress/)
-* [잡](/docs/tasks/administer-federation/job/)
-* [네임스페이스](/docs/tasks/administer-federation/namespaces/)
-* [레플리카 셋](/docs/tasks/administer-federation/replicaset/)
-* [시크릿](/docs/tasks/administer-federation/secret/)
+* [클러스터](/docs/tasks/federation/administer-federation/cluster/)
+* [컨피그 맵](/docs/tasks/federation/administer-federation/configmap/)
+* [데몬 셋](/docs/tasks/federation/administer-federation/daemonset/)
+* [디플로이먼트](/docs/tasks/federation/administer-federation/deployment/)
+* [이벤트](/docs/tasks/federation/administer-federation/events/)
+* [Hpa](/docs/tasks/federation/administer-federation/hpa/)
+* [인그레스](/docs/tasks/federation/administer-federation/ingress/)
+* [잡](/docs/tasks/federation/administer-federation/job/)
+* [네임스페이스](/docs/tasks/federation/administer-federation/namespaces/)
+* [레플리카 셋](/docs/tasks/federation/administer-federation/replicaset/)
+* [시크릿](/docs/tasks/federation/administer-federation/secret/)
 * [서비스](/docs/concepts/cluster-administration/federation-service-discovery/)
 
 

--- a/content/ko/docs/concepts/overview/working-with-objects/names.md
+++ b/content/ko/docs/concepts/overview/working-with-objects/names.md
@@ -6,11 +6,11 @@ weight: 20
 
 {{% capture overview %}}
 
-클러스터의 각 오브젝트에는 해당 유형의 리소스에 고유한 [_이름_](#names) 을 가지고 있다.
-또한, 모든 쿠버네티스 오브젝트에는 전체 클러스터에 걸쳐 고유한 [_UID_](#uids) 를 가지고 있다.
+클러스터의 각 오브젝트는 해당 유형의 리소스에 대하여 고유한 [_이름_](#names) 을 가지고 있다.
+또한, 모든 쿠버네티스 오브젝트는 전체 클러스터에 걸쳐 고유한 [_UID_](#uids) 를 가지고 있다.
 
-예를 들어, 이름이 “myapp-1234”인 파드는 하나만 가질 수 있지만, 각각 “myapp-1234”라는
-이름을 가진 하나의 파드와 디플로이먼트를 가질 수 있다.
+예를 들어, 이름이 “myapp-1234”인 파드는 하나만 가질 수 있지만, 이름이 “myapp-1234”인
+파드와 디플로이먼트는 각각 가질 수 있다.
 
 유일하지 않은 사용자 제공 속성에 대해서, 쿠버네티스는 [레이블](/docs/user-guide/labels)과 [어노테이션](/docs/concepts/overview/working-with-objects/annotations/)을 제공한다.
 
@@ -53,6 +53,6 @@ UUID는 ISO/IEC 9834-8 과 ITU-T X.667 로 표준화 되어 있다.
 
 {{% /capture %}}
 {{% capture whatsnext %}}
-* 쿠버네티스의 [레이블](/docs/concepts/overview/working-with-objects/labels/)에 대해 읽기.
+* 쿠버네티스의 [레이블](/ko/docs/concepts/overview/working-with-objects/labels/)에 대해 읽기.
 * [쿠버네티스의 식별자와 이름](https://git.k8s.io/community/contributors/design-proposals/architecture/identifiers.md) 디자인 문서 읽기.
 {{% /capture %}}

--- a/content/ko/docs/concepts/overview/working-with-objects/names.md
+++ b/content/ko/docs/concepts/overview/working-with-objects/names.md
@@ -6,11 +6,13 @@ weight: 20
 
 {{% capture overview %}}
 
-쿠버네티스 REST API의 모든 오브젝트는 이름과 UID로 명백히 식별된다.
+클러스터의 각 오브젝트에는 해당 유형의 리소스에 고유한 [_이름_](#names) 을 가지고 있다.
+또한, 모든 쿠버네티스 오브젝트에는 전체 클러스터에 걸쳐 고유한 [_UID_](#uids) 를 가지고 있다.
+
+예를 들어, 이름이 “myapp-1234”인 파드는 하나만 가질 수 있지만, 각각 “myapp-1234”라는
+이름을 가진 하나의 파드와 디플로이먼트를 가질 수 있다.
 
 유일하지 않은 사용자 제공 속성에 대해서, 쿠버네티스는 [레이블](/docs/user-guide/labels)과 [어노테이션](/docs/concepts/overview/working-with-objects/annotations/)을 제공한다.
-
-이름과 UID에 대한 정확한 구문 규칙은 [식별자 설계 문서](https://git.k8s.io/community/contributors/design-proposals/architecture/identifiers.md)를 참고한다.
 
 {{% /capture %}}
 
@@ -23,7 +25,7 @@ weight: 20
 
 관례에 따라, 쿠버네티스 리소스의 이름은 최대 253자까지 허용되고 소문자 알파벳과 숫자(alphanumeric), `-`, 그리고 `.`로 구성되며 특정 리소스는 보다 구체적인 제약을 갖는다.
 
-다음은 이름이 `nginx-demo`이고 컨테이너 이름이 `nginx`인 파드의 구성 파일 예시이다.
+여기 파드의 이름이 `nginx-demo`라는 매니페스트 예시가 있다.
 
 ```yaml
 apiVersion: v1
@@ -38,8 +40,19 @@ spec:
     - containerPort: 80
 ```
 
+{{< note >}}
+일부 리소스 유형은 이름에 추가적인 제약이 있다.
+{{< /note >}}
+
 ## UID {#uids}
 
 {{< glossary_definition term_id="uid" length="all" >}}
 
+쿠버네티스 UID는 보편적으로 고유한 식별자이다(또는 UUID라고 한다).
+UUID는 ISO/IEC 9834-8 과 ITU-T X.667 로 표준화 되어 있다.
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+* 쿠버네티스의 [레이블](/docs/concepts/overview/working-with-objects/labels/)에 대해 읽기.
+* [쿠버네티스의 식별자와 이름](https://git.k8s.io/community/contributors/design-proposals/architecture/identifiers.md) 디자인 문서 읽기.
 {{% /capture %}}

--- a/content/ko/docs/concepts/workloads/controllers/deployment.md
+++ b/content/ko/docs/concepts/workloads/controllers/deployment.md
@@ -156,24 +156,24 @@ _디플로이먼트_ 는 [파드](/ko/docs/concepts/workloads/pods/pod/)와
     ```shell
     kubectl --record deployment.apps/nginx-deployment set image deployment.v1.apps/nginx-deployment nginx=nginx:1.9.1
     ```
-   또는 간단하게 다음의 명령어를 사용한다.
+    또는 간단하게 다음의 명령어를 사용한다.
 
     ```shell
     kubectl set image deployment/nginx-deployment nginx=nginx:1.91 --record
     ```
 
-  이와 유사하게 출력된다.
+    이와 유사하게 출력된다.
     ```
     deployment.apps/nginx-deployment image updated
     ```
 
-  대안으로 디플로이먼트를 `edit` 해서 `.spec.template.spec.containers[0].image` 를 `nginx:1.7.9` 에서 `nginx:1.9.1` 로 변경한다.
+    대안으로 디플로이먼트를 `edit` 해서 `.spec.template.spec.containers[0].image` 를 `nginx:1.7.9` 에서 `nginx:1.9.1` 로 변경한다.
 
     ```shell
     kubectl edit deployment.v1.apps/nginx-deployment
     ```
 
-   이와 유사하게 출력된다.
+    이와 유사하게 출력된다.
     ```
     deployment.apps/nginx-deployment edited
     ```

--- a/content/ko/docs/reference/glossary/applications.md
+++ b/content/ko/docs/reference/glossary/applications.md
@@ -1,6 +1,6 @@
 ---
 title: 애플리케이션(Applications)
-id: appplications
+id: applications
 date: 2019-05-12
 full_link:
 short_description: >

--- a/content/ko/docs/reference/glossary/replica-set.md
+++ b/content/ko/docs/reference/glossary/replica-set.md
@@ -1,10 +1,10 @@
 ---
-title: 레플리카 셋(ReplicaSet)
+title: 레플리카셋(ReplicaSet)
 id: replica-set
 date: 2018-04-12
 full_link: /docs/concepts/workloads/controllers/replicaset/
 short_description: >
-  레플리카 셋은 차세대 레플리케이션 컨트롤러이다.
+  레플리카셋은 지정된 수의 파드 레플리카가 동시에 실행이 되도록 보장한다
 
 aka: 
 tags:
@@ -12,9 +12,10 @@ tags:
 - core-object
 - workload
 ---
- 레플리카 셋은 차세대 레플리케이션 컨트롤러이다.
+ 레플리카셋은 (목표로) 주어진 시간에 실행되는 레플리카 파드 셋을 유지 관리 한다.
 
 <!--more--> 
 
-레플리케이션 컨트롤러와 같은 레플리카 셋은, 지정된 수의 파드 레플리카가 동시에 동작하게 관리한다. 레플리카 셋은 레이블 사용자 가이드에 기술된 대로 셋(set) 기반의 셀렉터 요구 사항을 지원한다. 반면, 레플리케이션 컨트롤러는 동일성 기반의 셀렉터 요구 사항만 제공한다.
-
+{{< glossary_tooltip term_id="deployment" >}} 와 같은 워크로드 오브젝트는 레플리카셋을
+사용해서 해당 레플리카셋의 스펙에 따라 구성된 {{< glossary_tooltip term_id="pod" text="파드" >}} 의
+수를 클러스터에서 실행한다.

--- a/content/ko/docs/reference/kubectl/cheatsheet.md
+++ b/content/ko/docs/reference/kubectl/cheatsheet.md
@@ -58,6 +58,7 @@ kubectl config view
 # e2e 사용자의 암호를 확인한다
 kubectl config view -o jsonpath='{.users[?(@.name == "e2e")].user.password}'
 
+kubectl config view -o jsonpath='{.users[].name}'    # 첫 번째 사용자 출력
 kubectl config view -o jsonpath='{.users[*].name}'    # 사용자 리스트 조회
 kubectl config get-contexts                          # 컨텍스트 리스트 출력
 kubectl config current-context              # 현재 컨텍스트 출력
@@ -268,7 +269,7 @@ kubectl delete -f ./pod.json                                              # pod.
 kubectl delete pod,service baz foo                                        # "baz", "foo"와 동일한 이름을 가진 파드와 서비스 삭제
 kubectl delete pods,services -l name=myLabel                              # name=myLabel 라벨을 가진 파드와 서비스 삭제
 kubectl delete pods,services -l name=myLabel --include-uninitialized      # 초기화되지 않은 것을 포함하여, name=myLabel 라벨을 가진 파드와 서비스 삭제
-kubectl -n my-ns delete po,svc --all                                      # 초기화되지 않은 것을 포함하여, my-ns 네임스페이스 내 모든 파드와 서비스 삭제
+kubectl -n my-ns delete pod,svc --all                                      # 초기화되지 않은 것을 포함하여, my-ns 네임스페이스 내 모든 파드와 서비스 삭제
 # awk pattern1 또는 pattern2에 매칭되는 모든 파드 삭제
 kubectl get pods  -n mynamespace --no-headers=true | awk '/pattern1|pattern2/{print $1}' | xargs  kubectl delete -n mynamespace pod
 ```

--- a/content/ko/docs/setup/_index.md
+++ b/content/ko/docs/setup/_index.md
@@ -73,6 +73,7 @@ card:
 | [CloudStack](https://cloudstack.apache.org/)           |      |  |   | | &#x2714;|
 | [Canonical](https://ubuntu.com/kubernetes)      |       &#x2714;       | &#x2714;       |      &#x2714;       | &#x2714;     |&#x2714;  | &#x2714;
 | [Containership](https://containership.io/containership-platform)            | &#x2714;       |&#x2714;  |     |     |                   |
+| [D2iQ](https://d2iq.com/) |  | [Kommander](https://d2iq.com/solutions/ksphere) | [Konvoy](https://d2iq.com/solutions/ksphere/konvoy) | [Konvoy](https://d2iq.com/solutions/ksphere/konvoy) | [Konvoy](https://d2iq.com/solutions/ksphere/konvoy) | [Konvoy](https://d2iq.com/solutions/ksphere/konvoy) |
 | [Digital Rebar](https://provision.readthedocs.io/en/tip/README.html)            |        |  |      |     |  | &#x2714;
 | [DigitalOcean](https://www.digitalocean.com/products/kubernetes/)        | &#x2714;      |  |      |     |            |
 | [Docker Enterprise](https://www.docker.com/products/docker-enterprise) |       |&#x2714;  | &#x2714;     |  |     | &#x2714;

--- a/content/ko/docs/setup/best-practices/certificates.md
+++ b/content/ko/docs/setup/best-practices/certificates.md
@@ -83,7 +83,7 @@ etcd 역시 클라이언트와 피어 간에 상호 TLS 인증을 구현한다.
 | client | digital signature, key encipherment, client auth                                |
 
 {{< note >}}
-위에 나열된 호스트/SAN은 작업중인 클러스터를 획득하는데 권장된다. 특정 설정이 필요한 경우, 모든 서버 인증서에 SAN을 추가할 수 있다.
+위에 나열된 호스트/SAN은 작업 중인 클러스터를 획득하는데 권장된다. 특정 설정이 필요한 경우, 모든 서버 인증서에 SAN을 추가할 수 있다.
 {{< /note >}}
 
 {{< note >}}

--- a/content/ko/docs/setup/best-practices/certificates.md
+++ b/content/ko/docs/setup/best-practices/certificates.md
@@ -54,6 +54,8 @@ etcd 역시 클라이언트와 피어 간에 상호 TLS 인증을 구현한다.
 | etcd/ca.crt,key        | etcd-ca                   | 모든 etcd 관련 기능을 위해서     |
 | front-proxy-ca.crt,key | kubernetes-front-proxy-ca | [front-end proxy][proxy] 위해서  |
 
+위의 CA외에도, 서비스 계정 관리를 위한 공개/개인 키 쌍인 `sa.key` 와 `sa.pub` 을 얻는 것이 필요하다.
+
 ### 모든 인증서
 
 이런 개인키를 API 서버에 복사하기 원치 않는다면, 모든 인증서를 스스로 생성할 수 있다.
@@ -70,7 +72,8 @@ etcd 역시 클라이언트와 피어 간에 상호 TLS 인증을 구현한다.
 | kube-apiserver-kubelet-client | kubernetes-ca             | system:masters | client                                 |                                             |
 | front-proxy-client            | kubernetes-front-proxy-ca |                | client                                 |                                             |
 
-[1]: `kubernetes`, `kubernetes.default`, `kubernetes.default.svc`, `kubernetes.default.svc.cluster`, `kubernetes.default.svc.cluster.local`
+[1]: 클러스터에 접속한 다른 IP 또는 DNS 이름([kubeadm][kubeadm] 이 사용하는 로드 밸런서 안정 IP 또는 DNS 이름, `kubernetes`, `kubernetes.default`, `kubernetes.default.svc`,
+`kubernetes.default.svc.cluster`, `kubernetes.default.svc.cluster.local`)
 
 `kind`는 하나 이상의 [x509 키 사용][usage] 종류를 가진다.
 
@@ -78,6 +81,19 @@ etcd 역시 클라이언트와 피어 간에 상호 TLS 인증을 구현한다.
 |--------|---------------------------------------------------------------------------------|
 | server | digital signature, key encipherment, server auth                                |
 | client | digital signature, key encipherment, client auth                                |
+
+{{< note >}}
+위에 나열된 호스트/SAN은 작업중인 클러스터를 획득하는데 권장된다. 특정 설정이 필요한 경우, 모든 서버 인증서에 SAN을 추가할 수 있다.
+{{< /note >}}
+
+{{< note >}}
+kubeadm 사용자만 해당:
+
+* 개인 키 없이 클러스터 CA 인증서에 복사하는 시나리오는 kubeadm 문서에서 외부 CA라고 한다.
+* 위 목록을 kubeadm이 생성한 PKI와 비교하는 경우, `kube-etcd`, `kube-etcd-peer` 와 `kube-etcd-healthcheck-client` 인증서는
+  외부 etcd 케이스에서는 생성하지 않는 것을 알고 있어야 한다.
+
+{{< /note >}}
 
 ### 인증서 파일 경로
 
@@ -88,18 +104,24 @@ etcd 역시 클라이언트와 피어 간에 상호 TLS 인증을 구현한다.
 | etcd-ca                      |     etcd/ca.key                         | etcd/ca.crt                 | kube-apiserver |                              | --etcd-cafile                             |
 | etcd-client                  | apiserver-etcd-client.key    | apiserver-etcd-client.crt   | kube-apiserver | --etcd-keyfile               | --etcd-certfile                           |
 | kubernetes-ca                |    ca.key                          | ca.crt                      | kube-apiserver |                              | --client-ca-file                          |
+| kubernetes-ca                |    ca.key                          | ca.crt                      | kube-controller-manager | --cluster-signing-key-file      | --client-ca-file, --root-ca-file, --cluster-signing-cert-file  |
 | kube-apiserver               | apiserver.key                | apiserver.crt               | kube-apiserver | --tls-private-key-file       | --tls-cert-file                           |
-| apiserver-kubelet-client     |     apiserver-kubelet-client.key                         | apiserver-kubelet-client.crt| kube-apiserver |                              | --kubelet-client-certificate              |
+| apiserver-kubelet-client     |     apiserver-kubelet-client.key                         | apiserver-kubelet-client.crt| kube-apiserver | --kubelet-client-key | --kubelet-client-certificate              |
 | front-proxy-ca               |     front-proxy-ca.key                         | front-proxy-ca.crt          | kube-apiserver |                              | --requestheader-client-ca-file            |
+| front-proxy-ca               |     front-proxy-ca.key                         | front-proxy-ca.crt          | kube-controller-manager |                              | --requestheader-client-ca-file |
 | front-proxy-client           | front-proxy-client.key       | front-proxy-client.crt      | kube-apiserver | --proxy-client-key-file      | --proxy-client-cert-file                  |
-|                              |                              |                             |                |                              |                                           |
 | etcd-ca                      |         etcd/ca.key                     | etcd/ca.crt                 | etcd           |                              | --trusted-ca-file, --peer-trusted-ca-file |
 | kube-etcd                    | etcd/server.key              | etcd/server.crt             | etcd           | --key-file                   | --cert-file                               |
 | kube-etcd-peer               | etcd/peer.key                | etcd/peer.crt               | etcd           | --peer-key-file              | --peer-cert-file                          |
-| etcd-ca                      |                              | etcd/ca.crt                 | etcdctl[2]     |                              | --cacert                                  |
-| kube-etcd-healthcheck-client | etcd/healthcheck-client.key  | etcd/healthcheck-client.crt | etcdctl[2]     | --key                        | --cert                                    |
+| etcd-ca                      |                              | etcd/ca.crt                 | etcdctl    |                              | --cacert                                  |
+| kube-etcd-healthcheck-client | etcd/healthcheck-client.key  | etcd/healthcheck-client.crt | etcdctl     | --key                        | --cert                                    |
 
-[2]: 셀프 호스팅시, 생존신호(liveness probe)를 위해
+서비스 계정 키 쌍에도 동일한 고려 사항이 적용된다.
+
+| 개인키 경로             | 공개 키 경로             | 명령어                 | 파라미터                             |
+|------------------------------|-----------------------------|-------------------------|--------------------------------------|
+|  sa.key                      |                             | kube-controller-manager | service-account-private              |
+|                              | sa.pub                      | kube-apiserver          | service-account-key                  |
 
 ## 각 사용자 계정을 위한 인증서 설정하기
 

--- a/content/ko/docs/setup/best-practices/node-conformance.md
+++ b/content/ko/docs/setup/best-practices/node-conformance.md
@@ -73,7 +73,7 @@ sudo docker run -it --rm --privileged --net=host \
   k8s.gcr.io/node-test:0.2
 ```
 
-노드 적합성 테스트는 [노드 e2e 테스트](https://github.com/kubernetes/community/blob/{{< param "githubbranch" >}}/contributors/devel/e2e-node-tests.md)를 컨테이너화한 버전이다.
+노드 적합성 테스트는 [노드 e2e 테스트](https://github.com/kubernetes/community/blob/{{< param "githubbranch" >}}/contributors/devel/sig-node/e2e-node-tests.md)를 컨테이너화한 버전이다.
 기본적으로, 모든 적합성 테스트를 실행한다.
 
 이론적으로, 컨테이너와 필요한 볼륨을 적절히 설정했다면 어떤 노드 e2e 테스트도 수행할 수 있다.

--- a/content/ko/docs/tasks/debug-application-cluster/resource-metrics-pipeline.md
+++ b/content/ko/docs/tasks/debug-application-cluster/resource-metrics-pipeline.md
@@ -5,7 +5,7 @@ content_template: templates/concept
 
 {{% capture overview %}}
 
-쿠버네티스 1.8 부터 컨테이너 CPU 및 메모리 사용량과 같은 리소스 사용량 메트릭은 
+컨테이너 CPU 및 메모리 사용량과 같은 리소스 사용량 메트릭은 
 쿠버네티스의 메트릭 API를 통해 사용할 수 있다. 이 메트릭은 
 `kubectl top` 커맨드 사용과 같이 사용자가 직접적으로 액세스하거나, 
 Horizontal Pod Autoscaler 같은 클러스터의 컨트롤러에서 결정을 내릴 때 사용될 수 있다. 
@@ -37,15 +37,13 @@ Horizontal Pod Autoscaler 같은 클러스터의 컨트롤러에서 결정을 �
 ## 메트릭 서버
 
 [메트릭 서버](https://github.com/kubernetes-incubator/metrics-server)는 클러스터 전역에서 리소스 사용량 데이터를 집계한다.
-쿠버네티스 1.8 부터 `kube-up.sh` 스크립트에 의해 생성된 클러스터에는 기본적으로 메트릭 서버가 
+`kube-up.sh` 스크립트에 의해 생성된 클러스터에는 기본적으로 메트릭 서버가 
 디플로이먼트 오브젝트로 배포된다. 만약 다른 쿠버네티스 설치 메커니즘을 사용한다면, 제공된 
 [배포 yaml들](https://github.com/kubernetes-incubator/metrics-server/tree/master/deploy)을 사용하여 메트릭 서버를 배포할 수 있다.
-이 방식은 쿠버네티스 1.7 이상에서 지원된다. (상세 사항은 아래를 참조)
 
 메트릭 서버는 각 노드에서 [Kubelet](/docs/admin/kubelet/)에 의해 노출된 Summary API에서 메트릭을 수집한다.
 
-메트릭 서버는 쿠버네티스 1.7에서 도입된 
-[쿠버네티스 aggregator](/docs/concepts/api-extension/apiserver-aggregation/)를 
+메트릭 서버는 [쿠버네티스 aggregator](/docs/concepts/api-extension/apiserver-aggregation/)를 
 통해 메인 API 서버에 등록된다.
 
 [설계 문서](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/instrumentation/metrics-server.md)에서 메트릭 서버에 대해 자세하게 배울 수 있다.

--- a/content/ko/docs/tasks/manage-kubernetes-objects/declarative-config.md
+++ b/content/ko/docs/tasks/manage-kubernetes-objects/declarative-config.md
@@ -762,7 +762,7 @@ spec:
     rollingUpdate: # defaulted by apiserver - derived from strategy.type
       maxSurge: 1
       maxUnavailable: 1
-    type: RollingUpdate # defaulted apiserver
+    type: RollingUpdate # defaulted by apiserver
   template:
     metadata:
       creationTimestamp: null

--- a/content/ko/docs/tasks/manage-kubernetes-objects/imperative-config.md
+++ b/content/ko/docs/tasks/manage-kubernetes-objects/imperative-config.md
@@ -29,7 +29,7 @@ weight: 40
 * 선언형 오브젝트 구성
 
 각 종류별 오브젝트 관리의 장점과 단점에 대한 논의는
-[쿠버네티스 오브젝트 관리](/ko/docs/concepts/overview/object-management-kubectl/overview/)를 참고한다.
+[쿠버네티스 오브젝트 관리](/ko/docs/concepts/overview/working-with-objects/object-management/)를 참고한다.
 
 ## 오브젝트 생성 방법
 

--- a/content/ko/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/ko/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -308,7 +308,9 @@ spec:
     pods:
       metric:
         name: packets-per-second
-      targetAverageValue: 1k
+      target:
+        type: AverageValue
+        averageValue: 1k
   - type: Object
     object:
       metric:


### PR DESCRIPTION
### **14 out of 20 files to be modified**
- [x] content/ko/docs/concepts/architecture/cloud-controller.md
- [x] content/ko/docs/concepts/cluster-administration/federation.md
- [x] content/ko/docs/concepts/overview/working-with-objects/names.md
> 변경점이 많아 재번역을 진행했습니다.
- [x] content/ko/docs/concepts/workloads/controllers/deployment.md
- [x] content/ko/docs/reference/glossary/applications.md
- [x] content/ko/docs/reference/glossary/replica-set.md
> 변경점이 많아 재번역을 진행했습니다.
- [x] content/ko/docs/reference/kubectl/cheatsheet.md
- [x] content/ko/docs/setup/_index.md
- [x] content/ko/docs/setup/best-practices/certificates.md
> 변경점에 대한 번역 진행
- [x] content/ko/docs/setup/best-practices/node-conformance.md
- [x] content/ko/docs/tasks/debug-application-cluster/resource-metrics-pipeline.md
- [x] content/ko/docs/tasks/manage-kubernetes-objects/declarative-config.md
- [x] content/ko/docs/tasks/manage-kubernetes-objects/imperative-config.md
- [x] content/ko/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md

### **Unmodified document and reason.**
- [x] content/ko/docs/concepts/architecture/controller.md
- [x] content/ko/docs/concepts/workloads/pods/pod-overview.md
- [x] content/ko/docs/reference/glossary/cri.md 
- [x] content/ko/docs/setup/production-environment/windows/user-guide-windows-nodes.md
- [x] content/ko/docs/tutorials/stateless-application/guestbook-logs-metrics-with-elk.md
> #17059 에서 반영
- [x] content/ko/examples/controllers/daemonset.yaml
> #16962 에서 반영

from #17187
/language ko