### PR TITLE
Unify runtime references

### DIFF
--- a/content/en/docs/concepts/containers/runtime-class.md
+++ b/content/en/docs/concepts/containers/runtime-class.md
@@ -120,7 +120,7 @@ For more details on setting up CRI runtimes, see [CRI installation](/docs/setup/
 
 Kubernetes built-in dockershim CRI does not support runtime handlers.
 
-#### [containerd](https://containerd.io/)
+#### {{< glossary_tooltip term_id="containerd" >}}
 
 Runtime handlers are configured through containerd's configuration at
 `/etc/containerd/config.toml`. Valid handlers are configured under the runtimes section:
@@ -132,19 +132,20 @@ Runtime handlers are configured through containerd's configuration at
 See containerd's config documentation for more details:
 https://github.com/containerd/cri/blob/master/docs/config.md
 
-#### [cri-o](https://cri-o.io/)
+#### {{< glossary_tooltip term_id="cri-o" >}}
 
-Runtime handlers are configured through cri-o's configuration at `/etc/crio/crio.conf`. Valid
+Runtime handlers are configured through CRI-O's configuration at `/etc/crio/crio.conf`. Valid
 handlers are configured under the [crio.runtime
-table](https://github.com/kubernetes-sigs/cri-o/blob/master/docs/crio.conf.5.md#crioruntime-table):
+table](https://github.com/cri-o/cri-o/blob/master/docs/crio.conf.5.md#crioruntime-table):
 
 ```
 [crio.runtime.runtimes.${HANDLER_NAME}]
   runtime_path = "${PATH_TO_BINARY}"
 ```
 
-See cri-o's config documentation for more details:
-https://github.com/kubernetes-sigs/cri-o/blob/master/cmd/crio/config.go
+See CRI-O's [config documentation][100] for more details.
+
+[100]: https://raw.githubusercontent.com/cri-o/cri-o/9f11d1d/docs/crio.conf.5.md
 
 ### Scheduling
 

--- a/content/en/docs/reference/glossary/container-runtime.md
+++ b/content/en/docs/reference/glossary/container-runtime.md
@@ -15,7 +15,7 @@ tags:
 
 <!--more-->
 
-Kubernetes supports several container runtimes: [Docker](http://www.docker.com),
-[containerd](https://containerd.io), [cri-o](https://cri-o.io/),
-[rktlet](https://github.com/kubernetes-incubator/rktlet) and any implementation of
-the [Kubernetes CRI (Container Runtime Interface)](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/container-runtime-interface.md).
+Kubernetes supports several container runtimes: {{< glossary_tooltip term_id="docker">}},
+{{< glossary_tooltip term_id="containerd" >}}, {{< glossary_tooltip term_id="cri-o" >}},
+and any implementation of the [Kubernetes CRI (Container Runtime
+Interface)](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/container-runtime-interface.md).

--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -136,7 +136,7 @@ If the container runtime of choice is Docker, it is used through the built-in
 
 Other CRI-based runtimes include:
 
-- [containerd](https://github.com/containerd/cri) (CRI plugin built into containerd)
+- [containerd/cri](https://github.com/containerd/cri) (CRI plugin built into containerd)
 - [cri-o](https://cri-o.io/)
 - [frakti](https://github.com/kubernetes/frakti)
 

--- a/content/en/docs/setup/production-environment/tools/kubespray.md
+++ b/content/en/docs/setup/production-environment/tools/kubespray.md
@@ -62,9 +62,9 @@ Kubespray provides the ability to customize many aspects of the deployment:
 * Component versions
 * Calico route reflectors
 * Component runtime options
-  * docker
-  * rkt
-  * cri-o
+  * {{< glossary_tooltip term_id="docker" >}}
+  * {{< glossary_tooltip term_id="rkt" >}}
+  * {{< glossary_tooltip term_id="cri-o" >}}
 * Certificate generation methods (**Vault being discontinued**)
 
 Kubespray customizations can be made to a [variable file](http://docs.ansible.com/ansible/playbooks_variables.html). If you are just getting started with Kubespray, consider using the Kubespray defaults to deploy your cluster and explore Kubernetes.


### PR DESCRIPTION
- Use the glossary to correctly reference runtimes
- Updated runtime class documentation for CRI-O
- Removed rktlet from runtimes since its EOL
