### PR TITLE
Update adding-windows-nodes.md

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes.md
@@ -114,9 +114,20 @@ Once you have a Linux-based Kubernetes control-plane node you are ready to choos
     curl -L https://github.com/kubernetes-sigs/sig-windows-tools/releases/latest/download/kube-proxy.yml | sed 's/VERSION/{{< param "fullversion" >}}/g' | kubectl apply -f -
     kubectl apply -f https://github.com/kubernetes-sigs/sig-windows-tools/releases/latest/download/flannel-overlay.yml
     ```
-
     {{< note >}}
     If you're using host-gateway use https://github.com/kubernetes-sigs/sig-windows-tools/releases/latest/download/flannel-host-gw.yml instead
+    {{< /note >}}
+
+    {{< note >}}
+    If you're using a different interface rather than Ethernet (i.e. "Ethernet0 2") on the Windows nodes, you have to modify the line
+    ```wins cli process run --path /k/flannel/setup.exe --args "--mode=overlay --interface=Ethernet"```
+    in the flannel-*.yml file and specify your interface accordingly.
+    ```bash
+    # i.e.
+    curl -Lo flannel-overlay.yml https://github.com/kubernetes-sigs/sig-windows-tools/releases/latest/download/flannel-overlay.yml
+    sed -i "s|=Ethernet|Ethernet0 2|g"
+    kubectl apply -f flannel-overlay.yml
+    ```
     {{< /note >}}
 
 ### Joining a Windows worker node

--- a/content/en/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes.md
@@ -122,13 +122,15 @@ Once you have a Linux-based Kubernetes control-plane node you are ready to choos
     If you're using a different interface rather than Ethernet (i.e. "Ethernet0 2") on the Windows nodes, you have to modify the line
     ```wins cli process run --path /k/flannel/setup.exe --args "--mode=overlay --interface=Ethernet"```
     in the flannel-*.yml file and specify your interface accordingly.
+    {{< /note >}}
+    
     ```bash
-    # i.e.
+    # Example
     curl -Lo flannel-overlay.yml https://github.com/kubernetes-sigs/sig-windows-tools/releases/latest/download/flannel-overlay.yml
     sed -i "s|=Ethernet|Ethernet0 2|g"
     kubectl apply -f flannel-overlay.yml
     ```
-    {{< /note >}}
+
 
 ### Joining a Windows worker node
 {{< note >}}

--- a/content/en/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes.md
@@ -119,9 +119,12 @@ Once you have a Linux-based Kubernetes control-plane node you are ready to choos
     {{< /note >}}
 
     {{< note >}}
-    If you're using a different interface rather than Ethernet (i.e. "Ethernet0 2") on the Windows nodes, you have to modify the line
-    ```wins cli process run --path /k/flannel/setup.exe --args "--mode=overlay --interface=Ethernet"```
-    in the flannel-*.yml file and specify your interface accordingly.
+    If you're using a different interface rather than Ethernet (i.e. "Ethernet0 2") on the Windows nodes, you have to modify the line:
+    
+    ```powershell
+    wins cli process run --path /k/flannel/setup.exe --args "--mode=overlay --interface=Ethernet"
+    ```
+    in the flannel-host-gw.yml or flannel-overlay.yml file and specify your interface accordingly.
     {{< /note >}}
     
     ```bash

--- a/content/en/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes.md
@@ -129,9 +129,7 @@ Once you have a Linux-based Kubernetes control-plane node you are ready to choos
     
     ```bash
     # Example
-    curl -Lo flannel-overlay.yml https://github.com/kubernetes-sigs/sig-windows-tools/releases/latest/download/flannel-overlay.yml
-    sed -i "s|=Ethernet|Ethernet0 2|g"
-    kubectl apply -f flannel-overlay.yml
+    curl -L https://github.com/kubernetes-sigs/sig-windows-tools/releases/latest/download/flannel-overlay.yml | sed 's/Ethernet/Ethernet0 2/g' | kubectl apply -f -
     ```
 
 


### PR DESCRIPTION
The steps in the run.ps1 file defined in the flannel-*.yml ConfigMap should address the correct interface in case the Windows node has more than one, otherwise there are problems with connectivity to other pods.

It is related to this: https://github.com/kubernetes/kubeadm/issues/1056#issuecomment-518974508
