### PR TITLE
Remove deprecationwarning shortcode in /zh/_index.html in favor of layout partial

### DIFF
--- a/content/zh/_index.html
+++ b/content/zh/_index.html
@@ -4,7 +4,6 @@ abstract: "自动化的容器部署、扩展和管理"
 cid: home
 ---
 
-{{< deprecationwarning >}}
 
 {{< blocks/section id="oceanNodes" >}}
 {{% blocks/feature image="flower" %}}


### PR DESCRIPTION
Umbrella issue: https://github.com/kubernetes/website/issues/21609

Deprecation warnings are now implemented using a layout partial, `/partials/deprecation-warning.html`. This PR removes the unused shortcode.