### PR TITLE
Reduce header height when announcement shown

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -1,3 +1,5 @@
+$announcement-size-adjustment: 8px;
+
 /* GLOBAL */
 .td-main {
   .row {
@@ -382,4 +384,32 @@ main.content {
       }
     }
   }
+}
+
+/* ANNOUNCEMENTS */
+section#fp-announcement ~ .header-hero {
+    padding: $announcement-size-adjustment  0;
+
+    > div {
+       margin-top: $announcement-size-adjustment;
+       margin-bottom: $announcement-size-adjustment;
+    }
+
+    h1, h2, h3, h4, h5 {
+      margin: $announcement-size-adjustment 0;
+    }
+}
+
+section#announcement ~ .header-hero {
+    padding: #{$announcement-size-adjustment / 2} 0;
+
+    > div {
+       margin-top: #{$announcement-size-adjustment / 2};
+       margin-bottom: #{$announcement-size-adjustment / 2};
+       padding-bottom: #{$announcement-size-adjustment / 2};
+    }
+
+    h1, h2, h3, h4, h5 {
+      margin: #{$announcement-size-adjustment / 2} 0;
+    }
 }

--- a/assets/scss/_tablet.scss
+++ b/assets/scss/_tablet.scss
@@ -23,7 +23,7 @@ $main-nav-left-button-size: 50px;
 $main-nav-left-button-font-size: 18px;
 
 // hero
-$hero-padding-top: 136px;
+$hero-padding-top: 116px;
 $headline-wrapper-margin-bottom: 40px;
 $quickstart-button-padding: 0 50px;
 $vendor-strip-font-size: 16px;

--- a/static/css/announcement.css
+++ b/static/css/announcement.css
@@ -21,7 +21,7 @@
 }
 
 #announcement {
-  padding-top: 125px;
+  padding-top: 105px;
   padding-bottom: 25px;
 }
 
@@ -29,11 +29,14 @@
   padding-top: 40px;
 }
 
-#fp-announcement {
-  min-height: 30vh;
+/* Extra announcement height only for landscape viewports */
+@media (min-aspect-ratio: 8/9) {
+  #fp-announcement {
+    min-height: 25vh;
+  }
 }
 
 #fp-announcement aside {
-  padding-top: 125px;
-  padding-bottom: 35px;
+  padding-top: 115px;
+  padding-bottom: 25px;
 }


### PR DESCRIPTION
If there's an announcement showing, adjust the page header to use less vertical space.

Also reduce the height of the announcement itself.

Helps with issue #21797.


<details>
 <summary><a href="https://deploy-preview-21884--kubernetes-io-master-staging.netlify.app/training/">Preview</a> & screenshots: training page</summary>

 <h2>Before</h2>

 ![Before](https://user-images.githubusercontent.com/22591623/85020451-458ff980-b168-11ea-977b-998e9d3e882e.png)

 <h2>After</h2>

 ![After](https://user-images.githubusercontent.com/22591623/85020482-517bbb80-b168-11ea-9799-c08a879001c4.png)

</details>

<details>
 <summary><a href="https://deploy-preview-21884--kubernetes-io-master-staging.netlify.app/">Preview</a> & screenshots: top of site</summary>


  <h2>Before</h2>

![Before](https://user-images.githubusercontent.com/22591623/85020573-73753e00-b168-11ea-85ee-c45ac400b8ef.png)

 <h2>After</h2>


![After](https://user-images.githubusercontent.com/22591623/85020581-753f0180-b168-11ea-9c66-7d6f045715a1.png)

</details>


