### PR TITLE
Update Hugo version in netlify.toml to 0.59.1

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@ functions = "functions"
 command = "make non-production-build"
 
 [build.environment]
-HUGO_VERSION = "0.57.2"
+HUGO_VERSION = "0.59.1"
 
 [context.production.environment]
 HUGO_BASEURL = "https://kubernetes.io/"


### PR DESCRIPTION
This PR fixes a bug introduced by a partial upgrade in #17894. This PR updates the version to 0.59.1 in `netlify.toml` as well as `Makefile`.

```
11:07:44 PM:     [FAILURE] The Hugo version set in the Makefile is 0.59.1 while the version in netlify.toml is 0.57.2
11:07:44 PM:     [FAILURE] Please update these versions so that they are same (consider the higher of the two versions as canonical).
```
/assign @jimangel 