### PR TITLE
 Add note on `none` driver in minikube installation docs

### DIFF
--- a/content/en/docs/tasks/tools/install-minikube.md
+++ b/content/en/docs/tasks/tools/install-minikube.md
@@ -74,15 +74,15 @@ If you do not already have a hypervisor installed, install one of these now:
 
 • [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
 
-{{< note >}}
 Minikube also supports a `--vm-driver=none` option that runs the Kubernetes components on the host and not in a VM.
 Using this driver requires [Docker](https://www.docker.com/products/docker-desktop) and a Linux environment but not a hypervisor.
 It is recommended to use the apt installation of docker from [Docker](https://www.docker.com/products/docker-desktop), when using the none driver.
 (The snap installation of docker does not work with minikube.)
 
+{{< caution >}}
 The `none` VM driver can result in security and data loss issues.
 Before using `--vm-driver=none`, consult [this documentation](https://minikube.sigs.k8s.io/docs/reference/drivers/none/) for more information.
-{{< /note >}}
+{{< /caution >}}
 
 ### Install Minikube using a package
 

--- a/content/en/docs/tasks/tools/install-minikube.md
+++ b/content/en/docs/tasks/tools/install-minikube.md
@@ -79,6 +79,9 @@ Minikube also supports a `--vm-driver=none` option that runs the Kubernetes comp
 Using this driver requires [Docker](https://www.docker.com/products/docker-desktop) and a Linux environment but not a hypervisor.
 It is recommended to use the apt installation of docker from [Docker](https://www.docker.com/products/docker-desktop), when using the none driver.
 (The snap installation of docker does not work with minikube.)
+
+The `none` VM driver can result in security and data loss issues.
+Before using `--vm-driver=none`, consult [this documentation](https://minikube.sigs.k8s.io/docs/reference/drivers/none/) for more information.
 {{< /note >}}
 
 ### Install Minikube using a package

--- a/content/en/docs/tasks/tools/install-minikube.md
+++ b/content/en/docs/tasks/tools/install-minikube.md
@@ -76,8 +76,10 @@ If you do not already have a hypervisor installed, install one of these now:
 
 Minikube also supports a `--vm-driver=none` option that runs the Kubernetes components on the host and not in a VM.
 Using this driver requires [Docker](https://www.docker.com/products/docker-desktop) and a Linux environment but not a hypervisor.
-It is recommended to use the apt installation of docker from [Docker](https://www.docker.com/products/docker-desktop), when using the none driver.
-(The snap installation of docker does not work with minikube.)
+
+If you're using the `none` driver in Debian or a derivative, use the `.deb` packages for
+Docker rather than the snap package, which does not work with Minikube.
+You can download `.deb` packages from [Docker](https://www.docker.com/products/docker-desktop).
 
 {{< caution >}}
 The `none` VM driver can result in security and data loss issues.

--- a/content/en/docs/tasks/tools/install-minikube.md
+++ b/content/en/docs/tasks/tools/install-minikube.md
@@ -75,7 +75,10 @@ If you do not already have a hypervisor installed, install one of these now:
 • [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
 
 {{< note >}}
-Minikube also supports a `--vm-driver=none` option that runs the Kubernetes components on the host and not in a VM. Using this driver requires [Docker](https://www.docker.com/products/docker-desktop) and a Linux environment but not a hypervisor. It is recommended to use the apt installation of docker from [Docker](https://www.docker.com/products/docker-desktop), when using the none driver. The snap installation of docker does not work with minikube.
+Minikube also supports a `--vm-driver=none` option that runs the Kubernetes components on the host and not in a VM.
+Using this driver requires [Docker](https://www.docker.com/products/docker-desktop) and a Linux environment but not a hypervisor.
+It is recommended to use the apt installation of docker from [Docker](https://www.docker.com/products/docker-desktop), when using the none driver.
+(The snap installation of docker does not work with minikube.)
 {{< /note >}}
 
 ### Install Minikube using a package


### PR DESCRIPTION
Add a note describing security/data-loss concerns when using `--vm-driver=none`, links to relevant documentation.