### PR TITLE
Fix broken capture shortcode

### DIFF
--- a/content/id/docs/concepts/extend-kubernetes/operator.md
+++ b/content/id/docs/concepts/extend-kubernetes/operator.md
@@ -124,9 +124,7 @@ Kamu juga dapat mengimplementasikan Operator (yaitu, _Controller_) dengan
 menggunakan bahasa / _runtime_ yang dapat bertindak sebagai 
 [klien dari API Kubernetes](/docs/reference/using-api/client-libraries/).
 
-
-
-{{% capture Selanjutnya %}}
+## {{% heading "whatsnext" %}}
 
 * Memahami lebih lanjut tentang [_custome resources_](/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
 * Temukan "ready-made" _operators_ dalam [OperatorHub.io](https://operatorhub.io/) 


### PR DESCRIPTION
/kind cleanup

Fix a `capture` shortcode that seems to have been missed out from commit 7d031344565a44b3943f99dfb2392dc0f6cb3f18 (it was never valid, and that's why the conversion missed it).