### PR TITLE
fix: zh doc missleading to en link.

### DIFF
--- a/content/zh/docs/tutorials/kubernetes-basics/update/update-intro.html
+++ b/content/zh/docs/tutorials/kubernetes-basics/update/update-intro.html
@@ -177,7 +177,7 @@ weight: 10
                 <!--
                 <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/update/update-interactive/" role="button">Start Interactive Tutorial <span class="btn__next">›</span></a>
                 -->
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/update/update-interactive/" role="button">启动交互教程<span class="btn__next">›</span></a>
+                <a class="btn btn-lg btn-success" href="/zh/docs/tutorials/kubernetes-basics/update/update-interactive/" role="button">启动交互教程<span class="btn__next">›</span></a>
                 
             </div>
         </div>


### PR DESCRIPTION
fix: zh doc missleading to en link.

