### PR TITLE
Fixes SVG rendering issue in Safari

### DIFF
--- a/static/images/docs/KubernetesSolutions.svg
+++ b/static/images/docs/KubernetesSolutions.svg
@@ -333,7 +333,7 @@
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.49022865px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;vector-effect:none;fill:#f9f9f9;fill-opacity:1;stroke:none;stroke-width:0.25735444;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          y="175.30972"
          x="22.508406"
-         id="tspan1042">Data Plane</tspan></text>
+         id="tspan1042"><tspan>Data Plane</tspan></tspan></text>
     <text
        transform="scale(1.0168211,0.98345717)"
        id="use1038-6"
@@ -344,7 +344,7 @@
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.49022865px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;vector-effect:none;fill:#f9f9f9;fill-opacity:1;stroke:none;stroke-width:0.25735444;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          y="175.81094"
          x="107.50922"
-         id="tspan1042-9">Data Plane</tspan></text>
+         id="tspan1042-9"><tspan>Data Plane</tspan></tspan></text>
     <text
        transform="scale(1.0168211,0.98345717)"
        id="use1038-5"
@@ -355,7 +355,7 @@
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.49022865px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;vector-effect:none;fill:#f9f9f9;fill-opacity:1;stroke:none;stroke-width:0.25735444;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          y="176.32565"
          x="191.40685"
-         id="tspan1042-5">Data Plane</tspan></text>
+         id="tspan1042-5"><tspan>Data Plane</tspan></tspan></text>
     <text
        transform="scale(1.0168211,0.98345717)"
        id="use1038-5-1"
@@ -366,7 +366,7 @@
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.49022865px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;vector-effect:none;fill:#f9f9f9;fill-opacity:1;stroke:none;stroke-width:0.25735444;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          y="176.32573"
          x="275.81915"
-         id="tspan1042-5-3">Data Plane</tspan></text>
+         id="tspan1042-5-3"><tspan>Data Plane</tspan></tspan></text>
     <text
        transform="scale(1.0168211,0.98345717)"
        xml:space="preserve"


### PR DESCRIPTION
This fixes an issue on Safari (MacOS/iOS) with the "Data Plane" labels not being properly rendered in the SVG diagram in https://kubernetes.io/docs/setup/#production-environment, as shown below:

<img width="1293" alt="Screen Shot 2019-12-11 at 11 28 17 AM" src="https://user-images.githubusercontent.com/408952/70653746-ec1f9e80-1c09-11ea-97f0-a486b534d1a7.png">

Deploy preview with fix:
https://deploy-preview-17987--kubernetes-io-master-staging.netlify.com/docs/setup/#production-environment

<img width="1293" alt="Screen Shot 2019-12-11 at 11 47 18 AM" src="https://user-images.githubusercontent.com/408952/70654884-0fe3e400-1c0c-11ea-9af2-d4589fbd0145.png">


Note, I'm not an SVG expert but determined the fix by comparing the SVG structure to other labels in the same diagram that render correctly. The other labels are wrapped in an additional `<tspan>` element, which this PR applies to the Data Plane labels. 
