### PR TITLE
fix: zh doc missleading to english module 2

### DIFF
--- a/content/zh/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive.html
+++ b/content/zh/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive.html
@@ -40,7 +40,7 @@ weight: 20
                 <!--
                 <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/" role="button">Continue to Module 2<span class="btn__next">›</span></a>
                 -->
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/" role="button">继续阅读第二单元<span class="btn__next">›</span></a>
+                <a class="btn btn-lg btn-success" href="/zh/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/" role="button">继续阅读第二单元<span class="btn__next">›</span></a>
                 
             </div>
         </div>


### PR DESCRIPTION
`Continue to Module 2` btn in zh docs is leading to en version of module 2, this PR simply fix it to zh version.