### PR TITLE
Remove extra space in documentation

### DIFF
--- a/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
+++ b/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
@@ -36,7 +36,7 @@ By default, the kubelet uses [CFS quota](https://en.wikipedia.org/wiki/Completel
 to enforce pod CPU limits.  When the node runs many CPU-bound pods,
 the workload can move to different CPU cores depending on
 whether the pod is throttled and which CPU cores are available at
-scheduling time.  Many workloads are not sensitive to this migration and thus
+scheduling time. Many workloads are not sensitive to this migration and thus
 work fine without any intervention.
 
 However, in workloads where CPU cache affinity and scheduling latency


### PR DESCRIPTION
Hi,

There is an extra space in the documentation for CPU Management. This is an image for it : 

![image](https://user-images.githubusercontent.com/9096155/85445963-efed8f80-b561-11ea-9316-dd7ce1751280.png)
 
