### PR TITLE
 ko: Fix whitespace in ReplicationController glossary entry

### DIFF
--- a/content/ko/docs/reference/glossary/replication-controller.md
+++ b/content/ko/docs/reference/glossary/replication-controller.md
@@ -1,5 +1,5 @@
 ---
-title: 레플리케이션 컨트롤러(Replication Controller)
+title: 레플리케이션 컨트롤러(ReplicationController)
 id: replication-controller
 date: 2018-04-12
 full_link: 


### PR DESCRIPTION
The Kubernetes object is called ReplicationController. Fix whitespace in https://kubernetes.io/ko/docs/reference/glossary/?all=true#term-replication-controller.

/kind cleanup