### PR TITLE
Add guide to switch to cgroup v1

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
@@ -64,16 +64,7 @@ This may be caused by a number of problems. The most common are:
     [Configure cgroup driver used by kubelet on Master Node](/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#configure-cgroup-driver-used-by-kubelet-on-master-node)
 
 - control plane Docker containers are crashlooping or hanging. You can check this by running `docker ps` and investigating each container by running `docker logs`.
-- your OS uses cgroup2 which is currently not supported by kubelet which is failed to start  
-  Diagnostic:
-    - `journalctl --unit kubelet` has *Failed to start ContainerManager system validation failed - Following Cgroup subsystem not mounted: [cpu cpuacct cpuset memory]* right before unit terminaltion
-    - `mount | grep cgroup` shows single mount point
-  Solution: add *systemd.unified_cgroup_hierarchy=0* to kernel command line. For Fedora 31:
-  ```
-  sed -ri 's/^(GRUB_CMDLINE_LINUX=.*)"$/\1 systemd.unified_cgroup_hierarchy=0"/g' /etc/sysconfig/grub && \
-  grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg && \
-  reboot
-  ```
+- your Linux distribution uses cgroups v2 which are currently unsupported by the kubelet and it failed to start.
 
 ## kubeadm blocks when removing managed containers
 

--- a/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
@@ -64,6 +64,16 @@ This may be caused by a number of problems. The most common are:
     [Configure cgroup driver used by kubelet on Master Node](/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#configure-cgroup-driver-used-by-kubelet-on-master-node)
 
 - control plane Docker containers are crashlooping or hanging. You can check this by running `docker ps` and investigating each container by running `docker logs`.
+- your OS uses cgroup2 which is currently not supported by kubelet which is failed to start  
+  Diagnostic:
+    - `journalctl --unit kubelet` has *Failed to start ContainerManager system validation failed - Following Cgroup subsystem not mounted: [cpu cpuacct cpuset memory]* right before unit terminaltion
+    - `mount | grep cgroup` shows single mount point
+  Solution: add *systemd.unified_cgroup_hierarchy=0* to kernel command line. For Fedora 31:
+  ```
+  sed -ri 's/^(GRUB_CMDLINE_LINUX=.*)"$/\1 systemd.unified_cgroup_hierarchy=0"/g' /etc/sysconfig/grub && \
+  grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg && \
+  reboot
+  ```
 
 ## kubeadm blocks when removing managed containers
 


### PR DESCRIPTION
Change is to describe issue with cgroup2 on new OS-es itself and possible workaround as kubelet seems doesn't support cgroup2 (if I read [this](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/cm/container_manager_linux.go#L159) right).
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use
 for advice.

-->
