### PR TITLE
cri-o version must match the k8 version

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -160,7 +160,7 @@ for more information.
 
 This section contains the necessary steps to install `CRI-O` as CRI runtime.
 
-Use the following commands to install CRI-O on your system:
+Use the following commands to install CRI-O on your system (but be sure the major/minor version of CRI-O matches the major/minor version of kubernetes (see the [cri-o compatiblity matrix](https://github.com/cri-o/cri-o)):
 
 ### Prerequisites
 

--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -160,7 +160,12 @@ for more information.
 
 This section contains the necessary steps to install `CRI-O` as CRI runtime.
 
-Use the following commands to install CRI-O on your system (but be sure the major/minor version of CRI-O matches the major/minor version of kubernetes (see the [cri-o compatiblity matrix](https://github.com/cri-o/cri-o)):
+Use the following commands to install CRI-O on your system:
+
+{{< note >}}
+The CRI-O major and minor versions must match the Kubernetes major and minor versions.
+For more information, see the [CRI-O compatiblity matrix](https://github.com/cri-o/cri-o).
+{{< /note >}}
 
 ### Prerequisites
 


### PR DESCRIPTION
It's not clear from the doc that the cri-o version must match the k8 version as shown in the cri-o compatibility matrix. 

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use
 for advice.

-->
