### PR TITLE
fix: fixed the sequence of steps to remove node

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
@@ -531,10 +531,9 @@ Talking to the control-plane node with the appropriate credentials, run:
 
 ```bash
 kubectl drain <node name> --delete-local-data --force --ignore-daemonsets
-kubectl delete node <node name>
 ```
 
-Then, on the node being removed, reset all `kubeadm` installed state:
+Before removing the node, reset the state installed by `kubeadm`:
 
 ```bash
 kubeadm reset
@@ -550,6 +549,11 @@ If you want to reset the IPVS tables, you must run the following command:
 
 ```bash
 ipvsadm -C
+```
+
+Now remove the node:
+```bash
+kubectl delete node <node name>
 ```
 
 If you wish to start over simply run `kubeadm init` or `kubeadm join` with the


### PR DESCRIPTION
**What this PR does:**
This PR address changes that fixes the order of steps in the process removing node. Node needs to be deleted after resetting kubeadm installed state.

This PR fixes kubernetes/kubeadm#2201