### PR TITLE
Fix misspell of type of Pod condition at init container explanation (fr)

### DIFF
--- a/content/fr/docs/concepts/workloads/pods/init-containers.md
+++ b/content/fr/docs/concepts/workloads/pods/init-containers.md
@@ -265,7 +265,7 @@ Toutefois, si la `restartPolicy` du Pod est configurée à "Always", les init co
 
 Un Pod ne peut pas être `Ready` tant que tous les init containers ne se sont pas exécutés avec succès.
 Les ports d'un init container ne sont pas agrégés sous un Service. Un Pod qui s'initialise
-est dans l'état `Pending` mais devrait avoir une condition `Initializing` configurée à "true".
+est dans l'état `Pending` mais devrait avoir une condition `Initialized` configurée à "true".
 
 Si le Pod [redémarre](#raisons-du-redémarrage-d-un-pod) ou est redémarré, tous les init containers
 doivent s'exécuter à nouveau.


### PR DESCRIPTION
In explanation of init container, doc says 'Initializing' pod condition. However according to doc of pod [condition](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions), it should be 'Initialized'.

This commit fixes this misspell of French doc.
This misspell is verified by PR #17329 which fixes English doc.