### PR TITLE
mysql deployment object metadata includes "wordpress" label

### DIFF
--- a/content/en/examples/application/wordpress/mysql-deployment.yaml
+++ b/content/en/examples/application/wordpress/mysql-deployment.yaml
@@ -3,12 +3,12 @@ kind: Service
 metadata:
   name: wordpress-mysql
   labels:
-    app: wordpress
+    app: wordpress-mysql
 spec:
   ports:
     - port: 3306
   selector:
-    app: wordpress
+    app: wordpress-mysql
     tier: mysql
   clusterIP: None
 ---
@@ -17,7 +17,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: mysql-pv-claim
   labels:
-    app: wordpress
+    app: wordpress-mysql
 spec:
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
Changed "wordpress" labels to be "wordpress-mysql" to to prevent the actual wordpress Service from matching the mysql pod.  
Details here: https://github.com/kubernetes/website/issues/17612

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> Remember to delete this note before submitting your pull request.
>
> For pull requests on 1.17 Features: set Milestone to 1.17 and Base Branch to dev-1.17
>
> For pull requests on Chinese localization, set Base Branch to release-1.16
> Feel free to ask questions in #kubernetes-docs-zh
>
> For pull requests on Korean Localization: set Base Branch to dev-1.16-ko.\<latest team milestone>
>
> If you need Help on editing and submitting pull requests, visit:
> https://kubernetes.io/docs/contribute/start/#improve-existing-content.
>
> If you need Help on choosing which branch to use, visit:
> https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use.
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
