### PR TITLE
fix docs home page on mobile renders poorly

### DIFF
--- a/static/css/gridpage.css
+++ b/static/css/gridpage.css
@@ -23,7 +23,6 @@
     min-height: 152px;
 }
 
-
 .gridPage p {
     color: rgb(26,26,26);
     margin-left: 0 !important;
@@ -287,6 +286,15 @@ section.bullets .content {
     .gridPage #video h3 {
         max-width: 100%;
     }
+}
+
+@media screen and (max-width: 768px){
+  .launch-card {
+    width: 100%;
+    margin-bottom: 30px;
+    padding: 0;
+    min-height: auto;
+  }
 }
 
 @media screen and (max-width: 640px){


### PR DESCRIPTION
Before:
![a37d9a6435](https://user-images.githubusercontent.com/26163841/76800688-dc04f580-67dc-11ea-94e6-6dffd95fdd48.jpg)
After:
![1](https://user-images.githubusercontent.com/26163841/76843386-62a0ed80-6844-11ea-9d91-66157c8358a4.jpg)


#19671