### PR TITLE
Fix deployment name in tasks/administer-cluster/dns-horizontal-autoscaling.md

### DIFF
--- a/content/en/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
+++ b/content/en/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
@@ -97,7 +97,7 @@ kubectl apply -f dns-horizontal-autoscaler.yaml
 
 The output of a successful command is:
 
-    deployment.apps/kube-dns-autoscaler created
+    deployment.apps/dns-autoscaler created
 
 DNS horizontal autoscaling is now enabled.
 

--- a/content/zh/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
+++ b/content/zh/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
@@ -194,7 +194,7 @@ kubectl apply -f dns-horizontal-autoscaler.yaml
 
 The output of a successful command is:
 
-    deployment.apps/kube-dns-autoscaler created
+    deployment.apps/dns-autoscaler created
 
 DNS horizontal autoscaling is now enabled.
 -->
@@ -216,7 +216,7 @@ kubectl apply -f dns-horizontal-autoscaler.yaml
 
 一个成功的命令输出是：
 
-    deployment.apps/kube-dns-autoscaler created
+    deployment.apps/dns-autoscaler created
 
 DNS 水平自动伸缩在已经启用了。
 


### PR DESCRIPTION
Deployment metadata.name  in `dns-horizontal-autoscaler.yaml` is `dns-autoscaler`,  so the output of a successful command is `deployment.apps/dns-autoscaler created`

/sig docs
