### PR TITLE
Updated document commands to use placeholders.

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -91,7 +91,8 @@ The upgrade workflow at high level is the following:
 1.  Drain the control plane node:
 
     ```shell
-    kubectl drain $CP_NODE --ignore-daemonsets
+    # replace <cp-node-name> with the name of your control plane node
+    kubectl drain <cp-node-name> --ignore-daemonsets
     ```
 
 1.  On the control plane node, run:
@@ -144,10 +145,10 @@ The upgrade workflow at high level is the following:
 1.  Choose a version to upgrade to, and run the appropriate command. For example:
 
     ```shell
+    # replace x with the patch version you picked for this upgrade
     sudo kubeadm upgrade apply v1.17.x
     ```
 
-    - Replace `x` with the patch version you picked for this upgrade.
 
     You should see output similar to this:
 
@@ -237,10 +238,11 @@ The upgrade workflow at high level is the following:
 
     This step is not required on additional control plane nodes if the CNI provider runs as a DaemonSet.
 
-1.  Uncordon the control plane node
+1.  Uncordon the control plane node:
 
     ```shell
-    kubectl uncordon $CP_NODE
+    # replace <cp-node-name> with the name of your control plane node
+    kubectl uncordon <cp-node-name>
     ```
 
 ### Upgrade additional control plane nodes
@@ -306,10 +308,11 @@ without compromising the minimum required capacity for running your workloads.
 
 ### Drain the node
 
-1.  Prepare the node for maintenance by marking it unschedulable and evicting the workloads. Run:
+1.  Prepare the node for maintenance by marking it unschedulable and evicting the workloads:
 
     ```shell
-    kubectl drain $NODE --ignore-daemonsets
+    # replace <node-to-drain> with the name of your node you are draining
+    kubectl drain <node-to-drain> --ignore-daemonsets
     ```
 
     You should see output similar to this:
@@ -356,7 +359,8 @@ without compromising the minimum required capacity for running your workloads.
 1.  Bring the node back online by marking it schedulable:
 
     ```shell
-    kubectl uncordon $NODE
+    # replace <node-to-drain> with the name of your node 
+    kubectl uncordon <node-to-drain>
     ```
 
 ## Verify the status of the cluster


### PR DESCRIPTION
Some of the commands in the document were using $CP_NODE and $NODE. To make it clear to the user that these are not environment variables the document has been updated to use placeholders in the commands.