### PR TITLE
run command is deprecated

### DIFF
--- a/content/en/docs/concepts/cluster-administration/manage-deployment.md
+++ b/content/en/docs/concepts/cluster-administration/manage-deployment.md
@@ -427,7 +427,7 @@ We'll guide you through how to create and update applications with Deployments.
 Let's say you were running version 1.14.2 of nginx:
 
 ```shell
-kubectl run my-nginx --image=nginx:1.14.2 --replicas=3
+kubectl create deployment my-nginx --image=nginx:1.14.2
 ```
 ```shell
 deployment.apps/my-nginx created


### PR DESCRIPTION
Use `kubectl run`  create deployment resource is deprecated.

We should change this command into `kubectl create deployment`.