### PR TITLE
Fix example in certificate-signing-requests.md

### DIFF
--- a/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
+++ b/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
@@ -184,7 +184,7 @@ rules:
   - certificates.k8s.io
   resources:
   - signers
-  resourceName:
+  resourceNames:
   - example.com/my-signer-name # example.com/* can be used to authorize for all signers in the 'example.com' domain
   verbs:
   - approve


### PR DESCRIPTION
The example ClusterRole rule mentions 'resourceName' property, which do not exist.
It should be 'resourceNames'.
