### PR TITLE
Link to GitHub list of good first issues

### DIFF
--- a/content/en/docs/contribute/_index.md
+++ b/content/en/docs/contribute/_index.md
@@ -16,7 +16,7 @@ This website is maintained by [Kubernetes SIG Docs](/docs/contribute/#get-involv
 
 Kubernetes documentation contributors:
 
-- Improve existing content
+- [Improve existing content](https://github.com/kubernetes/website/contribute)
 - Create new content
 - Translate the documentation
 - Manage and publish the documentation parts of the Kubernetes release cycle

--- a/content/en/docs/contribute/_index.md
+++ b/content/en/docs/contribute/_index.md
@@ -16,7 +16,7 @@ This website is maintained by [Kubernetes SIG Docs](/docs/contribute/#get-involv
 
 Kubernetes documentation contributors:
 
-- [Improve existing content](https://github.com/kubernetes/website/contribute)
+- Improve existing content
 - Create new content
 - Translate the documentation
 - Manage and publish the documentation parts of the Kubernetes release cycle
@@ -44,6 +44,7 @@ roles and permissions.
 ## Your first contribution
 
 - Read the [Contribution overview](/docs/contribute/new-content/overview/) to learn about the different ways you can contribute.
+- See [good first issue](https://github.com/kubernetes/website/contribute) to find issues that make good entry points.
 - [Open a pull request using GitHub](/docs/contribute/new-content/new-content/#changes-using-github) to existing documentation and learn more about filing issues in GitHub.
 - [Review pull requests](/docs/contribute/review/reviewing-prs/) from other Kubernetes community members for accuracy and language.
 - Read the Kubernetes [content](/docs/contribute/style/content-guide/) and [style guides](/docs/contribute/style/style-guide/) so you can leave informed comments.

--- a/content/en/docs/contribute/_index.md
+++ b/content/en/docs/contribute/_index.md
@@ -44,7 +44,7 @@ roles and permissions.
 ## Your first contribution
 
 - Read the [Contribution overview](/docs/contribute/new-content/overview/) to learn about the different ways you can contribute.
-- See [good first issue](https://github.com/kubernetes/website/contribute) to find issues that make good entry points.
+- See [Contribute to kubernetes/website](https://github.com/kubernetes/website/contribute) to find issues that make good entry points.
 - [Open a pull request using GitHub](/docs/contribute/new-content/new-content/#changes-using-github) to existing documentation and learn more about filing issues in GitHub.
 - [Review pull requests](/docs/contribute/review/reviewing-prs/) from other Kubernetes community members for accuracy and language.
 - Read the Kubernetes [content](/docs/contribute/style/content-guide/) and [style guides](/docs/contribute/style/style-guide/) so you can leave informed comments.


### PR DESCRIPTION
Added a hyperlink https://github.com/kubernetes/website/contribute at line 19 (Improve existing content ) which points to "good first issue," available.
This will help new contributors to make their first contribution.

Closes #20160 

 