### PR TITLE
Use monospace for HostFolder and VM in japanese Minikube setup guide

### DIFF
--- a/content/ja/docs/setup/learning-environment/minikube.md
+++ b/content/ja/docs/setup/learning-environment/minikube.md
@@ -374,13 +374,13 @@ spec:
 ホストフォルダーの共有はKVMドライバーにはまだ実装されていません。
 {{< /note >}}
 
-| Driver | OS | HostFolder | VM |
-| --- | --- | --- | --- |
-| VirtualBox | Linux | /home | /hosthome |
-| VirtualBox | macOS | /Users | /Users |
-| VirtualBox | Windows | C://Users | /c/Users |
-| VMware Fusion | macOS | /Users | /Users |
-| Xhyve | macOS | /Users | /Users |
+| Driver	      | OS      | HostFolder  | VM          |
+|---------------|---------|-------------|-------------|
+| VirtualBox    | Linux   | ``/home``   |``/hosthome``|
+| VirtualBox    | macOS   | ``/Users``  |``/Users``   |
+| VirtualBox    | Windows | ``C:/Users``|``/c/Users`` |
+| VMware Fusion | macOS   | ``/Users``  |``/Users``   |
+| Xhyve         | macOS   | ``/Users``  |``/Users``   |
 
 ## プライベートコンテナレジストリ
 


### PR DESCRIPTION
Use monospace for HostFolder and VM in the japanese Minikube setup guide.