### PR TITLE
clean up in page toc

### DIFF
--- a/content/en/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases.md
+++ b/content/en/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases.md
@@ -8,7 +8,6 @@ weight: 60
 min-kubernetes-server-version: 1.7
 ---
 
-{{< toc >}}
 
 <!-- overview -->
 

--- a/content/en/docs/reference/command-line-tools-reference/kubelet-authentication-authorization.md
+++ b/content/en/docs/reference/command-line-tools-reference/kubelet-authentication-authorization.md
@@ -4,7 +4,6 @@ reviewers:
 title: Kubelet authentication/authorization
 ---
 
-{{< toc >}}
 
 ## Overview
 

--- a/content/en/docs/setup/best-practices/cluster-large.md
+++ b/content/en/docs/setup/best-practices/cluster-large.md
@@ -15,9 +15,6 @@ At {{< param "version" >}}, Kubernetes supports clusters with up to 5000 nodes. 
 * No more than 300000 total containers
 * No more than 100 pods per node
 
-<br>
-
-{{< toc >}}
 
 ## Setup
 

--- a/content/en/docs/setup/best-practices/node-conformance.md
+++ b/content/en/docs/setup/best-practices/node-conformance.md
@@ -5,7 +5,6 @@ title: Validate node setup
 weight: 30
 ---
 
-{{< toc >}}
 
 ## Node Conformance Test
 

--- a/content/en/docs/tasks/_index.md
+++ b/content/en/docs/tasks/_index.md
@@ -5,7 +5,6 @@ weight: 50
 content_type: concept
 ---
 
-{{< toc >}}
 
 <!-- overview -->
 


### PR DESCRIPTION
Remove in page toc shortcode from `en` pages.
The docsy theme creates a TOC from the H2 and H3 page headings.