### PR TITLE
Tidy port forward task

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
+++ b/content/en/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
@@ -2,6 +2,7 @@
 title: Use Port Forwarding to Access Applications in a Cluster
 content_template: templates/task
 weight: 40
+min-kubernetes-server-version: v1.10
 ---
 
 {{% capture overview %}}
@@ -121,7 +122,8 @@ for database debugging.
 
 ## Forward a local port to a port on the Pod
 
-1.  `kubectl port-forward` allows using resource name, such as a pod name, to select a matching pod to port forward to since Kubernetes v1.10.
+1.  `kubectl port-forward` allows using resource name, such as a pod name, to select a matching pod to port forward to.
+
 
     ```shell
     # Change redis-master-765d459796-258hz to the name of the Pod

--- a/content/en/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
+++ b/content/en/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
@@ -28,65 +28,94 @@ for database debugging.
 
 1. Create a Deployment that runs Redis:
 
-        kubectl apply -f https://k8s.io/examples/application/guestbook/redis-master-deployment.yaml
+    ```shell
+    kubectl apply -f https://k8s.io/examples/application/guestbook/redis-master-deployment.yaml
+    ```
 
     The output of a successful command verifies that the deployment was created:
 
-        deployment.apps/redis-master created
+    ```
+    deployment.apps/redis-master created
+    ```
 
     View the pod status to check that it is ready:
 
-        kubectl get pods
+    ```shell
+    kubectl get pods
+    ```
 
     The output displays the pod created:
 
-        NAME                            READY     STATUS    RESTARTS   AGE
-        redis-master-765d459796-258hz   1/1       Running   0          50s
+    ```
+    NAME                            READY     STATUS    RESTARTS   AGE
+    redis-master-765d459796-258hz   1/1       Running   0          50s
+    ```
 
     View the Deployment's status:
 
-        kubectl get deployment
+    ```shell
+    kubectl get deployment
+    ```
 
     The output displays that the Deployment was created:
 
-        NAME         READY   UP-TO-DATE   AVAILABLE   AGE
-        redis-master 1/1     1            1           55s
+    ```
+    NAME         READY   UP-TO-DATE   AVAILABLE   AGE
+    redis-master 1/1     1            1           55s
+    ```
 
     The Deployment automatically manages a ReplicaSet.
     View the ReplicaSet status using:
 
-        kubectl get rs
+    ```shell
+    kubectl get replicaset
+    ```
 
     The output displays that the ReplicaSet was created:
 
-        NAME                      DESIRED   CURRENT   READY     AGE
-        redis-master-765d459796   1         1         1         1m
+    ```
+    NAME                      DESIRED   CURRENT   READY     AGE
+    redis-master-765d459796   1         1         1         1m
+    ```
 
 
 2. Create a Service to expose Redis on the network:
 
-        kubectl apply -f https://k8s.io/examples/application/guestbook/redis-master-service.yaml
+    ```shell
+    kubectl apply -f https://k8s.io/examples/application/guestbook/redis-master-service.yaml
+    ```
 
     The output of a successful command verifies that the Service was created:
 
-        service/redis-master created
+    ```
+    service/redis-master created
+    ```
 
     Check the Service created:
 
-        kubectl get svc | grep redis
+    ```shell
+    kubectl get service redis-master
+    ```
 
     The output displays the service created:
 
-        NAME           TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)    AGE
-        redis-master   ClusterIP   10.0.0.213   <none>        6379/TCP   27s
+    ```
+    NAME           TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)    AGE
+    redis-master   ClusterIP   10.0.0.213   <none>        6379/TCP   27s
+    ```
 
 3. Verify that the Redis server is running in the Pod, and listening on port 6379:
 
-        kubectl get pods redis-master-765d459796-258hz --template='{{(index (index .spec.containers 0).ports 0).containerPort}}{{"\n"}}'
+    ```shell
+    # Change redis-master-765d459796-258hz to the name of the Pod
+    kubectl get pod redis-master-765d459796-258hz --template='{{(index (index .spec.containers 0).ports 0).containerPort}}{{"\n"}}'
+    ```
 
     The output displays the port for Redis in that Pod:
 
-        6379
+    ```
+    6379
+    ```
 
     (this is the TCP port allocated to Redis on the internet).
 
@@ -94,36 +123,53 @@ for database debugging.
 
 1.  `kubectl port-forward` allows using resource name, such as a pod name, to select a matching pod to port forward to since Kubernetes v1.10.
 
-        kubectl port-forward redis-master-765d459796-258hz 7000:6379
+    ```shell
+    # Change redis-master-765d459796-258hz to the name of the Pod
+    kubectl port-forward redis-master-765d459796-258hz 7000:6379
+    ```
 
     which is the same as
 
-        kubectl port-forward pods/redis-master-765d459796-258hz 7000:6379
+    ```shell
+    kubectl port-forward pods/redis-master-765d459796-258hz 7000:6379
+    ```
 
     or
 
-        kubectl port-forward deployment/redis-master 7000:6379
+    ```shell
+    kubectl port-forward deployment/redis-master 7000:6379
+    ```
 
     or
 
-        kubectl port-forward rs/redis-master 7000:6379
+    ```shell
+    kubectl port-forward replicaset/redis-master 7000:6379
+    ```
 
     or
 
-        kubectl port-forward svc/redis-master 7000:6379
+    ```shell
+    kubectl port-forward service/redis-master 7000:6379
+    ```
 
     Any of the above commands works. The output is similar to this:
 
-        I0710 14:43:38.274550    3655 portforward.go:225] Forwarding from 127.0.0.1:7000 -> 6379
-        I0710 14:43:38.274797    3655 portforward.go:225] Forwarding from [::1]:7000 -> 6379
+    ```
+    I0710 14:43:38.274550    3655 portforward.go:225] Forwarding from 127.0.0.1:7000 -> 6379
+    I0710 14:43:38.274797    3655 portforward.go:225] Forwarding from [::1]:7000 -> 6379
+    ```
 
 2.  Start the Redis command line interface:
 
-        redis-cli -p 7000
+    ```shell
+    redis-cli -p 7000
+    ```
 
 3.  At the Redis command line prompt, enter the `ping` command:
 
-        127.0.0.1:7000>ping
+    ```
+    ping
+    ```
 
     A successful ping request returns:
 

--- a/content/en/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
+++ b/content/en/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
@@ -136,11 +136,11 @@ Connections made to local port 7000 are forwarded to port 6379 of the pod that
 is running the Redis server. With this connection in place you can use your
 local workstation to debug the database that is running in the pod.
 
-{{< warning >}}
-Due to known limitations, port forward today only works for TCP protocol.
-The support to UDP protocol is being tracked in
+{{< note >}}
+`kubectl port-forward` is implemented for TCP ports only.
+The support for UDP protocol is tracked in
 [issue 47862](https://github.com/kubernetes/kubernetes/issues/47862).
-{{< /warning >}}
+{{< /note >}}
 
 {{% /capture %}}
 

--- a/content/en/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
+++ b/content/en/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
@@ -26,7 +26,7 @@ for database debugging.
 
 ## Creating Redis deployment and service
 
-1. Create a Redis deployment:
+1. Create a Deployment that runs Redis:
 
         kubectl apply -f https://k8s.io/examples/application/guestbook/redis-master-deployment.yaml
 
@@ -43,34 +43,35 @@ for database debugging.
         NAME                            READY     STATUS    RESTARTS   AGE
         redis-master-765d459796-258hz   1/1       Running   0          50s
 
-    View the deployment status:
+    View the Deployment's status:
 
         kubectl get deployment
 
-    The output displays that the deployment was created:
+    The output displays that the Deployment was created:
 
         NAME         READY   UP-TO-DATE   AVAILABLE   AGE
         redis-master 1/1     1            1           55s
 
-    View the replicaset status using:
+    The Deployment automatically manages a ReplicaSet.
+    View the ReplicaSet status using:
 
         kubectl get rs
 
-    The output displays that the replicaset was created:
+    The output displays that the ReplicaSet was created:
 
         NAME                      DESIRED   CURRENT   READY     AGE
         redis-master-765d459796   1         1         1         1m
 
 
-2. Create a Redis service:
+2. Create a Service to expose Redis on the network:
 
         kubectl apply -f https://k8s.io/examples/application/guestbook/redis-master-service.yaml
 
-    The output of a successful command verifies that the service was created:
+    The output of a successful command verifies that the Service was created:
 
         service/redis-master created
 
-    Check the service created:
+    Check the Service created:
 
         kubectl get svc | grep redis
 
@@ -79,16 +80,17 @@ for database debugging.
         NAME           TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)    AGE
         redis-master   ClusterIP   10.0.0.213   <none>        6379/TCP   27s
 
-3. Verify that the Redis server is running in the pod and listening on port 6379:
+3. Verify that the Redis server is running in the Pod, and listening on port 6379:
 
         kubectl get pods redis-master-765d459796-258hz --template='{{(index (index .spec.containers 0).ports 0).containerPort}}{{"\n"}}'
 
-    The output displays the port:
+    The output displays the port for Redis in that Pod:
 
         6379
 
+    (this is the TCP port allocated to Redis on the internet).
 
-## Forward a local port to a port on the pod
+## Forward a local port to a port on the Pod
 
 1.  `kubectl port-forward` allows using resource name, such as a pod name, to select a matching pod to port forward to since Kubernetes v1.10.
 
@@ -123,7 +125,11 @@ for database debugging.
 
         127.0.0.1:7000>ping
 
-    A successful ping request returns PONG.
+    A successful ping request returns:
+
+    ```
+    PONG
+    ```
 
 {{% /capture %}}
 
@@ -132,9 +138,9 @@ for database debugging.
 
 ## Discussion
 
-Connections made to local port 7000 are forwarded to port 6379 of the pod that
-is running the Redis server. With this connection in place you can use your
-local workstation to debug the database that is running in the pod.
+Connections made to local port 7000 are forwarded to port 6379 of the Pod that
+is running the Redis server. With this connection in place, you can use your
+local workstation to debug the database that is running in the Pod.
 
 {{< note >}}
 `kubectl port-forward` is implemented for TCP ports only.
@@ -148,6 +154,3 @@ The support for UDP protocol is tracked in
 {{% capture whatsnext %}}
 Learn more about [kubectl port-forward](/docs/reference/generated/kubectl/kubectl-commands/#port-forward).
 {{% /capture %}}
-
-
-


### PR DESCRIPTION
Tidy https://k8s.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/

- Downgrade a warning to a note
- Try to follow style guidelines
   - Highlight commands as shell code
- Specify minimum version of v1.10 so that `{{< version-check >}}` renders this detail automatically