### PR TITLE
Remove Brad and Luc from Chinese owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -146,14 +146,12 @@ aliases:
     - zacharysarah
     - zparnold
   sig-docs-zh-owners: # Admins for Chinese content
-    - bradtopol
     - chenopis
     - chenrui333
     - dchen1107
     - haibinxie
     - hanjiayao
     - lichuqiang
-    - lucperkins
     - markthink
     - SataQiu
     - tengqm


### PR DESCRIPTION
My guess is that we added some names at the very beginning of Chinese localization to seed the repo. However, getting PR reviews routed to these people could be confusing or even annoying before they have secured a Chinese certificate.
