### PR TITLE
Fix broken link to Xilinx FPGA device plugins

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
+++ b/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
@@ -223,7 +223,7 @@ Here are some examples of device plugin implementations:
 * The [RDMA device plugin](https://github.com/hustcat/k8s-rdma-device-plugin)
 * The [Solarflare device plugin](https://github.com/vikaschoudhary16/sfc-device-plugin)
 * The [SR-IOV Network device plugin](https://github.com/intel/sriov-network-device-plugin)
-* The [Xilinx FPGA device plugins](https://github.com/Xilinx/FPGA_as_a_Service/tree/master/k8s-fpga-device-plugin/trunk) for Xilinx FPGA devices
+* The [Xilinx FPGA device plugins](https://github.com/Xilinx/FPGA_as_a_Service/tree/master/k8s-fpga-device-plugin) for Xilinx FPGA devices
 
 
 ## {{% heading "whatsnext" %}}

--- a/content/id/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
+++ b/content/id/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
@@ -221,7 +221,7 @@ Berikut beberapa contoh implementasi _plugin_ perangkat:
 * [Plugin perangkat RDMA](https://github.com/hustcat/k8s-rdma-device-plugin)
 * [Plugin perangkat Solarflare](https://github.com/vikaschoudhary16/sfc-device-plugin)
 * [Plugin perangkat SR-IOV Network](https://github.com/intel/sriov-network-device-plugin)
-* [Plugin perangkat Xilinx FPGA](https://github.com/Xilinx/FPGA_as_a_Service/tree/master/k8s-fpga-device-plugin/trunk) untuk perangkat Xilinx FPGA
+* [Plugin perangkat Xilinx FPGA](https://github.com/Xilinx/FPGA_as_a_Service/tree/master/k8s-fpga-device-plugin) untuk perangkat Xilinx FPGA
 
 
 ## {{% heading "whatsnext" %}}

--- a/content/ko/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
+++ b/content/ko/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
@@ -222,7 +222,7 @@ pluginapi.Device{ID: "25102017", Health: pluginapi.Healthy, Topology:&pluginapi.
 * [RDMA 장치 플러그인](https://github.com/hustcat/k8s-rdma-device-plugin)
 * [Solarflare 장치 플러그인](https://github.com/vikaschoudhary16/sfc-device-plugin)
 * [SR-IOV 네트워크 장치 플러그인](https://github.com/intel/sriov-network-device-plugin)
-* Xilinx FPGA 장치용 [Xilinx FPGA 장치 플러그인](https://github.com/Xilinx/FPGA_as_a_Service/tree/master/k8s-fpga-device-plugin/trunk)
+* Xilinx FPGA 장치용 [Xilinx FPGA 장치 플러그인](https://github.com/Xilinx/FPGA_as_a_Service/tree/master/k8s-fpga-device-plugin)
 
 
 ## {{% heading "whatsnext" %}}

--- a/content/zh/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
+++ b/content/zh/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
@@ -322,7 +322,7 @@ Here are some examples of device plugin implementations:
 * The [RDMA device plugin](https://github.com/hustcat/k8s-rdma-device-plugin)
 * The [Solarflare device plugin](https://github.com/vikaschoudhary16/sfc-device-plugin)
 * The [SR-IOV Network device plugin](https://github.com/intel/sriov-network-device-plugin)
-* The [Xilinx FPGA device plugins](https://github.com/Xilinx/FPGA_as_a_Service/tree/master/k8s-fpga-device-plugin/trunk) for Xilinx FPGA devices
+* The [Xilinx FPGA device plugins](https://github.com/Xilinx/FPGA_as_a_Service/tree/master/k8s-fpga-device-plugin) for Xilinx FPGA devices
 -->
 ## 设备插件示例 {#examples}
 
@@ -337,7 +337,7 @@ Here are some examples of device plugin implementations:
 * [RDMA device plugin](https://github.com/hustcat/k8s-rdma-device-plugin)
 * [Solarflare device plugin](https://github.com/vikaschoudhary16/sfc-device-plugin)
 * [SR-IOV Network device plugin](https://github.com/intel/sriov-network-device-plugin)
-* [Xilinx FPGA device plugins](https://github.com/Xilinx/FPGA_as_a_Service/tree/master/k8s-fpga-device-plugin/trunk)
+* [Xilinx FPGA device plugins](https://github.com/Xilinx/FPGA_as_a_Service/tree/master/k8s-fpga-device-plugin)
 
 
 ## {{% heading "whatsnext" %}}


### PR DESCRIPTION
Fixes the broken _Xilinx FPGA device plugins_ link on https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/

/sig docs
/language en
/language id
/language zh
/language ko