### PR TITLE
Change anda to kamu in manage-deployment page

### DIFF
--- a/content/id/docs/concepts/cluster-administration/manage-deployment.md
+++ b/content/id/docs/concepts/cluster-administration/manage-deployment.md
@@ -322,7 +322,7 @@ kubectl scale deployment/my-nginx --replicas=1
 deployment.extensions/my-nginx scaled
 ```
 
-Sekarang anda hanya memiliki satu _pod_ yang dikelola oleh deployment.
+Sekarang kamu hanya memiliki satu _pod_ yang dikelola oleh deployment.
 
 ```shell
 kubectl get pods -l app=nginx


### PR DESCRIPTION
 Hello!

I change term `anda` to `kamu` in manage-deployment page.

/language id
