### PR TITLE
Federation Cleanup (3) doc: clean up the federation and kubefed(federation v1 cli) references.

### DIFF
--- a/content/en/docs/concepts/cluster-administration/cluster-administration-overview.md
+++ b/content/en/docs/concepts/cluster-administration/cluster-administration-overview.md
@@ -20,7 +20,6 @@ See the guides in [Setup](/docs/setup/) for examples of how to plan, set up, and
 Before choosing a guide, here are some considerations:
 
  - Do you just want to try out Kubernetes on your computer, or do you want to build a high-availability, multi-node cluster? Choose distros best suited for your needs.
- - **If you are designing for high-availability**, learn about configuring [clusters in multiple zones](/docs/concepts/cluster-administration/federation/).
  - Will you be using **a hosted Kubernetes cluster**, such as [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/), or **hosting your own cluster**?
  - Will your cluster be **on-premises**, or **in the cloud (IaaS)**? Kubernetes does not directly support hybrid clusters. Instead, you can set up multiple clusters.
  - **If you are configuring Kubernetes on-premises**, consider which [networking model](/docs/concepts/cluster-administration/networking/) fits best.

--- a/content/en/docs/reference/tools.md
+++ b/content/en/docs/reference/tools.md
@@ -18,11 +18,6 @@ Kubernetes contains several built-in tools to help you work with the Kubernetes 
 
 [`kubeadm`](/docs/setup/production-environment/tools/kubeadm/install-kubeadm/) is the command line tool for easily provisioning a secure Kubernetes cluster on top of physical or cloud servers or virtual machines (currently in alpha).
 
-## Kubefed
-
-[`kubefed`](/docs/tasks/federation/set-up-cluster-federation-kubefed/) is the command line tool
-to help you administrate your federated clusters.
-
 ## Minikube
 
 [`minikube`](/docs/tasks/tools/install-minikube/) is a tool that makes it

--- a/content/en/docs/tasks/debug-application-cluster/debug-cluster.md
+++ b/content/en/docs/tasks/debug-application-cluster/debug-cluster.md
@@ -124,7 +124,4 @@ This is an incomplete list of things that could go wrong, and how to adjust your
   - Mitigates: Node shutdown
   - Mitigates: Kubelet software fault
 
-- Action: [Multiple independent clusters](/docs/concepts/cluster-administration/federation/) (and avoid making risky changes to all clusters at once)
-  - Mitigates: Everything listed above.
-
 {{% /capture %}}

--- a/data/concepts.yml
+++ b/data/concepts.yml
@@ -118,7 +118,6 @@ toc:
   - docs/concepts/cluster-administration/logging.md
   - docs/concepts/cluster-administration/monitoring.md
   - docs/concepts/cluster-administration/kubelet-garbage-collection.md
-  - docs/concepts/cluster-administration/federation.md
   - docs/concepts/cluster-administration/sysctl-cluster.md
   - docs/concepts/cluster-administration/authenticate-across-clusters-kubeconfig.md
   - docs/concepts/cluster-administration/master-node-communication.md

--- a/data/docs-home.yml
+++ b/data/docs-home.yml
@@ -26,4 +26,3 @@ toc:
     - docs/home/contribute/generated-reference/kubernetes-components.md
     - docs/home/contribute/generated-reference/kubectl.md
     - docs/home/contribute/generated-reference/kubernetes-api.md
-    - docs/home/contribute/generated-reference/federation-api.md

--- a/data/overrides.yml
+++ b/data/overrides.yml
@@ -1,10 +1,7 @@
 overrides:
 - path: docs/admin/cloud-controller-manager.md
-- path: docs/admin/federation-apiserver.md
-- path: docs/admin/federation-controller-manager.md
 - path: docs/admin/kube-apiserver.md
 - path: docs/admin/kube-controller-manager.md
 - path: docs/admin/kube-proxy.md
 - path: docs/admin/kube-scheduler.md
 - path: docs/admin/kubelet.md
-- copypath: k8s/federation/docs/api-reference/ docs/federation/

--- a/data/reference.yml
+++ b/data/reference.yml
@@ -44,14 +44,6 @@ toc:
     - title: Swagger Spec
       path: https://git.k8s.io/kubernetes/api/swagger-spec/
 
-- title: Federation API
-  landing_page: /docs/reference/federation/v1/operations/
-  section:
-    - docs/reference/generated/federation/v1/operations.html
-    - docs/reference/generated/federation/v1/definitions.html
-    - docs/reference/generated/federation/extensions/v1beta1/operations.html
-    - docs/reference/generated/federation/extensions/v1beta1/definitions.html
-
 - title: kubectl CLI
   landing_page: /docs/user-guide/kubectl-overview/
   section:
@@ -79,14 +71,6 @@ toc:
     - docs/reference/setup-tools/kubeadm/kubeadm-version.md
     - docs/reference/setup-tools/kubeadm/kubeadm-alpha.md 
     - docs/reference/setup-tools/kubeadm/implementation-details.md 
-  - title: Kubefed
-    section:
-    - docs/reference/generated/kubefed.md
-    - docs/reference/generated/kubefed_options.md
-    - docs/reference/generated/kubefed_init.md
-    - docs/reference/generated/kubefed_join.md
-    - docs/reference/generated/kubefed_unjoin.md
-    - docs/reference/generated/kubefed_version.md
 
 - title: Command-line Tools Reference
   landing_page: /docs/admin/kubelet/
@@ -100,8 +84,6 @@ toc:
   - docs/reference/generated/kube-scheduler.md
   - docs/admin/kubelet-tls-bootstrapping.md
   - docs/reference/generated/cloud-controller-manager.md
-  - docs/reference/generated/federation-apiserver.md
-  - docs/reference/generated/federation-controller-manager.md
 
 - title: Kubernetes Issues and Security
   landing_page: https://github.com/kubernetes/kubernetes/issues/

--- a/static/_redirects
+++ b/static/_redirects
@@ -148,19 +148,6 @@
 /docs/deprecated/     /docs/reference/using-api/deprecation-policy/ 301
 /docs/deprecation-policy/     /docs/reference/using-api/deprecation-policy/ 301
 
-/docs/federation/api-reference/     /docs/reference/federation/v1/operations/ 301
-/docs/federation/api-reference/v1/definitions.html    /docs/reference/generated/federation/v1/definitions/ 301
-/docs/federation/api-reference/v1/operations.html     /docs/reference/generated/federation/v1/operations/ 301
-/docs/federation/api-reference/extensions/v1beta1/definitions/       /docs/reference/generated/federation/extensions/v1beta1/definitions/ 301
-/docs/federation/api-reference/extensions/v1beta1/definitions.html   /docs/reference/generated/federation/extensions/v1beta1/definitions/ 301
-/docs/federation/api-reference/extensions/v1beta1/operations/      /docs/reference/generated/federation/extensions/v1beta1/operations/ 301
-/docs/federation/api-reference/extensions/v1beta1/operations.html  /docs/reference/generated/federation/extensions/v1beta1/operations/ 301
-/docs/federation/api-reference/federation/v1beta1/definitions/      /docs/reference/generated/federation/extensions/v1beta1/definitions/ 301
-/docs/federation/api-reference/federation/v1beta1/definitions.html  /docs/reference/generated/federation/extensions/v1beta1/definitions/ 301
-/docs/federation/api-reference/federation/v1beta1/operations/      /docs/reference/generated/federation/extensions/v1beta1/operations/ 301
-/docs/federation/api-reference/federation/v1beta1/operations.html  /docs/reference/generated/federation/extensions/v1beta1/operations/ 301
-/docs/federation/api-reference/README/     /docs/reference/generated/federation/ 301
-
 /docs/getting-started-guides/*     /docs/setup/ 301
 
 /docs/hellonode/     /docs/tutorials/stateless-application/hello-minikube/ 301
@@ -173,7 +160,6 @@
 /docs/contribute/foundational/ /docs/contribute/start/ 301
 /docs/home/contribute/includes/ /docs/contribute/style/hugo-shortcodes/ 301
 /docs/home/contribute/style-guide/ /docs/contribute/style/style-guide/ 301
-/docs/home/contribute/generated-reference/federation-api/ /docs/contribute/generate-ref-docs/federation-api/ 301
 /docs/home/contribute/generated-reference/kubectl/ /docs/contribute/generate-ref-docs/kubectl/ 301
 /docs/home/contribute/generated-reference/kubernetes-api/ /docs/contribute/generate-ref-docs/kubernetes-api/ 301
 /docs/home/contribute/generated-reference/kubernetes-components/ /docs/contribute/generate-ref-docs/kubernetes-components/ 301
@@ -185,12 +171,8 @@
 /docs/home/contribute/write-new-topic/ /docs/contribute/style/write-new-topic/ 301
 
 /docs/reference/deprecation-policy/     /docs/reference/using-api/deprecation-policy/ 301
-/docs/reference/federation/v1beta1/definitions/     /docs/reference/federation/extensions/v1beta1/definitions/ 301
-/docs/reference/federation/v1beta1/operations/     /docs/reference/federation/extensions/v1beta1/operations/ 301
 
 /docs/reference/generated/cloud-controller-manager/     /docs/reference/command-line-tools-reference/cloud-controller-manager/ 301
-/docs/reference/generated/federation-apiserver/     /docs/reference/command-line-tools-reference/federation-apiserver/ 301
-/docs/reference/generated/federation-controller-manager/     /docs/reference/command-line-tools-reference/federation-controller-manager/ 301
 /docs/reference/generated/kubelet/     /docs/reference/command-line-tools-reference/kubelet/ 301
 /docs/reference/generated/kube-apiserver/     /docs/reference/command-line-tools-reference/kube-apiserver/ 301
 /docs/reference/generated/kube-controller-manager/     /docs/reference/command-line-tools-reference/kube-controller-manager/ 301
@@ -199,12 +181,6 @@
 /docs/reference/generated/kubectl/kubectl-options/     /docs/reference/kubectl/kubectl/ 301
 /docs/reference/generated/kubectl/kubectl/     /docs/reference/generated/kubectl/kubectl-commands/ 301
 /docs/reference/generated/kubectl/kubectl/kubectl_*.md    /docs/reference/generated/kubectl/kubectl-commands#:splat 301
-/docs/reference/generated/kubefed/     /docs/reference/setup-tools/kubefed/kubefed/ 301
-/docs/reference/generated/kubefed_init/     /docs/reference/setup-tools/kubefed/kubefed-init/ 301
-/docs/reference/generated/kubefed_join/     /docs/reference/setup-tools/kubefed/kubefed-join/ 301
-/docs/reference/generated/kubefed_options/     /docs/reference/setup-tools/kubefed/kubefed-options/ 301
-/docs/reference/generated/kubefed_unjoin/     /docs/reference/setup-tools/kubefed/kubefed-unjoin/ 301
-/docs/reference/generated/kubefed_version/     /docs/reference/setup-tools/kubefed/kubefed-version/ 301
 
 /docs/reference/glossary/maintainer/    /docs/reference/glossary/approver/ 301
 
@@ -466,14 +442,6 @@ https://kubernetes-io-v1-7.netlify.com/*    https://v1-7.docs.kubernetes.io/:spl
 /docs/admin/kube-scheduler/     /docs/reference/generated/kube-scheduler/ 301
 /docs/admin/kubeadm/     /docs/reference/generated/kubeadm/ 301
 /docs/admin/kubelet/      /docs/reference/generated/kubelet/ 301
-/docs/admin/federation-controller-manager/    /docs/reference/generated/federation-controller-manager/ 301
-/docs/admin/federation-apiserver/      /docs/reference/generated/federation-apiserver/ 301
-/docs/admin/kubefed/     /docs/reference/generated/kubefed/ 301
-/docs/admin/kubefed_init/    /docs/reference/generated/kubefed_init/ 301
-/docs/admin/kubefed_join/    /docs/reference/generated/kubefed_join/ 301
-/docs/admin/kubefed_options/    /docs/reference/generated/kubefed_options/ 301
-/docs/admin/kubefed_unjoin/     /docs/reference/generated/kubefed_unjoin/ 301
-/docs/admin/kubefed_version/    /docs/reference/generated/kubefed_version/ 301
 
 /docs/reference/generated/kubeadm/     /docs/reference/setup-tools/kubeadm/kubeadm/ 301
 

--- a/update-imported-docs/reference.yml
+++ b/update-imported-docs/reference.yml
@@ -53,26 +53,3 @@ repos:
     dst: content/en/docs/reference/kubectl/
   - src: gen-compdocs/build/kubeadm*.md
     dst: content/en/docs/reference/setup-tools/kubeadm/generated/
-
-#- name: federation
-#  remote: https://github.com/kubernetes/federation.git
-  # Change this to a release branch when federation has release branches.
-#  branch: master
-#  generate-command: hack/generate-docs.sh
-#  files:
-#  - src: docs/admin/federation-apiserver.md
-#    dst: content/en/docs/reference/command-line-tools-reference/federation-apiserver.md
-#  - src: docs/admin/federation-controller-manager.md
-#    dst: content/en/docs/reference/command-line-tools-reference/federation-controller-manager.md
-#  - src: docs/admin/kubefed_init.md
-#    dst: content/en/docs/reference/setup-tools/kubefed/kubefed_init.md
-#  - src: docs/admin/kubefed_join.md
-#    dst: content/en/docs/reference/setup-tools/kubefed/kubefed_join.md
-#  - src: docs/admin/kubefed.md
-#    dst: content/en/docs/reference/setup-tools/kubefed/kubefed.md
-#  - src: docs/admin/kubefed_options.md
-#    dst: content/en/docs/reference/setup-tools/kubefed/kubefed_options.md
-#  - src: docs/admin/kubefed_unjoin.md
-#    dst: content/en/docs/reference/setup-tools/kubefed/kubefed_unjoin.md
-#  - src: docs/admin/kubefed_version.md
-#    dst: content/en/docs/reference/setup-tools/kubefed/kubefed_version.md


### PR DESCRIPTION
This PR is the third PR and maybe the last PR for issue #19206 , the previous two are: #19581 , #19572 . It cleans all left federation v1 content (I think) . 
