### PR TITLE
Add caution to behavior of --from-env-file

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -223,7 +223,9 @@ data:
   lives: "3"
 ```
 
+{{< caution >}}
 When passing `--from-env-file` multiple times to create a ConfigMap from multiple data sources, only the last env-file is used:
+{{< /caution >}}
 
 ```shell
 # Download the sample files into `configure-pod-container/configmap/` directory

--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -224,8 +224,10 @@ data:
 ```
 
 {{< caution >}}
-When passing `--from-env-file` multiple times to create a ConfigMap from multiple data sources, only the last env-file is used:
+When passing `--from-env-file` multiple times to create a ConfigMap from multiple data sources, only the last env-file is used.
 {{< /caution >}}
+
+The behavior of passing `--from-env-file` multiple times is demonstrated by: 
 
 ```shell
 # Download the sample files into `configure-pod-container/configmap/` directory


### PR DESCRIPTION
Resolves #16729 

When creating ConfigMaps using `--from-env-file` command, the documentation provides a cautionary note and example about unexpected behavior when passing multiple files to the `--from-env-file` command. However, it it not signaled as a caution in the documentation which is confusing to readers who would otherwise gloss over this important detail, or think of it as a feature. 