### PR TITLE
Add HUAWEI CLOUD to cloud-provider vendor list

### DIFF
--- a/content/en/docs/concepts/architecture/cloud-controller.md
+++ b/content/en/docs/concepts/architecture/cloud-controller.md
@@ -231,6 +231,7 @@ The following cloud providers have implemented CCMs:
 * [DigitalOcean](https://github.com/digitalocean/digitalocean-cloud-controller-manager)
 * [GCP](https://github.com/kubernetes/cloud-provider-gcp)
 * [Hetzner](https://github.com/hetznercloud/hcloud-cloud-controller-manager)
+* [HUAWEI CLOUD](https://github.com/kubernetes-sigs/cloud-provider-huaweicloud)
 * [Linode](https://github.com/linode/linode-cloud-controller-manager)
 * [OpenStack](https://github.com/kubernetes/cloud-provider-openstack)
 * [Oracle](https://github.com/oracle/oci-cloud-controller-manager)


### PR DESCRIPTION
Add `HUAWEI CLOUD` to cloud-provider vendor list.

Fixes: https://github.com/kubernetes-sigs/cloud-provider-huaweicloud/issues/58