### PR TITLE
Revise kubectl installation task

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl.md
+++ b/content/en/docs/tasks/tools/install-kubectl.md
@@ -114,35 +114,35 @@ kubectl version --client
 
 1. Download the latest release:
 
-    ```	 
-    curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/darwin/amd64/kubectl"
-    ```
+   ```bash
+   curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/darwin/amd64/kubectl"
+   ```
 
-    To download a specific version, replace the `$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)` portion of the command with the specific version.
+   To download a specific version, replace the `$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)` portion of the command with the specific version.
 
-    For example, to download version {{< param "fullversion" >}} on macOS, type:
-		  
-    ```
-    curl -LO https://storage.googleapis.com/kubernetes-release/release/{{< param "fullversion" >}}/bin/darwin/amd64/kubectl
-    ```
+   For example, to download version {{< param "fullversion" >}} on macOS, type:
 
-2. Make the kubectl binary executable.
+   ```bash
+   curl -LO https://storage.googleapis.com/kubernetes-release/release/{{< param "fullversion" >}}/bin/darwin/amd64/kubectl
+   ```
 
-    ```
-    chmod +x ./kubectl
-    ```
+   Make the kubectl binary executable.
+
+   ```bash
+   chmod +x ./kubectl
+   ```
 
 3. Move the binary in to your PATH.
 
-    ```
-    sudo mv ./kubectl /usr/local/bin/kubectl
-    ```
+   ```bash
+   sudo mv ./kubectl /usr/local/bin/kubectl
+   ```
 
 4. Test to ensure the version you installed is up-to-date:
 
-    ```
-    kubectl version --client
-    ```
+   ```bash
+   kubectl version --client
+   ```
 
 ### Install with Homebrew on macOS
 
@@ -150,21 +150,21 @@ If you are on macOS and using [Homebrew](https://brew.sh/) package manager, you 
 
 1. Run the installation command:
 
-    ```
-    brew install kubectl 
-    ```
+   ```bash
+   brew install kubectl 
+   ```
 
-    or
+   or
 
-    ```
-    brew install kubernetes-cli
-    ```
+   ```bash
+   brew install kubernetes-cli
+   ```
 
 2. Test to ensure the version you installed is up-to-date:
 
-    ```
-    kubectl version --client
-    ```
+   ```bash
+   kubectl version --client
+   ```
 
 ### Install with Macports on macOS
 
@@ -172,16 +172,16 @@ If you are on macOS and using [Macports](https://macports.org/) package manager,
 
 1. Run the installation command:
 
-    ```
-    sudo port selfupdate
-    sudo port install kubectl
-    ```
-    
+   ```bash
+   sudo port selfupdate
+   sudo port install kubectl
+   ```
+
 2. Test to ensure the version you installed is up-to-date:
 
-    ```
-    kubectl version --client
-    ```
+   ```bash
+   kubectl version --client
+   ```
 
 ## Install kubectl on Windows
 
@@ -189,21 +189,21 @@ If you are on macOS and using [Macports](https://macports.org/) package manager,
 
 1. Download the latest release {{< param "fullversion" >}} from [this link](https://storage.googleapis.com/kubernetes-release/release/{{< param "fullversion" >}}/bin/windows/amd64/kubectl.exe).
 
-    Or if you have `curl` installed, use this command:
+   Or if you have `curl` installed, use this command:
 
-    ```
-    curl -LO https://storage.googleapis.com/kubernetes-release/release/{{< param "fullversion" >}}/bin/windows/amd64/kubectl.exe
-    ```
+   ```bash
+   curl -LO https://storage.googleapis.com/kubernetes-release/release/{{< param "fullversion" >}}/bin/windows/amd64/kubectl.exe
+   ```
 
-    To find out the latest stable version (for example, for scripting), take a look at [https://storage.googleapis.com/kubernetes-release/release/stable.txt](https://storage.googleapis.com/kubernetes-release/release/stable.txt).
+   To find out the latest stable version (for example, for scripting), take a look at [https://storage.googleapis.com/kubernetes-release/release/stable.txt](https://storage.googleapis.com/kubernetes-release/release/stable.txt).
 
 2. Add the binary in to your PATH.
 
 3. Test to ensure the version of `kubectl` is the same as downloaded:
 
-    ```
-    kubectl version --client
-    ```
+   ```bash
+   kubectl version --client
+   ```
 
 {{< note >}}
 [Docker Desktop for Windows](https://docs.docker.com/docker-for-windows/#kubernetes) adds its own version of `kubectl` to PATH.
@@ -216,21 +216,22 @@ If you are on Windows and using [Powershell Gallery](https://www.powershellgalle
 
 1. Run the installation commands (making sure to specify a `DownloadLocation`):
 
-    ```
-    Install-Script -Name install-kubectl -Scope CurrentUser -Force
-    install-kubectl.ps1 [-DownloadLocation <path>]
+   ```powershell
+   Install-Script -Name 'install-kubectl' -Scope CurrentUser -Force
+   install-kubectl.ps1 [-DownloadLocation <path>]
     ```
 
-{{< note >}}If you do not specify a `DownloadLocation`, `kubectl` will be installed in the user's temp Directory.
-{{< /note >}}
+   {{< note >}}
+   If you do not specify a `DownloadLocation`, `kubectl` will be installed in the user's temp Directory.
+   {{< /note >}}
 
    The installer creates `$HOME/.kube` and instructs it to create a config file.
 
 2. Test to ensure the version you installed is up-to-date:
 
-    ```
-    kubectl version --client
-    ```
+   ```powershell
+   kubectl version --client
+   ```
 
 {{< note >}}
 Updating the installation is performed by rerunning the two commands listed in step 1.
@@ -240,50 +241,54 @@ Updating the installation is performed by rerunning the two commands listed in s
 
 1. To install kubectl on Windows you can use either [Chocolatey](https://chocolatey.org) package manager or [Scoop](https://scoop.sh) command-line installer.
 
-{{< tabs name="kubectl_win_install" >}}
-{{% tab name="choco" %}}
-
-    choco install kubernetes-cli
-
-{{% /tab %}}
-{{% tab name="scoop" %}}
-
-    scoop install kubectl
-
-{{% /tab %}}
-{{< /tabs >}}
+   {{< tabs name="kubectl_win_install" >}}
+   {{% tab name="choco" %}}
+   ```powershell
+   choco install kubernetes-cli
+   ```
+   {{% /tab %}}
+   {{% tab name="scoop" %}}
+   ```powershell
+   scoop install kubectl
+   ```
+   {{% /tab %}}
+   {{< /tabs >}}
 
 
 2. Test to ensure the version you installed is up-to-date:
 
-    ```
-    kubectl version --client
-    ```
+   ```powershell
+   kubectl version --client
+   ```
 
 3. Navigate to your home directory:
 
-    ```
-    cd %USERPROFILE%
-    ```
+   ```powershell
+   # If you're using cmd.exe, run: cd %USERPROFILE%
+   cd ~
+   ```
+
 4. Create the `.kube` directory:
 
-    ```
-    mkdir .kube
-    ```
+   ```powershell
+   mkdir .kube
+   ```
 
 5. Change to the `.kube` directory you just created:
 
-    ```
-    cd .kube
-    ```
+   ```powershell
+   cd .kube
+   ```
 
 6. Configure kubectl to use a remote Kubernetes cluster:
 
-    ```
-    New-Item config -type file
-    ```
-    
-{{< note >}}Edit the config file with a text editor of your choice, such as Notepad.{{< /note >}}
+   ```powershell
+   New-Item config -type file
+   ```
+
+{{< note >}}
+Edit the config file with a text editor of your choice, such as Notepad.
+{{< /note >}}
 
 ## Download as part of the Google Cloud SDK
 
@@ -293,17 +298,17 @@ You can install kubectl as part of the Google Cloud SDK.
 
 2. Run the `kubectl` installation command:
 
-    ```
-    gcloud components install kubectl
-    ```
-    
+   ```shell
+   gcloud components install kubectl
+   ```
+
 3. Test to ensure the version you installed is up-to-date:
 
-    ```
-    kubectl version --client
-    ```
+   ```shell
+   kubectl version --client
+   ```
 
-## Verifying kubectl configuration 
+## Verifying kubectl configuration
 
 In order for kubectl to find and access a Kubernetes cluster, it needs a [kubeconfig file](/docs/tasks/access-application-cluster/configure-access-multiple-clusters/), which is created automatically when you create a cluster using [kube-up.sh](https://github.com/kubernetes/kubernetes/blob/master/cluster/kube-up.sh) or successfully deploy a Minikube cluster. By default, kubectl configuration is located at `~/.kube/config`.
 
@@ -317,7 +322,7 @@ If you see a URL response, kubectl is correctly configured to access your cluste
 
 If you see a message similar to the following, kubectl is not configured correctly or is not able to connect to a Kubernetes cluster.
 
-```shell
+```
 The connection to the server <server-name:port> was refused - did you specify the right host or port?
 ```
 
@@ -355,7 +360,7 @@ The above commands create `/usr/share/bash-completion/bash_completion`, which is
 
 To find out, reload your shell and run `type _init_completion`. If the command succeeds, you're already set, otherwise add the following to your `~/.bashrc` file:
 
-```shell
+```bash
 source /usr/share/bash-completion/bash_completion
 ```
 
@@ -367,17 +372,17 @@ You now need to ensure that the kubectl completion script gets sourced in all yo
 
 - Source the completion script in your `~/.bashrc` file:
 
-    ```shell
-    echo 'source <(kubectl completion bash)' >>~/.bashrc
-    ```
+   ```bash
+   echo 'source <(kubectl completion bash)' >>~/.bashrc
+   ```
 - Add the completion script to the `/etc/bash_completion.d` directory:
 
-    ```shell
-    kubectl completion bash >/etc/bash_completion.d/kubectl
-    ```
+   ```bash
+   kubectl completion bash >/etc/bash_completion.d/kubectl
+   ```
 If you have an alias for kubectl, you can extend shell completion to work with that alias:
 
-```shell
+```bash
 echo 'alias k=kubectl' >>~/.bashrc
 echo 'complete -F __start_kubectl k' >>~/.bashrc
 ```
@@ -408,19 +413,19 @@ There are two versions of bash-completion, v1 and v2. V1 is for Bash 3.2 (which 
 
 The instructions here assume you use Bash 4.1+. You can check your Bash's version by running:
 
-```shell
+```bash
 echo $BASH_VERSION
 ```
 
 If it is too old, you can install/upgrade it using Homebrew:
 
-```shell
+```bash
 brew install bash
 ```
 
 Reload your shell and verify that the desired version is being used:
 
-```shell
+```bash
 echo $BASH_VERSION $SHELL
 ```
 
@@ -434,13 +439,13 @@ As mentioned, these instructions assume you use Bash 4.1+, which means you will 
 
 You can test if you have bash-completion v2 already installed with `type _init_completion`. If not, you can install it with Homebrew:
 
-```shell
+```bash
 brew install bash-completion@2
 ```
 
 As stated in the output of this command, add the following to your `~/.bash_profile` file:
 
-```shell
+```bash
 export BASH_COMPLETION_COMPAT_DIR="/usr/local/etc/bash_completion.d"
 [[ -r "/usr/local/etc/profile.d/bash_completion.sh" ]] && . "/usr/local/etc/profile.d/bash_completion.sh"
 ```
@@ -453,29 +458,29 @@ You now have to ensure that the kubectl completion script gets sourced in all yo
 
 - Source the completion script in your `~/.bash_profile` file:
 
-    ```shell
+    ```bash
     echo 'source <(kubectl completion bash)' >>~/.bash_profile
 
     ```
 
 - Add the completion script to the `/usr/local/etc/bash_completion.d` directory:
 
-    ```shell
+    ```bash
     kubectl completion bash >/usr/local/etc/bash_completion.d/kubectl
     ```
 
 - If you have an alias for kubectl, you can extend shell completion to work with that alias:
 
-    ```shell
+    ```bash
     echo 'alias k=kubectl' >>~/.bash_profile
     echo 'complete -F __start_kubectl k' >>~/.bash_profile
     ```
-    
+
 - If you installed kubectl with Homebrew (as explained [above](#install-with-homebrew-on-macos)), then the kubectl completion script should already be in `/usr/local/etc/bash_completion.d/kubectl`. In that case, you don't need to do anything.
 
-  {{< note >}}
-  The Homebrew installation of bash-completion v2 sources all the files in the `BASH_COMPLETION_COMPAT_DIR` directory, that's why the latter two methods work.
-  {{< /note >}}
+   {{< note >}}
+   The Homebrew installation of bash-completion v2 sources all the files in the `BASH_COMPLETION_COMPAT_DIR` directory, that's why the latter two methods work.
+   {{< /note >}}
 
 In any case, after reloading your shell, kubectl completion should be working.
 {{% /tab %}}
@@ -486,36 +491,32 @@ The kubectl completion script for Zsh can be generated with the command `kubectl
 
 To do so in all your shell sessions, add the following to your `~/.zshrc` file:
 
-```shell
+```zsh
 source <(kubectl completion zsh)
 ```
 
 If you have an alias for kubectl, you can extend shell completion to work with that alias:
 
-```shell
+```zsh
 echo 'alias k=kubectl' >>~/.zshrc
 echo 'complete -F __start_kubectl k' >>~/.zshrc
 ```
-    
+
 After reloading your shell, kubectl autocompletion should be working.
 
 If you get an error like `complete:13: command not found: compdef`, then add the following to the beginning of your `~/.zshrc` file:
 
-```shell
+```zsh
 autoload -Uz compinit
 compinit
 ```
 {{% /tab %}}
 {{< /tabs >}}
 
-
-
-
 ## {{% heading "whatsnext" %}}
 
 * [Install Minikube](/docs/tasks/tools/install-minikube/)
-* See the [getting started guides](/docs/setup/) for more about creating clusters. 
+* See the [getting started guides](/docs/setup/) for more about creating clusters.
 * [Learn how to launch and expose your application.](/docs/tasks/access-application-cluster/service-access-application-cluster/)
 * If you need access to a cluster you didn't create, see the [Sharing Cluster Access document](/docs/tasks/access-application-cluster/configure-access-multiple-clusters/).
 * Read the [kubectl reference docs](/docs/reference/kubectl/kubectl/)
-


### PR DESCRIPTION
Revise https://kubernetes.io/docs/tasks/tools/install-kubectl/

Most important fix is to make https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-on-windows-using-chocolatey-or-scoop look right with the upcoming Docsy theme from PR #20874

**Note**: In this PR I won't remove the Google Cloud tools section per issue #20232. That removal needs its own specific issue.