### PR TITLE
Changing all incorrect headings of task 'list-all-running-container-images'

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/list-all-running-container-images.md
+++ b/content/en/docs/tasks/access-application-cluster/list-all-running-container-images.md
@@ -23,7 +23,7 @@ In this exercise you will use kubectl to fetch all of the Pods
 running in a cluster, and format the output to pull out the list
 of Containers for each.
 
-## List all Container Images in all namespaces
+## List all Container images in all namespaces
 
 - Fetch all Pods in all namespaces using `kubectl get pods --all-namespaces`
 - Format the output to include only the list of Container image names
@@ -68,7 +68,7 @@ the `.items[*]` portion of the path should be omitted because a single
 Pod is returned instead of a list of items.
 {{< /note >}}
 
-## List Container Images by Pod
+## List Container images by Pod
 
 The formatting can be controlled further by using the `range` operation to
 iterate over elements individually.
@@ -78,7 +78,7 @@ kubectl get pods --all-namespaces -o=jsonpath='{range .items[*]}{"\n"}{.metadata
 sort
 ```
 
-## List Container Images filtering by Pod label
+## List Container images filtering by Pod label
 
 To target only Pods matching a specific label, use the -l flag.  The
 following matches only Pods with labels matching `app=nginx`.
@@ -87,7 +87,7 @@ following matches only Pods with labels matching `app=nginx`.
 kubectl get pods --all-namespaces -o=jsonpath="{..image}" -l app=nginx
 ```
 
-## List Container Images filtering by Pod namespace
+## List Container images filtering by Pod namespace
 
 To target only pods in a specific namespace, use the namespace flag. The
 following matches only Pods in the `kube-system` namespace.
@@ -96,7 +96,7 @@ following matches only Pods in the `kube-system` namespace.
 kubectl get pods --namespace kube-system -o jsonpath="{..image}"
 ```
 
-## List Container Images using a go-template instead of jsonpath
+## List Container images using a go-template instead of jsonpath
 
 As an alternative to jsonpath, Kubectl supports using [go-templates](https://golang.org/pkg/text/template/)
 for formatting the output:

--- a/content/en/docs/tasks/access-application-cluster/list-all-running-container-images.md
+++ b/content/en/docs/tasks/access-application-cluster/list-all-running-container-images.md
@@ -23,7 +23,7 @@ In this exercise you will use kubectl to fetch all of the Pods
 running in a cluster, and format the output to pull out the list
 of Containers for each.
 
-## List all Containers in all namespaces
+## List all Container Images in all namespaces
 
 - Fetch all Pods in all namespaces using `kubectl get pods --all-namespaces`
 - Format the output to include only the list of Container image names
@@ -68,7 +68,7 @@ the `.items[*]` portion of the path should be omitted because a single
 Pod is returned instead of a list of items.
 {{< /note >}}
 
-## List Containers by Pod
+## List Container Images by Pod
 
 The formatting can be controlled further by using the `range` operation to
 iterate over elements individually.
@@ -78,7 +78,7 @@ kubectl get pods --all-namespaces -o=jsonpath='{range .items[*]}{"\n"}{.metadata
 sort
 ```
 
-## List Containers filtering by Pod label
+## List Container Images filtering by Pod label
 
 To target only Pods matching a specific label, use the -l flag.  The
 following matches only Pods with labels matching `app=nginx`.
@@ -87,7 +87,7 @@ following matches only Pods with labels matching `app=nginx`.
 kubectl get pods --all-namespaces -o=jsonpath="{..image}" -l app=nginx
 ```
 
-## List Containers filtering by Pod namespace
+## List Container Images filtering by Pod namespace
 
 To target only pods in a specific namespace, use the namespace flag. The
 following matches only Pods in the `kube-system` namespace.
@@ -96,7 +96,7 @@ following matches only Pods in the `kube-system` namespace.
 kubectl get pods --namespace kube-system -o jsonpath="{..image}"
 ```
 
-## List Containers using a go-template instead of jsonpath
+## List Container Images using a go-template instead of jsonpath
 
 As an alternative to jsonpath, Kubectl supports using [go-templates](https://golang.org/pkg/text/template/)
 for formatting the output:


### PR DESCRIPTION
The page https://k8s.io/docs/tasks/access-application-cluster/list-all-running-container-images/ describes various ways to list down container images using different filters. But all headings say it is listing container itself which is incorrect. so changing all headings to make it correct.
