### PR TITLE
Add descriptions of CPU and Memory metrics

### DIFF
--- a/content/en/docs/tasks/debug-application-cluster/resource-metrics-pipeline.md
+++ b/content/en/docs/tasks/debug-application-cluster/resource-metrics-pipeline.md
@@ -41,7 +41,7 @@ The API requires metrics server to be deployed in the cluster. Otherwise it will
 
 ### CPU
 
-CPU is reported as the average usage, in cores, over a period of time. This value is derrived by taking a rate over a cumulative CPU counter provided by the kernel (in both linux and windows kernels). The window chosen for the rate calculation is determined by the kubelet.
+CPU is reported as the average usage, in cores, over a period of time. This value is derived by taking a rate over a cumulative CPU counter provided by the kernel (in both Linux and Windows kernels). The kubelet chooses the window  for the rate calculation.
 
 ### Memory
 

--- a/content/en/docs/tasks/debug-application-cluster/resource-metrics-pipeline.md
+++ b/content/en/docs/tasks/debug-application-cluster/resource-metrics-pipeline.md
@@ -41,11 +41,11 @@ The API requires metrics server to be deployed in the cluster. Otherwise it will
 
 ### CPU
 
-CPU is reported as the average usage, in cores, over a period of time. This value is derived by taking a rate over a cumulative CPU counter provided by the kernel (in both Linux and Windows kernels). The kubelet chooses the window  for the rate calculation.
+CPU is reported as the average usage, in [CPU cores](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-cpu), over a period of time. This value is derived by taking a rate over a cumulative CPU counter provided by the kernel (in both Linux and Windows kernels). The kubelet chooses the window  for the rate calculation.
 
 ### Memory
 
-Memory is reported as the working set, in bytes, at the instant the metric was collected. In an ideal world, the "working set" is the amount of memory in-use that cannot be freed under memory pressure.  However, calculation of the working set varies by host OS, and generally makes heavy use of heuristics to produce an estimate.  It includes all anonymous (non-file-backed) memory since kubernetes does not support Swap, and generally includes some cached (file-backed) memory, as such pages can not always be reclaimed.
+Memory is reported as the working set, in bytes, at the instant the metric was collected. In an ideal world, the "working set" is the amount of memory in-use that cannot be freed under memory pressure.  However, calculation of the working set varies by host OS, and generally makes heavy use of heuristics to produce an estimate.  It includes all anonymous (non-file-backed) memory since kubernetes does not support swap. The metric typically also includes some cached (file-backed) memory, because the host OS cannot always reclaim such pages.
 
 ## Metrics Server
 

--- a/content/en/docs/tasks/debug-application-cluster/resource-metrics-pipeline.md
+++ b/content/en/docs/tasks/debug-application-cluster/resource-metrics-pipeline.md
@@ -37,6 +37,16 @@ repository. You can find more information about the API there.
 The API requires metrics server to be deployed in the cluster. Otherwise it will be not available.
 {{< /note >}}
 
+## Measuring Resource Usage
+
+### CPU
+
+CPU is reported as the average usage, in cores, over a period of time. This value is derrived by taking a rate over a cumulative CPU counter provided by the kernel (in both linux and windows kernels). The window chosen for the rate calculation is determined by the kubelet.
+
+### Memory
+
+Memory is reported as the working set, in bytes, at the instant the metric was collected. In an ideal world, the "working set" is the amount of memory in-use that cannot be freed under memory pressure.  However, calculation of the working set varies by host OS, and generally makes heavy use of heuristics to produce an estimate.  It includes all anonymous (non-file-backed) memory since kubernetes does not support Swap, and generally includes some cached (file-backed) memory, as such pages can not always be reclaimed.
+
 ## Metrics Server
 
 [Metrics Server](https://github.com/kubernetes-incubator/metrics-server) is a cluster-wide aggregator of resource usage data.


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/metrics-server/issues/404.

cc @derekwaynecarr @sjenning @vishh 

The metrics server mistakenly switched to using RSS as the memory metric, and has since switched back to using working set.  They requested a description of the memory metric to document the decision and shed some light on why we use the metrics we do.

I tried not to be too specific, so we still have some flexibility, but still provide an outline for why we use the working set.