### PR TITLE
[WIP] Document migration from integrated to external cloud provider

### DIFF
--- a/content/en/docs/tasks/administer-cluster/migrating-to-cloud-controller-manager.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-to-cloud-controller-manager.md
@@ -38,17 +38,74 @@ If you were previously running the KCM outside the Kubernetes cluster (as a
 systemd service, for example), you need to determine the command line arguments
 by appropriate means. This will not be covered here.
 
+Once you've determined which cloud provide you're using, ensure that an external
+alternative is available. Note that there may be several alternatives, with
+different features. Choose a provider has roughly the same feature set or, even
+better, is based on the former internal provider.
+
+**TODO** Links to external providers here
+
 {{% /capture %}}
 
 {{% capture steps %}}
 
-1. Ensure a CCM for your cloud environment is available, with roughly the same feature set than the integrated KCM provider. Determine compatibility issues (missing features, different implementation, etc).
-2. Prepare your cloud environment and workloads for the migration: Disable unsupported features, build a list of manual actions to be done after migration (deleting unused cloud resources, renaming, etc).
-3. Prepare the CCM for deployment: Write configuration files, deploy credentials, etc. **Do not deploy the CCM yet**
-4. Disable the integrated provider in KCM and kubelet: Remove flags, replace with --provider external, etc. Restart these services.
-5. Deploy the cloud provider.
-6. Ensure it synchronises with the running environment correctly, detects existing resources, deploys new resources where appropriate. Apply manual fixes where necessary.
-7. Test deploy new cloud resources such as LoadBalancers and Nodes.
+## Preparation
+
+### Determine compatibility issues between internal and external cloud provider
+
+* Missing features
+* Different implementation
+* etc.
+
+### Prepare your cloud environment and workloads for the migration
+
+* Disable unsupported features
+* Build a list of manual actions to be done after migration
+  Examples:
+  * Deleting unused cloud resources
+  * Renaming
+  * etc.
+
+### Prepare the CCM for deployment
+
+* Write configuration files
+* Deploy credentials
+* etc.
+
+**Do not deploy the CCM yet**
+
+### Disable the integrated provider
+
+* In KCM and kubelet:
+  * Replace `--cloud-provider <OLD CLOUD PROVIDER>` with `--cloud-provider external`
+  * Remove other `--cloud-` options
+  * Restart KCM and kubelet
+
+### Deploy the cloud provider
+
+Adapt the example deployment for your new external cloud provider:
+
+```yaml
+EXAMPLE DEPLOYMENT HERE
+```
+
+Apply this deployment into your system namespace:
+
+```shell
+kubectl apply -n kube-system -f cloud-provider.yml
+```
+
+### Ensure synchronization with existing environment
+
+Watch the log of the CCM. Check that:
+
+* Existing cloud resources (LoadBalancers and Nodes) are detected
+* New resources are applyied where appropriate
+* Apply manual fixes where necessary
+
+### Test
+
+Create test deployments, such as LoadBalancers and new Nodes.
 
 {{% /capture %}}
 

--- a/content/en/docs/tasks/administer-cluster/migrating-to-cloud-controller-manager.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-to-cloud-controller-manager.md
@@ -61,10 +61,12 @@ better, is based on the former internal provider.
 
 * Disable unsupported features
 * Build a list of manual actions to be done after migration
-  Examples:
-  * Deleting unused cloud resources
-  * Renaming
-  * etc.
+
+Resources to watch for:
+
+* Nodes, in particular labeling
+* LoadBalancers
+
 
 ### Prepare the CCM for deployment
 
@@ -72,14 +74,18 @@ better, is based on the former internal provider.
 * Deploy credentials
 * etc.
 
-**Do not deploy the CCM yet**
+**Do not deploy the CCM yet!**
+
+## Deploy Cloud Controller Manager
 
 ### Disable the integrated provider
 
-* In KCM and kubelet:
-  * Replace `--cloud-provider <OLD CLOUD PROVIDER>` with `--cloud-provider external`
-  * Remove other `--cloud-` options
-  * Restart KCM and kubelet
+In the `kube-controller-manager` and all `kubelet` deployments or services:
+
+* Replace `--cloud-provider <OLD CLOUD PROVIDER>` with `--cloud-provider external`
+* Remove other `--cloud-` options
+
+Restart all `kube-controller-manager` and all `kubelet` instances
 
 ### Deploy the cloud provider
 
@@ -94,6 +100,8 @@ Apply this deployment into your system namespace:
 ```shell
 kubectl apply -n kube-system -f cloud-provider.yml
 ```
+
+## Verify
 
 ### Ensure synchronization with existing environment
 

--- a/content/en/docs/tasks/administer-cluster/migrating-to-cloud-controller-manager.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-to-cloud-controller-manager.md
@@ -1,0 +1,61 @@
+---
+reviewers:
+- andrewsykim
+title: Migrating to Cloud Controller Manager
+content_template: templates/task
+---
+
+{{% capture overview %}}
+
+Cloud providers used to be integrated into the Kubernetes Controller Manager (KCM).
+In Kubernetes 1.17, this changes, and cloud platform integrations must run in a
+dedicated Cloud Controller Manager (CCM) that is specific to each cloud platform.
+
+This document describes how to migrate from the integrated cloud provider in KCM
+to a dedicated CCM.
+
+{{% /capture %}}
+
+{{% capture prerequisites %}}
+
+{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+
+Your cluster will most likely be running in cloud mode, using one of the
+integrated cloud providers. You can check by describing the KCM deployment:
+
+```shell
+kubectl describe pod kube-controller-manager -n kube-system
+```
+
+Look for the `--cloud-provider` option, which will show you which cloud
+provider was used.
+
+If the cloud provider is set to `external`, you are already running an external
+cloud provider. If the option is not set at all, you're most likely not
+using cloud integration. In this case, refer to [LINK TO DOCS ABOUT INSTALLING PROVIDER FROM SCRATCH].
+
+If you were previously running the KCM outside the Kubernetes cluster (as a
+systemd service, for example), you need to determine the command line arguments
+by appropriate means. This will not be covered here.
+
+{{% /capture %}}
+
+{{% capture steps %}}
+
+1. Ensure a CCM for your cloud environment is available, with roughly the same feature set than the integrated KCM provider. Determine compatibility issues (missing features, different implementation, etc).
+2. Prepare your cloud environment and workloads for the migration: Disable unsupported features, build a list of manual actions to be done after migration (deleting unused cloud resources, renaming, etc).
+3. Prepare the CCM for deployment: Write configuration files, deploy credentials, etc. **Do not deploy the CCM yet**
+4. Disable the integrated provider in KCM and kubelet: Remove flags, replace with --provider external, etc. Restart these services.
+5. Deploy the cloud provider.
+6. Ensure it synchronises with the running environment correctly, detects existing resources, deploys new resources where appropriate. Apply manual fixes where necessary.
+7. Test deploy new cloud resources such as LoadBalancers and Nodes.
+
+{{% /capture %}}
+
+{{% capture discussion %}}
+
+{{% /capture %}}
+
+{{% capture whatsnext %}}
+
+{{% /capture %}}


### PR DESCRIPTION
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use
 for advice.

-->
Re-target #18844 against master, as 1.18 is being released.

**Still work in progress. Do not merge yet.**

As the title says. Support for integrated cloud providers was removed in 1.18. Document how to migrate to external cloud providers.

Addresses kubernetes/cloud-provider#42

Cc @andrewsykim 