### PR TITLE
modify k8s_release clone string

### DIFF
--- a/update-imported-docs/reference.yml
+++ b/update-imported-docs/reference.yml
@@ -7,10 +7,10 @@ repos:
   generate-command: |
     cd $GOPATH
     # set the branch, ex: v1.17.0 while K8S_RELEASE=1.17
-    # CAUTION: The script won't work if you set K8S_RELEASE=1.18 before 1.18 is formally released.
-    # The `v${K8S_RELEASE}.0` string must be a valid tag name from the kubernetes repo, which
+    # CAUTION: The script won't work if you set K8S_RELEASE=1.18.0 before 1.18 is formally released.
+    # The `v${K8S_RELEASE}` string must be a valid tag name from the kubernetes repo, which
     # is only created after the formal release.
-    git clone --depth=1 --single-branch --branch v${K8S_RELEASE}.0 https://github.com/kubernetes/kubernetes.git src/k8s.io/kubernetes
+    git clone --depth=1 --single-branch --branch v${K8S_RELEASE} https://github.com/kubernetes/kubernetes.git src/k8s.io/kubernetes
     cd src/k8s.io/kubernetes
     make generated_files
     cp -L -R vendor $GOPATH/src
@@ -24,7 +24,7 @@ repos:
     cd $GOPATH
     go get -v github.com/kubernetes-sigs/reference-docs/gen-kubectldocs
     cd src/github.com/kubernetes-sigs/reference-docs/
-    # create versioned dirs if needed and fetch v${K8S_RELEASE}.0:swagger.json
+    # create versioned dirs if needed and fetch v${K8S_RELEASE}:swagger.json
     make updateapispec
     # generate kubectl cmd reference
     make copycli

--- a/update-imported-docs/update-imported-docs.py
+++ b/update-imported-docs/update-imported-docs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 ##
-# This script was tested with Python 3.7.4, Go 1.13+, and PyYAML 5.1.2
+# This script was tested with Python 3.7.4, Go 1.14.4+, and PyYAML 5.1.2
 # installed in a virtual environment.
 # This script assumes you have the Python package manager 'pip' installed.
 #
@@ -22,7 +22,7 @@
 # Config files:
 #     reference.yml  use this to update the reference docs
 #     release.yml    use this to auto-generate/import release notes
-# K8S_RELEASE: provide the release version such as, 1.17
+# K8S_RELEASE: provide a valid release tag such as, 1.17.0
 ##
 
 import argparse
@@ -167,7 +167,7 @@ def parse_input_args():
                         help="reference.yml to generate reference docs; "
                              "release.yml to generate release notes")
     parser.add_argument('k8s_release', type=str,
-                        help="k8s release version, ex: 1.17"
+                        help="k8s release version, ex: 1.17.0"
                         )
     return parser.parse_args()
 
@@ -187,6 +187,11 @@ def main():
     # second parse input argument
     k8s_release = in_args.k8s_release
     print("k8s_release is {}".format(k8s_release))
+
+    # if release string does not contain patch num, add zero
+    if len(k8s_release) == 4:
+        k8s_release = k8s_release + ".0"
+        print("k8s_release updated to {}".format(k8s_release))
 
     curr_dir = os.path.dirname(os.path.abspath(__file__))
     print("curr_dir {}".format(curr_dir))


### PR DESCRIPTION
Small change to k8s_release string.
Script accepts k8s_release version strings such as:
1.17, 1.18.0, 1.18.0-rc.4, 1.19.0-rc.3.
Tested script with versions: 1.18, 1.18.0, 1.19.0-rc.3