### PR TITLE
Rectified Pod FQDN typo

### DIFF
--- a/content/en/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/en/docs/concepts/services-networking/dns-pod-service.md
@@ -71,7 +71,7 @@ of the form `auto-generated-name.my-svc.my-namespace.svc.cluster-domain.example`
 Any pods created by a Deployment or DaemonSet have the following
 DNS resolution available:
 
-`pod-ip-address.deployment-name.my-namespace.svc.cluster-domain.example.`
+`pod-ip-address.deployment-name.my-namespace.pod.cluster-domain.example.`
 
 ### Pod's hostname and subdomain fields
 

--- a/content/ko/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/ko/docs/concepts/services-networking/dns-pod-service.md
@@ -78,7 +78,7 @@ SRV 레코드는 노멀 서비스 또는
 또한, 파드 스펙에는 선택적 필드인 `subdomain`이 있다. 이 필드는 서브도메인을 지정할 수 있다. 
 예를 들어 "`my-namespace`" 네임스페이스에서, `hostname` 필드가 "`foo`"로 설정되고, 
 `subdomain` 필드가 "`bar`"로 설정된 파드는 전체 주소 도메인 네임(FQDN)을 가지게 된다. 
-"`foo.bar.my-namespace.svc.cluster-domain.example`".
+"`foo.bar.my-namespace.pod.cluster-domain.example`".
 
 예시:
 


### PR DESCRIPTION
## Where?
Pods > Pod's hostname and subdomain fields > `foo.bar.my-namespace.svc.cluster-domain.example`

## issue
You are talking about a pod's FQDN, but there is `svc` in it.

## Rectification
I changed `svc` to `pod`

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

-->
