### PR TITLE
fix: zh doc missleading to en link.

### DIFF
--- a/content/zh/docs/tutorials/kubernetes-basics/scale/scale-intro.html
+++ b/content/zh/docs/tutorials/kubernetes-basics/scale/scale-intro.html
@@ -127,7 +127,7 @@ weight: 10
         <div class="row">
             <div class="col-md-12">
 								<!-- <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/scale-interactive/" role="button">Start Interactive Tutorial <span class="btn__next">›</span></a> -->
-								<a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/scale-interactive/" role="button">开始互动教程 <span class="btn__next">›</span></a>
+								<a class="btn btn-lg btn-success" href="/zh/docs/tutorials/kubernetes-basics/scale-interactive/" role="button">开始互动教程 <span class="btn__next">›</span></a>
             </div>
         </div>
 


### PR DESCRIPTION
fix zh doc missleading to en link.

