### PR TITLE
maintain the current relative path when switching to other site versions

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -17,7 +17,7 @@
                 </a>
                 <ul>
                 {{ range $langPage.Translations }}
-                    <li><a href="{{  .RelPermalink }}">{{ .Language.LanguageName }}</a></li>
+                    <li><a href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a></li>
                 {{ end }}
                 </ul>
             </li>
@@ -28,7 +28,7 @@
                 </a>
                 <ul>
                 {{ range site.Params.versions }}
-                    <li><a href="{{  .url }}">{{ .version }}</a></li>
+                    <li><a href="{{ .url }}{{ $.RelPermalink }}">{{ .version }}</a></li>
                 {{ end }}
                 </ul>
             </li>


### PR DESCRIPTION
I was switching between different versions of the k8s docs today, and noticed that the pathname wasn't preserved when selecting different versions. This fixes that. :smile: