### PR TITLE
nslookup target to include fully qualified service name

### DIFF
--- a/content/en/docs/concepts/workloads/pods/init-containers.md
+++ b/content/en/docs/concepts/workloads/pods/init-containers.md
@@ -122,10 +122,10 @@ spec:
   initContainers:
   - name: init-myservice
     image: busybox:1.28
-    command: ['sh', '-c', 'until nslookup myservice; do echo waiting for myservice; sleep 2; done;']
+    command: ['sh', '-c', "until nslookup myservice.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"]
   - name: init-mydb
     image: busybox:1.28
-    command: ['sh', '-c', 'until nslookup mydb; do echo waiting for mydb; sleep 2; done;']
+    command: ['sh', '-c', "until nslookup mydb.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for mydb; sleep 2; done"]
 ```
 
 You can start this Pod by running:

--- a/content/fr/docs/concepts/workloads/pods/init-containers.md
+++ b/content/fr/docs/concepts/workloads/pods/init-containers.md
@@ -111,10 +111,10 @@ spec:
   initContainers:
   - name: init-myservice
     image: busybox:1.28
-    command: ['sh', '-c', 'until nslookup myservice; do echo "En attente de myservice"; sleep 2; done;']
+    command: ['sh', '-c', "until nslookup myservice.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo en attente de myservice; sleep 2; done"]
   - name: init-mydb
     image: busybox:1.28
-    command: ['sh', '-c', 'until nslookup mydb; do echo "En attente de mydb"; sleep 2; done;']
+    command: ['sh', '-c', "until nslookup mydb.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo en attente de mydb; sleep 2; done"]
 ```
 
 Les fichiers YAML suivants résument les services `mydb` et `myservice` :

--- a/content/id/docs/concepts/workloads/pods/init-containers.md
+++ b/content/id/docs/concepts/workloads/pods/init-containers.md
@@ -78,12 +78,12 @@ metadata:
         {
             "name": "init-myservice",
             "image": "busybox:1.28",
-            "command": ["sh", "-c", "until nslookup myservice; do echo waiting for myservice; sleep 2; done;"]
+            "command": ['sh', '-c', "until nslookup myservice.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"]
         },
         {
             "name": "init-mydb",
             "image": "busybox:1.28",
-            "command": ["sh", "-c", "until nslookup mydb; do echo waiting for mydb; sleep 2; done;"]
+            "command": ['sh', '-c', "until nslookup mydb.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for mydb; sleep 2; done"]
         }
     ]'
 spec:

--- a/content/ja/docs/concepts/workloads/pods/init-containers.md
+++ b/content/ja/docs/concepts/workloads/pods/init-containers.md
@@ -76,12 +76,12 @@ metadata:
         {
             "name": "init-myservice",
             "image": "busybox:1.28",
-            "command": ["sh", "-c", "until nslookup myservice; do echo waiting for myservice; sleep 2; done;"]
+            "command": ['sh', '-c', "until nslookup myservice.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"]
         },
         {
             "name": "init-mydb",
             "image": "busybox:1.28",
-            "command": ["sh", "-c", "until nslookup mydb; do echo waiting for mydb; sleep 2; done;"]
+            "command": ['sh', '-c', "until nslookup mydb.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for mydb; sleep 2; done"]
         }
     ]'
 spec:

--- a/content/ko/docs/concepts/workloads/pods/init-containers.md
+++ b/content/ko/docs/concepts/workloads/pods/init-containers.md
@@ -120,10 +120,10 @@ spec:
   initContainers:
   - name: init-myservice
     image: busybox:1.28
-    command: ['sh', '-c', 'until nslookup myservice; do echo waiting for myservice; sleep 2; done;']
+    command: ['sh', '-c', "until nslookup myservice.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"]
   - name: init-mydb
     image: busybox:1.28
-    command: ['sh', '-c', 'until nslookup mydb; do echo waiting for mydb; sleep 2; done;']
+    command: ['sh', '-c', "until nslookup mydb.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for mydb; sleep 2; done"]
 ```
 
 다음 커맨드들을 이용하여 파드를 시작하거나 디버깅할 수 있다.

--- a/content/zh/docs/concepts/workloads/pods/init-containers.md
+++ b/content/zh/docs/concepts/workloads/pods/init-containers.md
@@ -186,10 +186,10 @@ spec:
   initContainers:
   - name: init-myservice
     image: busybox:1.28
-    command: ['sh', '-c', 'until nslookup myservice; do echo waiting for myservice; sleep 2; done;']
+    command: ['sh', '-c', "until nslookup myservice.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"]
   - name: init-mydb
     image: busybox:1.28
-    command: ['sh', '-c', 'until nslookup mydb; do echo waiting for mydb; sleep 2; done;']
+    command: ['sh', '-c', "until nslookup mydb.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for mydb; sleep 2; done"]
 ```
 
 下面的 yaml 文件展示了 `mydb` 和 `myservice` 两个 Service：


### PR DESCRIPTION
Hi All,

Whilst following the documentation on the initContainers page, I had an unexpected outcome.  After creating the initial myapp pod as per the documentation, upon running the apply, my pod went into a ready state without it going into the status of 'Init:0/2' as expected.

After further troubleshooting, I noticed that my ISP, has a DNS catch all for unknown resolutions, therefore causing the nslookup to succeed, where it should fail.  For example -

```
$ kubectl apply -f myapp.yaml
pod/myapp-pod created

$ kubectl get pods
NAME        READY   STATUS    RESTARTS   AGE
myapp-pod   1/1     Running   0          8s

$ kubectl exec -it myapp-pod sh
/ # nslookup mydb
Server:    10.96.0.10
Address 1: 10.96.0.10 kube-dns.kube-system.svc.cluster.local

Name:      mydb
Address 1: 92.242.132.24 unallocated.barefruit.co.uk
/ # nslookup myservice
Server:    10.96.0.10
Address 1: 10.96.0.10 kube-dns.kube-system.svc.cluster.local

Name:      myservice
Address 1: 92.242.132.24 unallocated.barefruit.co.uk
```

They seem to use this, to provide their own help/search page for mistyped domains.  Given that this is common with other ISP's and it may be encountered by others, I propose this pull request as an enhancement, maintaining expected functionality regardless of whether or not the upstream DNS has a catch-all configuration.

I've changed the nslookup, so that it will use the fully qualified service name.  I've also set the namespace to be looked up from the pod and have tested this, in another namespace.  With the changes, it works as expected.

In the documentation, I found 6 localised versions and have updated all 6 accordingly, taking into account the variations used in the yaml, i.e. command vs "command".  In the French localisation, I also took the opportunity to make the logging case consistent with the others, i.e. 'en attente de myservice' vs 'En attende de myservice'.

Hope this helps.

*** Edit ***

References to the updated URL's from the deploy preview -

En: https://deploy-preview-19603--kubernetes-io-master-staging.netlify.com/docs/concepts/workloads/pods/init-containers/

Fr: https://deploy-preview-19603--kubernetes-io-master-staging.netlify.com/fr/docs/concepts/workloads/pods/init-containers/

Id: https://deploy-preview-19603--kubernetes-io-master-staging.netlify.com/id/docs/concepts/workloads/pods/init-containers/

Ja: https://deploy-preview-19603--kubernetes-io-master-staging.netlify.com/ja/docs/concepts/workloads/pods/init-containers/

Ko: https://deploy-preview-19603--kubernetes-io-master-staging.netlify.com/ko/docs/concepts/workloads/pods/init-containers/

Zh: https://deploy-preview-19603--kubernetes-io-master-staging.netlify.com/zh/docs/concepts/workloads/pods/init-containers/