### PR TITLE
Add missing quote in Training index page

### DIFF
--- a/content/en/training/_index.html
+++ b/content/en/training/_index.html
@@ -88,7 +88,7 @@ class: training
         </h5>
         <p>The Certified Kubernetes Administrator (CKA) program provides assurance that CKAs have the skills, knowledge, and competency to perform the responsibilities of Kubernetes administrators.</p>
         <br>
-        <a href=https://training.linuxfoundation.org/certification/certified-kubernetes-administrator-cka/" target="_blank" class="button">Go to Certification</a>
+        <a href="https://training.linuxfoundation.org/certification/certified-kubernetes-administrator-cka/" target="_blank" class="button">Go to Certification</a>
       </center>
     </div>
   </div>


### PR DESCRIPTION
Add missing quote in the Training index page url link.