### PR TITLE
Correcting wrong label and its selector

### DIFF
--- a/content/en/docs/tasks/manage-kubernetes-objects/declarative-config.md
+++ b/content/en/docs/tasks/manage-kubernetes-objects/declarative-config.md
@@ -992,11 +992,11 @@ used only by the controller selector with no other semantic meaning.
 ```yaml
 selector:
   matchLabels:
-      controller-selector: "apps/v1/deployment/nginx"
+      app: "nginx"
 template:
   metadata:
     labels:
-      controller-selector: "apps/v1/deployment/nginx"
+      app: "nginx"
 ```
 
 {{% capture whatsnext %}}


### PR DESCRIPTION
Label used https://kubernetes.io/docs/tasks/manage-kubernetes-objects/declarative-config/#defining-controller-selectors-and-podtemplate-labels for this example contains slash. But slashes are not allowed for labels so this recommandation is giving error. So correcting that label and its selector. 