### PR TITLE
doc: remove tasks federation index from tasks main page.

### DIFF
--- a/content/en/docs/tasks/_index.md
+++ b/content/en/docs/tasks/_index.md
@@ -57,10 +57,6 @@ Configure your application to trust and use the cluster root Certificate Authori
 
 Learn common tasks for administering a cluster.
 
-## Administering Federation
-
-Configure components in a cluster federation.
-
 ## Managing Stateful Applications
 
 Perform common tasks for managing Stateful applications, including scaling, deleting, and debugging StatefulSets.


### PR DESCRIPTION
It's a follow up PR for cleaning federation index from tasks main page.
