### PR TITLE
jobs: clarify that there is no `restartPolicy` for the job itself

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/jobs-run-to-completion.md
+++ b/content/en/docs/concepts/workloads/controllers/jobs-run-to-completion.md
@@ -265,6 +265,9 @@ spec:
 
 Note that both the Job spec and the [Pod template spec](/docs/concepts/workloads/pods/init-containers/#detailed-behavior) within the Job have an `activeDeadlineSeconds` field. Ensure that you set this field at the proper level.
 
+Keep in mind that the `restartPolicy` applies to the Pod, and not to the Job itself: there is no automatic Job restart once the Job status is `type: Failed`.
+That is, the Job termination mechanisms activated with `.spec.activeDeadlineSeconds` and `.spec.backoffLimit` result in a permanent Job failure that requires manual intervention to resolve.
+
 ## Clean Up Finished Jobs Automatically
 
 Finished Jobs are usually no longer needed in the system. Keeping them around in


### PR DESCRIPTION
From the commit message:
```
Sometimes, as it happened to me, a Pod's `restartPolicy` 
is mistakenly taken as the corresponding Job's restart policy.

That was concluded before, here:
https://github.com/kubernetes/community/pull/583/files

The confusion happened here:
https://github.com/kubernetes/kubernetes/issues/30243
https://github.com/kubernetes/kubernetes/issues/43964

And here:
https://github.com/jaegertracing/jaeger-kubernetes/issues/32

This commit tries to clarify that there is no `restartPolicy` for
the job itself, and that using either of `backoffLimit` and
`activeDeadlineSeconds` may result in permanent failure.
```

Feedback welcome! This is my first (attempted) contribution to the Kubernetes docs. Let me know what you think, happy to iterate.

