### PR TITLE
fix: removed and from sentence

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -431,7 +431,7 @@ You can find more information about `ExternalName` resolution in
 
 ## Headless Services
 
-Sometimes you don't need load-balancing and a single Service IP.  In
+Sometimes you don't need load-balancing a single Service IP.  In
 this case, you can create what are termed “headless” Services, by explicitly
 specifying `"None"` for the cluster IP (`.spec.clusterIP`).
 


### PR DESCRIPTION
Looks like this `and` is redundant in this sentence
