### PR TITLE
added rbac redirect

### DIFF
--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -5,6 +5,7 @@ reviewers:
 - liggitt
 title: Using RBAC Authorization
 content_template: templates/concept
+url: /rbac
 weight: 70
 ---
 


### PR DESCRIPTION
Creates an alias for RBAC links: [k8s.io/docs/rbac](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) as tried and failed by @mauilion on [TGIK](https://youtu.be/ZB4LhAeiTCE?t=2575).

I believe this shorter redirect is good for presentation slides and intersects with doc's security efforts.