### PR TITLE
Remove reference to deprecated image

### DIFF
--- a/content/en/docs/tutorials/hello-minikube.md
+++ b/content/en/docs/tutorials/hello-minikube.md
@@ -7,7 +7,7 @@ menu:
     title: "Get Started"
     weight: 10
     post: >
-      <p>Ready to get your hands dirty? Build a simple Kubernetes cluster that runs "Hello World" for Node.js.</p>
+      <p>Ready to get your hands dirty? Build a simple Kubernetes cluster that runs a sample app.</p>
 card:
   name: tutorials
   weight: 10
@@ -15,7 +15,7 @@ card:
 
 {{% capture overview %}}
 
-This tutorial shows you how to run a simple Hello World Node.js app
+This tutorial shows you how to run a sample app
 on Kubernetes using [Minikube](/docs/setup/learning-environment/minikube) and Katacoda.
 Katacoda provides a free, in-browser Kubernetes environment.
 
@@ -27,7 +27,7 @@ You can also follow this tutorial if you've installed [Minikube locally](/docs/t
 
 {{% capture objectives %}}
 
-* Deploy a hello world application to Minikube.
+* Deploy a sample application to Minikube.
 * Run the app.
 * View application logs.
 
@@ -35,13 +35,7 @@ You can also follow this tutorial if you've installed [Minikube locally](/docs/t
 
 {{% capture prerequisites %}}
 
-This tutorial provides a container image built from the following files:
-
-{{< codenew language="js" file="minikube/server.js" >}}
-
-{{< codenew language="conf" file="minikube/Dockerfile" >}}
-
-For more information on the `docker build` command, read the [Docker documentation](https://docs.docker.com/engine/reference/commandline/build/).
+This tutorial provides a container image that uses NGINX to echo back all the requests.
 
 {{% /capture %}}
 
@@ -166,7 +160,7 @@ Kubernetes [*Service*](/docs/concepts/services-networking/service/).
 
 5. Katacoda environment only: Note the 5 digit port number displayed opposite to `8080` in services output. This port number is randomly generated and it can be different for you. Type your number in the port number text box, then click Display Port. Using the example from earlier, you would type `30369`.
 
-    This opens up a browser window that serves your app and shows the "Hello World" message.
+    This opens up a browser window that serves your app and shows the app's response.
 
 ## Enable addons
 

--- a/content/en/examples/minikube/Dockerfile
+++ b/content/en/examples/minikube/Dockerfile
@@ -1,4 +1,0 @@
-FROM node:6.14.2
-EXPOSE 8080
-COPY server.js .
-CMD [ "node", "server.js" ]

--- a/content/en/examples/minikube/server.js
+++ b/content/en/examples/minikube/server.js
@@ -1,9 +1,0 @@
-var http = require('http');
-
-var handleRequest = function(request, response) {
-  console.log('Received request for URL: ' + request.url);
-  response.writeHead(200);
-  response.end('Hello World!');
-};
-var www = http.createServer(handleRequest);
-www.listen(8080);


### PR DESCRIPTION
The #20553 changed the deprecated hello-node image to echoserver image. However, there is a reference to the old image later in the text. Point 5 implies that there will be a 'Hello World' message. This probably was true for the hello-node image but the echoserver does not print this (it echoes back the request with all of its params). This may be misleading, so change the text to a generic 'app's response'.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use
 for advice.

-->
