### PR TITLE
Fix #17113 - Remove references to federation pages which have been deleted.

### DIFF
--- a/content/en/docs/reference/_index.md
+++ b/content/en/docs/reference/_index.md
@@ -51,8 +51,6 @@ client libraries:
 * [kube-controller-manager](/docs/admin/kube-controller-manager/) - Daemon that embeds the core control loops shipped with Kubernetes.
 * [kube-proxy](/docs/admin/kube-proxy/) - Can do simple TCP/UDP stream forwarding or round-robin TCP/UDP forwarding across a set of back-ends.
 * [kube-scheduler](/docs/admin/kube-scheduler/) - Scheduler that manages availability, performance, and capacity.
-* [federation-apiserver](/docs/admin/federation-apiserver/) - API server for federated clusters.
-* [federation-controller-manager](/docs/admin/federation-controller-manager/) - Daemon that embeds the core control loops shipped with Kubernetes federation.
 
 ## Design Docs
 


### PR DESCRIPTION
Fixes #17113 