### PR TITLE
Revise & tidy “Define environment variables for a container” task

### DIFF
--- a/content/en/docs/tasks/inject-data-application/define-environment-variable-container.md
+++ b/content/en/docs/tasks/inject-data-application/define-environment-variable-container.md
@@ -14,7 +14,7 @@ in a Kubernetes Pod.
 
 {{% capture prerequisites %}}
 
-{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+{{< include "task-tutorial-prereqs.md" >}}
 
 {{% /capture %}}
 

--- a/content/en/docs/tasks/inject-data-application/define-environment-variable-container.md
+++ b/content/en/docs/tasks/inject-data-application/define-environment-variable-container.md
@@ -29,12 +29,12 @@ that run in the Pod. To set environment variables, include the `env` or
 
 In this exercise, you create a Pod that runs one container. The configuration
 file for the Pod defines an environment variable with name `DEMO_GREETING` and
-value `"Hello from the environment"`. Here is the configuration file for the
+value `"Hello from the environment"`. Here is the configuration manifest for the
 Pod:
 
 {{< codenew file="pods/inject/envars.yaml" >}}
 
-1. Create a Pod based on the YAML configuration file:
+1. Create a Pod based on that manifest:
 
     ```shell
     kubectl apply -f https://k8s.io/examples/pods/inject/envars.yaml
@@ -46,7 +46,7 @@ Pod:
     kubectl get pods -l purpose=demonstrate-envars
     ```
 
-    The output is similar to this:
+    The output is similar to:
 
     ```
     NAME            READY     STATUS    RESTARTS   AGE
@@ -62,7 +62,8 @@ Pod:
 1. In your shell, run the `printenv` command to list the environment variables.
 
     ```shell
-    root@envar-demo:/# printenv
+    # Run this in the shell inside the container
+    printenv
     ```
 
     The output is similar to this:
@@ -80,12 +81,19 @@ Pod:
 
 {{< note >}}
 The environment variables set using the `env` or `envFrom` field
-will override any environment variables specified in the container image.
+override any environment variables specified in the container image.
 {{< /note >}}
 
 ## Using environment variables inside of your config
 
-Environment variables that you define in a Pod's configuration can be used elsewhere in the configuration, for example in commands and arguments that you set for the Pod's containers. In the example configuration below, the `GREETING`, `HONORIFIC`, and `NAME` environment variables are set to `Warm greetings to`, `The Most Honorable`, and `Kubernetes`, respectively. Those environment variables are then used in the CLI arguments passed to the `env-print-demo` container.
+Environment variables that you define in a Pod's configuration can be used
+elsewhere in the configuration, for example in commands and arguments that
+you set for the Pod's containers.
+In the example configuration below, the `GREETING`, `HONORIFIC`, and
+`NAME` environment variables are set to `Warm greetings to`, `The Most
+Honorable`, and `Kubernetes`, respectively. Those environment variables
+are then used in the CLI arguments passed to the `env-print-demo`
+container.
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
Revise and tidy https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/

- Use style guide convention for running commands
  Don't include the prompt, even for commands run inside a container
- Call a manifest a manifest
- tweak some wording
- drop version requirement because all Kubernetes versions let you set environment variables