### PR TITLE
Clarified LimitRange is enabled by default

### DIFF
--- a/content/en/docs/concepts/policy/limit-range.md
+++ b/content/en/docs/concepts/policy/limit-range.md
@@ -26,9 +26,7 @@ A _LimitRange_ provides constraints that can:
 
 ## Enabling LimitRange
 
-LimitRange support is enabled by default for many Kubernetes distributions. It is
-enabled when the apiserver `--enable-admission-plugins=` flag has `LimitRanger` admission controller as
-one of its arguments.
+LimitRange support has been enabled by default since Kubernetes 1.10.
 
 A LimitRange is enforced in a particular namespace when there is a
 LimitRange object in that namespace.


### PR DESCRIPTION
> * Default enabled admission plugins are now `NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota`. Please note that if you previously had not set the `--admission-control` flag, your cluster behavior may change (to be more standard). ([58684](https://github.com/kubernetes/kubernetes/pull/58684), [hzxuzhonghu](https://github.com/hzxuzhonghu))


https://github.com/kubernetes/kubernetes/blob/a6b0eaecc99c07aef4952e8fae09642cabe4df5e/CHANGELOG/CHANGELOG-1.10.md

