### PR TITLE
daemon-reload prior to restarting kubelet

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -295,6 +295,7 @@ Upgrade the kubelet and kubectl on all control plane nodes:
 Restart the kubelet
 
 ```shell
+sudo systemctl daemon-reload
 sudo systemctl restart kubelet
 ```
 
@@ -373,6 +374,7 @@ without compromising the minimum required capacity for running your workloads.
 -  Restart the kubelet
 
     ```shell
+    sudo systemctl daemon-reload
     sudo systemctl restart kubelet
     ```
 


### PR DESCRIPTION
Doing a systemctl restart kubelet alone on CentOS gives a warning to reload the units.

"Warning: kubelet.service changed on disk. Run 'systemctl daemon-reload' to reload units."

So proposing to add     "systemctl daemon-reload" before restarting the kubelet.