### PR TITLE
Fix broken NodeRestriction anchor reference

### DIFF
--- a/content/en/docs/reference/access-authn-authz/node.md
+++ b/content/en/docs/reference/access-authn-authz/node.md
@@ -50,7 +50,7 @@ For specifics about how the kubelet determines the hostname, as well as cloud pr
 
 To enable the Node authorizer, start the apiserver with `--authorization-mode=Node`.
 
-To limit the API objects kubelets are able to write, enable the [NodeRestriction](/docs/reference/access-authn-authz/admission-controllers#NodeRestriction) admission plugin by starting the apiserver with `--enable-admission-plugins=...,NodeRestriction,...`
+To limit the API objects kubelets are able to write, enable the [NodeRestriction](/docs/reference/access-authn-authz/admission-controllers#noderestriction) admission plugin by starting the apiserver with `--enable-admission-plugins=...,NodeRestriction,...`
 
 ## Migration considerations
 


### PR DESCRIPTION
In 203391835d, an explicit anchor '#noderestriction' was added to the
NodeRestriction section of the Admission Controllers reference document,
which caused the link to the '#NodeRestriction' anchor in the Node
Authorization document to break and lead to the top of the Admission
Controllers document instead of to the NodeRestriction section further
down the page. This change fixes the link to point to the intended
section instead of to the whole page in general.