### PR TITLE
Update deprecated API details

### DIFF
--- a/content/en/blog/_posts/2019-07-18-some-apis-are-being-deprecated.md
+++ b/content/en/blog/_posts/2019-07-18-some-apis-are-being-deprecated.md
@@ -23,30 +23,30 @@ The **v1.16** release will stop serving the following deprecated API versions in
     Existing persisted data can be retrieved/updated via the new version.
   * Notable changes:
       * `spec.templateGeneration` is removed
-      * `spec.selector` is now required and immutable after creation
-      * `spec.updateStrategy.type` now defaults to `RollingUpdate`
+      * `spec.selector` is now required and immutable after creation; use the existing template labels as the selector for seamless upgrades
+      * `spec.updateStrategy.type` now defaults to `RollingUpdate` (the default in `extensions/v1beta1` was `OnDelete`)
 * Deployment in the **extensions/v1beta1**, **apps/v1beta1**, and **apps/v1beta2** API versions is no longer served
   * Migrate to use the **apps/v1** API version, available since v1.9.
     Existing persisted data can be retrieved/updated via the new version.
   * Notable changes:
       * `spec.rollbackTo` is removed
-      * `spec.selector` is now required and immutable after creation
-      * `spec.progressDeadlineSeconds` now defaults to `600` seconds
-      * `spec.revisionHistoryLimit` now defaults to `10`
-      * `maxSurge` and `maxUnavailable` now default to `25%`
+      * `spec.selector` is now required and immutable after creation; use the existing template labels as the selector for seamless upgrades
+      * `spec.progressDeadlineSeconds` now defaults to `600` seconds (the default in `extensions/v1beta1` was no deadline)
+      * `spec.revisionHistoryLimit` now defaults to `10` (the default in `apps/v1beta1` was `2`, the default in `extensions/v1beta1` was to retain all)
+      * `maxSurge` and `maxUnavailable` now default to `25%` (the default in `extensions/v1beta1` was `1`)
 * StatefulSet in the **apps/v1beta1** and **apps/v1beta2** API versions is no longer served
   * Migrate to use the **apps/v1** API version, available since v1.9.
     Existing persisted data can be retrieved/updated via the new version.
   * Notable changes:
-      * `spec.selector` is now required and immutable after creation
-      * `spec.updateStrategy.type` now defaults to `RollingUpdate`
+      * `spec.selector` is now required and immutable after creation; use the existing template labels as the selector for seamless upgrades
+      * `spec.updateStrategy.type` now defaults to `RollingUpdate` (the default in `apps/v1beta1` was `OnDelete`)
 * ReplicaSet in the **extensions/v1beta1**, **apps/v1beta1**, and **apps/v1beta2** API versions is no longer served
   * Migrate to use the **apps/v1** API version, available since v1.9.
     Existing persisted data can be retrieved/updated via the new version.
   * Notable changes:
-      * `spec.selector` is now required and immutable after creation
+      * `spec.selector` is now required and immutable after creation; use the existing template labels as the selector for seamless upgrades
 
-The **v1.20** release will stop serving the following deprecated API versions in favor of newer and more stable API versions:
+The **v1.22** release will stop serving the following deprecated API versions in favor of newer and more stable API versions:
 
 * Ingress in the **extensions/v1beta1** API version will no longer be served
   * Migrate to use the **networking.k8s.io/v1beta1** API version, available since v1.14.
@@ -84,8 +84,8 @@ apiserver startup arguments:
 
 Deprecations are announced in the Kubernetes release notes. You can see these
 announcements in
-[1.14](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.14.md#deprecations)
-and [1.15](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.15.md#deprecations-and-removals).
+[1.14](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.14.md#deprecations)
+and [1.15](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.15.md#deprecations-and-removals).
 
 You can read more [in our deprecation policy document](https://kubernetes.io/docs/reference/using-api/deprecation-policy/#deprecating-parts-of-the-api)
 about the deprecation policies for Kubernetes APIs, and other Kubernetes components.


### PR DESCRIPTION
Update deprecated API blog post with more details on previous defaults, and guidance for setting the new required selector fields