### PR TITLE
Workaround for new lines in field selector example

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/field-selectors.md
+++ b/content/en/docs/concepts/overview/working-with-objects/field-selectors.md
@@ -16,12 +16,7 @@ kubectl get pods --field-selector status.phase=Running
 ```
 
 {{< note >}}
-Field selectors are essentially resource *filters*. By default, no selectors/filters are applied, meaning that all resources of the specified type are selected. This makes the following `kubectl` queries equivalent:
-
-```shell
-kubectl get pods
-kubectl get pods --field-selector ""
-```
+Field selectors are essentially resource *filters*. By default, no selectors/filters are applied, meaning that all resources of the specified type are selected. This makes the `kubectl` queries `kubectl get pods` and `kubectl get pods --field-selector ""` equivalent.
 {{< /note >}}
 
 ## Supported fields


### PR DESCRIPTION
It looks like code block new lines do not work in note blocks. This PR works around this issue by splitting up the code block into two code lines.

Before:
![Screenshot 2020-06-08 at 19 11 41](https://user-images.githubusercontent.com/1156226/84060212-1e913500-a9bc-11ea-94c5-9f33a58ff3b8.png)
After:
![Screenshot 2020-06-08 at 19 11 32](https://user-images.githubusercontent.com/1156226/84060205-1a651780-a9bc-11ea-9a1c-37aa92b1393c.png)
