### PR TITLE
WIP: add indoclink for fixing multilingual linking issue.

### DIFF
--- a/content/en/docs/concepts/scheduling/kube-scheduler.md
+++ b/content/en/docs/concepts/scheduling/kube-scheduler.md
@@ -181,6 +181,8 @@ kube-scheduler has a default set of scheduling policies.
 {{% /capture %}}
 {{% capture whatsnext %}}
 * Read about [scheduler performance tuning](/docs/concepts/scheduling/scheduler-perf-tuning/)
+* Read about [scheduler performance tuning]({{< indoclink pagepath="/docs/concepts/scheduling/scheduler-perf-tuning/" >}})
+* Read about [Pod topology spread constraints]({{< indoclink pagepath="docs/concepts/workloads/pods/pod-topology-spread-constraints/" >}})
 * Read about [Pod topology spread constraints](/docs/concepts/workloads/pods/pod-topology-spread-constraints/)
 * Read the [reference documentation](/docs/reference/command-line-tools-reference/kube-scheduler/) for kube-scheduler
 * Learn about [configuring multiple schedulers](/docs/tasks/administer-cluster/configure-multiple-schedulers/)

--- a/content/en/docs/concepts/scheduling/kube-scheduler.md
+++ b/content/en/docs/concepts/scheduling/kube-scheduler.md
@@ -181,8 +181,8 @@ kube-scheduler has a default set of scheduling policies.
 {{% /capture %}}
 {{% capture whatsnext %}}
 * Read about [scheduler performance tuning](/docs/concepts/scheduling/scheduler-perf-tuning/)
-* Read about [scheduler performance tuning]({{< indoclink pagepath="/docs/concepts/scheduling/scheduler-perf-tuning/" >}})
-* Read about [Pod topology spread constraints]({{< indoclink pagepath="docs/concepts/workloads/pods/pod-topology-spread-constraints/" >}})
+* Read about [scheduler performance tuning]({{< doclink pagepath="/docs/concepts/scheduling/scheduler-perf-tuning/" >}})
+* Read about [Pod topology spread constraints]({{< doclink pagepath="docs/concepts/workloads/pods/pod-topology-spread-constraints/" >}})
 * Read about [Pod topology spread constraints](/docs/concepts/workloads/pods/pod-topology-spread-constraints/)
 * Read the [reference documentation](/docs/reference/command-line-tools-reference/kube-scheduler/) for kube-scheduler
 * Learn about [configuring multiple schedulers](/docs/tasks/administer-cluster/configure-multiple-schedulers/)

--- a/content/zh/docs/concepts/scheduling/kube-scheduler.md
+++ b/content/zh/docs/concepts/scheduling/kube-scheduler.md
@@ -311,6 +311,10 @@ kube-scheduler 有一系列的默认调度策略。
 {{% /capture %}}
 {{% capture whatsnext %}}
 * 阅读关于 [调度器性能调优](/zh/docs/concepts/scheduling/scheduler-perf-tuning/)
+
+* 进一步了解 [控制器]({{< indoclink pagepath="/docs/concepts/architecture/" >}})
+* 进一步了解 [kube-scheduler]({{< indoclink pagepath="docs/concepts/scheduling/kube-scheduler/" >}})
+
 * 阅读关于 [Pod 拓扑分布约束](/zh/docs/concepts/workloads/pods/pod-topology-spread-constraints/)
 * 阅读关于 kube-scheduler 的 [参考文档](/zh/docs/reference/command-line-tools-reference/kube-scheduler/)
 * 了解关于 [配置多个调度器](/zh/docs/tasks/administer-cluster/configure-multiple-schedulers/) 的方式

--- a/content/zh/docs/concepts/scheduling/kube-scheduler.md
+++ b/content/zh/docs/concepts/scheduling/kube-scheduler.md
@@ -312,8 +312,8 @@ kube-scheduler 有一系列的默认调度策略。
 {{% capture whatsnext %}}
 * 阅读关于 [调度器性能调优](/zh/docs/concepts/scheduling/scheduler-perf-tuning/)
 
-* 进一步了解 [控制器]({{< indoclink pagepath="/docs/concepts/architecture/" >}})
-* 进一步了解 [kube-scheduler]({{< indoclink pagepath="docs/concepts/scheduling/kube-scheduler/" >}})
+* 进一步了解 [控制器]({{< doclink pagepath="/docs/concepts/architecture/" >}})
+* 进一步了解 [kube-scheduler]({{< doclink pagepath="docs/concepts/scheduling/kube-scheduler/" >}})
 
 * 阅读关于 [Pod 拓扑分布约束](/zh/docs/concepts/workloads/pods/pod-topology-spread-constraints/)
 * 阅读关于 kube-scheduler 的 [参考文档](/zh/docs/reference/command-line-tools-reference/kube-scheduler/)

--- a/layouts/shortcodes/doclink.html
+++ b/layouts/shortcodes/doclink.html
@@ -1,0 +1,10 @@
+{{- $p := .Get "pagepath" -}}
+{{- $defaultLang := "en" -}}
+{{- $langPrefix := "/" -}}
+{{- if ne $defaultLang .Page.Lang -}}
+{{- $langPrefix = printf "/%s/" .Page.Lang -}}
+{{- end -}}
+{{- if hasPrefix $p "/" -}}
+{{- $p = strings.TrimPrefix "/" $p -}}
+{{- end -}}
+{{- printf "%s%s" $langPrefix $p -}}

--- a/layouts/shortcodes/indoclink.html
+++ b/layouts/shortcodes/indoclink.html
@@ -1,7 +1,0 @@
-{{- $p := .Get "pagepath" -}}
-{{- $defaultLang := "en" -}}
-{{- $langPrefix := "/" -}}
-{{- if ne $defaultLang .Page.Lang -}}
-{{- $langPrefix = printf "/%s" .Page.Lang -}}
-{{- end -}}
-{{- path.Join $langPrefix $p -}}

--- a/layouts/shortcodes/indoclink.html
+++ b/layouts/shortcodes/indoclink.html
@@ -1,0 +1,7 @@
+{{- $p := .Get "pagepath" -}}
+{{- $defaultLang := "en" -}}
+{{- $langPrefix := "/" -}}
+{{- if ne $defaultLang .Page.Lang -}}
+{{- $langPrefix = printf "/%s" .Page.Lang -}}
+{{- end -}}
+{{- path.Join $langPrefix $p -}}


### PR DESCRIPTION
This PR is trying to fix #18403, I am not sure whether it is the best solution, but it did work, as we:

1. keep same link content for english and other languages, no need to change for each l10n team;
2. if there is no content under current dir, it **would NOT throw error like `ref` and `relref` did**;
3. the custom shortcode `indoclink` is maintained by us, not hugo bulitin shortcode, that means we could do more things about customization without upstream support.

Thanks.
