### PR TITLE
[zh] Fix links in contribute section

### DIFF
--- a/content/en/docs/contribute/participate/_index.md
+++ b/content/en/docs/contribute/participate/_index.md
@@ -105,7 +105,7 @@ SIG Docs approvers. Here's how it works.
 - Any Kubernetes member can add the `lgtm` label by adding a `/lgtm` comment.
 - Only SIG Docs approvers can merge a pull request
   by adding an `/approve` comment. Some approvers also perform additional
-  specific roles, such as [PR Wrangler](/docs/contribute/advanced#be-the-pr-wrangler-for-a-week) or
+  specific roles, such as [PR Wrangler](/docs/contribute/participate/pr-wranglers/) or
   [SIG Docs chairperson](#sig-docs-chairperson).
 
 

--- a/content/zh/docs/contribute/advanced.md
+++ b/content/zh/docs/contribute/advanced.md
@@ -30,11 +30,11 @@ client and other tools for some of these tasks.
 <!--
 ## Propose improvements
 
-SIG Docs [members](/docs/contribute/participating/#members) can propose improvements.
+SIG Docs [members](/docs/contribute/participate/roles-and-responsibilities/#members) can propose improvements.
 -->
 ## 提出改进建议
 
-SIG Docs 的 [成员](/zh/docs/contribute/participating/#members) 可以提出改进建议。
+SIG Docs 的 [成员](/zh/docs/contribute/participate/roles-and-responsibilities/#members) 可以提出改进建议。
 
 <!--
 After you've been contributing to the Kubernetes documentation for a while, you
@@ -185,7 +185,7 @@ organization. The contributor's membership needs to be backed by two sponsors
 who are already reviewers.
 -->
 新的贡献者针对一个或多个 Kubernetes 项目仓库成功提交了 5 个实质性 PR 之后，
-就有资格申请 Kubernetes 组织的[成员身份](/zh/docs/contribute/participating#members)。
+就有资格申请 Kubernetes 组织的[成员身份](/zh/docs/contribute/participate/roles-and-responsibilities/#members)。
 贡献者的成员资格需要同时得到两位评审人的保荐。
 
 <!--
@@ -211,7 +211,7 @@ SIG Docs [approvers](/docs/contribute/participating/#approvers) can serve a term
 -->
 ## 担任 SIG 联合主席
 
-SIG Docs [批准人（Approvers）](/zh/docs/contribute/participating/#approvers)
+SIG Docs [批准人（Approvers）](/zh/docs/contribute/participate/roles-and-responsibilities/#approvers)
 可以担任 SIG Docs 的联合主席。
 
 ### 前提条件

--- a/content/zh/docs/contribute/generate-ref-docs/_index.md
+++ b/content/zh/docs/contribute/generate-ref-docs/_index.md
@@ -22,5 +22,5 @@ To build the reference documentation, see the following guide:
 本节的主题是描述如何生成 Kubernetes 参考指南。
 要生成参考文档，请参考下面的指南：
 
-* [生成参考文档快速入门](/docs/contribute/generate-ref-docs/quickstart/)
+* [生成参考文档快速入门](/zh/docs/contribute/generate-ref-docs/quickstart/)
 

--- a/content/zh/docs/contribute/generate-ref-docs/contribute-upstream.md
+++ b/content/zh/docs/contribute/generate-ref-docs/contribute-upstream.md
@@ -29,8 +29,8 @@ API or the `kube-*` components from the upstream code, see the following instruc
 -->
 如果您仅想从上游代码重新生成 Kubernetes API 或 `kube-*` 组件的参考文档。请参考以下说明：
 
-- [生成 Kubernetes API 的参考文档](/docs/contribute/generate-ref-docs/kubernetes-api/)
-- [生成 Kubernetes 组件和工具的参考文档](/docs/contribute/generate-ref-docs/kubernetes-components/)
+- [生成 Kubernetes API 的参考文档](/zh/docs/contribute/generate-ref-docs/kubernetes-api/)
+- [生成 Kubernetes 组件和工具的参考文档](/zh/docs/contribute/generate-ref-docs/kubernetes-components/)
 
 ## {{% heading "prerequisites" %}}
 
@@ -395,7 +395,7 @@ You are now ready to follow the [Generating Reference Documentation for the Kube
 [published Kubernetes API reference documentation](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/).
 -->
 现在，您可以按照
-[生成 Kubernetes API 的参考文档](/docs/contribute/generate-ref-docs/kubernetes-api/)
+[生成 Kubernetes API 的参考文档](/zh/docs/contribute/generate-ref-docs/kubernetes-api/)
 指南来生成
 [已发布的 Kubernetes API 参考文档](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/)。
 
@@ -406,7 +406,7 @@ You are now ready to follow the [Generating Reference Documentation for the Kube
 * [Generating Reference Docs for Kubernetes Components and Tools](/docs/home/contribute/generated-reference/kubernetes-components/)
 * [Generating Reference Documentation for kubectl Commands](/docs/home/contribute/generated-reference/kubectl/)
 -->
-* [生成 Kubernetes API 的参考文档](/docs/contribute/generate-ref-docs/kubernetes-api/)
-* [为 Kubernetes 组件和工具生成参考文档](/docs/home/contribute/generated-reference/kubernetes-components/)
-* [生成 kubectl 命令的参考文档](/docs/home/contribute/generated-reference/kubectl/)
+* [生成 Kubernetes API 的参考文档](/zh/docs/contribute/generate-ref-docs/kubernetes-api/)
+* [为 Kubernetes 组件和工具生成参考文档](/zh/docs/contribute/generate-ref-docs/kubernetes-components/)
+* [生成 kubectl 命令的参考文档](/zh/docs/contribute/generate-ref-docs/kubectl/)
 

--- a/content/zh/docs/contribute/generate-ref-docs/kubectl.md
+++ b/content/zh/docs/contribute/generate-ref-docs/kubectl.md
@@ -35,8 +35,8 @@ reference page, see
 本主题描述了如何为 [kubectl 命令](/docs/reference/generated/kubectl/kubectl-commands)
 生成参考文档，如 [kubectl apply](/docs/reference/generated/kubectl/kubectl-commands#apply) 和
 [kubectl taint](/docs/reference/generated/kubectl/kubectl-commands#taint)。
-本主题没有讨论如何生成 [kubectl](/docs/reference/generated/kubectl/kubectl/) 组件选项的参考页面。
-相关说明请参见[为 Kubernetes 组件和工具生成参考页面](/docs/home/contribute/generated-reference/kubernetes-components/)。
+本主题没有讨论如何生成 [kubectl](/docs/reference/generated/kubectl/kubectl-commands/) 组件选项的参考页面。
+相关说明请参见[为 Kubernetes 组件和工具生成参考页面](/zh/docs/contribute/generate-ref-docs/kubernetes-components/)。
 {{< /note >}}
 
 ## {{% heading "prerequisites" %}}
@@ -412,7 +412,7 @@ topics will be visible in the
 对 `kubernetes/website` 仓库创建 PR。跟踪你的 PR，并根据需要回应评审人的评论。
 继续跟踪你的 PR，直到它被合入。
 
-在 PR 合入的几分钟后，你更新的参考主题将出现在[已发布文档](/docs/home/)中。
+在 PR 合入的几分钟后，你更新的参考主题将出现在[已发布文档](/zh/docs/home/)中。
 
 ## {{% heading "whatsnext" %}}
 
@@ -421,7 +421,7 @@ topics will be visible in the
 * [Generating Reference Documentation for Kubernetes Components and Tools](/docs/contribute/generate-ref-docs/kubernetes-components/)
 * [Generating Reference Documentation for the Kubernetes API](/docs/contribute/generate-ref-docs/kubernetes-api/)
 -->
-* [生成参考文档快速入门](/docs/home/contribute/generate-ref-docs/quickstart/)
-* [为 Kubernetes 组件和工具生成参考文档](/docs/home/contribute/generate-ref-docs/kubernetes-components/)
-* [为 Kubernetes API 生成参考文档](/docs/home/contribute/generate-ref-docs/kubernetes-api/)
+* [生成参考文档快速入门](/zh/docs/contribute/generate-ref-docs/quickstart/)
+* [为 Kubernetes 组件和工具生成参考文档](/zh/docs/contribute/generate-ref-docs/kubernetes-components/)
+* [为 Kubernetes API 生成参考文档](/zh/docs/contribute/generate-ref-docs/kubernetes-api/)
 

--- a/content/zh/docs/contribute/generate-ref-docs/kubernetes-api.md
+++ b/content/zh/docs/contribute/generate-ref-docs/kubernetes-api.md
@@ -31,7 +31,7 @@ Kubernetes API 参考文档是从
 构建的，而工具是从
 [kubernetes-sigs/reference-docs](https://github.com/kubernetes-sigs/reference-docs) 构建的。
 
-如果您在生成的文档中发现错误，则需要[在上游修复](/docs/contribute/generate-ref-docs/contribute-upstream/)。
+如果您在生成的文档中发现错误，则需要[在上游修复](/zh/docs/contribute/generate-ref-docs/contribute-upstream/)。
 
 如果您只需要从 [OpenAPI](https://github.com/OAI/OpenAPI-Specification) 规范中重新生成参考文档，请继续阅读此页。
 
@@ -280,12 +280,12 @@ In `<web-base>` run `git add` and `git commit` to commit the change.
 
 <!-- 
 Submit your changes as a
-[pull request](/docs/contribute/start/) to the
+[pull request](/docs/contribute/new-content/open-a-pr/) to the
 [kubernetes/website](https://github.com/kubernetes/website) repository.
 Monitor your pull request, and respond to reviewer comments as needed. Continue
 to monitor your pull request until it has been merged.
 -->
-基于你所生成的更改[创建 PR](/docs/contribute/start/)，
+基于你所生成的更改[创建 PR](/zh/docs/contribute/new-content/open-a-pr/)，
 提交到 [kubernetes/website](https://github.com/kubernetes/website) 仓库。
 监视您提交的 PR，并根据需要回复 reviewer 的评论。继续监视您的 PR，直到合并为止。
 
@@ -296,7 +296,7 @@ to monitor your pull request until it has been merged.
 * [Generating Reference Docs for Kubernetes Components and Tools](/docs/contribute/generate-ref-docs/kubernetes-components/)
 * [Generating Reference Documentation for kubectl Commands](/docs/contribute/generate-ref-docs/kubectl/)
 -->
-* [生成参考文档快速入门](/docs/home/contribute/generate-ref-docs/quickstart/)
-* [为 Kubernetes 组件和工具生成参考文档](/docs/home/contribute/generate-ref-docs/kubernetes-components/)
-* [为 kubectl 命令集生成参考文档](/docs/home/contribute/generate-ref-docs/kubectl/)
+* [生成参考文档快速入门](/zh/docs/contribute/generate-ref-docs/quickstart/)
+* [为 Kubernetes 组件和工具生成参考文档](/zh/docs/contribute/generate-ref-docs/kubernetes-components/)
+* [为 kubectl 命令集生成参考文档](/zh/docs/contribute/generate-ref-docs/kubectl/)
 

--- a/content/zh/docs/contribute/generate-ref-docs/kubernetes-components.md
+++ b/content/zh/docs/contribute/generate-ref-docs/kubernetes-components.md
@@ -23,7 +23,7 @@ This page shows how to build the Kubernetes component and tool reference pages.
 Start with the [Prerequisites section](/docs/contribute/generate-ref-docs/quickstart/#before-you-begin)
 in the Reference Documentation Quickstart guide.
 -->
-阅读参考文档快速入门指南中的[准备工作](/docs/contribute/generate-ref-docs/quickstart/#before-you-begin)节。
+阅读参考文档快速入门指南中的[准备工作](/zh/docs/contribute/generate-ref-docs/quickstart/#before-you-begin)节。
 
 <!-- steps -->
 
@@ -31,7 +31,7 @@ in the Reference Documentation Quickstart guide.
 Follow the [Reference Documentation Quickstart](/docs/contribute/generate-ref-docs/quickstart/)
 to generate the Kubernetes component and tool reference pages.
 -->
-按照[参考文档快速入门](/docs/contribute/generate-ref-docs/quickstart/)
+按照[参考文档快速入门](/zh/docs/contribute/generate-ref-docs/quickstart/)
 指引，生成 Kubernetes 组件和工具的参考文档。
 
 ## {{% heading "whatsnext" %}}
@@ -43,8 +43,8 @@ to generate the Kubernetes component and tool reference pages.
 * [Contributing to the Upstream Kubernetes Project for Documentation](/docs/contribute/generate-ref-docs/contribute-upstream/)
 -->
 
-* [生成参考文档快速入门](/docs/home/contribute/generate-ref-docs/quickstart/) 
-* [为 kubectll 命令生成参考文档](/docs/home/contribute/generate-ref-docs/kubectl/)
-* [为 Kubernetes API 生成参考文档](/docs/home/contribute/generate-ref-docs/kubernetes-api/)
-* [为上游 Kubernetes 项目做贡献以改进文档](/docs/contribute/generate-ref-docs/contribute-upstream/)
+* [生成参考文档快速入门](/zh/docs/contribute/generate-ref-docs/quickstart/) 
+* [为 kubectll 命令生成参考文档](/zh/docs/contribute/generate-ref-docs/kubectl/)
+* [为 Kubernetes API 生成参考文档](/zh/docs/contribute/generate-ref-docs/kubernetes-api/)
+* [为上游 Kubernetes 项目做贡献以改进文档](/zh/docs/contribute/generate-ref-docs/contribute-upstream/)
 

--- a/content/zh/docs/contribute/generate-ref-docs/quickstart.md
+++ b/content/zh/docs/contribute/generate-ref-docs/quickstart.md
@@ -57,7 +57,7 @@ see the [contributing upstream guide](/docs/contribute/generate-ref-docs/contrib
 
 {{< note>}}
 如果你希望更改构建工具和 API 参考资料，可以阅读
-[上游贡献指南](/docs/contribute/generate-ref-docs/contribute-upstream).
+[上游贡献指南](/zh/docs/contribute/generate-ref-docs/contribute-upstream).
 {{< /note >}}
 
 <!--
@@ -185,7 +185,7 @@ Single page Markdown documents, imported by the tool, must adhere to
 the [Documentation Style Guide](/docs/contribute/style/style-guide/).
 -->
 通过工具导入的单页面的 Markdown 文档必须遵从
-[文档样式指南](/docs/contribute/style/style-guide/)。
+[文档样式指南](/zh/docs/contribute/style/style-guide/)。
 
 <!--
 ## Customizing reference.yml
@@ -385,7 +385,7 @@ topics will be visible in the
 继续监视该 PR 直到其被合并为止。
 
 当你的 PR 被合并几分钟之后，你所做的对参考文档的变更就会出现
-[发布的文档](/docs/home/)上。
+[发布的文档](/zh/docs/home/)上。
 
 ## {{% heading "whatsnext" %}}
 
@@ -399,7 +399,7 @@ running the build targets, see the following guides:
 -->
 要手动设置所需的构造仓库，执行构建目标，以生成各个参考文档，可参考下面的指南：
 
-* [为 Kubernetes 组件和工具生成参考文档](/docs/contribute/generate-ref-docs/kubernetes-components/)
-* [为 kubeclt 命令生成参考文档](/docs/contribute/generate-ref-docs/kubectl/)
-* [为 Kubernetes API 生成参考文档](/docs/contribute/generate-ref-docs/kubernetes-api/)
+* [为 Kubernetes 组件和工具生成参考文档](/zh/docs/contribute/generate-ref-docs/kubernetes-components/)
+* [为 kubeclt 命令生成参考文档](/zh/docs/contribute/generate-ref-docs/kubectl/)
+* [为 Kubernetes API 生成参考文档](/zh/docs/contribute/generate-ref-docs/kubernetes-api/)
 

--- a/content/zh/docs/contribute/localization.md
+++ b/content/zh/docs/contribute/localization.md
@@ -62,7 +62,7 @@ First, [create your own fork](/docs/contribute/start/#improve-existing-content) 
 ### 派生（fork）并且克隆仓库 {#fork-and-clone-the-repo}
 
 首先，为 [kubernetes/website](https://github.com/kubernetes/website) 仓库
-[创建你自己的副本](/zh/docs/contribute/new-content/new-content/#fork-the-repo)。
+[创建你自己的副本](/zh/docs/contribute/new-content/open-a-pr/#fork-the-repo)。
 
 <!--
 Then, clone your fork and `cd` into it:
@@ -359,7 +359,7 @@ Site strings | [All site strings in a new localized TOML file](https://github.co
 -----|-----
 主页 | [所有标题和副标题网址](/zh/docs/home/)
 安装 | [所有标题和副标题网址](/zh/docs/setup/)
-教程 | [Kubernetes 基础](/zh/docs/tutorials/kubernetes-basics/), [Hello Minikube](/zh/docs/tutorials/stateless-application/hello-minikube/)
+教程 | [Kubernetes 基础](/zh/docs/tutorials/kubernetes-basics/), [Hello Minikube](/zh/docs/tutorials/hello-minikube/)
 网站字符串 | [新的本地化 TOML 文件中的所有网站字符串](https://github.com/kubernetes/website/tree/master/i18n)
 
 <!-- 
@@ -545,11 +545,11 @@ For more information about working from forks or directly from the repository, s
 <!-- 
 ## Upstream contributions 
 
-SIG Docs welcomes [upstream contributions and corrections](/docs/contribute/intermediate#localize-content) to the English source.  
+SIG Docs welcomes upstream contributions and corrections to the English source.
 -->
 ### 上游贡献 {#upstream-contributions}
 
-Sig Docs 欢迎对英文原文的[上游贡献和修正](/zh/docs/contribute/intermediate#localize-content)。
+Sig Docs 欢迎对英文原文的上游贡献和修正。
 
 <!-- 
 ## Help an existing localization 

--- a/content/zh/docs/contribute/new-content/open-a-pr.md
+++ b/content/zh/docs/contribute/new-content/open-a-pr.md
@@ -879,5 +879,5 @@ PR，也可以添加对它们的链接。你可以多少了解该团队的流程
 <!--
 - Read [Reviewing](/docs/contribute/reviewing/revewing-prs) to learn more about the review process.
 -->
-- 阅读[评阅](/zh/docs/contribute/review/revewing-prs)节，学习评阅过程。
+- 阅读[评阅](/zh/docs/contribute/review/reviewing-prs)节，学习评阅过程。
 

--- a/content/zh/docs/contribute/participate/_index.md
+++ b/content/zh/docs/contribute/participate/_index.md
@@ -206,7 +206,7 @@ SIG Docs 批准人。下面是合并的工作机制：
 - 所有 Kubernetes 成员可以通过 `/lgtm` 评论添加 `lgtm` 标签。
 - 只有 SIG Docs 批准人可以通过评论 `/approve` 合并 PR。
   某些批准人还会执行一些其他角色，例如
-  [PR 管理者](/docs/contribute/advanced#be-the-pr-wrangler-for-a-week) 或
+  [PR 管理者](/zh/docs/contribute/participate/pr-wranglers/) 或
   [SIG Docs 主席](#sig-docs-chairperson)等。
 
 ## {{% heading "whatsnext" %}}
@@ -220,6 +220,6 @@ For more information about contributing to the Kubernetes documentation, see:
 -->
 关于贡献 Kubernetes 文档的更多信息，请参考：
 
-- [贡献新内容](/docs/contribute/overview/)
-- [评阅内容](/docs/contribute/review/reviewing-prs)
-- [文档样式指南](/docs/contribute/style/)
+- [贡献新内容](/zh/docs/contribute/new-content/overview/)
+- [评阅内容](/zh/docs/contribute/review/reviewing-prs)
+- [文档样式指南](/zh/docs/contribute/style/)

--- a/content/zh/docs/contribute/participate/roles-and-responsibilities.md
+++ b/content/zh/docs/contribute/participate/roles-and-responsibilities.md
@@ -58,7 +58,7 @@ For more information, see [contributing new content](/docs/contribute/new-conten
   [`kubernetes/website`](https://github.com/kubernetes/website) 上报告 Issue。
 - 对某 PR 给出无约束力的反馈信息
 - 为本地化提供帮助
-- 在 [Slack](http://slack.k8s.io/) 或
+- 在 [Slack](https://slack.k8s.io/) 或
   [SIG Docs 邮件列表](https://groups.google.com/forum/#!forum/kubernetes-sig-docs)
   上提出改进建议。
 

--- a/content/zh/docs/contribute/review/for-approvers.md
+++ b/content/zh/docs/contribute/review/for-approvers.md
@@ -15,7 +15,7 @@ weight: 20
 
 <!-- overview -->
 <!--
-SIG Docs [Reviewers](/docs/contribute/participating/#reviewers) and [Approvers](/docs/contribute/participating/#approvers) do a few extra things when reviewing a change.
+SIG Docs [Reviewers](/docs/contribute/participate/roles-and-responsibilities/#reviewers) and [Approvers](/docs/contribute/participate/roles-and-responsibilities/#approvers) do a few extra things when reviewing a change.
 
 Every week a specific docs approver volunteers to triage
 and review pull requests. This
@@ -26,8 +26,9 @@ requests (PRs) that are not already under active review.
 In addition to the rotation, a bot assigns reviewers and approvers
 for the PR based on the owners for the affected files.
 -->
-SIG Docs [评阅人（Reviewers）](/docs/contribute/participating/#reviewers)
-和[批准人（Approvers）](/docs/contribute/participating/#approvers)
+SIG Docs
+[评阅人（Reviewers）](/zh/docs/contribute/participate/roles-and-responsibilities/#reviewers)
+和[批准人（Approvers）](/zh/docs/contribute/participate/roles-and-responsibilities/#approvers)
 在对变更进行评审时需要做一些额外的事情。
 
 每周都有一个特定的文档批准人自愿负责对 PR 进行分类和评阅。
@@ -50,7 +51,7 @@ Everything described in [Reviewing a pull request](/docs/contribute/review/revie
 
 Kubernetes 文档遵循 [Kubernetes 代码评阅流程](https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md#the-code-review-process)。
 
-[评阅 PR](/docs/contribute/review/reviewing-prs) 文档中所描述的所有规程都适用，
+[评阅 PR](/zh/docs/contribute/review/reviewing-prs/) 文档中所描述的所有规程都适用，
 不过评阅人和批准人还要做以下工作：
 
 <!--
@@ -73,7 +74,7 @@ when it comes to requesting technical review from code contributors.
   你可以查看 Markdown 文件的文件头，其中的 `reviewers` 字段给出了哪些人可以为文档提供技术审核。
   {{< /note >}}
 
-- 确保 PR 遵从[内容指南](/docs/contribute/style/content-guide/)和[样式指南](/docs/contribute/style/style-guide/)；
+- 确保 PR 遵从[内容指南](/zh/docs/contribute/style/content-guide/)和[样式指南](/zh/docs/contribute/style/style-guide/)；
   如果 PR 没有达到要求，指引作者阅读指南中的相关部分。
 - 适当的时候使用 GitHub **Request Changes** 选项，建议 PR 作者实施所建议的修改。
 - 当你所提供的建议被采纳后，在 GitHub 中使用 `/approve` 或 `/lgtm` Prow 命令，改变评审状态。
@@ -406,9 +407,9 @@ Sample response to a request for support:
 This issue sounds more like a request for support and less
 like an issue specifically for docs. I encourage you to bring
 your question to the `#kubernetes-users` channel in
-[Kubernetes slack](http://slack.k8s.io/). You can also search
+[Kubernetes slack](https://slack.k8s.io/). You can also search
 resources like
-[Stack Overflow](http://stackoverflow.com/questions/tagged/kubernetes)
+[Stack Overflow](https://stackoverflow.com/questions/tagged/kubernetes)
 for answers to similar questions.
 
 You can also open issues for Kubernetes functionality in

--- a/content/zh/docs/contribute/review/reviewing-prs.md
+++ b/content/zh/docs/contribute/review/reviewing-prs.md
@@ -34,9 +34,9 @@ Before reviewing, it's a good idea to:
 
 在评阅之前，可以考虑：
 
-- 阅读[内容指南](/docs/contribute/style/content-guide/)和 
-  [样式指南](/docs/contribute/style/style-guide/)以便给出有价值的评论。
-- 了解 Kubernetes 文档社区中不同的[角色和职责](/docs/contribute/participating/#roles-and-responsibilities)。
+- 阅读[内容指南](/zh/docs/contribute/style/content-guide/)和 
+  [样式指南](/zh/docs/contribute/style/style-guide/)以便给出有价值的评论。
+- 了解 Kubernetes 文档社区中不同的[角色和职责](/zh/docs/contribute/participate/roles-and-responsibilities/)。
 
 <!-- body -->
 <!--
@@ -90,7 +90,7 @@ In general, review pull requests for content and style in English.
 2. 使用以下标签（组合）对待处理 PRs 进行过滤：
 
     - `cncf-cla: yes` （建议）：由尚未签署 CLA 的贡献者所发起的 PRs 不可以合并。
-      参考[签署 CLA](/docs/contribute/new-content/overview/#sign-the-cla) 以了解更多信息。
+      参考[签署 CLA](/zh/docs/contribute/new-content/overview/#sign-the-cla) 以了解更多信息。
     - `language/en` （建议）：仅查看英语语言的 PRs。
     - `size/<尺寸>`：过滤特定尺寸（规模）的 PRs。如果你刚入门，可以从较小的 PR 开始。
 
@@ -153,7 +153,7 @@ When reviewing, use the following as a starting point.
 - 是否存在明显的语言或语法错误？对某事的描述有更好的方式？
 - 是否存在一些过于复杂晦涩的用词，本可以用简单词汇来代替？
 - 是否有些用词、术语或短语可以用不带歧视性的表达方式代替？
-- 用词和大小写方面是否遵从了[样式指南](/docs/contribute/style/style-guide/)？
+- 用词和大小写方面是否遵从了[样式指南](/zh/docs/contribute/style/style-guide/)？
 - 是否有些句子太长，可以改得更短、更简单？
 - 是否某些段落过长，可以考虑使用列表或者表格来表达？
 
@@ -188,10 +188,10 @@ For small issues with a PR, like typos or whitespace, prefix your comments with 
   如果是这样，PR 是否会导致出现新的失效链接？
   是否有其他的办法，比如改变页面标题但不改变其 slug？
 - PR 是否引入新的页面？如果是：
-  - 该页面是否使用了正确的[页面内容类型](/docs/contribute/style/page-content-types/)
+  - 该页面是否使用了正确的[页面内容类型](/zh/docs/contribute/style/page-content-types/)
     及相关联的 Hugo 短代码（shortcodes）？
   - 该页面能否在对应章节的侧面导航中显示？显示得正确么？
-  - 该页面是否应出现在[网站主页面](/docs/home/)的列表中？
+  - 该页面是否应出现在[网站主页面](/zh/docs/home/)的列表中？
 - 变更是否正确出现在 Netlify 预览中了？
   要对列表、代码段、表格、注释和图像等元素格外留心
 

--- a/content/zh/docs/contribute/style/hugo-shortcodes/index.md
+++ b/content/zh/docs/contribute/style/hugo-shortcodes/index.md
@@ -358,7 +358,7 @@ println "This is tab 2."
 {{< tabs name="tab_with_file_include" >}}
 {{< tab name="Content File #1" include="example1" />}}
 {{< tab name="Content File #2" include="example2" />}}
-{{< tab name="JSON File" include="podtemplate" />}}
+{{< tab name="JSON File" include="podtemplate.json" />}}
 {{< /tabs >}}
 
 ## {{% heading "whatsnext" %}}
@@ -367,11 +367,13 @@ println "This is tab 2."
 * Learn about [Hugo](https://gohugo.io/).
 * Learn about [writing a new topic](/docs/home/contribute/style/write-new-topic/).
 * Learn about [page content types](/docs/home/contribute/style/page-content-types/).
-* Learn about [creating a pull request](/docs/home/contribute/create-pull-request/).
+* Learn about [creating a pull request](/docs/contribute/new-content/open-a-pr/).
+* Learn about [advanced contributing](/docs/contribute/advanced/).
 -->
 
 * 了解 [Hugo](https://gohugo.io/)。
-* 了解 [撰写新的话题](/zh/docs/contribute/write-new-topic/)。
-* 了解 [使用页面类型](/zh/docs/contribute/style/page-content-types/)。
-* 了解 [发起 PR](/zh/docs/contribute/new-content/create-a-pr/)。
+* 了解[撰写新的话题](/zh/docs/contribute/style/write-new-topic/)。
+* 了解[使用页面内容类型](/zh/docs/contribute/style/page-content-types/)。
+* 了解[发起 PR](/zh/docs/contribute/new-content/open-a-pr/)。
+* 了解[高级贡献](/zh/docs/contribute/advanced/)。
 

--- a/content/zh/docs/contribute/style/page-content-types.md
+++ b/content/zh/docs/contribute/style/page-content-types.md
@@ -354,7 +354,7 @@ An example of a published tutorial topic is
   阅读的主题。
 
 已发布的教程主题的一个例子是
-[使用 Deployment 运行无状态应用](/zh/docs/tutorials/stateless-application/run-stateless-application-deployment/).
+[使用 Deployment 运行无状态应用](/zh/docs/tasks/run-application/run-stateless-application-deployment/).
 
 <!--
 ### Reference

--- a/content/zh/docs/contribute/style/style-guide.md
+++ b/content/zh/docs/contribute/style/style-guide.md
@@ -38,12 +38,14 @@ discussion.
 
 <!-- body -->
 <!--
-Kubernetes documentation uses [Blackfriday Markdown Renderer](https://github.com/russross/blackfriday) along with a few [Hugo Shortcodes](/docs/home/contribute/includes/) to support glossary entries, tabs,
+Kubernetes documentation uses [Goldmark Markdown Renderer](https://github.com/yuin/goldmark)
+with some adjustments along with a few
+[Hugo Shortcodes](/docs/contribute/style/hugo-shortcodes/) to support glossary entries, tabs,
 and representing feature state.
 -->
 {{< note >}}
-Kubernetes 文档 [Blackfriday Markdown 解释器](https://github.com/russross/blackfriday)
-和一些 [Hugo 短代码](/zh/docs/home/contribute/includes/) 来支持词汇表项、Tab
+Kubernetes 文档使用带调整的 [Goldmark Markdown 解释器](https://github.com/yuin/goldmark/)
+和一些 [Hugo 短代码](/zh/docs/contribute/style/hugo-shortcodes/) 来支持词汇表项、Tab
 页以及特性门控标注。
 {{< /note >}}
 

--- a/content/zh/docs/contribute/style/write-new-topic.md
+++ b/content/zh/docs/contribute/style/write-new-topic.md
@@ -285,7 +285,7 @@ For an example of a topic that uses this technique, see
 [Running a Single-Instance Stateful Application](/docs/tutorials/stateful-application/run-stateful-application/).
 -->
 有关使用此技术的主题的示例，请参见
-[运行单实例有状态的应用](/zh/docs/tutorials/stateful-application/run-stateful-application/)。
+[运行单实例有状态的应用](/zh/docs/tasks/run-application/run-single-instance-stateful-application/)。
 
 <!--
 ## Adding images to a topic


### PR DESCRIPTION
This PR fixes bad links found in the contribute section, identified via:

```
./scripts/linkchecker.py -l zh -f /docs/contribute/**/*.md
```

*Fix Summary*:

- Bad links pointing nowhere: 23
- Links which should point to localized pages: 28
- Links which should avoid redirections: 5
- Unsafe links that use HTTP: 6

