### PR TITLE
Add "community" to the word list for Japanese localization

### DIFF
--- a/content/ja/docs/contribute/localization.md
+++ b/content/ja/docs/contribute/localization.md
@@ -98,7 +98,7 @@ container | コンテナ
 directory | ディレクトリ
 binary | バイナリ
 controller | コントローラー
-opeartor | オペレーター
+operator | オペレーター
 Aggregation Layer | アグリゲーションレイヤー
 Issue | Issue (ママ表記)
 Pull Request | Pull Request (ママ表記)

--- a/content/ja/docs/contribute/localization.md
+++ b/content/ja/docs/contribute/localization.md
@@ -108,6 +108,7 @@ architecture | アーキテクチャ
 secure | セキュア
 stacked | 積層(例: stacked etcd clusterは積層etcdクラスター)
 a set of ~ | ～の集合
+community | コミュニティ
 
 ### 備考
 


### PR DESCRIPTION
"community"(コミュニティ)を頻出単語リストに追加します。

参考: https://github.com/kubernetes/website/pull/23105#discussion_r469687733

(operatorの誤字を見つけたのでついでに修正しました。)