### PR TITLE
Remove API client-libraries section

### DIFF
--- a/content/en/docs/reference/using-api/client-libraries.md
+++ b/content/en/docs/reference/using-api/client-libraries.md
@@ -37,44 +37,4 @@ Machinery](https://github.com/kubernetes/community/tree/master/sig-api-machinery
 | JavaScript   | [github.com/kubernetes-client/javascript](https://github.com/kubernetes-client/javascript) | [browse](https://github.com/kubernetes-client/javascript/tree/master/examples)
 | Haskell  | [github.com/kubernetes-client/haskell](https://github.com/kubernetes-client/haskell) | [browse](https://github.com/kubernetes-client/haskell/tree/master/kubernetes-client/example)
 
-
-## Community-maintained client libraries
-
-The following Kubernetes API client libraries are provided and maintained by
-their authors, not the Kubernetes team.
-
-| Language             | Client Library                           |
-| -------------------- | ---------------------------------------- |
-| Clojure              | [github.com/yanatan16/clj-kubernetes-api](https://github.com/yanatan16/clj-kubernetes-api) |
-| Go                   | [github.com/ericchiang/k8s](https://github.com/ericchiang/k8s) |
-| Java (OSGi)          | [bitbucket.org/amdatulabs/amdatu-kubernetes](https://bitbucket.org/amdatulabs/amdatu-kubernetes) |
-| Java (Fabric8, OSGi) | [github.com/fabric8io/kubernetes-client](https://github.com/fabric8io/kubernetes-client) |
-| Java                 | [github.com/manusa/yakc](https://github.com/manusa/yakc) |
-| Lisp                 | [github.com/brendandburns/cl-k8s](https://github.com/brendandburns/cl-k8s) |
-| Lisp                 | [github.com/xh4/cube](https://github.com/xh4/cube) |
-| Node.js (TypeScript) | [github.com/Goyoo/node-k8s-client](https://github.com/Goyoo/node-k8s-client) |
-| Node.js              | [github.com/ajpauwels/easy-k8s](https://github.com/ajpauwels/easy-k8s)
-| Node.js              | [github.com/godaddy/kubernetes-client](https://github.com/godaddy/kubernetes-client) |
-| Node.js              | [github.com/tenxcloud/node-kubernetes-client](https://github.com/tenxcloud/node-kubernetes-client) |
-| Perl                 | [metacpan.org/pod/Net::Kubernetes](https://metacpan.org/pod/Net::Kubernetes) |
-| PHP                  | [github.com/allansun/kubernetes-php-client](https://github.com/allansun/kubernetes-php-client) |
-| PHP                  | [github.com/maclof/kubernetes-client](https://github.com/maclof/kubernetes-client) |
-| PHP                  | [github.com/travisghansen/kubernetes-client-php](https://github.com/travisghansen/kubernetes-client-php) |
-| Python               | [github.com/eldarion-gondor/pykube](https://github.com/eldarion-gondor/pykube) |
-| Python               | [github.com/fiaas/k8s](https://github.com/fiaas/k8s) |
-| Python               | [github.com/mnubo/kubernetes-py](https://github.com/mnubo/kubernetes-py) |
-| Python               | [github.com/tomplus/kubernetes_asyncio](https://github.com/tomplus/kubernetes_asyncio) |
-| Ruby                 | [github.com/abonas/kubeclient](https://github.com/abonas/kubeclient) |
-| Ruby                 | [github.com/Ch00k/kuber](https://github.com/Ch00k/kuber) |
-| Ruby                 | [github.com/kontena/k8s-client](https://github.com/kontena/k8s-client) |
-| Rust                 | [github.com/clux/kube-rs](https://github.com/clux/kube-rs) |
-| Rust                 | [github.com/ynqa/kubernetes-rust](https://github.com/ynqa/kubernetes-rust) |
-| Scala                | [github.com/doriordan/skuber](https://github.com/doriordan/skuber) |
-| Scala                | [github.com/joan38/kubernetes-client](https://github.com/joan38/kubernetes-client) |
-| DotNet               | [github.com/tonnyeremin/kubernetes_gen](https://github.com/tonnyeremin/kubernetes_gen) |
-| DotNet (RestSharp)   | [github.com/masroorhasan/Kubernetes.DotNet](https://github.com/masroorhasan/Kubernetes.DotNet) |
-| Elixir               | [github.com/obmarg/kazan](https://github.com/obmarg/kazan/) |
-| Elixir               | [github.com/coryodaniel/k8s](https://github.com/coryodaniel/k8s) |
 {{% /capture %}}
-
-


### PR DESCRIPTION
Remove the API client-library section in favor of maintained Kubernetes client libraries. 

/assign @zacharysarah 
/assign @jimangel 