### PR TITLE
Reword glossary entry for ReplicationController

### DIFF
--- a/content/en/docs/reference/glossary/replication-controller.md
+++ b/content/en/docs/reference/glossary/replication-controller.md
@@ -1,19 +1,25 @@
 ---
-title: Replication Controller
+title: ReplicationController
 id: replication-controller
 date: 2018-04-12
 full_link: 
 short_description: >
-  Kubernetes service that ensures a specific number of instances of a pod are always running.
+  A (deprecated) API object that manages a replicated application.
 
 aka: 
 tags:
 - workload
 - core-object
 ---
- Kubernetes service that ensures a specific number of instances of a {{< glossary_tooltip text="Pod" term_id="pod" >}} are always running.
+ A workload resource that manages a replicated application, ensuring that
+a specific number of instances of a {{< glossary_tooltip text="Pod" term_id="pod" >}} are running.
 
-<!--more--> 
+<!--more-->
 
-Will automatically add or remove running instances of a pod, based on a set value for that pod. Allows the pod to return to the defined number of instances if pods are deleted or if too many are started by mistake.
+The control plane ensures that the defined number of Pods are running, even if some
+Pods fail, if you delete Pods manually, or if too many are started by mistake.
 
+{{< note >}}
+ReplicationController is deprecated. See
+{{< glossary_tooltip text="Deployment" term_id="deployment" >}}, which is similar.
+{{< /note >}}


### PR DESCRIPTION
Reword https://kubernetes.io/docs/reference/glossary/?all=true#term-replication-controller ([preview](https://deploy-preview-18046--kubernetes-io-master-staging.netlify.com/docs/reference/glossary/?all=true#term-replication-controller))
- Use API resource name for clarity
- Mark as deprecated