### PR TITLE
Update configure-persistent-volume-storage.md

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
@@ -51,7 +51,7 @@ In your shell on that Node, create a `/mnt/data` directory:
 sudo mkdir /mnt/data
 ```
 
-If you are using minikube, you can do this with a line:
+If you are using Minikube, you can do this with a line:
 
 ```shell
 # This also assumes that your Node uses "sudo" to run commands

--- a/content/en/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
@@ -51,6 +51,13 @@ In your shell on that Node, create a `/mnt/data` directory:
 sudo mkdir /mnt/data
 ```
 
+If you are using minikube, you can do this with a line:
+
+```shell
+# This also assumes that your Node uses "sudo" to run commands
+# as the superuser
+minikube ssh sudo mkdir /mnt/data
+```
 
 In the `/mnt/data` directory, create an `index.html` file:
 


### PR DESCRIPTION

This PR add a tip for users that are using minikube to [Configure a Pod to Use a PersistentVolume for Storage
](https://kubernetes.io/docs/tasks/configure-pod-container/configure-persistent-volume-storage/#create-an-index-html-file-on-your-node)