### PR TITLE
Broken link fixed

### DIFF
--- a/content/en/docs/tasks/administer-cluster/access-cluster-api.md
+++ b/content/en/docs/tasks/administer-cluster/access-cluster-api.md
@@ -192,7 +192,7 @@ func main() {
 }
 ```
 
-If the application is deployed as a Pod in the cluster, please refer to the [next section](#accessing-the-api-from-within-a-pod).
+If the application is deployed as a Pod in the cluster, see [Accessing the API from within a Pod](#accessing-the-api-from-within-a-pod).
 
 #### Python client
 
@@ -450,5 +450,4 @@ The output will be similar to this:
 ```
 
 {{% /capture %}}
-
 

--- a/content/en/docs/tasks/administer-cluster/access-cluster-api.md
+++ b/content/en/docs/tasks/administer-cluster/access-cluster-api.md
@@ -192,7 +192,7 @@ func main() {
 }
 ```
 
-If the application is deployed as a Pod in the cluster, please refer to the [next section](#accessing-the-api-from-a-pod).
+If the application is deployed as a Pod in the cluster, please refer to the [next section](#accessing-the-api-from-within-a-pod).
 
 #### Python client
 


### PR DESCRIPTION
Broken link fixed: 
from 
https://kubernetes.io/docs/tasks/administer-cluster/access-cluster-api/#accessing-the-api-from-a-pod
to 
https://kubernetes.io/docs/tasks/administer-cluster/access-cluster-api/#accessing-the-api-from-within-a-pod