### PR TITLE
PVCProtection related conent cleanup

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -397,7 +397,6 @@ Each feature gate is designed for enabling/disabling a specific feature:
 - `ProcMountType`: Enables control over ProcMountType for containers.
 - `PVCProtection`: Enable the prevention of a PersistentVolumeClaim (PVC) from
   being deleted when it is still used by any Pod.
-  More details can be found [here](/docs/tasks/administer-cluster/storage-object-in-use-protection/).
 - `QOSReserved`: Allows resource reservations at the QoS level preventing pods at lower QoS levels from
   bursting into resources requested at higher QoS levels (memory only for now).
 - `ResourceLimitsPriorityFunction`: Enable a scheduler priority function that


### PR DESCRIPTION
After PVCProtection was deprecated in kubernetes/website@be48fb38e9a was
removed task used to describe the concept of it. The link wasn't removed
everywhere (this PR removes it) and was living in site documentation
since then.

In Addition - from tasks.yaml removed link pvc-protection articles
(also not exists) 