### PR TITLE
Install legacy iptables binaries for Ubuntu/Debian

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -66,6 +66,10 @@ switching to legacy mode, and is therefore incompatible with current kubeadm pac
 {{< tabs name="iptables_legacy" >}}
 {{% tab name="Debian or Ubuntu" %}}
 ```bash
+# ensure legacy binaries are installed
+sudo apt-get install -y iptables arptables ebtables
+
+# switch to legacy versions
 sudo update-alternatives --set iptables /usr/sbin/iptables-legacy
 sudo update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
 sudo update-alternatives --set arptables /usr/sbin/arptables-legacy


### PR DESCRIPTION
On the latest Debian 10, the `arptables-legacy` and `ebtables-legacy` binaries are not installed by default. Although the (non-legacy) versions are installed by default, it appears the respective packages that provide the legacy binaries must be installed in order to switch to the legacy alternatives. If you attempt to switch to the legacy alternatives without installing the `arptables` and `ebtables` packages, you will see an error:
```
update-alternatives: error: alternative /usr/sbin/arptables-legacy for arptables not registered; not setting
```

I have confirmed that the packages are present on Debian 10 and Ubuntu 19.10 and they provide the legacy alternatives. See:
* https://packages.ubuntu.com/eoan/amd64/iptables/filelist
* https://packages.ubuntu.com/eoan/amd64/arptables/filelist
* https://packages.ubuntu.com/eoan/amd64/ebtables/filelist
* https://packages.debian.org/buster/amd64/iptables/filelist
* https://packages.debian.org/buster/amd64/arptables/filelist
* https://packages.debian.org/buster/amd64/ebtables/filelist