### PR TITLE
Fix table syntax

### DIFF
--- a/content/fr/docs/concepts/storage/persistent-volumes.md
+++ b/content/fr/docs/concepts/storage/persistent-volumes.md
@@ -380,7 +380,7 @@ Dans la CLI, les modes d'accès sont abrégés comme suit:
   Par exemple, un GCEPersistentDisk peut être monté en tant que ReadWriteOnce par un seul nœud ou ReadOnlyMany par plusieurs nœuds, mais pas en même temps.
 
 | Volume Plugin        | ReadWriteOnce    | ReadOnlyMany     | ReadWriteMany                                    |
-|-:--------------------|-:-:--------------|-:-:--------------|-:-:----------------------------------------------|
+|----------------------|------------------|------------------|--------------------------------------------------|
 | AWSElasticBlockStore | &#x2713;         | -                | -                                                |
 | AzureFile            | &#x2713;         | &#x2713;         | &#x2713;                                         |
 | AzureDisk            | &#x2713;         | -                | -                                                |


### PR DESCRIPTION
Some `:` were added instead of `-` in table separator between table headers and tables body; so render was broken.

See issue here: https://kubernetes.io/fr/docs/concepts/storage/persistent-volumes/#modes-dacc%C3%A8s
