### PR TITLE
Update an out-of-date link

### DIFF
--- a/content/en/docs/reference/access-authn-authz/bootstrap-tokens.md
+++ b/content/en/docs/reference/access-authn-authz/bootstrap-tokens.md
@@ -185,6 +185,6 @@ many clients, since a compromised client can potentially man-in-the middle anoth
 client relying on the signature to bootstrap TLS trust.
 {{< /warning >}}
 
-Consult the [kubeadm security model](/docs/reference/generated/kubeadm/#security-model)
+Consult the [kubeadm implementation details](/docs/reference/setup-tools/kubeadm/implementation-details/)
 section for more information.
 {{% /capture %}}


### PR DESCRIPTION
Hello. At the the of [This page](https://kubernetes.io/docs/reference/access-authn-authz/bootstrap-tokens/#configmap-signing), the link `kubeadm security model` will be redirected to the page `Overview of kubeadm`, which seems not quite a good fit to me. So I replaced the old one with link to the page `Implementation details`.