### PR TITLE
Use shortcode for link to API reference

### DIFF
--- a/content/en/docs/reference/using-api/api-concepts.md
+++ b/content/en/docs/reference/using-api/api-concepts.md
@@ -450,7 +450,7 @@ request (if not forced, see [Conflicts](#conflicts)).
 
 Field management is stored in a newly introduced `managedFields` field that is
 part of an object's
-[`metadata`](/docs/reference/generated/kubernetes-api/v1.16/#objectmeta-v1-meta).
+[`metadata`](/docs/reference/generated/kubernetes-api/{{< latest-version >}}/#objectmeta-v1-meta).
 
 A simple example of an object created by Server Side Apply could look like this:
 


### PR DESCRIPTION
Follows on from PR #21271

Rather than always linking to v1.16 API docs, link to current release for this docs build.

/kind cleanup