### PR TITLE
Fix a typo in a markdown link

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
@@ -368,7 +368,7 @@ For information on using the `kubeadm` tool to set up a Kubernetes cluster with 
 
 {{% tab name="Weave Net" %}}
 
-For more information on setting up your Kubernetes cluster with Weave Net, please see [Integrating Kubernetes via the Addon]((https://www.weave.works/docs/net/latest/kube-addon/).
+For more information on setting up your Kubernetes cluster with Weave Net, please see [Integrating Kubernetes via the Addon](https://www.weave.works/docs/net/latest/kube-addon/).
 
 Weave Net works on `amd64`, `arm`, `arm64` and `ppc64le` platforms without any extra action required.
 Weave Net sets hairpin mode by default. This allows Pods to access themselves via their Service IP address


### PR DESCRIPTION
As per the title.

The additional `(` broke the markdown parsing of the URL.

It was added in a major rework of the docs:
https://github.com/kubernetes/website/commit/6a3c364706c49b1603f6f1ae56d8d2dae5af5921#diff-f2a40a553d60c0fe04e84ee9c1bf28a6R381