### PR TITLE
parser typographer setting, en-dash

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -25,6 +25,10 @@ disableLanguages = ["hi", "no"]
  [markup.goldmark]
    [markup.goldmark.renderer]
      unsafe = true
+   [markup.goldmark.extensions]
+      definitionList = true
+      table = true
+      typographer = false
   [markup.highlight]
     codeFences = true
     guessSyntax = false


### PR DESCRIPTION
The Hugo parser typographer setting defaults to true.
Turn this setting off.
The double dash (en-dash) was displaying as a solid dash.
For further information, see issue #20915.
