### PR TITLE
Add newly introduced ping_group_range sysctl

### DIFF
--- a/content/en/docs/tasks/administer-cluster/sysctl-cluster.md
+++ b/content/en/docs/tasks/administer-cluster/sysctl-cluster.md
@@ -57,7 +57,8 @@ The following sysctls are supported in the _safe_ set:
 
 - `kernel.shm_rmid_forced`,
 - `net.ipv4.ip_local_port_range`,
-- `net.ipv4.tcp_syncookies`.
+- `net.ipv4.tcp_syncookies`,
+- `net.ipv4.ping_group_range` (since Kubernetes 1.18).
 
 {{< note >}}
 The example `net.ipv4.tcp_syncookies` is not namespaced on Linux kernel version 4.4 or lower.


### PR DESCRIPTION
kubernetes/kubernetes#85463 introduced a new safe sysctl
`net.ipv4.ping_group_range`, which was not yet added to the docs.

Available since Kubernetes 1.18.