### PR TITLE
Drop vestigial paragraph about kube-proxy feature compatibility

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -220,14 +220,6 @@ There are a few reasons for using proxying for Services:
    on the DNS records could impose a high load on DNS that then becomes
    difficult to manage.
 
-### Version compatibility
-
-Since Kubernetes v1.0 you have been able to use the
-[userspace proxy mode](#proxy-mode-userspace).
-Kubernetes v1.1 added iptables mode proxying, and in Kubernetes v1.2 the
-iptables mode for kube-proxy became the default.
-Kubernetes v1.8 added ipvs proxy mode.
-
 ### User space proxy mode {#proxy-mode-userspace}
 
 In this mode, kube-proxy watches the Kubernetes master for the addition and


### PR DESCRIPTION
All supported Kubernetes versions offer all `kube-proxy` features previously listed, so the paragraph I'm removing isn't needed. 

[Preview](https://deploy-preview-17483--kubernetes-io-master-staging.netlify.com/docs/concepts/services-networking/service/)

/kind cleanup