### PR TITLE
Serve rendered content from tmpfs for local dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ docker-build:
 	$(DOCKER_RUN) $(DOCKER_IMAGE) hugo
 
 docker-serve:
-	$(DOCKER_RUN) -p 1313:1313 $(DOCKER_IMAGE) hugo server --buildFuture --bind 0.0.0.0
+	$(DOCKER_RUN) --mount type=tmpfs,destination=/src/resources,tmpfs-mode=0755 -p 1313:1313 $(DOCKER_IMAGE) hugo server --buildFuture --bind 0.0.0.0
 
 test-examples:
 	scripts/test_examples.sh install


### PR DESCRIPTION
You can run `make docker-serve` to run Hugo in a container, building the site and then serving it.

Rather than write the rendered content into the repository for this, set up a _tmpfs_ and write the content there, then serve it.

This change is also compatible with [podman](https://podman.io/).