### PR TITLE
fix: zh docs misleading to en link.

### DIFF
--- a/content/zh/docs/tasks/configure-pod-container/assign-memory-resource.md
+++ b/content/zh/docs/tasks/configure-pod-container/assign-memory-resource.md
@@ -515,25 +515,25 @@ kubectl delete namespace mem-example
 
 ### 应用开发者扩展阅读
 
-* [为容器和 Pod 分配 CPU 资源](/docs/tasks/configure-pod-container/assign-cpu-resource/)
+* [为容器和 Pod 分配 CPU 资源](/zh/docs/tasks/configure-pod-container/assign-cpu-resource/)
 
-* [配置 Pod 的服务质量](/docs/tasks/configure-pod-container/quality-service-pod/)
+* [配置 Pod 的服务质量](/zh/docs/tasks/configure-pod-container/quality-service-pod/)
 
 ### 集群管理员扩展阅读
 
-* [为命名空间配置默认的内存请求和限制](/docs/tasks/administer-cluster/memory-default-namespace/)
+* [为命名空间配置默认的内存请求和限制](/zh/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/)
 
-* [为命名空间配置默认的 CPU 请求和限制](/docs/tasks/administer-cluster/cpu-default-namespace/)
+* [为命名空间配置默认的 CPU 请求和限制](/zh/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace/)
 
-* [配置命名空间的最小和最大内存约束](/docs/tasks/administer-cluster/memory-constraint-namespace/)
+* [配置命名空间的最小和最大内存约束](/zh/docs/tasks/administer-cluster/manage-resources/memory-constraint-namespace/)
 
-* [配置命名空间的最小和最大 CPU 约束](/docs/tasks/administer-cluster/cpu-constraint-namespace/)
+* [配置命名空间的最小和最大 CPU 约束](/zh/docs/tasks/administer-cluster/manage-resources/cpu-constraint-namespace/)
 
-* [为命名空间配置内存和 CPU 配额](/docs/tasks/administer-cluster/quota-memory-cpu-namespace/)
+* [为命名空间配置内存和 CPU 配额](/zh/docs/tasks/administer-cluster/manage-resources/quota-memory-cpu-namespace/)
 
-* [配置命名空间下 Pod 总数](/docs/tasks/administer-cluster/quota-pod-namespace/)
+* [配置命名空间下 Pod 总数](/zh/docs/tasks/administer-cluster/manage-resources/quota-pod-namespace/)
 
-* [配置 API 对象配额](/docs/tasks/administer-cluster/quota-api-object/)
+* [配置 API 对象配额](/zh/docs/tasks/administer-cluster/quota-api-object/)
 
 
 


### PR DESCRIPTION
note that:

1. links reachable with /zh prefix is simply added prefix.
2. links redirected after visit and reachable with /zh prefix is updated to the redirected link and added prefix.

