### PR TITLE
Fix of pull request #18960

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -65,11 +65,11 @@ It defines an index.php page which performs some CPU intensive computations:
 First, we will start a deployment running the image and expose it as a service:
 
 ```shell
-kubectl run php-apache --image=k8s.gcr.io/hpa-example --requests=cpu=200m --limits=cpu=500m --expose --port=80  --generator=run-pod/v1
+kubectl apply -f https://k8s.io/examples/application/php-apache.yaml
 ```
 ```
-service/php-apache created
 deployment.apps/php-apache created
+service/php-apache created
 ```
 
 ## Create Horizontal Pod Autoscaler

--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -79,18 +79,17 @@ service/php-apache created
 
 ## Create Horizontal Pod Autoscaler
 
-Now that the server is running, we will create a Horizontal Pod Autoscaler that maintains between 1 and 10 replicas of the Pods
+Now that the server is running, we will create the autoscaler using
+[kubectl autoscale](/docs/reference/generated/kubectl/kubectl-commands#autoscale).
+The following command will create a Horizontal Pod Autoscaler that maintains between 1 and 10 replicas of the Pods
 controlled by the php-apache deployment we created in the first step of these instructions.
 Roughly speaking, HPA will increase and decrease the number of replicas
 (via the deployment) to maintain an average CPU utilization across all Pods of 50%
 (since each pod requests 200 milli-cores by `kubectl run`), this means average CPU usage of 100 milli-cores).
 See [here](/docs/tasks/run-application/horizontal-pod-autoscale/#algorithm-details) for more details on the algorithm.
 
-{{< codenew file="application/hpa/php-apache.yaml" >}}
-
-Run the following command:
 ```shell
-kubectl apply -f https://k8s.io/examples/application/hpa/php-apache.yaml
+kubectl autoscale deployment php-apache --cpu-percent=50 --min=1 --max=10
 ```
 ```
 horizontalpodautoscaler.autoscaling/php-apache autoscaled

--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -62,8 +62,13 @@ It defines an index.php page which performs some CPU intensive computations:
 ?>
 ```
 
-First, we will start a deployment running the image and expose it as a service:
+First, we will start a deployment running the image and expose it as a service
+using the following configuration:
 
+{{< codenew file="application/php-apache.yaml" >}}
+
+
+Run the following command:
 ```shell
 kubectl apply -f https://k8s.io/examples/application/php-apache.yaml
 ```
@@ -74,17 +79,18 @@ service/php-apache created
 
 ## Create Horizontal Pod Autoscaler
 
-Now that the server is running, we will create the autoscaler using
-[kubectl autoscale](/docs/reference/generated/kubectl/kubectl-commands#autoscale).
-The following command will create a Horizontal Pod Autoscaler that maintains between 1 and 10 replicas of the Pods
+Now that the server is running, we will create a Horizontal Pod Autoscaler that maintains between 1 and 10 replicas of the Pods
 controlled by the php-apache deployment we created in the first step of these instructions.
 Roughly speaking, HPA will increase and decrease the number of replicas
 (via the deployment) to maintain an average CPU utilization across all Pods of 50%
 (since each pod requests 200 milli-cores by `kubectl run`), this means average CPU usage of 100 milli-cores).
 See [here](/docs/tasks/run-application/horizontal-pod-autoscale/#algorithm-details) for more details on the algorithm.
 
+{{< codenew file="application/hpa/php-apache.yaml" >}}
+
+Run the following command:
 ```shell
-kubectl autoscale deployment php-apache --cpu-percent=50 --min=1 --max=10
+kubectl apply -f https://k8s.io/examples/application/hpa/php-apache.yaml
 ```
 ```
 horizontalpodautoscaler.autoscaling/php-apache autoscaled

--- a/content/en/examples/application/php-apache.yaml
+++ b/content/en/examples/application/php-apache.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: php-apache
+spec:
+  selector:
+    matchLabels:
+      run: php-apache
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: php-apache
+    spec:
+      containers:
+      - name: php-apache
+        image: k8s.gcr.io/hpa-example
+        ports:
+        - containerPort: 80
+        resources:
+          limits:
+            cpu: 500m
+          requests:
+            cpu: 200m
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: php-apache
+  labels:
+    run: php-apache
+spec:
+  ports:
+  - port: 80
+  selector:
+    run: php-apache
+


### PR DESCRIPTION
Update command for creating php-apache deployment and service due to the following warning: `kubectl run --generator=deployment/apps.v1 is DEPRECATED and will be removed in a future version. Use kubectl run --generator=run-pod/v1 or kubectl create instead.`