### PR TITLE
Add links to prior API references

### DIFF
--- a/content/en/docs/reference/_index.md
+++ b/content/en/docs/reference/_index.md
@@ -20,6 +20,7 @@ This section of the Kubernetes documentation contains references.
 
 * [Kubernetes API Overview](/docs/reference/using-api/api-overview/) - Overview of the API for Kubernetes.
 * [Kubernetes API Reference {{< latest-version >}}](/docs/reference/generated/kubernetes-api/{{< latest-version >}}/)
+* [Kubernetes API Reference for Prior Verions](/docs/reference/kubernetes-api/)
 
 ## API Client Libraries
 

--- a/content/en/docs/reference/kubernetes-api/_index.md
+++ b/content/en/docs/reference/kubernetes-api/_index.md
@@ -1,4 +1,11 @@
 ---
-title: API Reference
+title: API References
+content_type: concept
 weight: 30
 ---
+
+* [Kubernetes API Reference {{< latest-version >}}](/docs/reference/generated/kubernetes-api/{{< latest-version >}}/)
+* [Kubernetes API v1.17](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/)
+* [Kubernetes API v1.16](https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/)
+* [Kubernetes API v1.15](https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/)
+* [Kubernetes API v1.14](https://v1-14.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/)

--- a/content/en/docs/reference/kubernetes-api/api-index.md
+++ b/content/en/docs/reference/kubernetes-api/api-index.md
@@ -1,6 +1,1 @@
----
-title: v1.18
-weight: 50
----
 
-[Kubernetes API v1.18](/docs/reference/generated/kubernetes-api/v1.18/)


### PR DESCRIPTION
We have added some redirection entries to those removed references.
Seems like people still want explicit links to those versions.

closes: #21926 
