### PR TITLE
kubeadm: add links to external guides for HA topics

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/ha-topology.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/ha-topology.md
@@ -17,6 +17,11 @@ You can set up an HA cluster:
 
 You should carefully consider the advantages and disadvantages of each topology before setting up an HA cluster.
 
+{{< note >}}
+kubeadm bootstraps the etcd cluster statically. Read the etcd [Clustering Guide](https://github.com/etcd-io/etcd/blob/release-3.4/Documentation/op-guide/clustering.md#static)
+for more details.
+{{< /note >}}
+
 {{% /capture %}}
 
 {{% capture body %}}

--- a/content/en/docs/setup/production-environment/tools/kubeadm/high-availability.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/high-availability.md
@@ -77,10 +77,11 @@ option. Your cluster requirements may need a different configuration.
       on the apiserver port. It must also allow incoming traffic on its
       listening port.
 
-    - [HAProxy](http://www.haproxy.org/) can be used as a load balancer.
-
     - Make sure the address of the load balancer always matches
       the address of kubeadm's `ControlPlaneEndpoint`.
+
+    - Read the [Options for Software Load Balancing](https://github.com/kubernetes/kubeadm/blob/master/docs/ha-considerations.md#options-for-software-load-balancing)
+      guide for more details.
 
 1.  Add the first control plane nodes to the load balancer and test the
     connection:


### PR DESCRIPTION
- Add link that kubeadm uses static etcd bootstrap and link to
external details.
- Instead of linking to HA proxy, link to the kubeadm "LB options"
guide.

fxies kubernetes/kubeadm#2153

/kind feature
/sig cluster-lifecycle
/priority backlog
