### PR TITLE
Ingress snippet conforms to ingress spec

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -145,9 +145,9 @@ The following file is an Ingress resource that sends traffic to your Service via
         http:
           paths:
           - path: /
-        backend:
-          serviceName: web
-          servicePort: 8080
+            backend:
+              serviceName: web
+              servicePort: 8080
     ```
 
 1. Create the Ingress resource by running the following command:


### PR DESCRIPTION
I was following the [Set up Ingress on Minikube with the NGINX Ingress Controller](https://kubernetes.io/docs/tasks/access-application-cluster/ingress-minikube/) docs as I was learning more about ingress controllers.

I found that the snippet in the section [Create an Ingress resource](https://kubernetes.io/docs/tasks/access-application-cluster/ingress-minikube/#create-an-ingress-resource) produced a validation error when running it locally.

<img width="1437" alt="Screen Shot 2020-08-09 at 2 11 50 PM" src="https://user-images.githubusercontent.com/3106250/89739048-63345d80-da4b-11ea-985b-8fd507da96ff.png">

When I double checked some ingress documentation, I noticed that the `backend` property just needed a little extra indentation to be valid :+1:

<img width="617" alt="Screen Shot 2020-08-09 at 2 23 06 PM" src="https://user-images.githubusercontent.com/3106250/89739112-e655b380-da4b-11ea-9525-a547d0e22d61.png">

Funny enough, I found that this same snippet in other language docs were in this valid form.