### PR TITLE
Grammar correction

### DIFF
--- a/content/en/docs/concepts/services-networking/ingress.md
+++ b/content/en/docs/concepts/services-networking/ingress.md
@@ -46,7 +46,7 @@ Traffic routing is controlled by rules defined on the Ingress resource.
    [ Services ]
 ```
 
-An Ingress can be configured to give Services externally-reachable URLs, load balance traffic, terminate SSL / TLS, and offer name based virtual hosting. An [Ingress controller](/docs/concepts/services-networking/ingress-controllers) is responsible for fulfilling the Ingress, usually with a load balancer, though it may also configure your edge router or additional frontends to help handle the traffic.
+An Ingress may be configured to give Services externally-reachable URLs, load balance traffic, terminate SSL / TLS, and offer name based virtual hosting. An [Ingress controller](/docs/concepts/services-networking/ingress-controllers) is responsible for fulfilling the Ingress, usually with a load balancer, though it may also configure your edge router or additional frontends to help handle the traffic.
 
 An Ingress does not expose arbitrary ports or protocols. Exposing services other than HTTP and HTTPS to the internet typically
 uses a service of type [Service.Type=NodePort](/docs/concepts/services-networking/service/#nodeport) or

--- a/content/en/docs/reference/glossary/ingress.md
+++ b/content/en/docs/reference/glossary/ingress.md
@@ -16,5 +16,5 @@ tags:
 
 <!--more--> 
 
-Ingress can provide load balancing, SSL termination and name-based virtual hosting.
+Ingress may provide load balancing, SSL termination and name-based virtual hosting.
 


### PR DESCRIPTION
https://github.com/kubernetes/website/pull/17887 ← :baby:

We are discussing permission, not capability.

Also, and vaguely related, there is no `en-gb` in https://github.com/kubernetes/website/tree/master/content