### PR TITLE
Rendering issues on#service-account-permissions #21029

### DIFF
--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -1079,37 +1079,37 @@ In order from most secure to least secure, the approaches are:
 
 2. Grant a role to the "default" service account in a namespace
 
-    If an application does not specify a `serviceAccountName`, it uses the "default" service account.
+If an application does not specify a `serviceAccountName`, it uses the "default" service account.
 
-    {{< note >}}
-    Permissions given to the "default" service account are available to any pod
-    in the namespace that does not specify a `serviceAccountName`.
-    {{< /note >}}
+{{< note >}}
+Permissions given to the "default" service account are available to any pod
+in the namespace that does not specify a `serviceAccountName`.
+{{< /note >}}
 
-    For example, grant read-only permission within "my-namespace" to the "default" service account:
+For example, grant read-only permission within "my-namespace" to the "default" service account:
 
-    ```shell
-    kubectl create rolebinding default-view \
-      --clusterrole=view \
-      --serviceaccount=my-namespace:default \
-      --namespace=my-namespace
-    ```
+```shell
+kubectl create rolebinding default-view \
+  --clusterrole=view \
+  --serviceaccount=my-namespace:default \
+  --namespace=my-namespace
+```
 
-    Many [add-ons](/docs/concepts/cluster-administration/addons/) run as the
-    "default" service account in the `kube-system` namespace.
-    To allow those add-ons to run with super-user access, grant cluster-admin
-    permissions to the "default" service account in the `kube-system` namespace.
+Many [add-ons](/docs/concepts/cluster-administration/addons/) run as the
+"default" service account in the `kube-system` namespace.
+To allow those add-ons to run with super-user access, grant cluster-admin
+permissions to the "default" service account in the `kube-system` namespace.
 
-    {{< caution >}}
-    Enabling this means the `kube-system` namespace contains Secrets
-    that grant super-user access to your cluster's API.
-    {{< /caution >}}
+{{< caution >}}
+Enabling this means the `kube-system` namespace contains Secrets
+that grant super-user access to your cluster's API.
+{{< /caution >}}
 
-    ```shell
-    kubectl create clusterrolebinding add-on-cluster-admin \
-      --clusterrole=cluster-admin \
-      --serviceaccount=kube-system:default
-    ```
+```shell
+kubectl create clusterrolebinding add-on-cluster-admin \
+  --clusterrole=cluster-admin \
+  --serviceaccount=kube-system:default
+```
 
 3. Grant a role to all service accounts in a namespace
 


### PR DESCRIPTION
**Title**: Rendering issues on /docs/reference/access-authn-authz/rbac/#service-account-permissions #21029

**Description**:

*File to be changed*: [rbac.md]
(https://github.com/kubernetes/website/blame/master/content/en/docs/reference/access-authn-authz/rbac.md#L1098-L1106)

*Section modified*: ServiceAccount permissions
2. Grant a role to the “default” service account in a namespace

: Resolved indenting to render `hugo shortcodes` as intended

Local deployment:
<img width="1379" alt="kubernetes:website-localDeploy" src="https://user-images.githubusercontent.com/11659160/82576824-717c8700-9b8a-11ea-828a-1bc3dd44454b.png">

*Note:* 
>Dear reviewers,
I would also like to edit/fix rendering issues in ->
point 5: Grant super-user access to all service accounts cluster-wide (strongly discouraged).
Should I merge the change in the same PR or create a separate PR?

Thanks.