### PR TITLE
Fix typo in tasks index (French localization)

### DIFF
--- a/content/fr/docs/tasks/_index.md
+++ b/content/fr/docs/tasks/_index.md
@@ -16,7 +16,7 @@ Une page montre comment effectuer une seule chose, généralement en donnant une
 
 {{% capture body %}}
 
-## Interface web (Dashboard) #{dashboard}
+## Interface web (Dashboard) {#dashboard}
 
 Déployer et accéder au dashboard web de votre cluster pour vous aider à le gérer et administrer un cluster Kubernetes.
 


### PR DESCRIPTION
Two character fix. Makes https://kubernetes.io/fr/docs/tasks/ look right by correcting rendered text “Interface web (Dashboard) #{dashboard}” to “Interface web (Dashboard)”.