### PR TITLE
Update DaemonSet scheduling version inconsistency

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/daemonset.md
+++ b/content/en/docs/concepts/workloads/controllers/daemonset.md
@@ -112,22 +112,23 @@ when the Pod is created, so it is ignored by the scheduler).  Therefore:
  - The DaemonSet controller can make Pods even when the scheduler has not been started, which can help cluster
    bootstrap.
 
+However, by using the DaemonSet controller to schedule the DaemonSet pods that
+it creates introduces the following issues:
+
+ - Inconsistent Pod behavior: Normal Pods waiting to be scheduled are created
+   and in `Pending` state, but DaemonSet pods are not created in `Pending`
+   state. This is confusing to the user.
+ - [Pod preemption](/docs/concepts/configuration/pod-priority-preemption/)
+   is handled by default scheduler. When preemption is enabled, the DaemonSet controller
+   will make scheduling decisions without considering pod priority and preemption.
 
 ### Scheduled by default scheduler (enabled by default since 1.12)
 
 {{< feature-state state="beta" for-kubernetes-version="1.12" >}}
 
-A DaemonSet resource type ensures that all eligible nodes run a copy of a Pod. Normally, the
-node that a Pod runs on is selected by the Kubernetes scheduler. However,
-DaemonSet pods can also be created and scheduled by a DaemonSet controller instead.
-That introduces the following issues:
-
- * Inconsistent Pod behavior: Normal Pods waiting to be scheduled are created
-   and in `Pending` state, but DaemonSet pods are not created in `Pending`
-   state. This is confusing to the user.
- * [Pod preemption](/docs/concepts/configuration/pod-priority-preemption/)
-   is handled by default scheduler. When preemption is enabled, the DaemonSet controller
-   will make scheduling decisions without considering pod priority and preemption.
+A DaemonSet ensures that all eligible nodes run a copy of a Pod. Normally, the
+node that a Pod runs on is selected by the Kubernetes scheduler. This is also
+the default behavior of DaemonSet pods.
 
 `ScheduleDaemonSetPods` allows you to schedule DaemonSets using the default
 scheduler instead of the DaemonSet controller, by adding the `NodeAffinity` term

--- a/content/en/docs/concepts/workloads/controllers/daemonset.md
+++ b/content/en/docs/concepts/workloads/controllers/daemonset.md
@@ -117,9 +117,9 @@ when the Pod is created, so it is ignored by the scheduler).  Therefore:
 
 {{< feature-state state="beta" for-kubernetes-version="1.12" >}}
 
-A DaemonSet ensures that all eligible nodes run a copy of a Pod. Normally, the
+A DaemonSet resource type ensures that all eligible nodes run a copy of a Pod. Normally, the
 node that a Pod runs on is selected by the Kubernetes scheduler. However,
-DaemonSet pods are created and scheduled by the DaemonSet controller instead.
+DaemonSet pods can also be created and scheduled by a DaemonSet controller instead.
 That introduces the following issues:
 
  * Inconsistent Pod behavior: Normal Pods waiting to be scheduled are created


### PR DESCRIPTION
Fixes #17336

Check the issue for more details but in short: an update was made to the header specifying the default behavior when it switched over in 1.12 without modifying the intro paragraph (which still reflects that DaemonSet controller is the default scheduling behavior)