### PR TITLE
motidy extensions in content/zh/docs/reference/glossary/extensions

### DIFF
--- a/content/zh/docs/reference/glossary/extensions.md
+++ b/content/zh/docs/reference/glossary/extensions.md
@@ -35,4 +35,4 @@ tags:
 Most cluster administrators will use a hosted or distribution instance of Kubernetes. As a result, most Kubernetes users will need to install [extensions](/docs/concepts/extend-kubernetes/extend-cluster/#extensions) and fewer will need to author new ones.
 -->
 
-大多数集群管理员会使用 托管或发行实例 Kubernetes 。因此，大多数 Kubernetes 用户将需要安装 [扩展组件](/docs/concepts/extend-kubernetes/extend-cluster/#extensions)，较少用户会需要编写新的扩展组件。
+大多数集群管理员会使用托管的 Kubernetes 或其某种发行包。因此，大多数 Kubernetes 用户将需要安装 [扩展组件](/docs/concepts/extend-kubernetes/extend-cluster/#extensions)，较少用户会需要编写新的扩展组件。


### PR DESCRIPTION
zh-trans: motidy extensions in content/zh/docs/reference/glossary/extensions
Update: motidy extensions in content/zh/docs/reference/glossary/extensions
Co-Authored-By: lpf7551321