### PR TITLE
Using removable Pod instead of Deployment in HPA example

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -110,7 +110,7 @@ Now, we will see how the autoscaler reacts to increased load.
 We will start a container, and send an infinite loop of queries to the php-apache service (please run it in a different terminal):
 
 ```shell
-kubectl run -i --tty load-generator --image=busybox /bin/sh
+kubectl run --generator=run-pod/v1 -it --rm load-generator --image=busybox /bin/sh
 
 Hit enter for command prompt
 


### PR DESCRIPTION
Enhancement for the page [Tasks / Run Applications / Horizontal Pod Autoscaler Walkthrough](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#increase-load)

Using removable Pod instead of Deployment in HPA example.