### PR TITLE
zh: fix indentation

### DIFF
--- a/content/zh/docs/tasks/tools/install-kubectl.md
+++ b/content/zh/docs/tasks/tools/install-kubectl.md
@@ -498,7 +498,7 @@ kubectl 可以作为 Google Cloud SDK 的一部分进行安装。
 {{% tab name="Windows" %}}
 1. 从[本链接](https://storage.googleapis.com/kubernetes-release/release/{{< param "fullversion" >}}/bin/windows/amd64/kubectl.exe)下载 kubectl 的最新版 {{< param "fullversion" >}}。
 
-   或者如果您已经在系统中安装了 `curl` 工具，也可以通过以下命令下载：
+    或者如果您已经在系统中安装了 `curl` 工具，也可以通过以下命令下载：
 
     ```
     curl -LO https://storage.googleapis.com/kubernetes-release/release/{{< param "fullversion" >}}/bin/windows/amd64/kubectl.exe


### PR DESCRIPTION
This will fix:

![图片](https://user-images.githubusercontent.com/24759802/81530484-8f303c00-9393-11ea-9167-3371485d5243.png)

---

>  Use the default base branch, “master”, if you're documenting existing
 features in the English localization.
>
> If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use
 for advice.

I don't quite understand.
One is that `https://kubernetes.io/docs/contribute/start#choose-which-git-branch-to-use` is dead. Though I find `https://kubernetes.io/docs/contribute/localization/#branching-strategy`, but two is that there is no branch like `kubernetes:dev-1.12-zh.1`.