### PR TITLE
Add content/pt/docs/templates

### DIFF
--- a/content/pt/docs/templates/feature-state-alpha.txt
+++ b/content/pt/docs/templates/feature-state-alpha.txt
@@ -1,0 +1,7 @@
+Atualmente, esse recurso está no estado *alpha*, o que significa:
+
+* Os nomes das versões contêm alfa (ex. v1alpha1).
+* Pode estar bugado. A ativação do recurso pode expor bugs. Desabilitado por padrão.
+* O suporte ao recurso pode ser retirado a qualquer momento sem aviso prévio.
+* A API pode mudar de maneiras incompatíveis em uma versão de software posterior sem aviso prévio.
+* Recomendado para uso apenas em clusters de teste de curta duração, devido ao aumento do risco de erros e falta de suporte a longo prazo.

--- a/content/pt/docs/templates/feature-state-alpha.txt
+++ b/content/pt/docs/templates/feature-state-alpha.txt
@@ -1,7 +1,7 @@
 Atualmente, esse recurso está no estado *alpha*, o que significa:
 
 * Os nomes das versões contêm alfa (ex. v1alpha1).
-* Pode estar bugado. A ativação do recurso pode expor bugs. Desabilitado por padrão.
+* Pode estar com bugs. A ativação do recurso pode expor bugs. Desabilitado por padrão.
 * O suporte ao recurso pode ser retirado a qualquer momento sem aviso prévio.
 * A API pode mudar de maneiras incompatíveis em uma versão de software posterior sem aviso prévio.
 * Recomendado para uso apenas em clusters de teste de curta duração, devido ao aumento do risco de erros e falta de suporte a longo prazo.

--- a/content/pt/docs/templates/feature-state-beta.txt
+++ b/content/pt/docs/templates/feature-state-beta.txt
@@ -1,0 +1,8 @@
+Atualmente, esse recurso está no estado *beta*, o que significa:
+
+* Os nomes das versões contêm beta (ex, v2beta3).
+* O código está bem testado. A ativação do recurso é considerada segura. Ativado por padrão.
+* O suporte para o recurso geral não será descartado, embora os detalhes possam mudar.
+* O esquema e/ou semântica dos objetos podem mudar de maneiras incompatíveis em uma versão beta ou estável subsequente. Quando isso acontecer, forneceremos instruções para migrar para a próxima versão. Isso pode exigir a exclusão, edição e recriação de objetos da API. O processo de edição pode exigir alguma reflexão. Isso pode exigir tempo de inatividade para aplicativos que dependem do recurso.
+* Recomendado apenas para usos não comerciais, devido ao potencial de alterações incompatíveis nas versões subsequentes. Se você tiver vários clusters que podem ser atualizados independentemente, poderá relaxar essa restrição.
+* **Por favor, experimente nossos recursos beta e dê um feedback sobre eles! Depois que eles saem da versão beta, pode não ser prático para nós fazer mais alterações.**

--- a/content/pt/docs/templates/feature-state-deprecated.txt
+++ b/content/pt/docs/templates/feature-state-deprecated.txt
@@ -1,0 +1,1 @@
+Este recurso está *obsoleto*. Para obter mais informações sobre esse estado, consulte a [Política de descontinuação do Kubernetes](/docs/reference/deprecation-policy/).

--- a/content/pt/docs/templates/feature-state-stable.txt
+++ b/content/pt/docs/templates/feature-state-stable.txt
@@ -1,0 +1,4 @@
+Esse recurso é *estável*, o que significa:
+
+* O nome da versão é vX, em que X é um número inteiro.
+* Versões estáveis dos recursos aparecerão no software lançado para muitas versões subsequentes.

--- a/content/pt/docs/templates/index.md
+++ b/content/pt/docs/templates/index.md
@@ -1,0 +1,13 @@
+---
+headless: true
+
+resources:
+- src: "*alpha*"
+  title: "alpha"
+- src: "*beta*"
+  title: "beta"
+- src: "*deprecated*"
+  title: "deprecated"
+- src: "*stable*"
+  title: "stable"
+---


### PR DESCRIPTION
Related to #20170

Some pages need the contents of the [templates](https://github.com/kubernetes/website/tree/master/content/en/docs/templates) for the site to be deployed successfully.
This PR add the docs/templates content translated into portuguese.



