### PR TITLE
fix ServiceAccount link URL Path in docs/concepts/containers/images

### DIFF
--- a/content/en/docs/concepts/containers/images.md
+++ b/content/en/docs/concepts/containers/images.md
@@ -259,7 +259,7 @@ EOF
 This needs to be done for each pod that is using a private registry.
 
 However, setting of this field can be automated by setting the imagePullSecrets
-in a [ServiceAccount](/docs/tasks/configure-pod-container/configure-service-accounts/) resource.
+in a [ServiceAccount](/docs/tasks/configure-pod-container/configure-service-account/) resource.
 
 Check [Add ImagePullSecrets to a Service Account](/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account) for detailed instructions.
 


### PR DESCRIPTION
close #23022

cannot access the link destination of the word. If click this link, 404 error.
I see last "s" is unnecessary.

- Current
`configure-service-accounts`

- This PR
`configure-service-account`