### PR TITLE
Fix minikube image 'project:hello-minikube-zero-install' has been suspended.

### DIFF
--- a/content/fr/docs/tutorials/hello-minikube.md
+++ b/content/fr/docs/tutorials/hello-minikube.md
@@ -76,7 +76,7 @@ Les déploiements sont le moyen recommandé pour gérer la création et la mise 
 Pod utilise un conteneur basé sur l'image Docker fournie.
 
     ```shell
-    kubectl create deployment hello-node --image=gcr.io/hello-minikube-zero-install/hello-node
+    kubectl create deployment hello-node --image=k8s.gcr.io/echoserver:1.4
     ```
 
 2. Affichez le déploiement :


### PR DESCRIPTION
See #20530, the description for pull image 'project:hello-minikube-zero-install' seems wrong, and this PR is going to fix this.