### PR TITLE
Update Japanese translation of config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -222,7 +222,7 @@ no = 'Sorry to hear that. Please <a href="https://github.com/USERNAME/REPOSITORY
 	url = "https://discuss.kubernetes.io"
 	icon = "fa fa-envelope"
   desc = "Discussion and help from your fellow users"
-  
+
 [[params.links.user]]
 	name = "Twitter"
 	url = "https://twitter.com/kubernetesio"
@@ -259,7 +259,7 @@ no = 'Sorry to hear that. Please <a href="https://github.com/USERNAME/REPOSITORY
 	url = "https://git.k8s.io/community/contributors/guide"
 	icon = "fas fa-edit"
   desc = "Contribute to the Kubernetes website"
-  
+
 [[params.links.developer]]
 	name = "Stack Overflow"
 	url = "https://stackoverflow.com/questions/tagged/kubernetes"
@@ -300,7 +300,7 @@ language_alternatives = ["en"]
 
 [languages.ja]
 title = "Kubernetes"
-description = "Production-Grade Container Orchestration"
+description = "プロダクショングレードのコンテナ管理基盤"
 languageName = "日本語 Japanese"
 weight = 4
 contentDir = "content/ja"


### PR DESCRIPTION
## What

1. Translate `description` in `[languages.ja]` section in `config.toml`.
1. ~~Add and translate `version_menu`.~~ (moved to #22310)

**before**
![before](https://user-images.githubusercontent.com/1425259/86418516-57969e00-bd0b-11ea-95b9-d14108496988.png)

**after**
![after](https://user-images.githubusercontent.com/1425259/86418521-582f3480-bd0b-11ea-8915-5d9618a42036.png)

## Why

1. The string `description` in Japanese has not been translated yet.
1. ~~Before the docsy theme, there is no string "Versions" in the header (only a current version number like `v1.17`). By adding `version_menu` param, we can translate a new string "Versions".~~

## Comment

~~Other localizations have no translations for "Versions" string so maybe we can notify other localization members to add `version_menu` and translate it like this PR.~~

~~If necessary, I can add params for other localizations either in this PR or as a separate PR.~~
