### PR TITLE
kubeadm-join.md: correct alpha->beta wording

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
@@ -260,7 +260,7 @@ These commands should be run after `kubeadm init` but before `kubeadm join`.
 ### Using kubeadm join with a configuration file {#config-file}
 
 {{< caution >}}
-The config file is still considered alpha and may change in future versions.
+The config file is still considered beta and may change in future versions.
 {{< /caution >}}
 
 It's possible to configure `kubeadm join` with a configuration file instead of command


### PR DESCRIPTION
The kubeadm API has been beta for a while.

/kind cleanup
/sig cluster-lifecycle
