### PR TITLE
Minor typo fix on Services Networking Host Aliases

### DIFF
--- a/content/en/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases.md
+++ b/content/en/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases.md
@@ -71,7 +71,7 @@ For example: to resolve `foo.local`, `bar.local` to `127.0.0.1` and `foo.remote`
 
 {{< codenew file="service/networking/hostaliases-pod.yaml" >}}
 
-Yoyu can start a Pod with that configuration by running:
+You can start a Pod with that configuration by running:
 
 ```shell
 kubectl apply -f https://k8s.io/examples/service/networking/hostaliases-pod.yaml


### PR DESCRIPTION
This PR has a tiny commit fixing a typo found on Kubernetes [website](https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/) while I was going through the docs.

Hopefully, I'm not missing anything from the contributing guidelines.