### PR TITLE
Improve documentation for using Node-local DNS Cache add-on

### DIFF
--- a/content/en/docs/concepts/cluster-administration/addons.md
+++ b/content/en/docs/concepts/cluster-administration/addons.md
@@ -1,5 +1,5 @@
 ---
-title: Installing Addons
+title: Add-ons
 content_template: templates/concept
 ---
 

--- a/content/en/docs/concepts/cluster-administration/addons.md
+++ b/content/en/docs/concepts/cluster-administration/addons.md
@@ -38,6 +38,7 @@ Add-ons in each section are sorted alphabetically - the ordering does not imply 
 ## Service Discovery
 
 * [CoreDNS](https://coredns.io) is a flexible, extensible DNS server which can be [installed](https://github.com/coredns/deployment/tree/master/kubernetes) as the in-cluster DNS for pods.
+* [Node-local DNS cache](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/dns/nodelocaldns#nodelocal-dns-cache) lets you run a DNS cache on every Node, for improved performance. See [Using Node-Local DNS Cache](/docs/tasks/administer-cluster/nodelocaldns/) for more information.
 
 ## Visualization &amp; Control
 

--- a/content/en/docs/tasks/administer-cluster/nodelocaldns.md
+++ b/content/en/docs/tasks/administer-cluster/nodelocaldns.md
@@ -4,6 +4,7 @@ reviewers:
 - zihongz
 title: Using Node-local DNS Cache
 content_template: templates/task
+min-kubernetes-server-version: v1.15
 ---
 
 {{% capture overview %}}

--- a/content/en/docs/tasks/administer-cluster/nodelocaldns.md
+++ b/content/en/docs/tasks/administer-cluster/nodelocaldns.md
@@ -2,63 +2,63 @@
 reviewers:
 - bowei
 - zihongz
-title: Using NodeLocal DNSCache in Kubernetes clusters
+title: Using Node-local DNS Cache
 content_template: templates/task
 ---
- 
+
 {{% capture overview %}}
 {{< feature-state for_k8s_version="v1.15" state="beta" >}}
-This page provides an overview of NodeLocal DNSCache feature in Kubernetes.
+This page explains how to use the Node-local DNS Cache [add-on](/docs/concepts/cluster-administration/addons/) in your cluster.
+
+Node-local DNS Cache lets you improve DNS performance, by running a DNS caching agent as a {{< glossary_tooltip term_id="daemonset" >}}.
+
 {{% /capture %}}
 
 
 {{% capture prerequisites %}}
 
- {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
 {{% /capture %}}
 
- {{% capture steps %}}
-
-## Introduction
-
-NodeLocal DNSCache improves Cluster DNS performance by running a dns caching agent on cluster nodes as a DaemonSet. In today's architecture, Pods in ClusterFirst DNS mode reach out to a kube-dns serviceIP for DNS queries. This is translated to a kube-dns/CoreDNS endpoint via iptables rules added by kube-proxy. With this new architecture, Pods will reach out to the dns caching agent running on the same node, thereby avoiding iptables DNAT rules and connection tracking. The local caching agent will query kube-dns service for cache misses of cluster hostnames(cluster.local suffix by default).
-
+{{% capture steps %}}
 
 ## Motivation
 
-* With the current DNS architecture, it is possible that Pods with the highest DNS QPS have to reach out to a different node, if there is no local kube-dns/CoreDNS instance.  
-Having a local cache will help improve the latency in such scenarios.
+Without a local DNS cache on each Node, Pods in ClusterFirst DNS mode access the `kube-dns` application via its serviceIP in order to resolve DNS queries. Your cluster translates that serviceIP to a kube-dns or CoreDNS endpoint via kube-proxy.
+  With this add-on, Pods send DNS queries to a caching agent running on the same node. The local caching agent queries your cluster's kube-dns application when resolving cluster DNS queries. For cache hits, the local agent serves the response directly.
 
-* Skipping iptables DNAT and connection tracking will help reduce [conntrack races](https://github.com/kubernetes/kubernetes/issues/56903) and avoid UDP DNS entries filling up conntrack table.
+In detail:
 
-* Connections from local caching agent to kube-dns servie can be upgraded to TCP. TCP conntrack entries will be removed on connection close in contrast with UDP entries that have to timeout ([default](https://www.kernel.org/doc/Documentation/networking/nf_conntrack-sysctl.txt) `nf_conntrack_udp_timeout` is 30 seconds)
+* With the current DNS architecture, it is possible that Pods with the
+  highest DNS QPS have to reach out to a different node, if there is no
+  local kube-dns / CoreDNS instance.
+  Having a local cache help improve the latency in such scenarios.
 
-* Upgrading DNS queries from UDP to TCP would reduce tail latency attributed to dropped UDP packets and DNS timeouts usually up to 30s (3 retries + 10s timeout). Since the nodelocal cache listens for UDP DNS queries, applications don't need to be changed.
+* Skipping iptables DNAT and connection tracking helps to reduce [conntrack races](https://github.com/kubernetes/kubernetes/issues/56903) and to avoid UDP DNS entries filling up conntrack table.
+
+* Connections from local caching agent to kube-dns servie can be upgraded to TCP. TCP conntrack entries will be removed on connection close in contrast with UDP entries that have to time out ([default](https://www.kernel.org/doc/Documentation/networking/nf_conntrack-sysctl.txt) `nf_conntrack_udp_timeout` is 30 seconds)
+
+* Upgrading DNS queries from UDP to TCP would reduce tail latency attributed to dropped UDP packets and DNS timeouts usually up to 30s (3 retries + 10s timeout). Since the node-local cache container listens for UDP DNS queries, you don't need to change applications.
 
 * Metrics & visibility into dns requests at a node level.
 
-* Negative caching can be re-enabled, thereby reducing number of queries to kube-dns service.
+* Negative caching can be re-enabled, thereby reducing number of queries to the kube-dns service.
 
-## Architecture Diagram
+## Architecture diagram
 
-This is the path followed by DNS Queries after NodeLocal DNSCache is enabled:
+This is the path followed by DNS Queries after you enable the Node-local DNS Cache add-on.
 
+{{< figure src="/images/docs/nodelocaldns.jpg" alt="Node-local DNS Cache query flow" title="Node-local DNS Cache query flow" caption="This image shows how Node-local DNS Cache handles DNS queries." >}}
 
-{{< figure src="/images/docs/nodelocaldns.jpg" alt="NodeLocal DNSCache flow" title="Nodelocal DNSCache flow" caption="This image shows how NodeLocal DNSCache handles DNS queries." >}}
+## Set up
 
-## Configuration
+You can instead deploy this add-on by running YAML similar to [nodelocaldns.yaml](https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml) using `kubectl create -f nodelocaldns.yaml`.
 
-This feature can be enabled using the command:
+There is no need to modify the `--cluster-dns` flag since Node-Local DNS Cache listens on both the kube-dns service IP as well as to the IP address it adds to each node.
 
-`KUBE_ENABLE_NODELOCAL_DNS=true kubetest --up`
+Once enabled, Kubernetes runs node-local-dns Pods (in the `kube-system` namespace) on each cluster node. These Pods run [CoreDNS](https://github.com/coredns/coredns) in cache mode, so all CoreDNS metrics exposed by the different plugins be available on a per-node basis, in Prometheus / OpenMetrics format.
 
-This works for e2e clusters created on GCE. On all other environments, the following steps will setup NodeLocal DNSCache:
-
-* A yaml similar to [this](https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml) can be applied using `kubectl create -f` command.
-* No need to modify the --cluster-dns flag since NodeLocal DNSCache listens on both the kube-dns service IP as well as a link-local IP (169.254.20.10 by default)
-
-Once enabled, node-local-dns Pods will run in the kube-system namespace on each of the cluster nodes. This Pod runs [CoreDNS](https://github.com/coredns/coredns) in cache mode, so all CoreDNS metrics exposed by the different plugins will be available on a per-node basis.
-
-The feature can be disabled by removing the daemonset, using `kubectl delete -f` command. On e2e clusters created on GCE, the daemonset can be removed by deleting the node-local-dns yaml from `/etc/kubernetes/addons/0-dns/nodelocaldns.yaml`
-
- {{% /capture %}}
+{{% /capture %}}
+{{% capture whatsnext %}}
+* Read about [DNS in Kubernetes](/docs/concepts/services-networking/dns-pod-service/)
+{{% /capture %}}


### PR DESCRIPTION
The [Node-local DNS Cache](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/dns/nodelocaldns#nodelocal-dns-cache) is a very simple add-on, essentially one DaemonSet and a related ConfigMap.

_I haven't used tried using this feature_ but I did spot that the [existing documentation](https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/) was a bit far from the style guide, so I'm proposing these changes.
I think there's more work needed (what fills in the missing information? what are appropriate values? is link-local autoconfiguration the risk I think it is?); I'm aiming for these changes to be a first set of improvements.
[Preview of new page](https://deploy-preview-17944--kubernetes-io-master-staging.netlify.com/docs/tasks/administer-cluster/nodelocaldns/)

**Reviewers**: I've seen various names and capitalizations for this add-on. For documentation, I selected the name “Node-local DNS Cache” because it avoids the risk of looking like a Kubernetes feature flag or object. I don't want readers trying to `kubectl get NodeLocalDNSCache`, or even having to make a decision on whether that makes sense.

Relevant to #14822
/sig network