### PR TITLE
delete an 404 url

### DIFF
--- a/content/de/docs/setup/minikube.md
+++ b/content/de/docs/setup/minikube.md
@@ -431,7 +431,6 @@ Weitere Informationen zu Minikube finden Sie im [Vorschlag](https://git.k8s.io/c
 * **Ziele und Nichtziele**: Die Ziele und Nichtziele des Minikube-Projekts finden Sie in unserer [Roadmap](https://git.k8s.io/minikube/docs/contributors/roadmap.md).
 * **Entwicklungshandbuch**: Lesen Sie [CONTRIBUTING.md](https://git.k8s.io/minikube/CONTRIBUTING.md) für einen Überblick über das Senden von Pull-Requests.
 * **Minikube bauen**: Anweisungen zum Erstellen/Testen von Minikube aus dem Quellcode finden Sie im [build Handbuch](https://git.k8s.io/minikube/docs/contributors/build_guide.md).
-* **Neue Abhängigkeit hinzufügen**: Anweisungen zum Hinzufügen einer neuen Abhängigkeit zu Minikube finden Sie in der [Anleitung zum Hinzufügen von Abhängigkeiten](https://git.k8s.io/minikube/docs/contributors/adding_a_dependency.md).
 * **Neues Addon hinzufügen**: Anweisungen zum Hinzufügen eines neuen Addons für Minikube finden Sie im [Anleitung zum Hinzufügen eines Addons](https://git.k8s.io/minikube/docs/contributors/adding_an_addon.md).
 * **MicroK8s**: Linux-Benutzer, die die Ausführung einer virtuellen Maschine vermeiden möchten, sollten [MicroK8s](https://microk8s.io/) als Alternative in Betracht ziehen.
 

--- a/content/en/docs/setup/learning-environment/minikube.md
+++ b/content/en/docs/setup/learning-environment/minikube.md
@@ -462,7 +462,6 @@ For more information about Minikube, see the [proposal](https://git.k8s.io/commu
 * **Goals and Non-Goals**: For the goals and non-goals of the Minikube project, please see our [roadmap](https://git.k8s.io/minikube/docs/contributors/roadmap.md).
 * **Development Guide**: See [CONTRIBUTING.md](https://git.k8s.io/minikube/CONTRIBUTING.md) for an overview of how to send pull requests.
 * **Building Minikube**: For instructions on how to build/test Minikube from source, see the [build guide](https://git.k8s.io/minikube/docs/contributors/build_guide.md).
-* **Adding a New Dependency**: For instructions on how to add a new dependency to Minikube, see the [adding dependencies guide](https://git.k8s.io/minikube/docs/contributors/adding_a_dependency.md).
 * **Adding a New Addon**: For instructions on how to add a new addon for Minikube, see the [adding an addon guide](https://git.k8s.io/minikube/docs/contributors/adding_an_addon.md).
 * **MicroK8s**: Linux users wishing to avoid running a virtual machine may consider [MicroK8s](https://microk8s.io/) as an alternative.
 

--- a/content/fr/docs/setup/learning-environment/minikube.md
+++ b/content/fr/docs/setup/learning-environment/minikube.md
@@ -519,7 +519,6 @@ Pour plus d'informations sur Minikube, voir la [proposition](https://git.k8s.io/
 * **Objectifs et non-objectifs**: Pour les objectifs et non-objectifs du projet Minikube, veuillez consulter notre [roadmap](https://git.k8s.io/minikube/docs/contributors/roadmap.md).
 * **Guide de développement**: Voir [CONTRIBUTING.md](https://git.k8s.io/minikube/CONTRIBUTING.md) pour avoir un aperçu de comment envoyer des pull requests.
 * **Construire Minikube**: Pour obtenir des instructions sur la création / test de Minikube à partir des sources, voir le [guide de build](https://git.k8s.io/minikube/docs/contributors/build_guide.md).
-* **Ajout d'une nouvelle dépendance**: Pour savoir comment ajouter une nouvelle dépendance à Minikube, voir la section [guide d'ajout de dépendances](https://git.k8s.io/minikube/docs/contributors/adding_a_dependency.md).
 * **Ajout d'un nouvel addon**: Pour savoir comment ajouter un nouvel addon pour Minikube, reportez-vous au [Ajout d’un addon](https://git.k8s.io/minikube/docs/contributors/adding_an_addon.md).
 * **MicroK8s**: Les utilisateurs de Linux qui souhaitent éviter d’exécuter une machine virtuelle peuvent envisager [MicroK8s](https://microk8s.io/).
 

--- a/content/ja/docs/setup/learning-environment/minikube.md
+++ b/content/ja/docs/setup/learning-environment/minikube.md
@@ -433,7 +433,6 @@ Minikubeの詳細については、[proposal](https://git.k8s.io/community/contr
 * **目標と非目標**: Minikubeプロジェクトの目標と非目標については、[ロードマップ](https://git.k8s.io/minikube/docs/contributors/roadmap.md)を参照してください。
 * **開発ガイド**: プルリクエストを送る方法の概要については、[CONTRIBUTING.md](https://git.k8s.io/minikube/CONTRIBUTING.md)を参照してください。
 * **Minikubeのビルド**: Minikubeをソースからビルド/テストする方法については、[ビルドガイド](https://git.k8s.io/minikube/docs/contributors/build_guide.md)を参照してください。
-* **新しい依存性の追加**: Minikubeに新しい依存性を追加する方法については、[依存性追加ガイド](https://git.k8s.io/minikube/docs/contributors/adding_a_dependency.md)を参照してください。
 * **新しいアドオンの追加**: Minikubeに新しいアドオンを追加する方法については、[アドオン追加ガイド](https://git.k8s.io/minikube/docs/contributors/adding_an_addon.md)を参照してください。
 * **MicroK8s**: 仮想マシンを実行したくないLinuxユーザーは代わりに[MicroK8s](https://microk8s.io/)を検討してみてください。
 

--- a/content/ko/docs/setup/learning-environment/minikube.md
+++ b/content/ko/docs/setup/learning-environment/minikube.md
@@ -457,7 +457,6 @@ Minikube에 대한 더 자세한 정보는, [제안](https://git.k8s.io/communit
 * **목표와 비목표**: Minikube 프로젝트의 목표와 비목표에 대해서는 [로드맵](https://git.k8s.io/minikube/docs/contributors/roadmap.md)을 살펴보자.
 * **개발 가이드**: 풀 리퀘스트를 보내는 방법에 대한 개요는 [참여 가이드](https://git.k8s.io/minikube/CONTRIBUTING.md)를 살펴보자.
 * **Minikube 빌드**: Minikube를 소스에서 빌드/테스트하는 방법은 [빌드 가이드](https://git.k8s.io/minikube/docs/contributors/build_guide.md)를 살펴보자.
-* **새 의존성 추가하기**: Minikube에 새 의존성을 추가하는 방법에 대해서는, [의존성 추가 가이드](https://git.k8s.io/minikube/docs/contributors/adding_a_dependency.md)를 보자.
 * **새 애드온 추가하기**: Minikube에 새 애드온을 추가하는 방법에 대해서는, [애드온 추가 가이드](https://git.k8s.io/minikube/docs/contributors/adding_an_addon.md)를 보자. 
 * **MicroK8s**: 가상 머신을 사용하지 않으려는 Linux 사용자는 대안으로 [MicroK8s](https://microk8s.io/)를 고려할 수 있다.
 

--- a/content/zh/docs/setup/learning-environment/minikube.md
+++ b/content/zh/docs/setup/learning-environment/minikube.md
@@ -906,7 +906,6 @@ For more information about Minikube, see the [proposal](https://git.k8s.io/commu
 * **Goals and Non-Goals**: For the goals and non-goals of the Minikube project, please see our [roadmap](https://git.k8s.io/minikube/docs/contributors/roadmap.md).
 * **Development Guide**: See [CONTRIBUTING.md](https://git.k8s.io/minikube/CONTRIBUTING.md) for an overview of how to send pull requests.
 * **Building Minikube**: For instructions on how to build/test Minikube from source, see the [build guide](https://git.k8s.io/minikube/docs/contributors/build_guide.md).
-* **Adding a New Dependency**: For instructions on how to add a new dependency to Minikube, see the [adding dependencies guide](https://git.k8s.io/minikube/docs/contributors/adding_a_dependency.md).
 * **Adding a New Addon**: For instructions on how to add a new addon for Minikube, see the [adding an addon guide](https://git.k8s.io/minikube/docs/contributors/adding_an_addon.md).
 * **MicroK8s**: Linux users wishing to avoid running a virtual machine may consider [MicroK8s](https://microk8s.io/) as an alternative.
 -->
@@ -914,7 +913,6 @@ For more information about Minikube, see the [proposal](https://git.k8s.io/commu
 * **目标和非目标**: 有关 Minikube 项目的目标和非目标，请参阅我们的 [roadmap](https://git.k8s.io/minikube/docs/contributors/roadmap.md)。
 * **开发指南**: 请查阅 [CONTRIBUTING.md](https://git.k8s.io/minikube/CONTRIBUTING.md) 获取有关如何提交 Pull Request 的概述。
 * **构建 Minikube**: 有关如何从源代码构建/测试 Minikube 的说明，请参阅[构建指南](https://git.k8s.io/minikube/docs/contributors/build_guide.md)。
-* **添加新依赖**: 有关如何向 Minikube 添加新依赖的说明，请参阅[添加依赖项指南](https://git.k8s.io/minikube/docs/contributors/adding_a_dependency.md)。
 * **添加新插件**: 有关如何为 Minikube 添加新插件的说明，请参阅[添加插件指南](https://git.k8s.io/minikube/docs/contributors/adding_an_addon.md)。
 * **MicroK8s**: 希望避免运行虚拟机的 Linux 用户可以考虑使用 [MicroK8s](https://microk8s.io/) 作为替代品。
 


### PR DESCRIPTION
delete an 404 url:
https://git.k8s.io/minikube/docs/contributors/adding_a_dependency.md

Adding_a_dependency.md has been deleted in this commit:
https://github.com/kubernetes/minikube/commit/f464fa93dbaef63eadc9f54532d62614f6ca1b30#diff-21ec9486a84cff936d6f53e7c77eb0f6

ref:#17649