### PR TITLE
Make "Versions" string on the navbar translatable

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -222,7 +222,7 @@ no = 'Sorry to hear that. Please <a href="https://github.com/USERNAME/REPOSITORY
 	url = "https://discuss.kubernetes.io"
 	icon = "fa fa-envelope"
   desc = "Discussion and help from your fellow users"
-  
+
 [[params.links.user]]
 	name = "Twitter"
 	url = "https://twitter.com/kubernetesio"
@@ -259,7 +259,7 @@ no = 'Sorry to hear that. Please <a href="https://github.com/USERNAME/REPOSITORY
 	url = "https://git.k8s.io/community/contributors/guide"
 	icon = "fas fa-edit"
   desc = "Contribute to the Kubernetes website"
-  
+
 [[params.links.developer]]
 	name = "Stack Overflow"
 	url = "https://stackoverflow.com/questions/tagged/kubernetes"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -210,6 +210,9 @@ other = "Your Kubernetes server must be at or later than version "
 [version_check_tocheck]
 other = "To check the version, enter "
 
+[version_menu]
+other = "Versions"
+
 [warning]
 other = "Warning:"
 

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -58,6 +58,9 @@ other = "このページは役に立ちましたか？"
 [feedback_yes]
 other = "はい"
 
+[input_placeholder_email_address]
+other = "メールアドレス"
+
 [latest_version]
 other = "最新バージョン"
 
@@ -187,11 +190,11 @@ other = "作業するKubernetesサーバーは次のバージョン以降のも�
 [version_check_tocheck]
 other = "バージョンを確認するには次のコマンドを実行してください: "
 
-[whatsnext_heading]
-other = "次の項目"
+[version_menu]
+other = "バージョン"
 
 [warning]
 other = "警告:"
 
-[input_placeholder_email_address]
-other = "メールアドレス"
+[whatsnext_heading]
+other = "次の項目"

--- a/layouts/partials/navbar-version-selector.html
+++ b/layouts/partials/navbar-version-selector.html
@@ -1,0 +1,8 @@
+<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+  {{ T "version_menu" }}
+</a>
+<div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+	{{ range .Site.Params.versions }}
+	<a class="dropdown-item" href="{{ .url }}">{{ .version }}</a>
+	{{ end }}
+</div>


### PR DESCRIPTION
## What

This PR makes the "Versions" string on the navbar translatable. It also add `version_menu` parameter to each l18n TOML files.

**before**
![before](https://user-images.githubusercontent.com/1425259/86418516-57969e00-bd0b-11ea-95b9-d14108496988.png)

**after**
![after](https://user-images.githubusercontent.com/1425259/86418521-582f3480-bd0b-11ea-8915-5d9618a42036.png)

## Why

Before the docsy theme, there was no string "Versions" in the header (only a current version number like `v1.17`). By adding `version_menu` parameter to `l18n/<lang>.toml` and modifying `navbar-version-selector.html` partial, we can translate the string.

## Comment

- I remove `version_menu` from `config.toml` but this parameter is used only in `navbar-version-selector.html`. So the deletion doesn't affect elsewhere.
- I only changed line 2 of `navbar-version-selector.html` compared to the Docsy's original partial at `themes/docsy/layouts/partials/navbar-version-selector.html`

Related issue: #22287 
