### PR TITLE
ja-docs: fixes for broken links.

### DIFF
--- a/content/ja/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/ja/docs/reference/command-line-tools-reference/feature-gates.md
@@ -238,7 +238,7 @@ GAになってからさらなる変更を加えることは現実的ではない
 - `CSIMigrationGCE`: シムと変換ロジックを有効にしてボリューム操作をKubernetesリポジトリー内のGCE-PDプラグインからPD CSIプラグインにルーティングします。
 - `CSIMigrationOpenStack`: シムと変換ロジックを有効にしてボリューム操作をKubernetesリポジトリー内のCinderプラグインからCinder CSIプラグインにルーティングします。
 - `CSINodeInfo`: csi.storage.k8s.ioのCSINodeInfo APIオブジェクトに関連するすべてのロジックを有効にします。
-- `CSIPersistentVolume`: [CSI(Container Storage Interface)]((https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/container-storage-interface.md))互換のボリュームプラグインを通してプロビジョニングされたボリュームの検出とマウントを有効にします。
+- `CSIPersistentVolume`: [CSI(Container Storage Interface)](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/container-storage-interface.md)互換のボリュームプラグインを通してプロビジョニングされたボリュームの検出とマウントを有効にします。
   詳細については[`csi`ボリュームタイプ](/docs/concepts/storage/volumes/#csi)ドキュメントを確認してください。
 - `CustomCPUCFSQuotaPeriod`: ノードがCPUCFSQuotaPeriodを変更できるようにします。
 - `CustomPodDNS`: `dnsConfig`プロパティを使用したPodのDNS設定のカスタマイズを有効にします。詳細は[PodのDNS構成](/docs/concepts/services-networking/dns-pod-service/#pods-dns-config)で確認できます。

--- a/content/ja/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/ja/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -112,7 +112,7 @@ Other CRI-based runtimes include:
 - [cri-o](https://cri-o.io/)
 - [frakti](https://github.com/kubernetes/frakti)
 
-Refer to the [CRI installation instructions](/ja/docs/setup/cri) for more information.
+Refer to the [CRI installation instructions](/ja/docs/setup/production-environment/container-runtimes/) for more information.
 
 ## kubeadm、kubelet、kubectlのインストール
 

--- a/content/ja/docs/setup/production-environment/windows/user-guide-windows-containers.md
+++ b/content/ja/docs/setup/production-environment/windows/user-guide-windows-containers.md
@@ -22,7 +22,7 @@ Windows applications constitute a large portion of the services and applications
 
 ## Before you begin
 
-* Create a Kubernetes cluster that includes a [master and a worker node running Windows Server](../user-guide-windows-nodes)
+* Create a Kubernetes cluster that includes a [master and a worker node running Windows Server](/ja/docs/setup/production-environment/windows/user-guide-windows-nodes/)
 * It is important to note that creating and deploying services and workloads on Kubernetes behaves in much the same way for Linux and Windows containers. [Kubectl commands](/docs/reference/kubectl/overview/) to interface with the cluster are identical. The example in the section below is provided simply to jumpstart your experience with Windows containers.
 
 ## Getting Started: Deploying a Windows container

--- a/content/ja/docs/tasks/tools/install-minikube.md
+++ b/content/ja/docs/tasks/tools/install-minikube.md
@@ -110,7 +110,7 @@ Windowsに手動でMinikubeをダウンロードする場合、[`minikube-window
 
 {{% capture whatsnext %}}
 
-* [Minikubeを使ってローカルでKubernetesを実行する](/ja/docs/setup/minikube/)
+* [Minikubeを使ってローカルでKubernetesを実行する](/ja/docs/setup/learning-environment/minikube/)
 
 {{% /capture %}}
 

--- a/content/ja/docs/tutorials/kubernetes-basics/explore/explore-intro.html
+++ b/content/ja/docs/tutorials/kubernetes-basics/explore/explore-intro.html
@@ -106,7 +106,7 @@ weight: 10
         <div class="row">
             <div class="col-md-8">
                 <h2>kubectlを使ったトラブルシューティング</h2>
-                <p>モジュール<a href="/ja/docs/tutorials/kubernetes-basics/deploy/deploy-intro/">2</a>では、kubectlのコマンドラインインターフェースを使用しました。モジュール3でもこれを使用して、デプロイされたアプリケーションとその環境に関する情報を入手します。最も一般的な操作は、次のkubectlコマンドで実行できます。</p>
+                <p>モジュール<a href="/ja/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/">2</a>では、kubectlのコマンドラインインターフェースを使用しました。モジュール3でもこれを使用して、デプロイされたアプリケーションとその環境に関する情報を入手します。最も一般的な操作は、次のkubectlコマンドで実行できます。</p>
                 <ul>
                     <li><b>kubectl get</b> - リソースの一覧を表示</li>
                     <li><b>kubectl describe</b> - 単一リソースに関する詳細情報を表示</li>

--- a/content/ja/includes/task-tutorial-prereqs.md
+++ b/content/ja/includes/task-tutorial-prereqs.md
@@ -1,5 +1,5 @@
 Kubernetesクラスターが必要、かつそのクラスターと通信するためにkubectlコマンドラインツールが設定されている必要があります。
-まだクラスターがない場合、[Minikube](/ja/docs/setup/minikube)を使って作成するか、
+まだクラスターがない場合、[Minikube](/ja/docs/setup/learning-environment/minikube/)を使って作成するか、
 以下のいずれかのKubernetesプレイグラウンドも使用できます:
 
 * [Katacoda](https://www.katacoda.com/courses/kubernetes/playground)


### PR DESCRIPTION
1. Fixed markdown error that endup as 404 error at the URL
    https://kubernetes.io/ja/docs/reference/command-line-tools-reference/feature-gates/
    See - CSI(Container Storage Interface) link.

2. Minikube links at
    - content/ja/docs/tasks/tools/install-minikube.md
    - content/ja/includes/task-tutorial-prereqs.md

3. Link to CRI page at
   content/ja/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md

4. Windows Nodes link at

   https://kubernetes.io/ja/docs/setup/production-environment/windows/user-guide-windows-containers/