### PR TITLE
Add feature state for PodDisruptionBudget

### DIFF
--- a/content/en/docs/concepts/workloads/pods/disruptions.md
+++ b/content/en/docs/concepts/workloads/pods/disruptions.md
@@ -97,6 +97,8 @@ time as frequent voluntary disruptions.  We call this set of features
 
 ## How Disruption Budgets Work
 
+{{< feature-state for_k8s_version="v1.5" state="beta" >}}
+
 An Application Owner can create a `PodDisruptionBudget` object (PDB) for each application.
 A PDB limits the number of pods of a replicated application that are down simultaneously from
 voluntary disruptions.  For example, a quorum-based application would

--- a/content/en/docs/tasks/run-application/configure-pdb.md
+++ b/content/en/docs/tasks/run-application/configure-pdb.md
@@ -6,6 +6,8 @@ weight: 110
 
 {{% capture overview %}}
 
+{{< feature-state for_k8s_version="v1.5" state="beta" >}}
+
 This page shows how to limit the number of concurrent disruptions
 that your application experiences, allowing for higher availability
 while permitting the cluster administrator to manage the clusters


### PR DESCRIPTION
Fixes #20821 

By the way, `PodDisruptionBudget` is missing in the list of feature gates - https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/

Preview -
- https://deploy-preview-20833--kubernetes-io-master-staging.netlify.app/docs/concepts/workloads/pods/disruptions/#how-disruption-budgets-work
- https://deploy-preview-20833--kubernetes-io-master-staging.netlify.app/docs/tasks/run-application/configure-pdb/


<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use
 for advice.

-->
