### PR TITLE
Remove ryanmcginnis from OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -50,7 +50,6 @@ aliases:
     - kbhawkey
     - makoscafee
     - Rajakavitha1
-    - ryanmcginnis
     - sftim
     - steveperry-53
     - tengqm


### PR DESCRIPTION
This PR removes @ryanmcginnis from OWNERS_ALIASES for k/website.

Ryan has moved on from Kubernetes and is no longer active as an approver. I'm grateful for his time and wish him all the best.

/assign @jimangel 
/sig docs