### PR TITLE
Clarify permitted content

### DIFF
--- a/content/en/docs/contribute/style/content-guide.md
+++ b/content/en/docs/contribute/style/content-guide.md
@@ -32,9 +32,14 @@ project](https://github.com/kubernetes/kubernetes).
 
 ## What's allowed
 
-Kubernetes docs permit only some kinds of content.
+Kubernetes docs allow content for third-party projects only when:
+
+- Content documents software in the Kubernetes project
+- Content documents software that's out of project but necessary for Kubernetes to function
+- Content is canonical on kubernetes.io, or links to canonical content elsewhere
 
 ### Third party content
+
 Kubernetes documentation includes applied examples of projects in the Kubernetes project&mdash;projects that live in the [kubernetes](https://github.com/kubernetes) and
 [kubernetes-sigs](https://github.com/kubernetes-sigs) GitHub organizations. 
 
@@ -43,7 +48,7 @@ Links to active content in the Kubernetes project are always allowed.
 Kubernetes requires some third party content to function. Examples include container runtimes (containerd, CRI-O, Docker), 
 [networking policy](/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/) (CNI plugins), [Ingress controllers](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/), and [logging](https://kubernetes.io/docs/concepts/cluster-administration/logging/).
 
-Docs can link to third-party open source software (OSS) outside the Kubernetes project if it's necessary for Kubernetes to function.
+Docs can link to third-party open source software (OSS) outside the Kubernetes project only if it's necessary for Kubernetes to function.
 
 ### Dual sourced content
 


### PR DESCRIPTION
This PR clarifies the content guide's policy on third party and dual sourced content.