### PR TITLE
Linked entrypoint command link to the right page#21139

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/web-ui-dashboard.md
+++ b/content/en/docs/tasks/access-application-cluster/web-ui-dashboard.md
@@ -119,7 +119,7 @@ track=stable
 
 - **CPU requirement (cores)** and **Memory requirement (MiB)**: You can specify the minimum [resource limits](/docs/tasks/configure-pod-container/limit-range/) for the container. By default, Pods run with unbounded CPU and memory limits.
 
-- **Run command** and **Run command arguments**: By default, your containers run the specified Docker image's default [entrypoint command](/docs/user-guide/containers/#containers-and-commands). You can use the command options and arguments to override the default.
+- **Run command** and **Run command arguments**: By default, your containers run the specified Docker image's default [entrypoint command](/docs/tasks/inject-data-application/define-command-argument-container/). You can use the command options and arguments to override the default.
 
 - **Run as privileged**: This setting determines whether processes in [privileged containers](/docs/user-guide/pods/#privileged-mode-for-pod-containers) are equivalent to processes running as root on the host. Privileged containers can make use of capabilities like manipulating the network stack and accessing devices.
 


### PR DESCRIPTION
**Reference issue**: https://github.com/kubernetes/website/issues/21139

**Description**:
File modified: [web-ui-dashboard.md](content/en/docs/tasks/access-application-cluster/web-ui-dashboard.md)
Line no: 122

Local deployment:
The `entrypoint command` link navigates to the link shown in the address bar:  

<img width="1431" alt="Screenshot 2020-05-23 at 14 37 59" src="https://user-images.githubusercontent.com/11659160/82731304-1d96ad00-9d06-11ea-84fe-fbf61d6ddcd2.png">

