### PR TITLE
Fix typo in kube-scheduler.md

### DIFF
--- a/content/en/docs/reference/glossary/kube-scheduler.md
+++ b/content/en/docs/reference/glossary/kube-scheduler.md
@@ -11,7 +11,7 @@ tags:
 - architecture
 ---
 Control plane component that watches for newly created
-{{< glossary_tooltip term_id="node" >}} with no assigned
+{{< glossary_tooltip term_id="pod" >}} with no assigned
 {{< glossary_tooltip term_id="node" text="node">}}, and selects a node for them
 to run on.
 


### PR DESCRIPTION
Fixed typo in [kube-scheduler.md](https://github.com/kubernetes/website/blob/master/content/en/docs/reference/glossary/kube-scheduler.md).
I changed `{{< glossary_tooltip term_id="node" >}}` to `{{< glossary_tooltip term_id="pod" >}}`.

> original (before #18092) 
> Control Plane component that watches for newly created pods with no assigned node, and selects a node for them to run on.	

> after (after before #18092)
Control plane component that watches for newly created
{{< glossary_tooltip term_id="node" >}} with no assigned
{{< glossary_tooltip term_id="node" text="node">}}, and selects a node for them
to run on.

