### PR TITLE
Fix the no search result error when the keyword includes spaces.

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -11,7 +11,7 @@
     }
 
     window.getPaginationAnchors = (pages) => {
-        var pageAnchors = '', searchTerm  = window.location.search.split("=")[1].split("&")[0];
+        var pageAnchors = '', searchTerm  = window.location.search.split("=")[1].split("&")[0].replace(/%20/g, ' ');
         var currentPage = window.location.search.split("=")[2];
         currentPage = (!currentPage) ?  1 : currentPage.split("&")[0];
 
@@ -33,7 +33,7 @@
     }
 
     window.renderBingSearchResults = () => {
-        var searchTerm  = window.location.search.split("=")[1].split("&")[0],
+        var searchTerm  = window.location.search.split("=")[1].split("&")[0].replace(/%20/g,' '),
             page        = window.location.search.split("=")[2],
             q           = "site:kubernetes.io " + searchTerm;
 
@@ -47,6 +47,7 @@
         ajaxConf.beforeSend = function(xhr){ xhr.setRequestHeader('Ocp-Apim-Subscription-Key', '51efd23677624e04b4abe921225ea7ec'); };
 
         $.ajax(ajaxConf).done(function(res) {
+            if (res.webPages == null) return; // If no result, 'webPages' is 'undefined'
             var paginationAnchors = window.getPaginationAnchors(Math.ceil(res.webPages.totalEstimatedMatches / 10));
             res.webPages.value.map(ob => { results += window.getResultMarkupString(ob); })
 


### PR DESCRIPTION
Closes #21808 

## What

This PR fixes two issues related to search function:

1. When a search keyword includes spaces, it is URL encoded twice, causing no result error.
2. No error handring for the response of search API returning no result.

## Why

### 1.

Here is an example URL requested to the search API searver when searching `commands and args`:

 https://api.cognitive.microsoft.com/bingcustomsearch/v7.0/search?q=site%3Akubernetes.io%20commands%2520and%2520args&offset=0&customConfig=320659264

We can see commands `%2520and%2520args`. That means the duplicated URL encodings happens.

To mitigate this problem, the URL encoded space (`%20`) is replaced with ` `.

### 2.

When there is no search result, the following error happens:

```js
search.js:50 Uncaught TypeError: Cannot read property 'totalEstimatedMatches' of undefined
```

This happens because if there is no result, the API returns the object without `res.webPages` property which is used in the line, causing the error `'totalEstimatedMatches' of undefined`.

I made a change to make sure return the function before this value is used when no result is returned.
