### PR TITLE
Removing namespace flag from commands

### DIFF
--- a/content/en/docs/concepts/policy/limit-range.md
+++ b/content/en/docs/concepts/policy/limit-range.md
@@ -373,6 +373,11 @@ Delete the `limitrange-demo` namespace to free all resources:
 ```shell
 kubectl delete ns limitrange-demo
 ```
+Change your context to `default` namespace with the following command:
+
+```shell
+kubectl config set-context --current --namespace=default
+```
 
 ## Examples
 

--- a/content/en/docs/concepts/policy/limit-range.md
+++ b/content/en/docs/concepts/policy/limit-range.md
@@ -77,7 +77,7 @@ Here is the configuration file for a LimitRange object:
 
 This object defines minimum and maximum Memory/CPU limits,  default cpu/Memory requests  and default limits for CPU/Memory resources to be apply to containers.
 
-Create the `limit-mem-cpu-per-container` LimitRange in the `limitrange-demo` namespace with the following kubectl command:
+Create the `limit-mem-cpu-per-container` LimitRange with the following kubectl command:
 
 ```shell
 kubectl create -f https://k8s.io/examples/admin/resource/limit-mem-cpu-container.yaml

--- a/content/en/docs/concepts/policy/limit-range.md
+++ b/content/en/docs/concepts/policy/limit-range.md
@@ -366,7 +366,7 @@ The pod creation failed as the ratio here (`3`) is greater than the enforced lim
 Error from server (Forbidden): error when creating "limit-range-pod-3.yaml": pods "busybox3" is forbidden: memory max limit to request ratio per Pod is 2, but provided ratio is 3.000000.
 ```
 
-### Clean up
+## Clean up
 
 Delete the `limitrange-demo` namespace to free all resources:
 

--- a/content/en/docs/concepts/policy/limit-range.md
+++ b/content/en/docs/concepts/policy/limit-range.md
@@ -80,11 +80,11 @@ This object defines minimum and maximum Memory/CPU limits,  default cpu/Memory r
 Create the `limit-mem-cpu-per-container` LimitRange in the `limitrange-demo` namespace with the following kubectl command:
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/resource/limit-mem-cpu-container.yaml -n limitrange-demo
+kubectl create -f https://k8s.io/examples/admin/resource/limit-mem-cpu-container.yaml
 ```
 
 ```shell
-kubectl describe limitrange/limit-mem-cpu-per-container -n limitrange-demo
+kubectl describe limitrange/limit-mem-cpu-per-container
 ```
 
 ```shell
@@ -100,7 +100,7 @@ Here is the configuration file for a Pod with 04 containers to demonstrate Limit
 Create the `busybox1` Pod:
 
 ```shell
-kubectl apply -f https://k8s.io/examples/admin/resource/limit-range-pod-1.yaml -n limitrange-demo
+kubectl apply -f https://k8s.io/examples/admin/resource/limit-range-pod-1.yaml
 ```
 
 ### Container spec with valid CPU/Memory requests and limits
@@ -108,7 +108,7 @@ kubectl apply -f https://k8s.io/examples/admin/resource/limit-range-pod-1.yaml -
 View the `busybox-cnt01` resource configuration:
 
 ```shell
-kubectl get po/busybox1 -n limitrange-demo -o json | jq ".spec.containers[0].resources"
+kubectl get po/busybox1 -o json | jq ".spec.containers[0].resources"
 ```
 
 ```json
@@ -135,7 +135,7 @@ kubectl get po/busybox1 -n limitrange-demo -o json | jq ".spec.containers[0].res
 View the  `busybox-cnt02` resource configuration
 
 ```shell
-kubectl get po/busybox1 -n limitrange-demo -o json | jq ".spec.containers[1].resources"
+kubectl get po/busybox1 -o json | jq ".spec.containers[1].resources"
 ```
 
 ```json
@@ -161,7 +161,7 @@ kubectl get po/busybox1 -n limitrange-demo -o json | jq ".spec.containers[1].res
 View the `busybox-cnt03` resource configuration
 
 ```shell
-kubectl get po/busybox1 -n limitrange-demo -o json | jq ".spec.containers[2].resources"
+kubectl get po/busybox1 -o json | jq ".spec.containers[2].resources"
 ```
 ```json
 {
@@ -187,7 +187,7 @@ kubectl get po/busybox1 -n limitrange-demo -o json | jq ".spec.containers[2].res
 View the `busybox-cnt04` resource configuration:
 
 ```shell
-kubectl get po/busybox1 -n limitrange-demo -o json | jq ".spec.containers[3].resources"
+kubectl get po/busybox1 -o json | jq ".spec.containers[3].resources"
 ```
 
 ```json
@@ -222,7 +222,7 @@ The following section discusses how to constrain resources at Pod level.
 Without having to delete `busybox1` Pod, create the `limit-mem-cpu-pod` LimitRange in the `limitrange-demo` namespace:
 
 ```shell
-kubectl apply -f https://k8s.io/examples/admin/resource/limit-mem-cpu-pod.yaml -n limitrange-demo
+kubectl apply -f https://k8s.io/examples/admin/resource/limit-mem-cpu-pod.yaml
 ```
 The limitrange is created and limits CPU to 2 Core  and Memory to 2Gi per Pod:
 
@@ -250,7 +250,7 @@ Now create the `busybox2` Pod:
 {{< codenew file="admin/resource/limit-range-pod-2.yaml" >}}
 
 ```shell
-kubectl apply -f https://k8s.io/examples/admin/resource/limit-range-pod-2.yaml -n limitrange-demo
+kubectl apply -f https://k8s.io/examples/admin/resource/limit-range-pod-2.yaml
 ```
 
 The `busybox2`  Pod definition  is identical to `busybox1` but an error is reported since Pod's resources are now limited:
@@ -260,7 +260,7 @@ Error from server (Forbidden): error when creating "limit-range-pod-2.yaml": pod
 ```
 
 ```shell
-kubectl get po/busybox1 -n limitrange-demo -o json | jq ".spec.containers[].resources.limits.memory"
+kubectl get po/busybox1 -o json | jq ".spec.containers[].resources.limits.memory"
 "200Mi"
 "900Mi"
 "200Mi"
@@ -279,7 +279,7 @@ You can enforce  minimum and maximum  size  of [storage resources](/docs/concept
 Apply the YAML using `kubectl create`:
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/resource/storagelimits.yaml -n limitrange-demo
+kubectl create -f https://k8s.io/examples/admin/resource/storagelimits.yaml
 ```
 
 ```shell
@@ -305,7 +305,7 @@ PersistentVolumeClaim  storage   1Gi  2Gi  -                -              -
 {{< codenew file="admin/resource/pvc-limit-lower.yaml" >}}
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/resource/pvc-limit-lower.yaml -n limitrange-demo
+kubectl create -f https://k8s.io/examples/admin/resource/pvc-limit-lower.yaml
 ```
 
 While creating a PVC with `requests.storage` lower than the Min value in the LimitRange, an Error thrown by the server:
@@ -319,7 +319,7 @@ Same behaviour is noted if  the `requests.storage` is greater than the Max value
 {{< codenew file="admin/resource/pvc-limit-greater.yaml" >}}
 
 ```shell
-kubectl create -f https://k8s.io/examples/admin/resource/pvc-limit-greater.yaml -n limitrange-demo
+kubectl create -f https://k8s.io/examples/admin/resource/pvc-limit-greater.yaml
 ```
 
 ```shell


### PR DESCRIPTION
As at the start of a task, context is set to a namespace using a 'set-context' command, subsequent commands do not need '-n namespace-name' flag.
Also, added a command to change context back to default namespace in cleanup task.
This closes #18854 