### PR TITLE
Update content/en/docs/reference/kubectl/overview.md 

### DIFF
--- a/content/en/docs/reference/kubectl/overview.md
+++ b/content/en/docs/reference/kubectl/overview.md
@@ -91,7 +91,7 @@ Operation       | Syntax    |       Description
 `port-forward`    | `kubectl port-forward POD [LOCAL_PORT:]REMOTE_PORT [...[LOCAL_PORT_N:]REMOTE_PORT_N] [flags]` | Forward one or more local ports to a pod.
 `proxy`        | `kubectl proxy [--port=PORT] [--www=static-dir] [--www-prefix=prefix] [--api-prefix=prefix] [flags]` | Run a proxy to the Kubernetes API server.
 `replace`        | `kubectl replace -f FILENAME` | Replace a resource from a file or stdin.
-`run`        | </code>kubectl run NAME --image=image [--env="key=value"] [--port=port] [--replicas=replicas] [--dry-run=server&#124;client&#124;none] [--overrides=inline-json] [flags]</code> | Run a specified image on the cluster.
+`run`        | <code>kubectl run NAME --image=image [--env="key=value"] [--port=port] [--dry-run=server&#124;client&#124;none] [--overrides=inline-json] [flags]</code> | Run a specified image on the cluster.
 `scale`        | <code>kubectl scale (-f FILENAME &#124; TYPE NAME &#124; TYPE/NAME) --replicas=COUNT [--resource-version=version] [--current-replicas=count] [flags]</code> | Update the size of the specified replication controller.
 `version`        | `kubectl version [--client] [flags]` | Display the Kubernetes version running on the client and server.
 


### PR DESCRIPTION
Fix #20614 

This PR has 2 changes:
1) Remove the depreciated `--replicas` flag
2) Fix a bug that does not allow the phrase to be displayed completely


**Before**:
![Screenshot from 2020-04-29 09-04-30](https://user-images.githubusercontent.com/34755896/80594021-9d2ba780-89f8-11ea-8b4e-081f5bfc9ddd.png)

**After**:
![Screenshot from 2020-04-29 09-05-23](https://user-images.githubusercontent.com/34755896/80594027-a0269800-89f8-11ea-8ca6-0bdda490cd26.png)


**Page**: https://kubernetes.io/docs/reference/kubectl/#operations
