### PR TITLE
Correct name for Vietnamese language

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -270,7 +270,7 @@ language_alternatives = ["en"]
 [languages.vi]
 title = "Kubernetes"
 description = "Giải pháp điều phối container trong môi trường production"
-languageName = "Vietnamese"
+languageName = "Tiếng Việt"
 contentDir = "content/vi"
 weight = 12
 


### PR DESCRIPTION
Vietnamese in Vietnamese is "_Tiếng Việt_"; use this in the language chooser etc.

/language vi
/kind cleanup