### PR TITLE
open dual stack feature gate for apiserver is needed

### DIFF
--- a/content/en/docs/concepts/services-networking/dual-stack.md
+++ b/content/en/docs/concepts/services-networking/dual-stack.md
@@ -46,6 +46,8 @@ The following prerequisites are needed in order to utilize IPv4/IPv6 dual-stack 
 
 To enable IPv4/IPv6 dual-stack, enable the `IPv6DualStack` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) for the relevant components of your cluster, and set dual-stack cluster network assignments:
 
+   * kube-apiserver:
+      * `--feature-gates="IPv6DualStack=true"`
    * kube-controller-manager:
       * `--feature-gates="IPv6DualStack=true"`
       * `--cluster-cidr=<IPv4 CIDR>,<IPv6 CIDR>` eg. `--cluster-cidr=10.244.0.0/16,fc00::/24`
@@ -54,7 +56,7 @@ To enable IPv4/IPv6 dual-stack, enable the `IPv6DualStack` [feature gate](/docs/
    * kubelet:
       * `--feature-gates="IPv6DualStack=true"`
    * kube-proxy:
-      * `--proxy-mode=ipvs`
+      * `--proxy-mode=ipvs` or `--proxy-mode=iptables` (since 1.18)
       * `--cluster-cidr=<IPv4 CIDR>,<IPv6 CIDR>`
       * `--feature-gates="IPv6DualStack=true"`
 


### PR DESCRIPTION
according to https://github.com/kubernetes/website/pull/19682#issuecomment-602279846, I open this pr.

- apiserver should open dual stack feature gate
- iptables with dual stack is supported since kubernernetes 1.18