### PR TITLE
Task configure sa: 'Add image pull secrets to a service account' mino…

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-service-account.md
@@ -263,14 +263,14 @@ kubectl replace serviceaccount default -f ./sa.yaml
 
 Now, when a new Pod is created in the current namespace and using the default ServiceAccount, the new Pod has its  `spec.imagePullSecrets` field set automatically:
 
-````shell
+```shell
 kubectl run nginx --image=nginx --restart=Never
-kubectl get pod nginx -o=jsonpath='{.spec.imagePullSecrets[0].name}'
-````
+kubectl get pod nginx -o=jsonpath='{.spec.imagePullSecrets[0].name}{"\n"}'
+```
 
 The output is:
 
-```shell
+```
 myregistrykey
 ```
 


### PR DESCRIPTION
- Remove `shell` since it is an output as suggested here:
https://github.com/kubernetes/website/pull/21043#discussion_r427232266
- Add `\n`  line 268 otherwise output is not accurate 