### PR TITLE
Remove container level supplementalGroups and fsgroup from PSP standards doc

### DIFF
--- a/content/en/docs/concepts/security/pod-security-standards.md
+++ b/content/en/docs/concepts/security/pod-security-standards.md
@@ -236,11 +236,7 @@ well as lower-trust users.The following listed controls should be enforced/disal
 				spec.securityContext.supplementalGroups[*]<br>
 				spec.securityContext.fsGroup<br>
 				spec.containers[*].securityContext.runAsGroup<br>
-				spec.containers[*].securityContext.supplementalGroups[*]<br>
-				spec.containers[*].securityContext.fsGroup<br>
 				spec.initContainers[*].securityContext.runAsGroup<br>
-				spec.initContainers[*].securityContext.supplementalGroups[*]<br>
-				spec.initContainers[*].securityContext.fsGroup<br>
 				<br><b>Allowed Values:</b><br>
 				non-zero<br>
 				undefined / nil (except for `*.runAsGroup`)<br>


### PR DESCRIPTION
`supplementalGroups` and `fsGroup` are only supported as pod security context but not per container security context

```
error: error validating "example.yaml": error validating data: [ValidationError(Pod.spec.containers[0].securityContext): unknown field "fsGroup" in io.k8s.api.core.v1.SecurityContext, ValidationError(Pod.spec.containers[0].securityContext): unknown field "supplementalGroups" in io.k8s.api.core.v1.SecurityContext]; if you choose to ignore these errors, turn validation off with --validate=false
```

not supposed in containers: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#securitycontext-v1-core
supported in pods: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podsecuritycontext-v1-core