### PR TITLE
Remove approve/review status

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -171,7 +171,6 @@ aliases:
     - haibinxie
     - hanjiayao
     - lichuqiang
-    - markthink
     - SataQiu
     - tengqm
     - xiangpengzhao
@@ -181,7 +180,6 @@ aliases:
   sig-docs-zh-reviews: # PR reviews for Chinese content
     - chenrui333
     - idealhack
-    - markthink
     - SataQiu
     - tanjunchen
     - tengqm


### PR DESCRIPTION
This PR removes approval and reviewer permissions for @markthink. 

In https://github.com/kubernetes/website/pull/19999#pullrequestreview-400493888, @markthink approved a PR with 250+ commits despite clear instructions from other reviewers for the author to squash their commits. This was a destructive act with severe consequences for viability in the 1.19 development branch.

In light of https://github.com/kubernetes/org/pull/1293, it seems clear that @markthink does not demonstrate [sound technical judgment](https://github.com/kubernetes/community/blob/master/community-membership.md#responsibilities-and-privileges-2) and should be removed from all approver status.

/cc @jimangel @kbarnard10 