### PR TITLE
Better error message when window is too narrow to display Terminal

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive.html
+++ b/content/en/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive.html
@@ -19,7 +19,7 @@ weight: 20
 
         <div class="katacoda">
             <div class="katacoda__alert">
-                To interact with the Terminal, please use the desktop/tablet version
+                The screen is too narrow to interact with the Terminal, please use a desktop/tablet.
             </div>
             <div class="katacoda__box" id="inline-terminal-1"  data-katacoda-id="kubernetes-bootcamp/1" data-katacoda-color="326de6" data-katacoda-secondary="273d6d" data-katacoda-hideintro="false" data-katacoda-font="Roboto" data-katacoda-fontheader="Roboto Slab" data-katacoda-prompt="Kubernetes Bootcamp Terminal" style="height: 600px;"></div>
         </div>


### PR DESCRIPTION
If the desktop window is too narrow, Terminal does not show.
The old message was confusing in that case.
The new message can be understood in both contexts, when I use a mobile terminal, o when I use a narrow window in a desktop

