### PR TITLE
Document how to transfer ownership of server side applied fields

### DIFF
--- a/content/en/docs/reference/using-api/api-concepts.md
+++ b/content/en/docs/reference/using-api/api-concepts.md
@@ -688,7 +688,7 @@ kubectl apply -f application/ssa/nginx-deployment-replicas-only.yaml --server-si
 
 If the apply results in a conflict with the HPA controller, then do nothing. The
 conflict just indicates the controller has claimed the field earlier in the
-process that it sometimes does.
+process than it sometimes does.
 
 At this point the user may remove the `replicas` field from their configuration.
 

--- a/content/en/examples/application/ssa/nginx-deployment-no-replicas.yaml
+++ b/content/en/examples/application/ssa/nginx-deployment-no-replicas.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2

--- a/content/en/examples/application/ssa/nginx-deployment-replicas-only.yaml
+++ b/content/en/examples/application/ssa/nginx-deployment-replicas-only.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3

--- a/content/en/examples/application/ssa/nginx-deployment.yaml
+++ b/content/en/examples/application/ssa/nginx-deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2


### PR DESCRIPTION
Per release notes section of #92661 we need to clearly document how to safely transfer ownership of fields, like replicas during a owner->HPA transfer, such that they are not accidentally reset to their defaults (replicas has a default of 1).

Fixes https://github.com/kubernetes/kubernetes/issues/92844


Preview: https://deploy-preview-22412--kubernetes-io-vnext-staging.netlify.app/docs/reference/using-api/api-concepts/#server-side-apply

/sig api-machinery
/priority important-soon