### PR TITLE
Remove redundant information when deploy flannel on kubernetes include windows node

### DIFF
--- a/content/en/docs/setup/production-environment/windows/user-guide-windows-nodes.md
+++ b/content/en/docs/setup/production-environment/windows/user-guide-windows-nodes.md
@@ -140,12 +140,6 @@ Once you have a Linux-based Kubernetes control-plane ("Master") node you are rea
     kubectl apply -f kube-flannel.yml
     ```
 
-    Next, since the Flannel pods are Linux-based, apply a NodeSelector patch, which can be found [here](https://github.com/Microsoft/SDN/blob/1d5c055bb195fecba07ad094d2d7c18c188f9d2d/Kubernetes/flannel/l2bridge/manifests/node-selector-patch.yml), to the Flannel DaemonSet pod:
-
-    ```bash
-    kubectl patch ds/kube-flannel-ds-amd64 --patch "$(cat node-selector-patch.yml)" -n=kube-system
-    ```
-
     After a few minutes, you should see all the pods as running if the Flannel pod network was deployed.
 
     ```bash


### PR DESCRIPTION
Because the official flannel deployment yaml already contains the affinity options for deploying to linux nodes,there is no need to configure affinity in additional

The official documentation is as follows

https://github.com/coreos/flannel/blob/960b3243b9a7faccdfe7b3c09097105e68030ea7/Documentation/kube-flannel.yml#L152-L164
