### PR TITLE
Fixed number of parameters in api.listPodForAllNamespaces and minor typo

### DIFF
--- a/content/en/docs/tasks/administer-cluster/access-cluster-api.md
+++ b/content/en/docs/tasks/administer-cluster/access-cluster-api.md
@@ -269,8 +269,8 @@ public class KubeConfigFileClientExample {
     CoreV1Api api = new CoreV1Api();
 
     // invokes the CoreV1Api client
-    V1PodList list = api.listPodForAllNamespaces(null, null, null, null, null, null, null, null);
-    System.out.Println("Listing all pods: ");
+    V1PodList list = api.listPodForAllNamespaces(null, null, null, null, null, null, null, null, null);
+    System.out.println("Listing all pods: ");
     for (V1Pod item : list.getItems()) {
       System.out.println(item.getMetadata().getName());
     }


### PR DESCRIPTION
Fixed number of "null" parameters in api.listPodForAllNamespaces() call from 8 to the required 9
Fixed minor typo on System.out.Println call to make code work