### PR TITLE
Revert "Add instructions for switching to iptables-legacy"

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -68,38 +68,6 @@ Make sure that the `br_netfilter` module is loaded before this step. This can be
 For more details please see the [Network Plugin Requirements](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/#network-plugin-requirements) page.
 
 
-## Ensure iptables tooling does not use the nftables backend
-
-In Linux, nftables is available as a modern replacement for the kernel's iptables subsystem. The
-`iptables` tooling can act as a compatibility layer, behaving like iptables but actually configuring
-nftables. This nftables backend is not compatible with the current kubeadm packages: it causes duplicated
-firewall rules and breaks `kube-proxy`.
-
-If your system's `iptables` tooling uses the nftables backend, you will need to switch the `iptables`
-tooling to 'legacy' mode to avoid these problems. This is the case on at least Debian 10 (Buster),
-Ubuntu 19.04, Fedora 29 and newer releases of these distributions by default. RHEL 8 does not support
-switching to legacy mode, and is therefore incompatible with current kubeadm packages.
-
-{{< tabs name="iptables_legacy" >}}
-{{% tab name="Debian or Ubuntu" %}}
-```bash
-# ensure legacy binaries are installed
-sudo apt-get install -y iptables arptables ebtables
-
-# switch to legacy versions
-sudo update-alternatives --set iptables /usr/sbin/iptables-legacy
-sudo update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
-sudo update-alternatives --set arptables /usr/sbin/arptables-legacy
-sudo update-alternatives --set ebtables /usr/sbin/ebtables-legacy
-```
-{{% /tab %}}
-{{% tab name="Fedora" %}}
-```bash
-update-alternatives --set iptables /usr/sbin/iptables-legacy
-```
-{{% /tab %}}
-{{< /tabs >}}
-
 ## Check required ports
 
 ### Control-plane node(s)


### PR DESCRIPTION
As of kube 1.17, kubeadm supports systems using iptables in nft mode, but we forgot to remove the warnings claiming that it doesn't.

This patch removes the sentence "RHEL 8 does not support switching to legacy mode, and is therefore incompatible with current kubeadm packages.". However, nothing in the doc had claimed that RHEL 8 *was* supported before this, so I don't know if there are other issues, so I didn't add it to the list of supported platforms at the top.

This should be backported to the 1.17 docs. I'm not sure if that requires more than just "`/cherry-pick release-1.17`"? Note that this doesn't require any sort of belated release notes update, because it was already in the 1.17 release notes ("The official kube-proxy image (used by kubeadm, among other things) is now compatible with systems running iptables 1.8 in “nft” mode, and will autodetect which mode it should use.")

/cc @praseodym 
