### PR TITLE
Fix the usage of skew shortcode in the version-skew-policy page

### DIFF
--- a/content/en/docs/setup/release/version-skew-policy.md
+++ b/content/en/docs/setup/release/version-skew-policy.md
@@ -158,4 +158,4 @@ Example:
 If `kube-proxy` version is **{{< skew latestVersion >}}**:
 
 * `kubelet` version must be at the same minor version as **{{< skew latestVersion >}}**.
-* `kube-apiserver` version must be between **{{ skew oldestMinorVersion }}** and **{{ skew latestVersion }}**, inclusive.
+* `kube-apiserver` version must be between **{{< skew oldestMinorVersion >}}** and **{{< skew latestVersion >}}**, inclusive.


### PR DESCRIPTION
There are two skew shortcodes but they are not marked up properly. This PR fixes the errors.

**Where is the problem?**
[Kubernetes version and version skew support policy | Kubernetes](https://kubernetes.io/docs/setup/release/version-skew-policy/#kube-proxy)

**Before screenshot**
![kubernetes io_docs_setup_release_version-skew-policy_ (1)](https://user-images.githubusercontent.com/1425259/87059613-78e41680-c244-11ea-89d6-f73aa4cfa08c.png)
