### PR TITLE
Add a Korean l10n owner to OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -148,6 +148,7 @@ aliases:
     - gochist
     - ianychoi
     - seokho-son
+    - ysyukr
     - zacharysarah
   sig-docs-ko-reviews: # PR reviews for Korean content
     - ClaudiaJKang


### PR DESCRIPTION
This PR updates OWNERS_ALIASES
to add @ysyukr to sig-docs-ko-owners. (Korean l10n team owner)

@ysyukr is qulified to be an approver according to the following [requirements](https://github.com/kubernetes/community/blob/master/community-membership.md#requirements-2)

Reviewer of the codebase for at least 3 months: [4 Jan, 2020](https://github.com/kubernetes/website/pull/18209)

Primary reviewer for at least 10 substantial PRs to the codebase
[is:pr assignee:ysyukr](https://github.com/kubernetes/website/pulls?utf8=%E2%9C%93&q=is%3Apr+assignee%3Aysyukr)

Reviewed or merged at least 30 PRs to the codebase
[is:pr assignee:ysyukr](https://github.com/kubernetes/website/pulls?utf8=%E2%9C%93&q=is%3Apr+assignee%3Aysyukr)
[is:merged author:ysyukr](https://github.com/kubernetes/website/pulls?utf8=%E2%9C%93&q=is%3Amerged+author%3Aysyukr)

Nominated by a subproject owner
/cc @kubernetes/sig-docs-ko-owners

/assign @zacharysarah @jimangel

Thank you !!