### PR TITLE
Update assign-pod-node.md.

### DIFF
--- a/content/en/docs/concepts/configuration/assign-pod-node.md
+++ b/content/en/docs/concepts/configuration/assign-pod-node.md
@@ -160,9 +160,11 @@ You can use `NotIn` and `DoesNotExist` to achieve node anti-affinity behavior, o
 If you specify both `nodeSelector` and `nodeAffinity`, *both* must be satisfied for the pod
 to be scheduled onto a candidate node.
 
-If you specify multiple `nodeSelectorTerms` associated with `nodeAffinity` types, then the pod can be scheduled onto a node **only if all** `nodeSelectorTerms` can be satisfied.
+If you specify a list of `matchExpression and matchField` associated with `nodeSelectorTerms`, then the pod can be scheduled onto a node **if one of** the `matchExpression and matchField` is satisfied.
 
-If you specify multiple `matchExpressions` associated with `nodeSelectorTerms`, then the pod can be scheduled onto a node **if one of** the `matchExpressions` is satisfied.
+If you specify a  list of `nodeSelectorRequirement` associated with `matchExpressions` types, then the pod only can be scheduled onto a node **if all the** `nodeSelectorRequirement` can be satisfied.
+
+If you specify a list of `nodeSelectorRequirement` associated with `matchFields` types, then the pod only can be scheduled onto a node **if all the** `nodeSelectorRequirement` can be satisfied.
 
 If you remove or change the label of the node where the pod is scheduled, the pod won't be removed. In other words, the affinity selection works only at the time of scheduling the pod.
 


### PR DESCRIPTION
Problem:

Below Lines are incorrect from https://github.com/kubernetes/website/pull/17557

If you specify multiple nodeSelectorTerms associated with nodeAffinity types, then the pod can be scheduled onto a node only if all nodeSelectorTerms can be satisfied.

If you specify multiple matchExpressions associated with nodeSelectorTerms, then the pod can be scheduled onto a node if one of the matchExpressions is satisfied.

Proposed Solution:




Accordding to the code :

![image](https://user-images.githubusercontent.com/8232349/78768479-8deba800-79be-11ea-912a-f50da34ab723.png)


![image](https://user-images.githubusercontent.com/8232349/78768860-1d915680-79bf-11ea-8a2a-9eb6b016c159.png)


![image](https://user-images.githubusercontent.com/8232349/78771165-4c5cfc00-79c2-11ea-8164-9fc9b19574e5.png)




So we need to change the lines below

If you specify list of matchExpression and matchField associated with nodeSelectorTerms, then the pod can be scheduled onto a node if one of the matchExpression and matchField is satisfied.

If you specify list of nodeSelectorRequirement associated with matchExpressions types, then the pod can be scheduled onto a node only if all nodeSelectorRequirement can be satisfied.

If you specify list of nodeSelectorRequirement associated with matchFields types, then the pod can be scheduled onto a node only if all nodeSelectorRequirement can be satisfied.