### PR TITLE
Maintaining consistency of glossary entries acronyms

### DIFF
--- a/content/en/docs/reference/glossary/cgroup.md
+++ b/content/en/docs/reference/glossary/cgroup.md
@@ -1,5 +1,5 @@
 ---
-title: cgroup (control group)
+title: Control Group (cgroup)
 id: cgroup
 date: 2019-06-25
 full_link:

--- a/content/en/docs/reference/glossary/cidr.md
+++ b/content/en/docs/reference/glossary/cidr.md
@@ -1,5 +1,5 @@
 ---
-title: CIDR
+title: Classless Inter-Domain Routing (CIDR)
 id: cidr
 date: 2019-11-12
 full_link: 
@@ -10,7 +10,7 @@ aka:
 tags:
 - networking
 ---
-CIDR (Classless Inter-Domain Routing) is a notation for describing blocks of IP addresses and is used heavily in various networking configurations.
+Classless Inter-Domain Routing (CIDR) is a notation for describing blocks of IP addresses and is used heavily in various networking configurations.
 
 <!--more-->
 

--- a/content/en/docs/reference/glossary/cla.md
+++ b/content/en/docs/reference/glossary/cla.md
@@ -1,5 +1,5 @@
 ---
-title: CLA (Contributor License Agreement)
+title: Contributor License Agreement (CLA)
 id: cla
 date: 2018-04-12
 full_link: https://github.com/kubernetes/community/blob/master/CLA.md

--- a/content/en/docs/reference/glossary/rbac.md
+++ b/content/en/docs/reference/glossary/rbac.md
@@ -1,5 +1,5 @@
 ---
-title: RBAC (Role-Based Access Control)
+title: Role-Based Access Control (RBAC)
 id: rbac
 date: 2018-04-12
 full_link: /docs/reference/access-authn-authz/rbac/

--- a/content/en/docs/reference/glossary/sig.md
+++ b/content/en/docs/reference/glossary/sig.md
@@ -1,5 +1,5 @@
 ---
-title: SIG (special interest group)
+title: Special Interest Group (SIG)
 id: sig
 date: 2018-04-12
 full_link: https://github.com/kubernetes/community/blob/master/sig-list.md#master-sig-list

--- a/content/en/docs/reference/glossary/wg.md
+++ b/content/en/docs/reference/glossary/wg.md
@@ -1,5 +1,5 @@
 ---
-title: WG (working group)
+title: Working Group (WG)
 id: wg
 date: 2018-04-12
 full_link: https://github.com/kubernetes/community/blob/master/sig-list.md#master-working-group-list


### PR DESCRIPTION
The acronyms of the various glossary entries are provided inconsistently. This PR makes changes to make it consistent and approach followed is 'the title in full-term, followed by the acronym within parentheses'

This closes issue #19045 