### PR TITLE
Revise glossary definitions for cluster infrastructure & operations

### DIFF
--- a/content/en/docs/reference/glossary/cluster-infrastructure.md
+++ b/content/en/docs/reference/glossary/cluster-infrastructure.md
@@ -8,6 +8,6 @@ short_description: >
 
 aka:
 tags:
-- operations
+- operation
 ---
-The infrastructure layer provides and maintains VMs, networking, security groups and others.
+ The infrastructure layer provides and maintains VMs, networking, security groups and others.

--- a/content/en/docs/reference/glossary/cluster-operations.md
+++ b/content/en/docs/reference/glossary/cluster-operations.md
@@ -4,10 +4,18 @@ id: cluster-operations
 date: 2019-05-12
 full_link:
 short_description: >
- Activities such as upgrading the clusters, implementing security, storage, ingress, networking, logging and monitoring, and other operations involved in managing a Kubernetes cluster.
+ The work involved in managing a Kubernetes cluster.
 
 aka:
 tags:
-- operations
+- operation
 ---
- Activities such as upgrading the clusters, implementing security, storage, ingress, networking, logging and monitoring, and other operations involved in managing a Kubernetes cluster.
+ The work involved in managing a Kubernetes cluster: managing
+day-to-day operations, and co-ordinating upgrades.
+
+<!--more-->
+
+ Examples of cluster operations work include: deploying new Nodes to
+scale the cluster; performing software upgrades; implementing security
+controls; adding or removing storage; configuring cluster networking;
+managing cluster-wide observability; and responding to events.


### PR DESCRIPTION
Fixes #18294 

- Fix metadata typo (`operations` tag should be `operation`)
- Improve wording
