### PR TITLE
update default margin of vendorStrip li on narrow-width browser

### DIFF
--- a/assets/sass/_base.sass
+++ b/assets/sass/_base.sass
@@ -586,7 +586,7 @@ section
     font-weight: bold
 
   li + li
-    margin-left: 0
+    margin: 0 0.5em
 
 
 #docs


### PR DESCRIPTION
fix issue #18758 