### PR TITLE
Fix Pods concepts link in StatefulSet tutorial

### DIFF
--- a/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/content/en/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -21,7 +21,7 @@ demonstrates how to create, delete, scale, and update the Pods of StatefulSets.
 Before you begin this tutorial, you should familiarize yourself with the 
 following Kubernetes concepts.
 
-* [Pods](/docs/user-guide/pods/single-container/)
+* [Pods](/docs/concepts/workloads/pods/)
 * [Cluster DNS](/docs/concepts/services-networking/dns-pod-service/)
 * [Headless Services](/docs/concepts/services-networking/service/#headless-services)
 * [PersistentVolumes](/docs/concepts/storage/persistent-volumes/)


### PR DESCRIPTION
Without this change, the instruction to "get familiar with" the Pods
concept directs the user to the pods section of the User Guide, which
actually redirects to the "Run a Stateless Application Using a
Deployment" task, which is not strictly about Pods. This change fixes
the link to point to the Pods Overview in the Concepts section, which
makes more sense in this context.