### PR TITLE
Add "rollout restart" to cheatsheet

### DIFF
--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -207,6 +207,7 @@ kubectl rollout history deployment/frontend                      # Check the his
 kubectl rollout undo deployment/frontend                         # Rollback to the previous deployment
 kubectl rollout undo deployment/frontend --to-revision=2         # Rollback to a specific revision
 kubectl rollout status -w deployment/frontend                    # Watch rolling update status of "frontend" deployment until completion
+kubectl rollout restart deployment/frontend                      # Rolling restart of the "frontend" deployment
 
 
 # deprecated starting version 1.11


### PR DESCRIPTION
Document rollout restart in the cheatsheet since it's a pretty convenient people but it's hard to discover.