### PR TITLE
fix misrepresentation for  "at least one"

### DIFF
--- a/content/zh/docs/concepts/configuration/taint-and-toleration.md
+++ b/content/zh/docs/concepts/configuration/taint-and-toleration.md
@@ -154,9 +154,9 @@ effect `PreferNoSchedule` then Kubernetes will *try* to not schedule the pod ont
 the node (if it is already running on the node), and will not be
 scheduled onto the node (if it is not yet running on the node).
 -->
-* 如果未被过滤的 taint 中存在一个或一个以上 effect 值为 `NoSchedule` 的 taint，则 Kubernetes 不会将 pod 分配到该节点。
+* 如果未被过滤的 taint 中存在至少一个 effect 值为 `NoSchedule` 的 taint，则 Kubernetes 不会将 pod 分配到该节点。
 * 如果未被过滤的 taint 中不存在 effect 值为 `NoSchedule` 的 taint，但是存在 effect 值为 `PreferNoSchedule` 的 taint，则 Kubernetes 会 *尝试* 将 pod 分配到该节点。
-* 如果未被过滤的 taint 中存在一个或一个以上 effect 值为 `NoExecute` 的 taint，则 Kubernetes 不会将 pod 分配到该节点（如果 pod 还未在节点上运行），或者将 pod 从该节点驱逐（如果 pod 已经在节点上运行）。
+* 如果未被过滤的 taint 中存在至少一个 effect 值为 `NoExecute` 的 taint，则 Kubernetes 不会将 pod 分配到该节点（如果 pod 还未在节点上运行），或者将 pod 从该节点驱逐（如果 pod 已经在节点上运行）。
 
 <!--
 For example, imagine you taint a node like this

--- a/content/zh/docs/concepts/configuration/taint-and-toleration.md
+++ b/content/zh/docs/concepts/configuration/taint-and-toleration.md
@@ -154,9 +154,9 @@ effect `PreferNoSchedule` then Kubernetes will *try* to not schedule the pod ont
 the node (if it is already running on the node), and will not be
 scheduled onto the node (if it is not yet running on the node).
 -->
-* 如果未被过滤的 taint 中存在一个以上 effect 值为 `NoSchedule` 的 taint，则 Kubernetes 不会将 pod 分配到该节点。
+* 如果未被过滤的 taint 中存在一个或一个以上 effect 值为 `NoSchedule` 的 taint，则 Kubernetes 不会将 pod 分配到该节点。
 * 如果未被过滤的 taint 中不存在 effect 值为 `NoSchedule` 的 taint，但是存在 effect 值为 `PreferNoSchedule` 的 taint，则 Kubernetes 会 *尝试* 将 pod 分配到该节点。
-* 如果未被过滤的 taint 中存在一个以上 effect 值为 `NoExecute` 的 taint，则 Kubernetes 不会将 pod 分配到该节点（如果 pod 还未在节点上运行），或者将 pod 从该节点驱逐（如果 pod 已经在节点上运行）。
+* 如果未被过滤的 taint 中存在一个或一个以上 effect 值为 `NoExecute` 的 taint，则 Kubernetes 不会将 pod 分配到该节点（如果 pod 还未在节点上运行），或者将 pod 从该节点驱逐（如果 pod 已经在节点上运行）。
 
 <!--
 For example, imagine you taint a node like this


### PR DESCRIPTION
English is  "at least one"  so  Chinese  is  "一个或一个以上"   not  "一个以上"

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

-->
