### PR TITLE
Add kubectl patch example with quotes on Windows

### DIFF
--- a/content/en/docs/tasks/administer-cluster/change-pv-reclaim-policy.md
+++ b/content/en/docs/tasks/administer-cluster/change-pv-reclaim-policy.md
@@ -54,12 +54,14 @@ the corresponding `PersistentVolume` is not be deleted. Instead, it is moved to 
 
     where `<your-pv-name>` is the name of your chosen PersistentVolume.
 
-    *Note* if you are running `kubectl` on Windows, you'd need to use double quotes on the
+    {{< note >}}
+    If you are running `kubectl` on Windows, you'd need to use double quotes on the
     command line and thus escape the inner double quotes like this:
 
     ```shell
     kubectl patch pv <your-pv-name> -p "{\"spec\":{\"persistentVolumeReclaimPolicy\":\"Retain\"}}"
     ```
+    {{< /note >}}
 
 1. Verify that your chosen PersistentVolume has the right policy:
 

--- a/content/en/docs/tasks/administer-cluster/change-pv-reclaim-policy.md
+++ b/content/en/docs/tasks/administer-cluster/change-pv-reclaim-policy.md
@@ -55,12 +55,9 @@ the corresponding `PersistentVolume` is not be deleted. Instead, it is moved to 
     where `<your-pv-name>` is the name of your chosen PersistentVolume.
 
     {{< note >}}
-    If you are running `kubectl` on Windows, you'd need to use double quotes on the
-    command line and thus escape the inner double quotes like this:
+    On Windows, you must _double_ quote any JSONPath template that contains spaces (not single quote as shown above for bash). This in turn means that you must use a single quote or escaped double quote around any literals in the template. For example:
 
-    ```shell
-    kubectl patch pv <your-pv-name> -p "{\"spec\":{\"persistentVolumeReclaimPolicy\":\"Retain\"}}"
-    ```
+    C:\> kubectl patch pv <your-pv-name> -p "{\"spec\":{\"persistentVolumeReclaimPolicy\":\"Retain\"}}"
     {{< /note >}}
 
 1. Verify that your chosen PersistentVolume has the right policy:

--- a/content/en/docs/tasks/administer-cluster/change-pv-reclaim-policy.md
+++ b/content/en/docs/tasks/administer-cluster/change-pv-reclaim-policy.md
@@ -43,7 +43,7 @@ the corresponding `PersistentVolume` is not be deleted. Instead, it is moved to 
         pvc-b95650f8-b7b5-11e6-9d58-0ed433a7dd94   4Gi        RWO           Delete          Bound     default/claim2    manual                     6s
         pvc-bb3ca71d-b7b5-11e6-9d58-0ed433a7dd94   4Gi        RWO           Delete          Bound     default/claim3    manual                     3s
 
-   This list also includes the name of the claims that are bound to each volume
+     This list also includes the name of the claims that are bound to each volume
    for easier identification of dynamically provisioned volumes.
 
 1. Choose one of your PersistentVolumes and change its reclaim policy:
@@ -57,7 +57,10 @@ the corresponding `PersistentVolume` is not be deleted. Instead, it is moved to 
     {{< note >}}
     On Windows, you must _double_ quote any JSONPath template that contains spaces (not single quote as shown above for bash). This in turn means that you must use a single quote or escaped double quote around any literals in the template. For example:
 
-    C:\> kubectl patch pv <your-pv-name> -p "{\"spec\":{\"persistentVolumeReclaimPolicy\":\"Retain\"}}"
+```cmd
+C:\> kubectl patch pv <your-pv-name> -p "{\"spec\":{\"persistentVolumeReclaimPolicy\":\"Retain\"}}"
+```
+
     {{< /note >}}
 
 1. Verify that your chosen PersistentVolume has the right policy:

--- a/content/en/docs/tasks/administer-cluster/change-pv-reclaim-policy.md
+++ b/content/en/docs/tasks/administer-cluster/change-pv-reclaim-policy.md
@@ -54,6 +54,13 @@ the corresponding `PersistentVolume` is not be deleted. Instead, it is moved to 
 
     where `<your-pv-name>` is the name of your chosen PersistentVolume.
 
+    *Note* if you are running `kubectl` on Windows, you'd need to use double quotes on the
+    command line and thus escape the inner double quotes like this:
+
+    ```shell
+    kubectl patch pv <your-pv-name> -p "{\"spec\":{\"persistentVolumeReclaimPolicy\":\"Retain\"}}"
+    ```
+
 1. Verify that your chosen PersistentVolume has the right policy:
 
     ```shell

--- a/content/en/docs/tasks/administer-cluster/change-pv-reclaim-policy.md
+++ b/content/en/docs/tasks/administer-cluster/change-pv-reclaim-policy.md
@@ -58,7 +58,7 @@ the corresponding `PersistentVolume` is not be deleted. Instead, it is moved to 
     On Windows, you must _double_ quote any JSONPath template that contains spaces (not single quote as shown above for bash). This in turn means that you must use a single quote or escaped double quote around any literals in the template. For example:
 
 ```cmd
-C:\> kubectl patch pv <your-pv-name> -p "{\"spec\":{\"persistentVolumeReclaimPolicy\":\"Retain\"}}"
+kubectl patch pv <your-pv-name> -p "{\"spec\":{\"persistentVolumeReclaimPolicy\":\"Retain\"}}"
 ```
 
     {{< /note >}}


### PR DESCRIPTION
When running the `kubectl patch` example, on Windows systems you get an
error when passing the patch request in single quotes. Passing it in
double quotes with the inner ones escaped produced the desired behavior
as is in the example given for Linux systems. I've added a small note
for Windows users to have that in mind.

Signed-off-by: Mariyan Dimitrov <mariyan.dimitrov@gmail.com>