### PR TITLE
examples/minikube/Dockerfile: modify CMD to use exec form

### DIFF
--- a/content/en/examples/minikube/Dockerfile
+++ b/content/en/examples/minikube/Dockerfile
@@ -1,4 +1,4 @@
 FROM node:6.14.2
 EXPOSE 8080
 COPY server.js .
-CMD node server.js
+CMD [ "node", "server.js" ]


### PR DESCRIPTION
Quote from https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#cmd:

>CMD should almost always be used in the form of CMD ["executable", "param1", "param2"…]

This is because shell form doesn't pass a signal to an executable and that leads to a longer shutdown time as Docker has to kill a process after some timeout. See for details: https://docs.docker.com/engine/reference/builder/#shell-form-entrypoint-example

An example on the NodeJS site is also uses that form: https://nodejs.org/en/docs/guides/nodejs-docker-webapp/#creating-a-dockerfile

Translations (at least Russian) also should be updated but as far I understand it should be done in separate PRs.
