### PR TITLE
Add "latest" version of API docs to provide more durable link targets

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -189,7 +189,8 @@
 /docs/reference/generated/kubernetes-api/v1.15/    https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/  301
 /docs/reference/generated/kubernetes-api/v1.16/    https://v1-16.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/  301
 /docs/reference/generated/kubernetes-api/v1.17/    https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/  301
-
+# "latest" API version is a transparent redirect (i.e. rewrite) to the current version.
+/docs/reference/generated/kubernetes-api/latest/*    /docs/reference/generated/kubernetes-api/v1.18/:splat  200
 
 /docs/reporting-security-issues/     /security/ 301
 


### PR DESCRIPTION
This will allow external referrers to link to (for example)
https://kubernetes.io/docs/reference/generated/kubernetes-api/latest/#pod-v1-core
which might continue to work for many many versions instead
of the 5 or so that we support for current versions.