### PR TITLE
Update vmware shared folder location

### DIFF
--- a/content/en/docs/setup/learning-environment/minikube.md
+++ b/content/en/docs/setup/learning-environment/minikube.md
@@ -409,7 +409,7 @@ Host folder sharing is not implemented in the KVM driver yet.
 | VirtualBox | Linux | /home | /hosthome |
 | VirtualBox | macOS | /Users | /Users |
 | VirtualBox | Windows | C://Users | /c/Users |
-| VMware Fusion | macOS | /Users | /Users |
+| VMware Fusion | macOS | /Users | /mnt/hgfs/Users |
 | Xhyve | macOS | /Users | /Users |
 
 ## Private Container Registries


### PR DESCRIPTION
Related https://github.com/kubernetes/minikube/issues/6013

When using the `vmware` driver  for minikube the shared folder will be in `/mnt/hgfs` instead of directly on root `/`.
