### PR TITLE
Fix healthz-bind-address default

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/kube-proxy.md
+++ b/content/en/docs/reference/command-line-tools-reference/kube-proxy.md
@@ -108,7 +108,7 @@ kube-proxy [flags]
     </tr>
 
     <tr>
-      <td colspan="2">--healthz-bind-address 0.0.0.0&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 0.0.0.0:10256</td>
+      <td colspan="2">--healthz-bind-address 0.0.0.0&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 0.0.0.0</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The IP address for the health check server to serve on (set to 0.0.0.0 for all IPv4 interfaces and `::` for all IPv6 interfaces)</td>


### PR DESCRIPTION
This matches the documentation for:

```
--bind-address 0.0.0.0     Default: 0.0.0.0
```