### PR TITLE
Fix wrong number in example of resource-bin-packing.md

### DIFF
--- a/content/en/docs/concepts/configuration/resource-bin-packing.md
+++ b/content/en/docs/concepts/configuration/resource-bin-packing.md
@@ -172,7 +172,7 @@ Node Score:
 
 intel.com/foo  = resourceScoringFunction((2+2),8)
                =  (100 - ((8-4)*100/8)
-               =  (100 - 25)
+               =  (100 - 50)
                =  50
                =  rawScoringFunction(50)
                = 5


### PR DESCRIPTION
The number in the example should be 50 instead of 25:
```
intel.com/foo  = resourceScoringFunction((2+2),8)
                        =  (100 - ((8-4)*100/8)
                        =  (100 - 25)
```

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

-->
