### PR TITLE
Grammar correction

### DIFF
--- a/content/en/docs/reference/glossary/ingress.md
+++ b/content/en/docs/reference/glossary/ingress.md
@@ -16,5 +16,5 @@ tags:
 
 <!--more--> 
 
-Ingress can provide load balancing, SSL termination and name-based virtual hosting.
+Ingress may provide load balancing, SSL termination and name-based virtual hosting.
 


### PR DESCRIPTION
We are discussing permission, not capability.

Also, and vaguely related, there is no `en-gb` in https://github.com/kubernetes/website/tree/master/content