### PR TITLE
Removed several references to sig-pm

### DIFF
--- a/content/en/docs/contribute/advanced.md
+++ b/content/en/docs/contribute/advanced.md
@@ -47,8 +47,8 @@ docs for a Kubernetes release.
 
 Each Kubernetes release is coordinated by a team of people participating in the
 sig-release Special Interest Group (SIG). Others on the release team for a given
-release include an overall release lead, as well as representatives from sig-pm,
-sig-testing, and others. To find out more about Kubernetes release processes,
+release include an overall release lead, as well as representatives from
+sig-testing and others. To find out more about Kubernetes release processes,
 refer to
 [https://github.com/kubernetes/sig-release](https://github.com/kubernetes/sig-release).
 

--- a/content/fr/docs/contribute/advanced.md
+++ b/content/fr/docs/contribute/advanced.md
@@ -64,7 +64,7 @@ Par exemple, une mise à jour du guide de style ou du fonctionnement du site Web
 [Les approbateurs](/docs/contribute/participating/#approvers) SIG Docs peuvent coordonner les tâches liées à la documentation pour une release de Kubernetes.
 
 Chaque release de Kubernetes est coordonnée par une équipe de personnes participant au sig-release Special Interest Group (SIG).
-Les autres membres de l'équipe de publication pour une release donnée incluent un responsable général de la publication, ainsi que des représentants de sig-pm, de sig-testing et d'autres.
+Les autres membres de l'équipe de publication pour une release donnée incluent un responsable général de la publication, ainsi que des représentants de sig-testing et d'autres.
 Pour en savoir plus sur les processus de release de Kubernetes, reportez-vous à la section [https://github.com/kubernetes/sig-release](https://github.com/kubernetes/sig-release).
 
 Le représentant de SIG Docs pour une release donnée coordonne les tâches suivantes:

--- a/content/ko/docs/contribute/advanced.md
+++ b/content/ko/docs/contribute/advanced.md
@@ -108,7 +108,7 @@ SIG Docs [승인자](/ko/docs/contribute/participating/#승인자)는 쿠버네�
 
 각 쿠버네티스 릴리스는 sig-release SIG(Special Interest Group)에 참여하는
 사람들의 팀에 의해 조정된다. 특정 릴리스에 대한 릴리스 팀의 다른 구성원에는
-전체 릴리스 리드와 sig-pm, sig-testing 및 기타 담당자가
+전체 릴리스 리드와 sig-testing 및 기타 담당자가
 포함된다. 쿠버네티스 릴리스 프로세스에 대한 자세한 내용은
 [https://github.com/kubernetes/sig-release](https://github.com/kubernetes/sig-release)를
 참고한다.

--- a/content/ru/docs/contribute/advanced.md
+++ b/content/ru/docs/contribute/advanced.md
@@ -80,7 +80,7 @@ weight: 30
 
 [Утверждающие](/ru/docs/contribute/participating/#утверждающие) SIG Docs могут координировать документацию для выпуска Kubernetes.
 
-Каждый выпуск Kubernetes координируется командой людей, участвующих в специальной группе (Special Interest Group, SIG) sig-release. Другие члены команды в данном выпуске включают в себя общего руководителя выпуском, а также представителей sig-pm, sig-testing и др. Чтобы узнать больше о процессах выпуска версий Kubernetes, обратитесь к [https://github.com/kubernetes/sig-release](https://github.com/kubernetes/sig-release).
+Каждый выпуск Kubernetes координируется командой людей, участвующих в специальной группе (Special Interest Group, SIG) sig-release. Другие члены команды в данном выпуске включают в себя общего руководителя выпуском, а также представителей sig-testing и др. Чтобы узнать больше о процессах выпуска версий Kubernetes, обратитесь к [https://github.com/kubernetes/sig-release](https://github.com/kubernetes/sig-release).
 
 Представитель SIG Docs для данного выпуска координирует следующие задачи:
 

--- a/content/zh/docs/contribute/advanced.md
+++ b/content/zh/docs/contribute/advanced.md
@@ -214,7 +214,7 @@ refer to
 [https://github.com/kubernetes/sig-release](https://github.com/kubernetes/sig-release).
 -->
 每一个 Kubernetes 版本都是由参与 sig-release 的 SIG（特别兴趣小组）的一个团队协调的。
-指定版本的发布团队中还包括总体发布牵头人，以及来自 sig-pm、sig-testing 的代表等。
+指定版本的发布团队中还包括总体发布牵头人，以及来自 sig-testing 的代表等。
 要了解更多关于 Kubernetes 版本发布的流程，请参考
 [https://github.com/kubernetes/sig-release](https://github.com/kubernetes/sig-release)。
 


### PR DESCRIPTION
I deleted five references to sig-pm, which no longer exists (since April 2020).
