### PR TITLE
Add @sftim as website maintainer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -160,6 +160,7 @@ aliases:
     - jimangel
     - kbarnard10
     - pwittrock
+    - sftim
     - steveperry-53
     - zacharysarah
     - zparnold


### PR DESCRIPTION
Add @sftim (me) as a website maintainer.

I'm a technical lead for SIG Docs; see [`OWNERS_ALIASES@a4a1d2f`](https://github.com/kubernetes/community/blob/a4a1d2f561eac609403f0db7d31d764daaea3b00/OWNERS_ALIASES#L46) in [k/community](https://github.com/kubernetes/community).