### PR TITLE
Fix link to Minikube in Task & tutorial page snippet

### DIFF
--- a/content/en/includes/task-tutorial-prereqs.md
+++ b/content/en/includes/task-tutorial-prereqs.md
@@ -1,7 +1,7 @@
 You need to have a Kubernetes cluster, and the kubectl command-line tool must
 be configured to communicate with your cluster. If you do not already have a
 cluster, you can create one by using
-[Minikube](/docs/setup/minikube),
+[Minikube](/docs/setup/learning-environment/minikube/),
 or you can use one of these Kubernetes playgrounds:
 
 * [Katacoda](https://www.katacoda.com/courses/kubernetes/playground)


### PR DESCRIPTION
Task & tutorial pages can have a snippet about how to get hold of a Kubernetes cluster if you don't already have one. Update the link to Minikube from that snippet so that it is current

/kind cleanup
/priority important-longterm
/language en