### PR TITLE
【zh】update -enable-cadvisor-json-endpoints default value and tag deprecated

### DIFF
--- a/content/zh/docs/reference/command-line-tools-reference/kubelet.md
+++ b/content/zh/docs/reference/command-line-tools-reference/kubelet.md
@@ -658,9 +658,9 @@ kubelet [flags]
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">
       <!--
-      Enable cAdvisor json /spec and /stats/* endpoints. (default true)
+      Enable cAdvisor json /spec and /stats/* endpoints. (default false)
       -->
-      启用 cAdvisor JSON 数据的 /spec 和 /stats/* 端点。（默认值为 true）
+      启用 cAdvisor JSON 数据的 /spec 和 /stats/* 端点。（默认值为 false）（已弃用：未来版本将会移除该参数）
       </td>
     </tr>
 


### PR DESCRIPTION
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use
 for advice.

-->

Ref kubernetes/kubernetes#87440 and #20080

In the latest version (V1.18), the default value of --enable-cadvisor-json-endpoints has been set to false and will be deprecated later version

