### PR TITLE
Fix journalctl command on kubeadmin page

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
@@ -131,7 +131,7 @@ sudo kubeadm reset
 Inspecting the logs for docker may also be useful:
 
 ```sh
-journalctl -ul docker
+journalctl -u docker
 ```
 
 ## Pods in `RunContainerError`, `CrashLoopBackOff` or `Error` state


### PR DESCRIPTION
This PR is to fix: https://github.com/kubernetes/website/issues/21769

Update the journalctl command in the kubeadmin page. 
