### PR TITLE
Update configmap.md

### DIFF
--- a/content/en/docs/concepts/configuration/configmap.md
+++ b/content/en/docs/concepts/configuration/configmap.md
@@ -189,7 +189,7 @@ spec:
       readOnly: true
   volumes:
   - name: foo
-    configmap:
+    configMap:
       name: myconfigmap
 ```
 


### PR DESCRIPTION
Fixed configmap -> configMap

Having configmap gives this error:
error: error validating "cmvolume-pod.yaml": error validating data: ValidationError(Pod.spec.volumes[0]):unknown field "configmap" in io.k8s.api.core.v1.Volume; if you choose to ignore these errors, turn validation off with --validate=false