### PR TITLE
Signpost blog contributors to “Write a blog post”

### DIFF
--- a/content/en/blog/_index.md
+++ b/content/en/blog/_index.md
@@ -8,3 +8,9 @@ menu:
     post: >
        <p>Read the latest news for Kubernetes and the containers space in general, and get technical how-tos hot off the presses.</p>
 ---
+{{< comment >}}
+
+For information about contributing to the blog, see
+https://kubernetes.io/docs/contribute/new-content/blogs-case-studies/#write-a-blog-post
+
+{{< /comment >}}


### PR DESCRIPTION
Link from `content/en/blog/_index.md` to https://kubernetes.io/docs/contribute/new-content/blogs-case-studies/#write-a-blog-post, so that someone who's considering contributing to the blog can easily find advice on doing that.