### PR TITLE
grammar correction in kubelet.md

### DIFF
--- a/content/en/docs/reference/glossary/kubelet.md
+++ b/content/en/docs/reference/glossary/kubelet.md
@@ -15,4 +15,4 @@ tags:
 
 <!--more--> 
 
-The kubelet takes a set of PodSpecs that are provided through various mechanisms and ensures that the containers described in those PodSpecs are running and healthy. The kubelet doesn’t manage containers which were not created by Kubernetes.
+The kubelet takes a set of PodSpecs that are provided through various mechanisms and ensures that the containers described in those PodSpecs are running and healthy. The kubelet doesn’t manage containers that were not created by Kubernetes.


### PR DESCRIPTION
This PR is a simple grammatical correction in the glossary entry for kubelet. I switched "which" to "that".
