### PR TITLE
Add MP Interactive Tutorial to Stateless Section

### DIFF
--- a/content/en/docs/tutorials/stateless-application/configure-java-microservice/_index.md
+++ b/content/en/docs/tutorials/stateless-application/configure-java-microservice/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Configuring a Java Microservice"
+weight: 10
+---
+

--- a/content/en/docs/tutorials/stateless-application/configure-java-microservice/_index.md
+++ b/content/en/docs/tutorials/stateless-application/configure-java-microservice/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Configuring a Java Microservice"
+title: "Example: Configuring a Java Microservice"
 weight: 10
 ---
 

--- a/content/en/docs/tutorials/stateless-application/configure-java-microservice/configure-java-microservice-interactive.html
+++ b/content/en/docs/tutorials/stateless-application/configure-java-microservice/configure-java-microservice-interactive.html
@@ -1,0 +1,30 @@
+---
+title: Interactive Tutorial - Configuring a Java Microservice
+weight: 20
+---
+
+<!DOCTYPE html>
+
+<html lang="en">
+
+<body>
+
+<link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
+<link href="/docs/tutorials/kubernetes-basics/public/css/overrides.css" rel="stylesheet">
+<script src="https://katacoda.com/embed.js"></script>
+
+<div class="layout" id="top">
+
+    <main class="content katacoda-content">
+        <div class="katacoda">
+            <div class="katacoda__alert">
+                To interact with the Terminal, please use the desktop/tablet version
+            </div>
+            <div class="katacoda__box" id="inline-terminal-1"  data-katacoda-id="jamiecoleman/kubeconfig" data-katacoda-color="326de6" data-katacoda-secondary="273d6d" data-katacoda-hideintro="false" data-katacoda-font="Roboto" data-katacoda-fontheader="Roboto Slab" data-katacoda-prompt="Kubernetes Bootcamp Terminal" style="height: 600px;"></div>
+        </div>
+    </main>
+
+</div>
+
+</body>
+</html>

--- a/content/en/docs/tutorials/stateless-application/configure-java-microservice/configure-java-microservice-interactive.html
+++ b/content/en/docs/tutorials/stateless-application/configure-java-microservice/configure-java-microservice-interactive.html
@@ -1,5 +1,5 @@
 ---
-title: Interactive Tutorial - Configuring a Java Microservice
+title: "Interactive Tutorial - Configuring a Java Microservice"
 weight: 20
 ---
 

--- a/content/en/docs/tutorials/stateless-application/configure-java-microservice/configure-java-microservice.md
+++ b/content/en/docs/tutorials/stateless-application/configure-java-microservice/configure-java-microservice.md
@@ -1,0 +1,42 @@
+---
+title: Externalizing config using MicroProfile, ConfigMaps and Secrets
+content_template: templates/tutorial
+weight: 10
+---
+
+{{% capture overview %}}
+
+In this tutorial you will learn how and why to externalize your microservice’s configuration.  Specifically, you will learn how to use Kubernetes ConfigMaps and Secrets to set environment variables and then consume them using MicroProfile Config.
+
+{{% /capture %}}
+
+
+{{% capture prerequisites %}}
+
+### Externalizing Config from Code
+Externalized application configuration is useful because configuration usually changes depending on your environment.  In order to accomplish this, we'll use Java's Contexts and Dependency Injection (CDI) and [MicroProfile Config](https://github.com/eclipse/microprofile-config). MicroProfile Config is a feature of [MicroProfile](http://microprofile.io/), a set of open Java technologies for developing and deploying cloud-native microservices.
+
+CDI defines a rich set of complementary services that improve the application structure. This provides a standard dependency injection capability enabling an application to be assembled from collaborating, loosely-coupled beans.  During the interactive tutorial, you'll use the @Inject annotation to inject the value from an external configuration into your code.
+
+MicroProfile Config provides apps and microservices a standard way to obtain config properties from various sources, including the application, runtime, and environment.  Based on the source's defined priority, the properties are automatically combined into a single set of properties that the application can access via an API.  During the interactive tutorial you'll use the @ConfigProperty annotation to inject various externally provided property values into your code.
+
+Many open source frameworks and runtimes implement and support MicroProfile Config.  Throughout the interactive tutorial, you'll be using [Open Liberty](https://openliberty.io), a flexible open-source Java runtime for building and running cloud-native apps and microservices.  You can find more information on how to use MicroProfile Config in this [Open Liberty guide](https://www.openliberty.io/guides/microprofile-config-intro.html).
+
+### Creating Kubernetes ConfigMaps & Secrets
+There are several ways to set environment variables for a Docker container in Kubernetes, including: Dockerfile, kubernetes.yml, Kubernetes ConfigMaps, and Kubernetes Secrets.  In the tutorial, you will use the latter two for setting your environment variables whose values will be injected into your microservices.  One of the benefits for using ConfigMaps and Secrets is that they can be re-used across multiple containers, including being assigned to different environment variables for the different containers.  ConfigMaps and Secrets are stores of key-value pairs, however, Secrets are intended for storing Base64 encoded sensitive information.  For more information, see the following: [ConfigMaps](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/) & [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/).
+
+{{% /capture %}}
+
+
+{{% capture objectives %}}
+
+* Inject microservice configuration using MicroProfile Config
+* Create a Kubernetes ConfigMap and Secret
+  
+{{% /capture %}}
+  
+{{% capture lessoncontent %}}
+  
+## [Start Interactive Tutorial](/docs/tutorials/configuration/configure-java-microservice/configure-java-microservice-interactive/)  
+  
+{{% /capture %}}

--- a/content/en/docs/tutorials/stateless-application/configure-java-microservice/configure-java-microservice.md
+++ b/content/en/docs/tutorials/stateless-application/configure-java-microservice/configure-java-microservice.md
@@ -1,5 +1,5 @@
 ---
-title: Externalizing config using MicroProfile, ConfigMaps and Secrets
+title: "Externalizing config using MicroProfile, ConfigMaps and Secrets"
 content_template: templates/tutorial
 weight: 10
 ---
@@ -13,30 +13,37 @@ In this tutorial you will learn how and why to externalize your microservice’s
 
 {{% capture prerequisites %}}
 
+### Creating Kubernetes ConfigMaps & Secrets
+There are several ways to set environment variables for a Docker container in Kubernetes, including: Dockerfile, kubernetes.yml, Kubernetes ConfigMaps, and Kubernetes Secrets.  In the tutorial, you will learn how to use the latter two for setting your environment variables whose values will be injected into your microservices.  One of the benefits for using ConfigMaps and Secrets is that they can be re-used across multiple containers, including being assigned to different environment variables for the different containers.
+
+ConfigMaps are API Objects that store non-confidential key-value pairs.  In the Interactive Tutorial you will learn how to use a ConfigMap to store the application's name.  For more information regarding ConfigMaps, you can find the documentation [here](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/).
+
+Although Secrets are also used to store key-value pairs, they differ from ConfigMaps in that they're intended for confidential/sensitive information and are stored using Base64 encoding.  This makes secrets tha approrpriate choice for storing such things as credentials, keys, and tokens, the former of which you'll do in the Interactive Tutorial.  For more information on Secrets, you can find the documentation [here](https://kubernetes.io/docs/concepts/configuration/secret/).
+
+
 ### Externalizing Config from Code
 Externalized application configuration is useful because configuration usually changes depending on your environment.  In order to accomplish this, we'll use Java's Contexts and Dependency Injection (CDI) and [MicroProfile Config](https://github.com/eclipse/microprofile-config). MicroProfile Config is a feature of [MicroProfile](http://microprofile.io/), a set of open Java technologies for developing and deploying cloud-native microservices.
 
-CDI defines a rich set of complementary services that improve the application structure. This provides a standard dependency injection capability enabling an application to be assembled from collaborating, loosely-coupled beans.  During the interactive tutorial, you'll use the @Inject annotation to inject the value from an external configuration into your code.
-
-MicroProfile Config provides apps and microservices a standard way to obtain config properties from various sources, including the application, runtime, and environment.  Based on the source's defined priority, the properties are automatically combined into a single set of properties that the application can access via an API.  During the interactive tutorial you'll use the @ConfigProperty annotation to inject various externally provided property values into your code.
+CDI provides a standard dependency injection capability enabling an application to be assembled from collaborating, loosely-coupled beans.  MicroProfile Config provides apps and microservices a standard way to obtain config properties from various sources, including the application, runtime, and environment.  Based on the source's defined priority, the properties are automatically combined into a single set of properties that the application can access via an API.  Together, CDI & MicroProfile will be used in the Interactive Tutorial to retrieve the externally provided properties from the Kubernetes ConfigMaps and Secrets and get injected into your application code.
 
 Many open source frameworks and runtimes implement and support MicroProfile Config.  Throughout the interactive tutorial, you'll be using [Open Liberty](https://openliberty.io), a flexible open-source Java runtime for building and running cloud-native apps and microservices.  You can find more information on how to use MicroProfile Config in this [Open Liberty guide](https://www.openliberty.io/guides/microprofile-config-intro.html).
 
-### Creating Kubernetes ConfigMaps & Secrets
-There are several ways to set environment variables for a Docker container in Kubernetes, including: Dockerfile, kubernetes.yml, Kubernetes ConfigMaps, and Kubernetes Secrets.  In the tutorial, you will use the latter two for setting your environment variables whose values will be injected into your microservices.  One of the benefits for using ConfigMaps and Secrets is that they can be re-used across multiple containers, including being assigned to different environment variables for the different containers.  ConfigMaps and Secrets are stores of key-value pairs, however, Secrets are intended for storing Base64 encoded sensitive information.  For more information, see the following: [ConfigMaps](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/) & [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/).
+
 
 {{% /capture %}}
 
 
 {{% capture objectives %}}
 
-* Inject microservice configuration using MicroProfile Config
 * Create a Kubernetes ConfigMap and Secret
+* Inject microservice configuration using MicroProfile Config
+
   
 {{% /capture %}}
   
 {{% capture lessoncontent %}}
-  
-## [Start Interactive Tutorial](/docs/tutorials/configuration/configure-java-microservice/configure-java-microservice-interactive/)  
-  
+
+## Example: Externalizing config using MicroProfile, ConfigMaps and Secrets
+### [Start Interactive Tutorial](/docs/tutorials/configuration/configure-java-microservice/configure-java-microservice-interactive/) 
+
 {{% /capture %}}


### PR DESCRIPTION
This provides the previously discussed/socialized and demoed Interactive Tutorial for configuring Java microservices in Kubernetes.

There will be two PRs of which only one should be accepted.
The [first one](https://github.com/kubernetes/website/pull/21268) which places the tutorial under the "Configuration" (`/configuration`) section in the ToC.
The second PR (this one) has the exact same content, but places it under "Stateless Applications" (`/stateless-application`) section in the ToC.

Please note that (in both PRs) the Katacoda tutorial is hosted at `data-katacoda-id="jamiecoleman/kubeconfig"` and not at `kubernetes-bootcamp` so that will likely need an action to be moved/migrated in Katacoda, and then the PR updated to point at the location in `kubernetes-bootcamp`