### PR TITLE
Fix description of failureThreshold

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -332,7 +332,7 @@ to 1 second. Minimum value is 1.
 * `successThreshold`: Minimum consecutive successes for the probe to be
 considered successful after having failed. Defaults to 1. Must be 1 for
 liveness. Minimum value is 1.
-* `failureThreshold`: When a Pod starts and the probe fails, Kubernetes will
+* `failureThreshold`: When a probe fails, Kubernetes will
 try `failureThreshold` times before giving up. Giving up in case of liveness probe means restarting the container. In case of readiness probe the Pod will be marked Unready.
 Defaults to 3. Minimum value is 1.
 


### PR DESCRIPTION
This PR corrects the description of `failureThreshold`. The old description was misleading because it mentions "When a Pod starts". This makes it sound as if the `failureThreshold` only applies on pod start - which is not true. It applies always. The pod start isn't a special case and shouldn't be mentioned.