### PR TITLE
docs: fix broken etcd's official documents link

### DIFF
--- a/content/de/docs/reference/glossary/etcd.md
+++ b/content/de/docs/reference/glossary/etcd.md
@@ -15,5 +15,5 @@ tags:
 
 <!--more-->
 
-Halten Sie immer einen Sicherungsplan für etcds Daten für Ihren Kubernetes-Cluster bereit. Ausführliche Informationen zu etcd finden Sie in der [etcd Dokumentation](https://github.com/coreos/etcd/blob/master/Documentation/docs.md).
+Halten Sie immer einen Sicherungsplan für etcds Daten für Ihren Kubernetes-Cluster bereit. Ausführliche Informationen zu etcd finden Sie in der [etcd Dokumentation](https://etcd.io/docs).
 

--- a/content/id/docs/reference/glossary/etcd.md
+++ b/content/id/docs/reference/glossary/etcd.md
@@ -15,4 +15,4 @@ tags:
 
 <!--more-->
 
-Selalu perhatikan mekanisme untuk mem-<i>backup</i> data etcd pada klaster Kubernetes kamu. Untuk informasi lebih lanjut tentang etcd, lihat [dokumentasi etcd](https://github.com/coreos/etcd/blob/master/Documentation/docs.md).
+Selalu perhatikan mekanisme untuk mem-<i>backup</i> data etcd pada klaster Kubernetes kamu. Untuk informasi lebih lanjut tentang etcd, lihat [dokumentasi etcd](https://etcd.io/docs).

--- a/content/ko/docs/reference/glossary/etcd.md
+++ b/content/ko/docs/reference/glossary/etcd.md
@@ -19,4 +19,4 @@ tags:
 이 데이터를 [백업](/docs/tasks/administer-cluster/configure-upgrade-etcd/#backing-up-an-etcd-cluster)하는 계획은
 필수이다.
 
-etcd에 대한 자세한 정보는, 공식 [문서](https://github.com/coreos/etcd/blob/master/Documentation/docs.md)를 참고한다.
+etcd에 대한 자세한 정보는, 공식 [문서](https://etcd.io/docs)를 참고한다.

--- a/content/zh/docs/reference/glossary/etcd.md
+++ b/content/zh/docs/reference/glossary/etcd.md
@@ -37,7 +37,7 @@ etcd 是兼具一致性和高可用性的键值数据库，可以作为保存 Ku
 <!--more--> 
 
 <!--
-Always have a backup plan for etcd's data for your Kubernetes cluster. For in-depth information on etcd, see [etcd documentation](https://github.com/coreos/etcd/blob/master/Documentation/docs.md).
+Always have a backup plan for etcd's data for your Kubernetes cluster. For in-depth information on etcd, see [etcd documentation](https://etcd.io/docs).
 -->
 
-您的 Kubernetes 集群的 etcd 数据库通常需要有个备份计划。要了解 etcd 更深层次的信息，请参考 [etcd 文档](https://github.com/coreos/etcd/blob/master/Documentation/docs.md)。
+您的 Kubernetes 集群的 etcd 数据库通常需要有个备份计划。要了解 etcd 更深层次的信息，请参考 [etcd 文档](https://etcd.io/docs)。


### PR DESCRIPTION
This PR fixes broken etcd's official docs link in reference/glossary/etcd.md

- language
  - de
  - id
  - ko
  - zh