### PR TITLE
Add a Korean l10n reviewer to OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -140,6 +140,7 @@ aliases:
     - ianychoi
     - seokho-son
     - ysyukr
+    - pjhwa
   sig-docs-leads: # Website chairs and tech leads
     - jimangel
     - kbarnard10


### PR DESCRIPTION
This PR updates OWNERS_ALIASES
to add @pjhwa to sig-docs-ko-reviews. (Korean l10n team reviewer)

@pjhwa is qualified to be an reviewer according to the following [requirements](https://github.com/kubernetes/community/blob/master/community-membership.md#requirements-1).

Member for at least 3 months: [14 Apr, 2020](https://github.com/kubernetes/org/issues/1780)

Primary reviewer for at least 5 PRs to the codebase
[is:pr assignee:pjhwa](https://github.com/kubernetes/website/pulls?q=is%3Apr+assignee%3Apjhwa)

Reviewed or merged at least 20 substantial PRs to the codebase
[is:pr assignee:pjhwa](https://github.com/kubernetes/website/pulls?q=is%3Apr+assignee%3Apjhwa)
[is:merged author:pjhwa](https://github.com/kubernetes/website/pulls?q=is%3Amerged+author%3Apjhwa)

Nominated by a subproject approver
/cc @kubernetes/sig-docs-ko-owners

Thank you.