### PR TITLE
Updating docs for EndpointSlice changes in 1.18

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -93,6 +93,8 @@ different Kubernetes components.
 | `DynamicKubeletConfig` | `true` | Beta | 1.11 | |
 | `EndpointSlice` | `false` | Alpha | 1.16 | 1.16 |
 | `EndpointSlice` | `false` | Beta | 1.17 | |
+| `EndpointSlice` | `true` | Beta | 1.18 | |
+| `EndpointSliceProxying` | `false` | Alpha | 1.18 | |
 | `EphemeralContainers` | `false` | Alpha | 1.16 | |
 | `ExpandCSIVolumes` | `false` | Alpha | 1.14 | 1.15 |
 | `ExpandCSIVolumes` | `true` | Beta | 1.16 | |
@@ -392,8 +394,10 @@ Each feature gate is designed for enabling/disabling a specific feature:
    capabilities (e.g. `MKNODE`, `SYS_MODULE` etc.). This should only be enabled
    if user namespace remapping is enabled in the Docker daemon.
 - `EndpointSlice`: Enables Endpoint Slices for more scalable and extensible
-   network endpoints. Requires corresponding API and Controller to be enabled.
-   See [Enabling Endpoint Slices](/docs/tasks/administer-cluster/enabling-endpointslices/).
+   network endpoints. See [Enabling Endpoint Slices](/docs/tasks/administer-cluster/enabling-endpointslices/).
+- `EndpointSliceProxying`: When this feature gate is enabled, kube-proxy will
+   use EndpointSlices as the primary data source instead of Endpoints, enabling
+   scalability and performance improvements. See [Enabling Endpoint Slices](/docs/tasks/administer-cluster/enabling-endpointslices/).
 - `GCERegionalPersistentDisk`: Enable the regional PD feature on GCE.
 - `HugePages`: Enable the allocation and consumption of pre-allocated [huge pages](/docs/tasks/manage-hugepages/scheduling-hugepages/).
 - `HugePageStorageMediumSize`: Enable support for multiple sizes pre-allocated [huge pages](/docs/tasks/manage-hugepages/scheduling-hugepages/).

--- a/content/en/docs/tasks/administer-cluster/enabling-endpointslices.md
+++ b/content/en/docs/tasks/administer-cluster/enabling-endpointslices.md
@@ -35,28 +35,25 @@ components still rely on Endpoints. For now, enabling EndpointSlices should be
 seen as an addition to Endpoints in a cluster, not a replacement for them.
 {{< /note >}}
 
-EndpointSlices are considered a beta feature, but only the API is enabled by
-default. Both the EndpointSlice controller and the usage of EndpointSlices by
-kube-proxy are not enabled by default.
+EndpointSlices are a beta feature. Both the API and the EndpointSlice
+{< glossary_tooltip term_id="controller" >}} are enabled by default.
+{{<  glossary_tooltip text="kube-proxy" term_id="kube-proxy" >}}
+uses Endpoints by default, not EndpointSlices.
 
-The EndpointSlice controller creates and manages EndpointSlices in a cluster.
-You can enable it with the `EndpointSlice` [feature
-gate](/docs/reference/command-line-tools-reference/feature-gates/) on the {{<
-glossary_tooltip text="kube-apiserver" term_id="kube-apiserver" >}} and {{<
-glossary_tooltip text="kube-controller-manager"
-term_id="kube-controller-manager" >}} (`--feature-gates=EndpointSlice=true`).
-
-For better scalability, you can also enable this feature gate on {{<
-glossary_tooltip text="kube-proxy" term_id="kube-proxy" >}} so EndpointSlices
-will be used as the data source instead of Endpoints.
+For better scalability and performance, you can enable the
+`EndpointSliceProxying`
+[feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
+on kube-proxy. That change
+switches the data source to be EndpointSlices, which reduces the amount of
+Kubernetes API traffic to and from kube-proxy.
 
 ## Using EndpointSlices
 
 With EndpointSlices fully enabled in your cluster, you should see corresponding
 EndpointSlice resources for each Endpoints resource. In addition to supporting
-existing Endpoints functionality, EndpointSlices should include new bits of
-information such as topology. They will allow for greater scalability and
-extensibility of network endpoints in your cluster.
+existing Endpoints functionality, EndpointSlices include new bits of information
+such as topology. They will allow for greater scalability and extensibility of
+network endpoints in your cluster.
 
 {{% capture whatsnext %}}
 


### PR DESCRIPTION
This includes updates to the EndpointSlice documentation to cover the changes in 1.18. This is primarily that the EndpointSlice feature gate has been split into two. The `EndpointSlice` gate affects everything but kube-proxy, and a new `EndpointSliceProxying` gate affects kube-proxy. In addition to that, the `EndpointSlice` feature gate is now enabled by default (not the new `EndpointSliceProxying` gate).

Enhancement Issue: https://github.com/kubernetes/enhancements/issues/752
PR this is documenting: https://github.com/kubernetes/kubernetes/pull/86137

/sig network
/cc @sftim
