### PR TITLE
Clarify At-Most-One Semantic For DaemonSet Update

### DIFF
--- a/content/en/docs/tasks/manage-daemon/update-daemon-set.md
+++ b/content/en/docs/tasks/manage-daemon/update-daemon-set.md
@@ -33,7 +33,7 @@ DaemonSet has two update strategy types:
 * RollingUpdate: This is the default update strategy.  
   With `RollingUpdate` update strategy, after you update a
   DaemonSet template, old DaemonSet pods will be killed, and new DaemonSet pods
-  will be created automatically, in a controlled fashion. At most one pod will be running on each node during the whole update process.
+  will be created automatically, in a controlled fashion. At most one pod of the DaemonSet will be running on each node during the whole update process.
 
 ## Performing a Rolling Update
 

--- a/content/en/docs/tasks/manage-daemon/update-daemon-set.md
+++ b/content/en/docs/tasks/manage-daemon/update-daemon-set.md
@@ -33,7 +33,7 @@ DaemonSet has two update strategy types:
 * RollingUpdate: This is the default update strategy.  
   With `RollingUpdate` update strategy, after you update a
   DaemonSet template, old DaemonSet pods will be killed, and new DaemonSet pods
-  will be created automatically, in a controlled fashion.
+  will be created automatically, in a controlled fashion. At most one pod will be running on each node during the whole update process.
 
 ## Performing a Rolling Update
 


### PR DESCRIPTION
Make it explicit, that at most one pod will run on each node while updating a daemonset. As mentioned here: https://github.com/kubernetes/kubernetes/issues/48841

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use
 for advice.

-->
