### PR TITLE
WIP: Ensure that the load test uses current namespace

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -119,8 +119,12 @@ kubectl run --generator=run-pod/v1 -it --rm load-generator --image=busybox /bin/
 
 Hit enter for command prompt
 
-while true; do wget -q -O- http://php-apache.default.svc.cluster.local; done
+while true; do wget -q -O- http://php-apache.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; done
 ```
+
+{{< note >}}
+The file `/var/run/secrets/kubernetes.io/serviceaccount/namespace` on the running container is used to capture the name of the active namespace relating to the php-apache service.  The file is automatically placed into the container during deployment.  Further information available here - [Accessing the API from a Pod](/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod).
+{{< /note >}}
 
 Within a minute or so, we should see the higher CPU load by executing:
 


### PR DESCRIPTION
Hi All,

Recently I created a pull request to enhance another area of the documentation under https://github.com/kubernetes/website/pull/19603

This request is similar and part of it follows the same principle, making the example, namespace agnostic.

Whilst going through the horizontal pod autoscale walkthrough, and in particular, this section https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#increase-load

It failed for me when generating the load as it is assumed that the namespace, the example is being run from is 'default'.

This change, will allow the example in this walkthrough to work for any namespace that the walkthrough is run within.  Rather than assuming 'default', the namespace is looked up from the running pod  -

Before -

```
while true; do wget -q -O- http://php-apache.default.svc.cluster.local; done
```

After -

```
while true; do wget -q -O- http://php-apache.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; done
```

Link to the documentation change for convenience: https://deploy-preview-19901--kubernetes-io-master-staging.netlify.com/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#increase-load

I hope this helps.  Should it be accepted, I will follow up accordingly with corresponding pull requests for the ZH and KO locales.

Many Thanks


James