### PR TITLE
Add 3rd party content warning

### DIFF
--- a/content/en/docs/concepts/cluster-administration/addons.md
+++ b/content/en/docs/concepts/cluster-administration/addons.md
@@ -5,11 +5,11 @@ content_type: concept
 
 <!-- overview -->
 
+{{% thirdparty-content %}}
+
 Add-ons extend the functionality of Kubernetes.
 
 This page lists some of the available add-ons and links to their respective installation instructions.
-
-Add-ons in each section are sorted alphabetically - the ordering does not imply any preferential status.
 
 <!-- body -->
 

--- a/content/en/docs/concepts/cluster-administration/networking.md
+++ b/content/en/docs/concepts/cluster-administration/networking.md
@@ -79,6 +79,8 @@ as an introduction to various technologies and serves as a jumping-off point.
 The following networking options are sorted alphabetically - the order does not
 imply any preferential status.
 
+{{% thirdparty-content %}}
+
 ### ACI
 
 [Cisco Application Centric Infrastructure](https://www.cisco.com/c/en/us/solutions/data-center-virtualization/application-centric-infrastructure/index.html) offers an integrated overlay and underlay SDN solution that supports containers, virtual machines, and bare metal servers. [ACI](https://www.github.com/noironetworks/aci-containers) provides container networking integration for ACI. An overview of the integration is provided [here](https://www.cisco.com/c/dam/en/us/solutions/collateral/data-center-virtualization/application-centric-infrastructure/solution-overview-c22-739493.pdf).
@@ -112,7 +114,7 @@ Additionally, the CNI can be run alongside [Calico for network policy enforcemen
 [Azure CNI](https://docs.microsoft.com/en-us/azure/virtual-network/container-networking-overview) is an [open source](https://github.com/Azure/azure-container-networking/blob/master/docs/cni.md) plugin that integrates Kubernetes Pods with an Azure Virtual Network (also known as VNet) providing network performance at par with VMs. Pods can connect to peered VNet and to on-premises over Express Route or site-to-site VPN and are also directly reachable from these networks. Pods can access Azure services, such as storage and SQL, that are protected by Service Endpoints or Private Link. You can use VNet security policies and routing to filter Pod traffic. The plugin assigns VNet IPs to Pods by utilizing a pool of secondary IPs pre-configured on the Network Interface of a Kubernetes node.
 
 Azure CNI is available natively in the [Azure Kubernetes Service (AKS)] (https://docs.microsoft.com/en-us/azure/aks/configure-azure-cni).
- 
+
 
 ### Big Cloud Fabric from Big Switch Networks
 
@@ -314,4 +316,3 @@ to run, and in both cases, the network provides one IP address per pod - as is s
 The early design of the networking model and its rationale, and some future
 plans are described in more detail in the
 [networking design document](https://git.k8s.io/community/contributors/design-proposals/network/networking.md).
-

--- a/content/en/docs/reference/using-api/client-libraries.md
+++ b/content/en/docs/reference/using-api/client-libraries.md
@@ -40,6 +40,8 @@ The following client libraries are officially maintained by
 
 ## Community-maintained client libraries
 
+{{% thirdparty-content %}}
+
 The following Kubernetes API client libraries are provided and maintained by
 their authors, not the Kubernetes team.
 

--- a/content/en/docs/tasks/administer-cluster/declare-network-policy.md
+++ b/content/en/docs/tasks/administer-cluster/declare-network-policy.md
@@ -9,6 +9,7 @@ content_type: task
 <!-- overview -->
 This document helps you get started using the Kubernetes [NetworkPolicy API](/docs/concepts/services-networking/network-policies/) to declare network policies that govern how pods communicate with each other.
 
+{{% thirdparty-content %}}
 
 ## {{% heading "prerequisites" %}}
 
@@ -22,11 +23,6 @@ Make sure you've configured a network provider with network policy support. Ther
 * [Kube-router](/docs/tasks/administer-cluster/network-policy-provider/kube-router-network-policy/)
 * [Romana](/docs/tasks/administer-cluster/network-policy-provider/romana-network-policy/)
 * [Weave Net](/docs/tasks/administer-cluster/network-policy-provider/weave-network-policy/)
-
-{{< note >}}
-The above list is sorted alphabetically by product name, not by recommendation or preference. This example is valid for a Kubernetes cluster using any of these providers.
-{{< /note >}}
-
 
 <!-- steps -->
 

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -198,6 +198,10 @@ other = "Subscribe"
 [synopsis_heading]
 other = "Synopsis"
 
+
+[thirdparty_message]
+other = """This section links to third party projects that provide functionality required by Kubernetes. The Kubernetes project authors aren't responsible for these projects. This page follows <a href="https://github.com/cncf/foundation/blob/master/website-guidelines.md" target="_blank">CNCF website guidelines</a> by listing projects alphabetically. To add a project to this list, read the <a href="/contribute/style/content-guide/#third-party-content">content guide</a> before submitting a change."""
+
 [ui_search_placeholder]
 other = "Search"
 

--- a/layouts/shortcodes/thirdparty-content.html
+++ b/layouts/shortcodes/thirdparty-content.html
@@ -1,0 +1,4 @@
+<blockquote class="callout caution" role="alert">
+  <strong>{{ T "caution" | safeHTML }}</strong>
+  {{ T "thirdparty_message" | safeHTML }}
+</blockquote>


### PR DESCRIPTION
Closes https://github.com/kubernetes/website/issues/22962
Related: https://github.com/kubernetes/website/issues/20232

This PR creates a new shortcode, `3rdparty-content.html` which uses a reusable, translatable message to add warnings on pages that list third party content. 

This PR and issue are a result of ongoing discussions in SIG Docs as we implement the 3rd party content KEP. The KEP itself is a good start, but there is a need to warn contributors in a clear, ongoing basis about what kinds of projects are acceptable to list on pages like these. 

**Feedback I'd like to see**
- What other pages should we add the warning to?

**Preview link**
[Cluster Networking](https://deploy-preview-23107--kubernetes-io-master-staging.netlify.app/docs/concepts/cluster-administration/networking/#how-to-implement-the-kubernetes-networking-model)