### PR TITLE
Added description about the size of terminationMessage file

### DIFF
--- a/content/en/docs/tasks/debug-application-cluster/determine-reason-pod-failure.md
+++ b/content/en/docs/tasks/debug-application-cluster/determine-reason-pod-failure.md
@@ -82,6 +82,11 @@ value of `/dev/termination-log`. By customizing this field, you can tell Kuberne
 to use a different file. Kubernetes use the contents from the specified file to
 populate the Container's status message on both success and failure.
 
+The termination message is intended to be brief final status, such as an assertion failure message.
+The kubelet truncates messages that are longer than 4096 bytes. The total message length across all
+containers will be limited to 12KiB. The default termination message path is `/dev/termination-log`.
+You cannot set the termination message path after a Pod is launched
+
 In the following example, the container writes termination messages to
 `/tmp/my-log` for Kubernetes to retrieve:
 


### PR DESCRIPTION
fix https://github.com/kubernetes/kubernetes/issues/91133


The openapi of kubernetes has a description about the size of the terminationMessage file, so it is added in this document and aligned with openapi


https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core

/assign @tengqm