### PR TITLE
Remove readOnly from Downward API volume examples

### DIFF
--- a/content/en/examples/pods/inject/dapi-volume-resources.yaml
+++ b/content/en/examples/pods/inject/dapi-volume-resources.yaml
@@ -30,7 +30,6 @@ spec:
       volumeMounts:
         - name: podinfo
           mountPath: /etc/podinfo
-          readOnly: false
   volumes:
     - name: podinfo
       downwardAPI:

--- a/content/en/examples/pods/inject/dapi-volume.yaml
+++ b/content/en/examples/pods/inject/dapi-volume.yaml
@@ -25,7 +25,6 @@ spec:
       volumeMounts:
         - name: podinfo
           mountPath: /etc/podinfo
-          readOnly: false
   volumes:
     - name: podinfo
       downwardAPI:


### PR DESCRIPTION
Downward API volumes are not writeable, even if `readOnly:true` is set, so
including this in the example is potentially confusing for users who might expect to be able to change `readOnly` to `true` to write to the volume.