### PR TITLE
Update documentation to reflect Go 1.13 dependency for Kubernetes 1.17+

### DIFF
--- a/content/en/docs/contribute/generate-ref-docs/kubernetes-components.md
+++ b/content/en/docs/contribute/generate-ref-docs/kubernetes-components.md
@@ -19,7 +19,7 @@ reference documentation for tools and components in the
 
     * [Python](https://www.python.org/downloads/) v3.7.x
     * [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-    * [Golang](https://golang.org/doc/install) version 1.12 for Kubernetes 1.14+; Go 1.13 [is not supported](https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#go)
+    * [Golang](https://golang.org/doc/install) version 1.12 for Kubernetes 1.14+; Go 1.13 for [Kubernetes 1.17+](https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#go)
     * [Pip](https://pypi.org/project/pip/) used to install PyYAML
     * [PyYAML](https://pyyaml.org/) v5.1.2
     * [make](https://www.gnu.org/software/make/)

--- a/content/en/docs/contribute/generate-ref-docs/kubernetes-components.md
+++ b/content/en/docs/contribute/generate-ref-docs/kubernetes-components.md
@@ -19,7 +19,7 @@ reference documentation for tools and components in the
 
     * [Python](https://www.python.org/downloads/) v3.7.x
     * [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-    * [Golang](https://golang.org/doc/install) version 1.12 for Kubernetes 1.14+; Go 1.13 for [Kubernetes 1.17+](https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#go)
+    * [Golang](https://golang.org/doc/install) version 1.13+
     * [Pip](https://pypi.org/project/pip/) used to install PyYAML
     * [PyYAML](https://pyyaml.org/) v5.1.2
     * [make](https://www.gnu.org/software/make/)

--- a/content/fr/docs/contribute/generate-ref-docs/kubernetes-components.md
+++ b/content/fr/docs/contribute/generate-ref-docs/kubernetes-components.md
@@ -17,7 +17,7 @@ Cette page montre comment utiliser l'outil `update-importer-docs` pour générer
 
     * [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 
-    * [Golang](https://golang.org/doc/install) version 1.9 ou ultérieure
+    * [Golang](https://golang.org/doc/install) version 1.13 ou ultérieure
 
     * [make](https://www.gnu.org/software/make/)
 


### PR DESCRIPTION
Kubernetes 1.17+ requires Go 1.13 as stated on the development page, this PR updates the Kubernetes website to reflect this.