### PR TITLE
Update the vesion of Calico in kubeadm docs

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
@@ -303,10 +303,10 @@ Below you can find installation instructions for some popular Pod network plugin
 {{% tab name="Calico" %}}
 [Calico](https://docs.projectcalico.org/latest/introduction/) is a networking and network policy provider. Calico supports a flexible set of networking options so you can choose the most efficient option for your situation, including non-overlay and overlay networks, with or without BGP. Calico uses the same engine to enforce network policy for hosts, pods, and (if using Istio & Envoy) applications at the service mesh layer. Calico works on several architectures, including `amd64`, `arm64`, and `ppc64le`.
 
-By default, Calico uses `192.168.0.0/16` as the Pod network CIDR, though this can be configured in the calico.yaml file. For Calico to work correctly, you need to pass this same CIDR to the `kubeadm init` command using the `--pod-network-cidr=192.168.0.0/16` flag or via kubeadm's configuration.
+Calico will automatically detect which IP address range to use for pod IPs based on the value provided via the `--pod-network-cidr` flag or via kubeadm's configuration.
 
 ```shell
-kubectl apply -f https://docs.projectcalico.org/v3.11/manifests/calico.yaml
+kubectl apply -f https://docs.projectcalico.org/v3.14/manifests/calico.yaml
 ```
 
 {{% /tab %}}

--- a/content/en/docs/setup/production-environment/tools/kubeadm/high-availability.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/high-availability.md
@@ -122,8 +122,8 @@ option. Your cluster requirements may need a different configuration.
     {{< /note >}}
 
     {{< note >}}
-    Some CNI network plugins like Calico require a CIDR such as `192.168.0.0/16` and
-    some like Weave do not. See the [CNI network documentation](/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/#pod-network).
+    Some CNI network plugins require additional configuration, for example specifying the pod IP CIDR, while others do not.
+    See the [CNI network documentation](/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/#pod-network).
     To add a pod CIDR pass the flag `--pod-network-cidr`, or if you are using a kubeadm configuration file
     set the `podSubnet` field under the `networking` object of `ClusterConfiguration`.
     {{< /note >}}


### PR DESCRIPTION
Updates the version of Calico to the latest release - v3.14.0.

Also removes the need to specify a particular pod network CIDR for
Calico, since newer releases of Calico will detect the value chosen for
the cluster and use it automatically.