### PR TITLE
Add a note to skip cleanup if continuing to next tutorial.

### DIFF
--- a/content/en/docs/tutorials/stateless-application/guestbook.md
+++ b/content/en/docs/tutorials/stateless-application/guestbook.md
@@ -324,8 +324,9 @@ Scaling up or down is easy because your servers are defined as a Service that us
 {{% /capture %}}
 
 {{% capture cleanup %}}
+
 {{< note >}}
-The next tutorial [Example: Add logging and metrics to the PHP / Redis Guestbook example](../guestbook-logs-metrics-with-elk/) builds upon the infrastructure which you have created in this tutorial. If you plan to continue to that tutorial, you may want to skip the cleanup for now. The Cleanup at the end of that tutorial includes the cleanup steps from this tutorial.
+The [Example: Add logging and metrics to the PHP / Redis Guestbook example](/docs/tutorials/stateless-application/guestbook-logs-metrics-with-elk/) tutorial builds upon the resources created in this tutorial. If you plan to continue with the "logging and metrics" tutorial, you may want to wait to cleanup the guestbook resources.
 {{< /note >}}
 
 Deleting the Deployments and Services also deletes any running Pods. Use labels to delete multiple resources with one command.

--- a/content/en/docs/tutorials/stateless-application/guestbook.md
+++ b/content/en/docs/tutorials/stateless-application/guestbook.md
@@ -324,6 +324,10 @@ Scaling up or down is easy because your servers are defined as a Service that us
 {{% /capture %}}
 
 {{% capture cleanup %}}
+{{< note >}}
+The next tutorial [Example: Add logging and metrics to the PHP / Redis Guestbook example](../guestbook-logs-metrics-with-elk/) builds upon the infrastructure which you have created in this tutorial. If you plan to continue to that tutorial, you may want to skip the cleanup for now. The Cleanup at the end of that tutorial includes the cleanup steps from this tutorial.
+{{< /note >}}
+
 Deleting the Deployments and Services also deletes any running Pods. Use labels to delete multiple resources with one command.
 
 1. Run the following commands to delete all Pods, Deployments, and Services.


### PR DESCRIPTION
I have added a note suggesting that users who are continuing to the next tutorial skip the Cleanup from this tutorial since the next tutorial builds on this one.
This will help save the users time by preventing the need to rebuild.