### PR TITLE
Add the missing double quote (")

### DIFF
--- a/content/en/docs/tasks/administer-cluster/quota-api-object.md
+++ b/content/en/docs/tasks/administer-cluster/quota-api-object.md
@@ -122,7 +122,7 @@ by quotas:
 <table>
 <tr><th>String</th><th>API Object</th></tr>
 <tr><td>"pods"</td><td>Pod</td></tr>
-<tr><td>"services</td><td>Service</td></tr>
+<tr><td>"services"</td><td>Service</td></tr>
 <tr><td>"replicationcontrollers"</td><td>ReplicationController</td></tr>
 <tr><td>"resourcequotas"</td><td>ResourceQuota</td></tr>
 <tr><td>"secrets"</td><td>Secret</td></tr>


### PR DESCRIPTION
There is a missing double quote (") after the word services in the last table. I've added the same.

-----
Fixes #20712 
