### PR TITLE
bootstrap-tokens: promote to GA in 1.18

### DIFF
--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -120,7 +120,7 @@ Authorization: Bearer 31ada4fd-adec-460c-809a-9e56ceb75269
 
 ### Bootstrap Tokens
 
-This feature is currently in **beta**.
+{{< feature-state for_k8s_version="v1.18" state="stable" >}}
 
 To allow for streamlined bootstrapping for new clusters, Kubernetes includes a
 dynamically-managed Bearer token type called a *Bootstrap Token*. These tokens

--- a/content/en/docs/reference/access-authn-authz/bootstrap-tokens.md
+++ b/content/en/docs/reference/access-authn-authz/bootstrap-tokens.md
@@ -7,6 +7,9 @@ weight: 20
 ---
 
 {{% capture overview %}}
+
+{{< feature-state for_k8s_version="v1.18" state="stable" >}}
+
 Bootstrap tokens are a simple bearer token that is meant to be used when
 creating new clusters or joining new nodes to an existing cluster.  It was built
 to support [kubeadm](/docs/reference/setup-tools/kubeadm/kubeadm/), but can be used in other contexts
@@ -25,8 +28,6 @@ API Server.  Expired tokens are removed with the TokenCleaner controller in the
 Controller Manager.  The tokens are also used to create a signature for a
 specific ConfigMap used in a "discovery" process through a BootstrapSigner
 controller.
-
-{{< feature-state state="beta" >}}
 
 ## Token Format
 
@@ -115,7 +116,7 @@ authenticate to the API server as a bearer token.
 `cluster-info` ConfigMap as described below.
 
 The `expiration` field controls the expiry of the token.  Expired tokens are
-rejected when used for authentication and ignored during ConfigMap signing. 
+rejected when used for authentication and ignored during ConfigMap signing.
 The expiry value is encoded as an absolute UTC time using RFC3339.  Enable the
 `tokencleaner` controller to automatically delete expired tokens.
 

--- a/content/en/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping.md
+++ b/content/en/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping.md
@@ -117,7 +117,7 @@ While any authentication strategy can be used for the kubelet's initial
 bootstrap credentials, the following two authenticators are recommended for ease
 of provisioning.
 
-1. [Bootstrap Tokens](#bootstrap-tokens) - __beta__
+1. [Bootstrap Tokens](#bootstrap-tokens)
 2. [Token authentication file](#token-authentication-file)
 
 Bootstrap tokens are a simpler and more easily managed method to authenticate kubelets, and do not require any additional flags when starting kube-apiserver. 


### PR DESCRIPTION
we found there is nothing else to do for bootstrap tokens v1, so we are promoting them in the docs for v1.18. see https://github.com/kubernetes/kubernetes/pull/77669#issuecomment-545590770

tracking issue in kubeadm:
fixes kubernetes/kubeadm#964

related but a much bigger feature / effort (stale):
https://github.com/kubernetes/enhancements/issues/130

this graduation does not have a k/enhancements ticket.

/sig cluster-lifecycle
/kind feature
/assign @fabriziopandini 
@kubernetes/sig-cluster-lifecycle-pr-reviews 
