### PR TITLE
Replace wrong glossary reference to node with pod

### DIFF
--- a/content/en/docs/reference/glossary/kube-scheduler.md
+++ b/content/en/docs/reference/glossary/kube-scheduler.md
@@ -11,9 +11,9 @@ tags:
 - architecture
 ---
 Control plane component that watches for newly created
-{{< glossary_tooltip term_id="node" >}} with no assigned
-{{< glossary_tooltip term_id="node" text="node">}}, and selects a node for them
-to run on.
+{{< glossary_tooltip term_id="pod" text="Pods">}} with no assigned
+{{< glossary_tooltip term_id="node" >}}, and selects a
+{{< glossary_tooltip term_id="node" >}} for them to run on.
 
 <!--more-->
 


### PR DESCRIPTION
The glossary entry of kube-scheduler looks like this at the moment:

>  component that watches for newly created Node with no assigned node

See https://kubernetes.io/docs/concepts/overview/components/#kube-scheduler

This pull request hopefully changes the entry to:

> component that watches for newly created pods with no assigned node
