### PR TITLE
pipe char escape, flag --server-print, labels sample, exec extra --, config NL

### DIFF
--- a/content/en/docs/reference/kubectl/overview.md
+++ b/content/en/docs/reference/kubectl/overview.md
@@ -91,7 +91,7 @@ Operation       | Syntax    |       Description
 `port-forward`    | `kubectl port-forward POD [LOCAL_PORT:]REMOTE_PORT [...[LOCAL_PORT_N:]REMOTE_PORT_N] [flags]` | Forward one or more local ports to a pod.
 `proxy`        | `kubectl proxy [--port=PORT] [--www=static-dir] [--www-prefix=prefix] [--api-prefix=prefix] [flags]` | Run a proxy to the Kubernetes API server.
 `replace`        | `kubectl replace -f FILENAME` | Replace a resource from a file or stdin.
-`run`        | `kubectl run NAME --image=image [--env="key=value"] [--port=port] [--replicas=replicas] [--dry-run=server|client|none] [--overrides=inline-json] [flags]` | Run a specified image on the cluster.
+`run`        | </code>kubectl run NAME --image=image [--env="key=value"] [--port=port] [--replicas=replicas] [--dry-run=server&#124;client&#124;none] [--overrides=inline-json] [flags]</code> | Run a specified image on the cluster.
 `scale`        | <code>kubectl scale (-f FILENAME &#124; TYPE NAME &#124; TYPE/NAME) --replicas=COUNT [--resource-version=version] [--current-replicas=count] [flags]</code> | Update the size of the specified replication controller.
 `version`        | `kubectl version [--client] [flags]` | Display the Kubernetes version running on the client and server.
 
@@ -243,8 +243,8 @@ kubectl get pods <pod-name> --server-print=false
 Output looks like this:
 
 ```shell
-NAME       READY     STATUS              RESTARTS   AGE
-pod-name   1/1       Running             0          1m
+NAME       AGE
+pod-name   1m
 ```
 
 ### Sorting list objects
@@ -339,8 +339,8 @@ the pods running on it, the events generated for the node etc.
 # Delete a pod using the type and name specified in the pod.yaml file.
 kubectl delete -f pod.yaml
 
-# Delete all the pods and services that have the label name=<label-name>.
-kubectl delete pods,services -l name=<label-name>
+# Delete all the pods and services that have the label '<label-key>=<label-value>'.
+kubectl delete pods,services -l <label-key>=<label-value>
 
 # Delete all pods, including uninitialized ones.
 kubectl delete pods --all
@@ -350,13 +350,13 @@ kubectl delete pods --all
 
 ```shell
 # Get output from running 'date' from pod <pod-name>. By default, output is from the first container.
-kubectl exec <pod-name> date
+kubectl exec <pod-name> -- date
 
 # Get output from running 'date' in container <container-name> of pod <pod-name>.
-kubectl exec <pod-name> -c <container-name> date
+kubectl exec <pod-name> -c <container-name> -- date
 
 # Get an interactive TTY and run /bin/bash from pod <pod-name>. By default, output is from the first container.
-kubectl exec -ti <pod-name> /bin/bash
+kubectl exec -ti <pod-name> -- /bin/bash
 ```
 
 `kubectl logs` - Print the logs for a container in a pod.
@@ -451,7 +451,7 @@ cat ./kubectl-whoami
 
 # this plugin makes use of the `kubectl config` command in order to output
 # information about the current user, based on the currently selected context
-kubectl config view --template='{{ range .contexts }}{{ if eq .name "'$(kubectl config current-context)'" }}Current user: {{ .context.user }}{{ end }}{{ end }}'
+kubectl config view --template='{{ range .contexts }}{{ if eq .name "'$(kubectl config current-context)'" }}Current user: {{ printf "%s\n" .context.user }}{{ end }}{{ end }}'
 ```
 
 Running the above plugin gives us an output containing the user for the currently selected


### PR DESCRIPTION
Proposing fixes for some issues in the page:

1. Handle display issue for the 'kubectl run' command, where pipe character ('|') is not properly escaped, so the text gets trimmed.  
Currently the text is rendered like this: "run	`kubectl run NAME --image=image [--env=“key=value”] [--port=port] [--replicas=replicas] [--dry-run=server".<br />
The correct text will be displayed like:  
"kubectl run NAME --image=image [--env="key=value"] [--port=port] [--replicas=replicas] [--dry-run=server|client|none] [--overrides=inline-json] [flags]".  
Also, the description column would be displayed properly.

2. Fixing output of 'get pods' command, when flag --server-print is set to false.  
The only displayed columns would be NAME and AGE.  

3. Fixing description and sample command for delete pods (kubectl delete pods,service ..), where 'label-name' text is ambiguously used as the label's value. Labels are key-value pairs.  
Suggested way of writting it:  
"# Delete all the pods and services that have the label '<label-key>=<label-value>'.  
kubectl delete pods,services -l <label-key>=<label-value>"<br />
Another way to write it could be:  
"# Delete all the pods and services that have the label 'name=<label-value>'.  
kubectl delete pods,services -l name=<label-value>"

4. Updating the syntax for three 'kubectl exec' commands, to include the '--' before the user's command, to be inline with current way of working and to avoid deprecation message.  

5. Enhance sample for 'kubectl config' command, where the newline was not handled properly.  
Before:  
[user@wstation ~]$ kubectl config view --template='{{ range .contexts }}{{ if eq .name "'$(kubectl config current-context)'" }}Current user: {{ .context.user }}{{ end }}{{ end }}'  
Current user: kubernetes-admin[user@wstation ~]$<br />
After:  
[user@wstation ~]$ kubectl config view --template='{{ range .contexts }}{{ if eq .name "'$(kubectl config current-context)'" }}Current user: {{ printf "%s\n" .context.user }}{{ end }}{{ end }}'  
Current user: kubernetes-admin  
[user@wstation ~]$

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use
 for advice.

-->
