### PR TITLE
fix: zh doc missleading to english Start Interactive Tutorial

### DIFF
--- a/content/zh/docs/tutorials/kubernetes-basics/explore/explore-intro.html
+++ b/content/zh/docs/tutorials/kubernetes-basics/explore/explore-intro.html
@@ -210,7 +210,7 @@ weight: 10
 <!--
         <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/explore/explore-interactive/" role="button">Start Interactive Tutorial <span class="btn__next">›</span></a>
 -->
-        <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/explore/explore-interactive/" role="button"> 开始交互式教程 <span class="btn__next">›</span></a>
+        <a class="btn btn-lg btn-success" href="/zh/docs/tutorials/kubernetes-basics/explore/explore-interactive/" role="button"> 开始交互式教程 <span class="btn__next">›</span></a>
       </div>
     </div>
 


### PR DESCRIPTION
`Start Interactive Tutorial` btn in zh docs is leading to en version, this PR simply fix it to zh version.