### PR TITLE
Change the words for limit/request on the glossary

### DIFF
--- a/content/ko/docs/contribute/localization_ko.md
+++ b/content/ko/docs/contribute/localization_ko.md
@@ -287,8 +287,6 @@ Daemon | 데몬 |
 DaemonSet | 데몬셋(DaemonSet) | API 오브젝트인 경우
 Dashboard | 대시보드 |
 Data Plane | 데이터 플레인 |
-Default Limit | 기본 상한 |
-Default Request | 기본 요청량 |
 Deployment | 디플로이먼트(Deployment) | API 오브젝트인 경우
 deprecated | 사용 중단(deprecated) |
 descriptor | 디스크립터, 식별자 |
@@ -348,6 +346,7 @@ label | 레이블 |
 Lease | 리스(Lease) | API 오브젝트인 경우
 lifecycle | 라이프사이클 |
 LimitRange | 리밋레인지(LimitRange) | API 오브젝트인 경우
+limit | 한도(limit) | 리소스의 개수나 용량을 한정하기 위한 수치로 사용된 경우 선택적으로 사용 (API 오브젝트의 속성으로 limit을 사용한 경우는 가능한 영문 유지)
 Linux | 리눅스 |
 load | 부하 |
 LocalSubjectAccessReview | 로컬서브젝트액세스리뷰(LocalSubjectAccessReview) | API 오브젝트인 경우
@@ -357,7 +356,6 @@ Lost | Lost | 클레임의 상태에 한함
 Machine | 머신 |
 manifest | 매니페스트 |
 Master | 마스터 |
-max limit/request ratio | 최대 상한/요청량 비율 |
 metadata | 메타데이터 |
 metric | 메트릭 |
 masquerading | 마스커레이딩 |
@@ -410,8 +408,8 @@ ReplicaSet | 레플리카셋(ReplicaSet) | API 오브젝트인 경우
 replicas | 레플리카 |
 ReplicationController | 레플리케이션컨트롤러(ReplicationController) | API 오브젝트인 경우
 repository | 리포지터리 |
+request | 요청(request) | 리소스의 개수나 용량에 대한 요청 수치를 표현하기 위해 사용된 경우 선택적으로 사용 (API 오브젝트 속성으로 request를 사용한 경우는 가능한 영문을 유지)
 resource | 리소스 |
-Resource Limit | 리소스 상한 |
 ResourceQuota | 리소스쿼터(ResourceQuota) | API 오브젝트인 경우
 return | 반환하다 |
 revision | 리비전 |


### PR DESCRIPTION
Fixes #21266 

`limit` / `request` 는 각각 '제한' 과 '요청' 으로 번역하고,
독자의 이해를 돕기 위해 문서 내에서 처음 사용될 때 한영병기 하는 것을 권장하는 것이 좋을 것 같습니다.
- ResourceQuota, LimitRange 등의 API 오브젝트의 속성으로 쓰일 경우 yaml 파일 내의 표기를 참고하기 위함

English | 한글 | 비고
-- | -- | --
Default Limit | 기본 제한 |
Default Request | 기본 요청 |
max limit/request ratio | 최대 제한/요청 비율 |
Resource Limit | 리소스 제한 |
limit | 제한 | ResourceQuota, LimitRange 등의 오브젝트 속성으로 쓰이는 경우를 위해 한영병기를 권장
request | 요청 | ResourceQuota, LimitRange 등의 오브젝트 속성으로 쓰이는 경우를 위해 한영병기를 권장