### PR TITLE
Update container-lifecycle-hooks.md : PostStart section

### DIFF
--- a/content/en/docs/concepts/containers/container-lifecycle-hooks.md
+++ b/content/en/docs/concepts/containers/container-lifecycle-hooks.md
@@ -30,7 +30,7 @@ There are two hooks that are exposed to Containers:
 
 `PostStart`
 
-This hook executes immediately after a container is created.
+This hook is executed immediately after a container is created.
 However, there is no guarantee that the hook will execute before the container ENTRYPOINT.
 No parameters are passed to the handler.
 


### PR DESCRIPTION
Hello

To follow the same logic like the one for describing the **PreStop** hook, I think it's better to say **is executed** instead of *execute*.

Thank you
Regards