### PR TITLE
Added an example of a label for the sample k8s cronjob

### DIFF
--- a/content/en/examples/application/job/cronjob.yaml
+++ b/content/en/examples/application/job/cronjob.yaml
@@ -7,6 +7,9 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            lovely_label: "something_wonderful"
         spec:
           containers:
           - name: hello


### PR DESCRIPTION
Hi, since this PR was merged https://github.com/AmadeusITGroup/workflow-controller/pull/68/files which adds functionality for labels on the pods that jobs spawn I thought it fitting to update the example job with this so that it is intuitive how to add labels on jobs.

I ran across this issue when I was trying to add labels and struggled to figure out how to do it on jobs until I stumbled across the PR mentioned above. I would have known how to do it quickly if the example had this information in it. Anyway, fwiw, thought I'd add a PR and see what you think. :)