### PR TITLE
Update http-liveness.yaml with containerPort: 8080

### DIFF
--- a/content/en/examples/pods/probe/http-liveness.yaml
+++ b/content/en/examples/pods/probe/http-liveness.yaml
@@ -10,6 +10,8 @@ spec:
     image: k8s.gcr.io/liveness
     args:
     - /server
+    ports:
+    - containerPort: 8080
     livenessProbe:
       httpGet:
         path: /healthz


### PR DESCRIPTION
The ports part is missing, if you deploy the yaml like it was the probe gives an error.
