### PR TITLE
fix: zh doc missleading to english module 6

### DIFF
--- a/content/zh/docs/tutorials/kubernetes-basics/scale/scale-interactive.html
+++ b/content/zh/docs/tutorials/kubernetes-basics/scale/scale-interactive.html
@@ -34,7 +34,7 @@ weight: 20
         </div>
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/update/update-intro/" role="button"><!--Continue to Module 6-->继续参阅第6单元<span class="btn__next">›</span></a>
+                <a class="btn btn-lg btn-success" href="/zh/docs/tutorials/kubernetes-basics/update/update-intro/" role="button"><!--Continue to Module 6-->继续参阅第6单元<span class="btn__next">›</span></a>
             </div>
         </div>
     


### PR DESCRIPTION
`Continue to Module 6` btn in zh docs is leading to en version, this PR simply fix it.
