### PR TITLE
add ID holder for equivalent to PR19774 that was recently merged, tra…

### DIFF
--- a/content/id/docs/concepts/storage/persistent-volumes.md
+++ b/content/id/docs/concepts/storage/persistent-volumes.md
@@ -296,6 +296,10 @@ spec:
     server: 172.17.0.2
 ```
 
+{{< note >}}
+Helper programs relating to the volume type may be required for consumption of a PersistentVolume within a cluster.  In this example, the PersistentVolume is of type NFS and the helper program /sbin/mount.nfs is required to support the mounting of NFS filesystems.
+{{< /note >}}
+
 ### Kapasitas
 
 Secara umum, sebuah PV akan memiliki kapasitas _storage_ tertentu.  Hal ini ditentukan menggunakan atribut `capacity` pada PV.  Lihat [Model Sumber Daya](https://git.k8s.io/community/contributors/design-proposals/scheduling/resources.md) Kubernetes untuk memahami satuan yang diharapkan pada atribut `capacity`.

--- a/content/id/docs/concepts/storage/persistent-volumes.md
+++ b/content/id/docs/concepts/storage/persistent-volumes.md
@@ -297,7 +297,7 @@ spec:
 ```
 
 {{< note >}}
-Helper programs relating to the volume type may be required for consumption of a PersistentVolume within a cluster.  In this example, the PersistentVolume is of type NFS and the helper program /sbin/mount.nfs is required to support the mounting of NFS filesystems.
+Program pembantu yang berkaitan dengan tipe volume bisa saja diperlukan untuk mengonsumsi sebuah PersistentVolume di dalam klaster. Contoh ini menggunakan PersistentVolume dengan tipe NFS dan program pembantu /sbin/mount.nfs diperlukan untuk mendukung proses mounting sistem berkas (filesystem) NFS.
 {{< /note >}}
 
 ### Kapasitas


### PR DESCRIPTION
Hi All,

I recently made the equivalent change on the English equivalent to this page, it was merged under pull request - https://github.com/kubernetes/website/pull/19774

In the spirit of consistency, I can see that there is an equivalent locale version for Indonesia.  Unfortunately, Indonesian is not a language I know and I don't think an online translation service will do this the justice it deserves, so for now, I have put the equivalent holder in place.

Could someone please provide an appropriate translation in the comments and I will update accordingly for further review.

For convenience, the text that needs translation is -

"Helper programs relating to the volume type may be required for consumption of a PersistentVolume within a cluster.  In this example, the PersistentVolume is of type NFS and the helper program /sbin/mount.nfs is required to support the mounting of NFS filesystems."

Many Thanks


James