### PR TITLE
Remove local serving issues by updating RBAC alias

### DIFF
--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -5,7 +5,7 @@ reviewers:
 - liggitt
 title: Using RBAC Authorization
 content_template: templates/concept
-aliases: [../../../rbac/]
+aliases: [/rbac/]
 weight: 70
 ---
 


### PR DESCRIPTION
This PR fixes an issue with the `/rbac/` alias while trying to serve the site locally. Otherwise, Hugo throws an `error building site` message and the site does not start to serve locally.

Changes made:

- Alias update

