### PR TITLE
Update external credential providers docs with install hint details

### DIFF
--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -757,6 +757,19 @@ users:
       args:
       - "arg1"
       - "arg2"
+
+      # Text shown to the user when the executable doesn't seem to be present. Optional.
+      installHint: |
+        example-client-go-exec-plugin is required to authenticate
+        to the current cluster.  It can be installed:
+
+        On macOS: brew install example-client-go-exec-plugin
+
+        On Ubuntu: apt-get install example-client-go-exec-plugin
+
+        On Fedora: dnf install example-client-go-exec-plugin
+
+        ...
 clusters:
 - name: my-cluster
   cluster:


### PR DESCRIPTION
Signed-off-by: Andrew Keesler <akeesler@vmware.com>

Notes:
* Roughly, this feature provides a way to provide an optional install hint to help a user determine how to install an executable (used in the external credential provider flow) if it is missing.
* This doc update is a proper subset of https://github.com/kubernetes/website/pull/21626. It contains documentation for a single feature (install hints) in the external credential providers GA feature set. The rest of the GA feature set is not ready to go for 1.19, but we did manage to get this install hint feature in, so we want to document this install hint feature for 1.19.
* I tried to be a bit more verbose in the description of the `installHint` field as it exists in a `kubeconfig` in the hopes that this would help more users understand the purpose of this field by reading the docs - if it is agreed that this description is acceptable, I will make the corresponding changes to the KEP (https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/541-external-credential-providers).

PR: https://github.com/kubernetes/kubernetes/pull/91305
KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/541-external-credential-providers
Parent: https://github.com/kubernetes/website/pull/21626