### PR TITLE
Remove gochist from sig-docs-en-owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -41,7 +41,6 @@ aliases:
   sig-docs-en-owners: # Admins for English content
     - bradtopol
     - daminisatya
-    - gochist
     - jaredbhatti
     - jimangel
     - kbarnard10
@@ -58,7 +57,6 @@ aliases:
   sig-docs-en-reviews: # PR reviews for English content
     - bradtopol
     - daminisatya
-    - gochist
     - jaredbhatti
     - jimangel
     - kbarnard10


### PR DESCRIPTION
To make Korean localization easier, I've been listed in sig-docs-en-owner so I can approve changes to the i18n directory and the README-ko.md file by #15692. However, there are side effects that I recommend as a reviewer or assignee in other English documents. 

/cc @jimangel @zacharysarah 