### PR TITLE
Add to PSP/PV warning that hostPath PVs cannot be made readonly

### DIFF
--- a/content/en/docs/concepts/policy/pod-security-policy.md
+++ b/content/en/docs/concepts/policy/pod-security-policy.md
@@ -419,8 +419,10 @@ The **recommended minimum set** of allowed volumes for new PSPs are:
 - projected
 
 {{< warning >}}
-PodSecurityPolicy does not limit the types of `PersistentVolume` objects that may be referenced by a `PersistentVolumeClaim`.
-Only trusted users should be granted permission to create `PersistentVolume` objects.
+PodSecurityPolicy does not limit the types of `PersistentVolume` objects that
+may be referenced by a `PersistentVolumeClaim`, and hostPath type
+`PersistentVolumes` do not support read-only access mode. Only trusted users
+should be granted permission to create `PersistentVolume` objects.
 {{< /warning >}}
 
 **FSGroup** - Controls the supplemental group applied to some volumes.


### PR DESCRIPTION
After the Trail of Bits audit, we [added a warning](website/pull/15756/files) about the interaction (or lack thereof) between Persistent Volumes and PodSecurityPolicy. I think we should also call out that hostPath PersistentVolumes can't be made read-only, so folks don't assume that they can rely on read-only to protect against some of the concerns around hostPath volumes.