### PR TITLE
Add post for Contributor Summit postponement

### DIFF
--- a/content/en/blog/_posts/2020-03-04-Contributor-Summit-Delayed.md
+++ b/content/en/blog/_posts/2020-03-04-Contributor-Summit-Delayed.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-title: "Contributor Summit Amsterdam Postponed"
+title: Contributor Summit Amsterdam Postponed
 date: 2020-03-04
 slug: Contributor-Summit-Delayed
 ---

--- a/content/en/blog/_posts/2020-03-04-Contributor-Summit-Delayed.md
+++ b/content/en/blog/_posts/2020-03-04-Contributor-Summit-Delayed.md
@@ -1,7 +1,7 @@
 ---
 layout: blog
 title: "Contributor Summit Amsterdam Postponed"
-date: 2020-02-18
+date: 2020-03-04
 slug: Contributor-Summit-Delayed
 ---
 

--- a/content/en/blog/_posts/2020-03-04-Contributor-Summit-Delayed.md
+++ b/content/en/blog/_posts/2020-03-04-Contributor-Summit-Delayed.md
@@ -1,0 +1,15 @@
+---
+layout: blog
+title: "Contributor Summit Amsterdam Postponed"
+date: 2020-02-18
+slug: Contributor-Summit-Delayed
+---
+
+**Authors:** Dawn Foster (VMware), Jorge Castro (VMware) 
+
+The CNCF has announced that [KubeCon + CloudNativeCon EU has been delayed](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/attend/novel-coronavirus-update/) until July/August of 2020. As a result the Contributor Summit planning team is weighing options for how to proceed. Here’s the current plan:
+
+- There will be an in-person Contributor Summit as planned when KubeCon + CloudNativeCon is rescheduled.
+- We are looking at options for having additional virtual contributor activities in the meantime. 
+
+We will communicate via this blog and the usual communications channels on the final plan. Please bear with us as we adapt when we get more information. Thank you for being patient as the team pivots to bring you a great Contributor Summit!


### PR DESCRIPTION
KubeCon has been delayed, pushing out initial plans. 