### PR TITLE
deprecated kubectl run command flag replicas for zh

### DIFF
--- a/content/zh/docs/concepts/cluster-administration/manage-deployment.md
+++ b/content/zh/docs/concepts/cluster-administration/manage-deployment.md
@@ -631,7 +631,7 @@ Let's say you were running version 1.7.9 of nginx:
 假设您正运行的是 1.7.9 版本的 nginx：
 
 ```shell
-kubectl run my-nginx --image=nginx:1.7.9 --replicas=3
+kubectl create deployment my-nginx --image=nginx:1.7.9
 ```
 ```shell
 deployment.apps/my-nginx created

--- a/content/zh/docs/concepts/policy/resource-quotas.md
+++ b/content/zh/docs/concepts/policy/resource-quotas.md
@@ -729,7 +729,7 @@ kubectl create quota test --hard=count/deployments.extensions=2,count/replicaset
 ```
 
 ```shell
-kubectl run nginx --image=nginx --replicas=2 --namespace=myspace
+kubectl create deployment nginx --image=nginx --namespace=myspace
 ```
 
 ```shell

--- a/content/zh/docs/reference/kubectl/docker-cli-to-kubectl.md
+++ b/content/zh/docs/reference/kubectl/docker-cli-to-kubectl.md
@@ -57,7 +57,7 @@ kubectl run --image=nginx nginx-app --port=80 --env="DOMAIN=cluster"
 -->
 ```shell
 # 启动运行 nginx 的 Pod
-kubectl run --image=nginx nginx-app --port=80 --env="DOMAIN=cluster"
+kubectl create deployment --image=nginx nginx-app --port=80 --env="DOMAIN=cluster"
 ```
 ```
 deployment "nginx-app" created

--- a/content/zh/docs/reference/kubectl/docker-cli-to-kubectl.md
+++ b/content/zh/docs/reference/kubectl/docker-cli-to-kubectl.md
@@ -25,11 +25,10 @@ You can use the Kubernetes command line tool kubectl to interact with the API Se
 {{% capture body %}}
 ## docker run
 
-<!-- 
-To run an nginx Deployment and expose the Deployment, see [kubectl run](/docs/reference/generated/kubectl/kubectl-commands/#run). 
+<!--
+To run an nginx Deployment and expose the Deployment, see [kubectl create deployment](/docs/reference/generated/kubectl/kubectl-commands#-em-deployment-em-).
 -->
-要运行 nginx 部署并将其暴露，请参见 [kubectl 运行](/docs/reference/generated/kubectl/kubectl-commands/#run)。
-
+要运行 nginx 部署并将其暴露，请参见[kubectl create deployment](/docs/reference/generated/kubectl/kubectl-commands#-em-deployment-em-)
 docker:
 
 ```shell
@@ -57,10 +56,18 @@ kubectl run --image=nginx nginx-app --port=80 --env="DOMAIN=cluster"
 -->
 ```shell
 # 启动运行 nginx 的 Pod
-kubectl create deployment --image=nginx nginx-app --port=80 --env="DOMAIN=cluster"
+kubectl create deployment --image=nginx nginx-app
 ```
 ```
-deployment "nginx-app" created
+deployment.apps/nginx-app created
+```
+
+```
+# add env to nginx-app
+kubectl set env deployment/nginx-app  DOMAIN=cluster
+```
+```
+deployment.apps/nginx-app env updated
 ```
 
 {{< note >}}
@@ -89,10 +96,10 @@ By using kubectl, you can create a [Deployment](/docs/concepts/workloads/control
 -->
 在 kubectl 命令中，我们创建了一个 [Deployment](/docs/concepts/workloads/controllers/deployment/)，这将保证有 N 个运行 nginx 的 pod(N 代表 spec 中声明的 replica 数，默认为 1)。我们还创建了一个 [service](/docs/concepts/services-networking/service/)，其选择器与容器标签匹配。查看[使用服务访问群集中的应用程序](/docs/tasks/access-application-cluster/service-access-application-cluster) 获取更多信息。
 
-<!-- 
-By default images run in the background, similar to `docker run -d ...`. To run things in the foreground, use: 
+<!--
+By default images run in the background, similar to `docker run -d ...`. To run things in the foreground, use [`kubectl run`](/docs/reference/generated/kubectl/kubectl-commands/#run) to create pod:
 -->
-默认情况下镜像会在后台运行，与 `docker run -d ...` 类似，如果您想在前台运行，使用:
+默认情况下镜像会在后台运行，与 `docker run -d ...` 类似，如果您想在前台运行，使用 [`kubectl run`](/docs/reference/generated/kubectl/kubectl-commands/#run) 在前台运行 Pod:
 
 ```shell
 kubectl run [-i] [--tty] --attach <name> --image=<image>

--- a/content/zh/docs/tasks/administer-cluster/declare-network-policy.md
+++ b/content/zh/docs/tasks/administer-cluster/declare-network-policy.md
@@ -36,7 +36,7 @@ content_template: templates/task
 为了查看 Kubernetes 网络策略是怎样工作的，可以从创建一个`nginx` deployment 并且通过服务将其暴露开始
 
 ```console
-$ kubectl run nginx --image=nginx --replicas=2
+$ kubectl create deployment nginx --image=nginx
 deployment "nginx" created
 $ kubectl expose deployment nginx --port=80
 service "nginx" exposed
@@ -53,7 +53,6 @@ svc/nginx                   10.100.0.16   <none>        80/TCP     33s
 
 NAME                        READY         STATUS        RESTARTS   AGE
 po/nginx-701339712-e0qfq    1/1           Running       0          35s
-po/nginx-701339712-o00ef    1/1           Running       0          35s
 ```
 
 


### PR DESCRIPTION
[kubectl run ](https://github.com/kubernetes/kubernetes/issues/89651) become create pod ，so upgrade document of Chinese

Fix Issue：https://github.com/kubernetes/kubernetes/issues/91064