### PR TITLE
Localize “email address” placeholder on home page

### DIFF
--- a/i18n/nl.toml
+++ b/i18n/nl.toml
@@ -193,3 +193,6 @@ other = "Evenementenkalender"
 # UI elements
 [ui_search_placeholder]
 other = "Zoeken"
+
+[input_placeholder_email_address]
+other = "e-mailadres"


### PR DESCRIPTION
https://github.com/kubernetes/website/issues/19417

/language nl