### PR TITLE
Fix invalid CRI-O glossary links

### DIFF
--- a/content/en/docs/reference/glossary/cri-o.md
+++ b/content/en/docs/reference/glossary/cri-o.md
@@ -2,7 +2,7 @@
 title: CRI-O
 id: cri-o
 date: 2019-05-14
-full_link: https://cri-o.io/docs/
+full_link: https://cri-o.io/#what-is-cri-o
 short_description: >
   A lightweight container runtime specifically for Kubernetes
 

--- a/content/fr/docs/reference/glossary/cri-o.md
+++ b/content/fr/docs/reference/glossary/cri-o.md
@@ -2,7 +2,7 @@
 title: CRI-O
 id: cri-o
 date: 2019-05-14
-full_link: https://cri-o.io/docs/
+full_link: https://cri-o.io/#what-is-cri-o
 short_description: >
   Un runtime (environnement d'exécution) de conteneur, léger et spécifiquement conçu pour Kubernetes.
 


### PR DESCRIPTION
The /docs does not exists so we link to the main website from now on.