### PR TITLE
Update page headers for documentation section

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -391,3 +391,16 @@ main.content {
     }
   }
 }
+
+/* DOCUMENTATION */
+
+body.documentation {
+  main[role="main"] {
+    div.td-content > h1:first-of-type {
+      display: none;
+    }
+    > h1:first-of-type {
+      display: none;
+    }
+  }
+}

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -4,16 +4,13 @@
     {{ partial "head.html" . }}
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
   </head>
-  <body class="td-{{ .Kind }}">
+  <body class="documentation td-{{ .Kind }}">
     <header>
       {{ partial "navbar.html" . }}
       {{ partial "announcement.html" . }}
       <section class="header-hero text-center text-white font-bold pb-4">
         <h1>
-          {{ $sectionHeading := .Site.GetPage "section" .Section }}
-          {{ with $sectionHeading }}
-            {{ .Title }}
-          {{ end }}
+          {{ .Title }}
         </h1>
       </section>
     </header>


### PR DESCRIPTION
My take on #21797: make the title of pages in the documentation section be the title of the page, then suppress the `<h1>` element inside the (Docsy generated) page body. An alternative to PR #22043. [Documentation section preview](https://deploy-preview-21998--kubernetes-io-master-staging.netlify.app/docs/home/)

/hold
for discussion.