### PR TITLE
update /ja/docs/home/

### DIFF
--- a/content/ja/docs/home/_index.md
+++ b/content/ja/docs/home/_index.md
@@ -4,7 +4,7 @@ title: Kubernetesドキュメント
 noedit: true
 cid: docsHome
 layout: docsportal_home
-class: gridPage
+class: gridPage gridPageHome
 linkTitle: "ホーム"
 main_menu: true
 weight: 10
@@ -15,6 +15,8 @@ menu:
     weight: 20
     post: >
       <p>チュートリアル、サンプルやドキュメントのリファレンスを使って Kubernetes の利用方法を学んでください。あなたは<a href="/editdocs/" data-auto-burger-exclude>ドキュメントへコントリビュートをする</a>こともできます!</p>
+description: >
+  Kubernetesは、コンテナ化されたアプリケーションの展開、スケーリング、また管理を自動化するためのオープンソースコンテナプラットフォームです。このオープンソースプロジェクトは、Cloud Native Computing Foundationによってホストされています。
 overview: >
   Kubernetesは、コンテナ化されたアプリケーションの展開、スケーリング、また管理を自動化するためのオープンソースコンテナプラットフォームです。このオープンソースプロジェクトは、Cloud Native Computing Foundationによってホストされています（<a href="https://www.cncf.io/about">CNCF</a>）。
 cards:
@@ -38,6 +40,11 @@ cards:
   description: "一般的なタスク、そのタスクを短い手順でどのように実行するかを見てみます。"
   button: "タスクを見る"
   button_path: "/docs/tasks"
+- name: training
+  title: "トレーニング"
+  description: "Kubernetesの資格を取得して、クラウドネイティブプロジェクトを成功させます！"
+  button: "トレーニングを見る"
+  button_path: "/training"
 - name: reference
   title: "リファレンス情報を調べる"
   description: "用語、コマンドラインの構文、APIリソースタイプ、そして構築ツールのドキュメントを見て回ります。"

--- a/content/ja/training/_index.html
+++ b/content/ja/training/_index.html
@@ -1,0 +1,118 @@
+---
+title: Training
+bigheader: Kubernetes Training and Certification
+abstract: Training programs, certifications, and partners.
+layout: basic
+cid: training
+class: training
+---
+
+<section class="call-to-action">
+  <div class="main-section">
+    <div class="call-to-action" id="cta-certification">
+      <div class="logo-certification cta-image cta-image-before" id="logo-cka">
+        <img src="/images/training/kubernetes-cka-white.svg"/>
+      </div>
+      <div class="logo-certification cta-image cta-image-after" id="logo-ckad">
+        <img src="/images/training/kubernetes-ckad-white.svg"/>
+      </div>
+      <div class="cta-text">
+        <h2>Build your cloud native career</h2>
+        <p>Kubernetes is at the core of the cloud native movement. Training and certifications from the Linux Foundation and our training partners lets you invest in your career, learn Kubernetes, and make your cloud native projects successful.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="main-section padded">
+    <center>
+      <h2>Take a free course on edX</h2>
+    </center>
+  <div class="col-container">
+    <div class="col-nav">
+      <center>
+        <h5>
+          <b>Introduction to Kubernetes <br> &nbsp;</b>
+        </h5>
+        <p>Want to learn Kubernetes? Get an in-depth primer on this powerful system for managing containerized applications.</p>
+        <br>
+        <a href="https://www.edx.org/course/introduction-to-kubernetes" target="_blank" class="button">Go to Course</a>
+      </center>
+    </div>
+    <div class="col-nav">
+      <center>
+        <h5>
+          <b>Introduction to Cloud Infrastructure Technologies</b>
+        </h5>
+        <p>Learn the fundamentals of building and managing cloud technologies directly from The Linux Foundation, the leader in open source.</p>
+        <br>
+        <a href="https://www.edx.org/course/introduction-to-cloud-infrastructure-technologies" target="_blank" class="button">Go to Course</a>
+      </center>
+    </div>
+    <div class="col-nav">
+      <center>
+        <h5>
+          <b>Introduction to Linux</b>
+        </h5>
+        <p>Never learned Linux? Want a refresh? Develop a good working knowledge of Linux using both the graphical interface and command line across the major Linux distribution families.</p>
+        <br>
+        <a href="https://www.edx.org/course/introduction-to-linux" target="_blank" class="button">Go to Course</a>
+      </center>
+    </div>
+  </div>
+</section>
+
+<div class="padded lighter-gray-bg">
+  <div class="main-section two-thirds-centered">
+    <center>
+      <h2>Learn with the Linux Foundation</h2>
+      <p>The Linux Foundation offers instructor-led and self-paced courses for all aspects of the Kubernetes application development and operations lifecycle.</p>
+      <br/><br/>
+      <a href="https://training.linuxfoundation.org/training/course-catalog/?_sft_technology=kubernetes" target="_blank" class="button">See Courses</a>
+    </center>
+  </div>
+</div>
+
+<section>
+  <div class="main-section padded">
+    <center>
+        <h2>Get Kubernetes Certified</h2>
+    </center>
+    <div class="col-container">
+      <div class="col-nav">
+        <center>
+          <h5>
+            <b>Certified Kubernetes Application Developer (CKAD)</b>
+          </h5>
+          <p>The Certified Kubernetes Application Developer exam certifies that users can design, build, configure, and expose cloud native applications for Kubernetes.</p>
+          <br>
+          <a href="https://training.linuxfoundation.org/certification/certified-kubernetes-application-developer-ckad/" target="_blank" class="button">Go to Certification</a>
+        </center>
+      </div>
+      <div class="col-nav">
+        <center>
+          <h5>
+            <b>Certified Kubernetes Administrator (CKA)</b>
+          </h5>
+          <p>The Certified Kubernetes Administrator (CKA) program provides assurance that CKAs have the skills, knowledge, and competency to perform the responsibilities of Kubernetes administrators.</p>
+          <br>
+          <a href="https://training.linuxfoundation.org/certification/certified-kubernetes-administrator-cka/" target="_blank" class="button">Go to Certification</a>
+        </center>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="padded lighter-gray-bg">
+  <div class="main-section two-thirds-centered">
+    <center>
+      <h2>Kubernetes Training Partners</h2>
+      <p>Our network of Kubernetes Training Partners provide training services for Kubernetes and cloud native projects.</p>
+    </center>
+  </div>
+  <div class="main-section landscape-section">
+    <iframe src="https://landscape.cncf.io/category=kubernetes-training-partner&format=logo-mode&grouping=category&embed=yes" frameborder="0" id="landscape" scrolling="no"></iframe>
+    <script src="https://landscape.cncf.io/iframeResizer.js"></script>
+  </div>
+</div>


### PR DESCRIPTION
fixes #21287

The dev-1.17-ja.2 branch does not have `static/images/training/` directory and svg files.
So, `/ja/training/` cannot load 2 images as the picture below.
It will be resolved when the branch is rebased on or merged to master branch, right?
![ss_ 2020-05-29 17 01 16](https://user-images.githubusercontent.com/4710215/83236180-107a3200-a1ce-11ea-856d-e279008db730.png)
