### PR TITLE
jsonpath example of child with dot in name

### DIFF
--- a/content/en/docs/reference/kubectl/jsonpath.md
+++ b/content/en/docs/reference/kubectl/jsonpath.md
@@ -69,7 +69,7 @@ Function            | Description               | Example                       
 --------------------|---------------------------|-----------------------------------------------------------------|------------------
 `text`              | the plain text            | `kind is {.kind}`                                               | `kind is List`
 `@`                 | the current object        | `{@}`                                                           | the same as input
-`.` or `[]`         | child operator            | `{.kind}` or `{['kind']}`                                       | `List`
+`.` or `[]`         | child operator            | `{.kind}`, `{['kind']}` or `{['name\.type']}`                   | `List`
 `..`                | recursive descent         | `{..name}`                                                      | `127.0.0.1 127.0.0.2 myself e2e`
 `*`                 | wildcard. Get all objects | `{.items[*].metadata.name}`                                     | `[127.0.0.1 127.0.0.2]`
 `[start:end:step]` | subscript operator        | `{.users[0].name}`                                              | `myself`


### PR DESCRIPTION
Promoting the solution shown in https://github.com/kubernetes/kubernetes/issues/23386#issuecomment-305348170 to formal documentation.

