### PR TITLE
Update ingress-minikube.md

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -66,7 +66,7 @@ This page shows you how to set up a simple Ingress which routes requests to Serv
 1. Create a Deployment using the following command:
 
     ```shell
-    kubectl create deployment web --image=gcr.io/google-samples/hello-app:1.0 --port=8080
+    kubectl create deployment web --image=gcr.io/google-samples/hello-app:1.0
     ```
 
     Output:


### PR DESCRIPTION
The --port flag is not present for "create deployment" in kubectl v1.18.0.
Executing the command "kubectl create deployment web --image=gcr.io/google-samples/hello-app:1.0 --port=8080" returns an error message:
Error: unknown flag: --port
See 'kubectl create deployment --help' for usage.