### PR TITLE
update storage-classes pv section link

### DIFF
--- a/content/id/docs/concepts/storage/storage-classes.md
+++ b/content/id/docs/concepts/storage/storage-classes.md
@@ -40,7 +40,7 @@ dan objek yang sudah dibuat tidak dapat diubah lagi definisinya.
 
 Administrator dapat memberikan spesifikasi StorageClass _default_ bagi
 PVC yang tidak membutuhkan kelas tertentu untuk dapat melakukan mekanisme _bind_:
-kamu dapat membaca [bagian `PersistentVolumeClaim`](/docs/concepts/storage/persistent-volumes/#class-1)
+kamu dapat membaca [bagian `PersistentVolumeClaim`](/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims)
 untuk penjelasan lebih lanjut.
 
 ```yaml


### PR DESCRIPTION
Hi,

Hope you're all well today.  A nice and quick contribution, an Indonesian equivalent for a recent PR that was recently closed, https://github.com/kubernetes/website/pull/22108

This relates to issue https://github.com/kubernetes/website/issues/22107

In the original issue and fix, there are two files affected.  In the IN docs, I only found one and have fixed in the same way.

For convenience, updated page - https://deploy-preview-22109--kubernetes-io-master-staging.netlify.app/id/docs/concepts/storage/storage-classes/

And the updated link  - https://deploy-preview-22109--kubernetes-io-master-staging.netlify.app/id/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
