### PR TITLE
Add Kubernetes download button on 'home' page

### DIFF
--- a/content/en/docs/home/_index.md
+++ b/content/en/docs/home/_index.md
@@ -59,6 +59,8 @@ cards:
 - name: release-notes
   title: Release Notes
   description: If you are installing Kubernetes or upgrading to the newest version, refer to the current release notes.
+  button: "Download Kubernetes"
+  button_path: "/docs/setup/release/notes"
 - name: about
   title: About the documentation
   description: This website contains documentation for the current and previous 4 versions of Kubernetes.


### PR DESCRIPTION
References: #21643
Description:
Adding the Kubernetes Download button on the home page under the section 'Release Notes'

File changed: [content/en/docs/home/_index.md](content/en/docs/home/_index.md)

POC: 
<img width="297" alt="ReleaseNoes_DownloadKubernetes" src="https://user-images.githubusercontent.com/11659160/84820487-05226580-b01a-11ea-99b5-1bf202da2bcd.png">

**Download Kubernetes** button points to the [release page](https://deploy-preview-21825--kubernetes-io-master-staging.netlify.app/docs/setup/release/notes/)
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

-->
