### PR TITLE
feat: add ephermeral container approach inside pod debug page.

### DIFF
--- a/content/en/docs/tasks/debug-application-cluster/debug-pod-replication-controller.md
+++ b/content/en/docs/tasks/debug-application-cluster/debug-pod-replication-controller.md
@@ -123,6 +123,8 @@ As an example, to look at the logs from a running Cassandra pod, you might run:
 kubectl exec cassandra -- cat /var/log/cassandra/system.log
 ```
 
+If your cluster enabled it, you can also try adding an [ephemeral container](/docs/concepts/workloads/pods/ephemeral-containers/) into the existing pod. You can use the new temporary container to run arbitrary commands, for example, to diagnose problems inside the Pod. See the page about [ephemeral container](/docs/concepts/workloads/pods/ephemeral-containers/) for more details, including feature availability.
+
 If none of these approaches work, you can find the host machine that the pod is
 running on and SSH into that host.
 


### PR DESCRIPTION
This PR is going to fix #18720 , adding ephemeral container link inside pod debug page should be helpful for our users, since it is common case that we could NOT exec into a crash-loop pod.

Thanks.
