### PR TITLE
removing /en/docs links from /id/ localization.

### DIFF
--- a/content/id/docs/concepts/overview/components.md
+++ b/content/id/docs/concepts/overview/components.md
@@ -63,7 +63,7 @@ Kontroler-kontroler ini meliputi:
 
 ### cloud-controller-manager
 
-[Cloud-controller-manager](/en/docs/tasks/administer-cluster/running-cloud-controller/) merupakan kontroler yang berinteraksi dengan penyedia layanan <i>cloud</i>.
+[Cloud-controller-manager](/docs/tasks/administer-cluster/running-cloud-controller/) merupakan kontroler yang berinteraksi dengan penyedia layanan <i>cloud</i>.
 Kontroler ini merupakat fitur alfa yang diperkenalkan pada Kubernetes versi 1.6.
 
 <i>Cloud-controller-manager</i> hanya menjalankan iterasi kontroler <i>cloud-provider-specific</i> .
@@ -120,7 +120,7 @@ Meskipun tidak semua <i>addons</i> dibutuhkan, semua klaster Kubernetes hendakny
 memiliki DNS klaster. Komponen ini penting karena banyak dibutuhkan oleh komponen
 lainnya.
 
-[Klaster DNS](/en/docs/concepts/cluster-administration/addons/      ) adalah server DNS, selain beberapa server DNS lain yang sudah ada di
+[Klaster DNS](/docs/concepts/cluster-administration/addons/) adalah server DNS, selain beberapa server DNS lain yang sudah ada di
 <i>environment</i> kamu, yang berfungsi sebagai catatan DNS bagi Kubernetes <i>services</i>
 
 Kontainer yang dimulai oleh kubernetes secara otomatis akan memasukkan server DNS ini
@@ -129,21 +129,21 @@ ke dalam mekanisme pencarian DNS yang dimilikinya.
 
 ### <i>Web UI</i> (Dasbor)
 
-[Dasbor](/en/docs/tasks/access-application-cluster/web-ui-dashboard/) adalah antar muka berbasis web multifungsi yang ada pada klaster Kubernetes.
+[Dasbor](/docs/tasks/access-application-cluster/web-ui-dashboard/) adalah antar muka berbasis web multifungsi yang ada pada klaster Kubernetes.
 Dasbor ini memungkinkan user melakukan manajemen dan <i>troubleshooting</i> klaster maupun
 aplikasi yang ada pada klaster itu sendiri.
 
 
 ### <i>Container Resource Monitoring</i>
 
-[Container Resource Monitoring](/en/docs/tasks/debug-application-cluster/resource-usage-monitoring/) mencatat metrik <i>time-series</i> yang diperoleh
+[Container Resource Monitoring](/docs/tasks/debug-application-cluster/resource-usage-monitoring/) mencatat metrik <i>time-series</i> yang diperoleh
 dari kontainer ke dalam basis data serta menyediakan antar muka yang dapat digunakan
 untuk melakukan pencarian data yang dibutuhkan.
 
 
 ### <i>Cluster-level Logging</i>
 
-[Cluster-level logging](/en/docs/concepts/cluster-administration/logging/) bertanggung jawab mencatat <i>log</i> kontainer pada
+[Cluster-level logging](/docs/concepts/cluster-administration/logging/) bertanggung jawab mencatat <i>log</i> kontainer pada
 penyimpanan <i>log</i> terpusat dengan antar muka yang dapat digunakan untuk melakukan
 pencarian.
 


### PR DESCRIPTION
Links to english docs left as `/en/docs`, which generated a 404. Links are fixed.