### PR TITLE
Improve CronJob page

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/en/docs/concepts/workloads/controllers/cron-jobs.md
@@ -21,6 +21,11 @@ on a given schedule, written in [Cron](https://en.wikipedia.org/wiki/Cron) forma
 All **CronJob** `schedule:` times are based on the timezone of the master where the job is initiated.
 {{< /note >}}
 
+When creating the manifest for a CronJob resource, make sure the name you provide
+is no longer than 52 characters. This is because the CronJob controller will automatically
+append 11 characters to the job name provided and there is a constraint that the
+maximum length of a job name is no more than 63 characters.
+
 For instructions on creating and working with cron jobs, and for an example of a spec file for a cron job, see [Running automated tasks with cron jobs](/docs/tasks/job/automated-tasks-with-cron-jobs).
 
 {{% /capture %}}

--- a/content/en/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/en/docs/concepts/workloads/controllers/cron-jobs.md
@@ -24,7 +24,7 @@ All **CronJob** `schedule:` times are based on the timezone of the master where 
 When creating the manifest for a CronJob resource, make sure the name you provide
 is no longer than 52 characters. This is because the CronJob controller will automatically
 append 11 characters to the job name provided and there is a constraint that the
-maximum length of a job name is no more than 63 characters.
+maximum length of a Job name is no more than 63 characters.
 
 For instructions on creating and working with cron jobs, and for an example of a spec file for a cron job, see [Running automated tasks with cron jobs](/docs/tasks/job/automated-tasks-with-cron-jobs).
 


### PR DESCRIPTION
This PR adds a note about the special constraint on CronJob names. The constraint is not captured in the API specification or anywhere else to my knowledge.