### PR TITLE
Correct Privilege Escalation section

### DIFF
--- a/content/en/docs/concepts/security/pod-security-standards.md
+++ b/content/en/docs/concepts/security/pod-security-standards.md
@@ -209,11 +209,11 @@ well as lower-trust users.The following listed controls should be enforced/disal
 		<tr>
 			<td>Privilege Escalation</td>
 			<td>
-				Privilege escalation to root should not be allowed.<br>
+				Privilege escalation (typically via SUID/SGID file permission bits) should not be allowed.<br>
 				<br><b>Restricted Fields:</b><br>
-				spec.containers[*].securityContext.privileged<br>
-				spec.initContainers[*].securityContext.privileged<br>
-				<br><b>Allowed Values:</b> false, undefined/nil<br>
+				spec.containers[*].securityContext.allowPrivilegeEscalation<br>
+				spec.initContainers[*].securityContext.allowPrivilegeEscalation<br>
+				<br><b>Allowed Values:</b> false<br>
 			</td>
 		</tr>
 		<tr>

--- a/content/en/docs/concepts/security/pod-security-standards.md
+++ b/content/en/docs/concepts/security/pod-security-standards.md
@@ -209,7 +209,7 @@ well as lower-trust users.The following listed controls should be enforced/disal
 		<tr>
 			<td>Privilege Escalation</td>
 			<td>
-				Privilege escalation (typically via SUID/SGID file permission bits) should not be allowed.<br>
+				Privilege escalation (such as via set-user-ID or set-group-ID file mode) should not be allowed.<br>
 				<br><b>Restricted Fields:</b><br>
 				spec.containers[*].securityContext.allowPrivilegeEscalation<br>
 				spec.initContainers[*].securityContext.allowPrivilegeEscalation<br>


### PR DESCRIPTION
The "Privilege Escalation" section of the Pod Security Standards document appears to have been copy-pasted from the "Privileged" section and not been properly updated.

This PR aims to fix that by:
* Updating the PodSpec fields to be correct
* Updating the Allowed Values as appropriate (allowPrivilegeEscalation functionally defaults to True)
* Explaining more clearly what the setting does