### PR TITLE
Fix dead link of api-conventions doc (ja)

### DIFF
--- a/content/ja/docs/concepts/overview/kubernetes-api.md
+++ b/content/ja/docs/concepts/overview/kubernetes-api.md
@@ -10,7 +10,7 @@ card:
 
 {{% capture overview %}}
 
-全般的なAPIの規則は、[API規則ドキュメント](https://git.k8s.io/community/contributors/devel/api-conventions.md)に記載されています。
+全般的なAPIの規則は、[API規則ドキュメント](https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md)に記載されています。
 
 APIエンドポイント、リソースタイプ、そしてサンプルは[APIリファレンス](/docs/reference)に記載されています。
 

--- a/content/ja/docs/concepts/workloads/controllers/replicaset.md
+++ b/content/ja/docs/concepts/workloads/controllers/replicaset.md
@@ -192,7 +192,7 @@ pod2             1/1     Running   0          13s
 ReplicaSetでは、`kind`フィールドの値は`ReplicaSet`です。
 Kubernetes1.9において、ReplicaSetは`apps/v1`というAPIバージョンが現在のバージョンで、デフォルトで有効です。`apps/v1beta2`というAPIバージョンは廃止されています。先ほど作成した`frontend.yaml`ファイルの最初の行を参考にしてください。
 
-また、ReplicaSetは[`.spec` セクション](https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status)も必須です。
+また、ReplicaSetは[`.spec` セクション](https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status)も必須です。
 
 ### Pod テンプレート
 


### PR DESCRIPTION
I replaced all https://git.k8s.io/community/contributors/devel/api-conventions.md in **content/ja/docs** 
 with https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md.
