### PR TITLE
Add content/es/docs/concepts/overview/components.md

### DIFF
--- a/content/es/docs/concepts/overview/components.md
+++ b/content/es/docs/concepts/overview/components.md
@@ -1,0 +1,119 @@
+---
+reviewers:
+- raelga
+title: Componentes de Kubernetes
+content_template: templates/concept
+weight: 20
+card: 
+  name: concepts
+  weight: 20
+---
+
+{{% capture overview %}}
+Este documento describe los distintos componentes binarios que
+son necesarios para operar un cluster de Kubernetes.
+{{% /capture %}}
+
+{{% capture body %}}
+## Componentes maestros
+
+Los componentes maestros proveen el plano de control del cluster. Ellos toman decisiones globales sobre
+el cluster (por ejemplo, la planificación) y detectan y responden a eventos del cluster, como la creación
+de un nuevo pod cuando la propiedad `replicas` de un controlador de replicación no se cumpla.
+
+Estos componentes pueden ejecutarse en cualquier nodo del cluster. Sin embargo, y para simplificar, los
+scripts de instalación típicamente inician todos los componentes maestros en el mismo nodo, y no ejecutan
+contenedores de los usuarios allí. Vea [Construyendo clusters de alta disponibilidad](/docs/admin/high-availability/) para un ejemplo de configuración multi-master.
+
+### kube-apiserver
+
+{{< glossary_definition term_id="kube-apiserver" length="all" >}}
+
+### etcd
+
+{{< glossary_definition term_id="etcd" length="all" >}}
+
+### kube-scheduler
+
+{{< glossary_definition term_id="kube-scheduler" length="all" >}}
+
+### kube-controller-manager
+
+{{< glossary_definition term_id="kube-controller-manager" length="all" >}}
+
+Estos controladores incluyen:
+
+  * Controlador de nodos: es el responsable por detectar y responder cuando un nodo deja de funcionar
+  * Controlador de replicación: es el responsable de mantener el número correcto de pods para cada controlador
+  de replicación del sistema
+  * Controlador de endpoints: construye el objeto `Endpoints`, es decir, hace una unión entre los `Services` y los `Pods`
+  * Controladores de tokens y cuentas de servicio: crean cuentas y tokens de acceso a la API por defecto para los nuevos espacios de nombre
+
+### cloud-controller-manager
+
+[cloud-controller-manager](/docs/tasks/administer-cluster/running-cloud-controller/) ejecuta controladores que
+interactúan con proveedores de la nube. El binario `cloud-controller-manager` es una característica alpha que debutó en la versión 1.6 de Kubernetes.
+
+`cloud-controller-manager` solo ejecuta ciclos de control específicos de cada proveedor de la nube. Debes
+desactivar estos ciclos en `kube-controller-manager`. Puedes desactivarlos pasando la opción `--cloud-provider= external` cuando arranques el `kube-controller-manager`.
+
+`cloud-controller-manager` permite que el código de Kubernetes y el del proveedor de la nube evolucionen de manera independiente. Anteriormente, el código de Kubernetes dependía de la funcionalidad específica de cada proveedor de la nube. En el futuro, el código que sea específico a una plataforma debería ser mantenido por el proveedor de la nube y enlazadao a `cloud-controller-manager` al correr Kubernetes.
+
+Los siguientes controladores dependen de alguna forma de un proveedor de la nube:
+
+  * Controlador de nodos: para verificar con el proveedor si un nodo ha sido eliminado después de que deja de responder
+  * Controlador de rutas: para configurar rutas en la infraestructura de nube subyacente
+  * Controlador de servicios: para crear, actualizar y eliminar balanceadores de carga en la nube
+  * Controlador de volúmenes: para crear, conectar y montar volúmenes e interactuar con el proveedor de la nube para orquestarlos
+
+## Componentes de nodo
+
+Los componentes de nodo corren en cada nodo, manteniendo a los pods en funcionamiento y proveyendo el entorno de ejecución de Kubernetes.
+
+### kubelet
+
+{{< glossary_definition term_id="kubelet" length="all" >}}
+
+### kube-proxy
+
+[kube-proxy](/docs/admin/kube-proxy/) permite abstraer un servicio en Kubernetes manteniendo las
+reglas de red en el anfitrión y haciendo reenvío de conexiones.
+
+### Runtime de contenedores
+
+El runtim de contenedores es el software responsable por ejecutar los contenedores. Kubernetes soporta varios de
+ellos: [Docker](http://www.docker.com), [containerd](https://containerd.io), [cri-o](https://cri-o.io/), [rktlet](https://github.com/kubernetes-incubator/rktlet) y cualquier implementación de la interfaz de runtime de contenedores de Kubernetes, o [Kubernetes CRI](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/container-runtime-interface.md).
+
+## Addons
+
+Los _addons_ son pods y servicios que implementan funcionalidades del cluster. Estos pueden ser administrados
+por `Deployments`, `ReplicationControllers` y otros. Los _addons_ asignados a un espacio de nombres se crean en el espacio `kube-system`.
+
+Describimos algunos _addons_ más abajo. Para una lista más completa de los _addons_ disponibles por favor visite [Addons](/docs/concepts/cluster-administration/addons/).
+
+### DNS
+
+Si bien los otros _addons_ no son estrictamente necesarios, todos los clusters de Kubernetes deberían tener [cluster DNS](/docs/concepts/services-networking/dns-pod-service/) ya que la mayoría de los ejemplos lo requieren.
+
+Cluster DNS es un servidor DNS, adicional a los que ya podrías tener en tu red, que sirven registros DNS de los servicios de Kubernetes.
+
+Los contenedores que son iniciados por Kubernetes incluyen automáticamente este servidor en sus búsquedas DNS.
+
+### Web UI (Dashboard)
+
+El [Dashboard](/docs/tasks/access-application-cluster/web-ui-dashboard/) es una interfaz Web de propósito general para clusters de Kubernetes. Le permite a los usuarios administrar y resolver problemas que puedan presentar tanto las aplicaciones como el cluster.
+
+### Monitor de recursos de contenedores
+
+El [Monitor de recursos de contenedores](/docs/tasks/debug-application-cluster/resource-usage-monitoring/) almacena
+de forma centralizada series de tiempo con métricas sobre los contenedores, y provee una interfaz para navegar estos
+datos.
+
+### Registros del cluster
+
+El mecanismo de [registros del cluster](/docs/concepts/cluster-administration/logging/) está a cargo de almacenar
+los registros de los contenedores en un almacen central con una interfaz de búsqueda y navegación.
+
+{{% /capture %}}
+
+

--- a/content/es/docs/concepts/overview/components.md
+++ b/content/es/docs/concepts/overview/components.md
@@ -4,26 +4,26 @@ reviewers:
 title: Componentes de Kubernetes
 content_template: templates/concept
 weight: 20
-card: 
+card:
   name: concepts
   weight: 20
 ---
 
 {{% capture overview %}}
-Este documento describe los distintos componentes binarios que
-son necesarios para operar un cluster de Kubernetes.
+Este documento describe los distintos componentes que
+son necesarios para operar un clúster de Kubernetes.
 {{% /capture %}}
 
 {{% capture body %}}
 ## Componentes maestros
 
-Los componentes maestros proveen el plano de control del cluster. Ellos toman decisiones globales sobre
-el cluster (por ejemplo, la planificación) y detectan y responden a eventos del cluster, como la creación
+Los componentes maestros proveen el plano de control del clúster. Ellos toman decisiones globales sobre
+el clúster (por ejemplo, la planificación) y detectan y responden a eventos del clúster, como la creación
 de un nuevo pod cuando la propiedad `replicas` de un controlador de replicación no se cumpla.
 
-Estos componentes pueden ejecutarse en cualquier nodo del cluster. Sin embargo, y para simplificar, los
-scripts de instalación típicamente inician todos los componentes maestros en el mismo nodo, y no ejecutan
-contenedores de los usuarios allí. Vea [Construyendo clusters de alta disponibilidad](/docs/admin/high-availability/) para un ejemplo de configuración multi-master.
+Estos componentes pueden ejecutarse en cualquier nodo del clúster. Sin embargo, y para simplificar, los
+scripts de instalación típicamente inician todos los componentes maestros en el mismo nodo de forma exclusiva,
+sin ejecutar contenedores de los usuarios en esos nodos. Vea [Construyendo clústeres de alta disponibilidad](/docs/admin/high-availability/) para un ejemplo de configuración multi-master.
 
 ### kube-apiserver
 
@@ -47,7 +47,7 @@ Estos controladores incluyen:
   * Controlador de replicación: es el responsable de mantener el número correcto de pods para cada controlador
   de replicación del sistema
   * Controlador de endpoints: construye el objeto `Endpoints`, es decir, hace una unión entre los `Services` y los `Pods`
-  * Controladores de tokens y cuentas de servicio: crean cuentas y tokens de acceso a la API por defecto para los nuevos espacios de nombre
+  * Controladores de tokens y cuentas de servicio: crean cuentas y tokens de acceso a la API por defecto para los nuevos {{< glossary_tooltip text="Namespaces" term_id="namespace">}}.
 
 ### cloud-controller-manager
 
@@ -61,14 +61,14 @@ desactivar estos ciclos en `kube-controller-manager`. Puedes desactivarlos pasan
 
 Los siguientes controladores dependen de alguna forma de un proveedor de la nube:
 
-  * Controlador de nodos: para verificar con el proveedor si un nodo ha sido eliminado después de que deja de responder
+  * Controlador de nodos: es el responsable de detectar y actuar cuando un nodo deja de responder
   * Controlador de rutas: para configurar rutas en la infraestructura de nube subyacente
   * Controlador de servicios: para crear, actualizar y eliminar balanceadores de carga en la nube
   * Controlador de volúmenes: para crear, conectar y montar volúmenes e interactuar con el proveedor de la nube para orquestarlos
 
 ## Componentes de nodo
 
-Los componentes de nodo corren en cada nodo, manteniendo a los pods en funcionamiento y proveyendo el entorno de ejecución de Kubernetes.
+Los componentes de nodo corren en cada nodo, manteniendo a los pods en funcionamiento y proporcionando el entorno de ejecución de Kubernetes.
 
 ### kubelet
 
@@ -81,27 +81,27 @@ reglas de red en el anfitrión y haciendo reenvío de conexiones.
 
 ### Runtime de contenedores
 
-El runtim de contenedores es el software responsable por ejecutar los contenedores. Kubernetes soporta varios de
+El {{< glossary_definition term_id="container-runtime" text="runtime de los contenedores" >}} es el software responsable de ejecutar los contenedores. Kubernetes soporta varios de
 ellos: [Docker](http://www.docker.com), [containerd](https://containerd.io), [cri-o](https://cri-o.io/), [rktlet](https://github.com/kubernetes-incubator/rktlet) y cualquier implementación de la interfaz de runtime de contenedores de Kubernetes, o [Kubernetes CRI](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/container-runtime-interface.md).
 
 ## Addons
 
-Los _addons_ son pods y servicios que implementan funcionalidades del cluster. Estos pueden ser administrados
+Los _addons_ son pods y servicios que implementan funcionalidades del clúster. Estos pueden ser administrados
 por `Deployments`, `ReplicationControllers` y otros. Los _addons_ asignados a un espacio de nombres se crean en el espacio `kube-system`.
 
 Describimos algunos _addons_ más abajo. Para una lista más completa de los _addons_ disponibles por favor visite [Addons](/docs/concepts/cluster-administration/addons/).
 
 ### DNS
 
-Si bien los otros _addons_ no son estrictamente necesarios, todos los clusters de Kubernetes deberían tener [cluster DNS](/docs/concepts/services-networking/dns-pod-service/) ya que la mayoría de los ejemplos lo requieren.
+Si bien los otros _addons_ no son estrictamente necesarios, todos los clústers de Kubernetes deberían tener [DNS interno del clúster](/docs/concepts/services-networking/dns-pod-service/) ya que la mayoría de los ejemplos lo requieren.
 
-Cluster DNS es un servidor DNS, adicional a los que ya podrías tener en tu red, que sirven registros DNS de los servicios de Kubernetes.
+El DNS interno del clúster es un servidor DNS, adicional a los que ya podrías tener en tu red, que sirve registros DNS a los servicios de Kubernetes.
 
 Los contenedores que son iniciados por Kubernetes incluyen automáticamente este servidor en sus búsquedas DNS.
 
 ### Web UI (Dashboard)
 
-El [Dashboard](/docs/tasks/access-application-cluster/web-ui-dashboard/) es una interfaz Web de propósito general para clusters de Kubernetes. Le permite a los usuarios administrar y resolver problemas que puedan presentar tanto las aplicaciones como el cluster.
+El [Dashboard](/docs/tasks/access-application-cluster/web-ui-dashboard/) es una interfaz Web de propósito general para clústeres de Kubernetes. Le permite a los usuarios administrar y resolver problemas que puedan presentar tanto las aplicaciones como el clúster.
 
 ### Monitor de recursos de contenedores
 
@@ -109,10 +109,10 @@ El [Monitor de recursos de contenedores](/docs/tasks/debug-application-cluster/r
 de forma centralizada series de tiempo con métricas sobre los contenedores, y provee una interfaz para navegar estos
 datos.
 
-### Registros del cluster
+### Registros del clúster
 
-El mecanismo de [registros del cluster](/docs/concepts/cluster-administration/logging/) está a cargo de almacenar
-los registros de los contenedores en un almacen central con una interfaz de búsqueda y navegación.
+El mecanismo de [registros del clúster](/docs/concepts/cluster-administration/logging/) está a cargo de almacenar
+los registros de los contenedores de forma centralizada, proporcionando una interfaz de búsqueda y navegación.
 
 {{% /capture %}}
 

--- a/content/es/docs/concepts/overview/components.md
+++ b/content/es/docs/concepts/overview/components.md
@@ -20,12 +20,12 @@ son necesarios para operar un clúster de Kubernetes.
 
 Los componentes que forman el plano de control toman decisiones globales sobre
 el clúster (por ejemplo, la planificación) y detectan y responden a eventos del clúster, como la creación
-de un nuevo pod cuando la propiedad `replicas` de un controlador de replicación no se cumpla.
+de un nuevo pod cuando la propiedad `replicas` de un controlador de replicación no se cumple.
 
-Estos componentes pueden ejecutarse en cualquier nodo del clúster. Sin embargo, y para simplificar, los
-scripts de instalación típicamente los inicican en el mismo nodo de forma exclusiva,
-sin que se ejeccuten contenedores de los usuarios en esos nodo. El plano de control en varios nodos
-para garantizar [alta disponibilidad](/docs/admin/high-availability/).
+Estos componentes pueden ejecutarse en cualquier nodo del clúster. Sin embargo para simplificar, los
+scripts de instalación típicamente se inician en el mismo nodo de forma exclusiva,
+sin que se ejecuten contenedores de los usuarios en esos nodos. El plano de control se ejecuta en varios nodos
+para garantizar la [alta disponibilidad](/docs/admin/high-availability/).
 
 ### kube-apiserver
 
@@ -45,7 +45,7 @@ para garantizar [alta disponibilidad](/docs/admin/high-availability/).
 
 Estos controladores incluyen:
 
-  * Controlador de nodos: es el responsable por detectar y responder cuando un nodo deja de funcionar
+  * Controlador de nodos: es el responsable de detectar y responder cuándo un nodo deja de funcionar
   * Controlador de replicación: es el responsable de mantener el número correcto de pods para cada controlador
   de replicación del sistema
   * Controlador de endpoints: construye el objeto `Endpoints`, es decir, hace una unión entre los `Services` y los `Pods`
@@ -54,16 +54,16 @@ Estos controladores incluyen:
 ### cloud-controller-manager
 
 [cloud-controller-manager](/docs/tasks/administer-cluster/running-cloud-controller/) ejecuta controladores que
-interactúan con proveedores de la nube. El binario `cloud-controller-manager` es una característica alpha que debutó en la versión 1.6 de Kubernetes.
+interactúan con proveedores de la nube. El binario `cloud-controller-manager` es una característica alpha que se introdujo en la versión 1.6 de Kubernetes.
 
-`cloud-controller-manager` solo ejecuta ciclos de control específicos de cada proveedor de la nube. Debes
-desactivar estos ciclos en `kube-controller-manager`. Puedes desactivarlos pasando la opción `--cloud-provider= external` cuando arranques el `kube-controller-manager`.
+`cloud-controller-manager` sólo ejecuta ciclos de control específicos para cada proveedor de la nube. Es posible
+desactivar estos ciclos en `kube-controller-manager` pasando la opción `--cloud-provider= external` cuando se arranque el `kube-controller-manager`.
 
-`cloud-controller-manager` permite que el código de Kubernetes y el del proveedor de la nube evolucionen de manera independiente. Anteriormente, el código de Kubernetes dependía de la funcionalidad específica de cada proveedor de la nube. En el futuro, el código que sea específico a una plataforma debería ser mantenido por el proveedor de la nube y enlazadao a `cloud-controller-manager` al correr Kubernetes.
+`cloud-controller-manager` permite que el código de Kubernetes y el del proveedor de la nube evolucionen de manera independiente. Anteriormente, el código de Kubernetes dependía de la funcionalidad específica de cada proveedor de la nube. En el futuro, el código que sea específico a una plataforma debería ser mantenido por el proveedor de la nube y enlazado a `cloud-controller-manager` al correr Kubernetes.
 
 Los siguientes controladores dependen de alguna forma de un proveedor de la nube:
 
-  * Controlador de nodos: es el responsable de detectar y actuar cuando un nodo deja de responder
+  * Controlador de nodos: es el responsable de detectar y actuar cuándo un nodo deja de responder
   * Controlador de rutas: para configurar rutas en la infraestructura de nube subyacente
   * Controlador de servicios: para crear, actualizar y eliminar balanceadores de carga en la nube
   * Controlador de volúmenes: para crear, conectar y montar volúmenes e interactuar con el proveedor de la nube para orquestarlos
@@ -91,11 +91,11 @@ ellos: [Docker](http://www.docker.com), [containerd](https://containerd.io), [cr
 Los _addons_ son pods y servicios que implementan funcionalidades del clúster. Estos pueden ser administrados
 por `Deployments`, `ReplicationControllers` y otros. Los _addons_ asignados a un espacio de nombres se crean en el espacio `kube-system`.
 
-Describimos algunos _addons_ más abajo. Para una lista más completa de los _addons_ disponibles por favor visite [Addons](/docs/concepts/cluster-administration/addons/).
+Más abajo se describen algunos _addons_. Para una lista más completa de los _addons_ disponibles, por favor visite [Addons](/docs/concepts/cluster-administration/addons/).
 
 ### DNS
 
-Si bien los otros _addons_ no son estrictamente necesarios, todos los clústers de Kubernetes deberían tener [DNS interno del clúster](/docs/concepts/services-networking/dns-pod-service/) ya que la mayoría de los ejemplos lo requieren.
+Si bien los otros _addons_ no son estrictamente necesarios, todos los clústers de Kubernetes deberían tener un [DNS interno del clúster](/docs/concepts/services-networking/dns-pod-service/) ya que la mayoría de los ejemplos lo requieren.
 
 El DNS interno del clúster es un servidor DNS, adicional a los que ya podrías tener en tu red, que sirve registros DNS a los servicios de Kubernetes.
 

--- a/content/es/docs/concepts/overview/components.md
+++ b/content/es/docs/concepts/overview/components.md
@@ -9,12 +9,13 @@ card:
   weight: 20
 ---
 
-{{% capture overview %}}
+<!-- overview -->
+
 Este documento describe los distintos componentes que
 son necesarios para operar un clúster de Kubernetes.
-{{% /capture %}}
 
-{{% capture body %}}
+<!-- body -->
+
 ## Componentes maestros
 
 Los componentes maestros proveen el plano de control del clúster. Ellos toman decisiones globales sobre
@@ -113,7 +114,3 @@ datos.
 
 El mecanismo de [registros del clúster](/docs/concepts/cluster-administration/logging/) está a cargo de almacenar
 los registros de los contenedores de forma centralizada, proporcionando una interfaz de búsqueda y navegación.
-
-{{% /capture %}}
-
-

--- a/content/es/docs/concepts/overview/components.md
+++ b/content/es/docs/concepts/overview/components.md
@@ -100,7 +100,7 @@ El DNS interno del clúster es un servidor DNS, adicional a los que ya podrías 
 
 Los contenedores que son iniciados por Kubernetes incluyen automáticamente este servidor en sus búsquedas DNS.
 
-### Web UI (Dashboard)
+### Interfaz Web (Dashboard) {#dashboard}
 
 El [Dashboard](/docs/tasks/access-application-cluster/web-ui-dashboard/) es una interfaz Web de propósito general para clústeres de Kubernetes. Le permite a los usuarios administrar y resolver problemas que puedan presentar tanto las aplicaciones como el clúster.
 

--- a/content/es/docs/concepts/overview/components.md
+++ b/content/es/docs/concepts/overview/components.md
@@ -2,7 +2,7 @@
 reviewers:
 - raelga
 title: Componentes de Kubernetes
-content_template: templates/concept
+content_type: concept
 weight: 20
 card:
   name: concepts

--- a/content/es/docs/concepts/overview/components.md
+++ b/content/es/docs/concepts/overview/components.md
@@ -16,15 +16,16 @@ son necesarios para operar un clúster de Kubernetes.
 
 <!-- body -->
 
-## Componentes maestros
+## Componentes del plano de control
 
-Los componentes maestros proveen el plano de control del clúster. Ellos toman decisiones globales sobre
+Los componentes que forman el plano de control toman decisiones globales sobre
 el clúster (por ejemplo, la planificación) y detectan y responden a eventos del clúster, como la creación
 de un nuevo pod cuando la propiedad `replicas` de un controlador de replicación no se cumpla.
 
 Estos componentes pueden ejecutarse en cualquier nodo del clúster. Sin embargo, y para simplificar, los
-scripts de instalación típicamente inician todos los componentes maestros en el mismo nodo de forma exclusiva,
-sin ejecutar contenedores de los usuarios en esos nodos. Vea [Construyendo clústeres de alta disponibilidad](/docs/admin/high-availability/) para un ejemplo de configuración multi-master.
+scripts de instalación típicamente los inicican en el mismo nodo de forma exclusiva,
+sin que se ejeccuten contenedores de los usuarios en esos nodo. El plano de control en varios nodos
+para garantizar [alta disponibilidad](/docs/admin/high-availability/).
 
 ### kube-apiserver
 

--- a/content/es/docs/reference/glossary/controller.md
+++ b/content/es/docs/reference/glossary/controller.md
@@ -16,7 +16,7 @@ tags:
 
 En Kubernetes, los controladores son bucles de control que observan el estado del
 {{< glossary_tooltip term_id="cluster" text="clúster">}}, y ejecutan o solicitan
-los cambios que sean necesarios para llevar el estado actual del cluster más
+los cambios que sean necesarios para llevar el estado actual del clúster más
 cerca del estado deseado.
 
 <!--more-->
@@ -29,5 +29,5 @@ Algunos controladores también se ejecutan dentro del mismo plano de control,
 proporcionado los bucles de control necesarios para las operaciones principales
 de Kubernetes. Por ejemplo, el controlador de Deployments, el controlador de
 DaemonSets, el controlador de Namespaces y el controlador de volúmenes
-persistentes entre otros, se ejecutan dentro del
+persistentes, entre otros, se ejecutan dentro del
 {{< glossary_tooltip term_id="kube-controller-manager" >}}.

--- a/content/es/docs/reference/glossary/controller.md
+++ b/content/es/docs/reference/glossary/controller.md
@@ -1,0 +1,33 @@
+---
+title: Controlador
+id: controller
+date: 2018-04-12
+full_link: /docs/concepts/architecture/controller/
+short_description: >
+  Los controladores son bucles de control que observan el estado del clúster,
+  y ejecutan o solicitan los cambios que sean necesarios para alcanzar el estado
+  deseado.
+
+aka:
+tags:
+- architecture
+- fundamental
+---
+
+En Kubernetes, los controladores son bucles de control que observan el estado del
+{{< glossary_tooltip term_id="cluster" text="clúster">}}, y ejecutan o solicitan
+los cambios que sean necesarios para llevar el estado actual del cluster más
+cerca del estado deseado.
+
+<!--more-->
+
+Los controladores observan el estado compartido del clúster a través del
+{{< glossary_tooltip text="API Server" term_id="kube-apiserver" >}} (parte del
+{{< glossary_tooltip term_id="control-plane" text="plano de control" >}}).
+
+Algunos controladores también se ejecutan dentro del mismo plano de control,
+proporcionado los bucles de control necesarios para las operaciones principales
+de Kubernetes. Por ejemplo, el controlador de Deployments, el controlador de
+DaemonSets, el controlador de Namespaces y el controlador de volúmenes
+persistentes entre otros, se ejecutan dentro del
+{{< glossary_tooltip term_id="kube-controller-manager" >}}.

--- a/content/es/docs/reference/glossary/etcd.md
+++ b/content/es/docs/reference/glossary/etcd.md
@@ -1,0 +1,24 @@
+---
+title: etcd
+id: etcd
+date: 2018-04-12
+full_link: /docs/tasks/administer-cluster/configure-upgrade-etcd/
+short_description: >
+  Almacén de datos persistente, consistente y distribuido de clave-valor utilizado
+  para almacenar toda a la información del clúster de Kubernetes.
+
+aka:
+tags:
+- architecture
+- storage
+---
+
+Almacén de datos persistente, consistente y distribuido de clave-valor utilizado
+para almacenar toda a la información del clúster de Kubernetes.
+
+<!--more-->
+
+Si tu clúster utiliza etcd como sistema de almacenamiento, échale un vistazo a la
+documentación sobre [estrategias de backup](/docs/tasks/administer-cluster/configure-upgrade-etcd/#backing-up-an-etcd-cluster).
+
+Puedes encontrar información detallada sobre etcd en su [documentación oficial](https://etcd.io/docs/).

--- a/content/es/docs/reference/glossary/kube-apiserver.md
+++ b/content/es/docs/reference/glossary/kube-apiserver.md
@@ -1,0 +1,26 @@
+---
+title: API Server
+id: kube-apiserver
+date: 2020-07-01
+full_link: /docs/reference/generated/kube-apiserver/
+short_description: >
+  Componente del plano de control que expone la API de Kubernetes.
+
+aka:
+- Servidor de la API
+- kube-apiserver
+tags:
+- architecture
+- fundamental
+---
+
+El servidor de la API es el componente del {{< glossary_tooltip text="plano de control" term_id="control-plane" >}}
+de Kubernetes que expone la API de Kubernetes. Se trata del frontend de Kubernetes,
+recibe las peticiones y actualiza acordemente el estado en {{< glossary_tooltip term_id="etcd" length="all" >}}.
+
+<!--more-->
+
+La principal implementación de un servidor de la API de Kubernetes es
+[kube-apiserver](/docs/reference/generated/kube-apiserver/).
+Es una implementación preparada para ejecutarse en alta disponiblidad y que
+puede escalar horizontalmente para balancear la carga entre varias instancias.

--- a/content/es/docs/reference/glossary/kube-controller-manager.md
+++ b/content/es/docs/reference/glossary/kube-controller-manager.md
@@ -1,0 +1,21 @@
+---
+title: kube-controller-manager
+id: kube-controller-manager
+date: 2018-04-12
+full_link: /docs/reference/command-line-tools-reference/kube-controller-manager/
+short_description: >
+  Componente del plano de control que ejecuta los controladores de Kubernetes.
+
+aka:
+tags:
+- architecture
+- fundamental
+---
+
+Componente del plano de control que ejecuta los {{< glossary_tooltip text="controladores" term_id="controller" >}} de Kubernetes.
+
+<!--more-->
+
+Lógicamente cada {{< glossary_tooltip text="controlador" term_id="controller" >}}
+es un proceso independiente, pero para reducir la complejidad, todos se compilan
+en un único binario y se ejecuta en un mismo proceso.

--- a/content/es/docs/reference/glossary/kube-scheduler.md
+++ b/content/es/docs/reference/glossary/kube-scheduler.md
@@ -15,11 +15,11 @@ tags:
 Componente del plano de control que está pendiente de los
 {{< glossary_tooltip term_id="pod" text="Pods" >}} que no tienen ningún
 {{< glossary_tooltip term_id="node" text="nodo">}} asignado
-y seleciona uno dónde ejecutarlo.
+y seleciona uno donde ejecutarlo.
 
 <!--more-->
 
-Para decidir en que {{< glossary_tooltip term_id="node" text="nodo">}}
+Para decidir en qué {{< glossary_tooltip term_id="node" text="nodo">}}
 se ejecutará el {{< glossary_tooltip term_id="pod" text="pod" >}}, se tienen
-en cuenta diversos factores: requisitos de recursos, restricciones de hardware/software/polítcas,
+en cuenta diversos factores: requisitos de recursos, restricciones de hardware/software/políticas,
 afinidad y anti-afinidad, localización de datos dependientes, entre otros.

--- a/content/es/docs/reference/glossary/kube-scheduler.md
+++ b/content/es/docs/reference/glossary/kube-scheduler.md
@@ -1,0 +1,25 @@
+---
+title: kube-scheduler
+id: kube-scheduler
+date: 2018-04-12
+full_link: /docs/reference/generated/kube-scheduler/
+short_description: >
+  Componente del plano de control que está pendiente de los pods que no tienen
+  ningún nodo asignado y seleciona uno dónde ejecutarlo.
+
+aka:
+tags:
+- architecture
+---
+
+Componente del plano de control que está pendiente de los
+{{< glossary_tooltip term_id="pod" text="Pods" >}} que no tienen ningún
+{{< glossary_tooltip term_id="node" text="nodo">}} asignado
+y seleciona uno dónde ejecutarlo.
+
+<!--more-->
+
+Para decidir en que {{< glossary_tooltip term_id="node" text="nodo">}}
+se ejecutará el {{< glossary_tooltip term_id="pod" text="pod" >}}, se tienen
+en cuenta diversos factores: requisitos de recursos, restricciones de hardware/software/polítcas,
+afinidad y anti-afinidad, localización de datos dependientes, entre otros.

--- a/content/es/docs/reference/glossary/namespace.md
+++ b/content/es/docs/reference/glossary/namespace.md
@@ -1,0 +1,22 @@
+---
+title: Namespace
+id: namespace
+date: 2018-04-12
+full_link: /es/docs/concepts/overview/working-with-objects/namespaces/
+short_description: >
+  Abstracción utilizada por Kubernetes para soportar múltiples clústeres virtuales en el mismo clúster físico.
+aka:
+- Espacio de nombres
+tags:
+- fundamental
+---
+
+Abstracción utilizada por Kubernetes para soportar múltiples clústeres virtuales
+en el mismo {{< glossary_tooltip text="clúster" term_id="cluster" >}} físico.
+
+<!--more-->
+
+Los Namespaces, espacios de nombres, se utilizan para organizar objetos del clúster
+proporcionando un mecanismo para dividir los recusos del clúster. Los nombres de los
+objetos tienen que ser únicos dentro del mismo namespace, pero se pueden repetir en
+otros namespaces del mismo clúster.


### PR DESCRIPTION
Follows the awesome @bureado work, applies the pending suggestions from #14678 and adds all the missing glossary terms that were causing the build failure.