### PR TITLE
Remove "Unschedulable" pod condition type from the pod lifecycle docs

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -67,8 +67,6 @@ array has six possible fields:
     balancing pools of all matching Services;
   * `Initialized`: all [init containers](/docs/concepts/workloads/pods/init-containers)
     have started successfully;
-  * `Unschedulable`: the scheduler cannot schedule the Pod right now, for example
-    due to lack of resources or other constraints;
   * `ContainersReady`: all containers in the Pod are ready.
 
 


### PR DESCRIPTION
The pod lifecycle documentation erroneously indicated `Unschedulable` as a possible `type` of pod condition. That's not true. Only four condition types exist. The `Unschedulable` value is not a type, but one of the possible reasons of the `PodScheduled` condition type.