### PR TITLE
Tweak glossary entry for ServiceAccount

### DIFF
--- a/content/en/docs/reference/glossary/service-account.md
+++ b/content/en/docs/reference/glossary/service-account.md
@@ -1,5 +1,5 @@
 ---
-title: Service Account
+title: ServiceAccount
 id: service-account
 date: 2018-04-12
 full_link: /docs/tasks/configure-pod-container/configure-service-account/
@@ -16,4 +16,3 @@ tags:
 <!--more--> 
 
 When processes inside Pods access the cluster, they are authenticated by the API server as a particular service account, for example, `default`. When you create a Pod, if you do not specify a service account, it is automatically assigned the default service account in the same {{< glossary_tooltip text="Namespace" term_id="namespace" >}}.
-


### PR DESCRIPTION
Tweak https://kubernetes.io/docs/reference/glossary/?all=true#term-service-account ([preview](https://deploy-preview-18044--kubernetes-io-master-staging.netlify.com/docs/reference/glossary/?all=true#term-service-account))

Use API resource name for clarity (no space).