### PR TITLE
Update Topology Manager for 1.18

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -146,7 +146,8 @@ different Kubernetes components.
 | `TokenRequestProjection` | `false` | Alpha | 1.11 | 1.11 |
 | `TokenRequestProjection` | `true` | Beta | 1.12 | |
 | `TTLAfterFinished` | `false` | Alpha | 1.12 | |
-| `TopologyManager` | `false` | Alpha | 1.16 | |
+| `TopologyManager` | `false` | Alpha | 1.16 | 1.17 |
+| `TopologyManager` | `true` | Beta | 1.18 | |
 | `ValidateProxyRedirects` | `false` | Alpha | 1.10 | 1.13 |
 | `ValidateProxyRedirects` | `true` | Beta | 1.14 | |
 | `VolumePVCDataSource` | `false` | Alpha | 1.15 | 1.15 |

--- a/content/en/docs/tasks/administer-cluster/topology-manager.md
+++ b/content/en/docs/tasks/administer-cluster/topology-manager.md
@@ -12,7 +12,7 @@ content_template: templates/task
 
 {{% capture overview %}}
 
-{{< feature-state state="alpha" >}}
+{{< feature-state state="beta" >}}
 
 An increasing number of systems leverage a combination of CPUs and hardware accelerators to support latency-critical execution and high-throughput parallel computation. These include workloads in fields such as telecommunications, scientific computing, machine learning, financial services and data analytics. Such hybrid systems comprise a high performance environment.
 
@@ -176,12 +176,9 @@ In the case of the `BestEffort` pod the CPU Manager would send back the default 
 Using this information the Topology Manager calculates the optimal hint for the pod and stores this information, which will be used by the Hint Providers when they are making their resource assignments. 
 
 ### Known Limitations
-1. As of K8s 1.16 the Topology Manager is currently only guaranteed to work if a *single* container in the pod spec requires aligned resources. This is due to the hint generation being based on current resource allocations, and all containers in a pod generate hints before any resource allocation has been made. This results in unreliable hints for all but the first container in a pod.
-*Due to this limitation if multiple pods/containers are considered by Kubelet in quick succession they may not respect the Topology Manager policy.
+1. The maximum number of NUMA nodes that Topology Manager will allow is 8, past this there will be a state explosion when trying to enumerate the possible NUMA affinities and generating their hints.
 
-2. The maximum number of NUMA nodes that Topology Manager will allow is 8, past this there will be a state explosion when trying to enumerate the possible NUMA affinities and generating their hints.
-
-3. The scheduler is not topology-aware, so it is possible to be scheduled on a node and then fail on the node due to the Topology Manager. 
+2. The scheduler is not topology-aware, so it is possible to be scheduled on a node and then fail on the node due to the Topology Manager. 
 
 
 {{% /capture %}}

--- a/content/en/docs/tasks/administer-cluster/topology-manager.md
+++ b/content/en/docs/tasks/administer-cluster/topology-manager.md
@@ -176,7 +176,7 @@ In the case of the `BestEffort` pod the CPU Manager would send back the default 
 Using this information the Topology Manager calculates the optimal hint for the pod and stores this information, which will be used by the Hint Providers when they are making their resource assignments. 
 
 ### Known Limitations
-1. The maximum number of NUMA nodes that Topology Manager will allow is 8, past this there will be a state explosion when trying to enumerate the possible NUMA affinities and generating their hints.
+1. The maximum number of NUMA nodes that Topology Manager allows is 8. With more than 8 NUMA nodes there will be a state explosion when trying to enumerate the possible NUMA affinities and generating their hints.
 
 2. The scheduler is not topology-aware, so it is possible to be scheduled on a node and then fail on the node due to the Topology Manager. 
 

--- a/content/en/docs/tasks/administer-cluster/topology-manager.md
+++ b/content/en/docs/tasks/administer-cluster/topology-manager.md
@@ -8,6 +8,7 @@ reviewers:
 - nolancon
 
 content_template: templates/task
+min-kubernetes-server-version: v1.18
 ---
 
 {{% capture overview %}}
@@ -25,6 +26,8 @@ _Topology Manager_ is a Kubelet component that aims to co-ordinate the set of co
 {{% capture prerequisites %}}
 
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+In Kubernetes versions 1.16 and 1.17, the Topology Manager feature gate must be enabled manually via the Kubelet `--feature-gates` flag.
+Please see documentation related to the Topology Manager [`feature gate`](#topology-manager-kubelet-feature-gate) for more details.
 
 {{% /capture %}}
 
@@ -43,6 +46,11 @@ The Topology Manager provides an interface for components, called *Hint Provider
 The Topology manager receives Topology information from the *Hint Providers* as a bitmask denoting NUMA Nodes available and a preferred allocation indication. The Topology Manager policies perform a set of operations on the hints provided and converge on the hint determined by the policy to give the optimal result, if an undesirable hint is stored the preferred field for the hint will be set to false. In the current policies preferred is the narrowest preferred mask.
 The selected hint is stored as part of the Topology Manager. Depending on the policy configured the pod can be accepted or rejected from the node based on the selected hint.
 The hint is then stored in the Topology Manager for use by the *Hint Providers* when making the resource allocation decisions.
+
+### Topology Manager Kubelet Feature Gate
+
+As of Kubernetes version 1.18, the Topology Manager feature gate is enabled by default. 
+For Kubernetes versions 1.16 and 1.17, the Topology Manager feature gate must be set via the Kubelet flag, `--feature-gates=TopologyManager=true`.
 
 ### Topology Manager Policies
 

--- a/content/en/docs/tasks/administer-cluster/topology-manager.md
+++ b/content/en/docs/tasks/administer-cluster/topology-manager.md
@@ -26,8 +26,6 @@ _Topology Manager_ is a Kubelet component that aims to co-ordinate the set of co
 {{% capture prerequisites %}}
 
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
-In Kubernetes versions 1.16 and 1.17, the Topology Manager feature gate must be enabled manually via the Kubelet `--feature-gates` flag.
-Please see documentation related to the Topology Manager [`feature gate`](#topology-manager-kubelet-feature-gate) for more details.
 
 {{% /capture %}}
 
@@ -47,10 +45,9 @@ The Topology manager receives Topology information from the *Hint Providers* as 
 The selected hint is stored as part of the Topology Manager. Depending on the policy configured the pod can be accepted or rejected from the node based on the selected hint.
 The hint is then stored in the Topology Manager for use by the *Hint Providers* when making the resource allocation decisions.
 
-### Topology Manager Kubelet Feature Gate
+### Enable the Topology Manager feature
 
-As of Kubernetes version 1.18, the Topology Manager feature gate is enabled by default. 
-For Kubernetes versions 1.16 and 1.17, the Topology Manager feature gate must be set via the Kubelet flag, `--feature-gates=TopologyManager=true`.
+Support for the Topology Manager requires `TopologyManager` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) to be enabled. It is enabled by default starting with Kubernetes 1.18.
 
 ### Topology Manager Policies
 

--- a/content/en/docs/tasks/administer-cluster/topology-manager.md
+++ b/content/en/docs/tasks/administer-cluster/topology-manager.md
@@ -188,6 +188,6 @@ Using this information the Topology Manager calculates the optimal hint for the 
 
 2. The scheduler is not topology-aware, so it is possible to be scheduled on a node and then fail on the node due to the Topology Manager.
 
-3. Currently, the Device Manager and the CPU Manager are the only components to adopt the Topology Manager's HintProvider interface. This means that NUMA alignment can only be achieved for resources managed by the CPU Manager and the Device Manager. Memory or Hugepages are currently not considered by the Topology Manager for NUMA alignment.
+3. The Device Manager and the CPU Manager are the only components to adopt the Topology Manager's HintProvider interface. This means that NUMA alignment can only be achieved for resources managed by the CPU Manager and the Device Manager. Memory or Hugepages are not considered by the Topology Manager for NUMA alignment.
 
 {{% /capture %}}

--- a/content/en/docs/tasks/administer-cluster/topology-manager.md
+++ b/content/en/docs/tasks/administer-cluster/topology-manager.md
@@ -186,7 +186,8 @@ Using this information the Topology Manager calculates the optimal hint for the 
 ### Known Limitations
 1. The maximum number of NUMA nodes that Topology Manager allows is 8. With more than 8 NUMA nodes there will be a state explosion when trying to enumerate the possible NUMA affinities and generating their hints.
 
-2. The scheduler is not topology-aware, so it is possible to be scheduled on a node and then fail on the node due to the Topology Manager. 
+2. The scheduler is not topology-aware, so it is possible to be scheduled on a node and then fail on the node due to the Topology Manager.
 
+3. Currently, the Device Manager and the CPU Manager are the only components to adopt the Topology Manager's HintProvider interface. This means that NUMA alignment can only be achieved for resources managed by the CPU Manager and the Device Manager. Memory or Hugepages are currently not considered by the Topology Manager for NUMA alignment.
 
 {{% /capture %}}


### PR DESCRIPTION
Move from Alpha to Beta.
Remove Known Limitation - fixed in 1.18.
All criteria is now met for Topology Manager to move to `Beta` status so this PR is ready for final review and merge.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use
 for advice.

-->
