### PR TITLE
Tidy “Participating in SIG Docs”

### DIFF
--- a/content/en/docs/contribute/participating.md
+++ b/content/en/docs/contribute/participating.md
@@ -24,6 +24,7 @@ You can also become a [member](#members),
 access and entail certain responsibilities for approving and committing changes.
 See [community-membership](https://github.com/kubernetes/community/blob/master/community-membership.md)
 for more information on how membership works within the Kubernetes community.
+
 The rest of this document outlines some unique ways these roles function within
 SIG Docs, which is responsible for maintaining one of the most public-facing
 aspects of Kubernetes -- the Kubernetes website and documentation.
@@ -52,7 +53,8 @@ aspects of Kubernetes -- the Kubernetes website and documentation.
 Anyone can do the following:
 
 - Open a GitHub issue against any part of Kubernetes, including documentation.
-- Provide non-binding feedback on a pull request/
+- Provide non-binding feedback on a pull request.
+- Help to localize existing content
 - Bring up ideas for improvement on [Slack](http://slack.k8s.io/) or the [SIG docs mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-docs).
 - Use the `/lgtm` Prow command (short for "looks good to me") to recommend the changes in a pull request for merging.
   {{< note >}}
@@ -120,7 +122,6 @@ changes. Reviewers can:
 - Triage and categorize issues
 - Review pull requests and provide binding feedback
 - Create diagrams, graphics assets, and embeddable screencasts and videos
-- Localization
 - Edit user-facing strings in code
 - Improve code comments
 
@@ -166,7 +167,7 @@ add new members to a GitHub group.
 
 Approvers are members of the
 [@kubernetes/sig-docs-maintainers](https://github.com/orgs/kubernetes/teams/sig-docs-maintainers)
-GitHub group. See [Teams and groups within SIG Docs](#teams-and-groups-within-sig-docs).
+GitHub group. See [SIG Docs teams and automation](#sig-docs-teams-and-automation) for details.
 
 Approvers can do the following:
 


### PR DESCRIPTION
- Fix broken link
- Move localization work from **Reviewers** group to **Anyone**. You don't have to be a reviewer to localize docs.
- Minor other tidying