### PR TITLE
Fix URL of image for announcement

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,7 +1,7 @@
 # i18n strings for the English (main) site.
 # NOTE: Please keep the entries in alphabetical order when editing
 [announcement_title]
-other = "<img src=\"images/kubecon_ad_eu_2020.png\" style=\"float: right; height: 80px;\" /><a href=\"https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/?utm_source=kuberntes.io&utm_medium=search&utm_campaign=KC_CNC_Virtual\">KubeCon + CloudNativeCon EU 2020</a> <em>virtual</em>."
+other = "<img src=\"/images/kubecon_ad_eu_2020.png\" style=\"float: right; height: 80px;\" /><a href=\"https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/?utm_source=kuberntes.io&utm_medium=search&utm_campaign=KC_CNC_Virtual\">KubeCon + CloudNativeCon EU 2020</a> <em>virtual</em>."
 
 [announcement_message]
 other = "4 days of incredible opportunities to collaborate, learn + share with the entire community!<br />August 17 – 20 2020."


### PR DESCRIPTION
Netlify hides that the URL in the KubeCon 2020 EU announcement is wrong, but it breaks for local previews.
Fix that.