### PR TITLE
Update kops Linux Setup Step

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kops.md
+++ b/content/en/docs/setup/production-environment/tools/kops.md
@@ -52,7 +52,7 @@ On Linux:
 ```shell
 wget https://github.com/kubernetes/kops/releases/download/1.10.0/kops-linux-amd64
 chmod +x kops-linux-amd64
-mv kops-linux-amd64 /usr/local/bin/kops
+sudo mv kops-linux-amd64 /usr/local/bin/kops
 ```
 
 ### (2/5) Create a route53 domain for your cluster


### PR DESCRIPTION
Moving the downloaded kops binary in Linux to the path _/usr/local/bin/kops_ requires privileged permissions, hence the need to add the _sudo_ command.