### PR TITLE
Fix incorrect here document in https://k8s.io/docs/setup/production-environment/tools/kubeadm/

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -194,7 +194,7 @@ sudo apt-mark hold kubelet kubeadm kubectl
 cat <<EOF > /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-$basearch
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-\$basearch
 enabled=1
 gpgcheck=1
 repo_gpgcheck=1


### PR DESCRIPTION
Amend https://k8s.io/docs/setup/production-environment/tools/kubeadm/
The existing here document for setting up YUM on RHEL / CentOS would try to copy `$basearch` from the environment, rather than let YUM use its own variables.

Fix that.

I've tested the heredoc works how I expect. I haven't end-to-end tested that the fixed documentation works on RHEL / CentOS.

/priority important-soon
/sig cluster-lifecycle

Fixes #20279