### PR TITLE
add FR holder for equivalent to PR19774 that was recently merged, tra…

### DIFF
--- a/content/fr/docs/concepts/storage/persistent-volumes.md
+++ b/content/fr/docs/concepts/storage/persistent-volumes.md
@@ -335,7 +335,8 @@ spec:
 ```
 
 {{< note >}}
-Des logiciel additionnels supportant un type de montage de volume pourraient être nécessaires afin d'utiliser un PersistentVolume depuis un cluster. Dans l'exemple d'un PersistentVolume de type NFS, le logiciel additionnel `/sbin/mount.nfs` est requis pour permettre de monter des systèmes de fichiers de type NFS.
+Des logiciels additionnels supportant un type de montage de volume pourraient être nécessaires afin d'utiliser un PersistentVolume depuis un cluster.
+Dans l'exemple d'un PersistentVolume de type NFS, le logiciel additionnel `/sbin/mount.nfs` est requis pour permettre de monter des systèmes de fichiers de type NFS.
 {{< /note >}}
 
 ### Capacité

--- a/content/fr/docs/concepts/storage/persistent-volumes.md
+++ b/content/fr/docs/concepts/storage/persistent-volumes.md
@@ -334,6 +334,10 @@ spec:
     server: 172.17.0.2
 ```
 
+{{< note >}}
+Des logiciel additionnels supportant un type de montage de volume pourraient être nécessaires afin d'utiliser un PersistentVolume depuis un cluster. Dans l'exemple d'un PersistentVolume de type NFS, le logiciel additionnel `/sbin/mount.nfs` est requis pour permettre de monter des systèmes de fichiers de type NFS.
+{{< /note >}}
+
 ### Capacité
 
 Généralement, un PV aura une capacité de stockage spécifique.


### PR DESCRIPTION
Hi All,

I recently made the equivalent change on the English equivalent to this page, it was merged under pull request - https://github.com/kubernetes/website/pull/19774

In the spirit of consistency, I can see that there is an equivalent locale version for French.  Unfortunately, French is not a language I know and I don't think an online translation service will do this the justice it deserves, so for now, I have put the equivalent holder in place.

Could someone please provide an appropriate translation in the comments and I will update accordingly for further review.

For convenience, the text that needs translation is -

"Helper programs relating to the volume type may be required for consumption of a PersistentVolume within a cluster.  In this example, the PersistentVolume is of type NFS and the helper program /sbin/mount.nfs is required to support the mounting of NFS filesystems."

Many Thanks


James