### PR TITLE
Remove instructions to copy Etcd CA key in HA

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/high-availability.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/high-availability.md
@@ -345,7 +345,6 @@ SSH is required if you want to control all nodes from a single machine.
         scp /etc/kubernetes/pki/front-proxy-ca.crt "${USER}"@$host:
         scp /etc/kubernetes/pki/front-proxy-ca.key "${USER}"@$host:
         scp /etc/kubernetes/pki/etcd/ca.crt "${USER}"@$host:etcd-ca.crt
-        scp /etc/kubernetes/pki/etcd/ca.key "${USER}"@$host:etcd-ca.key
     done
     ```
 
@@ -368,6 +367,5 @@ SSH is required if you want to control all nodes from a single machine.
     mv /home/${USER}/front-proxy-ca.crt /etc/kubernetes/pki/
     mv /home/${USER}/front-proxy-ca.key /etc/kubernetes/pki/
     mv /home/${USER}/etcd-ca.crt /etc/kubernetes/pki/etcd/ca.crt
-    mv /home/${USER}/etcd-ca.key /etc/kubernetes/pki/etcd/ca.key
     ```
 {{% /capture %}}

--- a/content/en/docs/setup/production-environment/tools/kubeadm/high-availability.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/high-availability.md
@@ -345,6 +345,8 @@ SSH is required if you want to control all nodes from a single machine.
         scp /etc/kubernetes/pki/front-proxy-ca.crt "${USER}"@$host:
         scp /etc/kubernetes/pki/front-proxy-ca.key "${USER}"@$host:
         scp /etc/kubernetes/pki/etcd/ca.crt "${USER}"@$host:etcd-ca.crt
+        # Quote this line if you are using external etcd
+        scp /etc/kubernetes/pki/etcd/ca.key "${USER}"@$host:etcd-ca.key
     done
     ```
 
@@ -367,5 +369,7 @@ SSH is required if you want to control all nodes from a single machine.
     mv /home/${USER}/front-proxy-ca.crt /etc/kubernetes/pki/
     mv /home/${USER}/front-proxy-ca.key /etc/kubernetes/pki/
     mv /home/${USER}/etcd-ca.crt /etc/kubernetes/pki/etcd/ca.crt
+    # Quote this line if you are using external etcd
+    mv /home/${USER}/etcd-ca.key /etc/kubernetes/pki/etcd/ca.key
     ```
 {{% /capture %}}


### PR DESCRIPTION
No need to copy etcd CA key when manually copying certs from first master node to nodes joining the control plane.

https://github.com/kubernetes/kubernetes/blob/release-1.17/cmd/kubeadm/app/phases/copycerts/copycerts.go#L191-L198
@neolit123 