### PR TITLE
Fixes list rendering

### DIFF
--- a/content/en/docs/reference/access-authn-authz/extensible-admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/extensible-admission-controllers.md
@@ -961,6 +961,7 @@ Allowed values are `Exact` or `Equivalent`.
 * `Equivalent` means a request should be intercepted if modifies a resource listed in `rules`, even via another API group or version.
 
 In the example given above, the webhook that only registered for `apps/v1` could use `matchPolicy`:
+
 * `matchPolicy: Exact` would mean the `extensions/v1beta1` request would not be sent to the webhook
 * `matchPolicy: Equivalent` means the `extensions/v1beta1` request would be sent to the webhook (with the objects converted to a version the webhook had specified: `apps/v1`)
 


### PR DESCRIPTION
There is an issue with rendering one of the list on [this](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/) page.

<details>
  <summary>Very important screenshots</summary>
  Before:

<img width="636" alt="Screenshot 2020-01-06 at 21 40 14" src="https://user-images.githubusercontent.com/509198/71850964-60484780-30cd-11ea-9af7-f483c52915d9.png">

After:

<img width="630" alt="Screenshot 2020-01-06 at 21 40 59" src="https://user-images.githubusercontent.com/509198/71850975-65a59200-30cd-11ea-852b-8ab3f7ad42e3.png">
</details>


