### PR TITLE
Improve styling for callouts

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -268,22 +268,34 @@ main {
 
 // blockquotes and callouts
 
-blockquote {
-  padding: 0.4rem 0.4rem 0.4rem 1rem !important;
-}
+.td-content, body {
+  blockquote.callout {
+    padding: 0.4rem 0.4rem 0.4rem 1rem;
+    border: 1px solid #eee;
+    border-left-width: 0.5em;
+    background: #fff;
+    color: #000;
+    margin-top: 0.5em;
+    margin-bottom: 0.5em;
+  }
+  blockquote.callout {
+    border-radius: calc(1em/3);
+  }
+  .callout.caution {
+    border-left-color: #f0ad4e;
+  }
 
-// callouts are contained in static CSS as well. these require override.
+  .callout.note {
+    border-left-color: #428bca;
+  }
 
-.caution {
-  border-left-color: #f0ad4e !important;
-}
+  .callout.warning {
+    border-left-color: #d9534f;
+  }
 
-.note {
-  border-left-color: #428bca !important;
-}
-
-.warning {
-  border-left-color: #d9534f !important;
+  h1:first-of-type + blockquote.callout {
+    margin-top: 1.5em;
+  }
 }
 
 .deprecation-warning {

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -16,7 +16,7 @@
 {{- end }}
 
 <link rel="stylesheet" href="{{ "css/jquery-ui.min.css" | relURL }}">
-<link rel="stylesheet" href="{{ "css/callouts.css" | relURL }}">
+<link rel="stylesheet" href="{{ "css/feature-states.css" | relURL }}">
 <link rel="stylesheet" href="{{ "css/custom-jekyll/tags.css" | relURL }}">
 {{- if .Site.Params.announcement }}
 <link rel="stylesheet" href="{{ "css/announcement.css" | relURL }}">

--- a/layouts/shortcodes/caution.html
+++ b/layouts/shortcodes/caution.html
@@ -1,3 +1,3 @@
-<blockquote class="caution">
+<blockquote class="caution callout">
   <div><strong>{{ T "caution" }}</strong> {{ trim .Inner " \n" | markdownify }}</div>
 </blockquote>

--- a/layouts/shortcodes/deprecationfilewarning.html
+++ b/layouts/shortcodes/deprecationfilewarning.html
@@ -1,3 +1,3 @@
-<blockquote class="deprecation_file_warning">
+<blockquote class="deprecation_file_warning callout">
   <div><h4>{{ T "deprecation_file_warning" }}</h4> {{ .Inner | markdownify }}</div>
 </blockquote>

--- a/layouts/shortcodes/note.html
+++ b/layouts/shortcodes/note.html
@@ -1,3 +1,3 @@
-<blockquote class="note">
+<blockquote class="note callout">
   <div><strong>{{ T "note" }}</strong> {{ trim .Inner " \n" | markdownify }}</div>
 </blockquote>

--- a/layouts/shortcodes/warning.html
+++ b/layouts/shortcodes/warning.html
@@ -1,3 +1,3 @@
-<blockquote class="warning">
+<blockquote class="warning callout">
   <div><strong>{{ T "warning" }}</strong> {{ trim .Inner " \n" | markdownify }}</div>
 </blockquote>

--- a/static/css/feature-states.css
+++ b/static/css/feature-states.css
@@ -1,24 +1,3 @@
-/* Callouts */
-.caution, .note, .warning {
-    padding: 20px;
-    margin: 20px 0;
-    border: 1px solid #eee;
-    border-left-width: 5px;
-    border-radius: 3px;
-}
-
-.caution {
-    border-left-color: #f0ad4e;
-}
-
-.note {
-    border-left-color: #428bca;
-}
-
-.warning {
-    border-left-color: #d9534f;
-}
-
 /* Feature States */
 
 .beta, .stable, .alpha, .deprecated {


### PR DESCRIPTION
Update styles for callouts (`{{< warning >}}`, `{{< caution >}}`, and `{{< caution >}}`); also avoid applying callout-specific styles to general block quotes.

Add a `callout` class to callouts.

Also, make the left highlight a bit wider for high-DPI viewports - use `em` rather than `px` units.

/area web-development

You can compare an [example page](https://deploy-preview-23029--kubernetes-io-master-staging.netlify.app/docs/concepts/security/overview/) to its [original](https://k8s.io/docs/concepts/security/overview/).