### PR TITLE
Add phanama to sig-docs-id-reviews

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -124,6 +124,7 @@ aliases:
     - girikuncoro
     - irvifa
     - wahyuoi
+    - phanama
   sig-docs-it-owners: # Admins for Italian content
     - fabriziopandini
     - mattiaperi


### PR DESCRIPTION
This PR adds `phanama` as a a member of sig-docs-id-reviews