### PR TITLE
Fix broken link to dns specifications.

### DIFF
--- a/content/en/docs/tasks/administer-cluster/dns-custom-nameservers.md
+++ b/content/en/docs/tasks/administer-cluster/dns-custom-nameservers.md
@@ -54,8 +54,7 @@ inheriting DNS. Set it to a valid file path to specify a file other than
 
 ## CoreDNS
 
-CoreDNS is a general-purpose authoritative DNS server that can serve as cluster DNS, complying with the [dns specifications]
-(https://github.com/kubernetes/dns/blob/master/docs/specification.md). 
+CoreDNS is a general-purpose authoritative DNS server that can serve as cluster DNS, complying with the [dns specifications](https://github.com/kubernetes/dns/blob/master/docs/specification.md).
 
 ### CoreDNS ConfigMap options
 


### PR DESCRIPTION
## Problem
The introduction to the CoreDNS section of the [docs](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/#coredns) contains a broken link to  [dns specifications](https://github.com/kubernetes/dns/blob/master/docs/specification.md).

## Desired Outcome
Clicking on the link should take the user to [correct specification](https://github.com/kubernetes/dns/blob/master/docs/specification.md).

## Solution
Remove newline to create a proper link in Markdown.