### PR TITLE
Mark `make docker-serve` as deprecated in the docs

### DIFF
--- a/content/en/docs/contribute/generate-ref-docs/kubectl.md
+++ b/content/en/docs/contribute/generate-ref-docs/kubectl.md
@@ -237,6 +237,9 @@ Build the Kubernetes documentation in your local `<web-base>`.
 cd <web-base>
 make docker-serve
 ```
+{{< note >}}
+The use of `make docker-serve` is deprecated. Please use `make container-serve` instead.
+{{< /note >}}
 
 View the [local preview](https://localhost:1313/docs/reference/generated/kubectl/kubectl-commands/).
 

--- a/content/en/docs/contribute/generate-ref-docs/kubernetes-api.md
+++ b/content/en/docs/contribute/generate-ref-docs/kubernetes-api.md
@@ -185,6 +185,10 @@ cd <web-base>
 make docker-serve
 ```
 
+{{< note >}}
+The use of `make docker-serve` is deprecated. Please use `make container-serve` instead.
+{{< /note >}}
+
 ## Commit the changes
 
 In `<web-base>` run `git add` and `git commit` to commit the change.


### PR DESCRIPTION
The use of `docker-serve` is deprecated, we should use `container-serve` instead.
