### PR TITLE
update wrangler doc to relax style guidelines for content

### DIFF
--- a/content/en/docs/contribute/advanced.md
+++ b/content/en/docs/contribute/advanced.md
@@ -39,6 +39,7 @@ The PR wrangler’s duties include:
     - Assign `Doc Review: Open Issues` or `Tech Review: Open Issues` for PRs that have been reviewed and require further input or action before merging.
     - Assign `/lgtm` and `/approve` labels to PRs that can be merged.
 - Merge PRs when they are ready, or close PRs that shouldn’t be accepted.
+    - Because we are limited on resources, we are willing to accept solid technical content even if all [style guidelines](/docs/contribute/style/style-guide/) are not met. Consider merging this type of content and opening a good first issue to address the style concerns.
 - Triage and tag incoming issues daily. See [Triage and categorize issues](/docs/contribute/review/for-approvers/#triage-and-categorize-issues) for guidelines on how SIG Docs uses metadata.
 
 ### Helpful GitHub queries for wranglers

--- a/content/en/docs/contribute/advanced.md
+++ b/content/en/docs/contribute/advanced.md
@@ -39,7 +39,7 @@ The PR wrangler’s duties include:
     - Assign `Doc Review: Open Issues` or `Tech Review: Open Issues` for PRs that have been reviewed and require further input or action before merging.
     - Assign `/lgtm` and `/approve` labels to PRs that can be merged.
 - Merge PRs when they are ready, or close PRs that shouldn’t be accepted.
-    - Because we are limited on resources, we are willing to accept solid technical content even if all [style guidelines](/docs/contribute/style/style-guide/) are not met. Consider merging this type of content and opening a good first issue to address the style concerns.
+    - Consider accepting accurate technical content even if the content meets only some of the docs' [style guidelines](/docs/contribute/style/style-guide/). Open a new issue with the label `good first issue` to address style concerns.
 - Triage and tag incoming issues daily. See [Triage and categorize issues](/docs/contribute/review/for-approvers/#triage-and-categorize-issues) for guidelines on how SIG Docs uses metadata.
 
 ### Helpful GitHub queries for wranglers


### PR DESCRIPTION
Updated wrangler doc to denote agreed to relaxing of style guidelines for good technical content as agreed at last planning meeting.

Closes #21068

Signed-off-by: Brad Topol <btopol@us.ibm.com>


