### PR TITLE
Ingress Path Types: Fix typo

### DIFF
--- a/content/en/docs/concepts/services-networking/ingress.md
+++ b/content/en/docs/concepts/services-networking/ingress.md
@@ -124,7 +124,7 @@ Each path in an Ingress has a corresponding path type. There are three supported
 path types:
 
 * _`ImplementationSpecific`_ (default): With this path type, matching is up to
-  the IngressClass. Implementations can treat this as a separate `pathType or
+  the IngressClass. Implementations can treat this as a separate `pathType` or
   treat it identically to `Prefix` or `Exact` path types.
 
 * _`Exact`_: Matches the URL path exactly and with case sensitivity.


### PR DESCRIPTION
This patch adds a closing backtick to "pathType" so the whole sentence won't render as code.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use
 for advice.

-->
