### PR TITLE
Fix glossary_aka template formatting

### DIFF
--- a/layouts/docs/glossary.html
+++ b/layouts/docs/glossary.html
@@ -43,7 +43,7 @@
 		<div>
 			<div class="term-name"><b>{{ .Title }}</b><a href="{{ printf "#%s" $term_identifier }}" class="permalink hide">LINK</a></div>
 			{{ with .Params.aka }}
-			{{ T "layouts_docs_glossary_aka" }}:<i>{{ delimit . ", " }}</i>
+			{{ T "layouts_docs_glossary_aka" }}: <i>{{ delimit . ", " }}</i>
 			<br>
 			{{ end }}
 			<span class="preview-text">{{ .Summary }} <a href="javascript:void(0)" class="click-controller no-underline" data-target="{{ .Params.id }}">[+]</a></span>


### PR DESCRIPTION
Some glossary entries that use "aka" template like:
https://kubernetes.io/docs/reference/glossary/?all=true#term-cloud-provider
are rendered as: _"Also known as:Cloud Service Provider"_.

A separator is necessary after the colon.