### PR TITLE
Add latest-semver shortcode

### DIFF
--- a/layouts/shortcodes/latest-semver.html
+++ b/layouts/shortcodes/latest-semver.html
@@ -1,0 +1,3 @@
+{{- $latestVersion := site.Params.latest }}
+{{- $latestSemver := (replace $latestVersion "v" "") }}
+{{- $latestSemver }}


### PR DESCRIPTION
Provide a latest semver shortcode.
Possible usage:

```
-  You need to have a kubeadm Kubernetes cluster running version 1.16.0 or later.
- Make sure you read the [release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-{{< latest-semver >}}.md) carefully.
```
/cc @saschagrunert