### PR TITLE
Suppress printing any announcements

### DIFF
--- a/static/css/announcement.css
+++ b/static/css/announcement.css
@@ -1,3 +1,10 @@
+@media print {
+  /* Do not print announcements */
+  #announcement, section#announcement, #fp-announcement, section#fp-announcement {
+    display: none;
+  }
+}
+
 .announcement.content {
   margin-bottom: 0px;
 }


### PR DESCRIPTION
When people print the documentation, omit any configured announcement. Printed documentation may well outlive an announcement, and also space on the printed page is a little more precious.

/kind cleanup
/area web-development