### PR TITLE
Update version for Configuration HPA scaling enhancement

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -292,7 +292,7 @@ and [the walkthrough for using external metrics](/docs/tasks/run-application/hor
 ## Support for configurable scaling behavior
 
 Starting from
-[v1.17](https://github.com/kubernetes/enhancements/blob/master/keps/sig-autoscaling/20190307-configurable-scale-velocity-for-hpa.md)
+[v1.18](https://github.com/kubernetes/enhancements/blob/master/keps/sig-autoscaling/20190307-configurable-scale-velocity-for-hpa.md)
 the `v2beta2` API allows scaling behavior to be configured through the HPA
 `behavior` field. Behaviors are specified separately for scaling up and down in
 `scaleUp` or `scaleDown` section under the `behavior` field. A stabilization


### PR DESCRIPTION
I originally made a PR #18157 which was merged into the `master` branch. It was subsequently reverted on the `master` because the enhancement is targeted at _1.18_.  I tried to add the full commit from the original PR but the changes were already present on the `dev-1.18` branch because changes from master are synced in here. So I've just updated the version when this feature becomes available.


