### PR TITLE
Solve to and from selector example inconsistencies

### DIFF
--- a/content/en/docs/concepts/services-networking/network-policies.md
+++ b/content/en/docs/concepts/services-networking/network-policies.md
@@ -94,12 +94,12 @@ __egress__: Each `NetworkPolicy` may include a list of whitelist `egress` rules.
 So, the example NetworkPolicy:
 
 1. isolates "role=db" pods in the "default" namespace for both ingress and egress traffic (if they weren't already isolated)
-2. (Ingress rules) allows connections to all pods in the “default” namespace with the label “role=db” on TCP port 6379 from:
+2. (Ingress rules) allows connections from all pods in the “default” namespace with the label “role=db” on TCP port 6379 from:
 
    * any pod in the "default" namespace with the label "role=frontend"
    * any pod in a namespace with the label "project=myproject"
    * IP addresses in the ranges 172.17.0.0–172.17.0.255 and 172.17.2.0–172.17.255.255 (ie, all of 172.17.0.0/16 except 172.17.1.0/24)
-3. (Egress rules) allows connections from any pod in the "default" namespace with the label "role=db" to CIDR 10.0.0.0/24 on TCP port 5978
+3. (Egress rules) allows connections to any pod in the "default" namespace with the label "role=db" to CIDR 10.0.0.0/24 on TCP port 5978
 
 See the [Declare Network Policy](/docs/tasks/administer-cluster/declare-network-policy/) walkthrough for further examples.
 


### PR DESCRIPTION
The ingress rule example describes egress behavior, and vice versa for the egress rule example. 