### PR TITLE
fix duplicate Slack name, header

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -60,7 +60,7 @@
                 <div class="social">
                     <a href="https://twitter.com/kubernetesio" class="twitter"><span>{{ T "community_twitter_name" }}</span></a>
                     <a href="https://github.com/kubernetes/kubernetes" class="github"><span>{{ T "community_github_name" }}</span></a>
-                    <a href="http://slack.k8s.io/" class="slack"><span>{{ T "community_slack_name" }} Slack</span></a>
+                    <a href="http://slack.k8s.io/" class="slack"><span>{{ T "community_slack_name" }}</span></a>
                     <a href="https://stackoverflow.com/questions/tagged/kubernetes" class="stack-overflow"><span>{{ T "community_stack_overflow_name" }}</span></a>
                     <a href="https://www.youtube.com/kubernetescommunity" class="youtube"><span>{{ T "community_youtube_name" }}</span></a>
                     <a href="https://discuss.kubernetes.io" class="mailing-list"><span>{{ T "community_forum_name" }}</span></a>


### PR DESCRIPTION
With the addition of the `community_slack_name` variable, the `layouts/partials/header.html` contains two "Slack" strings. To view the issue from a minimized screen and browser: 
Select the hamburger menu. The drop down list contains an item, "Slack Slack".