### PR TITLE
pruning inactive approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -41,18 +41,15 @@ aliases:
   sig-docs-en-owners: # Admins for English content
     - bradtopol
     - celestehorgan
-    - daminisatya
     - jimangel
     - kbarnard10
     - kbhawkey
     - makoscafee
     - onlydole
-    - Rajakavitha1
     - savitharaghunathan
     - sftim
     - steveperry-53
     - tengqm
-    - vineethreddy02
     - xiangpengzhao
     - zacharysarah
     - zparnold


### PR DESCRIPTION
Removing @daminisatya @Rajakavitha1 and @VineethReddy02 from the k/website approvers OWNERS_ALIAS file. Any of ya'll are welcome back if you'd like and SIG Docs appreciates your past work!

/cc @zacharysarah @kbarnard10 
Related: https://github.com/kubernetes/org/pull/2031 