### PR TITLE
Adding reference to node concept page.

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/assign-pods-nodes.md
+++ b/content/en/docs/tasks/configure-pod-container/assign-pods-nodes.md
@@ -19,7 +19,7 @@ Kubernetes cluster.
 
 ## Add a label to a node
 
-1. List the nodes in your cluster, along with their labels:
+1. List the {{< glossary_tooltip term_id="node" text="nodes" >}} in your cluster, along with their labels:
 
     ```shell
     kubectl get nodes --show-labels

--- a/content/en/docs/tasks/configure-pod-container/assign-pods-nodes.md
+++ b/content/en/docs/tasks/configure-pod-container/assign-pods-nodes.md
@@ -97,7 +97,7 @@ Use the configuration file to create a pod that will get scheduled on `foo-node`
 {{% /capture %}}
 
 {{% capture whatsnext %}}
-Learn more about
-[labels and selectors](/docs/concepts/overview/working-with-objects/labels/).
+Learn more about [labels and selectors](/docs/concepts/overview/working-with-objects/labels/).
+Learn more about [nodes](/docs/concepts/architecture/nodes/).
 {{% /capture %}}
 

--- a/content/en/docs/tasks/configure-pod-container/assign-pods-nodes.md
+++ b/content/en/docs/tasks/configure-pod-container/assign-pods-nodes.md
@@ -97,7 +97,7 @@ Use the configuration file to create a pod that will get scheduled on `foo-node`
 {{% /capture %}}
 
 {{% capture whatsnext %}}
-Learn more about [labels and selectors](/docs/concepts/overview/working-with-objects/labels/).
-Learn more about [nodes](/docs/concepts/architecture/nodes/).
+* Learn more about [labels and selectors](/docs/concepts/overview/working-with-objects/labels/).
+* Learn more about [nodes](/docs/concepts/architecture/nodes/).
 {{% /capture %}}
 


### PR DESCRIPTION
This page discuss about assigning pods to the node but does not have reference to the node concept page. So for better navigation, added this reference in what's next section
