### PR TITLE
kubeadm: add notes about deprecating kube-dns usage in 1.18

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/implementation-details.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/implementation-details.md
@@ -447,22 +447,11 @@ A ServiceAccount for `kube-proxy` is created in the `kube-system` namespace; the
 
 #### DNS
 
-Note that:
-
+- In Kubernetes version 1.18 kube-dns usage with kubeadm is deprecated and will be removed in a future release
 - The CoreDNS service is named `kube-dns`. This is done to prevent any interruption
 in service when the user is switching the cluster DNS from kube-dns to CoreDNS or vice-versa
-- In Kubernetes version 1.10 and earlier, you must enable CoreDNS with `--feature-gates=CoreDNS=true`
-- In Kubernetes version 1.11 and 1.12, CoreDNS is the default DNS server and you must
-invoke kubeadm with `--feature-gates=CoreDNS=false` to install kube-dns instead
-- In Kubernetes version 1.13 and later, the `CoreDNS` feature gate is no longer available and kube-dns can be installed using the `--config` method described [here](/docs/reference/setup-tools/kubeadm/kubeadm-init-phase/#cmd-phase-addon)
-- In Kubernetes version 1.18 kube-dns usage with kubeadm is deprecated and will be removed in a future release
-
-
-A ServiceAccount for CoreDNS/kube-dns is created in the `kube-system` namespace.
-
-Deploy the `kube-dns` Deployment and Service:
-
-- It's the upstream CoreDNS deployment relatively unmodified
+the `--config` method described [here](/docs/reference/setup-tools/kubeadm/kubeadm-init-phase/#cmd-phase-addon)
+- A ServiceAccount for CoreDNS/kube-dns is created in the `kube-system` namespace.
 - The `kube-dns` ServiceAccount is bound to the privileges in the `system:kube-dns` ClusterRole
 
 ## kubeadm join phases internal design

--- a/content/en/docs/reference/setup-tools/kubeadm/implementation-details.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/implementation-details.md
@@ -455,6 +455,7 @@ in service when the user is switching the cluster DNS from kube-dns to CoreDNS o
 - In Kubernetes version 1.11 and 1.12, CoreDNS is the default DNS server and you must
 invoke kubeadm with `--feature-gates=CoreDNS=false` to install kube-dns instead
 - In Kubernetes version 1.13 and later, the `CoreDNS` feature gate is no longer available and kube-dns can be installed using the `--config` method described [here](/docs/reference/setup-tools/kubeadm/kubeadm-init-phase/#cmd-phase-addon)
+- In Kubernetes version 1.18 kube-dns usage with kubeadm is deprecated and will be removed in a future release
 
 
 A ServiceAccount for CoreDNS/kube-dns is created in the `kube-system` namespace.

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init-phase.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init-phase.md
@@ -157,6 +157,8 @@ dns:
   type: "kube-dns"
 ```
 
+Please note that kube-dns usage with kubeadm is deprecated as of v1.18 and will be removed in a future release.
+
 For more details on each field in the `v1beta2` configuration you can navigate to our
 [API reference pages.] (https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2)
 

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -67,9 +67,13 @@ following steps:
 
 1. Installs a DNS server (CoreDNS) and the kube-proxy addon components via the API server.
    In Kubernetes version 1.11 and later CoreDNS is the default DNS server.
-   To install kube-dns instead of CoreDNS, the DNS addon has to be configured in the kubeadm `ClusterConfiguration`. For more information about the configuration see the section
-   `Using kubeadm init with a configuration file` below.
+   To install kube-dns instead of CoreDNS, the DNS addon has to be configured in the kubeadm `ClusterConfiguration`.
+   For more information about the configuration see the section `Using kubeadm init with a configuration file` below.
    Please note that although the DNS server is deployed, it will not be scheduled until CNI is installed.
+
+   {{< warning >}}
+   kube-dns usage with kubeadm is deprecated as of v1.18 and will be removed in a future release.
+   {{< /warning >}}
 
 ### Using init phases with kubeadm {#init-phases}
 

--- a/content/en/docs/tasks/administer-cluster/coredns.md
+++ b/content/en/docs/tasks/administer-cluster/coredns.md
@@ -63,6 +63,10 @@ In Kubernetes 1.11, CoreDNS has graduated to General Availability (GA)
 and is installed by default.
 {{< /note >}}
 
+{{< warning >}}
+In Kubernetes 1.18, kube-dns usage with kubeadm has been deprecated and will be removed in a future version.
+{{< /warning >}}
+
 To install kube-dns on versions prior to 1.13, set the `CoreDNS` feature gate
 value to `false`:
 
@@ -72,9 +76,9 @@ kubeadm init --feature-gates=CoreDNS=false
 
 For versions 1.13 and later, follow the guide outlined [here](/docs/reference/setup-tools/kubeadm/kubeadm-init-phase#cmd-phase-addon).
 
-## Upgrading CoreDNS 
+## Upgrading CoreDNS
 
-CoreDNS is available in Kubernetes since v1.9. 
+CoreDNS is available in Kubernetes since v1.9.
 You can check the version of CoreDNS shipped with Kubernetes and the changes made to CoreDNS [here](https://github.com/coredns/deployment/blob/master/kubernetes/CoreDNS-k8s_version.md).
 
 CoreDNS can be upgraded manually in case you want to only upgrade CoreDNS or use your own custom image.


### PR DESCRIPTION
this deprecation is targeting 1.18.

xref https://github.com/kubernetes/kubeadm/issues/1943

/assign @sftim 
/kind deprecation
/sig cluster-lifecycle
