### PR TITLE
Update content/zh/docs/concepts/containers/runtime-class.md

### DIFF
--- a/content/zh/docs/concepts/containers/runtime-class.md
+++ b/content/zh/docs/concepts/containers/runtime-class.md
@@ -16,30 +16,21 @@ This page describes the RuntimeClass resource and runtime selection mechanism.
 -->
 本页面描述了 RuntimeClass 资源和运行时的选择机制。
 
-{{< warning >}}
 <!--
-RuntimeClass includes *breaking* changes in the beta upgrade in v1.14. If you were using
-RuntimeClass prior to v1.14, see [Upgrading RuntimeClass from Alpha to
-Beta](#upgrading-runtimeclass-from-alpha-to-beta).
--->RuntimeClass 特性在 v1.14 版本升级为 beta 特性时引入了不兼容的改变。
-如果你在 v1.14 以前的版本中使用 RuntimeClass，请查阅
-[Upgrading RuntimeClass from Alpha to Beta](#upgrading-runtimeclass-from-alpha-to-beta)。
-{{< /warning >}}
+RuntimeClass is a feature for selecting the container runtime configuration. The container runtime
+configuration is used to run a Pod's containers.
+-->
+RuntimeClass 是一个用于选择容器运行时配置的特性，容器运行时配置用于运行 Pod 中的容器。
 
 {{% /capture %}}
 
 
 {{% capture body %}}
 
-## Runtime Class
-
-<!--
-RuntimeClass is a feature for selecting the container runtime configuration. The container runtime
-configuration is used to run a Pod's containers.
--->
-RuntimeClass 是用于选择容器运行时配置的特性，容器运行时配置用于运行 Pod 中的容器。
-
+<!-- 
 ## Motivation
+ -->
+## 动机
 
 <!--
 You can set a different RuntimeClass between different Pods to provide a balance of
@@ -61,9 +52,9 @@ but with different settings.
 您还可以使用 RuntimeClass 运行具有相同容器运行时但具有不同设置的pod。
 
 <!-- 
-### Set Up
+## Setup
 -->
-### 设置
+## 设置
 
 <!--
 Ensure the RuntimeClass feature gate is enabled (it is by default). See [Feature
@@ -73,7 +64,7 @@ feature gates. The `RuntimeClass` feature gate must be enabled on apiservers _an
 确保 RuntimeClass 特性开关处于开启状态（默认为开启状态）。
 关于特性开关的详细介绍，请查阅
 [Feature Gates](/docs/reference/command-line-tools-reference/feature-gates/)。
-`RuntimeClass` 特性开关必须在 apiservers 和 kubelets 同时开启。
+`RuntimeClass` 特性开关必须在 apiserver 和 kubelet 同时开启。
 
 <!--
 1. Configure the CRI implementation on nodes (runtime dependent)
@@ -84,9 +75,9 @@ feature gates. The `RuntimeClass` feature gate must be enabled on apiservers _an
 2. 创建相应的 RuntimeClass 资源
 
 <!--
-#### 1. Configure the CRI implementation on nodes
+### 1. Configure the CRI implementation on nodes
 -->
-#### 1. 在节点上配置 CRI 实现
+### 1. 在节点上配置 CRI 实现
 
 <!--
 The configurations available through RuntimeClass are Container Runtime Interface (CRI)
@@ -100,9 +91,9 @@ RuntimeClass 的配置依赖于 运行时接口（CRI）的实现。
 <!--
 RuntimeClass assumes a homogeneous node configuration across the cluster by default (which means
 that all nodes are configured the same way with respect to container runtimes). To support
-heterogenous node configurations, see [Scheduling](#scheduling) below.-->RuntimeClass 假设集群中的节点配置是同构的
-（换言之，所有的节点在容器运行时方面的配置是相同的）。
-如果需要支持异构节点，配置方法请参阅下面的 [Scheduling](#scheduling)。
+heterogenous node configurations, see [Scheduling](#scheduling) below.-->
+RuntimeClass 假设集群中的节点配置是同构的（换言之，所有的节点在容器运行时方面的配置是相同的）。
+如果需要支持异构节点，配置方法请参阅下面的 [调度](#scheduling)。
 {{< /note >}}
 
 <!--
@@ -113,9 +104,9 @@ handler must be a valid DNS 1123 label (alpha-numeric + `-` characters).
 handler 必须符合 DNS-1123 命名规范（字母、数字、或 `-`）。
 
 <!--
-#### 2. Create the corresponding RuntimeClass resources
+### 2. Create the corresponding RuntimeClass resources
 -->
-#### 2. 创建相应的 RuntimeClass 资源
+### 2. 创建相应的 RuntimeClass 资源
 
 <!--
 The configurations setup in step 1 should each have an associated `handler` name, which identifies
@@ -149,9 +140,9 @@ Overview](/docs/reference/access-authn-authz/authorization/) for more details.--
 {{< /note >}}
 
 <!--
-### Usage
+## Usage
 -->
-### 使用说明
+## 使用说明
 
 <!--
 Once RuntimeClasses are configured for the cluster, using them is very simple. Specify a
@@ -187,12 +178,15 @@ to the behavior when the RuntimeClass feature is disabled.
 -->
 如果未指定 `runtimeClassName` ，则将使用默认的 RuntimeHandler，相当于禁用 RuntimeClass 功能特性。
 
+<!-- 
 ### CRI Configuration
+ -->
+### CRI 配置
 
 <!--
 For more details on setting up CRI runtimes, see [CRI installation](/docs/setup/production-environment/container-runtimes/).
 -->
-关于如何安装 CRI 运行时，请查阅[CRI installation](/docs/setup/production-environment/container-runtimes/)。
+关于如何安装 CRI 运行时，请查阅 [CRI 安装](/docs/setup/production-environment/container-runtimes/)。
 
 #### dockershim
 
@@ -229,7 +223,7 @@ handlers are configured under the [crio.runtime
 table](https://github.com/kubernetes-sigs/cri-o/blob/master/docs/crio.conf.5.md#crioruntime-table):
 -->
 通过 cri-o 的 `/etc/crio/crio.conf` 配置文件来配置运行时 handler。
-handler 需要配置在[crio.runtime 表](https://github.com/kubernetes-sigs/cri-o/blob/master/docs/crio.conf.5.md#crioruntime-table)
+handler 需要配置在 [crio.runtime 表](https://github.com/kubernetes-sigs/cri-o/blob/master/docs/crio.conf.5.md#crioruntime-table)
 下方：
 
 ```
@@ -244,7 +238,10 @@ https://github.com/kubernetes-sigs/cri-o/blob/master/cmd/crio/config.go
 更详细信息，请查阅 containerd 配置文档：
 https://github.com/kubernetes-sigs/cri-o/blob/master/cmd/crio/config.go
 
-### Scheduling
+<!-- 
+## Scheduling
+ -->
+## 调度
 
 {{< feature-state for_k8s_version="v1.16" state="beta" >}}
 
@@ -252,11 +249,11 @@ https://github.com/kubernetes-sigs/cri-o/blob/master/cmd/crio/config.go
 As of Kubernetes v1.16, RuntimeClass includes support for heterogenous clusters through its
 `scheduling` fields. Through the use of these fields, you can ensure that pods running with this
 RuntimeClass are scheduled to nodes that support it. To use the scheduling support, you must have
-the RuntimeClass [admission controller][] enabled (the default, as of 1.16).
+the [RuntimeClass admission controller][] enabled (the default, as of 1.16).
 -->
 在 Kubernetes v1.16 版本里，RuntimeClass 特性引入了 `scheduling` 字段来支持异构集群。
 通过该字段，可以确保 pod 被调度到支持指定运行时的节点上。
-该调度支持，需要确保 RuntimeClass [admission controller][] 处于开启状态（1.16 版本默认开启）。
+该调度支持，需要确保 [RuntimeClass admission controller][] 处于开启状态（1.16 版本默认开启）。
 
 <!--
 To ensure pods land on nodes supporting a specific RuntimeClass, that set of nodes should have a
@@ -285,83 +282,43 @@ Nodes](/docs/concepts/configuration/assign-pod-node/).
 更多有关 node selector 和 tolerations 的配置信息，请查阅 
 [Assigning Pods to Nodes](/docs/concepts/configuration/assign-pod-node/)。
 
-[admission controller]: /docs/reference/access-authn-authz/admission-controllers/
+[RuntimeClass admission controller]: /docs/reference/access-authn-authz/admission-controllers/
 
+<!-- 
 ### Pod Overhead
+ -->
+### Pod 开销
 
-{{< feature-state for_k8s_version="v1.16" state="alpha" >}}
+{{< feature-state for_k8s_version="v1.18" state="beta" >}}
 
 <!--
-As of Kubernetes v1.16, RuntimeClass includes support for specifying overhead associated with
-running a pod, as part of the [`PodOverhead`](/docs/concepts/configuration/pod-overhead) feature.
-To use `PodOverhead`, you must have the PodOverhead [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
-enabled (it is off by default).
+You can specify _overhead_ resources that are associated with running a Pod. Declaring overhead allows
+the cluster (including the scheduler) to account for it when making decisions about Pods and resources.  
+To use Pod overhead, you must have the PodOverhead [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
+enabled (it is on by default).
 -->
-在 Kubernetes v1.16 版本中，RuntimeClass 开始支持 pod 的 overhead，作为 [`PodOverhead`](/docs/concepts/configuration/pod-overhead)
-特性的一部分。
-若要使用 `PodOverhead` 特性，你需要确保 PodOverhead 特性开关处于开启状态（默认为关闭状态）。
+你可以指定与运行 Pod 相关的 _开销_ 资源。声明开销即允许集群（包括调度器）在决策 Pod 和资源时将其考虑在内。
+若要使用 Pod 开销特性，你必须确保 PodOverhead [特性开关](/docs/reference/command-line-tools-reference/feature-gates/) 处于开启状态（默认为启用状态）。
 
 <!--
 Pod overhead is defined in RuntimeClass through the `Overhead` fields. Through the use of these fields,
 you can specify the overhead of running pods utilizing this RuntimeClass and ensure these overheads
 are accounted for in Kubernetes.
 -->
-Pod 的 overhead 在 RuntimeClass 的 `Overhead` 字段定义，该字段用于指定使用 RuntimeClass 特性时带来的 overhead。
+Pod 开销通过 RuntimeClass 的 `overhead` 字段定义。通过使用这些字段，你可以指定使用该 RuntimeClass 运行 Pod 时的开销并确保 Kubernetes 将这些开销计算在内。
 
-### Upgrading RuntimeClass from Alpha to Beta
-
-<!--
-The RuntimeClass Beta feature includes the following changes:
--->
-RuntimeClass Beta 特性包含如下几个改变：
+{{% /capture %}}
+{{% capture whatsnext %}}
 
 <!--
-- The `node.k8s.io` API group and `runtimeclasses.node.k8s.io` resource have been migrated to a
-  built-in API from a CustomResourceDefinition.
-- The `spec` has been inlined in the RuntimeClass definition (i.e. there is no more
-  RuntimeClassSpec).
-- The `runtimeHandler` field has been renamed `handler`.
-- The `handler` field is now required in all API versions. This means the `runtimeHandler` field in
-  the Alpha API is also required.
-- The `handler` field must be a valid DNS label ([RFC 1123](https://tools.ietf.org/html/rfc1123)),
-  meaning it can no longer contain `.` characters (in all versions). Valid handlers match the
-  following regular expression: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`.
--->
-- `node.k8s.io` API 组和 `runtimeclasses.node.k8s.io` 资源已从 CRD 中迁移到内置的 API 中；
-- `spec` 被放置到 RuntimeClass 中（例如，没有 RuntimeClassSpec 了）；
-- `runtimeHandler` 字段重命名为 `handler`；
-- `handler` 字段需要在所有版本的 API 提供，这意味着 `runtimeHandler` 字段在 Alpha API 中也需要提供；
-- `handler` 字段必须是一个合法的 DNS 标识([RFC 1123](https://tools.ietf.org/html/rfc1123))，
-  这意味着不可以包含 `.` 字符。合法的 handler 必须满足如下规则：`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`。
-
-<!--
-**Action Required:** The following actions are required to upgrade from the alpha version of the
-RuntimeClass feature to the beta version:
--->
-**Action Required:** RuntimeClass 特性从 alpha 版本升级到 beta 版本，需要做如下动作：
-
-<!--
-- RuntimeClass resources must be recreated *after* upgrading to v1.14, and the
-  `runtimeclasses.node.k8s.io` CRD should be manually deleted:
-  ```
-  kubectl delete customresourcedefinitions.apiextensions.k8s.io runtimeclasses.node.k8s.io
-  ```
-- Alpha RuntimeClasses with an unspecified or empty `runtimeHandler` or those using a `.` character
-  in the handler are no longer valid, and must be migrated to a valid handler configuration (see
-  above).
--->
-- RuntimeClass 资源必须在升级到 v1.14 *之后* 再创建，并且 CRD 资源 `runtimeclasses.node.k8s.io` 必须要手动删除：
-  ```
-  kubectl delete customresourcedefinitions.apiextensions.k8s.io runtimeclasses.node.k8s.io
-  ```
-- RuntimeClasses 中未指定或为空的 `runtimeHandler` 和 使用包含 `.` 符号的 handler 将不再合法，
-  必须迁移成合法的 handler 配置（见上）。
-  
-### Further Reading
-
 - [RuntimeClass Design](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/runtime-class.md)
 - [RuntimeClass Scheduling Design](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/runtime-class-scheduling.md)
 - Read about the [Pod Overhead](/docs/concepts/configuration/pod-overhead/) concept
 - [PodOverhead Feature Design](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/20190226-pod-overhead.md)
+-->
+- [RuntimeClass 设计](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/runtime-class.md)
+- [RuntimeClass 调度设计](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/runtime-class-scheduling.md)
+- 阅读关于 [Pod 开销](/docs/concepts/configuration/pod-overhead/) 的概念
+- [PodOverhead 特性设计](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/20190226-pod-overhead.md)
 
 {{% /capture %}}


### PR DESCRIPTION
Update zh translation for release 1.18

See diff between release-1.17 and release-1.18:

```
git diff release-1.17 release-1.18 content/en/docs/concepts/containers/runtime-class.md
```

<details>
<summary>Diff: </summary>

```diff
diff --git a/content/en/docs/concepts/containers/runtime-class.md b/content/en/docs/concepts/containers/runtime-class.md
index 9ea21fa6b..d29825d69 100644
--- a/content/en/docs/concepts/containers/runtime-class.md
+++ b/content/en/docs/concepts/containers/runtime-class.md
@@ -13,22 +13,14 @@ weight: 20

 This page describes the RuntimeClass resource and runtime selection mechanism.

-{{< warning >}}
-RuntimeClass includes *breaking* changes in the beta upgrade in v1.14. If you were using
-RuntimeClass prior to v1.14, see [Upgrading RuntimeClass from Alpha to
-Beta](#upgrading-runtimeclass-from-alpha-to-beta).
-{{< /warning >}}
+RuntimeClass is a feature for selecting the container runtime configuration. The container runtime
+configuration is used to run a Pod's containers.

 {{% /capture %}}


 {{% capture body %}}

-## Runtime Class
-
-RuntimeClass is a feature for selecting the container runtime configuration. The container runtime
-configuration is used to run a Pod's containers.
-
 ## Motivation

 You can set a different RuntimeClass between different Pods to provide a balance of
@@ -41,7 +33,7 @@ additional overhead.
 You can also use RuntimeClass to run different Pods with the same container runtime
 but with different settings.

-### Set Up
+## Setup

 Ensure the RuntimeClass feature gate is enabled (it is by default). See [Feature
 Gates](/docs/reference/command-line-tools-reference/feature-gates/) for an explanation of enabling
@@ -50,7 +42,7 @@ feature gates. The `RuntimeClass` feature gate must be enabled on apiservers _an
 1. Configure the CRI implementation on nodes (runtime dependent)
 2. Create the corresponding RuntimeClass resources

-#### 1. Configure the CRI implementation on nodes
+### 1. Configure the CRI implementation on nodes

 The configurations available through RuntimeClass are Container Runtime Interface (CRI)
 implementation dependent. See the corresponding documentation ([below](#cri-configuration)) for your
@@ -65,7 +57,7 @@ heterogenous node configurations, see [Scheduling](#scheduling) below.
 The configurations have a corresponding `handler` name, referenced by the RuntimeClass. The
 handler must be a valid DNS 1123 label (alpha-numeric + `-` characters).

-#### 2. Create the corresponding RuntimeClass resources
+### 2. Create the corresponding RuntimeClass resources

 The configurations setup in step 1 should each have an associated `handler` name, which identifies
 the configuration. For each handler, create a corresponding RuntimeClass object.
@@ -91,7 +83,7 @@ restricted to the cluster administrator. This is typically the default. See [Aut
 Overview](/docs/reference/access-authn-authz/authorization/) for more details.
 {{< /note >}}

-### Usage
+## Usage

 Once RuntimeClasses are configured for the cluster, using them is very simple. Specify a
 `runtimeClassName` in the Pod spec. For example:
@@ -150,14 +142,14 @@ See CRI-O's [config documentation][100] for more details.

 [100]: https://raw.githubusercontent.com/cri-o/cri-o/9f11d1d/docs/crio.conf.5.md

-### Scheduling
+## Scheduling

 {{< feature-state for_k8s_version="v1.16" state="beta" >}}

 As of Kubernetes v1.16, RuntimeClass includes support for heterogenous clusters through its
 `scheduling` fields. Through the use of these fields, you can ensure that pods running with this
 RuntimeClass are scheduled to nodes that support it. To use the scheduling support, you must have
-the RuntimeClass [admission controller][] enabled (the default, as of 1.16).
+the [RuntimeClass admission controller][] enabled (the default, as of 1.16).

 To ensure pods land on nodes supporting a specific RuntimeClass, that set of nodes should have a
 common label which is then selected by the `runtimeclass.scheduling.nodeSelector` field. The
@@ -173,50 +165,23 @@ by each.
 To learn more about configuring the node selector and tolerations, see [Assigning Pods to
 Nodes](/docs/concepts/configuration/assign-pod-node/).

-[admission controller]: /docs/reference/access-authn-authz/admission-controllers/
+[RuntimeClass admission controller]: /docs/reference/access-authn-authz/admission-controllers/#runtimeclass

 ### Pod Overhead

-{{< feature-state for_k8s_version="v1.16" state="alpha" >}}
+{{< feature-state for_k8s_version="v1.18" state="beta" >}}

-As of Kubernetes v1.16, RuntimeClass includes support for specifying overhead associated with
-running a pod, as part of the [`PodOverhead`](/docs/concepts/configuration/pod-overhead/) feature.
-To use `PodOverhead`, you must have the PodOverhead [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
-enabled (it is off by default).
+You can specify _overhead_ resources that are associated with running a Pod. Declaring overhead allows
+the cluster (including the scheduler) to account for it when making decisions about Pods and resources.  
+To use Pod overhead, you must have the PodOverhead [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
+enabled (it is on by default).

-
-Pod overhead is defined in RuntimeClass through the `Overhead` fields. Through the use of these fields,
+Pod overhead is defined in RuntimeClass through the `overhead` fields. Through the use of these fields,
 you can specify the overhead of running pods utilizing this RuntimeClass and ensure these overheads
 are accounted for in Kubernetes.

-### Upgrading RuntimeClass from Alpha to Beta
-
-The RuntimeClass Beta feature includes the following changes:
-
-- The `node.k8s.io` API group and `runtimeclasses.node.k8s.io` resource have been migrated to a
-  built-in API from a CustomResourceDefinition.
-- The `spec` has been inlined in the RuntimeClass definition (i.e. there is no more
-  RuntimeClassSpec).
-- The `runtimeHandler` field has been renamed `handler`.
-- The `handler` field is now required in all API versions. This means the `runtimeHandler` field in
-  the Alpha API is also required.
-- The `handler` field must be a valid DNS label ([RFC 1123](https://tools.ietf.org/html/rfc1123)),
-  meaning it can no longer contain `.` characters (in all versions). Valid handlers match the
-  following regular expression: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`.
-
-**Action Required:** The following actions are required to upgrade from the alpha version of the
-RuntimeClass feature to the beta version:
-
-- RuntimeClass resources must be recreated *after* upgrading to v1.14, and the
-  `runtimeclasses.node.k8s.io` CRD should be manually deleted:
-  ```
-  kubectl delete customresourcedefinitions.apiextensions.k8s.io runtimeclasses.node.k8s.io
-  ```
-- Alpha RuntimeClasses with an unspecified or empty `runtimeHandler` or those using a `.` character
-  in the handler are no longer valid, and must be migrated to a valid handler configuration (see
-  above).
-
-### Further Reading
+{{% /capture %}}
+{{% capture whatsnext %}}

 - [RuntimeClass Design](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/runtime-class.md)
 - [RuntimeClass Scheduling Design](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/runtime-class-scheduling.md)
```
</details>