### PR TITLE
Added FIAAS Python client library

### DIFF
--- a/content/en/docs/reference/using-api/client-libraries.md
+++ b/content/en/docs/reference/using-api/client-libraries.md
@@ -60,6 +60,7 @@ their authors, not the Kubernetes team.
 | PHP                  | [github.com/allansun/kubernetes-php-client](https://github.com/allansun/kubernetes-php-client) |
 | PHP                  | [github.com/travisghansen/kubernetes-client-php](https://github.com/travisghansen/kubernetes-client-php) |
 | Python               | [github.com/eldarion-gondor/pykube](https://github.com/eldarion-gondor/pykube) |
+| Python               | [github.com/fiaas/k8s](https://github.com/fiaas/k8s) |
 | Python               | [github.com/mnubo/kubernetes-py](https://github.com/mnubo/kubernetes-py) |
 | Python               | [github.com/tomplus/kubernetes_asyncio](https://github.com/tomplus/kubernetes_asyncio) |
 | Ruby                 | [github.com/Ch00k/kuber](https://github.com/Ch00k/kuber) |


### PR DESCRIPTION
I have added the FIAAS Python client library. The library is still in development, and not complete. It has a different approach than most other libraries, which some developers might find more suited to their tastes.