### PR TITLE
Update Indonesian "Install Kubectl" page

### DIFF
--- a/content/id/docs/tasks/tools/install-kubectl.md
+++ b/content/id/docs/tasks/tools/install-kubectl.md
@@ -1,28 +1,28 @@
 ---
-title: Instalasi dan Konfigurasi kubectl
+title: Menginstal dan Menyiapkan kubectl
 content_template: templates/task
 weight: 10
 card:
   name: tasks
   weight: 20
-  title: Instalasi kubectl
+  title: Menginstal kubectl
 ---
 
 {{% capture overview %}}
-[Kubectl](/docs/user-guide/kubectl/) adalah perangkat barisan perintah Kubernetes yang digunakan untuk menjalankan berbagai perintah untuk kluster Kubernetes. Kamu dapat menggunakan `kubectl` untuk men-_deploy_ aplikasi, mengatur _resource_ kluster, dan melihat _log_. Daftar operasi `kubectl` dapat dilihat di [Ikhtisar kubectl](/docs/reference/kubectl/overview/).
+[Kubectl](/docs/user-guide/kubectl/) adalah alat baris perintah (_command line tool_) Kubernetes yang digunakan untuk menjalankan berbagai perintah untuk klaster Kubernetes. Kamu dapat menggunakan `kubectl` untuk men-_deploy_ aplikasi, mengatur sumber daya klaster, dan melihat log. Daftar operasi `kubectl` dapat dilihat di [Ikhtisar kubectl](/docs/reference/kubectl/overview/).
 {{% /capture %}}
 
 {{% capture prerequisites %}}
-Kamu boleh menggunakan `kubectl` versi berapapun selama versi minornya sama atau berbeda satu. Misal, klien v1.2 masih dapat digunakan dengan v1.1, v1.2, dan 1.3 master. Menggunakan versi terbaru `kubectl` dapat menghindari permasalahan yang tidak terduga.
+Kamu harus menggunakan kubectl dengan perbedaan maksimal satu versi minor dengan klaster kamu. Misalnya, klien v1.2 masih dapat digunakan dengan master v1.1, v1.2, dan 1.3. Menggunakan versi terbaru `kubectl` dapat menghindari permasalahan yang tidak terduga.
 {{% /capture %}}
 
 {{% capture steps %}}
 
-## Instalasi kubectl di Linux
+## Menginstal kubectl pada Linux
 
-### Instalasi binari kubectl dengan curl di Linux
+### Menginstal program kubectl menggunakan curl pada Linux
 
-1. Unduh versi terbaru dengan perintah:
+1. Unduh versi terbarunya dengan perintah:
 
     ```
     curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
@@ -30,30 +30,30 @@ Kamu boleh menggunakan `kubectl` versi berapapun selama versi minornya sama atau
 
     Untuk mengunduh versi spesifik, ganti bagian `curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt` dengan versi yang diinginkan.
 
-    Misal, untuk mengunduh versi {{< param "fullversion" >}} di Linux, ketik:
+    Misalnya, untuk mengunduh versi {{< param "fullversion" >}} di Linux, ketik:
     
     ```
     curl -LO https://storage.googleapis.com/kubernetes-release/release/{{< param "fullversion" >}}/bin/linux/amd64/kubectl
     ```
 
-1. Buat agar binari `kubectl` dapat dijalankan.
+2. Jadikan program `kubectl` dapat dieksekusi.
 
     ```
     chmod +x ./kubectl
     ```
 
-1. Pindahkan ke PATH komputer.
+3. Pindahkan ke PATH kamu.
 
     ```
     sudo mv ./kubectl /usr/local/bin/kubectl
     ```
-1. Pastikan instalasi sudah berhasil dengan melakukan pengecekan versi:
+4. Pastikan instalasinya sudah berhasil dengan melakukan pengecekan versi:
 
     ```
     kubectl version --client
     ```
 
-### Instalasi dengan paket manajer bawaan
+### Menginstal dengan manajer paket (_package manager_) bawaan
 
 {{< tabs name="kubectl_install" >}}
 {{< tab name="Ubuntu, Debian or HypriotOS" codelang="bash" >}}
@@ -76,11 +76,11 @@ yum install -y kubectl
 {{< /tab >}}
 {{< /tabs >}}
 
-### Instalasi dengan paket manajer lain
+### Menginstal dengan manajer paket lain
 
 {{< tabs name="other_kubectl_install" >}}
 {{% tab name="Snap" %}}
-Jika kamu menggunakan Ubuntu atau versi Linux lain yang mendukung paket manajer [snap](https://snapcraft.io/docs/core/install), `kubectl` tersedia dalam bentuk aplikasi di [snap](https://snapcraft.io/).
+Jika kamu menggunakan Ubuntu atau versi Linux lain yang mendukung manajer paket [snap](https://snapcraft.io/docs/core/install), `kubectl` tersedia dalam bentuk aplikasi di [snap](https://snapcraft.io/).
 
 ```shell
 snap install kubectl --classic
@@ -89,7 +89,7 @@ kubectl version --client
 ```
 {{% /tab %}}
 {{% tab name="Homebrew" %}}
-Jika kamu menggunakan Linux dengan paket manajer [Homebrew](https://docs.brew.sh/Homebrew-on-Linux), `kubectl` sudah tersedia untuk diinstal di [Homebrew](https://docs.brew.sh/Homebrew-on-Linux#install).
+Jika kamu menggunakan Linux dengan manajer paket [Homebrew](https://docs.brew.sh/Homebrew-on-Linux), `kubectl` sudah tersedia untuk diinstal di [Homebrew](https://docs.brew.sh/Homebrew-on-Linux#install).
 ```shell
 brew install kubectl
 
@@ -98,11 +98,11 @@ kubectl version --client
 {{% /tab %}}
 {{< /tabs >}}
 
-## Instalasi kubectl di macOS
+## Menginstal kubectl pada macOS
 
-### Instalasi binari kubectl dengan curl di macOS
+### Menginstal program kubectl dengan curl pada macOS
 
-1. Unduh versi terbaru dengan perintah:
+1. Unduh versi terbarunya dengan perintah:
 
     ```		 
     curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/darwin/amd64/kubectl"
@@ -110,32 +110,32 @@ kubectl version --client
 
     Untuk mengunduh versi spesifik, ganti bagian `curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt` dengan versi yang diinginkan.
 
-    Misal, untuk mengunduh versi {{< param "fullversion" >}} di macOS, ketik:
+    Misalnya, untuk mengunduh versi {{< param "fullversion" >}} pada macOS, ketik:
 		  
     ```
     curl -LO https://storage.googleapis.com/kubernetes-release/release/{{< param "fullversion" >}}/bin/darwin/amd64/kubectl
     ```
 
-1. Buat agar binari `kubectl` dapat dijalankan.
+2. Buat agar program `kubectl` dapat dijalankan.
 
     ```
     chmod +x ./kubectl
     ```
 
-1. Pindahkan ke PATH komputer.
+3. Pindahkan ke PATH kamu.
 
     ```
     sudo mv ./kubectl /usr/local/bin/kubectl
     ```
-1. Pastikan instalasi sudah berhasil dengan melakukan pengecekan versi:
+4. Pastikan instalasinya sudah berhasil dengan melakukan pengecekan versi:
 
     ```
     kubectl version --client
     ```
 
-### Instalasi dengan Homebrew di macOS
+### Menginstal dengan Homebrew pada macOS
 
-Jika kamu menggunakan macOS dan paket manajer [Homebrew](https://brew.sh/), kamu dapat menginstal `kubectl` langsung dengan Homebrew.
+Jika kamu menggunakan macOS dan manajer paket [Homebrew](https://brew.sh/), kamu dapat menginstal `kubectl` langsung dengan Homebrew.
 
 1. Jalankan perintah:
 
@@ -148,15 +148,15 @@ Jika kamu menggunakan macOS dan paket manajer [Homebrew](https://brew.sh/), kamu
     brew install kubernetes-cli
     ```
 
-1. Pastikan instalasi sudah berhasil dengan melakukan pengecekan versi:
+2. Pastikan instalasinya sudah berhasil dengan melakukan pengecekan versi:
 
     ```
     kubectl version --client
     ```
 
-### Instalasi dengan Macports di macOS
+### Menginstal dengan Macports pada macOS
 
-Jika kamu menggunakan macOS dan paket manajer [Macports](https://macports.org/), kamu dapat menginstal `kubectl` langsung dengan Macports.
+Jika kamu menggunakan macOS dan manajer paket [Macports](https://macports.org/), kamu dapat menginstal `kubectl` langsung dengan Macports.
 
 1. Jalankan perintah:
 
@@ -165,39 +165,39 @@ Jika kamu menggunakan macOS dan paket manajer [Macports](https://macports.org/),
     sudo port install kubectl
     ```
     
-1. Pastikan instalasi sudah berhasil dengan melakukan pengecekan versi:
+2. Pastikan instalasinya sudah berhasil dengan melakukan pengecekan versi:
 
     ```
     kubectl version --client
     ```
 
-## Instalasi kubectl di Windows
+## Menginstal kubectl pada Windows
 
-### Instalasi binari kubectl dengan curl di Windows
+### Menginstal program kubectl dengan curl pada Windows
 
-1. Unduh versi terbaru {{< param "fullversion" >}} dari [tautan ini](https://storage.googleapis.com/kubernetes-release/release/{{< param "fullversion" >}}/bin/windows/amd64/kubectl.exe).
+1. Unduh versi terbarunya {{< param "fullversion" >}} dari [tautan ini](https://storage.googleapis.com/kubernetes-release/release/{{< param "fullversion" >}}/bin/windows/amd64/kubectl.exe).
 
-    Atau jika sudah ada `curl`, jalankan perintah ini:
+    Atau jika sudah ada `curl` pada mesin kamu, jalankan perintah ini:
 
     ```
     curl -LO https://storage.googleapis.com/kubernetes-release/release/{{< param "fullversion" >}}/bin/windows/amd64/kubectl.exe
     ```
 
-    Untuk mendapatkan versi stabil terakhir (misal, untuk _scripting_), lihat di [https://storage.googleapis.com/kubernetes-release/release/stable.txt](https://storage.googleapis.com/kubernetes-release/release/stable.txt).
+    Untuk mendapatkan versi stabil terakhir (misalnya untuk _scripting_), lihat di [https://storage.googleapis.com/kubernetes-release/release/stable.txt](https://storage.googleapis.com/kubernetes-release/release/stable.txt).
 
-1. Tambahkan binary yang sudah diunduh ke PATH komputer.
-1. Pastikan instalasi sudah berhasil dengan melakukan pengecekan versi:
+2. Tambahkan program yang sudah diunduh tersebut ke PATH kamu.
+3. Pastikan instalasinya sudah berhasil dengan melakukan pengecekan versi:
 
     ```
     kubectl version --client
     ```
 {{< note >}}
-[Docker Desktop untuk Windows](https://docs.docker.com/docker-for-windows/#kubernetes) sudah menambahkan versi `kubectl`nya sendiri ke PATH. Jika kamu sudah menginstal Docker Desktop, kamu harus menambahkan _entry_ ke PATH sebelum yang ditambahkan oleh _installer_ Docker Desktop atau kamu dapat menghapus `kubectl` bawaan Docker Desktop.
+[Docker Desktop untuk Windows](https://docs.docker.com/docker-for-windows/#kubernetes) sudah menambahkan versi `kubectl`-nya sendiri ke PATH. Jika kamu sudah menginstal Docker Desktop, kamu harus menambahkan entrinya ke PATH sebelum yang ditambahkan oleh penginstal (_installer_) Docker Desktop atau kamu dapat menghapus `kubectl` bawaan dari Docker Desktop.
 {{< /note >}}
 
-### Instalasi dengan Powershell dari PSGallery
+### Menginstal dengan Powershell dari PSGallery
 
-Jika kamu menggunakan Windows dan paket manajer [Powershell Gallery](https://www.powershellgallery.com/), kamu dapat menginstal dan melakukan pembaruan `kubectl` dengan Powershell.
+Jika kamu menggunakan Windows dan manajer paket [Powershell Gallery](https://www.powershellgallery.com/), kamu dapat menginstal dan melakukan pembaruan `kubectl` dengan Powershell.
 
 1. Jalankan perintah berikut (jangan lupa untuk memasukkan `DownloadLocation`):
 
@@ -208,9 +208,9 @@ Jika kamu menggunakan Windows dan paket manajer [Powershell Gallery](https://www
     
     {{< note >}}Jika kamu tidak menambahkan `DownloadLocation`, `kubectl` akan diinstal di dalam direktori _temp_ pengguna.{{< /note >}}
     
-    _Installer_ akan membuat `$HOME/.kube` dan membuat berkas konfigurasi
+    Penginstal akan membuat `$HOME/.kube` dan membuat berkas konfigurasi
 
-1. Pastikan instalasi sudah berhasil dengan melakukan pengecekan versi:
+2. Pastikan instalasinya sudah berhasil dengan melakukan pengecekan versi:
 
     ```
     kubectl version --client
@@ -218,9 +218,9 @@ Jika kamu menggunakan Windows dan paket manajer [Powershell Gallery](https://www
 
     {{< note >}}Proses pembaruan dapat dilakukan dengan menjalankan ulang dua perintah yang terdapat pada langkah 1.{{< /note >}}
 
-### Instalasi di Windows menggunaakn Chocolatey atau Scoop
+### Menginstal pada Windows menggunakan Chocolatey atau Scoop
 
-Untuk menginstal `kubectl` di Windows kamu dapat menggunakan paket manajer [Chocolatey](https://chocolatey.org) atau _installer_ barisan perintah [Scoop](https://scoop.sh).
+Untuk menginstal `kubectl` pada Windows, kamu dapat menggunakan manajer paket [Chocolatey](https://chocolatey.org) atau penginstal baris perintah [Scoop](https://scoop.sh).
 {{< tabs name="kubectl_win_install" >}}
 {{% tab name="choco" %}}
 
@@ -233,49 +233,49 @@ Untuk menginstal `kubectl` di Windows kamu dapat menggunakan paket manajer [Choc
 
 {{% /tab %}}
 {{< /tabs >}}
-1. Pastikan instalasi sudah berhasil dengan melakukan pengecekan versi:
+1. Pastikan instalasinya sudah berhasil dengan melakukan pengecekan versi:
 
     ```
     kubectl version --client
     ```
 
-1. Pindah ke direktori utama:
+2. Pindah ke direktori utama:
 
     ```
     cd %USERPROFILE%
     ```
-1. Buat direktori `.kube`:
+3. Buat direktori `.kube`:
 
     ```
     mkdir .kube
     ```
 
-1. Pindah ke direktori `.kube` yang baru saja dibuat:
+4. Pindah ke direktori `.kube` yang baru saja dibuat:
 
     ```
     cd .kube
     ```
 
-1. Lakukan konfigurasi `kubectl` agar menggunakan _remote_ kluster Kubernetes:
+5. Lakukan konfigurasi `kubectl` untuk menggunakan klaster Kubernetes _remote_:
 
     ```
     New-Item config -type file
     ```
     
-    {{< note >}}Ubah berkas konfigurasi dengan editor teks pilihanmu, misal Notepad.{{< /note >}}
+    {{< note >}}Ubah berkas konfigurasi dengan penyunting (_editor_) teks pilihanmu, misalnya Notepad.{{< /note >}}
 
-## Unduh dengan menggunakan Google Cloud SDK
+## Mengunduh sebagai bagian dari Google Cloud SDK
 
-Kamu dapat menginstal `kubectl` dengan menggunakan Google Cloud SDK.
+Kamu dapat menginstal `kubectl` sebagai bagian dari Google Cloud SDK.
 
 1. Instal [Google Cloud SDK](https://cloud.google.com/sdk/).
-1. Jalankan perintah instalasi `kubectl`:
+2. Jalankan perintah instalasi `kubectl`:
 
     ```
     gcloud components install kubectl
     ```
     
-1. Pastikan instalasi sudah berhasil dengan melakukan pengecekan versi:
+3. Pastikan instalasinya sudah berhasil dengan melakukan pengecekan versi:
 
     ```
     kubectl version --client
@@ -283,78 +283,78 @@ Kamu dapat menginstal `kubectl` dengan menggunakan Google Cloud SDK.
 
 ## Memeriksa konfigurasi kubectl
 
-Agar `kubectl` dapat mengakses kluster Kubernetes, dibutuhkan sebuah [berkas kubeconfig](/docs/tasks/access-application-cluster/configure-access-multiple-clusters/), yang akan otomatis dibuat ketika kamu membuat kluster baru menggunakan [kube-up.sh](https://github.com/kubernetes/kubernetes/blob/master/cluster/kube-up.sh) atau setelah berhasil men-_deploy_ kluster Minikube. Secara _default_, konfigurasi `kubectl` disimpan di `~/.kube/config`.
+Agar `kubectl` dapat mengakses klaster Kubernetes, dibutuhkan sebuah [berkas kubeconfig](/docs/tasks/access-application-cluster/configure-access-multiple-clusters/), yang akan otomatis dibuat ketika kamu membuat klaster baru menggunakan [kube-up.sh](https://github.com/kubernetes/kubernetes/blob/master/cluster/kube-up.sh) atau setelah berhasil men-_deploy_ klaster Minikube. Secara bawaan, konfigurasi `kubectl` disimpan di `~/.kube/config`.
 
-Kamu dapat memeriksa apakah konfigurasi `kubectl` sudah benar dengan mengambil _state_ kluster:
+Kamu dapat memeriksa apakah konfigurasi `kubectl` sudah benar dengan mengambil keadaan klaster:
 
 ```shell
 kubectl cluster-info
 ```
-Jika kamu melihat respons URL maka konfigurasi kluster `kubectl` sudah benar.
+Jika kamu melihat respons berupa URL, maka konfigurasi klaster `kubectl` sudah benar.
 
-Tetapi jika kamu melihat pesan seperti di bawah maka `kubectl` belum dikonfigurasi dengan benar atau tidak dapat terhubung ke kluster Kubernetes.
+Tetapi, jika kamu melihat pesan seperti di bawah, maka `kubectl` belum dikonfigurasi dengan benar atau tidak dapat terhubung ke klaster Kubernetes.
 
 ```shell
 The connection to the server <server-name:port> was refused - did you specify the right host or port?
 ```
 
-Selanjutnya, apabila kamu ingin menjalankan kluster Kubernetes di laptop (lokal), kamu memerlukan sebuah perangkat seperti Minikube sebelum menjalankan ulang perintah yang ada di atas.
+Selanjutnya, jika kamu ingin menjalankan klaster Kubernetes di laptop (lokal) kamu, kamu memerlukan sebuah perangkat seperti Minikube sebelum menjalankan ulang perintah yang ada di atas.
 
-Jika `kubectl cluster-info` mengembalikan respons URL tetapi kamu masih belum dapat mengakses ke kluster, kamu bisa menggunakan perintah di bawah untuk memeriksa apakah kluster sudah dikonfigurasi dengan benar.
+Jika `kubectl cluster-info` mengembalikan respons URL tetapi kamu masih belum dapat mengakses klaster, kamu bisa menggunakan perintah di bawah untuk memeriksa apakah klaster sudah dikonfigurasi dengan benar.
 
 ```shell
 kubectl cluster-info dump
 ```
 
-## Konfigurasi kubectl yang dapat dilakukan
+## Konfigurasi kubectl opsional
 
-### Menyalakan _auto complete_ untuk terminal
+### Menyalakan penyelesaian otomatis untuk terminal
 
-`kubectl` menyediakan fitur _auto complete_ untuk Bash dan Zsh yang dapat memudahkanmu ketika mengetik di terminal.
+`kubectl` menyediakan fitur penyelesaian otomatis (_auto complete_) untuk Bash dan Zsh yang dapat memudahkanmu ketika mengetik di terminal.
 
-Ikuti petunjuk di bawah untuk menyalakan _auto complete_ untuk Bash dan Zsh.
+Ikuti petunjuk di bawah untuk menyalakan penyelesaian otomatis untuk Bash dan Zsh.
 
 {{< tabs name="kubectl_autocompletion" >}}
 
-{{% tab name="Bash di Linux" %}}
+{{% tab name="Bash pada Linux" %}}
 
 ### Pendahuluan
 
-_Completion script_ `kubectl` untuk Bash dapat dibuat dengan perintah `kubectl completion bash`. Masukkan skrip tersebut ke dalam terminal sebagai sumber untuk menyalakan _auto complete_ dari `kubectl`.
+Skrip penyelesaian (_completion script_) `kubectl` untuk Bash dapat dibuat dengan perintah `kubectl completion bash`. Masukkan skrip tersebut ke dalam terminal sebagai sumber untuk menyalakan penyelesaian otomatis dari `kubectl`.
 
-Namun, _completion script_ tersebut tergantung dengan [**bash-completion**](https://github.com/scop/bash-completion), yang artinya kamu harus menginstal program tersebut terlebih dahulu (kamu dapat memeriksa apakah kamu sudah memiliki bash-completion dengan menjalankan perintah `type _init_completion`).
+Namun, skrip penyelesaian tersebut bergantung pada [**bash-completion**](https://github.com/scop/bash-completion), yang artinya kamu harus menginstal program tersebut terlebih dahulu (kamu dapat memeriksa apakah kamu sudah memiliki bash-completion dengan menjalankan perintah `type _init_completion`).
 
-### Instalasi bash-completion
+### Menginstal bash-completion
 
-bash-completion disediakan oleh banyak manajer paket (lihat [di sini](https://github.com/scop/bash-completion#installation)). Kamu dapat menginstalnya dengan menggunakan perintah `apt-get install bash-completion` atau `yum install bash-completion`, atau dsb.
+bash-completion disediakan oleh banyak manajer paket (lihat [di sini](https://github.com/scop/bash-completion#installation)). Kamu dapat menginstalnya dengan menggunakan perintah `apt-get install bash-completion` atau `yum install bash-completion`, dsb.
 
-Perintah di atas akan membuat skrip utama bash-completion di `/usr/share/bash-completion/bash_completion`. Terkadang kamu juga harus menambahkan skrip tersebut ke dalam berkas `~/.bashrc`, tergantung paket manajer yang kamu pakai.
+Perintah di atas akan membuat skrip utama bash-completion di `/usr/share/bash-completion/bash_completion`. Terkadang kamu juga harus menambahkan skrip tersebut ke dalam berkas `~/.bashrc`, tergantung manajer paket yang kamu pakai.
 
-Untuk memastikan, muat ulang terminalmu dan jalankan `type _init_completion`. Jika perintah berhasil maka instalasi selesai. Jika tidak, tambahkan teks berikut ke dalam berkas `~/.bashrc`:
+Untuk memastikannya, muat ulang terminalmu dan jalankan `type _init_completion`. Jika perintah tersebut berhasil, maka instalasi selesai. Jika tidak, tambahkan teks berikut ke dalam berkas `~/.bashrc`:
 
 ```shell
 source /usr/share/bash-completion/bash_completion
 ```
 
-Muat ulang lagi terminalmu dan pastikan bash-completion sudah berhasil diinstal dengan menjalankan `type _init_completion`.
+Muat ulang terminalmu dan pastikan bash-completion sudah berhasil diinstal dengan menjalankan `type _init_completion`.
 
-### Menyalakan _auto complete_ kubectl
+### Menyalakan penyelesaian otomatis kubectl
 
-Sekarang kamu harus memastikan bahwa _completion script_ untuk `kubectl` sudah dimasukkan sebagai sumber _auto complete_ di semua sesi terminal. Kamu dapat melakukannya dengan dua cara:
+Sekarang kamu harus memastikan bahwa skrip penyelesaian untuk `kubectl` sudah dimasukkan sebagai sumber penyelesaian otomatis pada semua sesi terminal. Kamu dapat melakukannya dengan dua cara:
 
-- Masukkan _completion script_ sebagai sumber di berkas `~/.bashrc`:
+- Masukkan skrip penyelesaian sebagai sumber di berkas `~/.bashrc`:
 
     ```shell
     echo 'source <(kubectl completion bash)' >>~/.bashrc
     ```
 
-- Menambahkan _completion script_ ke direktori `/etc/bash_completion.d`:
+- Tambahkan skrip penyelesaian ke direktori `/etc/bash_completion.d`:
 
     ```shell
     kubectl completion bash >/etc/bash_completion.d/kubectl
     ```
 
-Jika kamu menggunakan alias untuk `kubectl`, kamu masih dapat menggunakan fitur _auto complete_ dengan menjalankan perintah:
+Jika kamu menggunakan alias untuk `kubectl`, kamu masih dapat menggunakan fitur penyelesaian otomatis dengan menjalankan perintah:
 
     ```shell
     echo 'alias k=kubectl' >>~/.bashrc
@@ -362,28 +362,28 @@ Jika kamu menggunakan alias untuk `kubectl`, kamu masih dapat menggunakan fitur 
     ```
 
 {{< note >}}
-Semua sumber _completion script_ bash-completion terdapat di `/etc/bash_completion.d`.
+Semua sumber skrip penyelesaian bash-completion terdapat di `/etc/bash_completion.d`.
 {{< /note >}}
 
-Kedua cara tersebut sama, kamu bisa mengambil salah satu cara saja. Setelah memuat ulang terminal, _auto complete_ dari `kubectl` seharusnya sudah dapat bekerja.
+Kedua cara tersebut sama, kamu bisa memilih salah satunya. Setelah memuat ulang terminal, penyelesaian otomatis dari `kubectl` seharusnya sudah dapat bekerja.
 
 {{% /tab %}}
 
 
-{{% tab name="Bash di macOS" %}}
+{{% tab name="Bash pada macOS" %}}
 
 
 ### Pendahuluan
 
-_Completion script_ `kubectl` untuk Bash dapat dibuat dengan perintah `kubectl completion bash`. Masukkan skrip tersebut ke dalam terminal sebagai sumber untuk menyalakan _auto complete_ dari `kubectl`.
+Skrip penyelesaian (_completion script_) `kubectl` untuk Bash dapat dibuat dengan perintah `kubectl completion bash`. Masukkan skrip tersebut ke dalam terminal sebagai sumber untuk menyalakan penyelesaian otomatis dari `kubectl`.
 
-Namun, _completion script_ tersebut tergantung dengan [**bash-completion**](https://github.com/scop/bash-completion), yang artinya kamu harus menginstal program tersebut terlebih dahulu.
+Namun, skrip penyelesaian tersebut bergantung pada [**bash-completion**](https://github.com/scop/bash-completion), yang artinya kamu harus menginstal program tersebut terlebih dahulu.
 
 {{< warning>}}
-Terdapat dua versi bash-completion, v1 dan v2. V1 untuk Bash 3.2 (_default_ dari macOs), dan v2 untuk Bash 4.1+. _Completion script_ `kubectl` **tidak kompatibel** dengan bash-completion v1 dan Bash 3.2. Dibutuhkan **bash-completion v2** dan **Bash 4.1+** agar _completion script_ `kubectl` dapat bekerja dengan baik. Maka dari itu, kamu harus menginstal dan menggunakan Bash 4.1+ ([*panduan*](https://itnext.io/upgrading-bash-on-macos-7138bd1066ba)) untuk dapat menggunakan fitur _auto complete_ dari `kubectl`. Ikuti panduan di bawah setelah kamu menginstal Bash 4.1+ (yang artinya Bash versi 4.1 atau lebih baru).
+Terdapat dua versi bash-completion, v1 dan v2. V1 untuk Bash 3.2 (bawaan dari macOs), dan v2 untuk Bash 4.1+. Skrip penyelesaian `kubectl` **tidak kompatibel** dengan bash-completion v1 dan Bash 3.2. Dibutuhkan **bash-completion v2** dan **Bash 4.1+** agar skrip penyelesaian `kubectl` dapat bekerja dengan baik. Maka dari itu, kamu harus menginstal dan menggunakan Bash 4.1+ ([*panduan*](https://itnext.io/upgrading-bash-on-macos-7138bd1066ba)) untuk dapat menggunakan fitur penyelesaian otomatis dari `kubectl`. Ikuti panduan di bawah setelah kamu menginstal Bash 4.1+ (yaitu, Bash versi 4.1 atau lebih baru).
 {{< /warning >}}
 
-### Pembaruan Bash
+### Pemutakhiran Bash
 
 Panduan di bawah berasumsi kamu menggunakan Bash 4.1+. Kamu dapat memeriksa versi Bash dengan menjalankan:
 
@@ -391,7 +391,7 @@ Panduan di bawah berasumsi kamu menggunakan Bash 4.1+. Kamu dapat memeriksa vers
 echo $BASH_VERSION
 ```
 
-Jika versinya sudah terlalu usang, kamu dapat menginstal/memperbaruinya dengan menggunakan Homebrew:
+Jika versinya sudah terlalu usang, kamu dapat menginstal/memutakhirkannya dengan menggunakan Homebrew:
 
 ```shell
 brew install bash
@@ -405,10 +405,10 @@ echo $BASH_VERSION $SHELL
 
 Homebrew biasanya akan menginstalnya di `/usr/local/bin/bash`.
 
-### Instalasi bash-completion
+### Menginstal bash-completion
 
 {{< note >}}
-Seperti yang sudah disebutkan, panduan di bawah berasumsi kamu menggunakan Bash 4.1+, yang berarti kamu akan menginstal bash-completion v2 (_auto complete_ dari `kubectl` tidak kompatibel dengan Bash 3.2 dan bash-completion v1).
+Seperti yang sudah disebutkan, panduan di bawah berasumsi kamu menggunakan Bash 4.1+, yang berarti kamu akan menginstal bash-completion v2 (penyelesaian otomatis dari `kubectl` tidak kompatibel dengan Bash 3.2 dan bash-completion v1).
 {{< /note >}}
 
 Kamu dapat memeriksa apakah kamu sudah memiliki bash-completion v2 dengan perintah `type _init_completion`. Jika belum, kamu dapat menginstalnya dengan menggunakan Homebrew:
@@ -417,7 +417,7 @@ Kamu dapat memeriksa apakah kamu sudah memiliki bash-completion v2 dengan perint
 brew install bash-completion@2
 ```
 
-Seperti yang disarankan keluaran perintah di atas, tambahkan teks berikut ke berkas `~/.bashrc`:
+Seperti yang disarankan pada keluaran perintah di atas, tambahkan teks berikut ke berkas `~/.bashrc`:
 
 ```shell
 export BASH_COMPLETION_COMPAT_DIR="/usr/local/etc/bash_completion.d"
@@ -426,55 +426,55 @@ export BASH_COMPLETION_COMPAT_DIR="/usr/local/etc/bash_completion.d"
 
 Muat ulang terminalmu dan pastikan bash-completion v2 sudah terinstal dengan perintah `type _init_completion`.
 
-### Menyalakan _auto complete_ kubectl
+### Menyalakan penyelesaian otomatis kubectl
 
-Sekarang kamu harus memastikan bahwa _completion script_ untuk `kubectl` sudah dimasukkan sebagai sumber _auto complete_ di semua sesi terminal. Kamu dapat melakukannya dengan beberapa cara:
+Sekarang kamu harus memastikan bahwa skrip penyelesaian untuk `kubectl` sudah dimasukkan sebagai sumber penyelesaian otomatis di semua sesi terminal. Kamu dapat melakukannya dengan beberapa cara:
 
-- Masukkan _completion script_ sebagai sumber di berkas `~/.bashrc`:
+- Masukkan skrip penyelesaian sebagai sumber di berkas `~/.bashrc`:
 
     ```shell
     echo 'source <(kubectl completion bash)' >>~/.bashrc
     ```
 
-- Menambahkan _completion script_ ke direktori `/etc/bash_completion.d`:
+- Menambahkan skrip penyelesaian ke direktori `/etc/bash_completion.d`:
 
     ```shell
     kubectl completion bash >/etc/bash_completion.d/kubectl
     ```
 
-- Jika kamu menggunakan alias untuk `kubectl`, kamu masih dapat menggunakan fitur _auto complete_ dengan menjalankan perintah:
+- Jika kamu menggunakan alias untuk `kubectl`, kamu masih dapat menggunakan fitur penyelesaian otomatis dengan menjalankan perintah:
 
     ```shell
     echo 'alias k=kubectl' >>~/.bashrc
     echo 'complete -F __start_kubectl k' >>~/.bashrc
     ```
-- Jika kamu menginstal `kubectl` dengan Homebrew (seperti yang sudah dijelaskan [di atas](#install-with-homebrew-on-macos)), maka _completion script_ untuk `kubectl` sudah berada di `/usr/local/etc/bash_completion.d/kubectl`. Kamu tidak perlu melakukan apa-apa lagi.
+- Jika kamu menginstal `kubectl` dengan Homebrew (seperti yang sudah dijelaskan [di atas](#install-with-homebrew-on-macos)), maka skrip penyelesaian untuk `kubectl` sudah berada di `/usr/local/etc/bash_completion.d/kubectl`. Kamu tidak perlu melakukan apa-apa lagi.
 
 {{< note >}}
-bash-completion v2 yang diinstal dengan Homebrew meletakkan semua berkas nya di direktori `BASH_COMPLETION_COMPAT_DIR`, yang membuat dua cara terakhir dapat bekerja.
+bash-completion v2 yang diinstal dengan Homebrew meletakkan semua berkas nya di direktori `BASH_COMPLETION_COMPAT_DIR`, itulah alasannya dua cara terakhir dapat bekerja.
 {{< /note >}}
 
-Setelah memuat ulang terminal, _auto complete_ dari `kubectl` seharusnya sudah dapat bekerja.
+Setelah memuat ulang terminal, penyelesaian otomatis dari `kubectl` seharusnya sudah dapat bekerja.
 {{% /tab %}}
 
 {{% tab name="Zsh" %}}
 
-_Completion script_ `kubectl` untuk Zsh dapat dibuat dengan perintah `kubectl completion zsh`. Masukkan skrip tersebut ke dalam terminal sebagai sumber untuk menyalakan _auto complete_ dari `kubectl`.
+Skrip penyelesaian (_completion script_) `kubectl` untuk Zsh dapat dibuat dengan perintah `kubectl completion zsh`. Masukkan skrip tersebut ke dalam terminal sebagai sumber untuk menyalakan penyelesaian otomatis dari `kubectl`.
 
-Tambahkan baris berikut di berkas `~/.zshrc` untuk menyalakan _auto complete_ dari `kubectl`:
+Tambahkan baris berikut di berkas `~/.zshrc` untuk menyalakan penyelesaian otomatis dari `kubectl`:
 
 ```shell
 source <(kubectl completion zsh)
 ```
 
-Jika kamu menggunakan alias untuk `kubectl`, kamu masih dapat menggunakan fitur _auto complete_ dengan menjalankan perintah:
+Jika kamu menggunakan alias untuk `kubectl`, kamu masih dapat menggunakan fitur penyelesaian otomatis dengan menjalankan perintah:
 
 ```shell
 echo 'alias k=kubectl' >>~/.zshrc
 echo 'complete -F __start_kubectl k' >>~/.zshrc
 ```
 
-Setelah memuat ulang terminal, _auto complete_ dari `kubectl` seharusnya sudah dapat bekerja.
+Setelah memuat ulang terminal, penyelesaian otomatis dari `kubectl` seharusnya sudah dapat bekerja.
 
 Jika kamu mendapatkan pesan gagal seperti `complete:13: command not found: compdef`, maka tambahkan teks berikut ke awal berkas `~/.zshrc`:
 
@@ -488,9 +488,9 @@ compinit
 {{% /capture %}}
 
 {{% capture whatsnext %}}
-* [Instalasi Minikube](/docs/tasks/tools/install-minikube/)
-* Lihat [panduan memulai](/docs/setup/) untuk mencari tahu tentang pembuatan kluster. 
+* [Menginstal Minikube.](/docs/tasks/tools/install-minikube/)
+* Lihat [panduan persiapan](/docs/setup/) untuk mencari tahu tentang pembuatan klaster. 
 * [Pelajari cara untuk menjalankan dan mengekspos aplikasimu.](/docs/tasks/access-application-cluster/service-access-application-cluster/)
-* Jika kamu membutuhkan akses ke kluster yang tidak kamu buat, lihat [dokumen Sharing Cluster Access](/docs/tasks/access-application-cluster/configure-access-multiple-clusters/).
+* Jika kamu membutuhkan akses ke klaster yang tidak kamu buat, lihat [dokumen Berbagi Akses Klaster](/docs/tasks/access-application-cluster/configure-access-multiple-clusters/).
 * Baca [dokumen referensi kubectl](/docs/reference/kubectl/kubectl/)
 {{% /capture %}}


### PR DESCRIPTION
This PR improves the Indonesian "Install Kubectl" page:

- Change several "instalasi" nouns to "menginstal" verbs
- Add some native Indonesian words with hints. E.g alat baris
perintah, skrip penyelesaian, penyelesaian otomatis.
- Fix some grammar, punctuations, and add clarity. E.g "di" to "pada" preposition, commas, 
manajer paket, etc.
- Fix broken list item numberings.
- Fix some non-standard words. E.g kluster to klaster, binari to
program.

This is related to a review thread in https://github.com/kubernetes/website/pull/20356/files#r410804473

Refs:
https://github.com/kubernetes/website/pull/20356/files#r410799861
https://github.com/kubernetes/website/pull/20356/files#r410806099
https://en.wiktionary.org/wiki/install
https://ivanlanin.wordpress.com/2011/03/27/di-dan-pada/
https://beritagar.id/artikel/tabik/di-ke-pada-dan-kepada

Signed-off-by: Yudi A Phanama <yudiandreanp@gmail.com>