### PR TITLE
Change virtual machine for docker - from experimental to preferred.

### DIFF
--- a/content/en/docs/setup/learning-environment/minikube.md
+++ b/content/en/docs/setup/learning-environment/minikube.md
@@ -200,7 +200,7 @@ plugins.
 
 * virtualbox
 * vmwarefusion
-* docker (EXPERIMENTAL)
+* docker ([driver installation](https://minikube.sigs.k8s.io/docs/drivers/docker/)
 * kvm2 ([driver installation](https://minikube.sigs.k8s.io/docs/reference/drivers/kvm2/))
 * hyperkit ([driver installation](https://minikube.sigs.k8s.io/docs/reference/drivers/hyperkit/))
 * hyperv ([driver installation](https://minikube.sigs.k8s.io/docs/reference/drivers/hyperv/))


### PR DESCRIPTION
Virtual machine as docker is preferred by Minikube maintainers


