### PR TITLE
ID translation for tutorial deploy app

### DIFF
--- a/content/id/docs/tutorials/kubernetes-basics/deploy-app/_index.md
+++ b/content/id/docs/tutorials/kubernetes-basics/deploy-app/_index.md
@@ -1,4 +1,4 @@
 ---
-title: _Deploy_ Aplikasi
+title: Menyebarkan (Deploy) Aplikasi
 weight: 20
 ---

--- a/content/id/docs/tutorials/kubernetes-basics/deploy-app/_index.md
+++ b/content/id/docs/tutorials/kubernetes-basics/deploy-app/_index.md
@@ -1,0 +1,4 @@
+---
+title: _Deploy_ Aplikasi
+weight: 20
+---

--- a/content/id/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive.html
+++ b/content/id/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive.html
@@ -1,0 +1,49 @@
+---
+title: Tutorial Interaktif - Men-<i>Deploy</i> Aplikasi
+weight: 20
+---
+
+<!DOCTYPE html>
+
+<html lang="id">
+
+<body>
+
+<link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
+<link href="/docs/tutorials/kubernetes-basics/public/css/overrides.css" rel="stylesheet">
+<script src="https://katacoda.com/embed.js"></script>
+
+<div class="layout" id="top">
+
+    <main class="content katacoda-content">
+
+        <div class="row">
+            <div class="col-md-12">
+                <p>
+                Pod merupakan unit eksekusi utama pada aplikasi Kubernetes. Setiap Pod mewakili sebagian dari beban kerja (<i>workload</i>) yang berjalan pada klaster kamu. <a href="id/docs/concepts/workloads/pods/pod-overview/#understanding-pods">Learn more about Pods</a>.
+                </p>
+            </div>
+        </div>
+
+        <br>
+        <div class="katacoda">
+            <div class="katacoda__alert">
+                Untuk berinteraksi dengan Terminal, silahkan gunakan desktop/tablet.
+            </div>
+
+            <div class="katacoda__box" id="inline-terminal-1" data-katacoda-lang="id" data-katacoda-id="kubernetes-bootcamp/7" data-katacoda-color="326de6" data-katacoda-secondary="273d6d" data-katacoda-hideintro="false" data-katacoda-font="Roboto" data-katacoda-fontheader="Roboto Slab" data-katacoda-prompt="Kubernetes Bootcamp Terminal" style="height: 600px;">
+            </div>
+
+        </div>
+        <div class="row">
+            <div class="col-md-12">
+                <a class="btn btn-lg btn-success" href="docs/tutorials/kubernetes-basics/explore/explore-intro/" role="button">Lanjut ke Modul 3<span class="btn__next">›</span></a>
+            </div>
+        </div>
+
+    </main>
+
+</div>
+
+</body>
+</html>

--- a/content/id/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive.html
+++ b/content/id/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive.html
@@ -1,5 +1,5 @@
 ---
-title: Tutorial Interaktif - Men-<i>Deploy</i> Aplikasi
+title: Tutorial Interaktif - Menyebarkan (Deploy) Aplikasi
 weight: 20
 ---
 
@@ -20,7 +20,7 @@ weight: 20
         <div class="row">
             <div class="col-md-12">
                 <p>
-                Pod merupakan unit eksekusi utama pada aplikasi Kubernetes. Setiap Pod mewakili sebagian dari beban kerja (<i>workload</i>) yang berjalan pada klaster kamu. <a href="id/docs/concepts/workloads/pods/pod-overview/#understanding-pods">Learn more about Pods</a>.
+                Pod merupakan unit eksekusi utama pada aplikasi Kubernetes. Setiap Pod mewakili sebagian dari beban kerja (<i>workload</i>) yang berjalan pada klaster kamu. <a href="/id/docs/concepts/workloads/pods/pod-overview/#understanding-pods">Learn more about Pods</a>.
                 </p>
             </div>
         </div>
@@ -37,7 +37,7 @@ weight: 20
         </div>
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="docs/tutorials/kubernetes-basics/explore/explore-intro/" role="button">Lanjut ke Modul 3<span class="btn__next">›</span></a>
+                <a class="btn btn-lg btn-success" href="/id/docs/tutorials/kubernetes-basics/explore/explore-intro/" role="button">Lanjut ke Modul 3<span class="btn__next">›</span></a>
             </div>
         </div>
 

--- a/content/id/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
+++ b/content/id/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
@@ -1,0 +1,109 @@
+---
+title: Menggunakan kubectl untuk membuat Deployment
+weight: 10
+---
+
+<!DOCTYPE html>
+
+<html lang="id">
+
+<body>
+
+    <link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
+
+<div class="layout" id="top">
+
+    <main class="content">
+
+        <div class="row">
+
+         <div class="col-md-8">
+          <h3>Tujuan</h3>
+                <ul>
+                    <li>Belajar tentang aplikasi Deployment.</li>
+                    <li><i>Deploy</i> aplikasi pertama kamu di Kubernetes dengan kubectl.</li>
+                </ul>
+            </div>
+
+            <div class="col-md-8">
+                <h3><i>Deployment</i> Kubernetes</h3>
+                <p>
+                Ketika klaster Kubernetes kamu sudah berjalan, kamu dapat men-<i>deploy</i> aplikasi terkontainerisasi di atasnya.
+                Untuk melakukannya, kamu perlu membuat konfigurasi <b>Deployment</b>. Deployemnt menginstruksikan Kubernetes
+                tentang bagaimana cara membuat dan memperbaharui <i>instance</i> aplikasi kamu. Ketika kamu selesai membuat Deployment, Kubernetes master
+                melakukan penjadwalan <i>instance</i> aplikasi yang terlibat dalam Deployment untuk berjalan di Node individu pada klaster.
+                </p>
+
+                <p>Setelah <i>instance</i> aplikasi telah dibuat, Kubernetes Deployment Controller akan melakukan monitoring <i>instance</i> tersebut secara kontinu. Jika <i>instance</i> pada hos Node <i>down</i> atau terhapus, Deployment Controller akan mengganti <i>instance</i> tersebut dengan <i>instance</i> Node lain dalam klaster. <b>Ia menyediakan mekanisme penyembuhan diri (<i>self-healing</i>) untuk mengatasi kegagalan mesin atau pemeliharaan (<i>maintenance</i>)</b></p>
+
+                <p>Pada masa pra-orkestrasi, instalasi <i>script</i> sering digunakan untuk memulai aplikasi, namun cara ini tidak memberikan mekanisme pemulihan ketika terjadi kegagalan mesin. Dengan kemampuan membuat <i>instance</i> aplikasi dan menjaganya tetap berjalan pada Node, Kubernetes Deployment menyediakan manajemen aplikasi dengan pendekatan fundamental yang berbeda. </p>
+
+            </div>
+
+            <div class="col-md-4">
+                <div class="content__box content__box_lined">
+                    <h3>Summary:</h3>
+                    <ul>
+                        <li>Deployment</li>
+                        <li>Kubectl</li>
+                    </ul>
+                </div>
+                <div class="content__box content__box_fill">
+                    <p><i>
+                        Sebuah Deployment bertanggung jawab untuk membuat dan memperbaharui instance dari aplikasi kamu
+                    </i></p>
+                </div>
+            </div>
+        </div>
+        <br>
+
+        <div class="row">
+            <div class="col-md-8">
+                <h2 style="color: #3771e3;">Men-<i>deploy</i> aplikasi pertama kamu pada Kubernetes</h2>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-md-8">
+                <p><img src="/docs/tutorials/kubernetes-basics/public/images/module_02_first_app.svg"></p>
+            </div>
+        </div>
+        <br>
+
+        <div class="row">
+            <div class="col-md-8">
+
+                <p>Kamu dapat membuat dan mengatur Deployment dengan menggunakan antar muka baris perintah Kubernetes, <b>Kubectl</b>. Kubectl menggunakan Kubernetes API untuk berinteraksi dengan klaster. Pada modul ini, kamu akan belajar perintah-perintah yang sering digunakan Kubectl dalam membuat Deployment untuk menjalankan aplikasi kamu pada klaster Kubernetes.</p>
+
+                <p>Ketika kamu membuat Deployment, kamu perlu mendefinisikan kontainer <i>image</i> untuk aplikasi kamu dan jumlah replika yang kamu inginkan. Kamu dapat mengganti informasi tersebut nanti dengan melakukan pembaharuan Deployment kamu; Modul <a href="docs/tutorials/kubernetes-basics/scale/scale-intro/">5</a> dan <a href="/docs/tutorials/kubernetes-basics/update/update-intro/">6</a> pada <i>bootcamp</i> ini mendiskusikan bagaimana cara melakukan perluasan (<i>scale</i>) dan pembaharuan Deployment kamu.</p>
+
+            </div>
+            <div class="col-md-4">
+                <div class="content__box content__box_fill">
+                    <p><i> Aplikasi perlu dikemas menjadi satu dengan format kontainer yang didukung supaya terdeploy pada Kubernetes</i></p>
+                </div>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-md-8">
+                <p>
+                Pada Deployment pertama kamu, kamu akan menggunakan aplikasi Node.js yang terkemas dalam kontainer Docker. (Jika kamu belum pernah mencoba membuat aplikasi Node.js dan men-<i>deploy</i>nya dengan kontainer, kamu dapat melakukannya dengan mengikuti instruksi dari <a href="/id/docs/tutorials/hello-minikube/">tutorial Hello Minikube</a>).
+                </p>
+                <p>Sekarang kamu tahu apa itu Deployment, mari kita ke tutorial <i>online</i> dan <i>deploy</i> aplikasi pertama kita!</p>
+            </div>
+        </div>
+        <br>
+
+        <div class="row">
+            <div class="col-md-12">
+                <a class="btn btn-lg btn-success" href="/id/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive/" role="button">Mulai Tutorial Interaktif <span class="btn__next">›</span></a>
+            </div>
+        </div>
+
+    </main>
+
+</div>
+
+</body>
+</html>

--- a/content/id/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
+++ b/content/id/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
@@ -20,15 +20,15 @@ weight: 10
          <div class="col-md-8">
           <h3>Tujuan</h3>
                 <ul>
-                    <li>Belajar tentang aplikasi Deployment.</li>
-                    <li><i>Deploy</i> aplikasi pertama kamu di Kubernetes dengan kubectl.</li>
+                    <li>Belajar tentang menyebarkan (<i>deploy</i>) aplikasi.</li>
+                    <li>Menyebarkan aplikasi pertama kamu di Kubernetes dengan kubectl.</li>
                 </ul>
             </div>
 
             <div class="col-md-8">
                 <h3><i>Deployment</i> Kubernetes</h3>
                 <p>
-                Ketika klaster Kubernetes kamu sudah berjalan, kamu dapat men-<i>deploy</i> aplikasi terkontainerisasi di atasnya.
+                Ketika klaster Kubernetes kamu sudah berjalan, kamu dapat menyebarkan aplikasi terkontainerisasi di atasnya.
                 Untuk melakukannya, kamu perlu membuat konfigurasi <b>Deployment</b>. Deployment menginstruksikan Kubernetes
                 tentang bagaimana cara membuat dan memperbarui <i>instance</i> aplikasi kamu. Ketika kamu selesai membuat Deployment, Kubernetes master
                 melakukan penjadwalan <i>instance</i> aplikasi yang terlibat dalam Deployment untuk berjalan di Node individu pada klaster.
@@ -42,7 +42,7 @@ weight: 10
 
             <div class="col-md-4">
                 <div class="content__box content__box_lined">
-                    <h3>Summary:</h3>
+                    <h3>Ringkasan:</h3>
                     <ul>
                         <li>Deployment</li>
                         <li>Kubectl</li>

--- a/content/id/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
+++ b/content/id/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
@@ -30,7 +30,7 @@ weight: 10
                 <p>
                 Ketika klaster Kubernetes kamu sudah berjalan, kamu dapat menyebarkan aplikasi terkontainerisasi di atasnya.
                 Untuk melakukannya, kamu perlu membuat konfigurasi <b>Deployment</b>. Deployment menginstruksikan Kubernetes
-                tentang bagaimana cara membuat dan memperbarui <i>instance</i> aplikasi kamu. Ketika kamu selesai membuat Deployment, Kubernetes master
+                tentang bagaimana cara membuat dan memperbarui <i>instance</i> aplikasi kamu. Ketika kamu selesai membuat Deployment, Kubernetes <i>control plane</i>
                 melakukan penjadwalan <i>instance</i> aplikasi yang terlibat dalam Deployment untuk berjalan di Node individu pada klaster.
                 </p>
 

--- a/content/id/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
+++ b/content/id/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
@@ -29,14 +29,14 @@ weight: 10
                 <h3><i>Deployment</i> Kubernetes</h3>
                 <p>
                 Ketika klaster Kubernetes kamu sudah berjalan, kamu dapat men-<i>deploy</i> aplikasi terkontainerisasi di atasnya.
-                Untuk melakukannya, kamu perlu membuat konfigurasi <b>Deployment</b>. Deployemnt menginstruksikan Kubernetes
-                tentang bagaimana cara membuat dan memperbaharui <i>instance</i> aplikasi kamu. Ketika kamu selesai membuat Deployment, Kubernetes master
+                Untuk melakukannya, kamu perlu membuat konfigurasi <b>Deployment</b>. Deployment menginstruksikan Kubernetes
+                tentang bagaimana cara membuat dan memperbarui <i>instance</i> aplikasi kamu. Ketika kamu selesai membuat Deployment, Kubernetes master
                 melakukan penjadwalan <i>instance</i> aplikasi yang terlibat dalam Deployment untuk berjalan di Node individu pada klaster.
                 </p>
 
-                <p>Setelah <i>instance</i> aplikasi telah dibuat, Kubernetes Deployment Controller akan melakukan monitoring <i>instance</i> tersebut secara kontinu. Jika <i>instance</i> pada hos Node <i>down</i> atau terhapus, Deployment Controller akan mengganti <i>instance</i> tersebut dengan <i>instance</i> Node lain dalam klaster. <b>Ia menyediakan mekanisme penyembuhan diri (<i>self-healing</i>) untuk mengatasi kegagalan mesin atau pemeliharaan (<i>maintenance</i>)</b></p>
+                <p>Setelah <i>instance</i> aplikasi telah dibuat, Kubernetes Deployment Controller akan melakukan monitoring <i>instance</i> tersebut secara kontinu. Jika <i>instance</i> pada hos Node mati atau terhapus, Deployment Controller akan mengganti <i>instance</i> tersebut dengan <i>instance</i> Node lain dalam klaster. <b>Ia menyediakan mekanisme penyembuhan diri (<i>self-healing</i>) untuk mengatasi kegagalan mesin atau pemeliharaan (<i>maintenance</i>)</b></p>
 
-                <p>Pada masa pra-orkestrasi, instalasi <i>script</i> sering digunakan untuk memulai aplikasi, namun cara ini tidak memberikan mekanisme pemulihan ketika terjadi kegagalan mesin. Dengan kemampuan membuat <i>instance</i> aplikasi dan menjaganya tetap berjalan pada Node, Kubernetes Deployment menyediakan manajemen aplikasi dengan pendekatan fundamental yang berbeda. </p>
+                <p>Pada masa pra-orkestrasi, instalasi <i>script</i> sering digunakan untuk memulai aplikasi, namun cara ini tidak memberikan mekanisme pemulihan ketika terjadi kegagalan mesin. Dengan kemampuan membuat <i>instance</i> aplikasi dan menjaganya tetap berjalan pada Node, Deployment Kubernetes menyediakan manajemen aplikasi dengan pendekatan fundamental yang berbeda. </p>
 
             </div>
 
@@ -50,7 +50,7 @@ weight: 10
                 </div>
                 <div class="content__box content__box_fill">
                     <p><i>
-                        Sebuah Deployment bertanggung jawab untuk membuat dan memperbaharui instance dari aplikasi kamu
+                        Sebuah Deployment bertanggung jawab untuk membuat dan memperbarui instance dari aplikasi kamu
                     </i></p>
                 </div>
             </div>
@@ -59,13 +59,13 @@ weight: 10
 
         <div class="row">
             <div class="col-md-8">
-                <h2 style="color: #3771e3;">Men-<i>deploy</i> aplikasi pertama kamu pada Kubernetes</h2>
+                <h2 style="color: #3771e3;">Menyebarkan aplikasi pertama kamu dalam Kubernetes</h2>
             </div>
         </div>
 
         <div class="row">
             <div class="col-md-8">
-                <p><img src="/docs/tutorials/kubernetes-basics/public/images/module_02_first_app.svg"></p>
+                <p><img src="/id/docs/tutorials/kubernetes-basics/public/images/module_02_first_app.svg"></p>
             </div>
         </div>
         <br>
@@ -73,14 +73,14 @@ weight: 10
         <div class="row">
             <div class="col-md-8">
 
-                <p>Kamu dapat membuat dan mengatur Deployment dengan menggunakan antar muka baris perintah Kubernetes, <b>Kubectl</b>. Kubectl menggunakan Kubernetes API untuk berinteraksi dengan klaster. Pada modul ini, kamu akan belajar perintah-perintah yang sering digunakan Kubectl dalam membuat Deployment untuk menjalankan aplikasi kamu pada klaster Kubernetes.</p>
+                <p>Kamu dapat membuat dan mengatur Deployment dengan menggunakan antar muka baris perintah (CLI) Kubernetes, <b>Kubectl</b>. Kubectl menggunakan Kubernetes API untuk berinteraksi dengan klaster. Pada modul ini, kamu akan belajar perintah-perintah yang sering digunakan Kubectl untuk membuat Deployment untuk menjalankan aplikasi kamu pada klaster Kubernetes.</p>
 
-                <p>Ketika kamu membuat Deployment, kamu perlu mendefinisikan kontainer <i>image</i> untuk aplikasi kamu dan jumlah replika yang kamu inginkan. Kamu dapat mengganti informasi tersebut nanti dengan melakukan pembaharuan Deployment kamu; Modul <a href="docs/tutorials/kubernetes-basics/scale/scale-intro/">5</a> dan <a href="/docs/tutorials/kubernetes-basics/update/update-intro/">6</a> pada <i>bootcamp</i> ini mendiskusikan bagaimana cara melakukan perluasan (<i>scale</i>) dan pembaharuan Deployment kamu.</p>
+                <p>Ketika kamu membuat Deployment, kamu perlu mendefinisikan Container <i>image</i> untuk aplikasi kamu dan jumlah replika yang kamu inginkan. Kamu dapat mengganti informasi tersebut nanti dengan melakukan pembaharuan Deployment kamu; Modul <a href="docs/tutorials/kubernetes-basics/scale/scale-intro/">5</a> dan <a href="/docs/tutorials/kubernetes-basics/update/update-intro/">6</a> pada <i>bootcamp</i> ini mendiskusikan bagaimana cara melakukan perluasan (<i>scale</i>) dan pembaruan Deployment kamu.</p>
 
             </div>
             <div class="col-md-4">
                 <div class="content__box content__box_fill">
-                    <p><i> Aplikasi perlu dikemas menjadi satu dengan format kontainer yang didukung supaya terdeploy pada Kubernetes</i></p>
+                    <p><i> Aplikasi perlu dikemas menjadi satu dengan format Container yang didukung supaya tersebar pada Kubernetes</i></p>
                 </div>
             </div>
         </div>
@@ -88,9 +88,9 @@ weight: 10
         <div class="row">
             <div class="col-md-8">
                 <p>
-                Pada Deployment pertama kamu, kamu akan menggunakan aplikasi Node.js yang terkemas dalam kontainer Docker. (Jika kamu belum pernah mencoba membuat aplikasi Node.js dan men-<i>deploy</i>nya dengan kontainer, kamu dapat melakukannya dengan mengikuti instruksi dari <a href="/id/docs/tutorials/hello-minikube/">tutorial Hello Minikube</a>).
+                Pada Deployment pertama kamu, kamu akan menggunakan aplikasi Node.js yang terkemas dalam Container Docker. (Jika kamu belum pernah mencoba membuat aplikasi Node.js dan menyebarkannya dengan Container, kamu dapat melakukannya dengan mengikuti instruksi pada <a href="/id/docs/tutorials/hello-minikube/">tutorial Hello Minikube</a>).
                 </p>
-                <p>Sekarang kamu tahu apa itu Deployment, mari kita ke tutorial <i>online</i> dan <i>deploy</i> aplikasi pertama kita!</p>
+                <p>Sekarang kamu tahu apa itu Deployment, mari kita ke tutorial <i>online</i> dan menyebarkan aplikasi pertama kita!</p>
             </div>
         </div>
         <br>


### PR DESCRIPTION
This PR is part of #22296 , translating `/docs/tutorials/kubernetes-basics/deploy-app/` into bahasa

/language id