### PR TITLE
Update content/zh/docs/concepts/configuration/taint-and-toleration.md

### DIFF
--- a/content/zh/docs/concepts/configuration/taint-and-toleration.md
+++ b/content/zh/docs/concepts/configuration/taint-and-toleration.md
@@ -278,10 +278,10 @@ manually add tolerations to your pods.
 
 <!--
 
-* **Taint based Evictions (beta feature)**: A per-pod-configurable eviction behavior
+* **Taint based Evictions**: A per-pod-configurable eviction behavior
 when there are node problems, which is described in the next section.
 -->
-* **基于 taint 的驱逐 （beta 特性）**: 这是在每个 pod 中配置的在节点出现问题时的驱逐行为，接下来的章节会描述这个特性
+* **基于 taint 的驱逐**: 这是在每个 pod 中配置的在节点出现问题时的驱逐行为，接下来的章节会描述这个特性
 
 <!--
 
@@ -290,6 +290,8 @@ when there are node problems, which is described in the next section.
 -->
 
 ## 基于 taint 的驱逐
+
+{{< feature-state for_k8s_version="v1.18" state="stable" >}}
 
 <!--
 Earlier we mentioned the `NoExecute` taint effect, which affects pods that are already
@@ -338,11 +340,12 @@ certain condition is true. The following taints are built in:
  * `node.cloudprovider.kubernetes.io/uninitialized`：如果 kubelet 启动时指定了一个 "外部" cloud provider，它将给当前节点添加一个 taint 将其标志为不可用。在 cloud-controller-manager 的一个 controller 初始化这个节点后，kubelet 将删除这个 taint。
 
 <!--
-In version 1.13, the `TaintBasedEvictions` feature is promoted to beta and enabled by default, hence the taints are automatically
-added by the NodeController (or kubelet) and the normal logic for evicting pods from nodes
-based on the Ready NodeCondition is disabled.
+In case a node is to be evicted, the node controller or the kubelet adds relevant taints
+with `NoExecute` effect. If the fault condition returns to normal the kubelet or node
+controller can remove the relevant taint(s).
 -->
-在版本1.13中，`TaintBasedEvictions` 功能已升级为Beta，并且默认启用，因此污点会自动给节点添加这类 taint，上述基于节点状态 Ready 对 pod 进行驱逐的逻辑会被禁用。
+在节点被驱逐时，节点控制器或者 kubelet 会添加带有 `NoExecute` 效应的相关污点。如果异常状态恢复正常，kubelet 或节点控制器能够移除相关的污点。
+
 
 {{< note >}}
 <!--
@@ -355,10 +358,10 @@ as the master becoming partitioned from the nodes.
 {{< /note >}}
 
 <!--
-This beta feature, in combination with `tolerationSeconds`, allows a pod
+This feature, in combination with `tolerationSeconds`, allows a pod
 to specify how long it should stay bound to a node that has one or both of these problems.
 -->
-使用这个 beta 功能特性，结合 `tolerationSeconds` ，pod 就可以指定当节点出现一个或全部上述问题时还将在这个节点上运行多长的时间。
+使用这个功能特性，结合 `tolerationSeconds` ，pod 就可以指定当节点出现一个或全部上述问题时还将在这个节点上运行多长的时间。
 
 <!--
 For example, an application with a lot of local state might want to stay
@@ -405,15 +408,14 @@ admission controller](https://git.k8s.io/kubernetes/plugin/pkg/admission/default
   * `node.kubernetes.io/unreachable`
   * `node.kubernetes.io/not-ready`
 
-This ensures that DaemonSet pods are never evicted due to these problems,
-which matches the behavior when this feature is disabled.
+This ensures that DaemonSet pods are never evicted due to these problems.
 -->
 [DaemonSet](/docs/concepts/workloads/controllers/daemonset/) 中的 pod 被创建时，针对以下 taint 自动添加的 `NoExecute` 的 toleration 将不会指定 `tolerationSeconds`：
 
   * `node.kubernetes.io/unreachable`
   * `node.kubernetes.io/not-ready`
 
-这保证了出现上述问题时 DaemonSet 中的 pod 永远不会被驱逐，这和 `TaintBasedEvictions` 这个特性被禁用后的行为是一样的。
+这保证了出现上述问题时 DaemonSet 中的 pod 永远不会被驱逐。
 
 <!--
 ## Taint Nodes by Condition
@@ -422,9 +424,8 @@ which matches the behavior when this feature is disabled.
 ## 基于节点状态添加 taint
 
 <!--
-The node lifecycle controller automatically creates taints corresponding to Node conditions.
+The node lifecycle controller automatically creates taints corresponding to Node conditions with `NoSchedule` effect.
 Similarly the scheduler does not check Node conditions; instead the scheduler checks taints. This assures that Node conditions don't affect what's scheduled onto the Node. The user can choose to ignore some of the Node's problems (represented as Node conditions) by adding appropriate Pod tolerations.
-Note that `TaintNodesByCondition` only taints nodes with `NoSchedule` effect. `NoExecute` effect is controlled by `TaintBasedEviction` which is a beta feature and enabled by default since version 1.13.
 
 Starting in Kubernetes 1.8, the DaemonSet controller automatically adds the
 following `NoSchedule` tolerations to all daemons, to prevent DaemonSets from
@@ -436,10 +437,10 @@ breaking.
   * `node.kubernetes.io/unschedulable` (1.10 or later)
   * `node.kubernetes.io/network-unavailable` (*host network only*)
 -->
-Node 生命周期控制器会自动创建与 Node 条件相对应的污点。
+Node 生命周期控制器会自动创建与 Node 条件相对应的带有 `NoSchedule` 效应的污点。
 同样，调度器不检查节点条件，而是检查节点污点。这确保了节点条件不会影响调度到节点上的内容。用户可以通过添加适当的 Pod 容忍度来选择忽略某些 Node 的问题(表示为 Node 的调度条件)。
-注意，`TaintNodesByCondition` 只会污染具有 `NoSchedule` 设定的节点。 `NoExecute` 效应由 `TaintBasedEviction` 控制，
-`TaintBasedEviction` 是 Beta 版功能，自 Kubernetes 1.13 起默认启用。
+
+自 Kubernetes 1.8 起， DaemonSet 控制器自动为所有守护进程添加如下 `NoSchedule` toleration 以防 DaemonSet 崩溃：
 
   * `node.kubernetes.io/memory-pressure`
   * `node.kubernetes.io/disk-pressure`


### PR DESCRIPTION
Update zh translation for release 1.18

See diff between release-1.17 and release-1.18:

```
git diff release-1.17 release-1.18 content/en/docs/concepts/configuration/taint-and-toleration.md
```

<details>
<summary>Diff:</summary>

```diff
diff --git a/content/en/docs/concepts/configuration/taint-and-toleration.md b/content/en/docs/concepts/configuration/taint-and-toleration.md
index eac6267e7..2026390ef 100644
--- a/content/en/docs/concepts/configuration/taint-and-toleration.md
+++ b/content/en/docs/concepts/configuration/taint-and-toleration.md
@@ -197,11 +197,13 @@ on the special hardware nodes. This will make sure that these special hardware
 nodes are dedicated for pods requesting such hardware and you don't have to
 manually add tolerations to your pods.

-* **Taint based Evictions (beta feature)**: A per-pod-configurable eviction behavior
+* **Taint based Evictions**: A per-pod-configurable eviction behavior
 when there are node problems, which is described in the next section.

 ## Taint based Evictions

+{{< feature-state for_k8s_version="1.18" state="stable" >}}
+
 Earlier we mentioned the `NoExecute` taint effect, which affects pods that are already
 running on the node as follows

@@ -229,9 +231,9 @@ certain condition is true. The following taints are built in:
     as unusable. After a controller from the cloud-controller-manager initializes
     this node, the kubelet removes this taint.

-In version 1.13, the `TaintBasedEvictions` feature is promoted to beta and enabled by default, hence the taints are automatically
-added by the NodeController (or kubelet) and the normal logic for evicting pods from nodes
-based on the Ready NodeCondition is disabled.
+In case a node is to be evicted, the node controller or the kubelet adds relevant taints
+with `NoExecute` effect. If the fault condition returns to normal the kubelet or node
+controller can remove the relevant taint(s).

 {{< note >}}
 To maintain the existing [rate limiting](/docs/concepts/architecture/nodes/)
@@ -240,7 +242,7 @@ in a rate-limited way. This prevents massive pod evictions in scenarios such
 as the master becoming partitioned from the nodes.
 {{< /note >}}

-This beta feature, in combination with `tolerationSeconds`, allows a pod
+The feature, in combination with `tolerationSeconds`, allows a pod
 to specify how long it should stay bound to a node that has one or both of these problems.

 For example, an application with a lot of local state might want to stay
@@ -277,15 +279,13 @@ admission controller](https://git.k8s.io/kubernetes/plugin/pkg/admission/default
   * `node.kubernetes.io/unreachable`
   * `node.kubernetes.io/not-ready`

-This ensures that DaemonSet pods are never evicted due to these problems,
-which matches the behavior when this feature is disabled.
+This ensures that DaemonSet pods are never evicted due to these problems.

 ## Taint Nodes by Condition

 The node lifecycle controller automatically creates taints corresponding to
-Node conditions.
+Node conditions with `NoSchedule` effect.
 Similarly the scheduler does not check Node conditions; instead the scheduler checks taints. This assures that Node conditions don't affect what's scheduled onto the Node. The user can choose to ignore some of the Node's problems (represented as Node conditions) by adding appropriate Pod tolerations.
-Note that `TaintNodesByCondition` only taints nodes with `NoSchedule` effect. `NoExecute` effect is controlled by `TaintBasedEviction` which is a beta feature and enabled by default since version 1.13.

 Starting in Kubernetes 1.8, the DaemonSet controller automatically adds the
 following `NoSchedule` tolerations to all daemons, to prevent DaemonSets from
```
</details>
