### PR TITLE
Fix docker install instruction

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -97,8 +97,8 @@ add-apt-repository \
 # Install Docker CE
 apt-get update && apt-get install -y \
   containerd.io=1.2.13-2 \
-  docker-ce=5:19.03.11~3-0~~ubuntu-$(lsb_release -cs) \
-  docker-ce-cli=5:19.03.11~3-0~~ubuntu-$(lsb_release -cs)
+  docker-ce=5:19.03.11~3-0~ubuntu-$(lsb_release -cs) \
+  docker-ce-cli=5:19.03.11~3-0~ubuntu-$(lsb_release -cs)
 ```
 
 ```shell


### PR DESCRIPTION
The docker CE installation instructions contains some extra characters which should be removed.
closes: #21740 