### PR TITLE
Fix rendering error in k8s.io/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes/ 

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes.md
@@ -118,7 +118,7 @@ Once you have a Linux-based Kubernetes control-plane node you are ready to choos
     If you're using host-gateway use https://github.com/kubernetes-sigs/sig-windows-tools/releases/latest/download/flannel-host-gw.yml instead
     {{< /note >}}
 
-{{< note >}}
+    {{< note >}}
 If you're using a different interface rather than Ethernet (i.e. "Ethernet0 2") on the Windows nodes, you have to modify the line:
 
 ```powershell
@@ -126,12 +126,13 @@ wins cli process run --path /k/flannel/setup.exe --args "--mode=overlay --interf
 ```
 
 in the `flannel-host-gw.yml` or `flannel-overlay.yml` file and specify your interface accordingly.
-{{< /note >}}
-    
+
 ```bash
 # Example
 curl -L https://github.com/kubernetes-sigs/sig-windows-tools/releases/latest/download/flannel-overlay.yml | sed 's/Ethernet/Ethernet0 2/g' | kubectl apply -f -
 ```
+    {{< /note >}}
+    
 
 
 ### Joining a Windows worker node

--- a/content/en/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes.md
@@ -118,19 +118,20 @@ Once you have a Linux-based Kubernetes control-plane node you are ready to choos
     If you're using host-gateway use https://github.com/kubernetes-sigs/sig-windows-tools/releases/latest/download/flannel-host-gw.yml instead
     {{< /note >}}
 
-    {{< note >}}
-    If you're using a different interface rather than Ethernet (i.e. "Ethernet0 2") on the Windows nodes, you have to modify the line:
+{{< note >}}
+If you're using a different interface rather than Ethernet (i.e. "Ethernet0 2") on the Windows nodes, you have to modify the line:
+
+```powershell
+wins cli process run --path /k/flannel/setup.exe --args "--mode=overlay --interface=Ethernet"
+```
+
+in the `flannel-host-gw.yml` or `flannel-overlay.yml` file and specify your interface accordingly.
+{{< /note >}}
     
-    ```powershell
-    wins cli process run --path /k/flannel/setup.exe --args "--mode=overlay --interface=Ethernet"
-    ```
-    in the flannel-host-gw.yml or flannel-overlay.yml file and specify your interface accordingly.
-    {{< /note >}}
-    
-    ```bash
-    # Example
-    curl -L https://github.com/kubernetes-sigs/sig-windows-tools/releases/latest/download/flannel-overlay.yml | sed 's/Ethernet/Ethernet0 2/g' | kubectl apply -f -
-    ```
+```bash
+# Example
+curl -L https://github.com/kubernetes-sigs/sig-windows-tools/releases/latest/download/flannel-overlay.yml | sed 's/Ethernet/Ethernet0 2/g' | kubectl apply -f -
+```
 
 
 ### Joining a Windows worker node


### PR DESCRIPTION
It seems removing the tabbing in the codeblocks fix the rendering
issues. Also added backticks to files to file names for emphasis.

Fixes #20130
Fixes #20483 
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use
 for advice.

-->
