### PR TITLE
Update Hello Minikube tutorial to use Metrics Server and not Heapster

### DIFF
--- a/content/de/docs/tutorials/hello-minikube.md
+++ b/content/de/docs/tutorials/hello-minikube.md
@@ -190,16 +190,16 @@ Minikube verfügt über eine Reihe von integrierten Add-Ons, die in der lokalen 
     storage-provisioner: enabled
     ```
 
-2. Aktivieren Sie ein Addon, zum Beispiel `heapster`:
+2. Aktivieren Sie ein Addon, zum Beispiel `metrics-server`:
 
     ```shell
-    minikube addons enable heapster
+    minikube addons enable metrics-server
     ```
 
     Ausgabe:
 
     ```shell
-    heapster was successfully enabled
+    metrics-server was successfully enabled
     ```
 
 3. Sehen Sie sich den Pod und den Service an, den Sie gerade erstellt haben:
@@ -212,7 +212,7 @@ Minikube verfügt über eine Reihe von integrierten Add-Ons, die in der lokalen 
 
     ```shell
     NAME                                        READY     STATUS    RESTARTS   AGE
-    pod/heapster-9jttx                          1/1       Running   0          26s
+    pod/metrics-server-6754dbc9df-q8zlg         1/1       Running   0          26s
     pod/influxdb-grafana-b29w8                  2/2       Running   0          26s
     pod/kube-addon-manager-minikube             1/1       Running   0          34m
     pod/kube-dns-6dcb57bcc8-gv7mw               3/3       Running   0          34m
@@ -220,23 +220,23 @@ Minikube verfügt über eine Reihe von integrierten Add-Ons, die in der lokalen 
     pod/storage-provisioner                     1/1       Running   0          34m
 
     NAME                           TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)             AGE
-    service/heapster               ClusterIP   10.96.241.45    <none>        80/TCP              26s
+    service/metrics-server         ClusterIP   10.96.94.175    <none>        443/TCP             26s
     service/kube-dns               ClusterIP   10.96.0.10      <none>        53/UDP,53/TCP       34m
     service/kubernetes-dashboard   NodePort    10.109.29.1     <none>        80:30000/TCP        34m
     service/monitoring-grafana     NodePort    10.99.24.54     <none>        80:30002/TCP        26s
     service/monitoring-influxdb    ClusterIP   10.111.169.94   <none>        8083/TCP,8086/TCP   26s
     ```
 
-4. Deaktivieren Sie `heapster`:
+4. Deaktivieren Sie `metrics-server`:
 
     ```shell
-    minikube addons disable heapster
+    minikube addons disable metrics-server
     ```
 
     Ausgabe:
 
     ```shell
-    heapster was successfully disabled
+    metrics-server was successfully disabled
     ```
 
 ## Aufräumen

--- a/content/en/docs/tutorials/hello-minikube.md
+++ b/content/en/docs/tutorials/hello-minikube.md
@@ -201,16 +201,16 @@ Minikube has a set of built-in addons that can be enabled, disabled and opened i
     storage-provisioner-gluster: disabled
     ```
    
-2. Enable an addon, for example, `heapster`:
+2. Enable an addon, for example, `metrics-server`:
 
     ```shell
-    minikube addons enable heapster
+    minikube addons enable metrics-server
     ```
   
     The output is similar to:
 
     ```
-    heapster was successfully enabled
+    metrics-server was successfully enabled
     ```
 
 3. View the Pod and Service you just created:
@@ -225,7 +225,7 @@ Minikube has a set of built-in addons that can be enabled, disabled and opened i
     NAME                                        READY     STATUS    RESTARTS   AGE
     pod/coredns-5644d7b6d9-mh9ll                1/1       Running   0          34m
     pod/coredns-5644d7b6d9-pqd2t                1/1       Running   0          34m
-    pod/heapster-9jttx                          1/1       Running   0          26s
+    pod/metrics-server-6754dbc9df-q8zlg         1/1       Running   0          26s
     pod/etcd-minikube                           1/1       Running   0          34m
     pod/influxdb-grafana-b29w8                  2/2       Running   0          26s
     pod/kube-addon-manager-minikube             1/1       Running   0          34m
@@ -236,22 +236,22 @@ Minikube has a set of built-in addons that can be enabled, disabled and opened i
     pod/storage-provisioner                     1/1       Running   0          34m
 
     NAME                           TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)             AGE
-    service/heapster               ClusterIP   10.96.241.45    <none>        80/TCP              26s
+    service/metrics-server         ClusterIP   10.96.94.175    <none>        443/TCP             26s
     service/kube-dns               ClusterIP   10.96.0.10      <none>        53/UDP,53/TCP       34m
     service/monitoring-grafana     NodePort    10.99.24.54     <none>        80:30002/TCP        26s
     service/monitoring-influxdb    ClusterIP   10.111.169.94   <none>        8083/TCP,8086/TCP   26s
     ```
 
-4. Disable `heapster`:
+4. Disable `metrics-server`:
 
     ```shell
-    minikube addons disable heapster
+    minikube addons disable metrics-server
     ```
   
     The output is similar to:
 
     ```
-    heapster was successfully disabled
+    metrics-server was successfully disabled
     ```
 
 ## Clean up

--- a/content/fr/docs/tutorials/hello-minikube.md
+++ b/content/fr/docs/tutorials/hello-minikube.md
@@ -191,16 +191,16 @@ Minikube dispose d'un ensemble d'extensions intégrées qui peuvent être activ�
     storage-provisioner: enabled
     ```
 
-2. Activez une extension, par exemple, `heapster` :
+2. Activez une extension, par exemple, `metrics-server` :
 
     ```shell
-    minikube addons enable heapster
+    minikube addons enable metrics-server
     ```
 
     Sortie :
 
     ```shell
-    heapster was successfully enabled
+    metrics-server was successfully enabled
     ```
 
 3. Affichez le pod et le service que vous venez de créer :
@@ -213,7 +213,7 @@ Minikube dispose d'un ensemble d'extensions intégrées qui peuvent être activ�
 
     ```shell
     NAME                                        READY     STATUS    RESTARTS   AGE
-    pod/heapster-9jttx                          1/1       Running   0          26s
+    pod/metrics-server-6754dbc9df-q8zlg         1/1       Running   0          26s
     pod/influxdb-grafana-b29w8                  2/2       Running   0          26s
     pod/kube-addon-manager-minikube             1/1       Running   0          34m
     pod/kube-dns-6dcb57bcc8-gv7mw               3/3       Running   0          34m
@@ -221,23 +221,23 @@ Minikube dispose d'un ensemble d'extensions intégrées qui peuvent être activ�
     pod/storage-provisioner                     1/1       Running   0          34m
 
     NAME                           TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)             AGE
-    service/heapster               ClusterIP   10.96.241.45    <none>        80/TCP              26s
+    service/metrics-server         ClusterIP   10.96.94.175    <none>        443/TCP             26s
     service/kube-dns               ClusterIP   10.96.0.10      <none>        53/UDP,53/TCP       34m
     service/kubernetes-dashboard   NodePort    10.109.29.1     <none>        80:30000/TCP        34m
     service/monitoring-grafana     NodePort    10.99.24.54     <none>        80:30002/TCP        26s
     service/monitoring-influxdb    ClusterIP   10.111.169.94   <none>        8083/TCP,8086/TCP   26s
     ```
 
-4. Désactivez `heapster` :
+4. Désactivez `metrics-server` :
 
     ```shell
-    minikube addons disable heapster
+    minikube addons disable metrics-server
     ```
 
     Sortie :
 
     ```shell
-    heapster was successfully disabled
+    metrics-server was successfully disabled
     ```
 
 ## Nettoyage

--- a/content/id/docs/tutorials/hello-minikube.md
+++ b/content/id/docs/tutorials/hello-minikube.md
@@ -189,16 +189,16 @@ Minikube punya beberapa <i>addons</i> yang bisa diaktifkan, dinon-aktifkan, maup
     storage-provisioner: enabled
     ```
 
-2. Aktifkan sebuah <i>addon</i>, misalnya `heapster`:
+2. Aktifkan sebuah <i>addon</i>, misalnya `metrics-server`:
 
     ```shell
-    minikube addons enable heapster
+    minikube addons enable metrics-server
     ```
 
     Keluaran:
 
     ```shell
-    heapster was successfully enabled
+    metrics-server was successfully enabled
     ```
 
 3. Lihat Pod dan Servis yang baru saja kamu buat:
@@ -211,7 +211,7 @@ Minikube punya beberapa <i>addons</i> yang bisa diaktifkan, dinon-aktifkan, maup
 
     ```shell
     NAME                                        READY     STATUS    RESTARTS   AGE
-    pod/heapster-9jttx                          1/1       Running   0          26s
+    pod/metrics-server-6754dbc9df-q8zlg         1/1       Running   0          26s
     pod/influxdb-grafana-b29w8                  2/2       Running   0          26s
     pod/kube-addon-manager-minikube             1/1       Running   0          34m
     pod/kube-dns-6dcb57bcc8-gv7mw               3/3       Running   0          34m
@@ -219,23 +219,23 @@ Minikube punya beberapa <i>addons</i> yang bisa diaktifkan, dinon-aktifkan, maup
     pod/storage-provisioner                     1/1       Running   0          34m
 
     NAME                           TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)             AGE
-    service/heapster               ClusterIP   10.96.241.45    <none>        80/TCP              26s
+    service/metrics-server         ClusterIP   10.96.94.175    <none>        443/TCP             26s
     service/kube-dns               ClusterIP   10.96.0.10      <none>        53/UDP,53/TCP       34m
     service/kubernetes-dashboard   NodePort    10.109.29.1     <none>        80:30000/TCP        34m
     service/monitoring-grafana     NodePort    10.99.24.54     <none>        80:30002/TCP        26s
     service/monitoring-influxdb    ClusterIP   10.111.169.94   <none>        8083/TCP,8086/TCP   26s
     ```
 
-4. Non-aktifkan `heapster`:
+4. Non-aktifkan `metrics-server`:
 
     ```shell
-    minikube addons disable heapster
+    minikube addons disable metrics-server
     ```
 
     Keluaran:
 
     ```shell
-    heapster was successfully disabled
+    metrics-server was successfully disabled
     ```
 
 ## Bersih-bersih

--- a/content/ja/docs/tutorials/hello-minikube.md
+++ b/content/ja/docs/tutorials/hello-minikube.md
@@ -183,16 +183,16 @@ Minikubeはビルトインのアドオンがあり、有効化、無効化、あ
     storage-provisioner: enabled
     ```
    
-2. ここでは例として`heapster`のアドオンを有効化します:
+2. ここでは例として`metrics-server`のアドオンを有効化します:
 
     ```shell
-    minikube addons enable heapster
+    minikube addons enable metrics-server
     ```
   
     出力:
 
     ```shell
-    heapster was successfully enabled
+    metrics-server was successfully enabled
     ```
 
 3. 作成されたポッドとサービスを確認します:
@@ -205,7 +205,7 @@ Minikubeはビルトインのアドオンがあり、有効化、無効化、あ
 
     ```shell
     NAME                                        READY     STATUS    RESTARTS   AGE
-    pod/heapster-9jttx                          1/1       Running   0          26s
+    pod/metrics-server-6754dbc9df-q8zlg         1/1       Running   0          26s
     pod/influxdb-grafana-b29w8                  2/2       Running   0          26s
     pod/kube-addon-manager-minikube             1/1       Running   0          34m
     pod/kube-dns-6dcb57bcc8-gv7mw               3/3       Running   0          34m
@@ -213,23 +213,23 @@ Minikubeはビルトインのアドオンがあり、有効化、無効化、あ
     pod/storage-provisioner                     1/1       Running   0          34m
 
     NAME                           TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)             AGE
-    service/heapster               ClusterIP   10.96.241.45    <none>        80/TCP              26s
+    service/metrics-server         ClusterIP   10.96.94.175    <none>        443/TCP             26s
     service/kube-dns               ClusterIP   10.96.0.10      <none>        53/UDP,53/TCP       34m
     service/kubernetes-dashboard   NodePort    10.109.29.1     <none>        80:30000/TCP        34m
     service/monitoring-grafana     NodePort    10.99.24.54     <none>        80:30002/TCP        26s
     service/monitoring-influxdb    ClusterIP   10.111.169.94   <none>        8083/TCP,8086/TCP   26s
     ```
 
-4. `heapster`を無効化します:
+4. `metrics-server`を無効化します:
 
     ```shell
-    minikube addons disable heapster
+    minikube addons disable metrics-server
     ```
 
     出力:
 
     ```shell
-    heapster was successfully disabled
+    metrics-server was successfully disabled
     ```
 
 ## クリーンアップ

--- a/content/ko/docs/tutorials/hello-minikube.md
+++ b/content/ko/docs/tutorials/hello-minikube.md
@@ -197,16 +197,16 @@ Minikube에는 활성화하거나 비활성화 할 수 있고 로컬 쿠버네�
     storage-provisioner: enabled
     ```
    
-2. 한 애드온을 활성화 한다. 예를 들어 `heapster`
+2. 한 애드온을 활성화 한다. 예를 들어 `metrics-server`
 
     ```shell
-    minikube addons enable heapster
+    minikube addons enable metrics-server
     ```
   
     출력:
 
     ```shell
-    heapster was successfully enabled
+    metrics-server was successfully enabled
     ```
 
 3. 방금 생성한 파드와 서비스를 확인한다.
@@ -219,7 +219,7 @@ Minikube에는 활성화하거나 비활성화 할 수 있고 로컬 쿠버네�
 
     ```shell
     NAME                                        READY     STATUS    RESTARTS   AGE
-    pod/heapster-9jttx                          1/1       Running   0          26s
+    pod/metrics-server-6754dbc9df-q8zlg         1/1       Running   0          26s
     pod/influxdb-grafana-b29w8                  2/2       Running   0          26s
     pod/kube-addon-manager-minikube             1/1       Running   0          34m
     pod/kube-dns-6dcb57bcc8-gv7mw               3/3       Running   0          34m
@@ -227,23 +227,23 @@ Minikube에는 활성화하거나 비활성화 할 수 있고 로컬 쿠버네�
     pod/storage-provisioner                     1/1       Running   0          34m
 
     NAME                           TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)             AGE
-    service/heapster               ClusterIP   10.96.241.45    <none>        80/TCP              26s
+    service/metrics-server         ClusterIP   10.96.94.175    <none>        443/TCP             26s
     service/kube-dns               ClusterIP   10.96.0.10      <none>        53/UDP,53/TCP       34m
     service/kubernetes-dashboard   NodePort    10.109.29.1     <none>        80:30000/TCP        34m
     service/monitoring-grafana     NodePort    10.99.24.54     <none>        80:30002/TCP        26s
     service/monitoring-influxdb    ClusterIP   10.111.169.94   <none>        8083/TCP,8086/TCP   26s
     ```
 
-4. `heapster` 비활성화
+4. `metrics-server` 비활성화
 
     ```shell
-    minikube addons disable heapster
+    minikube addons disable metrics-server
     ```
   
     출력:
 
     ```shell
-    heapster was successfully disabled
+    metrics-server was successfully disabled
     ```
 
 ## 제거하기

--- a/content/ru/docs/tutorials/hello-minikube.md
+++ b/content/ru/docs/tutorials/hello-minikube.md
@@ -184,16 +184,16 @@ Katacoda предоставляет бесплатную, встроенную �
     storage-provisioner: enabled
     ```
    
-2. Включить расширение, например, `heapster`:
+2. Включить расширение, например, `metrics-server`:
 
     ```shell
-    minikube addons enable heapster
+    minikube addons enable metrics-server
     ```
   
     Вывод:
 
     ```shell
-    heapster was successfully enabled
+    metrics-server was successfully enabled
     ```
 
 3. Посмотреть Pod и Service, которые вы только что создали:
@@ -206,7 +206,7 @@ Katacoda предоставляет бесплатную, встроенную �
 
     ```shell
     NAME                                        READY     STATUS    RESTARTS   AGE
-    pod/heapster-9jttx                          1/1       Running   0          26s
+    pod/metrics-server-6754dbc9df-q8zlg         1/1       Running   0          26s
     pod/influxdb-grafana-b29w8                  2/2       Running   0          26s
     pod/kube-addon-manager-minikube             1/1       Running   0          34m
     pod/kube-dns-6dcb57bcc8-gv7mw               3/3       Running   0          34m
@@ -214,23 +214,23 @@ Katacoda предоставляет бесплатную, встроенную �
     pod/storage-provisioner                     1/1       Running   0          34m
 
     NAME                           TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)             AGE
-    service/heapster               ClusterIP   10.96.241.45    <none>        80/TCP              26s
+    service/metrics-server         ClusterIP   10.96.94.175    <none>        443/TCP             26s
     service/kube-dns               ClusterIP   10.96.0.10      <none>        53/UDP,53/TCP       34m
     service/kubernetes-dashboard   NodePort    10.109.29.1     <none>        80:30000/TCP        34m
     service/monitoring-grafana     NodePort    10.99.24.54     <none>        80:30002/TCP        26s
     service/monitoring-influxdb    ClusterIP   10.111.169.94   <none>        8083/TCP,8086/TCP   26s
     ```
 
-4. Отключить `heapster`:
+4. Отключить `metrics-server`:
 
     ```shell
-    minikube addons disable heapster
+    minikube addons disable metrics-server
     ```
   
     Вывод:
 
     ```shell
-    heapster was successfully disabled
+    metrics-server was successfully disabled
     ```
 
 ## Освобождение ресурсов

--- a/content/zh/docs/tutorials/hello-minikube.md
+++ b/content/zh/docs/tutorials/hello-minikube.md
@@ -337,16 +337,16 @@ Minikube has a set of built-in addons that can be enabled, disabled and opened i
     storage-provisioner: enabled
     ```
 
-2. Enable an addon, for example, `heapster`:
+2. Enable an addon, for example, `metrics-server`:
 
     ```shell
-    minikube addons enable heapster
+    minikube addons enable metrics-server
     ```
 
     Output:
 
     ```shell
-    heapster was successfully enabled
+    metrics-server was successfully enabled
     ```
 
 3. View the Pod and Service you just created:
@@ -359,7 +359,7 @@ Minikube has a set of built-in addons that can be enabled, disabled and opened i
 
     ```shell
     NAME                                        READY     STATUS    RESTARTS   AGE
-    pod/heapster-9jttx                          1/1       Running   0          26s
+    pod/metrics-server-6754dbc9df-q8zlg         1/1       Running   0          26s
     pod/influxdb-grafana-b29w8                  2/2       Running   0          26s
     pod/kube-addon-manager-minikube             1/1       Running   0          34m
     pod/kube-dns-6dcb57bcc8-gv7mw               3/3       Running   0          34m
@@ -367,23 +367,23 @@ Minikube has a set of built-in addons that can be enabled, disabled and opened i
     pod/storage-provisioner                     1/1       Running   0          34m
 
     NAME                           TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)             AGE
-    service/heapster               ClusterIP   10.96.241.45    <none>        80/TCP              26s
+    service/metrics-server         ClusterIP   10.96.94.175    <none>        443/TCP             26s
     service/kube-dns               ClusterIP   10.96.0.10      <none>        53/UDP,53/TCP       34m
     service/kubernetes-dashboard   NodePort    10.109.29.1     <none>        80:30000/TCP        34m
     service/monitoring-grafana     NodePort    10.99.24.54     <none>        80:30002/TCP        26s
     service/monitoring-influxdb    ClusterIP   10.111.169.94   <none>        8083/TCP,8086/TCP   26s
     ```
 
-4. Disable `heapster`:
+4. Disable `metrics-server`:
 
     ```shell
-    minikube addons disable heapster
+    minikube addons disable metrics-server
     ```
 
     Output:
 
     ```shell
-    heapster was successfully disabled
+    metrics-server was successfully disabled
     ```
 -->
 ## 启用插件
@@ -419,13 +419,13 @@ Minikube 有一组内置的插件，可以在本地 Kubernetes 环境中启用�
 2. 启用插件，例如 `heapster`：
 
     ```shell
-    minikube addons enable heapster
+    minikube addons enable metrics-server
     ```
 
     输出:
 
     ```shell
-    heapster was successfully enabled
+    metrics-server was successfully enabled
     ```
 
 3. 查看刚才创建的 Pod 和 Service：
@@ -438,7 +438,7 @@ Minikube 有一组内置的插件，可以在本地 Kubernetes 环境中启用�
 
     ```shell
     NAME                                        READY     STATUS    RESTARTS   AGE
-    pod/heapster-9jttx                          1/1       Running   0          26s
+    pod/metrics-server-6754dbc9df-q8zlg                          1/1       Running   0          26s
     pod/influxdb-grafana-b29w8                  2/2       Running   0          26s
     pod/kube-addon-manager-minikube             1/1       Running   0          34m
     pod/kube-dns-6dcb57bcc8-gv7mw               3/3       Running   0          34m
@@ -446,7 +446,7 @@ Minikube 有一组内置的插件，可以在本地 Kubernetes 环境中启用�
     pod/storage-provisioner                     1/1       Running   0          34m
 
     NAME                           TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)             AGE
-    service/heapster               ClusterIP   10.96.241.45    <none>        80/TCP              26s
+ service/metrics-server         ClusterIP   10.96.94.175    <none>        443/TCP             26s
     service/kube-dns               ClusterIP   10.96.0.10      <none>        53/UDP,53/TCP       34m
     service/kubernetes-dashboard   NodePort    10.109.29.1     <none>        80:30000/TCP        34m
     service/monitoring-grafana     NodePort    10.99.24.54     <none>        80:30002/TCP        26s
@@ -456,13 +456,13 @@ Minikube 有一组内置的插件，可以在本地 Kubernetes 环境中启用�
 4. 禁用 `heapster`：
 
     ```shell
-    minikube addons disable heapster
+    minikube addons disable metrics-server
     ```
 
     输出:
 
     ```shell
-    heapster was successfully disabled
+    metrics-server was successfully disabled
     ```
 
 <!--


### PR DESCRIPTION
Fixes #18420 

Replace Heapster usages with Metrics Server as Heapster is no longer available via Minikube.