### PR TITLE
Change version selector to retain current page when switching versions (for website v1.15)

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -21,14 +21,14 @@
                 {{ end }}
                 </ul>
             </li>
-         
+
             <li>
                 <a href="#">
                     {{ site.Params.version }} <span class="ui-icon ui-icon-carat-1-s"></span>
                 </a>
                 <ul>
                 {{ range site.Params.versions }}
-                    <li><a href="{{  .url }}">{{ .version }}</a></li>
+                    <li><a href="{{ .url }}{{ $.RelPermalink }}">{{ .version }}</a></li>
                 {{ end }}
                 </ul>
             </li>


### PR DESCRIPTION
Fixes https://github.com/kubernetes/website/issues/19340 for version 1.15 of the website
(Additional PRs will be issued for other versions)