### PR TITLE
Update "verbatim" latin phrase to "exactly as is"

### DIFF
--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -14,7 +14,7 @@ weight: 50
 
 Kubernetes Secrets let you store and manage sensitive information, such
 as passwords, OAuth tokens, and ssh keys. Storing confidential information in a Secret
-is safer and more flexible than putting it verbatim in a
+is safer and more flexible than putting it exactly as is in a
 {{< glossary_tooltip term_id="pod" >}} definition or in a {{< glossary_tooltip text="container image" term_id="image" >}}. See [Secrets design document](https://git.k8s.io/community/contributors/design-proposals/auth/secrets.md) for more information.
 
 {{% /capture %}}


### PR DESCRIPTION
[SIG Docs recommends avoiding Latin phrases](https://kubernetes.io/docs/contribute/style/style-guide/#avoid-latin-phrases). "**verbatim**" is a latin phrase.

I've updated **verbatim** to **exactly as is**, which retains the "verbatim" latin phrase meaning.