### PR TITLE
docs(pv): Access-mode compat table is broken

### DIFF
--- a/content/fr/docs/concepts/storage/persistent-volumes.md
+++ b/content/fr/docs/concepts/storage/persistent-volumes.md
@@ -380,7 +380,7 @@ Dans la CLI, les modes d'accès sont abrégés comme suit:
   Par exemple, un GCEPersistentDisk peut être monté en tant que ReadWriteOnce par un seul nœud ou ReadOnlyMany par plusieurs nœuds, mais pas en même temps.
 
 | Volume Plugin        | ReadWriteOnce    | ReadOnlyMany     | ReadWriteMany                                    |
-|-:--------------------|-:-:--------------|-:-:--------------|-:-:----------------------------------------------|
+| :-: | :-: | :-: | :-: |
 | AWSElasticBlockStore | &#x2713;         | -                | -                                                |
 | AzureFile            | &#x2713;         | &#x2713;         | &#x2713;                                         |
 | AzureDisk            | &#x2713;         | -                | -                                                |


### PR DESCRIPTION
Fix source of markdown table of persistent volume access-mode compatibility table

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

-->
