### PR TITLE
Revise blog submission guidelines as per the blog subproject

### DIFF
--- a/content/en/docs/contribute/new-content/blogs-case-studies.md
+++ b/content/en/docs/contribute/new-content/blogs-case-studies.md
@@ -12,35 +12,73 @@ weight: 30
 Anyone can write a blog post and submit it for review.
 Case studies require extensive review before they're approved.
 
-
-
 <!-- body -->
 
-## Write a blog post
+## The Kubernetes Blog
 
-Blog posts should not be
-vendor pitches. They must contain content that applies broadly to
-the Kubernetes community. The SIG Docs [blog subproject](https://github.com/kubernetes/community/tree/master/sig-docs/blog-subproject) manages the review process for blog posts. For more information, see [Submit a post](https://github.com/kubernetes/community/tree/master/sig-docs/blog-subproject#submit-a-post).
+The Kubernetes blog is used by the project to communicate new features, community reports, and any news that might be relevant to the Kubernetes community. 
+This includes end users AND developers. 
+Generally speaking the blog tends to skew towards things that happen in the core project, however the community is always interested in things that are happening in the Kubernetes ecosystem, so we encourage you to consider submitting content to the blog. 
 
-To submit a blog post, you can either:
+Anyone can write a blog post and submit it for review.
 
-- Use the
-[Kubernetes blog submission form](https://docs.google.com/forms/d/e/1FAIpQLSdMpMoSIrhte5omZbTE7nB84qcGBy8XnnXhDFoW0h7p2zwXrw/viewform)
-- [Open a pull request](/docs/contribute/new-content/new-content/#fork-the-repo) with a new blog post. Create new blog posts in the [`content/en/blog/_posts`](https://github.com/kubernetes/website/tree/master/content/en/blog/_posts) directory.
+### Guidelines and expectations
 
-If you open a pull request, ensure that your blog post follows the correct naming conventions and frontmatter information:
+- Blog posts should not be vendor pitches. 
+  - Articles must contain content that applies broadly to the Kubernetes community - For example, a submission should focus on upstream Kubernetes as opposed to vendor-specific configurations.
+  - Links should primarily be to the official Kubernetes documentation. When using external references, links should be diverse - For example a submission shouldn't contain only links back to a single company's blog.
+  - This can sometime be a delicate balance. The [blog team](https://kubernetes.slack.com/messages/sig-docs-blog/) is there to give guidance on whether a post is appropriate for the Kubernetes blog, so don't hesistate to reach out. 
+- Blog posts do not offer deadlines.
+    - Articles are reviewed by community volunteers and _cannot guarantee_ any time-based deadlines, though we will try our best to accomodate you.
+  - Many core parts of the project are submitting posts during release windows and publication time will be delayed. Consider submitting during a quieter period of the release cycle.
+  - If you are looking for greater coordination on post release dates, coordinating with [CNCF marketing] is a more appropriate choice than submitting a blog post.
+  - Sometimes reviews can get backed up. If you feel your review isn't getting the attention it needs, you can reach out to the blog team via [this slack channel](https://kubernetes.slack.com/messages/sig-docs-blog/) to ask in real time. 
+- Blog posts should be relevant to Kubernetes users.
+  - Topics related to participation in or results of Kubernetes SIGs activities are always on topic (see the work in the [Upstream Marketing Team](https://github.com/kubernetes/community/blob/master/communication/marketing-team/blog-guidelines.md#upstream-marketing-blog-guidelines) for support on these posts). 
+  - The components of Kubernetes are purposely modular, so tools that use existing integration points like CNI and CSI are on topic. 
+  - Posts about other CNCF projects may or may not be on topic. We recommend asking the blog team before submitting a draft.
+    - Many CNCF projects have their own blog. These are often a better choice for posts. There are times of major feature or milestone for a CNCF project that users would be interested in reading on the Kubernetes blog.
+- Blog posts should aim to be future proof
+  - Given the development velocity of the project, we want evergreen content, that won't require updates to stay accurate to the reader. 
+  - It can be a better choice to add a tutorial or update official documentation, then write a higher level overview as a blog post.
+    - Consider concentrating the long technical content as a call to action of the blog post, and focus on the problem space or why readers should care.
 
-- The markdown file name must follow the format `YYY-MM-DD-Your-Title-Here.md`. For example, `2020-02-07-Deploying-External-OpenStack-Cloud-Provider-With-Kubeadm.md`.
-- The front matter must include the following:
+### Technical Considerations for submitting a blog post
 
-```yaml
----
-layout: blog
-title: "Your Title Here"
-date: YYYY-MM-DD
-slug: text-for-URL-link-here-no-spaces
----
-```
+Submissions need to be in Markdown format to be used by the [Hugo](https://gohugo.io/) generator for the blog. There are [many resources available] on how to use this technology stack.
+
+We recognize that this requirement makes the process more difficult for less-familiar folks to submit, and we're constantly looking at solutions to lower this bar. If you have ideas on how to lower the barrier, please volunteers to help out. 
+
+The SIG Docs [blog subproject](https://github.com/kubernetes/community/tree/master/sig-docs/blog-subproject) manages the review process for blog posts. For more information, see [Submit a post](https://github.com/kubernetes/community/tree/master/sig-docs/blog-subproject#submit-a-post).
+
+To submit a blog post follow these directions:
+
+- [Open a pull request](/docs/contribute/new-content/new-content/#fork-the-repo) with a new blog post. New blog posts go under the [`content/en/blog/_posts`](https://github.com/kubernetes/website/tree/master/content/en/blog/_posts) directory.
+
+- Ensure that your blog post follows the correct naming conventions and the following frontmatter (metadata) information:
+
+  - The Markdown file name must follow the format `YYYY-MM-DD-Your-Title-Here.md`. For example, `2020-02-07-Deploying-External-OpenStack-Cloud-Provider-With-Kubeadm.md`.
+  - The front matter must include the following:
+
+  ```yaml
+  ---
+  layout: blog
+  title: "Your Title Here"
+  date: YYYY-MM-DD
+  slug: text-for-URL-link-here-no-spaces
+  ---
+  ```
+  - The first or initial commit message should be a short summary of the work being done and should stand alone as a description of the blog post. Please note that subsequent edits to your blog will be squashed into this main commit, so it should be as useful as possible. 
+    - Examples of a good commit message:
+      -  _Add blog post on the foo kubernetes feature_
+      -  _blog: foobar announcement_
+    - Examples of bad commit message:
+      - _Add blog post_
+      - _._
+      - _initial commit_
+      - _draft post_
+  - The blog team will then review your PR and give you comments on things you might need to fix. After that the bot will merge your PR and your blog post will be published. 
+
 
 ## Submit a case study
 
@@ -55,6 +93,3 @@ Refer to the [case study guidelines](https://github.com/cncf/foundation/blob/mas
 
 
 ## {{% heading "whatsnext" %}}
-
-
-

--- a/content/en/docs/contribute/new-content/blogs-case-studies.md
+++ b/content/en/docs/contribute/new-content/blogs-case-studies.md
@@ -29,7 +29,7 @@ Anyone can write a blog post and submit it for review.
   - Links should primarily be to the official Kubernetes documentation. When using external references, links should be diverse - For example a submission shouldn't contain only links back to a single company's blog.
   - This can sometime be a delicate balance. The [blog team](https://kubernetes.slack.com/messages/sig-docs-blog/) is there to give guidance on whether a post is appropriate for the Kubernetes blog, so don't hesistate to reach out. 
 - Blog posts do not offer deadlines.
-    - Articles are reviewed by community volunteers and _cannot guarantee_ any time-based deadlines, though we will try our best to accomodate you.
+    - Articles are reviewed by community volunteers and **can not guarantee** any time-based deadlines, though we will try our best to accomodate you.
   - Many core parts of the project are submitting posts during release windows and publication time will be delayed. Consider submitting during a quieter period of the release cycle.
   - If you are looking for greater coordination on post release dates, coordinating with [CNCF marketing] is a more appropriate choice than submitting a blog post.
   - Sometimes reviews can get backed up. If you feel your review isn't getting the attention it needs, you can reach out to the blog team via [this slack channel](https://kubernetes.slack.com/messages/sig-docs-blog/) to ask in real time. 

--- a/content/en/docs/contribute/new-content/blogs-case-studies.md
+++ b/content/en/docs/contribute/new-content/blogs-case-studies.md
@@ -30,7 +30,7 @@ Anyone can write a blog post and submit it for review.
   - Sometimes this is a delicate balance. The [blog team](https://kubernetes.slack.com/messages/sig-docs-blog/) is there to give guidance on whether a post is appropriate for the Kubernetes blog, so don't hesitate to reach out. 
 - Blog posts are not published on specific dates.
     - Articles are reviewed by community volunteers. We'll try our best to accommodate specific timing, but we make no guarantees.
-  - Many core parts of the project are submitting posts during release windows and publication time will be delayed. Consider submitting during a quieter period of the release cycle.
+  - Many core parts of the Kubernetes projects submit blog posts during release windows, delaying publication times. Consider submitting during a quieter period of the release cycle.
   - If you are looking for greater coordination on post release dates, coordinating with [CNCF marketing](https://www.cncf.io/about/contact/) is a more appropriate choice than submitting a blog post.
   - Sometimes reviews can get backed up. If you feel your review isn't getting the attention it needs, you can reach out to the blog team via [this slack channel](https://kubernetes.slack.com/messages/sig-docs-blog/) to ask in real time. 
 - Blog posts should be relevant to Kubernetes users.

--- a/content/en/docs/contribute/new-content/blogs-case-studies.md
+++ b/content/en/docs/contribute/new-content/blogs-case-studies.md
@@ -29,7 +29,7 @@ Anyone can write a blog post and submit it for review.
   - Links should primarily be to the official Kubernetes documentation. When using external references, links should be diverse - For example a submission shouldn't contain only links back to a single company's blog.
   - This can sometime be a delicate balance. The [blog team](https://kubernetes.slack.com/messages/sig-docs-blog/) is there to give guidance on whether a post is appropriate for the Kubernetes blog, so don't hesistate to reach out. 
 - Blog posts are not published on specific dates.
-    - Articles are reviewed by community volunteers and **can not guarantee** any time-based deadlines, though we will try our best to accomodate you.
+    - Articles are reviewed by community volunteers. We'll try our best to accommodate specific timing, but we make no guarantees.
   - Many core parts of the project are submitting posts during release windows and publication time will be delayed. Consider submitting during a quieter period of the release cycle.
   - If you are looking for greater coordination on post release dates, coordinating with [CNCF marketing](https://www.cncf.io/about/contact/) is a more appropriate choice than submitting a blog post.
   - Sometimes reviews can get backed up. If you feel your review isn't getting the attention it needs, you can reach out to the blog team via [this slack channel](https://kubernetes.slack.com/messages/sig-docs-blog/) to ask in real time. 

--- a/content/en/docs/contribute/new-content/blogs-case-studies.md
+++ b/content/en/docs/contribute/new-content/blogs-case-studies.md
@@ -43,7 +43,7 @@ Anyone can write a blog post and submit it for review.
     - The [license](https://github.com/kubernetes/website/blob/master/LICENSE) for the blog does allow commercial use of the content for commercial purposes, just not the other way around. 
 - Blog posts should aim to be future proof
   - Given the development velocity of the project, we want evergreen content that won't require updates to stay accurate for the reader. 
-  - It can be a better choice to add a tutorial or update official documentation, then write a higher level overview as a blog post.
+  - It can be a better choice to add a tutorial or update official documentation than to write a high level overview as a blog post.
     - Consider concentrating the long technical content as a call to action of the blog post, and focus on the problem space or why readers should care.
 
 ### Technical Considerations for submitting a blog post

--- a/content/en/docs/contribute/new-content/blogs-case-studies.md
+++ b/content/en/docs/contribute/new-content/blogs-case-studies.md
@@ -61,6 +61,7 @@ To submit a blog post follow these directions:
 - Ensure that your blog post follows the correct naming conventions and the following frontmatter (metadata) information:
 
   - The Markdown file name must follow the format `YYYY-MM-DD-Your-Title-Here.md`. For example, `2020-02-07-Deploying-External-OpenStack-Cloud-Provider-With-Kubeadm.md`.
+  - Do **not** include dots in the filename. A name like `2020-01-01-whats-new-in-1.19.md` will causes failures during a build.
   - Do NOT include dots in the filename, this will break the renderer. Pay close attention when dealing with versions in your filename and slug, for example `1.15-is-great.md` will break, `1-15-is-great.md` is correct.
   - The front matter must include the following:
 

--- a/content/en/docs/contribute/new-content/blogs-case-studies.md
+++ b/content/en/docs/contribute/new-content/blogs-case-studies.md
@@ -18,7 +18,7 @@ Case studies require extensive review before they're approved.
 
 The Kubernetes blog is used by the project to communicate new features, community reports, and any news that might be relevant to the Kubernetes community. 
 This includes end users and developers. 
-Generally speaking the blog tends to skew towards things that happen in the core project, however the community is always interested in things that are happening in the Kubernetes ecosystem, so we encourage you to consider submitting content to the blog. 
+Most of the blog's content is about things happening in the core project, but we encourage you to submit about things happening elsewhere in the ecosystem too!
 
 Anyone can write a blog post and submit it for review.
 

--- a/content/en/docs/contribute/new-content/blogs-case-studies.md
+++ b/content/en/docs/contribute/new-content/blogs-case-studies.md
@@ -31,7 +31,7 @@ Anyone can write a blog post and submit it for review.
 - Blog posts do not offer deadlines.
     - Articles are reviewed by community volunteers and **can not guarantee** any time-based deadlines, though we will try our best to accomodate you.
   - Many core parts of the project are submitting posts during release windows and publication time will be delayed. Consider submitting during a quieter period of the release cycle.
-  - If you are looking for greater coordination on post release dates, coordinating with [CNCF marketing] is a more appropriate choice than submitting a blog post.
+  - If you are looking for greater coordination on post release dates, coordinating with [CNCF marketing](https://www.cncf.io/about/contact/) is a more appropriate choice than submitting a blog post.
   - Sometimes reviews can get backed up. If you feel your review isn't getting the attention it needs, you can reach out to the blog team via [this slack channel](https://kubernetes.slack.com/messages/sig-docs-blog/) to ask in real time. 
 - Blog posts should be relevant to Kubernetes users.
   - Topics related to participation in or results of Kubernetes SIGs activities are always on topic (see the work in the [Upstream Marketing Team](https://github.com/kubernetes/community/blob/master/communication/marketing-team/blog-guidelines.md#upstream-marketing-blog-guidelines) for support on these posts). 

--- a/content/en/docs/contribute/new-content/blogs-case-studies.md
+++ b/content/en/docs/contribute/new-content/blogs-case-studies.md
@@ -17,7 +17,7 @@ Case studies require extensive review before they're approved.
 ## The Kubernetes Blog
 
 The Kubernetes blog is used by the project to communicate new features, community reports, and any news that might be relevant to the Kubernetes community. 
-This includes end users AND developers. 
+This includes end users and developers. 
 Generally speaking the blog tends to skew towards things that happen in the core project, however the community is always interested in things that are happening in the Kubernetes ecosystem, so we encourage you to consider submitting content to the blog. 
 
 Anyone can write a blog post and submit it for review.

--- a/content/en/docs/contribute/new-content/blogs-case-studies.md
+++ b/content/en/docs/contribute/new-content/blogs-case-studies.md
@@ -45,7 +45,7 @@ Anyone can write a blog post and submit it for review.
 
 ### Technical Considerations for submitting a blog post
 
-Submissions need to be in Markdown format to be used by the [Hugo](https://gohugo.io/) generator for the blog. There are [many resources available] on how to use this technology stack.
+Submissions need to be in Markdown format to be used by the [Hugo](https://gohugo.io/) generator for the blog. There are [many resources available](https://gohugo.io/documentation/) on how to use this technology stack.
 
 We recognize that this requirement makes the process more difficult for less-familiar folks to submit, and we're constantly looking at solutions to lower this bar. If you have ideas on how to lower the barrier, please volunteers to help out. 
 

--- a/content/en/docs/contribute/new-content/blogs-case-studies.md
+++ b/content/en/docs/contribute/new-content/blogs-case-studies.md
@@ -61,6 +61,7 @@ To submit a blog post follow these directions:
 - Ensure that your blog post follows the correct naming conventions and the following frontmatter (metadata) information:
 
   - The Markdown file name must follow the format `YYYY-MM-DD-Your-Title-Here.md`. For example, `2020-02-07-Deploying-External-OpenStack-Cloud-Provider-With-Kubeadm.md`.
+  - Do NOT include dots in the filename, this will break the renderer. Pay close attention when dealing with versions in your filename and slug, for example `1.15-is-great.md` will break, `1-15-is-great.md` is correct.
   - The front matter must include the following:
 
   ```yaml

--- a/content/en/docs/contribute/new-content/blogs-case-studies.md
+++ b/content/en/docs/contribute/new-content/blogs-case-studies.md
@@ -91,8 +91,4 @@ real-world problems. The Kubernetes marketing team and members of the {{< glossa
 Have a look at the source for the
 [existing case studies](https://github.com/kubernetes/website/tree/master/content/en/case-studies).
 
-Refer to the [case study guidelines](https://github.com/cncf/foundation/blob/master/case-study-guidelines.md) and submit your request as outlined in the guidelines. 
-
-
-
-## {{% heading "whatsnext" %}}
+Refer to the [case study guidelines](https://github.com/cncf/foundation/blob/master/case-study-guidelines.md) and submit your request as outlined in the guidelines.

--- a/content/en/docs/contribute/new-content/blogs-case-studies.md
+++ b/content/en/docs/contribute/new-content/blogs-case-studies.md
@@ -42,7 +42,7 @@ Anyone can write a blog post and submit it for review.
     - The official blog is not for repurposing existing content from a third party as new content.
     - The [license](https://github.com/kubernetes/website/blob/master/LICENSE) for the blog does allow commercial use of the content for commercial purposes, just not the other way around. 
 - Blog posts should aim to be future proof
-  - Given the development velocity of the project, we want evergreen content, that won't require updates to stay accurate to the reader. 
+  - Given the development velocity of the project, we want evergreen content that won't require updates to stay accurate for the reader. 
   - It can be a better choice to add a tutorial or update official documentation, then write a higher level overview as a blog post.
     - Consider concentrating the long technical content as a call to action of the blog post, and focus on the problem space or why readers should care.
 

--- a/content/en/docs/contribute/new-content/blogs-case-studies.md
+++ b/content/en/docs/contribute/new-content/blogs-case-studies.md
@@ -50,7 +50,7 @@ Anyone can write a blog post and submit it for review.
 
 Submissions need to be in Markdown format to be used by the [Hugo](https://gohugo.io/) generator for the blog. There are [many resources available](https://gohugo.io/documentation/) on how to use this technology stack.
 
-We recognize that this requirement makes the process more difficult for less-familiar folks to submit, and we're constantly looking at solutions to lower this bar. If you have ideas on how to lower the barrier, please volunteers to help out. 
+We recognize that this requirement makes the process more difficult for less-familiar folks to submit, and we're constantly looking at solutions to lower this bar. If you have ideas on how to lower the barrier, please volunteer to help out. 
 
 The SIG Docs [blog subproject](https://github.com/kubernetes/community/tree/master/sig-docs/blog-subproject) manages the review process for blog posts. For more information, see [Submit a post](https://github.com/kubernetes/community/tree/master/sig-docs/blog-subproject#submit-a-post).
 

--- a/content/en/docs/contribute/new-content/blogs-case-studies.md
+++ b/content/en/docs/contribute/new-content/blogs-case-studies.md
@@ -61,7 +61,7 @@ To submit a blog post follow these directions:
 - Ensure that your blog post follows the correct naming conventions and the following frontmatter (metadata) information:
 
   - The Markdown file name must follow the format `YYYY-MM-DD-Your-Title-Here.md`. For example, `2020-02-07-Deploying-External-OpenStack-Cloud-Provider-With-Kubeadm.md`.
-  - Do **not** include dots in the filename. A name like `2020-01-01-whats-new-in-1.19.md` will causes failures during a build.
+  - Do **not** include dots in the filename. A name like `2020-01-01-whats-new-in-1.19.md` causes failures during a build.
   - Do NOT include dots in the filename, this will break the renderer. Pay close attention when dealing with versions in your filename and slug, for example `1.15-is-great.md` will break, `1-15-is-great.md` is correct.
   - The front matter must include the following:
 

--- a/content/en/docs/contribute/new-content/blogs-case-studies.md
+++ b/content/en/docs/contribute/new-content/blogs-case-studies.md
@@ -28,7 +28,7 @@ Anyone can write a blog post and submit it for review.
   - Articles must contain content that applies broadly to the Kubernetes community. For example, a submission should focus on upstream Kubernetes as opposed to vendor-specific configurations. Check the [Documentation style guide](https://kubernetes.io/docs/contribute/style/content-guide/#what-s-allowed) for what is typically allowed on Kubernetes properties. 
   - Links should primarily be to the official Kubernetes documentation. When using external references, links should be diverse - For example a submission shouldn't contain only links back to a single company's blog.
   - This can sometime be a delicate balance. The [blog team](https://kubernetes.slack.com/messages/sig-docs-blog/) is there to give guidance on whether a post is appropriate for the Kubernetes blog, so don't hesistate to reach out. 
-- Blog posts do not offer deadlines.
+- Blog posts are not published on specific dates.
     - Articles are reviewed by community volunteers and **can not guarantee** any time-based deadlines, though we will try our best to accomodate you.
   - Many core parts of the project are submitting posts during release windows and publication time will be delayed. Consider submitting during a quieter period of the release cycle.
   - If you are looking for greater coordination on post release dates, coordinating with [CNCF marketing](https://www.cncf.io/about/contact/) is a more appropriate choice than submitting a blog post.

--- a/content/en/docs/contribute/new-content/blogs-case-studies.md
+++ b/content/en/docs/contribute/new-content/blogs-case-studies.md
@@ -25,7 +25,7 @@ Anyone can write a blog post and submit it for review.
 ### Guidelines and expectations
 
 - Blog posts should not be vendor pitches. 
-  - Articles must contain content that applies broadly to the Kubernetes community - For example, a submission should focus on upstream Kubernetes as opposed to vendor-specific configurations. Check the [Documentation style guide](https://kubernetes.io/docs/contribute/style/content-guide/#what-s-allowed) for what is typically allowed on Kubernetes properties. 
+  - Articles must contain content that applies broadly to the Kubernetes community. For example, a submission should focus on upstream Kubernetes as opposed to vendor-specific configurations. Check the [Documentation style guide](https://kubernetes.io/docs/contribute/style/content-guide/#what-s-allowed) for what is typically allowed on Kubernetes properties. 
   - Links should primarily be to the official Kubernetes documentation. When using external references, links should be diverse - For example a submission shouldn't contain only links back to a single company's blog.
   - This can sometime be a delicate balance. The [blog team](https://kubernetes.slack.com/messages/sig-docs-blog/) is there to give guidance on whether a post is appropriate for the Kubernetes blog, so don't hesistate to reach out. 
 - Blog posts do not offer deadlines.

--- a/content/en/docs/contribute/new-content/blogs-case-studies.md
+++ b/content/en/docs/contribute/new-content/blogs-case-studies.md
@@ -27,7 +27,7 @@ Anyone can write a blog post and submit it for review.
 - Blog posts should not be vendor pitches. 
   - Articles must contain content that applies broadly to the Kubernetes community. For example, a submission should focus on upstream Kubernetes as opposed to vendor-specific configurations. Check the [Documentation style guide](https://kubernetes.io/docs/contribute/style/content-guide/#what-s-allowed) for what is typically allowed on Kubernetes properties. 
   - Links should primarily be to the official Kubernetes documentation. When using external references, links should be diverse - For example a submission shouldn't contain only links back to a single company's blog.
-  - This can sometime be a delicate balance. The [blog team](https://kubernetes.slack.com/messages/sig-docs-blog/) is there to give guidance on whether a post is appropriate for the Kubernetes blog, so don't hesistate to reach out. 
+  - Sometimes this is a delicate balance. The [blog team](https://kubernetes.slack.com/messages/sig-docs-blog/) is there to give guidance on whether a post is appropriate for the Kubernetes blog, so don't hesitate to reach out. 
 - Blog posts are not published on specific dates.
     - Articles are reviewed by community volunteers. We'll try our best to accommodate specific timing, but we make no guarantees.
   - Many core parts of the project are submitting posts during release windows and publication time will be delayed. Consider submitting during a quieter period of the release cycle.

--- a/content/en/docs/contribute/new-content/blogs-case-studies.md
+++ b/content/en/docs/contribute/new-content/blogs-case-studies.md
@@ -25,7 +25,7 @@ Anyone can write a blog post and submit it for review.
 ### Guidelines and expectations
 
 - Blog posts should not be vendor pitches. 
-  - Articles must contain content that applies broadly to the Kubernetes community - For example, a submission should focus on upstream Kubernetes as opposed to vendor-specific configurations.
+  - Articles must contain content that applies broadly to the Kubernetes community - For example, a submission should focus on upstream Kubernetes as opposed to vendor-specific configurations. Check the [Documentation style guide](https://kubernetes.io/docs/contribute/style/content-guide/#what-s-allowed) for what is typically allowed on Kubernetes properties. 
   - Links should primarily be to the official Kubernetes documentation. When using external references, links should be diverse - For example a submission shouldn't contain only links back to a single company's blog.
   - This can sometime be a delicate balance. The [blog team](https://kubernetes.slack.com/messages/sig-docs-blog/) is there to give guidance on whether a post is appropriate for the Kubernetes blog, so don't hesistate to reach out. 
 - Blog posts do not offer deadlines.
@@ -38,6 +38,9 @@ Anyone can write a blog post and submit it for review.
   - The components of Kubernetes are purposely modular, so tools that use existing integration points like CNI and CSI are on topic. 
   - Posts about other CNCF projects may or may not be on topic. We recommend asking the blog team before submitting a draft.
     - Many CNCF projects have their own blog. These are often a better choice for posts. There are times of major feature or milestone for a CNCF project that users would be interested in reading on the Kubernetes blog.
+- Blog posts should be original content
+    - The official blog is not for repurposing existing content from a third party as new content.
+    - The [license](https://github.com/kubernetes/website/blob/master/LICENSE) for the blog does allow commercial use of the content for commercial purposes, just not the other way around. 
 - Blog posts should aim to be future proof
   - Given the development velocity of the project, we want evergreen content, that won't require updates to stay accurate to the reader. 
   - It can be a better choice to add a tutorial or update official documentation, then write a higher level overview as a blog post.

--- a/content/en/docs/contribute/new-content/blogs-case-studies.md
+++ b/content/en/docs/contribute/new-content/blogs-case-studies.md
@@ -62,7 +62,6 @@ To submit a blog post follow these directions:
 
   - The Markdown file name must follow the format `YYYY-MM-DD-Your-Title-Here.md`. For example, `2020-02-07-Deploying-External-OpenStack-Cloud-Provider-With-Kubeadm.md`.
   - Do **not** include dots in the filename. A name like `2020-01-01-whats-new-in-1.19.md` causes failures during a build.
-  - Do NOT include dots in the filename, this will break the renderer. Pay close attention when dealing with versions in your filename and slug, for example `1.15-is-great.md` will break, `1-15-is-great.md` is correct.
   - The front matter must include the following:
 
   ```yaml


### PR DESCRIPTION
Signed-off-by: Jorge O. Castro <jorgec@vmware.com>

This removes the old google form submission process and streamlines everything under a PR/markdown workflow as our preferred means of submissions. 

/cc @kbarnard10 @mrbobbytables @onlydole @sftim 
