### PR TITLE
Removed Object Metadata from Concepts Overview.

### DIFF
--- a/content/en/docs/concepts/_index.md
+++ b/content/en/docs/concepts/_index.md
@@ -59,10 +59,6 @@ The Kubernetes master is responsible for maintaining the desired state for your 
 
 The nodes in a cluster are the machines (VMs, physical servers, etc) that run your applications and cloud workflows. The Kubernetes master controls each node; you'll rarely interact with nodes directly.
 
-#### Object Metadata
-
-
-* [Annotations](/docs/concepts/overview/working-with-objects/annotations/)
 
 {{% /capture %}}
 


### PR DESCRIPTION
`Object Metadata` section is misleading, as the Concept's overview is covering what master and non-master nodes are and list of objects. But there is no discussion on `Object Metadata` till the end and all of sudden there is Object Metadata section with no background introduction or definition, and just a reference to `Annotations` which is confusing if you read the content from the beginning. So it would be better to remove this as it is covered later here `https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/`.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> Remember to delete this note before submitting your pull request.
>
> For pull requests on 1.17 Features: set Milestone to 1.17 and Base Branch to dev-1.17
>
> For pull requests on Chinese localization, set Base Branch to release-1.16
> Feel free to ask questions in #kubernetes-docs-zh
>
> For pull requests on Korean Localization: set Base Branch to dev-1.16-ko.\<latest team milestone>
>
> If you need Help on editing and submitting pull requests, visit:
> https://kubernetes.io/docs/contribute/start/#improve-existing-content.
>
> If you need Help on choosing which branch to use, visit:
> https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use.
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
