### PR TITLE
Fixes broken link to website issues

### DIFF
--- a/content/en/docs/contribute/_index.md
+++ b/content/en/docs/contribute/_index.md
@@ -53,7 +53,7 @@ roles and permissions.
 
 - Read the [Contribution overview](/docs/contribute/new-content/overview/) to
   learn about the different ways you can contribute.
-- Check [kubernetes/website issues list](/https://github.com/kubernetes/website/issues/)
+- Check [`kubernetes/website` issues list](https://github.com/kubernetes/website/issues/)
   for issues that make good entry points.
 - [Open a pull request using GitHub](/docs/contribute/new-content/open-a-pr/#changes-using-github)
   to existing documentation and learn more about filing issues in GitHub.


### PR DESCRIPTION
This fixes the link to `kubernetes/website` issues which is currently broken because it starts with a `/`.

Adds formatting to match the rest of the page, kubernetes/website -> `kubernetes/website`.