### PR TITLE
Only kubectl apply manages last-applied-configuration

### DIFF
--- a/content/en/docs/concepts/cluster-administration/manage-deployment.md
+++ b/content/en/docs/concepts/cluster-administration/manage-deployment.md
@@ -371,7 +371,7 @@ Note that `kubectl apply` attaches an annotation to the resource in order to det
 
 Currently, resources are created without this annotation, so the first invocation of `kubectl apply` will fall back to a two-way diff between the provided input and the current configuration of the resource. During this first invocation, it cannot detect the deletion of properties set when the resource was created. For this reason, it will not remove them.
 
-All subsequent calls to `kubectl apply`, and other commands that modify the configuration, such as `kubectl replace` and `kubectl edit`, will update the annotation, allowing subsequent calls to `kubectl apply` to detect and perform deletions using a three-way diff.
+All subsequent calls to `kubectl apply` will update the annotation, allowing subsequent calls to `kubectl apply` to detect and perform deletions using a three-way diff.
 
 ### kubectl edit
 


### PR DESCRIPTION
Docs were suggesting that `kubectl edit` and `kubectl patch`, besides `kubectl apply`, will keep `kubectl.kubernetes.io/last-applied-configuration` annotation up-to-date. AFAIK this is not true. Only kubectl apply maintains the annotation. This PR removes the misleading documentation.