### PR TITLE
Add missing space in documentation line

### DIFF
--- a/content/en/docs/reference/kubectl/docker-cli-to-kubectl.md
+++ b/content/en/docs/reference/kubectl/docker-cli-to-kubectl.md
@@ -281,7 +281,7 @@ kubectl get po -l run=nginx-app
 ```
 
 {{< note >}}
-When you use kubectl, you don't delete the pod directly.You have to first delete the Deployment that owns the pod. If you delete the pod directly, the Deployment recreates the pod.
+When you use kubectl, you don't delete the pod directly. You have to first delete the Deployment that owns the pod. If you delete the pod directly, the Deployment recreates the pod.
 {{< /note >}}
 
 ## docker login


### PR DESCRIPTION
Added a missing space in a note on the section "docker stop and docker rm".