### PR TITLE
Clarify init container use case for security

### DIFF
--- a/content/en/docs/concepts/workloads/pods/init-containers.md
+++ b/content/en/docs/concepts/workloads/pods/init-containers.md
@@ -62,7 +62,6 @@ have some advantages for start-up related code:
 * Init containers can contain utilities or custom code for setup that are not present in an app
   image. For example, there is no need to make an image `FROM` another image just to use a tool like
   `sed`, `awk`, `python`, or `dig` during setup.
-* Init containers can securely run utilities that would make an app container image less secure.
 * The application image builder and deployer roles can work independently without
   the need to jointly build a single app image.
 * Init containers can run with a different view of the filesystem than app containers in the
@@ -71,6 +70,9 @@ have some advantages for start-up related code:
 * Because init containers run to completion before any app containers start, init containers offer
   a mechanism to block or delay app container startup until a set of preconditions are met. Once
   preconditions are met, all of the app containers in a Pod can start in parallel.
+* Init containers can securely run utilities or custom code that would otherwise make an app
+  container image less secure. By keeping unnecessary tools separate you can limit the attack  
+  surface of your app container image. 
 
 
 ### Examples


### PR DESCRIPTION
Fixes #16686

Reasoning: This bullet point has lead to some confusion about how exactly it increases security. I believe it makes more sense to put it at the _end_ of the bullet points list to introduce all concepts first, this makes it a little easier to follow. Second, clarify that running tools in your init containers reduces the attack surface of your application, introducing the clarity of _why_ it makes your app more secure. 
