### PR TITLE
Translate docs/reference/issues-security/_index.md into Korean

### DIFF
--- a/content/ko/docs/reference/issues-security/_index.md
+++ b/content/ko/docs/reference/issues-security/_index.md
@@ -1,0 +1,5 @@
+---
+title: 쿠버네티스 이슈와 보안
+weight: 10
+toc-hide: true
+---


### PR DESCRIPTION
Closes #21144 

Due to missing _index.md file in reference/issues-security/ directory, the existing translated docs such as "쿠버네티스 이슈 트래커" isn't located the right place.