### PR TITLE
Update kubectl run from docs where necessary

### DIFF
--- a/content/en/docs/concepts/configuration/overview.md
+++ b/content/en/docs/concepts/configuration/overview.md
@@ -103,7 +103,7 @@ The caching semantics of the underlying image provider make even `imagePullPolic
 
 - Use label selectors for `get` and `delete` operations instead of specific object names. See the sections on [label selectors](/docs/concepts/overview/working-with-objects/labels/#label-selectors) and [using labels effectively](/docs/concepts/cluster-administration/manage-deployment/#using-labels-effectively).
 
-- Use `kubectl run` and `kubectl expose` to quickly create single-container Deployments and Services. See [Use a Service to Access an Application in a Cluster](/docs/tasks/access-application-cluster/service-access-application-cluster/) for an example.
+- Use `kubectl create deployment` and `kubectl expose` to quickly create single-container Deployments and Services. See [Use a Service to Access an Application in a Cluster](/docs/tasks/access-application-cluster/service-access-application-cluster/) for an example.
 
 
 

--- a/content/en/docs/concepts/overview/working-with-objects/object-management.md
+++ b/content/en/docs/concepts/overview/working-with-objects/object-management.md
@@ -41,12 +41,6 @@ objects, it provides no history of previous configurations.
 Run an instance of the nginx container by creating a Deployment object:
 
 ```sh
-kubectl run nginx --image nginx
-```
-
-Do the same thing using a different syntax:
-
-```sh
 kubectl create deployment nginx --image nginx
 ```
 

--- a/content/en/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases.md
+++ b/content/en/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases.md
@@ -23,7 +23,7 @@ Modification not using HostAliases is not suggested because the file is managed 
 Start an Nginx Pod which is assigned a Pod IP:
 
 ```shell
-kubectl run nginx --image nginx --generator=run-pod/v1
+kubectl run nginx --image nginx
 ```
 
 ```
@@ -64,7 +64,7 @@ By default, the `hosts` file only includes IPv4 and IPv6 boilerplates like
 ## Adding additional entries with hostAliases
 
 In addition to the default boilerplate, you can add additional entries to the
-`hosts` file.  
+`hosts` file.
 For example: to resolve `foo.local`, `bar.local` to `127.0.0.1` and `foo.remote`,
 `bar.remote` to `10.1.2.3`, you can configure HostAliases for a Pod under
 `.spec.hostAliases`:

--- a/content/en/docs/contribute/style/style-guide.md
+++ b/content/en/docs/contribute/style/style-guide.md
@@ -121,7 +121,7 @@ document, use the backtick (`` ` ``).
 {{< table caption = "Do and Don't - Use code style for inline code and commands" >}}
 Do | Don't
 :--| :-----
-The `kubectl run`command creates a Deployment. | The "kubectl run" command creates a Deployment.
+The `kubectl run`command creates a Pod. | The "kubectl run" command creates a Pod.
 For declarative management, use `kubectl apply`. | For declarative management, use "kubectl apply".
 Enclose code samples with triple backticks. (\`\`\`)| Enclose code samples with any other syntax.
 Use single backticks to enclose inline code. For example, `var example = true`. | Use two asterisks (`**`) or an underscore (`_`) to enclose inline code. For example, **var example = true**.
@@ -496,7 +496,7 @@ Do | Don't
 :--| :-----
 You can explore the API using a browser. | The API can be explored using a browser.
 The YAML file specifies the replica count. | The replica count is specified in the YAML file.
-{{< /table >}}  
+{{< /table >}}
 
 
 Exception: Use passive voice if active voice leads to an awkward construction.
@@ -511,7 +511,7 @@ Do | Don't
 To create a ReplicaSet, ... | In order to create a ReplicaSet, ...
 See the configuration file. | Please see the configuration file.
 View the Pods. | With this next command, we'll view the Pods.
-{{< /table >}}  
+{{< /table >}}
 
 ### Address the reader as "you"
 
@@ -520,7 +520,7 @@ Do | Don't
 :--| :-----
 You can create a Deployment by ... | We'll create a Deployment by ...
 In the preceding output, you can see... | In the preceding output, we can see ...
-{{< /table >}}  
+{{< /table >}}
 
 
 ### Avoid Latin phrases
@@ -532,7 +532,7 @@ Do | Don't
 :--| :-----
 For example, ... | e.g., ...
 That is, ...| i.e., ...
-{{< /table >}}   
+{{< /table >}}
 
 
 Exception: Use "etc." for et cetera.
@@ -550,7 +550,7 @@ Do | Don't
 Version 1.4 includes ... | In version 1.4, we have added ...
 Kubernetes provides a new feature for ... | We provide a new feature ...
 This page teaches you how to use Pods. | In this page, we are going to learn about Pods.
-{{< /table >}}   
+{{< /table >}}
 
 
 ### Avoid jargon and idioms
@@ -562,7 +562,7 @@ Do | Don't
 :--| :-----
 Internally, ... | Under the hood, ...
 Create a new cluster. | Turn up a new cluster.
-{{< /table >}}   
+{{< /table >}}
 
 
 ### Avoid statements about the future
@@ -581,7 +581,7 @@ Do | Don't
 :--| :-----
 In version 1.4, ... | In the current version, ...
 The Federation feature provides ... | The new Federation feature provides ...
-{{< /table >}}  
+{{< /table >}}
 
 
 

--- a/content/en/docs/reference/kubectl/docker-cli-to-kubectl.md
+++ b/content/en/docs/reference/kubectl/docker-cli-to-kubectl.md
@@ -73,9 +73,6 @@ kubectl run [-i] [--tty] --attach <name> --image=<image>
 Unlike `docker run ...`, if you specify `--attach`, then you attach `stdin`, `stdout` and `stderr`. You cannot control which streams are attached (`docker -a ...`).
 To detach from the container, you can type the escape sequence Ctrl+P followed by Ctrl+Q.
 
-Because the kubectl run command starts a Deployment for the container, the Deployment restarts if you terminate the attached process by using Ctrl+C, unlike `docker run -it`.
-To destroy the Deployment and its pods you need to run `kubectl delete deployment <name>`.
-
 ## docker ps
 
 To list what is currently running, see [kubectl get](/docs/reference/generated/kubectl/kubectl-commands/#get).
@@ -188,7 +185,7 @@ docker exec -ti 55c103fa1296 /bin/sh
 kubectl:
 
 ```shell
-kubectl exec -ti nginx-app-5jyvm -- /bin/sh      
+kubectl exec -ti nginx-app-5jyvm -- /bin/sh
 # exit
 ```
 

--- a/content/en/docs/tutorials/kubernetes-basics/scale/scale-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/scale/scale-intro.html
@@ -40,7 +40,7 @@ weight: 10
                     </ul>
                 </div>
                 <div class="content__box content__box_fill">
-                    <p><i> You can create from the start a Deployment with multiple instances using the --replicas parameter for the kubectl run command </i></p>
+                    <p><i> You can create from the start a Deployment with multiple instances using the --replicas parameter for the kubectl create deployment command </i></p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
kubectl run starting from 1.18 is creating only Pods and there is no option to
create any other resource. Users should be using kubectl create
commands instead. This update the documentation in all those places
where kubectl create should be used instead or changes description to
reflect the situation.

