### PR TITLE
Updated network-policies.md for default deny all ingress and egress traffic

### DIFF
--- a/content/en/docs/concepts/services-networking/network-policies.md
+++ b/content/en/docs/concepts/services-networking/network-policies.md
@@ -199,7 +199,7 @@ If you want to allow all traffic from all pods in a namespace (even if policies 
 
 You can create a "default" policy for a namespace which prevents all ingress AND egress traffic by creating the following NetworkPolicy in that namespace.
 
-{{< codenew file="service/networking/network-policy-default-deny-egress.yaml" >}}
+{{< codenew file="service/networking/network-policy-default-deny-all.yaml" >}}
 
 This ensures that even pods that aren't selected by any other NetworkPolicy will not be allowed ingress or egress traffic.
 

--- a/content/en/examples/service/networking/network-policy-default-deny-all.yaml
+++ b/content/en/examples/service/networking/network-policy-default-deny-all.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:


### PR DESCRIPTION
1. Updated [network-policies.md ](content/en/docs/concepts/services-networking/network-policies.md) for the section "**Default deny all ingress and all egress traffic**" to refer to the proper file.
2. Updated [network-policy-default-deny-all.yaml
](content/en/examples/service/networking/network-policy-default-deny-all.yaml) for proper formatting.

Fixes [#19047](https://github.com/kubernetes/website/issues/19047)