### PR TITLE
Update Hugo to 0.64.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@ functions = "functions"
 command = "make non-production-build"
 
 [build.environment]
-HUGO_VERSION = "0.59.1"
+HUGO_VERSION = "0.64.0"
 
 [context.production.environment]
 HUGO_BASEURL = "https://kubernetes.io/"


### PR DESCRIPTION
This PR updates the website's Hugo version to the most recent bug-fix release.

This PR fixes #18406. 

This PR also updates k/website for the latest version of Goldmark support.

/sig docs
/kind cleanup
/assign @kbarnard10 