### PR TITLE
fixing information about dev contrib

### DIFF
--- a/content/en/docs/contribute/new-content/new-features.md
+++ b/content/en/docs/contribute/new-content/new-features.md
@@ -14,7 +14,7 @@ card:
 Each major Kubernetes release introduces new features that require documentation. New releases also bring updates to existing features and documentation (such as upgrading a feature from alpha to beta).
 
 Generally, the SIG responsible for a feature submits draft documentation of the
-feature as a pull request to the appropriate release branch of the
+feature as a pull request to the appropriate development branch of the
 `kubernetes/website` repository, and someone on the SIG Docs team provides
 editorial feedback or edits the draft directly. This section covers the branching
 conventions and process used during a release by both groups.
@@ -96,9 +96,9 @@ deadlines.
 ### Open a placeholder PR
 
 1. Open a pull request against the
-`release-X.Y` branch in the `kubernetes/website` repository, with a small
+`dev-{{< skew nextMinorVersion >}}` branch in the `kubernetes/website` repository, with a small
 commit that you will amend later.
-2. Use the Prow command `/milestone X.Y` to
+2. Use the Prow command `/milestone {{< skew nextMinorVersion >}}` to
 assign the PR to the relevant milestone. This alerts the docs person managing
 this release that the feature docs are coming.
 
@@ -121,7 +121,7 @@ content is not received, the feature may be removed from the milestone.
 
 ### All PRs reviewed and ready to merge
 
-If your PR has not yet been merged into the `release-X.Y` branch by the release deadline, work with the
+If your PR has not yet been merged into the `dev-{{< skew nextMinorVersion >}}` branch by the release deadline, work with the
 docs person managing the release to get it in by the deadline. If your feature needs
 documentation and the docs are not ready, the feature may be removed from the
 milestone.

--- a/layouts/shortcodes/skew.html
+++ b/layouts/shortcodes/skew.html
@@ -1,0 +1,42 @@
+<!-- capture version from first argument in "skew" -->
+{{- $version := .Get 0 -}}
+
+<!-- strip "v" from latest verison  -->
+{{- $latestVersion := site.Params.latest -}}
+{{- $latestVersion := (replace $latestVersion "v" "") -}}
+
+<!-- splits a string x.Xy into substrings separated by a "." delimiter  -->
+{{- $versionArray := split $latestVersion "." -}}
+
+<!-- capture minorVersion ("Xy") in a variable -->
+{{- $minorVersion := int (index $versionArray 1) -}}
+
+<!-- increment latest 1 minor number for "nextMinorVerison" -->
+{{- $nextMinorVersion := add $minorVersion 1 -}}
+
+<!-- subtract latest 1 minor number for "prevMinorVerison" -->
+{{- $prevMinorVersion := sub $minorVersion 1 -}}
+
+<!-- output nextMinorVersion based on captured arg -->
+{{- if eq $version "nextMinorVersion" -}}
+    {{- $nextMinorVersion := printf "%s.%d" (index $versionArray 0) $nextMinorVersion -}}
+    {{- $nextMinorVersion -}}
+{{- end -}}
+
+<!-- output latestVersion based on captured arg -->
+{{- if eq $version "latestVersion" -}}
+    {{- $latestVersion -}}
+{{- end -}}
+
+<!-- output prevMinorVersion based on captured arg -->
+{{- if eq $version "prevMinorVersion" -}}
+    {{- $prevMinorVersion := printf "%s.%d" (index $versionArray 0) $prevMinorVersion -}}
+    {{- $prevMinorVersion -}}
+{{- end -}}
+
+<!--
+example shortcode use:
+- skew nextMinorVersion
+- skew latestVersion
+- skew prevMinorVersion
+-->


### PR DESCRIPTION
Fixing some incorrect information about the release branches. ~~Mainly, adding a `future` variable that will point to the correct `dev-x.xx` branch.~~

~~**TODO:** If we agree this solution is acceptable, @VineethReddy02 will need to include the "future" variable update in the `config.toml` as part of the sig-docs release cycle.~~

Thanks to @kbhawkey's idea, there is no need to add an extra variable to manage as it is all parsed in the `skew.html` shortcode.

Fixes: https://kubernetes.io/docs/contribute/new-content/new-features/#for-developers-or-other-sig-members