### PR TITLE
Remove as reviewer/approver for it docs

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -126,12 +126,10 @@ aliases:
     - fabriziopandini
     - mattiaperi
     - micheleberardi
-    - rlenferink
   sig-docs-it-reviews: # PR reviews for Italian content
     - fabriziopandini
     - mattiaperi
     - micheleberardi
-    - rlenferink
   sig-docs-ja-owners: # Admins for Japanese content
     - cstoku
     - inductor


### PR DESCRIPTION
During bootstrapping of the Italian localization I helped out as reviewer/approver. Italian localization now has 3 approvers already. I wish to be removed (as non-italian).

/cc @sftim 
/assign @sftim 