### PR TITLE
backport assign inductor as sig-docs-ja approver (#17412) to dev-1.15-ja.1

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -109,6 +109,7 @@ aliases:
     - micheleberardi
   sig-docs-ja-owners: # Admins for Japanese content
     - cstoku
+    - inductor
     - nasa9084
     - zacharysarah
   sig-docs-ja-reviews: # PR reviews for Japanese content


### PR DESCRIPTION
Just cherry-pick'ed the master PR commit hash to approve current waiting PRs for Japanese docs!