### PR TITLE
fix: zh docs mislead to en link.

### DIFF
--- a/content/zh/includes/task-tutorial-prereqs.md
+++ b/content/zh/includes/task-tutorial-prereqs.md
@@ -1,5 +1,5 @@
 你必须拥有一个 Kubernetes 的集群，同时你的 Kubernetes 集群必须带有 kubectl 命令行工具。
-如果你还没有集群，你可以通过 [Minikube](/docs/getting-started-guides/minikube) 构建一
+如果你还没有集群，你可以通过 [Minikube](/zh/docs/setup/learning-environment/minikube/) 构建一
 个你自己的集群，或者你可以使用下面任意一个 Kubernetes 工具构建：
 <!--
 You need to have a Kubernetes cluster, and the kubectl command-line tool must


### PR DESCRIPTION
original link `/docs/getting-started-guides/minikube` is redirecting to `/docs/setup/`, which I think is not proper. so I change it to `/zh/docs/setup/learning-environment/minikube/`.

