### PR TITLE
en-docs: Minikube Installation via Homebrew

### DIFF
--- a/content/en/docs/tasks/tools/install-minikube.md
+++ b/content/en/docs/tasks/tools/install-minikube.md
@@ -102,6 +102,14 @@ sudo mkdir -p /usr/local/bin/
 sudo install minikube /usr/local/bin/
 ```
 
+### Install Minikube using Homebrew
+
+Install Linux [Homebrew](https://docs.brew.sh/Homebrew-on-Linux) and use it to install Minikube
+
+```shell
+brew install minikube
+```
+
 {{% /tab %}}
 {{% tab name="macOS" %}}
 ### Install kubectl

--- a/content/en/docs/tasks/tools/install-minikube.md
+++ b/content/en/docs/tasks/tools/install-minikube.md
@@ -104,7 +104,7 @@ sudo install minikube /usr/local/bin/
 
 ### Install Minikube using Homebrew
 
-Install Linux [Homebrew](https://docs.brew.sh/Homebrew-on-Linux) and use it to install Minikube
+As yet another alternative, you can install Minikube using Linux [Homebrew](https://docs.brew.sh/Homebrew-on-Linux):
 
 ```shell
 brew install minikube


### PR DESCRIPTION
- Add alternative method to install Minikube via Linux Homebrew.