### PR TITLE
Remove SCL reviewers/approvers from OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,21 +1,4 @@
 aliases:
-  sig-cluster-lifecycle-kubeadm-approvers: # Approving changes to kubeadm documentation
-    - timothysc
-    - lukemarsden
-    - luxas
-    - fabriziopandini
-  sig-cluster-lifecycle-kubeadm-reviewers: # Reviewing kubeadm documentation
-    - timothysc
-    - lukemarsden
-    - luxas
-    - fabriziopandini
-    - kad
-    - xiangpengzhao
-    - stealthybox
-    - liztio
-    - chuckha
-    - detiber
-    - dixudx
   sig-docs-blog-owners: # Approvers for blog content
     - castrojo
     - kbarnard10


### PR DESCRIPTION
For https://github.com/kubernetes/org/issues/2013

To adequately leverage the SCL reviewers/approvers list in OWNERS_ALIASES,
we would need to add multiple OWNERS files in various directories.
Otherwise, the bot ends up suggesting reviewers and approvers from
other parent directories.

To avoid this complexity, remove the list of SCL reviewers/approvers
from OWNERS_ALIASES.

Original commit message below.

----

As a part of cleaning up inactive members (who haven't been active since
the release of v1.11) from OWNERS, this commit removes lukemarsden from
the SIG Cluster reviewers/approvers list.

/assign @neolit123 
SCL lead

cc @mrbobbytables @lukemarsden 