### PR TITLE
Fix typo on CRD documentation

### DIFF
--- a/content/en/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions.md
+++ b/content/en/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions.md
@@ -255,7 +255,7 @@ A structural schema is an [OpenAPI v3.0 validation schema](/docs/tasks/access-ku
    * a node with `x-kubernetes-int-or-string: true`
    * a node with `x-kubernetes-preserve-unknown-fields: true`
 2. for each field in an object and each item in an array which is specified within any of `allOf`, `anyOf`, `oneOf` or `not`, the schema also specifies the field/item outside of those logical junctors (compare example 1 and 2).
-3. does not set `description`, `type`, `default`, `additionProperties`, `nullable` within an `allOf`, `anyOf`, `oneOf` or `not`, with the exception of the two pattern for `x-kubernetes-int-or-string: true` (see below).
+3. does not set `description`, `type`, `default`, `additionalProperties`, `nullable` within an `allOf`, `anyOf`, `oneOf` or `not`, with the exception of the two pattern for `x-kubernetes-int-or-string: true` (see below).
 4. if `metadata` is specified, then only restrictions on `metadata.name` and `metadata.generateName` are allowed. 
 
 


### PR DESCRIPTION
On https://kubernetes.io/docs/contribute/start/#improve-existing-content, under point 3, the field `additionProperties` should be `additionalProperties`
