### PR TITLE
Use --allow-change-held-packages flag

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -75,6 +75,10 @@ The upgrade workflow at high level is the following:
     apt-mark unhold kubeadm && \
     apt-get update && apt-get install -y kubeadm=1.17.x-00 && \
     apt-mark hold kubeadm
+
+    # since apt-get version 1.1 you can also use the following method
+    apt-get update && \
+    apt-get install -y --allow-change-held-packages kubeadm=1.17.x-00
     {{% /tab %}}
     {{% tab name="CentOS, RHEL or Fedora" %}}
     # replace x in 1.17.x-0 with the latest patch version
@@ -269,6 +273,10 @@ Also `sudo kubeadm upgrade plan` is not needed.
     apt-mark unhold kubelet kubectl && \
     apt-get update && apt-get install -y kubelet=1.17.x-00 kubectl=1.17.x-00 && \
     apt-mark hold kubelet kubectl
+
+    # since apt-get version 1.1 you can also use the following method
+    apt-get update && \
+    apt-get install -y --allow-change-held-packages kubelet=1.17.x-00 kubectl=1.17.x-00
     {{% /tab %}}
     {{% tab name="CentOS, RHEL or Fedora" %}}
     # replace x in 1.17.x-0 with the latest patch version
@@ -297,6 +305,10 @@ without compromising the minimum required capacity for running your workloads.
     apt-mark unhold kubeadm && \
     apt-get update && apt-get install -y kubeadm=1.17.x-00 && \
     apt-mark hold kubeadm
+
+    # since apt-get version 1.1 you can also use the following method
+    apt-get update && \
+    apt-get install -y --allow-change-held-packages kubeadm=1.17.x-00
     {{% /tab %}}
     {{% tab name="CentOS, RHEL or Fedora" %}}
     # replace x in 1.17.x-0 with the latest patch version
@@ -338,6 +350,10 @@ without compromising the minimum required capacity for running your workloads.
     apt-mark unhold kubelet kubectl && \
     apt-get update && apt-get install -y kubelet=1.17.x-00 kubectl=1.17.x-00 && \
     apt-mark hold kubelet kubectl
+
+    # since apt-get version 1.1 you can also use the following method
+    apt-get update && \
+    apt-get install -y --allow-change-held-packages kubelet=1.17.x-00 kubectl=1.17.x-00
     {{% /tab %}}
     {{% tab name="CentOS, RHEL or Fedora" %}}
     # replace x in 1.17.x-0 with the latest patch version


### PR DESCRIPTION
Flag `--allow-change-held-packages` was introduced in APT 1.1.

All distros since **Ubuntu 16.04** and **Debian 9** are supporting this