### PR TITLE
cncf.io link fix

### DIFF
--- a/content/en/blog/_posts/2018-07-10-coredns-ga.md
+++ b/content/en/blog/_posts/2018-07-10-coredns-ga.md
@@ -165,7 +165,7 @@ You can find out more on the [CoreDNS Blog](https://coredns.io/blog).
 
 ### Get involved with CoreDNS
 
-CoreDNS is an incubated [CNCF](https:://cncf.io) project.
+CoreDNS is an incubated [CNCF](https://cncf.io) project.
 
 We're most active on Slack (and GitHub):
 


### PR DESCRIPTION
This PR suppose to fix link to cnc.iof that appears broken