### PR TITLE
Fix minikube image 'project:hello-minikube-zero-install' has been suspended.

### DIFF
--- a/content/zh/docs/tutorials/hello-minikube.md
+++ b/content/zh/docs/tutorials/hello-minikube.md
@@ -137,7 +137,7 @@ Pod runs a Container based on the provided Docker image.
 1. 使用 `kubectl create` 命令创建管理 Pod 的 Deployment。该 Pod 根据提供的 Docker 镜像运行 Container。
 
     ```shell
-    kubectl create deployment hello-node --image=gcr.io/hello-minikube-zero-install/hello-node
+    kubectl create deployment hello-node --image=k8s.gcr.io/echoserver:1.4
     ```
 
 <!--


### PR DESCRIPTION
See #20530, the description for pull image 'project:hello-minikube-zero-install' seems wrong, and this PR is going to fix this.