### PR TITLE
adding in a docs alias

### DIFF
--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -5,7 +5,7 @@ reviewers:
 - liggitt
 title: Using RBAC Authorization
 content_template: templates/concept
-aliases: [/rbac/]
+aliases: [../../../rbac/]
 weight: 70
 ---
 


### PR DESCRIPTION
This PR updates the `/rbac` alias to use relative links to improve localization efforts and simplify portability.

When a team localizes a page with a relative alias, there will be no need for them to modify the front matter alias.

/cc @tengqm @zacharysarah 