### PR TITLE
kubeadm: add TS guide note about CoreOS read-only /usr

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
@@ -319,4 +319,46 @@ There are at least two workarounds:
 ```bash
 kubectl taint nodes NODE_NAME role.kubernetes.io/master:NoSchedule-
 ```
+
+## When the Linux distribution for a Node has a read-only mounted /usr directory
+
+On Linux distributions such as Fedora CoreOS, the directory `/usr` is mounted as a read-only filesystem.
+For [flex-volume support](https://github.com/kubernetes/community/blob/ab55d85/contributors/devel/sig-storage/flexvolume.md),
+Kubernetes components like the kubelet and kube-controller-manager use the default path of
+`/usr/libexec/kubernetes/kubelet-plugins/volume/exec/`, yet the flex-volume directory _must be writeable_
+for the feature to work.
+
+To workaround this issue you can configure the flex-volume directory using the kubeadm
+[configuration file](https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2).
+
+On the primary control-plane Node (created using `kubeadm init`) pass the following
+file using `--config`:
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: InitConfiguration
+nodeRegistration:
+  kubeletExtraArgs:
+    volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
+---
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: ClusterConfiguration
+controllerManager:
+  extraArgs:
+    flex-volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
+```
+
+On joining Nodes:
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: JoinConfiguration
+nodeRegistration:
+  kubeletExtraArgs:
+    volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
+```
+
+Alternatively, you can modify `/etc/fstab` to make the `/usr` mount writeable, but please
+be advised that this is modifying a design principle of the Linux distribution.
+
 {{% /capture %}}

--- a/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
@@ -320,7 +320,7 @@ There are at least two workarounds:
 kubectl taint nodes NODE_NAME role.kubernetes.io/master:NoSchedule-
 ```
 
-## When the Linux distribution for a Node has a read-only mounted /usr directory
+## `/usr` is mounted read-only on nodes {#usr-mounted-read-only}
 
 On Linux distributions such as Fedora CoreOS, the directory `/usr` is mounted as a read-only filesystem.
 For [flex-volume support](https://github.com/kubernetes/community/blob/ab55d85/contributors/devel/sig-storage/flexvolume.md),


### PR DESCRIPTION
making this change after seeing a number of similar reports from users facing the issue.

xref https://github.com/kubernetes/kubeadm/issues/2031

/sig cluster-lifecycle
/cc @rosti 
cc @skycastlelily2
