### PR TITLE
Bump Hugo version

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@ functions = "functions"
 command = "git submodule update --init --recursive --depth 1 && make non-production-build"
 
 [build.environment]
-HUGO_VERSION = "0.70.0"
+HUGO_VERSION = "0.74.3"
 NODE_VERSION = "10.20.0"
 RUBY_VERSION = "2.7.1"
 


### PR DESCRIPTION
Switch to Hugo version 0.74.3 as it's more recent and has [new features](https://gohugo.io/news/0.74.0-relnotes/).