### PR TITLE
Update the generated etcd ca command

### DIFF
--- a/content/zh/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
+++ b/content/zh/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
@@ -196,7 +196,7 @@ kubeadm 包含生成下述证书所需的所有必要的密码学工具；在这
     如果您还没有 CA，则在 `$HOST0`（您为 kubeadm 生成配置文件的位置）上运行此命令。
 
     ```
-    kubeadm alpha phase certs etcd-ca
+    kubeadm init alpha phase certs etcd-ca
     ```
 
     <!--


### PR DESCRIPTION
The command to generate the certificate in the Chinese document is incorrect, which prevents the certificate from being generated. The correct command is "kubeadm init alpha phase certs etcd-ca"

