### PR TITLE
Revise “What is Kubernetes”

### DIFF
--- a/content/en/docs/concepts/overview/what-is-kubernetes.md
+++ b/content/en/docs/concepts/overview/what-is-kubernetes.md
@@ -3,6 +3,8 @@ reviewers:
 - bgrant0607
 - mikedanese
 title: What is Kubernetes
+description: >
+  Kubernetes is a portable, extensible, open-source platform for managing containerized workloads and services, that facilitates both declarative configuration and automation. It has a large, rapidly growing ecosystem. Kubernetes services, support, and tools are widely available.
 content_template: templates/concept
 weight: 10
 card:

--- a/content/en/docs/concepts/overview/what-is-kubernetes.md
+++ b/content/en/docs/concepts/overview/what-is-kubernetes.md
@@ -19,9 +19,10 @@ This page is an overview of Kubernetes.
 {{% capture body %}}
 Kubernetes is a portable, extensible, open-source platform for managing containerized workloads and services, that facilitates both declarative configuration and automation. It has a large, rapidly growing ecosystem. Kubernetes services, support, and tools are widely available.
 
-The name Kubernetes originates from Greek, meaning helmsman or pilot. Google open-sourced the Kubernetes project in 2014. Kubernetes builds upon a [decade and a half of experience that Google has with running production workloads at scale](https://ai.google/research/pubs/pub43438), combined with best-of-breed ideas and practices from the community.
+The name Kubernetes originates from Greek, meaning helmsman or pilot. Google open-sourced the Kubernetes project in 2014. Kubernetes combines [over 15 years of Google's experience](/blog/2015/04/borg-predecessor-to-kubernetes/) running production workloads at scale with best-of-breed ideas and practices from the community.
 
 ## Going back in time
+
 Let's take a look at why Kubernetes is so useful by going back in time.
 
 ![Deployment evolution](/images/docs/Container_Evolution.svg)

--- a/content/en/docs/concepts/overview/what-is-kubernetes.md
+++ b/content/en/docs/concepts/overview/what-is-kubernetes.md
@@ -42,7 +42,7 @@ Containers have become popular because they provide extra benefits, such as:
 * Dev and Ops separation of concerns: create application container images at build/release time rather than deployment time, thereby decoupling applications from infrastructure.
 * Observability not only surfaces OS-level information and metrics, but also application health and other signals.
 * Environmental consistency across development, testing, and production: Runs the same on a laptop as it does in the cloud.
-* Cloud and OS distribution portability: Runs on Ubuntu, RHEL, CoreOS, on-prem, Google Kubernetes Engine, and anywhere else.
+* Cloud and OS distribution portability: Runs on Ubuntu, RHEL, CoreOS, on-premises, on major public clouds, and anywhere else.
 * Application-centric management: Raises the level of abstraction from running an OS on virtual hardware to running an application on an OS using logical resources.
 * Loosely coupled, distributed, elastic, liberated micro-services: applications are broken into smaller, independent pieces and can be deployed and managed dynamically – not a monolithic stack running on one big single-purpose machine.
 * Resource isolation: predictable application performance.


### PR DESCRIPTION
Revise https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/ [[preview](https://deploy-preview-19534--kubernetes-io-master-staging.netlify.com/docs/concepts/overview/what-is-kubernetes/)]

- Add page description (`<meta name="description" … />`)
- Link to blog post about Borg rather than directly to Google's paper
  The blog post has (a better) link to Google's paper about Borg. Because of the historical relevance of that paper and that blog article to the history of Kubernetes, I think it's OK to link there.
  Linking to the blog article provides a less academic introduction to the history of Kubernetes, with the option to click through and learn things  in detail.
- Expand list of places Kubernetes can run
  - As well as GKE, there are AKS, EKS, and more.

