### PR TITLE
Fix cursor not being correct on <code> copy icon

### DIFF
--- a/layouts/shortcodes/codenew.html
+++ b/layouts/shortcodes/codenew.html
@@ -25,7 +25,7 @@
                 {{ with $ghlink }}<a href="{{ . }}" download="{{ $file }}">{{ end }}
                     <code>{{ $file }}</code>
                 {{ if $ghlink }}</a>{{ end }}
-                <img src="{{ "images/copycode.svg" | relURL }}" style="max-height:24px" onclick="copyCode('{{ $file | anchorize }}')" title="Copy {{ $file }} to clipboard">
+                <img src="{{ "images/copycode.svg" | relURL }}" style="max-height:24px; cursor: pointer" onclick="copyCode('{{ $file | anchorize }}')" title="Copy {{ $file }} to clipboard">
             </th>
         </tr>
     </thead>


### PR DESCRIPTION
When using the `code` or `code-new` components, there is a neat "Copy to clipboard button" in the top right corner. When hovering the filename, the cursor is a pointer. When hovering the copy icon it is not a pointer.

This is potentially confusing the user (at least it confused me), as they become unsure whether the icon is behaving as a button (clickable?) or not. See below screenshot.

![Screenshot from 2020-01-29 15-13-22](https://user-images.githubusercontent.com/6052785/73369118-01c85080-42aa-11ea-8a1c-14a1ffc259ea.png)

This PR seeks to unify that behaviour.
Now hovering the copy icon will also yield a `cursor: pointer`.