### PR TITLE
Document new stable labels for zone, region and instance-type

### DIFF
--- a/content/en/docs/concepts/configuration/assign-pod-node.md
+++ b/content/en/docs/concepts/configuration/assign-pod-node.md
@@ -78,7 +78,10 @@ with a standard set of labels. These labels are
 * [`kubernetes.io/hostname`](/docs/reference/kubernetes-api/labels-annotations-taints/#kubernetes-io-hostname)
 * [`failure-domain.beta.kubernetes.io/zone`](/docs/reference/kubernetes-api/labels-annotations-taints/#failure-domain-beta-kubernetes-io-zone)
 * [`failure-domain.beta.kubernetes.io/region`](/docs/reference/kubernetes-api/labels-annotations-taints/#failure-domain-beta-kubernetes-io-region)
+* [`topology.kubernetes.io/zone`](/docs/reference/kubernetes-api/labels-annotations-taints/#topology-kubernetes-io-zone)
+* [`topology.kubernetes.io/region`](/docs/reference/kubernetes-api/labels-annotations-taints/#topology-kubernetes-io-region)
 * [`beta.kubernetes.io/instance-type`](/docs/reference/kubernetes-api/labels-annotations-taints/#beta-kubernetes-io-instance-type)
+* [`node.kubernetes.io/instance-type`](/docs/reference/kubernetes-api/labels-annotations-taints/#node-kubernetes-io-instance-type)
 * [`kubernetes.io/os`](/docs/reference/kubernetes-api/labels-annotations-taints/#kubernetes-io-os)
 * [`kubernetes.io/arch`](/docs/reference/kubernetes-api/labels-annotations-taints/#kubernetes-io-arch)
 

--- a/content/en/docs/reference/access-authn-authz/admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/admission-controllers.md
@@ -441,8 +441,11 @@ and kubelets will not be allowed to modify labels with that prefix.
   * `kubernetes.io/arch`
   * `kubernetes.io/os`
   * `beta.kubernetes.io/instance-type`
+  * `node.kubernetes.io/instance-type`
   * `failure-domain.beta.kubernetes.io/region`
   * `failure-domain.beta.kubernetes.io/zone`
+  * `topology.kubernetes.io/region`
+  * `topology.kubernetes.io/zone`
   * `kubelet.kubernetes.io/`-prefixed labels
   * `node.kubernetes.io/`-prefixed labels
 

--- a/content/en/docs/reference/kubernetes-api/labels-annotations-taints.md
+++ b/content/en/docs/reference/kubernetes-api/labels-annotations-taints.md
@@ -57,9 +57,24 @@ This will be set only if you are using a `cloudprovider`. This setting is handy
 if you want to target certain workloads to certain instance types, but typically you want
 to rely on the Kubernetes scheduler to perform resource-based scheduling. You should aim to schedule based on properties rather than on instance types (for example: require a GPU, instead of requiring a `g2.2xlarge`).
 
+**NOTE**: starting in v1.17, this label is deprecated in favor of [node.kubernetes.io/instance-type](nodekubernetesioinstance-type).
+
+## node.kubernetes.io/instance-type {#nodekubernetesioinstance-type}
+
+Example: `node.kubernetes.io/instance-type=m3.medium`
+
+Used on: Node
+
+The Kubelet populates this with the instance type as defined by the `cloudprovider`.
+This will be set only if you are using a `cloudprovider`. This setting is handy
+if you want to target certain workloads to certain instance types, but typically you want
+to rely on the Kubernetes scheduler to perform resource-based scheduling. You should aim to schedule based on properties rather than on instance types (for example: require a GPU, instead of requiring a `g2.2xlarge`).
+
 ## failure-domain.beta.kubernetes.io/region
 
 See [failure-domain.beta.kubernetes.io/zone](#failure-domainbetakubernetesiozone).
+
+**NOTE**: starting in v1.17, this label is deprecated in favor of [topology.kubernetes.io/region](topologykubernetesioregion).
 
 ## failure-domain.beta.kubernetes.io/zone {#failure-domainbetakubernetesiozone}
 
@@ -88,5 +103,40 @@ The expectation is that failures of nodes in different zones should be uncorrela
 
 If `PersistentVolumeLabel` does not support automatic labeling of your PersistentVolumes, you should consider
 adding the labels manually (or adding support for `PersistentVolumeLabel`). With `PersistentVolumeLabel`, the scheduler prevents Pods from mounting volumes in a different zone. If your infrastructure doesn't have this constraint, you don't need to add the zone labels to the volumes at all.
+
+**NOTE**: starting in v1.17, this label is deprecated in favor of [topology.kubernetes.io/zone](topologykubernetesiozone).
+
+## topology.kubernetes.io/region {#topologykubernetesioregion}
+
+See [topology.kubernetes.io/zone](#topologykubernetesiozone).
+
+## topology.kubernetes.io/zone {#topologykubernetesiozone}
+
+Example:
+
+`topology.kubernetes.io/region=us-east-1`
+
+`topology.kubernetes.io/zone=us-east-1c`
+
+Used on: Node, PersistentVolume
+
+On the Node: The `kubelet` populates this with the zone information as defined by the `cloudprovider`.
+This will be set only if you are using a `cloudprovider`. However, you should consider setting this
+on the nodes if it makes sense in your topology.
+
+On the PersistentVolume: The `PersistentVolumeLabel` admission controller will automatically add zone labels to PersistentVolumes, on GCE and AWS.
+
+Kubernetes will automatically spread the Pods in a replication controller or service across nodes in a single-zone cluster (to reduce the impact of failures). With multiple-zone clusters, this spreading behaviour is extended across zones (to reduce the impact of zone failures). This is achieved via _SelectorSpreadPriority_.
+
+_SelectorSpreadPriority_ is a best effort placement. If the zones in your cluster are heterogeneous (for example: different numbers of nodes, different types of nodes, or different pod resource requirements), this placement might prevent equal spreading of your Pods across zones. If desired, you can use homogenous zones (same number and types of nodes) to reduce the probability of unequal spreading.
+
+The scheduler (through the _VolumeZonePredicate_ predicate) also will ensure that Pods, that claim a given volume, are only placed into the same zone as that volume. Volumes cannot be attached across zones.
+
+The actual values of zone and region don't matter. Nor is the node hierarchy rigidly defined.
+The expectation is that failures of nodes in different zones should be uncorrelated unless the entire region has failed. For example, zones should typically avoid sharing a single network switch. The exact mapping depends on your particular infrastructure - a three rack installation will choose a very different setup to a multi-datacenter configuration.
+
+If `PersistentVolumeLabel` does not support automatic labeling of your PersistentVolumes, you should consider
+adding the labels manually (or adding support for `PersistentVolumeLabel`). With `PersistentVolumeLabel`, the scheduler prevents Pods from mounting volumes in a different zone. If your infrastructure doesn't have this constraint, you don't need to add the zone labels to the volumes at all.
+
 
 {{% /capture %}}


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

Enhancement: https://github.com/kubernetes/enhancements/issues/837
PRs: https://github.com/kubernetes/kubernetes/pull/81431 https://github.com/kubernetes/kubernetes/pull/82049

I didn't update examples/setup references to use the new labels because the old beta labels are still the source of truth for v1.17. Those will be updated for v1.18.
