### PR TITLE
Updated formatting in "Persistent Volumes" & "Storage Classes"

### DIFF
--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -294,7 +294,7 @@ spec:
     storage: 5Gi
   volumeMode: Filesystem
   accessModes:
-    - `Once
+    - ReadWriteOnce
   persistentVolumeReclaimPolicy: Recycle
   storageClassName: slow
   mountOptions:
@@ -326,20 +326,20 @@ A PersistentVolume can be mounted on a host in any way supported by the resource
 
 The access modes are:
 
-* `Once -- the volume can be mounted as read-write by a single node
+* ReadWriteOnce -- the volume can be mounted as read-write by a single node
 * ReadOnlyMany -- the volume can be mounted read-only by many nodes
-* `Many -- the volume can be mounted as read-write by many nodes
+* ReadWriteMany -- the volume can be mounted as read-write by many nodes
 
 In the CLI, the access modes are abbreviated to:
 
-* RWO - `Once
+* RWO - ReadWriteOnce
 * ROX - ReadOnlyMany
-* RWX - `Many
+* RWX - ReadWriteMany
 
-> __Important!__ A volume can only be mounted using one access mode at a time, even if it supports many.  For example, a GCEPersistentDisk can be mounted as `Once by a single node or ReadOnlyMany by many nodes, but not at the same time.
+> __Important!__ A volume can only be mounted using one access mode at a time, even if it supports many.  For example, a GCEPersistentDisk can be mounted as ReadWriteOnce by a single node or ReadOnlyMany by many nodes, but not at the same time.
 
 
-| Volume Plugin        | `Once          | ReadOnlyMany          | `Many|
+| Volume Plugin        | ReadWriteOnce          | ReadOnlyMany          | ReadWriteMany|
 | :---                 | :---:                  | :---:                 | :---:        |
 | AWSElasticBlockStore | &#x2713;               | -                     | -            |
 | AzureFile            | &#x2713;               | &#x2713;              | &#x2713;     |
@@ -447,7 +447,7 @@ metadata:
   name: myclaim
 spec:
   accessModes:
-    - `Once
+    - ReadWriteOnce
   volumeMode: Filesystem
   resources:
     requests:
@@ -583,7 +583,7 @@ spec:
   capacity:
     storage: 10Gi
   accessModes:
-    - `Once
+    - ReadWriteOnce
   volumeMode: Block
   persistentVolumeReclaimPolicy: Retain
   fc:
@@ -600,7 +600,7 @@ metadata:
   name: block-pvc
 spec:
   accessModes:
-    - `Once
+    - ReadWriteOnce
   volumeMode: Block
   resources:
     requests:
@@ -678,7 +678,7 @@ spec:
     kind: VolumeSnapshot
     apiGroup: snapshot.storage.k8s.io
   accessModes:
-    - `Once
+    - ReadWriteOnce
   resources:
     requests:
       storage: 10Gi
@@ -706,7 +706,7 @@ spec:
     name: existing-src-pvc-name
     kind: PersistentVolumeClaim
   accessModes:
-    - `Once
+    - ReadWriteOnce
   resources:
     requests:
       storage: 10Gi

--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -25,19 +25,13 @@ This document describes the current state of `PersistentVolumes` in Kubernetes. 
 
 ## Introduction
 
-Managing storage is a distinct problem from managing compute instances. The `PersistentVolume` subsystem provides an API for users and administrators that abstracts details of how storage is provided from how it is consumed. To do this, we introduce two new API resources:  `PersistentVolume` and `PersistentVolumeClaim`.
+Managing storage is a distinct problem from managing compute instances. The PersistentVolume subsystem provides an API for users and administrators that abstracts details of how storage is provided from how it is consumed. To do this, we introduce two new API resources:  PersistentVolume and PersistentVolumeClaim.
 
-A `PersistentVolume` (PV) is a piece of storage in the cluster that has been provisioned by an administrator or dynamically provisioned using [Storage Classes](/docs/concepts/storage/storage-classes/). It is a resource in the cluster just like a node is a cluster resource. PVs are volume plugins like Volumes, but have a lifecycle independent of any individual Pod that uses the PV. This API object captures the details of the implementation of the storage, be that NFS, iSCSI, or a cloud-provider-specific storage system.
+A PersistentVolume (PV) is a piece of storage in the cluster that has been provisioned by an administrator or dynamically provisioned using [Storage Classes](/docs/concepts/storage/storage-classes/). It is a resource in the cluster just like a node is a cluster resource. PVs are volume plugins like Volumes, but have a lifecycle independent of any individual Pod that uses the PV. This API object captures the details of the implementation of the storage, be that NFS, iSCSI, or a cloud-provider-specific storage system.
 
-A `PersistentVolumeClaim` (PVC) is a request for storage by a user. It is similar to a Pod. Pods consume node resources and PVCs consume PV resources. Pods can request specific levels of resources (CPU and Memory).  Claims can request specific size and access modes (e.g., they can be mounted once read/write or many times read-only).
+A PersistentVolumeClaim (PVC) is a request for storage by a user. It is similar to a Pod. Pods consume node resources and PVCs consume PV resources. Pods can request specific levels of resources (CPU and Memory).  Claims can request specific size and access modes (e.g., they can be mounted once read/write or many times read-only).
 
-While `PersistentVolumeClaims` allow a user to consume abstract storage
-resources, it is common that users need `PersistentVolumes` with varying
-properties, such as performance, for different problems. Cluster administrators
-need to be able to offer a variety of `PersistentVolumes` that differ in more
-ways than just size and access modes, without exposing users to the details of
-how those volumes are implemented. For these needs, there is the `StorageClass`
-resource.
+While `PersistentVolumeClaims` allow a user to consume abstract storage resources, it is common that users need `PersistentVolumes` with varying properties, such as performance, for different problems. Cluster administrators need to be able to offer a variety of `PersistentVolumes` that differ in more ways than just size and access modes, without exposing users to the details of how those volumes are implemented. For these needs, there is the StorageClass resource.
 
 See the [detailed walkthrough with working examples](/docs/tasks/configure-pod-container/configure-persistent-volume-storage/).
 
@@ -55,7 +49,7 @@ A cluster administrator creates a number of PVs. They carry the details of the r
 
 #### Dynamic
 
-When none of the static PVs the administrator created match a user's `PersistentVolumeClaim`,
+When none of the static PVs the administrator created match a user's PersistentVolumeClaim,
 the cluster may try to dynamically provision a volume specially for the PVC.
 This provisioning is based on `StorageClasses`: the PVC must request a
 [storage class](/docs/concepts/storage/storage-classes/) and
@@ -80,10 +74,10 @@ Claims will remain unbound indefinitely if a matching volume does not exist. Cla
 
 Pods use claims as volumes. The cluster inspects the claim to find the bound volume and mounts that volume for a Pod. For volumes that support multiple access modes, the user specifies which mode is desired when using their claim as a volume in a Pod.
 
-Once a user has a claim and that claim is bound, the bound PV belongs to the user for as long as they need it. Users schedule Pods and access their claimed PVs by including a `persistentVolumeClaim` in their Pod's volumes block. [See below for syntax details](#claims-as-volumes).
+Once a user has a claim and that claim is bound, the bound PV belongs to the user for as long as they need it. Users schedule Pods and access their claimed PVs by including a persistentVolumeClaim in their Pod's volumes block. [See below for syntax details](#claims-as-volumes).
 
 ### Storage Object in Use Protection
-The purpose of the Storage Object in Use Protection feature is to ensure that Persistent Volume Claims (PVCs) in active use by a Pod and Persistent Volume (PVs) that are bound to PVCs are not removed from the system, as this may result in data loss.
+The purpose of the Storage Object in Use Protection feature is to ensure that PersistentVolumeClaims (PVCs) in active use by a Pod and PersistentVolume (PVs) that are bound to PVCs are not removed from the system, as this may result in data loss.
 
 {{< note >}}
 PVC is in active use by a Pod when a Pod object exists that is using the PVC.
@@ -131,19 +125,19 @@ Events:            <none>
 
 ### Reclaiming
 
-When a user is done with their volume, they can delete the PVC objects from the API that allows reclamation of the resource. The reclaim policy for a `PersistentVolume` tells the cluster what to do with the volume after it has been released of its claim. Currently, volumes can either be Retained, Recycled, or Deleted.
+When a user is done with their volume, they can delete the PVC objects from the API that allows reclamation of the resource. The reclaim policy for a PersistentVolume tells the cluster what to do with the volume after it has been released of its claim. Currently, volumes can either be Retained, Recycled, or Deleted.
 
 #### Retain
 
-The `Retain` reclaim policy allows for manual reclamation of the resource. When the `PersistentVolumeClaim` is deleted, the `PersistentVolume` still exists and the volume is considered "released". But it is not yet available for another claim because the previous claimant's data remains on the volume. An administrator can manually reclaim the volume with the following steps.
+The `Retain` reclaim policy allows for manual reclamation of the resource. When the PersistentVolumeClaim is deleted, the PersistentVolume still exists and the volume is considered "released". But it is not yet available for another claim because the previous claimant's data remains on the volume. An administrator can manually reclaim the volume with the following steps.
 
-1. Delete the `PersistentVolume`. The associated storage asset in external infrastructure (such as an AWS EBS, GCE PD, Azure Disk, or Cinder volume) still exists after the PV is deleted.
+1. Delete the PersistentVolume. The associated storage asset in external infrastructure (such as an AWS EBS, GCE PD, Azure Disk, or Cinder volume) still exists after the PV is deleted.
 1. Manually clean up the data on the associated storage asset accordingly.
-1. Manually delete the associated storage asset, or if you want to reuse the same storage asset, create a new `PersistentVolume` with the storage asset definition.
+1. Manually delete the associated storage asset, or if you want to reuse the same storage asset, create a new PersistentVolume with the storage asset definition.
 
 #### Delete
 
-For volume plugins that support the `Delete` reclaim policy, deletion removes both the `PersistentVolume` object from Kubernetes, as well as the associated storage asset in the external infrastructure, such as an AWS EBS, GCE PD, Azure Disk, or Cinder volume. Volumes that were dynamically provisioned inherit the [reclaim policy of their `StorageClass`](#reclaim-policy), which defaults to `Delete`. The administrator should configure the `StorageClass` according to users' expectations; otherwise, the PV must be edited or patched after it is created. See [Change the Reclaim Policy of a PersistentVolume](/docs/tasks/administer-cluster/change-pv-reclaim-policy/).
+For volume plugins that support the `Delete` reclaim policy, deletion removes both the PersistentVolume object from Kubernetes, as well as the associated storage asset in the external infrastructure, such as an AWS EBS, GCE PD, Azure Disk, or Cinder volume. Volumes that were dynamically provisioned inherit the [reclaim policy of their StorageClass](#reclaim-policy), which defaults to `Delete`. The administrator should configure the StorageClass according to users' expectations; otherwise, the PV must be edited or patched after it is created. See [Change the Reclaim Policy of a PersistentVolume](/docs/tasks/administer-cluster/change-pv-reclaim-policy/).
 
 #### Recycle
 
@@ -213,8 +207,8 @@ allowVolumeExpansion: true
 ```
 
 To request a larger volume for a PVC, edit the PVC object and specify a larger
-size. This triggers expansion of the volume that backs the underlying `PersistentVolume`. A
-new `PersistentVolume` is never created to satisfy the claim. Instead, an existing volume is resized.
+size. This triggers expansion of the volume that backs the underlying PersistentVolume. A
+new PersistentVolume is never created to satisfy the claim. Instead, an existing volume is resized.
 
 #### CSI Volume expansion
 
@@ -228,7 +222,7 @@ Support for expanding CSI volumes is enabled by default but it also requires a s
 You can only resize volumes containing a file system if the file system is XFS, Ext3, or Ext4.
 
 When a volume contains a file system, the file system is only resized when a new Pod is using
-the `PersistentVolumeClaim` in ReadWrite mode. File system expansion is either done when a Pod is starting up
+the PersistentVolumeClaim in ReadWrite mode. File system expansion is either done when a Pod is starting up
 or when a Pod is running and the underlying file system supports online expansion.
 
 FlexVolumes allow resize if the driver is set with the `RequiresFSResize` capability to `true`.
@@ -261,7 +255,7 @@ Expanding EBS volumes is a time-consuming operation. Also, there is a per-volume
 
 ## Types of Persistent Volumes
 
-`PersistentVolume` types are implemented as plugins.  Kubernetes currently supports the following plugins:
+PersistentVolume types are implemented as plugins.  Kubernetes currently supports the following plugins:
 
 * GCEPersistentDisk
 * AWSElasticBlockStore
@@ -328,7 +322,7 @@ parameter.
 
 ### Access Modes
 
-A `PersistentVolume` can be mounted on a host in any way supported by the resource provider. As shown in the table below, providers will have different capabilities and each PV's access modes are set to the specific modes supported by that particular volume.  For example, NFS can support multiple read/write clients, but a specific NFS PV might be exported on the server as read-only. Each PV gets its own set of access modes describing that specific PV's capabilities.
+A PersistentVolume can be mounted on a host in any way supported by the resource provider. As shown in the table below, providers will have different capabilities and each PV's access modes are set to the specific modes supported by that particular volume.  For example, NFS can support multiple read/write clients, but a specific NFS PV might be exported on the server as read-only. Each PV gets its own set of access modes describing that specific PV's capabilities.
 
 The access modes are:
 
@@ -504,22 +498,22 @@ by the cluster, depending on whether the
 is turned on.
 
 * If the admission plugin is turned on, the administrator may specify a
-  default `StorageClass`. All PVCs that have no `storageClassName` can be bound only to
-  PVs of that default. Specifying a default `StorageClass` is done by setting the
+  default StorageClass. All PVCs that have no `storageClassName` can be bound only to
+  PVs of that default. Specifying a default StorageClass is done by setting the
   annotation `storageclass.kubernetes.io/is-default-class` equal to `true` in
-  a `StorageClass` object. If the administrator does not specify a default, the
+  a StorageClass object. If the administrator does not specify a default, the
   cluster responds to PVC creation as if the admission plugin were turned off. If
   more than one default is specified, the admission plugin forbids the creation of
   all PVCs.
 * If the admission plugin is turned off, there is no notion of a default
-  `StorageClass`. All PVCs that have no `storageClassName` can be bound only to PVs that
+  StorageClass. All PVCs that have no `storageClassName` can be bound only to PVs that
   have no class. In this case, the PVCs that have no `storageClassName` are treated the
   same way as PVCs that have their `storageClassName` set to `""`.
 
 Depending on installation method, a default StorageClass may be deployed
 to a Kubernetes cluster by addon manager during installation.
 
-When a PVC specifies a `selector` in addition to requesting a `StorageClass`,
+When a PVC specifies a `selector` in addition to requesting a StorageClass,
 the requirements are ANDed together: only a PV of the requested class and with
 the requested labels may be bound to the PVC.
 
@@ -533,7 +527,7 @@ it won't be supported in a future Kubernetes release.
 
 ## Claims As Volumes
 
-Pods access storage by using the claim as a volume. Claims must exist in the same namespace as the Pod using the claim. The cluster finds the claim in the Pod's namespace and uses it to get the `PersistentVolume` backing the claim. The volume is then mounted to the host and into the Pod.
+Pods access storage by using the claim as a volume. Claims must exist in the same namespace as the Pod using the claim. The cluster finds the claim in the Pod's namespace and uses it to get the PersistentVolume backing the claim. The volume is then mounted to the host and into the Pod.
 
 ```yaml
 apiVersion: v1
@@ -578,7 +572,7 @@ Only FC and iSCSI volumes supported raw block volumes in Kubernetes 1.9.
 Support for the additional plugins was added in 1.10.
 {{< /note >}}
 
-### Persistent Volumes using a Raw Block Volume
+### PersistentVolume using a Raw Block Volume
 
 ```yaml
 apiVersion: v1
@@ -597,7 +591,7 @@ spec:
     lun: 0
     readOnly: false
 ```
-### Persistent Volume Claim requesting a Raw Block Volume
+### PersistentVolumeClaim requesting a Raw Block Volume
 
 ```yaml
 apiVersion: v1
@@ -641,7 +635,7 @@ When adding a raw block device for a Pod, you specify the device path in the con
 
 ### Binding Block Volumes
 
-If a user requests a raw block volume by indicating this using the `volumeMode` field in the `PersistentVolumeClaim` spec, the binding rules differ slightly from previous releases that didn't consider this mode as part of the spec.
+If a user requests a raw block volume by indicating this using the `volumeMode` field in the PersistentVolumeClaim spec, the binding rules differ slightly from previous releases that didn't consider this mode as part of the spec.
 Listed is a table of possible combinations the user and admin might specify for requesting a raw block device. The table indicates if the volume will be bound or not given the combinations:
 Volume binding matrix for statically provisioned volumes:
 
@@ -670,7 +664,7 @@ Volume snapshot feature was added to support CSI Volume Plugins only. For detail
 To enable support for restoring a volume from a volume snapshot data source, enable the
 `VolumeSnapshotDataSource` feature gate on the apiserver and controller-manager.
 
-### Create Persistent Volume Claim from Volume Snapshot
+### Create PersistentVolumeClaim from Volume Snapshot
 
 ```yaml
 apiVersion: v1
@@ -699,7 +693,7 @@ Volume clone feature was added to support CSI Volume Plugins only. For details, 
 To enable support for cloning a volume from a PVC data source, enable the
 `VolumePVCDataSource` feature gate on the apiserver and controller-manager.
 
-### Create Persistent Volume Claim from an existing pvc
+### Create PersistentVolumeClaim from an existing pvc
 
 ```yaml
 apiVersion: v1
@@ -746,8 +740,8 @@ and need persistent storage, it is recommended that you use the following patter
 {{% /capture %}}
   {{% capture whatsnext %}}
 
-* Learn more about [Creating a Persistent Volume](/docs/tasks/configure-pod-container/configure-persistent-volume-storage/#create-a-persistentvolume).
-* Learn more about [Creating a Persistent Volume Claim](/docs/tasks/configure-pod-container/configure-persistent-volume-storage/#create-a-persistentvolumeclaim).
+* Learn more about [Creating a PersistentVolume](/docs/tasks/configure-pod-container/configure-persistent-volume-storage/#create-a-persistentvolume).
+* Learn more about [Creating a PersistentVolumeClaim](/docs/tasks/configure-pod-container/configure-persistent-volume-storage/#create-a-persistentvolumeclaim).
 * Read the [Persistent Storage design document](https://git.k8s.io/community/contributors/design-proposals/storage/persistent-storage.md).
 
 ### Reference

--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -16,7 +16,7 @@ weight: 20
 
 {{% capture overview %}}
 
-This document describes the current state of Persistent Volumes in Kubernetes. Familiarity with [volumes](/docs/concepts/storage/volumes/) is suggested.
+This document describes the current state of _persistent volumes_ in Kubernetes. Familiarity with [volumes](/docs/concepts/storage/volumes/) is suggested.
 
 {{% /capture %}}
 

--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -16,7 +16,7 @@ weight: 20
 
 {{% capture overview %}}
 
-This document describes the current state of `PersistentVolumes` in Kubernetes. Familiarity with [volumes](/docs/concepts/storage/volumes/) is suggested.
+This document describes the current state of Persistent Volumes in Kubernetes. Familiarity with [volumes](/docs/concepts/storage/volumes/) is suggested.
 
 {{% /capture %}}
 

--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -74,7 +74,7 @@ Claims will remain unbound indefinitely if a matching volume does not exist. Cla
 
 Pods use claims as volumes. The cluster inspects the claim to find the bound volume and mounts that volume for a Pod. For volumes that support multiple access modes, the user specifies which mode is desired when using their claim as a volume in a Pod.
 
-Once a user has a claim and that claim is bound, the bound PV belongs to the user for as long as they need it. Users schedule Pods and access their claimed PVs by including a `persistentVolumeClaim` section in a Pod's `volumes` block. [Claims As Volumes](#claims-as-volumes) for more details on this.
+Once a user has a claim and that claim is bound, the bound PV belongs to the user for as long as they need it. Users schedule Pods and access their claimed PVs by including a `persistentVolumeClaim` section in a Pod's `volumes` block. See [Claims As Volumes](#claims-as-volumes) for more details on this.
 
 ### Storage Object in Use Protection
 The purpose of the Storage Object in Use Protection feature is to ensure that PersistentVolumeClaims (PVCs) in active use by a Pod and PersistentVolume (PVs) that are bound to PVCs are not removed from the system, as this may result in data loss.

--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -31,7 +31,7 @@ A PersistentVolume (PV) is a piece of storage in the cluster that has been provi
 
 A PersistentVolumeClaim (PVC) is a request for storage by a user. It is similar to a Pod. Pods consume node resources and PVCs consume PV resources. Pods can request specific levels of resources (CPU and Memory).  Claims can request specific size and access modes (e.g., they can be mounted once read/write or many times read-only).
 
-While `PersistentVolumeClaims` allow a user to consume abstract storage resources, it is common that users need `PersistentVolumes` with varying properties, such as performance, for different problems. Cluster administrators need to be able to offer a variety of `PersistentVolumes` that differ in more ways than just size and access modes, without exposing users to the details of how those volumes are implemented. For these needs, there is the StorageClass resource.
+While PersistentVolumeClaims allow a user to consume abstract storage resources, it is common that users need PersistentVolumes with varying properties, such as performance, for different problems. Cluster administrators need to be able to offer a variety of PersistentVolumes that differ in more ways than just size and access modes, without exposing users to the details of how those volumes are implemented. For these needs, there is the _StorageClass_ resource.
 
 See the [detailed walkthrough with working examples](/docs/tasks/configure-pod-container/configure-persistent-volume-storage/).
 
@@ -51,7 +51,7 @@ A cluster administrator creates a number of PVs. They carry the details of the r
 
 When none of the static PVs the administrator created match a user's PersistentVolumeClaim,
 the cluster may try to dynamically provision a volume specially for the PVC.
-This provisioning is based on `StorageClasses`: the PVC must request a
+This provisioning is based on StorageClasses: the PVC must request a
 [storage class](/docs/concepts/storage/storage-classes/) and
 the administrator must have created and configured that class for dynamic
 provisioning to occur. Claims that request the class `""` effectively disable
@@ -74,7 +74,7 @@ Claims will remain unbound indefinitely if a matching volume does not exist. Cla
 
 Pods use claims as volumes. The cluster inspects the claim to find the bound volume and mounts that volume for a Pod. For volumes that support multiple access modes, the user specifies which mode is desired when using their claim as a volume in a Pod.
 
-Once a user has a claim and that claim is bound, the bound PV belongs to the user for as long as they need it. Users schedule Pods and access their claimed PVs by including a persistentVolumeClaim in their Pod's volumes block. [See below for syntax details](#claims-as-volumes).
+Once a user has a claim and that claim is bound, the bound PV belongs to the user for as long as they need it. Users schedule Pods and access their claimed PVs by including a `persistentVolumeClaim` section in a Pod's `volumes` block. [Claims As Volumes](#claims-as-volumes) for more details on this.
 
 ### Storage Object in Use Protection
 The purpose of the Storage Object in Use Protection feature is to ensure that PersistentVolumeClaims (PVCs) in active use by a Pod and PersistentVolume (PVs) that are bound to PVCs are not removed from the system, as this may result in data loss.
@@ -222,7 +222,7 @@ Support for expanding CSI volumes is enabled by default but it also requires a s
 You can only resize volumes containing a file system if the file system is XFS, Ext3, or Ext4.
 
 When a volume contains a file system, the file system is only resized when a new Pod is using
-the PersistentVolumeClaim in ReadWrite mode. File system expansion is either done when a Pod is starting up
+the PersistentVolumeClaim in `ReadWrite` mode. File system expansion is either done when a Pod is starting up
 or when a Pod is running and the underlying file system supports online expansion.
 
 FlexVolumes allow resize if the driver is set with the `RequiresFSResize` capability to `true`.
@@ -294,7 +294,7 @@ spec:
     storage: 5Gi
   volumeMode: Filesystem
   accessModes:
-    - ReadWriteOnce
+    - `Once
   persistentVolumeReclaimPolicy: Recycle
   storageClassName: slow
   mountOptions:
@@ -326,20 +326,20 @@ A PersistentVolume can be mounted on a host in any way supported by the resource
 
 The access modes are:
 
-* ReadWriteOnce -- the volume can be mounted as read-write by a single node
+* `Once -- the volume can be mounted as read-write by a single node
 * ReadOnlyMany -- the volume can be mounted read-only by many nodes
-* ReadWriteMany -- the volume can be mounted as read-write by many nodes
+* `Many -- the volume can be mounted as read-write by many nodes
 
 In the CLI, the access modes are abbreviated to:
 
-* RWO - ReadWriteOnce
+* RWO - `Once
 * ROX - ReadOnlyMany
-* RWX - ReadWriteMany
+* RWX - `Many
 
-> __Important!__ A volume can only be mounted using one access mode at a time, even if it supports many.  For example, a GCEPersistentDisk can be mounted as ReadWriteOnce by a single node or ReadOnlyMany by many nodes, but not at the same time.
+> __Important!__ A volume can only be mounted using one access mode at a time, even if it supports many.  For example, a GCEPersistentDisk can be mounted as `Once by a single node or ReadOnlyMany by many nodes, but not at the same time.
 
 
-| Volume Plugin        | ReadWriteOnce          | ReadOnlyMany          | ReadWriteMany|
+| Volume Plugin        | `Once          | ReadOnlyMany          | `Many|
 | :---                 | :---:                  | :---:                 | :---:        |
 | AWSElasticBlockStore | &#x2713;               | -                     | -            |
 | AzureFile            | &#x2713;               | &#x2713;              | &#x2713;     |
@@ -447,7 +447,7 @@ metadata:
   name: myclaim
 spec:
   accessModes:
-    - ReadWriteOnce
+    - `Once
   volumeMode: Filesystem
   resources:
     requests:
@@ -549,7 +549,7 @@ spec:
 
 ### A Note on Namespaces
 
-`PersistentVolumes` binds are exclusive, and since `PersistentVolumeClaims` are namespaced objects, mounting claims with "Many" modes (`ROX`, `RWX`) is only possible within one namespace.
+PersistentVolumes binds are exclusive, and since PersistentVolumeClaims are namespaced objects, mounting claims with "Many" modes (`ROX`, `RWX`) is only possible within one namespace.
 
 ## Raw Block Volume Support
 
@@ -572,7 +572,7 @@ Only FC and iSCSI volumes supported raw block volumes in Kubernetes 1.9.
 Support for the additional plugins was added in 1.10.
 {{< /note >}}
 
-### PersistentVolume using a Raw Block Volume
+### PersistentVolume using a Raw Block Volume {#persistent-volume-using-a-raw-block-volume}
 
 ```yaml
 apiVersion: v1
@@ -583,7 +583,7 @@ spec:
   capacity:
     storage: 10Gi
   accessModes:
-    - ReadWriteOnce
+    - `Once
   volumeMode: Block
   persistentVolumeReclaimPolicy: Retain
   fc:
@@ -591,7 +591,7 @@ spec:
     lun: 0
     readOnly: false
 ```
-### PersistentVolumeClaim requesting a Raw Block Volume
+### PersistentVolumeClaim requesting a Raw Block Volume {#persistent-volume-claim-requesting-a-raw-block-volume}
 
 ```yaml
 apiVersion: v1
@@ -600,7 +600,7 @@ metadata:
   name: block-pvc
 spec:
   accessModes:
-    - ReadWriteOnce
+    - `Once
   volumeMode: Block
   resources:
     requests:
@@ -664,7 +664,7 @@ Volume snapshot feature was added to support CSI Volume Plugins only. For detail
 To enable support for restoring a volume from a volume snapshot data source, enable the
 `VolumeSnapshotDataSource` feature gate on the apiserver and controller-manager.
 
-### Create PersistentVolumeClaim from Volume Snapshot
+### Create a PersistentVolumeClaim from a Volume Snapshot {#create-persistent-volume-claim-from-volume-snapshot}
 
 ```yaml
 apiVersion: v1
@@ -678,7 +678,7 @@ spec:
     kind: VolumeSnapshot
     apiGroup: snapshot.storage.k8s.io
   accessModes:
-    - ReadWriteOnce
+    - `Once
   resources:
     requests:
       storage: 10Gi
@@ -693,7 +693,7 @@ Volume clone feature was added to support CSI Volume Plugins only. For details, 
 To enable support for cloning a volume from a PVC data source, enable the
 `VolumePVCDataSource` feature gate on the apiserver and controller-manager.
 
-### Create PersistentVolumeClaim from an existing pvc
+### Create PersistentVolumeClaim from an existing PVC {#create-persistent-volume-claim-from-an-existing-pvc}
 
 ```yaml
 apiVersion: v1
@@ -706,7 +706,7 @@ spec:
     name: existing-src-pvc-name
     kind: PersistentVolumeClaim
   accessModes:
-    - ReadWriteOnce
+    - `Once
   resources:
     requests:
       storage: 10Gi

--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -61,7 +61,7 @@ volumeBindingMode: Immediate
 
 ### Provisioner
 
-Storage Classes have a provisioner that determines what volume plugin is used
+Each StorageClass has a provisioner that determines what volume plugin is used
 for provisioning PVs. This field must be specified.
 
 | Volume Plugin        | Internal Provisioner| Config Example                       |
@@ -104,19 +104,19 @@ vendors provide their own external provisioner.
 
 ### Reclaim Policy
 
-Persistent Volumes that are dynamically created by a StorageClass will have the
+PersistentVolumes that are dynamically created by a StorageClass will have the
 reclaim policy specified in the `reclaimPolicy` field of the class, which can be
 either `Delete` or `Retain`. If no `reclaimPolicy` is specified when a
 StorageClass object is created, it will default to `Delete`.
 
-Persistent Volumes that are created manually and managed via a StorageClass will have
+PersistentVolumes that are created manually and managed via a StorageClass will have
 whatever reclaim policy they were assigned at creation.
 
 ### Allow Volume Expansion
 
 {{< feature-state for_k8s_version="v1.11" state="beta" >}}
 
-Persistent Volumes can be configured to be expandable. This feature when set to `true`, 
+PersistentVolumes can be configured to be expandable. This feature when set to `true`, 
 allows the users to resize the volume by editing the corresponding PVC object. 
 
 The following types of volumes support volume expansion, when the underlying
@@ -146,7 +146,7 @@ You can only use the volume expansion feature to grow a Volume, not to shrink it
 
 ### Mount Options
 
-Persistent Volumes that are dynamically created by a StorageClass will have the
+PersistentVolumes that are dynamically created by a StorageClass will have the
 mount options specified in the `mountOptions` field of the class.
 
 If the volume plugin does not support mount options but mount options are
@@ -580,7 +580,7 @@ parameters:
 
 ### Azure Disk
 
-#### Azure Unmanaged Disk StorageClass
+#### Azure Unmanaged Disk storage class
 
 ```yaml
 apiVersion: storage.k8s.io/v1
@@ -601,7 +601,7 @@ parameters:
   ignored. If a storage account is not provided, a new storage account will be
   created in the same resource group as the cluster.
 
-#### New Azure Disk StorageClass (starting from v1.7.2)
+#### Azure Disk storage class (starting from v1.7.2)
 
 ```yaml
 apiVersion: storage.k8s.io/v1
@@ -766,8 +766,8 @@ parameters:
 * `pool`: The name of the StorageOS distributed capacity pool to provision the
   volume from.  Uses the `default` pool which is normally present if not specified.
 * `description`: The description to assign to volumes that were created dynamically.
-  All volume descriptions will be the same for the StorageClass, but different
-  Storage Classes can be used to allow descriptions for different use cases.
+  All volume descriptions will be the same for the storage class, but different
+  storage classes can be used to allow descriptions for different use cases.
   Defaults to `Kubernetes volume`.
 * `fsType`: The default filesystem type to request. Note that user-defined rules
   within StorageOS may override this value.  Defaults to `ext4`.

--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -21,7 +21,7 @@ with [volumes](/docs/concepts/storage/volumes/) and
 
 ## Introduction
 
-A `StorageClass` provides a way for administrators to describe the "classes" of
+A StorageClass provides a way for administrators to describe the "classes" of
 storage they offer. Different classes might map to quality-of-service levels,
 or to backup policies, or to arbitrary policies determined by the cluster
 administrators. Kubernetes itself is unopinionated about what classes
@@ -30,18 +30,18 @@ systems.
 
 ## The StorageClass Resource
 
-Each `StorageClass` contains the fields `provisioner`, `parameters`, and
-`reclaimPolicy`, which are used when a `PersistentVolume` belonging to the
+Each StorageClass contains the fields `provisioner`, `parameters`, and
+`reclaimPolicy`, which are used when a PersistentVolume belonging to the
 class needs to be dynamically provisioned.
 
-The name of a `StorageClass` object is significant, and is how users can
+The name of a StorageClass object is significant, and is how users can
 request a particular class. Administrators set the name and other parameters
-of a class when first creating `StorageClass` objects, and the objects cannot
+of a class when first creating StorageClass objects, and the objects cannot
 be updated once they are created.
 
-Administrators can specify a default `StorageClass` just for PVCs that don't
+Administrators can specify a default StorageClass just for PVCs that don't
 request any particular class to bind to: see the
-[`PersistentVolumeClaim` section](/docs/concepts/storage/persistent-volumes/#class-1)
+[PersistentVolumeClaim section](/docs/concepts/storage/persistent-volumes/#class-1)
 for details.
 
 ```yaml
@@ -61,7 +61,7 @@ volumeBindingMode: Immediate
 
 ### Provisioner
 
-Storage classes have a provisioner that determines what volume plugin is used
+Storage Classes have a provisioner that determines what volume plugin is used
 for provisioning PVs. This field must be specified.
 
 | Volume Plugin        | Internal Provisioner| Config Example                       |
@@ -104,12 +104,12 @@ vendors provide their own external provisioner.
 
 ### Reclaim Policy
 
-Persistent Volumes that are dynamically created by a storage class will have the
+Persistent Volumes that are dynamically created by a StorageClass will have the
 reclaim policy specified in the `reclaimPolicy` field of the class, which can be
 either `Delete` or `Retain`. If no `reclaimPolicy` is specified when a
-`StorageClass` object is created, it will default to `Delete`.
+StorageClass object is created, it will default to `Delete`.
 
-Persistent Volumes that are created manually and managed via a storage class will have
+Persistent Volumes that are created manually and managed via a StorageClass will have
 whatever reclaim policy they were assigned at creation.
 
 ### Allow Volume Expansion
@@ -120,7 +120,7 @@ Persistent Volumes can be configured to be expandable. This feature when set to 
 allows the users to resize the volume by editing the corresponding PVC object. 
 
 The following types of volumes support volume expansion, when the underlying
-Storage Class has the field `allowVolumeExpansion` set to true.
+StorageClass has the field `allowVolumeExpansion` set to true.
 
 {{< table caption = "Table of Volume types and the version of Kubernetes they require"  >}}
 
@@ -146,7 +146,7 @@ You can only use the volume expansion feature to grow a Volume, not to shrink it
 
 ### Mount Options
 
-Persistent Volumes that are dynamically created by a storage class will have the
+Persistent Volumes that are dynamically created by a StorageClass will have the
 mount options specified in the `mountOptions` field of the class.
 
 If the volume plugin does not support mount options but mount options are
@@ -219,7 +219,7 @@ allowedTopologies:
 
 ## Parameters
 
-Storage classes have parameters that describe volumes belonging to the storage
+Storage Classes have parameters that describe volumes belonging to the storage
 class. Different parameters may be accepted depending on the `provisioner`. For
  example, the value `io1`, for the parameter `type`, and the parameter
 `iopsPerGB` are specific to EBS. When a parameter is omitted, some default is
@@ -367,7 +367,7 @@ parameters:
   `"8452344e2becec931ece4e33c4674e4e,42982310de6c63381718ccfa6d8cf397"`. This
   is an optional parameter.
 * `gidMin`, `gidMax` : The minimum and maximum value of GID range for the
-  storage class. A unique value (GID) in this range ( gidMin-gidMax ) will be
+  StorageClass. A unique value (GID) in this range ( gidMin-gidMax ) will be
   used for dynamically provisioned volumes. These are optional values. If not
   specified, the volume will be provisioned with a value between 2000-2147483647
   which are defaults for gidMin and gidMax respectively.
@@ -441,7 +441,7 @@ This internal provisioner of OpenStack is deprecated. Please use [the external c
     ```
 
     `datastore`: The user can also specify the datastore in the StorageClass.
-    The volume will be created on the datastore specified in the storage class,
+    The volume will be created on the datastore specified in the StorageClass,
     which in this case is `VSANDatastore`. This field is optional. If the
     datastore is not specified, then the volume will be created on the datastore
     specified in the vSphere config file used to initialize the vSphere Cloud
@@ -580,7 +580,7 @@ parameters:
 
 ### Azure Disk
 
-#### Azure Unmanaged Disk Storage Class
+#### Azure Unmanaged Disk StorageClass
 
 ```yaml
 apiVersion: storage.k8s.io/v1
@@ -601,7 +601,7 @@ parameters:
   ignored. If a storage account is not provided, a new storage account will be
   created in the same resource group as the cluster.
 
-#### New Azure Disk Storage Class (starting from v1.7.2)
+#### New Azure Disk StorageClass (starting from v1.7.2)
 
 ```yaml
 apiVersion: storage.k8s.io/v1
@@ -766,8 +766,8 @@ parameters:
 * `pool`: The name of the StorageOS distributed capacity pool to provision the
   volume from.  Uses the `default` pool which is normally present if not specified.
 * `description`: The description to assign to volumes that were created dynamically.
-  All volume descriptions will be the same for the storage class, but different
-  storage classes can be used to allow descriptions for different use cases.
+  All volume descriptions will be the same for the StorageClass, but different
+  Storage Classes can be used to allow descriptions for different use cases.
   Defaults to `Kubernetes volume`.
 * `fsType`: The default filesystem type to request. Note that user-defined rules
   within StorageOS may override this value.  Defaults to `ext4`.

--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -580,7 +580,7 @@ parameters:
 
 ### Azure Disk
 
-#### Azure Unmanaged Disk storage class
+#### Azure Unmanaged Disk storage class {#azure-unmanaged-disk-storage-class}
 
 ```yaml
 apiVersion: storage.k8s.io/v1
@@ -601,7 +601,7 @@ parameters:
   ignored. If a storage account is not provided, a new storage account will be
   created in the same resource group as the cluster.
 
-#### Azure Disk storage class (starting from v1.7.2)
+#### Azure Disk storage class (starting from v1.7.2) {#azure-disk-storage-class}
 
 ```yaml
 apiVersion: storage.k8s.io/v1


### PR DESCRIPTION
* Removed backticks from all occurrences of PersistentVolume, PersistentVolumeClaim and StorageClass.
* Also update the page [Storage Class](https://kubernetes.io/docs/concepts/storage/storage-classes/)  with the same concept.

Fixes #19542 
