### PR TITLE
Make build of kubernetes-hugo image more reliable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,10 @@ serve: ## Boot the development server.
 	hugo server --buildFuture
 
 docker-image:
-	$(DOCKER) build . --tag $(DOCKER_IMAGE) --build-arg HUGO_VERSION=$(HUGO_VERSION)
+	$(DOCKER) build . \
+		--network=host \
+		--tag $(DOCKER_IMAGE) \
+		--build-arg HUGO_VERSION=$(HUGO_VERSION)
 
 docker-build:
 	$(DOCKER_RUN) $(DOCKER_IMAGE) hugo


### PR DESCRIPTION
Switch from default Docker bridge network to host network.

Fixes #20181

**Problem:**
When building kubernetes-hugo it can fail with below error because build process can't access internet.
By default docker build use bridge network to reach Internet which is not always correct assumption.
The same problem can be seen reported in few other places:

- https://github.com/kubernetes/website/issues/15549
- https://github.com/gliderlabs/docker-alpine/issues/386

*Error:*
`[root@c8k12 website]# make docker-image
docker build . --tag kubernetes-hugo --build-arg HUGO_VERSION=0.59.1
Sending build context to Docker daemon  3.584kB
Step 1/7 : FROM alpine:latest
 ---> a187dde48cd2
Step 2/7 : LABEL maintainer="Luc Perkins <lperkins@linuxfoundation.org>"
 ---> Using cache
 ---> 59a30229fd69
Step 3/7 : RUN apk add --no-cache     curl     git     openssh-client     rsync     build-base     libc6-compat
 ---> Running in 4e201dcc3e8a
fetch http://dl-cdn.alpinelinux.org/alpine/v3.11/main/x86_64/APKINDEX.tar.gz
WARNING: Ignoring http://dl-cdn.alpinelinux.org/alpine/v3.11/main/x86_64/APKINDEX.tar.gz: temporary error (try again later)
fetch http://dl-cdn.alpinelinux.org/alpine/v3.11/community/x86_64/APKINDEX.tar.gz
WARNING: Ignoring http://dl-cdn.alpinelinux.org/alpine/v3.11/community/x86_64/APKINDEX.tar.gz: temporary error (try again later)
ERROR: unsatisfiable constraints:
  build-base (missing):
    required by: world[build-base]
  curl (missing):
    required by: world[curl]
  git (missing):
    required by: world[git]
  libc6-compat (missing):
    required by: world[libc6-compat]
  openssh-client (missing):
    required by: world[openssh-client]
  rsync (missing):
    required by: world[rsync]
The command '/bin/sh -c apk add --no-cache     curl     git     openssh-client     rsync     build-base     libc6-compat' returned a non-zero code: 6
make: *** [Makefile:39: docker-image] Error 6`

**Proposed Solution:**
It would be more reliable to use docker host network instead of bridge network.
For building kubernetes-hugo, it doesn't really matter which network is used to pull all artifacts.
And docker host network almost always guarantees access to Internet. 