### PR TITLE
disable simplytunde as an approver due to inactivity.

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -52,7 +52,6 @@ aliases:
     - Rajakavitha1
     - ryanmcginnis
     - sftim
-    - simplytunde
     - steveperry-53
     - tengqm
     - xiangpengzhao
@@ -70,7 +69,6 @@ aliases:
     - makoscafee
     - rajakavitha1
     - sftim
-    - simplytunde
     - steveperry-53
     - tengqm
     - xiangpengzhao


### PR DESCRIPTION
Disabling simplytunde as an approver due to inactivity.
Always welcome to come back if able to become active
again

Signed-off-by: Brad Topol <btopol@us.ibm.com>


