### PR TITLE
Fixed the link of an example

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/en/docs/concepts/workloads/controllers/statefulset.md
@@ -267,7 +267,7 @@ StatefulSet will then begin to recreate the Pods using the reverted template.
 
 * Follow an example of [deploying a stateful application](/docs/tutorials/stateful-application/basic-stateful-set/).
 * Follow an example of [deploying Cassandra with Stateful Sets](/docs/tutorials/stateful-application/cassandra/).
-* Follow an example of [running a replicated stateful application](/docs/tasks/run-application/run-stateless-application-deployment/).
+* Follow an example of [running a replicated stateful application](/docs/tasks/run-application/run-replicated-stateful-application/).
 
 {{% /capture %}}
 


### PR DESCRIPTION
> Follow an example of running a replicated stateful application.

This sounds the link should be `run-replicated-stateful-application` but it was `run-stateless-application-deployment`.