### PR TITLE
Disable analytics for non-production environment

### DIFF
--- a/layouts/partials/git-info.html
+++ b/layouts/partials/git-info.html
@@ -3,9 +3,11 @@
   <hr/>
 
   <div class="issue-button-container">
+    {{ if eq (getenv "HUGO_ENV") "production" }}
     <p>
       <a href=""><img alt="Analytics" src="https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/{{ .Path }}?pixel"/></a>
     </p>
+    {{ end }}
     {{ if and (ne .Kind "404") (not (strings.Contains .Path "search")) }}
       {{ if not .Params.no_issue }}
         <script type="text/javascript">


### PR DESCRIPTION
The analytics code/link is not always working. It takes about 33 seconds to load and fail when building local sites for testing, and that is terrible.

This PR disables the analytics in non-production environment, so local build starts up in seconds!
