### PR TITLE
Document annotation to set default VolumeSnapshotClass

### DIFF
--- a/content/en/docs/concepts/storage/volume-snapshot-classes.md
+++ b/content/en/docs/concepts/storage/volume-snapshot-classes.md
@@ -39,14 +39,27 @@ request a particular class. Administrators set the name and other parameters
 of a class when first creating VolumeSnapshotClass objects, and the objects cannot
 be updated once they are created.
 
-Administrators can specify a default VolumeSnapshotClass just for VolumeSnapshots
-that don't request any particular class to bind to.
+```yaml
+apiVersion: snapshot.storage.k8s.io/v1beta1
+kind: VolumeSnapshotClass
+metadata:
+  name: csi-hostpath-snapclass
+driver: hostpath.csi.k8s.io
+deletionPolicy: Delete
+parameters:
+```
+
+Administrators can specify a default VolumeSnapshotClass for VolumeSnapshots
+that don't request any particular class to bind to by adding the
+`snapshot.storage.kubernetes.io/is-default-class: "true"` annotation:
 
 ```yaml
 apiVersion: snapshot.storage.k8s.io/v1beta1
 kind: VolumeSnapshotClass
 metadata:
   name: csi-hostpath-snapclass
+  annotations:
+    snapshot.storage.kubernetes.io/is-default-class: "true"
 driver: hostpath.csi.k8s.io
 deletionPolicy: Delete
 parameters:


### PR DESCRIPTION
This change documents how a default `VolumeSnapshotClass` can be set. While the existing documentation mentions that it is possible, it does not describe the exact mechanism (i.e., the specific annotation to use).

We also extend the example to better demonstrate how the annotation would look like on a real `VolumeSnapshotClass` manifest.