### PR TITLE
fix: zh doc missleading to english module 5, and translate.

### DIFF
--- a/content/zh/docs/tutorials/kubernetes-basics/expose/expose-interactive.html
+++ b/content/zh/docs/tutorials/kubernetes-basics/expose/expose-interactive.html
@@ -38,7 +38,7 @@ weight: 20
         </div>
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/scale/scale-intro/" role="button">Continue to Module 5<span class="btn__next">›</span></a>
+                <a class="btn btn-lg btn-success" href="/zh/docs/tutorials/kubernetes-basics/scale/scale-intro/" role="button">继续阅读第5单元<span class="btn__next">›</span></a>
             </div>
         </div>
 


### PR DESCRIPTION
`Continue to Module 5` btn in zh docs is leading to en version and have no translate, this PR simply fix it.
