### PR TITLE
ko: Fix whitespace in ServiceAccount glossary entry

### DIFF
--- a/content/ko/docs/reference/glossary/service-account.md
+++ b/content/ko/docs/reference/glossary/service-account.md
@@ -1,5 +1,5 @@
 ---
-title: 서비스 어카운트(Service Account)
+title: 서비스 어카운트(ServiceAccount)
 id: service-account
 date: 2018-04-12
 full_link: /docs/tasks/configure-pod-container/configure-service-account/


### PR DESCRIPTION
The Kubernetes object is called ServiceAccount. Fix spacing in https://kubernetes.io/ko/docs/reference/glossary/?all=true#term-service-account.

/kind cleanup