### PR TITLE
Remove note from Job concept about Pod backoff failure policy

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -219,9 +219,6 @@ back-off count is reset if no new failed Pods appear before the Job's next
 status check.
 
 {{< note >}}
-Issue [#54870](https://github.com/kubernetes/kubernetes/issues/54870) still exists for versions of Kubernetes prior to version 1.12
-{{< /note >}}
-{{< note >}}
 If your job has `restartPolicy = "OnFailure"`, keep in mind that your container running the Job
 will be terminated once the job backoff limit has been reached. This can make debugging the Job's executable more difficult. We suggest setting
 `restartPolicy = "Never"` when debugging the Job or using a logging system to ensure output


### PR DESCRIPTION
fix Page:
https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy

Tips for abandonment：
```
Note: Issue #54870 still exists for versions of Kubernetes prior to version 1.12
```

Issue [#54870](https://github.com/kubernetes/kubernetes/issues/54870) has been fixed, and I didn't reproduce the problem in v1.18.