### PR TITLE
Suggest scaling deployment to 3 before rollout of update

### DIFF
--- a/content/en/docs/concepts/cluster-administration/manage-deployment.md
+++ b/content/en/docs/concepts/cluster-administration/manage-deployment.md
@@ -433,6 +433,14 @@ kubectl create deployment my-nginx --image=nginx:1.14.2
 deployment.apps/my-nginx created
 ```
 
+with 3 replicas (so the old and new revisions can coexist):
+```shell
+kubectl scale deployment my-nginx --current-replicas=1 --replicas=3
+```
+```
+deployment.apps/my-nginx scaled
+```
+
 To update to version 1.16.1, simply change `.spec.template.spec.containers[0].image` from `nginx:1.14.2` to `nginx:1.16.1`, with the kubectl commands we learned above.
 
 ```shell


### PR DESCRIPTION
Tweak for PR #20141: before recommending that the reader update a the image for a Deployment's sole container, suggest scaling the deployment from 1 to 3.

/kind cleanup