### PR TITLE
Add stateful set which hpa has supported

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -16,7 +16,7 @@ weight: 90
 {{% capture overview %}}
 
 The Horizontal Pod Autoscaler automatically scales the number of pods
-in a replication controller, deployment or replica set based on observed CPU utilization (or, with
+in a replication controller, deployment, replica set or stateful set based on observed CPU utilization (or, with
 [custom metrics](https://git.k8s.io/community/contributors/design-proposals/instrumentation/custom-metrics-api.md)
 support, on some other application-provided metrics). Note that Horizontal
 Pod Autoscaling does not apply to objects that can't be scaled, for example, DaemonSets.


### PR DESCRIPTION
As https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/ and https://github.com/kubernetes/website/pull/16425 say, the hpa has already supported stateful set.

/language en
