### PR TITLE
fix: remove the redirect_from settings.

### DIFF
--- a/content/zh/docs/concepts/policy/pod-security-policy.md
+++ b/content/zh/docs/concepts/policy/pod-security-policy.md
@@ -2,9 +2,6 @@
 approvers:
 - pweil-
 title: Pod 安全策略
-redirect_from:
-- "/docs/user-guide/pod-security-policy/"
-- "/docs/user-guide/pod-security-policy/index.html"
 ---
 
 

--- a/content/zh/docs/concepts/workloads/pods/init-containers.md
+++ b/content/zh/docs/concepts/workloads/pods/init-containers.md
@@ -2,11 +2,6 @@
 approvers:
 - erictune
 title: Init 容器
-redirect_from:
-- "/docs/concepts/abstractions/init-containers/"
-- "/docs/concepts/abstractions/init-containers.html"
-- "/docs/user-guide/pods/init-container/"
-- "/docs/user-guide/pods/init-container.html"
 content_template: templates/concept
 ---
 

--- a/content/zh/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/zh/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -1,8 +1,5 @@
 ---
 title: Pod 的生命周期
-redirect_from:
-- "/docs/user-guide/pod-states/"
-- "/docs/user-guide/pod-states.html"
 content_template: templates/concept
 ---
 

--- a/content/zh/docs/tasks/access-application-cluster/communicate-containers-same-pod-shared-volume.md
+++ b/content/zh/docs/tasks/access-application-cluster/communicate-containers-same-pod-shared-volume.md
@@ -1,10 +1,5 @@
 ---
 title: 同 Pod 内的容器使用共享卷通信
-redirect_from:
-- "/docs/user-guide/pods/multi-container/"
-- "/docs/user-guide/pods/multi-container.html"
-- "/docs/tasks/configure-pod-container/communicate-containers-same-pod/"
-- "/docs/tasks/configure-pod-container/communicate-containers-same-pod.html"
 content_template: templates/task
 ---
 

--- a/content/zh/docs/tasks/administer-cluster/access-cluster-services.md
+++ b/content/zh/docs/tasks/administer-cluster/access-cluster-services.md
@@ -1,9 +1,6 @@
 ---
 
 title: 访问集群上运行的服务
-redirect_from:
-- "/docs/user-guide/accessing-the-cluster/"
-- "/docs/user-guide/accessing-the-cluster.html"
 content_template: templates/task
 ---
 


### PR DESCRIPTION
I have been checked the current `redirect_from` links from these zh pages, and all of them could be found at the [_redirects file](https://github.com/kubernetes/website/blob/master/static/_redirects), I also checked if the `redirect_from` links would redirect to zh pages if the site prefixed with zh, it didn't and return 404.

As a result, I think these redirect_from settings are legacy thing, and this PR is going to remove them. It fixes #19634 .

Thanks.
