### PR TITLE
Fix issue with content/ko/includes/task-tutorial-prereqs.md

### DIFF
--- a/content/ko/includes/task-tutorial-prereqs.md
+++ b/content/ko/includes/task-tutorial-prereqs.md
@@ -1,8 +1,8 @@
 쿠버네티스 클러스터가 필요하고, kubectl 커맨드-라인 툴이 클러스터와
-통신할 수 있도록 설정되어 있어야 합니다.
+통신할 수 있도록 설정되어 있어야 한다.
 만약, 아직 클러스터를 가지고 있지 않다면,
-[Minikube](/docs/setup/learning-environment/minikube/)를 사용해서 만들거나,
-다음의 쿠버네티스 플레이그라운드 중 하나를 사용할 수 있습니다:
+[Minikube](/ko/docs/setup/learning-environment/minikube/)를 사용해서 생성하거나,
+다음의 쿠버네티스 플레이그라운드 중 하나를 사용할 수 있다.
 
 * [Katacoda](https://www.katacoda.com/courses/kubernetes/playground)
 * [Play with Kubernetes](http://labs.play-with-k8s.com/)


### PR DESCRIPTION
This fixes #20541 .

평어체로 수정합니다.

- 설정되어 있어야 합니다. -> 설정되어 있어야 한다.
- 사용할 수 있습니다: -> 사용할 수 있다.
- Minikube에 대한 링크 수정: /ko/docs/setup/learning-environment/minikube/