### PR TITLE
Add missing `systemctl` step for running `cri-o`

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -200,6 +200,7 @@ yum install --nogpgcheck cri-o
 ### Start CRI-O
 
 ```
+systemctl daemon-reload
 systemctl start crio
 ```
 


### PR DESCRIPTION
After installing `cri-o`, we must run `systemctl daemon-reload` before
trying to run `systemctl start crio`. Otherwise, `systemd` doesn't know
about the crio configuration.

Similar instructions already exist for installing docker - this diff
adds these instructions for crio.