### PR TITLE
Add description for https://k8s.io/docs/home

### DIFF
--- a/content/en/docs/home/_index.md
+++ b/content/en/docs/home/_index.md
@@ -16,6 +16,8 @@ menu:
     weight: 20
     post: >
       <p>Learn how to use Kubernetes with conceptual, tutorial, and reference documentation. You can even <a href="/editdocs/" data-auto-burger-exclude>help contribute to the docs</a>!</p>
+description: >
+  Kubernetes is an open source container orchestration engine for automating deployment, scaling, and management of containerized applications. The open source project is hosted by the Cloud Native Computing Foundation.
 overview: >
   Kubernetes is an open source container orchestration engine for automating deployment, scaling, and management of containerized applications. The open source project is hosted by the Cloud Native Computing Foundation (<a href="https://www.cncf.io/about">CNCF</a>).
 cards:


### PR DESCRIPTION
Set a `description` for https://k8s.io/docs/home/ [[preview](https://deploy-preview-19538--kubernetes-io-master-staging.netlify.com/docs/home/)] so that this appears in page metadata, and search engines etc can pay attention to that.