### PR TITLE
Make glossary/kube-controller-manager.md follow v1.17 of the original text

### DIFF
--- a/content/ja/docs/reference/glossary/kube-controller-manager.md
+++ b/content/ja/docs/reference/glossary/kube-controller-manager.md
@@ -2,7 +2,7 @@
 title: kube-controller-manager
 id: kube-controller-manager
 date: 2018-04-12
-full_link: /docs/reference/generated/kube-controller-manager/
+full_link: /docs/reference/command-line-tools-reference/kube-controller-manager/
 short_description: >
   コントロールプレーン上で動作するコンポーネントで、複数のコントローラープロセスを実行します。
 

--- a/content/ja/docs/reference/glossary/kube-controller-manager.md
+++ b/content/ja/docs/reference/glossary/kube-controller-manager.md
@@ -4,15 +4,15 @@ id: kube-controller-manager
 date: 2018-04-12
 full_link: /docs/reference/generated/kube-controller-manager/
 short_description: >
-  マスター上に存在し、コントローラーを実行するコンポーネントです。
+  コントロールプレーン上で動作するコンポーネントで、複数のコントローラープロセスを実行します。
 
 aka: 
 tags:
 - architecture
 - fundamental
 ---
- マスター上に存在し、{{< glossary_tooltip text="controllers" term_id="controller" >}}を実行するコンポーネントです。
+ コントロールプレーン上で動作するコンポーネントで、複数の{{< glossary_tooltip text="コントローラー" term_id="controller" >}}プロセスを実行します。
 
 <!--more--> 
 
-論理的には、各{{< glossary_tooltip text="controller" term_id="controller" >}}は個別のプロセスですが、複雑になるのを避けるために一つの実行ファイルにまとめてコンパイルされ、単一のプロセスとして動きます。
+論理的には、各{{< glossary_tooltip text="コントローラー" term_id="controller" >}}は個別のプロセスですが、複雑さを減らすために一つの実行ファイルにまとめてコンパイルされ、単一のプロセスとして動きます。


### PR DESCRIPTION
close #21299

I changed the translation of "controller processes" to "複数のコントローラープロセス" easy to understand.

Also changed the tooltip text from English to Japanese in this context.

If it's not good, I'll fix. Please check.
