### PR TITLE
Update last link on open-a-pr.md

### DIFF
--- a/content/en/docs/contribute/new-content/open-a-pr.md
+++ b/content/en/docs/contribute/new-content/open-a-pr.md
@@ -496,6 +496,6 @@ the templates with as much detail as possible when you file issues or PRs.
 ## {{% heading "whatsnext" %}}
 
 
-- Read [Reviewing](/docs/contribute/reviewing/revewing-prs) to learn more about the review process.
+- Read [Reviewing](/docs/contribute/review/reviewing-prs) to learn more about the review process.
 
 


### PR DESCRIPTION
Last link to /contribute/review/reviewing-prs was misstyped. Change resolves 404 when clicking it.

FIRST PR (take 2)
