### PR TITLE
refact: merge HUGO_VERSION, add deploy-preview.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DOCKER       = docker
-HUGO_VERSION = 0.59.1
+HUGO_VERSION = $(shell grep ^HUGO_VERSION netlify.toml | tail -n 1 | cut -d '=' -f 2 | tr -d " \"\n")
 DOCKER_IMAGE = kubernetes-hugo
 DOCKER_RUN   = $(DOCKER) run --rm --interactive --tty --volume $(CURDIR):/src
 NODE_BIN     = node_modules/.bin
@@ -17,6 +17,9 @@ build: ## Build site with production settings and put deliverables in ./public
 
 build-preview: ## Build site with drafts and future posts enabled
 	hugo --buildDrafts --buildFuture
+
+deploy-preview: check-hugo-versions ## Deploy preview site via netlify
+	hugo --enableGitInfo --buildFuture -b $(DEPLOY_PRIME_URL)
 
 functions-build:
 	$(NETLIFY_FUNC) build functions-src

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,10 +15,10 @@ HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]
-command = "hugo --enableGitInfo --buildFuture -b $DEPLOY_PRIME_URL"
+command = "make deploy-preview"
 
 [context.branch-deploy]
-command = "hugo --enableGitInfo --buildFuture -b $DEPLOY_PRIME_URL"
+command = "make deploy-preview"
 
 [context.master]
 # This context is triggered by the `master` branch and allows search indexing


### PR DESCRIPTION
This PR is going to fix the difference of HUGO_VERSION between `Makefile` and `netlify.toml` permanently.

Thanks.