### PR TITLE
Fix typo in Configure Default CPU Requests and Limits for a Namespace section

### DIFF
--- a/content/en/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace.md
+++ b/content/en/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace.md
@@ -108,7 +108,7 @@ resources:
   limits:
     cpu: "1"
   requests:
-    cpu: "1"
+    cpu: "0.5"
 ```
 
 ## What if you specify a Container's request, but not its limit?


### PR DESCRIPTION
IMHO  `requests:cpu` must be 0.5 not 1 after
> Notice that the Container was not assigned the default CPU request value of 0.5 cpu.

Correct me if I am wrong

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use
 for advice.

-->
