### PR TITLE
coresPerReplica and nodesPerReplica are both floats

### DIFF
--- a/content/en/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
+++ b/content/en/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
@@ -135,7 +135,7 @@ calculated using this equation:
     replicas = max( ceil( cores × 1/coresPerReplica ) , ceil( nodes × 1/nodesPerReplica ) )
 
 Note that the values of both `coresPerReplica` and `nodesPerReplica` are
-integers.
+floats.
 
 The idea is that when a cluster is using nodes that have many cores,
 `coresPerReplica` dominates. When a cluster is using nodes that have fewer


### PR DESCRIPTION
as per the code, coresPerReplica and nodesPerReplica are floats referred to as integers in the docs
https://github.com/kubernetes-incubator/cluster-proportional-autoscaler/blob/master/pkg/autoscaler/controller/linearcontroller/linear_controller.go#L51-L52
