### PR TITLE
format search-input.html

### DIFF
--- a/layouts/partials/search-input.html
+++ b/layouts/partials/search-input.html
@@ -1,10 +1,30 @@
 {{ if or .Site.Params.gcs_engine_id .Site.Params.algolia_docsearch }}
-  <input type="search" class="form-control td-search-input" placeholder="&#xf002 {{ T "ui_search_placeholder" }}" aria-label="{{ T "ui_search_placeholder" }}" autocomplete="off">
+  <input
+    type="search"
+    class="form-control td-search-input"
+    placeholder="&#xf002; {{ T "ui_search_placeholder" }}"
+    aria-label="{{ T "ui_search_placeholder" }}"
+    autocomplete="off"
+  >
 {{ else if .Site.Params.offlineSearch }}
   <div id="search-nav-container">
-    <input type="search" id="search-input" autocomplete="off" class="form-control td-search-input" placeholder="&#xf002 {{ T "ui_search_placeholder" }}" autocomplete="on">
+    <input
+      type="search"
+      id="search-input"
+      autocomplete="off"
+      class="form-control td-search-input"
+      placeholder="&#xf002 {{ T "ui_search_placeholder" }}"
+      autocomplete="off"
+    >
     <div id="search-results" class="container"></div>
   </div>
 {{ else if .Site.Params.k8s_search }}
-  <input type="search" class="form-control td-search-input" name="q" placeholder="&#xf002 {{ T "ui_search_placeholder" }}" aria-label="{{ T "ui_search_placeholder" }}" autocomplete="off">
+  <input
+    type="search"
+    class="form-control td-search-input"
+    name="q"
+    placeholder="&#xf002 {{ T "ui_search_placeholder" }}"
+    aria-label="{{ T "ui_search_placeholder" }}"
+    autocomplete="off"
+  >
 {{ end }}


### PR DESCRIPTION
- To improve readability of parameters, format search-input.html (similar to corresponding Docsy file).
- As part of this PR, investigated the use of search.html and search.js in the site. The Docsy theme has similar files.
The site overrides theme files with static/js/search.js and layouts/docs/search.html. To work together, the local assets/js/search.js is needed.