### PR TITLE
Fix misleading contents in ko localization guide

### DIFF
--- a/content/ko/docs/contribute/localization_ko.md
+++ b/content/ko/docs/contribute/localization_ko.md
@@ -132,21 +132,29 @@ weight: 10
 
 ### API 오브젝트 용어 한글화 방침
 
-API 오브젝트 중 `kubectl api-resources` 결과의 `kind`에 해당하는 오브젝트는
+일반적으로 `kubectl api-resources` 결과의 `kind` 에 해당하는 API 오브젝트는
 [국립국어원 외래어 표기법](http://kornorms.korean.go.kr/regltn/regltnView.do?regltn_code=0003#a)에
-따라 한글 표기한다. 예를 들면 다음과 같다.
+따라 한글로 표기하고 영문을 병기한다. 예를 들면 다음과 같다.
+
+API 오브젝트(kind)      | 한글화(외래어 표기 및 영문 병기)
+---                   | ---
+ClusterRoleBinding    | 클러스터롤바인딩(ClusterRoleBinding)
+ConfigMap             | 컨피그맵(ConfigMap)
+Deployment            | 디플로이먼트(Deployment)
+PersistentVolumeClaim | 퍼시스턴트볼륨클레임(PersistentVolumeClaim)
+...                   | ...
+
+`kind` 에 속하는 API 오브젝트 중에서도 일부는 표현의 간결함을 위해 한영병기를 하지 않는 등의 예외가 있으며,
+예외에 대해서는 [한글화 용어집](#한글화-용어집)에 등록된 방식을 준용한다. 예를 들면 다음과 같다.
 
 API 오브젝트(kind)      | 한글화(외래어 표기)
 ---                   | ---
-ClusterRoleBinding    | 클러스터롤바인딩
-ConfigMap             | 컨피그맵
-Deployment            | 디플로이먼트
 Pod                   | 파드
-PersistentVolumeClaim | 퍼시스턴트볼륨클레임
 Service               | 서비스
 ...                   | ...
 
-그 이외의 API 오브젝트는, [한글화 용어집](#한글화-용어집)에 등록된 용어인 경우를 제외하고,
+
+`kind` 에 속하지 않는 API 오브젝트는, [한글화 용어집](#한글화-용어집)에 등록된 용어인 경우를 제외하고,
 모두 원문 그대로 표기한다. 예를 들면 다음과 같다.
 
 API 오브젝트(kind가 아닌 경우) | 한글화(원문 유지)
@@ -479,5 +487,3 @@ Windows | 윈도우 |
 Worker | 워커 | 노드의 형태에 한함
 Workload | 워크로드 |
 YAML | YAML |
-
-


### PR DESCRIPTION
This PR fixes misleading contents in ko localization guide 

about localization of API terms.

/language ko
/kind bug
