### PR TITLE
Renamed docker-* targets to container-* and deprecated docker-* targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,16 @@
-DOCKER      ?= docker
-HUGO_VERSION = $(shell grep ^HUGO_VERSION netlify.toml | tail -n 1 | cut -d '=' -f 2 | tr -d " \"\n")
-DOCKER_IMAGE = kubernetes-hugo
-DOCKER_RUN   = $(DOCKER) run --rm --interactive --tty --volume $(CURDIR):/src
-NODE_BIN     = node_modules/.bin
-NETLIFY_FUNC = $(NODE_BIN)/netlify-lambda
+HUGO_VERSION      = $(shell grep ^HUGO_VERSION netlify.toml | tail -n 1 | cut -d '=' -f 2 | tr -d " \"\n")
+NODE_BIN          = node_modules/.bin
+NETLIFY_FUNC      = $(NODE_BIN)/netlify-lambda
+
+# The CONTAINER_ENGINE variable is used for specifying the container engine. By default 'docker' is used
+# but this can be overridden when calling make, e.g.
+#   CONTAINER_ENGINE=podman make container-image
+CONTAINER_ENGINE ?= docker
+CONTAINER_IMAGE   = kubernetes-hugo
+CONTAINER_RUN     = $(CONTAINER_ENGINE) run --rm --interactive --tty --volume $(CURDIR):/src
+
+CCRED=\033[0;31m
+CCEND=\033[0m
 
 .PHONY: all build build-preview help serve
 
@@ -36,16 +43,28 @@ serve: ## Boot the development server.
 	hugo server --buildFuture
 
 docker-image:
-	$(DOCKER) build . \
-		--network=host \
-		--tag $(DOCKER_IMAGE) \
-		--build-arg HUGO_VERSION=$(HUGO_VERSION)
+	@echo -e "$(CCRED)**** The use of docker-image is deprecated. Use container-image instead. ****$(CCEND)"
+	$(MAKE) container-image
 
 docker-build:
-	$(DOCKER_RUN) $(DOCKER_IMAGE) hugo
+	@echo -e "$(CCRED)**** The use of docker-build is deprecated. Use container-build instead. ****$(CCEND)"
+	$(MAKE) container-build
 
 docker-serve:
-	$(DOCKER_RUN) --mount type=tmpfs,destination=/src/resources,tmpfs-mode=0755 -p 1313:1313 $(DOCKER_IMAGE) hugo server --buildFuture --bind 0.0.0.0
+	@echo -e "$(CCRED)**** The use of docker-serve is deprecated. Use container-serve instead. ****$(CCEND)"
+	$(MAKE) container-serve
+
+container-image:
+	$(CONTAINER_ENGINE) build . \
+		--network=host \
+		--tag $(CONTAINER_IMAGE) \
+		--build-arg HUGO_VERSION=$(HUGO_VERSION)
+
+container-build:
+	$(CONTAINER_RUN) $(CONTAINER_IMAGE) hugo
+
+container-serve:
+	$(CONTAINER_RUN) --mount type=tmpfs,destination=/src/resources,tmpfs-mode=0755 -p 1313:1313 $(CONTAINER_IMAGE) hugo server --buildFuture --bind 0.0.0.0
 
 test-examples:
 	scripts/test_examples.sh install
@@ -53,8 +72,13 @@ test-examples:
 
 .PHONY: link-checker-setup
 link-checker-image-pull:
-	docker pull wjdp/htmltest
+	$(CONTAINER_ENGINE) pull wjdp/htmltest
 
-docker-internal-linkcheck: link-checker-image-pull
-	$(DOCKER_RUN) $(DOCKER_IMAGE) hugo --config config.toml,linkcheck-config.toml --buildFuture
-	$(DOCKER) run --mount type=bind,source=$(CURDIR),target=/test --rm wjdp/htmltest htmltest
+docker-internal-linkcheck:
+	@echo -e "$(CCRED)**** The use of docker-internal-linkcheck is deprecated. Use container-internal-linkcheck instead. ****$(CCEND)"
+	$(MAKE) container-internal-linkcheck
+
+container-internal-linkcheck: link-checker-image-pull
+	$(CONTAINER_RUN) $(CONTAINER_IMAGE) hugo --config config.toml,linkcheck-config.toml --buildFuture
+	$(CONTAINER_ENGINE) run --mount type=bind,source=$(CURDIR),target=/test --rm wjdp/htmltest htmltest
+


### PR DESCRIPTION
This makes the container targets product agnostic instead of being pointed towards Docker as only container engine.

This way it makes more sense to e.g. use Podman.

Old:
```bash
DOCKER=podman make docker-image
```

New:
```bash
CONTAINER_ENGINE=podman make container-image
```

The old targets still exist but will show a deprecation notice in red.
![afbeelding](https://user-images.githubusercontent.com/10008950/84258362-1bf72280-ab17-11ea-9972-d3382a843b01.png)

/cc @sftim @kbhawkey 
/assign @sftim 