### PR TITLE
Reword glossary entry for “Cloud provider”

### DIFF
--- a/content/en/docs/reference/glossary/cloud-provider.md
+++ b/content/en/docs/reference/glossary/cloud-provider.md
@@ -4,15 +4,29 @@ id: cloud-provider
 date: 2018-04-12
 full_link: /docs/concepts/cluster-administration/cloud-providers
 short_description: >
-  Cloud provider is a company that offers cloud computing platform that can run Kubernetes clusters.
+  An organization that offers a cloud computing platform.
 
-aka: 
+aka:
+- Cloud Service Provider
 tags:
 - community
 ---
- Cloud provider is a company that offers cloud computing platform that can run Kubernetes clusters.
+ A business or other organization that offers a cloud computing platform.
 
-<!--more--> 
+<!--more-->
 
-Cloud providers or sometime called Cloud Service Provider (CSPs) provides cloud computing platforms.  They may offer services such as Infrastructure as a Service (IaaS) or Platform as a Service (PaaS).  Cloud providers host the Kubernetes cluster and also provide services that interact with the cluster, such as Load Balancers, Storage Classes etc. 
+Cloud providers, sometimes called Cloud Service Providers (CSPs), offer
+cloud computing platforms or services.
 
+Many cloud providers offer managed infrastructure (also called
+Infrastructure as a Service or IaaS).
+With managed infrastructure the cloud provider is responsible for
+servers, storage, and networking while you manage layers on top of that
+such as running a Kubernetes cluster.
+
+You can also find Kubernetes as a managed service; sometimes called
+Platform as a Service, or PaaS. With managed Kubernetes, your
+cloud provider is responsible for the Kubernetes control plane as well
+as the {{< glossary_tooltip term_id="node" text="nodes" >}} and the
+infrastructure they rely on: networking, storage, and possibly other
+elements such as load balancers.


### PR DESCRIPTION
I think this wording works better. Happy to hear feedback.

[Preview](https://deploy-preview-17429--kubernetes-io-master-staging.netlify.com/docs/reference/glossary/?all=true#term-cloud-provider)