### PR TITLE
Update crio installation steps for CentOS/RHEL

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -219,8 +219,7 @@ sudo apt-get install cri-o-1.17
 {{< tab name="CentOS/RHEL 7.4+" codelang="bash" >}}
 # Install prerequisites
 curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/CentOS_7/devel:kubic:libcontainers:stable.repo
-
-curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable:cri-o:[REQUIRED VERSION].repo https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable:cri-o:[REQUIRED VERSION]/CentOS_7/devel:kubic:libcontainers:stable:cri-o:[REQUIRED VERSION].repo
+curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable:cri-o:{{< skew latestVersion >}}.repo https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable:cri-o:{{< skew latestVersion >}}/CentOS_7/devel:kubic:libcontainers:stable:cri-o:{{< skew latestVersion >}}.repo
 
 # Install CRI-O
 yum install -y cri-o

--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -218,10 +218,12 @@ sudo apt-get install cri-o-1.17
 
 {{< tab name="CentOS/RHEL 7.4+" codelang="bash" >}}
 # Install prerequisites
-yum-config-manager --add-repo=https://cbs.centos.org/repos/paas7-crio-115-release/x86_64/os/
+curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/CentOS_7/devel:kubic:libcontainers:stable.repo
+
+curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable:cri-o:[REQUIRED VERSION].repo https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable:cri-o:[REQUIRED VERSION]/CentOS_7/devel:kubic:libcontainers:stable:cri-o:[REQUIRED VERSION].repo
 
 # Install CRI-O
-yum install --nogpgcheck -y cri-o
+yum install -y cri-o
 {{< /tab >}}
 
 {{< tab name="openSUSE Tumbleweed" codelang="bash" >}}


### PR DESCRIPTION
Hi,

crio installation steps for CentOS/RHEL distribution are not valid anymore(CBS repo does not exist anymore)

I'm updating the documentation following instructions reported on crio official repository https://github.com/cri-o/cri-o
