### PR TITLE
Cleanup tutorial title because singular is preferred

### DIFF
--- a/content/id/docs/tutorials/_index.md
+++ b/content/id/docs/tutorials/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Tutorials
+title: Tutorial
 main_menu: true
 weight: 60
 content_template: templates/concept


### PR DESCRIPTION
This removes the extra 's' in Tutorial title for bahasa indonesia

/language id