### PR TITLE
Add master term to glossary and extend control-plane definition

### DIFF
--- a/content/en/docs/reference/glossary/control-plane.md
+++ b/content/en/docs/reference/glossary/control-plane.md
@@ -11,3 +11,15 @@ tags:
 - fundamental
 ---
  The container orchestration layer that exposes the API and interfaces to define, deploy, and manage the lifecycle of containers.
+
+ <!--more--> 
+ 
+ This layer is composed by many different components, such as (but not restricted to):
+
+ * {{< glossary_tooltip text="etcd" term_id="etcd" >}}
+ * {{< glossary_tooltip text="API Server" term_id="kube-apiserver" >}}
+ * {{< glossary_tooltip text="Scheduler" term_id="kube-scheduler" >}}
+ * {{< glossary_tooltip text="Controller Manager" term_id="kube-controller-manager" >}}
+ * {{< glossary_tooltip text="Cloud Controller Manager" term_id="cloud-controller-manager" >}}
+
+ These components can be run as traditional operating system services (daemons) or as containers. The hosts running these components were historically called {{< glossary_tooltip text="masters" term_id="master" >}}.

--- a/content/en/docs/reference/glossary/master.md
+++ b/content/en/docs/reference/glossary/master.md
@@ -1,0 +1,15 @@
+---
+title: Master
+id: master
+date: 2020-04-16
+short_description: >
+  Legacy term, used as synonym for nodes running the control plane.
+
+aka:
+tags:
+- fundamental
+---
+ Legacy term, used as synonym for {{< glossary_tooltip text="nodes" term_id="node" >}} hosting the {{< glossary_tooltip text="control plane" term_id="control-plane" >}}.
+
+<!--more-->
+The term is still being used by some provisioning tools, such as {{< glossary_tooltip text="kubeadm" term_id="kubeadm" >}}, and managed services, to {{< glossary_tooltip text="label" term_id="label" >}} {{< glossary_tooltip text="nodes" term_id="node" >}} with `kubernetes.io/role` and control placement of {{< glossary_tooltip text="control plane" term_id="control-plane" >}} {{< glossary_tooltip text="pods" term_id="pod" >}}.


### PR DESCRIPTION
The term `master` is still referred by provisioning tools (`kubeadm`) and tasks (https://kubernetes.io/docs/tasks/administer-cluster/highly-available-master/) so it would be interesting to have it properly defined in the glossary. This PR adds the term as synonym of `control-plane`, and extends its definition.

Closes #18763 

/kind cleanup
/size S
