### PR TITLE
add note, regarding example requirement for nfs helper /sbin/mount.nfs

### DIFF
--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -312,6 +312,10 @@ spec:
     server: 172.17.0.2
 ```
 
+{{< note >}}
+Helper programs relating to the volume type may be required for consumption of a PersistentVolume within a cluster.  In this example, the PersistentVolume is of type NFS and the helper program /sbin/mount.nfs is required to support the mounting of NFS filesystems.
+{{< /note >}}
+
 ### Capacity
 
 Generally, a PV will have a specific storage capacity.  This is set using the PV's `capacity` attribute.  See the Kubernetes [Resource Model](https://git.k8s.io/community/contributors/design-proposals/scheduling/resources.md) to understand the units expected by `capacity`.


### PR DESCRIPTION
Hi All,

Whilst following the examples set out on this page, I encountered an issue on my cluster where I was missing a required component, to make use of the NFS PersistentVolume, as per the 'myclaim' example.

To summarise -

1.  I created an NFS server and shared a volume (using the standard ubuntu nfs server)
2.  I created the PersistentVolume using the example here - https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistent-volumes
3.  I created a PersistentVolumeClaim relating to the volume in step 2 using the example here -https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
4.  I created a Pod, making use of the PVC in step 3 using the example here - https://kubernetes.io/docs/concepts/storage/persistent-volumes/#claims-as-volumes

My pod failed, with the following -

```
  Warning  FailedMount  13s        kubelet, k8s-worker-1  MountVolume.SetUp failed for volume "pv0001" : mount failed: exit status 32
Mounting command: systemd-run
Mounting arguments: --description=Kubernetes transient mount for /var/lib/kubelet/pods/319701a1-0a16-443a-938e-9dd6551a2fbc/volumes/kubernetes.io~nfs/pv0001 --scope -- mount -t nfs -o hard,nfsvers=4.1 192.168.0.250:/local/nfs-server/nfs_export_0 /var/lib/kubelet/pods/319701a1-0a16-443a-938e-9dd6551a2fbc/volumes/kubernetes.io~nfs/pv0001
Output: Running scope as unit: run-ra0159646da3e47b4a7eaf7e1df3cb651.scope
mount: /var/lib/kubelet/pods/319701a1-0a16-443a-938e-9dd6551a2fbc/volumes/kubernetes.io~nfs/pv0001: bad option; for several filesystems (e.g. nfs, cifs) you might need a /sbin/mount.<type> helper program.
```

This was resolved with the installation of nfs-common (ubuntu) on the kubelets, for reference, the centos/rhel equivalent seems to be nfs-utils.

Given that I encountered this issue, I thought that it would be useful to include a Note, underneath the PersistentVolume step so that others were aware that they may need to look at the support requirements for their volume choice.

In my efforts to do so, I've tried to keep the Note generic so that it is relevant to any type of volume.  With respect to the example I have also given a pointer to the specific helper binary that needs to be available (rather than getting into OS package variants like Ubuntu/CentOS in which the supporting package name may vary).

For quick reference, the note is as follows -

```
Helper programs relating to the volume type may be required for consumption of a PersistentVolume within a cluster.  In this example, the PersistentVolume is of type NFS and the helper program /sbin/mount.nfs is required to support the mounting of NFS filesystems.
```

For convenience, direct link to the change from the Deploy Preview - https://deploy-preview-19774--kubernetes-io-master-staging.netlify.com/docs/concepts/storage/persistent-volumes/#persistent-volumes

Hope this helps.

Thanks


James