### PR TITLE
Correct target.type from AverageUtilization to Utilization

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -239,7 +239,7 @@ the only other supported resource metric is memory.  These resources do not chan
 to cluster, and should always be available, as long as the `metrics.k8s.io` API is available.
 
 You can also specify resource metrics in terms of direct values, instead of as percentages of the
-requested value, by using a `target` type of `AverageValue` instead of `AverageUtilization`, and
+requested value, by using a `target.type` of `AverageValue` instead of `Utilization`, and
 setting the corresponding `target.averageValue` field instead of the `target.averageUtilization`.
 
 There are two other types of metrics, both of which are considered *custom metrics*: pod metrics and


### PR DESCRIPTION
The HorizontalPodAutoscaler `target.type` must be either Utilization, Value, or AverageValue.
Correct the `target.type` from `AverageUtilization` to `Utilization`.

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>