### PR TITLE
Fix link to replicated stateful application

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/en/docs/concepts/workloads/controllers/statefulset.md
@@ -267,7 +267,7 @@ StatefulSet will then begin to recreate the Pods using the reverted template.
 
 * Follow an example of [deploying a stateful application](/docs/tutorials/stateful-application/basic-stateful-set/).
 * Follow an example of [deploying Cassandra with Stateful Sets](/docs/tutorials/stateful-application/cassandra/).
-* Follow an example of [running a replicated stateful application](/docs/tasks/run-application/run-stateless-application-deployment/).
+* Follow an example of [running a replicated stateful application](/docs/tasks/run-application/run-replicated-stateful-application/).
 
 {{% /capture %}}
 


### PR DESCRIPTION
PR #17430 added a link to the replicated stateless application example,
which isn't quite correct for the concepts that are meant to be
illustrated. A stateful application, such as MySQL, should have been the
actual target of the link.

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>
