### PR TITLE
Update the correct values for allocated resources per namespace

### DIFF
--- a/content/en/docs/concepts/configuration/manage-resources-containers.md
+++ b/content/en/docs/concepts/configuration/manage-resources-containers.md
@@ -657,7 +657,7 @@ Allocated resources:
   (Total limits may be over 100 percent, i.e., overcommitted.)
   CPU Requests    CPU Limits    Memory Requests    Memory Limits
   ------------    ----------    ---------------    -------------
-  680m (34%)      400m (20%)    920Mi (12%)        1070Mi (14%)
+  680m (34%)      400m (20%)    920Mi (11%)        1070Mi (13%)
 ```
 
 In the preceding output, you can see that if a Pod requests more than 1120m


### PR DESCRIPTION
In the example, Memory limits and Memory requests per namespace don't add up correctly to the total displayed under Total requests.

Previously the inference was "8+2+2+1 = 14" which is incorrect for memory limits.
Memory requests was "8+1+2=12" which is also incorrect.