### PR TITLE
Fix the link of "Page History" to show the commit history of the localized file

### DIFF
--- a/layouts/partials/git-info.html
+++ b/layouts/partials/git-info.html
@@ -42,7 +42,7 @@
       {{ .GitInfo.AuthorDate.Format "January 02, 2006 at 3:04 PM PST" }}
       {{ T "main_by" }}
       <a href="https://github.com/kubernetes/website/commit/{{ .GitInfo.Hash }}/">{{ .GitInfo.Subject }}</a>
-      (<a href="https://github.com/kubernetes/website/commits/master/content/en/{{ .File.Path }}">{{ T "main_page_history" }}</a>)
+      (<a href="https://github.com/kubernetes/website/commits/master/content/{{ site.Language.Lang }}/{{ .File.Path }}">{{ T "main_page_history" }}</a>)
     </div>
   {{ end }}
 </div>


### PR DESCRIPTION
At the bottom of each documentation page, there is "Page History" which navigates us to the commit history page on the GitHub. But this link always shows us the commit history page of the English one.

For example, there is a "Page History" link on [Kubernetes Documentation](https://kubernetes.io/docs/home/), which navigates us to this [commit history page](https://github.com/kubernetes/website/commits/master/content/en/docs/home/_index.md). However, the "Historique" link on the [French localization](https://kubernetes.io/fr/docs/home/) has a link that takes us to the commit history page of the same English page.

This PR fixes the link to allow us to see the commit history of the localized page.