### PR TITLE
[zh] Update install-minikube, add alibaba image

### DIFF
--- a/content/zh/docs/tasks/tools/install-minikube.md
+++ b/content/zh/docs/tasks/tools/install-minikube.md
@@ -403,7 +403,7 @@ For setting the `--vm-driver` with `minikube start`, enter the name of the hyper
 {{< /note >}}
 
 {{< note >}}
-由于国内无法直接连接k8s.gcr.io，推荐使用阿里云镜像，在`minikube start`中添加镜像参数
+由于国内无法直接连接 k8s.gcr.io，推荐使用阿里云镜像仓库，在 `minikube start` 中添加 `--image-repository` 参数。
 {{< /note >}}
 
 ```shell
@@ -487,4 +487,3 @@ minikube delete
 -->
 
 * [使用 Minikube 在本地运行 Kubernetes](/docs/setup/learning-environment/minikube/)
-

--- a/content/zh/docs/tasks/tools/install-minikube.md
+++ b/content/zh/docs/tasks/tools/install-minikube.md
@@ -402,8 +402,14 @@ For setting the `--vm-driver` with `minikube start`, enter the name of the hyper
 [指定 VM 驱动程序](/docs/setup/learning-environment/minikube/#specifying-the-vm-driver) 列举了 `--vm-driver` 值的完整列表。
 {{< /note >}}
 
+{{< note >}}
+由于国内无法直接连接k8s.gcr.io，推荐使用阿里云镜像，在`minikube start`中添加镜像参数
+{{< /note >}}
+
 ```shell
 minikube start --vm-driver=<driver_name>
+# Or when you need
+minikube start --vm-driver=<driver_name> --image-repository=registry.cn-hangzhou.aliyuncs.com/google_containers
 ```
 
 <!--


### PR DESCRIPTION
The problem is commented [here](https://github.com/kubernetes/minikube/issues/5860#issuecomment-553201689). Already tested and it works. Also the issue is tagged `needs-faq-entry`, I failed to find the FAQ area so I try to add it to the place is first appears.

It seems a common problem in China, but due to the command line `minikube start` appears at some other places like [here](https://kubernetes.io/zh/docs/setup/learning-environment/minikube/#%E5%BF%AB%E9%80%9F%E5%BC%80%E5%A7%8B), are there any needs to add this note to other places?
