### PR TITLE
translate configure-access-multiple-clusters into Japanese

### DIFF
--- a/content/ja/docs/tasks/access-application-cluster/configure-access-multiple-clusters.md
+++ b/content/ja/docs/tasks/access-application-cluster/configure-access-multiple-clusters.md
@@ -13,7 +13,7 @@ card:
 ここでは、設定ファイルを使って複数のクラスターにアクセスする方法を紹介します。クラスター、ユーザー、contextの情報を一つ以上の設定ファイルにまとめることで、`kubectl config use-context`のコマンドを使ってクラスターを素早く切り替えることができます。
 
 {{< note >}}
-クラスターへのアクセスを設定するファイルを、*kubeconfig file* と呼ぶことがあります。これは設定ファイルの一般的な呼び方です。`kubeconfig`という名前のファイルが存在するわけではありません。
+クラスターへのアクセスを設定するファイルを、*kubeconfig* ファイルと呼ぶことがあります。これは設定ファイルの一般的な呼び方です。`kubeconfig`という名前のファイルが存在するわけではありません。
 {{< /note >}}
 
 {{% /capture %}}
@@ -28,7 +28,7 @@ card:
 
 ## クラスター、ユーザー、contextを設定する
 
-例として、開発用のクラスターが一つ、実験用のクラスターが一つ、計二つのクラスターが存在するとしましょう。`development`と呼ばれる開発用のクラスター内では、フロントエンドの開発者は`frontend`というnamespace内で、ストレージの開発者は`storage`というnamespace内で作業をします。`scratch`と呼ばれる実験用のクラスター内では、開発者はデフォルトのnamespaceで作業をするか、状況に応じて追加のnamespaceを作成します。開発用のクラスターは証明書を通しての認証を必要とします。実験用のクラスターはユーザーネームとパスワードを通しての認証を必要とします。
+例として、開発用のクラスターが一つ、実験用のクラスターが一つ、計二つのクラスターが存在する場合を考えます。`development`と呼ばれる開発用のクラスター内では、フロントエンドの開発者は`frontend`というnamespace内で、ストレージの開発者は`storage`というnamespace内で作業をします。`scratch`と呼ばれる実験用のクラスター内では、開発者はデフォルトのnamespaceで作業をするか、状況に応じて追加のnamespaceを作成します。開発用のクラスターは証明書を通しての認証を必要とします。実験用のクラスターはユーザーネームとパスワードを通しての認証を必要とします。
 
 `config-exercise`というディレクトリを作成してください。`config-exercise`ディレクトリ内に、以下を含む`config-demo`というファイルを作成してください:
 
@@ -137,7 +137,7 @@ users:
 
 証明書ファイルのパスの代わりにbase64にエンコードされたデータを使用したい場合は、キーに`-data`の接尾辞を加えてください。例えば、`certificate-authority-data`、`client-certificate-data`、`client-key-data`とできます。
 
-それぞれのcontextは、クラスター、ユーザー、namespaceの三つ組からなっています。例えば、`dev-frontend`contextは、`developer`ユーザーの認証情報を使って`development`クラスターの`frontend`namespaceにアクセスしてください、と示しています。
+それぞれのcontextは、クラスター、ユーザー、namespaceの三つ組からなっています。例えば、`dev-frontend`contextは、`developer`ユーザーの認証情報を使って`development`クラスターの`frontend`namespaceへのアクセスを意味しています。
 
 現在のcontextを設定してください:
 
@@ -178,7 +178,7 @@ users:
     client-key: fake-key-file
 ```
 
-今度は、実験用のクラスター内でしばらく作業したいこととしましょう。
+今度は、実験用のクラスター内でしばらく作業する場合を考えます。
 
 現在のcontextを`exp-scratch`に切り替えてください:
 
@@ -194,7 +194,7 @@ kubectl config --kubeconfig=config-demo use-context exp-scratch
 kubectl config --kubeconfig=config-demo view --minify
 ```
 
-最後に、`development`クラスター内の`storage`namespaceでしばらく作業したいこととしましょう。
+最後に、`development`クラスター内の`storage`namespaceでしばらく作業する場合を考えます。
 
 現在のcontextを`dev-storage`に切り替えてください:
 
@@ -285,7 +285,7 @@ contexts:
   name: exp-scratch
 ```
 
-kubeconfigファイルに関するさらなる情報を参照するには、[kubeconfigファイルを使ってクラスターへのアクセスを管理する](/docs/concepts/configuration/organize-cluster-access-kubeconfig/)をご覧ください。
+kubeconfigファイルに関するさらなる情報を参照するには、[kubeconfigファイルを使ってクラスターへのアクセスを管理する](/docs/concepts/configuration/organize-cluster-access-kubeconfig/)を参照してください。
 
 ## $HOME/.kubeディレクトリの内容を確認する
 
@@ -314,7 +314,7 @@ kubectl config view
 
 ## クリーンアップ
 
-`KUBECONFIG`環境変数を元に戻してください。例えば:<br>
+`KUBECONFIG`環境変数を元に戻してください。例えば:
 
 Linux:
 ```shell

--- a/content/ja/docs/tasks/access-application-cluster/configure-access-multiple-clusters.md
+++ b/content/ja/docs/tasks/access-application-cluster/configure-access-multiple-clusters.md
@@ -1,0 +1,335 @@
+---
+title: 複数のクラスターへのアクセスを設定する
+content_template: templates/task
+weight: 30
+card:
+  name: tasks
+  weight: 40
+---
+
+
+{{% capture overview %}}
+
+ここでは、設定ファイルを使って複数のクラスターにアクセスする方法を紹介します。クラスター、ユーザー、contextの情報を一つ以上の設定ファイルにまとめることで、`kubectl config use-context`のコマンドを使ってクラスターを素早く切り替えることができます。
+
+{{< note >}}
+クラスターへのアクセスを設定するファイルを、*kubeconfig file* と呼ぶことがあります。これは設定ファイルの一般的な呼び方です。`kubeconfig`という名前のファイルが存在するわけではありません。
+{{< /note >}}
+
+{{% /capture %}}
+
+{{% capture prerequisites %}}
+
+{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+
+{{% /capture %}}
+
+{{% capture steps %}}
+
+## クラスター、ユーザー、contextを設定する
+
+例として、開発用のクラスターが一つ、実験用のクラスターが一つ、計二つのクラスターが存在するとしましょう。`development`と呼ばれる開発用のクラスター内では、フロントエンドの開発者は`frontend`というnamespace内で、ストレージの開発者は`storage`というnamespace内で作業をします。`scratch`と呼ばれる実験用のクラスター内では、開発者はデフォルトのnamespaceで作業をするか、状況に応じて追加のnamespaceを作成します。開発用のクラスターは証明書を通しての認証を必要とします。実験用のクラスターはユーザーネームとパスワードを通しての認証を必要とします。
+
+`config-exercise`というディレクトリを作成してください。`config-exercise`ディレクトリ内に、以下を含む`config-demo`というファイルを作成してください:
+
+```shell
+apiVersion: v1
+kind: Config
+preferences: {}
+
+clusters:
+- cluster:
+  name: development
+- cluster:
+  name: scratch
+
+users:
+- name: developer
+- name: experimenter
+
+contexts:
+- context:
+  name: dev-frontend
+- context:
+  name: dev-storage
+- context:
+  name: exp-scratch
+```
+
+設定ファイルには、クラスター、ユーザー、contextの情報が含まれています。上記の`config-demo`設定ファイルには、二つのクラスター、二人のユーザー、三つのcontextの情報が含まれています。
+
+`config-exercise`ディレクトリに移動してください。クラスター情報を設定ファイルに追加するために、以下のコマンドを実行してください:
+
+```shell
+kubectl config --kubeconfig=config-demo set-cluster development --server=https://1.2.3.4 --certificate-authority=fake-ca-file
+kubectl config --kubeconfig=config-demo set-cluster scratch --server=https://5.6.7.8 --insecure-skip-tls-verify
+```
+
+ユーザー情報を設定ファイルに追加してください:
+
+```shell
+kubectl config --kubeconfig=config-demo set-credentials developer --client-certificate=fake-cert-file --client-key=fake-key-seefile
+kubectl config --kubeconfig=config-demo set-credentials experimenter --username=exp --password=some-password
+```
+
+{{< note >}}
+`kubectl config unset users.<name>`を実行すると、ユーザーを削除することができます。
+{{< /note >}}
+
+context情報を設定ファイルに追加してください:
+
+```shell
+kubectl config --kubeconfig=config-demo set-context dev-frontend --cluster=development --namespace=frontend --user=developer
+kubectl config --kubeconfig=config-demo set-context dev-storage --cluster=development --namespace=storage --user=developer
+kubectl config --kubeconfig=config-demo set-context exp-scratch --cluster=scratch --namespace=default --user=experimenter
+```
+
+追加した情報を確認するために、`config-demo`ファイルを開いてください。`config-demo`ファイルを開く代わりに、`config view`のコマンドを使うこともできます。
+
+```shell
+kubectl config --kubeconfig=config-demo view
+```
+
+出力には、二つのクラスター、二人のユーザー、三つのcontextが表示されます:
+
+```shell
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: fake-ca-file
+    server: https://1.2.3.4
+  name: development
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://5.6.7.8
+  name: scratch
+contexts:
+- context:
+    cluster: development
+    namespace: frontend
+    user: developer
+  name: dev-frontend
+- context:
+    cluster: development
+    namespace: storage
+    user: developer
+  name: dev-storage
+- context:
+    cluster: scratch
+    namespace: default
+    user: experimenter
+  name: exp-scratch
+current-context: ""
+kind: Config
+preferences: {}
+users:
+- name: developer
+  user:
+    client-certificate: fake-cert-file
+    client-key: fake-key-file
+- name: experimenter
+  user:
+    password: some-password
+    username: exp
+```
+
+上記の`fake-ca-file`、`fake-cert-file`、`fake-key-file`は、証明書ファイルの実際のパスのプレースホルダーです。環境内にある証明書ファイルの実際のパスに変更してください。
+
+証明書ファイルのパスの代わりにbase64にエンコードされたデータを使用したい場合は、キーに`-data`の接尾辞を加えてください。例えば、`certificate-authority-data`、`client-certificate-data`、`client-key-data`とできます。
+
+それぞれのcontextは、クラスター、ユーザー、namespaceの三つ組からなっています。例えば、`dev-frontend`contextは、`developer`ユーザーの認証情報を使って`development`クラスターの`frontend`namespaceにアクセスしてください、と示しています。
+
+現在のcontextを設定してください:
+
+```shell
+kubectl config --kubeconfig=config-demo use-context dev-frontend
+```
+
+これ以降実行される`kubectl`コマンドは、`dev-frontend`contextに設定されたクラスターとnamespaceに適用されます。また、`dev-frontend`contextに設定されたユーザーの認証情報を使用します。
+
+現在のcontextの設定情報のみを確認するには、`--minify`フラグを使用してください。
+
+```shell
+kubectl config --kubeconfig=config-demo view --minify
+```
+
+出力には、`dev-frontend`contextの設定情報が表示されます:
+
+```shell
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: fake-ca-file
+    server: https://1.2.3.4
+  name: development
+contexts:
+- context:
+    cluster: development
+    namespace: frontend
+    user: developer
+  name: dev-frontend
+current-context: dev-frontend
+kind: Config
+preferences: {}
+users:
+- name: developer
+  user:
+    client-certificate: fake-cert-file
+    client-key: fake-key-file
+```
+
+今度は、実験用のクラスター内でしばらく作業したいこととしましょう。
+
+現在のcontextを`exp-scratch`に切り替えてください:
+
+```shell
+kubectl config --kubeconfig=config-demo use-context exp-scratch
+```
+
+これ以降実行される`kubectl`コマンドは、`scratch`クラスター内のデフォルトnamespaceに適用されます。また、`exp-scratch`contextに設定されたユーザーの認証情報を使用します。
+
+新しく切り替えた`exp-scratch`contextの設定を確認してください。
+
+```shell
+kubectl config --kubeconfig=config-demo view --minify
+```
+
+最後に、`development`クラスター内の`storage`namespaceでしばらく作業したいこととしましょう。
+
+現在のcontextを`dev-storage`に切り替えてください:
+
+```shell
+kubectl config --kubeconfig=config-demo use-context dev-storage
+```
+
+新しく切り替えた`dev-storage`contextの設定を確認してください。
+
+```shell
+kubectl config --kubeconfig=config-demo view --minify
+```
+
+## 二つ目の設定ファイルを作成する
+
+`config-exercise`ディレクトリ内に、以下を含む`config-demo-2`というファイルを作成してください:
+
+```shell
+apiVersion: v1
+kind: Config
+preferences: {}
+
+contexts:
+- context:
+    cluster: development
+    namespace: ramp
+    user: developer
+  name: dev-ramp-up
+```
+
+上記の設定ファイルは、`dev-ramp-up`というcontextを表します。
+
+## KUBECONFIG環境変数を設定する
+
+`KUBECONFIG`という環境変数が存在するかを確認してください。もし存在する場合は、後で復元できるようにバックアップしてください。例えば:
+
+### Linux
+```shell
+export KUBECONFIG_SAVED=$KUBECONFIG
+```
+### Windows PowerShell
+```shell
+$Env:KUBECONFIG_SAVED=$ENV:KUBECONFIG
+```
+
+`KUBECONFIG`環境変数は、設定ファイルのパスのリストです。リスト内のパスはLinuxとMacではコロンで区切られ、Windowsではセミコロンで区切られます。`KUBECONFIG`環境変数が存在する場合は、リスト内の設定ファイルの内容を確認してください。
+
+一時的に`KUBECONFIG`環境変数に以下の二つのパスを追加してください。例えば:<br>
+
+### Linux
+```shell
+export KUBECONFIG=$KUBECONFIG:config-demo:config-demo-2
+```
+### Windows PowerShell
+```shell
+$Env:KUBECONFIG=("config-demo;config-demo-2")
+```
+
+`config-exercise`ディレクトリ内から、以下のコマンドを実行してください:
+
+```shell
+kubectl config view
+```
+
+出力には、`KUBECONFIG`環境変数に含まれる全てのファイルの情報がまとめて表示されます。`config-demo-2`ファイルに設定された`dev-ramp-up`contextの情報と、`config-demo`ファイルに設定された三つのcontextの情報がまとめてあることに注目してください:
+
+```shell
+contexts:
+- context:
+    cluster: development
+    namespace: frontend
+    user: developer
+  name: dev-frontend
+- context:
+    cluster: development
+    namespace: ramp
+    user: developer
+  name: dev-ramp-up
+- context:
+    cluster: development
+    namespace: storage
+    user: developer
+  name: dev-storage
+- context:
+    cluster: scratch
+    namespace: default
+    user: experimenter
+  name: exp-scratch
+```
+
+kubeconfigファイルに関するさらなる情報を参照するには、[kubeconfigファイルを使ってクラスターへのアクセスを管理する](/docs/concepts/configuration/organize-cluster-access-kubeconfig/)をご覧ください。
+
+## $HOME/.kubeディレクトリの内容を確認する
+
+既にクラスターを所持していて、`kubectl`を使ってクラスターを操作できる場合は、`$HOME/.kube`ディレクトリ内に`config`というファイルが存在する可能性が高いです。
+
+`$HOME/.kube`に移動して、そこに存在するファイルを確認してください。`config`という設定ファイルが存在するはずです。他の設定ファイルも存在する可能性があります。全てのファイルの中身を確認してください。
+
+## $HOME/.kube/configをKUBECONFIG環境変数に追加する
+
+もし`$HOME/.kube/config`ファイルが存在していて、既に`KUBECONFIG`環境変数に追加されていない場合は、`KUBECONFIG`環境変数に追加してください。例えば:
+
+### Linux
+```shell
+export KUBECONFIG=$KUBECONFIG:$HOME/.kube/config
+```
+### Windows Powershell
+```shell
+$Env:KUBECONFIG=($Env:KUBECONFIG;$HOME/.kube/config)
+```
+
+`KUBECONFIG`環境変数内のファイルからまとめられた設定情報を確認してください。`config-exercise`ディレクトリ内から、以下のコマンドを実行してください:
+
+```shell
+kubectl config view
+```
+
+## クリーンアップ
+
+`KUBECONFIG`環境変数を元に戻してください。例えば:<br>
+
+Linux:
+```shell
+export KUBECONFIG=$KUBECONFIG_SAVED
+```
+Windows PowerShell
+```shell
+$Env:KUBECONFIG=$ENV:KUBECONFIG_SAVED
+```
+
+{{% /capture %}}
+
+{{% capture whatsnext %}}
+
+* [kubeconfigファイルを使ってクラスターへのアクセスを管理する](/docs/concepts/configuration/organize-cluster-access-kubeconfig/)
+* [kubectl config](/docs/reference/generated/kubectl/kubectl-commands#config)
+
+{{% /capture %}}


### PR DESCRIPTION
I would like to translate the [Configure Access to Multiple Clusters](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters) page into Japanese. Thank you!

"Linked issues" に #19248 を直接追加しようとしたのですが、write accessが無いためか追加できませんでした。

Closes #19248 

/language ja