### PR TITLE
ICP Cloud formation quick start guide is no longer available

### DIFF
--- a/content/en/docs/setup/production-environment/turnkey/icp.md
+++ b/content/en/docs/setup/production-environment/turnkey/icp.md
@@ -27,13 +27,9 @@ The following modules are available where you can deploy IBM Cloud Private by us
 
 ## IBM Cloud Private on AWS
 
-You can deploy an IBM Cloud Private cluster on Amazon Web Services (AWS) by using either AWS CloudFormation or Terraform.
+You can deploy an IBM Cloud Private cluster on Amazon Web Services (AWS) using Terraform.
 
-IBM Cloud Private has a Quick Start that automatically deploys IBM Cloud Private into a new virtual private cloud (VPC) on the AWS Cloud. A regular deployment takes about 60 minutes, and a high availability (HA) deployment takes about 75 minutes to complete. The Quick Start includes AWS CloudFormation templates and a deployment guide.
-
-This Quick Start is for users who want to explore application modernization and want to accelerate meeting their digital transformation goals, by using IBM Cloud Private and IBM tooling. The Quick Start helps users rapidly deploy a high availability (HA), production-grade, IBM Cloud Private reference architecture on AWS. For all of the details and the deployment guide, see the [IBM Cloud Private on AWS Quick Start](https://aws.amazon.com/quickstart/architecture/ibm-cloud-private/).
-
-IBM Cloud Private can also run on the AWS cloud platform by using Terraform. To deploy IBM Cloud Private in an AWS EC2 environment, see [Installing IBM Cloud Private on AWS](https://github.com/ibm-cloud-architecture/refarch-privatecloud/blob/master/Installing_ICp_on_aws.md).
+IBM Cloud Private can also run on the AWS cloud platform by using Terraform. To deploy IBM Cloud Private in an AWS EC2 environment, see [Installing IBM Cloud Private on AWS](https://github.com/ibm-cloud-architecture/terraform-icp-aws).
 
 ## IBM Cloud Private on Azure
 


### PR DESCRIPTION
Following AWS quick start guide is no longer available for ICP
https://aws.amazon.com/quickstart/architecture/ibm-cloud-private/

https://aws.amazon.com/about-aws/whats-new/2019/02/deploy-ibm-cloud-private-on-aws-with-new-quick-start/
NOTE: This Quick Start is no longer available. 

Also updated the legacy EC2 installation guide with latest terraform guide

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

-->
