### PR TITLE
(Temporarily) disable upcoming events for live site

### DIFF
--- a/layouts/shortcodes/upcoming-events.html
+++ b/layouts/shortcodes/upcoming-events.html
@@ -2,16 +2,4 @@
 
 
 {{/* Setting external resource based on whether hugo is running locally or public */}}
-{{ if .Site.IsServer }}
-{{ $jurl := printf "" $date }}
-{{ else }}
-{{ $jurl := printf "https://www.googleapis.com/calendar/v3/calendars/nt2tcnbtbied3l6gi2h29slvc0%%40group.calendar.google.com/events?orderBy=startTime&singleEvents=true&%s&key=AIzaSyAST-sCyPJzMQJSl6_vRPW9r4DNLPaDIyM" $date }}
-{{ $dataJ := getJSON $jurl }}
-
-{{ range first 4 $dataJ.items }}
-  {{ $url := findRE "(http|ftp|https)://([\\w_-]+(?:(?:\\.[\\w_-]+)+))([\\w.,@?^=%&:/~+#-]*[\\w@?^=%&/~+#-])?" .description }}
-  {{ $url := index $url 0 }}
-  <div class="event"><a href="{{ safeHTML $url }}">{{ .summary }}</a> - {{ .location }} - {{ .start.date }}</div>
-{{ end }}
-
-{{ end }}    
+{{/* Disabled as this is breaking website builds */}}


### PR DESCRIPTION
Live website builds are failing; disable this part of the shortcode to allow builds to resume.

Helps with issue #22222.