### PR TITLE
Fix erroneous RSS feed link in security.md

### DIFF
--- a/content/en/docs/reference/issues-security/security.md
+++ b/content/en/docs/reference/issues-security/security.md
@@ -19,7 +19,7 @@ This page describes Kubernetes security and disclosure information.
 
 Join the [kubernetes-security-announce](https://groups.google.com/forum/#!forum/kubernetes-security-announce) group for emails about security and major API announcements.
 
-You can also subscribe to an RSS feed of the above using [this link](https://groups.google.com/forum/feed/kubernetes-announce/msgs/rss_v2_0.xml?num=50).
+You can also subscribe to an RSS feed of the above using [this link](https://groups.google.com/forum/feed/kubernetes-security-announce/msgs/rss_v2_0.xml?num=50).
 
 ## Report a Vulnerability
 


### PR DESCRIPTION
When referring to the `kubernetes-security-announce` mailing list, an alternative RSS link is incorrectly given to `kubernetes-announce` instead. This PR updates that link.

Apologies if I have misunderstood the process to contribute this trivial change.