### PR TITLE
Appending the kustomization.yaml issue

### DIFF
--- a/content/en/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
+++ b/content/en/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
@@ -114,13 +114,13 @@ the name of the MySQL Service defined above, and WordPress will access the datab
       
 3. Add them to `kustomization.yaml` file.
 
-      ```shell
-      cat <<EOF >>./kustomization.yaml
-      resources:
-        - mysql-deployment.yaml
-        - wordpress-deployment.yaml
-      EOF
-      ```
+```shell
+cat <<EOF >>./kustomization.yaml
+resources:
+  - mysql-deployment.yaml
+  - wordpress-deployment.yaml
+EOF
+```
 
 ## Apply and Verify
 The `kustomization.yaml` contains all the resources for deploying a WordPress site and a 


### PR DESCRIPTION
Running the second part of filling the `kustomization.yaml`  using `cat` an issue arrises where the command breaks due to the additional white spaces. 
This could cause further issues for the reader might mistake the command as to replace the file content, and this will break the proper functioning of the cluster
