### PR TITLE
Fix a indent of the etcdctl command

### DIFF
--- a/content/en/docs/tasks/administer-cluster/encrypt-data.md
+++ b/content/en/docs/tasks/administer-cluster/encrypt-data.md
@@ -145,7 +145,7 @@ program to retrieve the contents of your secret.
 2. Using the etcdctl commandline, read that secret out of etcd:
 
     ```
-    ETCDCTL_API=3 etcdctl get /registry/secrets/default/secret1 [...] | hexdump -C
+    ETCDCTL_API=3 etcdctl get /registry/secrets/default/secret1 [...] | hexdump -C
     ```
 
     where `[...]` must be the additional arguments for connecting to the etcd server. 

--- a/content/zh/docs/tasks/administer-cluster/encrypt-data.md
+++ b/content/zh/docs/tasks/administer-cluster/encrypt-data.md
@@ -216,15 +216,16 @@ program to retrieve the contents of your secret.
 2. 使用 etcdctl 命令行，从 etcd 中读取 secret：
 
     ```
-    ETCDCTL_API=3 etcdctl get /registry/secrets/default/secret1 [...] | hexdump -C
+    ETCDCTL_API=3 etcdctl get /registry/secrets/default/secret1 [...] | hexdump -C
     ```
+
+    这里的 `[...]` 是用来连接 etcd 服务的额外参数。
 
 <!--
     where `[...]` must be the additional arguments for connecting to the etcd server.
 3. Verify the stored secret is prefixed with `k8s:enc:aescbc:v1:` which indicates the `aescbc` provider has encrypted the resulting data.
 4. Verify the secret is correctly decrypted when retrieved via the API:
 -->
-    这里的 `[...]` 是用来连接 etcd 服务的额外参数。
 3. 验证存储的密钥前缀是否为 `k8s:enc:aescbc:v1:`，这表明 `aescbc` provider 已加密结果数据。
 4. 通过 API 检索，验证 secret 是否被正确解密：
 


### PR DESCRIPTION
Hi, I fixed a indent of the etcdctl command.
URL: https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/

## Current

<img width="1041" alt="1231スクリーンショット_2020_05_14_16_03" src="https://user-images.githubusercontent.com/2158863/81903274-7ececa00-95fc-11ea-83d4-6b0f8f0153d3.png">

## Fixed

### en

<img width="846" alt="スクリーンショット_2020_05_14_16_01" src="https://user-images.githubusercontent.com/2158863/81903284-85f5d800-95fc-11ea-83d4-d28c2671b855.png">

### zh

<img width="873" alt="123123スクリーンショット_2020_05_14_16_17" src="https://user-images.githubusercontent.com/2158863/81904640-81322380-95fe-11ea-803f-ad995292a19a.png">
