### PR TITLE
Link to setup page about Kind

### DIFF
--- a/content/en/docs/setup/_index.md
+++ b/content/en/docs/setup/_index.md
@@ -41,7 +41,7 @@ If you're learning Kubernetes, use the Docker-based solutions: tools supported b
 |Community           |Ecosystem     |
 | ------------       | --------     |
 | [Minikube](/docs/setup/learning-environment/minikube/) | [CDK on LXD](https://www.ubuntu.com/kubernetes/docs/install-local) |
-| [kind (Kubernetes IN Docker)](https://github.com/kubernetes-sigs/kind) | [Docker Desktop](https://www.docker.com/products/docker-desktop)|
+| [kind (Kubernetes IN Docker)](/docs/setup/learning-environment/kind/) | [Docker Desktop](https://www.docker.com/products/docker-desktop)|
 |                     | [Minishift](https://docs.okd.io/latest/minishift/)|
 |                     | [MicroK8s](https://microk8s.io/)|
 |                     | [IBM Cloud Private-CE (Community Edition)](https://github.com/IBM/deploy-ibm-cloud-private) |


### PR DESCRIPTION
Following on from PR #17860, hyperlink from [/docs/setup/](https://kubernetes.io/docs/setup/) to [/docs/setup/learning-environment/kind/](https://kubernetes.io/docs/setup/learning-environment/kind/) now that that target page exists.