### PR TITLE
Add quotation marks around the value of the key "player_initial_lives"

### DIFF
--- a/content/en/docs/concepts/configuration/configmap.md
+++ b/content/en/docs/concepts/configuration/configmap.md
@@ -60,7 +60,7 @@ metadata:
   name: game-demo
 data:
   # property-like keys; each key maps to a simple value
-  player_initial_lives: 3
+  player_initial_lives: "3"
   ui_properties_file_name: "user-interface.properties"
   #
   # file-like keys


### PR DESCRIPTION
Add quotation marks around the value of the key `player_initial_lives` in configuration file of the ConfigMap called `game-demo`. Otherwise, kubectl version 1.18 gives the following error with the command `kubectl apply -f game-demo-configMap.yaml`

> Error from server (BadRequest): error when creating "game-demo-configMap.yaml": ConfigMap in version "v1" cannot be handled as a ConfigMap: v1.ConfigMap.Data: ReadString: expects " or n, but found 3, error found in #10 byte of ...|l_lives":3,"ui_prope|..., bigger context ...|player.maximum-lives=5\n","player_initial_lives":3,"ui_properties_file_name":"user-interface.propert|...