### PR TITLE
Add comment about DaemonSet toleration to run on masters

### DIFF
--- a/content/en/examples/controllers/daemonset.yaml
+++ b/content/en/examples/controllers/daemonset.yaml
@@ -15,6 +15,8 @@ spec:
         name: fluentd-elasticsearch
     spec:
       tolerations:
+      # this toleration is to have the daemonset runnable on master nodes
+      # remove it if your masters can't run pods
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
       containers:


### PR DESCRIPTION
Fixes issue #19512

Adds a comment regarding the toleration that is present in the daemonset example to run on masters. The reader will get more context and know that the toleration is not always applicable.
