### PR TITLE
Lease heartbeat: more description update error handling

### DIFF
--- a/content/en/docs/concepts/architecture/nodes.md
+++ b/content/en/docs/concepts/architecture/nodes.md
@@ -184,7 +184,7 @@ a Lease object.
   timeout for unreachable nodes).
 - The kubelet creates and then updates its Lease object every 10 seconds
   (the default update interval). Lease updates occur independently from the
-  `NodeStatus` updates.
+  `NodeStatus` updates. If the Lease update fails, the kubelet retries with exponential backoff starting at 200 milliseconds and capped at 7 seconds.
 
 #### Reliability
 


### PR DESCRIPTION
This PR adds an explanation of Node Lease update failure handling. Corresponding k8s logic: https://github.com/kubernetes/kubernetes/blob/abe6321296123aaba8e83978f7d17951ab1b64fd/pkg/kubelet/nodelease/controller.go#L123