### PR TITLE
Updating EndpointSlice documentation for Kubernetes 1.19

### DIFF
--- a/content/en/docs/concepts/services-networking/endpoint-slices.md
+++ b/content/en/docs/concepts/services-networking/endpoint-slices.md
@@ -130,6 +130,27 @@ EndpointSlices are up to date. The controller will manage EndpointSlices for
 every Service with a selector specified. These will represent the IPs of Pods
 matching the Service selector.
 
+## EndpointSliceMirroring Controller
+
+In some cases, custom Endpoints resources are created by applications. To ensure
+that these applications do not need to concurrently write to both Endpoints and
+EndpointSlice resources, the EndpointSliceMirroring controller mirrors custom
+Endpoints resources to corresponding EndpointSlices.
+
+This controller mirrors Endpoints resources unless:
+
+* the Endpoints resource has a `endpointslice.kubernetes.io/skip-mirror` label
+  set to `true`.
+* the Endpoints resource has a `control-plane.alpha.kubernetes.io/leader`
+  annotation.
+* the corresponding Service resource does not exist.
+* the corresponding Service resource has a non-nil selector.
+
+Individual Endpoints resources may translate into multiple EndpointSlices. This
+will occur if an Endpoints resource has multiple subsets or includes endpoints
+with multiple IP families (IPv4 and IPv6). A maximum of 1000 addresses per
+subset will be mirrored to EndpointSlices.
+
 ### Size of EndpointSlices
 
 By default, EndpointSlices are limited to a size of 100 endpoints each. You can

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -90,7 +90,8 @@ different Kubernetes components.
 | `EndpointSlice` | `false` | Alpha | 1.16 | 1.16 |
 | `EndpointSlice` | `false` | Beta | 1.17 | |
 | `EndpointSlice` | `true` | Beta | 1.18 | |
-| `EndpointSliceProxying` | `false` | Alpha | 1.18 | |
+| `EndpointSliceProxying` | `false` | Alpha | 1.18 | 1.18 |
+| `EndpointSliceProxying` | `true` | Beta | 1.19 | |
 | `EphemeralContainers` | `false` | Alpha | 1.16 | |
 | `ExpandCSIVolumes` | `false` | Alpha | 1.14 | 1.15 |
 | `ExpandCSIVolumes` | `true` | Beta | 1.16 | |
@@ -155,6 +156,7 @@ different Kubernetes components.
 | `ValidateProxyRedirects` | `true` | Beta | 1.14 | |
 | `VolumeSnapshotDataSource` | `false` | Alpha | 1.12 | 1.16 |
 | `VolumeSnapshotDataSource` | `true` | Beta | 1.17 | - |
+| `WindowsEndpointSliceProxying` | `false` | Alpha | 1.19 | |
 | `WindowsGMSA` | `false` | Alpha | 1.14 | |
 | `WindowsGMSA` | `true` | Beta | 1.16 | |
 | `WinDSR` | `false` | Alpha | 1.14 | |
@@ -424,9 +426,14 @@ Each feature gate is designed for enabling/disabling a specific feature:
    if user namespace remapping is enabled in the Docker daemon.
 - `EndpointSlice`: Enables Endpoint Slices for more scalable and extensible
    network endpoints. See [Enabling Endpoint Slices](/docs/tasks/administer-cluster/enabling-endpointslices/).
-- `EndpointSliceProxying`: When this feature gate is enabled, kube-proxy will
-   use EndpointSlices as the primary data source instead of Endpoints, enabling
-   scalability and performance improvements. See [Enabling Endpoint Slices](/docs/tasks/administer-cluster/enabling-endpointslices/).
+- `EndpointSliceProxying`: When this feature gate is enabled, kube-proxy running
+   on Linux will use EndpointSlices as the primary data source instead of
+   Endpoints, enabling scalability and performance improvements. See
+   [Enabling Endpoint Slices](/docs/tasks/administer-cluster/enabling-endpointslices/).
+- `WindowsEndpointSliceProxying`: When this feature gate is enabled, kube-proxy
+   running on Windows will use EndpointSlices as the primary data source instead
+   of Endpoints, enabling scalability and performance improvements. See
+   [Enabling Endpoint Slices](/docs/tasks/administer-cluster/enabling-endpointslices/).
 - `GCERegionalPersistentDisk`: Enable the regional PD feature on GCE.
 - `HugePages`: Enable the allocation and consumption of pre-allocated [huge pages](/docs/tasks/manage-hugepages/scheduling-hugepages/).
 - `HugePageStorageMediumSize`: Enable support for multiple sizes pre-allocated [huge pages](/docs/tasks/manage-hugepages/scheduling-hugepages/).

--- a/content/en/docs/tasks/administer-cluster/enabling-endpointslices.md
+++ b/content/en/docs/tasks/administer-cluster/enabling-endpointslices.md
@@ -36,17 +36,29 @@ components still rely on Endpoints. For now, enabling EndpointSlices should be
 seen as an addition to Endpoints in a cluster, not a replacement for them.
 {{< /note >}}
 
-EndpointSlices are a beta feature. Both the API and the EndpointSlice
-{{< glossary_tooltip term_id="controller" >}} are enabled by default.
-{{<  glossary_tooltip text="kube-proxy" term_id="kube-proxy" >}}
-uses Endpoints by default, not EndpointSlices.
-
-For better scalability and performance, you can enable the
-`EndpointSliceProxying`
-[feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
-on kube-proxy. That change
-switches the data source to be EndpointSlices, which reduces the amount of
-Kubernetes API traffic to and from kube-proxy.
+EndpointSlice functionality in Kubernetes is made up of several different
+components, most are enabled by default:
+* _The EndpointSlice API_: EndpointSlices are part of the
+  `discovery.k8s.io/v1beta1` API. This is beta and enabled by default since
+  Kubernetes 1.17. All components listed below are dependent on this API being
+  enabled.
+* _The EndpointSlice Controller_: This {{< glossary_tooltip text="controller"
+  term_id="controller" >}} maintains EndpointSlices for Services and the Pods
+  they reference. This is controlled by the `EndpointSlice` feature gate. It has
+  been enabled by default since Kubernetes 1.18.
+* _The EndpointSliceMirroring Controller_: This {{< glossary_tooltip
+  text="controller" term_id="controller" >}} mirrors custom Endpoints to
+  EndpointSlices. This is controlled by the `EndpointSlice` feature gate. It has
+  been enabled by default since Kubernetes 1.19.
+* _Kube-Proxy_: When {{< glossary_tooltip text="kube-proxy" term_id="kube-proxy">}}
+  is configured to use EndpointSlices, it can support higher numbers of Service
+  endpoints. This is controlled by the `EndpointSliceProxying` feature gate on
+  Linux and `WindowsEndpointSliceProxying` on Windows. It has been enabled by
+  default on Linux since Kubernetes 1.19. It is not enabled by default for
+  Windows nodes. To configure kube-proxy to use EndpointSlices on Windows, you
+  can enable the `WindowsEndpointSliceProxying` [feature
+  gate](/docs/reference/command-line-tools-reference/feature-gates/) on
+  kube-proxy.
 
 ## Using EndpointSlices
 


### PR DESCRIPTION
This PR updates the EndpointSlice documentation for Kubernetes 1.19.

Enhancement Issue: https://github.com/kubernetes/enhancements/issues/752

/sig network