### PR TITLE
Rename 'Download Kubernetes' card to 'Release Notes' on home page

### DIFF
--- a/content/en/docs/home/_index.md
+++ b/content/en/docs/home/_index.md
@@ -56,8 +56,8 @@ cards:
   description: Anyone can contribute, whether you’re new to the project or you’ve been around a long time.
   button: Contribute to the docs
   button_path: /docs/contribute
-- name: download
-  title: Download Kubernetes
+- name: release-notes
+  title: Release Notes
   description: If you are installing Kubernetes or upgrading to the newest version, refer to the current release notes.
 - name: about
   title: About the documentation

--- a/content/en/docs/setup/release/notes.md
+++ b/content/en/docs/setup/release/notes.md
@@ -2,7 +2,7 @@
 title: v1.18 Release Notes
 weight: 10
 card:
-  name: download
+  name: release-notes
   weight: 20
   anchors:
   - anchor: "#"


### PR DESCRIPTION
Fixes #21063