### PR TITLE
Document the health-for-strangers workaround

### DIFF
--- a/content/en/examples/priority-and-fairness/health-for-strangers.yaml
+++ b/content/en/examples/priority-and-fairness/health-for-strangers.yaml
@@ -1,0 +1,20 @@
+apiVersion: flowcontrol.apiserver.k8s.io/v1alpha1
+kind: FlowSchema
+metadata:
+  name: health-for-strangers
+spec:
+  matchingPrecedence: 1000
+  priorityLevelConfiguration:
+    name: exempt
+  rules:
+  - nonResourceRules:
+    - nonResourceURLs:
+      - "/healthz"
+      - "/livez"
+      - "/readyz"
+      verbs:
+      - "*"
+    subjects:
+    - kind: Group
+      group:
+        name: system:unauthenticated


### PR DESCRIPTION
This PR extends the Concepts page about API Priority and Fairness to discuss a problem and possible workaround, concerning the unauthenticated requests from the local kubelet to the kube-apiserver's health checking paths.

This is in response to https://github.com/kubernetes/kubernetes/issues/93359

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

-->
