### PR TITLE
Kubecon Amsterdam now scheduled for Aug 13-16

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -45,7 +45,7 @@ Kubernetes is open source giving you the freedom to take advantage of on-premise
         <br>
         <br>
         <br>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/?utm_source=kubernetes.io&utm_medium=nav&utm_campaign=kccnceu20" button id="desktopKCButton">Attend KubeCon in Amsterdam in July/August TBD</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/?utm_source=kubernetes.io&utm_medium=nav&utm_campaign=kccnceu20" button id="desktopKCButton">Attend KubeCon in Amsterdam on August 13-16, 2020</a>
         <br>
         <br>
         <br>


### PR DESCRIPTION
This PR updates KubeCon dates for Amsterdam on the website landing page.

Preview link: https://deploy-preview-19869--kubernetes-io-master-staging.netlify.com/