### PR TITLE
change main tag in announcement

### DIFF
--- a/layouts/partials/announcement.html
+++ b/layouts/partials/announcement.html
@@ -1,6 +1,6 @@
 {{ if .Page.Param "announcement" }}
 <section lang="en" id="announcement" style="background-color:{{ .Page.Param "announcement_bg" }}">
-  <main>
+  <aside>
     <div class="content announcement main-section">
 
       <h4 class="announcement">
@@ -9,6 +9,6 @@
       <p class="announcement">{{ T "announcement_message" | markdownify }}</p>
 
     </div>
-  </main>
+  </aside>
 </section>
 {{ end }}


### PR DESCRIPTION
The docsy theme creates anchors for the page headings.
The script that modifies the elements looked for a `main` tag.
There are two `main` elements on a page.

Change the `main` tag in `announcement.html` to `main-announce`.
Tested this with the docsy theme branch before integration into the docs.
 
**Notes:**
Create/update the headings as part of the static site generation.
To be consistent, possibly change `frontpage-announcement.html`.