### PR TITLE
Standardized pod security profiles

### DIFF
--- a/content/en/docs/concepts/policy/pod-security-policy.md
+++ b/content/en/docs/concepts/policy/pod-security-policy.md
@@ -374,6 +374,8 @@ several security mechanisms.
 
 {{< codenew file="policy/restricted-psp.yaml" >}}
 
+See [Pod Security Standards](/docs/concepts/security/pod-security-standards/#policy-instantiation) for more examples.
+
 ## Policy Reference
 
 ### Privileged
@@ -632,6 +634,8 @@ Refer to the [Sysctl documentation](
 {{% /capture %}}
 
 {{% capture whatsnext %}}
+
+See [Pod Security Standards](/docs/concepts/security/pod-security-standards/) for policy recommendations.
 
 Refer to [Pod Security Policy Reference](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#podsecuritypolicy-v1beta1-policy) for the api details.
 

--- a/content/en/docs/concepts/security/pod-security-standards.md
+++ b/content/en/docs/concepts/security/pod-security-standards.md
@@ -1,0 +1,300 @@
+---
+reviewers:
+- tallclair
+title: Pod Security Standards
+content_template: templates/concept
+weight: 10
+---
+
+{{% capture overview %}}
+
+Security settings for Pods are typically applied by using [security
+contexts](/docs/tasks/configure-pod-container/security-context/). Security Contexts allow for the
+definition of privilege and access controls on a per-Pod basis.
+
+The enforcement and policy-based definition of cluster requirements of security contexts has
+previously been achieved using [Pod Security Policy](/docs/concepts/policy/pod-security-policy/). A
+_Pod Security Policy_ is a cluster-level resource that controls security sensitive aspects of the
+Pod specification.
+
+However, numerous means of policy enforcement have arisen that augment or replace the use of
+PodSecurityPolicy. The intent of this page is to detail recommended Pod security profiles, decoupled
+from any specific instantiation.
+
+{{% /capture %}}
+
+{{% capture body %}}
+
+## Policy Types
+
+There is an immediate need for base policy definitions to broadly cover the security spectrum. These
+should range from highly restricted to highly flexible:
+
+- **_Privileged_** - Unrestricted policy, providing the widest possible level of permissions. This
+  policy allows for known privilege escalations.
+- **_Baseline/Default_** - Minimally restrictive policy while preventing known privilege
+  escalations. Allows the default (minimally specified) Pod configuration.
+- **_Restricted_** - Heavily restricted policy, following current Pod hardening best practices.
+
+## Policies
+
+### Privileged
+
+The Privileged policy is purposely-open, and entirely unrestricted. This type of policy is typically
+aimed at system- and infrastructure-level workloads managed by privileged, trusted users.
+
+The privileged policy is defined by an absence of restrictions. For blacklist-oriented enforcement
+mechanisms (such as gatekeeper), the privileged profile may be an absence of applied constraints
+rather than an instantiated policy. In contrast, for a whitelist oriented mechanism (such as Pod
+Security Policy) the privileged policy should enable all controls (disable all restrictions).
+
+### Baseline/Default
+
+The Baseline/Default policy is aimed at ease of adoption for common containerized workloads while
+preventing known privilege escalations. This policy is targeted at application operators and
+developers of non-critical applications. The following listed controls should be
+enforced/disallowed:
+
+<table>
+    <caption style="display:none">Baseline policy specification</caption>
+    <tbody>
+		<tr>
+			<td><strong>Control</strong></td>
+			<td><strong>Policy</strong></td>
+		</tr>
+		<tr>
+			<td>Host Namespaces</td>
+			<td>
+				Sharing the host namespaces must be disallowed.<br>
+				<br><b>Restricted Fields:</b><br>
+				spec.hostNetwork<br>
+				spec.hostPID<br>
+				spec.hostIPC<br>
+				<br><b>Allowed Values:</b> false<br>
+			</td>
+		</tr>
+		<tr>
+			<td>Privileged Containers</td>
+			<td>
+				Privileged Pods disable most security mechanisms and must be disallowed.<br>
+				<br><b>Restricted Fields:</b><br>
+				spec.containers[*].securityContext.privileged<br>
+				spec.initContainers[*].securityContext.privileged<br>
+				<br><b>Allowed Values:</b> false, undefined/nil<br>
+			</td>
+		</tr>
+		<tr>
+			<td>Capabilities</td>
+			<td>
+				Adding additional capabilities beyond the <a href="https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities">default set</a> must be disallowed.<br>
+				<br><b>Restricted Fields:</b><br>
+				spec.containers[*].securityContext.capabilities.add<br>
+				spec.initContainers[*].securityContext.capabilities.add<br>
+				<br><b>Allowed Values:</b> empty (optionally whitelisted defaults)<br>
+			</td>
+		</tr>
+		<tr>
+			<td>HostPath Volumes</td>
+			<td>
+				HostPath volumes must be forbidden.<br>
+				<br><b>Restricted Fields:</b><br>
+				spec.volumes[*].hostPath<br>
+				<br><b>Allowed Values:</b> undefined/nil<br>
+			</td>
+		</tr>
+		<tr>
+			<td>Host Ports</td>
+			<td>
+				HostPorts should be disallowed, or at minimum restricted to a whitelist.<br>
+				<br><b>Restricted Fields:</b><br>
+				spec.containers[*].ports[*].hostPort<br>
+				spec.initContainers[*].ports[*].hostPort<br>
+				<br><b>Allowed Values:</b> 0, undefined, (whitelisted)<br>
+			</td>
+		</tr>
+		<tr>
+			<td>AppArmor <em>(optional)</em></td>
+			<td>
+				On supported hosts, the `runtime/default` AppArmor profile is applied by default. The default policy should prevent overriding or disabling the policy, or restrict overrides to a whitelisted set of profiles.<br>
+				<br><b>Restricted Fields:</b><br>
+				metadata.annotations['container.apparmor.security.beta.kubernetes.io/*']<br>
+				<br><b>Allowed Values:</b> runtime/default, undefined<br>
+			</td>
+		</tr>
+		<tr>
+			<td>SELinux <em>(optional)</em></td>
+			<td>
+				Setting custom SELinux options should be disallowed.<br>
+				<br><b>Restricted Fields:</b><br>
+				spec.securityContext.seLinuxOptions<br>
+				spec.containers[*].securityContext.seLinuxOptions<br>
+				spec.initContainers[*].securityContext.seLinuxOptions<br>
+				<br><b>Allowed Values:</b> undefined/nil<br>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+### Restricted
+
+The Restricted policy is aimed at enforcing current Pod hardening best practices, at the expense of
+some compatibility. It is targeted at operators and developers of security-critical applications, as
+well as lower-trust users.The following listed controls should be enforced/disallowed:
+
+
+<table>
+    <caption style="display:none">Restricted policy specification</caption>
+	<tbody>
+		<tr>
+			<td><strong>Control</strong></td>
+			<td><strong>Policy</strong></td>
+		</tr>
+		<tr>
+			<td colspan="2"><em>Everything from the default profile.</em></td>
+		</tr>
+		<tr>
+			<td>Volume Types</td>
+			<td>
+				In addition to restricting HostPath volumes, the restricted profile limits usage of non-core volume types to those defined through PersistentVolumes.<br>
+				<br><b>Restricted Fields:</b><br>
+				spec.volumes[*].hostPath<br>
+				spec.volumes[*].gcePersistentDisk<br>
+				spec.volumes[*].awsElasticBlockStore<br>
+				spec.volumes[*].gitRepo<br>
+				spec.volumes[*].nfs<br>
+				spec.volumes[*].iscsi<br>
+				spec.volumes[*].glusterfs<br>
+				spec.volumes[*].rbd<br>
+				spec.volumes[*].flexVolume<br>
+				spec.volumes[*].cinder<br>
+				spec.volumes[*].cephFS<br>
+				spec.volumes[*].flocker<br>
+				spec.volumes[*].fc<br>
+				spec.volumes[*].azureFile<br>
+				spec.volumes[*].vsphereVolume<br>
+				spec.volumes[*].quobyte<br>
+				spec.volumes[*].azureDisk<br>
+				spec.volumes[*].portworxVolume<br>
+				spec.volumes[*].scaleIO<br>
+				spec.volumes[*].storageos<br>
+				spec.volumes[*].csi<br>
+				<br><b>Allowed Values:</b> undefined/nil<br>
+			</td>
+		</tr>
+		<tr>
+			<td>Privilege Escalation</td>
+			<td>
+                Privilege escalation to root should not be allowed.<br>
+				<br><b>Restricted Fields:</b><br>
+				spec.containers[*].securityContext.privileged<br>
+				spec.initContainers[*].securityContext.privileged<br>
+				<br><b>Allowed Values:</b> false, undefined/nil<br>
+			</td>
+		</tr>
+		<tr>
+			<td>Running as Non-root</td>
+			<td>
+                Containers must be required to run as non-root users.<br>
+				<br><b>Restricted Fields:</b><br>
+				spec.securityContext.runAsNonRoot<br>
+				spec.containers[*].securityContext.runAsNonRoot<br>
+				spec.initContainers[*].securityContext.runAsNonRoot<br>
+				<br><b>Allowed Values:</b> true<br>
+			</td>
+		</tr>
+		<tr>
+			<td>Non-root groups <em>(optional)</em></td>
+			<td>
+                Containers should be forbidden from running with a root primary or supplementary GID.<br>
+				<br><b>Restricted Fields:</b><br>
+				spec.securityContext.runAsGroup<br>
+				spec.securityContext.supplementalGroups[*]<br>
+				spec.securityContext.fsGroup<br>
+				spec.containers[*].securityContext.runAsGroup<br>
+				spec.containers[*].securityContext.supplementalGroups[*]<br>
+				spec.containers[*].securityContext.fsGroup<br>
+				spec.initContainers[*].securityContext.runAsGroup<br>
+				spec.initContainers[*].securityContext.supplementalGroups[*]<br>
+				spec.initContainers[*].securityContext.fsGroup<br>
+				<br><b>Allowed Values:</b><br>
+				non-zero<br>
+				undefined / nil (except for `*.runAsGroup`)<br>
+			</td>
+		</tr>
+		<tr>
+			<td>Seccomp</td>
+			<td>
+				The runtime/default seccomp profile must be required, or allow additional whitelisted values.<br>
+				<br><b>Restricted Fields:</b><br>
+				metadata.annotations['seccomp.security.alpha.kubernetes.io/pod']<br>
+				metadata.annotations['container.seccomp.security.alpha.kubernetes.io/*']<br>
+				<br><b>Allowed Values:</b><br>
+				runtime/default<br>
+				undefined (container annotation)<br>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+## Policy Instantiation
+
+Decoupling policy definition from policy instantiation allows for a common understanding and
+consistent language of policies across clusters, independent of the underlying enforcement
+mechanism.
+
+As mechanisms mature, they will be defined below on a per-policy basis. The methods of enforcement
+of individual policies are not defined here.
+
+[**PodSecurityPolicy**](/docs/concepts/policy/pod-security-policy/)
+
+- [Privileged](https://raw.githubusercontent.com/kubernetes/website/master/content/en/examples/policy/privileged-psp.yaml)
+- [Baseline](https://raw.githubusercontent.com/kubernetes/website/master/content/en/examples/policy/baseline-psp.yaml)
+- [Restricted](https://raw.githubusercontent.com/kubernetes/website/master/content/en/examples/policy/restricted-psp.yaml)
+
+## FAQ
+
+### Why isn't there a profile between privileged and default?
+
+The three profiles defined here have a clear linear progression from most secure (restricted) to least
+secure (privileged), and cover a broad set of workloads. Privileges required above the baseline
+policy are typically very application specific, so we do not offer a standard profile in this
+niche. This is not to say that the privileged profile should always be used in this case, but that
+policies in this space need to be defined on a case-by-case basis.
+
+SIG Auth may reconsider this position in the future, should a clear need for other profiles arise.
+
+### What's the difference between a security policy and a security context?
+
+[Security Contexts](/docs/tasks/configure-pod-container/security-context/) configure Pods and
+Containers at runtime. Security contexts are defined as part of the Pod and container specifications
+in the Pod manifest, and represent parameters to the container runtime.
+
+Security policies are control plane mechanisms to enforce specific settings in the Security Context,
+as well as other parameters outside the Security Contex. As of February 2020, the current native
+solution for enforcing these security policies is [Pod Security
+Policy](/docs/concepts/policy/pod-security-policy/) - a mechanism for centrally enforcing security
+policy on Pods across a cluster. Other alternatives for enforcing security policy are being
+developed in the Kubernetes ecosystem, such as [OPA
+Gatekeeper](https://github.com/open-policy-agent/gatekeeper).
+
+### What profiles should I apply to my Windows Pods?
+
+Windows in Kubernetes has some limitations and differentiators from standard Linux-based
+workloads. Specifically, the Pod SecurityContext fields [have no effect on
+Windows](/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#v1-podsecuritycontext). As
+such, no standardized Pod Security profiles currently exists.
+
+### What about sandboxed Pods?
+
+There is not currently an API standard that controls whether a Pod is considered sandboxed or
+not. Sandbox Pods may be identified by the use of a sandboxed runtime (such as gVisor or Kata
+Containers), but there is no standard definition of what a sandboxed runtime is.
+
+The protections necessary for sandboxed workloads can differ from others. For example, the need to
+restrict privileged permissions is lessened when the workload is isolated from the underlying
+kernel. This allows for workloads requiring heightened permissions to still be isolated.
+
+Additionally, the protection of sandboxed workloads is highly dependent on the method of
+sandboxing. As such, no single ‘recommended’ policy is recommended for all sandboxed workloads.
+
+{{% /capture %}}

--- a/content/en/examples/policy/baseline-psp.yaml
+++ b/content/en/examples/policy/baseline-psp.yaml
@@ -1,0 +1,74 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: baseline
+  annotations:
+    # Optional: Allow the default AppArmor profile, requires setting the default.
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+    # Optional: Allow the default seccomp profile, requires setting the default.
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default,unconfined'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'unconfined'
+spec:
+  privileged: false
+  # The moby default capability set, defined here:
+  # https://github.com/moby/moby/blob/0a5cec2833f82a6ad797d70acbf9cbbaf8956017/oci/caps/defaults.go#L6-L19
+  allowedCapabilities:
+    - 'CHOWN'
+    - 'DAC_OVERRIDE'
+    - 'FSETID'
+    - 'FOWNER'
+    - 'MKNOD'
+    - 'NET_RAW'
+    - 'SETGID'
+    - 'SETUID'
+    - 'SETFCAP'
+    - 'SETPCAP'
+    - 'NET_BIND_SERVICE'
+    - 'SYS_CHROOT'
+    - 'KILL'
+    - 'AUDIT_WRITE'
+  # Allow all volume types except hostpath
+  volumes:
+    # 'core' volume types
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    # Assume that persistentVolumes set up by the cluster admin are safe to use.
+    - 'persistentVolumeClaim'
+    # Allow all other non-hostpath volume types.
+    - 'awsElasticBlockStore'
+    - 'azureDisk'
+    - 'azureFile'
+    - 'cephFS'
+    - 'cinder'
+    - 'csi'
+    - 'fc'
+    - 'flexVolume'
+    - 'flocker'
+    - 'gcePersistentDisk'
+    - 'gitRepo'
+    - 'glusterfs'
+    - 'iscsi'
+    - 'nfs'
+    - 'photonPersistentDisk'
+    - 'portworxVolume'
+    - 'quobyte'
+    - 'rbd'
+    - 'scaleIO'
+    - 'storageos'
+    - 'vsphereVolume'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  readOnlyRootFilesystem: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'


### PR DESCRIPTION
Document a standard set of pod security policies targeting a wide set of workloads. This is a markdown conversion of [this document](https://docs.google.com/document/d/1d9c4BaDzRw1B5fAcf7gLOMZSVEvrpSutivjfNOwIqT0/edit#heading=h.ihgl7qlgtyzu) with some small content tweaks. This was presented to [SIG-Auth on February 19th](https://docs.google.com/document/d/1woLGRoONE3EBVx-wTb4pvp4CI7tmLZ6lS26VTbosLKM/edit#heading=h.bxqchvtk3vmr), and was well-received.

The goal is to be able to provide a set of standard implementation-agnostic policy recommendations. This will help users better understand security best practices, will help security benchmarks like CIS provide better recommendations, and our hope is that it will move the Kubernetes ecosystem (e.g. helm charts) towards a more standard set of permissions.

/sig auth