### PR TITLE
Add missing ClusterRoleBinding and leases permissions for running 2nd scheduler

### DIFF
--- a/content/en/examples/admin/sched/my-scheduler.yaml
+++ b/content/en/examples/admin/sched/my-scheduler.yaml
@@ -17,6 +17,19 @@ roleRef:
   name: system:kube-scheduler
   apiGroup: rbac.authorization.k8s.io
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: my-scheduler-as-volume-scheduler
+subjects:
+- kind: ServiceAccount
+  name: my-scheduler
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: system:volume-scheduler
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Fixes #18724

Added:

- Missing ClusterRoleBinding for `system:volume-scheduler`.
- Missing leases permission for `system:kube-scheduler` ClusterRole.
- Subsection to clarify what is relevant only for leader election.
