### PR TITLE
Change notes templating to be able to comply with Hugo 0.70.

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/deployment.md
+++ b/content/en/docs/concepts/workloads/controllers/deployment.md
@@ -55,7 +55,10 @@ In this example:
   as long as the Pod template itself satisfies the rule.
 
   {{< note >}}
-  The `.spec.selector.matchLabels` field is a map of {key,value} pairs. A single {key,value} in the `matchLabels` map is equivalent to an element of `matchExpressions`, whose key field is "key" the operator is "In", and the values array contains only "value". All of the requirements, from both `matchLabels` and `matchExpressions`, must be satisfied in order to match.
+  The `.spec.selector.matchLabels` field is a map of {key,value} pairs.
+  A single {key,value} in the `matchLabels` map is equivalent to an element of `matchExpressions`,
+  whose key field is "key" the operator is "In", and the values array contains only "value".
+  All of the requirements, from both `matchLabels` and `matchExpressions`, must be satisfied in order to match.
   {{< /note >}}
 
 * The `template` field contains the following sub-fields:
@@ -75,9 +78,10 @@ Follow the steps given below to create the above Deployment:
    kubectl apply -f https://k8s.io/examples/controllers/nginx-deployment.yaml
    ```
 
-   {{< note >}}
-   You can specify the `--record` flag to write the command executed in the resource annotation `kubernetes.io/change-cause`. The recorded change is useful for future introspection. For example, to see the commands executed in each Deployment revision.
-   {{< /note >}}
+  {{< note >}}
+  You can specify the `--record` flag to write the command executed in the resource annotation `kubernetes.io/change-cause`.
+  The recorded change is useful for future introspection. For example, to see the commands executed in each Deployment revision.
+  {{< /note >}}
 
 
 2. Run `kubectl get deployments` to check if the Deployment was created.
@@ -904,9 +908,9 @@ example, rollback the Deployment to its previous version.
 {{< /note >}}
 
 {{< note >}}
-If you pause a Deployment, Kubernetes does not check progress against your specified deadline. You can
-safely pause a Deployment in the middle of a rollout and resume without triggering the condition for exceeding the
-deadline.
+If you pause a Deployment, Kubernetes does not check progress against your specified deadline.
+You can safely pause a Deployment in the middle of a rollout and resume without triggering
+the condition for exceeding the deadline.
 {{< /note >}}
 
 You may experience transient errors with your Deployments, either due to a low timeout that you have set or

--- a/layouts/shortcodes/note.html
+++ b/layouts/shortcodes/note.html
@@ -1,3 +1,3 @@
 <blockquote class="note">
-  <div><strong>{{ T "note" }}</strong> {{ trim .Inner " \n" | markdownify }}</div>
+  <div><strong>{{ T "note" }}</strong> {{ replaceRE "\\s+|\n" " " .Inner | markdownify }}</div>
 </blockquote>


### PR DESCRIPTION
Using regex to allow rendering notes with an indent, for example:

```
    {{< note >}}
    If the last element of the path is a substring of the
   last element in request path, it is not a match (for example:
   `/foo/bar` matches`/foo/bar/baz`, but does not match `/foo/barbaz`).
   {{< /note >}}
```

After changing to hugo 0.70 trim seems to be not working. So for `note` class with indent,
need to remove the trailing white spaces, additional space in the replacement is needed
since after using `\n` we tends not to use trailing white space.


<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

-->
