### PR TITLE
Fix typo: default-manager -> default-scheduler

### DIFF
--- a/content/ja/docs/setup/best-practices/certificates.md
+++ b/content/ja/docs/setup/best-practices/certificates.md
@@ -110,7 +110,7 @@ You must manually configure these administrator account and service accounts:
 | admin.conf              | default-admin              | kubernetes-admin               | system:masters |
 | kubelet.conf            | default-auth               | system:node:`<nodeName>` (see note) | system:nodes   |
 | controller-manager.conf | default-controller-manager | system:kube-controller-manager |                |
-| scheduler.conf          | default-manager            | system:kube-scheduler          |                |
+| scheduler.conf          | default-scheduler          | system:kube-scheduler          |                |
 
 {{< note >}}
 The value of `<nodeName>` for `kubelet.conf` **must** match precisely the value of the node name provided by the kubelet as it registers with the apiserver. For further details, read the [Node Authorization](/docs/reference/access-authn-authz/node/).


### PR DESCRIPTION
like #18649 
`default-scheduler` as kube-scheduler's cert name is more appropriate than `default-manager`