### PR TITLE
Modify example output in automated-tasks-with-cron-jobs.md

### DIFF
--- a/content/en/docs/tasks/job/automated-tasks-with-cron-jobs.md
+++ b/content/en/docs/tasks/job/automated-tasks-with-cron-jobs.md
@@ -87,8 +87,8 @@ The output is similar to this:
 ```
 NAME               COMPLETIONS   DURATION   AGE
 hello-4111706356   0/1                      0s
-hello-4111706356   0/1   0s    0s
-hello-4111706356   1/1   5s    5s
+hello-4111706356   0/1           0s         0s
+hello-4111706356   1/1           5s         5s
 ```
 
 Now you've seen one running job scheduled by the "hello" cron job.


### PR DESCRIPTION
This PR fixes output of `kubectl get jobs --watch` in following content.
- https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/

```
NAME               COMPLETIONS   DURATION   AGE
hello-4111706356   0/1                      0s
hello-4111706356   0/1   0s    0s
hello-4111706356   1/1   5s    5s
```

In v1.17.0, the command outputs like the below. So, this PR adds spaces into the line to fit the column.
```
$ cluster/kubectl.sh version
Client Version: version.Info{Major:"1", Minor:"17+", GitVersion:"v1.17.0-rc.1.25+39bb6d68d8e525-dirty", GitCommit:"39bb6d68d8e525fa7180e9848a2ec3a20706c504", GitTreeState:"dirty", BuildDate:"2019-12-02T09:37:33Z", GoVersion:"go1.13.4", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"17+", GitVersion:"v1.17.0-rc.1.25+39bb6d68d8e525-dirty", GitCommit:"39bb6d68d8e525fa7180e9848a2ec3a20706c504", GitTreeState:"dirty", BuildDate:"2019-12-02T09:37:33Z", GoVersion:"go1.13.4", Compiler:"gc", Platform:"linux/amd64"}

$ cluster/kubectl.sh create -f https://k8s.io/examples/application/job/cronjob.yaml
cronjob.batch/hello created

$ cluster/kubectl.sh get jobs --watch
NAME               COMPLETIONS   DURATION   AGE
hello-1575279660   0/1                      0s
hello-1575279660   0/1           0s         0s
hello-1575279660   1/1           14s        14s
```