### PR TITLE
Add blog image OWNERS

### DIFF
--- a/static/images/blog/OWNERS
+++ b/static/images/blog/OWNERS
@@ -1,0 +1,12 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# Owned by Kubernetes Blog reviewers
+
+approvers:
+  - sig-docs-blog-owners # Defined in OWNERS_ALIASES
+
+reviewers:
+  -  sig-docs-blog-reviewers # Defined in OWNERS_ALIASES
+
+labels:
+  - area/blog


### PR DESCRIPTION
Noticed in https://github.com/kubernetes/website/pull/18229#issuecomment-572581072 That the approve label wasn't applied because their blog post had images.

This adds a copy of the owners file in [content/en/blog](https://github.com/kubernetes/website/blob/master/content/en/blog/OWNERS) to the blog sub-directory under static/images.

/cc @kbarnard10 @castrojo 