### PR TITLE
Add tasks, tutorials and setup main pages into pt documentation

### DIFF
--- a/content/pt/docs/concepts/_index.md
+++ b/content/pt/docs/concepts/_index.md
@@ -1,0 +1,16 @@
+---
+title: Conceitos
+main_menu: true
+content_type: concept
+weight: 40
+---
+
+<!-- overview -->
+
+A seção de Conceitos irá te ajudar a aprender mais sobre as partes do ecossistema Kubernetes e as abstrações que o Kubernetes usa para representar seu {{< glossary_tooltip text="cluster" term_id="cluster" length="all" >}}.
+
+Ela irá lhe ajudar a obter um entendimento mais profundo sobre como o Kubernetes funciona.
+
+
+
+<!-- body -->

--- a/content/pt/docs/reference/glossary/cluster.md
+++ b/content/pt/docs/reference/glossary/cluster.md
@@ -1,0 +1,18 @@
+---
+title: Cluster
+id: cluster
+date: 2020-08-03
+full_link: 
+short_description: >
+   Um conjunto de servidores de processamento, também chamados de nós, que executam aplicações containerizadas. Todo cluster possui ao menos um servidor de processamento (worker node).
+   
+aka: 
+tags:
+- fundamental
+- operation
+---
+Um conjunto de servidores de processamento, chamados {{< glossary_tooltip text="nós" term_id="node" >}}, que executam aplicações containerizadas. Todo cluster possui ao menos um servidor de processamento (_worker node_).
+
+<!--more-->
+O servidor de processamento hospeda os {{< glossary_tooltip text="Pods" term_id="pod" >}} que são componentes de uma aplicação. O {{< glossary_tooltip text="ambiente de gerenciamento" term_id="control-plane" >}} gerencia os nós de processamento e os Pods no cluster. Em ambientes de produção, o ambiente de gerenciamento geralmente executa em múltiplos computadores e um cluster geralmente executa em múltiplos nós (_nodes_) , provendo tolerância a falhas e alta disponibilidade.
+

--- a/content/pt/docs/reference/glossary/control-plane.md
+++ b/content/pt/docs/reference/glossary/control-plane.md
@@ -1,5 +1,5 @@
 ---
-title: Control Plane
+title: Ambiente de gerenciamento
 id: control-plane
 date: 2020-04-19
 full_link:

--- a/content/pt/docs/reference/glossary/node.md
+++ b/content/pt/docs/reference/glossary/node.md
@@ -1,17 +1,17 @@
 ---
-title: Node
+title: Nó
 id: node
 date: 2020-04-19
 full_link: /docs/concepts/architecture/nodes/
 short_description: >
-  Um Node é uma máquina de trabalho no Kubernetes.
+  Um Nó é uma máquina de trabalho no Kubernetes.
 
 aka: 
 tags:
 - fundamental
 ---
- Um Node é uma máquina de trabalho no Kubernetes.
+ Um Nó é uma máquina de trabalho no Kubernetes.
 
 <!--more--> 
 
-Um Node pode ser uma máquina virtual ou física, dependendo do cluster. Possui daemons ou serviços locais necessários para executar {{< glossary_tooltip text="Pods" term_id="pod" >}} e é gerenciado pelo {{< glossary_tooltip text="plano de controle" term_id="control-plane" >}}. Os daemons em um Node incluem  {{< glossary_tooltip text="kubelet" term_id="kubelet" >}}, {{< glossary_tooltip text="kube-proxy" term_id="kube-proxy" >}} e um contêiner runtime implementando o {{< glossary_tooltip text="CRI" term_id="cri" >}} como por exemplo o {{< glossary_tooltip term_id="docker" >}}.
+Um Nó pode ser uma máquina virtual ou física, dependendo do cluster. Possui daemons ou serviços locais necessários para executar {{< glossary_tooltip text="Pods" term_id="pod" >}} e é gerenciado pelo {{< glossary_tooltip text="ambiente de gerenciamento" term_id="control-plane" >}}. Os daemons em um Node incluem  {{< glossary_tooltip text="kubelet" term_id="kubelet" >}}, {{< glossary_tooltip text="kube-proxy" term_id="kube-proxy" >}} e um contêiner runtime implementando o {{< glossary_tooltip text="CRI" term_id="cri" >}} como por exemplo o {{< glossary_tooltip term_id="docker" >}}.

--- a/content/pt/docs/setup/_index.md
+++ b/content/pt/docs/setup/_index.md
@@ -1,0 +1,40 @@
+---
+no_issue: true
+title: Instalação
+main_menu: true
+weight: 30
+content_type: concept
+---
+
+<!-- overview -->
+
+Essa seção lista as diferentes formas de instalar e executar o Kubernetes. Quando você realiza a instalação de um cluster Kubernetes, deve decidir o tipo de instalação baseado em critérios como facilidade de manutenção, segurança, controle, quantidade de recursos disponíveis e a experiência necessária para gerenciar e operar o cluster.
+
+Você pode criar um cluster Kubernetes em uma máquina local, na nuvem, em um datacenter on-premises ou ainda escolher uma oferta de um cluster Kubernetes gerenciado pelo seu provedor de computação em nuvem.
+
+Existem ainda diversos outros tipos de soluções customizadas, que você pode se deparar ao buscar formas de instalação e gerenciamento de seu cluster.
+
+<!-- body -->
+
+## Ambientes de aprendizado
+
+Se você está aprendendo ou pretende aprender mais sobre o Kubernetes, use ferramentas suportadas pela comunidade, ou ferramentas no ecossistema que te permitam criar um cluster Kubernetes em sua máquina virtual.
+
+Temos como exemplo aqui o [Minikube](/docs/tasks/tools/install-minikube/) e o [KinD](https://kind.sigs.k8s.io/docs/user/quick-start/)
+
+
+## Ambientes de produção
+
+Ao analisar uma solução para um ambiente de produção, devem ser considerados quais aspectos de operação de um cluster Kubernetes você deseja gerenciar, ou então delegar ao seu provedor.
+
+Temos diversas opções para esse provisionamento, desde o uso de uma ferramenta de deployment de um cluster tal qual o [Kubeadm](/docs/setup/production-environment/tools/kubeadm/install-kubeadm/) ou o [Kubespray](/docs/setup/production-environment/tools/kubespray/) quando se trata de um cluster local, ou ainda o uso de um cluster gerenciado por seu provedor de nuvem.
+
+Para a escolha do melhor ambiente e da melhor forma para fazer essa instalação, você deve considerar:
+
+* Se você deseja se preocupar com a gestão de backup da sua estrutura do ambiente de gerenciamento
+* Se você deseja ter um cluster mais atualizado, com novas funcionalidades, ou se deseja seguir a versão suportada pelo fornecedor
+* Se você deseja ter um cluster com um alto nível de serviço, ou com auto provisionamento de alta disponibilidade
+* Quanto você deseja pagar por essa produção
+
+
+

--- a/content/pt/docs/tasks/_index.md
+++ b/content/pt/docs/tasks/_index.md
@@ -1,0 +1,15 @@
+---
+title: Tarefas
+main_menu: true
+weight: 50
+content_type: concept
+---
+
+<!-- overview -->
+
+Essa seção da documentação contém páginas que mostram como executar tarefas individuais.
+
+Essas tarefas são organizadas em uma curta sequência de etapas e passos que te auxiliam a entender conceitos básicos.
+
+Se você desejar adicionar uma tarefa, verifique como
+[criar um Pull Request para a documentação](/docs/contribute/new-content/open-a-pr/).

--- a/content/pt/docs/tutorials/_index.md
+++ b/content/pt/docs/tutorials/_index.md
@@ -1,0 +1,68 @@
+---
+title: Tutoriais
+main_menu: true
+no_list: true
+weight: 60
+content_type: concept
+---
+
+<!-- overview -->
+
+Essa seção da documentação contém tutoriais (em inglês). Um tutorial mostra como realizar um objetivo mais complexo que uma simples [tarefa](/docs/tasks/). Eles podem ser divididos em diversas seções, cada uma com uma sequência de passos e etapas a serem seguidos.
+
+Antes de iniciar um tutorial, é interessante que vocẽ salve a página de [Glossário](/pt/docs/reference/glossary/) para futuras referências.
+
+
+<!-- body -->
+
+## Básicos
+
+* [Kubernetes básico](/docs/tutorials/kubernetes-basics/) é um tutorial interativo que auxilia no entendimento do ecossistema Kubernetes, bem como te permite testar algumas funcionalidades básicas do Kubernetes.
+
+* [Introdução ao Kubernetes (edX)](https://www.edx.org/course/introduction-kubernetes-linuxfoundationx-lfs158x#) é um curso gratuíto da edX que te guia no entendimento do Kubernetes, seus conceitos, bem como na execução de tarefas mais simples.
+
+* [Hello Minikube](/docs/tutorials/hello-minikube/) é um "Hello World" que te permite testar rapidamente o Kubernetes em sua estação com o uso do Minikube
+
+## Configuração
+
+* [Configurando o Redis usando um ConfigMap](/docs/tutorials/configuration/configure-redis-using-configmap/)
+
+## Aplicações stateless
+
+* [Expondo um Endereço de IP externo para acessar uma aplicação no Cluster](/docs/tutorials/stateless-application/expose-external-ip-address/)
+
+* [Exemplo: Implantando a aplicação de Livro de Visitas (Guestbook) em  PHP com Redis](/docs/tutorials/stateless-application/guestbook/)
+
+## Aplicações stateful
+
+* [Básicos sobre StatefulSet](/docs/tutorials/stateful-application/basic-stateful-set/)
+
+* [Exemplo: WordPress e MySQL com Volumes Persistentes](/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/)
+
+* [Exemplo: Implantando Cassandra com Stateful Sets](/docs/tutorials/stateful-application/cassandra/)
+
+* [Executando ZooKeeper no Kubernetes](/docs/tutorials/stateful-application/zookeeper/)
+
+## Pipelines de CI/CD
+
+* [Configurando um Pipeline CI/CD com Kubernetes Parte 1: Visão Geral](https://www.linux.com/blog/learn/chapter/Intro-to-Kubernetes/2017/5/set-cicd-pipeline-kubernetes-part-1-overview)
+
+* [Configurando um Pipeline CI/CD com um Pod Jenkins no Kubernetes (Parte 2)](https://www.linux.com/blog/learn/chapter/Intro-to-Kubernetes/2017/6/set-cicd-pipeline-jenkins-pod-kubernetes-part-2)
+
+* [Executando e escalando um aplicativo distribuído de palavras cruzadas com CI/CD no Kubernetes (Parte 3)](https://www.linux.com/blog/learn/chapter/intro-to-kubernetes/2017/6/run-and-scale-distributed-crossword-puzzle-app-cicd-kubernetes-part-3)
+
+* [Configurando um CI/CD para um aplicativo distribuído de palavras cruzadas no Kubernetes (Parte 4)](https://www.linux.com/blog/learn/chapter/intro-to-kubernetes/2017/6/set-cicd-distributed-crossword-puzzle-app-kubernetes-part-4)
+
+## Clusters
+
+* [AppArmor](/docs/tutorials/clusters/apparmor/)
+
+## Serviços / "Services"
+
+* [Usando IP de origem](/docs/tutorials/services/source-ip/)
+
+## {{% heading "whatsnext" %}}
+
+Se você desejar escrever um tutorial, veja a página 
+[Utilizando templates](/docs/home/contribute/page-templates/) 
+para informações sobre o tipo de página e o formato a ser utilizado.


### PR DESCRIPTION
It seems there's a lack of pt documentation (mainly a index page for tutorial, tasks and setups) and this leads to some 404 when user is navigating through the widgets at https://kubernetes.io/pt/docs/home/

This PR adds those sections so at least the main page can direct users to the right initial path.

Signed-off-by: Ricardo Pchevuzinske Katz <ricardo.katz@serpro.gov.br>

Fixes: #22387




