### PR TITLE
Fix glossary definition shortcode

### DIFF
--- a/content/en/docs/contribute/style/hugo-shortcodes/index.md
+++ b/content/en/docs/contribute/style/hugo-shortcodes/index.md
@@ -90,18 +90,38 @@ Renders to:
 
 ## Glossary
 
+There are two glossary tooltips.
+
 You can reference glossary terms with an inclusion that automatically updates and replaces content with the relevant links from [our glossary](/docs/reference/glossary/). When the term is moused-over by someone
 using the online documentation, the glossary entry displays a tooltip.
 
+As well as inclusions with tooltips, you can reuse the definitions from the glossary in
+page content.
+
 The raw data for glossary terms is stored at [https://github.com/kubernetes/website/tree/master/content/en/docs/reference/glossary](https://github.com/kubernetes/website/tree/master/content/en/docs/reference/glossary), with a content file for each glossary term.
 
-### Glossary Demo
+### Glossary demo
 
 For example, the following include within the markdown renders to {{< glossary_tooltip text="cluster" term_id="cluster" >}} with a tooltip:
 
-```liquid
+```
 {{</* glossary_tooltip text="cluster" term_id="cluster" */>}}
 ```
+
+Here's a short glossary definition:
+
+```
+{{</* glossary_definition prepend="A cluster is" term_id="cluster" length="short" */>}}
+```
+which renders as:
+{{< glossary_definition prepend="A cluster is" term_id="cluster" length="short" >}}
+
+You can also include a full definition:
+```
+{{</* glossary_definition term_id="cluster" length="all" */>}}
+```
+which renders as:
+{{< glossary_definition term_id="cluster" length="all" >}}
 
 ## Table captions
 

--- a/layouts/shortcodes/glossary_definition.html
+++ b/layouts/shortcodes/glossary_definition.html
@@ -1,29 +1,40 @@
-
 {{- $id := .Get "term_id" -}}
 {{- $length := .Get "length" -}}
-{{- $prepend := .Get "prepend" }}
+{{- $prepend := .Get "prepend" -}}
 {{- $glossaryBundle := site.GetPage "page" "docs/reference/glossary" -}}
 {{- $glossaryItems :=  $glossaryBundle.Resources.ByType "page" -}}
 {{- $term_info := $glossaryItems.GetMatch (printf "%s.md" $id ) -}}
+{{- $showFullDefinition := false -}}
 {{- if not $term_info -}}
-{{- errorf "[%s] %q: %q is not a valid glossary term_id, see ./docs/reference/glossary/* for a full list" site.Language.Lang .Page.Path $id -}}
+  {{- errorf "[%s] %q: %q is not a valid glossary term_id, see ./docs/reference/glossary/* for a full list" site.Language.Lang .Page.Path $id -}}
 {{- end -}}
-{{- with $term_info -}}
-{{- if (strings.Contains "short" $length) -}}
-	{{- with .Summary -}}
-	{{- if $prepend }}{{- replace . "<p>" (printf "<P>%s %s" $prepend .) -}}{{ else }}{{- . -}}{{ end -}}
-	{{- else -}}
-	{{- partial "templates/errorthrower.html" (dict "block" "summary" "purpose" .purpose "describes the key term in greater depth, supplementing the short_description") . -}}
-	{{- end -}}
+{{- if or (eq "long" $length) (eq "all" $length) -}}
+  {{- $showFullDefinition = true -}}
+{{- else if (eq "short" $length) -}}
+  {{- $showFullDefinition = false -}}
+{{- else -}}
+  {{- errorf "[%s] %q: invalid glossary definition length %q" site.Language.Lang .Page.Path $length -}}
 {{- end -}}
-{{- if (strings.Contains "all|long" $length) -}}
-{{- with .Content -}}
-{{- if $prepend }}
-{{- $firstPara := index (findRE "(?s)<p>.*?</p>" . 1) 0 -}}
-{{- $firstPara := $firstPara | strings.TrimSuffix "</p>" | strings.TrimPrefix "<p>" -}}
-{{- $first := slicestr $firstPara 0 1 | lower }}
-{{- $prepended := printf "<p>%s %s%s</p>"  $prepend $first (slicestr $firstPara 1) -}}
-{{- replace . $firstPara $prepended | safeHTML -}}{{ else }}{{- . -}}{{ end -}}
-{{- end -}}
-{{- end -}}
+{{- with $term_info.Content -}}
+  {{- if not $showFullDefinition -}}
+    {{- $firstPara := index (findRE "(?s)<p>.*?</p>" . 1) 0 -}}
+    {{- $firstPara := $firstPara | strings.TrimSuffix "</p>" | strings.TrimPrefix "<p>" -}}
+    {{- $first := slicestr $firstPara 0 1 | lower -}}
+    {{- if $prepend -}}
+      {{- $prepended := printf "<p>%s %s%s</p>"  $prepend $first (slicestr $firstPara 1) -}}
+      {{- $prepended | safeHTML -}}
+    {{- else -}}
+      {{- $firstPara | safeHTML -}}
+    {{- end -}}
+  {{- else -}}
+    {{- if $prepend -}}
+      {{- $firstPara := index (findRE "(?s)<p>.*?</p>" . 1) 0 -}}
+      {{- $firstPara := $firstPara | strings.TrimSuffix "</p>" | strings.TrimPrefix "<p>" -}}
+      {{- $first := slicestr $firstPara 0 1 | lower -}}
+      {{- $prepended := printf "<p>%s %s%s</p>"  $prepend $first (slicestr $firstPara 1) -}}
+      {{- replace . $firstPara $prepended | safeHTML -}}
+    {{- else -}}
+      {{- . -}}
+    {{- end -}}
+  {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Fix a bug rendering short glossary definitions. Also, add an example of a short glossary definition to the style guide.

~This change exposed a content bug; it needs the fix from #23026 before it will preview.~

Fixes #20252

- [Before](https://kubernetes.io/docs/contribute/style/hugo-shortcodes/#glossary-demo)
- [After](https://deploy-preview-23028--kubernetes-io-master-staging.netlify.app/docs/contribute/style/hugo-shortcodes/#glossary-demo)