### PR TITLE
Fix indentation

### DIFF
--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -556,8 +556,8 @@ spec:
     - name: myfrontend
       image: nginx
       volumeMounts:
-      - mountPath: "/var/www/html"
-        name: mypd
+        - mountPath: "/var/www/html"
+          name: mypd
   volumes:
     - name: mypd
       persistentVolumeClaim:


### PR DESCRIPTION
The yaml provided in the volumeMount example is not valid because of incorrect indentation. This fixes the indentation.