### PR TITLE
rcs can not be a shortcut in kubectl command

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/replicationcontroller.md
+++ b/content/en/docs/concepts/workloads/controllers/replicationcontroller.md
@@ -39,7 +39,7 @@ only a single pod. A ReplicationController is similar to a process supervisor,
 but instead of supervising individual processes on a single node, the ReplicationController supervises multiple pods
 across multiple nodes.
 
-ReplicationController is often abbreviated to "rc" or "rcs" in discussion, and as a shortcut in
+ReplicationController is often abbreviated to "rc" in discussion, and as a shortcut in
 kubectl commands.
 
 A simple case is to create one ReplicationController object to reliably run one instance of


### PR DESCRIPTION
```shell
$ kubectl get rcs
error: the server doesn't have a resource type "rcs"
$ kubectl get rc
NAME    DESIRED   CURRENT   READY   AGE
nginx   3         3         3       29m

```