### PR TITLE
Revise full link target for kube-apiserver glossary term

### DIFF
--- a/content/en/docs/reference/glossary/kube-apiserver.md
+++ b/content/en/docs/reference/glossary/kube-apiserver.md
@@ -2,7 +2,7 @@
 title: API server
 id: kube-apiserver
 date: 2018-04-12
-full_link: /docs/reference/generated/kube-apiserver/
+full_link: /docs/concepts/overview/components/#kube-apiserver
 short_description: >
   Control plane component that serves the Kubernetes API.
 


### PR DESCRIPTION
PR Summary:
- Revised full link target for kube-apiserver glossary term
- Fixes #23240
- Preview https://deploy-preview-23241--kubernetes-io-master-staging.netlify.app/docs/concepts/overview/kubernetes-api/