### PR TITLE
Retain the current search keywords in the search input form

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -17,6 +17,15 @@ limitations under the License.
   var Search = {
     init: function () {
       $(document).ready(function () {
+        // Fill the search input form with the current search keywords
+        const searchKeywords = new URLSearchParams(location.search).get('q');
+        if (searchKeywords !== null && searchKeywords !== '') {
+          const searchInput = document.querySelector('.td-search-input');
+          searchInput.focus();
+          searchInput.value = searchKeywords;
+        }
+
+        // Set a keydown event
         $(document).on("keypress", ".td-search-input", function (e) {
           if (e.keyCode !== 13) {
             return;


### PR DESCRIPTION
After moving to the search result page, the search input form becomes empty.

It's helpful to prefill and focus on the input with the current keywords. It allows users to search again with similar keywords easily when they cannot find pages they look for.

**Before**
![Screenshot from 2020-08-09 12-16-26](https://user-images.githubusercontent.com/1425259/89724423-cfa86000-da3d-11ea-9285-8e2be6fc7d09.png)

**After**
![Screenshot from 2020-08-09 12-41-10](https://user-images.githubusercontent.com/1425259/89724410-bacbcc80-da3d-11ea-8531-a86b3aff4491.png)

**How to test this change?**
1. Click the Netlify preview URL: https://deploy-preview-23038--kubernetes-io-master-staging.netlify.app/docs/tutorials/kubernetes-basics/
1. Type arbitrary keywords you like
1. Press the return key
