### PR TITLE
Sync with the English document, revert #19959.

### DIFF
--- a/content/zh/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/zh/docs/concepts/workloads/controllers/cron-jobs.md
@@ -32,12 +32,19 @@ _Cron Job_ 创建基于时间调度的 [Jobs](/docs/concepts/workloads/controlle
 一个 CronJob 对象就像 _crontab_ (cron table) 文件中的一行。它用 [Cron](https://en.wikipedia.org/wiki/Cron) 格式进行编写，并周期性地在给定的调度时间执行 Job。
 
 <!--
-All **CronJob** `schedule:` times are based on the timezone of the master where the job is initiated.
+All **CronJob** `schedule:` times are based on the timezone of the
+
+If your control plane runs the kube-controller-manager in Pods or bare
+containers, the timezone set for the kube-controller-manager container determines the timezone
+that the cron job controller uses.
 -->
 
-{{< note >}}
-所有 **CronJob** 的 `schedule:` 时间都使用 UTC 时间表示。
-{{< /note >}}
+{{< caution >}}
+所有 **CronJob** 的 `schedule:` 时间都是基于初始 Job 的主控节点的时区。
+
+如果你的控制平面在 Pod 或是裸容器中运行了主控程序 (kube-controller-manager)，
+那么为该容器设置的时区将会决定定时任务的控制器所使用的时区。
+{{< /caution >}}
 
 <!--
 When creating the manifest for a CronJob resource, make sure the name you provide
@@ -127,4 +134,3 @@ the Job in turn is responsible for the management of the Pods it represents.
 CronJob 仅负责创建与其调度时间相匹配的 Job，而 Job 又负责管理其代表的 Pod。
 
 {{% /capture %}}
- 


### PR DESCRIPTION
According to #20301, the CronJob timezone comes from system timezone.

Signed-off-by: corvofeng <corvofeng@gmail.com>

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

-->
