### PR TITLE
Updating EndpointSlice documentation for beta release in 1.17

### DIFF
--- a/content/en/docs/concepts/services-networking/endpoint-slices.md
+++ b/content/en/docs/concepts/services-networking/endpoint-slices.md
@@ -14,7 +14,7 @@ weight: 10
 
 {{% capture overview %}}
 
-{{< feature-state for_k8s_version="v1.16" state="alpha" >}}
+{{< feature-state for_k8s_version="v1.17" state="beta" >}}
 
 _Endpoint Slices_ provide a simple way to track network endpoints within a
 Kubernetes cluster. They offer a more scalable and extensible alternative to
@@ -26,7 +26,7 @@ Endpoints.
 
 ## Endpoint Slice resources {#endpointslice-resource}
 
-In Kubernetes, an Endpoint Slice contains references to a set of network
+In Kubernetes, an EndpointSlice contains references to a set of network
 endpoints. The EndpointSlice controller automatically creates Endpoint Slices
 for a Kubernetes Service when a selector is specified. These Endpoint Slices
 will include references to any Pods that match the Service selector. Endpoint
@@ -36,13 +36,13 @@ As an example, here's a sample EndpointSlice resource for the `example`
 Kubernetes Service.
 
 ```yaml
-apiVersion: discovery.k8s.io/v1alpha1
+apiVersion: discovery.k8s.io/v1beta1
 kind: EndpointSlice
 metadata:
   name: example-abc
   labels:
     kubernetes.io/service-name: example
-addressType: IP
+addressType: IPv4
 ports:
   - name: http
     protocol: TCP
@@ -50,7 +50,6 @@ ports:
 endpoints:
   - addresses:
     - "10.1.2.3"
-    - "2001:db8::1234:5678"
     conditions:
       ready: true
     hostname: pod-1
@@ -66,6 +65,14 @@ with Endpoints and Services and have similar performance.
 Endpoint Slices can act as the source of truth for kube-proxy when it comes to
 how to route internal traffic. When enabled, they should provide a performance
 improvement for services with large numbers of endpoints.
+
+## Address Types
+
+EndpointSlices support three address types:
+
+* IPv4
+* IPv6
+* FQDN (Fully Qualified Domain Name)
 
 ## Motivation
 

--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -185,7 +185,7 @@ selectors and uses DNS names instead. For more information, see the
 [ExternalName](#externalname) section later in this document.
 
 ### Endpoint Slices
-{{< feature-state for_k8s_version="v1.16" state="alpha" >}}
+{{< feature-state for_k8s_version="v1.17" state="beta" >}}
 
 Endpoint Slices are an API resource that can provide a more scalable alternative
 to Endpoints. Although conceptually quite similar to Endpoints, Endpoint Slices

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -86,7 +86,8 @@ different Kubernetes components.
 | `DynamicAuditing` | `false` | Alpha | 1.13 | |
 | `DynamicKubeletConfig` | `false` | Alpha | 1.4 | 1.10 |
 | `DynamicKubeletConfig` | `true` | Beta | 1.11 | |
-| `EndpointSlice` | `false` | Alpha | 1.16 | |
+| `EndpointSlice` | `false` | Alpha | 1.16 | 1.16 |
+| `EndpointSlice` | `false` | Beta | 1.17 | |
 | `EphemeralContainers` | `false` | Alpha | 1.16 | |
 | `ExpandCSIVolumes` | `false` | Alpha | 1.14 | 1.15 |
 | `ExpandCSIVolumes` | `true` | Beta | 1.16 | |

--- a/content/en/docs/tasks/administer-cluster/enabling-endpointslices.md
+++ b/content/en/docs/tasks/administer-cluster/enabling-endpointslices.md
@@ -27,7 +27,7 @@ resources instead of a single large Endpoints resource.
 
 ## Enabling Endpoint Slices
 
-{{< feature-state for_k8s_version="v1.16" state="alpha" >}}
+{{< feature-state for_k8s_version="v1.17" state="beta" >}}
 
 {{< note >}}
 Although Endpoint Slices may eventually replace Endpoints, many Kubernetes
@@ -36,19 +36,7 @@ seen as an addition to Endpoints in a cluster, not a replacement for them.
 {{< /note >}}
 
 As an alpha feature, Endpoint Slices are not enabled by default in Kubernetes.
-Enabling Endpoint Slices requires as many as 3 changes to Kubernetes cluster
-configuration.
-
-To enable the Discovery API group that includes Endpoint Slices, use the runtime
- config flag (`--runtime-config=discovery.k8s.io/v1alpha1=true`).
-
-The logic responsible for watching services, pods, and nodes and creating or
-updating associated Endpoint Slices lives within the EndpointSlice controller.
-This is disabled by default but can be enabled with the controllers flag on
-kube-controller-manager (`--controllers=endpointslice`).
-
-For Kubernetes components like kube-proxy to actually start using Endpoint
-Slices, the EndpointSlice feature gate will need to be enabled
+To enable them, the EndpointSlice feature gate will need to be enabled
 (`--feature-gates=EndpointSlice=true`).
 
 ## Using Endpoint Slices


### PR DESCRIPTION
This updates the EndpointSlice documentation for the beta release targeted for v1.17. 

EndpointSlice Beta PR: https://github.com/kubernetes/kubernetes/pull/84390
EndpointSlice Enhancement Issue: https://github.com/kubernetes/enhancements/issues/752