### PR TITLE
Update expose-intro.html and remove a unnecessary  side note

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/expose/expose-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/expose/expose-intro.html
@@ -79,13 +79,8 @@ weight: 10
 					<li>Embed version tags</li>
 					<li>Classify an object using tags</li>
 				</ul>
-
 			</div>
-			<div class="col-md-4">
-				<div class="content__box content__box_fill">
-					<p><i>You can create a Service at the same time you create a Deployment by using<br><code>--expose</code> in kubectl.</i></p>
-				</div>
-			</div>
+			
 		</div>
 
 		<br>


### PR DESCRIPTION
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use
 for advice.

-->


Related to #19625

**This PR removes the [side note](https://kubernetes.io/docs/tutorials/kubernetes-basics/expose/expose-intro/#services-and-labels), because it is not working  ...**

I tried to create a deployment using the expose flag

    $ kubectl create -f deployment.yaml --expose

and the result was:

    Error: unknown flag: --expose
    See 'kubectl create --help' for usage.

env:

    $ kubectl version
    Client Version: version.Info{Major:"1", Minor:"17", GitVersion:"v1.17.3", GitCommit:"06ad960bfd03b39c8310aaf92d1e7c12ce618213", GitTreeState:"clean", BuildDate:"2020-02-11T18:14:22Z", GoVersion:"go1.13.6", Compiler:"gc", Platform:"linux/amd64"}
    Server Version: version.Info{Major:"1", Minor:"17", GitVersion:"v1.17.3", GitCommit:"06ad960bfd03b39c8310aaf92d1e7c12ce618213", GitTreeState:"clean", BuildDate:"2020-02-11T18:07:13Z", GoVersion:"go1.13.6", Compiler:"gc", Platform:"linux/amd64"}
