### PR TITLE
Latin Abbreviation "vs" Removed from Heading Text

### DIFF
--- a/content/en/docs/reference/access-authn-authz/service-accounts-admin.md
+++ b/content/en/docs/reference/access-authn-authz/service-accounts-admin.md
@@ -18,7 +18,7 @@ incomplete features are referred to in order to better describe service accounts
 {{% /capture %}}
 
 {{% capture body %}}
-## User accounts vs service accounts
+## User accounts versus service accounts
 
 Kubernetes distinguishes between the concept of a user account and a service account
 for a number of reasons:


### PR DESCRIPTION
fixes #19179

[SIG Docs recommends avoiding Latin phrases](https://kubernetes.io/docs/contribute/style/style-guide/#avoid-latin-phrases). "vs" is a latin abbreviation.

I updated "vs" to the non-latin variant "versus."