### PR TITLE
Adding the missing double quote in href-"Go to Certification" button on CKA course #21126

### DIFF
--- a/content/en/training/_index.html
+++ b/content/en/training/_index.html
@@ -97,7 +97,7 @@ class: training
           </h5>
           <p>The Certified Kubernetes Administrator (CKA) program provides assurance that CKAs have the skills, knowledge, and competency to perform the responsibilities of Kubernetes administrators.</p>
           <br>
-          <a href=https://training.linuxfoundation.org/certification/certified-kubernetes-administrator-cka/" target="_blank" class="button">Go to Certification</a>
+          <a href="https://training.linuxfoundation.org/certification/certified-kubernetes-administrator-cka/" target="_blank" class="button">Go to Certification</a>
         </center>
       </div>
     </div>


### PR DESCRIPTION
References: #21126 

Section: CKA course
Description: 
Added the missing opening `"`.

File modified: https://github.com/kubernetes/website/blob/master/content/en/training/_index.html

Line no: 100: `<a href="https://training.linuxfoundation.org/certification/certified-kubernetes-administrator-cka/" target="_blank" class="button">Go to Certification</a>`

Page link: [kubernetes.io/training](https://kubernetes.io/training/)