### PR TITLE
remove ns specifics for horizontal pod autoscale walkthrough

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -119,7 +119,7 @@ kubectl run --generator=run-pod/v1 -it --rm load-generator --image=busybox /bin/
 
 Hit enter for command prompt
 
-while true; do wget -q -O- http://php-apache.default.svc.cluster.local; done
+while true; do wget -q -O- http://php-apache; done
 ```
 
 Within a minute or so, we should see the higher CPU load by executing:
@@ -203,7 +203,6 @@ apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: php-apache
-  namespace: default
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -296,7 +295,6 @@ apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: php-apache
-  namespace: default
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/content/en/examples/application/hpa/php-apache.yaml
+++ b/content/en/examples/application/hpa/php-apache.yaml
@@ -2,7 +2,6 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: php-apache
-  namespace: default
 spec:
   scaleTargetRef:
     apiVersion: apps/v1


### PR DESCRIPTION
Hi All,

The changes in this commit remove the default namespace specifics, allowing this example to work whether run in the default namespace, or another.

It also brings consistency with the rest of the walkthrough as the service utilised, does not have a namespace declaration in .metadata as part of the walkthrough -

```
apiVersion: v1
kind: Service
metadata:
  name: php-apache
  labels:
    run: php-apache
spec:
  ports:
  - port: 80
  selector:
    run: php-apache
```

Hope this helps.  If this is accepted, I will follow up with equivalent changes for the other locales.

For convenience, direct link to the documentation changes here - https://deploy-preview-20555--kubernetes-io-master-staging.netlify.app/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough

Many Thanks

James