### PR TITLE
Manually fix up home folder path in generated docs

### DIFF
--- a/content/en/docs/reference/kubectl/kubectl.md
+++ b/content/en/docs/reference/kubectl/kubectl.md
@@ -62,7 +62,7 @@ kubectl [flags]
     </tr>
 
     <tr>
-      <td colspan="2">--cache-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/Users/username/.kube/http-cache"</td>
+      <td colspan="2">--cache-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "~/.kube/http-cache"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Default HTTP cache directory</td>


### PR DESCRIPTION
Fixup to override generation for kubectl docs done in #18010 

Proper fix belongs upstream; this is to keep things looking similar to how they were before the v1.17 release process.

/kind cleanup
/cc @daminisatya 