### PR TITLE
Swap must be disabled before initializing control-plane

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
@@ -105,6 +105,12 @@ must specify an IPv6 address, for example `--apiserver-advertise-address=fd00::1
 1. (Optional) Run `kubeadm config images pull` prior to `kubeadm init` to verify
 connectivity to the gcr.io container image registry.
 
+Swap must be disabled before initializing control-plane:
+
+```bash
+swapoff -a
+```
+
 To initialize the control-plane node run:
 
 ```bash


### PR DESCRIPTION
Otherwise we get this error:
```
error execution phase preflight: [preflight] Some fatal errors occurred:
	[ERROR Swap]: running with swap on is not supported. Please disable swap
```
