### PR TITLE
Changing links in the old interactive tutorials.

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
@@ -76,7 +76,7 @@ weight: 10
 
                 <p>You can create and manage a Deployment by using the Kubernetes command line interface, <b>Kubectl</b>. Kubectl uses the Kubernetes API to interact with the cluster. In this module, you'll learn the most common Kubectl commands needed to create Deployments that run your applications on a Kubernetes cluster.</p>
 
-                <p>When you create a Deployment, you'll need to specify the container image for your application and the number of replicas that you want to run. You can change that information later by updating your Deployment; Modules <a href="/docs/tutorials/kubernetes-basics/scale-intro/">5</a> and <a href="/docs/tutorials/kubernetes-basics/update-intro/">6</a> of the bootcamp discuss how you can scale and update your Deployments.</p>
+                <p>When you create a Deployment, you'll need to specify the container image for your application and the number of replicas that you want to run. You can change that information later by updating your Deployment; Modules <a href="/docs/tutorials/kubernetes-basics/scale/scale-intro/">5</a> and <a href="/docs/tutorials/kubernetes-basics/update/update-intro/">6</a> of the bootcamp discuss how you can scale and update your Deployments.</p>
 
 
 

--- a/content/en/docs/tutorials/kubernetes-basics/explore/explore-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/explore/explore-intro.html
@@ -29,7 +29,7 @@ weight: 10
 
             <div class="col-md-8">
                 <h2>Kubernetes Pods</h2>
-                <p>When you created a Deployment in Module <a href="/docs/tutorials/kubernetes-basics/deploy-intro/">2</a>, Kubernetes created a <b>Pod</b> to host your application instance. A Pod is a Kubernetes abstraction that represents a group of one or more application containers (such as Docker or rkt), and some shared resources for those containers. Those resources include:</p>
+                <p>When you created a Deployment in Module <a href="/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/">2</a>, Kubernetes created a <b>Pod</b> to host your application instance. A Pod is a Kubernetes abstraction that represents a group of one or more application containers (such as Docker or rkt), and some shared resources for those containers. Those resources include:</p>
                 <ul>
                     <li>Shared storage, as Volumes</li>
                     <li>Networking, as a unique cluster IP address</li>
@@ -108,7 +108,7 @@ weight: 10
         <div class="row">
             <div class="col-md-8">
                 <h2>Troubleshooting with kubectl</h2>
-                <p>In Module <a href="/docs/tutorials/kubernetes-basics/deploy-intro/">2</a>, you used Kubectl command-line interface. You'll continue to use it in Module 3 to get information about deployed applications and their environments. The most common operations can be done with the following kubectl commands:</p>
+                <p>In Module <a href="/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/">2</a>, you used Kubectl command-line interface. You'll continue to use it in Module 3 to get information about deployed applications and their environments. The most common operations can be done with the following kubectl commands:</p>
                 <ul>
                     <li><b>kubectl get</b> - list resources</li>
                     <li><b>kubectl describe</b> - show detailed information about a resource</li>


### PR DESCRIPTION
Fixes Step 1 for #20316 

Reason to have it - the localization team doesn't check if the links are really working (spoiler `they don't`). So this Error travels to localizations too.