### PR TITLE
Fix typo

### DIFF
--- a/content/id/docs/concepts/workloads/pods/pod.md
+++ b/content/id/docs/concepts/workloads/pods/pod.md
@@ -242,7 +242,7 @@ dokumentasi untuk [penghentian Pod dari StatefulSet](/docs/tasks/run-application
 
 ## Hak istimewa untuk kontainer pada Pod
 
-Setiap kontainer dalam Pod dapat mengaktifkan hak istimewa (mode _previleged_), dengan menggunakan tanda
+Setiap kontainer dalam Pod dapat mengaktifkan hak istimewa (mode _privileged_), dengan menggunakan tanda
 `privileged` pada [konteks keamanan](/docs/tasks/configure-pod-container/security-context/)
 pada spesifikasi kontainer. Ini akan berguna untuk kontainer yang ingin menggunakan 
 kapabilitas Linux seperti memanipulasi jaringan dan mengakses perangkat. Proses dalam


### PR DESCRIPTION
Fix [what I think is a] typo in https://kubernetes.io/id/docs/concepts/workloads/pods/pod/#hak-istimewa-untuk-kontainer-pada-pod

(This might be valid bahasa Indonesia and not a bug; if so, it's OK to close this PR).

/kind cleanup