### PR TITLE
Fix minikube image 'project:hello-minikube-zero-install' has been suspended. 

### DIFF
--- a/content/ja/docs/tutorials/hello-minikube.md
+++ b/content/ja/docs/tutorials/hello-minikube.md
@@ -70,7 +70,7 @@ Kubernetesの[*Pod*](/ja/docs/concepts/workloads/pods/pod/) は、コンテナ�
 1. `kubectl create` コマンドを使用してPodを管理するDeploymentを作成してください。Podは提供されたDockerイメージを元にコンテナを実行します。
 
     ```shell
-    kubectl create deployment hello-node --image=gcr.io/hello-minikube-zero-install/hello-node
+    kubectl create deployment hello-node --image=k8s.gcr.io/echoserver:1.4
     ```
 
 2. Deploymentを確認します:


### PR DESCRIPTION
See #20530, the description for pull image 'project:hello-minikube-zero-install' seems wrong, and this PR is going to fix this.