### PR TITLE
remove repeat space in yamls

### DIFF
--- a/content/en/examples/admin/resource/quota-mem-cpu-pod-2.yaml
+++ b/content/en/examples/admin/resource/quota-mem-cpu-pod-2.yaml
@@ -9,8 +9,7 @@ spec:
     resources:
       limits:
         memory: "1Gi"
-        cpu: "800m"      
+        cpu: "800m"
       requests:
         memory: "700Mi"
         cpu: "400m"
-      

--- a/content/en/examples/admin/resource/quota-mem-cpu-pod.yaml
+++ b/content/en/examples/admin/resource/quota-mem-cpu-pod.yaml
@@ -9,8 +9,7 @@ spec:
     resources:
       limits:
         memory: "800Mi"
-        cpu: "800m" 
+        cpu: "800m"
       requests:
         memory: "600Mi"
         cpu: "400m"
-      


### PR DESCRIPTION
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use
 for advice.

-->
see  https://github.com/kubernetes/website/pull/19882/files#diff-19ab59a3d52a81dcc002f84e31511907R12

when I try to sync en/ to zh/ by scripts , I find that  . I guess that we can remove this repeat space. 