### PR TITLE
en: Remove kubectl duplicate example

### DIFF
--- a/content/en/docs/reference/kubectl/overview.md
+++ b/content/en/docs/reference/kubectl/overview.md
@@ -343,9 +343,6 @@ kubectl delete -f pod.yaml
 # Delete all the pods and services that have the label name=<label-name>.
 kubectl delete pods,services -l name=<label-name>
 
-# Delete all the pods and services that have the label name=<label-name>.
-kubectl delete pods,services -l name=<label-name>
-
 # Delete all pods, including uninitialized ones.
 kubectl delete pods --all
 ```


### PR DESCRIPTION
With #16974 and the removal of --include-uninitialized flag, the second
and third examples of kubectl delete become equal, thus leading to
duplication and being confusing. Suggest to remove the duplicate and
replace it with another example in the future if needed.

Observed in v1.16 and v1.17 documentation.

Signed-off-by: Mariyan Dimitrov <mariyan.dimitrov@gmail.com>