### PR TITLE
Automatically detect MermaidJS shortcode

### DIFF
--- a/content/en/docs/test.md
+++ b/content/en/docs/test.md
@@ -1,7 +1,6 @@
 ---
 title: Docs smoke test page
 main_menu: false
-mermaid: true
 ---
 
 This page serves two purposes:
@@ -297,7 +296,8 @@ tables, use HTML instead.
 
 ## Visualizations with Mermaid
 
-Add `mermaid: true` to the [front matter](https://gohugo.io/content-management/front-matter/) of any page to enable [Mermaid JS](https://mermaidjs.github.io) visualizations. The Mermaid JS version is specified in [/layouts/partials/head.html](https://github.com/kubernetes/website/blob/master/layouts/partials/head.html)
+You can use [Mermaid JS](https://mermaidjs.github.io) visualizations.
+The Mermaid JS version is specified in [/layouts/partials/head.html](https://github.com/kubernetes/website/blob/master/layouts/partials/head.html)
 
 ```
 {{</* mermaid */>}}

--- a/content/en/docs/tutorials/services/source-ip.md
+++ b/content/en/docs/tutorials/services/source-ip.md
@@ -1,7 +1,6 @@
 ---
 title: Using Source IP
 content_type: tutorial
-mermaid: true
 min-kubernetes-server-version: v1.5
 ---
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -77,7 +77,7 @@
 <script src="{{ "js/jquery-ui-1.12.1.min.js" | relURL }}"></script>
 <script src="{{ "js/sweetalert-2.1.2.min.js" | relURL }}"></script>
 
-{{ if eq .Params.mermaid true }}
+{{ if .HasShortcode "mermaid" }}
 <!-- Copied from https://unpkg.com/mermaid@8.5.0/dist/mermaid.min.js -->
 <script async src="{{ "js/mermaid.min.js" | relURL }}"></script>
 {{ end }}


### PR DESCRIPTION
Rather than requiring metadata set in a page's front matter, automatically detect when a page relies on MermaidJS.

Previews:
- [page without MermaidJS](https://deploy-preview-22787--kubernetes-io-master-staging.netlify.app/docs/tutorials/kubernetes-basics/)
- [page with MermaidJS](https://deploy-preview-22787--kubernetes-io-master-staging.netlify.app/docs/tutorials/services/source-ip/)

/kind cleanup
/area web-development