### PR TITLE
Fix CoreDNS requirement for ExternalName Service

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -485,7 +485,7 @@ The default is `ClusterIP`.
 
      with its value. No proxying of any kind is set up.
      {{< note >}}
-     You need CoreDNS version 1.7 or higher to use the `ExternalName` type.
+     You need either kube-dns version 1.7 or CoreDNS version 0.0.8 or higher to use the `ExternalName` type.
      {{< /note >}}
 
 You can also use [Ingress](/docs/concepts/services-networking/ingress/) to expose your Service. Ingress is not a Service type, but it acts as the entry point for your cluster. It lets you consolidate your routing rules into a single resource as it can expose multiple services under the same IP address.

--- a/content/zh/docs/concepts/services-networking/service.md
+++ b/content/zh/docs/concepts/services-networking/service.md
@@ -815,7 +815,7 @@ The default is `ClusterIP`.
 
      with its value. No proxying of any kind is set up.
      {{< note >}}
-     You need CoreDNS version 1.7 or higher to use the `ExternalName` type.
+     You need either kube-dns version 1.7 or CoreDNS version 0.0.8 or higher to use the `ExternalName` type.
      {{< /note >}}
 
 You can also use [Ingress](/docs/concepts/services-networking/ingress/) to expose your Service. Ingress is not a Service type, but it acts as the entry point for your cluster. It lets you consolidate your routing rules into a single resource as it can expose multiple services under the same IP address.


### PR DESCRIPTION
The most recent CoreDNS release today is https://github.com/coredns/coredns/releases/tag/v1.6.6. Requiring 1.7 CoreDNS is therefore not very realistic :)

The `ExternalName` support to CoreDNS was added in https://github.com/coredns/coredns/pull/677, and should be released in https://github.com/coredns/coredns/releases/tag/v008. The https://github.com/kubernetes/website/pull/14526 has swapped `kube-dns` to CoreDNS without correcting the versioning.