### PR TITLE
Narrow the space between lines in buttons in docs/home

### DIFF
--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -65,8 +65,8 @@ footer {
   .button {
     display: inline-block;
     border-radius: 6px;
-    padding: 0 20px;
-    line-height: 40px;
+    padding: 6px 20px;
+    line-height: 1.3rem;
     color: white;
     background-color: $blue;
     text-decoration: none;

--- a/layouts/partials/docs/docs-portal-card.html
+++ b/layouts/partials/docs/docs-portal-card.html
@@ -19,9 +19,11 @@
         {{ end }}
     {{ end }}
     </ul>
-    <br>
-    <button id="btn-concepts" class="button" onClick="location.href='{{ .button_path | relLangURL }}';" aria-label="{{ .title }}">{{ .button }}</button>
-    <br>
-    <br>
+    {{ if .button }}
+      <br>
+      <button id="btn-concepts" class="button" onClick="location.href='{{ .button_path | relLangURL }}';" aria-label="{{ .title }}">{{ .button }}</button>
+      <br>
+      <br>
+    {{ end }}
 </div>
 {{ end }}


### PR DESCRIPTION
Closes #21816

## What

This PR changes two things:
1. Narrow the space between lines in buttons by modifying padding and line-height in `_base.sass` stylesheet.
2. Hide button when no parameter is specified.

## Why

The first change is needed to fix the problem described in #21816.

I also add a change to `docsportal_home.html` because the first change makes buttons without labels visible. These buttons are not needed and this change hides the button when `button` param is not specified in a card item in docs/home/_index.md.

## Screenshots

### Before the change

![Screenshot from 2020-06-16 22-06-39](https://user-images.githubusercontent.com/1425259/84784495-57b54f00-b025-11ea-89c8-48d0123719de.png)

### After only modifying the stylesheet

Meaningless buttons appears.

![Screenshot from 2020-06-16 22-06-49](https://user-images.githubusercontent.com/1425259/84784784-acf16080-b025-11ea-8a00-42bb1b050143.png)

### Final view

![Screenshot from 2020-06-16 22-09-44](https://user-images.githubusercontent.com/1425259/84784634-86332a00-b025-11ea-8363-c7df35cccc9b.png)

### English page example after the change

![Screenshot from 2020-06-16 23-05-03](https://user-images.githubusercontent.com/1425259/84785147-1a9d8c80-b026-11ea-9653-a0d0dd087cff.png)

Note that this fix is not specific to a localized page.