### PR TITLE
Modify RBAC Authorizer log message

### DIFF
--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -1182,7 +1182,7 @@ allowed by *either* the RBAC or ABAC policies is allowed.
 
 When the kube-apiserver is run with a log level of 5 or higher for the RBAC component
 (`--vmodule=rbac*=5` or `--v=5`), you can see RBAC denials in the API server log
-(prefixed with `RBAC:`).
+(prefixed with `RBAC`).
 You can use that information to determine which roles need to be granted to which users, groups, or service accounts.
 
 Once you have [granted roles to service accounts](#service-account-permissions) and workloads

--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -1182,7 +1182,7 @@ allowed by *either* the RBAC or ABAC policies is allowed.
 
 When the kube-apiserver is run with a log level of 5 or higher for the RBAC component
 (`--vmodule=rbac*=5` or `--v=5`), you can see RBAC denials in the API server log
-(prefixed with `RBAC DENY:`).
+(prefixed with `RBAC:`).
 You can use that information to determine which roles need to be granted to which users, groups, or service accounts.
 
 Once you have [granted roles to service accounts](#service-account-permissions) and workloads


### PR DESCRIPTION
With reference to [this](https://github.com/kubernetes/kubernetes/issues/89458) issue which was resolved using [this](https://github.com/kubernetes/kubernetes/pull/89608) PR, the RBAC authoriser log message prefix has been modified from `RBAC DENY:` to `RBAC`. This is done to reflect the tristate nature of the authoriser which also uses a NoOpinion decision. 
Consequently, this PR aims to reflect this change in the documentation as well.