### PR TITLE
Specify service-cluster-ip-range for apiserver (dualstack)

### DIFF
--- a/content/en/docs/concepts/services-networking/dual-stack.md
+++ b/content/en/docs/concepts/services-networking/dual-stack.md
@@ -47,6 +47,7 @@ To enable IPv4/IPv6 dual-stack, enable the `IPv6DualStack` [feature gate](/docs/
 
    * kube-apiserver:
       * `--feature-gates="IPv6DualStack=true"`
+      * `--service-cluster-ip-range=<IPv4 CIDR>,<IPv6 CIDR>`
    * kube-controller-manager:
       * `--feature-gates="IPv6DualStack=true"`
       * `--cluster-cidr=<IPv4 CIDR>,<IPv6 CIDR>`


### PR DESCRIPTION
Hi, the `--service-cluster-ip-range` option should also be specified for apiserver, otherwise services will be created with wrong IP for ipFamily:

```yaml
apiVersion: v1
kind: Service
metadata:
  name: nginx6
  namespace: default
spec:
  clusterIP: 10.108.15.61
  ipFamily: IPv6
  ports:
  - port: 80
    protocol: TCP
    targetPort: 80
  selector:
    app: nginx
  sessionAffinity: None
  type: ClusterIP
status:
  loadBalancer: {}
```

Force specified ClusterIPs also not working:

```
The Service "nginx6" is invalid: spec.clusterIP: Invalid value: "fd02:cea::1": provided IP is not in the valid range. The range of valid IPs is 10.0.0.0/24
```

**Reviewer note:** this flag is working only since kube-apiserver v1.19