### PR TITLE
Prune English content approvers for SIG Docs

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -37,8 +37,6 @@ aliases:
   sig-docs-en-owners: # Admins for English content
     - bradamant3
     - bradtopol
-    - chenopis
-    - cody-clark
     - daminisatya
     - gochist
     - jaredbhatti
@@ -51,7 +49,6 @@ aliases:
     - simplytunde
     - steveperry-53
     - tengqm
-    - tfogo
     - xiangpengzhao
     - zacharysarah
     - zparnold


### PR DESCRIPTION
This PR removes approvers who are no longer active in SIG Docs.

/assign @Bradamant3 