### PR TITLE
Correcting inconsistency of storage class name

### DIFF
--- a/content/en/docs/tasks/administer-cluster/change-default-storage-class.md
+++ b/content/en/docs/tasks/administer-cluster/change-default-storage-class.md
@@ -62,10 +62,10 @@ for details about addon manager and how to disable individual addons.
       To mark a StorageClass as non-default, you need to change its value to `false`:
 
       ```bash
-      kubectl patch storageclass <your-class-name> -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
+      kubectl patch storageclass standard -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
       ```
 
-      where `<your-class-name>` is the name of your chosen StorageClass.
+      where `standard` is the name of your chosen StorageClass.
 
 1. Mark a StorageClass as default:
 
@@ -73,7 +73,7 @@ for details about addon manager and how to disable individual addons.
       `storageclass.kubernetes.io/is-default-class=true`.
 
       ```bash
-      kubectl patch storageclass <your-class-name> -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+      kubectl patch storageclass gold -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
       ```
 
       Please note that at most one StorageClass can be marked as default. If two


### PR DESCRIPTION
https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/ page discusses a task to change the default storage class. Step 1 and 4 uses specific storage class names but middle two steps i.e 2nd and 3rd ask the user-provided name using a placeholder. We should stick with a naming convention for the resource name, either we can use dummy names or use placeholders. But this example was using both in a single set of steps which creates confusion. So this PR  Corrects inconsistency of storage class name.