### PR TITLE
Convert to {{ note }} shortcode

### DIFF
--- a/content/en/docs/tasks/run-application/run-replicated-stateful-application.md
+++ b/content/en/docs/tasks/run-application/run-replicated-stateful-application.md
@@ -18,9 +18,10 @@ This page shows how to run a replicated stateful application using a
 The example is a MySQL single-master topology with multiple slaves running
 asynchronous replication.
 
-Note that **this is not a production configuration**.
-In particular, MySQL settings remain on insecure defaults to keep the focus
+{{ < note > }}
+**This is not a production configuration**. MySQL settings remain on insecure defaults to keep the focus
 on general patterns for running stateful applications in Kubernetes.
+{{ < /note > }}
 
 {{% /capture %}}
 


### PR DESCRIPTION
Converts a "Note that.." phrasing to use the note shortcode.

This is also a test to see if editing a page via GitHub's markdown editor and not including a signoff in the description fails the CLA test or not, as I'm revising the instructions in the contribute section at the moment.