### PR TITLE
Update content/en/docs/tasks/manage-kubernetes-objects/declarative-config.md

### DIFF
--- a/content/en/docs/tasks/manage-kubernetes-objects/declarative-config.md
+++ b/content/en/docs/tasks/manage-kubernetes-objects/declarative-config.md
@@ -237,7 +237,7 @@ kubectl scale deployment/nginx-deployment --replicas=2
 Print the live configuration using `kubectl get`:
 
 ```shell
-kubectl get -f https://k8s.io/examples/application/simple_deployment.yaml -o yaml
+kubectl get deployment nginx-deployment -o yaml
 ```
 
 The output shows that the `replicas` field has been set to 2, and the `last-applied-configuration`
@@ -296,7 +296,7 @@ kubectl apply -f https://k8s.io/examples/application/update_deployment.yaml
 Print the live configuration using `kubectl get`:
 
 ```shell
-kubectl get -f https://k8s.io/examples/application/simple_deployment.yaml -o yaml
+kubectl get -f https://k8s.io/examples/application/update_deployment.yaml -o yaml
 ```
 
 The output shows the following changes to the live configuration:


### PR DESCRIPTION
As we can see in the issue #20701, the current way of displaying the live configuration in https://kubernetes.io/docs/tasks/manage-kubernetes-objects/declarative-config/#how-to-update-objects is very confusing. 

I think that is be better to use the deployment name instead of the entire file. The **kubectl get deploy deploy-name -o yaml** also display the live configurations



Updated page:
https://kubernetes.io/docs/tasks/manage-kubernetes-objects/declarative-config/#how-to-update-objects