### PR TITLE
Add info to `aws-load-balancer-security-groups` annotation

### DIFF
--- a/content/en/docs/concepts/cluster-administration/cloud-providers.md
+++ b/content/en/docs/concepts/cluster-administration/cloud-providers.md
@@ -99,7 +99,7 @@ Different settings can be applied to a load balancer service in AWS using _annot
 * `service.beta.kubernetes.io/aws-load-balancer-connection-draining-timeout`: Used on the service to specify a connection draining timeout.
 * `service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout`: Used on the service to specify the idle connection timeout.
 * `service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled`: Used on the service to enable or disable cross-zone load balancing.
-* `service.beta.kubernetes.io/aws-load-balancer-security-groups`: Used to specify the security groups to be added to ELB created. This replaces all other security groups previously assigned to the ELB. Under current behaviour, security groups defined here should not be shared between multiple services.
+* `service.beta.kubernetes.io/aws-load-balancer-security-groups`: Used to specify the security groups to be added to ELB created. This replaces all other security groups previously assigned to the ELB. Security groups defined here should not be shared between services.
 * `service.beta.kubernetes.io/aws-load-balancer-extra-security-groups`: Used on the service to specify additional security groups to be added to ELB created
 * `service.beta.kubernetes.io/aws-load-balancer-internal`: Used on the service to indicate that we want an internal ELB.
 * `service.beta.kubernetes.io/aws-load-balancer-proxy-protocol`: Used on the service to enable the proxy protocol on an ELB. Right now we only accept the value `*` which means enabling the proxy protocol on all ELB backends. In the future we could adjust this to allow setting the proxy protocol only on certain backends.

--- a/content/en/docs/concepts/cluster-administration/cloud-providers.md
+++ b/content/en/docs/concepts/cluster-administration/cloud-providers.md
@@ -99,7 +99,7 @@ Different settings can be applied to a load balancer service in AWS using _annot
 * `service.beta.kubernetes.io/aws-load-balancer-connection-draining-timeout`: Used on the service to specify a connection draining timeout.
 * `service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout`: Used on the service to specify the idle connection timeout.
 * `service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled`: Used on the service to enable or disable cross-zone load balancing.
-* `service.beta.kubernetes.io/aws-load-balancer-security-groups`: Used to specify the security groups to be added to ELB created. This replaces all other security groups previously assigned to the ELB.
+* `service.beta.kubernetes.io/aws-load-balancer-security-groups`: Used to specify the security groups to be added to ELB created. This replaces all other security groups previously assigned to the ELB. Under current behaviour, security groups defined here should not be shared between multiple services.
 * `service.beta.kubernetes.io/aws-load-balancer-extra-security-groups`: Used on the service to specify additional security groups to be added to ELB created
 * `service.beta.kubernetes.io/aws-load-balancer-internal`: Used on the service to indicate that we want an internal ELB.
 * `service.beta.kubernetes.io/aws-load-balancer-proxy-protocol`: Used on the service to enable the proxy protocol on an ELB. Right now we only accept the value `*` which means enabling the proxy protocol on all ELB backends. In the future we could adjust this to allow setting the proxy protocol only on certain backends.


### PR DESCRIPTION
Add a warning to avoid sharing security groups between multiple services in the `service.beta.kubernetes.io/aws-load-balancer-security-groups` annotation

Based on source code (1.14) below (same behavior in release-1.18 branch)
https://github.com/kubernetes/kubernetes/blob/release-1.14/pkg/cloudprovider/providers/aws/aws.go#L4064

Context:
In AWS, when a LoadBalancer service using the `service.beta.kubernetes.io/aws-load-balancer-security-groups` annotation is created, one of the security groups (SGs) in the annotation is selected as the "primary" ELB SG. An ingress rule is then dynamically added to the worker node SG(s) to allow traffic from the ELB -> Worker nodes, which looks like the following:

`Allow ALL/ALL from <primary-elb-sg>`

When multiple services share the same set of security groups, the "primary" SG selected here could be the same. Hence, the ingress rule ends up being identical. AWS EC2 security groups do not permit duplicate/identical rules however, and the current behavior of the controller manager is to simply skip creating this rule if it already exists.

When a service is deleted, the current implementation of the SG ingress rule cleanup will simply remove the ingress rule in the aforementioned form (refer to linked code):

`Allow ALL/ALL from <primary-elb-sg>`

If there are other k8s LoadBalancer type services that rely on this rule (e.g. other services that have identical/shared SGs in this annotation), the ELBs for those services may unexpectedly end up failing to communicate with the worker nodes.

An open feature request to track/change this behavior is here:
https://github.com/aws/containers-roadmap/issues/729