### PR TITLE
Tidy pages for PodPreset

### DIFF
--- a/content/en/docs/concepts/workloads/pods/podpreset.md
+++ b/content/en/docs/concepts/workloads/pods/podpreset.md
@@ -7,6 +7,8 @@ weight: 50
 ---
 
 {{% capture overview %}}
+{{< feature-state for_k8s_version="v1.6" state="alpha" >}}
+
 This page provides an overview of PodPresets, which are objects for injecting
 certain information into pods at creation time. The information can include
 secrets, volumes, volume mounts, and environment variables.
@@ -14,20 +16,38 @@ secrets, volumes, volume mounts, and environment variables.
 
 
 {{% capture body %}}
-## Understanding Pod Presets
+## Understanding Pod presets
 
-A `Pod Preset` is an API resource for injecting additional runtime requirements
+A PodPreset is an API resource for injecting additional runtime requirements
 into a Pod at creation time.
 You use [label selectors](/docs/concepts/overview/working-with-objects/labels/#label-selectors)
-to specify the Pods to which a given Pod Preset applies.
+to specify the Pods to which a given PodPreset applies.
 
-Using a Pod Preset allows pod template authors to not have to explicitly provide
+Using a PodPreset allows pod template authors to not have to explicitly provide
 all information for every pod. This way, authors of pod templates consuming a
 specific service do not need to know all the details about that service.
 
-For more information about the background, see the [design proposal for PodPreset](https://git.k8s.io/community/contributors/design-proposals/service-catalog/pod-preset.md).
 
-## How It Works
+## Enable PodPreset in your cluster {#enable-pod-preset}
+
+In order to use Pod presets in your cluster you must ensure the following:
+
+1.  You have enabled the API type `settings.k8s.io/v1alpha1/podpreset`. For
+    example, this can be done by including `settings.k8s.io/v1alpha1=true` in
+    the `--runtime-config` option for the API server. In minikube add this flag
+    `--extra-config=apiserver.runtime-config=settings.k8s.io/v1alpha1=true` while
+    starting the cluster.
+1.  You have enabled the admission controller `PodPreset`. One way to doing this
+    is to include `PodPreset` in the `--enable-admission-plugins` option value specified
+    for the API server. In minikube, add this flag
+    
+    ```shell
+    --extra-config=apiserver.enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,PodPreset
+    ```
+    
+    while starting the cluster.
+
+## How it works
 
 Kubernetes provides an admission controller (`PodPreset`) which, when enabled,
 applies Pod Presets to incoming pod creation requests.
@@ -62,31 +82,12 @@ There may be instances where you wish for a Pod to not be altered by any Pod
 Preset mutations. In these cases, you can add an annotation in the Pod Spec
 of the form: `podpreset.admission.kubernetes.io/exclude: "true"`.
 
-## Enable Pod Preset
-
-In order to use Pod Presets in your cluster you must ensure the following:
-
-1.  You have enabled the API type `settings.k8s.io/v1alpha1/podpreset`. For
-    example, this can be done by including `settings.k8s.io/v1alpha1=true` in
-    the `--runtime-config` option for the API server. In minikube add this flag
-    `--extra-config=apiserver.runtime-config=settings.k8s.io/v1alpha1=true` while
-    starting the cluster.
-1.  You have enabled the admission controller `PodPreset`. One way to doing this
-    is to include `PodPreset` in the `--enable-admission-plugins` option value specified
-    for the API server. In minikube add this flag
-    
-    ```shell
-    --extra-config=apiserver.enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,PodPreset
-    ```
-    
-    while starting the cluster.
-1.  You have defined your Pod Presets by creating `PodPreset` objects in the
-    namespace you will use.
-
 {{% /capture %}}
 
 {{% capture whatsnext %}}
 
-* [Injecting data into a Pod using PodPreset](/docs/tasks/inject-data-application/podpreset/)
+See [Injecting data into a Pod using PodPreset](/docs/tasks/inject-data-application/podpreset/)
+
+For more information about the background, see the [design proposal for PodPreset](https://git.k8s.io/community/contributors/design-proposals/service-catalog/pod-preset.md).
 
 {{% /capture %}}

--- a/content/en/docs/tasks/inject-data-application/podpreset.md
+++ b/content/en/docs/tasks/inject-data-application/podpreset.md
@@ -2,12 +2,14 @@
 reviewers:
 - jessfraz
 title: Inject Information into Pods Using a PodPreset
-min-kubernetes-server-version: v1.10
+min-kubernetes-server-version: v1.6
 content_template: templates/task
 weight: 60
 ---
 
 {{% capture overview %}}
+
+{{< feature-state for_k8s_version="v1.6" state="alpha" >}}
 
 This page shows how to use PodPreset objects to inject information like {{< glossary_tooltip text="Secrets" term_id="secret" >}}, volume mounts, and {{< glossary_tooltip text="environment variables" term_id="container-env-variables" >}} into Pods at creation time.
 
@@ -15,7 +17,8 @@ This page shows how to use PodPreset objects to inject information like {{< glos
 
 {{% capture prerequisites %}}
 
-{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+You need to have a Kubernetes cluster, and the kubectl command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one using [Minikube](/docs/setup/learning-environment/minikube/).
+Make sure that you have [enabled PodPreset](/docs/concepts/workloads/pods/podpreset/#enable-pod-preset) in your cluster.
 
 {{% /capture %}}
 


### PR DESCRIPTION
- mark PodPreset as alpha
- adopt website style guidelines more
- ensure Task page guides readers to enable PodPreset admission controller first
- other tidying

Previews:
1. [Pod Preset](https://deploy-preview-18342--kubernetes-io-master-staging.netlify.com/docs/concepts/workloads/pods/podpreset/)
2. [Inject Information into Pods Using a PodPreset](https://deploy-preview-18342--kubernetes-io-master-staging.netlify.com/docs/tasks/inject-data-application/podpreset/)