### PR TITLE
Remove 404 disallow from robots.txt

### DIFF
--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -3,7 +3,5 @@ User-agent: *
 Disallow: /legacy/
 Disallow: /v1.0/
 Disallow: /v1.1/
-Disallow: /404/
-Disallow: /404.html
 
 SITEMAP: {{ "sitemap.xml" | absLangURL }}


### PR DESCRIPTION
404 should be authorized otherwise the crawler gets blocked when it encounters one and stop the crawling.

Soft 404 should also be avoided.

https://support.google.com/webmasters/forum/AAAA2Jdx3sUX-N_C271Pxw/?hl=ko