### PR TITLE
Updated "Use an HTTP Proxy to Access the Kubernetes API" to match style guide

### DIFF
--- a/content/en/docs/tasks/access-kubernetes-api/http-proxy-access-api.md
+++ b/content/en/docs/tasks/access-kubernetes-api/http-proxy-access-api.md
@@ -38,6 +38,8 @@ Get the API versions:
 
     curl http://localhost:8080/api/
 
+The output should look similar to this:
+
     {
       "kind": "APIVersions",
       "versions": [
@@ -54,6 +56,8 @@ Get the API versions:
 Get a list of pods:
 
     curl http://localhost:8080/api/v1/namespaces/default/pods
+
+The output should look similar to this:
 
     {
       "kind": "PodList",


### PR DESCRIPTION
This PR separates commands and outputs on the "Use an HTTP Proxy to Access the Kubernetes API"-page as proposed in the style guide. 

Fixes #19017 