### PR TITLE
add a yaml exmaple for type nodeport

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -545,12 +545,12 @@ spec:
   selector:
     app: MyApp
   ports:
+      # By default and for convenience, the `targetPort` is set to the same value as the `port` field.
     - port: 80
       targetPort: 80
-      # By default and for convenience, the `targetPort` is set to the same value as the `port` field.
-      nodePort: 30007
       # Optional field
       # By default and for convenience, the Kubernetes control plane will allocate a port from a range (default: 30000-32767)
+      nodePort: 30007
 ```
 
 ### Type LoadBalancer {#loadbalancer}

--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -534,6 +534,25 @@ to just expose one or more nodes' IPs directly.
 Note that this Service is visible as `<NodeIP>:spec.ports[*].nodePort`
 and `.spec.clusterIP:spec.ports[*].port`. (If the `--nodeport-addresses` flag in kube-proxy is set, <NodeIP> would be filtered NodeIP(s).)
 
+For example:
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+spec:
+  type: NodePort
+  selector:
+    app: MyApp
+  ports:
+    - port: 80
+      # By default and for convenience, the targetPort is set to the same value as the port field.
+      targetPort: 80
+      # `targetPort` is the port of pod, you would like to expose
+      NodePort: 30007
+      # `NodePort` is the port of node, you would like to expose
+```
+
 ### Type LoadBalancer {#loadbalancer}
 
 On cloud providers which support external load balancers, setting the `type`

--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -546,11 +546,11 @@ spec:
     app: MyApp
   ports:
     - port: 80
-      # By default and for convenience, the targetPort is set to the same value as the port field.
       targetPort: 80
-      # `targetPort` is the port of pod, you would like to expose
-      NodePort: 30007
-      # `NodePort` is the port of node, you would like to expose
+      # By default and for convenience, the `targetPort` is set to the same value as the `port` field.
+      nodePort: 30007
+      # Optional field
+      # By default and for convenience, the Kubernetes control plane will allocates a port from a range (default: 30000-32767)
 ```
 
 ### Type LoadBalancer {#loadbalancer}

--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -550,7 +550,7 @@ spec:
       # By default and for convenience, the `targetPort` is set to the same value as the `port` field.
       nodePort: 30007
       # Optional field
-      # By default and for convenience, the Kubernetes control plane will allocates a port from a range (default: 30000-32767)
+      # By default and for convenience, the Kubernetes control plane will allocate a port from a range (default: 30000-32767)
 ```
 
 ### Type LoadBalancer {#loadbalancer}


### PR DESCRIPTION
Hi.

As I current study k8s, I find that the service page does not offer the example for `NodePort`. So I would like to add back an example for the new joiner.

Best,
Alpha