### PR TITLE
Training page in the top nav

### DIFF
--- a/assets/sass/_desktop.sass
+++ b/assets/sass/_desktop.sass
@@ -107,7 +107,7 @@ $video-section-height: 550px
     padding-right: 10px
 
   #home
-    section, header, footer
+    section, header
       .main-section
         max-width: 1000px
 
@@ -178,16 +178,18 @@ $video-section-height: 550px
     nav
       overflow: hidden
       margin-bottom: 20px
+      display: flex
+      justify-content: space-between
 
       a
-        width: 16.65%
+        width: auto
         float: left
         font-size: 24px
         font-weight: 300
         white-space: nowrap
 
     .social
-      padding: 0 30px
+      padding: 0 0px
       max-width: 1200px
 
       div

--- a/assets/sass/_desktop.sass
+++ b/assets/sass/_desktop.sass
@@ -189,7 +189,7 @@ $video-section-height: 550px
         white-space: nowrap
 
     .social
-      padding: 0 0px
+      padding: 0
       max-width: 1200px
 
       div

--- a/assets/sass/_tablet.sass
+++ b/assets/sass/_tablet.sass
@@ -219,9 +219,8 @@ $feature-box-div-width: 45%
   footer
     nav
       text-align: center
-
       a
-        width: 30%
+        width: auto
         padding: 0 20px
 
     .social

--- a/content/en/training/_index.html
+++ b/content/en/training/_index.html
@@ -10,7 +10,7 @@ class: training
 <div class="padded blue-bg">
   <div class="main-section two-thirds-centered white-text">
     <center>
-      <h1>Build your cloud native career</h1>
+      <h2>Build your cloud native career</h2>
       <p>Kubernetes is at the core of the cloud native movement. Training and certifications from the Linux Foundation and our training partners lets you invest in your career, learn Kubernetes, and make your cloud native projects successful.</p>
     </center>
   </div>
@@ -101,8 +101,8 @@ class: training
       <p>Our network of Kubernetes Training Partners provide training services for Kubernetes and cloud native projects.</p>
     </center>
   </div>
-  <div class="main-section">
-    <iframe src="https://landscape.cncf.io/category=kubernetes-training-partner&format=logo-mode&grouping=category&embed=yes" frameborder="0" id="landscape" scrolling="no" style="opacity: 1; visibility: visible; overflow: hidden; height: 1200px; width: 100%"></iframe>
+  <div class="main-section landscape-section">
+    <iframe src="https://landscape.cncf.io/category=kubernetes-training-partner&format=logo-mode&grouping=category&embed=yes" frameborder="0" id="landscape" scrolling="no"></iframe>
     <script src="https://landscape.cncf.io/iframeResizer.js"></script>
   </div>
 </div>

--- a/content/en/training/_index.html
+++ b/content/en/training/_index.html
@@ -6,20 +6,20 @@ class: gridPage
 cid: training
 ---
 
-<section id="training">
-
-  <div class="main-section" style="padding-top: 100px">
-    <div style="width: 66%; margin-left: 16.5%">
-      <center>
-        <h1>Build your cloud native career</h1>
-        <p>Kubernetes is at the core of the cloud native movement. Training and certifications from the Linux Foundation and our training partners lets you invest in your career, learn Kubernetes, and make your cloud native projects successful.</p>
-      </center>
-    </div>
+<div style="padding-top: 100px; padding-bottom: 100px; background-color: #3371e3; color:#fff"  >
+  <div class="main-section" style="width: 66%; margin-left: 16.5%;">
+    <center>
+      <h1>Build your cloud native career</h1>
+      <p style="color:#fff">Kubernetes is at the core of the cloud native movement. Training and certifications from the Linux Foundation and our training partners lets you invest in your career, learn Kubernetes, and make your cloud native projects successful.</p>
+    </center>
   </div>
-  <div class="main-section" style="padding-top: 100px">
-    <div>
+</div>
+
+<section>
+  <div class="main-section" style="padding-top: 100px; padding-bottom: 100px">
+    <center>
       <h2>Take a free course on edX</h2>
-    </div>
+    </center>
   <div class="col-container">
     <div class="col-nav">
       <center>
@@ -52,22 +52,23 @@ cid: training
       </center>
     </div>
   </div>
+</section>
 
-  <div class="main-section" style="padding-top: 100px">
-    <div style="width: 66%; margin-left: 16.5%">
-      <center>
-        <h2>Learn with the Linux Foundation</h2>
-        <p>The Linux Foundation offers instructor-led and self-paced courses for all aspects of the Kuberenetes application development and operations lifecycle.</p>
-        <a href="https://training.linuxfoundation.org/training/course-catalog/?_sft_technology=kubernetes" target="_blank" class="button">See Courses</a>
-      </center>
-    </div>
+<div style="padding-top: 100px; padding-bottom: 100px; background-color: #4c4c4c; color: #fff">
+  <div class="main-section" style="width: 66%; margin-left: 16.5%">
+    <center>
+      <h2>Learn with the Linux Foundation</h2>
+      <p>The Linux Foundation offers instructor-led and self-paced courses for all aspects of the Kuberenetes application development and operations lifecycle.</p>
+      <a href="https://training.linuxfoundation.org/training/course-catalog/?_sft_technology=kubernetes" target="_blank" class="button">See Courses</a>
+    </center>
   </div>
+</div>
 
-  </div>
-  <div class="main-section" style="padding-top: 100px">
-    <div>
-        <h2>Get certified</h2>
-    </div>
+<section>
+  <div class="main-section" style="padding-top: 100px; padding-bottom: 100px">
+    <center>
+        <h2>Get Kubernetes Certified</h2>
+    </center>
     <div class="col-nav">
       <center>
         <h5>
@@ -89,17 +90,16 @@ cid: training
       </center>
     </div>
   </div>
-
-  <div class="main-section" style="padding-top: 100px">
-    <div style="width: 66%; margin-left: 16.5%">
-      <center>
-        <h2>Kubernetes Training Partners</h2>
-        <p>Our network of Kubernetes Training Parnters provide training and consulting services for Kubernetes and cloud native projects.</p>
-        <a href="/partners/#ktp" target="_blank" class="button">See Kubernetes Training Partners</a>
-      </center>
-    </div>
-
 </section>
+
+<div style="padding-top: 100px; padding-bottom: 100px; background-color: #cccccc;">
+  <div class="main-section" style="width: 66%; margin-left: 16.5%">
+    <center>
+      <h2>Kubernetes Training Partners</h2>
+      <p>Our network of Kubernetes Training Parnters provide training and consulting services for Kubernetes and cloud native projects.</p>
+      <a href="/partners/#ktp" target="_blank" class="button">See Kubernetes Training Partners</a>
+    </center>
+  </div>
 
 <style>
     {{< include "partner-style.css" >}}

--- a/content/en/training/_index.html
+++ b/content/en/training/_index.html
@@ -88,7 +88,7 @@ class: training
         </h5>
         <p>The Certified Kubernetes Administrator (CKA) program provides assurance that CKAs have the skills, knowledge, and competency to perform the responsibilities of Kubernetes administrators.</p>
         <br>
-        <a href="https://training.linuxfoundation.org/certification/certified-kubernetes-application-developer-ckad/" target="_blank" class="button">Go to Certification</a>
+        <a href=https://training.linuxfoundation.org/certification/certified-kubernetes-administrator-cka/" target="_blank" class="button">Go to Certification</a>
       </center>
     </div>
   </div>

--- a/content/en/training/_index.html
+++ b/content/en/training/_index.html
@@ -28,7 +28,7 @@ class: training
           <b>Introduction to Kubernetes <br> &nbsp;</b>
         </h5>
         <p>Want to learn Kubernetes? Get an in-depth primer on this powerful system for managing containerized applications.</p>
-        <br><br>
+        <br>
         <a href="https://www.edx.org/course/introduction-to-kubernetes" target="_blank" class="button">Go to Course</a>
       </center>
     </div>

--- a/content/en/training/_index.html
+++ b/content/en/training/_index.html
@@ -45,11 +45,11 @@ class: training
     <div class="col-nav">
       <center>
         <h5>
-          <b>Fundamentals of Containers, Kubernetes, and Red Hat OpenShift</b>
+          <b>Introduction to Linux</b>
         </h5>
-        <p>Learn practical techniques for creating and deploying containers on a Kubernetes cluster using Red Hat® OpenShift Container Platform.</p>
+        <p>Never learned Linux? Want a refresh? Develop a good working knowledge of Linux using both the graphical interface and command line across the major Linux distribution families.</p>
         <br>
-        <a href="https://www.edx.org/course/fundamentals-of-containers-kubernetes-and-red-hat" target="_blank" class="button">Go to Course</a>
+        <a href=https://www.edx.org/course/introduction-to-linux" target="_blank" class="button">Go to Course</a>
       </center>
     </div>
   </div>

--- a/content/en/training/_index.html
+++ b/content/en/training/_index.html
@@ -49,7 +49,7 @@ class: training
         </h5>
         <p>Never learned Linux? Want a refresh? Develop a good working knowledge of Linux using both the graphical interface and command line across the major Linux distribution families.</p>
         <br>
-        <a href=https://www.edx.org/course/introduction-to-linux" target="_blank" class="button">Go to Course</a>
+        <a href="https://www.edx.org/course/introduction-to-linux" target="_blank" class="button">Go to Course</a>
       </center>
     </div>
   </div>
@@ -99,7 +99,9 @@ class: training
     <center>
       <h2>Kubernetes Training Partners</h2>
       <p>Our network of Kubernetes Training Parnters provide training and consulting services for Kubernetes and cloud native projects.</p>
-      <br><br>
-      <a href="/partners/#ktp" target="_blank" class="button">See Kubernetes Training Partners</a>
     </center>
   </div>
+  <div class="main-section">
+    <iframe src="https://landscape.cncf.io/category=kubernetes-training-partner&format=logo-mode&grouping=category&embed=yes" frameborder="0" id="landscape" scrolling="no" style="opacity: 1; visibility: visible; overflow: hidden; height: 1200px; width: 100%"></iframe>
+  </div>
+</div>

--- a/content/en/training/_index.html
+++ b/content/en/training/_index.html
@@ -1,0 +1,106 @@
+---
+title: Training
+bigheader: Kubernetes Training and Certification
+abstract: Training programs, certifications, and partners.
+class: gridPage
+cid: training
+---
+
+<section id="training">
+
+  <div class="main-section" style="padding-top: 100px">
+    <div style="width: 66%; margin-left: 16.5%">
+      <center>
+        <h1>Build your cloud native career</h1>
+        <p>Kubernetes is at the core of the cloud native movement. Training and certifications from the Linux Foundation and our training partners lets you invest in your career, learn Kubernetes, and make your cloud native projects successful.</p>
+      </center>
+    </div>
+  </div>
+  <div class="main-section" style="padding-top: 100px">
+    <div>
+      <h2>Take a free course on edX</h2>
+    </div>
+  <div class="col-container">
+    <div class="col-nav">
+      <center>
+        <h5>
+          <b>Introduction to Kubernetes <br> &nbsp;</b>
+        </h5>
+        <p>Want to learn Kubernetes? Get an in-depth primer on this powerful system for managing containerized applications.</p>
+        <br><br>
+        <a href="https://www.edx.org/course/introduction-to-kubernetes" target="_blank" class="button">Go to Course</a>
+      </center>
+    </div>
+    <div class="col-nav">
+      <center>
+        <h5>
+          <b>Introduction to Cloud Infrastructure Technologies</b>
+        </h5>
+        <p>Learn the fundamentals of building and managing cloud technologies directly from The Linux Foundation, the leader in open source.</p>
+        <br>
+        <a href="https://www.edx.org/course/introduction-to-cloud-infrastructure-technologies" target="_blank" class="button">Go to Course</a>
+      </center>
+    </div>
+    <div class="col-nav">
+      <center>
+        <h5>
+          <b>Fundamentals of Containers, Kubernetes, and Red Hat OpenShift</b>
+        </h5>
+        <p>Learn practical techniques for creating and deploying containers on a Kubernetes cluster using Red Hat® OpenShift Container Platform.</p>
+        <br>
+        <a href="https://www.edx.org/course/fundamentals-of-containers-kubernetes-and-red-hat" target="_blank" class="button">Go to Course</a>
+      </center>
+    </div>
+  </div>
+
+  <div class="main-section" style="padding-top: 100px">
+    <div style="width: 66%; margin-left: 16.5%">
+      <center>
+        <h2>Learn with the Linux Foundation</h2>
+        <p>The Linux Foundation offers instructor-led and self-paced courses for all aspects of the Kuberenetes application development and operations lifecycle.</p>
+        <a href="https://training.linuxfoundation.org/training/course-catalog/?_sft_technology=kubernetes" target="_blank" class="button">See Courses</a>
+      </center>
+    </div>
+  </div>
+
+  </div>
+  <div class="main-section" style="padding-top: 100px">
+    <div>
+        <h2>Get certified</h2>
+    </div>
+    <div class="col-nav">
+      <center>
+        <h5>
+          <b>Certified Kubernetes Application Developer (CKAD)</b>
+        </h5>
+        <p>The Certified Kubernetes Application Developer exam certifies that users can design, build, configure, and expose cloud native applications for Kubernetes.</p>
+        <br>
+        <a href="https://training.linuxfoundation.org/certification/certified-kubernetes-application-developer-ckad/" target="_blank" class="button">Go to Certification</a>
+      </center>
+    </div>
+    <div class="col-nav">
+      <center>
+        <h5>
+          <b>Certified Kubernetes Administrator (CKA)</b>
+        </h5>
+        <p>The Certified Kubernetes Administrator (CKA) program provides assurance that CKAs have the skills, knowledge, and competency to perform the responsibilities of Kubernetes administrators.</p>
+        <br>
+        <a href="https://training.linuxfoundation.org/certification/certified-kubernetes-application-developer-ckad/" target="_blank" class="button">Go to Certification</a>
+      </center>
+    </div>
+  </div>
+
+  <div class="main-section" style="padding-top: 100px">
+    <div style="width: 66%; margin-left: 16.5%">
+      <center>
+        <h2>Kubernetes Training Partners</h2>
+        <p>Our network of Kubernetes Training Parnters provide training and consulting services for Kubernetes and cloud native projects.</p>
+        <a href="/partners/#ktp" target="_blank" class="button">See Kubernetes Training Partners</a>
+      </center>
+    </div>
+
+</section>
+
+<style>
+    {{< include "partner-style.css" >}}
+</style>

--- a/content/en/training/_index.html
+++ b/content/en/training/_index.html
@@ -55,7 +55,7 @@ class: training
   </div>
 </section>
 
-<div class="padded medium-gray-bg white-text">
+<div class="padded lighter-gray-bg">
   <div class="main-section two-thirds-centered">
     <center>
       <h2>Learn with the Linux Foundation</h2>

--- a/content/en/training/_index.html
+++ b/content/en/training/_index.html
@@ -2,21 +2,22 @@
 title: Training
 bigheader: Kubernetes Training and Certification
 abstract: Training programs, certifications, and partners.
-class: gridPage
+layout: basic
 cid: training
+class: training
 ---
 
-<div style="padding-top: 100px; padding-bottom: 100px; background-color: #3371e3; color:#fff"  >
-  <div class="main-section" style="width: 66%; margin-left: 16.5%;">
+<div class="padded blue-bg">
+  <div class="main-section two-thirds-centered white-text">
     <center>
       <h1>Build your cloud native career</h1>
-      <p style="color:#fff">Kubernetes is at the core of the cloud native movement. Training and certifications from the Linux Foundation and our training partners lets you invest in your career, learn Kubernetes, and make your cloud native projects successful.</p>
+      <p>Kubernetes is at the core of the cloud native movement. Training and certifications from the Linux Foundation and our training partners lets you invest in your career, learn Kubernetes, and make your cloud native projects successful.</p>
     </center>
   </div>
 </div>
 
 <section>
-  <div class="main-section" style="padding-top: 100px; padding-bottom: 100px">
+  <div class="main-section padded">
     <center>
       <h2>Take a free course on edX</h2>
     </center>
@@ -54,18 +55,19 @@ cid: training
   </div>
 </section>
 
-<div style="padding-top: 100px; padding-bottom: 100px; background-color: #4c4c4c; color: #fff">
-  <div class="main-section" style="width: 66%; margin-left: 16.5%">
+<div class="padded medium-gray-bg white-text">
+  <div class="main-section two-thirds-centered">
     <center>
       <h2>Learn with the Linux Foundation</h2>
       <p>The Linux Foundation offers instructor-led and self-paced courses for all aspects of the Kuberenetes application development and operations lifecycle.</p>
+      <br><br>
       <a href="https://training.linuxfoundation.org/training/course-catalog/?_sft_technology=kubernetes" target="_blank" class="button">See Courses</a>
     </center>
   </div>
 </div>
 
 <section>
-  <div class="main-section" style="padding-top: 100px; padding-bottom: 100px">
+  <div class="main-section padded">
     <center>
         <h2>Get Kubernetes Certified</h2>
     </center>
@@ -92,15 +94,12 @@ cid: training
   </div>
 </section>
 
-<div style="padding-top: 100px; padding-bottom: 100px; background-color: #cccccc;">
-  <div class="main-section" style="width: 66%; margin-left: 16.5%">
+<div class="padded lighter-gray-bg">
+  <div class="main-section two-thirds-centered">
     <center>
       <h2>Kubernetes Training Partners</h2>
       <p>Our network of Kubernetes Training Parnters provide training and consulting services for Kubernetes and cloud native projects.</p>
+      <br><br>
       <a href="/partners/#ktp" target="_blank" class="button">See Kubernetes Training Partners</a>
     </center>
   </div>
-
-<style>
-    {{< include "partner-style.css" >}}
-</style>

--- a/content/en/training/_index.html
+++ b/content/en/training/_index.html
@@ -98,10 +98,11 @@ class: training
   <div class="main-section two-thirds-centered">
     <center>
       <h2>Kubernetes Training Partners</h2>
-      <p>Our network of Kubernetes Training Parnters provide training and consulting services for Kubernetes and cloud native projects.</p>
+      <p>Our network of Kubernetes Training Partners provide training services for Kubernetes and cloud native projects.</p>
     </center>
   </div>
   <div class="main-section">
     <iframe src="https://landscape.cncf.io/category=kubernetes-training-partner&format=logo-mode&grouping=category&embed=yes" frameborder="0" id="landscape" scrolling="no" style="opacity: 1; visibility: visible; overflow: hidden; height: 1200px; width: 100%"></iframe>
+    <script src="https://landscape.cncf.io/iframeResizer.js"></script>
   </div>
 </div>

--- a/content/en/training/index.html
+++ b/content/en/training/index.html
@@ -1,7 +1,0 @@
----
-title: Training
-bigheader: Kubernetes Training and Certification
-abstract: fill me out later gal.
-class: gridPage
-cid: partners
----

--- a/content/en/training/index.html
+++ b/content/en/training/index.html
@@ -1,0 +1,7 @@
+---
+title: Training
+bigheader: Kubernetes Training and Certification
+abstract: fill me out later gal.
+class: gridPage
+cid: partners
+---

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -25,6 +25,9 @@
 {{- if eq .Params.class "gridPage" }}
 <link rel="stylesheet" href="{{ "css/gridpage.css" | relURL }}">
 {{- end }}
+{{- if eq .Params.class "training" }}
+<link rel="stylesheet" href="{{ "css/training.css" | relURL }}">
+{{- end }}
 {{- with .Params.css }}
 {{- $extraCss := split . "," }}
 {{- range $extraCss }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,7 +2,7 @@
     <div class="light-text main-section">
         <nav>
             {{ with site.GetPage "page" "docs/tutorials/stateless-application/hello-minikube" }}<a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>{{ end }}
-            {{ $sections := slice "docs/home" "training" "blog" "partners" "community" "case-studies" }}
+            {{ $sections := slice "docs/home" "blog" "training" "partners" "community" "case-studies" }}
             {{ range $sections }}
             {{ with site.GetPage "section" . }}<a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>{{ end }}
             {{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,7 +2,7 @@
     <div class="light-text main-section">
         <nav>
             {{ with site.GetPage "page" "docs/tutorials/stateless-application/hello-minikube" }}<a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>{{ end }}
-            {{ $sections := slice "docs/home" "blog" "partners" "community" "case-studies" }}
+            {{ $sections := slice "docs/home" "training" "blog" "partners" "community" "case-studies" }}
             {{ range $sections }}
             {{ with site.GetPage "section" . }}<a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>{{ end }}
             {{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,7 +5,7 @@
 
     <div class="nav-buttons" data-auto-burger="primary">
         <ul class="global-nav">
-            {{ $sections := slice "docs" "training" "blog" "partners" "community" "case-studies" }}
+            {{ $sections := slice "docs" "blog" "training" "partners" "community" "case-studies" }}
             {{ range $sections }}
             {{ with site.GetPage "section" . }}<li><a href="{{ .RelPermalink }}"{{ if eq .Section $.Section }} class="active"{{ end}}>{{ .LinkTitle }}</a></li>{{ end }}
             {{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,7 +5,7 @@
 
     <div class="nav-buttons" data-auto-burger="primary">
         <ul class="global-nav">
-            {{ $sections := slice "docs" "blog" "partners" "community" "case-studies" }}
+            {{ $sections := slice "docs" "training" "blog" "partners" "community" "case-studies" }}
             {{ range $sections }}
             {{ with site.GetPage "section" . }}<li><a href="{{ .RelPermalink }}"{{ if eq .Section $.Section }} class="active"{{ end}}>{{ .LinkTitle }}</a></li>{{ end }}
             {{ end }}

--- a/static/css/gridpage.css
+++ b/static/css/gridpage.css
@@ -25,7 +25,7 @@
 
 
 .gridPage p {
-    color: rgb(26,26,26) !important;
+    color: rgb(26,26,26);
     margin-left: 0 !important;
     padding-left: 0 !important;
     font-weight: 300 !important;

--- a/static/css/training.css
+++ b/static/css/training.css
@@ -1,0 +1,95 @@
+#hero {
+  text-align: left;
+  padding-bottom: 20px;
+}
+
+.section {
+	clear: both;
+	padding: 0px;
+	margin-bottom: 2em;
+}
+
+.col {
+	display: block;
+	float:left;
+	margin: 1% 0 1% 1.6%;
+	background-color: #f9f9f9;
+}
+.col:first-child { margin-left: 0; }
+
+.col-container {
+    display: table; /* Make the container element behave like a table */
+    width: 100%; /* Set full-width to expand the whole page */
+		padding-bottom: 30px;
+}
+
+.col-nav {
+    display: table-cell; /* Make elements inside the container behave like table cells */
+		width: 18%;
+		background-color: #f9f9f9;
+		padding: 20px;
+		border: 5px solid white;
+}
+
+
+/*  GO FULL WIDTH AT LESS THAN 480 PIXELS */
+
+@media only screen and (max-width: 480px) {
+	.col { margin: 1% 0 1% 0%;}
+}
+
+@media only screen and (max-width: 650px) {
+    .col-nav {
+        display: block;
+        width: 100%;
+    }
+}
+
+.button{
+  max-width: 100%;
+	box-sizing: border-box;
+	font-family: "Roboto", sans-serif;
+  margin: 1em 0;
+	display: inline-block;
+	border-radius: 6px;
+	padding: 0 20px;
+	line-height: 40px;
+	color: #ffffff;
+	font-size: 16px;
+	background-color: #3371e3;
+	text-decoration: none;
+ }
+
+ h5 {
+	font-size: 16px;
+  font-weight: 500;
+	line-height: 1.5em;
+	margin-bottom: 2em;
+}
+
+.white-text {
+  color: #fff;
+}
+
+.padded {
+  padding-top: 100px;
+  padding-bottom: 100px;
+}
+
+.blue-bg {
+  background-color: #3371e3;
+}
+
+.medium-gray-bg {
+  background-color: #4c4c4c;
+}
+
+.lighter-gray-bg {
+  background-color: #cccccc;
+}
+
+.two-thirds-centered {
+  width: 66%;
+  margin-left: 16.5%;
+  margin-right: 16.5%;
+}

--- a/static/css/training.css
+++ b/static/css/training.css
@@ -80,12 +80,8 @@ h5 {
   background-color: #3371e3;
 }
 
-.medium-gray-bg {
-  background-color: #4c4c4c;
-}
-
 .lighter-gray-bg {
-  background-color: #cccccc;
+  background-color: #f4f4f4;
 }
 
 .two-thirds-centered {

--- a/static/css/training.css
+++ b/static/css/training.css
@@ -86,6 +86,20 @@ h5 {
 
 .two-thirds-centered {
   width: 66%;
-  margin-left: 16.5%;
-  margin-right: 16.5%;
+  max-width: 950px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.landscape-section {
+  margin-left: auto;
+  margin-right: auto;
+  width: 1200px;
+}
+
+#landscape {
+  opacity: 1;
+  visibility: visible;
+  overflow: hidden;
+  width: 1200px;
 }

--- a/static/css/training.css
+++ b/static/css/training.css
@@ -4,67 +4,67 @@
 }
 
 .section {
-	clear: both;
-	padding: 0px;
-	margin-bottom: 2em;
+  clear: both;
+  padding: 0px;
+  margin-bottom: 2em;
 }
 
 .col {
-	display: block;
-	float:left;
-	margin: 1% 0 1% 1.6%;
-	background-color: #f9f9f9;
+  display: block;
+  float:left;
+  margin: 1% 0 1% 1.6%;
+  background-color: #f9f9f9;
 }
 .col:first-child { margin-left: 0; }
 
 .col-container {
-    display: table; /* Make the container element behave like a table */
-    width: 100%; /* Set full-width to expand the whole page */
-		padding-bottom: 30px;
+  display: table; /* Make the container element behave like a table */
+  width: 100%; /* Set full-width to expand the whole page */
+  padding-bottom: 30px;
 }
 
 .col-nav {
-    display: table-cell; /* Make elements inside the container behave like table cells */
-		width: 18%;
-		background-color: #f9f9f9;
-		padding: 20px;
-		border: 5px solid white;
+  display: table-cell; /* Make elements inside the container behave like table cells */
+  width: 18%;
+  background-color: #f9f9f9;
+  padding: 20px;
+  border: 5px solid white;
 }
 
 
 /*  GO FULL WIDTH AT LESS THAN 480 PIXELS */
 
 @media only screen and (max-width: 480px) {
-	.col { margin: 1% 0 1% 0%;}
+  .col { margin: 1% 0 1% 0%;}
 }
 
 @media only screen and (max-width: 650px) {
-    .col-nav {
-        display: block;
-        width: 100%;
-    }
+  .col-nav {
+    display: block;
+    width: 100%;
+  }
 }
 
 .button{
   max-width: 100%;
-	box-sizing: border-box;
-	font-family: "Roboto", sans-serif;
+  box-sizing: border-box;
+  font-family: "Roboto", sans-serif;
   margin: 1em 0;
-	display: inline-block;
-	border-radius: 6px;
-	padding: 0 20px;
-	line-height: 40px;
-	color: #ffffff;
-	font-size: 16px;
-	background-color: #3371e3;
-	text-decoration: none;
- }
+  display: inline-block;
+  border-radius: 6px;
+  padding: 0 20px;
+  line-height: 40px;
+  color: #ffffff;
+  font-size: 16px;
+  background-color: #3371e3;
+  text-decoration: none;
+}
 
- h5 {
-	font-size: 16px;
+h5 {
+  font-size: 16px;
   font-weight: 500;
-	line-height: 1.5em;
-	margin-bottom: 2em;
+  line-height: 1.5em;
+  margin-bottom: 2em;
 }
 
 .white-text {


### PR DESCRIPTION
Closes #19112. 

This PR creates a new top navigation page, **Training**, which highlights both free and paid offerings for training and certification available to Kubernetes developers and admins.

 **I would like review and discussion!** as it's a fairly high visibility change.
