### PR TITLE
fix translate docs format

### DIFF
--- a/content/zh/docs/tasks/configure-pod-container/configure-volume-storage.md
+++ b/content/zh/docs/tasks/configure-pod-container/configure-volume-storage.md
@@ -150,10 +150,10 @@ of `Always`.
 -->
 
 1. 用 shell 终端进入重新启动的容器中：
-
 <!--
 1.Get a shell into the restarted Container:
 -->
+
     ```shell
     kubectl exec -it redis -- /bin/bash
     ```
@@ -162,6 +162,7 @@ of `Always`.
 <!--
 1.In your shell, goto `/data/redis`, and verify that `test-file` is still there.
 -->
+
     ```shell
     root@redis:/data/redis# cd /data/redis/
     root@redis:/data/redis# ls
@@ -169,10 +170,10 @@ of `Always`.
     ```
 
 1. 删除为此练习所创建的 Pod：
-
 <!--
 1.Delete the Pod that you created for this exercise:
 -->
+
     ```shell
     kubectl delete pod redis
     ```


### PR DESCRIPTION
fix translate docs format as follows:

![image](https://user-images.githubusercontent.com/45066503/73991344-ce12b800-4986-11ea-86d1-267191a1ba25.png)

After modification is as follows：

![image](https://user-images.githubusercontent.com/45066503/73992045-e2f04b00-4988-11ea-88c9-97d0cbc23fab.png)

https://deploy-preview-19018--kubernetes-io-master-staging.netlify.com/zh/docs/tasks/configure-pod-container/configure-volume-storage/
