### PR TITLE
Instructions to upgrade Bash for shell autocompletion

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl.md
+++ b/content/en/docs/tasks/tools/install-kubectl.md
@@ -385,6 +385,27 @@ However, the kubectl completion script depends on [**bash-completion**](https://
 there are two versions of bash-completion, v1 and v2. V1 is for Bash 3.2 (which is the default on macOS), and v2 is for Bash 4.1+. The kubectl completion script **doesn't work** correctly with bash-completion v1 and Bash 3.2. It requires **bash-completion v2** and **Bash 4.1+**. Thus, to be able to correctly use kubectl completion on macOS, you have to install and use Bash 4.1+ ([*instructions*](https://itnext.io/upgrading-bash-on-macos-7138bd1066ba)). The following instructions assume that you use Bash 4.1+ (that is, any Bash version of 4.1 or newer).
 {{< /warning >}}
 
+### Upgrade Bash
+
+You can check your Bash's version by running:
+
+```shell
+echo $BASH_VERSION
+```
+
+If it is too old, you can install it from Homebrew (or upgrade it if it already exists):
+
+```shell
+brew install bash
+```
+
+Reload your shell and verify that it is the one you just installed or upgraded:
+
+```shell
+echo $SHELL
+```
+
+Homebrew usually installs it at `/usr/local/bin/bash`.
 
 ### Install bash-completion
 

--- a/content/en/docs/tasks/tools/install-kubectl.md
+++ b/content/en/docs/tasks/tools/install-kubectl.md
@@ -393,16 +393,16 @@ You can check your Bash's version by running:
 echo $BASH_VERSION
 ```
 
-If it is too old, you can install it from Homebrew (or upgrade it if it already exists):
+If it is too old, you can install/upgrade it using Homebrew:
 
 ```shell
 brew install bash
 ```
 
-Reload your shell and verify that it is the one you just installed or upgraded:
+Reload your shell and verify that the desired version is being used:
 
 ```shell
-echo $SHELL
+echo $BASH_VERSION $SHELL
 ```
 
 Homebrew usually installs it at `/usr/local/bin/bash`.

--- a/content/en/docs/tasks/tools/install-kubectl.md
+++ b/content/en/docs/tasks/tools/install-kubectl.md
@@ -387,7 +387,7 @@ there are two versions of bash-completion, v1 and v2. V1 is for Bash 3.2 (which 
 
 ### Upgrade Bash
 
-You can check your Bash's version by running:
+The instructions here assume you use Bash 4.1+. You can check your Bash's version by running:
 
 ```shell
 echo $BASH_VERSION


### PR DESCRIPTION
I found some Macs are using an older Bash (3.2). And it seems Homebrew does not change the login shell of your Mac, you will quite likely still use the old version even after installing the new one from Homebrew. In this PR, I add instructions on installing/upgrading Bash and how to verify the desired version is used. To avoid confusion, I did not mention the possible issue mentioned above.