### PR TITLE
Remove extra note in note shortcode

### DIFF
--- a/content/zh/docs/contribute/style/hugo-shortcodes/index.md
+++ b/content/zh/docs/contribute/style/hugo-shortcodes/index.md
@@ -201,18 +201,19 @@ println "This is tab 2."
 {{< /tab >}}
 {{< /tabs >}}
 
-### Tabs demo: Inline Markdown and HTML
+<!-- ### Tabs demo: Inline Markdown and HTML -->
+### 标签页演示：内联 Markdown 和 HTML
 
 ```go-html-template
 {{</* tabs name="tab_with_md" >}}
 {{% tab name="Markdown" %}}
-This is **some markdown.**
-{{< note >}}**Note:** It can even contain shortcodes.{{< /note >}}
+这是 **一些 markdown 。**
+{{< note >}}它甚至可以包含短代码。{{< /note >}}
 {{% /tab %}}
 {{< tab name="HTML" >}}
 <div>
-	<h3>Plain HTML</h3>
-	<p>This is some <i>plain</i> HTML.</p>
+	<h3>纯 HTML</h3>
+	<p>这是一些 <i>纯</i> HTML 。</p>
 </div>
 {{< /tab >}}
 {{< /tabs */>}}
@@ -223,13 +224,13 @@ This is **some markdown.**
 
 {{< tabs name="tab_with_md" >}}
 {{% tab name="Markdown" %}}
-This is **some markdown.**
-{{< note >}}It can even contain shortcodes.{{< /note >}}
+这是 **一些 markdown 。**
+{{< note >}}它甚至可以包含短代码。{{< /note >}}
 {{% /tab %}}
 {{< tab name="HTML" >}}
 <div>
-	<h3>Plain HTML</h3>
-	<p>This is some <i>plain</i> HTML.</p>
+	<h3>纯 HTML</h3>
+	<p>这是一些 <i>纯</i> HTML 。</p>
 </div>
 {{< /tab >}}
 {{< /tabs >}}

--- a/content/zh/docs/contribute/style/hugo-shortcodes/index.md
+++ b/content/zh/docs/contribute/style/hugo-shortcodes/index.md
@@ -224,7 +224,7 @@ This is **some markdown.**
 {{< tabs name="tab_with_md" >}}
 {{% tab name="Markdown" %}}
 This is **some markdown.**
-{{< note >}}**Note:** It can even contain shortcodes.{{< /note >}}
+{{< note >}}It can even contain shortcodes.{{< /note >}}
 {{% /tab %}}
 {{< tab name="HTML" >}}
 <div>


### PR DESCRIPTION
No need to add `note` in a note shortcode.
![Screen Shot 2020-02-15 at 2 41 39 PM](https://user-images.githubusercontent.com/6169722/74583372-6b15c680-5001-11ea-9a0c-79669032cedc.png)
