### PR TITLE
Clean-up extra line in tasks configure pod container

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/assign-cpu-resource.md
+++ b/content/en/docs/tasks/configure-pod-container/assign-cpu-resource.md
@@ -180,9 +180,6 @@ The output shows that the Pod status is Pending. That is, the Pod has not been
 scheduled to run on any Node, and it will remain in the Pending state indefinitely:
 
 
-```shell
-kubectl get pod cpu-demo-2 --namespace=cpu-example
-```
 ```
 NAME         READY     STATUS    RESTARTS   AGE
 cpu-demo-2   0/1       Pending   0          7m

--- a/content/en/examples/pods/security/security-context-3.yaml
+++ b/content/en/examples/pods/security/security-context-3.yaml
@@ -6,6 +6,3 @@ spec:
   containers:
   - name: sec-ctx-3
     image: gcr.io/google-samples/node-hello:1.0
-
-
-


### PR DESCRIPTION
### Fix extra lines

- Remove extra line: security-context-3.yaml, as it was causing as bad display here: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container
- `kubectl get pod cpu-demo-2 --namespace=cpu-example` was repeated twice