### PR TITLE
kubectl-plugin example: Double-quote to prevent word splitting

### DIFF
--- a/content/en/docs/tasks/extend-kubectl/kubectl-plugins.md
+++ b/content/en/docs/tasks/extend-kubectl/kubectl-plugins.md
@@ -78,7 +78,7 @@ fi
 # optional argument handling
 if [[ "$1" == "config" ]]
 then
-    echo $KUBECONFIG
+    echo "$KUBECONFIG"
     exit 0
 fi
 


### PR DESCRIPTION
It doesn't make a huge difference in this example, but best practices would quote this var.
See: https://www.shellcheck.net/wiki/SC2086

Signed-off-by: Manuel Rüger <manuel@rueg.eu>
