### PR TITLE
added note on --etcd-servers-overrides

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/kube-apiserver.md
+++ b/content/en/docs/reference/command-line-tools-reference/kube-apiserver.md
@@ -570,7 +570,7 @@ kube-apiserver [flags]
       <td colspan="2">--etcd-servers-overrides stringSlice</td>
     </tr>
     <tr>
-      <td></td><td style="line-height: 130%; word-wrap: break-word;">Per-resource etcd servers overrides, comma separated. The individual override format: group/resource#servers, where servers are URLs, semicolon separated.</td>
+      <td></td><td style="line-height: 130%; word-wrap: break-word;">Per-resource etcd servers overrides, comma separated. The individual override format: group/resource#servers, where servers are URLs, semicolon separated. Note that etcd servers overrides currently do not support CRDs.</td>
     </tr>
 
     <tr>


### PR DESCRIPTION
Added a note on `etcd-servers-overrides` option, to clarify CRDs are not supported (yet).