### PR TITLE
remove example of deprecated option: kubectl get --export

### DIFF
--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -148,7 +148,6 @@ kubectl get pods -o wide                      # List all pods in the current nam
 kubectl get deployment my-dep                 # List a particular deployment
 kubectl get pods                              # List all pods in the namespace
 kubectl get pod my-pod -o yaml                # Get a pod's YAML
-kubectl get pod my-pod -o yaml --export       # Get a pod's YAML without cluster specific information
 
 # Describe commands with verbose output
 kubectl describe nodes my-node


### PR DESCRIPTION
The `--export` flag for the `kubectl get` command, deprecated since v1.14, will be removed in v1.18.
I'm using v1.17.3, and it seems that `kubectl get --export` does not work as expected (not omit status, metadata.ownerReferences and so on).