### PR TITLE
Update link for HPA object to point to API docs instead of old design doc

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -181,7 +181,8 @@ are preserved as annotations when working with `autoscaling/v1`.
 When you create a HorizontalPodAutoscaler API object, make sure the name specified is a valid
 [DNS subdomain name](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names).
 More details about the API object can be found at
-[HorizontalPodAutoscaler Object](https://git.k8s.io/community/contributors/design-proposals/autoscaling/horizontal-pod-autoscaler.md#horizontalpodautoscaler-object).
+[HorizontalPodAutoscaler Object](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#horizontalpodautoscaler-v1-autoscaling).
+
 
 ## Support for Horizontal Pod Autoscaler in kubectl
 


### PR DESCRIPTION
The HPA has been around for quite some time and now has two new beta versions of its object. This link update makes it easier to find the acutal object spec instead of the outdated design doc.