### PR TITLE
Fixed wrong file location in example.

### DIFF
--- a/content/en/docs/tasks/manage-daemon/update-daemon-set.md
+++ b/content/en/docs/tasks/manage-daemon/update-daemon-set.md
@@ -102,7 +102,7 @@ If you update DaemonSets using
 use `kubectl apply`:
 
 ```shell
-kubectl apply -f https://k8s.io/examples/application/fluentd-daemonset-update.yaml
+kubectl apply -f https://k8s.io/examples/controllers/fluentd-daemonset-update.yaml
 ```
 
 #### Imperative commands


### PR DESCRIPTION
The previous command referenced a non-existing file https://k8s.io/examples/application/fluentd-daemonset-update.yaml. This PR fixes it to point to the correct location (https://k8s.io/examples/controllers/fluentd-daemonset-update.yaml).