### PR TITLE
install container runtimes without prompts

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -74,7 +74,7 @@ Use the following commands to install Docker on your system:
 # Install Docker CE
 ## Set up the repository:
 ### Install packages to allow apt to use a repository over HTTPS
-apt-get update && apt-get install \
+apt-get update && apt-get install -y \
   apt-transport-https ca-certificates curl software-properties-common
 
 ### Add Docker’s official GPG key
@@ -87,7 +87,7 @@ add-apt-repository \
   stable"
 
 ## Install Docker CE.
-apt-get update && apt-get install \
+apt-get update && apt-get install -y \
   containerd.io=1.2.10-3 \
   docker-ce=5:19.03.4~3-0~ubuntu-$(lsb_release -cs) \
   docker-ce-cli=5:19.03.4~3-0~ubuntu-$(lsb_release -cs)
@@ -115,14 +115,14 @@ systemctl restart docker
 # Install Docker CE
 ## Set up the repository
 ### Install required packages.
-yum install yum-utils device-mapper-persistent-data lvm2
+yum install -y yum-utils device-mapper-persistent-data lvm2
 
 ### Add Docker repository.
 yum-config-manager --add-repo \
   https://download.docker.com/linux/centos/docker-ce.repo
 
 ## Install Docker CE.
-yum update && yum install \
+yum update -y && yum install -y \
   containerd.io-1.2.10 \
   docker-ce-19.03.4 \
   docker-ce-cli-19.03.4
@@ -183,13 +183,13 @@ sysctl --system
 
 # Install prerequisites
 apt-get update
-apt-get install software-properties-common
+apt-get install -y software-properties-common
 
 add-apt-repository ppa:projectatomic/ppa
 apt-get update
 
 # Install CRI-O
-apt-get install cri-o-1.15
+apt-get install -y cri-o-1.15
 
 {{< /tab >}}
 {{< tab name="CentOS/RHEL 7.4+" codelang="bash" >}}
@@ -198,7 +198,7 @@ apt-get install cri-o-1.15
 yum-config-manager --add-repo=https://cbs.centos.org/repos/paas7-crio-115-release/x86_64/os/
 
 # Install CRI-O
-yum install --nogpgcheck cri-o
+yum install --nogpgcheck -y cri-o
 
 {{< /tab >}}
 {{< /tabs >}}
@@ -272,7 +272,7 @@ systemctl restart containerd
 # Install containerd
 ## Set up the repository
 ### Install required packages
-yum install yum-utils device-mapper-persistent-data lvm2
+yum install -y yum-utils device-mapper-persistent-data lvm2
 
 ### Add docker repository
 yum-config-manager \
@@ -280,7 +280,7 @@ yum-config-manager \
     https://download.docker.com/linux/centos/docker-ce.repo
 
 ## Install containerd
-yum update && yum install containerd.io
+yum update -y && yum install -y containerd.io
 
 # Configure containerd
 mkdir -p /etc/containerd


### PR DESCRIPTION
In Kubernetes docs, all of the packages that are required to set up the
Kubernetes are installed without requiring any prompts through
the package manager (like apt or yum) except for the container runtimes.

https://kubernetes.io/docs/setup/production-environment/container-runtimes/

So, it would be better to have these installations with prompts (yes) disabled.
#18892