### PR TITLE
Added simple install instructions

### DIFF
--- a/content/en/docs/concepts/cluster-administration/networking.md
+++ b/content/en/docs/concepts/cluster-administration/networking.md
@@ -94,8 +94,9 @@ Thanks to the "programmable" characteristic of Open vSwitch, Antrea is able to i
 
 * `NodeIPAMController` must be enabled in the Kubernetes cluster. 
   When deploying a cluster with kubeadm the `--pod-network-cidr <cidr>` option must be specified.
+* Open vSwitch kernel module must be present on every Kubernetes node.
 
-To deploy the latest version of Antrea (built from the master branch), use the
+To deploy the latest version of Antrea, use the
 checked-in [deployment
 yaml](https://github.com/vmware-tanzu/antrea/blob/master/build/yamls/antrea.yml):
 

--- a/content/en/docs/concepts/cluster-administration/networking.md
+++ b/content/en/docs/concepts/cluster-administration/networking.md
@@ -79,7 +79,7 @@ as an introduction to various technologies and serves as a jumping-off point.
 The following networking options are sorted alphabetically - the order does not
 imply any preferential status.
 
-Where available, simplified / one-line installation instructions are provided here to simplify lab installations. For real-world and production installation, please follow the projects official documentation.
+Where available, simplified installation instructions are provided for lab environments. For production installations, follow the project's official documentation.
 
 ### ACI
 
@@ -94,7 +94,6 @@ Thanks to the "programmable" characteristic of Open vSwitch, Antrea is able to i
 
 * `NodeIPAMController` must be enabled in the Kubernetes cluster. 
   When deploying a cluster with kubeadm the `--pod-network-cidr <cidr>` option must be specified.
-* Open vSwitch kernel module must be present on every Kubernetes node.
 
 To deploy the latest version of Antrea (built from the master branch), use the
 checked-in [deployment


### PR DESCRIPTION
As a follow on from https://github.com/kubernetes/website/pull/22600, this PR addresses the issues for new users and CKA exam takers by adding simplified / one-liner install information to the Kubernetes Networking Model page - https://kubernetes.io/docs/concepts/cluster-administration/networking.

Not all projects have simplified install instructions, and obviously this page doesn't want to become the oracle for all installations, but having some installation documentation under kubernetes.io will help those taking the CKA (where referencing this is part of the exam), but also for new users to Kubernetes who maybe just want to quickly spin up a cluster but get intimidated by the different options and reading required to understand how to get started.
