### PR TITLE
#20970-fixed broken link in concepts/workloads/controllers/statefulset/

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/en/docs/concepts/workloads/controllers/statefulset.md
@@ -156,7 +156,7 @@ Cluster Domain | Service (ns/name) | StatefulSet (ns/name)  | StatefulSet Domain
 
 {{< note >}}
 Cluster Domain will be set to `cluster.local` unless
-[otherwise configured](/docs/concepts/services-networking/dns-pod-service/#how-it-works).
+[otherwise configured](/docs/concepts/services-networking/dns-pod-service/).
 {{< /note >}}
 
 ### Stable Storage

--- a/content/es/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/es/docs/concepts/workloads/controllers/statefulset.md
@@ -146,7 +146,7 @@ Cluster Domain | Service (ns/nombre) | StatefulSet (ns/nombre)  | StatefulSet Do
 
 {{< note >}}
 El valor de Cluster Domain se pondrá a `cluster.local` a menos que
-[se configure de otra forma](/docs/concepts/services-networking/dns-pod-service/#how-it-works).
+[se configure de otra forma](/docs/concepts/services-networking/dns-pod-service/).
 {{< /note >}}
 
 ### Almacenamiento estable

--- a/content/id/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/id/docs/concepts/workloads/controllers/statefulset.md
@@ -147,7 +147,7 @@ Domain Klaster | Service (ns/nama) | StatefulSet (ns/nama)  | Domain StatefulSet
 
 {{< note >}}
 Domain klaster akan diatur menjadi `cluster.local` kecuali
-[nilainya dikonfigurasi](/docs/concepts/services-networking/dns-pod-service/#how-it-works).
+[nilainya dikonfigurasi](/docs/concepts/services-networking/dns-pod-service/).
 {{< /note >}}
 
 ### Penyimpanan Stabil

--- a/content/ja/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/ja/docs/concepts/workloads/controllers/statefulset.md
@@ -131,7 +131,7 @@ Cluster Domain | Service (ns/name) | StatefulSet (ns/name)  | StatefulSet Domain
  kube.local    | foo/nginx         | foo/web           | nginx.foo.svc.kube.local        | web-{0..N-1}.nginx.foo.svc.kube.local        | web-{0..N-1} |
 
 {{< note >}}
-クラスタードメインは[その他の設定](/docs/concepts/services-networking/dns-pod-service/#how-it-works)がされない限り、`cluster.local`にセットされます。
+クラスタードメインは[その他の設定](/docs/concepts/services-networking/dns-pod-service/)がされない限り、`cluster.local`にセットされます。
 {{< /note >}}
 
 ### 安定したストレージ

--- a/content/ko/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/ko/docs/concepts/workloads/controllers/statefulset.md
@@ -147,7 +147,7 @@ N개의 레플리카가 있는 스테이트풀셋은 스테이트풀셋에 있�
  kube.local    | foo/nginx         | foo/web           | nginx.foo.svc.kube.local        | web-{0..N-1}.nginx.foo.svc.kube.local        | web-{0..N-1} |
 
 {{< note >}}
-클러스터 도메인이 달리 [구성된 경우](/ko/docs/concepts/services-networking/dns-pod-service/#how-it-works)가 
+클러스터 도메인이 달리 [구성된 경우](/ko/docs/concepts/services-networking/dns-pod-service/)가 
 아니라면 `cluster.local`로 설정된다.
 {{< /note >}}
 

--- a/content/zh/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/zh/docs/concepts/workloads/controllers/statefulset.md
@@ -227,7 +227,7 @@ Cluster Domain will be set to `cluster.local` unless
 [otherwise configured](/docs/concepts/services-networking/dns-pod-service/#how-it-works).
 -->
 {{< note >}}
-集群域会被设置为 `cluster.local`，除非有[其他配置](/docs/concepts/services-networking/dns-pod-service/#how-it-works)。
+集群域会被设置为 `cluster.local`，除非有[其他配置](/docs/concepts/services-networking/dns-pod-service/)。
 {{< /note >}}
 
 <!--


### PR DESCRIPTION
Problem:
This link is broken. The target page exists, but #how-it-works does not.
Error in the page: /docs/concepts/workloads/controllers/statefulset.md

https://github.com/kubernetes/website/blob/991aadb64f986cc74d2f50d00d631fc430e567ea/content/en/docs/concepts/workloads/controllers/statefulset.md#L159

Solution: 
Removed the #how-it-works

Files modified:
content/en/docs/concepts/workloads/controllers/statefulset.md
content/es/docs/concepts/workloads/controllers/statefulset.md
content/id/docs/concepts/workloads/controllers/statefulset.md
content/ja/docs/concepts/workloads/controllers/statefulset.md
content/ko/docs/concepts/workloads/controllers/statefulset.md
content/zh/docs/concepts/workloads/controllers/statefulset.md

