### PR TITLE
Fix HTML table content was incorrectly set to pre-formatted code

### DIFF
--- a/content/fr/docs/reference/kubectl/kubectl.md
+++ b/content/fr/docs/reference/kubectl/kubectl.md
@@ -24,477 +24,409 @@ kubectl [flags]
     <col span="1" />
   </colgroup>
   <tbody>
-
-    <tr>
+   <tr>
       <td colspan="2">--add-dir-header</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Si vrai, ajoute le répertoire du fichier à l'entête</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--alsologtostderr</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">log sur l'erreur standard en plus d'un fichier</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--application-metrics-count-limit int&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut : 100</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Nombre max de métriques d'applications à stocker (par conteneur)</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--as chaîne</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Nom d'utilisateur à utiliser pour l'opération</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--as-group tableauDeChaînes</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Groupe à utiliser pour l'opération, ce flag peut être répété pour spécifier plusieurs groupes</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--azure-container-registry-config chaîne</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Chemin du fichier contenant les informations de configuration du registre de conteneurs Azure</td>
     </tr>
-
-     <tr>
+   <tr>
       <td colspan="2">--boot-id-file string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut : "/proc/sys/kernel/random/boot_id"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Liste séparée par des virgules de fichiers dans lesquels rechercher le boot-id. Utilise le premier trouvé.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--cache-dir chaîne&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut: "/home/karen/.kube/http-cache"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Répertoire de cache HTTP par défaut</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--certificate-authority chaîne</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Chemin vers un fichier cert pour l'autorité de certification</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--client-certificate chaîne</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Chemin vers un fichier de certificat client pour TLS</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--client-key chaîne</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Chemin vers un fichier de clé client pour TLS</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--cloud-provider-gce-lb-src-cidrs cidrs&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut: 130.211.0.0/22,209.85.152.0/22,209.85.204.0/22,35.191.0.0/16</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">CIDRs ouverts dans le firewall GCE pour le proxy de trafic LB & health checks</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--cluster chaîne</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Le nom du cluster kubeconfig à utiliser</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--container-hints chaîne&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut : "/etc/cadvisor/container_hints.json"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">location du fichier hints du conteneur</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--containerd chaîne&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut : "/run/containerd/containerd.sock"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Point de terminaison de containerd</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--containerd-namespace chaîne&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut : "k8s.io"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">namespace de containerd</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--context chaîne</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Le nom du contexte kubeconfig à utiliser</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--default-not-ready-toleration-seconds int&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut: 300</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Indique les tolerationSeconds de la tolérance pour notReady:NoExecute qui sont ajoutées par défaut à tous les pods qui n'ont pas défini une telle tolérance</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--default-unreachable-toleration-seconds int&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut: 300</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Indique les tolerationSeconds de la tolérance pour unreachable:NoExecute qui sont ajoutées par défaut à tous les pods qui n'ont pas défini une telle tolérance</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--disable-root-cgroup-stats</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Désactive la collecte des stats du Cgroup racine</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--docker chaîne&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut : "unix:///var/run/docker.sock"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Point de terminaison docker</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--docker-env-metadata-whitelist chaîne</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">une liste séparée par des virgules de variables d'environnement qui doivent être collectées pour les conteneurs docker</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--docker-only</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Remonte uniquement les stats Docker en plus des stats racine</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--docker-root chaîne&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut : "/var/lib/docker"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">DÉPRÉCIÉ : la racine de docker est lue depuis docker info (ceci est une solution de secours, défaut : /var/lib/docker)</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--docker-tls</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">utiliser TLS pour se connecter à docker</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--docker-tls-ca chaîne&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut : "ca.pem"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">chemin vers CA de confiance</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--docker-tls-cert chaîne&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut : "cert.pem"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">chemin vers le certificat client</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--docker-tls-key chaîne&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut : "key.pem"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">chemin vers la clef privée</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--enable-load-reader</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Activer le lecteur de la charge CPU</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--event-storage-age-limit chaîne&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut : "default=0"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Durée maximale pendant laquelle stocker les événements  (par type). La valeur est une liste séparée par des virgules de clefs/valeurs, où les clefs sont des types d'événements (par ex: creation, oom) ou "default" et la valeur est la durée. La valeur par défaut est appliquée à tous les types d'événements non spécifiés</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--event-storage-event-limit chaîne&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut : "default=0"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Nombre max d'événements à stocker (par type). La valeur est une liste séparée par des virgules de clefs/valeurs, où les clefs sont les types d'événements (par ex: creation, oom) ou "default" et la valeur est un entier. La valeur par défaut est appliquée à tous les types d'événements non spécifiés</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--global-housekeeping-interval durée&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut : 1m0s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Intevalle entre ménages globaux</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">-h, --help</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">aide pour kubectl</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--housekeeping-interval durée&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut : 10s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Intervalle entre ménages des conteneurs</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--insecure-skip-tls-verify</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Si vrai, la validité du certificat du serveur ne sera pas vérifiée. Ceci rend vos connexions HTTPS non sécurisées</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--kubeconfig chaîne</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Chemin du fichier kubeconfig à utiliser pour les requêtes du CLI</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--log-backtrace-at traceLocation&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut: :0</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">lorsque les logs arrivent à la ligne fichier:N, émet une stack trace</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--log-cadvisor-usage</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Activer les logs d'usage du conteneur cAdvisor</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--log-dir chaîne</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Si non vide, écrit les fichiers de log dans ce répertoire</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--log-file chaîne</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Si non vide, utilise ce fichier de log</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--log-file-max-size uint&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut : 1800</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Définit la taille maximale d'un fichier de log. L'unité est le mega-octet. Si la valeur est 0, la taille de fichier maximale est illimitée.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--log-flush-frequency durée&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut: 5s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Nombre de secondes maximum entre flushs des logs</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--logtostderr&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut: true</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">log sur l'erreur standard plutôt que dans un fichier</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--machine-id-file chaîne&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut : "/etc/machine-id,/var/lib/dbus/machine-id"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">liste séparée par des virgules de fichiers dans lesquels rechercher le machine-id. Utiliser le premier trouvé.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--match-server-version</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">La version du serveur doit correspondre à la version du client</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">-n, --namespace chaîne</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Si présent, la portée de namespace pour la requête du CLI</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--password chaîne</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Mot de passe pour l'authentification de base au serveur d'API</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--profile chaîne&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut: "none"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Nom du profil à capturer. Parmi (none|cpu|heap|goroutine|threadcreate|block|mutex)</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--profile-output chaîne&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut: "profile.pprof"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Nom du fichier dans lequel écrire le profil</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--request-timeout chaîne&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut: "0"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">La durée à attendre avant d'abandonner une requête au serveur. Les valeurs non égales à zéro doivent contenir une unité de temps correspondante (ex 1s, 2m, 3h). Une valeur à zéro indique de ne pas abandonner les requêtes</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">-s, --server chaîne</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">L'adresse et le port de l'API server Kubernetes</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--skip-headers</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Si vrai, n'affiche pas les entêtes dans les messages de log</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--skip-log-headers</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Si vrai, évite les entêtes lors de l'ouverture des fichiers de log</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--stderrthreshold sévérité&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut: 2</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">logs à cette sévérité et au dessus de ce seuil vont dans stderr</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--storage-driver-buffer-duration durée&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut : 1m0s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Les écritures dans le driver de stockage seront bufferisés pour cette durée, et seront envoyés aux backends non-mémoire en une seule transaction</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--storage-driver-db chaîne&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut : "cadvisor"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">nom de la base de données</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--storage-driver-host chaîne&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut : "localhost:8086"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">hôte:port de la base de données</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--storage-driver-password chaîne&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut : "root"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Mot de passe de la base de données</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--storage-driver-secure</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">utiliser une connexion sécurisée avec la base de données</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--storage-driver-table chaîne&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut : "stats"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Nom de la table dans la base de données</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--storage-driver-user chaîne&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut : "root"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">nom d'utilisateur de la base de données</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--token chaîne</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Bearer token pour l'authentification auprès de l'API server</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--update-machine-info-interval durée&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Défaut : 5m0s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Intevalle entre mises à jour des infos machine.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--user chaîne</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Le nom de l'utilisateur kubeconfig à utiliser</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--username chaîne</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Nom d'utilisateur pour l'authentification de base au serveur  d'API</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">-v, --v Niveau</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Niveau de verbosité des logs</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--version version[=true]</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Affiche les informations de version et quitte</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--vmodule moduleSpec</td>
     </tr>
     <tr>

--- a/content/ru/docs/reference/kubectl/kubectl.md
+++ b/content/ru/docs/reference/kubectl/kubectl.md
@@ -25,485 +25,416 @@ kubectl [flags]
     <col span="1" />
   </colgroup>
   <tbody>
-
-    <tr>
+   <tr>
       <td colspan="2">--add-dir-header</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Если true, добавляет директорию файла в заголовок</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--alsologtostderr</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Логировать в стандартный поток ошибок, а также в файлы</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--application-metrics-count-limit int&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: 100</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Максимальное количество сохраняемых метрик приложения (на каждый контейнер)</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--as string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Имя пользователя, от которого будет выполняться операция</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--as-group stringArray</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Группа, от которой будет выполняться операция, этот флаг можно использовать неоднократно, чтобы указать несколько групп.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--azure-container-registry-config string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Путь к файлу, который содержит информацию с конфигурацией реестра контейнера Azure.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--boot-id-file string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: "/proc/sys/kernel/random/boot_id"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Разделенный запятыми список файлов для проверки boot-id. Используйте первый существующий.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--cache-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: "$HOME/.kube/http-cache"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Директория HTTP-кеша по умолчанию</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--certificate-authority string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Путь к файлу сертификата для центра сертификации</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--client-certificate string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Путь к файлу клиентского сертификата для TLS</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--client-key string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Путь к файлу клиентского ключа для TLS</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--cloud-provider-gce-l7lb-src-cidrs cidrs&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: 130.211.0.0/22,35.191.0.0/16</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Открыть CIDR в брандмауэре GCE для прокси трафика L7 LB и проверки работоспособности</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--cloud-provider-gce-lb-src-cidrs cidrs&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: 130.211.0.0/22,209.85.152.0/22,209.85.204.0/22,35.191.0.0/16</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Открыть CIDR в брандмауэре GCE для прокси трафика L4 LB и проверки работоспособности</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--cluster string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Имя используемого кластера kubeconfig</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--container-hints string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: "/etc/cadvisor/container_hints.json"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Путь к файлу подсказок контейнера</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--containerd string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: "/run/containerd/containerd.sock"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Конечная точка containerd</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--containerd-namespace string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: "k8s.io"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Пространство имени containerd</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--context string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Имя контекста kubeconfig</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--default-not-ready-toleration-seconds int&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: 300</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Указывает tolerationSeconds для допущения notReady:NoExecute, которое по умолчанию добавляется к каждому поду, у которого нет установлено такое допущение.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--default-unreachable-toleration-seconds int&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: 300</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Указывает tolerationSeconds для допущения unreachable:NoExecute, которое по умолчанию добавляется к каждому поду, у которого нет установлено такое допущение.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--disable-root-cgroup-stats</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Отключить сбор статистики корневой группы (Cgroup)</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--docker string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: "unix:///var/run/docker.sock"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">docker endpoint</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--docker-env-metadata-whitelist string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Список ключей переменных окружения, разделенный запятыми, которые необходимо собрать для Docker-контейнеров</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--docker-only</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">В дополнение к корневой статистике уведомлять только о Docker-контейнерах</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--docker-root string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: "/var/lib/docker"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">УСТАРЕЛО: корень docker считывается из информации docker (запасной вариант, по умолчанию: /var/lib/docker)</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--docker-tls</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Использовать TLS для подключения к Docker</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--docker-tls-ca string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: "ca.pem"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Путь к доверенному CA</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--docker-tls-cert string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: "cert.pem"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">путь к клиентскому сертификату</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--docker-tls-key string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: "key.pem"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Путь к приватному ключу</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--enable-load-reader</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Включить считыватель нагрузки процессора</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--event-storage-age-limit string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: "default=0"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Максимальный период времени для хранения события (по каждому типу). Значение флага — список из ключей и значений, разделенные запятыми, где ключи — это типы событий (например: создание, oom) либо "default", а значение — длительность. По умолчанию флаг применяется ко всем неуказанным типам событий</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--event-storage-event-limit string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: "default=0"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Максимальное количество событий для хранения (по каждому типу). Значение флага — список из ключей и значений, разделенные запятыми, где ключи — это типы событий (например: создание, oom) либо "default", а значение — целое число. По умолчанию флаг применяется ко всем неуказанным типам событий</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--global-housekeeping-interval duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: 1m0s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Интервал между глобальными служебными операциями (housekeepings)</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">-h, --help</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Получить справочную информацию по команде kubectl</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--housekeeping-interval duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: 10s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Интервал между служебными операциями (housekeepings) контейнера</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--insecure-skip-tls-verify</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Если true, значит сертификат сервера не будет проверятся на достоверность. Это сделает подключения через HTTPS небезопасными.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--kubeconfig string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Путь к файлу kubeconfig для использования в CLI-запросах.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--log-backtrace-at traceLocation&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: :0</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">При логировании указанной строки (file:N), сгенерировать трассировку стека</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--log-cadvisor-usage</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Записывать ли в журнал использование контейнера cAdvisor</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--log-dir string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Если указан, хранить лог-файлы в этой директории.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--log-file string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Если указан, использовать этот лог-файл</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--log-file-max-size uint&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: 1800</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Установить максимальный размер файла лог-файла (в Мб). Если значение равно 0, максимальный размер файла не ограничен.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--log-flush-frequency duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: 5s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Максимальное количество секунд между очисткой лог-файлов</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--logtostderr&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: true</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Логировать в стандартный поток ошибок вместо сохранения логов в файлы</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--machine-id-file string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: "/etc/machine-id,/var/lib/dbus/machine-id"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Список файлов, разделенных запятыми, для проверки machine-id. Используйте первый существующий.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--match-server-version</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Убедиться, что версия сервера соответствует версии клиента</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">-n, --namespace string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Указать область пространства имен для данного запроса CLI</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--password string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Пароль для базовой аутентификации на API-сервере</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--profile string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: "none"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Имя профиля. Может быть одним из перечисленных значений: none|cpu|heap|goroutine|threadcreate|block|mutex</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--profile-output string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: "profile.pprof"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Имя файла для записи профиля.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: "0"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Время ожидания перед тем, как перестать ожидать ответ от сервера. Значения должны содержать соответствующую единицу времени (например, 1s, 2m, 3h). Нулевое значение означает, что у запросов нет тайм-аута.
 .</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">-s, --server string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Адрес и порт API-сервера Kubernetes</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--skip-headers</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Если true, не отображать заголовки в сообщениях лога.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--skip-log-headers</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Если true, не отображать заголовки при открытии лог-файлов.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--stderrthreshold severity&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: 2</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Логи указанного уровня серьёзности или выше выводить в поток stderr</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--storage-driver-buffer-duration duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: 1m0s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Буферизировать запись в драйвере хранилища в течение указанного времени, и сохранять в файловом хранилище в виде одной транзакции</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--storage-driver-db string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: "cadvisor"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Имя базы данных</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--storage-driver-host string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: "localhost:8086"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Хост и порт базы данных, записанный в формате host:port</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--storage-driver-password string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: "root"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Пароль к базе данных</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--storage-driver-secure</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Использовать безопасное соединение с базой данных</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--storage-driver-table string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: "stats"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Имя таблицы</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--storage-driver-user string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: "root"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Имя пользователя базы данных</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--token string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Аутентификационный (bearer) токен для аутентификации на API-сервере</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--update-machine-info-interval duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;По умолчанию: 5m0s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Интервал между обновлениями информации о машине.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--user string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Имя пользователя для kubeconfig</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--username string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Имя пользователя для базовой аутентификации на API-сервере</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">-v, --v Level</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Номер уровня серьёзности логирования</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--version version[=true]</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Вывод версии команды</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--vmodule moduleSpec</td>
     </tr>
     <tr>

--- a/content/zh/docs/reference/command-line-tools-reference/kube-controller-manager.md
+++ b/content/zh/docs/reference/command-line-tools-reference/kube-controller-manager.md
@@ -41,771 +41,661 @@ kube-controller-manager [flags]
     <col span="1" />
   </colgroup>
   <tbody>
-
-    <tr>
+   <tr>
       <td colspan="2">--allocate-node-cidrs</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Should CIDRs for Pods be allocated and set on the cloud provider.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--alsologtostderr</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">log to standard error as well as files</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--attach-detach-reconcile-sync-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 1m0s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The reconciler sync wait time between volume attach detach. This duration must be larger than one second, and increasing this value from the default may allow for volumes to be mismatched with pods.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--authentication-kubeconfig string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">kubeconfig file pointing at the 'core' kubernetes server with enough rights to create tokenaccessreviews.authentication.k8s.io. This is optional. If empty, all token requests are considered to be anonymous and no client CA is looked up in the cluster.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--authentication-skip-lookup</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">If false, the authentication-kubeconfig will be used to lookup missing authentication configuration from the cluster.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--authentication-token-webhook-cache-ttl duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The duration to cache responses from the webhook token authenticator.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--authentication-tolerate-lookup-failure</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">If true, failures to look up missing authentication configuration from the cluster are not considered fatal. Note that this can result in authentication that treats all requests as anonymous.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--authorization-always-allow-paths stringSlice&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: [/healthz]</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">A list of HTTP paths to skip during authorization, i.e. these are authorized without contacting the 'core' kubernetes server.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--authorization-kubeconfig string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">kubeconfig file pointing at the 'core' kubernetes server with enough rights to create subjectaccessreviews.authorization.k8s.io. This is optional. If empty, all requests not skipped by authorization are forbidden.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--authorization-webhook-cache-authorized-ttl duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The duration to cache 'authorized' responses from the webhook authorizer.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--authorization-webhook-cache-unauthorized-ttl duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The duration to cache 'unauthorized' responses from the webhook authorizer.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--azure-container-registry-config string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Path to the file containing Azure container registry configuration information.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--bind-address ip&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 0.0.0.0</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The IP address on which to listen for the --secure-port port. The associated interface(s) must be reachable by the rest of the cluster, and by CLI/web clients. If blank, all interfaces will be used (0.0.0.0 for all IPv4 interfaces and :: for all IPv6 interfaces).</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--cert-dir string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The directory where the TLS certs are located. If --tls-cert-file and --tls-private-key-file are provided, this flag will be ignored.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--cidr-allocator-type string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "RangeAllocator"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Type of CIDR allocator to use</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--client-ca-file string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">If set, any request presenting a client certificate signed by one of the authorities in the client-ca-file is authenticated with an identity corresponding to the CommonName of the client certificate.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--cloud-config string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The path to the cloud provider configuration file. Empty string for no configuration file.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--cloud-provider string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The provider for cloud services. Empty string for no provider.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--cluster-cidr string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">CIDR Range for Pods in cluster. Requires --allocate-node-cidrs to be true</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--cluster-name string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "kubernetes"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The instance prefix for the cluster.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--cluster-signing-cert-file string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/etc/kubernetes/ca/ca.pem"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Filename containing a PEM-encoded X509 CA certificate used to issue cluster-scoped certificates</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--cluster-signing-key-file string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/etc/kubernetes/ca/ca.key"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Filename containing a PEM-encoded RSA or ECDSA private key used to sign cluster-scoped certificates</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--concurrent-deployment-syncs int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The number of deployment objects that are allowed to sync concurrently. Larger number = more responsive deployments, but more CPU (and network) load</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--concurrent-endpoint-syncs int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The number of endpoint syncing operations that will be done concurrently. Larger number = faster endpoint updating, but more CPU (and network) load</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--concurrent-gc-syncs int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 20</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The number of garbage collector workers that are allowed to sync concurrently.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--concurrent-namespace-syncs int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The number of namespace objects that are allowed to sync concurrently. Larger number = more responsive namespace termination, but more CPU (and network) load</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--concurrent-replicaset-syncs int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The number of replica sets that are allowed to sync concurrently. Larger number = more responsive replica management, but more CPU (and network) load</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--concurrent-resource-quota-syncs int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The number of resource quotas that are allowed to sync concurrently. Larger number = more responsive quota management, but more CPU (and network) load</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--concurrent-service-syncs int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 1</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The number of services that are allowed to sync concurrently. Larger number = more responsive service management, but more CPU (and network) load</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--concurrent-serviceaccount-token-syncs int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The number of service account token objects that are allowed to sync concurrently. Larger number = more responsive token generation, but more CPU (and network) load</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--concurrent-ttl-after-finished-syncs int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The number of TTL-after-finished controller workers that are allowed to sync concurrently.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--concurrent_rc_syncs int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The number of replication controllers that are allowed to sync concurrently. Larger number = more responsive replica management, but more CPU (and network) load</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--configure-cloud-routes&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Should CIDRs allocated by allocate-node-cidrs be configured on the cloud provider.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--contention-profiling</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Enable lock contention profiling, if profiling is enabled</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--controller-start-interval duration</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Interval between starting controller managers.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--controllers stringSlice&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: [*]</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">A list of controllers to enable. '*' enables all on-by-default controllers, 'foo' enables the controller named 'foo', '-foo' disables the controller named 'foo'.<br/>All controllers: attachdetach, bootstrapsigner, cloud-node-lifecycle, clusterrole-aggregation, cronjob, csrapproving, csrcleaner, csrsigning, daemonset, deployment, disruption, endpoint, garbagecollector, horizontalpodautoscaling, job, namespace, nodeipam, nodelifecycle, persistentvolume-binder, persistentvolume-expander, podgc, pv-protection, pvc-protection, replicaset, replicationcontroller, resourcequota, root-ca-cert-publisher, route, service, serviceaccount, serviceaccount-token, statefulset, tokencleaner, ttl, ttl-after-finished<br/>Disabled-by-default controllers: bootstrapsigner, tokencleaner</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--deployment-controller-sync-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 30s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Period for syncing the deployments.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--disable-attach-detach-reconcile-sync</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Disable volume attach detach reconciler sync. Disabling this may cause volumes to be mismatched with pods. Use wisely.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--enable-dynamic-provisioning&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Enable dynamic provisioning for environments that support it.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--enable-garbage-collector&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Enables the generic garbage collector. MUST be synced with the corresponding flag of the kube-apiserver.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--enable-hostpath-provisioner</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Enable HostPath PV provisioning when running without a cloud provider. This allows testing and development of provisioning features.  HostPath provisioning is not supported in any way, won't work in a multi-node cluster, and should not be used for anything other than testing or development.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--enable-taint-manager&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">WARNING: Beta feature. If set to true enables NoExecute Taints and will evict all not-tolerating Pod running on Nodes tainted with this kind of Taints.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--experimental-cluster-signing-duration duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 8760h0m0s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The length of duration signed certificates will be given.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--external-cloud-volume-plugin string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The plugin to use when cloud provider is set to external. Can be empty, should only be set when cloud-provider is external. Currently used to allow node and volume controllers to work for in tree cloud providers.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--feature-gates mapStringBool</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:<br/>APIListChunking=true|false (BETA - default=true)<br/>APIResponseCompression=true|false (ALPHA - default=false)<br/>AllAlpha=true|false (ALPHA - default=false)<br/>AppArmor=true|false (BETA - default=true)<br/>AttachVolumeLimit=true|false (BETA - default=true)<br/>BalanceAttachedNodeVolumes=true|false (ALPHA - default=false)<br/>BlockVolume=true|false (BETA - default=true)<br/>BoundServiceAccountTokenVolume=true|false (ALPHA - default=false)<br/>CPUManager=true|false (BETA - default=true)<br/>CRIContainerLogRotation=true|false (BETA - default=true)<br/>CSIBlockVolume=true|false (BETA - default=true)<br/>CSIDriverRegistry=true|false (BETA - default=true)<br/>CSIInlineVolume=true|false (ALPHA - default=false)<br/>CSIMigration=true|false (ALPHA - default=false)<br/>CSIMigrationAWS=true|false (ALPHA - default=false)<br/>CSIMigrationGCE=true|false (ALPHA - default=false)<br/>CSIMigrationOpenStack=true|false (ALPHA - default=false)<br/>CSINodeInfo=true|false (BETA - default=true)<br/>CustomCPUCFSQuotaPeriod=true|false (ALPHA - default=false)<br/>CustomResourcePublishOpenAPI=true|false (ALPHA - default=false)<br/>CustomResourceSubresources=true|false (BETA - default=true)<br/>CustomResourceValidation=true|false (BETA - default=true)<br/>CustomResourceWebhookConversion=true|false (ALPHA - default=false)<br/>DebugContainers=true|false (ALPHA - default=false)<br/>DevicePlugins=true|false (BETA - default=true)<br/>DryRun=true|false (BETA - default=true)<br/>DynamicAuditing=true|false (ALPHA - default=false)<br/>DynamicKubeletConfig=true|false (BETA - default=true)<br/>ExpandCSIVolumes=true|false (ALPHA - default=false)<br/>ExpandInUsePersistentVolumes=true|false (ALPHA - default=false)<br/>ExpandPersistentVolumes=true|false (BETA - default=true)<br/>ExperimentalCriticalPodAnnotation=true|false (ALPHA - default=false)<br/>ExperimentalHostUserNamespaceDefaulting=true|false (BETA - default=false)<br/>HyperVContainer=true|false (ALPHA - default=false)<br/>KubeletPodResources=true|false (ALPHA - default=false)<br/>LocalStorageCapacityIsolation=true|false (BETA - default=true)<br/>MountContainers=true|false (ALPHA - default=false)<br/>NodeLease=true|false (BETA - default=true)<br/>PodShareProcessNamespace=true|false (BETA - default=true)<br/>ProcMountType=true|false (ALPHA - default=false)<br/>QOSReserved=true|false (ALPHA - default=false)<br/>ResourceLimitsPriorityFunction=true|false (ALPHA - default=false)<br/>ResourceQuotaScopeSelectors=true|false (BETA - default=true)<br/>RotateKubeletClientCertificate=true|false (BETA - default=true)<br/>RotateKubeletServerCertificate=true|false (BETA - default=true)<br/>RunAsGroup=true|false (BETA - default=true)<br/>RuntimeClass=true|false (BETA - default=true)<br/>SCTPSupport=true|false (ALPHA - default=false)<br/>ScheduleDaemonSetPods=true|false (BETA - default=true)<br/>ServerSideApply=true|false (ALPHA - default=false)<br/>ServiceNodeExclusion=true|false (ALPHA - default=false)<br/>StorageVersionHash=true|false (ALPHA - default=false)<br/>StreamingProxyRedirects=true|false (BETA - default=true)<br/>SupportNodePidsLimit=true|false (ALPHA - default=false)<br/>SupportPodPidsLimit=true|false (BETA - default=true)<br/>Sysctls=true|false (BETA - default=true)<br/>TTLAfterFinished=true|false (ALPHA - default=false)<br/>TaintBasedEvictions=true|false (BETA - default=true)<br/>TaintNodesByCondition=true|false (BETA - default=true)<br/>TokenRequest=true|false (BETA - default=true)<br/>TokenRequestProjection=true|false (BETA - default=true)<br/>ValidateProxyRedirects=true|false (BETA - default=true)<br/>VolumeSnapshotDataSource=true|false (ALPHA - default=false)<br/>VolumeSubpathEnvExpansion=true|false (ALPHA - default=false)<br/>WinDSR=true|false (ALPHA - default=false)<br/>WinOverlay=true|false (ALPHA - default=false)<br/>WindowsGMSA=true|false (ALPHA - default=false)</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--flex-volume-plugin-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Full path of the directory in which the flex volume plugin should search for additional third party volume plugins.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">-h, --help</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">help for kube-controller-manager</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--horizontal-pod-autoscaler-cpu-initialization-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5m0s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The period after pod start when CPU samples might be skipped.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--horizontal-pod-autoscaler-downscale-stabilization duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5m0s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The period for which autoscaler will look backwards and not scale down below any recommendation it made during that period.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--horizontal-pod-autoscaler-initial-readiness-delay duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 30s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The period after pod start during which readiness changes will be treated as initial readiness.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--horizontal-pod-autoscaler-sync-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 15s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The period for syncing the number of pods in horizontal pod autoscaler.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--horizontal-pod-autoscaler-tolerance float&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 0.1</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The minimum change (from 1.0) in the desired-to-actual metrics ratio for the horizontal pod autoscaler to consider scaling.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--http2-max-streams-per-connection int</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The limit that the server gives to clients for the maximum number of streams in an HTTP/2 connection. Zero means to use golang's default.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--kube-api-burst int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 30</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Burst to use while talking with kubernetes apiserver.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--kube-api-content-type string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "application/vnd.kubernetes.protobuf"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Content type of requests sent to apiserver.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--kube-api-qps float32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 20</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">QPS to use while talking with kubernetes apiserver.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--kubeconfig string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Path to kubeconfig file with authorization and master location information.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--large-cluster-size-threshold int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 50</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Number of nodes from which NodeController treats the cluster as large for the eviction logic purposes. --secondary-node-eviction-rate is implicitly overridden to 0 for clusters this size or smaller.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--leader-elect&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--leader-elect-lease-duration duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 15s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--leader-elect-renew-deadline duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The interval between attempts by the acting master to renew a leadership slot before it stops leading. This must be less than or equal to the lease duration. This is only applicable if leader election is enabled.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--leader-elect-resource-lock endpoints&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "endpoints"</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The type of resource object that is used for locking during leader election. Supported options are endpoints (default) and `configmaps`.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--leader-elect-retry-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 2s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The duration the clients should wait between attempting acquisition and renewal of a leadership. This is only applicable if leader election is enabled.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--log-backtrace-at traceLocation&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: :0</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">when logging hits line file:N, emit a stack trace</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--log-dir string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">If non-empty, write log files in this directory</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--log-file string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">If non-empty, use this log file</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--log-flush-frequency duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Maximum number of seconds between log flushes</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--logtostderr&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">log to standard error instead of files</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--master string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The address of the Kubernetes API server (overrides any value in kubeconfig).</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--min-resync-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 12h0m0s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The resync period in reflectors will be random between MinResyncPeriod and 2*MinResyncPeriod.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--namespace-sync-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5m0s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The period for syncing namespace life-cycle updates</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--node-cidr-mask-size int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 24</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Mask size for node cidr in cluster.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--node-eviction-rate float32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 0.1</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Number of nodes per second on which pods are deleted in case of node failure when a zone is healthy (see --unhealthy-zone-threshold for definition of healthy/unhealthy). Zone refers to entire cluster in non-multizone clusters.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--node-monitor-grace-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 40s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Amount of time which we allow running Node to be unresponsive before marking it unhealthy. Must be N times more than kubelet's nodeStatusUpdateFrequency, where N means number of retries allowed for kubelet to post node status.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--node-monitor-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The period for syncing NodeStatus in NodeController.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--node-startup-grace-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 1m0s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Amount of time which we allow starting Node to be unresponsive before marking it unhealthy.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--pod-eviction-timeout duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5m0s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The grace period for deleting pods on failed nodes.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--profiling</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Enable profiling via web interface host:port/debug/pprof/</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--pv-recycler-increment-timeout-nfs int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 30</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">the increment of time added per Gi to ActiveDeadlineSeconds for an NFS scrubber pod</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--pv-recycler-minimum-timeout-hostpath int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 60</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The minimum ActiveDeadlineSeconds to use for a HostPath Recycler pod.  This is for development and testing only and will not work in a multi-node cluster.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--pv-recycler-minimum-timeout-nfs int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 300</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The minimum ActiveDeadlineSeconds to use for an NFS Recycler pod</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--pv-recycler-pod-template-filepath-hostpath string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The file path to a pod definition used as a template for HostPath persistent volume recycling. This is for development and testing only and will not work in a multi-node cluster.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--pv-recycler-pod-template-filepath-nfs string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The file path to a pod definition used as a template for NFS persistent volume recycling</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--pv-recycler-timeout-increment-hostpath int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 30</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">the increment of time added per Gi to ActiveDeadlineSeconds for a HostPath scrubber pod.  This is for development and testing only and will not work in a multi-node cluster.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--pvclaimbinder-sync-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 15s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The period for syncing persistent volumes and persistent volume claims</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--requestheader-allowed-names stringSlice</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">List of client certificate common names to allow to provide usernames in headers specified by --requestheader-username-headers. If empty, any client certificate validated by the authorities in --requestheader-client-ca-file is allowed.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--requestheader-client-ca-file string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Root certificate bundle to use to verify client certificates on incoming requests before trusting usernames in headers specified by --requestheader-username-headers. WARNING: generally do not depend on authorization being already done for incoming requests.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--requestheader-extra-headers-prefix stringSlice&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: [x-remote-extra-]</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">List of request header prefixes to inspect. X-Remote-Extra- is suggested.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--requestheader-group-headers stringSlice&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: [x-remote-group]</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">List of request headers to inspect for groups. X-Remote-Group is suggested.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--requestheader-username-headers stringSlice&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: [x-remote-user]</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">List of request headers to inspect for usernames. X-Remote-User is common.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--resource-quota-sync-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5m0s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The period for syncing quota usage status in the system</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--root-ca-file string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">If set, this root certificate authority will be included in service account's token secret. This must be a valid PEM-encoded CA bundle.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--route-reconciliation-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10s</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The period for reconciling routes created for Nodes by cloud provider.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--secondary-node-eviction-rate float32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 0.01</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Number of nodes per second on which pods are deleted in case of node failure when a zone is unhealthy (see --unhealthy-zone-threshold for definition of healthy/unhealthy). Zone refers to entire cluster in non-multizone clusters. This value is implicitly overridden to 0 if the cluster size is smaller than --large-cluster-size-threshold.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--secure-port int&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10257</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">The port on which to serve HTTPS with authentication and authorization.If 0, don't serve HTTPS at all.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--service-account-private-key-file string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Filename containing a PEM-encoded private RSA or ECDSA key used to sign service account tokens.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--service-cluster-ip-range string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">CIDR Range for Services in cluster. Requires --allocate-node-cidrs to be true</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--skip-headers</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">If true, avoid header prefixes in the log messages</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--stderrthreshold severity&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 2</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">logs at or above this threshold go to stderr</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--terminated-pod-gc-threshold int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 12500</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Number of terminated pods that can exist before the terminated pod garbage collector starts deleting terminated pods. If &lt;= 0, the terminated pod garbage collector is disabled.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--tls-cert-file string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">File containing the default x509 Certificate for HTTPS. (CA cert, if any, concatenated after server cert). If HTTPS serving is enabled, and --tls-cert-file and --tls-private-key-file are not provided, a self-signed certificate and key are generated for the public address and saved to the directory specified by --cert-dir.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--tls-cipher-suites stringSlice</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Comma-separated list of cipher suites for the server. If omitted, the default Go cipher suites will be use.  Possible values: TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_RC4_128_SHA,TLS_RSA_WITH_3DES_EDE_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_RC4_128_SHA</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--tls-min-version string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Minimum TLS version supported. Possible values: VersionTLS10, VersionTLS11, VersionTLS12</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--tls-private-key-file string</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">File containing the default x509 private key matching --tls-cert-file.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--tls-sni-cert-key namedCertKey&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: []</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">A pair of x509 certificate and private key file paths, optionally suffixed with a list of domain patterns which are fully qualified domain names, possibly with prefixed wildcard segments. If no domain patterns are provided, the names of the certificate are extracted. Non-wildcard matches trump over wildcard matches, explicit domain patterns trump over extracted names. For multiple key/certificate pairs, use the --tls-sni-cert-key multiple times. Examples: "example.crt,example.key" or "foo.crt,foo.key:*.foo.com,foo.com".</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--unhealthy-zone-threshold float32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 0.55</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Fraction of Nodes in a zone which needs to be not Ready (minimum 3) for zone to be treated as unhealthy. </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--use-service-account-credentials</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">If true, use individual service account credentials for each controller.</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">-v, --v Level</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">number for the log level verbosity</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--version version[=true]</td>
     </tr>
     <tr>
       <td></td><td style="line-height: 130%; word-wrap: break-word;">Print version information and quit</td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--vmodule moduleSpec</td>
     </tr>
     <tr>

--- a/content/zh/docs/reference/command-line-tools-reference/kube-scheduler.md
+++ b/content/zh/docs/reference/command-line-tools-reference/kube-scheduler.md
@@ -39,8 +39,7 @@ kube-scheduler [flags]
     <col span="1" />
   </colgroup>
   <tbody>
-
-    <tr>
+   <tr>
       <td colspan="2">--add-dir-header</td>
     </tr>
     <tr>
@@ -51,8 +50,7 @@ kube-scheduler [flags]
       如果为 true，则将文件目录添加到标题中
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!-- 
       --address string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0.0.0.0" 
@@ -68,8 +66,7 @@ kube-scheduler [flags]
       弃用: 要监听 --port 端口的 IP 地址（对于所有 IPv4 接口设置为 0.0.0.0，对于所有 IPv6 接口设置为 ::）。 请参阅 --bind-address。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--algorithm-provider string</td>
     </tr>
     <tr>
@@ -80,8 +77,7 @@ kube-scheduler [flags]
       弃用: 要使用的调度算法，可选值：ClusterAutoscalerProvider | DefaultProvider
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--alsologtostderr</td>
     </tr>
     <tr>
@@ -91,8 +87,7 @@ kube-scheduler [flags]
       -->
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--authentication-kubeconfig string</td>
     </tr>
     <tr>
@@ -102,8 +97,7 @@ kube-scheduler [flags]
       -->
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--authentication-skip-lookup</td>
     </tr>
     <tr>
@@ -114,8 +108,7 @@ kube-scheduler [flags]
       如果为 false，则 authentication-kubeconfig 将用于从集群中查找缺少的身份验证配置。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --authentication-token-webhook-cache-ttl duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10s
@@ -131,8 +124,7 @@ kube-scheduler [flags]
       缓存来自 Webhook 令牌身份验证器的响应的持续时间。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --authentication-tolerate-lookup-failure&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true
@@ -148,8 +140,7 @@ kube-scheduler [flags]
       如果为 true，则无法从集群中查找缺少的身份验证配置是致命的。请注意，这可能导致身份验证将所有请求视为匿名。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --authorization-always-allow-paths stringSlice&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: [/healthz]
@@ -165,8 +156,7 @@ kube-scheduler [flags]
       在授权过程中跳过的 HTTP 路径列表，即在不联系 'core'  kubernetes 服务器的情况下被授权的 HTTP 路径。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--authorization-kubeconfig string</td>
     </tr>
     <tr>
@@ -177,8 +167,7 @@ kube-scheduler [flags]
       指向具有足够权限以创建 subjectaccessreviews.authorization.k8s.io 的 'core' kubernetes 服务器的 kubeconfig 文件。这是可选的。如果为空，则禁止所有未经授权跳过的请求。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --authorization-webhook-cache-authorized-ttl duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10s
@@ -194,8 +183,7 @@ kube-scheduler [flags]
       缓存来自 Webhook 授权者的 'authorized' 响应的持续时间。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --authorization-webhook-cache-unauthorized-ttl duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10s
@@ -211,8 +199,7 @@ kube-scheduler [flags]
       缓存来自 Webhook 授权者的 'unauthorized' 响应的持续时间。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--azure-container-registry-config string</td>
     </tr>
     <tr>
@@ -223,8 +210,7 @@ kube-scheduler [flags]
       包含 Azure 容器仓库配置信息的文件的路径。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --bind-address ip&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 0.0.0.0
@@ -240,8 +226,7 @@ kube-scheduler [flags]
       侦听 --secure-port 端口的 IP 地址。集群的其余部分以及 CLI/ Web 客户端必须可以访问关联的接口。如果为空，将使用所有接口（所有 IPv4 接口使用 0.0.0.0，所有 IPv6 接口使用 ::）。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--cert-dir string</td>
     </tr>
     <tr>
@@ -252,8 +237,7 @@ kube-scheduler [flags]
       TLS 证书所在的目录。如果提供了--tls-cert-file 和 --tls private-key-file，则将忽略此参数。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--client-ca-file string</td>
     </tr>
     <tr>
@@ -264,8 +248,7 @@ kube-scheduler [flags]
       如果已设置，由 client-ca-file 中的授权机构签名的客户端证书的任何请求都将使用与客户端证书的 CommonName 对应的身份进行身份验证。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--config string</td>
     </tr>
     <tr>
@@ -276,8 +259,7 @@ kube-scheduler [flags]
       配置文件的路径。标志会覆盖此文件中的值。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--contention-profiling</td>
     </tr>
     <tr>
@@ -288,8 +270,7 @@ kube-scheduler [flags]
       弃用: 如果启用了性能分析，则启用锁竞争分析
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--feature-gates mapStringBool</td>
     </tr>
     <tr>
@@ -300,8 +281,7 @@ kube-scheduler [flags]
       一组 key=value 对，描述了 alpha/experimental 特征开关。选项包括：<br/>APIListChunking=true|false (BETA - 默认值=true)<br/>APIResponseCompression=true|false (BETA - 默认值=true)<br/>AllAlpha=true|false (ALPHA - 默认值=false)<br/>AppArmor=true|false (BETA - 默认值=true)<br/>AttachVolumeLimit=true|false (BETA - 默认值=true)<br/>BalanceAttachedNodeVolumes=true|false (ALPHA - 默认值=false)<br/>BlockVolume=true|false (BETA - 默认值=true)<br/>BoundServiceAccountTokenVolume=true|false (ALPHA - 默认值=false)<br/>CPUManager=true|false (BETA - 默认值=true)<br/>CRIContainerLogRotation=true|false (BETA - 默认值=true)<br/>CSIBlockVolume=true|false (BETA - 默认值=true)<br/>CSIDriverRegistry=true|false (BETA - 默认值=true)<br/>CSIInlineVolume=true|false (BETA - 默认值=true)<br/>CSIMigration=true|false (ALPHA - 默认值=false)<br/>CSIMigrationAWS=true|false (ALPHA - 默认值=false)<br/>CSIMigrationAzureDisk=true|false (ALPHA - 默认值=false)<br/>CSIMigrationAzureFile=true|false (ALPHA - 默认值=false)<br/>CSIMigrationGCE=true|false (ALPHA - 默认值=false)<br/>CSIMigrationOpenStack=true|false (ALPHA - 默认值=false)<br/>CSINodeInfo=true|false (BETA - 默认值=true)<br/>CustomCPUCFSQuotaPeriod=true|false (ALPHA - 默认值=false)<br/>CustomResourceDefaulting=true|false (BETA - 默认值=true)<br/>DevicePlugins=true|false (BETA - 默认值=true)<br/>DryRun=true|false (BETA - 默认值=true)<br/>DynamicAuditing=true|false (ALPHA - 默认值=false)<br/>DynamicKubeletConfig=true|false (BETA - 默认值=true)<br/>EndpointSlice=true|false (ALPHA - 默认值=false)<br/>EphemeralContainers=true|false (ALPHA - 默认值=false)<br/>EvenPodsSpread=true|false (ALPHA - 默认值=false)<br/>ExpandCSIVolumes=true|false (BETA - 默认值=true)<br/>ExpandInUsePersistentVolumes=true|false (BETA - 默认值=true)<br/>ExpandPersistentVolumes=true|false (BETA - 默认值=true)<br/>ExperimentalHostUserNamespaceDefaulting=true|false (BETA - 默认值=false)<br/>HPAScaleToZero=true|false (ALPHA - 默认值=false)<br/>HyperVContainer=true|false (ALPHA - 默认值=false)<br/>IPv6DualStack=true|false (ALPHA - 默认值=false)<br/>KubeletPodResources=true|false (BETA - 默认值=true)<br/>LegacyNodeRoleBehavior=true|false (ALPHA - 默认值=true)<br/>LocalStorageCapacityIsolation=true|false (BETA - 默认值=true)<br/>LocalStorageCapacityIsolationFSQuotaMonitoring=true|false (ALPHA - 默认值=false)<br/>MountContainers=true|false (ALPHA - 默认值=false)<br/>NodeDisruptionExclusion=true|false (ALPHA - 默认值=false)<br/>NodeLease=true|false (BETA - 默认值=true)<br/>NonPreemptingPriority=true|false (ALPHA - 默认值=false)<br/>PodOverhead=true|false (ALPHA - 默认值=false)<br/>PodShareProcessNamespace=true|false (BETA - 默认值=true)<br/>ProcMountType=true|false (ALPHA - 默认值=false)<br/>QOSReserved=true|false (ALPHA - 默认值=false)<br/>RemainingItemCount=true|false (BETA - 默认值=true)<br/>RemoveSelfLink=true|false (ALPHA - 默认值=false)<br/>RequestManagement=true|false (ALPHA - 默认值=false)<br/>ResourceLimitsPriorityFunction=true|false (ALPHA - 默认值=false)<br/>ResourceQuotaScopeSelectors=true|false (BETA - 默认值=true)<br/>RotateKubeletClientCertificate=true|false (BETA - 默认值=true)<br/>RotateKubeletServerCertificate=true|false (BETA - 默认值=true)<br/>RunAsGroup=true|false (BETA - 默认值=true)<br/>RuntimeClass=true|false (BETA - 默认值=true)<br/>SCTPSupport=true|false (ALPHA - 默认值=false)<br/>ScheduleDaemonSetPods=true|false (BETA - 默认值=true)<br/>ServerSideApply=true|false (BETA - 默认值=true)<br/>ServiceLoadBalancerFinalizer=true|false (BETA - 默认值=true)<br/>ServiceNodeExclusion=true|false (ALPHA - 默认值=false)<br/>StartupProbe=true|false (BETA - 默认值=true)<br/>StorageVersionHash=true|false (BETA - 默认值=true)<br/>StreamingProxyRedirects=true|false (BETA - 默认值=true)<br/>SupportNodePidsLimit=true|false (BETA - 默认值=true)<br/>SupportPodPidsLimit=true|false (BETA - 默认值=true)<br/>Sysctls=true|false (BETA - 默认值=true)<br/>TTLAfterFinished=true|false (ALPHA - 默认值=false)<br/>TaintBasedEvictions=true|false (BETA - 默认值=true)<br/>TaintNodesByCondition=true|false (BETA - 默认值=true)<br/>TokenRequest=true|false (BETA - 默认值=true)<br/>TokenRequestProjection=true|false (BETA - 默认值=true)<br/>TopologyManager=true|false (ALPHA - 默认值=false)<br/>ValidateProxyRedirects=true|false (BETA - 默认值=true)<br/>VolumePVCDataSource=true|false (BETA - 默认值=true)<br/>VolumeSnapshotDataSource=true|false (ALPHA - 默认值=false)<br/>VolumeSubpathEnvExpansion=true|false (BETA - 默认值=true)<br/>WatchBookmark=true|false (BETA - 默认值=true)<br/>WinDSR=true|false (ALPHA - 默认值=false)<br/>WinOverlay=true|false (ALPHA - 默认值=false)<br/>WindowsGMSA=true|false (BETA - 默认值=true)<br/>WindowsRunAsUserName=true|false (ALPHA - 默认值=false)
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --hard-pod-affinity-symmetric-weight int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 1
@@ -317,8 +297,7 @@ kube-scheduler [flags]
       弃用: RequiredDuringScheduling 亲和力不是对称的，但是存在与每个 RequiredDuringScheduling 关联性规则相对应的隐式 PreferredDuringScheduling 关联性规则 --hard-pod-affinity-symmetric-weight 代表隐式 PreferredDuringScheduling 关联性规则的权重。权重必须在 0-100 范围内。此选项已移至策略配置文件。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">-h, --help</td>
     </tr>
     <tr>
@@ -329,8 +308,7 @@ kube-scheduler [flags]
        kube-scheduler 帮助命令
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--http2-max-streams-per-connection int</td>
     </tr>
     <tr>
@@ -341,8 +319,7 @@ kube-scheduler [flags]
       服务器为客户端提供的 HTTP/2 连接最大限制。零表示使用 golang 的默认值。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --kube-api-burst int32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 100
@@ -358,8 +335,7 @@ kube-scheduler [flags]
       弃用: 与 kubernetes apiserver 通信时使用
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --kube-api-content-type string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "application/vnd.kubernetes.protobuf"
@@ -375,8 +351,7 @@ kube-scheduler [flags]
       弃用: 发送到 apiserver 的请求的内容类型。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --kube-api-qps float32&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 50
@@ -392,8 +367,7 @@ kube-scheduler [flags]
       弃用: 与 kubernetes apiserver 通信时要使用的 QPS
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--kubeconfig string</td>
     </tr>
     <tr>
@@ -404,8 +378,7 @@ kube-scheduler [flags]
       弃用: 具有授权和主节点位置信息的 kubeconfig 文件的路径。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --leader-elect&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true
@@ -421,8 +394,7 @@ kube-scheduler [flags]
       在执行主循环之前，开始领导者选举并选出领导者。为实现高可用性，运行多副本的组件并选出领导者。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --leader-elect-lease-duration duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 15s
@@ -438,8 +410,7 @@ kube-scheduler [flags]
       非领导者候选人在观察到领导者更新后将等待直到试图获得领导但未更新的领导者职位的等待时间。这实际上是领导者在被另一位候选人替代之前可以停止的最大持续时间。该情况仅在启用了领导者选举的情况下才适用。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --leader-elect-renew-deadline duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10s
@@ -455,8 +426,7 @@ kube-scheduler [flags]
       </td>
       领导者尝试在停止领导之前更新领导职位的间隔时间。该时间必须小于或等于租赁期限。仅在启用了领导者选举的情况下才适用。
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --leader-elect-resource-lock endpoints&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "endpoints"
@@ -472,8 +442,7 @@ kube-scheduler [flags]
       在领导者选举期间用于锁定的资源对象的类型。支持的选项是端点（默认）和 `configmaps`
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --leader-elect-resource-name string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "kube-scheduler"
@@ -489,8 +458,7 @@ kube-scheduler [flags]
       在领导者选举期间用于锁定的资源对象的名称。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --leader-elect-resource-namespace string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "kube-system"
@@ -506,8 +474,7 @@ kube-scheduler [flags]
       在领导者选举期间用于锁定的资源对象的命名空间。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --leader-elect-retry-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 2s
@@ -523,8 +490,7 @@ kube-scheduler [flags]
       客户应在尝试获取和更新领导之间等待的时间。仅在启用了领导者选举的情况下才适用。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --lock-object-name string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "kube-scheduler"
@@ -540,8 +506,7 @@ kube-scheduler [flags]
       弃用: 定义锁对象的名称。将被删除以便使用 Leader-elect-resource-name
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --lock-object-namespace string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "kube-system"
@@ -557,8 +522,7 @@ kube-scheduler [flags]
       弃用: 定义锁对象的命名空间。将被删除以便使用 leader-elect-resource-namespace。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --log-backtrace-at traceLocation&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: :0
@@ -574,8 +538,7 @@ kube-scheduler [flags]
       当记录命中行文件：N 时发出堆栈跟踪
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--log-dir string</td>
     </tr>
     <tr>
@@ -586,8 +549,7 @@ kube-scheduler [flags]
       如果为非空，则在此目录中写入日志文件
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--log-file string</td>
     </tr>
     <tr>
@@ -598,8 +560,7 @@ kube-scheduler [flags]
       如果为非空，请使用此日志文件
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --log-file-max-size uint&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 1800
@@ -615,8 +576,7 @@ kube-scheduler [flags]
       定义日志文件可以增长到的最大值。单位为兆字节。如果值为0，则最大文件大小为无限制。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --log-flush-frequency duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 5s
@@ -632,8 +592,7 @@ kube-scheduler [flags]
       两次日志刷新之间的最大秒数
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --logtostderr&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true
@@ -649,8 +608,7 @@ kube-scheduler [flags]
       日志记录到标准错误而不是文件
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--master string</td>
     </tr>
     <tr>
@@ -661,8 +619,7 @@ kube-scheduler [flags]
        Kubernetes API 服务器的地址（覆盖 kubeconfig 中的任何值）
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--policy-config-file string</td>
     </tr>
     <tr>
@@ -673,8 +630,7 @@ kube-scheduler [flags]
       弃用：具有调度程序策略配置的文件。如果未提供 policy ConfigMap 或 --use-legacy-policy-config = true，则使用此文件
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--policy-configmap string</td>
     </tr>
     <tr>
@@ -685,8 +641,7 @@ kube-scheduler [flags]
       弃用: 包含调度程序策略配置的 ConfigMap 对象的名称。如果 --use-legacy-policy-config = false，则它必须在调度程序初始化之前存在于系统命名空间中。必须将配置作为键为 'policy.cfg' 的 'Data' 映射中元素的值提供
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --policy-configmap-namespace string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "kube-system"
@@ -702,8 +657,7 @@ kube-scheduler [flags]
       弃用: 策略 ConfigMap 所在的命名空间。如果未提供或为空，则将使用 kube-system 命名空间。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --port int&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10251
@@ -719,8 +673,7 @@ kube-scheduler [flags]
       弃用: 在没有身份验证和授权的情况下不安全地为 HTTP 服务的端口。如果为0，则根本不提供 HTTP。请参见--secure-port。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--profiling</td>
     </tr>
     <tr>
@@ -731,8 +684,7 @@ kube-scheduler [flags]
       弃用: 通过 Web 界面主机启用配置文件：port/debug/pprof/
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--requestheader-allowed-names stringSlice</td>
     </tr>
     <tr>
@@ -743,8 +695,7 @@ kube-scheduler [flags]
       客户端证书通用名称列表允许在 --requestheader-username-headers 指定的头部中提供用户名。如果为空，则允许任何由权威机构 --requestheader-client-ca-file 验证的客户端证书。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--requestheader-client-ca-file string</td>
     </tr>
     <tr>
@@ -755,8 +706,7 @@ kube-scheduler [flags]
       在信任 --requestheader-username-headers 指定的头部中的用户名之前用于验证传入请求上的客户端证书的根证书包。警告：通常不依赖于传入请求已经完成的授权。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --requestheader-extra-headers-prefix stringSlice&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: [x-remote-extra-]
@@ -772,8 +722,7 @@ kube-scheduler [flags]
       要检查请求头部前缀列表。建议使用 X-Remote-Extra- 
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --requestheader-group-headers stringSlice&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: [x-remote-group]
@@ -789,8 +738,7 @@ kube-scheduler [flags]
       用于检查组的请求头部列表。建议使用 X-Remote-Group。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --requestheader-username-headers stringSlice&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: [x-remote-user]
@@ -806,8 +754,7 @@ kube-scheduler [flags]
       用于检查用户名的请求头部列表。  X-Remote-User 很常见。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --scheduler-name string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "default-scheduler"
@@ -823,8 +770,7 @@ kube-scheduler [flags]
       弃用: 调度程序名称用于根据 Pod 的 "spec.schedulerName" 选择此调度程序将处理的 Pod。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --secure-port int&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10259
@@ -840,8 +786,7 @@ kube-scheduler [flags]
       通过身份验证和授权为 HTTPS 服务的端口。如果为 0，则根本不提供 HTTPS。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--skip-headers</td>
     </tr>
     <tr>
@@ -852,8 +797,7 @@ kube-scheduler [flags]
       如果为 true，请在日志消息中避免头部前缀
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--skip-log-headers</td>
     </tr>
     <tr>
@@ -864,8 +808,7 @@ kube-scheduler [flags]
       如果为true，则在打开日志文件时避免头部
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --stderrthreshold severity&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 2
@@ -881,8 +824,7 @@ kube-scheduler [flags]
       达到或超过此阈值的日志转到 stderr
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--tls-cert-file string</td>
     </tr>
     <tr>
@@ -893,8 +835,7 @@ kube-scheduler [flags]
       包含默认的 HTTPS x509 证书的文件。（CA证书（如果有）在服务器证书之后并置）。如果启用了 HTTPS 服务，并且未提供 --tls-cert-file 和 --tls-private-key-file，则会为公共地址生成一个自签名证书和密钥，并将其保存到 --cert-dir 指定的目录中。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--tls-cipher-suites stringSlice</td>
     </tr>
     <tr>
@@ -906,8 +847,7 @@ kube-scheduler [flags]
       TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_RC4_128_SHA,TLS_RSA_WITH_3DES_EDE_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_RC4_128_SHA
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--tls-min-version string</td>
     </tr>
     <tr>
@@ -918,8 +858,7 @@ kube-scheduler [flags]
       支持的最低 TLS 版本。可能的值：VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--tls-private-key-file string</td>
     </tr>
     <tr>
@@ -930,8 +869,7 @@ kube-scheduler [flags]
       包含与 --tls-cert-file 匹配的默认 x509 私钥的文件。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">
       <!--
       --tls-sni-cert-key namedCertKey&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: []
@@ -947,8 +885,7 @@ kube-scheduler [flags]
       一对 x509 证书和私钥文件路径，可选地后缀为完全限定域名的域模式列表，并可能带有前缀的通配符段。如果未提供域模式，则获取证书名称。非通配符匹配胜过通配符匹配，显式域模式胜过获取名称。 对于多个密钥/证书对，请多次使用 --tls-sni-cert-key。例如: "example.crt,example.key" 或者 "foo.crt,foo.key:*.foo.com,foo.com"。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--use-legacy-policy-config</td>
     </tr>
     <tr>
@@ -959,8 +896,7 @@ kube-scheduler [flags]
       弃用: 设置为 true 时，调度程序将忽略策略 ConfigMap 并使用策略配置文件
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">-v, --v Level</td>
     </tr>
     <tr>
@@ -971,8 +907,7 @@ kube-scheduler [flags]
       日志级别详细程度的数字
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--version version[=true]</td>
     </tr>
     <tr>
@@ -983,8 +918,7 @@ kube-scheduler [flags]
       打印版本信息并退出
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--vmodule moduleSpec</td>
     </tr>
     <tr>
@@ -995,8 +929,7 @@ kube-scheduler [flags]
       以逗号分隔的 pattern = N 设置列表，用于文件过滤的日志记录
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--write-config-to string</td>
     </tr>
     <tr>

--- a/content/zh/docs/reference/kubectl/kubectl.md
+++ b/content/zh/docs/reference/kubectl/kubectl.md
@@ -39,8 +39,7 @@ kubectl [flags]
     <col span="1" />
   </colgroup>
   <tbody>
-
-    <tr>
+   <tr>
       <td colspan="2">--add-dir-header</td>
     </tr>
     <tr>
@@ -51,8 +50,7 @@ kubectl [flags]
       设置为 true 表示添加文件目录到 header 中
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--alsologtostderr</td>
     </tr>
     <tr>
@@ -63,8 +61,7 @@ kubectl [flags]
       表示将日志输出到文件的同时输出到 stderr
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--as string</td>
     </tr>
     <tr>
@@ -75,8 +72,7 @@ kubectl [flags]
       以指定用户的身份执行操作
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--as-group stringArray</td>
     </tr>
     <tr>
@@ -87,8 +83,7 @@ kubectl [flags]
       模拟指定的组来执行操作，可以使用这个标志来指定多个组。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--azure-container-registry-config string</td>
     </tr>
     <tr>
@@ -99,8 +94,7 @@ kubectl [flags]
       包含 Azure 容器仓库配置信息的文件的路径。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--cache-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值: "~/.kube/http-cache"</td>
     </tr>
     <tr>
@@ -111,8 +105,7 @@ kubectl [flags]
       默认 HTTP 缓存目录
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--certificate-authority string</td>
     </tr>
     <tr>
@@ -123,8 +116,7 @@ kubectl [flags]
       指向证书机构的 cert 文件路径
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--client-certificate string</td>
     </tr>
     <tr>
@@ -135,8 +127,7 @@ kubectl [flags]
       TLS 使用的客户端证书路径
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--client-key string</td>
     </tr>
     <tr>
@@ -147,8 +138,7 @@ kubectl [flags]
       TLS 使用的客户端密钥文件路径
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--cloud-provider-gce-lb-src-cidrs cidrs&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值: 130.211.0.0/22,209.85.152.0/22,209.85.204.0/22,35.191.0.0/16</td>
     </tr>
     <tr>
@@ -159,8 +149,7 @@ kubectl [flags]
       在 GCE 防火墙中打开 CIDR，以进行 LB 流量代理和运行状况检查。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--cluster string</td>
     </tr>
     <tr>
@@ -171,8 +160,7 @@ kubectl [flags]
       要使用的 kubeconfig 集群的名称
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--context string</td>
     </tr>
     <tr>
@@ -183,8 +171,7 @@ kubectl [flags]
       要使用的 kubeconfig 上下文的名称
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--default-not-ready-toleration-seconds int&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值: 300</td>
     </tr>
     <tr>
@@ -195,8 +182,7 @@ kubectl [flags]
       表示 `notReady` 状态的容忍度秒数：默认情况下，`NoExecute` 被添加到尚未具有此容忍度的每个 Pod 中。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--default-unreachable-toleration-seconds int&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值: 300</td>
     </tr>
     <tr>
@@ -207,8 +193,7 @@ kubectl [flags]
       表示 `unreachable` 状态的容忍度秒数：默认情况下，`NoExecute` 被添加到尚未具有此容忍度的每个 Pod 中。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">-h, --help</td>
     </tr>
     <tr>
@@ -219,8 +204,7 @@ kubectl [flags]
       kubectl 操作的帮助命令
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--insecure-skip-tls-verify</td>
     </tr>
     <tr>
@@ -231,8 +215,7 @@ kubectl [flags]
       设置为 true，则表示不会检查服务器证书的有效性。这样会导致您的 HTTPS 连接不安全。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--kubeconfig string</td>
     </tr>
     <tr>
@@ -243,8 +226,7 @@ kubectl [flags]
       CLI 请求使用的 kubeconfig 配置文件的路径。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--log-backtrace-at traceLocation&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值: 0</td>
     </tr>
     <tr>
@@ -255,8 +237,7 @@ kubectl [flags]
       当日志机制运行到指定文件的指定行（file:N）时，打印调用堆栈信息
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--log-dir string</td>
     </tr>
     <tr>
@@ -267,8 +248,7 @@ kubectl [flags]
       如果不为空，则将日志文件写入此目录
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--log-file string</td>
     </tr>
     <tr>
@@ -279,8 +259,7 @@ kubectl [flags]
       如果不为空，则将使用此日志文件
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--log-file-max-size uint&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值: 1800</td>
     </tr>
     <tr>
@@ -291,8 +270,7 @@ kubectl [flags]
       定义日志文件的最大尺寸。单位为兆字节。如果值设置为 0，则表示日志文件大小不受限制。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--log-flush-frequency duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值: 5s</td>
     </tr>
     <tr>
@@ -303,8 +281,7 @@ kubectl [flags]
       两次日志刷新操作之间的最长时间（秒）
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--logtostderr&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值: true</td>
     </tr>
     <tr>
@@ -315,8 +292,7 @@ kubectl [flags]
       日志输出到 stderr 而不是文件中
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--match-server-version</td>
     </tr>
     <tr>
@@ -327,8 +303,7 @@ kubectl [flags]
       要求客户端版本和服务端版本相匹配
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">-n, --namespace string</td>
     </tr>
     <tr>
@@ -339,8 +314,7 @@ kubectl [flags]
       如果存在，CLI 请求将使用此命名空间
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--password string</td>
     </tr>
     <tr>
@@ -351,8 +325,7 @@ kubectl [flags]
       API 服务器进行基本身份验证的密码
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--profile string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值: "none"</td>
     </tr>
     <tr>
@@ -363,8 +336,7 @@ kubectl [flags]
       要记录的性能指标的名称。可取 (none|cpu|heap|goroutine|threadcreate|block|mutex) 其中之一。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--profile-output string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值: "profile.pprof"</td>
     </tr>
     <tr>
@@ -375,8 +347,7 @@ kubectl [flags]
       用于转储所记录的性能信息的文件名
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值: "0"</td>
     </tr>
     <tr>
@@ -387,8 +358,7 @@ kubectl [flags]
       放弃单个服务器请求之前的等待时间，非零值需要包含相应时间单位（例如：1s、2m、3h）。零值则表示不做超时要求。
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">-s, --server string</td>
     </tr>
     <tr>
@@ -399,8 +369,7 @@ kubectl [flags]
       Kubernetes API 服务器的地址和端口
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--skip-headers</td>
     </tr>
     <tr>
@@ -411,8 +380,7 @@ kubectl [flags]
       设置为 true 则表示跳过在日志消息中出现 header 前缀信息
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--skip-log-headers</td>
     </tr>
     <tr>
@@ -423,8 +391,7 @@ kubectl [flags]
       设置为 true 则表示在打开日志文件时跳过 header 信息
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--stderrthreshold severity&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值: 2</td>
     </tr>
     <tr>
@@ -435,8 +402,7 @@ kubectl [flags]
       等于或高于此阈值的日志将输出到标准错误输出（stderr）
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--token string</td>
     </tr>
     <tr>
@@ -447,8 +413,7 @@ kubectl [flags]
       用于对 API 服务器进行身份认证的持有者令牌
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--user string</td>
     </tr>
     <tr>
@@ -459,8 +424,7 @@ kubectl [flags]
       指定使用 kubeconfig 配置文件中的用户名
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--username string</td>
     </tr>
     <tr>
@@ -471,8 +435,7 @@ kubectl [flags]
       用于 API 服务器的基本身份验证的用户名
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">-v, --v Level</td>
     </tr>
     <tr>
@@ -483,8 +446,7 @@ kubectl [flags]
       指定输出日志的日志详细级别
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--version version[=true]</td>
     </tr>
     <tr>
@@ -495,8 +457,7 @@ kubectl [flags]
       打印 kubectl 版本信息并退出
       </td>
     </tr>
-
-    <tr>
+   <tr>
       <td colspan="2">--vmodule moduleSpec</td>
     </tr>
     <tr>


### PR DESCRIPTION
There are five document files that use the wrong markdown syntax, resulting that document with HTML table content was incorrectly to set to pre-formatted code in markdown. This is not the original intention of the document, this commit fixes this issue.

The five markdown files are as follows:

- content/fr/docs/reference/kubectl/kubectl.md
- content/ru/docs/reference/kubectl/kubectl.md
- content/zh/docs/reference/command-line-tools-reference/kube-controller-manager.md
- content/zh/docs/reference/command-line-tools-reference/kube-scheduler.md
- content/zh/docs/reference/kubectl/kubectl.md

Example of the current issue:  
Access https://kubernetes.io/fr/docs/reference/kubectl/kubectl/ , Screenshot:
![image](https://user-images.githubusercontent.com/7868679/83787560-8e56a580-a6c6-11ea-8e26-c26371c8a774.png)

I try to used a regular expression `\n\n(\t|( {4,}))<` to find all the issue like this and fix them by this commit.