### PR TITLE
Remove feature gate VolumeSubpathEnvExpansion

### DIFF
--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -1193,7 +1193,6 @@ spec:
 
 
 Use the `subPathExpr` field to construct `subPath` directory names from Downward API environment variables.
-This feature requires the `VolumeSubpathEnvExpansion` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) to be enabled. It is enabled by default starting with Kubernetes 1.15.
 The `subPath` and `subPathExpr` properties are mutually exclusive.
 
 In this example, a Pod uses `subPathExpr` to create a directory `pod1` within the hostPath volume `/var/log/pods`, using the pod name from the Downward API.  The host directory `/var/log/pods/pod1` is mounted at `/logs` in the container.


### PR DESCRIPTION
The feature gate is removed in 1.19, so documentation here is to reflect that
Related to https://github.com/kubernetes/kubernetes/pull/89584