### PR TITLE
Update Japanese localization on concepts/containers/container-lifecyc…

### DIFF
--- a/content/ja/docs/concepts/containers/container-lifecycle-hooks.md
+++ b/content/ja/docs/concepts/containers/container-lifecycle-hooks.md
@@ -34,7 +34,7 @@ Angularなどのコンポーネントライフサイクルフックを持つ多�
 これはブロッキング、つまり同期的であるため、コンテナを削除するための呼び出しを送信する前に完了する必要があります。
 ハンドラーにパラメーターは渡されません。
 
-終了動作の詳細な説明は、[Termination of Pods](/ja/docs/concepts/workloads/pods/pod/#termination-of-pods)にあります。
+終了動作の詳細な説明は、[Termination of Pods](/ja/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination)にあります。
 
 ### フックハンドラーの実装
 

--- a/content/ja/docs/concepts/containers/container-lifecycle-hooks.md
+++ b/content/ja/docs/concepts/containers/container-lifecycle-hooks.md
@@ -34,7 +34,7 @@ Angularなどのコンポーネントライフサイクルフックを持つ多�
 これはブロッキング、つまり同期的であるため、コンテナを削除するための呼び出しを送信する前に完了する必要があります。
 ハンドラーにパラメーターは渡されません。
 
-終了動作の詳細な説明は、[Termination of Pods](/ja/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination)にあります。
+終了動作の詳細な説明は、[Termination of Pods](/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination)にあります。
 
 ### フックハンドラーの実装
 
@@ -100,6 +100,5 @@ Events:
 
 * [コンテナ環境](/ja/docs/concepts/containers/container-environment/)の詳細
 * [コンテナライフサイクルイベントへのハンドラー紐付け](/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/)のハンズオン
-
 
 


### PR DESCRIPTION
**What this PR does / why we need it:**
content/ja/docs/concepts/containers/container-lifecycle-hooks.md is outdated.

File to update
https://github.com/kubernetes/website/blob/dev-1.18-ja.1/content/ja/docs/concepts/containers/container-lifecycle-hooks.md

Original
https://github.com/kubernetes/website/blob/fb6364d/content/en/docs/concepts/containers/container-lifecycle-hooks.md

diff between translated and v1.18
https://gist.github.com/cb8130f11db134d87d4cbd82164582c5

**Which issue(s) this PR fixes:**
#23243 

**Special notes for your reviewer:**
It is better to merge this PR after the following documents are updated.
 - https://github.com/kubernetes/website/blob/dev-1.18-ja.1/content/ja/docs/concepts/workloads/pods/pod.md
   - Issue(not created)
 - https://github.com/kubernetes/website/blob/dev-1.18-ja.1/content/ja/docs/concepts/workloads/pods/pod-lifecycle.md
   - [Issue](https://github.com/kubernetes/website/issues/23450)

I changed the link of pod termination in this PR.
Original English doc moved the document about pod termination, so link URL was changed in original document.
In this case, Japanese doc also should move the document about pod termination, and then we change link URL in this PR.