### PR TITLE
fix error in StartupProbe feature gate

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -128,7 +128,7 @@ different Kubernetes components.
 | `ServerSideApply` | `false` | Alpha | 1.14 | 1.15 |
 | `ServerSideApply` | `true` | Beta | 1.16 | |
 | `ServiceNodeExclusion` | `false` | Alpha | 1.8 | |
-| `StartupProbe` | `true` | Beta | 1.17 | |
+| `StartupProbe` | `false` | Alpha | 1.16 | |
 | `StorageVersionHash` | `false` | Alpha | 1.14 | 1.14 |
 | `StorageVersionHash` | `true` | Beta | 1.15 | |
 | `StreamingProxyRedirects` | `false` | Beta | 1.5 | 1.5 |


### PR DESCRIPTION
Signed-off-by: Patrik Cyvoct <patrik@ptrk.io>
Fixes #19097 
Change the state of startup probe from beta to alpha since it's still in Alpha

```
 docker run -it gcr.io/google-containers/kube-apiserver-amd64:v1.17.3 kube-apiserver --help | grep Startup
                                                     StartupProbe=true|false (ALPHA - default=false)

```