### PR TITLE
Updates kubectl version command to use --client flag.

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl.md
+++ b/content/en/docs/tasks/tools/install-kubectl.md
@@ -52,7 +52,7 @@ You must use a kubectl version that is within one minor version difference of yo
 4. Test to ensure the version you installed is up-to-date:
 
     ```
-    kubectl version
+    kubectl version --client
     ```
 
 ### Install using native package management
@@ -129,7 +129,7 @@ kubectl version
 4. Test to ensure the version you installed is up-to-date:
 
     ```
-    kubectl version
+    kubectl version --client
     ```
 
 ### Install with Homebrew on macOS
@@ -150,7 +150,7 @@ If you are on macOS and using [Homebrew](https://brew.sh/) package manager, you 
 2. Test to ensure the version you installed is up-to-date:
 
     ```
-    kubectl version
+    kubectl version --client
     ```
 
 ### Install with Macports on macOS
@@ -167,7 +167,7 @@ If you are on macOS and using [Macports](https://macports.org/) package manager,
 2. Test to ensure the version you installed is up-to-date:
 
     ```
-    kubectl version
+    kubectl version --client
     ```
 
 ## Install kubectl on Windows
@@ -188,7 +188,7 @@ If you are on macOS and using [Macports](https://macports.org/) package manager,
 3. Test to ensure the version of `kubectl` is the same as downloaded:
 
     ```
-    kubectl version
+    kubectl version --client
     ```
 {{< note >}}
 [Docker Desktop for Windows](https://docs.docker.com/docker-for-windows/#kubernetes) adds its own version of `kubectl` to PATH.
@@ -213,7 +213,7 @@ If you are on Windows and using [Powershell Gallery](https://www.powershellgalle
 2. Test to ensure the version you installed is up-to-date:
 
     ```
-    kubectl version
+    kubectl version --client
     ```
 
     {{< note >}}Updating the installation is performed by rerunning the two commands listed in step 1.{{< /note >}}
@@ -236,7 +236,7 @@ To install kubectl on Windows you can use either [Chocolatey](https://chocolatey
 2. Test to ensure the version you installed is up-to-date:
 
     ```
-    kubectl version
+    kubectl version --client
     ```
 
 3. Navigate to your home directory:
@@ -278,7 +278,7 @@ You can install kubectl as part of the Google Cloud SDK.
 3. Test to ensure the version you installed is up-to-date:
 
     ```
-    kubectl version
+    kubectl version --client
     ```
 
 ## Verifying kubectl configuration 


### PR DESCRIPTION
Document is mainly concerned with the installation of kubectl. To confirm the installed version of kubectl the document asks the user to run ```kubectl version``` which by default displays kubectl client and server versions. The command takes a few seconds to timeout if a server is not available. It makes sense to display just the client version ```kubectl version --client`` and avoid the connection to the server so that the information is displayed without a delay. Fixes #17913
