### PR TITLE
Correct meaning of scheduling affinity benefits

### DIFF
--- a/content/en/docs/concepts/configuration/assign-pod-node.md
+++ b/content/en/docs/concepts/configuration/assign-pod-node.md
@@ -111,9 +111,10 @@ For example, `example.com.node-restriction.kubernetes.io/fips=true` or `example.
 `nodeSelector` provides a very simple way to constrain pods to nodes with particular labels. The affinity/anti-affinity
 feature, greatly expands the types of constraints you can express. The key enhancements are
 
-1. the language is more expressive (not just "AND or exact match")
+1. The affinity/anti-affinity language is more expressive. The language offers more matching rules
+   besides exact matches created with a logical AND operation;
 2. you can indicate that the rule is "soft"/"preference" rather than a hard requirement, so if the scheduler
-   can't satisfy it, the pod will still be scheduled
+   can't satisfy it, the pod will still be scheduled;
 3. you can constrain against labels on other pods running on the node (or other topological domain),
    rather than against labels on the node itself, which allows rules about which pods can and cannot be co-located
 


### PR DESCRIPTION
https://github.com/kubernetes/website/pull/18732 incorrectly reworded the benefits of using affinity / anti-affinity for Pod scheduling.

Revise this with new wording. 

Thanks to @gedimitr for pointing this out in https://github.com/kubernetes/website/pull/18732#issuecomment-575823739.

/kind cleanup
/sig scheduling