### PR TITLE
fixed yaml block so it renders

### DIFF
--- a/content/en/docs/reference/access-authn-authz/extensible-admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/extensible-admission-controllers.md
@@ -184,21 +184,21 @@ the webhooks. There are three steps to complete the configuration.
   (yes, the same schema that's used by kubectl), so the field name is
   `kubeConfigFile`. Here is an example admission control configuration file:
 
-```yaml
-apiVersion: apiserver.k8s.io/v1alpha1
-kind: AdmissionConfiguration
-plugins:
-- name: ValidatingAdmissionWebhook
-  configuration:
-    apiVersion: apiserver.config.k8s.io/v1alpha1
-    kind: WebhookAdmission
-    kubeConfigFile: "<path-to-kubeconfig-file>"
-- name: MutatingAdmissionWebhook
-  configuration:
-    apiVersion: apiserver.config.k8s.io/v1alpha1
-    kind: WebhookAdmission
-    kubeConfigFile: "<path-to-kubeconfig-file>"
-```
+    ```yaml
+    apiVersion: apiserver.k8s.io/v1alpha1
+    kind: AdmissionConfiguration
+    plugins:
+    - name: ValidatingAdmissionWebhook
+      configuration:
+        apiVersion: apiserver.config.k8s.io/v1alpha1
+        kind: WebhookAdmission
+        kubeConfigFile: "<path-to-kubeconfig-file>"
+    - name: MutatingAdmissionWebhook
+      configuration:
+        apiVersion: apiserver.config.k8s.io/v1alpha1
+        kind: WebhookAdmission
+        kubeConfigFile: "<path-to-kubeconfig-file>"
+    ```
 
 The schema of `admissionConfiguration` is defined
 [here](https://github.com/kubernetes/kubernetes/blob/v1.13.0/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/types.go#L27).
@@ -206,51 +206,51 @@ See the [webhook configuration](#webhook-configuration) section for details abou
 
 * In the kubeConfig file, provide the credentials:
 
-```yaml
-apiVersion: v1
-kind: Config
-users:
-# name should be set to the DNS name of the service or the host (including port) of the URL the webhook is configured to speak to.
-# If a non-443 port is used for services, it must be included in the name when configuring 1.16+ API servers.
-#
-# For a webhook configured to speak to a service on the default port (443), specify the DNS name of the service:
-# - name: webhook1.ns1.svc
-#   user: ...
-#
-# For a webhook configured to speak to a service on non-default port (e.g. 8443), specify the DNS name and port of the service in 1.16+:
-# - name: webhook1.ns1.svc:8443
-#   user: ...
-# and optionally create a second stanza using only the DNS name of the service for compatibility with 1.15 API servers:
-# - name: webhook1.ns1.svc
-#   user: ...
-#
-# For webhooks configured to speak to a URL, match the host (and port) specified in the webhook's URL. Examples:
-# A webhook with `url: https://www.example.com`:
-# - name: www.example.com
-#   user: ...
-#
-# A webhook with `url: https://www.example.com:443`:
-# - name: www.example.com:443
-#   user: ...
-#
-# A webhook with `url: https://www.example.com:8443`:
-# - name: www.example.com:8443
-#   user: ...
-#
-- name: 'webhook1.ns1.svc'
-  user:
-    client-certificate-data: "<pem encoded certificate>"
-    client-key-data: "<pem encoded key>"
-# The `name` supports using * to wildcard-match prefixing segments.
-- name: '*.webhook-company.org'
-  user:
-    password: "<password>"
-    username: "<name>"
-# '*' is the default match.
-- name: '*'
-  user:
-    token: "<token>"
-```
+    ```yaml
+    apiVersion: v1
+    kind: Config
+    users:
+    # name should be set to the DNS name of the service or the host (including port) of the URL the webhook is configured to speak to.
+    # If a non-443 port is used for services, it must be included in the name when configuring 1.16+ API servers.
+    #
+    # For a webhook configured to speak to a service on the default port (443), specify the DNS name of the service:
+    # - name: webhook1.ns1.svc
+    #   user: ...
+    #
+    # For a webhook configured to speak to a service on non-default port (e.g. 8443), specify the DNS name and port of the service in 1.16+:
+    # - name: webhook1.ns1.svc:8443
+    #   user: ...
+    # and optionally create a second stanza using only the DNS name of the service for compatibility with 1.15 API servers:
+    # - name: webhook1.ns1.svc
+    #   user: ...
+    #
+    # For webhooks configured to speak to a URL, match the host (and port) specified in the webhook's URL. Examples:
+    # A webhook with `url: https://www.example.com`:
+    # - name: www.example.com
+    #   user: ...
+    #
+    # A webhook with `url: https://www.example.com:443`:
+    # - name: www.example.com:443
+    #   user: ...
+    #
+    # A webhook with `url: https://www.example.com:8443`:
+    # - name: www.example.com:8443
+    #   user: ...
+    #
+    - name: 'webhook1.ns1.svc'
+      user:
+        client-certificate-data: "<pem encoded certificate>"
+        client-key-data: "<pem encoded key>"
+    # The `name` supports using * to wildcard-match prefixing segments.
+    - name: '*.webhook-company.org'
+      user:
+        password: "<password>"
+        username: "<name>"
+    # '*' is the default match.
+    - name: '*'
+      user:
+        token: "<token>"
+    ```
 
 Of course you need to set up the webhook server to handle these authentications.
 


### PR DESCRIPTION
If a code block is underneath a bullet, and not properly indented, it does not render. (potentially a more strict check was introduced with blackfriday v1.5.3, that came with the Hugo 0.57.x upgrade)

Indenting blocks underneath bullets fixes this problem.

- [Before](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#authenticate-apiservers)
- [After](https://deploy-preview-17259--kubernetes-io-master-staging.netlify.com/docs/reference/access-authn-authz/extensible-admission-controllers/#authenticate-apiservers)

More context: https://kubernetes.slack.com/archives/C1J0BPD2M/p1572286360131000