### PR TITLE
Use LABEL instead of MAINTAINER for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 
 FROM alpine:latest
 
-LABEL maintainer "Luc Perkins <lperkins@linuxfoundation.org>"
+LABEL maintainer="Luc Perkins <lperkins@linuxfoundation.org>"
 
 RUN apk add --no-cache \
     curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 
 FROM alpine:latest
 
-MAINTAINER Luc Perkins <lperkins@linuxfoundation.org>
+LABEL maintainer "Luc Perkins <lperkins@linuxfoundation.org>"
 
 RUN apk add --no-cache \
     curl \


### PR DESCRIPTION
MAINTAINER is deprecated since ages ago, so let's use LABEL instead