### PR TITLE
Fix typo in pod-lifecycle.md

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -164,7 +164,7 @@ Field name           | Description
 `lastProbeTime`      | Timestamp of when the Pod condition was last probed.
 `lastTransitionTime` | Timestamp for when the Pod last transitioned from one status to another.
 `reason`             | Machine-readable, UpperCamelCase text indicating the reason for the condition's last transition.
-`messsage            | Human-readable message indicating details about the last status transition.
+`message`            | Human-readable message indicating details about the last status transition.
 
 
 ### Pod readiness {#pod-readiness-gate}


### PR DESCRIPTION
Fix typo in https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions.

The current table isn't rendered properly as follows:

![Screenshot 2020-07-28 at 4 37 56](https://user-images.githubusercontent.com/21333876/88584192-3fa50680-d08c-11ea-9ae3-1015a48bf758.png)
