### PR TITLE
Remove deployment flannel daemonset  redundant information on k8s cluster include windows node

### DIFF
--- a/content/en/docs/setup/production-environment/windows/user-guide-windows-nodes.md
+++ b/content/en/docs/setup/production-environment/windows/user-guide-windows-nodes.md
@@ -140,12 +140,6 @@ Once you have a Linux-based Kubernetes control-plane ("Master") node you are rea
     kubectl apply -f kube-flannel.yml
     ```
 
-    Next, since the Flannel pods are Linux-based, apply a NodeSelector patch, which can be found [here](https://github.com/Microsoft/SDN/blob/1d5c055bb195fecba07ad094d2d7c18c188f9d2d/Kubernetes/flannel/l2bridge/manifests/node-selector-patch.yml), to the Flannel DaemonSet pod:
-
-    ```bash
-    kubectl patch ds/kube-flannel-ds-amd64 --patch "$(cat node-selector-patch.yml)" -n=kube-system
-    ```
-
     After a few minutes, you should see all the pods as running if the Flannel pod network was deployed.
 
     ```bash

--- a/content/ja/docs/setup/production-environment/windows/user-guide-windows-nodes.md
+++ b/content/ja/docs/setup/production-environment/windows/user-guide-windows-nodes.md
@@ -131,12 +131,6 @@ Once you have a Linux-based Kubernetes master node you are ready to choose a net
     kubectl apply -f kube-flannel.yml
     ```
 
-    Next, since the Flannel pods are Linux-based, apply a NodeSelector patch, which can be found [here](https://github.com/Microsoft/SDN/blob/1d5c055bb195fecba07ad094d2d7c18c188f9d2d/Kubernetes/flannel/l2bridge/manifests/node-selector-patch.yml), to the Flannel DaemonSet pod:
-
-    ```bash
-    kubectl patch ds/kube-flannel-ds-amd64 --patch "$(cat node-selector-patch.yml)" -n=kube-system
-    ```
-
     After a few minutes, you should see all the pods as running if the Flannel pod network was deployed.
 
     ```bash

--- a/content/ko/docs/setup/production-environment/windows/user-guide-windows-nodes.md
+++ b/content/ko/docs/setup/production-environment/windows/user-guide-windows-nodes.md
@@ -137,12 +137,6 @@ v1.14 이후의 최신 바이너리를 [https://github.com/kubernetes/kubernetes
     kubectl apply -f kube-flannel.yml
     ```
 
-    다음은 플라넬 파드는 리눅스 기반이라 [여기](https://github.com/Microsoft/SDN/blob/1d5c055bb195fecba07ad094d2d7c18c188f9d2d/Kubernetes/flannel/l2bridge/manifests/node-selector-patch.yml) 나온 노드 셀렉터 패치를 플라넬 데몬셋 파드에 적용한다.
-
-    ```bash
-    kubectl patch ds/kube-flannel-ds-amd64 --patch "$(cat node-selector-patch.yml)" -n=kube-system
-    ```
-
     몇 분 뒤에 플라넬 파드 네트워크가 배포되었다면, 모든 파드에서 운영 중인 것을 확인할 수 있다.
 
     ```bash


### PR DESCRIPTION
Because the official flannel deployment yaml already contains the affinity options for deploying to linux nodes,there is no need to configure affinity in additional

The official documentation is as follows

https://github.com/coreos/flannel/blob/960b3243b9a7faccdfe7b3c09097105e68030ea7/Documentation/kube-flannel.yml#L152-L164