### PR TITLE
Document server-side dry-run is GA in 1.18

### DIFF
--- a/content/en/blog/_posts/2019-01-14-apiserver-dry-run-and-kubectl-diff.md
+++ b/content/en/blog/_posts/2019-01-14-apiserver-dry-run-and-kubectl-diff.md
@@ -97,3 +97,11 @@ semantics to fields! It's also going to improve support for CRDs and unions!
 - Some kubectl apply features are missing from diff and could be useful, like the ability
 to filter by label, or to display pruned resources.
 - Eventually, kubectl diff will use server-side apply!
+
+{{< note >}}
+
+The flag `kubectl apply --server-dry-run` is deprecated in v1.18.
+Use the flag `--dry-run=server` for using server-side dry-run in
+`kubectl apply` and other subcommands.
+
+{{< /note >}}

--- a/content/en/blog/_posts/2019-01-14-apiserver-dry-run-and-kubectl-diff.md
+++ b/content/en/blog/_posts/2019-01-14-apiserver-dry-run-and-kubectl-diff.md
@@ -21,7 +21,7 @@ experience with Kubernetes, and we tried to address some of these:
 
 - While compilers and linters do a good job to detect errors in pull-requests
   for code, a good validation is missing for Kubernetes configuration files.
-  The existing solution is to run `kubectl apply --dry-run=client`, but this runs a
+  The existing solution is to run `kubectl apply --dry-run`, but this runs a
   *local* dry-run that doesn't talk to the server: it doesn't have server
   validation and doesn't go through validating admission controllers. As an
   example, Custom resource names are only validated on the server so a local
@@ -67,7 +67,7 @@ have side-effects on dry-run (or at all).
 ### How to use it
 
 You can trigger the feature from kubectl by using `kubectl apply
---dry-run=server`, which will decorate the request with the dryRun flag
+--server-dry-run`, which will decorate the request with the dryRun flag
 and return the object as it would have been applied, or an error if it would
 have failed.
 

--- a/content/en/blog/_posts/2019-01-14-apiserver-dry-run-and-kubectl-diff.md
+++ b/content/en/blog/_posts/2019-01-14-apiserver-dry-run-and-kubectl-diff.md
@@ -21,7 +21,7 @@ experience with Kubernetes, and we tried to address some of these:
 
 - While compilers and linters do a good job to detect errors in pull-requests
   for code, a good validation is missing for Kubernetes configuration files.
-  The existing solution is to run `kubectl apply --dry-run`, but this runs a
+  The existing solution is to run `kubectl apply --dry-run=client`, but this runs a
   *local* dry-run that doesn't talk to the server: it doesn't have server
   validation and doesn't go through validating admission controllers. As an
   example, Custom resource names are only validated on the server so a local
@@ -67,7 +67,7 @@ have side-effects on dry-run (or at all).
 ### How to use it
 
 You can trigger the feature from kubectl by using `kubectl apply
---server-dry-run`, which will decorate the request with the dryRun flag
+--dry-run=server`, which will decorate the request with the dryRun flag
 and return the object as it would have been applied, or an error if it would
 have failed.
 

--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -894,7 +894,7 @@ Examples:
 * Test applying a manifest file of RBAC objects, displaying changes that would be made:
 
     ```
-    kubectl auth reconcile -f my-rbac-rules.yaml --dry-run
+    kubectl auth reconcile -f my-rbac-rules.yaml --dry-run=client
     ```
 
 * Apply a manifest file of RBAC objects, preserving any extra permissions (in roles) and any extra subjects (in bindings):

--- a/content/en/docs/reference/kubectl/overview.md
+++ b/content/en/docs/reference/kubectl/overview.md
@@ -92,7 +92,7 @@ Operation       | Syntax    |       Description
 `proxy`        | `kubectl proxy [--port=PORT] [--www=static-dir] [--www-prefix=prefix] [--api-prefix=prefix] [flags]` | Run a proxy to the Kubernetes API server.
 `replace`        | `kubectl replace -f FILENAME` | Replace a resource from a file or stdin.
 `rolling-update`    | <code>kubectl rolling-update OLD_CONTROLLER_NAME ([NEW_CONTROLLER_NAME] --image=NEW_CONTAINER_IMAGE &#124; -f NEW_CONTROLLER_SPEC) [flags]</code> | Perform a rolling update by gradually replacing the specified replication controller and its pods.
-`run`        | `kubectl run NAME --image=image [--env="key=value"] [--port=port] [--replicas=replicas] [--dry-run=bool] [--overrides=inline-json] [flags]` | Run a specified image on the cluster.
+`run`        | `kubectl run NAME --image=image [--env="key=value"] [--port=port] [--replicas=replicas] [--dry-run=server|client|none] [--overrides=inline-json] [flags]` | Run a specified image on the cluster.
 `scale`        | <code>kubectl scale (-f FILENAME &#124; TYPE NAME &#124; TYPE/NAME) --replicas=COUNT [--resource-version=version] [--current-replicas=count] [flags]</code> | Update the size of the specified replication controller.
 `version`        | `kubectl version [--client] [flags]` | Display the Kubernetes version running on the client and server.
 

--- a/content/en/docs/reference/using-api/api-concepts.md
+++ b/content/en/docs/reference/using-api/api-concepts.md
@@ -336,12 +336,12 @@ Once the last finalizer is removed, the resource is actually removed from etcd.
 
 ## Dry-run
 
-{{< feature-state for_k8s_version="v1.13" state="beta" >}} In version 1.13, the dry-run beta feature is enabled by default. The modifying verbs (`POST`, `PUT`, `PATCH`, and `DELETE`) can accept requests in a dry-run mode. DryRun mode helps to evaluate a request through the typical request stages (admission chain, validation, merge conflicts) up until persisting objects to storage. The response body for the request is as close as possible to a non-dry-run response. The system guarantees that dry-run requests will not be persisted in storage or have any other side effects.
+{{< feature-state for_k8s_version="v1.18" state="stable" >}} In version 1.18 the dry-run feature is enabled by default. The modifying verbs (`POST`, `PUT`, `PATCH`, and `DELETE`) can accept requests in a dry-run mode. DryRun mode helps to evaluate a request through the typical request stages (admission chain, validation, merge conflicts) up until persisting objects to storage. The response body for the request is as close as possible to a non-dry-run response. The system guarantees that dry-run requests will not be persisted in storage or have any other side effects.
 
 
 ### Make a dry-run request
 
-Dry-run is triggered by setting the `dryRun` query parameter. This parameter is a string, working as an enum, and in 1.13 the only accepted values are:
+Dry-run is triggered by setting the `dryRun` query parameter. This parameter is a string, working as an enum, and in 1.18 the only accepted values are:
 
 * `All`: Every stage runs as normal, except for the final storage stage. Admission controllers are run to check that the request is valid, mutating controllers mutate the request, merge is performed on `PATCH`, fields are defaulted, and schema validation occurs. The changes are not persisted to the underlying storage, but the final object which would have been persisted is still returned to the user, along with the normal status code. If the request would trigger an admission controller which would have side effects, the request will be failed rather than risk an unwanted side effect. All built in admission control plugins support dry-run. Additionally, admission webhooks can declare in their [configuration object](/docs/reference/generated/kubernetes-api/v1.13/#webhook-v1beta1-admissionregistration-k8s-io) that they do not have side effects by setting the sideEffects field to "None". If a webhook actually does have side effects, then the sideEffects field should be set to "NoneOnDryRun", and the webhook should also be modified to understand the `DryRun` field in AdmissionReview, and prevent side effects on dry-run requests.
 * Leave the value empty, which is also the default: Keep the default modifying behavior.

--- a/content/en/docs/reference/using-api/api-concepts.md
+++ b/content/en/docs/reference/using-api/api-concepts.md
@@ -343,7 +343,7 @@ The modifying verbs (`POST`, `PUT`, `PATCH`, and `DELETE`) can accept requests i
 
 ### Make a dry-run request
 
-Dry-run is triggered by setting the `dryRun` query parameter. This parameter is a string, working as an enum, and in 1.18 the only accepted values are:
+Dry-run is triggered by setting the `dryRun` query parameter. This parameter is a string, working as an enum, and the only accepted values are:
 
 * `All`: Every stage runs as normal, except for the final storage stage. Admission controllers are run to check that the request is valid, mutating controllers mutate the request, merge is performed on `PATCH`, fields are defaulted, and schema validation occurs. The changes are not persisted to the underlying storage, but the final object which would have been persisted is still returned to the user, along with the normal status code. If the request would trigger an admission controller which would have side effects, the request will be failed rather than risk an unwanted side effect. All built in admission control plugins support dry-run. Additionally, admission webhooks can declare in their [configuration object](/docs/reference/generated/kubernetes-api/v1.13/#webhook-v1beta1-admissionregistration-k8s-io) that they do not have side effects by setting the sideEffects field to "None". If a webhook actually does have side effects, then the sideEffects field should be set to "NoneOnDryRun", and the webhook should also be modified to understand the `DryRun` field in AdmissionReview, and prevent side effects on dry-run requests.
 * Leave the value empty, which is also the default: Keep the default modifying behavior.

--- a/content/en/docs/reference/using-api/api-concepts.md
+++ b/content/en/docs/reference/using-api/api-concepts.md
@@ -336,7 +336,9 @@ Once the last finalizer is removed, the resource is actually removed from etcd.
 
 ## Dry-run
 
-{{< feature-state for_k8s_version="v1.18" state="stable" >}} In version 1.18 the dry-run feature is enabled by default. The modifying verbs (`POST`, `PUT`, `PATCH`, and `DELETE`) can accept requests in a dry-run mode. DryRun mode helps to evaluate a request through the typical request stages (admission chain, validation, merge conflicts) up until persisting objects to storage. The response body for the request is as close as possible to a non-dry-run response. The system guarantees that dry-run requests will not be persisted in storage or have any other side effects.
+ {{< feature-state for_k8s_version="v1.18" state="stable" >}}
+
+The modifying verbs (`POST`, `PUT`, `PATCH`, and `DELETE`) can accept requests in a _dry run_ mode. Dry run mode helps to evaluate a request through the typical request stages (admission chain, validation, merge conflicts) up until persisting objects to storage. The response body for the request is as close as possible to a non-dry-run response. The system guarantees that dry-run requests will not be persisted in storage or have any other side effects.
 
 
 ### Make a dry-run request

--- a/content/en/docs/tasks/configure-pod-container/configure-gmsa.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-gmsa.md
@@ -42,7 +42,7 @@ Installing the above webhooks and associated objects require the steps below:
 
 1. Create the validating and mutating webhook configurations referring to the deployment. 
 
-A [script](https://github.com/kubernetes-sigs/windows-gmsa/blob/master/admission-webhook/deploy/deploy-gmsa-webhook.sh) can be used to deploy and configure the GMSA webhooks and associated objects mentioned above. The script can be run with a ```--dry-run``` option to allow you to review the changes that would be made to your cluster.
+A [script](https://github.com/kubernetes-sigs/windows-gmsa/blob/master/admission-webhook/deploy/deploy-gmsa-webhook.sh) can be used to deploy and configure the GMSA webhooks and associated objects mentioned above. The script can be run with a ```--dry-run=server``` option to allow you to review the changes that would be made to your cluster.
 
 The [YAML template](https://github.com/kubernetes-sigs/windows-gmsa/blob/master/admission-webhook/deploy/gmsa-webhook.yml.tpl) used by the script may also be used to deploy the webhooks and associated objects manually (with appropriate substitutions for the parameters)
 

--- a/content/en/docs/tasks/manage-daemon/update-daemon-set.md
+++ b/content/en/docs/tasks/manage-daemon/update-daemon-set.md
@@ -57,7 +57,7 @@ If you haven't created the DaemonSet in the system, check your DaemonSet
 manifest with the following command instead:
 
 ```shell
-kubectl apply -f ds.yaml --dry-run -o go-template='{{.spec.updateStrategy.type}}{{"\n"}}'
+kubectl apply -f ds.yaml --dry-run=client -o go-template='{{.spec.updateStrategy.type}}{{"\n"}}'
 ```
 
 The output from both commands should be:

--- a/content/en/docs/tasks/manage-kubernetes-objects/imperative-command.md
+++ b/content/en/docs/tasks/manage-kubernetes-objects/imperative-command.md
@@ -139,10 +139,10 @@ creation. This is done by piping the output of the `create` command to the
 `set` command, and then back to the `create` command. Here's an example:
 
 ```sh
-kubectl create service clusterip my-svc --clusterip="None" -o yaml --dry-run | kubectl set selector --local -f - 'environment=qa' -o yaml | kubectl create -f -
+kubectl create service clusterip my-svc --clusterip="None" -o yaml --dry-run=client | kubectl set selector --local -f - 'environment=qa' -o yaml | kubectl create -f -
 ```
 
-1. The `kubectl create service -o yaml --dry-run` command creates the configuration for the Service, but prints it to stdout as YAML instead of sending it to the Kubernetes API server.
+1. The `kubectl create service -o yaml --dry-run=client` command creates the configuration for the Service, but prints it to stdout as YAML instead of sending it to the Kubernetes API server.
 1. The `kubectl set selector --local -f - -o yaml` command reads the configuration from stdin, and writes the updated configuration to stdout as YAML.
 1. The `kubectl create -f -` command creates the object using the configuration provided via stdin.
 
@@ -152,7 +152,7 @@ You can use `kubectl create --edit` to make arbitrary changes to an object
 before it is created. Here's an example:
 
 ```sh
-kubectl create service clusterip my-svc --clusterip="None" -o yaml --dry-run > /tmp/srv.yaml
+kubectl create service clusterip my-svc --clusterip="None" -o yaml --dry-run=client > /tmp/srv.yaml
 kubectl create --edit -f /tmp/srv.yaml
 ```
 


### PR DESCRIPTION
For https://github.com/kubernetes/kubernetes/issues/86526.

* Promote server-side dry-run feature state to stable in 1.18
* Replace --dry-run usage with --dry-run=server|client|none accordingly
* Update server-side dry-run blog post

/assign @apelisse 
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use
 for advice.

-->
