### PR TITLE
fix svc type error

### DIFF
--- a/content/en/docs/tutorials/services/source-ip.md
+++ b/content/en/docs/tutorials/services/source-ip.md
@@ -177,7 +177,7 @@ service/nodeport exposed
 
 ```shell
 NODEPORT=$(kubectl get -o jsonpath="{.spec.ports[0].nodePort}" services nodeport)
-NODES=$(kubectl get nodes -o jsonpath='{ $.items[*].status.addresses[?(@.type=="ExternalIP")].address }')
+NODES=$(kubectl get nodes -o jsonpath='{ $.items[*].status.addresses[?(@.type=="InternalIP")].address }')
 ```
 
 If you're running on a cloud provider, you may need to open up a firewall-rule

--- a/content/zh/docs/tutorials/services/source-ip.md
+++ b/content/zh/docs/tutorials/services/source-ip.md
@@ -150,7 +150,7 @@ service/nodeport exposed
 
 ```console
 NODEPORT=$(kubectl get -o jsonpath="{.spec.ports[0].nodePort}" services nodeport)
-NODES=$(kubectl get nodes -o jsonpath='{ $.items[*].status.addresses[?(@.type=="ExternalIP")].address }')
+NODES=$(kubectl get nodes -o jsonpath='{ $.items[*].status.addresses[?(@.type=="InternalIP")].address }')
 ```
 
 如果你的集群运行在一个云服务上，你可能需要为上面报告的 `nodes:nodeport` 开启一条防火墙规则。


### PR DESCRIPTION
fix issue: https://github.com/kubernetes/website/issues/22599

How to reproduce:

According it: [Use `NodePort` to access applications](https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-type-nodeport)

Tried on both Katakoda & Play with k8s
Expected Output:
```shell
kubectl get nodes -o jsonpath='{ $.items[*].status.addresses[?(@.type=="InternalIP")].address}'
```
```
192.168.0.33
```

In this scenario, the `NodePort` method is used to expose the service, and InternalIP should be used to access the service.