### PR TITLE
Fix misspell of type of Pod condition at init container explanation

### DIFF
--- a/content/en/docs/concepts/workloads/pods/init-containers.md
+++ b/content/en/docs/concepts/workloads/pods/init-containers.md
@@ -277,7 +277,7 @@ if the Pod `restartPolicy` is set to Always, the init containers use
 
 A Pod cannot be `Ready` until all init containers have succeeded. The ports on an
 init container are not aggregated under a Service. A Pod that is initializing
-is in the `Pending` state but should have a condition `Initializing` set to true.
+is in the `Pending` state but should have a condition `Initialized` set to true.
 
 If the Pod [restarts](#pod-restart-reasons), or is restarted, all init containers
 must execute again.


### PR DESCRIPTION
In explanation of init container, doc says 'Initializing' pod condition. However according to [doc of pod condition](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions), it should be 'Initialized'.

This commit fixes this misspell.