### PR TITLE
add kubectl diff to cheatsheet

### DIFF
--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -195,6 +195,9 @@ kubectl get pods -o json | jq '.items[].spec.containers[].env[]?.valueFrom.secre
 
 # List Events sorted by timestamp
 kubectl get events --sort-by=.metadata.creationTimestamp
+
+# Compares the current state of the cluster against the state that the cluster would be in if the manifest was applied.
+kubectl diff -f ./my-manifest.yaml
 ```
 
 ## Updating Resources


### PR DESCRIPTION
Add `kubectl diff` to cheatsheet as `kubectl diff` is already GA.
Part of https://github.com/kubernetes/kubernetes/issues/86525.