### PR TITLE
Fix ordering of entries in i18n/en.toml

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -58,6 +58,9 @@ other = "Was this page helpful?"
 [feedback_yes]
 other = "Yes"
 
+[input_placeholder_email_address]
+other = "email address"
+
 [latest_version]
 other = "latest version."
 
@@ -189,6 +192,3 @@ other = "Warning:"
 
 [whatsnext_heading]
 other = "What's next"
-
-[input_placeholder_email_address]
-other = "email address"


### PR DESCRIPTION
Put entries in alphabetical order in `i18n/en.toml`

(Fixup for PR #19359)

/kind cleanup
/language en