### PR TITLE
Fix left panel navigating bar layout issue for zh

### DIFF
--- a/content/zh/blog/_index.md
+++ b/content/zh/blog/_index.md
@@ -8,16 +8,3 @@ menu:
     post: >
        <p>阅读关于 kubernetes 和容器规范的最新信息,以及获取最新的技术。</p>
 ---
-
-<!--
----
-title: Kubernetes Blog
-linkTitle: Blog
-menu:
-  main:
-    title: "Blog"
-    weight: 40
-    post: >
-       <p>Read the latest news for Kubernetes and the containers space in general, and get technical how-tos hot off the presses.</p>
----
--->

--- a/content/zh/case-studies/_index.html
+++ b/content/zh/case-studies/_index.html
@@ -7,15 +7,3 @@ layout: basic
 class: gridPage
 cid: caseStudies
 ---
-
-<!--
----
-title: Case Studies
-linkTitle: Case Studies
-bigheader: Kubernetes User Case Studies
-abstract: A collection of users running Kubernetes in production.
-layout: basic
-class: gridPage
-cid: caseStudies
----
--->

--- a/content/zh/docs/_index.md
+++ b/content/zh/docs/_index.md
@@ -2,8 +2,3 @@
 title: 文档
 weight: 5
 ---
-
-<!-- ---
-title: Home
-weight: 5
---- -->

--- a/content/zh/docs/concepts/architecture/_index.md
+++ b/content/zh/docs/concepts/architecture/_index.md
@@ -2,10 +2,3 @@
 title: "Kubernetes 架构"
 weight: 30
 ---
-
-<!--
----
-title: "Kubernetes Architecture"
-weight: 30
----
--->

--- a/content/zh/docs/concepts/cluster-administration/_index.md
+++ b/content/zh/docs/concepts/cluster-administration/_index.md
@@ -2,10 +2,3 @@
 title: "计算、存储和网络扩展"
 weight: 30
 ---
-
-<!--
----
-title: "Compute, Storage, and Networking Extensions"
-weight: 30
----
--->

--- a/content/zh/docs/concepts/configuration/_index.md
+++ b/content/zh/docs/concepts/configuration/_index.md
@@ -2,10 +2,3 @@
 title: "配置"
 weight: 70
 ---
-
-<!--
----
-title: "Configuration"
-weight: 70
----
--->

--- a/content/zh/docs/concepts/containers/_index.md
+++ b/content/zh/docs/concepts/containers/_index.md
@@ -2,10 +2,3 @@
 title: "容器"
 weight: 50
 ---
-
-<!--
----
-title: "Containers"
-weight: 50
----
--->

--- a/content/zh/docs/concepts/extend-kubernetes/_index.md
+++ b/content/zh/docs/concepts/extend-kubernetes/_index.md
@@ -2,10 +2,3 @@
 title: 扩展 Kubernetes
 weight: 40
 ---
-
-<!--
----
-title: Extending Kubernetes
-weight: 40
----
--->

--- a/content/zh/docs/concepts/extend-kubernetes/api-extension/_index.md
+++ b/content/zh/docs/concepts/extend-kubernetes/api-extension/_index.md
@@ -2,10 +2,3 @@
 title: 扩展 Kubernetes API
 weight: 20
 ---
-
-<!--
----
-title: Extending the Kubernetes API
-weight: 20
----
--->

--- a/content/zh/docs/concepts/extend-kubernetes/compute-storage-net/_index.md
+++ b/content/zh/docs/concepts/extend-kubernetes/compute-storage-net/_index.md
@@ -2,10 +2,3 @@
 title: 计算、存储和网络扩展
 weight: 30
 ---
-
-<!--
----
-title: Compute, Storage, and Networking Extensions
-weight: 30
----
--->

--- a/content/zh/docs/concepts/overview/_index.md
+++ b/content/zh/docs/concepts/overview/_index.md
@@ -2,10 +2,3 @@
 title: 概述
 weight: 20
 ---
-
-<!--
----
-title: "Overview"
-weight: 20
----
--->

--- a/content/zh/docs/concepts/overview/working-with-objects/_index.md
+++ b/content/zh/docs/concepts/overview/working-with-objects/_index.md
@@ -2,10 +2,3 @@
 title: "使用 Kubernetes 对象"
 weight: 40
 ---
-
-<!--
----
-title: "Working with Kubernetes Objects"
-weight: 40
----
--->

--- a/content/zh/docs/concepts/policy/_index.md
+++ b/content/zh/docs/concepts/policy/_index.md
@@ -2,10 +2,3 @@
 title: "策略"
 weight: 160
 ---
-
-<!--
----
-title: "Policies"
-weight: 160
----
--->

--- a/content/zh/docs/concepts/scheduling/_index.md
+++ b/content/zh/docs/concepts/scheduling/_index.md
@@ -2,8 +2,3 @@
 title: "调度"
 weight: 90
 ---
-
-<!--
-title: "Scheduling"
-weight: 90
--->

--- a/content/zh/docs/concepts/security/_index.md
+++ b/content/zh/docs/concepts/security/_index.md
@@ -2,8 +2,3 @@
 title: "安全"
 weight: 81
 ---
-
-<!--
-title: "Security"
-weight: 81
--->

--- a/content/zh/docs/concepts/services-networking/_index.md
+++ b/content/zh/docs/concepts/services-networking/_index.md
@@ -2,10 +2,3 @@
 title: "服务、负载均衡和联网"
 weight: 80
 ---
-
-<!--
----
-title: "Services, Load Balancing, and Networking"
-weight: 80
----
--->

--- a/content/zh/docs/concepts/storage/_index.md
+++ b/content/zh/docs/concepts/storage/_index.md
@@ -2,10 +2,3 @@
 title: "存储"
 weight: 70
 ---
-
-<!--
----
-title: "Storage"
-weight: 70
----
--->

--- a/content/zh/docs/concepts/workloads/_index.md
+++ b/content/zh/docs/concepts/workloads/_index.md
@@ -2,10 +2,3 @@
 title: "工作负载"
 weight: 50
 ---
-
-<!--
----
-title: "Workloads"
-weight: 50
----
--->

--- a/content/zh/docs/concepts/workloads/controllers/_index.md
+++ b/content/zh/docs/concepts/workloads/controllers/_index.md
@@ -2,10 +2,3 @@
 title: "控制器"
 weight: 20
 ---
-
-<!--
----
-title: "Controllers"
-weight: 20
----
--->

--- a/content/zh/docs/concepts/workloads/pods/_index.md
+++ b/content/zh/docs/concepts/workloads/pods/_index.md
@@ -2,10 +2,3 @@
 title: "Pods"
 weight: 10
 ---
-
-<!--
----
-title: "Pods"
-weight: 10
----
--->

--- a/content/zh/docs/reference/command-line-tools-reference/_index.md
+++ b/content/zh/docs/reference/command-line-tools-reference/_index.md
@@ -3,11 +3,3 @@ title: 命令行工具参考
 weight: 60
 toc-hide: true
 ---
-
-<!--
----
-title: Command line tools reference
-weight: 60
-toc-hide: true
----
--->

--- a/content/zh/docs/reference/issues-security/_index.md
+++ b/content/zh/docs/reference/issues-security/_index.md
@@ -3,11 +3,3 @@ title: Kubernetes 问题和安全
 weight: 10
 toc-hide: true
 ---
-
-<!--
----
-title: Kubernetes Issues and Security
-weight: 10
-toc-hide: true
----
--->

--- a/content/zh/docs/reference/kubectl/_index.md
+++ b/content/zh/docs/reference/kubectl/_index.md
@@ -2,10 +2,3 @@
 title: "kubectl 命令行界面"
 weight: 60
 ---
-
-<!--
----
-title: "kubectl CLI"
-weight: 60
----
--->

--- a/content/zh/docs/reference/kubernetes-api/_index.md
+++ b/content/zh/docs/reference/kubernetes-api/_index.md
@@ -2,10 +2,3 @@
 title: API 参考
 weight: 30
 ---
-
-<!--
----
-title: API Reference
-weight: 30
----
--->

--- a/content/zh/docs/reference/using-api/_index.md
+++ b/content/zh/docs/reference/using-api/_index.md
@@ -3,11 +3,3 @@ title: 使用 Kubernetes API
 weight: 10
 toc-hide: true
 ---
-
-<!--
----
-title: Using the Kubernetes API
-weight: 10
-toc-hide: true
----
--->

--- a/content/zh/docs/setup/best-practices/_index.md
+++ b/content/zh/docs/setup/best-practices/_index.md
@@ -2,8 +2,3 @@
 title: 最佳实践
 weight: 40
 ---
-
-<!--
-title: Best practices
-weight: 40
--->

--- a/content/zh/docs/setup/learning-environment/_index.md
+++ b/content/zh/docs/setup/learning-environment/_index.md
@@ -2,10 +2,3 @@
 title: 学习环境
 weight: 20
 ---
-
-<!--
----
-title: Learning environment
-weight: 20
----
--->

--- a/content/zh/docs/setup/production-environment/_index.md
+++ b/content/zh/docs/setup/production-environment/_index.md
@@ -2,8 +2,3 @@
 title: 生产环境
 weight: 30
 ---
-
-<!--
-title: Production environment
-weight: 30
--->

--- a/content/zh/docs/setup/production-environment/on-premises-vm/_index.md
+++ b/content/zh/docs/setup/production-environment/on-premises-vm/_index.md
@@ -2,9 +2,3 @@
 title: 本地 VMs
 weight: 40
 ---
-<!--
----
-title: On-Premises VMs
-weight: 40
----
--->

--- a/content/zh/docs/setup/production-environment/tools/_index.md
+++ b/content/zh/docs/setup/production-environment/tools/_index.md
@@ -2,8 +2,3 @@
 title: 使用部署工具安装 Kubernetes
 weight: 30
 ---
-
-<!--
-title: Installing Kubernetes with deployment tools
-weight: 30
--->

--- a/content/zh/docs/setup/production-environment/tools/kubeadm/_index.md
+++ b/content/zh/docs/setup/production-environment/tools/kubeadm/_index.md
@@ -2,8 +2,3 @@
 title: "使用 kubeadm 引导集群"
 weight: 10
 ---
-
-<!--
-title: "Bootstrapping clusters with kubeadm"
-weight: 10
--->

--- a/content/zh/docs/setup/production-environment/turnkey/_index.md
+++ b/content/zh/docs/setup/production-environment/turnkey/_index.md
@@ -2,8 +2,3 @@
 title: Turnkey 云解决方案
 weight: 30
 ---
-
-<!--
-title: Turnkey Cloud Solutions
-weight: 30
--->

--- a/content/zh/docs/setup/production-environment/windows/_index.md
+++ b/content/zh/docs/setup/production-environment/windows/_index.md
@@ -2,8 +2,3 @@
 title: "Windows Kubernetes"
 weight: 50
 ---
-
-<!--
-title: "Windows in Kubernetes"
-weight: 50
--->

--- a/content/zh/docs/setup/release/_index.md
+++ b/content/zh/docs/setup/release/_index.md
@@ -2,10 +2,3 @@
 title: "Kubernetes 发行说明和版本偏差"
 weight: 10
 ---
-
-<!--
----
-title: "Release notes and version skew"
-weight: 10
----
--->

--- a/content/zh/docs/tasks/access-application-cluster/_index.md
+++ b/content/zh/docs/tasks/access-application-cluster/_index.md
@@ -2,10 +2,3 @@
 title: 访问集群中的应用程序
 weight: 60
 ---
-
-<!--
----
-title: "Access Applications in a Cluster"
-weight: 60
----
--->

--- a/content/zh/docs/tasks/access-kubernetes-api/_index.md
+++ b/content/zh/docs/tasks/access-kubernetes-api/_index.md
@@ -2,10 +2,3 @@
 title: "扩展 Kubernetes"
 weight: 90
 ---
-
-<!--
----
-title: "Extend Kubernetes"
-weight: 90
----
--->

--- a/content/zh/docs/tasks/access-kubernetes-api/custom-resources/_index.md
+++ b/content/zh/docs/tasks/access-kubernetes-api/custom-resources/_index.md
@@ -2,8 +2,3 @@
 title: "使用自定义资源"
 weight: 10
 ---
-
-<!-- ---
-title: "Use Custom Resources"
-weight: 10
---- -->

--- a/content/zh/docs/tasks/administer-cluster/_index.md
+++ b/content/zh/docs/tasks/administer-cluster/_index.md
@@ -2,10 +2,3 @@
 title: "管理集群"
 weight: 20
 ---
-
-<!--
----
-title: "Administer a Cluster"
-weight: 20
----
--->

--- a/content/zh/docs/tasks/administer-cluster/kubeadm/_index.md
+++ b/content/zh/docs/tasks/administer-cluster/kubeadm/_index.md
@@ -2,10 +2,3 @@
 title: "用 kubeadm 进行管理"
 weight: 10
 ---
-
-<!--
----
-title: "Administration with kubeadm"
-weight: 10
----
--->

--- a/content/zh/docs/tasks/administer-cluster/manage-resources/_index.md
+++ b/content/zh/docs/tasks/administer-cluster/manage-resources/_index.md
@@ -2,10 +2,3 @@
 title: 管理内存，CPU 和 API 资源
 weight: 20
 ---
-
-<!--
----
-title: Manage Memory, CPU, and API Resources
-weight: 20
----
--->

--- a/content/zh/docs/tasks/administer-cluster/network-policy-provider/_index.md
+++ b/content/zh/docs/tasks/administer-cluster/network-policy-provider/_index.md
@@ -1,10 +1,3 @@
-<!--
----
-title: Install a Network Policy Provider
-weight: 30
----
--->
-
 ---
 title: 安装网络规则驱动
 weight: 30

--- a/content/zh/docs/tasks/configure-pod-container/_index.md
+++ b/content/zh/docs/tasks/configure-pod-container/_index.md
@@ -2,9 +2,3 @@
 title: "配置 Pods 和容器"
 weight: 20
 ---
-
-<!--
-title: "Configure Pods and Containers"
-weight: 20
--->
-

--- a/content/zh/docs/tasks/debug-application-cluster/_index.md
+++ b/content/zh/docs/tasks/debug-application-cluster/_index.md
@@ -2,10 +2,3 @@
 title: "监控、日志和排错"
 weight: 80
 ---
-
-<!--
----
-title: "Monitor, Log, and Debug"
-weight: 80
----
--->

--- a/content/zh/docs/tasks/federation/_index.md
+++ b/content/zh/docs/tasks/federation/_index.md
@@ -2,10 +2,3 @@
 title: "联邦 - 在多个集群上运行一个应用"
 weight: 120
 ---
-
-<!--
----
-title: "Federation - Run an App on Multiple Clusters"
-weight: 120
----
--->

--- a/content/zh/docs/tasks/federation/administer-federation/_index.md
+++ b/content/zh/docs/tasks/federation/administer-federation/_index.md
@@ -2,10 +2,3 @@
 title: "管理联邦控制平面"
 weight: 160
 ---
-
-<!--
----
-title: "Administer Federation Control Plane"
-weight: 160
----
--->

--- a/content/zh/docs/tasks/inject-data-application/_index.md
+++ b/content/zh/docs/tasks/inject-data-application/_index.md
@@ -2,14 +2,3 @@
 title: "给应用注入数据"
 weight: 30
 ---
-
-<!--
----
-title: "Inject Data Into Applications"
-weight: 30
----
--->
-
-
-
-

--- a/content/zh/docs/tasks/job/_index.md
+++ b/content/zh/docs/tasks/job/_index.md
@@ -2,10 +2,3 @@
 title: "运行 Jobs"
 weight: 50
 ---
-
-<!--
----
-title: "Run Jobs"
-weight: 50
----
--->

--- a/content/zh/docs/tasks/manage-daemon/_index.md
+++ b/content/zh/docs/tasks/manage-daemon/_index.md
@@ -2,10 +2,3 @@
 title: "管理集群守护进程"
 weight: 130
 ---
-
-<!--
----
-title: "Manage Cluster Daemons"
-weight: 130
----
--->

--- a/content/zh/docs/tasks/manage-kubernetes-objects/_index.md
+++ b/content/zh/docs/tasks/manage-kubernetes-objects/_index.md
@@ -2,8 +2,3 @@
 title: "管理 Kubernetes 对象"
 weight: 25
 ---
-
-<!--
-title: "Manage Kubernetes Objects"
-weight: 25
--->

--- a/content/zh/docs/tasks/network/_index.md
+++ b/content/zh/docs/tasks/network/_index.md
@@ -2,8 +2,3 @@
 title: "网络"
 weight: 160
 ---
-
-<!--
-title: "Network"
-weight: 160
--->

--- a/content/zh/docs/tasks/run-application/_index.md
+++ b/content/zh/docs/tasks/run-application/_index.md
@@ -2,10 +2,3 @@
 title: "运行应用"
 weight: 40
 ---
-
-<!--
----
-title: "Run Applications"
-weight: 40
----
--->

--- a/content/zh/docs/tasks/service-catalog/_index.md
+++ b/content/zh/docs/tasks/service-catalog/_index.md
@@ -2,10 +2,3 @@
 title: "安装服务目录"
 weight: 150
 ---
-
-<!--
----
-title: "Install Service Catalog"
-weight: 150
----
--->

--- a/content/zh/docs/tasks/tools/_index.md
+++ b/content/zh/docs/tasks/tools/_index.md
@@ -2,10 +2,3 @@
 title: "安装工具"
 weight: 10
 ---
-
-<!--
----
-title: "Install Tools"
-weight: 10
----
--->

--- a/content/zh/docs/tutorials/clusters/_index.md
+++ b/content/zh/docs/tutorials/clusters/_index.md
@@ -2,10 +2,3 @@
 title: "集群"
 weight: 60
 ---
-
-<!--
----
-title: "Clusters"
-weight: 60
----
--->

--- a/content/zh/docs/tutorials/configuration/_index.md
+++ b/content/zh/docs/tutorials/configuration/_index.md
@@ -2,10 +2,3 @@
 title: "配置"
 weight: 30
 ---
-
-<!--
----
-title: "Configuration"
-weight: 30
----
--->

--- a/content/zh/docs/tutorials/kubernetes-basics/create-cluster/_index.md
+++ b/content/zh/docs/tutorials/kubernetes-basics/create-cluster/_index.md
@@ -2,10 +2,3 @@
 title: 创建集群
 weight: 10
 ---
-
-<!--
----
-title: Create a Cluster
-weight: 10
----
--->

--- a/content/zh/docs/tutorials/kubernetes-basics/deploy-app/_index.md
+++ b/content/zh/docs/tutorials/kubernetes-basics/deploy-app/_index.md
@@ -2,10 +2,3 @@
 title: 部署应用
 weight: 20
 ---
-
-<!--
----
-title: Deploy an App
-weight: 20
----
--->

--- a/content/zh/docs/tutorials/kubernetes-basics/explore/_index.md
+++ b/content/zh/docs/tutorials/kubernetes-basics/explore/_index.md
@@ -2,8 +2,3 @@
 title: 了解你的应用
 weight: 30
 ---
-
-<!-- ---
-title: Explore Your App
-weight: 30
---- -->

--- a/content/zh/docs/tutorials/kubernetes-basics/expose/_index.md
+++ b/content/zh/docs/tutorials/kubernetes-basics/expose/_index.md
@@ -2,10 +2,3 @@
 title: 公开地暴露你的应用
 weight: 40
 ---
-
-<!--
----
-title: Expose Your App Publicly
-weight: 40
----
--->

--- a/content/zh/docs/tutorials/kubernetes-basics/scale/_index.md
+++ b/content/zh/docs/tutorials/kubernetes-basics/scale/_index.md
@@ -2,10 +2,3 @@
 title: 伸缩您的应用
 weight: 50
 ---
-
-<!--
----
-title: Scale Your App
-weight: 50
----
--->

--- a/content/zh/docs/tutorials/kubernetes-basics/update/_index.md
+++ b/content/zh/docs/tutorials/kubernetes-basics/update/_index.md
@@ -2,10 +2,3 @@
 title: 更新你的应用
 weight: 60
 ---
-
-<!--
----
-title: Update Your App
-weight: 60
----
--->

--- a/content/zh/docs/tutorials/online-training/_index.md
+++ b/content/zh/docs/tutorials/online-training/_index.md
@@ -2,10 +2,3 @@
 title: "在线培训课程"
 weight: 20
 ---
-
-<!--
----
-title: "Online Training Courses"
-weight: 20
----
--->

--- a/content/zh/docs/tutorials/services/_index.md
+++ b/content/zh/docs/tutorials/services/_index.md
@@ -2,10 +2,3 @@
 title: "Services"
 weight: 70
 ---
-
-<!--
----
-title: "Services"
-weight: 70
----
--->

--- a/content/zh/docs/tutorials/stateful-application/_index.md
+++ b/content/zh/docs/tutorials/stateful-application/_index.md
@@ -2,10 +2,3 @@
 title: "有状态的应用"
 weight: 50
 ---
-
-<!--
----
-title: "Stateful Applications"
-weight: 50
----
--->

--- a/content/zh/docs/tutorials/stateless-application/_index.md
+++ b/content/zh/docs/tutorials/stateless-application/_index.md
@@ -2,10 +2,3 @@
 title: "无状态应用程序"
 weight: 40
 ---
-
-<!--
----
-title: "Stateless Applications"
-weight: 40
----
--->


### PR DESCRIPTION
Remove comments in `_index.md` file to fix left panel navigating bar layout issue. I think this fix is ok for two reasons:

- The content in `_index.md` is simple and stable.
- Other languages also organize the `_index.md` files like this.

fix #18737
