### PR TITLE
Revise prerequisites for “Configure Access to Multiple Clusters”

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/configure-access-multiple-clusters.md
+++ b/content/en/docs/tasks/access-application-cluster/configure-access-multiple-clusters.md
@@ -25,7 +25,12 @@ It does not mean that there is a file named `kubeconfig`.
 
 {{% capture prerequisites %}}
 
-{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+{{< include "task-tutorial-prereqs.md" >}}
+
+To check that {{< glossary_tooltip text="kubectl" term_id="kubectl" >}} is installed,
+run `kubectl version --client`. The kubectl version should be
+[within one minor version](/docs/setup/release/version-skew-policy/#kubectl) of your
+cluster's API server.
 
 {{% /capture %}}
 


### PR DESCRIPTION
The existing content of [Configure Access to Multiple Clusters](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/) recommended running `kubectl version`, which will error out for readers who have not yet configured a cluster.

Reword with that in mind.