### PR TITLE
Add Managed Computer Resources for DigitalOcean

### DIFF
--- a/content/en/docs/concepts/configuration/manage-compute-resources-container.md
+++ b/content/en/docs/concepts/configuration/manage-compute-resources-container.md
@@ -73,6 +73,7 @@ One cpu, in Kubernetes, is equivalent to:
 - 1 AWS vCPU
 - 1 GCP Core
 - 1 Azure vCore
+- 1 DigitalOcean vCPU
 - 1 IBM vCPU
 - 1 *Hyperthread* on a bare-metal Intel processor with Hyperthreading
 


### PR DESCRIPTION
### Description

DigitalOcean runs a Managed Kubernetes offering. The `Meaning of CPU` in the [Kubernetes Documentation](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-cpu) does not list DigitalOcean. This PR adds DigitalOcean to that list. 

### Docs

According to the [DigitalOcean Kubernetes Documentation page](https://www.digitalocean.com/docs/kubernetes/#worker-nodes-and-node-pools), the Worker Nodes run on Droplets, and abide by the same standard Droplet resources. 

See image below of the detailed description of compute resources during Cluster Create:
![image](https://user-images.githubusercontent.com/4130121/75044043-f4f4e200-548e-11ea-9c49-e9e3d62ff87a.png)


