### PR TITLE
Fixed hyperlink in docs of all languages

### DIFF
--- a/content/de/docs/reference/glossary/kube-apiserver.md
+++ b/content/de/docs/reference/glossary/kube-apiserver.md
@@ -2,7 +2,7 @@
 title: kube-apiserver
 id: kube-apiserver
 date: 2018-04-12
-full_link: /docs/reference/generated/kube-apiserver/
+full_link: /docs/concepts/overview/components/#kube-apiserver
 short_description: >
   Komponente auf dem Master, der die Kubernetes-API verfügbar macht. Es ist das Frontend für die Kubernetes-Steuerebene.
 

--- a/content/en/docs/reference/glossary/kube-apiserver.md
+++ b/content/en/docs/reference/glossary/kube-apiserver.md
@@ -2,7 +2,7 @@
 title: API server
 id: kube-apiserver
 date: 2018-04-12
-full_link: /docs/reference/generated/kube-apiserver/
+full_link: /docs/concepts/overview/components/#kube-apiserver
 short_description: >
   Control plane component that serves the Kubernetes API.
 

--- a/content/es/docs/reference/glossary/kube-apiserver.md
+++ b/content/es/docs/reference/glossary/kube-apiserver.md
@@ -2,7 +2,7 @@
 title: API Server
 id: kube-apiserver
 date: 2020-07-01
-full_link: /docs/reference/generated/kube-apiserver/
+full_link: /docs/concepts/overview/components/#kube-apiserver
 short_description: >
   Componente del plano de control que expone la API de Kubernetes.
 

--- a/content/fr/docs/reference/glossary/kube-apiserver.md
+++ b/content/fr/docs/reference/glossary/kube-apiserver.md
@@ -2,7 +2,7 @@
 title: kube-apiserver
 id: kube-apiserver
 date: 2018-04-12
-full_link: /docs/reference/generated/kube-apiserver/
+full_link: /docs/concepts/overview/components/#kube-apiserver
 short_description: >
   Composant sur le master qui expose l'API Kubernetes. Il s'agit du front-end pour le plan de contrôle Kubernetes.
 

--- a/content/id/docs/reference/glossary/kube-apiserver.md
+++ b/content/id/docs/reference/glossary/kube-apiserver.md
@@ -2,7 +2,7 @@
 title: kube-apiserver
 id: kube-apiserver
 date: 2019-04-21
-full_link: /docs/reference/generated/kube-apiserver/
+full_link: /docs/concepts/overview/components/#kube-apiserver
 short_description: >
   Komponen di master yang mengekspos API Kubernetes. Merupakan <i> front-end </i> dari <i> kontrol plane </i> Kubernetes.
 

--- a/content/it/docs/reference/glossary/kube-apiserver.md
+++ b/content/it/docs/reference/glossary/kube-apiserver.md
@@ -2,7 +2,7 @@
 title: API server
 id: kube-apiserver
 date: 2018-04-12
-full_link: /docs/reference/generated/kube-apiserver/
+full_link: /docs/concepts/overview/components/#kube-apiserver
 short_description: >
   Componente della Control plane che serve le Kubernetes API.
 

--- a/content/ja/docs/reference/glossary/kube-apiserver.md
+++ b/content/ja/docs/reference/glossary/kube-apiserver.md
@@ -2,7 +2,7 @@
 title: APIサーバー
 id: kube-apiserver
 date: 2018-04-12
-full_link: /docs/reference/generated/kube-apiserver/
+full_link: /docs/concepts/overview/components/#kube-apiserver
 short_description: >
   Kubernetes APIを提供するコントロールプレーンのコンポーネントです。
 

--- a/content/ko/docs/reference/glossary/kube-apiserver.md
+++ b/content/ko/docs/reference/glossary/kube-apiserver.md
@@ -2,7 +2,7 @@
 title: API 서버
 id: kube-apiserver
 date: 2018-04-12
-full_link: /docs/reference/generated/kube-apiserver/
+full_link: /docs/concepts/overview/components/#kube-apiserver
 short_description: >
   쿠버네티스 API를 제공하는 컨트롤 플레인 컴포넌트.
 

--- a/content/pl/docs/reference/glossary/kube-apiserver.md
+++ b/content/pl/docs/reference/glossary/kube-apiserver.md
@@ -2,7 +2,7 @@
 title: Serwer API
 id: kube-apiserver
 date: 2018-04-12
-full_link: /docs/reference/generated/kube-apiserver/
+full_link: /docs/concepts/overview/components/#kube-apiserver
 short_description: >
   Składnik warstwy sterowania udostępniający API Kubernetes. 
 

--- a/content/ru/docs/reference/glossary/kube-apiserver.md
+++ b/content/ru/docs/reference/glossary/kube-apiserver.md
@@ -2,7 +2,7 @@
 title: API-сервер
 id: kube-apiserver
 date: 2018-04-12
-full_link: /docs/reference/generated/kube-apiserver/
+full_link: /docs/concepts/overview/components/#kube-apiserver
 short_description: >
   Компонент панели управления, обслуживающий API Kubernetes.
 

--- a/content/uk/docs/reference/glossary/kube-apiserver.md
+++ b/content/uk/docs/reference/glossary/kube-apiserver.md
@@ -3,7 +3,7 @@
 title: API-сервер
 id: kube-apiserver
 date: 2018-04-12
-full_link: /docs/reference/generated/kube-apiserver/
+full_link: /docs/concepts/overview/components/#kube-apiserver
 # short_description: >
 #  Control plane component that serves the Kubernetes API.
 short_description: >

--- a/content/vi/docs/reference/glossary/kube-apiserver.md
+++ b/content/vi/docs/reference/glossary/kube-apiserver.md
@@ -2,7 +2,7 @@
 title: API server
 id: kube-apiserver
 date: 2020-02-26
-full_link: /docs/reference/generated/kube-apiserver/
+full_link: /docs/concepts/overview/components/#kube-apiserver
 short_description: >
   Thành phần tầng điểu khiển (control plane), được dùng để phục vụ Kubernetes API.
 

--- a/content/zh/docs/reference/glossary/kube-apiserver.md
+++ b/content/zh/docs/reference/glossary/kube-apiserver.md
@@ -2,7 +2,7 @@
 title: kube-apiserver
 id: kube-apiserver
 date: 2018-04-12
-full_link: /docs/reference/generated/kube-apiserver/
+full_link: /docs/concepts/overview/components/#kube-apiserver
 short_description: >
   主节点上负责提供 Kubernetes API 服务的组件；它是 Kubernetes 控制面的前端。
 


### PR DESCRIPTION
## Description

Revise the full link target for kube-apiserver glossary term in the documentation. Fixed the hyperlink of "API-Server" in all docs file of different languages 

Fixes #23240