### PR TITLE
Remove capture shortcodes & warn on future use.

### DIFF
--- a/content/en/docs/tasks/tls/manual-rotation-of-ca-certificates.md
+++ b/content/en/docs/tasks/tls/manual-rotation-of-ca-certificates.md
@@ -1,7 +1,7 @@
 ---
 title: Manual Rotation of CA Certificates
 min-kubernetes-server-version: v1.13
-content_template: templates/task
+content_type: task
 ---
 
 <!-- overview -->

--- a/content/es/docs/concepts/workloads/controllers/deployment.md
+++ b/content/es/docs/concepts/workloads/controllers/deployment.md
@@ -5,11 +5,11 @@ feature:
   description: >
     Kubernetes despliega los cambios a tu aplicación o su configuración de forma progresiva mientras monitoriza la salud de la aplicación para asegurarse que no elimina todas tus instancias al mismo tiempo. Si algo sale mal, Kubernetes revertirá el cambio por ti. Aprovéchate del creciente ecosistema de soluciones de despliegue.
 
-content_template: templates/concept
+content_type: concept
 weight: 30
 ---
 
-{{% capture overview %}}
+<!-- overview -->
 
 Un controlador de _Deployment_ proporciona actualizaciones declarativas para los [Pods](/docs/concepts/workloads/pods/pod/) y los
 [ReplicaSets](/docs/concepts/workloads/controllers/replicaset/).
@@ -23,10 +23,10 @@ Todos los casos de uso deberían cubrirse manipulando el objeto Deployment.
 Considera la posibilidad de abrir un incidente en el repositorio principal de Kubernetes si tu caso de uso no está soportado por el motivo que sea.
 {{< /note >}}
 
-{{% /capture %}}
 
 
-{{% capture body %}}
+
+<!-- body -->
 
 ## Casos de uso
 
@@ -1107,4 +1107,4 @@ no generará nuevos despliegues mientras esté pausado. Un Deployment se pausa d
 de forma similar. Pero se recomienda el uso de Deployments porque se declaran del lado del servidor, y proporcionan características adicionales
 como la posibilidad de retroceder a revisiones anteriores incluso después de haber terminado una actualización continua.
 
-{{% /capture %}}
+

--- a/content/es/docs/concepts/workloads/controllers/garbage-collection.md
+++ b/content/es/docs/concepts/workloads/controllers/garbage-collection.md
@@ -1,18 +1,15 @@
 ---
 title: Recolección de Basura
-content_template: templates/concept
+content_type: concept
 weight: 60
 ---
 
-{{% capture overview %}}
+<!-- overview -->
 
 El papel del recolector de basura de Kubernetes es el de eliminar determinados objetos
 que en algún momento tuvieron un propietario, pero que ahora ya no.
 
-{{% /capture %}}
-
-
-{{% capture body %}}referencias de propietario
+<!-- body -->
 
 ## Propietarios y subordinados
 
@@ -168,16 +165,12 @@ Ver [kubeadm/#149](https://github.com/kubernetes/kubeadm/issues/149#issuecomment
 
 Seguimiento en [#26120](https://github.com/kubernetes/kubernetes/issues/26120)
 
-{{% /capture %}}
 
 
-{{% capture whatsnext %}}
+## {{% heading "whatsnext" %}}
+
 
 [Documento de Diseño 1](https://git.k8s.io/community/contributors/design-proposals/api-machinery/garbage-collection.md)
 
 [Documento de Diseño 2](https://git.k8s.io/community/contributors/design-proposals/api-machinery/synchronous-garbage-collection.md)
-
-{{% /capture %}}
-
-
 

--- a/content/es/docs/concepts/workloads/controllers/jobs-run-to-completion.md
+++ b/content/es/docs/concepts/workloads/controllers/jobs-run-to-completion.md
@@ -1,6 +1,6 @@
 ---
 title: Jobs - Ejecución hasta el final
-content_template: templates/concept
+content_type: concept
 feature:
   title: Ejecución en lotes
   description: >
@@ -8,7 +8,7 @@ feature:
 weight: 70
 ---
 
-{{% capture overview %}}
+<!-- overview -->
 
 Un Job crea uno o más Pods y se asegura de que un número específico de ellos termina de forma satisfactoria.
 Conforme los pods terminan satisfactoriamente, el Job realiza el seguimiento de las ejecuciones satisfactorias.
@@ -21,10 +21,10 @@ como consecuencia de un fallo de hardware o un reinicio en un nodo).
 
 También se puede usar un Job para ejecutar múltiples Pods en paralelo.
 
-{{% /capture %}}
 
 
-{{% capture body %}}
+
+<!-- body -->
 
 ## Ejecutar un Job de ejemplo
 
@@ -454,4 +454,4 @@ además del control completo de los Pods que se crean y cómo se les asigna trab
 Puedes utilizar un [`CronJob`](/docs/concepts/workloads/controllers/cron-jobs/) para crear un Job que se ejecute en una hora/fecha determinadas, de forma similar
 a la herramienta `cron` de Unix.
 
-{{% /capture %}}
+

--- a/content/es/docs/concepts/workloads/controllers/replicaset.md
+++ b/content/es/docs/concepts/workloads/controllers/replicaset.md
@@ -1,19 +1,19 @@
 ---
 title: ReplicaSet
-content_template: templates/concept
+content_type: concept
 weight: 10
 ---
 
-{{% capture overview %}}
+<!-- overview -->
 
 El objeto de un ReplicaSet es el de mantener un conjunto estable de réplicas de Pods ejecutándose
 en todo momento. Así, se usa en numerosas ocasiones para garantizar la disponibilidad de un
 número específico de Pods idénticos.
 
 
-{{% /capture %}}
 
-{{% capture body %}}
+
+<!-- body -->
 
 ## Cómo funciona un ReplicaSet
 
@@ -367,4 +367,4 @@ Los dos sirven al mismo propósito, y se comportan de forma similar, excepto por
 no soporta los requisitos del selector basado en conjunto, como se describe en la [guía de usuario de etiquetas](/docs/concepts/overview/working-with-objects/labels/#label-selectors).
 Por ello, se prefiere los ReplicaSets a los ReplicationControllers.
 
-{{% /capture %}}
+

--- a/content/es/docs/concepts/workloads/pods/pod.md
+++ b/content/es/docs/concepts/workloads/pods/pod.md
@@ -1,18 +1,18 @@
 ---
 reviewers:
 title: Pods
-content_template: templates/concept
+content_type: concept
 weight: 20
 ---
 
-{{% capture overview %}}
+<!-- overview -->
 
 Los _Pods_ son las unidades de computación desplegables más pequeñas que se pueden crear y gestionar en Kubernetes.
 
-{{% /capture %}}
 
 
-{{% capture body %}}
+
+<!-- body -->
 
 ## ¿Qué és un Pod?
 
@@ -151,4 +151,4 @@ Pod es un recurso de nivel superior en la API REST de Kubernetes.
 La definición de [objeto de API Pod](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#pod-v1-core)
 describe el objeto en detalle.
 
-{{% /capture %}}
+

--- a/content/fr/docs/reference/kubectl/kubectl.md
+++ b/content/fr/docs/reference/kubectl/kubectl.md
@@ -1,6 +1,6 @@
 ---
 title: kubectl
-content_template: templates/tool-reference
+content_type: tool-reference
 description: Référence kubectl
 notitle: true
 ---

--- a/content/fr/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/fr/docs/tasks/configure-pod-container/configure-service-account.md
@@ -1,10 +1,10 @@
 ---
 title: Configurer les comptes de service pour les pods
-content_template: templates/task
+content_type: task
 weight: 90
 ---
 
-{{% capture overview %}}
+<!-- overview -->
 Un ServiceAccount (compte de service) fournit une identité pour les processus qui s'exécutent dans un Pod.
 
 *Ceci est une introduction aux comptes de service pour les utilisateurs. Voir aussi
@@ -18,16 +18,17 @@ Lorsque vous (un humain) accédez au cluster (par exemple, en utilisant `kubectl
 authentifié par l'apiserver en tant que compte d'utilisateur particulier (actuellement, il s'agit 
 généralement de l'utilisateur `admin`, à moins que votre administrateur de cluster n'ait personnalisé votre cluster). Les processus dans les conteneurs dans les Pods peuvent également contacter l'apiserver. Dans ce cas, ils sont authentifiés en tant que compte de service particulier (par exemple, `default`).
 
-{{% /capture %}}
 
 
-{{% capture prerequisites %}}
+
+## {{% heading "prerequisites" %}}
+
 
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
 
-{{% /capture %}}
 
-{{% capture steps %}}
+
+<!-- steps -->
 
 ## Utiliser le compte de service par défaut pour accéder au API server.
 
@@ -279,5 +280,3 @@ kubectl create -f https://k8s.io/examples/pods/pod-projected-svc-token.yaml
 Kubelet demandera et stockera le token a la place du Pod, rendra le token disponible pour le Pod à un chemin d'accès configurable, et rafraîchissez le token à l'approche de son expiration. Kubelet fait tourner le token de manière proactive s'il est plus vieux que 80% de son TTL total, ou si le token est plus vieux que 24 heures.
 
 L'application est responsable du rechargement du token lorsque celui ci est renouvelé. Un rechargement périodique (par ex. toutes les 5 minutes) est suffisant pour la plupart des cas d'utilisation.
-
-{{% /capture %}}

--- a/content/id/docs/concepts/policy/limit-range.md
+++ b/content/id/docs/concepts/policy/limit-range.md
@@ -1,6 +1,6 @@
 ---
 title: LimitRange
-content_template: templates/concept
+content_type: concept
 weight: 10
 ---
 

--- a/content/id/docs/concepts/workloads/pods/pod-topology-spread-constraints.md
+++ b/content/id/docs/concepts/workloads/pods/pod-topology-spread-constraints.md
@@ -1,10 +1,10 @@
 ---
 title: Batasan Persebaran Topologi Pod
-content_template: templates/concept
+content_type: concept
 weight: 50
 ---
 
-{{% capture overview %}}
+<!-- overview -->
 
 {{< feature-state for_k8s_version="v1.18" state="beta" >}}
 
@@ -14,9 +14,9 @@ pada klaster yang ditetapkan sebagai _failure-domains_, seperti wilayah, zona, N
 topologi yang ditentukan oleh pengguna. Ini akan membantu untuk mencapai ketersediaan yang tinggi
 dan juga penggunaan sumber daya yang efisien.
 
-{{% /capture %}}
 
-{{% capture body %}}
+
+<!-- body -->
 
 ## Persyaratan
 
@@ -287,4 +287,4 @@ Pada versi 1.18, dimana fitur ini masih Beta, beberapa limitasi yang sudah diket
 - Pengurangan jumlah Deployment akan membuat ketidakseimbangan pada persebaran Pod.
 - Pod yang cocok pada _tainted_ Node akan dihargai. Lihat [Issue 80921](https://github.com/kubernetes/kubernetes/issues/80921)
 
-{{% /capture %}}
+

--- a/content/id/docs/reference/access-authn-authz/rbac.md
+++ b/content/id/docs/reference/access-authn-authz/rbac.md
@@ -1,16 +1,16 @@
 ---
 title: Menggunakan Otorisasi RBAC
-content_template: templates/concept
+content_type: concept
 aliases: [../../../rbac/]
 weight: 70
 ---
 
-{{% capture overview %}}
+<!-- overview -->
 Kontrol akses berbasis peran (RBAC) adalah metode pengaturan akses ke sumber daya komputer 
 atau jaringan berdasarkan peran pengguna individu dalam organisasi kamu.
-{{% /capture %}}
 
-{{% capture body %}}
+
+<!-- body -->
 Otorisasi RBAC menggunakan `rbac.authorization.k8s.io` kelompok API untuk mengendalikan keputusan
 otorisasi, memungkinkan kamu untuk mengkonfigurasi kebijakan secara dinamis melalui API Kubernetes.
 
@@ -1192,4 +1192,4 @@ kubectl create clusterrolebinding permissive-binding \
 After you have transitioned to use RBAC, you should adjust the access controls
 for your cluster to ensure that these meet your information security needs.
 
-{{% /capture %}}
+

--- a/content/id/docs/setup/best-practices/multiple-zones.md
+++ b/content/id/docs/setup/best-practices/multiple-zones.md
@@ -1,16 +1,16 @@
 ---
 title: Menjalankan klaster dalam beberapa zona
 weight: 10
-content_template: templates/concept
+content_type: concept
 ---
 
-{{% capture overview %}}
+<!-- overview -->
 
 Laman ini menjelaskan tentang bagaimana menjalankan sebuah klaster dalam beberapa zona.
 
-{{% /capture %}}
 
-{{% capture body %}}
+
+<!-- body -->
 
 ## Pendahuluan
 
@@ -398,4 +398,4 @@ KUBERNETES_PROVIDER=aws KUBE_USE_EXISTING_MASTER=true KUBE_AWS_ZONE=us-west-2b k
 KUBERNETES_PROVIDER=aws KUBE_AWS_ZONE=us-west-2a kubernetes/cluster/kube-down.sh
 ```
 
-{{% /capture %}}
+

--- a/content/id/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
+++ b/content/id/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
@@ -1,10 +1,10 @@
 ---
 title: Membuat sebuah klaster dengan control-plane tunggal menggunakan kubeadm
-content_template: templates/task
+content_type: task
 weight: 30
 ---
 
-{{% capture overview %}}
+<!-- overview -->
 
 Perkakas <img src="https://raw.githubusercontent.com/kubernetes/kubeadm/master/logos/stacked/color/kubeadm-stacked-color.png" align="right" width="150px">`kubeadm` membantu kamu membuat sebuah klaster Kubernetes minimum yang layak dan sesuai dengan _best practice_. Bahkan, kamu dapat menggunakan `kubeadm` untuk membuat sebuah klaster yang lolos [uji Kubernetes Conformance](https://kubernetes.io/blog/2017/10/software-conformance-certification).  
 `kubeadm` juga mendukung fungsi siklus hidup (_lifecycle_)
@@ -22,9 +22,10 @@ server di _cloud_, sebuah Raspberry Pi, dan lain-lain. Baik itu men-_deploy_ pad
 _cloud_ ataupun _on-premise_, kamu dapat mengintegrasikan `kubeadm` pada sistem _provisioning_ seperti
 Ansible atau Terraform.
 
-{{% /capture %}}
 
-{{% capture prerequisites %}}
+
+## {{% heading "prerequisites" %}}
+
 
 Untuk mengikuti panduan ini, kamu membutuhkan:
 
@@ -51,9 +52,9 @@ sedikit seiring dengan berevolusinya kubeadm, namun secara umum implementasinya 
 Semua perintah di dalam `kubeadm alpha`, sesuai definisi, didukung pada level _alpha_.
 {{< /note >}}
 
-{{% /capture %}}
 
-{{% capture steps %}}
+
+<!-- steps -->
 
 ## Tujuan
 
@@ -559,9 +560,9 @@ Lihat dokumentasi referensi [`kubeadm reset`](/docs/reference/setup-tools/kubead
 untuk informasi lebih lanjut mengenai sub-perintah ini dan
 opsinya.
 
-{{% /capture %}}
 
-{{% capture discussion %}}
+
+<!-- discussion -->
 
 ## Selanjutnya
 
@@ -635,4 +636,4 @@ mendukung platform pilihanmu.
 
 Jika kamu menemui kesulitan dengan kubeadm, silakan merujuk pada [dokumen penyelesaian masalah](/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm/).
 
-{{% /capture %}}
+

--- a/content/id/docs/tasks/access-application-cluster/create-external-load-balancer.md
+++ b/content/id/docs/tasks/access-application-cluster/create-external-load-balancer.md
@@ -1,11 +1,11 @@
 ---
 title: Membuat Load Balancer Eksternal
-content_template: templates/task
+content_type: task
 weight: 80
 ---
 
 
-{{% capture overview %}}
+<!-- overview -->
 
 Laman ini menjelaskan bagaimana membuat _Load Balancer_ Eksternal.
 
@@ -21,15 +21,16 @@ Untuk informasi mengenai penyediaan dan penggunaan sumber daya Ingress yang dapa
 servis URL yang dapat dijangkau secara eksternal, penyeimbang beban lalu lintas, terminasi SSL, dll.,
 silahkan cek dokumentasi [Ingress](/docs/concepts/services-networking/ingress/)
 
-{{% /capture %}}
 
-{{% capture prerequisites %}}
+
+## {{% heading "prerequisites" %}}
+
 
 * {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
 
-{{% /capture %}}
 
-{{% capture steps %}}
+
+<!-- steps -->
 
 ## Berkas konfigurasi
 
@@ -193,4 +194,4 @@ Sekali _load balancer_ eksternal menyediakan bobot, fungsionalitas ini dapat dit
 
 Pod internal ke lalu lintas Pod harus berperilaku sama seperti Service ClusterIP, dengan probabilitas yang sama pada seluruh Pod. 
 
-{{% /capture %}}
+

--- a/content/id/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/id/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -1,10 +1,10 @@
 ---
 title: Mengatur Probe Liveness, Readiness dan Startup
-content_template: templates/task
+content_type: task
 weight: 110
 ---
 
-{{% capture overview %}}
+<!-- overview -->
 
 Laman ini memperlihatkan bagaimana cara untuk mengatur _probe liveness_, _readiness_, dan
 _startup_ untuk Container.
@@ -26,15 +26,16 @@ berhasil, kamu harus memastikan _probe_ tersebut tidak mengganggu _startup_ dari
 Mekanisme ini dapat digunakan untuk mengadopsi pemeriksaan _liveness_ pada saat memulai Container yang lambat,
 untuk menghindari Container dimatikan oleh kubelet sebelum Container mulai dan berjalan.
 
-{{% /capture %}}
 
-{{% capture prerequisites %}}
+
+## {{% heading "prerequisites" %}}
+
 
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
 
-{{% /capture %}}
 
-{{% capture steps %}}
+
+<!-- steps -->
 
 ## Mendefinisikan perintah liveness
 
@@ -358,9 +359,10 @@ Untuk _probe_ TCP, kubelet membuat koneksi _probe_ pada Node, tidak pada Pod, ya
 kamu tidak menggunakan nama Service di dalam parameter `host` karena kubelet tidak bisa
 me-_resolve_-nya.
 
-{{% /capture %}}
 
-{{% capture whatsnext %}}
+
+## {{% heading "whatsnext" %}}
+
 
 * Pelajari lebih lanjut tentang
 [Probe Container](/id/docs/concepts/workloads/pods/pod-lifecycle/#container-probes).
@@ -371,4 +373,4 @@ Kamu juga dapat membaca rujukan API untuk:
 * [Container](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#container-v1-core)
 * [Probe](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#probe-v1-core)
 
-{{% /capture %}}
+

--- a/content/id/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
+++ b/content/id/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
@@ -1,10 +1,10 @@
 ---
 title: Mengatur Pod untuk Penyimpanan dengan PersistentVolume
-content_template: templates/task
+content_type: task
 weight: 60
 ---
 
-{{% capture overview %}}
+<!-- overview -->
 
 Laman ini akan menjelaskan bagaimana kamu dapat mengatur sebuah Pod dengan menggunakan
 {{< glossary_tooltip text="PersistentVolumeClaim" term_id="persistent-volume-claim" >}}
@@ -19,9 +19,10 @@ PersistentVolumeClaim yang secara otomatis terikat dengan PersistentVolume yang 
 
 3. Kamu membuat sebuah Pod yang menggunakan PersistentVolumeClaim di atas untuk penyimpanan.
 
-{{% /capture %}}
 
-{{% capture prerequisites %}}
+
+## {{% heading "prerequisites" %}}
+
 
 * Kamu membutuhkan sebuah klaster Kubernetes yang hanya memiliki satu Node, dan 
 {{< glossary_tooltip text="kubectl" term_id="kubectl" >}}
@@ -32,9 +33,9 @@ tidak memiliki sebuah klaster dengan Node tunggal, kamu dapat membuatnya dengan
 * Familiar dengan materi di
 [Persistent Volumes](/id/docs/concepts/storage/persistent-volumes/).
 
-{{% /capture %}}
 
-{{% capture steps %}}
+
+<!-- steps -->
 
 ## Membuat sebuah berkas index.html di dalam Node kamu
 
@@ -235,10 +236,10 @@ sudo rmdir /mnt/data
 
 Sekarang kamu dapat menutup _shell_ Node kamu.
 
-{{% /capture %}}
 
 
-{{% capture discussion %}}
+
+<!-- discussion -->
 
 ## Kontrol akses
 
@@ -266,10 +267,11 @@ Ketika sebuah Pod mengkonsumsi PersistentVolume, GID yang terkait dengan Persist
 tidak ada di dalam sumberdaya Pod itu sendiri.
 {{< /note >}}
 
-{{% /capture %}}
 
 
-{{% capture whatsnext %}}
+
+## {{% heading "whatsnext" %}}
+
 
 * Belajar lebih lanjut tentang [PersistentVolume](/id/docs/concepts/storage/persistent-volumes/).
 * Baca [dokumen perancangan Penyimpanan _Persistent_](https://git.k8s.io/community/contributors/design-proposals/storage/persistent-storage.md).
@@ -281,4 +283,4 @@ tidak ada di dalam sumberdaya Pod itu sendiri.
 * [PersistentVolumeClaim](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#persistentvolumeclaim-v1-core)
 * [PersistentVolumeClaimSpec](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#persistentvolumeclaimspec-v1-core)
 
-{{% /capture %}}
+

--- a/content/id/docs/tasks/configure-pod-container/security-context.md
+++ b/content/id/docs/tasks/configure-pod-container/security-context.md
@@ -1,10 +1,10 @@
 ---
 title: Mengonfigurasi Konteks Keamanan untuk Pod atau Container
-content_template: templates/task
+content_type: task
 weight: 80
 ---
 
-{{% capture overview %}}
+<!-- overview -->
 
 Konteks keamanan (_security context_) menentukan wewenang (_privilege_) dan aturan kontrol akses untuk sebuah Pod 
 atau Container. Aturan konteks keamanan meliputi hal-hal berikut ini namun tidak terbatas pada hal-hal tersebut:
@@ -31,15 +31,16 @@ Poin-poin di atas bukanlah sekumpulan lengkap dari aturan konteks keamanan - sil
 Untuk informasi lebih lanjut tentang mekanisme keamanan pada Linux, silahkan lihat
 [ikhtisar fitur keamanan pada Kernel Linux](https://www.linux.com/learn/overview-linux-kernel-security-features)
 
-{{% /capture %}}
 
-{{% capture prerequisites %}}
+
+## {{% heading "prerequisites" %}}
+
 
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
 
-{{% /capture %}}
 
-{{% capture steps %}}
+
+<!-- steps -->
 
 ## Mengatur konteks keamanan untuk Pod
 
@@ -401,9 +402,10 @@ kubectl delete pod security-context-demo-3
 kubectl delete pod security-context-demo-4
 ```
 
-{{% /capture %}}
 
-{{% capture whatsnext %}}
+
+## {{% heading "whatsnext" %}}
+
 
 * [PodSecurityContext](/docs/reference/generated/kubernetes-api/{{<param"version">}}/#podsecuritycontext-v1-core)
 * [SecurityContext](/docs/reference/generated/kubernetes-api/{{<param"version">}}/#securitycontext-v1-core)
@@ -413,4 +415,4 @@ kubectl delete pod security-context-demo-4
 * [Kebijakan keamanan Pod](/docs/concepts/policy/pod-security-policy/)
 * [Dokumen desain AllowPrivilegeEscalation](https://git.k8s.io/community/contributors/design-proposals/auth/no-new-privs.md)
 
-{{% /capture %}}
+

--- a/content/id/docs/tasks/debug-application-cluster/get-shell-running-container.md
+++ b/content/id/docs/tasks/debug-application-cluster/get-shell-running-container.md
@@ -1,24 +1,25 @@
 ---
 title: Mendapatkan Shell Untuk Masuk ke Container yang Sedang Berjalan
-content_template: templates/task
+content_type: task
 ---
 
-{{% capture overview %}}
+<!-- overview -->
 
 Laman ini menunjukkan bagaimana cara menggunakan `kubectl exec` untuk 
 mendapatkan _shell_ untuk masuk ke dalam Container yang sedang berjalan.
 
-{{% /capture %}}
 
 
-{{% capture prerequisites %}}
+
+## {{% heading "prerequisites" %}}
+
 
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
 
-{{% /capture %}}
 
 
-{{% capture steps %}}
+
+<!-- steps -->
 
 ## Mendapatkan sebuah _shell_ untuk masuk ke sebuah Container
 
@@ -118,9 +119,9 @@ kubectl exec shell-demo ls /
 kubectl exec shell-demo cat /proc/1/mounts
 ```
 
-{{% /capture %}}
 
-{{% capture discussion %}}
+
+<!-- discussion -->
 
 ## Membuka sebuah _shell_ ketika sebuah Pod memiliki lebih dari satu Container
 
@@ -134,14 +135,15 @@ _shell_ ke Container dengan nama main-app.
 kubectl exec -it my-pod --container main-app -- /bin/bash
 ```
 
-{{% /capture %}}
 
 
-{{% capture whatsnext %}}
+
+## {{% heading "whatsnext" %}}
+
 
 * [kubectl exec](/docs/reference/generated/kubectl/kubectl-commands/#exec)
 
-{{% /capture %}}
+
 
 
 

--- a/content/id/docs/tasks/inject-data-application/define-command-argument-container.md
+++ b/content/id/docs/tasks/inject-data-application/define-command-argument-container.md
@@ -1,26 +1,27 @@
 ---
 title: Mendefinisikan Perintah dan Argumen untuk sebuah Kontainer
-content_template: templates/task
+content_type: task
 weight: 10
 ---
 
-{{% capture overview %}}
+<!-- overview -->
 
 Laman ini menunjukkan bagaimana cara mendefinisikan perintah-perintah
 dan argumen-argumen saat kamu menjalankan Container
 dalam sebuah {{< glossary_tooltip term_id="Pod" >}}.
 
-{{% /capture %}}
 
 
-{{% capture prerequisites %}}
+
+## {{% heading "prerequisites" %}}
+
 
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
 
-{{% /capture %}}
 
 
-{{% capture steps %}}
+
+<!-- steps -->
 
 ## Mendefinisikan sebuah perintah dan argumen-argumen saat kamu membuat sebuah Pod
 
@@ -145,12 +146,13 @@ Berikut ini beberapa contoh:
 |     `[/ep-1]`      |   `[foo bar]`    |   `[/ep-2]`         |     `[zoo boo]`    | `[ep-2 zoo boo]` |
 
 
-{{% /capture %}}
 
-{{% capture whatsnext %}}
+
+## {{% heading "whatsnext" %}}
+
 
 * Pelajari lebih lanjut tentang [mengatur Pod and Container](/id/docs/tasks/).
 * Pelajari lebih lanjut tentang [menjalankan perintah di dalam sebuah Container](/id/docs/tasks/debug-application-cluster/get-shell-running-container/).
 * Lihat [Container](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#container-v1-core).
 
-{{% /capture %}}
+

--- a/content/id/docs/tasks/run-application/horizontal-pod-autoscaler.md
+++ b/content/id/docs/tasks/run-application/horizontal-pod-autoscaler.md
@@ -4,11 +4,11 @@ feature:
   title: Horizontal scaling
   description: >
     Scale up dan scale down aplikasimu dengan sebuah perintah yang serderhana, dengan UI, atau otomatis bersadarkan penggunaan CPU.
-content_template: templates/concept
+content_type: concept
 weight: 90
 ---
 
-{{% capture overview %}}
+<!-- overview -->
 
 HorizontalPodAutoscaler secara otomatis akan memperbanyak jumlah Pod di dalam ReplicationController, Deployment, 
 ReplicaSet ataupun StatefulSet berdasarkan hasil observasi penggunaan CPU(atau, dengan 
@@ -20,10 +20,10 @@ HorizontalPodAutoscaler diimplementasikan sebagai Kubernetes API *resource* dan 
 Kontroler akan mengubah jumlah replika pada ReplicationController atau pada Deployment untuk menyesuaikan dengan hasil observasi rata-rata
 penggunaan CPU sesuai dengan yang ditentukan oleh pengguna.
 
-{{% /capture %}}
 
 
-{{% capture body %}}
+
+<!-- body -->
 
 ## Bagaimana cara kerja HorizontalPodAutoscaler?
 
@@ -441,12 +441,13 @@ behavior:
     selectPolicy: Disabled
 ```
 
-{{% /capture %}}
 
-{{% capture whatsnext %}}
+
+## {{% heading "whatsnext" %}}
+
 
 * Dokumentasi desain [Horizontal Pod Autoscaling](https://git.k8s.io/community/contributors/design-proposals/autoscaling/horizontal-pod-autoscaler.md).
 * Perintah kubectl autoscale [kubectl autoscale](/docs/reference/generated/kubectl/kubectl-commands/#autoscale).
 * Contoh penggunaan [HorizontalPodAutoscaler](/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/).
 
-{{% /capture %}}
+

--- a/content/ko/docs/reference/kubectl/overview.md
+++ b/content/ko/docs/reference/kubectl/overview.md
@@ -1,6 +1,6 @@
 ---
 title: kubectl 개요
-content_template: templates/concept
+content_type: concept
 weight: 20
 card:
   name: reference

--- a/content/ko/docs/tasks/debug-application-cluster/determine-reason-pod-failure.md
+++ b/content/ko/docs/tasks/debug-application-cluster/determine-reason-pod-failure.md
@@ -1,6 +1,6 @@
 ---
 title: 파드 실패의 원인 검증하기
-content_template: templates/task
+content_type: task
 ---
 
 <!-- overview -->

--- a/content/ru/docs/reference/kubectl/kubectl.md
+++ b/content/ru/docs/reference/kubectl/kubectl.md
@@ -1,6 +1,6 @@
 ---
 title: kubectl
-content_template: templates/tool-reference
+content_type: tool-reference
 weight: 28
 ---
 

--- a/content/zh/docs/reference/command-line-tools-reference/kube-proxy.md
+++ b/content/zh/docs/reference/command-line-tools-reference/kube-proxy.md
@@ -1,12 +1,12 @@
 ---
 title: kube-proxy
-content_template: templates/tool-reference
+content_type: tool-reference
 weight: 30
 ---
 <!-- 
 ---
 title: kube-proxy
-content_template: templates/tool-reference
+content_type: tool-reference
 weight: 28
 --- 
 -->

--- a/content/zh/docs/reference/command-line-tools-reference/kube-scheduler.md
+++ b/content/zh/docs/reference/command-line-tools-reference/kube-scheduler.md
@@ -1,12 +1,12 @@
 ---
 title: kube-scheduler
-content_template: templates/tool-reference
+content_type: tool-reference
 weight: 28
 ---
 <!-- 
 ---
 title: kube-scheduler
-content_template: templates/tool-reference
+content_type: tool-reference
 weight: 28
 --- 
 -->

--- a/content/zh/docs/reference/command-line-tools-reference/kubelet.md
+++ b/content/zh/docs/reference/command-line-tools-reference/kubelet.md
@@ -1,6 +1,6 @@
 ---
 title: kubelet
-content_template: templates/tool-reference
+content_type: tool-reference
 weight: 28
 ---
 

--- a/content/zh/docs/reference/kubectl/kubectl.md
+++ b/content/zh/docs/reference/kubectl/kubectl.md
@@ -1,12 +1,12 @@
 ---
 title: kubectl
-content_template: templates/tool-reference
+content_type: tool-reference
 weight: 28
 ---
 <!--
 ---
 title: kubectl
-content_template: templates/tool-reference
+content_type: tool-reference
 weight: 28
 ---
 -->

--- a/layouts/shortcodes/capture.html
+++ b/layouts/shortcodes/capture.html
@@ -3,5 +3,6 @@
 {{- if not $id -}}
 {{- errorf "missing id in capture" -}}
 {{- end -}}
-{{- $capture_id := printf "__cid_%s" $id -}}
+{{- $capture_id := printf "capture %s" $id -}}
 {{- .Page.Scratch.Set $capture_id .Inner -}}
+{{ warnf "Invalid shortcode: %s, in %q" $capture_id (relLangURL .Page.Path) }}


### PR DESCRIPTION
After PR #21359 merged, some more capture shortcodes have crept in.

This PR
- removes the extra capture shortcodes
- emits a warning if someone uses a capture shortcode

I chose a warning rather than error to reduce the risk of a misguided merge breaking the site. There's no lint about broken shortcodes, and the CI tests the code from the fork, rather than testing the result of a simulated merge into _master_.