### PR TITLE
(fr) Broken links

### DIFF
--- a/content/fr/docs/concepts/workloads/pods/pod-overview.md
+++ b/content/fr/docs/concepts/workloads/pods/pod-overview.md
@@ -101,5 +101,5 @@ Plutôt que de spécifier tous les états désirés courants de tous les réplic
 {{% capture whatsnext %}}
 * En savoir plus sur le comportement des Pods :
   * [Terminaison d'un Pod](/docs/concepts/workloads/pods/pod/#termination-of-pods)
-  * [Cycle de vie d'un Pod](../pod-lifecycle)
+  * [Cycle de vie d'un Pod](/docs/concepts/workloads/pods/pod-lifecycle/)
 {{% /capture %}}

--- a/content/fr/docs/reference/_index.md
+++ b/content/fr/docs/reference/_index.md
@@ -35,7 +35,7 @@ Pour appeler l'API de Kubernetes depuis un langage de programmation on peut util
 
 ## Documents de Référence des outils en ligne de commande (CLI)
 
-* [kubectl](/docs/reference/command-line-tools-reference/kubelet/) - Principal outil en ligne de commande (CLI) pour exécuter et gérer un cluster Kubernetes.
+* [kubectl](/docs/reference/kubectl/overview/) - Principal outil en ligne de commande (CLI) pour exécuter et gérer un cluster Kubernetes.
     * [JSONPath](/docs/user-guide/jsonpath/) - Guide de la syntaxe des [expressions JSONPath](http://goessner.net/articles/JsonPath/) avec kubectl.
 * [kubeadm](/docs/admin/kubeadm/) - Outil en ligne de commande (CLI) pour provisionner facilement un cluster Kubernetes sécurisé.
 * [kubefed](/docs/admin/kubefed/) - Outil en ligne de commande (CLI) pour aider à administrer des clusters fédérés.

--- a/content/fr/docs/reference/_index.md
+++ b/content/fr/docs/reference/_index.md
@@ -35,7 +35,7 @@ Pour appeler l'API de Kubernetes depuis un langage de programmation on peut util
 
 ## Documents de Référence des outils en ligne de commande (CLI)
 
-* [kubectl](docs/reference/command-line-tools-reference/kubelet/) - Principal outil en ligne de commande (CLI) pour exécuter et gérer un cluster Kubernetes.
+* [kubectl](/docs/reference/command-line-tools-reference/kubelet/) - Principal outil en ligne de commande (CLI) pour exécuter et gérer un cluster Kubernetes.
     * [JSONPath](/docs/user-guide/jsonpath/) - Guide de la syntaxe des [expressions JSONPath](http://goessner.net/articles/JsonPath/) avec kubectl.
 * [kubeadm](/docs/admin/kubeadm/) - Outil en ligne de commande (CLI) pour provisionner facilement un cluster Kubernetes sécurisé.
 * [kubefed](/docs/admin/kubefed/) - Outil en ligne de commande (CLI) pour aider à administrer des clusters fédérés.

--- a/content/fr/docs/reference/glossary/admission-controller.md
+++ b/content/fr/docs/reference/glossary/admission-controller.md
@@ -19,4 +19,4 @@ Les contrôleurs d'accès sont configurables pour le serveur API de Kubernetes. 
 les deux. Tout contrôleur d'accès peut rejeter la demande. Les contrôleurs modifiant peuvent modifier les objets qu'ils admettent ;
 alors que les contrôleurs validants ne le peuvent pas.
 
-* ["Contrôleur d'accès" dans la documentation de Kubernetes](fr/docs/reference/access-authn-authz/admission-controllers/)
+* ["Contrôleur d'accès" dans la documentation de Kubernetes](/docs/reference/access-authn-authz/admission-controllers/)

--- a/content/fr/docs/reference/glossary/admission-controller.md
+++ b/content/fr/docs/reference/glossary/admission-controller.md
@@ -2,7 +2,7 @@
 title: Admission Controller
 id: admission-controller
 date: 2019-06-28
-full_link: fr/docs/reference/access-authn-authz/admission-controllers/
+full_link: /docs/reference/access-authn-authz/admission-controllers/
 short_description: >
   Un morceau de code qui intercepte les requêtes adressées au serveur API de Kubernetes avant la persistance de l'objet.
 

--- a/content/fr/docs/reference/glossary/container-lifecycle-hooks.md
+++ b/content/fr/docs/reference/glossary/container-lifecycle-hooks.md
@@ -2,7 +2,7 @@
 title: Container Lifecycle Hooks
 id: container-lifecycle-hooks
 date: 2018-10-08
-full_link: fr/docs/concepts/containers/container-lifecycle-hooks/
+full_link: /docs/concepts/containers/container-lifecycle-hooks/
 short_description: >
   Les hooks (ou déclencheurs) du cycle de vie exposent les événements du cycle de vie de la gestion du conteneur et permettent à l'utilisateur d'exécuter le code lorsque les événements se produisent.
 

--- a/content/fr/docs/reference/glossary/customresourcedefinition.md
+++ b/content/fr/docs/reference/glossary/customresourcedefinition.md
@@ -2,7 +2,7 @@
 title: CustomResourceDefinition
 id: CustomResourceDefinition
 date: 2018-04-12
-full_link: fr/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/
+full_link: /docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/
 short_description: >
   Définition d'une ressource personnalisée qui est ajoutée au serveur d'API Kubernetes sans construire un serveur personnalisé complet.
 

--- a/content/fr/docs/reference/glossary/pod.md
+++ b/content/fr/docs/reference/glossary/pod.md
@@ -2,7 +2,7 @@
 title: Pod
 id: pod
 date: 2018-04-12
-full_link: fr/docs/concepts/workloads/pods/pod-overview/
+full_link: /docs/concepts/workloads/pods/pod-overview/
 short_description: >
   Le plus petit et le plus simple des objets Kubernetes. Un Pod est un ensemble de conteneurs fonctionnant sur votre cluster.
 

--- a/content/fr/docs/reference/glossary/pod.md
+++ b/content/fr/docs/reference/glossary/pod.md
@@ -2,7 +2,7 @@
 title: Pod
 id: pod
 date: 2018-04-12
-full_link: /docs/concepts/workloads/pods/pod-overview/
+full_link: /fr/docs/concepts/workloads/pods/pod-overview/
 short_description: >
   Le plus petit et le plus simple des objets Kubernetes. Un Pod est un ensemble de conteneurs fonctionnant sur votre cluster.
 

--- a/content/fr/docs/tutorials/hello-minikube.md
+++ b/content/fr/docs/tutorials/hello-minikube.md
@@ -16,7 +16,7 @@ card:
 
 {{% capture overview %}}
 
-Ce tutoriel vous montre comment exécuter une simple application Hello World Node.js sur Kubernetes en utilisant [Minikube](/docs/getting-started-guides/minikube) et Katacoda.
+Ce tutoriel vous montre comment exécuter une simple application Hello World Node.js sur Kubernetes en utilisant [Minikube](/docs/getting-started-guides/minikube/) et Katacoda.
 Katacoda fournit un environnement Kubernetes gratuit dans le navigateur.
 
 {{< note >}}

--- a/content/fr/docs/tutorials/hello-minikube.md
+++ b/content/fr/docs/tutorials/hello-minikube.md
@@ -16,7 +16,7 @@ card:
 
 {{% capture overview %}}
 
-Ce tutoriel vous montre comment exécuter une simple application Hello World Node.js sur Kubernetes en utilisant [Minikube](/docs/getting-start-guides/minikube) et Katacoda.
+Ce tutoriel vous montre comment exécuter une simple application Hello World Node.js sur Kubernetes en utilisant [Minikube](/docs/getting-started-guides/minikube) et Katacoda.
 Katacoda fournit un environnement Kubernetes gratuit dans le navigateur.
 
 {{< note >}}


### PR DESCRIPTION
Multiple broken links

* malfomed urls in glossary (had trailing "fr/")
* malformed url docs (no trailing "/")
* relative link ".."