### PR TITLE
add enable Endpoint Slices

### DIFF
--- a/content/en/docs/concepts/services-networking/endpoint-slices.md
+++ b/content/en/docs/concepts/services-networking/endpoint-slices.md
@@ -59,6 +59,8 @@ endpoints:
       topology.kubernetes.io/zone: us-west2-a
 ```
 
+Additionally, you must [enable Endpoint Slices](/docs/tasks/administer-cluster/enabling-endpoint-slices/#enabling-endpoint-slices) first.
+
 By default, Endpoint Slices managed by the EndpointSlice controller will have no
 more than 100 endpoints each. Below this scale, Endpoint Slices should map 1:1
 with Endpoints and Services and have similar performance.


### PR DESCRIPTION
When running the example in page [https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/](https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/) , it failed with errors like this:
```shell
kubectl create -f eps.yaml
error: unable to recognize "eps.yaml": no matches for kind "EndpointSlice" in version "discovery.k8s.io/v1alpha1"
```
Add enable Endpoint Slices.