### PR TITLE
Remove a toc shortcode from concepts/services-networking/network-policies

### DIFF
--- a/content/en/docs/concepts/services-networking/network-policies.md
+++ b/content/en/docs/concepts/services-networking/network-policies.md
@@ -8,8 +8,6 @@ content_type: concept
 weight: 50
 ---
 
-{{< toc >}}
-
 <!-- overview -->
 A network policy is a specification of how groups of {{< glossary_tooltip text="pods" term_id="pod">}} are allowed to communicate with each other and other network endpoints.
 


### PR DESCRIPTION
After Docsy introduced, TOC is shown on the right sidebar and other toc shortcodes were removed from all the pages. This should be the last remaining toc shortcode.

Affected page: https://kubernetes.io/docs/concepts/services-networking/network-policies/

Related: #21779