### PR TITLE
Update what's next contents

### DIFF
--- a/content/en/docs/contribute/style/hugo-shortcodes/index.md
+++ b/content/en/docs/contribute/style/hugo-shortcodes/index.md
@@ -240,8 +240,8 @@ Renders to:
 ## {{% heading "whatsnext" %}}
 
 * Learn about [Hugo](https://gohugo.io/).
-* Learn about [writing a new topic](/docs/home/contribute/style/write-new-topic/).
-* Learn about [page content types](/docs/home/contribute/style/page-content-types/).
-* Learn about [staging your changes](/docs/home/contribute/stage-documentation-changes/)
-* Learn about [creating a pull request](/docs/home/contribute/create-pull-request/).
+* Learn about [writing a new topic](/docs/contribute/style/write-new-topic/).
+* Learn about [page content types](/docs/contribute/style/page-content-types/).
+* Learn about [creating a pull request](/docs/contribute/new-content/new-content/).
+* Learn about [advanced contributing](docs/contribute/advanced/).
 

--- a/content/en/docs/contribute/style/hugo-shortcodes/index.md
+++ b/content/en/docs/contribute/style/hugo-shortcodes/index.md
@@ -243,5 +243,5 @@ Renders to:
 * Learn about [writing a new topic](/docs/contribute/style/write-new-topic/).
 * Learn about [page content types](/docs/contribute/style/page-content-types/).
 * Learn about [creating a pull request](/docs/contribute/new-content/new-content/).
-* Learn about [advanced contributing](docs/contribute/advanced/).
+* Learn about [advanced contributing](/docs/contribute/advanced/).
 


### PR DESCRIPTION
- fix broken links
- `staging your changes` page was removed in the past. So I suggest adding `advanced contributing` page instead of it.