### PR TITLE
Fix typo in secret.md

### DIFF
--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -214,7 +214,7 @@ For example, if your application uses the following configuration file:
 
 ```yaml
 apiUrl: "https://my.api.com/api/v1"
-username: "user"
+username: "username"
 password: "password"
 ```
 


### PR DESCRIPTION
In following lines it's “username”, to maintain context consistency, I think it should be "username" here.
