### PR TITLE
fix: Metadata name of ConfigMap must be lower case

### DIFF
--- a/content/en/docs/concepts/configuration/configmap.md
+++ b/content/en/docs/concepts/configuration/configmap.md
@@ -57,7 +57,7 @@ format.
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  Name: game-demo
+  name: game-demo
 data:
   # property-like keys; each key maps to a simple value
   player_initial_lives: 3


### PR DESCRIPTION
Fix error when copy/paste example

```
error validating data: ValidationError(ConfigMap.metadata): unknown field "Name" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
```