### PR TITLE
Correct description of registering APIService

### DIFF
--- a/content/en/docs/tasks/access-kubernetes-api/configure-aggregation-layer.md
+++ b/content/en/docs/tasks/access-kubernetes-api/configure-aggregation-layer.md
@@ -251,15 +251,14 @@ The name of an APIService object must be a valid
 
 #### Contacting the extension apiserver
 
-Once the Kubernetes apiserver has determined a request should be sent to a extension apiserver,
+Once the Kubernetes apiserver has determined a request should be sent to an extension apiserver,
 it needs to know how to contact it.
 
-The `service` stanza is a reference to the service for a extension apiserver.
+The `service` stanza is a reference to the service for an extension apiserver.
 The service namespace and name are required. The port is optional and defaults to 443.
-The path is optional and defaults to "/".
 
-Here is an example of an extension apiserver that is configured to be called on port "1234"
-at the subpath "/my-path", and to verify the TLS connection against the ServerName
+Here is an example of an extension apiserver that is configured to be called on port "1234",
+and to verify the TLS connection against the ServerName
 `my-service-name.my-service-namespace.svc` using a custom CA bundle.
 
 ```yaml


### PR DESCRIPTION
APIService doesn't have `path` field and cannot call a service at
specified subpath. This might be a copy-paste error from service in CRD
webhook.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use
 for advice.

-->
