### PR TITLE
Update add-entries-to-pod-etc-hosts-with-host-aliases.md

### DIFF
--- a/content/en/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases.md
+++ b/content/en/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases.md
@@ -93,7 +93,7 @@ hostaliases-pod                0/1       Completed   0          6s        10.200
 The `hosts` file content would look like this:
 
 ```shell
-kubectl exec hostaliases-pod -- cat /etc/hosts
+kubectl logs hostaliases-pod
 ```
 
 ```none


### PR DESCRIPTION
https://github.com/kubernetes/website/issues/21383

The command indicated in the documentation is misleading since its not possible to exec to a completed pod. 
The correct command is to view the logs since the container runs the cat /etc/hosts command. 
