### PR TITLE
[WIP] Improve scrolling behavior with narrow viewports

### DIFF
--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -41,7 +41,10 @@ $video-section-height: 200px;
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 body {
-  background-color: white;
+  main {
+    width: 100vw;
+    overflow-x: auto;
+  }
 }
 
 section {

--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -1,4 +1,13 @@
 /* GLOBAL */
+body {
+  @media only screen and (min-width: 768px) {
+    main {
+      width: initial;
+      overflow-x: initial;
+    }
+  }
+}
+
 .td-main {
   .row {
     margin: 0;


### PR DESCRIPTION
Draft fix for issue #19307

Set the `<main>` element to scroll, only if the viewport is less than 768px wide.