### PR TITLE
specify components requiring feature gate

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/ttlafterfinished.md
+++ b/content/en/docs/concepts/workloads/controllers/ttlafterfinished.md
@@ -16,7 +16,7 @@ objects that have finished execution. TTL controller only handles
 now, and may be expanded to handle other resources that will finish execution,
 such as Pods and custom resources.
 
-Alpha Disclaimer: this feature is currently alpha, and can be enabled with
+Alpha Disclaimer: this feature is currently alpha, and can be enabled with both kube-controller-manager and kube-scheduler
 [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
 `TTLAfterFinished`.
 

--- a/content/en/docs/concepts/workloads/controllers/ttlafterfinished.md
+++ b/content/en/docs/concepts/workloads/controllers/ttlafterfinished.md
@@ -16,7 +16,7 @@ objects that have finished execution. TTL controller only handles
 now, and may be expanded to handle other resources that will finish execution,
 such as Pods and custom resources.
 
-Alpha Disclaimer: this feature is currently alpha, and can be enabled with both kube-controller-manager and kube-scheduler
+Alpha Disclaimer: this feature is currently alpha, and can be enabled with both kube-apiserver and kube-controller-manager
 [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
 `TTLAfterFinished`.
 


### PR DESCRIPTION
currently, TTLafterfinished feature gate is a flag that can be passed to kube-apiserver, kube-scheduler and kube-controller-manager. The current description doesn't state what components to pass the flag to.

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> Remember to delete this note before submitting your pull request.
>
> For pull requests on 1.17 Features: set Milestone to 1.17 and Base Branch to dev-1.17
>
> For pull requests on Chinese localization, set Base Branch to release-1.16
> Feel free to ask questions in #kubernetes-docs-zh
>
> For pull requests on Korean Localization: set Base Branch to dev-1.16-ko.\<latest team milestone>
>
> If you need Help on editing and submitting pull requests, visit:
> https://kubernetes.io/docs/contribute/start/#improve-existing-content.
>
> If you need Help on choosing which branch to use, visit:
> https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use.
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
