### PR TITLE
Correct note shortcode for run-replicated-stateful-application.md

### DIFF
--- a/content/en/docs/tasks/run-application/run-replicated-stateful-application.md
+++ b/content/en/docs/tasks/run-application/run-replicated-stateful-application.md
@@ -18,10 +18,10 @@ This page shows how to run a replicated stateful application using a
 The example is a MySQL single-master topology with multiple slaves running
 asynchronous replication.
 
-{{ < note > }}
+{{< note >}}
 **This is not a production configuration**. MySQL settings remain on insecure defaults to keep the focus
 on general patterns for running stateful applications in Kubernetes.
-{{ < /note > }}
+{{< /note >}}
 
 {{% /capture %}}
 


### PR DESCRIPTION
Correct shortcode `{{< note >}}`.

![Screen Shot 2020-02-15 at 2 48 45 PM](https://user-images.githubusercontent.com/6169722/74583537-e0ce6200-5002-11ea-89b6-fc1e40053517.png)
