### PR TITLE
More description to add-dir-header flag

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/cloud-controller-manager.md
+++ b/content/en/docs/reference/command-line-tools-reference/cloud-controller-manager.md
@@ -29,7 +29,7 @@ cloud-controller-manager [flags]
       <td colspan="2">--add-dir-header</td>
     </tr>
     <tr>
-      <td></td><td style="line-height: 130%; word-wrap: break-word;">If true, adds the file directory to the header</td>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;">If true, adds the file directory to the header of the log messages</td>
     </tr>
 
     <tr>

--- a/content/en/docs/reference/command-line-tools-reference/kube-apiserver.md
+++ b/content/en/docs/reference/command-line-tools-reference/kube-apiserver.md
@@ -31,7 +31,7 @@ kube-apiserver [flags]
       <td colspan="2">--add-dir-header</td>
     </tr>
     <tr>
-      <td></td><td style="line-height: 130%; word-wrap: break-word;">If true, adds the file directory to the header</td>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;">If true, adds the file directory to the header of the log messages</td>
     </tr>
 
     <tr>

--- a/content/en/docs/reference/command-line-tools-reference/kube-controller-manager.md
+++ b/content/en/docs/reference/command-line-tools-reference/kube-controller-manager.md
@@ -35,7 +35,7 @@ kube-controller-manager [flags]
       <td colspan="2">--add-dir-header</td>
     </tr>
     <tr>
-      <td></td><td style="line-height: 130%; word-wrap: break-word;">If true, adds the file directory to the header</td>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;">If true, adds the file directory to the header of the log messages</td>
     </tr>
 
     <tr>

--- a/content/en/docs/reference/command-line-tools-reference/kube-scheduler.md
+++ b/content/en/docs/reference/command-line-tools-reference/kube-scheduler.md
@@ -34,7 +34,7 @@ kube-scheduler [flags]
       <td colspan="2">--add-dir-header</td>
     </tr>
     <tr>
-      <td></td><td style="line-height: 130%; word-wrap: break-word;">If true, adds the file directory to the header</td>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;">If true, adds the file directory to the header of the log messages</td>
     </tr>
 
     <tr>

--- a/content/en/docs/reference/command-line-tools-reference/kubelet.md
+++ b/content/en/docs/reference/command-line-tools-reference/kubelet.md
@@ -40,7 +40,7 @@ kubelet [flags]
       <td colspan="2">--add-dir-header</td>
     </tr>
     <tr>
-      <td></td><td style="line-height: 130%; word-wrap: break-word;">If true, adds the file directory to the header</td>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;">If true, adds the file directory to the header of the log messages</td>
     </tr>
     
     <tr>

--- a/content/en/docs/reference/kubectl/kubectl.md
+++ b/content/en/docs/reference/kubectl/kubectl.md
@@ -30,7 +30,7 @@ kubectl [flags]
       <td colspan="2">--add-dir-header</td>
     </tr>
     <tr>
-      <td></td><td style="line-height: 130%; word-wrap: break-word;">If true, adds the file directory to the header</td>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;">If true, adds the file directory to the header of the log messages</td>
     </tr>
 
     <tr>

--- a/content/zh/docs/reference/command-line-tools-reference/kube-scheduler.md
+++ b/content/zh/docs/reference/command-line-tools-reference/kube-scheduler.md
@@ -46,7 +46,7 @@ kube-scheduler [flags]
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">
       <!-- 
-      If true, adds the file directory to the header
+      If true, adds the file directory to the header of the log messages
       -->
       如果为 true，则将文件目录添加到标题中
       </td>

--- a/content/zh/docs/reference/command-line-tools-reference/kubelet.md
+++ b/content/zh/docs/reference/command-line-tools-reference/kubelet.md
@@ -58,7 +58,7 @@ kubelet [flags]
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">
       <!--
-      If true, adds the file directory to the header
+      If true, adds the file directory to the header of the log messages
       -->
       设置为 true 表示添加文件目录到 header 中
       </td>

--- a/content/zh/docs/reference/kubectl/kubectl.md
+++ b/content/zh/docs/reference/kubectl/kubectl.md
@@ -46,7 +46,7 @@ kubectl [flags]
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">
       <!--
-      If true, adds the file directory to the header
+      If true, adds the file directory to the header of the log messages
       -->
       设置为 true 表示添加文件目录到 header 中
       </td>


### PR DESCRIPTION
The description on the `add-dir-header` doesn't reflect the area it applies to (logging=klog). Hopefully this pr will make the flag purpose more clear to an end user.

Please advise if there is anything special follow-up needed on the zh translation front



