### PR TITLE
Remove version checks for Job and CronJob task pages

### DIFF
--- a/content/en/docs/tasks/job/automated-tasks-with-cron-jobs.md
+++ b/content/en/docs/tasks/job/automated-tasks-with-cron-jobs.md
@@ -1,5 +1,6 @@
 ---
 title: Running Automated Tasks with a CronJob
+min-kubernetes-server-version: v1.8
 reviewers:
 - chenopis
 content_template: templates/task

--- a/content/en/docs/tasks/job/automated-tasks-with-cron-jobs.md
+++ b/content/en/docs/tasks/job/automated-tasks-with-cron-jobs.md
@@ -25,7 +25,7 @@ For more limitations, see [CronJobs](/docs/concepts/workloads/controllers/cron-j
 
 {{% capture prerequisites %}}
 
-* {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+* {{< include "task-tutorial-prereqs.md" >}}
 
 {{% /capture %}}
 

--- a/content/en/docs/tasks/job/coarse-parallel-processing-work-queue.md
+++ b/content/en/docs/tasks/job/coarse-parallel-processing-work-queue.md
@@ -1,5 +1,6 @@
 ---
 title: Coarse Parallel Processing Using a Work Queue
+min-kubernetes-server-version: v1.8
 content_template: templates/task
 weight: 30
 ---

--- a/content/en/docs/tasks/job/coarse-parallel-processing-work-queue.md
+++ b/content/en/docs/tasks/job/coarse-parallel-processing-work-queue.md
@@ -31,7 +31,7 @@ Here is an overview of the steps in this example:
 Be familiar with the basic,
 non-parallel, use of [Job](/docs/concepts/jobs/run-to-completion-finite-workloads/).
 
-{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+{{< include "task-tutorial-prereqs.md" >}}
 
 {{% /capture %}}
 

--- a/content/en/docs/tasks/job/fine-parallel-processing-work-queue.md
+++ b/content/en/docs/tasks/job/fine-parallel-processing-work-queue.md
@@ -1,6 +1,7 @@
 ---
 title: Fine Parallel Processing Using a Work Queue
 content_template: templates/task
+min-kubernetes-server-version: v1.8
 weight: 40
 ---
 

--- a/content/en/docs/tasks/job/fine-parallel-processing-work-queue.md
+++ b/content/en/docs/tasks/job/fine-parallel-processing-work-queue.md
@@ -30,7 +30,7 @@ Here is an overview of the steps in this example:
 
 {{% capture prerequisites %}}
 
-{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+{{< include "task-tutorial-prereqs.md" >}}
 
 {{% /capture %}}
 

--- a/content/en/docs/tasks/job/parallel-processing-expansion.md
+++ b/content/en/docs/tasks/job/parallel-processing-expansion.md
@@ -1,6 +1,7 @@
 ---
 title: Parallel Processing using Expansions
 content_template: templates/concept
+min-kubernetes-server-version: v1.8
 weight: 20
 ---
 


### PR DESCRIPTION
Currently the [pages](https://kubernetes.io/docs/tasks/job/) about Job & CronJob instruct readers to check their cluster version, without saying what version is needed.

Job has been in Kubernetes for a good while and CronJob has been beta since v1.8
With that in mind, drop the version check from the relevant Task pages.

/kind cleanup