### PR TITLE
fix: fixed eating initial 2 spaces inside code.

### DIFF
--- a/content/en/docs/concepts/configuration/taint-and-toleration.md
+++ b/content/en/docs/concepts/configuration/taint-and-toleration.md
@@ -73,6 +73,7 @@ A toleration "matches" a taint if the keys are the same and the effects are the 
 `Operator` defaults to `Equal` if not specified.
 
 {{< note >}}
+
 There are two special cases:
 
 * An empty `key` with operator `Exists` matches all keys, values and effects which means this
@@ -88,8 +89,9 @@ tolerations:
 ```yaml
 tolerations:
 - key: "key"
-  operator: "Exists"
+      operator: "Exists"
 ```
+
 {{< /note >}}
 
 The above example used `effect` of `NoSchedule`. Alternatively, you can use `effect` of `PreferNoSchedule`.


### PR DESCRIPTION
This PR is going to fix #18905 . The code indent usage between list item and simple paragraph content is different, see [CommonMark Spec](https://spec.commonmark.org/0.25/#indented-code-block), and I add 6 leading spaces to make the `operator` line renders as expect.

Thanks.
