### PR TITLE
Update nodelocaldns feature status.

### DIFF
--- a/content/en/docs/tasks/administer-cluster/nodelocaldns.md
+++ b/content/en/docs/tasks/administer-cluster/nodelocaldns.md
@@ -8,7 +8,7 @@ content_template: templates/task
 ---
  
 {{% capture overview %}}
-{{< feature-state for_k8s_version="v1.15" state="beta" >}}
+{{< feature-state for_k8s_version="v1.18" state="stable" >}}
 This page provides an overview of NodeLocal DNSCache feature in Kubernetes.
 {{% /capture %}}
 


### PR DESCRIPTION
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use
 for advice.

-->
NodeLocal DnsCache is graduating to stable, in k8s 1.18. this PR updates docs to reflect this.