### PR TITLE
Allow specifying alternative tool for containerized local testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DOCKER       = docker
+DOCKER      ?= docker
 HUGO_VERSION = $(shell grep ^HUGO_VERSION netlify.toml | tail -n 1 | cut -d '=' -f 2 | tr -d " \"\n")
 DOCKER_IMAGE = kubernetes-hugo
 DOCKER_RUN   = $(DOCKER) run --rm --interactive --tty --volume $(CURDIR):/src


### PR DESCRIPTION
After this pull request is merged you'll be able to run:
```bash
DOCKER=podman make docker-image # other container tools are available 😉
DOCKER=podman make docker-serve
```
and spin up the website locally for testing, without using Docker or needing to have Docker installed.
