### PR TITLE
Modify reference links for translated documents added from previous branches.

### DIFF
--- a/content/ko/docs/concepts/services-networking/endpoint-slices.md
+++ b/content/ko/docs/concepts/services-networking/endpoint-slices.md
@@ -92,6 +92,6 @@ EndpointSlice는 다음 주소 유형을 지원한다.
 {{% capture whatsnext %}}
 
 * [엔드포인트 슬라이스 활성화하기](/docs/tasks/administer-cluster/enabling-endpointslices)
-* [애플리케이션을 서비스와 함께 연결하기](/docs/concepts/services-networking/connect-applications-service/) 를 읽는다.
+* [애플리케이션을 서비스와 함께 연결하기](/ko/docs/concepts/services-networking/connect-applications-service/) 를 읽는다.
 
 {{% /capture %}}

--- a/content/ko/docs/reference/issues-security/issues.md
+++ b/content/ko/docs/reference/issues-security/issues.md
@@ -3,7 +3,7 @@ title: 쿠버네티스 이슈 트래커
 weight: 10
 ---
 
-보안 문제를 보고하려면 [쿠버네티스 보안 공개 프로세스](/docs/reference/issues-security/security/#report-a-vulnerability)를 따른다.
+보안 문제를 보고하려면 [쿠버네티스 보안 공개 프로세스](/ko/docs/reference/issues-security/security/#취약점-보고)를 따른다.
 
 쿠버네티스 코드 작업 및 공개 이슈는 [깃허브 이슈](https://github.com/kubernetes/kubernetes/issues/)를 사용하여 추적된다.
 

--- a/content/ko/docs/tutorials/services/source-ip.md
+++ b/content/ko/docs/tutorials/services/source-ip.md
@@ -346,7 +346,7 @@ $ kubectl delete deployment source-ip-app
 {{% /capture %}}
 
 {{% capture whatsnext %}}
-* [서비스를 통한 애플리케이션 연결하기](/docs/concepts/services-networking/connect-applications-service/)에 대해 더 공부하기
+* [서비스를 통한 애플리케이션 연결하기](/ko/docs/concepts/services-networking/connect-applications-service/)에 대해 더 공부하기
 * [부하분산](/docs/user-guide/load-balancer)에 대해 더 공부하기
 {{% /capture %}}
 

--- a/content/ko/docs/tutorials/stateless-application/expose-external-ip-address.md
+++ b/content/ko/docs/tutorials/stateless-application/expose-external-ip-address.md
@@ -158,6 +158,6 @@ Hello World 애플리케이션을 실행 중인 디플로이먼트, 레플리카
 
 {{% capture whatsnext %}}
 
-[애플리케이션과 서비스 연결하기](/docs/concepts/services-networking/connect-applications-service/)에 대해
+[애플리케이션과 서비스 연결하기](/ko/docs/concepts/services-networking/connect-applications-service/)에 대해
 더 배워 본다.
 {{% /capture %}}

--- a/content/ko/docs/tutorials/stateless-application/guestbook.md
+++ b/content/ko/docs/tutorials/stateless-application/guestbook.md
@@ -362,7 +362,7 @@ Google Compute Engine 또는 Google Kubernetes Engine과 같은 일부 클라우
 * [ELK 로깅과 모니터링](/ko/docs/tutorials/stateless-application/guestbook-logs-metrics-with-elk/)을 방명록 애플리케이션에 추가하기
 * [쿠버네티스 기초](/ko/docs/tutorials/kubernetes-basics/) 튜토리얼을 완료
 * [MySQL과 Wordpress을 위한 퍼시스턴트 볼륨](/ko/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/#visit-your-new-wordpress-blog)을 사용하여 블로그 생성하는데 쿠버네티스 이용하기
-* [애플리케이션 접속](/docs/concepts/services-networking/connect-applications-service/)에 대해 더 알아보기
+* [애플리케이션 접속](/ko/docs/concepts/services-networking/connect-applications-service/)에 대해 더 알아보기
 * [자원 관리](/docs/concepts/cluster-administration/manage-deployment/#using-labels-effectively)에 대해 더 알아보기
 {{% /capture %}}
 


### PR DESCRIPTION
dev-1.17-ko.1에서 추가된 신규문서의 원문을 링크로 가지고 있는 문서들을 수정했습니다.

from #18431 
/language ko