### PR TITLE
Update nginx to modern versions on ja docs

### DIFF
--- a/content/ja/docs/concepts/configuration/assign-pod-node.md
+++ b/content/ja/docs/concepts/configuration/assign-pod-node.md
@@ -207,7 +207,7 @@ Pod AffinityとPod Anti-Affinityで使用できるオペレーターは、`In`�
 `labelSelector`と`topologyKey`に加え、`labelSelector`が合致すべき`namespaces`のリストを特定することも可能です(これは`labelSelector`と`topologyKey`を定義することと同等です)。
 省略した場合や空の場合は、AffinityとAnti-Affinityが定義されたPodのnamespaceがデフォルトで設定されます。
 
-`requiredDuringSchedulingIgnoredDuringExecution`が指定されたAffinityとAnti-Affinityでは、`matchExpressions`に記載された全ての条件が満たされるNodeにPodがスケジュールされます。
+`requiredDuringSchedulingIgnoredDuringExecution`が指定されたAffinityとAnti-Affinityでは、`matchExpressions`に記載された全ての条件が満たされるNodeにPodがスケジュールされます。 
 
 
 #### 実際的なユースケース

--- a/content/ja/docs/concepts/configuration/assign-pod-node.md
+++ b/content/ja/docs/concepts/configuration/assign-pod-node.md
@@ -207,7 +207,7 @@ Pod AffinityとPod Anti-Affinityで使用できるオペレーターは、`In`�
 `labelSelector`と`topologyKey`に加え、`labelSelector`が合致すべき`namespaces`のリストを特定することも可能です(これは`labelSelector`と`topologyKey`を定義することと同等です)。
 省略した場合や空の場合は、AffinityとAnti-Affinityが定義されたPodのnamespaceがデフォルトで設定されます。
 
-`requiredDuringSchedulingIgnoredDuringExecution`が指定されたAffinityとAnti-Affinityでは、`matchExpressions`に記載された全ての条件が満たされるNodeにPodがスケジュールされます。 
+`requiredDuringSchedulingIgnoredDuringExecution`が指定されたAffinityとAnti-Affinityでは、`matchExpressions`に記載された全ての条件が満たされるNodeにPodがスケジュールされます。
 
 
 #### 実際的なユースケース
@@ -296,7 +296,7 @@ spec:
             topologyKey: "kubernetes.io/hostname"
       containers:
       - name: web-app
-        image: nginx:1.12-alpine
+        image: nginx:1.16-alpine
 ```
 
 上記2つのDeploymentが生成されると、3つのノードは以下のようになります。

--- a/content/ja/docs/concepts/workloads/controllers/deployment.md
+++ b/content/ja/docs/concepts/workloads/controllers/deployment.md
@@ -11,7 +11,7 @@ weight: 30
 
 {{% capture overview %}}
 
-_Deployment_ コントローラーは[Pod](/docs/concepts/workloads/pods/pod/)と[ReplicaSet](/docs/concepts/workloads/controllers/replicaset/)の宣言的なアップデート機能を提供します。  
+_Deployment_ コントローラーは[Pod](/docs/concepts/workloads/pods/pod/)と[ReplicaSet](/docs/concepts/workloads/controllers/replicaset/)の宣言的なアップデート機能を提供します。
 
 ユーザーはDeploymentにおいて_理想的な状態_ を定義し、Deploymentコントローラーは指定された頻度で現在の状態を理想的な状態に変更させます。ユーザーはDeploymentを定義して、新しいReplicaSetを作成したり、既存のDeploymentを削除して新しいDeploymentで全てのリソースを適用できます。
 
@@ -28,7 +28,7 @@ Deploymentによって作成されたReplicaSetを管理しないでください
 
 下記の項目はDeploymentの典型的なユースケースです。
 
-* ReplicaSetをロールアウトするために[Deploymentの作成](#creating-a-deployment)を行う: ReplicaSetはバックグラウンドでPodを作成します。Podの作成が完了したかどうかは、ロールアウトのステータスを確認してください。  
+* ReplicaSetをロールアウトするために[Deploymentの作成](#creating-a-deployment)を行う: ReplicaSetはバックグラウンドでPodを作成します。Podの作成が完了したかどうかは、ロールアウトのステータスを確認してください。
 * DeploymentのPodTemplateSpecを更新することにより[Podの新しい状態を宣言する](#updating-a-deployment): 新しいReplicaSetが作成され、Deploymentは指定された頻度で古いReplicaSetから新しいReplicaSetへのPodの移行を管理します。新しいReplicaSetはDeploymentのリビジョンを更新します。
 * Deploymentの現在の状態が不安定な場合、[Deploymentのロールバック](#rolling-back-a-deployment)をする: ロールバックによる各更新作業は、Deploymentのリビジョンを更新します。
 * より多くの負荷をさばけるように、[Deploymentをスケールアップ](#scaling-a-deployment)する
@@ -52,7 +52,7 @@ Deploymentによって作成されたReplicaSetを管理しないでください
     {{< /note >}}
 * `template`フィールドは、下記のサブフィールドを持ちます。:
   * Podは`labels`フィールドによって指定された`app: nginx`というラベルがつけられる
-  * PodTemplateの仕様もしくは、`.template.spec`フィールドは、このPodは`nginx`という名前のコンテナーを1つ稼働させ、それは`nginx`というさせ、[Docker Hub](https://hub.docker.com/)にある`nginx`のバージョン1.7.9を使うことを示します
+  * PodTemplateの仕様もしくは、`.template.spec`フィールドは、このPodは`nginx`という名前のコンテナーを1つ稼働させ、それは`nginx`というさせ、[Docker Hub](https://hub.docker.com/)にある`nginx`のバージョン1.14.2を使うことを示します
   * 1つのコンテナを作成し、`name`フィールドを使って`nginx`という名前をつけます
 
   上記のDeploymentを作成するために、以下に示すステップにしたがってください。
@@ -136,10 +136,10 @@ Deploymentのロールアウトは、DeploymentのPodテンプレート(この�
 
 Deploymentを更新するには下記のステップに従ってください。
 
-1. nginxのPodで、`nginx:1.7.9`イメージの代わりに`nginx:1.9.1`を使うように更新します。
+1. nginxのPodで、`nginx:1.14.2`イメージの代わりに`nginx:1.16.1`を使うように更新します。
 
     ```shell
-    kubectl --record deployment.apps/nginx-deployment set image deployment.v1.apps/nginx-deployment nginx=nginx:1.9.1
+    kubectl --record deployment.apps/nginx-deployment set image deployment.v1.apps/nginx-deployment nginx=nginx:1.16.1
     ```
 
     実行結果は下記のとおりです。
@@ -147,7 +147,7 @@ Deploymentを更新するには下記のステップに従ってください。
     deployment.apps/nginx-deployment image updated
     ```
 
-    また、Deploymentを`編集`して、`.spec.template.spec.containers[0].image`を`nginx:1.7.9`から`nginx:1.9.1`に変更することができます。
+    また、Deploymentを`編集`して、`.spec.template.spec.containers[0].image`を`nginx:1.14.2`から`nginx:1.16.1`に変更することができます。
 
     ```shell
     kubectl edit deployment.v1.apps/nginx-deployment
@@ -237,7 +237,7 @@ Deploymentを更新するには下記のステップに従ってください。
     Labels:  app=nginx
      Containers:
       nginx:
-        Image:        nginx:1.9.1
+        Image:        nginx:1.16.1
         Port:         80/TCP
         Environment:  <none>
         Mounts:       <none>
@@ -268,7 +268,7 @@ Deploymentコントローラーにより、新しいDeploymentが観測される
 
 Deploymentのロールアウトが進行中にDeploymentを更新すると、Deploymentは更新する毎に新しいReplicaSetを作成してスケールアップさせ、以前にスケールアップしたReplicaSetのロールオーバーを行います。Deploymentは更新前のReplicaSetを古いReplicaSetのリストに追加し、スケールダウンを開始します。
 
-例えば、5つのレプリカを持つ`nginx:1.7.9`のDeploymentを作成し、`nginx:1.7.9`の3つのレプリカが作成されているときに5つのレプリカを持つ`nginx:1.9.1`に更新します。このケースではDeploymentは作成済みの`nginx:1.7.9`の3つのPodをすぐに削除し、`nginx:1.9.1`のPodの作成を開始します。`nginx:1.7.9`の5つのレプリカを全て作成するのを待つことはありません。
+例えば、5つのレプリカを持つ`nginx:1.14.2`のDeploymentを作成し、`nginx:1.14.2`の3つのレプリカが作成されているときに5つのレプリカを持つ`nginx:1.16.1`に更新します。このケースではDeploymentは作成済みの`nginx:1.14.2`の3つのPodをすぐに削除し、`nginx:1.16.1`のPodの作成を開始します。`nginx:1.14.2`の5つのレプリカを全て作成するのを待つことはありません。
 
 ### ラベルセレクターの更新
 
@@ -290,10 +290,10 @@ Deploymentのロールバックを行いたい場合があります。例えば�
 Deploymentのリビジョンは、Deploymentのロールアウトがトリガーされた時に作成されます。これはDeploymentのPodテンプレート(`.spec.template`)が変更されたときのみ新しいリビジョンが作成されることを意味します。Deploymentのスケーリングなど、他の種類の更新においてはDeploymentのリビジョンは作成されません。これは手動もしくはオートスケーリングを同時に行うことができるようにするためです。これは過去のリビジョンにロールバックするとき、DeploymentのPodテンプレートの箇所のみロールバックされることを意味します。
 {{< /note >}}
 
-* `nginx:1.9.1`の代わりに`nginx:1.91`というイメージに更新して、Deploymentの更新中にタイプミスをしたと仮定します。
+* `nginx:1.16.1`の代わりに`nginx:1.161`というイメージに更新して、Deploymentの更新中にタイプミスをしたと仮定します。
 
     ```shell
-    kubectl set image deployment.v1.apps/nginx-deployment nginx=nginx:1.91 --record=true
+    kubectl set image deployment.v1.apps/nginx-deployment nginx=nginx:1.161 --record=true
     ```
 
     実行結果は下記のとおりです。
@@ -367,7 +367,7 @@ Deploymentのリビジョンは、Deploymentのロールアウトがトリガー
       Labels:  app=nginx
       Containers:
        nginx:
-        Image:        nginx:1.91
+        Image:        nginx:1.161
         Port:         80/TCP
         Host Port:    0/TCP
         Environment:  <none>
@@ -408,13 +408,13 @@ Deploymentのリビジョンは、Deploymentのロールアウトがトリガー
     deployments "nginx-deployment"
     REVISION    CHANGE-CAUSE
     1           kubectl apply --filename=https://k8s.io/examples/controllers/nginx-deployment.yaml --record=true
-    2           kubectl set image deployment.v1.apps/nginx-deployment nginx=nginx:1.9.1 --record=true
-    3           kubectl set image deployment.v1.apps/nginx-deployment nginx=nginx:1.91 --record=true
+    2           kubectl set image deployment.v1.apps/nginx-deployment nginx=nginx:1.16.1 --record=true
+    3           kubectl set image deployment.v1.apps/nginx-deployment nginx=nginx:1.161 --record=true
     ```
 
     `CHANGE-CAUSE`はリビジョンの作成時にDeploymentの`kubernetes.io/change-cause`アノテーションからリビジョンにコピーされます。下記の手段により`CHANGE-CAUSE`メッセージを指定できます。
 
-    * `kubectl annotate deployment.v1.apps/nginx-deployment kubernetes.io/change-cause="image updated to 1.9.1"`の実行によりアノテーションを追加する。
+    * `kubectl annotate deployment.v1.apps/nginx-deployment kubernetes.io/change-cause="image updated to 1.16.1"`の実行によりアノテーションを追加する。
     * リソースの変更時に`kubectl`コマンドの内容を記録するために`--record`フラグを追加する。
     * リソースのマニフェストを手動で編集する。
 
@@ -428,10 +428,10 @@ Deploymentのリビジョンは、Deploymentのロールアウトがトリガー
     deployments "nginx-deployment" revision 2
       Labels:       app=nginx
               pod-template-hash=1159050644
-      Annotations:  kubernetes.io/change-cause=kubectl set image deployment.v1.apps/nginx-deployment nginx=nginx:1.9.1 --record=true
+      Annotations:  kubernetes.io/change-cause=kubectl set image deployment.v1.apps/nginx-deployment nginx=nginx:1.16.1 --record=true
       Containers:
        nginx:
-        Image:      nginx:1.9.1
+        Image:      nginx:1.16.1
         Port:       80/TCP
          QoS Tier:
             cpu:      BestEffort
@@ -488,7 +488,7 @@ Deploymentのリビジョンは、Deploymentのロールアウトがトリガー
     CreationTimestamp:      Sun, 02 Sep 2018 18:17:55 -0500
     Labels:                 app=nginx
     Annotations:            deployment.kubernetes.io/revision=4
-                            kubernetes.io/change-cause=kubectl set image deployment.v1.apps/nginx-deployment nginx=nginx:1.9.1 --record=true
+                            kubernetes.io/change-cause=kubectl set image deployment.v1.apps/nginx-deployment nginx=nginx:1.16.1 --record=true
     Selector:               app=nginx
     Replicas:               3 desired | 3 updated | 3 total | 3 available | 0 unavailable
     StrategyType:           RollingUpdate
@@ -498,7 +498,7 @@ Deploymentのリビジョンは、Deploymentのロールアウトがトリガー
       Labels:  app=nginx
       Containers:
        nginx:
-        Image:        nginx:1.9.1
+        Image:        nginx:1.16.1
         Port:         80/TCP
         Host Port:    0/TCP
         Environment:  <none>
@@ -615,7 +615,7 @@ Deploymentのローリングアップデートは、同時に複数のバージ�
 
 ユーザーは1つ以上の更新処理をトリガーする前に更新の一時停止と再開ができます。これにより、不必要なロールアウトを実行することなく一時停止と再開を行う間に複数の修正を反映できます。
 
-* 例えば、作成直後のDeploymentを考えます。  
+* 例えば、作成直後のDeploymentを考えます。
   Deploymentの詳細情報を確認します。
   ```shell
   kubectl get deploy
@@ -647,7 +647,7 @@ Deploymentのローリングアップデートは、同時に複数のバージ�
 
 * 次にDeploymentのイメージを更新します。
     ```shell
-    kubectl set image deployment.v1.apps/nginx-deployment nginx=nginx:1.9.1
+    kubectl set image deployment.v1.apps/nginx-deployment nginx=nginx:1.16.1
     ```
 
     実行結果は下記のとおりです。

--- a/content/ja/docs/concepts/workloads/controllers/deployment.md
+++ b/content/ja/docs/concepts/workloads/controllers/deployment.md
@@ -11,7 +11,7 @@ weight: 30
 
 {{% capture overview %}}
 
-_Deployment_ コントローラーは[Pod](/docs/concepts/workloads/pods/pod/)と[ReplicaSet](/docs/concepts/workloads/controllers/replicaset/)の宣言的なアップデート機能を提供します。
+_Deployment_ コントローラーは[Pod](/docs/concepts/workloads/pods/pod/)と[ReplicaSet](/docs/concepts/workloads/controllers/replicaset/)の宣言的なアップデート機能を提供します。  
 
 ユーザーはDeploymentにおいて_理想的な状態_ を定義し、Deploymentコントローラーは指定された頻度で現在の状態を理想的な状態に変更させます。ユーザーはDeploymentを定義して、新しいReplicaSetを作成したり、既存のDeploymentを削除して新しいDeploymentで全てのリソースを適用できます。
 
@@ -28,7 +28,7 @@ Deploymentによって作成されたReplicaSetを管理しないでください
 
 下記の項目はDeploymentの典型的なユースケースです。
 
-* ReplicaSetをロールアウトするために[Deploymentの作成](#creating-a-deployment)を行う: ReplicaSetはバックグラウンドでPodを作成します。Podの作成が完了したかどうかは、ロールアウトのステータスを確認してください。
+* ReplicaSetをロールアウトするために[Deploymentの作成](#creating-a-deployment)を行う: ReplicaSetはバックグラウンドでPodを作成します。Podの作成が完了したかどうかは、ロールアウトのステータスを確認してください。  
 * DeploymentのPodTemplateSpecを更新することにより[Podの新しい状態を宣言する](#updating-a-deployment): 新しいReplicaSetが作成され、Deploymentは指定された頻度で古いReplicaSetから新しいReplicaSetへのPodの移行を管理します。新しいReplicaSetはDeploymentのリビジョンを更新します。
 * Deploymentの現在の状態が不安定な場合、[Deploymentのロールバック](#rolling-back-a-deployment)をする: ロールバックによる各更新作業は、Deploymentのリビジョンを更新します。
 * より多くの負荷をさばけるように、[Deploymentをスケールアップ](#scaling-a-deployment)する
@@ -615,7 +615,7 @@ Deploymentのローリングアップデートは、同時に複数のバージ�
 
 ユーザーは1つ以上の更新処理をトリガーする前に更新の一時停止と再開ができます。これにより、不必要なロールアウトを実行することなく一時停止と再開を行う間に複数の修正を反映できます。
 
-* 例えば、作成直後のDeploymentを考えます。
+* 例えば、作成直後のDeploymentを考えます。  
   Deploymentの詳細情報を確認します。
   ```shell
   kubectl get deploy

--- a/content/ja/docs/tasks/run-application/run-stateless-application-deployment.md
+++ b/content/ja/docs/tasks/run-application/run-stateless-application-deployment.md
@@ -32,7 +32,7 @@ weight: 10
 
 ## nginx deploymentの作成と探検
 
-Kubernetes Deploymentオブジェクトを作成することでアプリケーションを実行できます。また、YAMLファイルでDeploymentを記述できます。例えば、このYAMLファイルはnginx:1.7.9 Dockerイメージを実行するデプロイメントを記述しています:
+Kubernetes Deploymentオブジェクトを作成することでアプリケーションを実行できます。また、YAMLファイルでDeploymentを記述できます。例えば、このYAMLファイルはnginx:1.14.2 Dockerイメージを実行するデプロイメントを記述しています:
 
 {{< codenew file="application/deployment.yaml" >}}
 
@@ -62,7 +62,7 @@ Kubernetes Deploymentオブジェクトを作成することでアプリケー�
           Labels:       app=nginx
           Containers:
            nginx:
-            Image:              nginx:1.7.9
+            Image:              nginx:1.14.2
             Port:               80/TCP
             Environment:        <none>
             Mounts:             <none>

--- a/content/ja/examples/application/deployment-scale.yaml
+++ b/content/ja/examples/application/deployment-scale.yaml
@@ -14,6 +14,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:1.8
+        image: nginx:1.14.2
         ports:
         - containerPort: 80

--- a/content/ja/examples/application/deployment-update.yaml
+++ b/content/ja/examples/application/deployment-update.yaml
@@ -14,6 +14,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:1.8 # Update the version of nginx from 1.7.9 to 1.8
+        image: nginx:1.16.1 # Update the version of nginx from 1.14.2 to 1.16.1
         ports:
         - containerPort: 80

--- a/content/ja/examples/application/deployment.yaml
+++ b/content/ja/examples/application/deployment.yaml
@@ -14,6 +14,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:1.7.9
+        image: nginx:1.14.2
         ports:
         - containerPort: 80

--- a/content/ja/examples/application/nginx-app.yaml
+++ b/content/ja/examples/application/nginx-app.yaml
@@ -29,6 +29,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:1.7.9
+        image: nginx:1.14.2
         ports:
         - containerPort: 80

--- a/content/ja/examples/application/nginx/nginx-deployment.yaml
+++ b/content/ja/examples/application/nginx/nginx-deployment.yaml
@@ -14,6 +14,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:1.7.9
+        image: nginx:1.14.2
         ports:
         - containerPort: 80

--- a/content/ja/examples/application/simple_deployment.yaml
+++ b/content/ja/examples/application/simple_deployment.yaml
@@ -14,6 +14,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:1.7.9
+        image: nginx:1.14.2
         ports:
         - containerPort: 80

--- a/content/ja/examples/application/update_deployment.yaml
+++ b/content/ja/examples/application/update_deployment.yaml
@@ -13,6 +13,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:1.11.9 # update the image
+        image: nginx:1.16.1 # update the image
         ports:
         - containerPort: 80

--- a/content/ja/examples/controllers/nginx-deployment.yaml
+++ b/content/ja/examples/controllers/nginx-deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:1.15.4
+        image: nginx:1.14.2
         ports:
         - containerPort: 80

--- a/content/ja/examples/pods/simple-pod.yaml
+++ b/content/ja/examples/pods/simple-pod.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx:1.7.9
+    image: nginx:1.14.2
     ports:
     - containerPort: 80


### PR DESCRIPTION
~Example's nginx version and that description's nginx version are different.~

~This PR fixes the example's nginx version.~

Update nginx to modern versions on ja docs.
It also fixes wrong version of nginx.

https://kubernetes.io/ja/docs/concepts/workloads/controllers/deployment/#creating-a-deployment

<details>
<summary>Screenshots</summary>

![image](https://user-images.githubusercontent.com/6136383/76842156-29d13a80-687d-11ea-8787-eaace926bb65.png)


![image](https://user-images.githubusercontent.com/6136383/76842141-26d64a00-687d-11ea-9b16-860dc5dd5624.png)
</details>