### PR TITLE
Remove references to heapster

### DIFF
--- a/content/en/docs/concepts/configuration/manage-compute-resources-container.md
+++ b/content/en/docs/concepts/configuration/manage-compute-resources-container.md
@@ -191,7 +191,7 @@ resource limits, see the
 
 The resource usage of a Pod is reported as part of the Pod status.
 
-If [optional monitoring](http://releases.k8s.io/{{< param "githubbranch" >}}/cluster/addons/cluster-monitoring/README.md)
+If [optional monitoring](/docs/tasks/debug-application-cluster/resource-metrics-pipeline/)
 is configured for your cluster, then Pod resource usage can be retrieved from
 the monitoring system.
 

--- a/content/zh/docs/concepts/configuration/manage-compute-resources-container.md
+++ b/content/zh/docs/concepts/configuration/manage-compute-resources-container.md
@@ -275,7 +275,7 @@ resource limits, see the
 
 The resource usage of a Pod is reported as part of the Pod status.
 
-If [optional monitoring](http://releases.k8s.io/{{< param "githubbranch" >}}/cluster/addons/cluster-monitoring/README.md)
+If [optional monitoring](/docs/tasks/debug-application-cluster/resource-metrics-pipeline/)
 is configured for your cluster, then Pod resource usage can be retrieved from
 the monitoring system.
 -->
@@ -284,7 +284,7 @@ the monitoring system.
 
 Pod 的资源使用情况被报告为 Pod 状态的一部分。
 
-如果为集群配置了 [可选监控](http://releases.k8s.io/{{< param "githubbranch" >}}/cluster/addons/cluster-monitoring/README.md)，则可以从监控系统检索 Pod 资源的使用情况。
+如果为集群配置了 [可选监控](/docs/tasks/debug-application-cluster/resource-metrics-pipeline/)，则可以从监控系统检索 Pod 资源的使用情况。
 
 <!--
 ## Troubleshooting


### PR DESCRIPTION
With heapster being deprecated, I bumped into some broken links on https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/. 