### PR TITLE
Add blog post to memorialize Brad Childs

### DIFF
--- a/content/en/blog/_posts/2020-01-10-Remembering-Brad-Childs.md
+++ b/content/en/blog/_posts/2020-01-10-Remembering-Brad-Childs.md
@@ -1,0 +1,23 @@
+---
+layout: blog
+title: "Remembering Brad Childs"
+date: 2020-01-10T10:00:00-08:00
+slug: Remembering-Brad-Childs
+---
+
+**Authors:** Paul Morie, Red Hat
+
+Earlier this year, the Kubernetes family lost one of its own. Brad Childs was a
+SIG Storage chair and long time contributor to the project. Brad worked on a
+number of features in storage and was known as much for his friendliness and
+sense of humor as for his technical contributions and leadership.
+
+We recently spent time remembering Brad at Kubecon NA:
+
+- [A Tribute to Bradley Childs](https://youtu.be/4eI2PTAJ-sE)
+- [CNCF Memorial](https://github.com/cncf/memorials/blob/master/bradley-childs.md)
+
+Our hearts go out to Brad’s friends and family and others whose lives he touched
+inside and outside the Kubernetes community.
+
+Thank you for everything, Brad. We’ll miss you.


### PR DESCRIPTION
This PR adds a blog post (created with the Kubernetes steering committee and others) to memorialize Brad Childs. I've made the publication date Jan 10 as a placeholder but I will change that as we decide on the date.