### PR TITLE
Fix french setup broken links

### DIFF
--- a/content/fr/docs/setup/_index.md
+++ b/content/fr/docs/setup/_index.md
@@ -35,7 +35,7 @@ Vous devriez choisir une solution locale si vous souhaitez :
 * Essayer ou commencer à apprendre Kubernetes
 * Développer et réaliser des tests sur des clusters locaux
 
-Choisissez une [solution locale] (/docs/setup/pick-right-solution/#local-machine-solutions).
+Choisissez une [solution locale] (/fr/docs/setup/pick-right-solution/#solutions-locales).
 
 ## Solutions hébergées
 
@@ -49,7 +49,7 @@ Vous devriez choisir une solution hébergée si vous :
 * N'avez pas d'équipe de Site Reliability Engineering (SRE) dédiée, mais que vous souhaitez une haute disponibilité.
 * Vous n'avez pas les ressources pour héberger et surveiller vos clusters
 
-Choisissez une [solution hébergée] (/fr/docs/setup/pick-right-solution/#hosted-solutions).
+Choisissez une [solution hébergée] (/fr/docs/setup/pick-right-solution/#solutions-hebergées).
 
 ## Solutions cloud clés en main
 
@@ -63,7 +63,7 @@ Vous devriez choisir une solution cloud clés en main si vous :
 * Voulez plus de contrôle sur vos clusters que ne le permettent les solutions hébergées
 * Voulez réaliser vous même un plus grand nombre d'operations
 
-Choisissez une [solution clé en main] (/docs/setup/pick-right-solution/#turnkey-cloud-solutions)
+Choisissez une [solution clé en main] (/fr/docs/setup/pick-right-solution/#solutions-clés-en-main)
 
 ## Solutions clés en main sur site
 
@@ -76,7 +76,7 @@ Vous devriez choisir une solution de cloud clé en main sur site si vous :
 * Disposez d'une équipe SRE dédiée
 * Avez les ressources pour héberger et surveiller vos clusters
 
-Choisissez une [solution clé en main sur site] (/docs/setup/pick-right-solution/#on-premises-turnkey-cloud-solutions).
+Choisissez une [solution clé en main sur site] (/fr/docs/setup/pick-right-solution/#solutions-on-premises-clés-en-main).
 
 ## Solutions personnalisées
 
@@ -84,10 +84,10 @@ Les solutions personnalisées vous offrent le maximum de liberté sur vos cluste
 d'expertise. Ces solutions vont du bare-metal aux fournisseurs de cloud sur
 différents systèmes d'exploitation.
 
-Choisissez une [solution personnalisée] (/docs/setup/pick-right-solution/#custom-solutions).
+Choisissez une [solution personnalisée] (/fr/docs/setup/pick-right-solution/#solutions-personnalisées).
 
 {{% /capture %}}
 
 {{% capture whatsnext %}}
-Allez à [Choisir la bonne solution] (/docs/setup/pick-right-solution/) pour une liste complète de solutions.
+Allez à [Choisir la bonne solution] (/fr/docs/setup/pick-right-solution/) pour une liste complète de solutions.
 {{% /capture %}}

--- a/content/fr/docs/setup/pick-right-solution.md
+++ b/content/fr/docs/setup/pick-right-solution.md
@@ -13,18 +13,19 @@ Kubernetes peut fonctionner sur des plateformes variées: sur votre PC portable,
 de serveurs bare-metal. L'effort demandé pour configurer un cluster varie de l'éxécution d'une simple commande à la création
 de votre propre cluster personnalisé. Utilisez ce guide pour choisir la solution qui correspond le mieux à vos besoins.
 
-Si vous voulez simplement jeter un coup d'oeil rapide, utilisez alors de préférence les [solutions locales basées sur Docker](#local-machine-solutions).
+Si vous voulez simplement jeter un coup d'oeil rapide, utilisez alors de préférence les [solutions locales basées sur Docker](#solutions-locales).
 
-Lorsque vous êtes prêts à augmenter le nombre de machines et souhaitez bénéficier de la haute disponibilité, une
-[solution hébergée](#hosted-solutions) est la plus simple à déployer et à maintenir.
+Lorsque vous êtes prêts à augmenter le nombre de machines et souhaitez bénéficier de la haute disponibilité, une 
+[solution hébergée](#solutions-hebergées) est la plus simple à déployer et à maintenir.
 
-[Les solutions cloud clés en main](#turnkey-cloud-solutions) ne demandent que peu de commande pour déployer et couvrent un large panel de
- fournisseurs de cloud. [Les solutions clés en main pour cloud privé](#on-premises-turnkey-cloud-solutions) possèdent la simplicité des solutions cloud clés en main combinées avec la sécurité de votre propre réseau privé.
+[Les solutions cloud clés en main](#solutions-clés-en-main) ne demandent que peu de commande pour déployer et couvrent un large panel de 
+ fournisseurs de cloud. [Les solutions clés en main pour cloud privé](#solutions-on-premises-clés-en-main) possèdent la simplicité des solutions cloud clés en main combinées avec la sécurité de votre propre réseau privé.
 
-Si vous avez déjà un moyen de configurer vos resources, utilisez [kubeadm](/docs/setup/independent/create-cluster-kubeadm/) pour facilement
+Si vous avez déjà un moyen de configurer vos resources, utilisez [kubeadm](/fr/docs/setup/independent/create-cluster-kubeadm/) pour facilement
 déployer un cluster grâce à une seule ligne de commande par machine.
 
-[Les solutions personnalisées](#custom-solutions) varient d'instructions pas à pas, à des conseils relativement généraux pour déployer un
+[Les solutions personnalisées](#solutions-personnalisées) varient d'instructions pas à pas, à des conseils relativement généraux pour déployer un
+
 cluster Kubernetes en partant du début.
 
 {{% /capture %}}
@@ -33,7 +34,7 @@ cluster Kubernetes en partant du début.
 
 ## Solutions locales
 
-* [Minikube](/docs/setup/minikube/) est une méthode pour créer un cluster Kubernetes local à noeud unique pour le développement et le test. L'installation est entièrement automatisée et ne nécessite pas de compte de fournisseur de cloud.
+* [Minikube](/fr/docs/setup/learning-environment/minikube/) est une méthode pour créer un cluster Kubernetes local à noeud unique pour le développement et le test. L'installation est entièrement automatisée et ne nécessite pas de compte de fournisseur de cloud.
 
 * [Docker Desktop](https://www.docker.com/products/docker-desktop) est une
 application facile à installer pour votre environnement Mac ou Windows qui vous permet de


### PR DESCRIPTION
Hello,

Browsing the french documentation I found some broken links on the following pages:

- https://kubernetes.io/fr/docs/setup/#a-suivre
- https://kubernetes.io/fr/docs/setup/pick-right-solution/#tableau-des-solutions

Here is the patch.

Thomas