### PR TITLE
fix: zh doc missleading to english module 3

### DIFF
--- a/content/zh/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive.html
+++ b/content/zh/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive.html
@@ -33,7 +33,7 @@ weight: 20
         <div class="row">
             <div class="col-md-12">
                 <!-- <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/explore/explore-intro/" role="button">Continue to Module 3<span class="btn__next">›</span></a> -->
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/explore/explore-intro/" role="button">继续阅读第3单元<span class="btn__next">›</span></a>
+                <a class="btn btn-lg btn-success" href="/zh/docs/tutorials/kubernetes-basics/explore/explore-intro/" role="button">继续阅读第3单元<span class="btn__next">›</span></a>
             </div>
         </div>
 


### PR DESCRIPTION
`Continue to Module 3` btn in zh docs is leading to en version of module 3, this PR simply fix it to zh version.