### PR TITLE
Use built-in version check & metadata for CRD versions task

### DIFF
--- a/content/en/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning.md
+++ b/content/en/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning.md
@@ -5,6 +5,7 @@ reviewers:
 - liggitt
 content_template: templates/task
 weight: 30
+min-kubernetes-server-version: v1.16
 ---
 
 {{% capture overview %}}
@@ -16,19 +17,17 @@ level of your CustomResourceDefinitions or advance your API to a new version wit
 
 {{% capture prerequisites %}}
 
-{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+{{< include "task-tutorial-prereqs.md" >}}
 
-* Make sure your Kubernetes cluster has a master version of 1.16.0 or higher for `apiextensions.k8s.io/v1`, or 1.11.0 or higher for `apiextensions.k8s.io/v1beta1`.
+You should have a initial understanding of [custom resources](/docs/concepts/api-extension/custom-resources/).
 
-* Read about [custom resources](/docs/concepts/api-extension/custom-resources/).
+{{< version-check >}}
 
 {{% /capture %}}
 
 {{% capture steps %}}
 
 ## Overview
-
-{{< feature-state state="stable" for_kubernetes_version="1.16" >}}
 
 The CustomResourceDefinition API provides a workflow for introducing and upgrading
 to new versions of a CustomResourceDefinition.


### PR DESCRIPTION
Update https://k8s.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning/ to specify cluster version requirement (v1.16 or later) using metadata and a shortcode, rather than natural language.

If you want documentation for a version before v1.16, there's a separate mechanism to find older documentation. I hope that's good enough; it should be.

/kind cleanup
/sig api-machinery