### PR TITLE
Task configure sa: 'Add image pull secrets to a service account' sect…

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-service-account.md
@@ -183,27 +183,38 @@ The content of `token` is elided here.
 
 ## Add ImagePullSecrets to a service account
 
-First, create an imagePullSecret, as described [here](/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod).
-Next, verify it has been created. For example:
+### Create an imagePullSecret
 
-```shell
-kubectl get secrets myregistrykey
-```
+- Create an imagePullSecret, as described in [Specifying ImagePullSecrets on a Pod](/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod).
 
-The output is similar to this:
+    ```shell
+    kubectl create secret docker-registry myregistrykey --docker-server=DUMMY_SERVER \
+            --docker-username=DUMMY_USERNAME --docker-password=DUMMY_DOCKER_PASSWORD \
+            --docker-email=DUMMY_DOCKER_EMAIL
+    ```
 
-```
-NAME             TYPE                              DATA    AGE
-myregistrykey    kubernetes.io/.dockerconfigjson   1       1d
-```
+- Verify it has been created.
+   ```shell
+   kubectl get secrets myregistrykey
+   ```
+
+    The output is similar to this:
+
+    ```
+    NAME             TYPE                              DATA    AGE
+    myregistrykey    kubernetes.io/.dockerconfigjson   1       1d
+    ```
+
+### Add image pull secret to service account
 
 Next, modify the default service account for the namespace to use this secret as an imagePullSecret.
+
 
 ```shell
 kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "myregistrykey"}]}'
 ```
 
-Interactive version requires manual edit:
+You can instead use `kubectl edit`, or manually edit the YAML manifests as shown below:
 
 ```shell
 kubectl get serviceaccounts default -o yaml > ./sa.yaml
@@ -248,12 +259,19 @@ Finally replace the serviceaccount with the new updated `sa.yaml` file
 kubectl replace serviceaccount default -f ./sa.yaml
 ```
 
-Now, any new pods created in the current namespace will have this added to their spec:
+### Verify imagePullSecrets was added to pod spec
 
-```yaml
-spec:
-  imagePullSecrets:
-  - name: myregistrykey
+Now, when a new Pod is created in the current namespace and using the default ServiceAccount, the new Pod has its  `spec.imagePullSecrets` field set automatically:
+
+````shell
+kubectl run nginx --image=nginx --restart=Never
+kubectl get pod nginx -o=jsonpath='{.spec.imagePullSecrets[0].name}'
+````
+
+The output is:
+
+```shell
+myregistrykey
 ```
 
 <!--## Adding Secrets to a service account.


### PR DESCRIPTION
Improvement proposal to show:
- editing yaml file is an alternative of path
- `spec.imagePullSecrets` field added if in namespace but also using correct sa  (line 264)