### PR TITLE
Localize “email address” placeholder on home page

### DIFF
--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -193,3 +193,6 @@ other = "Calendario de eventos"
 # UI elements
 [ui_search_placeholder]
 other = "Buscar"
+
+[input_placeholder_email_address]
+other = "dirección de correo electrónico"


### PR DESCRIPTION
https://github.com/kubernetes/website/issues/19364