### PR TITLE
Adjust HTML generated for announcements

### DIFF
--- a/layouts/partials/announcement.html
+++ b/layouts/partials/announcement.html
@@ -1,7 +1,7 @@
 {{ if .Page.Param "announcement" }}
 <section lang="en" id="announcement" style="background-color:{{ .Page.Param "announcement_bg" }}">
   <aside>
-    <div class="content announcement main-section">
+    <div class="content announcement main-section" data-nosnippet>
 
       <h4 class="announcement">
           {{ T "announcement_title" | markdownify }}

--- a/layouts/partials/frontpage-announcement.html
+++ b/layouts/partials/frontpage-announcement.html
@@ -1,6 +1,6 @@
 {{ if .Page.Param "announcement" }}
 <section lang="en" id="fp-announcement" style="background-color:{{ .Page.Param "announcement_bg" }}">
-  <main>
+  <aside>
     <div class="content announcement main-section">
 
       <h3>
@@ -9,6 +9,6 @@
       <p>{{ T "announcement_message" | markdownify }}</p>
 
     </div>
-  </main>
+  </aside>
 </section>
 {{ end }}

--- a/layouts/partials/frontpage-announcement.html
+++ b/layouts/partials/frontpage-announcement.html
@@ -1,7 +1,7 @@
 {{ if .Page.Param "announcement" }}
 <section lang="en" id="fp-announcement" style="background-color:{{ .Page.Param "announcement_bg" }}">
-  <aside>
-    <div class="content announcement main-section">
+  <aside >
+    <div class="content announcement main-section" data-nosnippet>
 
       <h3>
           {{ T "announcement_title" |  markdownify }}

--- a/static/css/announcement.css
+++ b/static/css/announcement.css
@@ -33,7 +33,7 @@
   min-height: 30vh;
 }
 
-#fp-announcement main {
+#fp-announcement aside {
   padding-top: 125px;
   padding-bottom: 35px;
 }


### PR DESCRIPTION
Mark front page announcements as `<aside>` elements

This matches the HTML that gets generated for announcements on the rest of the site. It helps avoid search engines treating the announcement banner as the primary content of the web page.

Spotted during triage for issue #22036.

Fixes #22036.
Fixes #21788.