### PR TITLE
Update installation of minikube on macOS

### DIFF
--- a/content/de/docs/tasks/tools/install-minikube.md
+++ b/content/de/docs/tasks/tools/install-minikube.md
@@ -49,7 +49,7 @@ Minikube unterstützt auch die Option `--vm-driver=none`, mit der die Kubernetes
 Die einfachste Möglichkeit, Minikube unter macOS zu installieren, ist die Verwendung von [Homebrew](https://brew.sh):
 
 ```shell
-brew cask install minikube
+brew install minikube
 ```
 
 Sie können es auch auf macOS installieren, indem Sie eine statische Binärdatei herunterladen:


### PR DESCRIPTION
Installation through brew cask install minikube is no longer supported, as there is not such a binary. Corrected to brew install minikube works.

Sidenote: It's correct in the english version, but was wrong on the german version
