### PR TITLE
Added date metadata to blog articles #19503

### DIFF
--- a/layouts/blog/post.html
+++ b/layouts/blog/post.html
@@ -1,3 +1,3 @@
-<h4 class="date-header">{{ .Date.Format site.Params.time_format_blog }}</h4>
+<h4 class="date-header"><time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format site.Params.time_format_blog }}</time></h4>
 <h3 class="post-title entry-title"><a href="{{ .Permalink }}">{{ .Title }}</a></h3>
 {{ .Content }}


### PR DESCRIPTION
Added <time> </time> HTML element to the date heading in blog post articles. 
The opening <time> tag also was given a datetime attribute, with the value using another Hugo shortcode. Since these use Go time patterns; we included the following in the opening <time> tag datetime="{{ .Date.Format "2006-01-02" }}".

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use
 for advice.

-->
