### PR TITLE
Add useful synopsis to scheduler reference

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/kube-scheduler.md
+++ b/content/en/docs/reference/command-line-tools-reference/kube-scheduler.md
@@ -6,8 +6,9 @@ weight: 28
 
 {{% capture synopsis %}}
 
+The Kubernetes scheduler watches for newly created Pods that have no Node assigned. For every Pod that the scheduler discovers, the scheduler becomes responsible for finding the best Node for that Pod to run on.
 
-The Kubernetes scheduler is a policy-rich, topology-aware,
+The scheduler is a policy-rich, topology-aware,
 workload-specific function that significantly impacts availability, performance,
 and capacity. The scheduler needs to take into account individual and collective
 resource requirements, quality of service requirements, hardware/software/policy


### PR DESCRIPTION
The scheduler CLI reference doesn't have a newbie-friendly explanation of what the scheduler actually does. It just says "The scheduler is important!" without a meaningful explanation.

This PR copies the first few sentences from https://kubernetes.io/docs/concepts/scheduling/kube-scheduler/ to explain what the scheduler does.