### PR TITLE
Fix typo in install-kubeadm.md

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -217,7 +217,7 @@ systemctl enable --now kubelet
     `net.bridge.bridge-nf-call-iptables` is set to 1 in your `sysctl` config, e.g.
 
     ```bash
-    cat <<EOF >  /etc/sysctl.d/k8s.conf
+    cat <<EOF > /etc/sysctl.d/k8s.conf
     net.bridge.bridge-nf-call-ip6tables = 1
     net.bridge.bridge-nf-call-iptables = 1
     EOF


### PR DESCRIPTION
This PR removes an extra whitespace in `install-kubeadm.md`.