### PR TITLE
[Trival] beta.kubernetes.io/os deprecated since v1.14, are targeted for removal in v1.18 

### DIFF
--- a/content/ja/docs/setup/production-environment/windows/user-guide-windows-containers.md
+++ b/content/ja/docs/setup/production-environment/windows/user-guide-windows-containers.md
@@ -64,7 +64,7 @@ To deploy a Windows container on Kubernetes, you must first create an example ap
             - -command
             - "<#code used from https://gist.github.com/wagnerandrade/5424431#> ; $$listener = New-Object System.Net.HttpListener ; $$listener.Prefixes.Add('http://*:80/') ; $$listener.Start() ; $$callerCounts = @{} ; Write-Host('Listening at http://*:80/') ; while ($$listener.IsListening) { ;$$context = $$listener.GetContext() ;$$requestUrl = $$context.Request.Url ;$$clientIP = $$context.Request.RemoteEndPoint.Address ;$$response = $$context.Response ;Write-Host '' ;Write-Host('> {0}' -f $$requestUrl) ;  ;$$count = 1 ;$$k=$$callerCounts.Get_Item($$clientIP) ;if ($$k -ne $$null) { $$count += $$k } ;$$callerCounts.Set_Item($$clientIP, $$count) ;$$ip=(Get-NetAdapter | Get-NetIpAddress); $$header='<html><body><H1>Windows Container Web Server</H1>' ;$$callerCountsString='' ;$$callerCounts.Keys | % { $$callerCountsString+='<p>IP {0} callerCount {1} ' -f $$ip[1].IPAddress,$$callerCounts.Item($$_) } ;$$footer='</body></html>' ;$$content='{0}{1}{2}' -f $$header,$$callerCountsString,$$footer ;Write-Output $$content ;$$buffer = [System.Text.Encoding]::UTF8.GetBytes($$content) ;$$response.ContentLength64 = $$buffer.Length ;$$response.OutputStream.Write($$buffer, 0, $$buffer.Length) ;$$response.Close() ;$$responseStatus = $$response.StatusCode ;Write-Host('< {0}' -f $$responseStatus)  } ; "
           nodeSelector:
-            beta.kubernetes.io/os: windows
+            kubernetes.io/os: windows
 ```
 
 {{< note >}}
@@ -113,8 +113,8 @@ Users today need to use some combination of taints and node selectors in order t
 
 Users can ensure Windows containers can be scheduled on the appropriate host using Taints and Tolerations. All Kubernetes nodes today have the following default labels:
 
-* beta.kubernetes.io/os = [windows|linux]
-* beta.kubernetes.io/arch = [amd64|arm64|...]
+* kubernetes.io/os = [windows|linux]
+* kubernetes.io/arch = [amd64|arm64|...]
 
 If a Pod specification does not specify a nodeSelector like `"beta.kubernetes.io/os": windows`, it is possible the Pod can be scheduled on any host, Windows or Linux. This can be problematic since a Windows container can only run on Windows and a Linux container can only run on Linux. The best practice is to use a nodeSelector.
 

--- a/content/ja/examples/windows/configmap-pod.yaml
+++ b/content/ja/examples/windows/configmap-pod.yaml
@@ -28,4 +28,4 @@ spec:
             name: example-config
             key: example.property.2
   nodeSelector:
-    beta.kubernetes.io/os: windows
+    kubernetes.io/os: windows

--- a/content/ja/examples/windows/daemonset.yaml
+++ b/content/ja/examples/windows/daemonset.yaml
@@ -17,5 +17,5 @@ spec:
       - name: foo
         image: microsoft/windowsservercore:1709
       nodeSelector:
-        beta.kubernetes.io/os: windows
+        kubernetes.io/os: windows
 

--- a/content/ja/examples/windows/emptydir-pod.yaml
+++ b/content/ja/examples/windows/emptydir-pod.yaml
@@ -17,4 +17,4 @@ spec:
   - name: scratch-volume
     emptyDir: {}
   nodeSelector:
-    beta.kubernetes.io/os: windows
+    kubernetes.io/os: windows

--- a/content/ja/examples/windows/hostpath-volume-pod.yaml
+++ b/content/ja/examples/windows/hostpath-volume-pod.yaml
@@ -11,7 +11,7 @@ spec:
       mountPath: "C:\\etc\\foo"
       readOnly: true
   nodeSelector:
-    beta.kubernetes.io/os: windows
+    kubernetes.io/os: windows
   volumes:
   - name: foo
     hostPath:

--- a/content/ja/examples/windows/secret-pod.yaml
+++ b/content/ja/examples/windows/secret-pod.yaml
@@ -29,4 +29,4 @@ spec:
             name: mysecret
             key: password
   nodeSelector:
-    beta.kubernetes.io/os: windows
+    kubernetes.io/os: windows


### PR DESCRIPTION
https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#beta-kubernetes-io-os-deprecated

beta.kubernetes.io/os deprecated since v1.14, are targeted for removal in v1.18 

ref #20815

/assign @inductor