### PR TITLE
Fix for Code-Style

### DIFF
--- a/content/en/docs/concepts/storage/volume-snapshots.md
+++ b/content/en/docs/concepts/storage/volume-snapshots.md
@@ -61,9 +61,9 @@ In the case of pre-provisioned binding, the VolumeSnapshot will remain unbound u
 
 ### Persistent Volume Claim as Snapshot Source Protection
 
-The purpose of this protection is to ensure that in-use PersistentVolumeClaim API objects are not removed from the system while a snapshot is being taken from it (as this may result in data loss).
+The purpose of this protection is to ensure that in-use `PersistentVolumeClaim` API objects are not removed from the system while a snapshot is being taken from it (as this may result in data loss).
 
-While a snapshot is being taken of a PersistentVolumeClaim, that PersistentVolumeClaim is in-use. If you delete a PersistentVolumeClaim API object in active use as a snapshot source, the PersistentVolumeClaim object is not removed immediately. Instead, removal of the PersistentVolumeClaim object is postponed until the snapshot is readyToUse or aborted.
+While a snapshot is being taken of a `PersistentVolumeClaim`, that `PersistentVolumeClaim` is in-use. If you delete a `PersistentVolumeClaim` API object in active use as a snapshot source, the `PersistentVolumeClaim` object is not removed immediately. Instead, removal of the `PersistentVolumeClaim` object is postponed until the snapshot is readyToUse or aborted.
 
 ### Delete
 


### PR DESCRIPTION
Fixed code-style for the object "PersistentVolumeClaim"

Before Fix - The purpose of this protection is to ensure that in-use PersistentVolumeClaim API objects are not removed from the system while a snapshot is being taken from it (as this may result in data loss).
After Fix - The purpose of this protection is to ensure that in-use `PersistentVolumeClaim` API objects are not removed from the system while a snapshot is being taken from it (as this may result in data loss).

Fix - Code Style is applied on the PersistentVolumeClaim object as per Documentation standards.