### PR TITLE
Use default font size in body td cells

### DIFF
--- a/assets/sass/_base.sass
+++ b/assets/sass/_base.sass
@@ -997,9 +997,6 @@ dd
   th
     font-weight: normal
 
-  td
-    font-size: 0.85em
-
   #editPageButton
     position: absolute
     top: -25px


### PR DESCRIPTION
For unknown reasons, we set the font size to be 0.85em for table cells
in the body. This setting is makeing the fonts barely readable.
