### PR TITLE
(fix) Broken links in Korean documentation.

### DIFF
--- a/content/ko/docs/concepts/workloads/controllers/replicationcontroller.md
+++ b/content/ko/docs/concepts/workloads/controllers/replicationcontroller.md
@@ -286,6 +286,6 @@ API 오브젝트에 대한 더 자세한 것은
 
 ## 더 자세한 정보는
 
-[스테이트리스 애플리케이션 레플리케이션 컨트롤러 실행하기](docs/tutorials/stateless-application/run-stateless-ap-replication-controller/) 를 참조하라.
+[스테이트리스 애플리케이션 레플리케이션 컨트롤러 실행하기](/docs/tutorials/stateless-application/run-stateless-ap-replication-controller/) 를 참조하라.
 
 {{% /capture %}}

--- a/static/_redirects
+++ b/static/_redirects
@@ -319,9 +319,11 @@
 /docs/tutorials/kubernetes-basics/scale-interactive/     /docs/tutorials/kubernetes-basics/scale/scale-interactive/ 301
 /docs/tutorials/kubernetes-basics/scale-intro/     /docs/tutorials/kubernetes-basics/scale/scale-intro/ 301
 /ja/docs/tutorials/kubernetes-basics/scale-intro/     /ja/docs/tutorials/kubernetes-basics/scale/scale-intro/ 301
+/ko/docs/tutorials/kubernetes-basics/scale-intro/     /ko/docs/tutorials/kubernetes-basics/scale/scale-intro/ 301
 /docs/tutorials/kubernetes-basics/update-interactive/    /docs/tutorials/kubernetes-basics/update/update-interactive/ 301
 /docs/tutorials/kubernetes-basics/update-intro/     /docs/tutorials/kubernetes-basics/update/update-intro/ 301
 /ja/docs/tutorials/kubernetes-basics/update-intro/     /ja/docs/tutorials/kubernetes-basics/update/update-intro/ 301
+/ko/docs/tutorials/kubernetes-basics/update-intro/     /ko/docs/tutorials/kubernetes-basics/update/update-intro/ 301
 /docs/tutorials/example-tutorial-template.md -> /example-templates/example-tutorial-template.md 301
 /docs/tutorials/object-management-kubectl/declarative-object-management-configuration/      /docs/concepts/overview/object-management-kubectl/declarative-config/ 301
 /docs/tutorials/object-management-kubectl/imperative-object-management-command/      /docs/concepts/overview/object-management-kubectl/imperative-command/ 301


### PR DESCRIPTION
This commit fix two issues in Korean documentation:

1) malformed link to documentation
(see page https://kubernetes.io/ko/docs/concepts/workloads/controllers/replicationcontroller)

2) missing redirections (was existing only in English and Japanese before)
- From :  https://kubernetes.io/ko/docs/tutorials/kubernetes-basics/scale-intro/
  To   :  https://kubernetes.io/ko/docs/tutorials/kubernetes-basics/scale/scale-intro/

- From :  https://kubernetes.io/ko/docs/tutorials/kubernetes-basics/update-intro/
  To   :  https://kubernetes.io/ko/docs/tutorials/kubernetes-basics/update/update-intro/