### PR TITLE
fix documentation conflict regarding postStart 

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -186,7 +186,7 @@ Once Pod is assigned to a node by scheduler, kubelet starts creating containers 
 	  ...
    ```
    
-* `Running`: Indicates that the container is executing without issues. Once a container enters into Running, `postStart` hook (if any) is executed. This state also displays the time when the container entered Running state.  
+* `Running`: Indicates that the container is executing without issues. The `postStart` hook (if any) is executed prior to the container entering a Running state. This state also displays the time when the container entered Running state.
    
    ```yaml
    ...


### PR DESCRIPTION
Fix the documentation conflict regarding postStart on the page - https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-states

Current observed behavior is documented here - 

https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/#discussion
`The Container’s status is not set to RUNNING until the postStart handler completes.`

Fixes issue [#17795](https://github.com/kubernetes/website/issues/17795)