### PR TITLE
Add note for LB behaviour for cordoned nodes.

### DIFF
--- a/content/en/docs/concepts/architecture/nodes.md
+++ b/content/en/docs/concepts/architecture/nodes.md
@@ -275,6 +275,12 @@ and do not respect the unschedulable attribute on a node. This assumes that daem
 the machine even if it is being drained of applications while it prepares for a reboot.
 {{< /note >}}
 
+{{< note >}}
+`kubectl cordon` marks a node as 'unschedulable', which has the side effect of the service
+controller removing the node from any LoadBalancer node target lists it was previously 
+eligible for, effectively removing incoming load balancer traffic from the cordoned node(s).
+{{< /note >}}
+
 ### Node capacity
 
 The capacity of the node (number of cpus and amount of memory) is part of the node object.

--- a/content/en/docs/concepts/architecture/nodes.md
+++ b/content/en/docs/concepts/architecture/nodes.md
@@ -275,11 +275,11 @@ and do not respect the unschedulable attribute on a node. This assumes that daem
 the machine even if it is being drained of applications while it prepares for a reboot.
 {{< /note >}}
 
-{{< note >}}
+{{< caution >}}
 `kubectl cordon` marks a node as 'unschedulable', which has the side effect of the service
 controller removing the node from any LoadBalancer node target lists it was previously 
 eligible for, effectively removing incoming load balancer traffic from the cordoned node(s).
-{{< /note >}}
+{{< /caution >}}
 
 ### Node capacity
 


### PR DESCRIPTION
See also https://github.com/kubernetes/kubernetes/issues/65013
This is a reasonably common pitfall: `kubectl cordon <all nodes>` will also drop all LB traffic to the cluster, but this is not documented anywhere but in issues, when found it is usually already too late.
