### PR TITLE
Add translation for configuring service account for ID localization

### DIFF
--- a/content/id/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/id/docs/tasks/configure-pod-container/configure-service-account.md
@@ -290,7 +290,7 @@ Buat Pod:
 kubectl create -f https://k8s.io/examples/pods/pod-projected-svc-token.yaml
 ```
 
-Kubelet akan me-_request_ dan menyimpan _token_ mewakili Pod, buat _token_ dapat diakses oleh Pod pada _file path_ yang ditentukan, dan _refresh_ _token_ ketika telah mendekati waktu berakhir. Kubelet akan mengganti _token_ jika _token_ telah melewati 80% dari total TTL, atau jika _token_ telah melebihi waktu 24 jam.
+_Token_ yang mewakili Pod akan diminta dan disimpan kubelet, lalu kubelet akan membuat _token_ yang dapat diakses oleh Pod pada _file path_ yang ditentukan, dan melakukan _refresh_ _token_ ketika telah mendekati waktu berakhir. _Token_ akan diganti oleh kubelet jika _token_ telah melewati 80% dari total TTL, atau jika _token_ telah melebihi waktu 24 jam.
 
 Aplikasi bertanggung jawab untuk memuat ulang _token_ ketika terjadi penggantian. Pemuatan ulang teratur (misalnya sekali setiap 5 menit) cukup untuk mencakup kebanyakan kasus. 
 

--- a/content/id/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/id/docs/tasks/configure-pod-container/configure-service-account.md
@@ -298,7 +298,7 @@ Aplikasi bertanggung jawab untuk memuat ulang _token_ ketika terjadi penggantian
 
 {{< feature-state for_k8s_version="v1.18" state="alpha" >}}
 
-Fitur _Service Account Issuer Discovery_ diaktifkan dengan mengaktifkan _[feature gate](/docs/reference/command-line-tools-reference/feature-gate)_ `ServiceAccountIssuerDiscovery` dan mengaktifkan fitur _Service Account Token Volume Projection_ seperti yang telah dijelaskan [di atas](#service-account-token-volume-projection).
+Fitur _Service Account Issuer Discovery_ diaktifkan dengan mengaktifkan [gerbang fitur](/docs/reference/command-line-tools-reference/feature-gate) `ServiceAccountIssuerDiscovery` dan mengaktifkan fitur _Service Account Token Volume Projection_ seperti yang telah dijelaskan [di atas](#service-account-token-volume-projection).
 
 {{< note >}}
 URL _issuer_ harus sesuai dengan _[OIDC Discovery Spec](https://openid.net/specs/openid-connect-discovery-1_0.html)_. Pada implementasinya, hal ini berarti URL harus menggunakan skema `https` dan harus menyediakan konfigurasi penyedia OpenID pada `{service-account-issuer}/.well-known/openid-configuration`.

--- a/content/id/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/id/docs/tasks/configure-pod-container/configure-service-account.md
@@ -1,0 +1,333 @@
+---
+title: Mengatur Service Account untuk Pod
+content_type: task
+weight: 90
+---
+
+<!-- overview -->
+Akun servis (_service account_) menyediakan identitas untuk proses yang sedang berjalan dalam sebuah Pod.
+
+{{< note >}}
+Dokumen ini digunakan sebagai pengenalan untuk pengguna terhadap _Service Account_ dan menjelaskan bagaimana perilaku _service account_ dalam konfigurasi kluster seperti yang direkomendasikan Kubernetes. Pengubahan perilaku yang bisa saja dilakukan administrator kluster terhadap kluster tidak menjadi bagian pembahasan dokumentasi ini.
+{{< /note >}}
+
+Ketika kamu mengakses kluster (contohnya menggunakan `kubectl`), kamu terautentikasi oleh apiserver sebagai sebuah User Account (untuk sekarang umumnya sebagai `admin`, kecuali jika administrator klustermu telah melakukan pengubahan). Berbagai proses yang ada di dalam kontainer dalam pod juga dapat mengontak apiserver. Ketika itu terjadi, mereka akan diautentikasi sebagai sebuah Service Account (contohnya sebagai `default`).
+
+
+
+
+## {{% heading "prerequisites" %}}
+
+
+{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+
+
+
+<!-- steps -->
+
+## Menggunakan Default Service Account untuk Mengakses API server.
+
+Ketika kamu membuat sebuah pod, jika kamu tidak menentukan sebuah _service account_, maka ia akan otomatis ditetapkan sebagai _service account_`default` di namespace yang sama. Jika kamu mendapatkan json atau yaml mentah untuk sebuah pod yang telah kamu buat (contohnya menggunakan `kubectl get pods/<podname> -o yaml`), kamu akan melihat _field_ `spec.serviceAccountName` yang telah secara [otomatis ditentukan](/docs/user-guide/working-with-resources/#resources-are-automatically-modified).
+
+Kamu dapat mengakses API dari dalam pod menggunakan kredensial _service account_ yang ditambahkan secara otomatis seperti yang dijelaskan dalam [Mengakses Klaster](/docs/user-guide/accessing-the-cluster/#accessing-the-api-from-a-pod).
+Hak akses API dari _service account_ menyesuaikan dengan [kebijakan dan plugin otorisasi](/docs/reference/access-authn-authz/authorization/#authorization-modules) yang sedang digunakan.
+
+Di versi 1.6+, kamu dapat tidak memilih _automounting_ kredensial API dari sebuah _service account_ dengan mengatur `automountServiceAccountToken: false` pada _service account_:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: build-robot
+automountServiceAccountToken: false
+...
+```
+
+Di versi 1.6+, kamu juga dapat tidak memilih _automounting_ kredensial API dari suatu pod tertentu:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-pod
+spec:
+  serviceAccountName: build-robot
+  automountServiceAccountToken: false
+  ...
+```
+
+Pengaturan dari spesifikasi pod didahulukan dibanding _service account_ jika keduanya menentukan nilai dari `automountServiceAccountToken`.
+
+## Menggunakan Beberapa Service Account.
+
+Setiap namespace memiliki _resource_ _service account_ standar `default`.
+Kamu dapat melihatnya dan _resource_ serviceAccount lainnya di namespace tersebut dengan perintah:
+
+```shell
+kubectl get serviceaccounts
+```
+Keluarannya akan serupa dengan:
+
+```
+NAME      SECRETS    AGE
+default   1          1d
+```
+
+Kamu dapat membuat obyek ServiceAccount tambahan seperti ini:
+
+```shell
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: build-robot
+EOF
+```
+
+Nama dari obyek ServiceAccount haruslah sebuah [nama subdomain DNS](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names) yang valid.
+
+Jika kamu mendapatkan obyek _service account_ secara komplit, seperti ini:
+
+```shell
+kubectl get serviceaccounts/build-robot -o yaml
+```
+Keluarannya akan serupa dengan:
+
+```
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: 2015-06-16T00:12:59Z
+  name: build-robot
+  namespace: default
+  resourceVersion: "272500"
+  uid: 721ab723-13bc-11e5-aec2-42010af0021e
+secrets:
+- name: build-robot-token-bvbk5
+```
+
+maka kamu dapat melihat bahwa _token_ telah dibuat secara otomatis dan dirujuk oleh _service account_.
+
+Kamu dapat menggunakan _plugin_ otorisasi untuk [mengatur hak akses dari service account](/docs/reference/access-authn-authz/rbac/#service-account-permissions).
+
+Untuk menggunakan _service account_ selain nilai standar, atur _field_ `spec.serviceAccountName` dari pod menjadi nama dari _service account_ yang hendak kamu gunakan.
+
+_Service account_ harus ada ketika pod dibuat, jika tidak maka akan ditolak.
+
+Kamu tidak dapat memperbarui _service account_ dari pod yang telah dibuat.
+
+Kamu dapat menghapus _service account_ dari contoh seperti ini:
+
+```shell
+kubectl delete serviceaccount/build-robot
+```
+
+## Membuat token API service account secara manual.
+
+Asumsikan kita memiliki _service account_ dengan nama "build-robot" seperti yang disebukan di atas, dan kita membuat _secret_ secara manual.
+
+```shell
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: build-robot-secret
+  annotations:
+    kubernetes.io/service-account.name: build-robot
+type: kubernetes.io/service-account-token
+EOF
+```
+
+Sekarang kamu dapat mengonfirmasi bahwa _secret_ yang baru saja dibuat diisi dengan _token_ API dari _service account_ "build-robot".
+
+Setiap _token_ dari _service account_ yang tidak ada akan dihapus oleh _token controller_.
+
+```shell
+kubectl describe secrets/build-robot-secret
+```
+Keluarannya akan serupa dengan:
+
+```
+Name:           build-robot-secret
+Namespace:      default
+Labels:         <none>
+Annotations:    kubernetes.io/service-account.name=build-robot
+                kubernetes.io/service-account.uid=da68f9c6-9d26-11e7-b84e-002dc52800da
+
+Type:   kubernetes.io/service-account-token
+
+Data
+====
+ca.crt:         1338 bytes
+namespace:      7 bytes
+token:          ...
+```
+
+{{< note >}}
+Isi dari `token` tidak dirinci di sini.
+{{< /note >}}
+
+## Menambahkan ImagePullSecrets ke service account.
+
+### Membuat imagePullSecret
+
+- Membuat sebuah imagePullSecret, seperti yang dijelaskan pada [Menentukan ImagePullSecrets pada Pod](/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod).
+
+    ```shell
+    kubectl create secret docker-registry myregistrykey --docker-server=DUMMY_SERVER \
+            --docker-username=DUMMY_USERNAME --docker-password=DUMMY_DOCKER_PASSWORD \
+            --docker-email=DUMMY_DOCKER_EMAIL
+    ```
+
+- Memastikan bahwa _secret_ telah terbuat.
+   ```shell
+   kubectl get secrets myregistrykey
+   ```
+
+    Keluarannya akan serupa dengan:
+
+    ```
+    NAME             TYPE                              DATA    AGE
+    myregistrykey    kubernetes.io/.dockerconfigjson   1       1d
+    ```
+
+### Menambahkan imagePullSecret ke service account
+
+Selanjutnya, modifikasi _service account_ standar dari namespace untuk menggunakan _secret_ ini sebagai imagePullSecret.
+
+
+```shell
+kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "myregistrykey"}]}'
+```
+
+Sebagai gantinya kamu dapat menggunakan `kubectl edit`, atau melakukan pengubahan secara manual _manifest_ YAML seperti di bawah ini:
+
+```shell
+kubectl get serviceaccounts default -o yaml > ./sa.yaml
+```
+
+Keluaran dari _file_ `sa.yaml` akan serupa dengan:
+
+```shell
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: 2015-08-07T22:02:39Z
+  name: default
+  namespace: default
+  resourceVersion: "243024"
+  uid: 052fb0f4-3d50-11e5-b066-42010af0d7b6
+secrets:
+- name: default-token-uudge
+```
+
+Menggunakan _editor_ pilihanmu (misalnya `vi`), buka _file_ `sa.yaml`, hapus baris dengan _key_ `resourceVersion`, tambahkan baris dengan `imagePullSecrets:` dan simpan.
+
+Keluaran dari _file_ `sa.yaml` akan serupa dengan:
+
+```shell
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: 2015-08-07T22:02:39Z
+  name: default
+  namespace: default
+  uid: 052fb0f4-3d50-11e5-b066-42010af0d7b6
+secrets:
+- name: default-token-uudge
+imagePullSecrets:
+- name: myregistrykey
+```
+
+Terakhir ganti serviceaccount dengan _file_ `sa.yaml` yang telah diperbarui.
+
+```shell
+kubectl replace serviceaccount default -f ./sa.yaml
+```
+
+### Memverifikasi imagePullSecrets sudah ditambahkan ke spesifikasi pod
+
+Ketika Pod baru dibuat dalam namespace yang sedang aktif dan menggunakan ServiceAccount, Pod baru akan memiliki _field_ `spec.imagePullSecrets` yang ditentukan secara otomatis:
+
+```shell
+kubectl run nginx --image=nginx --restart=Never
+kubectl get pod nginx -o=jsonpath='{.spec.imagePullSecrets[0].name}{"\n"}'
+```
+
+Keluarannya adalah:
+
+```
+myregistrykey
+```
+
+<!--## Menambahkan Secrets ke sebuah service account.
+
+TODO: Tes dan jelaskan bagaimana cara menambahkan secret tambahan non-K8s dengan service account yang sudah ada.
+-->
+
+## Service Account Token Volume Projection
+
+{{< feature-state for_k8s_version="v1.12" state="beta" >}}
+
+{{< note >}}
+ServiceAccountTokenVolumeProjection masih dalam tahap __beta__ untuk versi 1.12 dan diaktifkan dengan memberikan _flag_ berikut ini ke API _server_:
+
+* `--service-account-issuer`
+* `--service-account-signing-key-file`
+* `--service-account-api-audiences`
+
+{{< /note >}}
+
+Kubelet juga dapat memproyeksikan _token_ _service account_ ke Pod. Kamu dapat menentukan properti yang diinginkan dari _token_ seperti target pengguna dan durasi validitas. Properti tersebut tidak dapat diubah pada _token_ _service account_ standar. _Token_ _service account_ juga akan menjadi tidak valid terhadap API ketika Pod atau ServiceAccount dihapus.
+
+Perilaku ini diatur pada PodSpec menggunakan tipe ProjectedVolume yaitu [ServiceAccountToken](/docs/concepts/storage/volumes/#projected). Untuk memungkinkan pod dengan _token_ dengan pengguna bertipe _"vault"_ dan durasi validitas selama dua jam, kamu harus mengubah bagian ini pada PodSpec:
+
+{{< codenew file="pods/pod-projected-svc-token.yaml" >}}
+
+Buat Pod:
+
+```shell
+kubectl create -f https://k8s.io/examples/pods/pod-projected-svc-token.yaml
+```
+
+Kubelet akan me-_request_ dan menyimpan _token_ mewakili pod, buat _token_ dapat diakses oleh pod pada _file path_ yang ditentukan, dan _refresh_ _token_ ketika telah mendekati waktu berakhir. Kubelet akan mengganti _token_ jika _token_ telah melewati 80% dari total TTL, atau jika _token_ telah melebihi waktu 24 jam.
+
+Aplikasi bertanggung jawab untuk memuat ulang _token_ ketika terjadi penggantian. Pemuatan ulang teratur (misalnya sekali setiap 5 menit) cukup untuk mencakup kebanyakan kasus. 
+
+## Service Account Issuer Discovery
+
+{{< feature-state for_k8s_version="v1.18" state="alpha" >}}
+
+Fitur _Service Account Issuer Discovery_ diaktifkan dengan mengaktifkan _[feature gate](/docs/reference/command-line-tools-reference/feature-gate)_ `ServiceAccountIssuerDiscovery` dan mengaktifkan fitur _Service Account Token Volume Projection_ seperti yang telah dijelaskan [di atas](#service-account-token-volume-projection).
+
+{{< note >}}
+URL _issuer_ harus sesuai dengan _[OIDC Discovery Spec](https://openid.net/specs/openid-connect-discovery-1_0.html)_. Pada implementasinya, hal ini berarti URL harus menggunakan skema `https` dan harus menyediakan konfigurasi penyedia OpenID pada `{service-account-issuer}/.well-known/openid-configuration`.
+
+Jika URL tidak sesuai dengan aturan, _endpoint_ `ServiceAccountIssuerDiscovery` tidak akan didaftarkan meskipun fitur telah diaktifkan.
+{{< /note >}}
+
+Fitur _Service Account Issuer Discovery_ memungkinkan federasi dari berbagai _token_ _service account_ Kubernetes yang dibuat oleh sebuah kluster (penyedia identitas) dan sistem eksternal.
+
+Ketika diaktifkan, _server_ API Kubernetes menyediakan dokumen OpenID Provider Configuration pada `/.well-known/openid-configuration` dan JSON Web Key Set (JWKS) terkait pada `/openid/v1/jwks`. OpenID Provider Configuration terkadang disebut juga dengan sebutan _discovery document_.
+
+Ketika diaktifkan, kluster juga dikonfigurasi dengan RBAC ClusterRole standar yaitu `system:service-account-issuer-discovery`. _Role binding_ tidak disediakan secara _default_. Administrator dimungkinkan untuk, sebagai contoh, menentukan apakah peran akan disematkan ke `system:authenticated` atau `system:unauthenticated` tergantung terhadap kebutuhan keamanan dan sistem eksternal yang direncakanan untuk diintegrasikan.
+
+{{< note >}}
+Respons yang disediakan pada `/.well-known/openid-configuration` dan`/openid/v1/jwks` dirancang untuk kompatibel dengan OIDC, tetapi tidak sepenuhnya sesuai dengan ketentuan OIDC. Dokumen tersebut hanya berisi parameter yang dibutuhkan untuk melakukan validasi terhadap _token_ _service account_ Kubernetes.
+{{< /note >}}
+
+Respons JWKS memuat kunci publik yang dapat digunakan oleh sistem eksternal untuk melakukan validasi _token_ _service account_ Kubernetes. Awalnya sistem eksternal akan mengkueri OpenID Provider Configuration, dan selanjutnya dapat menggunakan _field_ `jwks_uri` pada respons kueri untuk mendapatkan JWKS.
+
+Pada banyak kasus, _server_ API Kubernetes tidak tersedia di internet publik, namun _endpoint_ publik yang menyediakan respons hasil _cache_ dari _server_ API dapat dibuat menjadi tersedia oleh pengguna atau penyedia servis. Pada kasus ini, dimungkinkan untuk mengganti `jwks_uri` pada OpenID Provider Configuration untuk diarahkan ke _endpoint_ publik sebagai ganti alamat _server_ API dengan memberikan _flag_ `--service-account-jwks-uri` ke API server. serupa dengan URL _issuer_, URI JWKS diharuskan untuk menggunakan skema `https`.
+
+
+## {{% heading "whatsnext" %}}
+
+
+Lihat juga:
+
+- [Panduan Admin Kluster mengenai Service Account](/docs/reference/access-authn-authz/service-accounts-admin/)
+- [Service Account Signing Key Retrieval KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/20190730-oidc-discovery.md)
+- [OIDC Discovery Spec](https://openid.net/specs/openid-connect-discovery-1_0.html)
+
+

--- a/content/id/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/id/docs/tasks/configure-pod-container/configure-service-account.md
@@ -8,10 +8,10 @@ weight: 90
 ServiceAccount menyediakan identitas untuk proses yang sedang berjalan dalam sebuah Pod.
 
 {{< note >}}
-Dokumen ini digunakan sebagai pengenalan untuk pengguna terhadap ServiceAccount dan menjelaskan bagaimana perilaku ServiceAccount dalam konfigurasi kluster seperti yang direkomendasikan Kubernetes. Pengubahan perilaku yang bisa saja dilakukan administrator kluster terhadap kluster tidak menjadi bagian pembahasan dokumentasi ini.
+Dokumen ini digunakan sebagai pengenalan untuk pengguna terhadap ServiceAccount dan menjelaskan bagaimana perilaku ServiceAccount dalam konfigurasi klaster seperti yang direkomendasikan Kubernetes. Pengubahan perilaku yang bisa saja dilakukan administrator klaster terhadap klaster tidak menjadi bagian pembahasan dokumentasi ini.
 {{< /note >}}
 
-Ketika kamu mengakses kluster (contohnya menggunakan `kubectl`), kamu terautentikasi oleh apiserver sebagai sebuah User Account (untuk sekarang umumnya sebagai `admin`, kecuali jika administrator klustermu telah melakukan pengubahan). Berbagai proses yang ada di dalam kontainer dalam pod juga dapat mengontak apiserver. Ketika itu terjadi, mereka akan diautentikasi sebagai sebuah ServiceAccount (contohnya sebagai `default`).
+Ketika kamu mengakses klaster (contohnya menggunakan `kubectl`), kamu terautentikasi oleh apiserver sebagai sebuah User Account (untuk sekarang umumnya sebagai `admin`, kecuali jika administrator klustermu telah melakukan pengubahan). Berbagai proses yang ada di dalam kontainer dalam pod juga dapat mengontak apiserver. Ketika itu terjadi, mereka akan diautentikasi sebagai sebuah ServiceAccount (contohnya sebagai `default`).
 
 
 
@@ -306,11 +306,11 @@ URL _issuer_ harus sesuai dengan _[OIDC Discovery Spec](https://openid.net/specs
 Jika URL tidak sesuai dengan aturan, _endpoint_ `ServiceAccountIssuerDiscovery` tidak akan didaftarkan meskipun fitur telah diaktifkan.
 {{< /note >}}
 
-Fitur _Service Account Issuer Discovery_ memungkinkan federasi dari berbagai _token_ ServiceAccount Kubernetes yang dibuat oleh sebuah kluster (penyedia identitas) dan sistem eksternal.
+Fitur _Service Account Issuer Discovery_ memungkinkan federasi dari berbagai _token_ ServiceAccount Kubernetes yang dibuat oleh sebuah klaster (penyedia identitas) dan sistem eksternal.
 
 Ketika diaktifkan, _server_ API Kubernetes menyediakan dokumen OpenID Provider Configuration pada `/.well-known/openid-configuration` dan JSON Web Key Set (JWKS) terkait pada `/openid/v1/jwks`. OpenID Provider Configuration terkadang disebut juga dengan sebutan _discovery document_.
 
-Ketika diaktifkan, kluster juga dikonfigurasi dengan RBAC ClusterRole standar yaitu `system:service-account-issuer-discovery`. _Role binding_ tidak disediakan secara _default_. Administrator dimungkinkan untuk, sebagai contoh, menentukan apakah peran akan disematkan ke `system:authenticated` atau `system:unauthenticated` tergantung terhadap kebutuhan keamanan dan sistem eksternal yang direncakanan untuk diintegrasikan.
+Ketika diaktifkan, klaster juga dikonfigurasi dengan RBAC ClusterRole standar yaitu `system:service-account-issuer-discovery`. _Role binding_ tidak disediakan secara _default_. Administrator dimungkinkan untuk, sebagai contoh, menentukan apakah peran akan disematkan ke `system:authenticated` atau `system:unauthenticated` tergantung terhadap kebutuhan keamanan dan sistem eksternal yang direncakanan untuk diintegrasikan.
 
 {{< note >}}
 Respons yang disediakan pada `/.well-known/openid-configuration` dan`/openid/v1/jwks` dirancang untuk kompatibel dengan OIDC, tetapi tidak sepenuhnya sesuai dengan ketentuan OIDC. Dokumen tersebut hanya berisi parameter yang dibutuhkan untuk melakukan validasi terhadap _token_ ServiceAccount Kubernetes.

--- a/content/id/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/id/docs/tasks/configure-pod-container/configure-service-account.md
@@ -11,7 +11,7 @@ ServiceAccount menyediakan identitas untuk proses yang sedang berjalan dalam seb
 Dokumen ini digunakan sebagai pengenalan untuk pengguna terhadap ServiceAccount dan menjelaskan bagaimana perilaku ServiceAccount dalam konfigurasi klaster seperti yang direkomendasikan Kubernetes. Pengubahan perilaku yang bisa saja dilakukan administrator klaster terhadap klaster tidak menjadi bagian pembahasan dokumentasi ini.
 {{< /note >}}
 
-Ketika kamu mengakses klaster (contohnya menggunakan `kubectl`), kamu terautentikasi oleh apiserver sebagai sebuah akun pengguna (untuk sekarang umumnya sebagai `admin`, kecuali jika administrator klustermu telah melakukan pengubahan). Berbagai proses yang ada di dalam kontainer dalam pod juga dapat mengontak apiserver. Ketika itu terjadi, mereka akan diautentikasi sebagai sebuah ServiceAccount (contohnya sebagai `default`).
+Ketika kamu mengakses klaster (contohnya menggunakan `kubectl`), kamu terautentikasi oleh apiserver sebagai sebuah akun pengguna (untuk sekarang umumnya sebagai `admin`, kecuali jika administrator klustermu telah melakukan pengubahan). Berbagai proses yang ada di dalam kontainer dalam Pod juga dapat mengontak apiserver. Ketika itu terjadi, mereka akan diautentikasi sebagai sebuah ServiceAccount (contohnya sebagai `default`).
 
 
 
@@ -27,9 +27,9 @@ Ketika kamu mengakses klaster (contohnya menggunakan `kubectl`), kamu terautenti
 
 ## Menggunakan Default ServiceAccount untuk Mengakses API server.
 
-Ketika kamu membuat sebuah pod, jika kamu tidak menentukan sebuah ServiceAccount, maka ia akan otomatis ditetapkan sebagai ServiceAccount`default` di namespace yang sama. Jika kamu mendapatkan json atau yaml mentah untuk sebuah pod yang telah kamu buat (contohnya menggunakan `kubectl get pods/<podname> -o yaml`), kamu akan melihat _field_ `spec.serviceAccountName` yang telah secara [otomatis ditentukan](/docs/user-guide/working-with-resources/#resources-are-automatically-modified).
+Ketika kamu membuat sebuah Pod, jika kamu tidak menentukan sebuah ServiceAccount, maka ia akan otomatis ditetapkan sebagai ServiceAccount`default` di namespace yang sama. Jika kamu mendapatkan json atau yaml mentah untuk sebuah Pod yang telah kamu buat (contohnya menggunakan `kubectl get pods/<podname> -o yaml`), kamu akan melihat _field_ `spec.serviceAccountName` yang telah secara [otomatis ditentukan](/docs/user-guide/working-with-resources/#resources-are-automatically-modified).
 
-Kamu dapat mengakses API dari dalam pod menggunakan kredensial ServiceAccount yang ditambahkan secara otomatis seperti yang dijelaskan dalam [Mengakses Klaster](/docs/user-guide/accessing-the-cluster/#accessing-the-api-from-a-pod).
+Kamu dapat mengakses API dari dalam Pod menggunakan kredensial ServiceAccount yang ditambahkan secara otomatis seperti yang dijelaskan dalam [Mengakses Klaster](/docs/user-guide/accessing-the-cluster/#accessing-the-api-from-a-pod).
 Hak akses API dari ServiceAccount menyesuaikan dengan [kebijakan dan plugin otorisasi](/docs/reference/access-authn-authz/authorization/#authorization-modules) yang sedang digunakan.
 
 Di versi 1.6+, kamu dapat tidak memilih _automounting_ kredensial API dari sebuah ServiceAccount dengan mengatur `automountServiceAccountToken: false` pada ServiceAccount:
@@ -43,7 +43,7 @@ automountServiceAccountToken: false
 ...
 ```
 
-Di versi 1.6+, kamu juga dapat tidak memilih _automounting_ kredensial API dari suatu pod tertentu:
+Di versi 1.6+, kamu juga dapat tidak memilih _automounting_ kredensial API dari suatu Pod tertentu:
 
 ```yaml
 apiVersion: v1
@@ -56,7 +56,7 @@ spec:
   ...
 ```
 
-Pengaturan dari spesifikasi pod didahulukan dibanding ServiceAccount jika keduanya menentukan nilai dari `automountServiceAccountToken`.
+Pengaturan dari spesifikasi Pod didahulukan dibanding ServiceAccount jika keduanya menentukan nilai dari `automountServiceAccountToken`.
 
 ## Menggunakan Beberapa ServiceAccount.
 
@@ -110,11 +110,11 @@ maka kamu dapat melihat bahwa _token_ telah dibuat secara otomatis dan dirujuk o
 
 Kamu dapat menggunakan _plugin_ otorisasi untuk [mengatur hak akses dari ServiceAccount](/docs/reference/access-authn-authz/rbac/#service-account-permissions).
 
-Untuk menggunakan ServiceAccount selain nilai standar, atur _field_ `spec.serviceAccountName` dari pod menjadi nama dari ServiceAccount yang hendak kamu gunakan.
+Untuk menggunakan ServiceAccount selain nilai standar, atur _field_ `spec.serviceAccountName` dari Pod menjadi nama dari ServiceAccount yang hendak kamu gunakan.
 
-_Service account_ harus ada ketika pod dibuat, jika tidak maka akan ditolak.
+_Service account_ harus ada ketika Pod dibuat, jika tidak maka akan ditolak.
 
-Kamu tidak dapat memperbarui ServiceAccount dari pod yang telah dibuat.
+Kamu tidak dapat memperbarui ServiceAccount dari Pod yang telah dibuat.
 
 Kamu dapat menghapus ServiceAccount dari contoh seperti ini:
 
@@ -245,7 +245,7 @@ Terakhir ganti serviceaccount dengan _file_ `sa.yaml` yang telah diperbarui.
 kubectl replace serviceaccount default -f ./sa.yaml
 ```
 
-### Memverifikasi imagePullSecrets sudah ditambahkan ke spesifikasi pod
+### Memverifikasi imagePullSecrets sudah ditambahkan ke spesifikasi Pod
 
 Ketika Pod baru dibuat dalam namespace yang sedang aktif dan menggunakan ServiceAccount, Pod baru akan memiliki _field_ `spec.imagePullSecrets` yang ditentukan secara otomatis:
 
@@ -280,7 +280,7 @@ ServiceAccountTokenVolumeProjection masih dalam tahap __beta__ untuk versi 1.12 
 
 Kubelet juga dapat memproyeksikan _token_ ServiceAccount ke Pod. Kamu dapat menentukan properti yang diinginkan dari _token_ seperti target pengguna dan durasi validitas. Properti tersebut tidak dapat diubah pada _token_ ServiceAccount standar. _Token_ ServiceAccount juga akan menjadi tidak valid terhadap API ketika Pod atau ServiceAccount dihapus.
 
-Perilaku ini diatur pada PodSpec menggunakan tipe ProjectedVolume yaitu [ServiceAccountToken](/docs/concepts/storage/volumes/#projected). Untuk memungkinkan pod dengan _token_ dengan pengguna bertipe _"vault"_ dan durasi validitas selama dua jam, kamu harus mengubah bagian ini pada PodSpec:
+Perilaku ini diatur pada PodSpec menggunakan tipe ProjectedVolume yaitu [ServiceAccountToken](/docs/concepts/storage/volumes/#projected). Untuk memungkinkan Pod dengan _token_ dengan pengguna bertipe _"vault"_ dan durasi validitas selama dua jam, kamu harus mengubah bagian ini pada PodSpec:
 
 {{< codenew file="pods/pod-projected-svc-token.yaml" >}}
 
@@ -290,7 +290,7 @@ Buat Pod:
 kubectl create -f https://k8s.io/examples/pods/pod-projected-svc-token.yaml
 ```
 
-Kubelet akan me-_request_ dan menyimpan _token_ mewakili pod, buat _token_ dapat diakses oleh pod pada _file path_ yang ditentukan, dan _refresh_ _token_ ketika telah mendekati waktu berakhir. Kubelet akan mengganti _token_ jika _token_ telah melewati 80% dari total TTL, atau jika _token_ telah melebihi waktu 24 jam.
+Kubelet akan me-_request_ dan menyimpan _token_ mewakili Pod, buat _token_ dapat diakses oleh Pod pada _file path_ yang ditentukan, dan _refresh_ _token_ ketika telah mendekati waktu berakhir. Kubelet akan mengganti _token_ jika _token_ telah melewati 80% dari total TTL, atau jika _token_ telah melebihi waktu 24 jam.
 
 Aplikasi bertanggung jawab untuk memuat ulang _token_ ketika terjadi penggantian. Pemuatan ulang teratur (misalnya sekali setiap 5 menit) cukup untuk mencakup kebanyakan kasus. 
 

--- a/content/id/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/id/docs/tasks/configure-pod-container/configure-service-account.md
@@ -221,7 +221,7 @@ secrets:
 - name: default-token-uudge
 ```
 
-Menggunakan _editor_ pilihanmu (misalnya `vi`), buka berkas `sa.yaml`, hapus baris dengan _key_ `resourceVersion`, tambahkan baris dengan `imagePullSecrets:` dan simpan.
+Menggunakan _editor_ pilihanmu (misalnya `vi`), buka berkas `sa.yaml`, hapus baris dengan key `resourceVersion`, tambahkan baris dengan `imagePullSecrets:` dan simpan.
 
 Keluaran dari berkas `sa.yaml` akan serupa dengan:
 

--- a/content/id/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/id/docs/tasks/configure-pod-container/configure-service-account.md
@@ -200,7 +200,7 @@ Selanjutnya, modifikasi ServiceAccount standar dari Namespace untuk menggunakan 
 kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "myregistrykey"}]}'
 ```
 
-Sebagai gantinya kamu dapat menggunakan `kubectl edit`, atau melakukan pengubahan secara manual _manifest_ YAML seperti di bawah ini:
+Sebagai gantinya kamu dapat menggunakan `kubectl edit`, atau melakukan pengubahan secara manual manifes YAML seperti di bawah ini:
 
 ```shell
 kubectl get serviceaccounts default -o yaml > ./sa.yaml

--- a/content/id/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/id/docs/tasks/configure-pod-container/configure-service-account.md
@@ -171,7 +171,7 @@ Isi dari `token` tidak dirinci di sini.
 
 ### Membuat imagePullSecret
 
-- Membuat sebuah imagePullSecret, seperti yang dijelaskan pada [Menentukan ImagePullSecret pada Pod](/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod).
+- Membuat sebuah imagePullSecret, seperti yang dijelaskan pada [Menentukan ImagePullSecret pada Pod](/id/docs/concepts/containers/images/#tentukan-imagepullsecrets-pada-sebuah-pod).
 
     ```shell
     kubectl create secret docker-registry myregistrykey --docker-server=DUMMY_SERVER \

--- a/content/id/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/id/docs/tasks/configure-pod-container/configure-service-account.md
@@ -27,7 +27,7 @@ Ketika kamu mengakses klaster (contohnya menggunakan `kubectl`), kamu terautenti
 
 ## Menggunakan Default ServiceAccount untuk Mengakses API server.
 
-Ketika kamu membuat sebuah Pod, jika kamu tidak menentukan sebuah ServiceAccount, maka ia akan otomatis ditetapkan sebagai ServiceAccount`default` di namespace yang sama. Jika kamu mendapatkan json atau yaml mentah untuk sebuah Pod yang telah kamu buat (contohnya menggunakan `kubectl get pods/<podname> -o yaml`), kamu akan melihat _field_ `spec.serviceAccountName` yang telah secara [otomatis ditentukan](/docs/user-guide/working-with-resources/#resources-are-automatically-modified).
+Ketika kamu membuat sebuah Pod, jika kamu tidak menentukan sebuah ServiceAccount, maka ia akan otomatis ditetapkan sebagai ServiceAccount`default` di Namespace yang sama. Jika kamu mendapatkan json atau yaml mentah untuk sebuah Pod yang telah kamu buat (contohnya menggunakan `kubectl get pods/<podname> -o yaml`), kamu akan melihat _field_ `spec.serviceAccountName` yang telah secara [otomatis ditentukan](/docs/user-guide/working-with-resources/#resources-are-automatically-modified).
 
 Kamu dapat mengakses API dari dalam Pod menggunakan kredensial ServiceAccount yang ditambahkan secara otomatis seperti yang dijelaskan dalam [Mengakses Klaster](/docs/user-guide/accessing-the-cluster/#accessing-the-api-from-a-pod).
 Hak akses API dari ServiceAccount menyesuaikan dengan [kebijakan dan plugin otorisasi](/docs/reference/access-authn-authz/authorization/#authorization-modules) yang sedang digunakan.
@@ -60,8 +60,8 @@ Pengaturan dari spesifikasi Pod didahulukan dibanding ServiceAccount jika keduan
 
 ## Menggunakan Beberapa ServiceAccount.
 
-Setiap namespace memiliki _resource_ ServiceAccount standar `default`.
-Kamu dapat melihatnya dan _resource_ serviceAccount lainnya di namespace tersebut dengan perintah:
+Setiap Namespace memiliki _resource_ ServiceAccount standar `default`.
+Kamu dapat melihatnya dan _resource_ serviceAccount lainnya di Namespace tersebut dengan perintah:
 
 ```shell
 kubectl get serviceaccounts
@@ -193,7 +193,7 @@ Isi dari `token` tidak dirinci di sini.
 
 ### Menambahkan imagePullSecret ke ServiceAccount
 
-Selanjutnya, modifikasi ServiceAccount standar dari namespace untuk menggunakan _secret_ ini sebagai imagePullSecret.
+Selanjutnya, modifikasi ServiceAccount standar dari Namespace untuk menggunakan _secret_ ini sebagai imagePullSecret.
 
 
 ```shell
@@ -247,7 +247,7 @@ kubectl replace serviceaccount default -f ./sa.yaml
 
 ### Memverifikasi imagePullSecrets sudah ditambahkan ke spesifikasi Pod
 
-Ketika Pod baru dibuat dalam namespace yang sedang aktif dan menggunakan ServiceAccount, Pod baru akan memiliki _field_ `spec.imagePullSecrets` yang ditentukan secara otomatis:
+Ketika Pod baru dibuat dalam Namespace yang sedang aktif dan menggunakan ServiceAccount, Pod baru akan memiliki _field_ `spec.imagePullSecrets` yang ditentukan secara otomatis:
 
 ```shell
 kubectl run nginx --image=nginx --restart=Never

--- a/content/id/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/id/docs/tasks/configure-pod-container/configure-service-account.md
@@ -124,7 +124,7 @@ kubectl delete serviceaccount/build-robot
 
 ## Membuat token API ServiceAccount secara manual.
 
-Asumsikan kita memiliki ServiceAccount dengan nama "build-robot" seperti yang disebukan di atas, dan kita membuat _secret_ secara manual.
+Asumsikan kita memiliki ServiceAccount dengan nama "build-robot" seperti yang disebukan di atas, dan kita membuat Secret secara manual.
 
 ```shell
 kubectl apply -f - <<EOF
@@ -138,7 +138,7 @@ type: kubernetes.io/service-account-token
 EOF
 ```
 
-Sekarang kamu dapat mengonfirmasi bahwa _secret_ yang baru saja dibuat diisi dengan _token_ API dari ServiceAccount "build-robot".
+Sekarang kamu dapat mengonfirmasi bahwa Secret yang baru saja dibuat diisi dengan _token_ API dari ServiceAccount "build-robot".
 
 Setiap _token_ dari ServiceAccount yang tidak ada akan dihapus oleh _token controller_.
 
@@ -179,7 +179,7 @@ Isi dari `token` tidak dirinci di sini.
             --docker-email=DUMMY_DOCKER_EMAIL
     ```
 
-- Memastikan bahwa _secret_ telah terbuat.
+- Memastikan bahwa Secret telah terbuat.
    ```shell
    kubectl get secrets myregistrykey
    ```
@@ -193,7 +193,7 @@ Isi dari `token` tidak dirinci di sini.
 
 ### Menambahkan imagePullSecret ke ServiceAccount
 
-Selanjutnya, modifikasi ServiceAccount standar dari Namespace untuk menggunakan _secret_ ini sebagai imagePullSecret.
+Selanjutnya, modifikasi ServiceAccount standar dari Namespace untuk menggunakan Secret ini sebagai imagePullSecret.
 
 
 ```shell
@@ -262,7 +262,7 @@ myregistrykey
 
 <!--## Menambahkan Secrets ke sebuah ServiceAccount.
 
-TODO: Tes dan jelaskan bagaimana cara menambahkan secret tambahan non-K8s dengan ServiceAccount yang sudah ada.
+TODO: Tes dan jelaskan bagaimana cara menambahkan Secret tambahan non-K8s dengan ServiceAccount yang sudah ada.
 -->
 
 ## ServiceAccount Token Volume Projection

--- a/content/id/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/id/docs/tasks/configure-pod-container/configure-service-account.md
@@ -60,8 +60,8 @@ Pengaturan dari spesifikasi Pod didahulukan dibanding ServiceAccount jika keduan
 
 ## Menggunakan Beberapa ServiceAccount.
 
-Setiap Namespace memiliki _resource_ ServiceAccount standar `default`.
-Kamu dapat melihatnya dan _resource_ serviceAccount lainnya di Namespace tersebut dengan perintah:
+Setiap Namespace memiliki sumber daya ServiceAccount standar `default`.
+Kamu dapat melihatnya dan sumber daya serviceAccount lainnya di Namespace tersebut dengan perintah:
 
 ```shell
 kubectl get serviceaccounts

--- a/content/id/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/id/docs/tasks/configure-pod-container/configure-service-account.md
@@ -11,7 +11,7 @@ ServiceAccount menyediakan identitas untuk proses yang sedang berjalan dalam seb
 Dokumen ini digunakan sebagai pengenalan untuk pengguna terhadap ServiceAccount dan menjelaskan bagaimana perilaku ServiceAccount dalam konfigurasi klaster seperti yang direkomendasikan Kubernetes. Pengubahan perilaku yang bisa saja dilakukan administrator klaster terhadap klaster tidak menjadi bagian pembahasan dokumentasi ini.
 {{< /note >}}
 
-Ketika kamu mengakses klaster (contohnya menggunakan `kubectl`), kamu terautentikasi oleh apiserver sebagai sebuah User Account (untuk sekarang umumnya sebagai `admin`, kecuali jika administrator klustermu telah melakukan pengubahan). Berbagai proses yang ada di dalam kontainer dalam pod juga dapat mengontak apiserver. Ketika itu terjadi, mereka akan diautentikasi sebagai sebuah ServiceAccount (contohnya sebagai `default`).
+Ketika kamu mengakses klaster (contohnya menggunakan `kubectl`), kamu terautentikasi oleh apiserver sebagai sebuah akun pengguna (untuk sekarang umumnya sebagai `admin`, kecuali jika administrator klustermu telah melakukan pengubahan). Berbagai proses yang ada di dalam kontainer dalam pod juga dapat mengontak apiserver. Ketika itu terjadi, mereka akan diautentikasi sebagai sebuah ServiceAccount (contohnya sebagai `default`).
 
 
 

--- a/content/id/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/id/docs/tasks/configure-pod-container/configure-service-account.md
@@ -206,7 +206,7 @@ Sebagai gantinya kamu dapat menggunakan `kubectl edit`, atau melakukan pengubaha
 kubectl get serviceaccounts default -o yaml > ./sa.yaml
 ```
 
-Keluaran dari _file_ `sa.yaml` akan serupa dengan:
+Keluaran dari berkas `sa.yaml` akan serupa dengan:
 
 ```shell
 apiVersion: v1
@@ -221,9 +221,9 @@ secrets:
 - name: default-token-uudge
 ```
 
-Menggunakan _editor_ pilihanmu (misalnya `vi`), buka _file_ `sa.yaml`, hapus baris dengan _key_ `resourceVersion`, tambahkan baris dengan `imagePullSecrets:` dan simpan.
+Menggunakan _editor_ pilihanmu (misalnya `vi`), buka berkas `sa.yaml`, hapus baris dengan _key_ `resourceVersion`, tambahkan baris dengan `imagePullSecrets:` dan simpan.
 
-Keluaran dari _file_ `sa.yaml` akan serupa dengan:
+Keluaran dari berkas `sa.yaml` akan serupa dengan:
 
 ```shell
 apiVersion: v1
@@ -239,7 +239,7 @@ imagePullSecrets:
 - name: myregistrykey
 ```
 
-Terakhir ganti serviceaccount dengan _file_ `sa.yaml` yang telah diperbarui.
+Terakhir ganti serviceaccount dengan berkas `sa.yaml` yang telah diperbarui.
 
 ```shell
 kubectl replace serviceaccount default -f ./sa.yaml

--- a/content/id/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/id/docs/tasks/configure-pod-container/configure-service-account.md
@@ -270,7 +270,7 @@ TODO: Tes dan jelaskan bagaimana cara menambahkan Secret tambahan non-K8s dengan
 {{< feature-state for_k8s_version="v1.12" state="beta" >}}
 
 {{< note >}}
-ServiceAccountTokenVolumeProjection masih dalam tahap __beta__ untuk versi 1.12 dan diaktifkan dengan memberikan _flag_ berikut ini ke API _server_:
+ServiceAccountTokenVolumeProjection masih dalam tahap __beta__ untuk versi 1.12 dan diaktifkan dengan memberikan _flag_ berikut ini ke API server:
 
 * `--service-account-issuer`
 * `--service-account-signing-key-file`
@@ -308,7 +308,7 @@ Jika URL tidak sesuai dengan aturan, _endpoint_ `ServiceAccountIssuerDiscovery` 
 
 Fitur _Service Account Issuer Discovery_ memungkinkan federasi dari berbagai _token_ ServiceAccount Kubernetes yang dibuat oleh sebuah klaster (penyedia identitas) dan sistem eksternal.
 
-Ketika diaktifkan, _server_ API Kubernetes menyediakan dokumen OpenID Provider Configuration pada `/.well-known/openid-configuration` dan JSON Web Key Set (JWKS) terkait pada `/openid/v1/jwks`. OpenID Provider Configuration terkadang disebut juga dengan sebutan _discovery document_.
+Ketika diaktifkan, server API Kubernetes menyediakan dokumen OpenID Provider Configuration pada `/.well-known/openid-configuration` dan JSON Web Key Set (JWKS) terkait pada `/openid/v1/jwks`. OpenID Provider Configuration terkadang disebut juga dengan sebutan _discovery document_.
 
 Ketika diaktifkan, klaster juga dikonfigurasi dengan RBAC ClusterRole standar yaitu `system:service-account-issuer-discovery`. _Role binding_ tidak disediakan secara _default_. Administrator dimungkinkan untuk, sebagai contoh, menentukan apakah peran akan disematkan ke `system:authenticated` atau `system:unauthenticated` tergantung terhadap kebutuhan keamanan dan sistem eksternal yang direncakanan untuk diintegrasikan.
 
@@ -318,7 +318,7 @@ Respons yang disediakan pada `/.well-known/openid-configuration` dan`/openid/v1/
 
 Respons JWKS memuat kunci publik yang dapat digunakan oleh sistem eksternal untuk melakukan validasi _token_ ServiceAccount Kubernetes. Awalnya sistem eksternal akan mengkueri OpenID Provider Configuration, dan selanjutnya dapat menggunakan _field_ `jwks_uri` pada respons kueri untuk mendapatkan JWKS.
 
-Pada banyak kasus, _server_ API Kubernetes tidak tersedia di internet publik, namun _endpoint_ publik yang menyediakan respons hasil _cache_ dari _server_ API dapat dibuat menjadi tersedia oleh pengguna atau penyedia servis. Pada kasus ini, dimungkinkan untuk mengganti `jwks_uri` pada OpenID Provider Configuration untuk diarahkan ke _endpoint_ publik sebagai ganti alamat _server_ API dengan memberikan _flag_ `--service-account-jwks-uri` ke API server. serupa dengan URL _issuer_, URI JWKS diharuskan untuk menggunakan skema `https`.
+Pada banyak kasus, server API Kubernetes tidak tersedia di internet publik, namun _endpoint_ publik yang menyediakan respons hasil _cache_ dari server API dapat dibuat menjadi tersedia oleh pengguna atau penyedia servis. Pada kasus ini, dimungkinkan untuk mengganti `jwks_uri` pada OpenID Provider Configuration untuk diarahkan ke _endpoint_ publik sebagai ganti alamat server API dengan memberikan _flag_ `--service-account-jwks-uri` ke API server. serupa dengan URL _issuer_, URI JWKS diharuskan untuk menggunakan skema `https`.
 
 
 ## {{% heading "whatsnext" %}}

--- a/content/id/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/id/docs/tasks/configure-pod-container/configure-service-account.md
@@ -265,7 +265,7 @@ myregistrykey
 TODO: Tes dan jelaskan bagaimana cara menambahkan Secret tambahan non-K8s dengan ServiceAccount yang sudah ada.
 -->
 
-## ServiceAccount Token Volume Projection
+## ServiceAccountTokenVolumeProjection
 
 {{< feature-state for_k8s_version="v1.12" state="beta" >}}
 
@@ -294,11 +294,11 @@ _Token_ yang mewakili Pod akan diminta dan disimpan kubelet, lalu kubelet akan m
 
 Aplikasi bertanggung jawab untuk memuat ulang _token_ ketika terjadi penggantian. Pemuatan ulang teratur (misalnya sekali setiap 5 menit) cukup untuk mencakup kebanyakan kasus. 
 
-## ServiceAccount Issuer Discovery
+## ServiceAccountIssuerDiscovery
 
 {{< feature-state for_k8s_version="v1.18" state="alpha" >}}
 
-Fitur _Service Account Issuer Discovery_ diaktifkan dengan mengaktifkan [gerbang fitur](/docs/reference/command-line-tools-reference/feature-gate) `ServiceAccountIssuerDiscovery` dan mengaktifkan fitur _Service Account Token Volume Projection_ seperti yang telah dijelaskan [di atas](#service-account-token-volume-projection).
+Fitur ServiceAccountIssuerDiscovery diaktifkan dengan mengaktifkan [gerbang fitur](/docs/reference/command-line-tools-reference/feature-gate) `ServiceAccountIssuerDiscovery` dan mengaktifkan fitur _Service Account Token Volume Projection_ seperti yang telah dijelaskan [di atas](#service-account-token-volume-projection).
 
 {{< note >}}
 URL _issuer_ harus sesuai dengan _[OIDC Discovery Spec](https://openid.net/specs/openid-connect-discovery-1_0.html)_. Pada implementasinya, hal ini berarti URL harus menggunakan skema `https` dan harus menyediakan konfigurasi penyedia OpenID pada `{service-account-issuer}/.well-known/openid-configuration`.

--- a/content/id/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/id/docs/tasks/configure-pod-container/configure-service-account.md
@@ -73,7 +73,7 @@ NAME      SECRETS    AGE
 default   1          1d
 ```
 
-Kamu dapat membuat obyek ServiceAccount tambahan seperti ini:
+Kamu dapat membuat objek ServiceAccount tambahan seperti ini:
 
 ```shell
 kubectl apply -f - <<EOF
@@ -84,9 +84,9 @@ metadata:
 EOF
 ```
 
-Nama dari obyek ServiceAccount haruslah sebuah [nama subdomain DNS](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names) yang valid.
+Nama dari objek ServiceAccount haruslah sebuah [nama subdomain DNS](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names) yang valid.
 
-Jika kamu mendapatkan obyek ServiceAccount secara komplit, seperti ini:
+Jika kamu mendapatkan objek ServiceAccount secara komplit, seperti ini:
 
 ```shell
 kubectl get serviceaccounts/build-robot -o yaml

--- a/content/id/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/id/docs/tasks/configure-pod-container/configure-service-account.md
@@ -1,17 +1,17 @@
 ---
-title: Mengatur Service Account untuk Pod
+title: Mengatur ServiceAccount untuk Pod
 content_type: task
 weight: 90
 ---
 
 <!-- overview -->
-Akun servis (_service account_) menyediakan identitas untuk proses yang sedang berjalan dalam sebuah Pod.
+ServiceAccount menyediakan identitas untuk proses yang sedang berjalan dalam sebuah Pod.
 
 {{< note >}}
-Dokumen ini digunakan sebagai pengenalan untuk pengguna terhadap _Service Account_ dan menjelaskan bagaimana perilaku _service account_ dalam konfigurasi kluster seperti yang direkomendasikan Kubernetes. Pengubahan perilaku yang bisa saja dilakukan administrator kluster terhadap kluster tidak menjadi bagian pembahasan dokumentasi ini.
+Dokumen ini digunakan sebagai pengenalan untuk pengguna terhadap ServiceAccount dan menjelaskan bagaimana perilaku ServiceAccount dalam konfigurasi kluster seperti yang direkomendasikan Kubernetes. Pengubahan perilaku yang bisa saja dilakukan administrator kluster terhadap kluster tidak menjadi bagian pembahasan dokumentasi ini.
 {{< /note >}}
 
-Ketika kamu mengakses kluster (contohnya menggunakan `kubectl`), kamu terautentikasi oleh apiserver sebagai sebuah User Account (untuk sekarang umumnya sebagai `admin`, kecuali jika administrator klustermu telah melakukan pengubahan). Berbagai proses yang ada di dalam kontainer dalam pod juga dapat mengontak apiserver. Ketika itu terjadi, mereka akan diautentikasi sebagai sebuah Service Account (contohnya sebagai `default`).
+Ketika kamu mengakses kluster (contohnya menggunakan `kubectl`), kamu terautentikasi oleh apiserver sebagai sebuah User Account (untuk sekarang umumnya sebagai `admin`, kecuali jika administrator klustermu telah melakukan pengubahan). Berbagai proses yang ada di dalam kontainer dalam pod juga dapat mengontak apiserver. Ketika itu terjadi, mereka akan diautentikasi sebagai sebuah ServiceAccount (contohnya sebagai `default`).
 
 
 
@@ -25,14 +25,14 @@ Ketika kamu mengakses kluster (contohnya menggunakan `kubectl`), kamu terautenti
 
 <!-- steps -->
 
-## Menggunakan Default Service Account untuk Mengakses API server.
+## Menggunakan Default ServiceAccount untuk Mengakses API server.
 
-Ketika kamu membuat sebuah pod, jika kamu tidak menentukan sebuah _service account_, maka ia akan otomatis ditetapkan sebagai _service account_`default` di namespace yang sama. Jika kamu mendapatkan json atau yaml mentah untuk sebuah pod yang telah kamu buat (contohnya menggunakan `kubectl get pods/<podname> -o yaml`), kamu akan melihat _field_ `spec.serviceAccountName` yang telah secara [otomatis ditentukan](/docs/user-guide/working-with-resources/#resources-are-automatically-modified).
+Ketika kamu membuat sebuah pod, jika kamu tidak menentukan sebuah ServiceAccount, maka ia akan otomatis ditetapkan sebagai ServiceAccount`default` di namespace yang sama. Jika kamu mendapatkan json atau yaml mentah untuk sebuah pod yang telah kamu buat (contohnya menggunakan `kubectl get pods/<podname> -o yaml`), kamu akan melihat _field_ `spec.serviceAccountName` yang telah secara [otomatis ditentukan](/docs/user-guide/working-with-resources/#resources-are-automatically-modified).
 
-Kamu dapat mengakses API dari dalam pod menggunakan kredensial _service account_ yang ditambahkan secara otomatis seperti yang dijelaskan dalam [Mengakses Klaster](/docs/user-guide/accessing-the-cluster/#accessing-the-api-from-a-pod).
-Hak akses API dari _service account_ menyesuaikan dengan [kebijakan dan plugin otorisasi](/docs/reference/access-authn-authz/authorization/#authorization-modules) yang sedang digunakan.
+Kamu dapat mengakses API dari dalam pod menggunakan kredensial ServiceAccount yang ditambahkan secara otomatis seperti yang dijelaskan dalam [Mengakses Klaster](/docs/user-guide/accessing-the-cluster/#accessing-the-api-from-a-pod).
+Hak akses API dari ServiceAccount menyesuaikan dengan [kebijakan dan plugin otorisasi](/docs/reference/access-authn-authz/authorization/#authorization-modules) yang sedang digunakan.
 
-Di versi 1.6+, kamu dapat tidak memilih _automounting_ kredensial API dari sebuah _service account_ dengan mengatur `automountServiceAccountToken: false` pada _service account_:
+Di versi 1.6+, kamu dapat tidak memilih _automounting_ kredensial API dari sebuah ServiceAccount dengan mengatur `automountServiceAccountToken: false` pada ServiceAccount:
 
 ```yaml
 apiVersion: v1
@@ -56,11 +56,11 @@ spec:
   ...
 ```
 
-Pengaturan dari spesifikasi pod didahulukan dibanding _service account_ jika keduanya menentukan nilai dari `automountServiceAccountToken`.
+Pengaturan dari spesifikasi pod didahulukan dibanding ServiceAccount jika keduanya menentukan nilai dari `automountServiceAccountToken`.
 
-## Menggunakan Beberapa Service Account.
+## Menggunakan Beberapa ServiceAccount.
 
-Setiap namespace memiliki _resource_ _service account_ standar `default`.
+Setiap namespace memiliki _resource_ ServiceAccount standar `default`.
 Kamu dapat melihatnya dan _resource_ serviceAccount lainnya di namespace tersebut dengan perintah:
 
 ```shell
@@ -86,7 +86,7 @@ EOF
 
 Nama dari obyek ServiceAccount haruslah sebuah [nama subdomain DNS](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names) yang valid.
 
-Jika kamu mendapatkan obyek _service account_ secara komplit, seperti ini:
+Jika kamu mendapatkan obyek ServiceAccount secara komplit, seperti ini:
 
 ```shell
 kubectl get serviceaccounts/build-robot -o yaml
@@ -106,25 +106,25 @@ secrets:
 - name: build-robot-token-bvbk5
 ```
 
-maka kamu dapat melihat bahwa _token_ telah dibuat secara otomatis dan dirujuk oleh _service account_.
+maka kamu dapat melihat bahwa _token_ telah dibuat secara otomatis dan dirujuk oleh ServiceAccount.
 
-Kamu dapat menggunakan _plugin_ otorisasi untuk [mengatur hak akses dari service account](/docs/reference/access-authn-authz/rbac/#service-account-permissions).
+Kamu dapat menggunakan _plugin_ otorisasi untuk [mengatur hak akses dari ServiceAccount](/docs/reference/access-authn-authz/rbac/#service-account-permissions).
 
-Untuk menggunakan _service account_ selain nilai standar, atur _field_ `spec.serviceAccountName` dari pod menjadi nama dari _service account_ yang hendak kamu gunakan.
+Untuk menggunakan ServiceAccount selain nilai standar, atur _field_ `spec.serviceAccountName` dari pod menjadi nama dari ServiceAccount yang hendak kamu gunakan.
 
 _Service account_ harus ada ketika pod dibuat, jika tidak maka akan ditolak.
 
-Kamu tidak dapat memperbarui _service account_ dari pod yang telah dibuat.
+Kamu tidak dapat memperbarui ServiceAccount dari pod yang telah dibuat.
 
-Kamu dapat menghapus _service account_ dari contoh seperti ini:
+Kamu dapat menghapus ServiceAccount dari contoh seperti ini:
 
 ```shell
 kubectl delete serviceaccount/build-robot
 ```
 
-## Membuat token API service account secara manual.
+## Membuat token API ServiceAccount secara manual.
 
-Asumsikan kita memiliki _service account_ dengan nama "build-robot" seperti yang disebukan di atas, dan kita membuat _secret_ secara manual.
+Asumsikan kita memiliki ServiceAccount dengan nama "build-robot" seperti yang disebukan di atas, dan kita membuat _secret_ secara manual.
 
 ```shell
 kubectl apply -f - <<EOF
@@ -138,9 +138,9 @@ type: kubernetes.io/service-account-token
 EOF
 ```
 
-Sekarang kamu dapat mengonfirmasi bahwa _secret_ yang baru saja dibuat diisi dengan _token_ API dari _service account_ "build-robot".
+Sekarang kamu dapat mengonfirmasi bahwa _secret_ yang baru saja dibuat diisi dengan _token_ API dari ServiceAccount "build-robot".
 
-Setiap _token_ dari _service account_ yang tidak ada akan dihapus oleh _token controller_.
+Setiap _token_ dari ServiceAccount yang tidak ada akan dihapus oleh _token controller_.
 
 ```shell
 kubectl describe secrets/build-robot-secret
@@ -167,7 +167,7 @@ token:          ...
 Isi dari `token` tidak dirinci di sini.
 {{< /note >}}
 
-## Menambahkan ImagePullSecrets ke service account.
+## Menambahkan ImagePullSecrets ke ServiceAccount.
 
 ### Membuat imagePullSecret
 
@@ -191,9 +191,9 @@ Isi dari `token` tidak dirinci di sini.
     myregistrykey    kubernetes.io/.dockerconfigjson   1       1d
     ```
 
-### Menambahkan imagePullSecret ke service account
+### Menambahkan imagePullSecret ke ServiceAccount
 
-Selanjutnya, modifikasi _service account_ standar dari namespace untuk menggunakan _secret_ ini sebagai imagePullSecret.
+Selanjutnya, modifikasi ServiceAccount standar dari namespace untuk menggunakan _secret_ ini sebagai imagePullSecret.
 
 
 ```shell
@@ -260,12 +260,12 @@ Keluarannya adalah:
 myregistrykey
 ```
 
-<!--## Menambahkan Secrets ke sebuah service account.
+<!--## Menambahkan Secrets ke sebuah ServiceAccount.
 
-TODO: Tes dan jelaskan bagaimana cara menambahkan secret tambahan non-K8s dengan service account yang sudah ada.
+TODO: Tes dan jelaskan bagaimana cara menambahkan secret tambahan non-K8s dengan ServiceAccount yang sudah ada.
 -->
 
-## Service Account Token Volume Projection
+## ServiceAccount Token Volume Projection
 
 {{< feature-state for_k8s_version="v1.12" state="beta" >}}
 
@@ -278,7 +278,7 @@ ServiceAccountTokenVolumeProjection masih dalam tahap __beta__ untuk versi 1.12 
 
 {{< /note >}}
 
-Kubelet juga dapat memproyeksikan _token_ _service account_ ke Pod. Kamu dapat menentukan properti yang diinginkan dari _token_ seperti target pengguna dan durasi validitas. Properti tersebut tidak dapat diubah pada _token_ _service account_ standar. _Token_ _service account_ juga akan menjadi tidak valid terhadap API ketika Pod atau ServiceAccount dihapus.
+Kubelet juga dapat memproyeksikan _token_ ServiceAccount ke Pod. Kamu dapat menentukan properti yang diinginkan dari _token_ seperti target pengguna dan durasi validitas. Properti tersebut tidak dapat diubah pada _token_ ServiceAccount standar. _Token_ ServiceAccount juga akan menjadi tidak valid terhadap API ketika Pod atau ServiceAccount dihapus.
 
 Perilaku ini diatur pada PodSpec menggunakan tipe ProjectedVolume yaitu [ServiceAccountToken](/docs/concepts/storage/volumes/#projected). Untuk memungkinkan pod dengan _token_ dengan pengguna bertipe _"vault"_ dan durasi validitas selama dua jam, kamu harus mengubah bagian ini pada PodSpec:
 
@@ -294,7 +294,7 @@ Kubelet akan me-_request_ dan menyimpan _token_ mewakili pod, buat _token_ dapat
 
 Aplikasi bertanggung jawab untuk memuat ulang _token_ ketika terjadi penggantian. Pemuatan ulang teratur (misalnya sekali setiap 5 menit) cukup untuk mencakup kebanyakan kasus. 
 
-## Service Account Issuer Discovery
+## ServiceAccount Issuer Discovery
 
 {{< feature-state for_k8s_version="v1.18" state="alpha" >}}
 
@@ -306,17 +306,17 @@ URL _issuer_ harus sesuai dengan _[OIDC Discovery Spec](https://openid.net/specs
 Jika URL tidak sesuai dengan aturan, _endpoint_ `ServiceAccountIssuerDiscovery` tidak akan didaftarkan meskipun fitur telah diaktifkan.
 {{< /note >}}
 
-Fitur _Service Account Issuer Discovery_ memungkinkan federasi dari berbagai _token_ _service account_ Kubernetes yang dibuat oleh sebuah kluster (penyedia identitas) dan sistem eksternal.
+Fitur _Service Account Issuer Discovery_ memungkinkan federasi dari berbagai _token_ ServiceAccount Kubernetes yang dibuat oleh sebuah kluster (penyedia identitas) dan sistem eksternal.
 
 Ketika diaktifkan, _server_ API Kubernetes menyediakan dokumen OpenID Provider Configuration pada `/.well-known/openid-configuration` dan JSON Web Key Set (JWKS) terkait pada `/openid/v1/jwks`. OpenID Provider Configuration terkadang disebut juga dengan sebutan _discovery document_.
 
 Ketika diaktifkan, kluster juga dikonfigurasi dengan RBAC ClusterRole standar yaitu `system:service-account-issuer-discovery`. _Role binding_ tidak disediakan secara _default_. Administrator dimungkinkan untuk, sebagai contoh, menentukan apakah peran akan disematkan ke `system:authenticated` atau `system:unauthenticated` tergantung terhadap kebutuhan keamanan dan sistem eksternal yang direncakanan untuk diintegrasikan.
 
 {{< note >}}
-Respons yang disediakan pada `/.well-known/openid-configuration` dan`/openid/v1/jwks` dirancang untuk kompatibel dengan OIDC, tetapi tidak sepenuhnya sesuai dengan ketentuan OIDC. Dokumen tersebut hanya berisi parameter yang dibutuhkan untuk melakukan validasi terhadap _token_ _service account_ Kubernetes.
+Respons yang disediakan pada `/.well-known/openid-configuration` dan`/openid/v1/jwks` dirancang untuk kompatibel dengan OIDC, tetapi tidak sepenuhnya sesuai dengan ketentuan OIDC. Dokumen tersebut hanya berisi parameter yang dibutuhkan untuk melakukan validasi terhadap _token_ ServiceAccount Kubernetes.
 {{< /note >}}
 
-Respons JWKS memuat kunci publik yang dapat digunakan oleh sistem eksternal untuk melakukan validasi _token_ _service account_ Kubernetes. Awalnya sistem eksternal akan mengkueri OpenID Provider Configuration, dan selanjutnya dapat menggunakan _field_ `jwks_uri` pada respons kueri untuk mendapatkan JWKS.
+Respons JWKS memuat kunci publik yang dapat digunakan oleh sistem eksternal untuk melakukan validasi _token_ ServiceAccount Kubernetes. Awalnya sistem eksternal akan mengkueri OpenID Provider Configuration, dan selanjutnya dapat menggunakan _field_ `jwks_uri` pada respons kueri untuk mendapatkan JWKS.
 
 Pada banyak kasus, _server_ API Kubernetes tidak tersedia di internet publik, namun _endpoint_ publik yang menyediakan respons hasil _cache_ dari _server_ API dapat dibuat menjadi tersedia oleh pengguna atau penyedia servis. Pada kasus ini, dimungkinkan untuk mengganti `jwks_uri` pada OpenID Provider Configuration untuk diarahkan ke _endpoint_ publik sebagai ganti alamat _server_ API dengan memberikan _flag_ `--service-account-jwks-uri` ke API server. serupa dengan URL _issuer_, URI JWKS diharuskan untuk menggunakan skema `https`.
 
@@ -326,8 +326,8 @@ Pada banyak kasus, _server_ API Kubernetes tidak tersedia di internet publik, na
 
 Lihat juga:
 
-- [Panduan Admin Kluster mengenai Service Account](/docs/reference/access-authn-authz/service-accounts-admin/)
-- [Service Account Signing Key Retrieval KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/20190730-oidc-discovery.md)
+- [Panduan Admin Kluster mengenai ServiceAccount](/docs/reference/access-authn-authz/service-accounts-admin/)
+- [ServiceAccount Signing Key Retrieval KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/20190730-oidc-discovery.md)
 - [OIDC Discovery Spec](https://openid.net/specs/openid-connect-discovery-1_0.html)
 
 

--- a/content/id/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/id/docs/tasks/configure-pod-container/configure-service-account.md
@@ -167,11 +167,11 @@ token:          ...
 Isi dari `token` tidak dirinci di sini.
 {{< /note >}}
 
-## Menambahkan ImagePullSecrets ke ServiceAccount.
+## Menambahkan ImagePullSecret ke ServiceAccount.
 
 ### Membuat imagePullSecret
 
-- Membuat sebuah imagePullSecret, seperti yang dijelaskan pada [Menentukan ImagePullSecrets pada Pod](/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod).
+- Membuat sebuah imagePullSecret, seperti yang dijelaskan pada [Menentukan ImagePullSecret pada Pod](/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod).
 
     ```shell
     kubectl create secret docker-registry myregistrykey --docker-server=DUMMY_SERVER \

--- a/content/id/examples/pods/pod-projected-svc-token.yaml
+++ b/content/id/examples/pods/pod-projected-svc-token.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+spec:
+  containers:
+  - image: nginx
+    name: nginx
+    volumeMounts:
+    - mountPath: /var/run/secrets/tokens
+      name: vault-token
+  serviceAccountName: build-robot
+  volumes:
+  - name: vault-token
+    projected:
+      sources:
+      - serviceAccountToken:
+          path: vault-token
+          expirationSeconds: 7200
+          audience: vault


### PR DESCRIPTION
Address #20111 for `/docs/tasks/configure-pod-container/configure-service-account`
