### PR TITLE
Localize “email address” placeholder on home page

### DIFF
--- a/i18n/pt.toml
+++ b/i18n/pt.toml
@@ -193,3 +193,6 @@ other = "Calendário de Eventos"
 # UI elements
 [ui_search_placeholder]
 other = "Procurar"
+
+[input_placeholder_email_address]
+other = "endereço de e-mail"


### PR DESCRIPTION
https://github.com/kubernetes/website/issues/20568
/language pt