### PR TITLE
Fix navigation bar

### DIFF
--- a/assets/sass/_base.sass
+++ b/assets/sass/_base.sass
@@ -105,11 +105,11 @@ header
   left: 0
   width: 100%
   z-index: 8888
-  background-color: transparent
+  // background-color: transparent
   box-shadow: 0 0 0 transparent
   transition: 0.3s
   text-align: center
-  overflow: hidden
+  // overflow: hidden
 
 
 .logo

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -33,41 +33,7 @@
                 </ul>
             </li>
         </ul>
-        {{ with site.GetPage "section" "docs/tutorials/kubernetes-basics" }}
-        <a href="{{ .RelPermalink }}" class="button" id="tryKubernetes" data-auto-burger-exclude>{{ .LinkTitle }}</a>
-        {{ end }}
-
         <button id="hamburger" onclick="kub.toggleMenu()" data-auto-burger-exclude><div></div></button>
     </div>
 
-    <nav id="mainNav">
-        <div class="main-section" data-auto-burger="primary">
-         {{ range site.Menus.main }}
-           <div class="nav-box">
-            <h3><a href="{{ .URL }}">{{ .Title }}</a></h3>
-           {{ .Post }}
-            </div>
-         {{ end }}
-        </div>
-        <div class="main-section" data-auto-burger="primary">
-            <div class="left">
-                <h5 class="github-invite">{{ T "main_github_invite" }}</h5>
-                <a href="https://github.com/kubernetes/kubernetes" class="button" data-auto-burger-exclude>{{ T "main_github_view_on" }}</a>
-            </div>
-
-            <div class="right">
-                <h5 class="github-invite">{{ T "main_community_explore" }}</h5>
-                <div class="social">
-                    <a href="https://twitter.com/kubernetesio" class="twitter"><span>{{ T "community_twitter_name" }}</span></a>
-                    <a href="https://github.com/kubernetes/kubernetes" class="github"><span>{{ T "community_github_name" }}</span></a>
-                    <a href="http://slack.k8s.io/" class="slack"><span>{{ T "community_slack_name" }}</span></a>
-                    <a href="https://stackoverflow.com/questions/tagged/kubernetes" class="stack-overflow"><span>{{ T "community_stack_overflow_name" }}</span></a>
-                    <a href="https://www.youtube.com/kubernetescommunity" class="youtube"><span>{{ T "community_youtube_name" }}</span></a>
-                    <a href="https://discuss.kubernetes.io" class="mailing-list"><span>{{ T "community_forum_name" }}</span></a>
-                    <a href="https://calendar.google.com/calendar/embed?src=nt2tcnbtbied3l6gi2h29slvc0%40group.calendar.google.com" class="calendar"><span>{{ T "community_events_calendar" }}</span></a>
-                </div>
-            </div>
-            <div class="clear" style="clear: both"></div>
-        </div>
-    </nav>
 </header>


### PR DESCRIPTION
The `header` element has an `overflow: hidden` property set which
prevents the language/version dropdown menu from properly show up on
Safari. When removing that `overflow: hidden;` style setting, we found
that there are very old contents which is currently invisible on all
pages due to the `overflow: hidden;` setting.

This PR removes the `overflow: hidden;` property and also kills the
invisible content in the 'header' to make sure we have a cleaner
'header' for all pages.

Tested on Safari, Firefox and Chrome.

Fixes: #18003
