### PR TITLE
Tidy & fix deprecation warnings

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -284,6 +284,82 @@ blockquote {
   border-left-color: #d9534f !important;
 }
 
+.deprecation-warning {
+    padding: 20px;
+    margin: 20px 0;
+    background-color: #faf5b6;
+    color: #000;
+}
+
+body.td-home .deprecation-warning, body.td-blog .deprecation-warning, body.td-documentation .deprecation-warning {
+    border-radius: 3px;
+}
+
+body.td-home #deprecation-warning {
+    max-width: 1000px;
+    margin-top: 2.5rem;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+#caseStudies body > #deprecation-warning, body.cid-casestudies > #deprecation-warning, body.cid-community > #deprecation-warning {
+    display: inline-block;
+    vertical-align: top;
+    position: relative;
+    background-color: #326ce5; // Kubernetes blue
+    color: #fff;
+    padding: 0;
+    margin: 0;
+    width: 100vw;
+}
+#caseStudies body > #deprecation-warning, body.cid-casestudies > #deprecation-warning {
+    padding-top: 32px;
+}
+body.cid-partners > #deprecation-warning {
+    padding: 0;
+    margin-right: 0;
+    margin-left: 0;
+    margin-top: 0;
+    width: 100vw;
+}
+body.cid-partners > #deprecation-warning > .content {
+    width: 100%;
+    max-width: initial;
+    margin-right: 0;
+    margin-left: 0;
+    margin-top: 0;
+    padding-left: 5vw;
+    padding-right: 5vw;
+    padding-top: 2rem;
+    padding-bottom: 2rem;
+}
+body.cid-community > #deprecation-warning > .deprecation-warning {
+    margin-left: 20px;
+    margin-right: 20px;
+    color: #faf5b6;
+    background-color: inherit;
+}
+body.cid-community > #deprecation-warning > .deprecation-warning > * {
+    color: inherit;
+    background-color: inherit;
+}
+
+#caseStudies body > #deprecation-warning > .deprecation-warning, body.cid-casestudies > #deprecation-warning > .deprecation-warning {
+    color: inherit;
+    background: inherit;
+    width: 80%;
+    margin: 0;
+    margin-top: 120px;
+    margin-left: auto;
+    margin-right: auto;
+    border-radius: initial;
+}
+#deprecation-warning > .deprecation-warning a {
+    background: transparent;
+    color: inherit;
+    text-decoration: underline;
+}
+
 // search & sidebar
 .td-sidebar {
   @media only screen and (min-width: 768px) {

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -3,7 +3,7 @@
   <head>
     {{ partial "head.html" . }}
   </head>
-  <body class="td-{{ .Kind }}">
+  <body class="td-{{ .Kind }}{{- if ne .Params.cid "" -}}{{- printf " cid-%s" (lower .Params.cid) -}}{{- end -}}">
     <header>
       {{ partial "navbar.html" . }}
     </header>
@@ -27,7 +27,7 @@
 		</section>
 		{{ block "post-hero" . }}
       {{ block "deprecated" . }}
-        {{ if .IsHome }}
+        {{ if or .IsHome ( eq .Params.cid "partners" ) ( eq .Params.cid "community" ) }}
           {{ partial "deprecation-warning.html" . }}
         {{ end }}
       {{ end }}

--- a/layouts/blog/baseof.html
+++ b/layouts/blog/baseof.html
@@ -27,6 +27,9 @@
             {{ partial "blog-sidebar.html" . }}
           </div>
           <main class="col-12 col-md-9 col-xl-8 pl-md-5 pr-md-4" role="main">
+            {{ block "deprecated" . }}
+              {{ partial "deprecation-warning.html" . }}
+            {{ end }}
             {{ with .CurrentSection.OutputFormats.Get "rss" -}}
             <a class="btn btn-lg -bg-orange td-rss-button d-none d-lg-block" href="{{ .Permalink | safeURL }}" target="_blank">
               RSS <i class="fa fa-rss ml-2 "></i>

--- a/layouts/case-studies/list.html
+++ b/layouts/case-studies/list.html
@@ -12,6 +12,7 @@
 <section id="mainContent">
 	<div class="main-section">
 		<div class="content">
+		{{ partial "deprecation-warning.html" . }}
 			<div class="case-studies">
 				{{ range $featured }}
 				{{ template "case-study-featured-block" (dict "ctx" $ "page" .) }}

--- a/layouts/case-studies/single-baseof.html
+++ b/layouts/case-studies/single-baseof.html
@@ -5,6 +5,7 @@
 	</head>
 	<body>
 		{{ partial "navbar.html" . }}
+		{{ partial "deprecation-warning.html" . }}
 		{{ block "main" . }}{{ end }}
 		{{ partialCached "footer.html" . }}
 		<!-- Disabling this as elements queries do not appear to exist on case studies -->

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -4,7 +4,7 @@
     {{ partial "head.html" . }}
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
   </head>
-  <body class="td-{{ .Kind }}">
+  <body class="td-{{ .Kind }} td-documentation">
     <header>
       {{ partial "navbar.html" . }}
       {{ partial "announcement.html" . }}
@@ -25,6 +25,9 @@
           </div>
           <main class="col-12 col-md-9 col-xl-8 pl-md-5" role="main">
             {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
+            {{ block "deprecated" . }}
+              {{ partial "deprecation-warning.html" . }}
+            {{ end }}
               {{ block "main" . }}{{ end }}
             {{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) }}
               {{ partial "feedback.html" .Site.Params.ui.feedback }}

--- a/layouts/index.headers
+++ b/layouts/index.headers
@@ -14,9 +14,6 @@
 {{- range $pages }}
 {{- if or (.Params.deprecated) (eq .Params.class "gridPage") (.Params.case_study_styles) (.Params.css) (.Params.js) }}
 {{ .URL }}
-  {{- if .Params.deprecated }}
-  Link: </css/deprecation-warning.css>; rel=preload; as=style
-  {{- end -}}
   {{- if eq .Params.class "gridPage" }}
   Link: </css/gridpage.css>; rel=preload; as=style
   {{- end -}}

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -21,9 +21,6 @@
 {{- if .Site.Params.announcement }}
 <link rel="stylesheet" href="{{ "css/announcement.css" | relURL }}">
 {{- end }}
-{{- if .Site.Params.deprecated }}
-<link rel="stylesheet" href="{{ "css/deprecation-warning.css" | relURL }}">
-{{- end }}
 
 {{- if or (eq .Params.class "gridPage") (eq .Params.class "gridPage gridPageHome") }}
   <link rel="stylesheet" href="{{ "css/gridpage.css" | relURL }}">

--- a/layouts/partials/deprecation-warning.html
+++ b/layouts/partials/deprecation-warning.html
@@ -1,14 +1,12 @@
-{{ if .Site.Param "deprecated" }}
-<section id="deprecationWarning">
-  <main>
-    <div class="content deprecation-warning">
-      <h3>
-        {{ T "deprecation_title" }} {{ .Param "version" }}
-      </h3>
-      <p> Kubernetes {{ .Param "version" }} {{ T "deprecation_warning" }}
-        <a href="{{ site.Params.currentUrl }}">{{ T "latest_version" }}</a>
-      </p>
-    </div>
-  </main>
+{{ if (.Site.Param "deprecated") }}
+<section id="deprecation-warning">
+  <div class="content deprecation-warning">
+    <h3>
+      {{ T "deprecation_title" }} {{ .Param "version" }}
+    </h3>
+    <p> Kubernetes {{ .Param "version" }} {{ T "deprecation_warning" }}
+      <a href="{{ site.Params.currentUrl }}">{{ T "latest_version" }}</a>
+    </p>
+  </div>
 </section>
 {{ end }}

--- a/layouts/partials/docs/content-page.html
+++ b/layouts/partials/docs/content-page.html
@@ -1,3 +1,4 @@
+{{ if not (.Site.Param "deprecated") }}
 {{- $filepath := .page.File.Path }}
 {{- $editLink := printf "https://github.com/kubernetes/website/edit/master/content/%s/%s" .page.Language.Lang $filepath }}
 <p>
@@ -5,6 +6,7 @@
     Edit This Page
   </a>
 </p>
+{{- end -}}
 {{ if not .page.Params.notitle }}
   <h1>{{ .page.Title }}</h1>
   {{ $desc := .page.Description }}

--- a/static/css/deprecation-warning.css
+++ b/static/css/deprecation-warning.css
@@ -1,6 +1,0 @@
-.deprecation-warning {
-    padding: 20px;
-    margin: 20px 0;
-    border-radius: 3px;
-    background-color: #faf5b6;
-}


### PR DESCRIPTION
Fixes #23031

To preview these changes, check out locally, eg:
```
git fetch upstream pull/22565/head:pr-22032
git checkout pr-22032
```
then set `deprecated = true` inside `config.toml` and preview, eg: `make container-serve`.

I also recommend previewing without an announcement visible; we don't put announcements on archived websites.