### PR TITLE
remove white bar on the blog page

### DIFF
--- a/static/css/blog.css
+++ b/static/css/blog.css
@@ -497,6 +497,10 @@ img.big-img {
   overflow-x: scroll;
 }
 
+.flyout-button {
+  display: none;
+}
+
 /* .content img {
 max-width: 100%;
 } */


### PR DESCRIPTION
issue #20809
Added a fix to blog.css that would not affect the rest of the site, checked on chrome, opera, firefox and a mobile phone.