### PR TITLE
Table of contents causes grievous screen space wastage

### DIFF
--- a/assets/sass/_desktop.sass
+++ b/assets/sass/_desktop.sass
@@ -2,7 +2,7 @@ $main-max-width: 1200px
 $vendor-strip-height: 44px
 $video-section-height: 550px
 
-@media screen and (min-width: 1025px)
+@media screen and (min-width: 1100px)
   #hamburger
     display: none
 


### PR DESCRIPTION
The way the table of contents is laid out means that as soon as the user scrolls past it, half of their screen space is wasted and eg. tables are hard to read. Not saying that this code change fixes the flaw -- perhaps having some way to "wrap" text that appears after the ToC would be better. I'm not a CSS expert.

Before:
<img width="1051" alt="Screenshot 2020-01-31 at 12 20 56" src="https://user-images.githubusercontent.com/18679515/73538987-3f50e900-4424-11ea-870a-a5e201be6012.png">


After:
<img width="1049" alt="Screenshot 2020-01-31 at 12 21 16" src="https://user-images.githubusercontent.com/18679515/73538996-4546ca00-4424-11ea-994c-bf4f89a22b59.png">