### PR TITLE
Document char encoding in mapped volumes

### DIFF
--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -305,6 +305,11 @@ A Container using a ConfigMap as a [subPath](#using-subpath) volume mount will n
 receive ConfigMap updates.
 {{< /note >}}
 
+{{< note >}}
+Text data is exposed as files using the UTF-8 character encoding. To use some other character encoding, use binaryData.
+{{< /note >}}
+
+
 ### downwardAPI {#downwardapi}
 
 A `downwardAPI` volume is used to make downward API data available to applications.

--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -588,6 +588,10 @@ SPECIAL_TYPE
 If there are some files in the `/etc/config/` directory, they will be deleted.
 {{< /caution >}}
 
+{{< note >}}
+Text data is exposed as files using the UTF-8 character encoding. To use some other character encoding, use binaryData.
+{{< /note >}}
+
 ### Add ConfigMap data to a specific path in the Volume
 
 Use the `path` field to specify the desired file path for specific ConfigMap items.


### PR DESCRIPTION
ConfigMaps can contain text data (chracters) which then can be exposed as files to the container. Files are byte sequences. Hence, when presenting text data as files, a character encoding is important.

This change documents that UTF-8 is used when exposing ConfigMap items as files.

This is a follow up to https://github.com/kubernetes/kubernetes/issues/90633.