### PR TITLE
Removing non required details about the context

### DIFF
--- a/content/en/docs/tasks/administer-cluster/namespaces.md
+++ b/content/en/docs/tasks/administer-cluster/namespaces.md
@@ -187,88 +187,22 @@ This delete is asynchronous, so for a time you will see the namespace in the `Te
 
     To demonstrate this, let's spin up a simple Deployment and Pods in the `development` namespace.
 
-    We first check what is the current context:
-
     ```shell
-    kubectl config view
-    ```
-    ```yaml
-    apiVersion: v1
-    clusters:
-     cluster:
-        certificate-authority-data: REDACTED
-        server: https://130.211.122.180
-      name: lithe-cocoa-92103_kubernetes
-    contexts:
-     context:
-        cluster: lithe-cocoa-92103_kubernetes
-        user: lithe-cocoa-92103_kubernetes
-      name: lithe-cocoa-92103_kubernetes
-    current-context: lithe-cocoa-92103_kubernetes
-    kind: Config
-    preferences: {}
-    users:
-     name: lithe-cocoa-92103_kubernetes
-      user:
-        client-certificate-data: REDACTED
-        client-key-data: REDACTED
-        token: 65rZW78y8HbwXXtSXuUw9DbP4FLjHi4b
-     name: lithe-cocoa-92103_kubernetes-basic-auth
-      user:
-        password: h5M0FtUUIflBSdI7
-        username: admin
-    ```
-
-    ```shell
-    kubectl config current-context
-    ```
-    ```
-    lithe-cocoa-92103_kubernetes
-    ```
-
-    The next step is to define a context for the kubectl client to work in each namespace. The values of "cluster" and "user" fields are copied from the current context.
-
-    ```shell
-    kubectl config set-context dev --namespace=development --cluster=lithe-cocoa-92103_kubernetes --user=lithe-cocoa-92103_kubernetes
-    kubectl config set-context prod --namespace=production --cluster=lithe-cocoa-92103_kubernetes --user=lithe-cocoa-92103_kubernetes
-    ```
-
-    The above commands provided two request contexts you can alternate against depending on what namespace you
-    wish to work against.
-
-    Let's switch to operate in the `development` namespace.
-
-    ```shell
-    kubectl config use-context dev
-    ```
-
-    You can verify your current context by doing the following:
-
-    ```shell
-    kubectl config current-context
-    dev
-    ```
-
-    At this point, all requests we make to the Kubernetes cluster from the command line are scoped to the `development` namespace.
-
-    Let's create some contents.
-
-    ```shell
-    kubectl run snowflake --image=k8s.gcr.io/serve_hostname --replicas=2
+    kubectl run snowflake --image=k8s.gcr.io/serve_hostname --replicas=2 -n=development
     ```
     We have just created a deployment whose replica size is 2 that is running the pod called `snowflake` with a basic container that just serves the hostname.
     Note that `kubectl run` creates deployments only on Kubernetes cluster >= v1.2. If you are running older versions, it creates replication controllers instead.
     If you want to obtain the old behavior, use `--generator=run/v1` to create replication controllers. See [`kubectl run`](/docs/reference/generated/kubectl/kubectl-commands/#run) for more details.
 
     ```shell
-    kubectl get deployment
+    kubectl get deployment -n=development
     ```
     ```
     NAME         READY   UP-TO-DATE   AVAILABLE   AGE
     snowflake    2/2     2            2           2m
     ```
     ```shell
-    kubectl get pods -l run=snowflake
+    kubectl get pods -l run=snowflake -n=development
     ```
     ```
     NAME                         READY     STATUS    RESTARTS   AGE
@@ -280,23 +214,19 @@ This delete is asynchronous, so for a time you will see the namespace in the `Te
 
     Let's switch to the `production` namespace and show how resources in one namespace are hidden from the other.
 
-    ```shell
-    kubectl config use-context prod
-    ```
-
     The `production` namespace should be empty, and the following commands should return nothing.
 
     ```shell
-    kubectl get deployment
-    kubectl get pods
+    kubectl get deployment -n=production
+    kubectl get pods -n=production
     ```
 
     Production likes to run cattle, so let's create some cattle pods.
 
     ```shell
-    kubectl run cattle --image=k8s.gcr.io/serve_hostname --replicas=5
+    kubectl run cattle --image=k8s.gcr.io/serve_hostname --replicas=5 -n=production
 
-    kubectl get deployment
+    kubectl get deployment -n=production
     ```
     ```
     NAME         READY   UP-TO-DATE   AVAILABLE   AGE
@@ -304,7 +234,7 @@ This delete is asynchronous, so for a time you will see the namespace in the `Te
     ```
 
     ```shell
-    kubectl get pods -l run=cattle
+    kubectl get pods -l run=cattle -n=production
     ```
     ```
     NAME                      READY     STATUS    RESTARTS   AGE


### PR DESCRIPTION
Removing non-required details about the context. Without explanation, the text suddenly starts referring to contexts while talking about namespaces. But they are completely different, as contexts refer to entire clusters, while namespaces are a subdivision of a specific cluster. This is very confusing to users.
This PR closes issue #19161 
