### PR TITLE
Modify wget comment so that 10.0.170.92 refers to ClusterIP of the service and not the PodIP

### DIFF
--- a/content/en/docs/tutorials/services/source-ip.md
+++ b/content/en/docs/tutorials/services/source-ip.md
@@ -150,7 +150,7 @@ ip addr
 
 …then use `wget` to query the local webserver
 ```shell
-# Replace 10.0.170.92 with the Pod's IPv4 address
+# Replace "10.0.170.92" with the IPv4 address of the Service named "clusterip"
 wget -qO - 10.0.170.92
 ```
 ```


### PR DESCRIPTION
Proposal to change previous comment here "Replace 10.0.170.92 with the Pod's IPv4 address",
In my opinion it is confusing with the IP address of the pod itself (not through a service, though it would lead [same results](https://github.com/scoulomb/myDNS/blob/master/2-advanced-bind/1-bind-in-docker-and-kubernetes/2-understand-source-ip-in-k8s.md#target-source-ip-app-from-another-pod)).
Here "10.0.170.92" refers to ClusterIP of the service and not the PodIP.