### PR TITLE
Fix kubectl alpha debug invocation

### DIFF
--- a/content/en/blog/_posts/2020-03-25-kubernetes-1.18-release-announcement.md
+++ b/content/en/blog/_posts/2020-03-25-kubernetes-1.18-release-announcement.md
@@ -30,9 +30,9 @@ In Kubernetes 1.18, there are two significant additions to Ingress: A new `pathT
 
 The `IngressClass` resource is used to describe a type of Ingress within a Kubernetes cluster. Ingresses can specify the class they are associated with by using a new `ingressClassName` field on Ingresses. This new resource and field replace the deprecated `kubernetes.io/ingress.class` annotation.
 
-### SIG-CLI introduces kubectl debug
+### SIG-CLI introduces kubectl alpha debug
 
-SIG-CLI was debating the need for a debug utility for quite some time already. With the development of [ephemeral containers](https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/), it became more obvious how we can support developers with tooling built on top of `kubectl exec`. The addition of the [`kubectl debug` command](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cli/20190805-kubectl-debug.md) (it is alpha but your feedback is more than welcome), allows developers to easily debug their Pods inside the cluster. We think this addition is invaluable.  This command allows one to create a temporary container which runs next to the Pod one is trying to examine, but also attaches to the console for interactive troubleshooting.
+SIG-CLI was debating the need for a debug utility for quite some time already. With the development of [ephemeral containers](https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/), it became more obvious how we can support developers with tooling built on top of `kubectl exec`. The addition of the [`kubectl alpha debug` command](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cli/20190805-kubectl-debug.md) (it is alpha but your feedback is more than welcome), allows developers to easily debug their Pods inside the cluster. We think this addition is invaluable.  This command allows one to create a temporary container which runs next to the Pod one is trying to examine, but also attaches to the console for interactive troubleshooting.
 
 
 ### Introducing Windows CSI support alpha for Kubernetes


### PR DESCRIPTION
https://kubernetes.io/blog/2020/03/25/kubernetes-1-18-release-announcement/ uses `kubectl debug` which is causing confusion, because the command itself as alpha lives under `kubectl alpha debug` this PR fixes the invocations not to confuse readers. 