### PR TITLE
Don't mention EndpointSlice resource on front page

### DIFF
--- a/content/en/docs/concepts/services-networking/endpoint-slices.md
+++ b/content/en/docs/concepts/services-networking/endpoint-slices.md
@@ -2,11 +2,6 @@
 reviewers:
 - freehan
 title: EndpointSlices
-feature:
-  title: EndpointSlices
-  description: >
-    Scalable tracking of network endpoints in a Kubernetes cluster.
-
 content_template: templates/concept
 weight: 15
 ---


### PR DESCRIPTION
EndpointSlice is a nice idea, but it's not front-page-of-site nice. At the moment there's text about EndpointSlice showing on https://k8s.io/

This PR leaves the documentation in place but removes the front page callout.

Previews:
- https://deploy-preview-20761--kubernetes-io-master-staging.netlify.app/
- https://deploy-preview-20761--kubernetes-io-master-staging.netlify.app/docs/concepts/services-networking/endpoint-slices/

/sig network
/kind cleanup