### PR TITLE
KO equivalent for PR20555

### DIFF
--- a/content/ko/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/ko/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -113,7 +113,7 @@ kubectl run --generator=run-pod/v1 -it --rm load-generator --image=busybox /bin/
 
 Hit enter for command prompt
 
-while true; do wget -q -O- http://php-apache.default.svc.cluster.local; done
+while true; do wget -q -O- http://php-apache; done
 ```
 
 실행 후, 약 1분 정도 후에 CPU 부하가 올라가는 것을 볼 수 있다.
@@ -197,7 +197,6 @@ apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: php-apache
-  namespace: default
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -294,7 +293,6 @@ apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: php-apache
-  namespace: default
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/content/ko/examples/application/hpa/php-apache.yaml
+++ b/content/ko/examples/application/hpa/php-apache.yaml
@@ -2,7 +2,6 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: php-apache
-  namespace: default
 spec:
   scaleTargetRef:
     apiVersion: apps/v1


### PR DESCRIPTION
Hi,

KO Locale equivalent to recently merged https://github.com/kubernetes/website/pull/20555

For context -

The changes in this commit remove the default namespace specifics, allowing this example to work whether run in the default namespace, or another.

It also brings consistency with the rest of the walkthrough as the service utilised, does not have a namespace declaration in .metadata as part of the walkthrough -

```
apiVersion: v1
kind: Service
metadata:
  name: php-apache
  labels:
    run: php-apache
spec:
  ports:
  - port: 80
  selector:
    run: php-apache
```

For convenience, direct link to the documentation changes here - https://deploy-preview-20563--kubernetes-io-master-staging.netlify.app/ko/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/

Many Thanks

James