### PR TITLE
Remove the --generator deprecated flag of a tutorial

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -115,7 +115,7 @@ Now, we will see how the autoscaler reacts to increased load.
 We will start a container, and send an infinite loop of queries to the php-apache service (please run it in a different terminal):
 
 ```shell
-kubectl run --generator=run-pod/v1 -it --rm load-generator --image=busybox /bin/sh
+kubectl run -it --rm load-generator --image=busybox /bin/sh
 
 Hit enter for command prompt
 


### PR DESCRIPTION
Related to #20414 

Remove the **--generator=run-pod/v1** flag of the [example](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#increase-load)

![Captura de tela de 2020-04-17 20-35-18](https://user-images.githubusercontent.com/34755896/79621796-0fdc7f00-80eb-11ea-90b3-52ad828b9b72.png)

Note that this flag has no effect


**Updated Page:** https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#increase-load
