### PR TITLE
Remove the 'slug' attribute from open-a-pr

### DIFF
--- a/content/en/docs/contribute/new-content/open-a-pr.md
+++ b/content/en/docs/contribute/new-content/open-a-pr.md
@@ -1,6 +1,5 @@
 ---
 title: Opening a pull request
-slug: new-content
 content_type: concept
 weight: 10
 card:


### PR DESCRIPTION
The `slug` is causing problems for tracking missing links. Other than that, I'm not seeing any advantage of using it.

closes: #22614