### PR TITLE
Update service mesh in the Korean glossary

### DIFF
--- a/content/ko/docs/contribute/localization_ko.md
+++ b/content/ko/docs/contribute/localization_ko.md
@@ -266,7 +266,7 @@ Self-healing | 자가 치유 |
 Service | 서비스 | 
 Service Account | 서비스 어카운트 | 
 service discovery | 서비스 디스커버리 | 
-service mesh | 서비스 메쉬 |
+service mesh | 서비스 메시 |
 Session | 세션 | 
 Session Affinity | 세션 어피니티(Affinity) |
 Setting | 세팅 | 


### PR DESCRIPTION
[국립국어원에 따르면](https://www.korean.go.kr/front/imprv/refineView.do?mn_id=158&imprv_refine_seq=17330) "메쉬"는 그른 표기이므로 "메시"로 용어집을 업데이트 합니다.

