### PR TITLE
Delete insecure external link.

### DIFF
--- a/content/en/docs/tasks/administer-cluster/reserve-compute-resources.md
+++ b/content/en/docs/tasks/administer-cluster/reserve-compute-resources.md
@@ -94,8 +94,7 @@ be configured to use the `systemd` cgroup driver.
 `kube-reserved` is meant to capture resource reservation for kubernetes system
 daemons like the `kubelet`, `container runtime`, `node problem detector`, etc.
 It is not meant to reserve resources for system daemons that are run as pods.
-`kube-reserved` is typically a function of `pod density` on the nodes. [This blog
-post](https://kubernetes.io/blog/2016/11/visualize-kubelet-performance-with-node-dashboard)
+`kube-reserved` is typically a function of `pod density` on the nodes. [Visualize Kubelet Performance with Node Dashboard](https://kubernetes.io/blog/2016/11/visualize-kubelet-performance-with-node-dashboard)
 explains how the dashboard can be interpreted to come up with a suitable
 `kube-reserved` reservation.
 

--- a/content/en/docs/tasks/administer-cluster/reserve-compute-resources.md
+++ b/content/en/docs/tasks/administer-cluster/reserve-compute-resources.md
@@ -94,9 +94,7 @@ be configured to use the `systemd` cgroup driver.
 `kube-reserved` is meant to capture resource reservation for kubernetes system
 daemons like the `kubelet`, `container runtime`, `node problem detector`, etc.
 It is not meant to reserve resources for system daemons that are run as pods.
-`kube-reserved` is typically a function of `pod density` on the nodes. [Visualize Kubelet Performance with Node Dashboard](https://kubernetes.io/blog/2016/11/visualize-kubelet-performance-with-node-dashboard)
-explains how the dashboard can be interpreted to come up with a suitable
-`kube-reserved` reservation.
+`kube-reserved` is typically a function of `pod density` on the nodes.
 
 In addition to `cpu`, `memory`, and `ephemeral-storage`, `pid` may be
 specified to reserve the specified number of process IDs for

--- a/content/en/docs/tasks/administer-cluster/reserve-compute-resources.md
+++ b/content/en/docs/tasks/administer-cluster/reserve-compute-resources.md
@@ -94,10 +94,7 @@ be configured to use the `systemd` cgroup driver.
 `kube-reserved` is meant to capture resource reservation for kubernetes system
 daemons like the `kubelet`, `container runtime`, `node problem detector`, etc.
 It is not meant to reserve resources for system daemons that are run as pods.
-`kube-reserved` is typically a function of `pod density` on the nodes. [This
-performance dashboard](http://node-perf-dash.k8s.io/#/builds) exposes `cpu` and
-`memory` usage profiles of `kubelet` and `docker engine` at multiple levels of
-pod density. [This blog
+`kube-reserved` is typically a function of `pod density` on the nodes. [This blog
 post](https://kubernetes.io/blog/2016/11/visualize-kubelet-performance-with-node-dashboard)
 explains how the dashboard can be interpreted to come up with a suitable
 `kube-reserved` reservation.


### PR DESCRIPTION
Delete insecure external link. The website hasn't an HTTPS version.
Also, the project (https://github.com/kubernetes-retired/contrib/tree/master/node-perf-dash) was archived 2 years ago.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use
 for advice.

-->
