### PR TITLE
adding some glossaries for docs-reference-glossary

### DIFF
--- a/content/vi/docs/reference/glossary/cluster.md
+++ b/content/vi/docs/reference/glossary/cluster.md
@@ -1,0 +1,18 @@
+---
+title: Cluster
+id: cluster
+date: 2020-02-26
+full_link: 
+short_description: >
+   Một tập các worker machine, được gọi là node, dùng để chạy các containerized application. Mỗi cụm (cluster) có ít nhất một worker node.
+
+aka: 
+tags:
+- fundamental
+- operation
+---
+Một tập các worker machine, được gọi là node, dùng để chạy các containerized application. Mỗi cụm (cluster) có ít nhất một worker node.
+
+<!--more-->
+Các worker node chứa các pod (là những thành phần của ứng dụng). Control Plane quản lý các worker node và pod trong cluster.
+Trong môi trường sản phẩm (production environment), Control Plane thường chạy trên nhiều máy tính và một cluster thường nhạy trên nhiều nodes, cung cấp khả năng chịu lỗi (fault-tolerance) và tính sẵn sàng cao (high availability).

--- a/content/vi/docs/reference/glossary/cluster.md
+++ b/content/vi/docs/reference/glossary/cluster.md
@@ -4,7 +4,7 @@ id: cluster
 date: 2020-02-26
 full_link: 
 short_description: >
-   Một tập các worker machine, được gọi là node, dùng để chạy các containerized application. Mỗi cụm (cluster) có ít nhất một worker node.
+   Một tập các worker machine, được gọi là node, dùng để chạy các các ứng dụng được đóng gói (containerized application). Mỗi cụm (cluster) có ít nhất một worker node.
 
 aka: 
 tags:
@@ -15,4 +15,4 @@ Một tập các worker machine, được gọi là node, dùng để chạy cá
 
 <!--more-->
 Các worker node chứa các pod (là những thành phần của ứng dụng). Control Plane quản lý các worker node và pod trong cluster.
-Trong môi trường sản phẩm (production environment), Control Plane thường chạy trên nhiều máy tính và một cluster thường nhạy trên nhiều nodes, cung cấp khả năng chịu lỗi (fault-tolerance) và tính sẵn sàng cao (high availability).
+Trong môi trường sản phẩm (production environment), Control Plane thường chạy trên nhiều máy tính và một cluster thường chạy trên nhiều node, cung cấp khả năng chịu lỗi (fault-tolerance) và tính sẵn sàng cao (high availability).

--- a/content/vi/docs/reference/glossary/containerd.md
+++ b/content/vi/docs/reference/glossary/containerd.md
@@ -1,0 +1,15 @@
+---
+title: containerd
+id: containerd
+date: 2020-03-04
+full_link: https://containerd.io/docs/
+short_description: >
+  Một container runtime tập trung vào sự đơn giản, mạnh mẽ và linh động.
+aka:
+tags:
+- tool
+---
+ Một container runtime tập trung vào sự đơn giản, mạnh mẽ và linh động.
+
+<!--more-->
+containerd là một {{< glossary_tooltip text="container" term_id="container" >}} runtime cái mà chạy như một daemon trên Linux hoặc Windows. containerd quan tâm tới việc lấy và lưu trữ các container image, thực thi các container, cung cấp truy cập mạng, và nhiều hơn nữa.

--- a/content/vi/docs/reference/glossary/control-plane.md
+++ b/content/vi/docs/reference/glossary/control-plane.md
@@ -1,0 +1,15 @@
+---
+title: Control Plane
+id: control-plane
+date: 2020-03-04
+full_link:
+short_description: >
+  Tầng điều khiển container, được dùng để đưa ra API và các interface để định nghĩa, triển khai, và quản lý vòng đời của các container.
+
+aka:
+tags:
+- fundamental
+---
+ Tầng điều khiển container, được dùng để đưa ra API và các interface để định nghĩa, triển khai, và quản lý vòng đời của các container.
+
+

--- a/content/vi/docs/reference/glossary/cri-o.md
+++ b/content/vi/docs/reference/glossary/cri-o.md
@@ -5,7 +5,7 @@ date: 2020-03-05
 full_link: https://cri-o.io/#what-is-cri-o
 short_description: >
   A lightweight container runtime specifically for Kubernetes
-  Một lightweight container runtime đặc biệt cho Kubernetes
+  Một container runtime nhẹ dành riêng cho Kubernetes
 aka:
 tags:
 - tool
@@ -14,14 +14,7 @@ Một công cụ giúp bạn sử dụng các OCI container runtime với Kubern
 
 <!--more-->
 
-CRI-O is an implementation of the {{< glossary_tooltip term_id="cri" >}}
-to enable using {{< glossary_tooltip text="container" term_id="container" >}}
-runtimes that are compatible with the Open Container Initiative (OCI)
-[runtime spec](http://www.github.com/opencontainers/runtime-spec).
-
-Deploying CRI-O allows Kubernetes to use any OCI-compliant runtime as the container
-runtime for running {{< glossary_tooltip text="Pods" term_id="pod" >}}, and to fetch
-OCI container images from remote registries.
 CRI-O là một thực thi của {{< glossary_tooltip term_id="cri" >}} để cho phép sử dụng các {{< glossary_tooltip text="container" term_id="container" >}} runtime cái mà tương thích với Open Container Initiative (OCI)
 [runtime spec](http://www.github.com/opencontainers/runtime-spec).
+
 Triển khai CRI-O cho phép Kuberentes sử dụng bất kì OCI-compliant runtime như container runtime để chạy {{< glossary_tooltip text="Pods" term_id="pod" >}}, và để lấy CRI container image từ các remote registry.

--- a/content/vi/docs/reference/glossary/cri-o.md
+++ b/content/vi/docs/reference/glossary/cri-o.md
@@ -1,0 +1,27 @@
+---
+title: CRI-O
+id: cri-o
+date: 2020-03-05
+full_link: https://cri-o.io/#what-is-cri-o
+short_description: >
+  A lightweight container runtime specifically for Kubernetes
+  Một lightweight container runtime đặc biệt cho Kubernetes
+aka:
+tags:
+- tool
+---
+Một công cụ giúp bạn sử dụng các OCI container runtime với Kubernetes CRI.
+
+<!--more-->
+
+CRI-O is an implementation of the {{< glossary_tooltip term_id="cri" >}}
+to enable using {{< glossary_tooltip text="container" term_id="container" >}}
+runtimes that are compatible with the Open Container Initiative (OCI)
+[runtime spec](http://www.github.com/opencontainers/runtime-spec).
+
+Deploying CRI-O allows Kubernetes to use any OCI-compliant runtime as the container
+runtime for running {{< glossary_tooltip text="Pods" term_id="pod" >}}, and to fetch
+OCI container images from remote registries.
+CRI-O là một thực thi của {{< glossary_tooltip term_id="cri" >}} để cho phép sử dụng các {{< glossary_tooltip text="container" term_id="container" >}} runtime cái mà tương thích với Open Container Initiative (OCI)
+[runtime spec](http://www.github.com/opencontainers/runtime-spec).
+Triển khai CRI-O cho phép Kuberentes sử dụng bất kì OCI-compliant runtime như container runtime để chạy {{< glossary_tooltip text="Pods" term_id="pod" >}}, và để lấy CRI container image từ các remote registry.

--- a/content/vi/docs/reference/glossary/cri-o.md
+++ b/content/vi/docs/reference/glossary/cri-o.md
@@ -4,7 +4,6 @@ id: cri-o
 date: 2020-03-05
 full_link: https://cri-o.io/#what-is-cri-o
 short_description: >
-  A lightweight container runtime specifically for Kubernetes
   Một container runtime nhẹ dành riêng cho Kubernetes
 aka:
 tags:

--- a/content/vi/docs/reference/glossary/daemonset.md
+++ b/content/vi/docs/reference/glossary/daemonset.md
@@ -1,0 +1,19 @@
+---
+title: DaemonSet
+id: daemonset
+date: 2020-03-05
+full_link: /docs/concepts/workloads/controllers/daemonset
+short_description: >
+  Đảm bảo một bản sao của Pod đang chạy trên một tập các node của cluster.
+aka: 
+tags:
+- fundamental
+- core-object
+- workload
+---
+ Đảm bảo một bản sao của {{< glossary_tooltip text="Pod" term_id="pod" >}} đang chạy trên một tập các node của {{< glossary_tooltip text="cluster" term_id="cluster" >}}.
+
+<!--more--> 
+
+Được sử dụng để deploy những system daemon ví dụ như log collector, monitoring agent, những cái thường phải chạy trên mọi {{< glossary_tooltip term_id="node" >}}.
+

--- a/content/vi/docs/reference/glossary/etcd.md
+++ b/content/vi/docs/reference/glossary/etcd.md
@@ -1,0 +1,20 @@
+---
+title: etcd
+id: etcd
+date: 2020-27-02
+full_link: /docs/tasks/administer-cluster/configure-upgrade-etcd/
+short_description: >
+  Key value store nhất quán (consistent) và sẵn sàng cao (highly-available) được sử dụng như một kho lưu trữ của Kubernetes cho tất cả dữ liệu của cluster.
+
+aka: 
+tags:
+- architecture
+- storage
+---
+ Key value store nhất quán (consistent) và sẵn sàng cao (highly-available) được sử dụng như một kho lưu trữ của Kubernetes cho tất cả dữ liệu của cluster.
+
+<!--more-->
+
+Nếu Kubernetes cluster của bạn sử dụng etcd như kho lưu trữ của nó, chắc chắn bạn có một kế hoạch [back up](/docs/tasks/administer-cluster/configure-upgrade-etcd/#backing-up-an-etcd-cluster) cho những dữ liệu này.
+
+Bạn có thể tìm thêm thông tin chi tiết về etcd tại [documentation](https://etcd.io/docs/).

--- a/content/vi/docs/reference/glossary/kube-apiserver.md
+++ b/content/vi/docs/reference/glossary/kube-apiserver.md
@@ -1,0 +1,22 @@
+---
+title: API server
+id: kube-apiserver
+date: 2020-02-26
+full_link: /docs/reference/generated/kube-apiserver/
+short_description: >
+  Thành phần tầng điểu khiển (control plane), được dùng để phục vụ Kubernetes API.
+
+aka:
+- kube-apiserver
+tags:
+- architecture
+- fundamental
+---
+ API server là một thành phần của Kubernetes {{< glossary_tooltip text="control plane" term_id="control-plane" >}}, được dùng để đưa ra Kubernetes API.
+API server là front end của Kubernetes control plane.
+
+<!--more-->
+
+Thực thi chính của API server là [kube-apiserver](/docs/reference/generated/kube-apiserver/).
+kube-apiserver được thiết kế để co giãn theo chiều ngang &mdash; có nghĩa là nó co giãn bằng cách triển khai thêm các thực thể.
+Bạn có thể chạy một vài thực thể của kube-apiserver và cân bằng lưu lượng giữa các thực thể này.

--- a/content/vi/docs/reference/glossary/kube-scheduler.md
+++ b/content/vi/docs/reference/glossary/kube-scheduler.md
@@ -1,0 +1,17 @@
+---
+title: kube-scheduler
+id: kube-scheduler
+date: 2020-03-05
+full_link: /docs/reference/generated/kube-scheduler/
+short_description: >
+  Thành phần của Control Plane, được dùng để giám sát việc tạo những pod mới mà chưa được chỉ định vào node nào, và chọn một node để chúng chạy trên đó.
+
+aka: 
+tags:
+- architecture
+---
+ Thành phần của Control Plane, được dùng để giám sát việc tạo những pod mới mà chưa được chỉ định vào node nào, và chọn một node để chúng chạy trên đó.
+
+<!--more--> 
+
+Những yếu tố trong những quyết định lập lịch bao gồm những yêu cầu về tài nguyên, những đòi hỏi về phần cứng/phần mềm/chính sách, những thông số về affinity và anti-affinity, dữ liệu tại chỗ (data locality), nhiễu inter-workload và thời hạn (deadline).


### PR DESCRIPTION
Add some glossaries: cluster, containerd, control-plane, cri-o, daemonset, etcd, kube-apiserver, kube-scheduler
