### PR TITLE
fix(kustomization): service selector should be 'app'

### DIFF
--- a/content/en/docs/tasks/manage-kubernetes-objects/kustomization.md
+++ b/content/en/docs/tasks/manage-kubernetes-objects/kustomization.md
@@ -327,7 +327,7 @@ spec:
   - port: 80
     protocol: TCP
   selector:
-    run: my-nginx
+    app: my-nginx
 EOF
 
 # Create a kustomization.yaml composing them
@@ -605,7 +605,7 @@ spec:
   - port: 80
     protocol: TCP
   selector:
-    run: my-nginx
+    app: my-nginx
 EOF
 
 cat <<EOF >./kustomization.yaml

--- a/content/ko/docs/tasks/manage-kubernetes-objects/kustomization.md
+++ b/content/ko/docs/tasks/manage-kubernetes-objects/kustomization.md
@@ -328,7 +328,7 @@ spec:
   - port: 80
     protocol: TCP
   selector:
-    run: my-nginx
+    app: my-nginx
 EOF
 
 # 이들을 구성하는 kustomization.yaml 생성
@@ -606,7 +606,7 @@ spec:
   - port: 80
     protocol: TCP
   selector:
-    run: my-nginx
+    app: my-nginx
 EOF
 
 cat <<EOF >./kustomization.yaml


### PR DESCRIPTION
Hello! I think I just spotted a typo here. In order to link a service to a deployment, the correct spec  should be `.spec.selector.app` instead of `.spec.selector.run`.