### PR TITLE
Fix a bug of shortcode 'glossary_definition' which selects a wrong term

### DIFF
--- a/layouts/shortcodes/glossary_definition.html
+++ b/layouts/shortcodes/glossary_definition.html
@@ -4,7 +4,7 @@
 {{- $prepend := .Get "prepend" }}
 {{- $glossaryBundle := site.GetPage "page" "docs/reference/glossary" -}}
 {{- $glossaryItems :=  $glossaryBundle.Resources.ByType "page" -}}
-{{- $term_info := $glossaryItems.GetMatch (printf "%s*" $id ) -}}
+{{- $term_info := $glossaryItems.GetMatch (printf "%s.md" $id ) -}}
 {{- if not $term_info -}}
 {{- errorf "[%s] %q: %q is not a valid glossary term_id, see ./docs/reference/glossary/* for a full list" site.Language.Lang .Page.Path $id -}}
 {{- end -}}


### PR DESCRIPTION
Fixes #21039.

**Description**
There is a bug in [`glossary_definition` shortcode](https://github.com/kubernetes/website/blob/master/layouts/shortcodes/glossary_definition.html) where a wrong definition is selected in case some specific `term_id` is used.

For example, when we specify `{{< glossary_definition term_id="name" length="all" >}}`, this shortcode select [`namespace.md`](https://github.com/kubernetes/website/blob/master/content/ja/docs/reference/glossary/namespace.md) instead of [`name.md`](https://github.com/kubernetes/website/blob/master/content/ja/docs/reference/glossary/name.md). This is the bug found in #21039.

**Cause and solution**
This shortcode searches a Markdown file whose name has the string specified in `term_id` attribute (by `"%s*"`). But in this case, this blob selects a wrong file because `namespace.md` is smaller than `name.md` if they are sorted alphabetically. Replacing `"%s*"` with `"%s.md"` should fix this bug.

**Comments**
I confirmed this fixes #21039. But this change affects all the localizations not only Japanese pages. We need to check if this change will not make any regressions. Some localization pages may rely on`"%s*"`.

This could be done for example by grepping `{{< glossary_definition term_id="name" ...` or something.