### PR TITLE
Note CronJob timezone comes from system timezone

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/en/docs/concepts/workloads/controllers/cron-jobs.md
@@ -18,7 +18,7 @@ One CronJob object is like one line of a _crontab_ (cron table) file. It runs a 
 on a given schedule, written in [Cron](https://en.wikipedia.org/wiki/Cron) format.
 
 {{< note >}}
-All **CronJob** `schedule:` times are denoted in UTC.
+All **CronJob** `schedule:` times are based on the timezone of the master where the job is initiated.
 {{< /note >}}
 
 When creating the manifest for a CronJob resource, make sure the name you provide

--- a/content/en/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/en/docs/concepts/workloads/controllers/cron-jobs.md
@@ -17,9 +17,14 @@ A _CronJob_ creates {{< glossary_tooltip term_id="job" text="Jobs" >}} on a repe
 One CronJob object is like one line of a _crontab_ (cron table) file. It runs a job periodically
 on a given schedule, written in [Cron](https://en.wikipedia.org/wiki/Cron) format.
 
-{{< note >}}
-All **CronJob** `schedule:` times are based on the timezone of the master where the job is initiated.
-{{< /note >}}
+{{< caution >}}
+All **CronJob** `schedule:` times are based on the timezone of the
+{{< glossary_tooltip term_id="kube-controller-manager" text="kube-controller-manager" >}}.
+
+If your control plane runs the kube-controller-manager in Pods or bare
+containers, the timezone set for the kube-controller-manager container determines the timezone
+that the cron job controller uses.
+{{< /caution >}}
 
 When creating the manifest for a CronJob resource, make sure the name you provide
 is a valid [DNS subdomain name](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names).


### PR DESCRIPTION
PR #19116 incorrectly reverted a valid [fix](https://github.com/kubernetes/website/pull/19269) for the CronJob concept. Replay that fix.

Fixes #19003
Fixes #18579

/kind bug
/priority important-soon