### PR TITLE
correct the sample content

### DIFF
--- a/content/en/docs/concepts/policy/pod-security-policy.md
+++ b/content/en/docs/concepts/policy/pod-security-policy.md
@@ -302,7 +302,7 @@ kubectl-user delete pod pause
 Let's try that again, slightly differently:
 
 ```shell
-kubectl-user run pause --image=k8s.gcr.io/pause
+kubectl-user create deployment pause --image=k8s.gcr.io/pause
 deployment "pause" created
 
 kubectl-user get pods


### PR DESCRIPTION
in the example `kubectl run` ... is an outdated method of use.
```yaml
kubectl-user run pause --image=k8s.gcr.io/pause
deployment "pause" created
```

let's clearly state the type of resources used.
```yaml
kubectl-user create deployment pause --image=k8s.gcr.io/pause
deployment "pause" created
```
