### PR TITLE
Remove reference of unsupported k8s versions for CPUManager.

### DIFF
--- a/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
+++ b/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
@@ -44,8 +44,7 @@ management policies to determine some placement preferences on the node.
 
 ### Configuration
 
-The CPU Manager is an alpha feature in Kubernetes v1.8. It was enabled by
-default as a beta feature since v1.10.
+The CPU Manager feature is currently in beta and is enabled by default.
 
 The CPU Manager policy is set with the `--cpu-manager-policy` kubelet
 option. There are two supported policies:

--- a/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
+++ b/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
@@ -76,11 +76,6 @@ System services such as the container runtime and the kubelet itself can continu
 {{< /note >}}
 
 {{< note >}}
-The alpha version of this policy does not guarantee static
-exclusive allocations across Kubelet restarts.
-{{< /note >}}
-
-{{< note >}}
 CPU Manager doesn't support offlining and onlining of
 CPUs at runtime. Also, if the set of online CPUs changes on the node,
 the node must be drained and CPU manager manually reset by deleting the

--- a/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
+++ b/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
@@ -9,7 +9,7 @@ content_template: templates/task
 
 {{% capture overview %}}
 
-{{< feature-state state="beta" >}}
+{{< feature-state for_k8s_version="v1.12" state="beta" >}}
 
 Kubernetes keeps many aspects of how pods execute on nodes abstracted
 from the user. This is by design.  However, some workloads require
@@ -44,13 +44,11 @@ management policies to determine some placement preferences on the node.
 
 ### Configuration
 
-The CPU Manager feature is currently in beta and is enabled by default.
-
 The CPU Manager policy is set with the `--cpu-manager-policy` kubelet
 option. There are two supported policies:
 
-* `none`: the default, which represents the existing scheduling behavior.
-* `static`: allows pods with certain resource characteristics to be
+* [`none`](#none-policy): the default policy.
+* [`static`](#static-policy): allows pods with certain resource characteristics to be
   granted increased CPU affinity and exclusivity on the node.
 
 The CPU manager periodically writes resource updates through the CRI in


### PR DESCRIPTION
Removing references to v1.8, v1.10 as they are no longer supported and the feature is enabled by default.