### PR TITLE
#18239 Make wordpress snippet copy/pastable

### DIFF
--- a/content/en/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
+++ b/content/en/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
@@ -114,13 +114,13 @@ the name of the MySQL Service defined above, and WordPress will access the datab
       
 3. Add them to `kustomization.yaml` file.
 
-      ```shell
-      cat <<EOF >>./kustomization.yaml
-      resources:
-        - mysql-deployment.yaml
-        - wordpress-deployment.yaml
-      EOF
-      ```
+```shell
+cat <<EOF >>./kustomization.yaml
+resources:
+  - mysql-deployment.yaml
+  - wordpress-deployment.yaml
+EOF
+```
 
 ## Apply and Verify
 The `kustomization.yaml` contains all the resources for deploying a WordPress site and a 


### PR DESCRIPTION
Remove leading space to make it copy pastable.

Fixes https://github.com/kubernetes/website/issues/18239
