### PR TITLE
Improve CronJob concept

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/en/docs/concepts/workloads/controllers/cron-jobs.md
@@ -12,7 +12,7 @@ weight: 80
 
 {{< feature-state for_k8s_version="v1.8" state="beta" >}}
 
-A _Cron Job_ creates [Jobs](/docs/concepts/workloads/controllers/jobs-run-to-completion/) on a time-based schedule.
+A _CronJob_ creates {{< glossary_tooltip term_id="job" text="Jobs" >}} on a repeating schedule.
 
 One CronJob object is like one line of a _crontab_ (cron table) file. It runs a job periodically
 on a given schedule, written in [Cron](https://en.wikipedia.org/wiki/Cron) format.
@@ -27,14 +27,26 @@ The name must be no longer than 52 characters. This is because the CronJob contr
 append 11 characters to the job name provided and there is a constraint that the
 maximum length of a Job name is no more than 63 characters.
 
-For instructions on creating and working with cron jobs, and for an example of a spec file for a cron job, see [Running automated tasks with cron jobs](/docs/tasks/job/automated-tasks-with-cron-jobs).
 
 {{% /capture %}}
-
-
 {{% capture body %}}
 
-## Cron Job Limitations
+## CronJob
+
+CronJobs are useful for creating periodic and recurring tasks, like running backups or
+sending emails. CronJobs can also schedule individual tasks for a specific time, such as
+scheduling a Job for when your cluster is likely to be idle.
+
+### Example
+
+This example CronJob manifest prints the current time and a hello message every minute:
+
+{{< codenew file="application/job/cronjob.yaml" >}}
+
+([Running Automated Tasks with a CronJob](/docs/tasks/job/automated-tasks-with-cron-jobs/)
+takes you through this example in more detail).
+
+## CronJob limitations {#cron-job-limitations}
 
 A cron job creates a job object _about_ once per execution time of its schedule. We say "about" because there
 are certain circumstances where two jobs might be created, or no job might be created. We attempt to make these rare,
@@ -64,5 +76,13 @@ be down for the same period as the previous example (`08:29:00` to `10:21:00`,) 
 
 The CronJob is only responsible for creating Jobs that match its schedule, and
 the Job in turn is responsible for the management of the Pods it represents.
+
+{{% /capture %}}
+{{% capture whatsnext %}}
+[Cron expression format](https://pkg.go.dev/github.com/robfig/cron?tab=doc#hdr-CRON_Expression_Format)
+documents the format of CronJob `schedule` fields.
+
+For instructions on creating and working with cron jobs, and for an example of CronJob
+manifest, see [Running automated tasks with cron jobs](/docs/tasks/job/automated-tasks-with-cron-jobs).
 
 {{% /capture %}}


### PR DESCRIPTION
Improve https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/

- Add an example
- Add a what's next section and move a link there
- Rewrite “Cron Job” to “CronJob”

Relevant to #4500
Fixes #18196