### PR TITLE
Localize logo title in page header

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,7 +1,7 @@
 <div id="cellophane" onclick="kub.toggleMenu()"></div>
 
 <header>
-    <a href="{{ site.Home.RelPermalink }}" class="logo" title="Production-Grade Container Orchestration - Kubernetes" aria-label="Kubernetes website"></a>
+    <a href="{{ site.Home.RelPermalink }}" class="logo" title="{{ site.Home.Title }} - {{ site.Params.title }}" aria-label="Kubernetes website"></a>
 
     <div class="nav-buttons" data-auto-burger="primary">
         <ul class="global-nav">


### PR DESCRIPTION
The Kubernetes logo links to the top-of-site for the current localization, so localize the `title` attribute of that hyperlink.

Some previews:
- [English](https://deploy-preview-18318--kubernetes-io-master-staging.netlify.com/), [docs](https://deploy-preview-18318--kubernetes-io-master-staging.netlify.com/docs/home/)
- [Korean](https://deploy-preview-18318--kubernetes-io-master-staging.netlify.com/ko/), [docs](https://deploy-preview-18318--kubernetes-io-master-staging.netlify.com/ko/docs/home/)
- [German](https://deploy-preview-18318--kubernetes-io-master-staging.netlify.com/de/), [docs](https://deploy-preview-18318--kubernetes-io-master-staging.netlify.com/de/docs/home/)