### PR TITLE
Note CronJob timezone comes from system timezone

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/en/docs/concepts/workloads/controllers/cron-jobs.md
@@ -18,7 +18,7 @@ One CronJob object is like one line of a _crontab_ (cron table) file. It runs a 
 on a given schedule, written in [Cron](https://en.wikipedia.org/wiki/Cron) format.
 
 {{< note >}}
-All **CronJob** `schedule:` times are denoted in UTC.
+All **CronJob** `schedule:` times are based on the timezone of the master where the job is initiated.
 {{< /note >}}
 
 When creating the manifest for a CronJob resource, make sure the name you provide

--- a/content/en/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/en/docs/concepts/workloads/controllers/cron-jobs.md
@@ -17,9 +17,14 @@ A _Cron Job_ creates [Jobs](/docs/concepts/workloads/controllers/jobs-run-to-com
 One CronJob object is like one line of a _crontab_ (cron table) file. It runs a job periodically
 on a given schedule, written in [Cron](https://en.wikipedia.org/wiki/Cron) format.
 
-{{< note >}}
-All **CronJob** `schedule:` times are based on the timezone of the master where the job is initiated.
-{{< /note >}}
+{{< caution >}}
+All **CronJob** `schedule:` times are based on the timezone of the
+{{< glossary_tooltip term_id="kube-controller-manager" text="kube-controller-manager" >}}.
+
+If your control plane runs the kube-controller-manager in Pods or bare
+containers, the timezone set for the kube-controller-manager container determines the timezone
+that the cron job controller uses.
+{{< /caution >}}
 
 When creating the manifest for a CronJob resource, make sure the name you provide
 is no longer than 52 characters. This is because the CronJob controller will automatically


### PR DESCRIPTION
The timezone for the [kube-controller-manager](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/) determines when [CronJobs](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) are scheduled. [[preview](https://deploy-preview-19269--kubernetes-io-master-staging.netlify.com/docs/concepts/workloads/controllers/cron-jobs/)]

Revert commit bad124b857a2927b75be739646244aacc5190580 from #18715 and add some extra details.

/do-not-merge work-in-progress