### PR TITLE
Use monospace font for HostFolder and VM column

### DIFF
--- a/content/en/docs/setup/learning-environment/minikube.md
+++ b/content/en/docs/setup/learning-environment/minikube.md
@@ -404,13 +404,13 @@ Some drivers will mount a host folder within the VM so that you can easily share
 Host folder sharing is not implemented in the KVM driver yet.
 {{< /note >}}
 
-| Driver | OS | HostFolder | VM |
-| --- | --- | --- | --- |
-| VirtualBox | Linux | /home | /hosthome |
-| VirtualBox | macOS | /Users | /Users |
-| VirtualBox | Windows | C://Users | /c/Users |
-| VMware Fusion | macOS | /Users | /mnt/hgfs/Users |
-| Xhyve | macOS | /Users | /Users |
+| Driver        | OS      | HostFolder     | VM           |
+|---------------|---------|----------------|--------------|
+| VirtualBox    | Linux   | ``/home``      | ``/hosthome``|
+| VirtualBox    | macOS   | ``/Users``     | ``/Users``   |
+| VirtualBox    | Windows | ``C:/Users``  | ``/c/Users`` |
+| VMware Fusion | macOS   | ``/Users``     | ``/Users``   |
+| Xhyve         | macOS   | ``/Users``     | ``/Users``   |
 
 ## Private Container Registries
 

--- a/content/fr/docs/setup/learning-environment/minikube.md
+++ b/content/fr/docs/setup/learning-environment/minikube.md
@@ -462,13 +462,13 @@ Celles-ci ne sont pas configurables pour le moment et diffèrent selon le pilote
 Le partage de dossier hôte n'est pas encore implémenté dans le pilote KVM.
 {{< /note >}}
 
-| Pilote        | OS      | HostFolder     | VM           |
-|---------------|---------|----------------|--------------|
-| VirtualBox    | Linux   | ``/home``      | ``/hosthome``|
-| VirtualBox    | macOS   | ``/Users``     | ``/Users``   |
-| VirtualBox    | Windows | ``C:/Users``  | ``/c/Users`` |
-| VMware Fusion | macOS   | ``/Users``     | ``/Users``   |
-| Xhyve         | macOS   | ``/Users``     | ``/Users``   |
+| Pilote        | OS      | HostFolder| VM       |
+|---------------|---------|-----------|----------|
+| VirtualBox    | Linux   | /home     | /hosthome|
+| VirtualBox    | macOS   | /Users    | /Users   |
+| VirtualBox    | Windows | C:/Users| | /c/Users |
+| VMware Fusion | macOS   | /Users    | /Users   |
+| Xhyve         | macOS   | /Users    | /Users   |
 
 ## Registres de conteneurs privés
 

--- a/content/fr/docs/setup/learning-environment/minikube.md
+++ b/content/fr/docs/setup/learning-environment/minikube.md
@@ -462,13 +462,13 @@ Celles-ci ne sont pas configurables pour le moment et diffèrent selon le pilote
 Le partage de dossier hôte n'est pas encore implémenté dans le pilote KVM.
 {{< /note >}}
 
-| Pilote        | OS      | HostFolder | VM        |
-|---------------|---------|------------|-----------|
-| VirtualBox    | Linux   | /home      | /hosthome |
-| VirtualBox    | macOS   | /Users     | /Users    |
-| VirtualBox    | Windows | C://Users  | /c/Users  |
-| VMware Fusion | macOS   | /Users     | /Users    |
-| Xhyve         | macOS   | /Users     | /Users    |
+| Pilote        | OS      | HostFolder     | VM           |
+|---------------|---------|----------------|--------------|
+| VirtualBox    | Linux   | ``/home``      | ``/hosthome``|
+| VirtualBox    | macOS   | ``/Users``     | ``/Users``   |
+| VirtualBox    | Windows | ``C:/Users``  | ``/c/Users`` |
+| VMware Fusion | macOS   | ``/Users``     | ``/Users``   |
+| Xhyve         | macOS   | ``/Users``     | ``/Users``   |
 
 ## Registres de conteneurs privés
 

--- a/content/ja/docs/setup/learning-environment/minikube.md
+++ b/content/ja/docs/setup/learning-environment/minikube.md
@@ -374,13 +374,13 @@ spec:
 ホストフォルダーの共有はKVMドライバーにはまだ実装されていません。
 {{< /note >}}
 
-| Driver | OS | HostFolder | VM |
-| --- | --- | --- | --- |
-| VirtualBox | Linux | /home | /hosthome |
-| VirtualBox | macOS | /Users | /Users |
-| VirtualBox | Windows | C://Users | /c/Users |
-| VMware Fusion | macOS | /Users | /Users |
-| Xhyve | macOS | /Users | /Users |
+| Driver        | OS      | HostFolder     | VM           |
+|---------------|---------|----------------|--------------|
+| VirtualBox    | Linux   | ``/home``      | ``/hosthome``|
+| VirtualBox    | macOS   | ``/Users``     | ``/Users``   |
+| VirtualBox    | Windows | ``C:/Users``  | ``/c/Users`` |
+| VMware Fusion | macOS   | ``/Users``     | ``/Users``   |
+| Xhyve         | macOS   | ``/Users``     | ``/Users``   |
 
 ## プライベートコンテナレジストリ
 

--- a/content/ja/docs/setup/learning-environment/minikube.md
+++ b/content/ja/docs/setup/learning-environment/minikube.md
@@ -376,11 +376,11 @@ spec:
 
 | Driver        | OS      | HostFolder     | VM           |
 |---------------|---------|----------------|--------------|
-| VirtualBox    | Linux   | ``/home``      | ``/hosthome``|
-| VirtualBox    | macOS   | ``/Users``     | ``/Users``   |
-| VirtualBox    | Windows | ``C:/Users``  | ``/c/Users`` |
-| VMware Fusion | macOS   | ``/Users``     | ``/Users``   |
-| Xhyve         | macOS   | ``/Users``     | ``/Users``   |
+| VirtualBox    | Linux   | /home     | /hosthome|
+| VirtualBox    | macOS   | /Users    | /Users   |
+| VirtualBox    | Windows | C:/Users| | /c/Users |
+| VMware Fusion | macOS   | /Users    | /Users   |
+| Xhyve         | macOS   | /Users    | /Users   |
 
 ## プライベートコンテナレジストリ
 

--- a/content/ko/docs/setup/learning-environment/minikube.md
+++ b/content/ko/docs/setup/learning-environment/minikube.md
@@ -399,13 +399,13 @@ spec:
 호스트 폴더 공유는 KVM 드라이버에서 아직 구현되어 있지 않다.
 {{< /note >}}
 
-| Driver        | OS      | HostFolder     | VM           |
-|---------------|---------|----------------|--------------|
-| VirtualBox    | Linux   | ``/home``      | ``/hosthome``|
-| VirtualBox    | macOS   | ``/Users``     | ``/Users``   |
-| VirtualBox    | Windows | ``C:/Users``  | ``/c/Users`` |
-| VMware Fusion | macOS   | ``/Users``     | ``/Users``   |
-| Xhyve         | macOS   | ``/Users``     | ``/Users``   |
+| Driver        | OS      | HostFolder| VM       |
+|---------------|---------|-----------|----------|
+| VirtualBox    | Linux   | /home     | /hosthome|
+| VirtualBox    | macOS   | /Users    | /Users   |
+| VirtualBox    | Windows | C:/Users| | /c/Users |
+| VMware Fusion | macOS   | /Users    | /Users   |
+| Xhyve         | macOS   | /Users    | /Users   |
 
 ## 프라이빗 컨테이너 레지스트리
 

--- a/content/ko/docs/setup/learning-environment/minikube.md
+++ b/content/ko/docs/setup/learning-environment/minikube.md
@@ -399,13 +399,13 @@ spec:
 호스트 폴더 공유는 KVM 드라이버에서 아직 구현되어 있지 않다.
 {{< /note >}}
 
-| Driver | OS | HostFolder | VM |
-| --- | --- | --- | --- |
-| VirtualBox | Linux | /home | /hosthome |
-| VirtualBox | macOS | /Users | /Users |
-| VirtualBox | Windows | C://Users | /c/Users |
-| VMware Fusion | macOS | /Users | /Users |
-| Xhyve | macOS | /Users | /Users |
+| Driver        | OS      | HostFolder     | VM           |
+|---------------|---------|----------------|--------------|
+| VirtualBox    | Linux   | ``/home``      | ``/hosthome``|
+| VirtualBox    | macOS   | ``/Users``     | ``/Users``   |
+| VirtualBox    | Windows | ``C:/Users``  | ``/c/Users`` |
+| VMware Fusion | macOS   | ``/Users``     | ``/Users``   |
+| Xhyve         | macOS   | ``/Users``     | ``/Users``   |
 
 ## 프라이빗 컨테이너 레지스트리
 


### PR DESCRIPTION
Use monospace font for HostFolder and VM column on the Minikube setup page.
Fixes #18710 .