### PR TITLE
Fix grammatical error

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/kubelet.md
+++ b/content/en/docs/reference/command-line-tools-reference/kubelet.md
@@ -12,7 +12,7 @@ node. It can register the node with the apiserver using one of: the hostname; a 
 The kubelet works in terms of a PodSpec. A PodSpec is a YAML or JSON object
 that describes a pod. The kubelet takes a set of PodSpecs that are provided through various mechanisms (primarily through the apiserver) and ensures that the containers described in those PodSpecs are running and healthy. The kubelet doesn't manage containers which were not created by Kubernetes.
 
-Other than from an PodSpec from the apiserver, there are three ways that a container manifest can be provided to the Kubelet.
+Other than from a PodSpec from the apiserver, there are three ways that a container manifest can be provided to the Kubelet.
 
 File: Path passed as a flag on the command line. Files under this path will be monitored periodically for updates. The monitoring period is 20s by default and is configurable via a flag.
 


### PR DESCRIPTION
Small change to correct a use of `an` to be `a` when referring to `a PodSpec`.