### PR TITLE
Fix language selector issue

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -34,7 +34,7 @@
 {{ end }}
 {{ partialCached "head-css.html" . "asdf" }}
 <script
-  src="https://code.jquery.com/jquery-3.3.1.min.js"
+  src="{{ "js/jquery-3.3.1.min.js" | relURL }}"
   integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
   crossorigin="anonymous"></script>
 {{ if and (.Site.Params.offlineSearch) (not .Site.Params.gcs_engine_id) }}

--- a/layouts/partials/navbar-lang-selector.html
+++ b/layouts/partials/navbar-lang-selector.html
@@ -1,6 +1,6 @@
 {{/* Link directly to documentation etc., if possible. */}}
 {{ $langPage := cond (gt (len .Translations) 0) . .Site.Home }}
-<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+<a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 	{{ $langPage.Language.LanguageName }}
 </a>
 <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownMenuLink">


### PR DESCRIPTION
The language selector is not working. We are getting ERR_CONNECTION_CLOSED
when fetching jquery-3.3.1.min.js from code.jquery.com. The failure of
jquery is breaking other scripts such as jquery-ui-1.12.1.min.js,
script.js, bootstrap.min.js etc.

This PR changes the head partial to use cached version of
jquery-3.3.1.min.js in hope we fix the language selector issue and
possibly other relate problems.

closes: #22539
