### PR TITLE
automatically tag docker image based on hugo version and dockerfile v…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,11 @@
 # change is that the Hugo version is now an overridable argument rather than a fixed
 # environment variable.
 
+# Bump this by 1 whenever you change the Dockerfile below, e.g. if
+# `DOCKERFFILE_VERSION=1` then change this to `DOCKERFILE_VERSION=2` when you
+# change something else in this file.
+# DOCKERFILE_VERSION=0
+
 FROM alpine:latest
 
 LABEL maintainer="Luc Perkins <lperkins@linuxfoundation.org>"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,6 @@
 # change is that the Hugo version is now an overridable argument rather than a fixed
 # environment variable.
 
-# Bump this by 1 whenever you change the Dockerfile below, e.g. if
-# `DOCKERFFILE_VERSION=1` then change this to `DOCKERFILE_VERSION=2` when you
-# change something else in this file.
-# DOCKERFILE_VERSION=0
-
 FROM alpine:latest
 
 LABEL maintainer="Luc Perkins <lperkins@linuxfoundation.org>"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ NETLIFY_FUNC      = $(NODE_BIN)/netlify-lambda
 # but this can be overridden when calling make, e.g.
 # CONTAINER_ENGINE=podman make container-image
 CONTAINER_ENGINE ?= docker
-CONTAINER_IMAGE   = kubernetes-hugo
+DOCKERFILE_VERSION = $(shell grep DOCKERFILE_VERSION Dockerfile | tail -n 1 | cut -d '=' -f 2 | tr -d " \"\n")
+CONTAINER_IMAGE   = kubernetes-hugo:v$(HUGO_VERSION)-$(DOCKERFILE_VERSION)
 CONTAINER_RUN     = $(CONTAINER_ENGINE) run --rm --interactive --tty --volume $(CURDIR):/src
 
 CCRED=\033[0;31m

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ NETLIFY_FUNC      = $(NODE_BIN)/netlify-lambda
 # but this can be overridden when calling make, e.g.
 # CONTAINER_ENGINE=podman make container-image
 CONTAINER_ENGINE ?= docker
-DOCKERFILE_VERSION = $(shell grep DOCKERFILE_VERSION Dockerfile | tail -n 1 | cut -d '=' -f 2 | tr -d " \"\n")
-CONTAINER_IMAGE   = kubernetes-hugo:v$(HUGO_VERSION)-$(DOCKERFILE_VERSION)
+IMAGE_VERSION=$(shell scripts/hash-files.sh Dockerfile Makefile | cut -c 1-12)
+CONTAINER_IMAGE   = kubernetes-hugo:v$(HUGO_VERSION)-$(IMAGE_VERSION)
 CONTAINER_RUN     = $(CONTAINER_ENGINE) run --rm --interactive --tty --volume $(CURDIR):/src
 
 CCRED=\033[0;31m

--- a/scripts/hash-files.sh
+++ b/scripts/hash-files.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# this script emits as hash for the files listed in $@
+if command -v shasum >/dev/null 2>&1; then
+  cat "$@" | shasum -a 256 | cut -d' ' -f1
+elif command -v sha256sum >/dev/null 2>&1; then
+  cat "$@" | sha256sum | cut -d' ' -f1
+else
+  echo "missing shasum tool" 1>&2
+  exit 1
+fi


### PR DESCRIPTION
…ersion

(instead of just `:latest` which isn't used in k8s.gcr.io images / the image promoter)

related to: https://github.com/kubernetes/website/issues/22515

The idea is then we'd have a `postsubmit` job push this image to staging whenever `Dockerfile`, `Makefile`, or `netlify.tomly` change (using `run_if_changed`).
If the `HUGO_VERSION` or Dockerfile version changed we'd file a promotion PR for the auto-pushed image to promote it from staging to the production registry. Otherwise we'd keep using the current version for any other commit.
