### PR TITLE
fix: correct the kube-proxy cluster-cidr arg for zh

### DIFF
--- a/content/zh/docs/concepts/services-networking/dual-stack.md
+++ b/content/zh/docs/concepts/services-networking/dual-stack.md
@@ -108,7 +108,7 @@ To enable IPv4/IPv6 dual-stack, enable the `IPv6DualStack` [feature gate](/docs/
       * `--feature-gates="IPv6DualStack=true"`
    * kube-proxy:
       * `--proxy-mode=ipvs`
-      * `--cluster-cidrs=<IPv4 CIDR>,<IPv6 CIDR>` 
+      * `--cluster-cidr=<IPv4 CIDR>,<IPv6 CIDR>`
       * `--feature-gates="IPv6DualStack=true"`
 
 {{< caution >}}


### PR DESCRIPTION
This PR is going to fix #19350 .