### PR TITLE
Remove hero header from documentation section

### DIFF
--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -832,3 +832,16 @@ section#cncf {
     font-size: 1rem;
   }
 }
+
+/* DOCUMENTATION */
+
+body.td-documentation {
+    header > .header-filler {
+      height: $hero-padding-top;
+      background-color: black;
+    }
+    /* Special case for if an announcement is active */
+    header section#announcement ~ .header-filler {
+      display: none;
+    }
+}

--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -421,3 +421,18 @@ section#announcement ~ .header-hero {
       margin: #{$announcement-size-adjustment / 2} 0;
     }
 }
+
+/* DOCUMENTATION */
+
+/* Don't show lead text */
+body.td-documentation {
+  main {
+    @media only screen {
+       > * {
+         > .lead:first-of-type {
+         display: none;
+        }
+      }
+    }
+  }
+}

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -1,3 +1,4 @@
 ---
+linktitle: Kubernetes Documentation
 title: Documentation
 ---

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -4,18 +4,11 @@
     {{ partial "head.html" . }}
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
   </head>
-  <body class="td-{{ .Kind }}">
+  <body class="td-{{ .Kind }} td-documentation">
     <header>
       {{ partial "navbar.html" . }}
       {{ partial "announcement.html" . }}
-      <section class="header-hero text-center text-white font-bold pb-4">
-        <h1>
-          {{ $sectionHeading := .Site.GetPage "section" .Section }}
-          {{ with $sectionHeading }}
-            {{ .Title }}
-          {{ end }}
-        </h1>
-      </section>
+      <div class="header-filler"></div>
     </header>
     <div class="container-fluid td-outer">
       <div class="td-main">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -7,7 +7,7 @@
         <ul class="global-nav">
             {{ $sections := slice "docs" "blog" "training" "partners" "community" "case-studies" }}
             {{ range $sections }}
-            {{ with site.GetPage "section" . }}<li><a href="{{ .RelPermalink }}"{{ if eq .Section $.Section }} class="active"{{ end}} data-proofer-ignore>{{ .LinkTitle }}</a></li>{{ end }}
+            {{ with site.GetPage "section" . }}<li><a href="{{ .RelPermalink }}"{{ if eq .Section $.Section }} class="active"{{ end}} data-proofer-ignore>{{ .Title }}</a></li>{{ end }}
             {{ end }}
             {{/* Link directly to documentation etc., if possible. */}}
             {{ $langPage := cond (gt (len .Translations) 0) . site.Home }}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -10,7 +10,7 @@
 			{{ with site.GetPage "section" . }}
 			<li class="nav-item mr-2 mb-lg-0">
 				{{ $active := eq .Section $.Section }}
-				<a class="nav-link{{if $active }} active{{end}}" href="{{ .RelPermalink }}" >{{ .LinkTitle }}</span></a>
+				<a class="nav-link{{if $active }} active{{end}}" href="{{ .RelPermalink }}" >{{ .Title }}</span></a>
 			</li>
 			{{ end }}
 			{{ end }}

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -26,13 +26,13 @@
 {{ $show := or (eq $s $p.FirstSection) (and (not $p.Site.Params.ui.sidebar_menu_compact) ($p.IsDescendant $s)) }}
 {{ $sid := $s.RelPermalink | anchorize }}
 <ul class="td-sidebar-nav__section pr-md-3">
+  {{ if (ne $s.File.Path "docs/_index.md") }}
   <li class="td-sidebar-nav__section-title">
     <a  href="{{ $s.RelPermalink }}" class="align-left pl-0 pr-2{{ if not $show }} collapsed{{ end }}{{ if $active}} active{{ end }} td-sidebar-link td-sidebar-link__section">
-      {{ if not (eq $s.LinkTitle "Documentation") }}
       {{ $s.LinkTitle }}
-      {{ end }}
     </a>
   </li>
+  {{ end }}
   <ul>
     <li class="collapse {{ if $show }}show{{ end }}" id="{{ $sid }}">
       {{ $pages := where (union $s.Pages $s.Sections).ByWeight ".Params.toc_hide" "!=" true }}


### PR DESCRIPTION
My second take on #21797, an alternative to PR #21998

Remove the hero header for the documentation section. [Documentation section preview](https://deploy-preview-22043--kubernetes-io-master-staging.netlify.app/docs/home/).

Removing the hero header means there is more vertical space for documentation, on all form factors. I've also added the word “Kubernetes” to the breadcrumb trail.

This change also suppresses the lead text (from `description` in the front matter) on pages. The lead text stays in place for sections, or if you print the page.

**Note to reviewers**: I recommend that you preview this locally with and without an announcement enabled.

~/hold~
~for discussion~