### PR TITLE
Verbose blocks error

### DIFF
--- a/layouts/partials/templates/blocks.html
+++ b/layouts/partials/templates/blocks.html
@@ -14,7 +14,9 @@
 {{ $header := . | replaceRE "</?h2.*?>" "" | htmlUnescape | safeHTML }}
 <li><a href="#{{ $id }}">{{ $header }}</a></li>
 {{ end }}
+{{ if  $section }}
 {{ $.ctx.Scratch.Add "sections" $section }}
+{{ end }}
 {{ end }}
 </ul>
 {{ range .ctx.Scratch.Get "sections" }}


### PR DESCRIPTION
Hello!

I try to translate 2 pages, which include code blocks.
I spent a lot of time for debugging, which file I lost (#21020 ).

Now error show like
```bash
hugo server --buildFuture
Built in 17279 ms
Error: Error building site: failed to render pages:
render of "page" failed: execute of template failed: template: docs/single.html:3:3: executing "content" at <partial "docs/content-page" (dict "ctx" . "page" .)>:
error calling partial: execute of template failed: template: partials/docs/content-page.html:12:3: executing "partials/docs/content-page.html" at <partial . $>:
error calling partial: execute of template failed: template: partials/templates/task.html:11:3: executing "partials/templates/task.html" at <partial "templates/blocks" .>:
error calling partial: "layouts/partials/templates/blocks.html:17:4": execute of template failed: template: partials/templates/blocks.html:17:4:
executing "partials/templates/blocks.html" at <$.ctx.Scratch.Add>:
error calling Add: reflect: call of reflect.Value.Type on zero Value
```

After my fix error show like

```bash
hugo server --buildFuture
Built in 17201 ms
Error: Error building site: "content/ru/docs/tasks/configure-pod-container/assign-memory-resource.md:51:1":
failed to render shortcode "capture": failed to process shortcode:
"layouts/shortcodes/codenew.html:14:16":
execute of template failed: template: shortcodes/codenew.html:14:16:
executing "shortcodes/codenew.html" at <readFile $filename>: error calling readFile: file
"content/ru/examples/pods/resource/memory-request-limit.yaml" does not exist
```

You will see filepath, which not exists.

