### PR TITLE
Fix minikube image 'project:hello-minikube-zero-install' has been suspended.

### DIFF
--- a/content/de/docs/tutorials/hello-minikube.md
+++ b/content/de/docs/tutorials/hello-minikube.md
@@ -75,7 +75,7 @@ Deployments sind die empfohlene Methode zum Verwalten der Erstellung und Skalier
 Der Pod führt einen Container basierend auf dem bereitgestellten Docker-Image aus.
 
     ```shell
-    kubectl create deployment hello-node --image=gcr.io/hello-minikube-zero-install/hello-node
+    kubectl create deployment hello-node --image=k8s.gcr.io/echoserver:1.4
     ```
 
 2. Anzeigen des Deployments:


### PR DESCRIPTION
See #20530, the description for pull image 'project:hello-minikube-zero-install' seems wrong, and this PR is going to fix this.