### PR TITLE
Fix links which pointed to unavailable location

### DIFF
--- a/content/en/blog/_posts/2018-12-04-kubeadm-ga-release.md
+++ b/content/en/blog/_posts/2018-12-04-kubeadm-ga-release.md
@@ -23,7 +23,7 @@ To keep kubeadm lean, focused, and vendor/infrastructure agnostic, the following
 - Non-critical add-ons, e.g. for monitoring, logging, and visualization
 - Specific cloud provider integrations
 
-Infrastructure provisioning, for example, is left to other SIG Cluster Lifecycle projects, such as the [Cluster API](https://github.com/kubernetes-sigs/cluster-api). Instead, kubeadm covers only the common denominator in every Kubernetes cluster: the [control plane](/docs/concepts/#kubernetes-control-plane). The user may install their preferred networking solution and other add-ons on top of Kubernetes *after* cluster creation.
+Infrastructure provisioning, for example, is left to other SIG Cluster Lifecycle projects, such as the [Cluster API](https://github.com/kubernetes-sigs/cluster-api). Instead, kubeadm covers only the common denominator in every Kubernetes cluster: the [control plane](/docs/reference/glossary/?all=true#term-control-plane). The user may install their preferred networking solution and other add-ons on top of Kubernetes *after* cluster creation.
 
 ### What kubeadm's GA release means
 

--- a/content/en/blog/_posts/2019-06-24-kubeadm-ha-v115.md
+++ b/content/en/blog/_posts/2019-06-24-kubeadm-ha-v115.md
@@ -43,7 +43,7 @@ Those tasks are addressed by other SIG Cluster Lifecycle projects, such as the
 [Cluster API](https://github.com/kubernetes-sigs/cluster-api) for infrastructure provisioning and management. 
 
 Instead, kubeadm covers only the common denominator in every Kubernetes cluster: the
-[control plane](/docs/concepts/#kubernetes-control-plane). 
+[control plane](/docs/reference/glossary/?all=true#term-control-plane). 
 
 ![Cluster Lifecycle Layers](/images/blog/2019-06-24-kubeadm-ha-v115/overview.png)
 

--- a/content/en/blog/_posts/2019-06-24-kubeadm-ha-v115.md
+++ b/content/en/blog/_posts/2019-06-24-kubeadm-ha-v115.md
@@ -43,7 +43,7 @@ Those tasks are addressed by other SIG Cluster Lifecycle projects, such as the
 [Cluster API](https://github.com/kubernetes-sigs/cluster-api) for infrastructure provisioning and management. 
 
 Instead, kubeadm covers only the common denominator in every Kubernetes cluster: the
-[control plane](https://kubernetes.io/docs/concepts/#kubernetes-control-plane). 
+[control plane](/docs/concepts/#kubernetes-control-plane). 
 
 ![Cluster Lifecycle Layers](/images/blog/2019-06-24-kubeadm-ha-v115/overview.png)
 

--- a/content/en/docs/concepts/architecture/controller.md
+++ b/content/en/docs/concepts/architecture/controller.md
@@ -154,7 +154,7 @@ controller does.
 
 ## {{% heading "whatsnext" %}}
 
-* Read about the [Kubernetes control plane](/docs/concepts/#kubernetes-control-plane)
+* Read about the [Kubernetes control plane](/docs/reference/glossary/?all=true#term-control-plane)
 * Discover some of the basic [Kubernetes objects](/docs/concepts/#kubernetes-objects)
 * Learn more about the [Kubernetes API](/docs/concepts/overview/kubernetes-api/)
 * If you want to write your own controller, see [Extension Patterns](/docs/concepts/extend-kubernetes/extend-cluster/#extension-patterns) in Extending Kubernetes.

--- a/content/en/docs/concepts/architecture/controller.md
+++ b/content/en/docs/concepts/architecture/controller.md
@@ -155,7 +155,7 @@ controller does.
 ## {{% heading "whatsnext" %}}
 
 * Read about the [Kubernetes control plane](/docs/reference/glossary/?all=true#term-control-plane)
-* Discover some of the basic [Kubernetes objects](/docs/concepts/#kubernetes-objects)
+* Discover some of the basic [Kubernetes objects](/docs/concepts/overview/working-with-objects)
 * Learn more about the [Kubernetes API](/docs/concepts/overview/kubernetes-api/)
 * If you want to write your own controller, see [Extension Patterns](/docs/concepts/extend-kubernetes/extend-cluster/#extension-patterns) in Extending Kubernetes.
 

--- a/content/en/docs/concepts/extend-kubernetes/operator.md
+++ b/content/en/docs/concepts/extend-kubernetes/operator.md
@@ -9,7 +9,7 @@ weight: 30
 Operators are software extensions to Kubernetes that make use of
 [custom resources](/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
 to manage applications and their components. Operators follow
-Kubernetes principles, notably the [control loop](/docs/concepts/#kubernetes-control-plane).
+Kubernetes principles, notably the [control loop](/docs/reference/glossary/?all=true#term-control-plane).
 
 <!-- body -->
 

--- a/content/id/docs/concepts/architecture/controller.md
+++ b/content/id/docs/concepts/architecture/controller.md
@@ -172,7 +172,7 @@ khusus itu lakukan.
 
 ## {{% heading "whatsnext" %}}
 
-* Silahkan baca tentang [_control plane_ Kubernetes](/docs/concepts/#kubernetes-control-plane)
+* Silahkan baca tentang [_control plane_ Kubernetes](/docs/reference/glossary/?all=true#term-control-plane)
 * Temukan beberapa dasar tentang [objek-objek Kubernetes](/docs/concepts/#kubernetes-objects)
 * Pelajari lebih lanjut tentang [Kubernetes API](/id/docs/concepts/overview/kubernetes-api/)
 * Apabila kamu ingin membuat _controller_ sendiri, silakan lihat [pola perluasan](/id/docs/concepts/extend-kubernetes/extend-cluster/#extension-patterns) dalam memperluas Kubernetes.

--- a/content/id/docs/concepts/architecture/controller.md
+++ b/content/id/docs/concepts/architecture/controller.md
@@ -173,7 +173,7 @@ khusus itu lakukan.
 ## {{% heading "whatsnext" %}}
 
 * Silahkan baca tentang [_control plane_ Kubernetes](/docs/reference/glossary/?all=true#term-control-plane)
-* Temukan beberapa dasar tentang [objek-objek Kubernetes](/docs/concepts/#kubernetes-objects)
+* Temukan beberapa dasar tentang [objek-objek Kubernetes](/docs/concepts/overview/working-with-objects)
 * Pelajari lebih lanjut tentang [Kubernetes API](/id/docs/concepts/overview/kubernetes-api/)
 * Apabila kamu ingin membuat _controller_ sendiri, silakan lihat [pola perluasan](/id/docs/concepts/extend-kubernetes/extend-cluster/#extension-patterns) dalam memperluas Kubernetes.
 

--- a/content/id/docs/concepts/extend-kubernetes/operator.md
+++ b/content/id/docs/concepts/extend-kubernetes/operator.md
@@ -9,7 +9,7 @@ weight: 30
 Operator adalah ekstensi perangkat lunak untuk Kubernetes yang memanfaatkan 
 [_custom resource_](/id/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
 untuk mengelola aplikasi dan komponen-komponennya. Operator mengikuti prinsip 
-Kubernetes, khususnya dalam hal [_control loop_](/docs/concepts/#kubernetes-control-plane).
+Kubernetes, khususnya dalam hal [_control loop_](/docs/reference/glossary/?all=true#term-control-plane).
 
 
 

--- a/content/it/docs/concepts/architecture/controller.md
+++ b/content/it/docs/concepts/architecture/controller.md
@@ -84,7 +84,7 @@ Al fine di estendere Kubernetes, si possono avere _controller_ in esecuzione al 
 
 ## {{% heading "whatsnext" %}}
 * Leggi in merito [Kubernetes control plane](/docs/reference/glossary/?all=true#term-control-plane)
-* Scopri alcune delle basi degli [oggetti di Kubernetes](/docs/concepts/#kubernetes-objects)
+* Scopri alcune delle basi degli [oggetti di Kubernetes](/docs/concepts/overview/working-with-objects)
 * Per saperne di più riguardo alle [API di Kubernetes](/docs/concepts/overview/kubernetes-api/)
 * Se vuoi creare un tuo _controller_, guarda [i modelli per l'estensibilità](/docs/concepts/extend-kubernetes/extend-cluster/#extension-patterns) in Estendere Kubernetes.
 

--- a/content/it/docs/concepts/architecture/controller.md
+++ b/content/it/docs/concepts/architecture/controller.md
@@ -83,7 +83,7 @@ Kubernetes consente di eseguire un _piano di controllo_(_control plane_) resilie
 Al fine di estendere Kubernetes, si possono avere _controller_ in esecuzione al di fuori del piano di controllo. Oppure, se si desidera, è possibile scriversi un nuovo _controller_. È possibile eseguire il proprio controller come una serie di _Pod_, oppure esternamente rispetto a Kubernetes. Quale sia la soluzione migliore, dipende dalla responsabilità di un dato controller.
 
 ## {{% heading "whatsnext" %}}
-* Leggi in merito [Kubernetes control plane](/docs/concepts/#kubernetes-control-plane)
+* Leggi in merito [Kubernetes control plane](/docs/reference/glossary/?all=true#term-control-plane)
 * Scopri alcune delle basi degli [oggetti di Kubernetes](/docs/concepts/#kubernetes-objects)
 * Per saperne di più riguardo alle [API di Kubernetes](/docs/concepts/overview/kubernetes-api/)
 * Se vuoi creare un tuo _controller_, guarda [i modelli per l'estensibilità](/docs/concepts/extend-kubernetes/extend-cluster/#extension-patterns) in Estendere Kubernetes.

--- a/content/ja/docs/concepts/extend-kubernetes/operator.md
+++ b/content/ja/docs/concepts/extend-kubernetes/operator.md
@@ -7,7 +7,7 @@ weight: 30
 <!-- overview -->
 
 オペレーターはサードパーティのアプリケーション、コンポーネントを管理するためのリソースを活用する、Kubernetesへのソフトウェア拡張です。
-オペレーターは、特に[制御ループ](/docs/concepts/#kubernetes-control-plane)のようなKubernetesが持つ仕組みに準拠しています。
+オペレーターは、特に[制御ループ](/docs/reference/glossary/?all=true#term-control-plane)のようなKubernetesが持つ仕組みに準拠しています。
 
 
 

--- a/content/pt/docs/concepts/architecture/controller.md
+++ b/content/pt/docs/concepts/architecture/controller.md
@@ -150,7 +150,7 @@ controlador faz em particular.
 
 ## {{% heading "whatsnext" %}}
 
-* Leia mais sobre o [plano de controle do Kubernetes](/docs/concepts/#kubernetes-control-plane)
+* Leia mais sobre o [plano de controle do Kubernetes](/docs/reference/glossary/?all=true#term-control-plane)
 * Descubra alguns dos [objetos Kubernetes](/docs/concepts/#kubernetes-objects) básicos.
 * Aprenda mais sobre [API do Kubernetes](/docs/concepts/overview/kubernetes-api/)
 * Se pretender escrever o seu próprio controlador, veja [Padrões de Extensão](/docs/concepts/extend-kubernetes/extend-cluster/#extension-patterns)

--- a/content/pt/docs/concepts/architecture/controller.md
+++ b/content/pt/docs/concepts/architecture/controller.md
@@ -151,7 +151,7 @@ controlador faz em particular.
 ## {{% heading "whatsnext" %}}
 
 * Leia mais sobre o [plano de controle do Kubernetes](/docs/reference/glossary/?all=true#term-control-plane)
-* Descubra alguns dos [objetos Kubernetes](/docs/concepts/#kubernetes-objects) básicos.
+* Descubra alguns dos [objetos Kubernetes](/docs/concepts/overview/working-with-objects) básicos.
 * Aprenda mais sobre [API do Kubernetes](/docs/concepts/overview/kubernetes-api/)
 * Se pretender escrever o seu próprio controlador, veja [Padrões de Extensão](/docs/concepts/extend-kubernetes/extend-cluster/#extension-patterns)
 

--- a/content/pt/docs/concepts/extend-kubernetes/operator.md
+++ b/content/pt/docs/concepts/extend-kubernetes/operator.md
@@ -9,7 +9,7 @@ weight: 30
 Operadores são extensões de software para o Kubernetes que
 fazem uso de [*recursos personalizados*](/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
 para gerir aplicações e os seus componentes. Operadores seguem os  
-princípios do Kubernetes, notavelmente o [ciclo de controle](/docs/concepts/#kubernetes-control-plane).
+princípios do Kubernetes, notavelmente o [ciclo de controle](/docs/reference/glossary/?all=true#term-control-plane).
 
 
 

--- a/content/zh/docs/concepts/architecture/controller.md
+++ b/content/zh/docs/concepts/architecture/controller.md
@@ -231,7 +231,7 @@ or externally to Kubernetes. What fits best will depend on what that particular
 controller does.
 
 * Read about the [Kubernetes control plane](/docs/reference/glossary/?all=true#term-control-plane)
-* Discover some of the basic [Kubernetes objects](/docs/concepts/#kubernetes-objects)
+* Discover some of the basic [Kubernetes objects](/docs/concepts/overview/working-with-objects)
 * Learn more about the [Kubernetes API](/docs/concepts/overview/kubernetes-api/)
 * If you want to write your own controller, see [Extension Patterns](/docs/concepts/extend-kubernetes/extend-cluster/#extension-patterns) in Extending Kubernetes.
 -->
@@ -249,7 +249,7 @@ Deployment 控制器和 Job 控制器是 Kubernetes 内置控制器的典型例�
 ## {{% heading "whatsnext" %}}
 
 * 请阅读 [Kubernetes 控制平面](/docs/reference/glossary/?all=true#term-control-plane)
-* 了解一些基本的 [Kubernetes 对象](/docs/concepts/#kubernetes-objects)
+* 了解一些基本的 [Kubernetes 对象](/docs/concepts/overview/working-with-objects)
 * 学习更多的 [Kubernetes API](/docs/concepts/overview/kubernetes-api/)
 * 如果你想写自己的控制器，请看 Kubernetes 的[扩展模式](/docs/concepts/extend-kubernetes/extend-cluster/#extension-patterns)。
 

--- a/content/zh/docs/concepts/architecture/controller.md
+++ b/content/zh/docs/concepts/architecture/controller.md
@@ -230,7 +230,7 @@ You can run your own controller as a set of Pods,
 or externally to Kubernetes. What fits best will depend on what that particular
 controller does.
 
-* Read about the [Kubernetes control plane](/docs/concepts/#kubernetes-control-plane)
+* Read about the [Kubernetes control plane](/docs/reference/glossary/?all=true#term-control-plane)
 * Discover some of the basic [Kubernetes objects](/docs/concepts/#kubernetes-objects)
 * Learn more about the [Kubernetes API](/docs/concepts/overview/kubernetes-api/)
 * If you want to write your own controller, see [Extension Patterns](/docs/concepts/extend-kubernetes/extend-cluster/#extension-patterns) in Extending Kubernetes.
@@ -248,7 +248,7 @@ Deployment 控制器和 Job 控制器是 Kubernetes 内置控制器的典型例�
 
 ## {{% heading "whatsnext" %}}
 
-* 请阅读 [Kubernetes 控制平面](/docs/concepts/#kubernetes-control-plane)
+* 请阅读 [Kubernetes 控制平面](/docs/reference/glossary/?all=true#term-control-plane)
 * 了解一些基本的 [Kubernetes 对象](/docs/concepts/#kubernetes-objects)
 * 学习更多的 [Kubernetes API](/docs/concepts/overview/kubernetes-api/)
 * 如果你想写自己的控制器，请看 Kubernetes 的[扩展模式](/docs/concepts/extend-kubernetes/extend-cluster/#extension-patterns)。

--- a/content/zh/docs/concepts/extend-kubernetes/operator.md
+++ b/content/zh/docs/concepts/extend-kubernetes/operator.md
@@ -18,11 +18,11 @@ weight: 30
 Operators are software extensions to Kubernetes that make use of [custom
 resources](/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
 to manage applications and their components. Operators follow
-Kubernetes principles, notably the [control loop](/docs/concepts/#kubernetes-control-plane).
+Kubernetes principles, notably the [control loop](/docs/reference/glossary/?all=true#term-control-plane).
 -->
 
 Operator 是 Kubernetes 的扩展软件，它利用[自定义资源](/docs/concepts/extend-kubernetes/api-extension/custom-resources/)管理应用及其组件。
-Operator 遵循 Kubernetes 的理念，特别是在[控制回路](/docs/concepts/#kubernetes-control-plane)方面。
+Operator 遵循 Kubernetes 的理念，特别是在[控制回路](/docs/reference/glossary/?all=true#term-control-plane)方面。
 
 
 


### PR DESCRIPTION
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

-->

Routes `/docs/concepts/#kubernetes-control-plane` and `/docs/concepts/#kubernetes-objects` don't work as they are expected, due to unimplemented anchors perhaps. Could be better if they directly point to topics.