### PR TITLE
fix - broken link

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-upgrade.md
@@ -25,7 +25,7 @@ To use kube-dns with upgrades in Kubernetes v1.13.0 and later please follow [thi
 In Kubernetes v1.15.0 and later, `kubeadm upgrade apply` and `kubeadm upgrade node` will also
 automatically renew the kubeadm managed certificates on this node, including those stored in kubeconfig files.
 To opt-out, it is possible to pass the flag `--certificate-renewal=false`. For more details about certificate
-renewal see the [certificate management documentation](docs/tasks/administer-cluster/kubeadm/kubeadm-certs).
+renewal see the [certificate management documentation](/docs/tasks/administer-cluster/kubeadm/kubeadm-certs).
 
 {{< note >}}
 The commands `kubeadm upgrade apply` and `kubeadm upgrade plan` have a legacy `--config`


### PR DESCRIPTION
Fix for brokenlink at "kubeadm upgrade" page
https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-upgrade/

(see link "certificate management documentation" )