### PR TITLE
Fix broken layout in docs

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/web-ui-dashboard.md
+++ b/content/en/docs/tasks/access-application-cluster/web-ui-dashboard.md
@@ -97,7 +97,7 @@ If needed, you can expand the **Advanced options** section where you can specify
 
   Example:
 
-  ```conf
+```conf
 release=1.0
 tier=frontend
 environment=pod


### PR DESCRIPTION
On [this page](https://kubernetes.io/docs/tasks/access-application-cluster/web-ui-dashboard/) at the bottom, the markdown is breaking the layout. 
![image](https://user-images.githubusercontent.com/785186/81709744-19ce7500-9440-11ea-9025-3e0e9b292642.png)
