### PR TITLE
Looping over logs of all jobs using a single command

### DIFF
--- a/content/en/docs/tasks/job/parallel-processing-expansion.md
+++ b/content/en/docs/tasks/job/parallel-processing-expansion.md
@@ -119,14 +119,10 @@ process-item-banana-wrsf7   0/1       Completed   0          4m
 process-item-cherry-dnfu9   0/1       Completed   0          4m
 ```
 
-There is not a single command to check on the output of all jobs at once,
-but looping over all the pods is pretty easy:
+We can use this single command to check on the output of all jobs at once:
 
 ```shell
-for p in $(kubectl get pods -l jobgroup=jobexample -o name)
-do
-  kubectl logs $p
-done
+  kubectl logs -f -l jobgroup=jobexample
 ```
 
 The output is:

--- a/content/en/docs/tasks/job/parallel-processing-expansion.md
+++ b/content/en/docs/tasks/job/parallel-processing-expansion.md
@@ -122,7 +122,7 @@ process-item-cherry-dnfu9   0/1       Completed   0          4m
 We can use this single command to check on the output of all jobs at once:
 
 ```shell
-  kubectl logs -f -l jobgroup=jobexample
+kubectl logs -f -l jobgroup=jobexample
 ```
 
 The output is:


### PR DESCRIPTION
Using the label constuct `-l` to loop over output of all jobs (or pods) using a single command

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> Remember to delete this note before submitting your pull request.
>
> For pull requests on 1.17 Features: set Milestone to 1.17 and Base Branch to dev-1.17
>
> For pull requests on Chinese localization, set Base Branch to release-1.16
> Feel free to ask questions in #kubernetes-docs-zh
>
> For pull requests on Korean Localization: set Base Branch to dev-1.16-ko.\<latest team milestone>
>
> If you need Help on editing and submitting pull requests, visit:
> https://kubernetes.io/docs/contribute/start/#improve-existing-content.
>
> If you need Help on choosing which branch to use, visit:
> https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use.
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
