### PR TITLE
Fix possible typo `logs files` -> `log files`

### DIFF
--- a/content/en/docs/tasks/debug-application-cluster/audit.md
+++ b/content/en/docs/tasks/debug-application-cluster/audit.md
@@ -31,7 +31,7 @@ answer the following questions:
 of its execution generates an event, which is then pre-processed according to
 a certain policy and written to a backend. The policy determines what's recorded
 and the backends persist the records. The current backend implementations
-include log files and webhooks.
+include logging of files and webhooks.
 
 Each request can be recorded with an associated "stage". The known stages are:
 

--- a/content/en/docs/tasks/debug-application-cluster/audit.md
+++ b/content/en/docs/tasks/debug-application-cluster/audit.md
@@ -31,7 +31,7 @@ answer the following questions:
 of its execution generates an event, which is then pre-processed according to
 a certain policy and written to a backend. The policy determines what's recorded
 and the backends persist the records. The current backend implementations
-include logs files and webhooks.
+include log files and webhooks.
 
 Each request can be recorded with an associated "stage". The known stages are:
 


### PR DESCRIPTION
I think the correct sentence is :
`The current backend implementations include logging of files and webhooks.`
and not
`The current backend implementations include logs files and webhooks.`

But I might be wrong / interpreting it incorrectly.