### PR TITLE
Added line 35 to point new contributor to Contribute to Kubernetes docs link.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,8 @@ Kubernetes.io uses github issues to track documentation issues and requests. If 
 
 Note that code issues should be filed against the main kubernetes repository, while documentation issues should go in the kubernetes.io repository.
 
+If you’re just getting started, consider exploring this resource [Contribute to Kubernetes docs](https://kubernetes.io/docs/contribute/).
+
 ### Submitting Documentation Pull Requests
 
 If you're fixing an issue in the existing documentation, you should submit a PR against the master branch.  Follow [these instructions to create a documentation pull request against the kubernetes.io repository](http://kubernetes.io/docs/home/contribute/create-pull-request/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Kubernetes.io uses github issues to track documentation issues and requests. If 
 
 Note that code issues should be filed against the main kubernetes repository, while documentation issues should go in the kubernetes.io repository.
 
-If you’re just getting started, consider exploring this resource [Contribute to Kubernetes docs](https://kubernetes.io/docs/contribute/).
+For more information, see ["Contribute to Kubernetes docs"](https://kubernetes.io/docs/contribute/).
 
 ### Submitting Documentation Pull Requests
 


### PR DESCRIPTION


Added line 35 to point new contributor to Contribute to Kubernetes docs link(https://github.com/kubernetes/website/contribute).

Closes #20161


