### PR TITLE
fix zh translation error in webhook response example

### DIFF
--- a/content/zh/docs/reference/access-authn-authz/extensible-admission-controllers.md
+++ b/content/zh/docs/reference/access-authn-authz/extensible-admission-controllers.md
@@ -631,9 +631,9 @@ Example of a minimal response from a webhook to allow a request:
 * `allowed`，设置为 `true` 或 `false`
 
 <!--
-Example of a minimal response from a webhook to forbid a request:
+Example of a minimal response from a webhook to allow a request:
 -->
-Webhook 禁止请求的最简单响应示例：
+Webhook 允许请求的最简单响应示例：
 
 {{< tabs name="AdmissionReview_response_allow" >}}
 {{% tab name="admission.k8s.io/v1" %}}


### PR DESCRIPTION
fix zh translation error in webhook response example.

original English 
doc:  `Example of a minimal response from a webhook to allow a request:`  
location: response section in https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/  

error Chinese 
doc: `Webhook 禁止请求的最简单响应示例:`
location: response section in https://kubernetes.io/zh/docs/reference/access-authn-authz/extensible-admission-controllers/

fixed Chinese 
doc: `Webhook 允许请求的最简单响应示例:`