### PR TITLE
Redundant "Below is an example:" sentence

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -216,7 +216,7 @@ a list of additional conditions that the kubelet evaluates for Pod readiness.
 Readiness gates are determined by the current state of `status.condition`
 fields for the Pod. If Kubernetes cannot find such a
 condition in the `status.conditions` field of a Pod, the status of the condition
-is defaulted to "`False`". Below is an example:
+is defaulted to "`False`".
 
 Here is an example:
 


### PR DESCRIPTION
The "Here is an example:" sentence follows a " Below is an example:" sentence. One of these 2 sentences is redundant.

Removed the "Below is an example:" sentence.

This was approved through https://github.com/kubernetes/website/pull/21603, but the Release process seems to be stuck, so creating a new PR.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

-->
