### PR TITLE
sig-release: Update references to the patch release process

### DIFF
--- a/content/en/docs/setup/release/version-skew-policy.md
+++ b/content/en/docs/setup/release/version-skew-policy.md
@@ -27,11 +27,11 @@ For more information, see [Kubernetes Release Versioning](https://github.com/kub
 The Kubernetes project maintains release branches for the most recent three minor releases ({{< skew latestVersion >}}, {{< skew prevMinorVersion >}}, {{< skew oldestMinorVersion >}}).
 
 Applicable fixes, including security fixes, may be backported to those three release branches, depending on severity and feasibility.
-Patch releases are cut from those branches at a regular cadence, or as needed.
-This decision is owned by the [patch release team](https://github.com/kubernetes/sig-release/blob/master/release-engineering/role-handbooks/patch-release-team.md#release-timing).
-The patch release team is part of [release managers](https://github.com/kubernetes/sig-release/blob/master/release-managers.md). For more information, see [Kubernetes Patch releases](https://github.com/kubernetes/sig-release/blob/master/releases/patch-releases.md).
+Patch releases are cut from those branches at a [regular cadence](https://git.k8s.io/sig-release/releases/patch-releases.md#cadence), plus additional urgent releases, when required.
 
-Minor releases occur approximately every 3 months, so each minor release branch is maintained for approximately 9 months.
+The [Release Managers](https://git.k8s.io/sig-release/release-managers.md) group owns this decision.
+
+For more information, see the Kubernetes [patch releases](https://git.k8s.io/sig-release/releases/patch-releases.md) page.
 
 ## Supported version skew
 


### PR DESCRIPTION
Update patch release info to reference @kubernetes/release-managers, as we'll be consolidating the Patch Release Team and Branch Managers into one team.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/hold until https://github.com/kubernetes/sig-release/pull/1106 merges
/assign @tpepper 
cc: @kubernetes/release-engineering 
cc: @kubernetes/sig-docs-ja-owners @kubernetes/sig-docs-zh-owners 
(As the JA and ZH translations will need to be updated as well.) 