### PR TITLE
Correcting name of concept 'Container Enviorment Variables'

### DIFF
--- a/content/en/docs/concepts/cluster-administration/cluster-administration-overview.md
+++ b/content/en/docs/concepts/cluster-administration/cluster-administration-overview.md
@@ -44,7 +44,7 @@ Note: Not all distros are actively maintained. Choose distros which have been te
 
 * [Certificates](/docs/concepts/cluster-administration/certificates/) describes the steps to generate certificates using different tool chains.
 
-* [Kubernetes Container Environment](/docs/concepts/containers/container-environment-variables/) describes the environment for Kubelet managed containers on a Kubernetes node.
+* [Kubernetes Container Environment](/docs/concepts/containers/container-environment/) describes the environment for Kubelet managed containers on a Kubernetes node.
 
 * [Controlling Access to the Kubernetes API](/docs/reference/access-authn-authz/controlling-access/) describes how to set up permissions for users and service accounts.
 

--- a/content/en/docs/concepts/containers/container-environment.md
+++ b/content/en/docs/concepts/containers/container-environment.md
@@ -2,7 +2,7 @@
 reviewers:
 - mikedanese
 - thockin
-title: Container Environment Variables
+title: Container Environment
 content_template: templates/concept
 weight: 20
 ---

--- a/content/en/docs/concepts/containers/container-lifecycle-hooks.md
+++ b/content/en/docs/concepts/containers/container-lifecycle-hooks.md
@@ -116,7 +116,7 @@ Events:
 
 {{% capture whatsnext %}}
 
-* Learn more about the [Container environment](/docs/concepts/containers/container-environment-variables/).
+* Learn more about the [Container environment](/docs/concepts/containers/container-environment/).
 * Get hands-on experience
   [attaching handlers to Container lifecycle events](/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/).
 


### PR DESCRIPTION
This page(https://k8s.io/docs/concepts/containers/container-environment-variables/) discusses the details of the container environment and container environment variables are part of it. So name of the page should be 'Container Environment' and not 'Container Environment Variables' so removing a 'variables' word to make it more correct.

