### PR TITLE
Follow up for ID high-availability

### DIFF
--- a/content/id/docs/setup/production-environment/tools/kubeadm/high-availability.md
+++ b/content/id/docs/setup/production-environment/tools/kubeadm/high-availability.md
@@ -200,7 +200,7 @@ pada berkas konfigurasi kubeadm.
 
 ### Memasang klaster etcd
 
-1.  Ikuti [petunjuk berikut](/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm/) untuk membangun klaster etcd.
+1.  Ikuti [petunjuk berikut](/id/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm/) untuk membangun klaster etcd.
 
 2.  Lakukan pengaturan SSH seperti yang dijelaskan [di sini](#distribusi-sertifikat-manual).
 


### PR DESCRIPTION
This PR is a follow-up for #22669.

Referenced docs now use `/id/` version even though the referenced page hasn't been translated yet, so when the page is translated no further changes are needed.