### PR TITLE
fix portworx io priority parameter name [EN]

### DIFF
--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -686,7 +686,7 @@ provisioner: kubernetes.io/portworx-volume
 parameters:
   repl: "1"
   snap_interval:   "70"
-  io_priority:  "high"
+  priority_io:  "high"
 
 ```
 
@@ -695,7 +695,7 @@ parameters:
 * `repl`: number of synchronous replicas to be provided in the form of
   replication factor `1..3` (default: `1`) A string is expected here i.e.
   `"1"` and not `1`.
-* `io_priority`: determines whether the volume will be created from higher
+* `priority_io`: determines whether the volume will be created from higher
   performance or a lower priority storage `high/medium/low` (default: `low`).
 * `snap_interval`: clock/time interval in minutes for when to trigger snapshots.
   Snapshots are incremental based on difference with the prior snapshot, 0


### PR DESCRIPTION
duplicate of #21215 after signing cla
splitted from #22419 to be language specific

update `io_priority` to `priority_io`
see https://docs.portworx.com/portworx-install-with-kubernetes/storage-operations/create-pvcs/dynamic-provisioning/
Name: priority_io
Description: IO Priority: low|medium|high
Example: priority_io: “high”