### PR TITLE
Specify a node version in netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,6 +8,7 @@ command = "make non-production-build"
 
 [build.environment]
 HUGO_VERSION = "0.70.0"
+NODE_VERSION = "10.20.0"
 
 [context.production.environment]
 HUGO_BASEURL = "https://kubernetes.io/"


### PR DESCRIPTION
This PR attempts to address the [Node version error](https://github.com/kubernetes/website/pull/20874#issuecomment-627658093) we see when trying to build a preview for #20874. 

I'm taking this approach based on [this conversation](https://community.netlify.com/t/specifying-a-node-version/9701) in Netlify docs, with formatting from [npm docs](https://docs.npmjs.com/files/package.json#engines). 

This is my first time adding an `engines:` block, so who knows if I'm doing it right. 🤷 

**UPDATE**: Netlify ignored the version set in `package.json`, so I specified a `NODE_VERSION` in `netlify.toml` instead, which works fine, but does highlight a whole bunch of build-related errors that show we don't really know where our environments are specified.