### PR TITLE
Add update exclusion to kubernetes.repo

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -199,6 +199,7 @@ enabled=1
 gpgcheck=1
 repo_gpgcheck=1
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+exclude=kubelet kubeadm kubectl
 EOF
 
 # Set SELinux in permissive mode (effectively disabling it)


### PR DESCRIPTION
Add an update exclusion for `kubelet`, `kubeadm`, and `kubectl` in the CentOS to mirror the Ubuntu, Debian, or HypriotOS instructions.