### PR TITLE
Updated Deployment description for clarity.

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
@@ -31,7 +31,8 @@ weight: 10
                 Once you have a running Kubernetes cluster, you can deploy your containerized applications on top of it.
                 To do so, you create a Kubernetes <b>Deployment</b> configuration. The Deployment instructs Kubernetes
                 how to create and update instances of your application. Once you've created a Deployment, the Kubernetes
-                master schedules mentioned application instances onto individual Nodes in the cluster.
+                master schedules the application instances included in that Deployment to run on individual Nodes in the
+                cluster.
                 </p>
 
                 <p>Once the application instances are created, a Kubernetes Deployment Controller continuously monitors those instances. If the Node hosting an instance goes down or is deleted, the Deployment controller replaces the instance with an instance on another Node in the cluster. <b>This provides a self-healing mechanism to address machine failure or maintenance.</b></p>


### PR DESCRIPTION
Rephrases part of the description of a Deployment in the "Deploy an App" section of the "Kubernetes Basics" tutorial to be more clear.

Fixes https://github.com/kubernetes/website/issues/19312