### PR TITLE
Avoid using deprecated commands in task

### DIFF
--- a/content/en/docs/tasks/extend-kubernetes/http-proxy-access-api.md
+++ b/content/en/docs/tasks/extend-kubernetes/http-proxy-access-api.md
@@ -17,7 +17,7 @@ If you do not already have an application running in your cluster, start
 a Hello world application by entering this command:
 
 ```shell
-kubectl run node-hello --image=gcr.io/google-samples/node-hello:1.0 --port=8080
+kubectl create deployment node-hello --image=gcr.io/google-samples/node-hello:1.0 --port=8080
 ```
 
 <!-- steps -->


### PR DESCRIPTION
The `kubectl run` way of creating Deployment is deprecated. This PR
replaces it with the new equivalent command.

closes: #18978
