### PR TITLE
Fix broken link

### DIFF
--- a/content/en/docs/tasks/debug-application-cluster/resource-metrics-pipeline.md
+++ b/content/en/docs/tasks/debug-application-cluster/resource-metrics-pipeline.md
@@ -52,7 +52,7 @@ Memory is reported as the working set, in bytes, at the instant the metric was c
 [Metrics Server](https://github.com/kubernetes-incubator/metrics-server) is a cluster-wide aggregator of resource usage data.
 It is deployed by default in clusters created by `kube-up.sh` script
 as a Deployment object. If you use a different Kubernetes setup mechanism you can deploy it using the provided
-[deployment yamls](https://github.com/kubernetes-incubator/metrics-server/tree/master/deploy).
+[deployment component.yaml](https://github.com/kubernetes-sigs/metrics-server/releases) file.
 
 Metric server collects metrics from the Summary API, exposed by [Kubelet](/docs/admin/kubelet/) on each node.
 

--- a/content/en/docs/tasks/debug-application-cluster/resource-metrics-pipeline.md
+++ b/content/en/docs/tasks/debug-application-cluster/resource-metrics-pipeline.md
@@ -52,7 +52,7 @@ Memory is reported as the working set, in bytes, at the instant the metric was c
 [Metrics Server](https://github.com/kubernetes-incubator/metrics-server) is a cluster-wide aggregator of resource usage data.
 It is deployed by default in clusters created by `kube-up.sh` script
 as a Deployment object. If you use a different Kubernetes setup mechanism you can deploy it using the provided
-[deployment component.yaml](https://github.com/kubernetes-sigs/metrics-server/releases) file.
+[deployment components.yaml](https://github.com/kubernetes-sigs/metrics-server/releases) file.
 
 Metric server collects metrics from the Summary API, exposed by [Kubelet](/docs/admin/kubelet/) on each node.
 


### PR DESCRIPTION
Structure of the repo changed and broke the link, see [Deployment](https://github.com/kubernetes-sigs/metrics-server/blob/master/README.md#deployment) section of the readme for more info
