### PR TITLE
[zh] update content/zh/docs/concepts/overview/components.md

### DIFF
--- a/content/zh/docs/concepts/overview/components.md
+++ b/content/zh/docs/concepts/overview/components.md
@@ -21,7 +21,7 @@ card:
 
 <!--
 When you deploy Kubernetes, you get a cluster.
-{{< glossary_definition term_id="cluster" length="all" prepend="A Kubernetes cluster consists of">}}
+{< glossary_definition term_id="cluster" length="all" prepend="A Kubernetes cluster consists of">}}
 
 This document outlines the various components you need to have
 a complete and working Kubernetes cluster.


### PR DESCRIPTION
The web page https://kubernetes.io/zh/docs/concepts/overview/components/ have some mistakes on the top of the content. I found that Hugo shortcodes in the html-style comments (`<!-- {{< glossary_definition ... >}} -->`) caused the problem. 

I deleted a '{' to cancel Hugo shortcodes. It's not that elegant but works. 