### PR TITLE
Update install-kubeadm.md

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -285,7 +285,7 @@ This file will be used by `kubeadm init` and `kubeadm join` to source extra
 user defined arguments for the kubelet.
 
 Please mind, that you **only** have to do that if the cgroup driver of your CRI
-is not `cgroupfs`, because that is the default value in the kubelet already.
+is not `systemd`, because that is the default value in the kubelet already.
 
 Restarting the kubelet is required:
 


### PR DESCRIPTION
Fixed default cgroup driver of kubelet from `cgroupfs` to `systemd`.
