### PR TITLE
Revise setup page to follow content guidelines

### DIFF
--- a/content/en/docs/setup/_index.md
+++ b/content/en/docs/setup/_index.md
@@ -44,8 +44,6 @@ If you're learning Kubernetes, use the Docker-based solutions: tools supported b
 | [kind (Kubernetes IN Docker)](/docs/setup/learning-environment/kind/) | [Docker Desktop](https://www.docker.com/products/docker-desktop)|
 |                     | [Minishift](https://docs.okd.io/latest/minishift/)|
 |                     | [MicroK8s](https://microk8s.io/)|
-|                     | [IBM Cloud Private-CE (Community Edition)](https://github.com/IBM/deploy-ibm-cloud-private) |
-|                     | [IBM Cloud Private-CE (Community Edition) on Linux Containers](https://github.com/HSBawa/icp-ce-on-linux-containers)|
 
 
 ## Production environment

--- a/content/en/docs/setup/_index.md
+++ b/content/en/docs/setup/_index.md
@@ -46,7 +46,6 @@ If you're learning Kubernetes, use the Docker-based solutions: tools supported b
 |                     | [MicroK8s](https://microk8s.io/)|
 |                     | [IBM Cloud Private-CE (Community Edition)](https://github.com/IBM/deploy-ibm-cloud-private) |
 |                     | [IBM Cloud Private-CE (Community Edition) on Linux Containers](https://github.com/HSBawa/icp-ce-on-linux-containers)|
-|                     | [k3s](https://k3s.io)|
 
 
 ## Production environment

--- a/content/en/docs/setup/_index.md
+++ b/content/en/docs/setup/_index.md
@@ -53,6 +53,6 @@ If you're learning Kubernetes, use the Docker-based solutions: tools supported b
 
 When evaluating a solution for a production environment, consider which aspects of operating a Kubernetes cluster (or _abstractions_) you want to manage yourself or offload to a provider.
 
-For a list of [Certified Kubernetes](https://github.com/cncf/k8s-conformance/#certified-kubernetes) providers, see "[Partners](https://kubernetes.io/partners/#conformance)". 
+[Kubernetes Partners](https://kubernetes.io/partners/#conformance) includes a list of [Certified Kubernetes](https://github.com/cncf/k8s-conformance/#certified-kubernetes) providers.
 
 {{% /capture %}}

--- a/content/en/docs/setup/_index.md
+++ b/content/en/docs/setup/_index.md
@@ -40,9 +40,8 @@ If you're learning Kubernetes, use the Docker-based solutions: tools supported b
 
 |Community           |Ecosystem     |
 | ------------       | --------     |
-| [Minikube](/docs/setup/learning-environment/minikube/) | [CDK on LXD](https://www.ubuntu.com/kubernetes/docs/install-local) |
-| [kind (Kubernetes IN Docker)](/docs/setup/learning-environment/kind/) | [Docker Desktop](https://www.docker.com/products/docker-desktop)|
-|                     | [Minishift](https://docs.okd.io/latest/minishift/)|
+| [Minikube](/docs/setup/learning-environment/minikube/) | [Docker Desktop](https://www.docker.com/products/docker-desktop)|
+| [kind (Kubernetes IN Docker)](/docs/setup/learning-environment/kind/) | [Minishift](https://docs.okd.io/latest/minishift/)|
 |                     | [MicroK8s](https://microk8s.io/)|
 
 


### PR DESCRIPTION
Following KEP [doc-policies-for-third-party-content](https://github.com/kubernetes/enhancements/blob/master/keps/sig-docs/20191020-doc-policies-for-third-party-content.md) and https://kubernetes.io/docs/contribute/style/content-guide/, revise https://kubernetes.io/docs/setup/ to remove 3rd party learning environments that don't fit in with those guidelines.

It's OK to /hold this change if it needs notice to affected parties etc.
/kind cleanup

Follows on from PR #19486