### PR TITLE
Update kubectl explain usage case

### DIFF
--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -95,7 +95,7 @@ kubectl apply -f ./my1.yaml -f ./my2.yaml      # create from multiple files
 kubectl apply -f ./dir                         # create resource(s) in all manifest files in dir
 kubectl apply -f https://git.io/vPieo          # create resource(s) from url
 kubectl create deployment nginx --image=nginx  # start a single instance of nginx
-kubectl explain pods,svc                       # get the documentation for pod and svc manifests
+kubectl explain pods                           # get the documentation for pod manifests
 
 # Create multiple YAML objects from stdin
 cat <<EOF | kubectl apply -f -


### PR DESCRIPTION
You can't specify more then one resources at one for explain. See error below:
```
$ kubectl explain pods,svc
the server doesn't have a resource type "pods,svc"
$ kubectl explain pods, svc
error: We accept only this format: explain RESOURCE
```