### PR TITLE
(doc-fix): Removing extra space in kubectl command

### DIFF
--- a/content/en/docs/concepts/policy/limit-range.md
+++ b/content/en/docs/concepts/policy/limit-range.md
@@ -108,7 +108,7 @@ kubectl apply -f https://k8s.io/examples/admin/resource/limit-range-pod-1.yaml -
 View the `busybox-cnt01` resource configuration:
 
 ```shell
-kubectl get  po/busybox1 -n limitrange-demo -o json | jq ".spec.containers[0].resources"
+kubectl get po/busybox1 -n limitrange-demo -o json | jq ".spec.containers[0].resources"
 ```
 
 ```json
@@ -135,7 +135,7 @@ kubectl get  po/busybox1 -n limitrange-demo -o json | jq ".spec.containers[0].re
 View the  `busybox-cnt02` resource configuration
 
 ```shell
-kubectl get  po/busybox1 -n limitrange-demo -o json | jq ".spec.containers[1].resources"
+kubectl get po/busybox1 -n limitrange-demo -o json | jq ".spec.containers[1].resources"
 ```
 
 ```json
@@ -161,7 +161,7 @@ kubectl get  po/busybox1 -n limitrange-demo -o json | jq ".spec.containers[1].re
 View the `busybox-cnt03` resource configuration
 
 ```shell
-kubectl get  po/busybox1 -n limitrange-demo -o json | jq ".spec.containers[2].resources"
+kubectl get po/busybox1 -n limitrange-demo -o json | jq ".spec.containers[2].resources"
 ```
 ```json
 {
@@ -187,7 +187,7 @@ kubectl get  po/busybox1 -n limitrange-demo -o json | jq ".spec.containers[2].re
 View the `busybox-cnt04` resource configuration:
 
 ```shell
-kubectl get  po/busybox1 -n limitrange-demo -o json | jq ".spec.containers[3].resources"
+kubectl get po/busybox1 -n limitrange-demo -o json | jq ".spec.containers[3].resources"
 ```
 
 ```json
@@ -260,7 +260,7 @@ Error from server (Forbidden): error when creating "limit-range-pod-2.yaml": pod
 ```
 
 ```shell
-kubectl get  po/busybox1  -n limitrange-demo -o json | jq ".spec.containers[].resources.limits.memory"
+kubectl get po/busybox1 -n limitrange-demo -o json | jq ".spec.containers[].resources.limits.memory"
 "200Mi"
 "900Mi"
 "200Mi"


### PR DESCRIPTION
Signed-off-by: Raj <mail.rajdas@gmail.com>
removing extra space in some kubectl commands
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> Remember to delete this note before submitting your pull request.
>
> For pull requests on 1.18 Features: set Milestone to 1.18 and Base Branch to dev-1.18
>
> For pull requests on Chinese localization, set Base Branch to release-1.16
> Feel free to ask questions in #kubernetes-docs-zh
>
> For pull requests on Korean Localization: set Base Branch to dev-1.16-ko.\<latest team milestone>
>
> If you need Help on editing and submitting pull requests, visit:
> https://kubernetes.io/docs/contribute/start/#improve-existing-content.
>
> If you need Help on choosing which branch to use, visit:
> https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use.
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
