### PR TITLE
Fixes Hugo error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DOCKER       = docker
-HUGO_VERSION = 0.53
+HUGO_VERSION = 0.57.2
 DOCKER_IMAGE = kubernetes-hugo
 DOCKER_RUN   = $(DOCKER) run --rm --interactive --tty --volume $(CURDIR):/src
 NODE_BIN     = node_modules/.bin


### PR DESCRIPTION
6:16:23 PM:     [FAILURE] The Hugo version set in the Makefile is 0.53 while the version in netlify.toml is 0.57.2
6:16:23 PM:     [FAILURE] Please update these versions so that they are same (consider the higher of the two versions as