### PR TITLE
Fix header layout on Safari

### DIFF
--- a/assets/sass/_base.sass
+++ b/assets/sass/_base.sass
@@ -107,7 +107,6 @@ header
   z-index: 8888
   background-color: transparent
   box-shadow: 0 0 0 transparent
-  overflow: hidden
   transition: 0.3s
   text-align: center
 
@@ -245,6 +244,8 @@ header
       background-color: white
 
 #mainNav
+  display: none
+  
   h5
     color: $blue
     font-weight: normal


### PR DESCRIPTION
There is an issue with dropdown lists for language and versions in the header when using Safari, so we are not able to choose list items:

<img width="500" alt="image" src="https://user-images.githubusercontent.com/18210256/73214219-08dc4b00-4152-11ea-8949-f53a1d5a35fc.png">

Basically, removing `overflow:hidden` from `<header>` helps, but it also makes `#mainNav` block visible. I made a quick research and it seems like `#mainNav` isn't used already for some time. At least I wasn't able to invoke it.

So provided that `#mainNav` is obsolete, the quick fix without breaking anything is also just to add `display: none` to that id. There is also #14248, which confirms my understanding.

In turn, we get better browser compatibility.