### PR TITLE
Fix layout of the section "Service - Publishing Services (ServiceTypes)"

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -499,11 +499,11 @@ The default is `ClusterIP`.
      load balancer routes, are automatically created.
    * [`ExternalName`](#externalname): Maps the Service to the contents of the
      `externalName` field (e.g. `foo.bar.example.com`), by returning a `CNAME` record
-
      with its value. No proxying of any kind is set up.
-     {{< note >}}
-     You need either kube-dns version 1.7 or CoreDNS version 0.0.8 or higher to use the `ExternalName` type.
-     {{< /note >}}
+
+  {{< note >}}
+  You need either kube-dns version 1.7 or CoreDNS version 0.0.8 or higher to use the `ExternalName` type.
+  {{< /note >}}
 
 You can also use [Ingress](/docs/concepts/services-networking/ingress/) to expose your Service. Ingress is not a Service type, but it acts as the entry point for your cluster. It lets you consolidate your routing rules into a single resource as it can expose multiple services under the same IP address.
 


### PR DESCRIPTION
The section "Service - Publishing Services (ServiceTypes)" now looks like this:

<img width="866" alt="Screen Shot 2020-06-04 at 09 50 32" src="https://user-images.githubusercontent.com/1290376/83706189-72f98500-a649-11ea-9c85-d6fbc743c776.png">

where the layout is bit messed up.

After this PR, it would like like this:

<img width="861" alt="Screen Shot 2020-06-04 at 09 53 22" src="https://user-images.githubusercontent.com/1290376/83706255-94f30780-a649-11ea-9947-fae79a44eb28.png">
