### PR TITLE
Dead link replacement

### DIFF
--- a/content/en/docs/concepts/cluster-administration/addons.md
+++ b/content/en/docs/concepts/cluster-administration/addons.md
@@ -46,7 +46,7 @@ Add-ons in each section are sorted alphabetically - the ordering does not imply 
 
 ## Infrastructure
 
-* [KubeVirt](https://kubevirt.io/user-guide/docs/latest/administration/intro.html#cluster-side-add-on-deployment) is an add-on to run virtual machines on Kubernetes. Usually run on bare-metal clusters.
+* [KubeVirt](https://kubevirt.io/user-guide/#/installation/installation) is an add-on to run virtual machines on Kubernetes. Usually run on bare-metal clusters.
 
 ## Legacy Add-ons
 


### PR DESCRIPTION
This link generates a 404:
https://kubevirt.io/user-guide/docs/latest/administration/intro.html#cluster-side-add-on-deployment

I suggest moving to think link.
https://kubevirt.io/user-guide/#/installation/installation

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use
 for advice.

-->
