### PR TITLE
Fix redirect link for feature-gates page on configure-service-account

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-service-account.md
@@ -323,7 +323,7 @@ The application is responsible for reloading the token when it rotates. Periodic
 {{< feature-state for_k8s_version="v1.18" state="alpha" >}}
 
 The Service Account Issuer Discovery feature is enabled by enabling the
-`ServiceAccountIssuerDiscovery` [feature gate](/docs/reference/command-line-tools-reference/feature)
+`ServiceAccountIssuerDiscovery` [feature gate](/docs/reference/command-line-tools-reference/feature-gates)
 and then enabling the Service Account Token Projection feature as described
 [above](#service-account-token-volume-projection).
 


### PR DESCRIPTION
I noticed while working for ID localization on #21960 that the link to the `feature-gate` page on the `tasks/configure-pod-container/configure-service-account` page is broken, which used `/docs/reference/command-line-tools-reference/feature` instead of `/docs/reference/command-line-tools-reference/feature-gates` which will return 404 in the former. 