### PR TITLE
[docs]remove redundant string to avoid incorrect description

### DIFF
--- a/content/zh/docs/concepts/configuration/configmap.md
+++ b/content/zh/docs/concepts/configuration/configmap.md
@@ -6,7 +6,7 @@ weight: 20
 
 <!-- overview -->
 
-{{< glossary_definition term_id="configmap" prepend="ConfigMap 是" length="all" >}}
+{{< glossary_definition term_id="configmap" prepend="" length="all" >}}
 
 {{< caution >}}
 <!--

--- a/content/zh/docs/concepts/configuration/configmap.md
+++ b/content/zh/docs/concepts/configuration/configmap.md
@@ -6,7 +6,7 @@ weight: 20
 
 <!-- overview -->
 
-{{< glossary_definition term_id="configmap" prepend="" length="all" >}}
+{{< glossary_definition term_id="configmap" length="all" >}}
 
 {{< caution >}}
 <!--


### PR DESCRIPTION
Current format will lead to the string"ConfigMap 是 " repeated.

“ConfigMap 是 configMap 是一种 API 对象，用来将非机密性的数据保存到健值对中。使用时可以用作环境变量、命令行参数或者存储卷中的配置文件。”


So I think we'd better remove the redandunt string block

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

-->
