### PR TITLE
Removed extra quoting in “DNS for Services and Pods”#21161

### DIFF
--- a/content/en/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/en/docs/concepts/services-networking/dns-pod-service.md
@@ -254,7 +254,7 @@ options ndots:5
 
 ### Feature availability
 
-The availability of Pod DNS Config and DNS Policy "`None`"" is shown as below.
+The availability of Pod DNS Config and DNS Policy "`None`" is shown as below.
 
 | k8s version | Feature support |
 | :---------: |:-----------:|


### PR DESCRIPTION
**Description**: Extra quoting surrounding "`none`""

*File modified*:  [dns-pod-service.md](content/en/docs/concepts/services-networking/dns-pod-service.md)

*Section*: [Feature availability](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#feature-availability)

*Solution*: Removed extra quoting
*Local deployment*: 
<img width="1375" alt="Screenshot 2020-05-24 at 14 46 37" src="https://user-images.githubusercontent.com/11659160/82755071-a1699b80-9dd1-11ea-9027-12e953269607.png">


<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

-->
