### PR TITLE
ZH equivalent for PR20555

### DIFF
--- a/content/zh/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/zh/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -170,7 +170,7 @@ kubectl run -i --tty load-generator --image=busybox /bin/sh
 
 Hit enter for command prompt
 
-while true; do wget -q -O- http://php-apache.default.svc.cluster.local; done
+while true; do wget -q -O- http://php-apache; done
 ```
 
 <!--
@@ -295,7 +295,6 @@ apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: php-apache
-  namespace: default
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -424,7 +423,6 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: php-apache
-  namespace: default
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/content/zh/examples/application/hpa/php-apache.yaml
+++ b/content/zh/examples/application/hpa/php-apache.yaml
@@ -2,7 +2,6 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: php-apache
-  namespace: default
 spec:
   scaleTargetRef:
     apiVersion: apps/v1


### PR DESCRIPTION
Hi,

ZH Locale equivalent to recently merged https://github.com/kubernetes/website/pull/20555

For context -

The changes in this commit remove the default namespace specifics, allowing this example to work whether run in the default namespace, or another.

It also brings consistency with the rest of the walkthrough as the service utilised, does not have a namespace declaration in .metadata as part of the walkthrough -

```
apiVersion: v1
kind: Service
metadata:
  name: php-apache
  labels:
    run: php-apache
spec:
  ports:
  - port: 80
  selector:
    run: php-apache
```

For convenience, direct link to the documentation changes here - https://deploy-preview-20564--kubernetes-io-master-staging.netlify.app/zh/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough

Many Thanks

James