### PR TITLE
axe two stray words in service.md

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -1015,7 +1015,7 @@ worth understanding.
 One of the primary philosophies of Kubernetes is that you should not be
 exposed to situations that could cause your actions to fail through no fault
 of your own. For the design of the Service resource, this means not making
-you choose your own port number for a if that choice might collide with
+you choose your own port number if that choice might collide with
 someone else's choice.  That is an isolation failure.
 
 In order to allow you to choose a port number for your Services, we must


### PR DESCRIPTION
changes for #14526 had either a stray "for a" or missed "service" as in "for a service".  
Since it's quite lengthy and "for a service" is unnecessary in service.md, I opted to removed it.
