### PR TITLE
Bump nvidia-device-plugin.yml to 1.0.0-beta4

### DIFF
--- a/content/en/docs/tasks/manage-gpus/scheduling-gpus.md
+++ b/content/en/docs/tasks/manage-gpus/scheduling-gpus.md
@@ -104,7 +104,7 @@ To deploy the NVIDIA device plugin once your cluster is running and the above
 requirements are satisfied:
 
 ```shell
-kubectl create -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/1.0.0-beta/nvidia-device-plugin.yml
+kubectl create -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/1.0.0-beta4/nvidia-device-plugin.yml
 ```
 
 You can report issues with this third-party device plugin by logging an issue in


### PR DESCRIPTION
This resolves `no matches for kind "DaemonSet" in version "extensions/v1beta1"` with Kubernetes >=1.16.
