### PR TITLE
Fix minikube image 'project:hello-minikube-zero-install' has been suspended.

### DIFF
--- a/content/ru/docs/tutorials/hello-minikube.md
+++ b/content/ru/docs/tutorials/hello-minikube.md
@@ -72,7 +72,7 @@ Katacoda предоставляет бесплатную, встроенную �
 1. Используйте команду `kubectl create` для создание деплоймента для управления подом. Под запускает контейнер на основе предоставленного Docker образа.
 
     ```shell
-    kubectl create deployment hello-node --image=gcr.io/hello-minikube-zero-install/hello-node
+    kubectl create deployment hello-node --image=k8s.gcr.io/echoserver:1.4
     ```
 
 2. Посмотреть информацию о Deployment:


### PR DESCRIPTION
See #20530, the description for pull image 'project:hello-minikube-zero-install' seems wrong, and this PR is going to fix this.