### PR TITLE
Move documentation page lead text after the heading

### DIFF
--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -1,6 +1,5 @@
 {{ define "main" }}
 	<div class="td-content">
-		{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 		{{ $hasContent := false }}
 		{{ with .File }}
 			{{ if ne .Filename "" }}
@@ -12,6 +11,7 @@
 		{{ else }}
 			<h1>{{ .Title }}</h1>
 		{{ end }}
+		{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 		{{ partial "section-index.html" . }}
 	</div>
 {{ end }}


### PR DESCRIPTION
Implement @kbhawkey's idea from https://github.com/kubernetes/website/pull/21997#issuecomment-649056053: move the lead text after the page heading.

This helps because the lead text follows the page heading on the section index that links to a page. More consistency should mean more readability.

Also related to #21753