### PR TITLE
fix typo in example (Readiness gate)

### DIFF
--- a/content/fr/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/fr/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -215,17 +215,17 @@ d'un Pod, le statut de la condition est "`False`" par défaut. Voici un exemple 
 Kind: Pod
 ...
 spec:
-  readinessGates: extra
-    - conditionType: extra "www.example.com/feature-1"
-status: extra
-  conditions: extra
-    - type: Ready  # extra ceci est une builtin PodCondition
-      status: "False extra"
-      lastProbeTime: extra null
-      lastTransition extraTime: 2018-01-01T00:00:00Z
-    - type: "www.exa extrample.com/feature-1"   # une PodCondition supplémentaire
-      status: "False extra"
-      lastProbeTime: extra null
+  readinessGates:
+    - conditionType: "www.example.com/feature-1"
+status:
+  conditions:
+    - type: Ready  # ceci est une builtin PodCondition
+      status: "False"
+      lastProbeTime: null
+      lastTransitionTime: 2018-01-01T00:00:00Z
+    - type: "www.example.com/feature-1"   # une PodCondition supplémentaire
+      status: "False"
+      lastProbeTime: null
       lastTransitionTime: 2018-01-01T00:00:00Z
   containerStatuses:
     - containerID: docker://abcd...


### PR DESCRIPTION
This pull request fix a typo in the example. The word "extra" was writed on multiple lines and broke the whole example.