### PR TITLE
Fix the markdown format in authorization.md

### DIFF
--- a/content/en/docs/reference/access-authn-authz/authorization.md
+++ b/content/en/docs/reference/access-authn-authz/authorization.md
@@ -138,8 +138,6 @@ field of the returned object is the result of the query.
 
 ```bash
 kubectl create -f - -o yaml << EOF
-```
-```
 apiVersion: authorization.k8s.io/v1
 kind: SelfSubjectAccessReview
 spec:
@@ -149,7 +147,10 @@ spec:
     verb: create
     namespace: dev
 EOF
+```
 
+The generated `SelfSubjectAccessReview` is:
+```
 apiVersion: authorization.k8s.io/v1
 kind: SelfSubjectAccessReview
 metadata:


### PR DESCRIPTION
this fixes the markdown format, the full command should be

```
kubectl create -f - -o yaml << EOF
apiVersion: authorization.k8s.io/v1
kind: SelfSubjectAccessReview
spec:
  resourceAttributes:
    group: apps
    resource: deployments
    verb: create
    namespace: dev
EOF
```