### PR TITLE
Fix whitespace trimming for note callout shortcode

### DIFF
--- a/layouts/shortcodes/note.html
+++ b/layouts/shortcodes/note.html
@@ -1,3 +1,3 @@
 <blockquote class="note">
-  <div><strong>{{ T "note" }}</strong> {{ replaceRE "\\s+|\n" " " .Inner | markdownify }}</div>
+  <div><strong>{{ T "note" }}</strong> {{ trim .Inner " \n" | markdownify }}</div>
 </blockquote>


### PR DESCRIPTION
Use the same whitespace trimming for `{{< note >}}` that the other callout shortcodes (warning, caution) use, and avoid excessive newline removal.

Fixes issue #22487. Also obviates issue #22488.