### PR TITLE
update deprecated image in hello minikube

### DIFF
--- a/content/en/docs/tutorials/hello-minikube.md
+++ b/content/en/docs/tutorials/hello-minikube.md
@@ -78,7 +78,7 @@ recommended way to manage the creation and scaling of Pods.
 Pod runs a Container based on the provided Docker image.
 
     ```shell
-    kubectl create deployment hello-node --image=gcr.io/hello-minikube-zero-install/hello-node
+    kubectl create deployment hello-node --image=k8s.gcr.io/echoserver:1.4
     ```
 
 2. View the Deployment:


### PR DESCRIPTION
as  reported by minikube users https://github.com/kubernetes/minikube/issues/7901:

the image in this tutorial is deprecated and no longer accessible, on [minikube's webiste](https://minikube.sigs.k8s.io/docs/start/) we have updated the getting started guide to echoserver image,  
```
 Failed to pull image "gcr.io/hello-minikube-zero-install/hello-node": rpc error: code = Unknown desc = Error response from daemon: Get https://gcr.io/v2/hello-minikube-zero-install/hello-node/manifests/latest: denied: Permission denied: Consumer 'project:hello-minikube-zero-install' has been suspended.
```
