### PR TITLE
Fix refs to old K8s releases on glossary entries

### DIFF
--- a/content/en/docs/reference/glossary/cloud-controller-manager.md
+++ b/content/en/docs/reference/glossary/cloud-controller-manager.md
@@ -4,7 +4,7 @@ id: cloud-controller-manager
 date: 2018-04-12
 full_link: /docs/tasks/administer-cluster/running-cloud-controller/
 short_description: >
-  Cloud Controller Manager is an alpha feature in 1.8. In upcoming releases it will be the preferred way to integrate Kubernetes with any cloud.
+  Cloud Controller Manager is a Kubernetes component that embeds cloud-specific control logic.
 
 aka: 
 tags:
@@ -12,8 +12,8 @@ tags:
 - architecture
 - operation
 ---
- Cloud Controller Manager is an alpha feature in 1.8. In upcoming releases it will be the preferred way to integrate Kubernetes with any cloud.
+ Cloud Controller Manager is a Kubernetes component that embeds cloud-specific control logic.
 
 <!--more--> 
 
-Kubernetes v1.6 contains a new binary called cloud-controller-manager. cloud-controller-manager is a daemon that embeds cloud-specific control loops. These cloud-specific control loops were originally in the kube-controller-manager. Since cloud providers develop and release at a different pace compared to the Kubernetes project, abstracting the provider-specific code to the cloud-controller-manager binary allows cloud vendors to evolve independently from the core Kubernetes code.
+Originally part of the kube-controller-manager, the cloud-controller-manager is responsible to decoupling the interoperability logic between Kubernetes and the underlying cloud infrastructure, enabling cloud providers to release features at a different pace compared to the main project.

--- a/content/en/docs/reference/glossary/host-aliases.md
+++ b/content/en/docs/reference/glossary/host-aliases.md
@@ -2,7 +2,7 @@
 title: HostAliases
 id: HostAliases
 date: 2019-01-31
-full_link: /docs/reference/generated/kubernetes-api/v1.13/#hostalias-v1-core
+full_link: /docs/reference/generated/kubernetes-api/{{< param "version" >}}/#hostalias-v1-core
 short_description: >
   A HostAliases is a mapping between the IP address and hostname to be injected into a Pod's hosts file.
 
@@ -14,4 +14,4 @@ tags:
 
 <!--more-->
 
-[HostAliases](/docs/reference/generated/kubernetes-api/v1.13/#hostalias-v1-corev) is an optional list of hostnames and IP addresses that will be injected into the Pod's hosts file if specified. This is only valid for non-hostNetwork Pods.
+[HostAliases](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#hostalias-v1-core) is an optional list of hostnames and IP addresses that will be injected into the Pod's hosts file if specified. This is only valid for non-hostNetwork Pods.


### PR DESCRIPTION
This PR replace references to old Kubernetes releases and API states.

Closes #19535 

/kind cleanup
/language en
/size S