### PR TITLE
Update feature gate status for VolumePVCDataSource

### DIFF
--- a/content/en/docs/concepts/storage/volume-pvc-datasource.md
+++ b/content/en/docs/concepts/storage/volume-pvc-datasource.md
@@ -14,13 +14,6 @@ weight: 30
 {{< feature-state for_k8s_version="v1.16" state="beta" >}}
 This document describes the concept of cloning existing CSI Volumes in Kubernetes.  Familiarity with [Volumes](/docs/concepts/storage/volumes) is suggested.
 
-This feature requires VolumePVCDataSource feature gate to be enabled:
-
-```
---feature-gates=VolumePVCDataSource=true
-```
-
-
 {{% /capture %}}
 
 


### PR DESCRIPTION
VolumePVCDataSource is default true. Add  it is by default.
```
VolumePVCDataSource=true|false (BETA - default=true)
VolumeSnapshotDataSource=true|false (ALPHA - default=false)
VolumeSubpathEnvExpansion=true|false (BETA - default=true)
```