### PR TITLE
Updated dashboard installation command to use v2.0.0

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/web-ui-dashboard.md
+++ b/content/en/docs/tasks/access-application-cluster/web-ui-dashboard.md
@@ -30,7 +30,7 @@ Dashboard also provides information on the state of Kubernetes resources in your
 The Dashboard UI is not deployed by default. To deploy it, run the following command:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0-beta8/aio/deploy/recommended.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0/aio/deploy/recommended.yaml
 ```
 
 ## Accessing the Dashboard UI

--- a/content/id/docs/tasks/access-application-cluster/web-ui-dashboard.md
+++ b/content/id/docs/tasks/access-application-cluster/web-ui-dashboard.md
@@ -26,7 +26,7 @@ Dashboard juga menyediakan informasi tentang status dari sumber daya Kubernetes 
 Antarmuka Dashboard tidak ter-_deploy_ secara bawaan. Untuk men-_deploy_-nya, kamu dapat menjalankan perintah berikut:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0-beta8/aio/deploy/recommended.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0/aio/deploy/recommended.yaml
 ```
 
 ## Mengakses Antarmuka Dashboard

--- a/content/ko/docs/tasks/access-application-cluster/web-ui-dashboard.md
+++ b/content/ko/docs/tasks/access-application-cluster/web-ui-dashboard.md
@@ -26,7 +26,7 @@ card:
 대시보드 UI는 기본으로 배포되지 않는다. 배포하려면 다음 커맨드를 동작한다.
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0-beta8/aio/deploy/recommended.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0/aio/deploy/recommended.yaml
 ```
 
 ## 대시보드 UI 접근

--- a/content/zh/docs/tasks/access-application-cluster/web-ui-dashboard.md
+++ b/content/zh/docs/tasks/access-application-cluster/web-ui-dashboard.md
@@ -56,7 +56,7 @@ The Dashboard UI is not deployed by default. To deploy it, run the following com
 默认情况下不会部署 Dashboard。可以通过以下命令部署：
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0-beta4/aio/deploy/recommended.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0/aio/deploy/recommended.yaml
 ```
 
 <!--


### PR DESCRIPTION
K8s dashboard release v2.0.0 is out: https://github.com/kubernetes/dashboard/releases
Time to update the docs.