### PR TITLE
Link to better page on cron schedule format

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/en/docs/concepts/workloads/controllers/cron-jobs.md
@@ -85,7 +85,7 @@ the Job in turn is responsible for the management of the Pods it represents.
 
 ## {{% heading "whatsnext" %}}
 
-[Cron expression format](https://pkg.go.dev/github.com/robfig/cron?tab=doc#hdr-CRON_Expression_Format)
+[Cron expression format](https://en.wikipedia.org/wiki/Cron)
 documents the format of CronJob `schedule` fields.
 
 For instructions on creating and working with cron jobs, and for an example of CronJob

--- a/content/ko/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/ko/docs/concepts/workloads/controllers/cron-jobs.md
@@ -80,7 +80,7 @@ Cannot determine if job needs to be started. Too many missed start time (> 100).
 
 ## {{% heading "whatsnext" %}}
 
-[크론 표현 포맷](https://pkg.go.dev/github.com/robfig/cron?tab=doc#hdr-CRON_Expression_Format)은
+[크론 표현 포맷](https://ko.wikipedia.org/wiki/Cron)은
 크론잡 `schedule` 필드의 포맷을 문서화 한다.
 
 크론 잡 생성과 작업에 대한 지침과 크론잡 매니페스트의


### PR DESCRIPTION
The current link is to documentation for the 6 field cron schedule format with an extra seconds field at the start.
    
The Wikipedia page is better as it documents the 5 field version of the cron schedule format.

Closes #21741