### PR TITLE
Fix yaml syntax highlight

### DIFF
--- a/content/ja/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/ja/docs/concepts/workloads/controllers/statefulset.md
@@ -44,10 +44,6 @@ StatefulSetは下記の1つ以上の項目を要求するアプリケーショ�
 
 下記の例は、StatefulSetのコンポーネントのデモンストレーションとなります。
 
-* nginxという名前のHeadlessServiceは、ネットワークドメインをコントロールするために使われます。
-* webという名前のStatefulSetは、specで3つのnginxコンテナのレプリカを持ち、そのコンテナはそれぞれ別のPodで稼働するように設定されています。
-* volumeClaimTemplatesは、PersistentVolumeプロビジョナーによってプロビジョンされた[PersistentVolume](/docs/concepts/storage/persistent-volumes/)を使って安定したストレージを提供します。
-
 ```yaml
 apiVersion: v1
 kind: Service
@@ -98,6 +94,12 @@ spec:
         requests:
           storage: 1Gi
 ```
+
+上記の例では、
+
+* nginxという名前のHeadlessServiceは、ネットワークドメインをコントロールするために使われます。
+* webという名前のStatefulSetは、specで3つのnginxコンテナのレプリカを持ち、そのコンテナはそれぞれ別のPodで稼働するように設定されています。
+* volumeClaimTemplatesは、PersistentVolumeプロビジョナーによってプロビジョンされた[PersistentVolume](/docs/concepts/storage/persistent-volumes/)を使って安定したストレージを提供します。
 
 ## Podセレクター
 ユーザーは、StatefulSetの`.spec.template.metadata.labels`のラベルと一致させるため、StatefulSetの`.spec.selector`フィールドをセットしなくてはなりません。Kubernetes1.8以前では、`.spec.selector`フィールドは省略された場合デフォルト値になります。Kubernetes1.8とそれ以降のバージョンでは、ラベルに一致するPodセレクターの指定がない場合はStatefulSetの作成時にバリデーションエラーになります。


### PR DESCRIPTION
I fixed the document order in the documentation because the indent of yaml was wrong.

## Before
<img width="901" alt="スクリーンショット 2019-12-19 12 52 30" src="https://user-images.githubusercontent.com/964694/71334524-ee76e680-2581-11ea-9dde-947743feed6d.png">


## After
<img width="847" alt="スクリーンショット 2019-12-19 12 51 32" src="https://user-images.githubusercontent.com/964694/71334594-28e08380-2582-11ea-9341-c11953a618f7.png">


## Current English Version
<img width="796" alt="スクリーンショット 2019-12-19 12 53 12" src="https://user-images.githubusercontent.com/964694/71334465-b8396700-2581-11ea-92d4-2cae5725ce88.png">

