### PR TITLE
update the outdated ja tutorials/_index.md based on the v1.17 en page

### DIFF
--- a/content/ja/docs/tutorials/_index.md
+++ b/content/ja/docs/tutorials/_index.md
@@ -17,8 +17,6 @@ content_template: templates/concept
 
 * [Kubernetesの基本](/ja/docs/tutorials/kubernetes-basics/)は、Kubernetesのシステムを理解し、基本的な機能を試すのに役立つ、詳細な対話式のチュートリアルです。
 
-* [Scalable Microservices with Kubernetes (Udacity)](https://www.udacity.com/course/scalable-microservices-with-kubernetes--ud615)
-
 * [Introduction to Kubernetes (edX)](https://www.edx.org/course/introduction-kubernetes-linuxfoundationx-lfs158x#)
 
 * [Hello Minikube](/ja/docs/tutorials/hello-minikube/)


### PR DESCRIPTION
Closes #21368 

This PR updates tutorials/_index.md to follow v1.17 of the original (Englist) text.
