### PR TITLE
Minor correction on 'safely drain node' task page

### DIFF
--- a/content/en/docs/tasks/administer-cluster/safely-drain-node.md
+++ b/content/en/docs/tasks/administer-cluster/safely-drain-node.md
@@ -156,7 +156,7 @@ application owners and cluster owners to establish an agreement on behavior in t
 {{% capture whatsnext %}}
 
 * Follow steps to protect your application by [configuring a Pod Disruption Budget](/docs/tasks/run-application/configure-pdb/).
-* Learn more about [maintenance on a node](docs/tasks/administer-cluster/cluster-management/#maintenance-on-a-node).
+* Learn more about [maintenance on a node](/docs/tasks/administer-cluster/cluster-management/#maintenance-on-a-node).
 
 {{% /capture %}}
 

--- a/content/en/docs/tasks/administer-cluster/safely-drain-node.md
+++ b/content/en/docs/tasks/administer-cluster/safely-drain-node.md
@@ -9,7 +9,7 @@ content_template: templates/task
 ---
 
 {{% capture overview %}}
-This page shows how to safely drain a machine, respecting the PodDisruptionBudget you have defined.
+This page shows how to safely drain a node, respecting the PodDisruptionBudget you have defined.
 {{% /capture %}}
 
 {{% capture prerequisites %}}
@@ -156,6 +156,7 @@ application owners and cluster owners to establish an agreement on behavior in t
 {{% capture whatsnext %}}
 
 * Follow steps to protect your application by [configuring a Pod Disruption Budget](/docs/tasks/run-application/configure-pdb/).
+* Learn more about [maintenance on a node](docs/tasks/administer-cluster/cluster-management/#maintenance-on-a-node).
 
 {{% /capture %}}
 


### PR DESCRIPTION
Below two changes has been done on page https://k8s.io/docs/tasks/administer-cluster/safely-drain-node/
1. 'kubectl drain' command drains node and not a machine. So the machine word is replaced with node. 
2. Also, added a reference link to 'maintenance on a node' task in what's next section
