### PR TITLE
update link to /ja/docs/tutorials/hello-minikube/ and /ja/docs/concepts/architecture/nodes/

### DIFF
--- a/content/ja/docs/concepts/configuration/assign-pod-node.md
+++ b/content/ja/docs/concepts/configuration/assign-pod-node.md
@@ -7,7 +7,7 @@ weight: 30
 
 {{% capture overview %}}
 
-[Pod](/ja/docs/concepts/workloads/pods/pod/)が稼働する[Node](/docs/concepts/architecture/nodes/)を特定のものに指定したり、優先条件を指定して制限することができます。
+[Pod](/ja/docs/concepts/workloads/pods/pod/)が稼働する[Node](/ja/docs/concepts/architecture/nodes/)を特定のものに指定したり、優先条件を指定して制限することができます。
 これを実現するためにはいくつかの方法がありますが、推奨されている方法は[ラベルでの選択](/docs/concepts/overview/working-with-objects/labels/)です。
 スケジューラーが最適な配置を選択するため、一般的にはこのような制限は不要です(例えば、複数のPodを別々のNodeへデプロイしたり、Podを配置する際にリソースが不十分なNodeにはデプロイされないことが挙げられます)が、
 SSDが搭載されているNodeにPodをデプロイしたり、同じアベイラビリティーゾーン内で通信する異なるサービスのPodを同じNodeにデプロイする等、柔軟な制御が必要なこともあります。

--- a/content/ja/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/ja/docs/reference/command-line-tools-reference/feature-gates.md
@@ -385,7 +385,7 @@ GAになってからさらなる変更を加えることは現実的ではない
 - `SupportPodPidsLimit`: PodのPID制限のサポートを有効にします。
 - `Sysctls`: 各podに設定できる名前空間付きのカーネルパラメーター(sysctl)のサポートを有効にします。詳細は[sysctls](/docs/tasks/administer-cluster/sysctl-cluster/)で確認できます。
 - `TaintBasedEvictions`: ノードの汚染とpodの許容に基づいてノードからpodを排除できるようにします。。詳細は[汚染と許容](/docs/concepts/configuration/taint-and-toleration/)で確認できます。
-- `TaintNodesByCondition`: [ノードの条件](/docs/concepts/architecture/nodes/#condition)に基づいてノードの自動汚染を有効にします。
+- `TaintNodesByCondition`: [ノードの条件](/ja/docs/concepts/architecture/nodes/#condition)に基づいてノードの自動汚染を有効にします。
 - `TokenRequest`: サービスアカウントリソースで`TokenRequest`エンドポイントを有効にします。
 - `TokenRequestProjection`: [投影ボリューム](/docs/concepts/storage/volumes/#projected)を使用したpodへのサービスアカウントのトークンの注入を有効にします。
 - `TTLAfterFinished`: [TTLコントローラー](/docs/concepts/workloads/controllers/ttlafterfinished/)が実行終了後にリソースをクリーンアップできるようにします。

--- a/content/ja/docs/reference/glossary/node.md
+++ b/content/ja/docs/reference/glossary/node.md
@@ -2,7 +2,7 @@
 title: ノード
 id: node
 date: 2018-04-12
-full_link: /docs/concepts/architecture/nodes/
+full_link: /ja/docs/concepts/architecture/nodes/
 short_description: >
   ノードはKubernetesのワーカーマシンです。
 

--- a/content/ja/docs/tutorials/_index.md
+++ b/content/ja/docs/tutorials/_index.md
@@ -21,7 +21,7 @@ content_template: templates/concept
 
 * [Introduction to Kubernetes (edX)](https://www.edx.org/course/introduction-kubernetes-linuxfoundationx-lfs158x#)
 
-* [Hello Minikube](/docs/tutorials/hello-minikube/)
+* [Hello Minikube](/ja/docs/tutorials/hello-minikube/)
 
 ## 設定
 


### PR DESCRIPTION
ref #18929 

以下の2ページへのリンクを更新しました。
- /ja/docs/tutorials/hello-minikube/ 
- /ja/docs/concepts/architecture/nodes/