### PR TITLE
[GSoD'20] Update how the Kubernetes website serves API references

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "themes/docsy"]
 	path = themes/docsy
 	url = https://github.com/google/docsy.git
+[submodule "api-ref-generator"]
+	path = api-ref-generator
+	url = https://github.com/kubernetes-sigs/reference-docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # change is that the Hugo version is now an overridable argument rather than a fixed
 # environment variable.
 
-FROM alpine:latest
+FROM golang:1.15-alpine
 
 LABEL maintainer="Luc Perkins <lperkins@linuxfoundation.org>"
 

--- a/Makefile
+++ b/Makefile
@@ -85,3 +85,10 @@ docker-internal-linkcheck:
 container-internal-linkcheck: link-checker-image-pull
 	$(CONTAINER_RUN) $(CONTAINER_IMAGE) hugo --config config.toml,linkcheck-config.toml --buildFuture
 	$(CONTAINER_ENGINE) run --mount type=bind,source=$(CURDIR),target=/test --rm wjdp/htmltest htmltest
+
+clean-api-reference: ## Clean all directories in API reference directory, preserve _index.md
+	rm -rf content/en/docs/reference/kubernetes-api/*/
+
+api-reference: clean-api-reference ## Build the API reference pages. go needed
+	cd api-ref-generator/gen-resourcesdocs && \
+		go run cmd/main.go kwebsite --config-dir config/v1.20/ --file api/v1.20/swagger.json --output-dir ../../content/en/docs/reference/kubernetes-api --templates templates

--- a/README.md
+++ b/README.md
@@ -59,6 +59,49 @@ make serve
 
 This will start the local Hugo server on port 1313. Open up your browser to http://localhost:1313 to view the website. As you make changes to the source files, Hugo updates the website and forces a browser refresh.
 
+## Building the API reference pages
+
+The API reference pages located in `content/en/docs/reference/kubernetes-api` are built from the Swagger specification, using https://github.com/kubernetes-sigs/reference-docs/tree/master/gen-resourcesdocs.
+
+To update the reference pages for a new Kubernetes release (replace v1.20 in the following examples with the release to update to):
+
+1. Pull the `kubernetes-resources-reference` submodule:
+
+```
+git submodule update --init --recursive --depth 1
+```
+
+2. Create a new API revision into the submodule, and add the Swagger specification:
+
+```
+mkdir api-ref-generator/gen-resourcesdocs/api/v1.20
+curl 'https://raw.githubusercontent.com/kubernetes/kubernetes/master/api/openapi-spec/swagger.json' > api-ref-generator/gen-resourcesdocs/api/v1.20/swagger.json
+```
+
+3. Copy the table of contents and fields configuration for the new release from a previous one:
+
+```
+mkdir api-ref-generator/gen-resourcesdocs/api/v1.20
+cp api-ref-generator/gen-resourcesdocs/api/v1.19/* api-ref-generator/gen-resourcesdocs/api/v1.20/
+```
+
+4. Adapt the files `toc.yaml` and `fields.yaml` to reflect the changes between the two releases
+
+5. Next, build the pages:
+
+```
+make api-reference
+```
+
+You can test the results locally by making and serving the site from a container image:
+
+```
+make container-image
+make container-serve
+```
+
+6. When all changes of the new contract are reflected into the configuration files `toc.yaml` and `fields.yaml`, create a Pull Request with the newly generated API reference pages.
+
 ## Troubleshooting
 ### error: failed to transform resource: TOCSS: failed to transform "scss/main.scss" (text/x-scss): this feature is not available in your current Hugo version
 

--- a/content/en/docs/reference/_index.md
+++ b/content/en/docs/reference/_index.md
@@ -18,7 +18,8 @@ This section of the Kubernetes documentation contains references.
 
 ## API Reference
 
-* [API Reference for Kubernetes {{< param "version" >}}](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/)
+* [Kubernetes API Reference](/docs/reference/kubernetes-api/)
+* [One-page API Reference for Kubernetes {{< param "version" >}}](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/)
 * [Using The Kubernetes API](/docs/reference/using-api/) - overview of the API for Kubernetes.
 
 ## API Client Libraries

--- a/content/en/docs/reference/kubernetes-api/_index.md
+++ b/content/en/docs/reference/kubernetes-api/_index.md
@@ -1,4 +1,8 @@
 ---
-title: API Reference
+title: "Kubernetes API"
 weight: 30
 ---
+
+<!-- overview -->
+
+{{< glossary_definition prepend="Kubernetes' API is" term_id="kubernetes-api" length="all" >}}

--- a/content/en/docs/reference/kubernetes-api/api-index.md
+++ b/content/en/docs/reference/kubernetes-api/api-index.md
@@ -1,6 +1,0 @@
----
-title: v1.20
-weight: 50
----
-
-[Kubernetes API v1.20](/docs/reference/generated/kubernetes-api/v1.20/)

--- a/content/en/docs/reference/kubernetes-api/authentication-resources/_index.md
+++ b/content/en/docs/reference/kubernetes-api/authentication-resources/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Authentication Resources"
+weight: 4
+---

--- a/content/en/docs/reference/kubernetes-api/authentication-resources/certificate-signing-request-v1.md
+++ b/content/en/docs/reference/kubernetes-api/authentication-resources/certificate-signing-request-v1.md
@@ -1,0 +1,846 @@
+---
+api_metadata:
+  apiVersion: "certificates.k8s.io/v1"
+  import: "k8s.io/api/certificates/v1"
+  kind: "CertificateSigningRequest"
+content_type: "api_reference"
+description: "CertificateSigningRequest objects provide a mechanism to obtain x509 certificates by submitting a certificate signing request, and having it asynchronously approved and issued."
+title: "CertificateSigningRequest"
+weight: 4
+---
+
+`apiVersion: certificates.k8s.io/v1`
+
+`import "k8s.io/api/certificates/v1"`
+
+
+## CertificateSigningRequest {#CertificateSigningRequest}
+
+CertificateSigningRequest objects provide a mechanism to obtain x509 certificates by submitting a certificate signing request, and having it asynchronously approved and issued.
+
+Kubelets use this API to obtain:
+ 1. client certificates to authenticate to kube-apiserver (with the "kubernetes.io/kube-apiserver-client-kubelet" signerName).
+ 2. serving certificates for TLS endpoints kube-apiserver can connect to securely (with the "kubernetes.io/kubelet-serving" signerName).
+
+This API can be used to request client certificates to authenticate to kube-apiserver (with the "kubernetes.io/kube-apiserver-client" signerName), or to obtain certificates from custom non-Kubernetes signers.
+
+<hr>
+
+- **apiVersion**: certificates.k8s.io/v1
+
+
+- **kind**: CertificateSigningRequest
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+
+- **spec** (<a href="{{< ref "../authentication-resources/certificate-signing-request-v1#CertificateSigningRequestSpec" >}}">CertificateSigningRequestSpec</a>), required
+
+  spec contains the certificate request, and is immutable after creation. Only the request, signerName, and usages fields can be set on creation. Other fields are derived by Kubernetes and cannot be modified by users.
+
+- **status** (<a href="{{< ref "../authentication-resources/certificate-signing-request-v1#CertificateSigningRequestStatus" >}}">CertificateSigningRequestStatus</a>)
+
+  status contains information about whether the request is approved or denied, and the certificate issued by the signer, or the failure condition indicating signer failure.
+
+
+
+
+
+## CertificateSigningRequestSpec {#CertificateSigningRequestSpec}
+
+CertificateSigningRequestSpec contains the certificate request.
+
+<hr>
+
+- **request** ([]byte), required
+
+  *Atomic: will be replaced during a merge*
+  
+  request contains an x509 certificate signing request encoded in a "CERTIFICATE REQUEST" PEM block. When serialized as JSON or YAML, the data is additionally base64-encoded.
+
+- **signerName** (string), required
+
+  signerName indicates the requested signer, and is a qualified name.
+  
+  List/watch requests for CertificateSigningRequests can filter on this field using a "spec.signerName=NAME" fieldSelector.
+  
+  Well-known Kubernetes signers are:
+   1. "kubernetes.io/kube-apiserver-client": issues client certificates that can be used to authenticate to kube-apiserver.
+    Requests for this signer are never auto-approved by kube-controller-manager, can be issued by the "csrsigning" controller in kube-controller-manager.
+   2. "kubernetes.io/kube-apiserver-client-kubelet": issues client certificates that kubelets use to authenticate to kube-apiserver.
+    Requests for this signer can be auto-approved by the "csrapproving" controller in kube-controller-manager, and can be issued by the "csrsigning" controller in kube-controller-manager.
+   3. "kubernetes.io/kubelet-serving" issues serving certificates that kubelets use to serve TLS endpoints, which kube-apiserver can connect to securely.
+    Requests for this signer are never auto-approved by kube-controller-manager, and can be issued by the "csrsigning" controller in kube-controller-manager.
+  
+  More details are available at https://k8s.io/docs/reference/access-authn-authz/certificate-signing-requests/#kubernetes-signers
+  
+  Custom signerNames can also be specified. The signer defines:
+   1. Trust distribution: how trust (CA bundles) are distributed.
+   2. Permitted subjects: and behavior when a disallowed subject is requested.
+   3. Required, permitted, or forbidden x509 extensions in the request (including whether subjectAltNames are allowed, which types, restrictions on allowed values) and behavior when a disallowed extension is requested.
+   4. Required, permitted, or forbidden key usages / extended key usages.
+   5. Expiration/certificate lifetime: whether it is fixed by the signer, configurable by the admin.
+   6. Whether or not requests for CA certificates are allowed.
+
+- **extra** (map[string][]string)
+
+  extra contains extra attributes of the user that created the CertificateSigningRequest. Populated by the API server on creation and immutable.
+
+- **groups** ([]string)
+
+  *Atomic: will be replaced during a merge*
+  
+  groups contains group membership of the user that created the CertificateSigningRequest. Populated by the API server on creation and immutable.
+
+- **uid** (string)
+
+  uid contains the uid of the user that created the CertificateSigningRequest. Populated by the API server on creation and immutable.
+
+- **usages** ([]string)
+
+  *Atomic: will be replaced during a merge*
+  
+  usages specifies a set of key usages requested in the issued certificate.
+  
+  Requests for TLS client certificates typically request: "digital signature", "key encipherment", "client auth".
+  
+  Requests for TLS serving certificates typically request: "key encipherment", "digital signature", "server auth".
+  
+  Valid values are:
+   "signing", "digital signature", "content commitment",
+   "key encipherment", "key agreement", "data encipherment",
+   "cert sign", "crl sign", "encipher only", "decipher only", "any",
+   "server auth", "client auth",
+   "code signing", "email protection", "s/mime",
+   "ipsec end system", "ipsec tunnel", "ipsec user",
+   "timestamping", "ocsp signing", "microsoft sgc", "netscape sgc"
+
+- **username** (string)
+
+  username contains the name of the user that created the CertificateSigningRequest. Populated by the API server on creation and immutable.
+
+
+
+
+
+## CertificateSigningRequestStatus {#CertificateSigningRequestStatus}
+
+CertificateSigningRequestStatus contains conditions used to indicate approved/denied/failed status of the request, and the issued certificate.
+
+<hr>
+
+- **certificate** ([]byte)
+
+  *Atomic: will be replaced during a merge*
+  
+  certificate is populated with an issued certificate by the signer after an Approved condition is present. This field is set via the /status subresource. Once populated, this field is immutable.
+  
+  If the certificate signing request is denied, a condition of type "Denied" is added and this field remains empty. If the signer cannot issue the certificate, a condition of type "Failed" is added and this field remains empty.
+  
+  Validation requirements:
+   1. certificate must contain one or more PEM blocks.
+   2. All PEM blocks must have the "CERTIFICATE" label, contain no headers, and the encoded data
+    must be a BER-encoded ASN.1 Certificate structure as described in section 4 of RFC5280.
+   3. Non-PEM content may appear before or after the "CERTIFICATE" PEM blocks and is unvalidated,
+    to allow for explanatory text as described in section 5.2 of RFC7468.
+  
+  If more than one PEM block is present, and the definition of the requested spec.signerName does not indicate otherwise, the first block is the issued certificate, and subsequent blocks should be treated as intermediate certificates and presented in TLS handshakes.
+  
+  The certificate is encoded in PEM format.
+  
+  When serialized as JSON or YAML, the data is additionally base64-encoded, so it consists of:
+  
+      base64(
+      -----BEGIN CERTIFICATE-----
+      ...
+      -----END CERTIFICATE-----
+      )
+
+- **conditions** ([]CertificateSigningRequestCondition)
+
+  *Map: unique values on key type will be kept during a merge*
+  
+  conditions applied to the request. Known conditions are "Approved", "Denied", and "Failed".
+
+  <a name="CertificateSigningRequestCondition"></a>
+  *CertificateSigningRequestCondition describes a condition of a CertificateSigningRequest object*
+
+  - **conditions.status** (string), required
+
+    status of the condition, one of True, False, Unknown. Approved, Denied, and Failed conditions may not be "False" or "Unknown".
+
+  - **conditions.type** (string), required
+
+    type of the condition. Known conditions are "Approved", "Denied", and "Failed".
+    
+    An "Approved" condition is added via the /approval subresource, indicating the request was approved and should be issued by the signer.
+    
+    A "Denied" condition is added via the /approval subresource, indicating the request was denied and should not be issued by the signer.
+    
+    A "Failed" condition is added via the /status subresource, indicating the signer failed to issue the certificate.
+    
+    Approved and Denied conditions are mutually exclusive. Approved, Denied, and Failed conditions cannot be removed once added.
+    
+    Only one condition of a given type is allowed.
+
+  - **conditions.lastTransitionTime** (Time)
+
+    lastTransitionTime is the time the condition last transitioned from one status to another. If unset, when a new condition type is added or an existing condition's status is changed, the server defaults this to the current time.
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **conditions.lastUpdateTime** (Time)
+
+    lastUpdateTime is the time of the last update to this condition
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **conditions.message** (string)
+
+    message contains a human readable message with details about the request state
+
+  - **conditions.reason** (string)
+
+    reason indicates a brief reason for the request state
+
+
+
+
+
+## CertificateSigningRequestList {#CertificateSigningRequestList}
+
+CertificateSigningRequestList is a collection of CertificateSigningRequest objects
+
+<hr>
+
+- **apiVersion**: certificates.k8s.io/v1
+
+
+- **kind**: CertificateSigningRequestList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+
+- **items** ([]<a href="{{< ref "../authentication-resources/certificate-signing-request-v1#CertificateSigningRequest" >}}">CertificateSigningRequest</a>), required
+
+  items is a collection of CertificateSigningRequest objects
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified CertificateSigningRequest
+
+#### HTTP Request
+
+GET /apis/certificates.k8s.io/v1/certificatesigningrequests/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CertificateSigningRequest
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authentication-resources/certificate-signing-request-v1#CertificateSigningRequest" >}}">CertificateSigningRequest</a>): OK
+
+401: Unauthorized
+
+
+### `get` read approval of the specified CertificateSigningRequest
+
+#### HTTP Request
+
+GET /apis/certificates.k8s.io/v1/certificatesigningrequests/{name}/approval
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CertificateSigningRequest
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authentication-resources/certificate-signing-request-v1#CertificateSigningRequest" >}}">CertificateSigningRequest</a>): OK
+
+401: Unauthorized
+
+
+### `get` read status of the specified CertificateSigningRequest
+
+#### HTTP Request
+
+GET /apis/certificates.k8s.io/v1/certificatesigningrequests/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CertificateSigningRequest
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authentication-resources/certificate-signing-request-v1#CertificateSigningRequest" >}}">CertificateSigningRequest</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind CertificateSigningRequest
+
+#### HTTP Request
+
+GET /apis/certificates.k8s.io/v1/certificatesigningrequests
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authentication-resources/certificate-signing-request-v1#CertificateSigningRequestList" >}}">CertificateSigningRequestList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a CertificateSigningRequest
+
+#### HTTP Request
+
+POST /apis/certificates.k8s.io/v1/certificatesigningrequests
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../authentication-resources/certificate-signing-request-v1#CertificateSigningRequest" >}}">CertificateSigningRequest</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authentication-resources/certificate-signing-request-v1#CertificateSigningRequest" >}}">CertificateSigningRequest</a>): OK
+
+201 (<a href="{{< ref "../authentication-resources/certificate-signing-request-v1#CertificateSigningRequest" >}}">CertificateSigningRequest</a>): Created
+
+202 (<a href="{{< ref "../authentication-resources/certificate-signing-request-v1#CertificateSigningRequest" >}}">CertificateSigningRequest</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified CertificateSigningRequest
+
+#### HTTP Request
+
+PUT /apis/certificates.k8s.io/v1/certificatesigningrequests/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CertificateSigningRequest
+
+
+- **body**: <a href="{{< ref "../authentication-resources/certificate-signing-request-v1#CertificateSigningRequest" >}}">CertificateSigningRequest</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authentication-resources/certificate-signing-request-v1#CertificateSigningRequest" >}}">CertificateSigningRequest</a>): OK
+
+201 (<a href="{{< ref "../authentication-resources/certificate-signing-request-v1#CertificateSigningRequest" >}}">CertificateSigningRequest</a>): Created
+
+401: Unauthorized
+
+
+### `update` replace approval of the specified CertificateSigningRequest
+
+#### HTTP Request
+
+PUT /apis/certificates.k8s.io/v1/certificatesigningrequests/{name}/approval
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CertificateSigningRequest
+
+
+- **body**: <a href="{{< ref "../authentication-resources/certificate-signing-request-v1#CertificateSigningRequest" >}}">CertificateSigningRequest</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authentication-resources/certificate-signing-request-v1#CertificateSigningRequest" >}}">CertificateSigningRequest</a>): OK
+
+201 (<a href="{{< ref "../authentication-resources/certificate-signing-request-v1#CertificateSigningRequest" >}}">CertificateSigningRequest</a>): Created
+
+401: Unauthorized
+
+
+### `update` replace status of the specified CertificateSigningRequest
+
+#### HTTP Request
+
+PUT /apis/certificates.k8s.io/v1/certificatesigningrequests/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CertificateSigningRequest
+
+
+- **body**: <a href="{{< ref "../authentication-resources/certificate-signing-request-v1#CertificateSigningRequest" >}}">CertificateSigningRequest</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authentication-resources/certificate-signing-request-v1#CertificateSigningRequest" >}}">CertificateSigningRequest</a>): OK
+
+201 (<a href="{{< ref "../authentication-resources/certificate-signing-request-v1#CertificateSigningRequest" >}}">CertificateSigningRequest</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified CertificateSigningRequest
+
+#### HTTP Request
+
+PATCH /apis/certificates.k8s.io/v1/certificatesigningrequests/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CertificateSigningRequest
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authentication-resources/certificate-signing-request-v1#CertificateSigningRequest" >}}">CertificateSigningRequest</a>): OK
+
+401: Unauthorized
+
+
+### `patch` partially update approval of the specified CertificateSigningRequest
+
+#### HTTP Request
+
+PATCH /apis/certificates.k8s.io/v1/certificatesigningrequests/{name}/approval
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CertificateSigningRequest
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authentication-resources/certificate-signing-request-v1#CertificateSigningRequest" >}}">CertificateSigningRequest</a>): OK
+
+401: Unauthorized
+
+
+### `patch` partially update status of the specified CertificateSigningRequest
+
+#### HTTP Request
+
+PATCH /apis/certificates.k8s.io/v1/certificatesigningrequests/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CertificateSigningRequest
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authentication-resources/certificate-signing-request-v1#CertificateSigningRequest" >}}">CertificateSigningRequest</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a CertificateSigningRequest
+
+#### HTTP Request
+
+DELETE /apis/certificates.k8s.io/v1/certificatesigningrequests/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CertificateSigningRequest
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of CertificateSigningRequest
+
+#### HTTP Request
+
+DELETE /apis/certificates.k8s.io/v1/certificatesigningrequests
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/authentication-resources/service-account-v1.md
+++ b/content/en/docs/reference/kubernetes-api/authentication-resources/service-account-v1.md
@@ -1,0 +1,546 @@
+---
+api_metadata:
+  apiVersion: "v1"
+  import: "k8s.io/api/core/v1"
+  kind: "ServiceAccount"
+content_type: "api_reference"
+description: "ServiceAccount binds together: * a name, understood by users, and perhaps by peripheral systems, for an identity * a principal that can be authenticated and authorized * a set of secrets."
+title: "ServiceAccount"
+weight: 1
+---
+
+`apiVersion: v1`
+
+`import "k8s.io/api/core/v1"`
+
+
+## ServiceAccount {#ServiceAccount}
+
+ServiceAccount binds together: * a name, understood by users, and perhaps by peripheral systems, for an identity * a principal that can be authenticated and authorized * a set of secrets
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: ServiceAccount
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **automountServiceAccountToken** (boolean)
+
+  AutomountServiceAccountToken indicates whether pods running as this service account should have an API token automatically mounted. Can be overridden at the pod level.
+
+- **imagePullSecrets** ([]<a href="{{< ref "../common-definitions/local-object-reference#LocalObjectReference" >}}">LocalObjectReference</a>)
+
+  ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+
+- **secrets** ([]<a href="{{< ref "../common-definitions/object-reference#ObjectReference" >}}">ObjectReference</a>)
+
+  *Patch strategy: merge on key `name`*
+  
+  Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount. More info: https://kubernetes.io/docs/concepts/configuration/secret
+
+
+
+
+
+## ServiceAccountList {#ServiceAccountList}
+
+ServiceAccountList is a list of ServiceAccount objects
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: ServiceAccountList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+- **items** ([]<a href="{{< ref "../authentication-resources/service-account-v1#ServiceAccount" >}}">ServiceAccount</a>), required
+
+  List of ServiceAccounts. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified ServiceAccount
+
+#### HTTP Request
+
+GET /api/v1/namespaces/{namespace}/serviceaccounts/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ServiceAccount
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authentication-resources/service-account-v1#ServiceAccount" >}}">ServiceAccount</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind ServiceAccount
+
+#### HTTP Request
+
+GET /api/v1/namespaces/{namespace}/serviceaccounts
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authentication-resources/service-account-v1#ServiceAccountList" >}}">ServiceAccountList</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind ServiceAccount
+
+#### HTTP Request
+
+GET /api/v1/serviceaccounts
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authentication-resources/service-account-v1#ServiceAccountList" >}}">ServiceAccountList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a ServiceAccount
+
+#### HTTP Request
+
+POST /api/v1/namespaces/{namespace}/serviceaccounts
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../authentication-resources/service-account-v1#ServiceAccount" >}}">ServiceAccount</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authentication-resources/service-account-v1#ServiceAccount" >}}">ServiceAccount</a>): OK
+
+201 (<a href="{{< ref "../authentication-resources/service-account-v1#ServiceAccount" >}}">ServiceAccount</a>): Created
+
+202 (<a href="{{< ref "../authentication-resources/service-account-v1#ServiceAccount" >}}">ServiceAccount</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified ServiceAccount
+
+#### HTTP Request
+
+PUT /api/v1/namespaces/{namespace}/serviceaccounts/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ServiceAccount
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../authentication-resources/service-account-v1#ServiceAccount" >}}">ServiceAccount</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authentication-resources/service-account-v1#ServiceAccount" >}}">ServiceAccount</a>): OK
+
+201 (<a href="{{< ref "../authentication-resources/service-account-v1#ServiceAccount" >}}">ServiceAccount</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified ServiceAccount
+
+#### HTTP Request
+
+PATCH /api/v1/namespaces/{namespace}/serviceaccounts/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ServiceAccount
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authentication-resources/service-account-v1#ServiceAccount" >}}">ServiceAccount</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a ServiceAccount
+
+#### HTTP Request
+
+DELETE /api/v1/namespaces/{namespace}/serviceaccounts/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ServiceAccount
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authentication-resources/service-account-v1#ServiceAccount" >}}">ServiceAccount</a>): OK
+
+202 (<a href="{{< ref "../authentication-resources/service-account-v1#ServiceAccount" >}}">ServiceAccount</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of ServiceAccount
+
+#### HTTP Request
+
+DELETE /api/v1/namespaces/{namespace}/serviceaccounts
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/authentication-resources/token-request-v1.md
+++ b/content/en/docs/reference/kubernetes-api/authentication-resources/token-request-v1.md
@@ -1,0 +1,165 @@
+---
+api_metadata:
+  apiVersion: "authentication.k8s.io/v1"
+  import: "k8s.io/api/authentication/v1"
+  kind: "TokenRequest"
+content_type: "api_reference"
+description: "TokenRequest requests a token for a given service account."
+title: "TokenRequest"
+weight: 2
+---
+
+`apiVersion: authentication.k8s.io/v1`
+
+`import "k8s.io/api/authentication/v1"`
+
+
+## TokenRequest {#TokenRequest}
+
+TokenRequest requests a token for a given service account.
+
+<hr>
+
+- **apiVersion**: authentication.k8s.io/v1
+
+
+- **kind**: TokenRequest
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+
+- **spec** (<a href="{{< ref "../authentication-resources/token-request-v1#TokenRequestSpec" >}}">TokenRequestSpec</a>), required
+
+
+- **status** (<a href="{{< ref "../authentication-resources/token-request-v1#TokenRequestStatus" >}}">TokenRequestStatus</a>)
+
+
+
+
+
+
+## TokenRequestSpec {#TokenRequestSpec}
+
+TokenRequestSpec contains client provided parameters of a token request.
+
+<hr>
+
+- **audiences** ([]string), required
+
+  Audiences are the intendend audiences of the token. A recipient of a token must identitfy themself with an identifier in the list of audiences of the token, and otherwise should reject the token. A token issued for multiple audiences may be used to authenticate against any of the audiences listed but implies a high degree of trust between the target audiences.
+
+- **boundObjectRef** (BoundObjectReference)
+
+  BoundObjectRef is a reference to an object that the token will be bound to. The token will only be valid for as long as the bound object exists. NOTE: The API server's TokenReview endpoint will validate the BoundObjectRef, but other audiences may not. Keep ExpirationSeconds small if you want prompt revocation.
+
+  <a name="BoundObjectReference"></a>
+  *BoundObjectReference is a reference to an object that a token is bound to.*
+
+  - **boundObjectRef.apiVersion** (string)
+
+    API version of the referent.
+
+  - **boundObjectRef.kind** (string)
+
+    Kind of the referent. Valid kinds are 'Pod' and 'Secret'.
+
+  - **boundObjectRef.name** (string)
+
+    Name of the referent.
+
+  - **boundObjectRef.uid** (string)
+
+    UID of the referent.
+
+- **expirationSeconds** (int64)
+
+  ExpirationSeconds is the requested duration of validity of the request. The token issuer may return a token with a different validity duration so a client needs to check the 'expiration' field in a response.
+
+
+
+
+
+## TokenRequestStatus {#TokenRequestStatus}
+
+TokenRequestStatus is the result of a token request.
+
+<hr>
+
+- **expirationTimestamp** (Time), required
+
+  ExpirationTimestamp is the time of expiration of the returned token.
+
+  <a name="Time"></a>
+  *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+- **token** (string), required
+
+  Token is the opaque bearer token.
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `create` create token of a ServiceAccount
+
+#### HTTP Request
+
+POST /api/v1/namespaces/{namespace}/serviceaccounts/{name}/token
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the TokenRequest
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../authentication-resources/token-request-v1#TokenRequest" >}}">TokenRequest</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authentication-resources/token-request-v1#TokenRequest" >}}">TokenRequest</a>): OK
+
+201 (<a href="{{< ref "../authentication-resources/token-request-v1#TokenRequest" >}}">TokenRequest</a>): Created
+
+202 (<a href="{{< ref "../authentication-resources/token-request-v1#TokenRequest" >}}">TokenRequest</a>): Accepted
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/authentication-resources/token-review-v1.md
+++ b/content/en/docs/reference/kubernetes-api/authentication-resources/token-review-v1.md
@@ -1,0 +1,158 @@
+---
+api_metadata:
+  apiVersion: "authentication.k8s.io/v1"
+  import: "k8s.io/api/authentication/v1"
+  kind: "TokenReview"
+content_type: "api_reference"
+description: "TokenReview attempts to authenticate a token to a known user."
+title: "TokenReview"
+weight: 3
+---
+
+`apiVersion: authentication.k8s.io/v1`
+
+`import "k8s.io/api/authentication/v1"`
+
+
+## TokenReview {#TokenReview}
+
+TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be cached by the webhook token authenticator plugin in the kube-apiserver.
+
+<hr>
+
+- **apiVersion**: authentication.k8s.io/v1
+
+
+- **kind**: TokenReview
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+
+- **spec** (<a href="{{< ref "../authentication-resources/token-review-v1#TokenReviewSpec" >}}">TokenReviewSpec</a>), required
+
+  Spec holds information about the request being evaluated
+
+- **status** (<a href="{{< ref "../authentication-resources/token-review-v1#TokenReviewStatus" >}}">TokenReviewStatus</a>)
+
+  Status is filled in by the server and indicates whether the request can be authenticated.
+
+
+
+
+
+## TokenReviewSpec {#TokenReviewSpec}
+
+TokenReviewSpec is a description of the token authentication request.
+
+<hr>
+
+- **audiences** ([]string)
+
+  Audiences is a list of the identifiers that the resource server presented with the token identifies as. Audience-aware token authenticators will verify that the token was intended for at least one of the audiences in this list. If no audiences are provided, the audience will default to the audience of the Kubernetes apiserver.
+
+- **token** (string)
+
+  Token is the opaque bearer token.
+
+
+
+
+
+## TokenReviewStatus {#TokenReviewStatus}
+
+TokenReviewStatus is the result of the token authentication request.
+
+<hr>
+
+- **audiences** ([]string)
+
+  Audiences are audience identifiers chosen by the authenticator that are compatible with both the TokenReview and token. An identifier is any identifier in the intersection of the TokenReviewSpec audiences and the token's audiences. A client of the TokenReview API that sets the spec.audiences field should validate that a compatible audience identifier is returned in the status.audiences field to ensure that the TokenReview server is audience aware. If a TokenReview returns an empty status.audience field where status.authenticated is "true", the token is valid against the audience of the Kubernetes API server.
+
+- **authenticated** (boolean)
+
+  Authenticated indicates that the token was associated with a known user.
+
+- **error** (string)
+
+  Error indicates that the token couldn't be checked
+
+- **user** (UserInfo)
+
+  User is the UserInfo associated with the provided token.
+
+  <a name="UserInfo"></a>
+  *UserInfo holds the information about the user needed to implement the user.Info interface.*
+
+  - **user.extra** (map[string][]string)
+
+    Any additional information provided by the authenticator.
+
+  - **user.groups** ([]string)
+
+    The names of groups this user is a part of.
+
+  - **user.uid** (string)
+
+    A unique value that identifies this user across time. If this user is deleted and another user by the same name is added, they will have different UIDs.
+
+  - **user.username** (string)
+
+    The name that uniquely identifies this user among all active users.
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `create` create a TokenReview
+
+#### HTTP Request
+
+POST /apis/authentication.k8s.io/v1/tokenreviews
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../authentication-resources/token-review-v1#TokenReview" >}}">TokenReview</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authentication-resources/token-review-v1#TokenReview" >}}">TokenReview</a>): OK
+
+201 (<a href="{{< ref "../authentication-resources/token-review-v1#TokenReview" >}}">TokenReview</a>): Created
+
+202 (<a href="{{< ref "../authentication-resources/token-review-v1#TokenReview" >}}">TokenReview</a>): Accepted
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/authorization-resources/_index.md
+++ b/content/en/docs/reference/kubernetes-api/authorization-resources/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Authorization Resources"
+weight: 5
+---

--- a/content/en/docs/reference/kubernetes-api/authorization-resources/cluster-role-binding-v1.md
+++ b/content/en/docs/reference/kubernetes-api/authorization-resources/cluster-role-binding-v1.md
@@ -1,0 +1,471 @@
+---
+api_metadata:
+  apiVersion: "rbac.authorization.k8s.io/v1"
+  import: "k8s.io/api/rbac/v1"
+  kind: "ClusterRoleBinding"
+content_type: "api_reference"
+description: "ClusterRoleBinding references a ClusterRole, but not contain it."
+title: "ClusterRoleBinding"
+weight: 6
+---
+
+`apiVersion: rbac.authorization.k8s.io/v1`
+
+`import "k8s.io/api/rbac/v1"`
+
+
+## ClusterRoleBinding {#ClusterRoleBinding}
+
+ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.
+
+<hr>
+
+- **apiVersion**: rbac.authorization.k8s.io/v1
+
+
+- **kind**: ClusterRoleBinding
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata.
+
+- **roleRef** (RoleRef), required
+
+  RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
+
+  <a name="RoleRef"></a>
+  *RoleRef contains information that points to the role being used*
+
+  - **roleRef.apiGroup** (string), required
+
+    APIGroup is the group for the resource being referenced
+
+  - **roleRef.kind** (string), required
+
+    Kind is the type of resource being referenced
+
+  - **roleRef.name** (string), required
+
+    Name is the name of resource being referenced
+
+- **subjects** ([]Subject)
+
+  Subjects holds references to the objects the role applies to.
+
+  <a name="Subject"></a>
+  *Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.*
+
+  - **subjects.kind** (string), required
+
+    Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+
+  - **subjects.name** (string), required
+
+    Name of the object being referenced.
+
+  - **subjects.apiGroup** (string)
+
+    APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+
+  - **subjects.namespace** (string)
+
+    Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+
+
+
+
+
+## ClusterRoleBindingList {#ClusterRoleBindingList}
+
+ClusterRoleBindingList is a collection of ClusterRoleBindings
+
+<hr>
+
+- **apiVersion**: rbac.authorization.k8s.io/v1
+
+
+- **kind**: ClusterRoleBindingList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard object's metadata.
+
+- **items** ([]<a href="{{< ref "../authorization-resources/cluster-role-binding-v1#ClusterRoleBinding" >}}">ClusterRoleBinding</a>), required
+
+  Items is a list of ClusterRoleBindings
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified ClusterRoleBinding
+
+#### HTTP Request
+
+GET /apis/rbac.authorization.k8s.io/v1/clusterrolebindings/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ClusterRoleBinding
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authorization-resources/cluster-role-binding-v1#ClusterRoleBinding" >}}">ClusterRoleBinding</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind ClusterRoleBinding
+
+#### HTTP Request
+
+GET /apis/rbac.authorization.k8s.io/v1/clusterrolebindings
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authorization-resources/cluster-role-binding-v1#ClusterRoleBindingList" >}}">ClusterRoleBindingList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a ClusterRoleBinding
+
+#### HTTP Request
+
+POST /apis/rbac.authorization.k8s.io/v1/clusterrolebindings
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../authorization-resources/cluster-role-binding-v1#ClusterRoleBinding" >}}">ClusterRoleBinding</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authorization-resources/cluster-role-binding-v1#ClusterRoleBinding" >}}">ClusterRoleBinding</a>): OK
+
+201 (<a href="{{< ref "../authorization-resources/cluster-role-binding-v1#ClusterRoleBinding" >}}">ClusterRoleBinding</a>): Created
+
+202 (<a href="{{< ref "../authorization-resources/cluster-role-binding-v1#ClusterRoleBinding" >}}">ClusterRoleBinding</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified ClusterRoleBinding
+
+#### HTTP Request
+
+PUT /apis/rbac.authorization.k8s.io/v1/clusterrolebindings/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ClusterRoleBinding
+
+
+- **body**: <a href="{{< ref "../authorization-resources/cluster-role-binding-v1#ClusterRoleBinding" >}}">ClusterRoleBinding</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authorization-resources/cluster-role-binding-v1#ClusterRoleBinding" >}}">ClusterRoleBinding</a>): OK
+
+201 (<a href="{{< ref "../authorization-resources/cluster-role-binding-v1#ClusterRoleBinding" >}}">ClusterRoleBinding</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified ClusterRoleBinding
+
+#### HTTP Request
+
+PATCH /apis/rbac.authorization.k8s.io/v1/clusterrolebindings/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ClusterRoleBinding
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authorization-resources/cluster-role-binding-v1#ClusterRoleBinding" >}}">ClusterRoleBinding</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a ClusterRoleBinding
+
+#### HTTP Request
+
+DELETE /apis/rbac.authorization.k8s.io/v1/clusterrolebindings/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ClusterRoleBinding
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of ClusterRoleBinding
+
+#### HTTP Request
+
+DELETE /apis/rbac.authorization.k8s.io/v1/clusterrolebindings
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/authorization-resources/cluster-role-v1.md
+++ b/content/en/docs/reference/kubernetes-api/authorization-resources/cluster-role-v1.md
@@ -1,0 +1,467 @@
+---
+api_metadata:
+  apiVersion: "rbac.authorization.k8s.io/v1"
+  import: "k8s.io/api/rbac/v1"
+  kind: "ClusterRole"
+content_type: "api_reference"
+description: "ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding."
+title: "ClusterRole"
+weight: 5
+---
+
+`apiVersion: rbac.authorization.k8s.io/v1`
+
+`import "k8s.io/api/rbac/v1"`
+
+
+## ClusterRole {#ClusterRole}
+
+ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.
+
+<hr>
+
+- **apiVersion**: rbac.authorization.k8s.io/v1
+
+
+- **kind**: ClusterRole
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata.
+
+- **aggregationRule** (AggregationRule)
+
+  AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
+
+  <a name="AggregationRule"></a>
+  *AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole*
+
+  - **aggregationRule.clusterRoleSelectors** ([]<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
+
+    ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added
+
+- **rules** ([]PolicyRule)
+
+  Rules holds all the PolicyRules for this ClusterRole
+
+  <a name="PolicyRule"></a>
+  *PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.*
+
+  - **rules.apiGroups** ([]string)
+
+    APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.
+
+  - **rules.resources** ([]string)
+
+    Resources is a list of resources this rule applies to.  ResourceAll represents all resources.
+
+  - **rules.verbs** ([]string), required
+
+    Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.
+
+  - **rules.resourceNames** ([]string)
+
+    ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+
+  - **rules.nonResourceURLs** ([]string)
+
+    NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
+
+
+
+
+
+## ClusterRoleList {#ClusterRoleList}
+
+ClusterRoleList is a collection of ClusterRoles
+
+<hr>
+
+- **apiVersion**: rbac.authorization.k8s.io/v1
+
+
+- **kind**: ClusterRoleList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard object's metadata.
+
+- **items** ([]<a href="{{< ref "../authorization-resources/cluster-role-v1#ClusterRole" >}}">ClusterRole</a>), required
+
+  Items is a list of ClusterRoles
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified ClusterRole
+
+#### HTTP Request
+
+GET /apis/rbac.authorization.k8s.io/v1/clusterroles/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ClusterRole
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authorization-resources/cluster-role-v1#ClusterRole" >}}">ClusterRole</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind ClusterRole
+
+#### HTTP Request
+
+GET /apis/rbac.authorization.k8s.io/v1/clusterroles
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authorization-resources/cluster-role-v1#ClusterRoleList" >}}">ClusterRoleList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a ClusterRole
+
+#### HTTP Request
+
+POST /apis/rbac.authorization.k8s.io/v1/clusterroles
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../authorization-resources/cluster-role-v1#ClusterRole" >}}">ClusterRole</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authorization-resources/cluster-role-v1#ClusterRole" >}}">ClusterRole</a>): OK
+
+201 (<a href="{{< ref "../authorization-resources/cluster-role-v1#ClusterRole" >}}">ClusterRole</a>): Created
+
+202 (<a href="{{< ref "../authorization-resources/cluster-role-v1#ClusterRole" >}}">ClusterRole</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified ClusterRole
+
+#### HTTP Request
+
+PUT /apis/rbac.authorization.k8s.io/v1/clusterroles/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ClusterRole
+
+
+- **body**: <a href="{{< ref "../authorization-resources/cluster-role-v1#ClusterRole" >}}">ClusterRole</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authorization-resources/cluster-role-v1#ClusterRole" >}}">ClusterRole</a>): OK
+
+201 (<a href="{{< ref "../authorization-resources/cluster-role-v1#ClusterRole" >}}">ClusterRole</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified ClusterRole
+
+#### HTTP Request
+
+PATCH /apis/rbac.authorization.k8s.io/v1/clusterroles/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ClusterRole
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authorization-resources/cluster-role-v1#ClusterRole" >}}">ClusterRole</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a ClusterRole
+
+#### HTTP Request
+
+DELETE /apis/rbac.authorization.k8s.io/v1/clusterroles/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ClusterRole
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of ClusterRole
+
+#### HTTP Request
+
+DELETE /apis/rbac.authorization.k8s.io/v1/clusterroles
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/authorization-resources/local-subject-access-review-v1.md
+++ b/content/en/docs/reference/kubernetes-api/authorization-resources/local-subject-access-review-v1.md
@@ -1,0 +1,100 @@
+---
+api_metadata:
+  apiVersion: "authorization.k8s.io/v1"
+  import: "k8s.io/api/authorization/v1"
+  kind: "LocalSubjectAccessReview"
+content_type: "api_reference"
+description: "LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace."
+title: "LocalSubjectAccessReview"
+weight: 1
+---
+
+`apiVersion: authorization.k8s.io/v1`
+
+`import "k8s.io/api/authorization/v1"`
+
+
+## LocalSubjectAccessReview {#LocalSubjectAccessReview}
+
+LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.
+
+<hr>
+
+- **apiVersion**: authorization.k8s.io/v1
+
+
+- **kind**: LocalSubjectAccessReview
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+
+- **spec** (<a href="{{< ref "../authorization-resources/subject-access-review-v1#SubjectAccessReviewSpec" >}}">SubjectAccessReviewSpec</a>), required
+
+  Spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace you made the request against.  If empty, it is defaulted.
+
+- **status** (<a href="{{< ref "../authorization-resources/subject-access-review-v1#SubjectAccessReviewStatus" >}}">SubjectAccessReviewStatus</a>)
+
+  Status is filled in by the server and indicates whether the request is allowed or not
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `create` create a LocalSubjectAccessReview
+
+#### HTTP Request
+
+POST /apis/authorization.k8s.io/v1/namespaces/{namespace}/localsubjectaccessreviews
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../authorization-resources/local-subject-access-review-v1#LocalSubjectAccessReview" >}}">LocalSubjectAccessReview</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authorization-resources/local-subject-access-review-v1#LocalSubjectAccessReview" >}}">LocalSubjectAccessReview</a>): OK
+
+201 (<a href="{{< ref "../authorization-resources/local-subject-access-review-v1#LocalSubjectAccessReview" >}}">LocalSubjectAccessReview</a>): Created
+
+202 (<a href="{{< ref "../authorization-resources/local-subject-access-review-v1#LocalSubjectAccessReview" >}}">LocalSubjectAccessReview</a>): Accepted
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/authorization-resources/role-binding-v1.md
+++ b/content/en/docs/reference/kubernetes-api/authorization-resources/role-binding-v1.md
@@ -1,0 +1,574 @@
+---
+api_metadata:
+  apiVersion: "rbac.authorization.k8s.io/v1"
+  import: "k8s.io/api/rbac/v1"
+  kind: "RoleBinding"
+content_type: "api_reference"
+description: "RoleBinding references a role, but does not contain it."
+title: "RoleBinding"
+weight: 8
+---
+
+`apiVersion: rbac.authorization.k8s.io/v1`
+
+`import "k8s.io/api/rbac/v1"`
+
+
+## RoleBinding {#RoleBinding}
+
+RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.
+
+<hr>
+
+- **apiVersion**: rbac.authorization.k8s.io/v1
+
+
+- **kind**: RoleBinding
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata.
+
+- **roleRef** (RoleRef), required
+
+  RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
+
+  <a name="RoleRef"></a>
+  *RoleRef contains information that points to the role being used*
+
+  - **roleRef.apiGroup** (string), required
+
+    APIGroup is the group for the resource being referenced
+
+  - **roleRef.kind** (string), required
+
+    Kind is the type of resource being referenced
+
+  - **roleRef.name** (string), required
+
+    Name is the name of resource being referenced
+
+- **subjects** ([]Subject)
+
+  Subjects holds references to the objects the role applies to.
+
+  <a name="Subject"></a>
+  *Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.*
+
+  - **subjects.kind** (string), required
+
+    Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+
+  - **subjects.name** (string), required
+
+    Name of the object being referenced.
+
+  - **subjects.apiGroup** (string)
+
+    APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+
+  - **subjects.namespace** (string)
+
+    Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+
+
+
+
+
+## RoleBindingList {#RoleBindingList}
+
+RoleBindingList is a collection of RoleBindings
+
+<hr>
+
+- **apiVersion**: rbac.authorization.k8s.io/v1
+
+
+- **kind**: RoleBindingList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard object's metadata.
+
+- **items** ([]<a href="{{< ref "../authorization-resources/role-binding-v1#RoleBinding" >}}">RoleBinding</a>), required
+
+  Items is a list of RoleBindings
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified RoleBinding
+
+#### HTTP Request
+
+GET /apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/rolebindings/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the RoleBinding
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authorization-resources/role-binding-v1#RoleBinding" >}}">RoleBinding</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind RoleBinding
+
+#### HTTP Request
+
+GET /apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/rolebindings
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authorization-resources/role-binding-v1#RoleBindingList" >}}">RoleBindingList</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind RoleBinding
+
+#### HTTP Request
+
+GET /apis/rbac.authorization.k8s.io/v1/rolebindings
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authorization-resources/role-binding-v1#RoleBindingList" >}}">RoleBindingList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a RoleBinding
+
+#### HTTP Request
+
+POST /apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/rolebindings
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../authorization-resources/role-binding-v1#RoleBinding" >}}">RoleBinding</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authorization-resources/role-binding-v1#RoleBinding" >}}">RoleBinding</a>): OK
+
+201 (<a href="{{< ref "../authorization-resources/role-binding-v1#RoleBinding" >}}">RoleBinding</a>): Created
+
+202 (<a href="{{< ref "../authorization-resources/role-binding-v1#RoleBinding" >}}">RoleBinding</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified RoleBinding
+
+#### HTTP Request
+
+PUT /apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/rolebindings/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the RoleBinding
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../authorization-resources/role-binding-v1#RoleBinding" >}}">RoleBinding</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authorization-resources/role-binding-v1#RoleBinding" >}}">RoleBinding</a>): OK
+
+201 (<a href="{{< ref "../authorization-resources/role-binding-v1#RoleBinding" >}}">RoleBinding</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified RoleBinding
+
+#### HTTP Request
+
+PATCH /apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/rolebindings/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the RoleBinding
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authorization-resources/role-binding-v1#RoleBinding" >}}">RoleBinding</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a RoleBinding
+
+#### HTTP Request
+
+DELETE /apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/rolebindings/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the RoleBinding
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of RoleBinding
+
+#### HTTP Request
+
+DELETE /apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/rolebindings
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/authorization-resources/role-v1.md
+++ b/content/en/docs/reference/kubernetes-api/authorization-resources/role-v1.md
@@ -1,0 +1,559 @@
+---
+api_metadata:
+  apiVersion: "rbac.authorization.k8s.io/v1"
+  import: "k8s.io/api/rbac/v1"
+  kind: "Role"
+content_type: "api_reference"
+description: "Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding."
+title: "Role"
+weight: 7
+---
+
+`apiVersion: rbac.authorization.k8s.io/v1`
+
+`import "k8s.io/api/rbac/v1"`
+
+
+## Role {#Role}
+
+Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.
+
+<hr>
+
+- **apiVersion**: rbac.authorization.k8s.io/v1
+
+
+- **kind**: Role
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata.
+
+- **rules** ([]PolicyRule)
+
+  Rules holds all the PolicyRules for this Role
+
+  <a name="PolicyRule"></a>
+  *PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.*
+
+  - **rules.apiGroups** ([]string)
+
+    APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.
+
+  - **rules.resources** ([]string)
+
+    Resources is a list of resources this rule applies to.  ResourceAll represents all resources.
+
+  - **rules.verbs** ([]string), required
+
+    Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.
+
+  - **rules.resourceNames** ([]string)
+
+    ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+
+  - **rules.nonResourceURLs** ([]string)
+
+    NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
+
+
+
+
+
+## RoleList {#RoleList}
+
+RoleList is a collection of Roles
+
+<hr>
+
+- **apiVersion**: rbac.authorization.k8s.io/v1
+
+
+- **kind**: RoleList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard object's metadata.
+
+- **items** ([]<a href="{{< ref "../authorization-resources/role-v1#Role" >}}">Role</a>), required
+
+  Items is a list of Roles
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified Role
+
+#### HTTP Request
+
+GET /apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Role
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authorization-resources/role-v1#Role" >}}">Role</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind Role
+
+#### HTTP Request
+
+GET /apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authorization-resources/role-v1#RoleList" >}}">RoleList</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind Role
+
+#### HTTP Request
+
+GET /apis/rbac.authorization.k8s.io/v1/roles
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authorization-resources/role-v1#RoleList" >}}">RoleList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a Role
+
+#### HTTP Request
+
+POST /apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../authorization-resources/role-v1#Role" >}}">Role</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authorization-resources/role-v1#Role" >}}">Role</a>): OK
+
+201 (<a href="{{< ref "../authorization-resources/role-v1#Role" >}}">Role</a>): Created
+
+202 (<a href="{{< ref "../authorization-resources/role-v1#Role" >}}">Role</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified Role
+
+#### HTTP Request
+
+PUT /apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Role
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../authorization-resources/role-v1#Role" >}}">Role</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authorization-resources/role-v1#Role" >}}">Role</a>): OK
+
+201 (<a href="{{< ref "../authorization-resources/role-v1#Role" >}}">Role</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified Role
+
+#### HTTP Request
+
+PATCH /apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Role
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authorization-resources/role-v1#Role" >}}">Role</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a Role
+
+#### HTTP Request
+
+DELETE /apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Role
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of Role
+
+#### HTTP Request
+
+DELETE /apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/authorization-resources/self-subject-access-review-v1.md
+++ b/content/en/docs/reference/kubernetes-api/authorization-resources/self-subject-access-review-v1.md
@@ -1,0 +1,155 @@
+---
+api_metadata:
+  apiVersion: "authorization.k8s.io/v1"
+  import: "k8s.io/api/authorization/v1"
+  kind: "SelfSubjectAccessReview"
+content_type: "api_reference"
+description: "SelfSubjectAccessReview checks whether or the current user can perform an action."
+title: "SelfSubjectAccessReview"
+weight: 2
+---
+
+`apiVersion: authorization.k8s.io/v1`
+
+`import "k8s.io/api/authorization/v1"`
+
+
+## SelfSubjectAccessReview {#SelfSubjectAccessReview}
+
+SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means "in all namespaces".  Self is a special case, because users should always be able to check whether they can perform an action
+
+<hr>
+
+- **apiVersion**: authorization.k8s.io/v1
+
+
+- **kind**: SelfSubjectAccessReview
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+
+- **spec** (<a href="{{< ref "../authorization-resources/self-subject-access-review-v1#SelfSubjectAccessReviewSpec" >}}">SelfSubjectAccessReviewSpec</a>), required
+
+  Spec holds information about the request being evaluated.  user and groups must be empty
+
+- **status** (<a href="{{< ref "../authorization-resources/subject-access-review-v1#SubjectAccessReviewStatus" >}}">SubjectAccessReviewStatus</a>)
+
+  Status is filled in by the server and indicates whether the request is allowed or not
+
+
+
+
+
+## SelfSubjectAccessReviewSpec {#SelfSubjectAccessReviewSpec}
+
+SelfSubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set
+
+<hr>
+
+- **nonResourceAttributes** (NonResourceAttributes)
+
+  NonResourceAttributes describes information for a non-resource access request
+
+  <a name="NonResourceAttributes"></a>
+  *NonResourceAttributes includes the authorization attributes available for non-resource requests to the Authorizer interface*
+
+  - **nonResourceAttributes.path** (string)
+
+    Path is the URL path of the request
+
+  - **nonResourceAttributes.verb** (string)
+
+    Verb is the standard HTTP verb
+
+- **resourceAttributes** (ResourceAttributes)
+
+  ResourceAuthorizationAttributes describes information for a resource access request
+
+  <a name="ResourceAttributes"></a>
+  *ResourceAttributes includes the authorization attributes available for resource requests to the Authorizer interface*
+
+  - **resourceAttributes.group** (string)
+
+    Group is the API Group of the Resource.  "*" means all.
+
+  - **resourceAttributes.name** (string)
+
+    Name is the name of the resource being requested for a "get" or deleted for a "delete". "" (empty) means all.
+
+  - **resourceAttributes.namespace** (string)
+
+    Namespace is the namespace of the action being requested.  Currently, there is no distinction between no namespace and all namespaces "" (empty) is defaulted for LocalSubjectAccessReviews "" (empty) is empty for cluster-scoped resources "" (empty) means "all" for namespace scoped resources from a SubjectAccessReview or SelfSubjectAccessReview
+
+  - **resourceAttributes.resource** (string)
+
+    Resource is one of the existing resource types.  "*" means all.
+
+  - **resourceAttributes.subresource** (string)
+
+    Subresource is one of the existing resource types.  "" means none.
+
+  - **resourceAttributes.verb** (string)
+
+    Verb is a kubernetes resource API verb, like: get, list, watch, create, update, delete, proxy.  "*" means all.
+
+  - **resourceAttributes.version** (string)
+
+    Version is the API Version of the Resource.  "*" means all.
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `create` create a SelfSubjectAccessReview
+
+#### HTTP Request
+
+POST /apis/authorization.k8s.io/v1/selfsubjectaccessreviews
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../authorization-resources/self-subject-access-review-v1#SelfSubjectAccessReview" >}}">SelfSubjectAccessReview</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authorization-resources/self-subject-access-review-v1#SelfSubjectAccessReview" >}}">SelfSubjectAccessReview</a>): OK
+
+201 (<a href="{{< ref "../authorization-resources/self-subject-access-review-v1#SelfSubjectAccessReview" >}}">SelfSubjectAccessReview</a>): Created
+
+202 (<a href="{{< ref "../authorization-resources/self-subject-access-review-v1#SelfSubjectAccessReview" >}}">SelfSubjectAccessReview</a>): Accepted
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/authorization-resources/self-subject-rules-review-v1.md
+++ b/content/en/docs/reference/kubernetes-api/authorization-resources/self-subject-rules-review-v1.md
@@ -1,0 +1,159 @@
+---
+api_metadata:
+  apiVersion: "authorization.k8s.io/v1"
+  import: "k8s.io/api/authorization/v1"
+  kind: "SelfSubjectRulesReview"
+content_type: "api_reference"
+description: "SelfSubjectRulesReview enumerates the set of actions the current user can perform within a namespace."
+title: "SelfSubjectRulesReview"
+weight: 3
+---
+
+`apiVersion: authorization.k8s.io/v1`
+
+`import "k8s.io/api/authorization/v1"`
+
+
+## SelfSubjectRulesReview {#SelfSubjectRulesReview}
+
+SelfSubjectRulesReview enumerates the set of actions the current user can perform within a namespace. The returned list of actions may be incomplete depending on the server's authorization mode, and any errors experienced during the evaluation. SelfSubjectRulesReview should be used by UIs to show/hide actions, or to quickly let an end user reason about their permissions. It should NOT Be used by external systems to drive authorization decisions as this raises confused deputy, cache lifetime/revocation, and correctness concerns. SubjectAccessReview, and LocalAccessReview are the correct way to defer authorization decisions to the API server.
+
+<hr>
+
+- **apiVersion**: authorization.k8s.io/v1
+
+
+- **kind**: SelfSubjectRulesReview
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+
+- **spec** (<a href="{{< ref "../authorization-resources/self-subject-rules-review-v1#SelfSubjectRulesReviewSpec" >}}">SelfSubjectRulesReviewSpec</a>), required
+
+  Spec holds information about the request being evaluated.
+
+- **status** (SubjectRulesReviewStatus)
+
+  Status is filled in by the server and indicates the set of actions a user can perform.
+
+  <a name="SubjectRulesReviewStatus"></a>
+  *SubjectRulesReviewStatus contains the result of a rules check. This check can be incomplete depending on the set of authorizers the server is configured with and any errors experienced during evaluation. Because authorization rules are additive, if a rule appears in a list it's safe to assume the subject has that permission, even if that list is incomplete.*
+
+  - **status.incomplete** (boolean), required
+
+    Incomplete is true when the rules returned by this call are incomplete. This is most commonly encountered when an authorizer, such as an external authorizer, doesn't support rules evaluation.
+
+  - **status.nonResourceRules** ([]NonResourceRule), required
+
+    NonResourceRules is the list of actions the subject is allowed to perform on non-resources. The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
+
+    <a name="NonResourceRule"></a>
+    *NonResourceRule holds information that describes a rule for the non-resource*
+
+  - **status.nonResourceRules.verbs** ([]string), required
+
+    Verb is a list of kubernetes non-resource API verbs, like: get, post, put, delete, patch, head, options.  "*" means all.
+
+  - **status.nonResourceRules.nonResourceURLs** ([]string)
+
+    NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path.  "*" means all.
+
+  - **status.resourceRules** ([]ResourceRule), required
+
+    ResourceRules is the list of actions the subject is allowed to perform on resources. The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
+
+    <a name="ResourceRule"></a>
+    *ResourceRule is the list of actions the subject is allowed to perform on resources. The list ordering isn't significant, may contain duplicates, and possibly be incomplete.*
+
+  - **status.resourceRules.verbs** ([]string), required
+
+    Verb is a list of kubernetes resource API verbs, like: get, list, watch, create, update, delete, proxy.  "*" means all.
+
+  - **status.resourceRules.apiGroups** ([]string)
+
+    APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.  "*" means all.
+
+  - **status.resourceRules.resourceNames** ([]string)
+
+    ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.  "*" means all.
+
+  - **status.resourceRules.resources** ([]string)
+
+    Resources is a list of resources this rule applies to.  "*" means all in the specified apiGroups.
+     "*/foo" represents the subresource 'foo' for all resources in the specified apiGroups.
+
+  - **status.evaluationError** (string)
+
+    EvaluationError can appear in combination with Rules. It indicates an error occurred during rule evaluation, such as an authorizer that doesn't support rule evaluation, and that ResourceRules and/or NonResourceRules may be incomplete.
+
+
+
+
+
+## SelfSubjectRulesReviewSpec {#SelfSubjectRulesReviewSpec}
+
+
+
+<hr>
+
+- **namespace** (string)
+
+  Namespace to evaluate rules for. Required.
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `create` create a SelfSubjectRulesReview
+
+#### HTTP Request
+
+POST /apis/authorization.k8s.io/v1/selfsubjectrulesreviews
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../authorization-resources/self-subject-rules-review-v1#SelfSubjectRulesReview" >}}">SelfSubjectRulesReview</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authorization-resources/self-subject-rules-review-v1#SelfSubjectRulesReview" >}}">SelfSubjectRulesReview</a>): OK
+
+201 (<a href="{{< ref "../authorization-resources/self-subject-rules-review-v1#SelfSubjectRulesReview" >}}">SelfSubjectRulesReview</a>): Created
+
+202 (<a href="{{< ref "../authorization-resources/self-subject-rules-review-v1#SelfSubjectRulesReview" >}}">SelfSubjectRulesReview</a>): Accepted
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/authorization-resources/subject-access-review-v1.md
+++ b/content/en/docs/reference/kubernetes-api/authorization-resources/subject-access-review-v1.md
@@ -1,0 +1,197 @@
+---
+api_metadata:
+  apiVersion: "authorization.k8s.io/v1"
+  import: "k8s.io/api/authorization/v1"
+  kind: "SubjectAccessReview"
+content_type: "api_reference"
+description: "SubjectAccessReview checks whether or not a user or group can perform an action."
+title: "SubjectAccessReview"
+weight: 4
+---
+
+`apiVersion: authorization.k8s.io/v1`
+
+`import "k8s.io/api/authorization/v1"`
+
+
+## SubjectAccessReview {#SubjectAccessReview}
+
+SubjectAccessReview checks whether or not a user or group can perform an action.
+
+<hr>
+
+- **apiVersion**: authorization.k8s.io/v1
+
+
+- **kind**: SubjectAccessReview
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+
+- **spec** (<a href="{{< ref "../authorization-resources/subject-access-review-v1#SubjectAccessReviewSpec" >}}">SubjectAccessReviewSpec</a>), required
+
+  Spec holds information about the request being evaluated
+
+- **status** (<a href="{{< ref "../authorization-resources/subject-access-review-v1#SubjectAccessReviewStatus" >}}">SubjectAccessReviewStatus</a>)
+
+  Status is filled in by the server and indicates whether the request is allowed or not
+
+
+
+
+
+## SubjectAccessReviewSpec {#SubjectAccessReviewSpec}
+
+SubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set
+
+<hr>
+
+- **extra** (map[string][]string)
+
+  Extra corresponds to the user.Info.GetExtra() method from the authenticator.  Since that is input to the authorizer it needs a reflection here.
+
+- **groups** ([]string)
+
+  Groups is the groups you're testing for.
+
+- **nonResourceAttributes** (NonResourceAttributes)
+
+  NonResourceAttributes describes information for a non-resource access request
+
+  <a name="NonResourceAttributes"></a>
+  *NonResourceAttributes includes the authorization attributes available for non-resource requests to the Authorizer interface*
+
+  - **nonResourceAttributes.path** (string)
+
+    Path is the URL path of the request
+
+  - **nonResourceAttributes.verb** (string)
+
+    Verb is the standard HTTP verb
+
+- **resourceAttributes** (ResourceAttributes)
+
+  ResourceAuthorizationAttributes describes information for a resource access request
+
+  <a name="ResourceAttributes"></a>
+  *ResourceAttributes includes the authorization attributes available for resource requests to the Authorizer interface*
+
+  - **resourceAttributes.group** (string)
+
+    Group is the API Group of the Resource.  "*" means all.
+
+  - **resourceAttributes.name** (string)
+
+    Name is the name of the resource being requested for a "get" or deleted for a "delete". "" (empty) means all.
+
+  - **resourceAttributes.namespace** (string)
+
+    Namespace is the namespace of the action being requested.  Currently, there is no distinction between no namespace and all namespaces "" (empty) is defaulted for LocalSubjectAccessReviews "" (empty) is empty for cluster-scoped resources "" (empty) means "all" for namespace scoped resources from a SubjectAccessReview or SelfSubjectAccessReview
+
+  - **resourceAttributes.resource** (string)
+
+    Resource is one of the existing resource types.  "*" means all.
+
+  - **resourceAttributes.subresource** (string)
+
+    Subresource is one of the existing resource types.  "" means none.
+
+  - **resourceAttributes.verb** (string)
+
+    Verb is a kubernetes resource API verb, like: get, list, watch, create, update, delete, proxy.  "*" means all.
+
+  - **resourceAttributes.version** (string)
+
+    Version is the API Version of the Resource.  "*" means all.
+
+- **uid** (string)
+
+  UID information about the requesting user.
+
+- **user** (string)
+
+  User is the user you're testing for. If you specify "User" but not "Groups", then is it interpreted as "What if User were not a member of any groups
+
+
+
+
+
+## SubjectAccessReviewStatus {#SubjectAccessReviewStatus}
+
+SubjectAccessReviewStatus
+
+<hr>
+
+- **allowed** (boolean), required
+
+  Allowed is required. True if the action would be allowed, false otherwise.
+
+- **denied** (boolean)
+
+  Denied is optional. True if the action would be denied, otherwise false. If both allowed is false and denied is false, then the authorizer has no opinion on whether to authorize the action. Denied may not be true if Allowed is true.
+
+- **evaluationError** (string)
+
+  EvaluationError is an indication that some error occurred during the authorization check. It is entirely possible to get an error and be able to continue determine authorization status in spite of it. For instance, RBAC can be missing a role, but enough roles are still present and bound to reason about the request.
+
+- **reason** (string)
+
+  Reason is optional.  It indicates why a request was allowed or denied.
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `create` create a SubjectAccessReview
+
+#### HTTP Request
+
+POST /apis/authorization.k8s.io/v1/subjectaccessreviews
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../authorization-resources/subject-access-review-v1#SubjectAccessReview" >}}">SubjectAccessReview</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../authorization-resources/subject-access-review-v1#SubjectAccessReview" >}}">SubjectAccessReview</a>): OK
+
+201 (<a href="{{< ref "../authorization-resources/subject-access-review-v1#SubjectAccessReview" >}}">SubjectAccessReview</a>): Created
+
+202 (<a href="{{< ref "../authorization-resources/subject-access-review-v1#SubjectAccessReview" >}}">SubjectAccessReview</a>): Accepted
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/_index.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Cluster Resources"
+weight: 8
+---

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/api-service-v1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/api-service-v1.md
@@ -1,0 +1,654 @@
+---
+api_metadata:
+  apiVersion: "apiregistration.k8s.io/v1"
+  import: "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+  kind: "APIService"
+content_type: "api_reference"
+description: "APIService represents a server for a particular GroupVersion."
+title: "APIService"
+weight: 4
+---
+
+`apiVersion: apiregistration.k8s.io/v1`
+
+`import "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"`
+
+
+## APIService {#APIService}
+
+APIService represents a server for a particular GroupVersion. Name must be "version.group".
+
+<hr>
+
+- **apiVersion**: apiregistration.k8s.io/v1
+
+
+- **kind**: APIService
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+
+- **spec** (<a href="{{< ref "../cluster-resources/api-service-v1#APIServiceSpec" >}}">APIServiceSpec</a>)
+
+  Spec contains information for locating and communicating with a server
+
+- **status** (<a href="{{< ref "../cluster-resources/api-service-v1#APIServiceStatus" >}}">APIServiceStatus</a>)
+
+  Status contains derived information about an API server
+
+
+
+
+
+## APIServiceSpec {#APIServiceSpec}
+
+APIServiceSpec contains information for locating and communicating with a server. Only https is supported, though you are able to disable certificate verification.
+
+<hr>
+
+- **groupPriorityMinimum** (int32), required
+
+  GroupPriorityMininum is the priority this group should have at least. Higher priority means that the group is preferred by clients over lower priority ones. Note that other versions of this group might specify even higher GroupPriorityMininum values such that the whole group gets a higher priority. The primary sort is based on GroupPriorityMinimum, ordered highest number to lowest (20 before 10). The secondary sort is based on the alphabetical comparison of the name of the object.  (v1.bar before v1.foo) We'd recommend something like: *.k8s.io (except extensions) at 18000 and PaaSes (OpenShift, Deis) are recommended to be in the 2000s
+
+- **versionPriority** (int32), required
+
+  VersionPriority controls the ordering of this API version inside of its group.  Must be greater than zero. The primary sort is based on VersionPriority, ordered highest to lowest (20 before 10). Since it's inside of a group, the number can be small, probably in the 10s. In case of equal version priorities, the version string will be used to compute the order inside a group. If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version), then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
+
+- **caBundle** ([]byte)
+
+  *Atomic: will be replaced during a merge*
+  
+  CABundle is a PEM encoded CA bundle which will be used to validate an API server's serving certificate. If unspecified, system trust roots on the apiserver are used.
+
+- **group** (string)
+
+  Group is the API group name this server hosts
+
+- **insecureSkipTLSVerify** (boolean)
+
+  InsecureSkipTLSVerify disables TLS certificate verification when communicating with this server. This is strongly discouraged.  You should use the CABundle instead.
+
+- **service** (ServiceReference)
+
+  Service is a reference to the service for this API server.  It must communicate on port 443. If the Service is nil, that means the handling for the API groupversion is handled locally on this server. The call will simply delegate to the normal handler chain to be fulfilled.
+
+  <a name="ServiceReference"></a>
+  *ServiceReference holds a reference to Service.legacy.k8s.io*
+
+  - **service.name** (string)
+
+    Name is the name of the service
+
+  - **service.namespace** (string)
+
+    Namespace is the namespace of the service
+
+  - **service.port** (int32)
+
+    If specified, the port on the service that hosting webhook. Default to 443 for backward compatibility. `port` should be a valid port number (1-65535, inclusive).
+
+- **version** (string)
+
+  Version is the API version this server hosts.  For example, "v1"
+
+
+
+
+
+## APIServiceStatus {#APIServiceStatus}
+
+APIServiceStatus contains derived information about an API server
+
+<hr>
+
+- **conditions** ([]APIServiceCondition)
+
+  *Patch strategy: merge on key `type`*
+  
+  *Map: unique values on key type will be kept during a merge*
+  
+  Current service state of apiService.
+
+  <a name="APIServiceCondition"></a>
+  *APIServiceCondition describes the state of an APIService at a particular point*
+
+  - **conditions.status** (string), required
+
+    Status is the status of the condition. Can be True, False, Unknown.
+
+  - **conditions.type** (string), required
+
+    Type is the type of the condition.
+
+  - **conditions.lastTransitionTime** (Time)
+
+    Last time the condition transitioned from one status to another.
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **conditions.message** (string)
+
+    Human-readable message indicating details about last transition.
+
+  - **conditions.reason** (string)
+
+    Unique, one-word, CamelCase reason for the condition's last transition.
+
+
+
+
+
+## APIServiceList {#APIServiceList}
+
+APIServiceList is a list of APIService objects.
+
+<hr>
+
+- **apiVersion**: apiregistration.k8s.io/v1
+
+
+- **kind**: APIServiceList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+
+- **items** ([]<a href="{{< ref "../cluster-resources/api-service-v1#APIService" >}}">APIService</a>), required
+
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified APIService
+
+#### HTTP Request
+
+GET /apis/apiregistration.k8s.io/v1/apiservices/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the APIService
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/api-service-v1#APIService" >}}">APIService</a>): OK
+
+401: Unauthorized
+
+
+### `get` read status of the specified APIService
+
+#### HTTP Request
+
+GET /apis/apiregistration.k8s.io/v1/apiservices/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the APIService
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/api-service-v1#APIService" >}}">APIService</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind APIService
+
+#### HTTP Request
+
+GET /apis/apiregistration.k8s.io/v1/apiservices
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/api-service-v1#APIServiceList" >}}">APIServiceList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create an APIService
+
+#### HTTP Request
+
+POST /apis/apiregistration.k8s.io/v1/apiservices
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../cluster-resources/api-service-v1#APIService" >}}">APIService</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/api-service-v1#APIService" >}}">APIService</a>): OK
+
+201 (<a href="{{< ref "../cluster-resources/api-service-v1#APIService" >}}">APIService</a>): Created
+
+202 (<a href="{{< ref "../cluster-resources/api-service-v1#APIService" >}}">APIService</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified APIService
+
+#### HTTP Request
+
+PUT /apis/apiregistration.k8s.io/v1/apiservices/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the APIService
+
+
+- **body**: <a href="{{< ref "../cluster-resources/api-service-v1#APIService" >}}">APIService</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/api-service-v1#APIService" >}}">APIService</a>): OK
+
+201 (<a href="{{< ref "../cluster-resources/api-service-v1#APIService" >}}">APIService</a>): Created
+
+401: Unauthorized
+
+
+### `update` replace status of the specified APIService
+
+#### HTTP Request
+
+PUT /apis/apiregistration.k8s.io/v1/apiservices/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the APIService
+
+
+- **body**: <a href="{{< ref "../cluster-resources/api-service-v1#APIService" >}}">APIService</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/api-service-v1#APIService" >}}">APIService</a>): OK
+
+201 (<a href="{{< ref "../cluster-resources/api-service-v1#APIService" >}}">APIService</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified APIService
+
+#### HTTP Request
+
+PATCH /apis/apiregistration.k8s.io/v1/apiservices/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the APIService
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/api-service-v1#APIService" >}}">APIService</a>): OK
+
+401: Unauthorized
+
+
+### `patch` partially update status of the specified APIService
+
+#### HTTP Request
+
+PATCH /apis/apiregistration.k8s.io/v1/apiservices/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the APIService
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/api-service-v1#APIService" >}}">APIService</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete an APIService
+
+#### HTTP Request
+
+DELETE /apis/apiregistration.k8s.io/v1/apiservices/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the APIService
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of APIService
+
+#### HTTP Request
+
+DELETE /apis/apiregistration.k8s.io/v1/apiservices
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/binding-v1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/binding-v1.md
@@ -1,0 +1,149 @@
+---
+api_metadata:
+  apiVersion: "v1"
+  import: "k8s.io/api/core/v1"
+  kind: "Binding"
+content_type: "api_reference"
+description: "Binding ties one object to another; for example, a pod is bound to a node by a scheduler."
+title: "Binding"
+weight: 9
+---
+
+`apiVersion: v1`
+
+`import "k8s.io/api/core/v1"`
+
+
+## Binding {#Binding}
+
+Binding ties one object to another; for example, a pod is bound to a node by a scheduler. Deprecated in 1.7, please use the bindings subresource of pods instead.
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: Binding
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **target** (<a href="{{< ref "../common-definitions/object-reference#ObjectReference" >}}">ObjectReference</a>), required
+
+  The target object that you want to bind to the standard object.
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `create` create a Binding
+
+#### HTTP Request
+
+POST /api/v1/namespaces/{namespace}/bindings
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../cluster-resources/binding-v1#Binding" >}}">Binding</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/binding-v1#Binding" >}}">Binding</a>): OK
+
+201 (<a href="{{< ref "../cluster-resources/binding-v1#Binding" >}}">Binding</a>): Created
+
+202 (<a href="{{< ref "../cluster-resources/binding-v1#Binding" >}}">Binding</a>): Accepted
+
+401: Unauthorized
+
+
+### `create` create binding of a Pod
+
+#### HTTP Request
+
+POST /api/v1/namespaces/{namespace}/pods/{name}/binding
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Binding
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../cluster-resources/binding-v1#Binding" >}}">Binding</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/binding-v1#Binding" >}}">Binding</a>): OK
+
+201 (<a href="{{< ref "../cluster-resources/binding-v1#Binding" >}}">Binding</a>): Created
+
+202 (<a href="{{< ref "../cluster-resources/binding-v1#Binding" >}}">Binding</a>): Accepted
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/component-status-v1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/component-status-v1.md
@@ -1,0 +1,191 @@
+---
+api_metadata:
+  apiVersion: "v1"
+  import: "k8s.io/api/core/v1"
+  kind: "ComponentStatus"
+content_type: "api_reference"
+description: "ComponentStatus (and ComponentStatusList) holds the cluster validation info."
+title: "ComponentStatus"
+weight: 10
+---
+
+`apiVersion: v1`
+
+`import "k8s.io/api/core/v1"`
+
+
+## ComponentStatus {#ComponentStatus}
+
+ComponentStatus (and ComponentStatusList) holds the cluster validation info. Deprecated: This API is deprecated in v1.19+
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: ComponentStatus
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **conditions** ([]ComponentCondition)
+
+  *Patch strategy: merge on key `type`*
+  
+  List of component conditions observed
+
+  <a name="ComponentCondition"></a>
+  *Information about the condition of a component.*
+
+  - **conditions.status** (string), required
+
+    Status of the condition for a component. Valid values for "Healthy": "True", "False", or "Unknown".
+
+  - **conditions.type** (string), required
+
+    Type of condition for a component. Valid value: "Healthy"
+
+  - **conditions.error** (string)
+
+    Condition error code for a component. For example, a health check error code.
+
+  - **conditions.message** (string)
+
+    Message about the condition for a component. For example, information about a health check.
+
+
+
+
+
+## ComponentStatusList {#ComponentStatusList}
+
+Status of all the conditions for the component as a list of ComponentStatus objects. Deprecated: This API is deprecated in v1.19+
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: ComponentStatusList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+- **items** ([]<a href="{{< ref "../cluster-resources/component-status-v1#ComponentStatus" >}}">ComponentStatus</a>), required
+
+  List of ComponentStatus objects.
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified ComponentStatus
+
+#### HTTP Request
+
+GET /api/v1/componentstatuses/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ComponentStatus
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/component-status-v1#ComponentStatus" >}}">ComponentStatus</a>): OK
+
+401: Unauthorized
+
+
+### `list` list objects of kind ComponentStatus
+
+#### HTTP Request
+
+GET /api/v1/componentstatuses
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/component-status-v1#ComponentStatusList" >}}">ComponentStatusList</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/event-v1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/event-v1.md
@@ -1,0 +1,621 @@
+---
+api_metadata:
+  apiVersion: "events.k8s.io/v1"
+  import: "k8s.io/api/events/v1"
+  kind: "Event"
+content_type: "api_reference"
+description: "Event is a report of an event somewhere in the cluster."
+title: "Event"
+weight: 3
+---
+
+`apiVersion: events.k8s.io/v1`
+
+`import "k8s.io/api/events/v1"`
+
+
+## Event {#Event}
+
+Event is a report of an event somewhere in the cluster. It generally denotes some state change in the system. Events have a limited retention time and triggers and messages may evolve with time.  Event consumers should not rely on the timing of an event with a given Reason reflecting a consistent underlying trigger, or the continued existence of events with that Reason.  Events should be treated as informative, best-effort, supplemental data.
+
+<hr>
+
+- **apiVersion**: events.k8s.io/v1
+
+
+- **kind**: Event
+
+
+- **eventTime** (MicroTime), required
+
+  eventTime is the time when this Event was first observed. It is required.
+
+  <a name="MicroTime"></a>
+  *MicroTime is version of Time with microsecond level precision.*
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>), required
+
+
+- **action** (string)
+
+  action is what action was taken/failed regarding to the regarding object. It is machine-readable. This field cannot be empty for new Events and it can have at most 128 characters.
+
+- **deprecatedCount** (int32)
+
+  deprecatedCount is the deprecated field assuring backward compatibility with core.v1 Event type.
+
+- **deprecatedFirstTimestamp** (Time)
+
+  deprecatedFirstTimestamp is the deprecated field assuring backward compatibility with core.v1 Event type.
+
+  <a name="Time"></a>
+  *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+- **deprecatedLastTimestamp** (Time)
+
+  deprecatedLastTimestamp is the deprecated field assuring backward compatibility with core.v1 Event type.
+
+  <a name="Time"></a>
+  *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+- **deprecatedSource** (EventSource)
+
+  deprecatedSource is the deprecated field assuring backward compatibility with core.v1 Event type.
+
+  <a name="EventSource"></a>
+  *EventSource contains information for an event.*
+
+  - **deprecatedSource.component** (string)
+
+    Component from which the event is generated.
+
+  - **deprecatedSource.host** (string)
+
+    Node name on which the event is generated.
+
+- **note** (string)
+
+  note is a human-readable description of the status of this operation. Maximal length of the note is 1kB, but libraries should be prepared to handle values up to 64kB.
+
+- **reason** (string)
+
+  reason is why the action was taken. It is human-readable. This field cannot be empty for new Events and it can have at most 128 characters.
+
+- **regarding** (<a href="{{< ref "../common-definitions/object-reference#ObjectReference" >}}">ObjectReference</a>)
+
+  regarding contains the object this Event is about. In most cases it's an Object reporting controller implements, e.g. ReplicaSetController implements ReplicaSets and this event is emitted because it acts on some changes in a ReplicaSet object.
+
+- **related** (<a href="{{< ref "../common-definitions/object-reference#ObjectReference" >}}">ObjectReference</a>)
+
+  related is the optional secondary object for more complex actions. E.g. when regarding object triggers a creation or deletion of related object.
+
+- **reportingController** (string)
+
+  reportingController is the name of the controller that emitted this Event, e.g. `kubernetes.io/kubelet`. This field cannot be empty for new Events.
+
+- **reportingInstance** (string)
+
+  reportingInstance is the ID of the controller instance, e.g. `kubelet-xyzf`. This field cannot be empty for new Events and it can have at most 128 characters.
+
+- **series** (EventSeries)
+
+  series is data about the Event series this event represents or nil if it's a singleton Event.
+
+  <a name="EventSeries"></a>
+  *EventSeries contain information on series of events, i.e. thing that was/is happening continuously for some time. How often to update the EventSeries is up to the event reporters. The default event reporter in "k8s.io/client-go/tools/events/event_broadcaster.go" shows how this struct is updated on heartbeats and can guide customized reporter implementations.*
+
+  - **series.count** (int32), required
+
+    count is the number of occurrences in this series up to the last heartbeat time.
+
+  - **series.lastObservedTime** (MicroTime), required
+
+    lastObservedTime is the time when last Event from the series was seen before last heartbeat.
+
+    <a name="MicroTime"></a>
+    *MicroTime is version of Time with microsecond level precision.*
+
+- **type** (string)
+
+  type is the type of this event (Normal, Warning), new types could be added in the future. It is machine-readable. This field cannot be empty for new Events.
+
+
+
+
+
+## EventList {#EventList}
+
+EventList is a list of Event objects.
+
+<hr>
+
+- **apiVersion**: events.k8s.io/v1
+
+
+- **kind**: EventList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **items** ([]<a href="{{< ref "../cluster-resources/event-v1#Event" >}}">Event</a>), required
+
+  items is a list of schema objects.
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified Event
+
+#### HTTP Request
+
+GET /apis/events.k8s.io/v1/namespaces/{namespace}/events/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Event
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/event-v1#Event" >}}">Event</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind Event
+
+#### HTTP Request
+
+GET /apis/events.k8s.io/v1/namespaces/{namespace}/events
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/event-v1#EventList" >}}">EventList</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind Event
+
+#### HTTP Request
+
+GET /apis/events.k8s.io/v1/events
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/event-v1#EventList" >}}">EventList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create an Event
+
+#### HTTP Request
+
+POST /apis/events.k8s.io/v1/namespaces/{namespace}/events
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../cluster-resources/event-v1#Event" >}}">Event</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/event-v1#Event" >}}">Event</a>): OK
+
+201 (<a href="{{< ref "../cluster-resources/event-v1#Event" >}}">Event</a>): Created
+
+202 (<a href="{{< ref "../cluster-resources/event-v1#Event" >}}">Event</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified Event
+
+#### HTTP Request
+
+PUT /apis/events.k8s.io/v1/namespaces/{namespace}/events/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Event
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../cluster-resources/event-v1#Event" >}}">Event</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/event-v1#Event" >}}">Event</a>): OK
+
+201 (<a href="{{< ref "../cluster-resources/event-v1#Event" >}}">Event</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified Event
+
+#### HTTP Request
+
+PATCH /apis/events.k8s.io/v1/namespaces/{namespace}/events/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Event
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/event-v1#Event" >}}">Event</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete an Event
+
+#### HTTP Request
+
+DELETE /apis/events.k8s.io/v1/namespaces/{namespace}/events/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Event
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of Event
+
+#### HTTP Request
+
+DELETE /apis/events.k8s.io/v1/namespaces/{namespace}/events
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/flow-schema-v1beta1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/flow-schema-v1beta1.md
@@ -1,0 +1,756 @@
+---
+api_metadata:
+  apiVersion: "flowcontrol.apiserver.k8s.io/v1beta1"
+  import: "k8s.io/api/flowcontrol/v1beta1"
+  kind: "FlowSchema"
+content_type: "api_reference"
+description: "FlowSchema defines the schema of a group of flows."
+title: "FlowSchema v1beta1"
+weight: 7
+---
+
+`apiVersion: flowcontrol.apiserver.k8s.io/v1beta1`
+
+`import "k8s.io/api/flowcontrol/v1beta1"`
+
+
+## FlowSchema {#FlowSchema}
+
+FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
+
+<hr>
+
+- **apiVersion**: flowcontrol.apiserver.k8s.io/v1beta1
+
+
+- **kind**: FlowSchema
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **spec** (<a href="{{< ref "../cluster-resources/flow-schema-v1beta1#FlowSchemaSpec" >}}">FlowSchemaSpec</a>)
+
+  `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+- **status** (<a href="{{< ref "../cluster-resources/flow-schema-v1beta1#FlowSchemaStatus" >}}">FlowSchemaStatus</a>)
+
+  `status` is the current status of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+
+
+
+
+## FlowSchemaSpec {#FlowSchemaSpec}
+
+FlowSchemaSpec describes how the FlowSchema's specification looks like.
+
+<hr>
+
+- **priorityLevelConfiguration** (PriorityLevelConfigurationReference), required
+
+  `priorityLevelConfiguration` should reference a PriorityLevelConfiguration in the cluster. If the reference cannot be resolved, the FlowSchema will be ignored and marked as invalid in its status. Required.
+
+  <a name="PriorityLevelConfigurationReference"></a>
+  *PriorityLevelConfigurationReference contains information that points to the "request-priority" being used.*
+
+  - **priorityLevelConfiguration.name** (string), required
+
+    `name` is the name of the priority level configuration being referenced Required.
+
+- **distinguisherMethod** (FlowDistinguisherMethod)
+
+  `distinguisherMethod` defines how to compute the flow distinguisher for requests that match this schema. `nil` specifies that the distinguisher is disabled and thus will always be the empty string.
+
+  <a name="FlowDistinguisherMethod"></a>
+  *FlowDistinguisherMethod specifies the method of a flow distinguisher.*
+
+  - **distinguisherMethod.type** (string), required
+
+    `type` is the type of flow distinguisher method The supported types are "ByUser" and "ByNamespace". Required.
+
+- **matchingPrecedence** (int32)
+
+  `matchingPrecedence` is used to choose among the FlowSchemas that match a given request. The chosen FlowSchema is among those with the numerically lowest (which we take to be logically highest) MatchingPrecedence.  Each MatchingPrecedence value must be ranged in [1,10000]. Note that if the precedence is not specified, it will be set to 1000 as default.
+
+- **rules** ([]PolicyRulesWithSubjects)
+
+  *Atomic: will be replaced during a merge*
+  
+  `rules` describes which requests will match this flow schema. This FlowSchema matches a request if and only if at least one member of rules matches the request. if it is an empty slice, there will be no requests matching the FlowSchema.
+
+  <a name="PolicyRulesWithSubjects"></a>
+  *PolicyRulesWithSubjects prescribes a test that applies to a request to an apiserver. The test considers the subject making the request, the verb being requested, and the resource to be acted upon. This PolicyRulesWithSubjects matches a request if and only if both (a) at least one member of subjects matches the request and (b) at least one member of resourceRules or nonResourceRules matches the request.*
+
+  - **rules.subjects** ([]Subject), required
+
+    *Atomic: will be replaced during a merge*
+    
+    subjects is the list of normal user, serviceaccount, or group that this rule cares about. There must be at least one member in this slice. A slice that includes both the system:authenticated and system:unauthenticated user groups matches every request. Required.
+
+    <a name="Subject"></a>
+    *Subject matches the originator of a request, as identified by the request authentication system. There are three ways of matching an originator; by user, group, or service account.*
+
+  - **rules.subjects.kind** (string), required
+
+    Required
+
+  - **rules.subjects.group** (GroupSubject)
+
+
+    <a name="GroupSubject"></a>
+    *GroupSubject holds detailed information for group-kind subject.*
+
+  - **rules.subjects.group.name** (string), required
+
+    name is the user group that matches, or "*" to match all user groups. See https://github.com/kubernetes/apiserver/blob/master/pkg/authentication/user/user.go for some well-known group names. Required.
+
+  - **rules.subjects.serviceAccount** (ServiceAccountSubject)
+
+
+    <a name="ServiceAccountSubject"></a>
+    *ServiceAccountSubject holds detailed information for service-account-kind subject.*
+
+  - **rules.subjects.serviceAccount.name** (string), required
+
+    `name` is the name of matching ServiceAccount objects, or "*" to match regardless of name. Required.
+
+  - **rules.subjects.serviceAccount.namespace** (string), required
+
+    `namespace` is the namespace of matching ServiceAccount objects. Required.
+
+  - **rules.subjects.user** (UserSubject)
+
+
+    <a name="UserSubject"></a>
+    *UserSubject holds detailed information for user-kind subject.*
+
+  - **rules.subjects.user.name** (string), required
+
+    `name` is the username that matches, or "*" to match all usernames. Required.
+
+  - **rules.nonResourceRules** ([]NonResourcePolicyRule)
+
+    *Atomic: will be replaced during a merge*
+    
+    `nonResourceRules` is a list of NonResourcePolicyRules that identify matching requests according to their verb and the target non-resource URL.
+
+    <a name="NonResourcePolicyRule"></a>
+    *NonResourcePolicyRule is a predicate that matches non-resource requests according to their verb and the target non-resource URL. A NonResourcePolicyRule matches a request if and only if both (a) at least one member of verbs matches the request and (b) at least one member of nonResourceURLs matches the request.*
+
+  - **rules.nonResourceRules.nonResourceURLs** ([]string), required
+
+    *Set: unique values will be kept during a merge*
+    
+    `nonResourceURLs` is a set of url prefixes that a user should have access to and may not be empty. For example:
+      - "/healthz" is legal
+      - "/hea*" is illegal
+      - "/hea" is legal but matches nothing
+      - "/hea/*" also matches nothing
+      - "/healthz/*" matches all per-component health checks.
+    "*" matches all non-resource urls. if it is present, it must be the only entry. Required.
+
+  - **rules.nonResourceRules.verbs** ([]string), required
+
+    *Set: unique values will be kept during a merge*
+    
+    `verbs` is a list of matching verbs and may not be empty. "*" matches all verbs. If it is present, it must be the only entry. Required.
+
+  - **rules.resourceRules** ([]ResourcePolicyRule)
+
+    *Atomic: will be replaced during a merge*
+    
+    `resourceRules` is a slice of ResourcePolicyRules that identify matching requests according to their verb and the target resource. At least one of `resourceRules` and `nonResourceRules` has to be non-empty.
+
+    <a name="ResourcePolicyRule"></a>
+    *ResourcePolicyRule is a predicate that matches some resource requests, testing the request's verb and the target resource. A ResourcePolicyRule matches a resource request if and only if: (a) at least one member of verbs matches the request, (b) at least one member of apiGroups matches the request, (c) at least one member of resources matches the request, and (d) least one member of namespaces matches the request.*
+
+  - **rules.resourceRules.apiGroups** ([]string), required
+
+    *Set: unique values will be kept during a merge*
+    
+    `apiGroups` is a list of matching API groups and may not be empty. "*" matches all API groups and, if present, must be the only entry. Required.
+
+  - **rules.resourceRules.resources** ([]string), required
+
+    *Set: unique values will be kept during a merge*
+    
+    `resources` is a list of matching resources (i.e., lowercase and plural) with, if desired, subresource.  For example, [ "services", "nodes/status" ].  This list may not be empty. "*" matches all resources and, if present, must be the only entry. Required.
+
+  - **rules.resourceRules.verbs** ([]string), required
+
+    *Set: unique values will be kept during a merge*
+    
+    `verbs` is a list of matching verbs and may not be empty. "*" matches all verbs and, if present, must be the only entry. Required.
+
+  - **rules.resourceRules.clusterScope** (boolean)
+
+    `clusterScope` indicates whether to match requests that do not specify a namespace (which happens either because the resource is not namespaced or the request targets all namespaces). If this field is omitted or false then the `namespaces` field must contain a non-empty list.
+
+  - **rules.resourceRules.namespaces** ([]string)
+
+    *Set: unique values will be kept during a merge*
+    
+    `namespaces` is a list of target namespaces that restricts matches.  A request that specifies a target namespace matches only if either (a) this list contains that target namespace or (b) this list contains "*".  Note that "*" matches any specified namespace but does not match a request that _does not specify_ a namespace (see the `clusterScope` field for that). This list may be empty, but only if `clusterScope` is true.
+
+
+
+
+
+## FlowSchemaStatus {#FlowSchemaStatus}
+
+FlowSchemaStatus represents the current state of a FlowSchema.
+
+<hr>
+
+- **conditions** ([]FlowSchemaCondition)
+
+  *Map: unique values on key type will be kept during a merge*
+  
+  `conditions` is a list of the current states of FlowSchema.
+
+  <a name="FlowSchemaCondition"></a>
+  *FlowSchemaCondition describes conditions for a FlowSchema.*
+
+  - **conditions.lastTransitionTime** (Time)
+
+    `lastTransitionTime` is the last time the condition transitioned from one status to another.
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **conditions.message** (string)
+
+    `message` is a human-readable message indicating details about last transition.
+
+  - **conditions.reason** (string)
+
+    `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
+
+  - **conditions.status** (string)
+
+    `status` is the status of the condition. Can be True, False, Unknown. Required.
+
+  - **conditions.type** (string)
+
+    `type` is the type of the condition. Required.
+
+
+
+
+
+## FlowSchemaList {#FlowSchemaList}
+
+FlowSchemaList is a list of FlowSchema objects.
+
+<hr>
+
+- **apiVersion**: flowcontrol.apiserver.k8s.io/v1beta1
+
+
+- **kind**: FlowSchemaList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  `metadata` is the standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **items** ([]<a href="{{< ref "../cluster-resources/flow-schema-v1beta1#FlowSchema" >}}">FlowSchema</a>), required
+
+  `items` is a list of FlowSchemas.
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified FlowSchema
+
+#### HTTP Request
+
+GET /apis/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the FlowSchema
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/flow-schema-v1beta1#FlowSchema" >}}">FlowSchema</a>): OK
+
+401: Unauthorized
+
+
+### `get` read status of the specified FlowSchema
+
+#### HTTP Request
+
+GET /apis/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the FlowSchema
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/flow-schema-v1beta1#FlowSchema" >}}">FlowSchema</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind FlowSchema
+
+#### HTTP Request
+
+GET /apis/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/flow-schema-v1beta1#FlowSchemaList" >}}">FlowSchemaList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a FlowSchema
+
+#### HTTP Request
+
+POST /apis/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../cluster-resources/flow-schema-v1beta1#FlowSchema" >}}">FlowSchema</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/flow-schema-v1beta1#FlowSchema" >}}">FlowSchema</a>): OK
+
+201 (<a href="{{< ref "../cluster-resources/flow-schema-v1beta1#FlowSchema" >}}">FlowSchema</a>): Created
+
+202 (<a href="{{< ref "../cluster-resources/flow-schema-v1beta1#FlowSchema" >}}">FlowSchema</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified FlowSchema
+
+#### HTTP Request
+
+PUT /apis/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the FlowSchema
+
+
+- **body**: <a href="{{< ref "../cluster-resources/flow-schema-v1beta1#FlowSchema" >}}">FlowSchema</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/flow-schema-v1beta1#FlowSchema" >}}">FlowSchema</a>): OK
+
+201 (<a href="{{< ref "../cluster-resources/flow-schema-v1beta1#FlowSchema" >}}">FlowSchema</a>): Created
+
+401: Unauthorized
+
+
+### `update` replace status of the specified FlowSchema
+
+#### HTTP Request
+
+PUT /apis/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the FlowSchema
+
+
+- **body**: <a href="{{< ref "../cluster-resources/flow-schema-v1beta1#FlowSchema" >}}">FlowSchema</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/flow-schema-v1beta1#FlowSchema" >}}">FlowSchema</a>): OK
+
+201 (<a href="{{< ref "../cluster-resources/flow-schema-v1beta1#FlowSchema" >}}">FlowSchema</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified FlowSchema
+
+#### HTTP Request
+
+PATCH /apis/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the FlowSchema
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/flow-schema-v1beta1#FlowSchema" >}}">FlowSchema</a>): OK
+
+401: Unauthorized
+
+
+### `patch` partially update status of the specified FlowSchema
+
+#### HTTP Request
+
+PATCH /apis/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the FlowSchema
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/flow-schema-v1beta1#FlowSchema" >}}">FlowSchema</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a FlowSchema
+
+#### HTTP Request
+
+DELETE /apis/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the FlowSchema
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of FlowSchema
+
+#### HTTP Request
+
+DELETE /apis/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/lease-v1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/lease-v1.md
@@ -1,0 +1,572 @@
+---
+api_metadata:
+  apiVersion: "coordination.k8s.io/v1"
+  import: "k8s.io/api/coordination/v1"
+  kind: "Lease"
+content_type: "api_reference"
+description: "Lease defines a lease concept."
+title: "Lease"
+weight: 5
+---
+
+`apiVersion: coordination.k8s.io/v1`
+
+`import "k8s.io/api/coordination/v1"`
+
+
+## Lease {#Lease}
+
+Lease defines a lease concept.
+
+<hr>
+
+- **apiVersion**: coordination.k8s.io/v1
+
+
+- **kind**: Lease
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **spec** (<a href="{{< ref "../cluster-resources/lease-v1#LeaseSpec" >}}">LeaseSpec</a>)
+
+  Specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+
+
+
+
+## LeaseSpec {#LeaseSpec}
+
+LeaseSpec is a specification of a Lease.
+
+<hr>
+
+- **acquireTime** (MicroTime)
+
+  acquireTime is a time when the current lease was acquired.
+
+  <a name="MicroTime"></a>
+  *MicroTime is version of Time with microsecond level precision.*
+
+- **holderIdentity** (string)
+
+  holderIdentity contains the identity of the holder of a current lease.
+
+- **leaseDurationSeconds** (int32)
+
+  leaseDurationSeconds is a duration that candidates for a lease need to wait to force acquire it. This is measure against time of last observed RenewTime.
+
+- **leaseTransitions** (int32)
+
+  leaseTransitions is the number of transitions of a lease between holders.
+
+- **renewTime** (MicroTime)
+
+  renewTime is a time when the current holder of a lease has last updated the lease.
+
+  <a name="MicroTime"></a>
+  *MicroTime is version of Time with microsecond level precision.*
+
+
+
+
+
+## LeaseList {#LeaseList}
+
+LeaseList is a list of Lease objects.
+
+<hr>
+
+- **apiVersion**: coordination.k8s.io/v1
+
+
+- **kind**: LeaseList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **items** ([]<a href="{{< ref "../cluster-resources/lease-v1#Lease" >}}">Lease</a>), required
+
+  Items is a list of schema objects.
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified Lease
+
+#### HTTP Request
+
+GET /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Lease
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/lease-v1#Lease" >}}">Lease</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind Lease
+
+#### HTTP Request
+
+GET /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/lease-v1#LeaseList" >}}">LeaseList</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind Lease
+
+#### HTTP Request
+
+GET /apis/coordination.k8s.io/v1/leases
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/lease-v1#LeaseList" >}}">LeaseList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a Lease
+
+#### HTTP Request
+
+POST /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../cluster-resources/lease-v1#Lease" >}}">Lease</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/lease-v1#Lease" >}}">Lease</a>): OK
+
+201 (<a href="{{< ref "../cluster-resources/lease-v1#Lease" >}}">Lease</a>): Created
+
+202 (<a href="{{< ref "../cluster-resources/lease-v1#Lease" >}}">Lease</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified Lease
+
+#### HTTP Request
+
+PUT /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Lease
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../cluster-resources/lease-v1#Lease" >}}">Lease</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/lease-v1#Lease" >}}">Lease</a>): OK
+
+201 (<a href="{{< ref "../cluster-resources/lease-v1#Lease" >}}">Lease</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified Lease
+
+#### HTTP Request
+
+PATCH /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Lease
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/lease-v1#Lease" >}}">Lease</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a Lease
+
+#### HTTP Request
+
+DELETE /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Lease
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of Lease
+
+#### HTTP Request
+
+DELETE /apis/coordination.k8s.io/v1/namespaces/{namespace}/leases
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/namespace-v1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/namespace-v1.md
@@ -1,0 +1,582 @@
+---
+api_metadata:
+  apiVersion: "v1"
+  import: "k8s.io/api/core/v1"
+  kind: "Namespace"
+content_type: "api_reference"
+description: "Namespace provides a scope for Names."
+title: "Namespace"
+weight: 2
+---
+
+`apiVersion: v1`
+
+`import "k8s.io/api/core/v1"`
+
+
+## Namespace {#Namespace}
+
+Namespace provides a scope for Names. Use of multiple namespaces is optional.
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: Namespace
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **spec** (<a href="{{< ref "../cluster-resources/namespace-v1#NamespaceSpec" >}}">NamespaceSpec</a>)
+
+  Spec defines the behavior of the Namespace. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+- **status** (<a href="{{< ref "../cluster-resources/namespace-v1#NamespaceStatus" >}}">NamespaceStatus</a>)
+
+  Status describes the current status of a Namespace. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+
+
+
+
+## NamespaceSpec {#NamespaceSpec}
+
+NamespaceSpec describes the attributes on a Namespace.
+
+<hr>
+
+- **finalizers** ([]string)
+
+  Finalizers is an opaque list of values that must be empty to permanently remove object from storage. More info: https://kubernetes.io/docs/tasks/administer-cluster/namespaces/
+
+
+
+
+
+## NamespaceStatus {#NamespaceStatus}
+
+NamespaceStatus is information about the current status of a Namespace.
+
+<hr>
+
+- **conditions** ([]NamespaceCondition)
+
+  *Patch strategy: merge on key `type`*
+  
+  Represents the latest available observations of a namespace's current state.
+
+  <a name="NamespaceCondition"></a>
+  *NamespaceCondition contains details about state of namespace.*
+
+  - **conditions.status** (string), required
+
+    Status of the condition, one of True, False, Unknown.
+
+  - **conditions.type** (string), required
+
+    Type of namespace controller condition.
+
+  - **conditions.lastTransitionTime** (Time)
+
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **conditions.message** (string)
+
+
+  - **conditions.reason** (string)
+
+
+- **phase** (string)
+
+  Phase is the current lifecycle phase of the namespace. More info: https://kubernetes.io/docs/tasks/administer-cluster/namespaces/
+
+
+
+
+
+## NamespaceList {#NamespaceList}
+
+NamespaceList is a list of Namespaces.
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: NamespaceList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+- **items** ([]<a href="{{< ref "../cluster-resources/namespace-v1#Namespace" >}}">Namespace</a>), required
+
+  Items is the list of Namespace objects in the list. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified Namespace
+
+#### HTTP Request
+
+GET /api/v1/namespaces/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Namespace
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/namespace-v1#Namespace" >}}">Namespace</a>): OK
+
+401: Unauthorized
+
+
+### `get` read status of the specified Namespace
+
+#### HTTP Request
+
+GET /api/v1/namespaces/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Namespace
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/namespace-v1#Namespace" >}}">Namespace</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind Namespace
+
+#### HTTP Request
+
+GET /api/v1/namespaces
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/namespace-v1#NamespaceList" >}}">NamespaceList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a Namespace
+
+#### HTTP Request
+
+POST /api/v1/namespaces
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../cluster-resources/namespace-v1#Namespace" >}}">Namespace</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/namespace-v1#Namespace" >}}">Namespace</a>): OK
+
+201 (<a href="{{< ref "../cluster-resources/namespace-v1#Namespace" >}}">Namespace</a>): Created
+
+202 (<a href="{{< ref "../cluster-resources/namespace-v1#Namespace" >}}">Namespace</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified Namespace
+
+#### HTTP Request
+
+PUT /api/v1/namespaces/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Namespace
+
+
+- **body**: <a href="{{< ref "../cluster-resources/namespace-v1#Namespace" >}}">Namespace</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/namespace-v1#Namespace" >}}">Namespace</a>): OK
+
+201 (<a href="{{< ref "../cluster-resources/namespace-v1#Namespace" >}}">Namespace</a>): Created
+
+401: Unauthorized
+
+
+### `update` replace finalize of the specified Namespace
+
+#### HTTP Request
+
+PUT /api/v1/namespaces/{name}/finalize
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Namespace
+
+
+- **body**: <a href="{{< ref "../cluster-resources/namespace-v1#Namespace" >}}">Namespace</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/namespace-v1#Namespace" >}}">Namespace</a>): OK
+
+201 (<a href="{{< ref "../cluster-resources/namespace-v1#Namespace" >}}">Namespace</a>): Created
+
+401: Unauthorized
+
+
+### `update` replace status of the specified Namespace
+
+#### HTTP Request
+
+PUT /api/v1/namespaces/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Namespace
+
+
+- **body**: <a href="{{< ref "../cluster-resources/namespace-v1#Namespace" >}}">Namespace</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/namespace-v1#Namespace" >}}">Namespace</a>): OK
+
+201 (<a href="{{< ref "../cluster-resources/namespace-v1#Namespace" >}}">Namespace</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified Namespace
+
+#### HTTP Request
+
+PATCH /api/v1/namespaces/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Namespace
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/namespace-v1#Namespace" >}}">Namespace</a>): OK
+
+401: Unauthorized
+
+
+### `patch` partially update status of the specified Namespace
+
+#### HTTP Request
+
+PATCH /api/v1/namespaces/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Namespace
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/namespace-v1#Namespace" >}}">Namespace</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a Namespace
+
+#### HTTP Request
+
+DELETE /api/v1/namespaces/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Namespace
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/node-v1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/node-v1.md
@@ -1,0 +1,938 @@
+---
+api_metadata:
+  apiVersion: "v1"
+  import: "k8s.io/api/core/v1"
+  kind: "Node"
+content_type: "api_reference"
+description: "Node is a worker node in Kubernetes."
+title: "Node"
+weight: 1
+---
+
+`apiVersion: v1`
+
+`import "k8s.io/api/core/v1"`
+
+
+## Node {#Node}
+
+Node is a worker node in Kubernetes. Each node will have a unique identifier in the cache (i.e. in etcd).
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: Node
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **spec** (<a href="{{< ref "../cluster-resources/node-v1#NodeSpec" >}}">NodeSpec</a>)
+
+  Spec defines the behavior of a node. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+- **status** (<a href="{{< ref "../cluster-resources/node-v1#NodeStatus" >}}">NodeStatus</a>)
+
+  Most recently observed status of the node. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+
+
+
+
+## NodeSpec {#NodeSpec}
+
+NodeSpec describes the attributes that a node is created with.
+
+<hr>
+
+- **configSource** (NodeConfigSource)
+
+  If specified, the source to get node configuration from The DynamicKubeletConfig feature gate must be enabled for the Kubelet to use this field
+
+  <a name="NodeConfigSource"></a>
+  *NodeConfigSource specifies a source of node configuration. Exactly one subfield (excluding metadata) must be non-nil.*
+
+  - **configSource.configMap** (ConfigMapNodeConfigSource)
+
+    ConfigMap is a reference to a Node's ConfigMap
+
+    <a name="ConfigMapNodeConfigSource"></a>
+    *ConfigMapNodeConfigSource contains the information to reference a ConfigMap as a config source for the Node.*
+
+  - **configSource.configMap.kubeletConfigKey** (string), required
+
+    KubeletConfigKey declares which key of the referenced ConfigMap corresponds to the KubeletConfiguration structure This field is required in all cases.
+
+  - **configSource.configMap.name** (string), required
+
+    Name is the metadata.name of the referenced ConfigMap. This field is required in all cases.
+
+  - **configSource.configMap.namespace** (string), required
+
+    Namespace is the metadata.namespace of the referenced ConfigMap. This field is required in all cases.
+
+  - **configSource.configMap.resourceVersion** (string)
+
+    ResourceVersion is the metadata.ResourceVersion of the referenced ConfigMap. This field is forbidden in Node.Spec, and required in Node.Status.
+
+  - **configSource.configMap.uid** (string)
+
+    UID is the metadata.UID of the referenced ConfigMap. This field is forbidden in Node.Spec, and required in Node.Status.
+
+- **externalID** (string)
+
+  Deprecated. Not all kubelets will set this field. Remove field after 1.13. see: https://issues.k8s.io/61966
+
+- **podCIDR** (string)
+
+  PodCIDR represents the pod IP range assigned to the node.
+
+- **podCIDRs** ([]string)
+
+  podCIDRs represents the IP ranges assigned to the node for usage by Pods on that node. If this field is specified, the 0th entry must match the podCIDR field. It may contain at most 1 value for each of IPv4 and IPv6.
+
+- **providerID** (string)
+
+  ID of the node assigned by the cloud provider in the format: \<ProviderName>://\<ProviderSpecificNodeID>
+
+- **taints** ([]Taint)
+
+  If specified, the node's taints.
+
+  <a name="Taint"></a>
+  *The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.*
+
+  - **taints.effect** (string), required
+
+    Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+
+  - **taints.key** (string), required
+
+    Required. The taint key to be applied to a node.
+
+  - **taints.timeAdded** (Time)
+
+    TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **taints.value** (string)
+
+    The taint value corresponding to the taint key.
+
+- **unschedulable** (boolean)
+
+  Unschedulable controls node schedulability of new pods. By default, node is schedulable. More info: https://kubernetes.io/docs/concepts/nodes/node/#manual-node-administration
+
+
+
+
+
+## NodeStatus {#NodeStatus}
+
+NodeStatus is information about the current status of a node.
+
+<hr>
+
+- **addresses** ([]NodeAddress)
+
+  *Patch strategy: merge on key `type`*
+  
+  List of addresses reachable to the node. Queried from cloud provider, if available. More info: https://kubernetes.io/docs/concepts/nodes/node/#addresses Note: This field is declared as mergeable, but the merge key is not sufficiently unique, which can cause data corruption when it is merged. Callers should instead use a full-replacement patch. See http://pr.k8s.io/79391 for an example.
+
+  <a name="NodeAddress"></a>
+  *NodeAddress contains information for the node's address.*
+
+  - **addresses.address** (string), required
+
+    The node address.
+
+  - **addresses.type** (string), required
+
+    Node address type, one of Hostname, ExternalIP or InternalIP.
+
+- **allocatable** (map[string]<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+  Allocatable represents the resources of a node that are available for scheduling. Defaults to Capacity.
+
+- **capacity** (map[string]<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+  Capacity represents the total resources of a node. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#capacity
+
+- **conditions** ([]NodeCondition)
+
+  *Patch strategy: merge on key `type`*
+  
+  Conditions is an array of current observed node conditions. More info: https://kubernetes.io/docs/concepts/nodes/node/#condition
+
+  <a name="NodeCondition"></a>
+  *NodeCondition contains condition information for a node.*
+
+  - **conditions.status** (string), required
+
+    Status of the condition, one of True, False, Unknown.
+
+  - **conditions.type** (string), required
+
+    Type of node condition.
+
+  - **conditions.lastHeartbeatTime** (Time)
+
+    Last time we got an update on a given condition.
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **conditions.lastTransitionTime** (Time)
+
+    Last time the condition transit from one status to another.
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **conditions.message** (string)
+
+    Human readable message indicating details about last transition.
+
+  - **conditions.reason** (string)
+
+    (brief) reason for the condition's last transition.
+
+- **config** (NodeConfigStatus)
+
+  Status of the config assigned to the node via the dynamic Kubelet config feature.
+
+  <a name="NodeConfigStatus"></a>
+  *NodeConfigStatus describes the status of the config assigned by Node.Spec.ConfigSource.*
+
+  - **config.active** (NodeConfigSource)
+
+    Active reports the checkpointed config the node is actively using. Active will represent either the current version of the Assigned config, or the current LastKnownGood config, depending on whether attempting to use the Assigned config results in an error.
+
+    <a name="NodeConfigSource"></a>
+    *NodeConfigSource specifies a source of node configuration. Exactly one subfield (excluding metadata) must be non-nil.*
+
+  - **config.active.configMap** (ConfigMapNodeConfigSource)
+
+    ConfigMap is a reference to a Node's ConfigMap
+
+    <a name="ConfigMapNodeConfigSource"></a>
+    *ConfigMapNodeConfigSource contains the information to reference a ConfigMap as a config source for the Node.*
+
+  - **config.active.configMap.kubeletConfigKey** (string), required
+
+    KubeletConfigKey declares which key of the referenced ConfigMap corresponds to the KubeletConfiguration structure This field is required in all cases.
+
+  - **config.active.configMap.name** (string), required
+
+    Name is the metadata.name of the referenced ConfigMap. This field is required in all cases.
+
+  - **config.active.configMap.namespace** (string), required
+
+    Namespace is the metadata.namespace of the referenced ConfigMap. This field is required in all cases.
+
+  - **config.active.configMap.resourceVersion** (string)
+
+    ResourceVersion is the metadata.ResourceVersion of the referenced ConfigMap. This field is forbidden in Node.Spec, and required in Node.Status.
+
+  - **config.active.configMap.uid** (string)
+
+    UID is the metadata.UID of the referenced ConfigMap. This field is forbidden in Node.Spec, and required in Node.Status.
+
+  - **config.assigned** (NodeConfigSource)
+
+    Assigned reports the checkpointed config the node will try to use. When Node.Spec.ConfigSource is updated, the node checkpoints the associated config payload to local disk, along with a record indicating intended config. The node refers to this record to choose its config checkpoint, and reports this record in Assigned. Assigned only updates in the status after the record has been checkpointed to disk. When the Kubelet is restarted, it tries to make the Assigned config the Active config by loading and validating the checkpointed payload identified by Assigned.
+
+    <a name="NodeConfigSource"></a>
+    *NodeConfigSource specifies a source of node configuration. Exactly one subfield (excluding metadata) must be non-nil.*
+
+  - **config.assigned.configMap** (ConfigMapNodeConfigSource)
+
+    ConfigMap is a reference to a Node's ConfigMap
+
+    <a name="ConfigMapNodeConfigSource"></a>
+    *ConfigMapNodeConfigSource contains the information to reference a ConfigMap as a config source for the Node.*
+
+  - **config.assigned.configMap.kubeletConfigKey** (string), required
+
+    KubeletConfigKey declares which key of the referenced ConfigMap corresponds to the KubeletConfiguration structure This field is required in all cases.
+
+  - **config.assigned.configMap.name** (string), required
+
+    Name is the metadata.name of the referenced ConfigMap. This field is required in all cases.
+
+  - **config.assigned.configMap.namespace** (string), required
+
+    Namespace is the metadata.namespace of the referenced ConfigMap. This field is required in all cases.
+
+  - **config.assigned.configMap.resourceVersion** (string)
+
+    ResourceVersion is the metadata.ResourceVersion of the referenced ConfigMap. This field is forbidden in Node.Spec, and required in Node.Status.
+
+  - **config.assigned.configMap.uid** (string)
+
+    UID is the metadata.UID of the referenced ConfigMap. This field is forbidden in Node.Spec, and required in Node.Status.
+
+  - **config.error** (string)
+
+    Error describes any problems reconciling the Spec.ConfigSource to the Active config. Errors may occur, for example, attempting to checkpoint Spec.ConfigSource to the local Assigned record, attempting to checkpoint the payload associated with Spec.ConfigSource, attempting to load or validate the Assigned config, etc. Errors may occur at different points while syncing config. Earlier errors (e.g. download or checkpointing errors) will not result in a rollback to LastKnownGood, and may resolve across Kubelet retries. Later errors (e.g. loading or validating a checkpointed config) will result in a rollback to LastKnownGood. In the latter case, it is usually possible to resolve the error by fixing the config assigned in Spec.ConfigSource. You can find additional information for debugging by searching the error message in the Kubelet log. Error is a human-readable description of the error state; machines can check whether or not Error is empty, but should not rely on the stability of the Error text across Kubelet versions.
+
+  - **config.lastKnownGood** (NodeConfigSource)
+
+    LastKnownGood reports the checkpointed config the node will fall back to when it encounters an error attempting to use the Assigned config. The Assigned config becomes the LastKnownGood config when the node determines that the Assigned config is stable and correct. This is currently implemented as a 10-minute soak period starting when the local record of Assigned config is updated. If the Assigned config is Active at the end of this period, it becomes the LastKnownGood. Note that if Spec.ConfigSource is reset to nil (use local defaults), the LastKnownGood is also immediately reset to nil, because the local default config is always assumed good. You should not make assumptions about the node's method of determining config stability and correctness, as this may change or become configurable in the future.
+
+    <a name="NodeConfigSource"></a>
+    *NodeConfigSource specifies a source of node configuration. Exactly one subfield (excluding metadata) must be non-nil.*
+
+  - **config.lastKnownGood.configMap** (ConfigMapNodeConfigSource)
+
+    ConfigMap is a reference to a Node's ConfigMap
+
+    <a name="ConfigMapNodeConfigSource"></a>
+    *ConfigMapNodeConfigSource contains the information to reference a ConfigMap as a config source for the Node.*
+
+  - **config.lastKnownGood.configMap.kubeletConfigKey** (string), required
+
+    KubeletConfigKey declares which key of the referenced ConfigMap corresponds to the KubeletConfiguration structure This field is required in all cases.
+
+  - **config.lastKnownGood.configMap.name** (string), required
+
+    Name is the metadata.name of the referenced ConfigMap. This field is required in all cases.
+
+  - **config.lastKnownGood.configMap.namespace** (string), required
+
+    Namespace is the metadata.namespace of the referenced ConfigMap. This field is required in all cases.
+
+  - **config.lastKnownGood.configMap.resourceVersion** (string)
+
+    ResourceVersion is the metadata.ResourceVersion of the referenced ConfigMap. This field is forbidden in Node.Spec, and required in Node.Status.
+
+  - **config.lastKnownGood.configMap.uid** (string)
+
+    UID is the metadata.UID of the referenced ConfigMap. This field is forbidden in Node.Spec, and required in Node.Status.
+
+- **daemonEndpoints** (NodeDaemonEndpoints)
+
+  Endpoints of daemons running on the Node.
+
+  <a name="NodeDaemonEndpoints"></a>
+  *NodeDaemonEndpoints lists ports opened by daemons running on the Node.*
+
+  - **daemonEndpoints.kubeletEndpoint** (DaemonEndpoint)
+
+    Endpoint on which Kubelet is listening.
+
+    <a name="DaemonEndpoint"></a>
+    *DaemonEndpoint contains information about a single Daemon endpoint.*
+
+  - **daemonEndpoints.kubeletEndpoint.Port** (int32), required
+
+    Port number of the given endpoint.
+
+- **images** ([]ContainerImage)
+
+  List of container images on this node
+
+  <a name="ContainerImage"></a>
+  *Describe a container image*
+
+  - **images.names** ([]string), required
+
+    Names by which this image is known. e.g. ["k8s.gcr.io/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
+
+  - **images.sizeBytes** (int64)
+
+    The size of the image in bytes.
+
+- **nodeInfo** (NodeSystemInfo)
+
+  Set of ids/uuids to uniquely identify the node. More info: https://kubernetes.io/docs/concepts/nodes/node/#info
+
+  <a name="NodeSystemInfo"></a>
+  *NodeSystemInfo is a set of ids/uuids to uniquely identify the node.*
+
+  - **nodeInfo.architecture** (string), required
+
+    The Architecture reported by the node
+
+  - **nodeInfo.bootID** (string), required
+
+    Boot ID reported by the node.
+
+  - **nodeInfo.containerRuntimeVersion** (string), required
+
+    ContainerRuntime Version reported by the node through runtime remote API (e.g. docker://1.5.0).
+
+  - **nodeInfo.kernelVersion** (string), required
+
+    Kernel Version reported by the node from 'uname -r' (e.g. 3.16.0-0.bpo.4-amd64).
+
+  - **nodeInfo.kubeProxyVersion** (string), required
+
+    KubeProxy Version reported by the node.
+
+  - **nodeInfo.kubeletVersion** (string), required
+
+    Kubelet Version reported by the node.
+
+  - **nodeInfo.machineID** (string), required
+
+    MachineID reported by the node. For unique machine identification in the cluster this field is preferred. Learn more from man(5) machine-id: http://man7.org/linux/man-pages/man5/machine-id.5.html
+
+  - **nodeInfo.operatingSystem** (string), required
+
+    The Operating System reported by the node
+
+  - **nodeInfo.osImage** (string), required
+
+    OS Image reported by the node from /etc/os-release (e.g. Debian GNU/Linux 7 (wheezy)).
+
+  - **nodeInfo.systemUUID** (string), required
+
+    SystemUUID reported by the node. For unique machine identification MachineID is preferred. This field is specific to Red Hat hosts https://access.redhat.com/documentation/en-us/red_hat_subscription_management/1/html/rhsm/uuid
+
+- **phase** (string)
+
+  NodePhase is the recently observed lifecycle phase of the node. More info: https://kubernetes.io/docs/concepts/nodes/node/#phase The field is never populated, and now is deprecated.
+
+- **volumesAttached** ([]AttachedVolume)
+
+  List of volumes that are attached to the node.
+
+  <a name="AttachedVolume"></a>
+  *AttachedVolume describes a volume attached to a node*
+
+  - **volumesAttached.devicePath** (string), required
+
+    DevicePath represents the device path where the volume should be available
+
+  - **volumesAttached.name** (string), required
+
+    Name of the attached volume
+
+- **volumesInUse** ([]string)
+
+  List of attachable volumes in use (mounted) by the node.
+
+
+
+
+
+## NodeList {#NodeList}
+
+NodeList is the whole list of all Nodes which have been registered with master.
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: NodeList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+- **items** ([]<a href="{{< ref "../cluster-resources/node-v1#Node" >}}">Node</a>), required
+
+  List of nodes
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified Node
+
+#### HTTP Request
+
+GET /api/v1/nodes/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Node
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/node-v1#Node" >}}">Node</a>): OK
+
+401: Unauthorized
+
+
+### `get` read status of the specified Node
+
+#### HTTP Request
+
+GET /api/v1/nodes/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Node
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/node-v1#Node" >}}">Node</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind Node
+
+#### HTTP Request
+
+GET /api/v1/nodes
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/node-v1#NodeList" >}}">NodeList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a Node
+
+#### HTTP Request
+
+POST /api/v1/nodes
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../cluster-resources/node-v1#Node" >}}">Node</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/node-v1#Node" >}}">Node</a>): OK
+
+201 (<a href="{{< ref "../cluster-resources/node-v1#Node" >}}">Node</a>): Created
+
+202 (<a href="{{< ref "../cluster-resources/node-v1#Node" >}}">Node</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified Node
+
+#### HTTP Request
+
+PUT /api/v1/nodes/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Node
+
+
+- **body**: <a href="{{< ref "../cluster-resources/node-v1#Node" >}}">Node</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/node-v1#Node" >}}">Node</a>): OK
+
+201 (<a href="{{< ref "../cluster-resources/node-v1#Node" >}}">Node</a>): Created
+
+401: Unauthorized
+
+
+### `update` replace status of the specified Node
+
+#### HTTP Request
+
+PUT /api/v1/nodes/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Node
+
+
+- **body**: <a href="{{< ref "../cluster-resources/node-v1#Node" >}}">Node</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/node-v1#Node" >}}">Node</a>): OK
+
+201 (<a href="{{< ref "../cluster-resources/node-v1#Node" >}}">Node</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified Node
+
+#### HTTP Request
+
+PATCH /api/v1/nodes/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Node
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/node-v1#Node" >}}">Node</a>): OK
+
+401: Unauthorized
+
+
+### `patch` partially update status of the specified Node
+
+#### HTTP Request
+
+PATCH /api/v1/nodes/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Node
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/node-v1#Node" >}}">Node</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a Node
+
+#### HTTP Request
+
+DELETE /api/v1/nodes/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Node
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of Node
+
+#### HTTP Request
+
+DELETE /api/v1/nodes
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/priority-level-configuration-v1beta1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/priority-level-configuration-v1beta1.md
@@ -1,0 +1,661 @@
+---
+api_metadata:
+  apiVersion: "flowcontrol.apiserver.k8s.io/v1beta1"
+  import: "k8s.io/api/flowcontrol/v1beta1"
+  kind: "PriorityLevelConfiguration"
+content_type: "api_reference"
+description: "PriorityLevelConfiguration represents the configuration of a priority level."
+title: "PriorityLevelConfiguration v1beta1"
+weight: 8
+---
+
+`apiVersion: flowcontrol.apiserver.k8s.io/v1beta1`
+
+`import "k8s.io/api/flowcontrol/v1beta1"`
+
+
+## PriorityLevelConfiguration {#PriorityLevelConfiguration}
+
+PriorityLevelConfiguration represents the configuration of a priority level.
+
+<hr>
+
+- **apiVersion**: flowcontrol.apiserver.k8s.io/v1beta1
+
+
+- **kind**: PriorityLevelConfiguration
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **spec** (<a href="{{< ref "../cluster-resources/priority-level-configuration-v1beta1#PriorityLevelConfigurationSpec" >}}">PriorityLevelConfigurationSpec</a>)
+
+  `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+- **status** (<a href="{{< ref "../cluster-resources/priority-level-configuration-v1beta1#PriorityLevelConfigurationStatus" >}}">PriorityLevelConfigurationStatus</a>)
+
+  `status` is the current status of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+
+
+
+
+## PriorityLevelConfigurationSpec {#PriorityLevelConfigurationSpec}
+
+PriorityLevelConfigurationSpec specifies the configuration of a priority level.
+
+<hr>
+
+- **type** (string), required
+
+  `type` indicates whether this priority level is subject to limitation on request execution.  A value of `"Exempt"` means that requests of this priority level are not subject to a limit (and thus are never queued) and do not detract from the capacity made available to other priority levels.  A value of `"Limited"` means that (a) requests of this priority level _are_ subject to limits and (b) some of the server's limited capacity is made available exclusively to this priority level. Required.
+
+- **limited** (LimitedPriorityLevelConfiguration)
+
+  `limited` specifies how requests are handled for a Limited priority level. This field must be non-empty if and only if `type` is `"Limited"`.
+
+  <a name="LimitedPriorityLevelConfiguration"></a>
+  *LimitedPriorityLevelConfiguration specifies how to handle requests that are subject to limits. It addresses two issues:
+   * How are requests for this priority level limited?
+   * What should be done with requests that exceed the limit?*
+
+  - **limited.assuredConcurrencyShares** (int32)
+
+    `assuredConcurrencyShares` (ACS) configures the execution limit, which is a limit on the number of requests of this priority level that may be exeucting at a given time.  ACS must be a positive number. The server's concurrency limit (SCL) is divided among the concurrency-controlled priority levels in proportion to their assured concurrency shares. This produces the assured concurrency value (ACV) --- the number of requests that may be executing at a time --- for each such priority level:
+    
+                ACV(l) = ceil( SCL * ACS(l) / ( sum[priority levels k] ACS(k) ) )
+    
+    bigger numbers of ACS mean more reserved concurrent requests (at the expense of every other PL). This field has a default value of 30.
+
+  - **limited.limitResponse** (LimitResponse)
+
+    `limitResponse` indicates what to do with requests that can not be executed right now
+
+    <a name="LimitResponse"></a>
+    *LimitResponse defines how to handle requests that can not be executed right now.*
+
+  - **limited.limitResponse.type** (string), required
+
+    `type` is "Queue" or "Reject". "Queue" means that requests that can not be executed upon arrival are held in a queue until they can be executed or a queuing limit is reached. "Reject" means that requests that can not be executed upon arrival are rejected. Required.
+
+  - **limited.limitResponse.queuing** (QueuingConfiguration)
+
+    `queuing` holds the configuration parameters for queuing. This field may be non-empty only if `type` is `"Queue"`.
+
+    <a name="QueuingConfiguration"></a>
+    *QueuingConfiguration holds the configuration parameters for queuing*
+
+  - **limited.limitResponse.queuing.handSize** (int32)
+
+    `handSize` is a small positive number that configures the shuffle sharding of requests into queues.  When enqueuing a request at this priority level the request's flow identifier (a string pair) is hashed and the hash value is used to shuffle the list of queues and deal a hand of the size specified here.  The request is put into one of the shortest queues in that hand. `handSize` must be no larger than `queues`, and should be significantly smaller (so that a few heavy flows do not saturate most of the queues).  See the user-facing documentation for more extensive guidance on setting this field.  This field has a default value of 8.
+
+  - **limited.limitResponse.queuing.queueLengthLimit** (int32)
+
+    `queueLengthLimit` is the maximum number of requests allowed to be waiting in a given queue of this priority level at a time; excess requests are rejected.  This value must be positive.  If not specified, it will be defaulted to 50.
+
+  - **limited.limitResponse.queuing.queues** (int32)
+
+    `queues` is the number of queues for this priority level. The queues exist independently at each apiserver. The value must be positive.  Setting it to 1 effectively precludes shufflesharding and thus makes the distinguisher method of associated flow schemas irrelevant.  This field has a default value of 64.
+
+
+
+
+
+## PriorityLevelConfigurationStatus {#PriorityLevelConfigurationStatus}
+
+PriorityLevelConfigurationStatus represents the current state of a "request-priority".
+
+<hr>
+
+- **conditions** ([]PriorityLevelConfigurationCondition)
+
+  *Map: unique values on key type will be kept during a merge*
+  
+  `conditions` is the current state of "request-priority".
+
+  <a name="PriorityLevelConfigurationCondition"></a>
+  *PriorityLevelConfigurationCondition defines the condition of priority level.*
+
+  - **conditions.lastTransitionTime** (Time)
+
+    `lastTransitionTime` is the last time the condition transitioned from one status to another.
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **conditions.message** (string)
+
+    `message` is a human-readable message indicating details about last transition.
+
+  - **conditions.reason** (string)
+
+    `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
+
+  - **conditions.status** (string)
+
+    `status` is the status of the condition. Can be True, False, Unknown. Required.
+
+  - **conditions.type** (string)
+
+    `type` is the type of the condition. Required.
+
+
+
+
+
+## PriorityLevelConfigurationList {#PriorityLevelConfigurationList}
+
+PriorityLevelConfigurationList is a list of PriorityLevelConfiguration objects.
+
+<hr>
+
+- **apiVersion**: flowcontrol.apiserver.k8s.io/v1beta1
+
+
+- **kind**: PriorityLevelConfigurationList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **items** ([]<a href="{{< ref "../cluster-resources/priority-level-configuration-v1beta1#PriorityLevelConfiguration" >}}">PriorityLevelConfiguration</a>), required
+
+  `items` is a list of request-priorities.
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified PriorityLevelConfiguration
+
+#### HTTP Request
+
+GET /apis/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PriorityLevelConfiguration
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/priority-level-configuration-v1beta1#PriorityLevelConfiguration" >}}">PriorityLevelConfiguration</a>): OK
+
+401: Unauthorized
+
+
+### `get` read status of the specified PriorityLevelConfiguration
+
+#### HTTP Request
+
+GET /apis/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PriorityLevelConfiguration
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/priority-level-configuration-v1beta1#PriorityLevelConfiguration" >}}">PriorityLevelConfiguration</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind PriorityLevelConfiguration
+
+#### HTTP Request
+
+GET /apis/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/priority-level-configuration-v1beta1#PriorityLevelConfigurationList" >}}">PriorityLevelConfigurationList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a PriorityLevelConfiguration
+
+#### HTTP Request
+
+POST /apis/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../cluster-resources/priority-level-configuration-v1beta1#PriorityLevelConfiguration" >}}">PriorityLevelConfiguration</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/priority-level-configuration-v1beta1#PriorityLevelConfiguration" >}}">PriorityLevelConfiguration</a>): OK
+
+201 (<a href="{{< ref "../cluster-resources/priority-level-configuration-v1beta1#PriorityLevelConfiguration" >}}">PriorityLevelConfiguration</a>): Created
+
+202 (<a href="{{< ref "../cluster-resources/priority-level-configuration-v1beta1#PriorityLevelConfiguration" >}}">PriorityLevelConfiguration</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified PriorityLevelConfiguration
+
+#### HTTP Request
+
+PUT /apis/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PriorityLevelConfiguration
+
+
+- **body**: <a href="{{< ref "../cluster-resources/priority-level-configuration-v1beta1#PriorityLevelConfiguration" >}}">PriorityLevelConfiguration</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/priority-level-configuration-v1beta1#PriorityLevelConfiguration" >}}">PriorityLevelConfiguration</a>): OK
+
+201 (<a href="{{< ref "../cluster-resources/priority-level-configuration-v1beta1#PriorityLevelConfiguration" >}}">PriorityLevelConfiguration</a>): Created
+
+401: Unauthorized
+
+
+### `update` replace status of the specified PriorityLevelConfiguration
+
+#### HTTP Request
+
+PUT /apis/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PriorityLevelConfiguration
+
+
+- **body**: <a href="{{< ref "../cluster-resources/priority-level-configuration-v1beta1#PriorityLevelConfiguration" >}}">PriorityLevelConfiguration</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/priority-level-configuration-v1beta1#PriorityLevelConfiguration" >}}">PriorityLevelConfiguration</a>): OK
+
+201 (<a href="{{< ref "../cluster-resources/priority-level-configuration-v1beta1#PriorityLevelConfiguration" >}}">PriorityLevelConfiguration</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified PriorityLevelConfiguration
+
+#### HTTP Request
+
+PATCH /apis/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PriorityLevelConfiguration
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/priority-level-configuration-v1beta1#PriorityLevelConfiguration" >}}">PriorityLevelConfiguration</a>): OK
+
+401: Unauthorized
+
+
+### `patch` partially update status of the specified PriorityLevelConfiguration
+
+#### HTTP Request
+
+PATCH /apis/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PriorityLevelConfiguration
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/priority-level-configuration-v1beta1#PriorityLevelConfiguration" >}}">PriorityLevelConfiguration</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a PriorityLevelConfiguration
+
+#### HTTP Request
+
+DELETE /apis/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PriorityLevelConfiguration
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of PriorityLevelConfiguration
+
+#### HTTP Request
+
+DELETE /apis/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/runtime-class-v1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/runtime-class-v1.md
@@ -1,0 +1,486 @@
+---
+api_metadata:
+  apiVersion: "node.k8s.io/v1"
+  import: "k8s.io/api/node/v1"
+  kind: "RuntimeClass"
+content_type: "api_reference"
+description: "RuntimeClass defines a class of container runtime supported in the cluster."
+title: "RuntimeClass"
+weight: 6
+---
+
+`apiVersion: node.k8s.io/v1`
+
+`import "k8s.io/api/node/v1"`
+
+
+## RuntimeClass {#RuntimeClass}
+
+RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://kubernetes.io/docs/concepts/containers/runtime-class/
+
+<hr>
+
+- **apiVersion**: node.k8s.io/v1
+
+
+- **kind**: RuntimeClass
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **handler** (string), required
+
+  Handler specifies the underlying runtime and configuration that the CRI implementation will use to handle pods of this class. The possible values are specific to the node & CRI configuration.  It is assumed that all handlers are available on every node, and handlers of the same name are equivalent on every node. For example, a handler called "runc" might specify that the runc OCI runtime (using native Linux containers) will be used to run the containers in a pod. The Handler must be lowercase, conform to the DNS Label (RFC 1123) requirements, and is immutable.
+
+- **overhead** (Overhead)
+
+  Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. For more details, see
+   https://kubernetes.io/docs/concepts/scheduling-eviction/pod-overhead/
+  This field is in beta starting v1.18 and is only honored by servers that enable the PodOverhead feature.
+
+  <a name="Overhead"></a>
+  *Overhead structure represents the resource overhead associated with running a pod.*
+
+  - **overhead.podFixed** (map[string]<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    PodFixed represents the fixed resource overhead associated with running a pod.
+
+- **scheduling** (Scheduling)
+
+  Scheduling holds the scheduling constraints to ensure that pods running with this RuntimeClass are scheduled to nodes that support it. If scheduling is nil, this RuntimeClass is assumed to be supported by all nodes.
+
+  <a name="Scheduling"></a>
+  *Scheduling specifies the scheduling constraints for nodes supporting a RuntimeClass.*
+
+  - **scheduling.nodeSelector** (map[string]string)
+
+    nodeSelector lists labels that must be present on nodes that support this RuntimeClass. Pods using this RuntimeClass can only be scheduled to a node matched by this selector. The RuntimeClass nodeSelector is merged with a pod's existing nodeSelector. Any conflicts will cause the pod to be rejected in admission.
+
+  - **scheduling.tolerations** ([]Toleration)
+
+    *Atomic: will be replaced during a merge*
+    
+    tolerations are appended (excluding duplicates) to pods running with this RuntimeClass during admission, effectively unioning the set of nodes tolerated by the pod and the RuntimeClass.
+
+    <a name="Toleration"></a>
+    *The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.*
+
+  - **scheduling.tolerations.key** (string)
+
+    Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+
+  - **scheduling.tolerations.operator** (string)
+
+    Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+  - **scheduling.tolerations.value** (string)
+
+    Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+
+  - **scheduling.tolerations.effect** (string)
+
+    Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+  - **scheduling.tolerations.tolerationSeconds** (int64)
+
+    TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+
+
+
+
+
+## RuntimeClassList {#RuntimeClassList}
+
+RuntimeClassList is a list of RuntimeClass objects.
+
+<hr>
+
+- **apiVersion**: node.k8s.io/v1
+
+
+- **kind**: RuntimeClassList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **items** ([]<a href="{{< ref "../cluster-resources/runtime-class-v1#RuntimeClass" >}}">RuntimeClass</a>), required
+
+  Items is a list of schema objects.
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified RuntimeClass
+
+#### HTTP Request
+
+GET /apis/node.k8s.io/v1/runtimeclasses/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the RuntimeClass
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/runtime-class-v1#RuntimeClass" >}}">RuntimeClass</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind RuntimeClass
+
+#### HTTP Request
+
+GET /apis/node.k8s.io/v1/runtimeclasses
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/runtime-class-v1#RuntimeClassList" >}}">RuntimeClassList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a RuntimeClass
+
+#### HTTP Request
+
+POST /apis/node.k8s.io/v1/runtimeclasses
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../cluster-resources/runtime-class-v1#RuntimeClass" >}}">RuntimeClass</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/runtime-class-v1#RuntimeClass" >}}">RuntimeClass</a>): OK
+
+201 (<a href="{{< ref "../cluster-resources/runtime-class-v1#RuntimeClass" >}}">RuntimeClass</a>): Created
+
+202 (<a href="{{< ref "../cluster-resources/runtime-class-v1#RuntimeClass" >}}">RuntimeClass</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified RuntimeClass
+
+#### HTTP Request
+
+PUT /apis/node.k8s.io/v1/runtimeclasses/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the RuntimeClass
+
+
+- **body**: <a href="{{< ref "../cluster-resources/runtime-class-v1#RuntimeClass" >}}">RuntimeClass</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/runtime-class-v1#RuntimeClass" >}}">RuntimeClass</a>): OK
+
+201 (<a href="{{< ref "../cluster-resources/runtime-class-v1#RuntimeClass" >}}">RuntimeClass</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified RuntimeClass
+
+#### HTTP Request
+
+PATCH /apis/node.k8s.io/v1/runtimeclasses/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the RuntimeClass
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../cluster-resources/runtime-class-v1#RuntimeClass" >}}">RuntimeClass</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a RuntimeClass
+
+#### HTTP Request
+
+DELETE /apis/node.k8s.io/v1/runtimeclasses/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the RuntimeClass
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of RuntimeClass
+
+#### HTTP Request
+
+DELETE /apis/node.k8s.io/v1/runtimeclasses
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/common-definitions/_index.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Common Definitions"
+weight: 9
+---

--- a/content/en/docs/reference/kubernetes-api/common-definitions/delete-options.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/delete-options.md
@@ -1,0 +1,63 @@
+---
+api_metadata:
+  apiVersion: ""
+  import: "k8s.io/apimachinery/pkg/apis/meta/v1"
+  kind: "DeleteOptions"
+content_type: "api_reference"
+description: "DeleteOptions may be provided when deleting an API object."
+title: "DeleteOptions"
+weight: 1
+---
+
+
+
+`import "k8s.io/apimachinery/pkg/apis/meta/v1"`
+
+
+DeleteOptions may be provided when deleting an API object.
+
+<hr>
+
+- **apiVersion** (string)
+
+  APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+- **dryRun** ([]string)
+
+  When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed
+
+- **gracePeriodSeconds** (int64)
+
+  The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.
+
+- **kind** (string)
+
+  Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+- **orphanDependents** (boolean)
+
+  Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the "orphan" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.
+
+- **preconditions** (Preconditions)
+
+  Must be fulfilled before a deletion is carried out. If not possible, a 409 Conflict status will be returned.
+
+  <a name="Preconditions"></a>
+  *Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.*
+
+  - **preconditions.resourceVersion** (string)
+
+    Specifies the target ResourceVersion
+
+  - **preconditions.uid** (string)
+
+    Specifies the target UID.
+
+- **propagationPolicy** (string)
+
+  Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.
+
+
+
+
+

--- a/content/en/docs/reference/kubernetes-api/common-definitions/downward-api-volume-file.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/downward-api-volume-file.md
@@ -1,0 +1,40 @@
+---
+api_metadata:
+  apiVersion: ""
+  import: "k8s.io/api/core/v1"
+  kind: "DownwardAPIVolumeFile"
+content_type: "api_reference"
+description: "DownwardAPIVolumeFile represents information to create the file containing the pod field."
+title: "DownwardAPIVolumeFile"
+weight: 2
+---
+
+
+
+`import "k8s.io/api/core/v1"`
+
+
+DownwardAPIVolumeFile represents information to create the file containing the pod field
+
+<hr>
+
+- **path** (string), required
+
+  Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'
+
+- **fieldRef** (<a href="{{< ref "../common-definitions/object-field-selector#ObjectFieldSelector" >}}">ObjectFieldSelector</a>)
+
+  Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.
+
+- **mode** (int32)
+
+  Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+
+- **resourceFieldRef** (<a href="{{< ref "../common-definitions/resource-field-selector#ResourceFieldSelector" >}}">ResourceFieldSelector</a>)
+
+  Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+
+
+
+
+

--- a/content/en/docs/reference/kubernetes-api/common-definitions/exec-action.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/exec-action.md
@@ -1,0 +1,28 @@
+---
+api_metadata:
+  apiVersion: ""
+  import: "k8s.io/api/core/v1"
+  kind: "ExecAction"
+content_type: "api_reference"
+description: "ExecAction describes a \"run in container\" action."
+title: "ExecAction"
+weight: 3
+---
+
+
+
+`import "k8s.io/api/core/v1"`
+
+
+ExecAction describes a "run in container" action.
+
+<hr>
+
+- **command** ([]string)
+
+  Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+
+
+
+
+

--- a/content/en/docs/reference/kubernetes-api/common-definitions/http-get-action.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/http-get-action.md
@@ -1,0 +1,58 @@
+---
+api_metadata:
+  apiVersion: ""
+  import: "k8s.io/api/core/v1"
+  kind: "HTTPGetAction"
+content_type: "api_reference"
+description: "HTTPGetAction describes an action based on HTTP Get requests."
+title: "HTTPGetAction"
+weight: 4
+---
+
+
+
+`import "k8s.io/api/core/v1"`
+
+
+HTTPGetAction describes an action based on HTTP Get requests.
+
+<hr>
+
+- **port** (IntOrString), required
+
+  Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+
+  <a name="IntOrString"></a>
+  *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
+
+- **host** (string)
+
+  Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+
+- **httpHeaders** ([]HTTPHeader)
+
+  Custom headers to set in the request. HTTP allows repeated headers.
+
+  <a name="HTTPHeader"></a>
+  *HTTPHeader describes a custom header to be used in HTTP probes*
+
+  - **httpHeaders.name** (string), required
+
+    The header field name
+
+  - **httpHeaders.value** (string), required
+
+    The header field value
+
+- **path** (string)
+
+  Path to access on the HTTP server.
+
+- **scheme** (string)
+
+  Scheme to use for connecting to the host. Defaults to HTTP.
+
+
+
+
+

--- a/content/en/docs/reference/kubernetes-api/common-definitions/json-schema-props.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/json-schema-props.md
@@ -1,0 +1,226 @@
+---
+api_metadata:
+  apiVersion: ""
+  import: "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+  kind: "JSONSchemaProps"
+content_type: "api_reference"
+description: "JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-schema."
+title: "JSONSchemaProps"
+weight: 5
+---
+
+
+
+`import "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"`
+
+
+JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-schema.org/).
+
+<hr>
+
+- **$ref** (string)
+
+
+- **$schema** (string)
+
+
+- **additionalItems** (JSONSchemaPropsOrBool)
+
+
+  <a name="JSONSchemaPropsOrBool"></a>
+  *JSONSchemaPropsOrBool represents JSONSchemaProps or a boolean value. Defaults to true for the boolean property.*
+
+- **additionalProperties** (JSONSchemaPropsOrBool)
+
+
+  <a name="JSONSchemaPropsOrBool"></a>
+  *JSONSchemaPropsOrBool represents JSONSchemaProps or a boolean value. Defaults to true for the boolean property.*
+
+- **allOf** ([]<a href="{{< ref "../common-definitions/json-schema-props#JSONSchemaProps" >}}">JSONSchemaProps</a>)
+
+
+- **anyOf** ([]<a href="{{< ref "../common-definitions/json-schema-props#JSONSchemaProps" >}}">JSONSchemaProps</a>)
+
+
+- **default** (JSON)
+
+  default is a default value for undefined object fields. Defaulting is a beta feature under the CustomResourceDefaulting feature gate. Defaulting requires spec.preserveUnknownFields to be false.
+
+  <a name="JSON"></a>
+  *JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.*
+
+- **definitions** (map[string]<a href="{{< ref "../common-definitions/json-schema-props#JSONSchemaProps" >}}">JSONSchemaProps</a>)
+
+
+- **dependencies** (map[string]JSONSchemaPropsOrStringArray)
+
+
+  <a name="JSONSchemaPropsOrStringArray"></a>
+  *JSONSchemaPropsOrStringArray represents a JSONSchemaProps or a string array.*
+
+- **description** (string)
+
+
+- **enum** ([]JSON)
+
+
+  <a name="JSON"></a>
+  *JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.*
+
+- **example** (JSON)
+
+
+  <a name="JSON"></a>
+  *JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.*
+
+- **exclusiveMaximum** (boolean)
+
+
+- **exclusiveMinimum** (boolean)
+
+
+- **externalDocs** (ExternalDocumentation)
+
+
+  <a name="ExternalDocumentation"></a>
+  *ExternalDocumentation allows referencing an external resource for extended documentation.*
+
+  - **externalDocs.description** (string)
+
+
+  - **externalDocs.url** (string)
+
+
+- **format** (string)
+
+  format is an OpenAPI v3 format string. Unknown formats are ignored. The following formats are validated:
+  
+  - bsonobjectid: a bson object ID, i.e. a 24 characters hex string - uri: an URI as parsed by Golang net/url.ParseRequestURI - email: an email address as parsed by Golang net/mail.ParseAddress - hostname: a valid representation for an Internet host name, as defined by RFC 1034, section 3.1 [RFC1034]. - ipv4: an IPv4 IP as parsed by Golang net.ParseIP - ipv6: an IPv6 IP as parsed by Golang net.ParseIP - cidr: a CIDR as parsed by Golang net.ParseCIDR - mac: a MAC address as parsed by Golang net.ParseMAC - uuid: an UUID that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid3: an UUID3 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid4: an UUID4 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - uuid5: an UUID5 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - isbn: an ISBN10 or ISBN13 number string like "0321751043" or "978-0321751041" - isbn10: an ISBN10 number string like "0321751043" - isbn13: an ISBN13 number string like "978-0321751041" - creditcard: a credit card number defined by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\d{3})\d{11})$ with any non digit characters mixed in - ssn: a U.S. social security number following the regex ^\d{3}[- ]?\d{2}[- ]?\d{4}$ - hexcolor: an hexadecimal color code like "#FFFFFF: following the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$ - rgbcolor: an RGB color code like rgb like "rgb(255,255,2559" - byte: base64 encoded binary data - password: any kind of string - date: a date string like "2006-01-02" as defined by full-date in RFC3339 - duration: a duration string like "22 ns" as parsed by Golang time.ParseDuration or compatible with Scala duration format - datetime: a date time string like "2014-12-15T19:30:20.000Z" as defined by date-time in RFC3339.
+
+- **id** (string)
+
+
+- **items** (JSONSchemaPropsOrArray)
+
+
+  <a name="JSONSchemaPropsOrArray"></a>
+  *JSONSchemaPropsOrArray represents a value that can either be a JSONSchemaProps or an array of JSONSchemaProps. Mainly here for serialization purposes.*
+
+- **maxItems** (int64)
+
+
+- **maxLength** (int64)
+
+
+- **maxProperties** (int64)
+
+
+- **maximum** (double)
+
+
+- **minItems** (int64)
+
+
+- **minLength** (int64)
+
+
+- **minProperties** (int64)
+
+
+- **minimum** (double)
+
+
+- **multipleOf** (double)
+
+
+- **not** (<a href="{{< ref "../common-definitions/json-schema-props#JSONSchemaProps" >}}">JSONSchemaProps</a>)
+
+
+- **nullable** (boolean)
+
+
+- **oneOf** ([]<a href="{{< ref "../common-definitions/json-schema-props#JSONSchemaProps" >}}">JSONSchemaProps</a>)
+
+
+- **pattern** (string)
+
+
+- **patternProperties** (map[string]<a href="{{< ref "../common-definitions/json-schema-props#JSONSchemaProps" >}}">JSONSchemaProps</a>)
+
+
+- **properties** (map[string]<a href="{{< ref "../common-definitions/json-schema-props#JSONSchemaProps" >}}">JSONSchemaProps</a>)
+
+
+- **required** ([]string)
+
+
+- **title** (string)
+
+
+- **type** (string)
+
+
+- **uniqueItems** (boolean)
+
+
+- **x-kubernetes-embedded-resource** (boolean)
+
+  x-kubernetes-embedded-resource defines that the value is an embedded Kubernetes runtime.Object, with TypeMeta and ObjectMeta. The type must be object. It is allowed to further restrict the embedded object. kind, apiVersion and metadata are validated automatically. x-kubernetes-preserve-unknown-fields is allowed to be true, but does not have to be if the object is fully specified (up to kind, apiVersion, metadata).
+
+- **x-kubernetes-int-or-string** (boolean)
+
+  x-kubernetes-int-or-string specifies that this value is either an integer or a string. If this is true, an empty type is allowed and type as child of anyOf is permitted if following one of the following patterns:
+  
+  1) anyOf:
+     - type: integer
+     - type: string
+  2) allOf:
+     - anyOf:
+       - type: integer
+       - type: string
+     - ... zero or more
+
+- **x-kubernetes-list-map-keys** ([]string)
+
+  x-kubernetes-list-map-keys annotates an array with the x-kubernetes-list-type `map` by specifying the keys used as the index of the map.
+  
+  This tag MUST only be used on lists that have the "x-kubernetes-list-type" extension set to "map". Also, the values specified for this attribute must be a scalar typed field of the child structure (no nesting is supported).
+  
+  The properties specified must either be required or have a default value, to ensure those properties are present for all list items.
+
+- **x-kubernetes-list-type** (string)
+
+  x-kubernetes-list-type annotates an array to further describe its topology. This extension must only be used on lists and may have 3 possible values:
+  
+  1) `atomic`: the list is treated as a single entity, like a scalar.
+       Atomic lists will be entirely replaced when updated. This extension
+       may be used on any type of list (struct, scalar, ...).
+  2) `set`:
+       Sets are lists that must not have multiple items with the same value. Each
+       value must be a scalar, an object with x-kubernetes-map-type `atomic` or an
+       array with x-kubernetes-list-type `atomic`.
+  3) `map`:
+       These lists are like maps in that their elements have a non-index key
+       used to identify them. Order is preserved upon merge. The map tag
+       must only be used on a list with elements of type object.
+  Defaults to atomic for arrays.
+
+- **x-kubernetes-map-type** (string)
+
+  x-kubernetes-map-type annotates an object to further describe its topology. This extension must only be used when type is object and may have 2 possible values:
+  
+  1) `granular`:
+       These maps are actual maps (key-value pairs) and each fields are independent
+       from each other (they can each be manipulated by separate actors). This is
+       the default behaviour for all maps.
+  2) `atomic`: the list is treated as a single entity, like a scalar.
+       Atomic maps will be entirely replaced when updated.
+
+- **x-kubernetes-preserve-unknown-fields** (boolean)
+
+  x-kubernetes-preserve-unknown-fields stops the API server decoding step from pruning fields which are not specified in the validation schema. This affects fields recursively, but switches back to normal pruning behaviour if nested properties or additionalProperties are specified in the schema. This can either be true or undefined. False is forbidden.
+
+
+
+
+

--- a/content/en/docs/reference/kubernetes-api/common-definitions/key-to-path.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/key-to-path.md
@@ -1,0 +1,36 @@
+---
+api_metadata:
+  apiVersion: ""
+  import: "k8s.io/api/core/v1"
+  kind: "KeyToPath"
+content_type: "api_reference"
+description: "Maps a string key to a path within a volume."
+title: "KeyToPath"
+weight: 6
+---
+
+
+
+`import "k8s.io/api/core/v1"`
+
+
+Maps a string key to a path within a volume.
+
+<hr>
+
+- **key** (string), required
+
+  The key to project.
+
+- **path** (string), required
+
+  The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+
+- **mode** (int32)
+
+  Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+
+
+
+
+

--- a/content/en/docs/reference/kubernetes-api/common-definitions/label-selector.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/label-selector.md
@@ -1,0 +1,49 @@
+---
+api_metadata:
+  apiVersion: ""
+  import: "k8s.io/apimachinery/pkg/apis/meta/v1"
+  kind: "LabelSelector"
+content_type: "api_reference"
+description: "A label selector is a label query over a set of resources."
+title: "LabelSelector"
+weight: 7
+---
+
+
+
+`import "k8s.io/apimachinery/pkg/apis/meta/v1"`
+
+
+A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+
+<hr>
+
+- **matchExpressions** ([]LabelSelectorRequirement)
+
+  matchExpressions is a list of label selector requirements. The requirements are ANDed.
+
+  <a name="LabelSelectorRequirement"></a>
+  *A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.*
+
+  - **matchExpressions.key** (string), required
+
+    *Patch strategy: merge on key `key`*
+    
+    key is the label key that the selector applies to.
+
+  - **matchExpressions.operator** (string), required
+
+    operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+
+  - **matchExpressions.values** ([]string)
+
+    values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+
+- **matchLabels** (map[string]string)
+
+  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+
+
+
+
+

--- a/content/en/docs/reference/kubernetes-api/common-definitions/list-meta.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/list-meta.md
@@ -1,0 +1,42 @@
+---
+api_metadata:
+  apiVersion: ""
+  import: "k8s.io/apimachinery/pkg/apis/meta/v1"
+  kind: "ListMeta"
+content_type: "api_reference"
+description: "ListMeta describes metadata that synthetic resources must have, including lists and various status objects."
+title: "ListMeta"
+weight: 8
+---
+
+
+
+`import "k8s.io/apimachinery/pkg/apis/meta/v1"`
+
+
+ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.
+
+<hr>
+
+- **continue** (string)
+
+  continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a consistent list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response, unless you have received this token from an error message.
+
+- **remainingItemCount** (int64)
+
+  remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.
+
+- **resourceVersion** (string)
+
+  String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+
+- **selfLink** (string)
+
+  selfLink is a URL representing this object. Populated by the system. Read-only.
+  
+  DEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.
+
+
+
+
+

--- a/content/en/docs/reference/kubernetes-api/common-definitions/local-object-reference.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/local-object-reference.md
@@ -1,0 +1,28 @@
+---
+api_metadata:
+  apiVersion: ""
+  import: "k8s.io/api/core/v1"
+  kind: "LocalObjectReference"
+content_type: "api_reference"
+description: "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace."
+title: "LocalObjectReference"
+weight: 9
+---
+
+
+
+`import "k8s.io/api/core/v1"`
+
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+<hr>
+
+- **name** (string)
+
+  Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+
+
+
+

--- a/content/en/docs/reference/kubernetes-api/common-definitions/node-affinity.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/node-affinity.md
@@ -1,0 +1,72 @@
+---
+api_metadata:
+  apiVersion: ""
+  import: "k8s.io/api/core/v1"
+  kind: "NodeAffinity"
+content_type: "api_reference"
+description: "Node affinity is a group of node affinity scheduling rules."
+title: "NodeAffinity"
+weight: 10
+---
+
+
+
+`import "k8s.io/api/core/v1"`
+
+
+Node affinity is a group of node affinity scheduling rules.
+
+<hr>
+
+- **preferredDuringSchedulingIgnoredDuringExecution** ([]PreferredSchedulingTerm)
+
+  The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+
+  <a name="PreferredSchedulingTerm"></a>
+  *An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).*
+
+  - **preferredDuringSchedulingIgnoredDuringExecution.preference** (NodeSelectorTerm), required
+
+    A node selector term, associated with the corresponding weight.
+
+    <a name="NodeSelectorTerm"></a>
+    *A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.*
+
+  - **preferredDuringSchedulingIgnoredDuringExecution.preference.matchExpressions** ([]<a href="{{< ref "../common-definitions/node-selector-requirement#NodeSelectorRequirement" >}}">NodeSelectorRequirement</a>)
+
+    A list of node selector requirements by node's labels.
+
+  - **preferredDuringSchedulingIgnoredDuringExecution.preference.matchFields** ([]<a href="{{< ref "../common-definitions/node-selector-requirement#NodeSelectorRequirement" >}}">NodeSelectorRequirement</a>)
+
+    A list of node selector requirements by node's fields.
+
+  - **preferredDuringSchedulingIgnoredDuringExecution.weight** (int32), required
+
+    Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+
+- **requiredDuringSchedulingIgnoredDuringExecution** (NodeSelector)
+
+  If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+
+  <a name="NodeSelector"></a>
+  *A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.*
+
+  - **requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms** ([]NodeSelectorTerm), required
+
+    Required. A list of node selector terms. The terms are ORed.
+
+    <a name="NodeSelectorTerm"></a>
+    *A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.*
+
+  - **requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms.matchExpressions** ([]<a href="{{< ref "../common-definitions/node-selector-requirement#NodeSelectorRequirement" >}}">NodeSelectorRequirement</a>)
+
+    A list of node selector requirements by node's labels.
+
+  - **requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms.matchFields** ([]<a href="{{< ref "../common-definitions/node-selector-requirement#NodeSelectorRequirement" >}}">NodeSelectorRequirement</a>)
+
+    A list of node selector requirements by node's fields.
+
+
+
+
+

--- a/content/en/docs/reference/kubernetes-api/common-definitions/node-selector-requirement.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/node-selector-requirement.md
@@ -1,0 +1,36 @@
+---
+api_metadata:
+  apiVersion: ""
+  import: "k8s.io/api/core/v1"
+  kind: "NodeSelectorRequirement"
+content_type: "api_reference"
+description: "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values."
+title: "NodeSelectorRequirement"
+weight: 11
+---
+
+
+
+`import "k8s.io/api/core/v1"`
+
+
+A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+
+<hr>
+
+- **key** (string), required
+
+  The label key that the selector applies to.
+
+- **operator** (string), required
+
+  Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+- **values** ([]string)
+
+  An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+
+
+
+
+

--- a/content/en/docs/reference/kubernetes-api/common-definitions/object-field-selector.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/object-field-selector.md
@@ -1,0 +1,32 @@
+---
+api_metadata:
+  apiVersion: ""
+  import: "k8s.io/api/core/v1"
+  kind: "ObjectFieldSelector"
+content_type: "api_reference"
+description: "ObjectFieldSelector selects an APIVersioned field of an object."
+title: "ObjectFieldSelector"
+weight: 12
+---
+
+
+
+`import "k8s.io/api/core/v1"`
+
+
+ObjectFieldSelector selects an APIVersioned field of an object.
+
+<hr>
+
+- **fieldPath** (string), required
+
+  Path of the field to select in the specified API version.
+
+- **apiVersion** (string)
+
+  Version of the schema the FieldPath is written in terms of, defaults to "v1".
+
+
+
+
+

--- a/content/en/docs/reference/kubernetes-api/common-definitions/object-meta.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/object-meta.md
@@ -1,0 +1,185 @@
+---
+api_metadata:
+  apiVersion: ""
+  import: "k8s.io/apimachinery/pkg/apis/meta/v1"
+  kind: "ObjectMeta"
+content_type: "api_reference"
+description: "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create."
+title: "ObjectMeta"
+weight: 13
+---
+
+
+
+`import "k8s.io/apimachinery/pkg/apis/meta/v1"`
+
+
+ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.
+
+<hr>
+
+- **name** (string)
+
+  Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names
+
+- **generateName** (string)
+
+  GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+  
+  If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+  
+  Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+
+- **namespace** (string)
+
+  Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+  
+  Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+
+- **labels** (map[string]string)
+
+  Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels
+
+- **annotations** (map[string]string)
+
+  Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations
+
+
+
+### System {#System}
+
+
+- **finalizers** ([]string)
+
+  Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.
+
+- **managedFields** ([]ManagedFieldsEntry)
+
+  ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
+
+  <a name="ManagedFieldsEntry"></a>
+  *ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.*
+
+  - **managedFields.apiVersion** (string)
+
+    APIVersion defines the version of this resource that this field set applies to. The format is "group/version" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.
+
+  - **managedFields.fieldsType** (string)
+
+    FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: "FieldsV1"
+
+  - **managedFields.fieldsV1** (FieldsV1)
+
+    FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
+
+    <a name="FieldsV1"></a>
+    *FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.
+    
+    Each key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.
+    
+    The exact format is defined in sigs.k8s.io/structured-merge-diff*
+
+  - **managedFields.manager** (string)
+
+    Manager is an identifier of the workflow managing these fields.
+
+  - **managedFields.operation** (string)
+
+    Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.
+
+  - **managedFields.time** (Time)
+
+    Time is timestamp of when these fields were set. It should always be empty if Operation is 'Apply'
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+- **ownerReferences** ([]OwnerReference)
+
+  *Patch strategy: merge on key `uid`*
+  
+  List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.
+
+  <a name="OwnerReference"></a>
+  *OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.*
+
+  - **ownerReferences.apiVersion** (string), required
+
+    API version of the referent.
+
+  - **ownerReferences.kind** (string), required
+
+    Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+  - **ownerReferences.name** (string), required
+
+    Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names
+
+  - **ownerReferences.uid** (string), required
+
+    UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+
+  - **ownerReferences.blockOwnerDeletion** (boolean)
+
+    If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
+
+  - **ownerReferences.controller** (boolean)
+
+    If true, this reference points to the managing controller.
+
+### Read-only {#Read-only}
+
+
+- **creationTimestamp** (Time)
+
+  CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+  
+  Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+  <a name="Time"></a>
+  *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+- **deletionGracePeriodSeconds** (int64)
+
+  Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.
+
+- **deletionTimestamp** (Time)
+
+  DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.
+  
+  Populated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+  <a name="Time"></a>
+  *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+- **generation** (int64)
+
+  A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.
+
+- **resourceVersion** (string)
+
+  An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+  
+  Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+
+- **selfLink** (string)
+
+  SelfLink is a URL representing this object. Populated by the system. Read-only.
+  
+  DEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.
+
+- **uid** (string)
+
+  UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+  
+  Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+
+### Ignored {#Ignored}
+
+
+- **clusterName** (string)
+
+  The name of the cluster which the object belongs to. This is used to distinguish resources with same name and namespace in different clusters. This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.
+
+
+

--- a/content/en/docs/reference/kubernetes-api/common-definitions/object-reference.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/object-reference.md
@@ -1,0 +1,52 @@
+---
+api_metadata:
+  apiVersion: ""
+  import: "k8s.io/api/core/v1"
+  kind: "ObjectReference"
+content_type: "api_reference"
+description: "ObjectReference contains enough information to let you inspect or modify the referred object."
+title: "ObjectReference"
+weight: 14
+---
+
+
+
+`import "k8s.io/api/core/v1"`
+
+
+ObjectReference contains enough information to let you inspect or modify the referred object.
+
+<hr>
+
+- **apiVersion** (string)
+
+  API version of the referent.
+
+- **fieldPath** (string)
+
+  If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object.
+
+- **kind** (string)
+
+  Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+- **name** (string)
+
+  Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+- **namespace** (string)
+
+  Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+
+- **resourceVersion** (string)
+
+  Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+
+- **uid** (string)
+
+  UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+
+
+
+
+

--- a/content/en/docs/reference/kubernetes-api/common-definitions/patch.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/patch.md
@@ -1,0 +1,24 @@
+---
+api_metadata:
+  apiVersion: ""
+  import: "k8s.io/apimachinery/pkg/apis/meta/v1"
+  kind: "Patch"
+content_type: "api_reference"
+description: "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body."
+title: "Patch"
+weight: 15
+---
+
+
+
+`import "k8s.io/apimachinery/pkg/apis/meta/v1"`
+
+
+Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.
+
+<hr>
+
+
+
+
+

--- a/content/en/docs/reference/kubernetes-api/common-definitions/pod-affinity.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/pod-affinity.md
@@ -1,0 +1,73 @@
+---
+api_metadata:
+  apiVersion: ""
+  import: "k8s.io/api/core/v1"
+  kind: "PodAffinity"
+content_type: "api_reference"
+description: "Pod affinity is a group of inter pod affinity scheduling rules."
+title: "PodAffinity"
+weight: 16
+---
+
+
+
+`import "k8s.io/api/core/v1"`
+
+
+Pod affinity is a group of inter pod affinity scheduling rules.
+
+<hr>
+
+- **preferredDuringSchedulingIgnoredDuringExecution** ([]WeightedPodAffinityTerm)
+
+  The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+
+  <a name="WeightedPodAffinityTerm"></a>
+  *The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)*
+
+  - **preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm** (PodAffinityTerm), required
+
+    Required. A pod affinity term, associated with the corresponding weight.
+
+    <a name="PodAffinityTerm"></a>
+    *Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running*
+
+  - **preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm.topologyKey** (string), required
+
+    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+
+  - **preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm.labelSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
+
+    A label query over a set of resources, in this case pods.
+
+  - **preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm.namespaces** ([]string)
+
+    namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+
+  - **preferredDuringSchedulingIgnoredDuringExecution.weight** (int32), required
+
+    weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+
+- **requiredDuringSchedulingIgnoredDuringExecution** ([]PodAffinityTerm)
+
+  If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+
+  <a name="PodAffinityTerm"></a>
+  *Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running*
+
+  - **requiredDuringSchedulingIgnoredDuringExecution.topologyKey** (string), required
+
+    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+
+  - **requiredDuringSchedulingIgnoredDuringExecution.labelSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
+
+    A label query over a set of resources, in this case pods.
+
+  - **requiredDuringSchedulingIgnoredDuringExecution.namespaces** ([]string)
+
+    namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+
+
+
+
+

--- a/content/en/docs/reference/kubernetes-api/common-definitions/pod-anti-affinity.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/pod-anti-affinity.md
@@ -1,0 +1,73 @@
+---
+api_metadata:
+  apiVersion: ""
+  import: "k8s.io/api/core/v1"
+  kind: "PodAntiAffinity"
+content_type: "api_reference"
+description: "Pod anti affinity is a group of inter pod anti affinity scheduling rules."
+title: "PodAntiAffinity"
+weight: 17
+---
+
+
+
+`import "k8s.io/api/core/v1"`
+
+
+Pod anti affinity is a group of inter pod anti affinity scheduling rules.
+
+<hr>
+
+- **preferredDuringSchedulingIgnoredDuringExecution** ([]WeightedPodAffinityTerm)
+
+  The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+
+  <a name="WeightedPodAffinityTerm"></a>
+  *The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)*
+
+  - **preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm** (PodAffinityTerm), required
+
+    Required. A pod affinity term, associated with the corresponding weight.
+
+    <a name="PodAffinityTerm"></a>
+    *Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running*
+
+  - **preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm.topologyKey** (string), required
+
+    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+
+  - **preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm.labelSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
+
+    A label query over a set of resources, in this case pods.
+
+  - **preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm.namespaces** ([]string)
+
+    namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+
+  - **preferredDuringSchedulingIgnoredDuringExecution.weight** (int32), required
+
+    weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+
+- **requiredDuringSchedulingIgnoredDuringExecution** ([]PodAffinityTerm)
+
+  If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+
+  <a name="PodAffinityTerm"></a>
+  *Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running*
+
+  - **requiredDuringSchedulingIgnoredDuringExecution.topologyKey** (string), required
+
+    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+
+  - **requiredDuringSchedulingIgnoredDuringExecution.labelSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
+
+    A label query over a set of resources, in this case pods.
+
+  - **requiredDuringSchedulingIgnoredDuringExecution.namespaces** ([]string)
+
+    namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+
+
+
+
+

--- a/content/en/docs/reference/kubernetes-api/common-definitions/quantity.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/quantity.md
@@ -1,0 +1,54 @@
+---
+api_metadata:
+  apiVersion: ""
+  import: "k8s.io/apimachinery/pkg/api/resource"
+  kind: "Quantity"
+content_type: "api_reference"
+description: "Quantity is a fixed-point representation of a number."
+title: "Quantity"
+weight: 18
+---
+
+
+
+`import "k8s.io/apimachinery/pkg/api/resource"`
+
+
+Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+The serialization format is:
+
+\<quantity>        ::= \<signedNumber>\<suffix>
+  (Note that \<suffix> may be empty, from the "" case in \<decimalSI>.)
+\<digit>           ::= 0 | 1 | ... | 9 \<digits>          ::= \<digit> | \<digit>\<digits> \<number>          ::= \<digits> | \<digits>.\<digits> | \<digits>. | .\<digits> \<sign>            ::= "+" | "-" \<signedNumber>    ::= \<number> | \<sign>\<number> \<suffix>          ::= \<binarySI> | \<decimalExponent> | \<decimalSI> \<binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+\<decimalSI>       ::= m | "" | k | M | G | T | P | E
+  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+\<decimalExponent> ::= "e" \<signedNumber> | "E" \<signedNumber>
+
+No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+  a. No precision is lost
+  b. No fractional digits will be emitted
+  c. The exponent (or suffix) is as large as possible.
+The sign will be omitted unless the number is negative.
+
+Examples:
+  1.5 will be serialized as "1500m"
+  1.5Gi will be serialized as "1536Mi"
+
+Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+
+<hr>
+
+
+
+
+

--- a/content/en/docs/reference/kubernetes-api/common-definitions/resource-field-selector.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/resource-field-selector.md
@@ -1,0 +1,36 @@
+---
+api_metadata:
+  apiVersion: ""
+  import: "k8s.io/api/core/v1"
+  kind: "ResourceFieldSelector"
+content_type: "api_reference"
+description: "ResourceFieldSelector represents container resources (cpu, memory) and their output format."
+title: "ResourceFieldSelector"
+weight: 19
+---
+
+
+
+`import "k8s.io/api/core/v1"`
+
+
+ResourceFieldSelector represents container resources (cpu, memory) and their output format
+
+<hr>
+
+- **resource** (string), required
+
+  Required: resource to select
+
+- **containerName** (string)
+
+  Container name: required for volumes, optional for env vars
+
+- **divisor** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+  Specifies the output format of the exposed resources, defaults to "1"
+
+
+
+
+

--- a/content/en/docs/reference/kubernetes-api/common-definitions/status.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/status.md
@@ -1,0 +1,102 @@
+---
+api_metadata:
+  apiVersion: ""
+  import: "k8s.io/apimachinery/pkg/apis/meta/v1"
+  kind: "Status"
+content_type: "api_reference"
+description: "Status is a return value for calls that don't return other objects."
+title: "Status"
+weight: 20
+---
+
+
+
+`import "k8s.io/apimachinery/pkg/apis/meta/v1"`
+
+
+Status is a return value for calls that don't return other objects.
+
+<hr>
+
+- **apiVersion** (string)
+
+  APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+- **code** (int32)
+
+  Suggested HTTP return code for this status, 0 if not set.
+
+- **details** (StatusDetails)
+
+  Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.
+
+  <a name="StatusDetails"></a>
+  *StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.*
+
+  - **details.causes** ([]StatusCause)
+
+    The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.
+
+    <a name="StatusCause"></a>
+    *StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.*
+
+  - **details.causes.field** (string)
+
+    The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+    
+    Examples:
+      "name" - the field "name" on the current resource
+      "items[0].name" - the field "name" on the first array entry in "items"
+
+  - **details.causes.message** (string)
+
+    A human-readable description of the cause of the error.  This field may be presented as-is to a reader.
+
+  - **details.causes.reason** (string)
+
+    A machine-readable description of the cause of the error. If this value is empty there is no information available.
+
+  - **details.group** (string)
+
+    The group attribute of the resource associated with the status StatusReason.
+
+  - **details.kind** (string)
+
+    The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+  - **details.name** (string)
+
+    The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).
+
+  - **details.retryAfterSeconds** (int32)
+
+    If specified, the time in seconds before the operation should be retried. Some errors may indicate the client must take an alternate action - for those errors this field may indicate how long to wait before taking the alternate action.
+
+  - **details.uid** (string)
+
+    UID of the resource. (when there is a single resource which can be described). More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+
+- **kind** (string)
+
+  Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+- **message** (string)
+
+  A human-readable description of the status of this operation.
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+- **reason** (string)
+
+  A machine-readable description of why this operation is in the "Failure" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.
+
+- **status** (string)
+
+  Status of the operation. One of: "Success" or "Failure". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+
+
+
+

--- a/content/en/docs/reference/kubernetes-api/common-definitions/tcp-socket-action.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/tcp-socket-action.md
@@ -1,0 +1,35 @@
+---
+api_metadata:
+  apiVersion: ""
+  import: "k8s.io/api/core/v1"
+  kind: "TCPSocketAction"
+content_type: "api_reference"
+description: "TCPSocketAction describes an action based on opening a socket."
+title: "TCPSocketAction"
+weight: 21
+---
+
+
+
+`import "k8s.io/api/core/v1"`
+
+
+TCPSocketAction describes an action based on opening a socket
+
+<hr>
+
+- **port** (IntOrString), required
+
+  Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+
+  <a name="IntOrString"></a>
+  *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
+
+- **host** (string)
+
+  Optional: Host name to connect to, defaults to the pod IP.
+
+
+
+
+

--- a/content/en/docs/reference/kubernetes-api/common-definitions/typed-local-object-reference.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/typed-local-object-reference.md
@@ -1,0 +1,36 @@
+---
+api_metadata:
+  apiVersion: ""
+  import: "k8s.io/api/core/v1"
+  kind: "TypedLocalObjectReference"
+content_type: "api_reference"
+description: "TypedLocalObjectReference contains enough information to let you locate the typed referenced object inside the same namespace."
+title: "TypedLocalObjectReference"
+weight: 22
+---
+
+
+
+`import "k8s.io/api/core/v1"`
+
+
+TypedLocalObjectReference contains enough information to let you locate the typed referenced object inside the same namespace.
+
+<hr>
+
+- **kind** (string), required
+
+  Kind is the type of resource being referenced
+
+- **name** (string), required
+
+  Name is the name of resource being referenced
+
+- **apiGroup** (string)
+
+  APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+
+
+
+
+

--- a/content/en/docs/reference/kubernetes-api/common-parameters/common-parameters.md
+++ b/content/en/docs/reference/kubernetes-api/common-parameters/common-parameters.md
@@ -1,0 +1,184 @@
+---
+api_metadata:
+  apiVersion: ""
+  import: ""
+  kind: "Common Parameters"
+content_type: "api_reference"
+description: ""
+title: "Common Parameters"
+weight: 10
+---
+
+
+
+
+
+
+## allowWatchBookmarks {#allowWatchBookmarks}
+
+allowWatchBookmarks requests watch events with type "BOOKMARK". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored. If the feature gate WatchBookmarks is not enabled in apiserver, this field is ignored.
+
+<hr>
+
+
+
+
+
+## continue {#continue}
+
+The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the "next key".
+
+This field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.
+
+<hr>
+
+
+
+
+
+## dryRun {#dryRun}
+
+When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed
+
+<hr>
+
+
+
+
+
+## fieldManager {#fieldManager}
+
+fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.
+
+<hr>
+
+
+
+
+
+## fieldSelector {#fieldSelector}
+
+A selector to restrict the list of returned objects by their fields. Defaults to everything.
+
+<hr>
+
+
+
+
+
+## force {#force}
+
+Force is going to "force" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.
+
+<hr>
+
+
+
+
+
+## gracePeriodSeconds {#gracePeriodSeconds}
+
+The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.
+
+<hr>
+
+
+
+
+
+## labelSelector {#labelSelector}
+
+A selector to restrict the list of returned objects by their labels. Defaults to everything.
+
+<hr>
+
+
+
+
+
+## limit {#limit}
+
+limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.
+
+The server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.
+
+<hr>
+
+
+
+
+
+## namespace {#namespace}
+
+object name and auth scope, such as for teams and projects
+
+<hr>
+
+
+
+
+
+## pretty {#pretty}
+
+If 'true', then the output is pretty printed.
+
+<hr>
+
+
+
+
+
+## propagationPolicy {#propagationPolicy}
+
+Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.
+
+<hr>
+
+
+
+
+
+## resourceVersion {#resourceVersion}
+
+resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.
+
+Defaults to unset
+
+<hr>
+
+
+
+
+
+## resourceVersionMatch {#resourceVersionMatch}
+
+resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.
+
+Defaults to unset
+
+<hr>
+
+
+
+
+
+## timeoutSeconds {#timeoutSeconds}
+
+Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.
+
+<hr>
+
+
+
+
+
+## watch {#watch}
+
+Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.
+
+<hr>
+
+
+
+
+

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/_index.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Config and Storage Resources"
+weight: 3
+---

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/config-map-v1.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/config-map-v1.md
@@ -1,0 +1,544 @@
+---
+api_metadata:
+  apiVersion: "v1"
+  import: "k8s.io/api/core/v1"
+  kind: "ConfigMap"
+content_type: "api_reference"
+description: "ConfigMap holds configuration data for pods to consume."
+title: "ConfigMap"
+weight: 1
+---
+
+`apiVersion: v1`
+
+`import "k8s.io/api/core/v1"`
+
+
+## ConfigMap {#ConfigMap}
+
+ConfigMap holds configuration data for pods to consume.
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: ConfigMap
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **binaryData** (map[string][]byte)
+
+  BinaryData contains the binary data. Each key must consist of alphanumeric characters, '-', '_' or '.'. BinaryData can contain byte sequences that are not in the UTF-8 range. The keys stored in BinaryData must not overlap with the ones in the Data field, this is enforced during validation process. Using this field will require 1.10+ apiserver and kubelet.
+
+- **data** (map[string]string)
+
+  Data contains the configuration data. Each key must consist of alphanumeric characters, '-', '_' or '.'. Values with non-UTF-8 byte sequences must use the BinaryData field. The keys stored in Data must not overlap with the keys in the BinaryData field, this is enforced during validation process.
+
+- **immutable** (boolean)
+
+  Immutable, if set to true, ensures that data stored in the ConfigMap cannot be updated (only object metadata can be modified). If not set to true, the field can be modified at any time. Defaulted to nil. This is a beta field enabled by ImmutableEphemeralVolumes feature gate.
+
+
+
+
+
+## ConfigMapList {#ConfigMapList}
+
+ConfigMapList is a resource containing a list of ConfigMap objects.
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: ConfigMapList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **items** ([]<a href="{{< ref "../config-and-storage-resources/config-map-v1#ConfigMap" >}}">ConfigMap</a>), required
+
+  Items is the list of ConfigMaps.
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified ConfigMap
+
+#### HTTP Request
+
+GET /api/v1/namespaces/{namespace}/configmaps/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ConfigMap
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/config-map-v1#ConfigMap" >}}">ConfigMap</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind ConfigMap
+
+#### HTTP Request
+
+GET /api/v1/namespaces/{namespace}/configmaps
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/config-map-v1#ConfigMapList" >}}">ConfigMapList</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind ConfigMap
+
+#### HTTP Request
+
+GET /api/v1/configmaps
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/config-map-v1#ConfigMapList" >}}">ConfigMapList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a ConfigMap
+
+#### HTTP Request
+
+POST /api/v1/namespaces/{namespace}/configmaps
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../config-and-storage-resources/config-map-v1#ConfigMap" >}}">ConfigMap</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/config-map-v1#ConfigMap" >}}">ConfigMap</a>): OK
+
+201 (<a href="{{< ref "../config-and-storage-resources/config-map-v1#ConfigMap" >}}">ConfigMap</a>): Created
+
+202 (<a href="{{< ref "../config-and-storage-resources/config-map-v1#ConfigMap" >}}">ConfigMap</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified ConfigMap
+
+#### HTTP Request
+
+PUT /api/v1/namespaces/{namespace}/configmaps/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ConfigMap
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../config-and-storage-resources/config-map-v1#ConfigMap" >}}">ConfigMap</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/config-map-v1#ConfigMap" >}}">ConfigMap</a>): OK
+
+201 (<a href="{{< ref "../config-and-storage-resources/config-map-v1#ConfigMap" >}}">ConfigMap</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified ConfigMap
+
+#### HTTP Request
+
+PATCH /api/v1/namespaces/{namespace}/configmaps/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ConfigMap
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/config-map-v1#ConfigMap" >}}">ConfigMap</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a ConfigMap
+
+#### HTTP Request
+
+DELETE /api/v1/namespaces/{namespace}/configmaps/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ConfigMap
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of ConfigMap
+
+#### HTTP Request
+
+DELETE /api/v1/namespaces/{namespace}/configmaps
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/csi-driver-v1.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/csi-driver-v1.md
@@ -1,0 +1,509 @@
+---
+api_metadata:
+  apiVersion: "storage.k8s.io/v1"
+  import: "k8s.io/api/storage/v1"
+  kind: "CSIDriver"
+content_type: "api_reference"
+description: "CSIDriver captures information about a Container Storage Interface (CSI) volume driver deployed on the cluster."
+title: "CSIDriver"
+weight: 8
+---
+
+`apiVersion: storage.k8s.io/v1`
+
+`import "k8s.io/api/storage/v1"`
+
+
+## CSIDriver {#CSIDriver}
+
+CSIDriver captures information about a Container Storage Interface (CSI) volume driver deployed on the cluster. Kubernetes attach detach controller uses this object to determine whether attach is required. Kubelet uses this object to determine whether pod information needs to be passed on mount. CSIDriver objects are non-namespaced.
+
+<hr>
+
+- **apiVersion**: storage.k8s.io/v1
+
+
+- **kind**: CSIDriver
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object metadata. metadata.Name indicates the name of the CSI driver that this object refers to; it MUST be the same name returned by the CSI GetPluginName() call for that driver. The driver name must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), dots (.), and alphanumerics between. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **spec** (<a href="{{< ref "../config-and-storage-resources/csi-driver-v1#CSIDriverSpec" >}}">CSIDriverSpec</a>), required
+
+  Specification of the CSI Driver.
+
+
+
+
+
+## CSIDriverSpec {#CSIDriverSpec}
+
+CSIDriverSpec is the specification of a CSIDriver.
+
+<hr>
+
+- **attachRequired** (boolean)
+
+  attachRequired indicates this CSI volume driver requires an attach operation (because it implements the CSI ControllerPublishVolume() method), and that the Kubernetes attach detach controller should call the attach volume interface which checks the volumeattachment status and waits until the volume is attached before proceeding to mounting. The CSI external-attacher coordinates with CSI volume driver and updates the volumeattachment status when the attach operation is complete. If the CSIDriverRegistry feature gate is enabled and the value is specified to false, the attach operation will be skipped. Otherwise the attach operation will be called.
+
+- **fsGroupPolicy** (string)
+
+  Defines if the underlying volume supports changing ownership and permission of the volume before being mounted. Refer to the specific FSGroupPolicy values for additional details. This field is alpha-level, and is only honored by servers that enable the CSIVolumeFSGroupPolicy feature gate.
+
+- **podInfoOnMount** (boolean)
+
+  If set to true, podInfoOnMount indicates this CSI volume driver requires additional pod information (like podName, podUID, etc.) during mount operations. If set to false, pod information will not be passed on mount. Default is false. The CSI driver specifies podInfoOnMount as part of driver deployment. If true, Kubelet will pass pod information as VolumeContext in the CSI NodePublishVolume() calls. The CSI driver is responsible for parsing and validating the information passed in as VolumeContext. The following VolumeConext will be passed if podInfoOnMount is set to true. This list might grow, but the prefix will be used. "csi.storage.k8s.io/pod.name": pod.Name "csi.storage.k8s.io/pod.namespace": pod.Namespace "csi.storage.k8s.io/pod.uid": string(pod.UID) "csi.storage.k8s.io/ephemeral": "true" iff the volume is an ephemeral inline volume
+                                  defined by a CSIVolumeSource, otherwise "false"
+  
+  "csi.storage.k8s.io/ephemeral" is a new feature in Kubernetes 1.16. It is only required for drivers which support both the "Persistent" and "Ephemeral" VolumeLifecycleMode. Other drivers can leave pod info disabled and/or ignore this field. As Kubernetes 1.15 doesn't support this field, drivers can only support one mode when deployed on such a cluster and the deployment determines which mode that is, for example via a command line parameter of the driver.
+
+- **requiresRepublish** (boolean)
+
+  RequiresRepublish indicates the CSI driver wants `NodePublishVolume` being periodically called to reflect any possible change in the mounted volume. This field defaults to false.
+  
+  Note: After a successful initial NodePublishVolume call, subsequent calls to NodePublishVolume should only update the contents of the volume. New mount points will not be seen by a running container.
+  
+  This is an alpha feature and only available when the CSIServiceAccountToken feature is enabled.
+
+- **storageCapacity** (boolean)
+
+  If set to true, storageCapacity indicates that the CSI volume driver wants pod scheduling to consider the storage capacity that the driver deployment will report by creating CSIStorageCapacity objects with capacity information.
+  
+  The check can be enabled immediately when deploying a driver. In that case, provisioning new volumes with late binding will pause until the driver deployment has published some suitable CSIStorageCapacity object.
+  
+  Alternatively, the driver can be deployed with the field unset or false and it can be flipped later when storage capacity information has been published.
+  
+  This is an alpha field and only available when the CSIStorageCapacity feature is enabled. The default is false.
+
+- **tokenRequests** ([]TokenRequest)
+
+  *Atomic: will be replaced during a merge*
+  
+  TokenRequests indicates the CSI driver needs pods' service account tokens it is mounting volume for to do necessary authentication. Kubelet will pass the tokens in VolumeContext in the CSI NodePublishVolume calls. The CSI driver should parse and validate the following VolumeContext: "csi.storage.k8s.io/serviceAccount.tokens": {
+    "\<audience>": {
+      "token": \<token>,
+      "expirationTimestamp": \<expiration timestamp in RFC3339>,
+    },
+    ...
+  }
+  
+  Note: Audience in each TokenRequest should be different and at most one token is empty string. To receive a new token after expiry, RequiresRepublish can be used to trigger NodePublishVolume periodically.
+  
+  This is an alpha feature and only available when the CSIServiceAccountToken feature is enabled.
+
+  <a name="TokenRequest"></a>
+  *TokenRequest contains parameters of a service account token.*
+
+  - **tokenRequests.audience** (string), required
+
+    Audience is the intended audience of the token in "TokenRequestSpec". It will default to the audiences of kube apiserver.
+
+  - **tokenRequests.expirationSeconds** (int64)
+
+    ExpirationSeconds is the duration of validity of the token in "TokenRequestSpec". It has the same default value of "ExpirationSeconds" in "TokenRequestSpec".
+
+- **volumeLifecycleModes** ([]string)
+
+  *Set: unique values will be kept during a merge*
+  
+  volumeLifecycleModes defines what kind of volumes this CSI volume driver supports. The default if the list is empty is "Persistent", which is the usage defined by the CSI specification and implemented in Kubernetes via the usual PV/PVC mechanism. The other mode is "Ephemeral". In this mode, volumes are defined inline inside the pod spec with CSIVolumeSource and their lifecycle is tied to the lifecycle of that pod. A driver has to be aware of this because it is only going to get a NodePublishVolume call for such a volume. For more information about implementing this mode, see https://kubernetes-csi.github.io/docs/ephemeral-local-volumes.html A driver can support one or more of these modes and more modes may be added in the future. This field is beta.
+
+
+
+
+
+## CSIDriverList {#CSIDriverList}
+
+CSIDriverList is a collection of CSIDriver objects.
+
+<hr>
+
+- **apiVersion**: storage.k8s.io/v1
+
+
+- **kind**: CSIDriverList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **items** ([]<a href="{{< ref "../config-and-storage-resources/csi-driver-v1#CSIDriver" >}}">CSIDriver</a>), required
+
+  items is the list of CSIDriver
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified CSIDriver
+
+#### HTTP Request
+
+GET /apis/storage.k8s.io/v1/csidrivers/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CSIDriver
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/csi-driver-v1#CSIDriver" >}}">CSIDriver</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind CSIDriver
+
+#### HTTP Request
+
+GET /apis/storage.k8s.io/v1/csidrivers
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/csi-driver-v1#CSIDriverList" >}}">CSIDriverList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a CSIDriver
+
+#### HTTP Request
+
+POST /apis/storage.k8s.io/v1/csidrivers
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../config-and-storage-resources/csi-driver-v1#CSIDriver" >}}">CSIDriver</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/csi-driver-v1#CSIDriver" >}}">CSIDriver</a>): OK
+
+201 (<a href="{{< ref "../config-and-storage-resources/csi-driver-v1#CSIDriver" >}}">CSIDriver</a>): Created
+
+202 (<a href="{{< ref "../config-and-storage-resources/csi-driver-v1#CSIDriver" >}}">CSIDriver</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified CSIDriver
+
+#### HTTP Request
+
+PUT /apis/storage.k8s.io/v1/csidrivers/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CSIDriver
+
+
+- **body**: <a href="{{< ref "../config-and-storage-resources/csi-driver-v1#CSIDriver" >}}">CSIDriver</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/csi-driver-v1#CSIDriver" >}}">CSIDriver</a>): OK
+
+201 (<a href="{{< ref "../config-and-storage-resources/csi-driver-v1#CSIDriver" >}}">CSIDriver</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified CSIDriver
+
+#### HTTP Request
+
+PATCH /apis/storage.k8s.io/v1/csidrivers/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CSIDriver
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/csi-driver-v1#CSIDriver" >}}">CSIDriver</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a CSIDriver
+
+#### HTTP Request
+
+DELETE /apis/storage.k8s.io/v1/csidrivers/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CSIDriver
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/csi-driver-v1#CSIDriver" >}}">CSIDriver</a>): OK
+
+202 (<a href="{{< ref "../config-and-storage-resources/csi-driver-v1#CSIDriver" >}}">CSIDriver</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of CSIDriver
+
+#### HTTP Request
+
+DELETE /apis/storage.k8s.io/v1/csidrivers
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/csi-node-v1.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/csi-node-v1.md
@@ -1,0 +1,475 @@
+---
+api_metadata:
+  apiVersion: "storage.k8s.io/v1"
+  import: "k8s.io/api/storage/v1"
+  kind: "CSINode"
+content_type: "api_reference"
+description: "CSINode holds information about all CSI drivers installed on a node."
+title: "CSINode"
+weight: 9
+---
+
+`apiVersion: storage.k8s.io/v1`
+
+`import "k8s.io/api/storage/v1"`
+
+
+## CSINode {#CSINode}
+
+CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need to create the CSINode object directly. As long as they use the node-driver-registrar sidecar container, the kubelet will automatically populate the CSINode object for the CSI driver as part of kubelet plugin registration. CSINode has the same name as a node. If the object is missing, it means either there are no CSI Drivers available on the node, or the Kubelet version is low enough that it doesn't create this object. CSINode has an OwnerReference that points to the corresponding node object.
+
+<hr>
+
+- **apiVersion**: storage.k8s.io/v1
+
+
+- **kind**: CSINode
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  metadata.name must be the Kubernetes node name.
+
+- **spec** (<a href="{{< ref "../config-and-storage-resources/csi-node-v1#CSINodeSpec" >}}">CSINodeSpec</a>), required
+
+  spec is the specification of CSINode
+
+
+
+
+
+## CSINodeSpec {#CSINodeSpec}
+
+CSINodeSpec holds information about the specification of all CSI drivers installed on a node
+
+<hr>
+
+- **drivers** ([]CSINodeDriver), required
+
+  *Patch strategy: merge on key `name`*
+  
+  drivers is a list of information of all CSI Drivers existing on a node. If all drivers in the list are uninstalled, this can become empty.
+
+  <a name="CSINodeDriver"></a>
+  *CSINodeDriver holds information about the specification of one CSI driver installed on a node*
+
+  - **drivers.name** (string), required
+
+    This is the name of the CSI driver that this object refers to. This MUST be the same name returned by the CSI GetPluginName() call for that driver.
+
+  - **drivers.nodeID** (string), required
+
+    nodeID of the node from the driver point of view. This field enables Kubernetes to communicate with storage systems that do not share the same nomenclature for nodes. For example, Kubernetes may refer to a given node as "node1", but the storage system may refer to the same node as "nodeA". When Kubernetes issues a command to the storage system to attach a volume to a specific node, it can use this field to refer to the node name using the ID that the storage system will understand, e.g. "nodeA" instead of "node1". This field is required.
+
+  - **drivers.allocatable** (VolumeNodeResources)
+
+    allocatable represents the volume resources of a node that are available for scheduling. This field is beta.
+
+    <a name="VolumeNodeResources"></a>
+    *VolumeNodeResources is a set of resource limits for scheduling of volumes.*
+
+  - **drivers.allocatable.count** (int32)
+
+    Maximum number of unique volumes managed by the CSI driver that can be used on a node. A volume that is both attached and mounted on a node is considered to be used once, not twice. The same rule applies for a unique volume that is shared among multiple pods on the same node. If this field is not specified, then the supported number of volumes on this node is unbounded.
+
+  - **drivers.topologyKeys** ([]string)
+
+    topologyKeys is the list of keys supported by the driver. When a driver is initialized on a cluster, it provides a set of topology keys that it understands (e.g. "company.com/zone", "company.com/region"). When a driver is initialized on a node, it provides the same topology keys along with values. Kubelet will expose these topology keys as labels on its own node object. When Kubernetes does topology aware provisioning, it can use this list to determine which labels it should retrieve from the node object and pass back to the driver. It is possible for different nodes to use different topology keys. This can be empty if driver does not support topology.
+
+
+
+
+
+## CSINodeList {#CSINodeList}
+
+CSINodeList is a collection of CSINode objects.
+
+<hr>
+
+- **apiVersion**: storage.k8s.io/v1
+
+
+- **kind**: CSINodeList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **items** ([]<a href="{{< ref "../config-and-storage-resources/csi-node-v1#CSINode" >}}">CSINode</a>), required
+
+  items is the list of CSINode
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified CSINode
+
+#### HTTP Request
+
+GET /apis/storage.k8s.io/v1/csinodes/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CSINode
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/csi-node-v1#CSINode" >}}">CSINode</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind CSINode
+
+#### HTTP Request
+
+GET /apis/storage.k8s.io/v1/csinodes
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/csi-node-v1#CSINodeList" >}}">CSINodeList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a CSINode
+
+#### HTTP Request
+
+POST /apis/storage.k8s.io/v1/csinodes
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../config-and-storage-resources/csi-node-v1#CSINode" >}}">CSINode</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/csi-node-v1#CSINode" >}}">CSINode</a>): OK
+
+201 (<a href="{{< ref "../config-and-storage-resources/csi-node-v1#CSINode" >}}">CSINode</a>): Created
+
+202 (<a href="{{< ref "../config-and-storage-resources/csi-node-v1#CSINode" >}}">CSINode</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified CSINode
+
+#### HTTP Request
+
+PUT /apis/storage.k8s.io/v1/csinodes/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CSINode
+
+
+- **body**: <a href="{{< ref "../config-and-storage-resources/csi-node-v1#CSINode" >}}">CSINode</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/csi-node-v1#CSINode" >}}">CSINode</a>): OK
+
+201 (<a href="{{< ref "../config-and-storage-resources/csi-node-v1#CSINode" >}}">CSINode</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified CSINode
+
+#### HTTP Request
+
+PATCH /apis/storage.k8s.io/v1/csinodes/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CSINode
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/csi-node-v1#CSINode" >}}">CSINode</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a CSINode
+
+#### HTTP Request
+
+DELETE /apis/storage.k8s.io/v1/csinodes/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CSINode
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/csi-node-v1#CSINode" >}}">CSINode</a>): OK
+
+202 (<a href="{{< ref "../config-and-storage-resources/csi-node-v1#CSINode" >}}">CSINode</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of CSINode
+
+#### HTTP Request
+
+DELETE /apis/storage.k8s.io/v1/csinodes
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1.md
@@ -1,0 +1,787 @@
+---
+api_metadata:
+  apiVersion: "v1"
+  import: "k8s.io/api/core/v1"
+  kind: "PersistentVolumeClaim"
+content_type: "api_reference"
+description: "PersistentVolumeClaim is a user's request for and claim to a persistent volume."
+title: "PersistentVolumeClaim"
+weight: 4
+---
+
+`apiVersion: v1`
+
+`import "k8s.io/api/core/v1"`
+
+
+## PersistentVolumeClaim {#PersistentVolumeClaim}
+
+PersistentVolumeClaim is a user's request for and claim to a persistent volume
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: PersistentVolumeClaim
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **spec** (<a href="{{< ref "../config-and-storage-resources/persistent-volume-claim-v1#PersistentVolumeClaimSpec" >}}">PersistentVolumeClaimSpec</a>)
+
+  Spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+
+- **status** (<a href="{{< ref "../config-and-storage-resources/persistent-volume-claim-v1#PersistentVolumeClaimStatus" >}}">PersistentVolumeClaimStatus</a>)
+
+  Status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+
+
+
+
+
+## PersistentVolumeClaimSpec {#PersistentVolumeClaimSpec}
+
+PersistentVolumeClaimSpec describes the common attributes of storage devices and allows a Source for provider-specific attributes
+
+<hr>
+
+- **accessModes** ([]string)
+
+  AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+
+- **selector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
+
+  A label query over volumes to consider for binding.
+
+- **resources** (ResourceRequirements)
+
+  Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+
+  <a name="ResourceRequirements"></a>
+  *ResourceRequirements describes the compute resource requirements.*
+
+  - **resources.limits** (map[string]<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+
+  - **resources.requests** (map[string]<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+
+- **volumeName** (string)
+
+  VolumeName is the binding reference to the PersistentVolume backing this claim.
+
+- **storageClassName** (string)
+
+  Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+
+- **volumeMode** (string)
+
+  volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+
+
+
+### Alpha level
+
+
+- **dataSource** (<a href="{{< ref "../common-definitions/typed-local-object-reference#TypedLocalObjectReference" >}}">TypedLocalObjectReference</a>)
+
+  This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) * An existing custom resource that implements data population (Alpha) In order to use custom resource types that implement data population, the AnyVolumeDataSource feature gate must be enabled. If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source.
+
+
+
+## PersistentVolumeClaimStatus {#PersistentVolumeClaimStatus}
+
+PersistentVolumeClaimStatus is the current status of a persistent volume claim.
+
+<hr>
+
+- **accessModes** ([]string)
+
+  AccessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+
+- **capacity** (map[string]<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+  Represents the actual resources of the underlying volume.
+
+- **conditions** ([]PersistentVolumeClaimCondition)
+
+  *Patch strategy: merge on key `type`*
+  
+  Current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.
+
+  <a name="PersistentVolumeClaimCondition"></a>
+  *PersistentVolumeClaimCondition contails details about state of pvc*
+
+  - **conditions.status** (string), required
+
+
+  - **conditions.type** (string), required
+
+
+  - **conditions.lastProbeTime** (Time)
+
+    Last time we probed the condition.
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **conditions.lastTransitionTime** (Time)
+
+    Last time the condition transitioned from one status to another.
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **conditions.message** (string)
+
+    Human-readable message indicating details about last transition.
+
+  - **conditions.reason** (string)
+
+    Unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
+
+- **phase** (string)
+
+  Phase represents the current phase of PersistentVolumeClaim.
+
+
+
+
+
+## PersistentVolumeClaimList {#PersistentVolumeClaimList}
+
+PersistentVolumeClaimList is a list of PersistentVolumeClaim items.
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: PersistentVolumeClaimList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+- **items** ([]<a href="{{< ref "../config-and-storage-resources/persistent-volume-claim-v1#PersistentVolumeClaim" >}}">PersistentVolumeClaim</a>), required
+
+  A list of persistent volume claims. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified PersistentVolumeClaim
+
+#### HTTP Request
+
+GET /api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PersistentVolumeClaim
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-claim-v1#PersistentVolumeClaim" >}}">PersistentVolumeClaim</a>): OK
+
+401: Unauthorized
+
+
+### `get` read status of the specified PersistentVolumeClaim
+
+#### HTTP Request
+
+GET /api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PersistentVolumeClaim
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-claim-v1#PersistentVolumeClaim" >}}">PersistentVolumeClaim</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind PersistentVolumeClaim
+
+#### HTTP Request
+
+GET /api/v1/namespaces/{namespace}/persistentvolumeclaims
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-claim-v1#PersistentVolumeClaimList" >}}">PersistentVolumeClaimList</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind PersistentVolumeClaim
+
+#### HTTP Request
+
+GET /api/v1/persistentvolumeclaims
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-claim-v1#PersistentVolumeClaimList" >}}">PersistentVolumeClaimList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a PersistentVolumeClaim
+
+#### HTTP Request
+
+POST /api/v1/namespaces/{namespace}/persistentvolumeclaims
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../config-and-storage-resources/persistent-volume-claim-v1#PersistentVolumeClaim" >}}">PersistentVolumeClaim</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-claim-v1#PersistentVolumeClaim" >}}">PersistentVolumeClaim</a>): OK
+
+201 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-claim-v1#PersistentVolumeClaim" >}}">PersistentVolumeClaim</a>): Created
+
+202 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-claim-v1#PersistentVolumeClaim" >}}">PersistentVolumeClaim</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified PersistentVolumeClaim
+
+#### HTTP Request
+
+PUT /api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PersistentVolumeClaim
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../config-and-storage-resources/persistent-volume-claim-v1#PersistentVolumeClaim" >}}">PersistentVolumeClaim</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-claim-v1#PersistentVolumeClaim" >}}">PersistentVolumeClaim</a>): OK
+
+201 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-claim-v1#PersistentVolumeClaim" >}}">PersistentVolumeClaim</a>): Created
+
+401: Unauthorized
+
+
+### `update` replace status of the specified PersistentVolumeClaim
+
+#### HTTP Request
+
+PUT /api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PersistentVolumeClaim
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../config-and-storage-resources/persistent-volume-claim-v1#PersistentVolumeClaim" >}}">PersistentVolumeClaim</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-claim-v1#PersistentVolumeClaim" >}}">PersistentVolumeClaim</a>): OK
+
+201 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-claim-v1#PersistentVolumeClaim" >}}">PersistentVolumeClaim</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified PersistentVolumeClaim
+
+#### HTTP Request
+
+PATCH /api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PersistentVolumeClaim
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-claim-v1#PersistentVolumeClaim" >}}">PersistentVolumeClaim</a>): OK
+
+401: Unauthorized
+
+
+### `patch` partially update status of the specified PersistentVolumeClaim
+
+#### HTTP Request
+
+PATCH /api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PersistentVolumeClaim
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-claim-v1#PersistentVolumeClaim" >}}">PersistentVolumeClaim</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a PersistentVolumeClaim
+
+#### HTTP Request
+
+DELETE /api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PersistentVolumeClaim
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-claim-v1#PersistentVolumeClaim" >}}">PersistentVolumeClaim</a>): OK
+
+202 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-claim-v1#PersistentVolumeClaim" >}}">PersistentVolumeClaim</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of PersistentVolumeClaim
+
+#### HTTP Request
+
+DELETE /api/v1/namespaces/{namespace}/persistentvolumeclaims
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1.md
@@ -1,0 +1,1360 @@
+---
+api_metadata:
+  apiVersion: "v1"
+  import: "k8s.io/api/core/v1"
+  kind: "PersistentVolume"
+content_type: "api_reference"
+description: "PersistentVolume (PV) is a storage resource provisioned by an administrator."
+title: "PersistentVolume"
+weight: 5
+---
+
+`apiVersion: v1`
+
+`import "k8s.io/api/core/v1"`
+
+
+## PersistentVolume {#PersistentVolume}
+
+PersistentVolume (PV) is a storage resource provisioned by an administrator. It is analogous to a node. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: PersistentVolume
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **spec** (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolumeSpec" >}}">PersistentVolumeSpec</a>)
+
+  Spec defines a specification of a persistent volume owned by the cluster. Provisioned by an administrator. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes
+
+- **status** (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolumeStatus" >}}">PersistentVolumeStatus</a>)
+
+  Status represents the current information/status for the persistent volume. Populated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes
+
+
+
+
+
+## PersistentVolumeSpec {#PersistentVolumeSpec}
+
+PersistentVolumeSpec is the specification of a persistent volume.
+
+<hr>
+
+- **accessModes** ([]string)
+
+  AccessModes contains all ways the volume can be mounted. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes
+
+- **capacity** (map[string]<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+  A description of the persistent volume's resources and capacity. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#capacity
+
+- **claimRef** (<a href="{{< ref "../common-definitions/object-reference#ObjectReference" >}}">ObjectReference</a>)
+
+  ClaimRef is part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim. Expected to be non-nil when bound. claim.VolumeName is the authoritative bind between PV and PVC. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#binding
+
+- **mountOptions** ([]string)
+
+  A list of mount options, e.g. ["ro", "soft"]. Not validated - mount will simply fail if one is invalid. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#mount-options
+
+- **nodeAffinity** (VolumeNodeAffinity)
+
+  NodeAffinity defines constraints that limit what nodes this volume can be accessed from. This field influences the scheduling of pods that use this volume.
+
+  <a name="VolumeNodeAffinity"></a>
+  *VolumeNodeAffinity defines constraints that limit what nodes this volume can be accessed from.*
+
+  - **nodeAffinity.required** (NodeSelector)
+
+    Required specifies hard node constraints that must be met.
+
+    <a name="NodeSelector"></a>
+    *A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.*
+
+  - **nodeAffinity.required.nodeSelectorTerms** ([]NodeSelectorTerm), required
+
+    Required. A list of node selector terms. The terms are ORed.
+
+    <a name="NodeSelectorTerm"></a>
+    *A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.*
+
+  - **nodeAffinity.required.nodeSelectorTerms.matchExpressions** ([]<a href="{{< ref "../common-definitions/node-selector-requirement#NodeSelectorRequirement" >}}">NodeSelectorRequirement</a>)
+
+    A list of node selector requirements by node's labels.
+
+  - **nodeAffinity.required.nodeSelectorTerms.matchFields** ([]<a href="{{< ref "../common-definitions/node-selector-requirement#NodeSelectorRequirement" >}}">NodeSelectorRequirement</a>)
+
+    A list of node selector requirements by node's fields.
+
+- **persistentVolumeReclaimPolicy** (string)
+
+  What happens to a persistent volume when released from its claim. Valid options are Retain (default for manually created PersistentVolumes), Delete (default for dynamically provisioned PersistentVolumes), and Recycle (deprecated). Recycle must be supported by the volume plugin underlying this PersistentVolume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#reclaiming
+
+- **storageClassName** (string)
+
+  Name of StorageClass to which this persistent volume belongs. Empty value means that this volume does not belong to any StorageClass.
+
+- **volumeMode** (string)
+
+  volumeMode defines if a volume is intended to be used with a formatted filesystem or to remain in raw block state. Value of Filesystem is implied when not included in spec.
+
+
+
+### Local
+
+
+- **hostPath** (HostPathVolumeSource)
+
+  HostPath represents a directory on the host. Provisioned by a developer or tester. This is useful for single-node development and testing only! On-host storage is not supported in any way and WILL NOT WORK in a multi-node cluster. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+
+  <a name="HostPathVolumeSource"></a>
+  *Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux relabeling.*
+
+  - **hostPath.path** (string), required
+
+    Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+
+  - **hostPath.type** (string)
+
+    Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+
+- **local** (LocalVolumeSource)
+
+  Local represents directly-attached storage with node affinity
+
+  <a name="LocalVolumeSource"></a>
+  *Local represents directly-attached storage with node affinity (Beta feature)*
+
+  - **local.path** (string), required
+
+    The full path to the volume on the node. It can be either a directory or block device (disk, partition, ...).
+
+  - **local.fsType** (string)
+
+    Filesystem type to mount. It applies only when the Path is a block device. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default value is to auto-select a fileystem if unspecified.
+
+### Persistent volumes
+
+
+- **awsElasticBlockStore** (AWSElasticBlockStoreVolumeSource)
+
+  AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+  <a name="AWSElasticBlockStoreVolumeSource"></a>
+  *Represents a Persistent Disk resource in AWS.
+  
+  An AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.*
+
+  - **awsElasticBlockStore.volumeID** (string), required
+
+    Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+  - **awsElasticBlockStore.fsType** (string)
+
+    Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+  - **awsElasticBlockStore.partition** (int32)
+
+    The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+
+  - **awsElasticBlockStore.readOnly** (boolean)
+
+    Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+- **azureDisk** (AzureDiskVolumeSource)
+
+  AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+
+  <a name="AzureDiskVolumeSource"></a>
+  *AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.*
+
+  - **azureDisk.diskName** (string), required
+
+    The Name of the data disk in the blob storage
+
+  - **azureDisk.diskURI** (string), required
+
+    The URI the data disk in the blob storage
+
+  - **azureDisk.cachingMode** (string)
+
+    Host Caching mode: None, Read Only, Read Write.
+
+  - **azureDisk.fsType** (string)
+
+    Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+  - **azureDisk.kind** (string)
+
+    Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared
+
+  - **azureDisk.readOnly** (boolean)
+
+    Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+- **azureFile** (AzureFilePersistentVolumeSource)
+
+  AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+
+  <a name="AzureFilePersistentVolumeSource"></a>
+  *AzureFile represents an Azure File Service mount on the host and bind mount to the pod.*
+
+  - **azureFile.secretName** (string), required
+
+    the name of secret that contains Azure Storage Account Name and Key
+
+  - **azureFile.shareName** (string), required
+
+    Share Name
+
+  - **azureFile.readOnly** (boolean)
+
+    Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+  - **azureFile.secretNamespace** (string)
+
+    the namespace of the secret that contains Azure Storage Account Name and Key default is the same as the Pod
+
+- **cephfs** (CephFSPersistentVolumeSource)
+
+  CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+
+  <a name="CephFSPersistentVolumeSource"></a>
+  *Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.*
+
+  - **cephfs.monitors** ([]string), required
+
+    Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+  - **cephfs.path** (string)
+
+    Optional: Used as the mounted root, rather than the full Ceph tree, default is /
+
+  - **cephfs.readOnly** (boolean)
+
+    Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+  - **cephfs.secretFile** (string)
+
+    Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+  - **cephfs.secretRef** (SecretReference)
+
+    Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+    <a name="SecretReference"></a>
+    *SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace*
+
+  - **cephfs.secretRef.name** (string)
+
+    Name is unique within a namespace to reference a secret resource.
+
+  - **cephfs.secretRef.namespace** (string)
+
+    Namespace defines the space within which the secret name must be unique.
+
+  - **cephfs.user** (string)
+
+    Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+- **cinder** (CinderPersistentVolumeSource)
+
+  Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+  <a name="CinderPersistentVolumeSource"></a>
+  *Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.*
+
+  - **cinder.volumeID** (string), required
+
+    volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+  - **cinder.fsType** (string)
+
+    Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+  - **cinder.readOnly** (boolean)
+
+    Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+  - **cinder.secretRef** (SecretReference)
+
+    Optional: points to a secret object containing parameters used to connect to OpenStack.
+
+    <a name="SecretReference"></a>
+    *SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace*
+
+  - **cinder.secretRef.name** (string)
+
+    Name is unique within a namespace to reference a secret resource.
+
+  - **cinder.secretRef.namespace** (string)
+
+    Namespace defines the space within which the secret name must be unique.
+
+- **fc** (FCVolumeSource)
+
+  FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+
+  <a name="FCVolumeSource"></a>
+  *Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.*
+
+  - **fc.fsType** (string)
+
+    Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+  - **fc.lun** (int32)
+
+    Optional: FC target lun number
+
+  - **fc.readOnly** (boolean)
+
+    Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+  - **fc.targetWWNs** ([]string)
+
+    Optional: FC target worldwide names (WWNs)
+
+  - **fc.wwids** ([]string)
+
+    Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+
+- **flexVolume** (FlexPersistentVolumeSource)
+
+  FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+
+  <a name="FlexPersistentVolumeSource"></a>
+  *FlexPersistentVolumeSource represents a generic persistent volume resource that is provisioned/attached using an exec based plugin.*
+
+  - **flexVolume.driver** (string), required
+
+    Driver is the name of the driver to use for this volume.
+
+  - **flexVolume.fsType** (string)
+
+    Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+
+  - **flexVolume.options** (map[string]string)
+
+    Optional: Extra command options if any.
+
+  - **flexVolume.readOnly** (boolean)
+
+    Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+  - **flexVolume.secretRef** (SecretReference)
+
+    Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.
+
+    <a name="SecretReference"></a>
+    *SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace*
+
+  - **flexVolume.secretRef.name** (string)
+
+    Name is unique within a namespace to reference a secret resource.
+
+  - **flexVolume.secretRef.namespace** (string)
+
+    Namespace defines the space within which the secret name must be unique.
+
+- **flocker** (FlockerVolumeSource)
+
+  Flocker represents a Flocker volume attached to a kubelet's host machine and exposed to the pod for its usage. This depends on the Flocker control service being running
+
+  <a name="FlockerVolumeSource"></a>
+  *Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.*
+
+  - **flocker.datasetName** (string)
+
+    Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
+
+  - **flocker.datasetUUID** (string)
+
+    UUID of the dataset. This is unique identifier of a Flocker dataset
+
+- **gcePersistentDisk** (GCEPersistentDiskVolumeSource)
+
+  GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+  <a name="GCEPersistentDiskVolumeSource"></a>
+  *Represents a Persistent Disk resource in Google Compute Engine.
+  
+  A GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.*
+
+  - **gcePersistentDisk.pdName** (string), required
+
+    Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+  - **gcePersistentDisk.fsType** (string)
+
+    Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+  - **gcePersistentDisk.partition** (int32)
+
+    The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+  - **gcePersistentDisk.readOnly** (boolean)
+
+    ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+- **glusterfs** (GlusterfsPersistentVolumeSource)
+
+  Glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod. Provisioned by an admin. More info: https://examples.k8s.io/volumes/glusterfs/README.md
+
+  <a name="GlusterfsPersistentVolumeSource"></a>
+  *Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.*
+
+  - **glusterfs.endpoints** (string), required
+
+    EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+
+  - **glusterfs.path** (string), required
+
+    Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+
+  - **glusterfs.endpointsNamespace** (string)
+
+    EndpointsNamespace is the namespace that contains Glusterfs endpoint. If this field is empty, the EndpointNamespace defaults to the same namespace as the bound PVC. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+
+  - **glusterfs.readOnly** (boolean)
+
+    ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+
+- **iscsi** (ISCSIPersistentVolumeSource)
+
+  ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin.
+
+  <a name="ISCSIPersistentVolumeSource"></a>
+  *ISCSIPersistentVolumeSource represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.*
+
+  - **iscsi.iqn** (string), required
+
+    Target iSCSI Qualified Name.
+
+  - **iscsi.lun** (int32), required
+
+    iSCSI Target Lun number.
+
+  - **iscsi.targetPortal** (string), required
+
+    iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+
+  - **iscsi.chapAuthDiscovery** (boolean)
+
+    whether support iSCSI Discovery CHAP authentication
+
+  - **iscsi.chapAuthSession** (boolean)
+
+    whether support iSCSI Session CHAP authentication
+
+  - **iscsi.fsType** (string)
+
+    Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+
+  - **iscsi.initiatorName** (string)
+
+    Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface \<target portal>:\<volume name> will be created for the connection.
+
+  - **iscsi.iscsiInterface** (string)
+
+    iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+
+  - **iscsi.portals** ([]string)
+
+    iSCSI Target Portal List. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+
+  - **iscsi.readOnly** (boolean)
+
+    ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+
+  - **iscsi.secretRef** (SecretReference)
+
+    CHAP Secret for iSCSI target and initiator authentication
+
+    <a name="SecretReference"></a>
+    *SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace*
+
+  - **iscsi.secretRef.name** (string)
+
+    Name is unique within a namespace to reference a secret resource.
+
+  - **iscsi.secretRef.namespace** (string)
+
+    Namespace defines the space within which the secret name must be unique.
+
+- **nfs** (NFSVolumeSource)
+
+  NFS represents an NFS mount on the host. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+
+  <a name="NFSVolumeSource"></a>
+  *Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management or SELinux relabeling.*
+
+  - **nfs.path** (string), required
+
+    Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+
+  - **nfs.server** (string), required
+
+    Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+
+  - **nfs.readOnly** (boolean)
+
+    ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+
+- **photonPersistentDisk** (PhotonPersistentDiskVolumeSource)
+
+  PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+
+  <a name="PhotonPersistentDiskVolumeSource"></a>
+  *Represents a Photon Controller persistent disk resource.*
+
+  - **photonPersistentDisk.pdID** (string), required
+
+    ID that identifies Photon Controller persistent disk
+
+  - **photonPersistentDisk.fsType** (string)
+
+    Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+- **portworxVolume** (PortworxVolumeSource)
+
+  PortworxVolume represents a portworx volume attached and mounted on kubelets host machine
+
+  <a name="PortworxVolumeSource"></a>
+  *PortworxVolumeSource represents a Portworx volume resource.*
+
+  - **portworxVolume.volumeID** (string), required
+
+    VolumeID uniquely identifies a Portworx volume
+
+  - **portworxVolume.fsType** (string)
+
+    FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+
+  - **portworxVolume.readOnly** (boolean)
+
+    Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+- **quobyte** (QuobyteVolumeSource)
+
+  Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+
+  <a name="QuobyteVolumeSource"></a>
+  *Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.*
+
+  - **quobyte.registry** (string), required
+
+    Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
+
+  - **quobyte.volume** (string), required
+
+    Volume is a string that references an already created Quobyte volume by name.
+
+  - **quobyte.group** (string)
+
+    Group to map volume access to Default is no group
+
+  - **quobyte.readOnly** (boolean)
+
+    ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+
+  - **quobyte.tenant** (string)
+
+    Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+
+  - **quobyte.user** (string)
+
+    User to map volume access to Defaults to serivceaccount user
+
+- **rbd** (RBDPersistentVolumeSource)
+
+  RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md
+
+  <a name="RBDPersistentVolumeSource"></a>
+  *Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.*
+
+  - **rbd.image** (string), required
+
+    The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+  - **rbd.monitors** ([]string), required
+
+    A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+  - **rbd.fsType** (string)
+
+    Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+
+  - **rbd.keyring** (string)
+
+    Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+  - **rbd.pool** (string)
+
+    The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+  - **rbd.readOnly** (boolean)
+
+    ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+  - **rbd.secretRef** (SecretReference)
+
+    SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+    <a name="SecretReference"></a>
+    *SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace*
+
+  - **rbd.secretRef.name** (string)
+
+    Name is unique within a namespace to reference a secret resource.
+
+  - **rbd.secretRef.namespace** (string)
+
+    Namespace defines the space within which the secret name must be unique.
+
+  - **rbd.user** (string)
+
+    The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+- **scaleIO** (ScaleIOPersistentVolumeSource)
+
+  ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+
+  <a name="ScaleIOPersistentVolumeSource"></a>
+  *ScaleIOPersistentVolumeSource represents a persistent ScaleIO volume*
+
+  - **scaleIO.gateway** (string), required
+
+    The host address of the ScaleIO API Gateway.
+
+  - **scaleIO.secretRef** (SecretReference), required
+
+    SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
+
+    <a name="SecretReference"></a>
+    *SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace*
+
+  - **scaleIO.secretRef.name** (string)
+
+    Name is unique within a namespace to reference a secret resource.
+
+  - **scaleIO.secretRef.namespace** (string)
+
+    Namespace defines the space within which the secret name must be unique.
+
+  - **scaleIO.system** (string), required
+
+    The name of the storage system as configured in ScaleIO.
+
+  - **scaleIO.fsType** (string)
+
+    Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs"
+
+  - **scaleIO.protectionDomain** (string)
+
+    The name of the ScaleIO Protection Domain for the configured storage.
+
+  - **scaleIO.readOnly** (boolean)
+
+    Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+  - **scaleIO.sslEnabled** (boolean)
+
+    Flag to enable/disable SSL communication with Gateway, default false
+
+  - **scaleIO.storageMode** (string)
+
+    Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+
+  - **scaleIO.storagePool** (string)
+
+    The ScaleIO Storage Pool associated with the protection domain.
+
+  - **scaleIO.volumeName** (string)
+
+    The name of a volume already created in the ScaleIO system that is associated with this volume source.
+
+- **storageos** (StorageOSPersistentVolumeSource)
+
+  StorageOS represents a StorageOS volume that is attached to the kubelet's host machine and mounted into the pod More info: https://examples.k8s.io/volumes/storageos/README.md
+
+  <a name="StorageOSPersistentVolumeSource"></a>
+  *Represents a StorageOS persistent volume resource.*
+
+  - **storageos.fsType** (string)
+
+    Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+  - **storageos.readOnly** (boolean)
+
+    Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+  - **storageos.secretRef** (<a href="{{< ref "../common-definitions/object-reference#ObjectReference" >}}">ObjectReference</a>)
+
+    SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
+
+  - **storageos.volumeName** (string)
+
+    VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+
+  - **storageos.volumeNamespace** (string)
+
+    VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+
+- **vsphereVolume** (VsphereVirtualDiskVolumeSource)
+
+  VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+
+  <a name="VsphereVirtualDiskVolumeSource"></a>
+  *Represents a vSphere volume resource.*
+
+  - **vsphereVolume.volumePath** (string), required
+
+    Path that identifies vSphere volume vmdk
+
+  - **vsphereVolume.fsType** (string)
+
+    Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+  - **vsphereVolume.storagePolicyID** (string)
+
+    Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+
+  - **vsphereVolume.storagePolicyName** (string)
+
+    Storage Policy Based Management (SPBM) profile name.
+
+### Beta level
+
+
+- **csi** (CSIPersistentVolumeSource)
+
+  CSI represents storage that is handled by an external CSI driver (Beta feature).
+
+  <a name="CSIPersistentVolumeSource"></a>
+  *Represents storage that is managed by an external CSI volume driver (Beta feature)*
+
+  - **csi.driver** (string), required
+
+    Driver is the name of the driver to use for this volume. Required.
+
+  - **csi.volumeHandle** (string), required
+
+    VolumeHandle is the unique volume name returned by the CSI volume plugin’s CreateVolume to refer to the volume on all subsequent calls. Required.
+
+  - **csi.controllerExpandSecretRef** (SecretReference)
+
+    ControllerExpandSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI ControllerExpandVolume call. This is an alpha field and requires enabling ExpandCSIVolumes feature gate. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed.
+
+    <a name="SecretReference"></a>
+    *SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace*
+
+  - **csi.controllerExpandSecretRef.name** (string)
+
+    Name is unique within a namespace to reference a secret resource.
+
+  - **csi.controllerExpandSecretRef.namespace** (string)
+
+    Namespace defines the space within which the secret name must be unique.
+
+  - **csi.controllerPublishSecretRef** (SecretReference)
+
+    ControllerPublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI ControllerPublishVolume and ControllerUnpublishVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed.
+
+    <a name="SecretReference"></a>
+    *SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace*
+
+  - **csi.controllerPublishSecretRef.name** (string)
+
+    Name is unique within a namespace to reference a secret resource.
+
+  - **csi.controllerPublishSecretRef.namespace** (string)
+
+    Namespace defines the space within which the secret name must be unique.
+
+  - **csi.fsType** (string)
+
+    Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs".
+
+  - **csi.nodePublishSecretRef** (SecretReference)
+
+    NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed.
+
+    <a name="SecretReference"></a>
+    *SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace*
+
+  - **csi.nodePublishSecretRef.name** (string)
+
+    Name is unique within a namespace to reference a secret resource.
+
+  - **csi.nodePublishSecretRef.namespace** (string)
+
+    Namespace defines the space within which the secret name must be unique.
+
+  - **csi.nodeStageSecretRef** (SecretReference)
+
+    NodeStageSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodeStageVolume and NodeStageVolume and NodeUnstageVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed.
+
+    <a name="SecretReference"></a>
+    *SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace*
+
+  - **csi.nodeStageSecretRef.name** (string)
+
+    Name is unique within a namespace to reference a secret resource.
+
+  - **csi.nodeStageSecretRef.namespace** (string)
+
+    Namespace defines the space within which the secret name must be unique.
+
+  - **csi.readOnly** (boolean)
+
+    Optional: The value to pass to ControllerPublishVolumeRequest. Defaults to false (read/write).
+
+  - **csi.volumeAttributes** (map[string]string)
+
+    Attributes of the volume to publish.
+
+
+
+## PersistentVolumeStatus {#PersistentVolumeStatus}
+
+PersistentVolumeStatus is the current status of a persistent volume.
+
+<hr>
+
+- **message** (string)
+
+  A human-readable message indicating details about why the volume is in this state.
+
+- **phase** (string)
+
+  Phase indicates if a volume is available, bound to a claim, or released by a claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#phase
+
+- **reason** (string)
+
+  Reason is a brief CamelCase string that describes any failure and is meant for machine parsing and tidy display in the CLI.
+
+
+
+
+
+## PersistentVolumeList {#PersistentVolumeList}
+
+PersistentVolumeList is a list of PersistentVolume items.
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: PersistentVolumeList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+- **items** ([]<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>), required
+
+  List of persistent volumes. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified PersistentVolume
+
+#### HTTP Request
+
+GET /api/v1/persistentvolumes/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PersistentVolume
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>): OK
+
+401: Unauthorized
+
+
+### `get` read status of the specified PersistentVolume
+
+#### HTTP Request
+
+GET /api/v1/persistentvolumes/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PersistentVolume
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind PersistentVolume
+
+#### HTTP Request
+
+GET /api/v1/persistentvolumes
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolumeList" >}}">PersistentVolumeList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a PersistentVolume
+
+#### HTTP Request
+
+POST /api/v1/persistentvolumes
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>): OK
+
+201 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>): Created
+
+202 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified PersistentVolume
+
+#### HTTP Request
+
+PUT /api/v1/persistentvolumes/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PersistentVolume
+
+
+- **body**: <a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>): OK
+
+201 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>): Created
+
+401: Unauthorized
+
+
+### `update` replace status of the specified PersistentVolume
+
+#### HTTP Request
+
+PUT /api/v1/persistentvolumes/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PersistentVolume
+
+
+- **body**: <a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>): OK
+
+201 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified PersistentVolume
+
+#### HTTP Request
+
+PATCH /api/v1/persistentvolumes/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PersistentVolume
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>): OK
+
+401: Unauthorized
+
+
+### `patch` partially update status of the specified PersistentVolume
+
+#### HTTP Request
+
+PATCH /api/v1/persistentvolumes/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PersistentVolume
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a PersistentVolume
+
+#### HTTP Request
+
+DELETE /api/v1/persistentvolumes/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PersistentVolume
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>): OK
+
+202 (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolume" >}}">PersistentVolume</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of PersistentVolume
+
+#### HTTP Request
+
+DELETE /api/v1/persistentvolumes
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/secret-v1.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/secret-v1.md
@@ -1,0 +1,548 @@
+---
+api_metadata:
+  apiVersion: "v1"
+  import: "k8s.io/api/core/v1"
+  kind: "Secret"
+content_type: "api_reference"
+description: "Secret holds secret data of a certain type."
+title: "Secret"
+weight: 2
+---
+
+`apiVersion: v1`
+
+`import "k8s.io/api/core/v1"`
+
+
+## Secret {#Secret}
+
+Secret holds secret data of a certain type. The total bytes of the values in the Data field must be less than MaxSecretSize bytes.
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: Secret
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **data** (map[string][]byte)
+
+  Data contains the secret data. Each key must consist of alphanumeric characters, '-', '_' or '.'. The serialized form of the secret data is a base64 encoded string, representing the arbitrary (possibly non-string) data value here. Described in https://tools.ietf.org/html/rfc4648#section-4
+
+- **immutable** (boolean)
+
+  Immutable, if set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified). If not set to true, the field can be modified at any time. Defaulted to nil. This is a beta field enabled by ImmutableEphemeralVolumes feature gate.
+
+- **stringData** (map[string]string)
+
+  stringData allows specifying non-binary secret data in string form. It is provided as a write-only convenience method. All keys and values are merged into the data field on write, overwriting any existing values. It is never output when reading from the API.
+
+- **type** (string)
+
+  Used to facilitate programmatic handling of secret data.
+
+
+
+
+
+## SecretList {#SecretList}
+
+SecretList is a list of Secret.
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: SecretList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+- **items** ([]<a href="{{< ref "../config-and-storage-resources/secret-v1#Secret" >}}">Secret</a>), required
+
+  Items is a list of secret objects. More info: https://kubernetes.io/docs/concepts/configuration/secret
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified Secret
+
+#### HTTP Request
+
+GET /api/v1/namespaces/{namespace}/secrets/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Secret
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/secret-v1#Secret" >}}">Secret</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind Secret
+
+#### HTTP Request
+
+GET /api/v1/namespaces/{namespace}/secrets
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/secret-v1#SecretList" >}}">SecretList</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind Secret
+
+#### HTTP Request
+
+GET /api/v1/secrets
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/secret-v1#SecretList" >}}">SecretList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a Secret
+
+#### HTTP Request
+
+POST /api/v1/namespaces/{namespace}/secrets
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../config-and-storage-resources/secret-v1#Secret" >}}">Secret</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/secret-v1#Secret" >}}">Secret</a>): OK
+
+201 (<a href="{{< ref "../config-and-storage-resources/secret-v1#Secret" >}}">Secret</a>): Created
+
+202 (<a href="{{< ref "../config-and-storage-resources/secret-v1#Secret" >}}">Secret</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified Secret
+
+#### HTTP Request
+
+PUT /api/v1/namespaces/{namespace}/secrets/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Secret
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../config-and-storage-resources/secret-v1#Secret" >}}">Secret</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/secret-v1#Secret" >}}">Secret</a>): OK
+
+201 (<a href="{{< ref "../config-and-storage-resources/secret-v1#Secret" >}}">Secret</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified Secret
+
+#### HTTP Request
+
+PATCH /api/v1/namespaces/{namespace}/secrets/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Secret
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/secret-v1#Secret" >}}">Secret</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a Secret
+
+#### HTTP Request
+
+DELETE /api/v1/namespaces/{namespace}/secrets/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Secret
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of Secret
+
+#### HTTP Request
+
+DELETE /api/v1/namespaces/{namespace}/secrets
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/storage-class-v1.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/storage-class-v1.md
@@ -1,0 +1,477 @@
+---
+api_metadata:
+  apiVersion: "storage.k8s.io/v1"
+  import: "k8s.io/api/storage/v1"
+  kind: "StorageClass"
+content_type: "api_reference"
+description: "StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned."
+title: "StorageClass"
+weight: 6
+---
+
+`apiVersion: storage.k8s.io/v1`
+
+`import "k8s.io/api/storage/v1"`
+
+
+## StorageClass {#StorageClass}
+
+StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned.
+
+StorageClasses are non-namespaced; the name of the storage class according to etcd is in ObjectMeta.Name.
+
+<hr>
+
+- **apiVersion**: storage.k8s.io/v1
+
+
+- **kind**: StorageClass
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **provisioner** (string), required
+
+  Provisioner indicates the type of the provisioner.
+
+- **allowVolumeExpansion** (boolean)
+
+  AllowVolumeExpansion shows whether the storage class allow volume expand
+
+- **allowedTopologies** ([]TopologySelectorTerm)
+
+  Restrict the node topologies where volumes can be dynamically provisioned. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.
+
+  <a name="TopologySelectorTerm"></a>
+  *A topology selector term represents the result of label queries. A null or empty topology selector term matches no objects. The requirements of them are ANDed. It provides a subset of functionality as NodeSelectorTerm. This is an alpha feature and may change in the future.*
+
+  - **allowedTopologies.matchLabelExpressions** ([]TopologySelectorLabelRequirement)
+
+    A list of topology selector requirements by labels.
+
+    <a name="TopologySelectorLabelRequirement"></a>
+    *A topology selector requirement is a selector that matches given label. This is an alpha feature and may change in the future.*
+
+  - **allowedTopologies.matchLabelExpressions.key** (string), required
+
+    The label key that the selector applies to.
+
+  - **allowedTopologies.matchLabelExpressions.values** ([]string), required
+
+    An array of string values. One value must match the label to be selected. Each entry in Values is ORed.
+
+- **mountOptions** ([]string)
+
+  Dynamically provisioned PersistentVolumes of this storage class are created with these mountOptions, e.g. ["ro", "soft"]. Not validated - mount of the PVs will simply fail if one is invalid.
+
+- **parameters** (map[string]string)
+
+  Parameters holds the parameters for the provisioner that should create volumes of this storage class.
+
+- **reclaimPolicy** (string)
+
+  Dynamically provisioned PersistentVolumes of this storage class are created with this reclaimPolicy. Defaults to Delete.
+
+- **volumeBindingMode** (string)
+
+  VolumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound.  When unset, VolumeBindingImmediate is used. This field is only honored by servers that enable the VolumeScheduling feature.
+
+
+
+
+
+## StorageClassList {#StorageClassList}
+
+StorageClassList is a collection of storage classes.
+
+<hr>
+
+- **apiVersion**: storage.k8s.io/v1
+
+
+- **kind**: StorageClassList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **items** ([]<a href="{{< ref "../config-and-storage-resources/storage-class-v1#StorageClass" >}}">StorageClass</a>), required
+
+  Items is the list of StorageClasses
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified StorageClass
+
+#### HTTP Request
+
+GET /apis/storage.k8s.io/v1/storageclasses/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the StorageClass
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/storage-class-v1#StorageClass" >}}">StorageClass</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind StorageClass
+
+#### HTTP Request
+
+GET /apis/storage.k8s.io/v1/storageclasses
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/storage-class-v1#StorageClassList" >}}">StorageClassList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a StorageClass
+
+#### HTTP Request
+
+POST /apis/storage.k8s.io/v1/storageclasses
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../config-and-storage-resources/storage-class-v1#StorageClass" >}}">StorageClass</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/storage-class-v1#StorageClass" >}}">StorageClass</a>): OK
+
+201 (<a href="{{< ref "../config-and-storage-resources/storage-class-v1#StorageClass" >}}">StorageClass</a>): Created
+
+202 (<a href="{{< ref "../config-and-storage-resources/storage-class-v1#StorageClass" >}}">StorageClass</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified StorageClass
+
+#### HTTP Request
+
+PUT /apis/storage.k8s.io/v1/storageclasses/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the StorageClass
+
+
+- **body**: <a href="{{< ref "../config-and-storage-resources/storage-class-v1#StorageClass" >}}">StorageClass</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/storage-class-v1#StorageClass" >}}">StorageClass</a>): OK
+
+201 (<a href="{{< ref "../config-and-storage-resources/storage-class-v1#StorageClass" >}}">StorageClass</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified StorageClass
+
+#### HTTP Request
+
+PATCH /apis/storage.k8s.io/v1/storageclasses/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the StorageClass
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/storage-class-v1#StorageClass" >}}">StorageClass</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a StorageClass
+
+#### HTTP Request
+
+DELETE /apis/storage.k8s.io/v1/storageclasses/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the StorageClass
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/storage-class-v1#StorageClass" >}}">StorageClass</a>): OK
+
+202 (<a href="{{< ref "../config-and-storage-resources/storage-class-v1#StorageClass" >}}">StorageClass</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of StorageClass
+
+#### HTTP Request
+
+DELETE /apis/storage.k8s.io/v1/storageclasses
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/volume-attachment-v1.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/volume-attachment-v1.md
@@ -1,0 +1,647 @@
+---
+api_metadata:
+  apiVersion: "storage.k8s.io/v1"
+  import: "k8s.io/api/storage/v1"
+  kind: "VolumeAttachment"
+content_type: "api_reference"
+description: "VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node."
+title: "VolumeAttachment"
+weight: 7
+---
+
+`apiVersion: storage.k8s.io/v1`
+
+`import "k8s.io/api/storage/v1"`
+
+
+## VolumeAttachment {#VolumeAttachment}
+
+VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
+
+VolumeAttachment objects are non-namespaced.
+
+<hr>
+
+- **apiVersion**: storage.k8s.io/v1
+
+
+- **kind**: VolumeAttachment
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **spec** (<a href="{{< ref "../config-and-storage-resources/volume-attachment-v1#VolumeAttachmentSpec" >}}">VolumeAttachmentSpec</a>), required
+
+  Specification of the desired attach/detach volume behavior. Populated by the Kubernetes system.
+
+- **status** (<a href="{{< ref "../config-and-storage-resources/volume-attachment-v1#VolumeAttachmentStatus" >}}">VolumeAttachmentStatus</a>)
+
+  Status of the VolumeAttachment request. Populated by the entity completing the attach or detach operation, i.e. the external-attacher.
+
+
+
+
+
+## VolumeAttachmentSpec {#VolumeAttachmentSpec}
+
+VolumeAttachmentSpec is the specification of a VolumeAttachment request.
+
+<hr>
+
+- **attacher** (string), required
+
+  Attacher indicates the name of the volume driver that MUST handle this request. This is the name returned by GetPluginName().
+
+- **nodeName** (string), required
+
+  The node that the volume should be attached to.
+
+- **source** (VolumeAttachmentSource), required
+
+  Source represents the volume that should be attached.
+
+  <a name="VolumeAttachmentSource"></a>
+  *VolumeAttachmentSource represents a volume that should be attached. Right now only PersistenVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.*
+
+  - **source.inlineVolumeSpec** (<a href="{{< ref "../config-and-storage-resources/persistent-volume-v1#PersistentVolumeSpec" >}}">PersistentVolumeSpec</a>)
+
+    inlineVolumeSpec contains all the information necessary to attach a persistent volume defined by a pod's inline VolumeSource. This field is populated only for the CSIMigration feature. It contains translated fields from a pod's inline VolumeSource to a PersistentVolumeSpec. This field is alpha-level and is only honored by servers that enabled the CSIMigration feature.
+
+  - **source.persistentVolumeName** (string)
+
+    Name of the persistent volume to attach.
+
+
+
+
+
+## VolumeAttachmentStatus {#VolumeAttachmentStatus}
+
+VolumeAttachmentStatus is the status of a VolumeAttachment request.
+
+<hr>
+
+- **attached** (boolean), required
+
+  Indicates the volume is successfully attached. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
+
+- **attachError** (VolumeError)
+
+  The last error encountered during attach operation, if any. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
+
+  <a name="VolumeError"></a>
+  *VolumeError captures an error encountered during a volume operation.*
+
+  - **attachError.message** (string)
+
+    String detailing the error encountered during Attach or Detach operation. This string may be logged, so it should not contain sensitive information.
+
+  - **attachError.time** (Time)
+
+    Time the error was encountered.
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+- **attachmentMetadata** (map[string]string)
+
+  Upon successful attach, this field is populated with any information returned by the attach operation that must be passed into subsequent WaitForAttach or Mount calls. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
+
+- **detachError** (VolumeError)
+
+  The last error encountered during detach operation, if any. This field must only be set by the entity completing the detach operation, i.e. the external-attacher.
+
+  <a name="VolumeError"></a>
+  *VolumeError captures an error encountered during a volume operation.*
+
+  - **detachError.message** (string)
+
+    String detailing the error encountered during Attach or Detach operation. This string may be logged, so it should not contain sensitive information.
+
+  - **detachError.time** (Time)
+
+    Time the error was encountered.
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+
+
+
+
+## VolumeAttachmentList {#VolumeAttachmentList}
+
+VolumeAttachmentList is a collection of VolumeAttachment objects.
+
+<hr>
+
+- **apiVersion**: storage.k8s.io/v1
+
+
+- **kind**: VolumeAttachmentList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **items** ([]<a href="{{< ref "../config-and-storage-resources/volume-attachment-v1#VolumeAttachment" >}}">VolumeAttachment</a>), required
+
+  Items is the list of VolumeAttachments
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified VolumeAttachment
+
+#### HTTP Request
+
+GET /apis/storage.k8s.io/v1/volumeattachments/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the VolumeAttachment
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/volume-attachment-v1#VolumeAttachment" >}}">VolumeAttachment</a>): OK
+
+401: Unauthorized
+
+
+### `get` read status of the specified VolumeAttachment
+
+#### HTTP Request
+
+GET /apis/storage.k8s.io/v1/volumeattachments/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the VolumeAttachment
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/volume-attachment-v1#VolumeAttachment" >}}">VolumeAttachment</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind VolumeAttachment
+
+#### HTTP Request
+
+GET /apis/storage.k8s.io/v1/volumeattachments
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/volume-attachment-v1#VolumeAttachmentList" >}}">VolumeAttachmentList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a VolumeAttachment
+
+#### HTTP Request
+
+POST /apis/storage.k8s.io/v1/volumeattachments
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../config-and-storage-resources/volume-attachment-v1#VolumeAttachment" >}}">VolumeAttachment</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/volume-attachment-v1#VolumeAttachment" >}}">VolumeAttachment</a>): OK
+
+201 (<a href="{{< ref "../config-and-storage-resources/volume-attachment-v1#VolumeAttachment" >}}">VolumeAttachment</a>): Created
+
+202 (<a href="{{< ref "../config-and-storage-resources/volume-attachment-v1#VolumeAttachment" >}}">VolumeAttachment</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified VolumeAttachment
+
+#### HTTP Request
+
+PUT /apis/storage.k8s.io/v1/volumeattachments/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the VolumeAttachment
+
+
+- **body**: <a href="{{< ref "../config-and-storage-resources/volume-attachment-v1#VolumeAttachment" >}}">VolumeAttachment</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/volume-attachment-v1#VolumeAttachment" >}}">VolumeAttachment</a>): OK
+
+201 (<a href="{{< ref "../config-and-storage-resources/volume-attachment-v1#VolumeAttachment" >}}">VolumeAttachment</a>): Created
+
+401: Unauthorized
+
+
+### `update` replace status of the specified VolumeAttachment
+
+#### HTTP Request
+
+PUT /apis/storage.k8s.io/v1/volumeattachments/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the VolumeAttachment
+
+
+- **body**: <a href="{{< ref "../config-and-storage-resources/volume-attachment-v1#VolumeAttachment" >}}">VolumeAttachment</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/volume-attachment-v1#VolumeAttachment" >}}">VolumeAttachment</a>): OK
+
+201 (<a href="{{< ref "../config-and-storage-resources/volume-attachment-v1#VolumeAttachment" >}}">VolumeAttachment</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified VolumeAttachment
+
+#### HTTP Request
+
+PATCH /apis/storage.k8s.io/v1/volumeattachments/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the VolumeAttachment
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/volume-attachment-v1#VolumeAttachment" >}}">VolumeAttachment</a>): OK
+
+401: Unauthorized
+
+
+### `patch` partially update status of the specified VolumeAttachment
+
+#### HTTP Request
+
+PATCH /apis/storage.k8s.io/v1/volumeattachments/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the VolumeAttachment
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/volume-attachment-v1#VolumeAttachment" >}}">VolumeAttachment</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a VolumeAttachment
+
+#### HTTP Request
+
+DELETE /apis/storage.k8s.io/v1/volumeattachments/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the VolumeAttachment
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../config-and-storage-resources/volume-attachment-v1#VolumeAttachment" >}}">VolumeAttachment</a>): OK
+
+202 (<a href="{{< ref "../config-and-storage-resources/volume-attachment-v1#VolumeAttachment" >}}">VolumeAttachment</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of VolumeAttachment
+
+#### HTTP Request
+
+DELETE /apis/storage.k8s.io/v1/volumeattachments
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/volume.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/volume.md
@@ -1,0 +1,855 @@
+---
+api_metadata:
+  apiVersion: ""
+  import: "k8s.io/api/core/v1"
+  kind: "Volume"
+content_type: "api_reference"
+description: "Volume represents a named volume in a pod that may be accessed by any container in the pod."
+title: "Volume"
+weight: 3
+---
+
+
+
+`import "k8s.io/api/core/v1"`
+
+
+Volume represents a named volume in a pod that may be accessed by any container in the pod.
+
+<hr>
+
+- **name** (string), required
+
+  Volume's name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+
+
+### Exposed Persistent volumes {#Exposed Persistent volumes}
+
+
+- **persistentVolumeClaim** (PersistentVolumeClaimVolumeSource)
+
+  PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+
+  <a name="PersistentVolumeClaimVolumeSource"></a>
+  *PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).*
+
+  - **persistentVolumeClaim.claimName** (string), required
+
+    ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+
+  - **persistentVolumeClaim.readOnly** (boolean)
+
+    Will force the ReadOnly setting in VolumeMounts. Default false.
+
+### Projections {#Projections}
+
+
+- **configMap** (ConfigMapVolumeSource)
+
+  ConfigMap represents a configMap that should populate this volume
+
+  <a name="ConfigMapVolumeSource"></a>
+  *Adapts a ConfigMap into a volume.
+  
+  The contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.*
+
+  - **configMap.name** (string)
+
+    Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+  - **configMap.optional** (boolean)
+
+    Specify whether the ConfigMap or its keys must be defined
+
+  - **configMap.defaultMode** (int32)
+
+    Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+
+  - **configMap.items** ([]<a href="{{< ref "../common-definitions/key-to-path#KeyToPath" >}}">KeyToPath</a>)
+
+    If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+
+- **secret** (SecretVolumeSource)
+
+  Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+
+  <a name="SecretVolumeSource"></a>
+  *Adapts a Secret into a volume.
+  
+  The contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.*
+
+  - **secret.secretName** (string)
+
+    Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+
+  - **secret.optional** (boolean)
+
+    Specify whether the Secret or its keys must be defined
+
+  - **secret.defaultMode** (int32)
+
+    Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+
+  - **secret.items** ([]<a href="{{< ref "../common-definitions/key-to-path#KeyToPath" >}}">KeyToPath</a>)
+
+    If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+
+- **downwardAPI** (DownwardAPIVolumeSource)
+
+  DownwardAPI represents downward API about the pod that should populate this volume
+
+  <a name="DownwardAPIVolumeSource"></a>
+  *DownwardAPIVolumeSource represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling.*
+
+  - **downwardAPI.defaultMode** (int32)
+
+    Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+
+  - **downwardAPI.items** ([]<a href="{{< ref "../common-definitions/downward-api-volume-file#DownwardAPIVolumeFile" >}}">DownwardAPIVolumeFile</a>)
+
+    Items is a list of downward API volume file
+
+- **projected** (ProjectedVolumeSource)
+
+  Items for all in one resources secrets, configmaps, and downward API
+
+  <a name="ProjectedVolumeSource"></a>
+  *Represents a projected volume source*
+
+  - **projected.defaultMode** (int32)
+
+    Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+
+  - **projected.sources** ([]VolumeProjection)
+
+    list of volume projections
+
+    <a name="VolumeProjection"></a>
+    *Projection that may be projected along with other supported volume types*
+
+  - **projected.sources.configMap** (ConfigMapProjection)
+
+    information about the configMap data to project
+
+    <a name="ConfigMapProjection"></a>
+    *Adapts a ConfigMap into a projected volume.
+    
+    The contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.*
+
+  - **projected.sources.configMap.name** (string)
+
+    Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+  - **projected.sources.configMap.optional** (boolean)
+
+    Specify whether the ConfigMap or its keys must be defined
+
+  - **projected.sources.configMap.items** ([]<a href="{{< ref "../common-definitions/key-to-path#KeyToPath" >}}">KeyToPath</a>)
+
+    If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+
+  - **projected.sources.downwardAPI** (DownwardAPIProjection)
+
+    information about the downwardAPI data to project
+
+    <a name="DownwardAPIProjection"></a>
+    *Represents downward API info for projecting into a projected volume. Note that this is identical to a downwardAPI volume source without the default mode.*
+
+  - **projected.sources.downwardAPI.items** ([]<a href="{{< ref "../common-definitions/downward-api-volume-file#DownwardAPIVolumeFile" >}}">DownwardAPIVolumeFile</a>)
+
+    Items is a list of DownwardAPIVolume file
+
+  - **projected.sources.secret** (SecretProjection)
+
+    information about the secret data to project
+
+    <a name="SecretProjection"></a>
+    *Adapts a secret into a projected volume.
+    
+    The contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.*
+
+  - **projected.sources.secret.name** (string)
+
+    Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+  - **projected.sources.secret.optional** (boolean)
+
+    Specify whether the Secret or its key must be defined
+
+  - **projected.sources.secret.items** ([]<a href="{{< ref "../common-definitions/key-to-path#KeyToPath" >}}">KeyToPath</a>)
+
+    If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+
+  - **projected.sources.serviceAccountToken** (ServiceAccountTokenProjection)
+
+    information about the serviceAccountToken data to project
+
+    <a name="ServiceAccountTokenProjection"></a>
+    *ServiceAccountTokenProjection represents a projected service account token volume. This projection can be used to insert a service account token into the pods runtime filesystem for use against APIs (Kubernetes API Server or otherwise).*
+
+  - **projected.sources.serviceAccountToken.path** (string), required
+
+    Path is the path relative to the mount point of the file to project the token into.
+
+  - **projected.sources.serviceAccountToken.audience** (string)
+
+    Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+
+  - **projected.sources.serviceAccountToken.expirationSeconds** (int64)
+
+    ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+
+### Local / Temporary Directory {#Local / Temporary Directory}
+
+
+- **emptyDir** (EmptyDirVolumeSource)
+
+  EmptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+
+  <a name="EmptyDirVolumeSource"></a>
+  *Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.*
+
+  - **emptyDir.medium** (string)
+
+    What type of storage medium should back this directory. The default is "" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+
+  - **emptyDir.sizeLimit** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir
+
+- **hostPath** (HostPathVolumeSource)
+
+  HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+
+  <a name="HostPathVolumeSource"></a>
+  *Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux relabeling.*
+
+  - **hostPath.path** (string), required
+
+    Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+
+  - **hostPath.type** (string)
+
+    Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+
+### Persistent volumes {#Persistent volumes}
+
+
+- **awsElasticBlockStore** (AWSElasticBlockStoreVolumeSource)
+
+  AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+  <a name="AWSElasticBlockStoreVolumeSource"></a>
+  *Represents a Persistent Disk resource in AWS.
+  
+  An AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.*
+
+  - **awsElasticBlockStore.volumeID** (string), required
+
+    Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+  - **awsElasticBlockStore.fsType** (string)
+
+    Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+  - **awsElasticBlockStore.partition** (int32)
+
+    The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+
+  - **awsElasticBlockStore.readOnly** (boolean)
+
+    Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+- **azureDisk** (AzureDiskVolumeSource)
+
+  AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+
+  <a name="AzureDiskVolumeSource"></a>
+  *AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.*
+
+  - **azureDisk.diskName** (string), required
+
+    The Name of the data disk in the blob storage
+
+  - **azureDisk.diskURI** (string), required
+
+    The URI the data disk in the blob storage
+
+  - **azureDisk.cachingMode** (string)
+
+    Host Caching mode: None, Read Only, Read Write.
+
+  - **azureDisk.fsType** (string)
+
+    Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+  - **azureDisk.kind** (string)
+
+    Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared
+
+  - **azureDisk.readOnly** (boolean)
+
+    Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+- **azureFile** (AzureFileVolumeSource)
+
+  AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+
+  <a name="AzureFileVolumeSource"></a>
+  *AzureFile represents an Azure File Service mount on the host and bind mount to the pod.*
+
+  - **azureFile.secretName** (string), required
+
+    the name of secret that contains Azure Storage Account Name and Key
+
+  - **azureFile.shareName** (string), required
+
+    Share Name
+
+  - **azureFile.readOnly** (boolean)
+
+    Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+- **cephfs** (CephFSVolumeSource)
+
+  CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+
+  <a name="CephFSVolumeSource"></a>
+  *Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.*
+
+  - **cephfs.monitors** ([]string), required
+
+    Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+  - **cephfs.path** (string)
+
+    Optional: Used as the mounted root, rather than the full Ceph tree, default is /
+
+  - **cephfs.readOnly** (boolean)
+
+    Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+  - **cephfs.secretFile** (string)
+
+    Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+  - **cephfs.secretRef** (<a href="{{< ref "../common-definitions/local-object-reference#LocalObjectReference" >}}">LocalObjectReference</a>)
+
+    Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+  - **cephfs.user** (string)
+
+    Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+- **cinder** (CinderVolumeSource)
+
+  Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+  <a name="CinderVolumeSource"></a>
+  *Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.*
+
+  - **cinder.volumeID** (string), required
+
+    volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+  - **cinder.fsType** (string)
+
+    Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+  - **cinder.readOnly** (boolean)
+
+    Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+  - **cinder.secretRef** (<a href="{{< ref "../common-definitions/local-object-reference#LocalObjectReference" >}}">LocalObjectReference</a>)
+
+    Optional: points to a secret object containing parameters used to connect to OpenStack.
+
+- **fc** (FCVolumeSource)
+
+  FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+
+  <a name="FCVolumeSource"></a>
+  *Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.*
+
+  - **fc.fsType** (string)
+
+    Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+  - **fc.lun** (int32)
+
+    Optional: FC target lun number
+
+  - **fc.readOnly** (boolean)
+
+    Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+  - **fc.targetWWNs** ([]string)
+
+    Optional: FC target worldwide names (WWNs)
+
+  - **fc.wwids** ([]string)
+
+    Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+
+- **flexVolume** (FlexVolumeSource)
+
+  FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+
+  <a name="FlexVolumeSource"></a>
+  *FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.*
+
+  - **flexVolume.driver** (string), required
+
+    Driver is the name of the driver to use for this volume.
+
+  - **flexVolume.fsType** (string)
+
+    Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+
+  - **flexVolume.options** (map[string]string)
+
+    Optional: Extra command options if any.
+
+  - **flexVolume.readOnly** (boolean)
+
+    Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+  - **flexVolume.secretRef** (<a href="{{< ref "../common-definitions/local-object-reference#LocalObjectReference" >}}">LocalObjectReference</a>)
+
+    Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.
+
+- **flocker** (FlockerVolumeSource)
+
+  Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+
+  <a name="FlockerVolumeSource"></a>
+  *Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.*
+
+  - **flocker.datasetName** (string)
+
+    Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
+
+  - **flocker.datasetUUID** (string)
+
+    UUID of the dataset. This is unique identifier of a Flocker dataset
+
+- **gcePersistentDisk** (GCEPersistentDiskVolumeSource)
+
+  GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+  <a name="GCEPersistentDiskVolumeSource"></a>
+  *Represents a Persistent Disk resource in Google Compute Engine.
+  
+  A GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.*
+
+  - **gcePersistentDisk.pdName** (string), required
+
+    Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+  - **gcePersistentDisk.fsType** (string)
+
+    Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+  - **gcePersistentDisk.partition** (int32)
+
+    The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+  - **gcePersistentDisk.readOnly** (boolean)
+
+    ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+- **glusterfs** (GlusterfsVolumeSource)
+
+  Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md
+
+  <a name="GlusterfsVolumeSource"></a>
+  *Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.*
+
+  - **glusterfs.endpoints** (string), required
+
+    EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+
+  - **glusterfs.path** (string), required
+
+    Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+
+  - **glusterfs.readOnly** (boolean)
+
+    ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+
+- **iscsi** (ISCSIVolumeSource)
+
+  ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md
+
+  <a name="ISCSIVolumeSource"></a>
+  *Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.*
+
+  - **iscsi.iqn** (string), required
+
+    Target iSCSI Qualified Name.
+
+  - **iscsi.lun** (int32), required
+
+    iSCSI Target Lun number.
+
+  - **iscsi.targetPortal** (string), required
+
+    iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+
+  - **iscsi.chapAuthDiscovery** (boolean)
+
+    whether support iSCSI Discovery CHAP authentication
+
+  - **iscsi.chapAuthSession** (boolean)
+
+    whether support iSCSI Session CHAP authentication
+
+  - **iscsi.fsType** (string)
+
+    Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+
+  - **iscsi.initiatorName** (string)
+
+    Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface \<target portal>:\<volume name> will be created for the connection.
+
+  - **iscsi.iscsiInterface** (string)
+
+    iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+
+  - **iscsi.portals** ([]string)
+
+    iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+
+  - **iscsi.readOnly** (boolean)
+
+    ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+
+  - **iscsi.secretRef** (<a href="{{< ref "../common-definitions/local-object-reference#LocalObjectReference" >}}">LocalObjectReference</a>)
+
+    CHAP Secret for iSCSI target and initiator authentication
+
+- **nfs** (NFSVolumeSource)
+
+  NFS represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+
+  <a name="NFSVolumeSource"></a>
+  *Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management or SELinux relabeling.*
+
+  - **nfs.path** (string), required
+
+    Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+
+  - **nfs.server** (string), required
+
+    Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+
+  - **nfs.readOnly** (boolean)
+
+    ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+
+- **photonPersistentDisk** (PhotonPersistentDiskVolumeSource)
+
+  PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+
+  <a name="PhotonPersistentDiskVolumeSource"></a>
+  *Represents a Photon Controller persistent disk resource.*
+
+  - **photonPersistentDisk.pdID** (string), required
+
+    ID that identifies Photon Controller persistent disk
+
+  - **photonPersistentDisk.fsType** (string)
+
+    Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+- **portworxVolume** (PortworxVolumeSource)
+
+  PortworxVolume represents a portworx volume attached and mounted on kubelets host machine
+
+  <a name="PortworxVolumeSource"></a>
+  *PortworxVolumeSource represents a Portworx volume resource.*
+
+  - **portworxVolume.volumeID** (string), required
+
+    VolumeID uniquely identifies a Portworx volume
+
+  - **portworxVolume.fsType** (string)
+
+    FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+
+  - **portworxVolume.readOnly** (boolean)
+
+    Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+- **quobyte** (QuobyteVolumeSource)
+
+  Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+
+  <a name="QuobyteVolumeSource"></a>
+  *Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.*
+
+  - **quobyte.registry** (string), required
+
+    Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
+
+  - **quobyte.volume** (string), required
+
+    Volume is a string that references an already created Quobyte volume by name.
+
+  - **quobyte.group** (string)
+
+    Group to map volume access to Default is no group
+
+  - **quobyte.readOnly** (boolean)
+
+    ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+
+  - **quobyte.tenant** (string)
+
+    Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+
+  - **quobyte.user** (string)
+
+    User to map volume access to Defaults to serivceaccount user
+
+- **rbd** (RBDVolumeSource)
+
+  RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md
+
+  <a name="RBDVolumeSource"></a>
+  *Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.*
+
+  - **rbd.image** (string), required
+
+    The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+  - **rbd.monitors** ([]string), required
+
+    A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+  - **rbd.fsType** (string)
+
+    Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+
+  - **rbd.keyring** (string)
+
+    Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+  - **rbd.pool** (string)
+
+    The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+  - **rbd.readOnly** (boolean)
+
+    ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+  - **rbd.secretRef** (<a href="{{< ref "../common-definitions/local-object-reference#LocalObjectReference" >}}">LocalObjectReference</a>)
+
+    SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+  - **rbd.user** (string)
+
+    The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+- **scaleIO** (ScaleIOVolumeSource)
+
+  ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+
+  <a name="ScaleIOVolumeSource"></a>
+  *ScaleIOVolumeSource represents a persistent ScaleIO volume*
+
+  - **scaleIO.gateway** (string), required
+
+    The host address of the ScaleIO API Gateway.
+
+  - **scaleIO.secretRef** (<a href="{{< ref "../common-definitions/local-object-reference#LocalObjectReference" >}}">LocalObjectReference</a>), required
+
+    SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
+
+  - **scaleIO.system** (string), required
+
+    The name of the storage system as configured in ScaleIO.
+
+  - **scaleIO.fsType** (string)
+
+    Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+
+  - **scaleIO.protectionDomain** (string)
+
+    The name of the ScaleIO Protection Domain for the configured storage.
+
+  - **scaleIO.readOnly** (boolean)
+
+    Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+  - **scaleIO.sslEnabled** (boolean)
+
+    Flag to enable/disable SSL communication with Gateway, default false
+
+  - **scaleIO.storageMode** (string)
+
+    Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+
+  - **scaleIO.storagePool** (string)
+
+    The ScaleIO Storage Pool associated with the protection domain.
+
+  - **scaleIO.volumeName** (string)
+
+    The name of a volume already created in the ScaleIO system that is associated with this volume source.
+
+- **storageos** (StorageOSVolumeSource)
+
+  StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+
+  <a name="StorageOSVolumeSource"></a>
+  *Represents a StorageOS persistent volume resource.*
+
+  - **storageos.fsType** (string)
+
+    Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+  - **storageos.readOnly** (boolean)
+
+    Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+  - **storageos.secretRef** (<a href="{{< ref "../common-definitions/local-object-reference#LocalObjectReference" >}}">LocalObjectReference</a>)
+
+    SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
+
+  - **storageos.volumeName** (string)
+
+    VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+
+  - **storageos.volumeNamespace** (string)
+
+    VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+
+- **vsphereVolume** (VsphereVirtualDiskVolumeSource)
+
+  VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+
+  <a name="VsphereVirtualDiskVolumeSource"></a>
+  *Represents a vSphere volume resource.*
+
+  - **vsphereVolume.volumePath** (string), required
+
+    Path that identifies vSphere volume vmdk
+
+  - **vsphereVolume.fsType** (string)
+
+    Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+  - **vsphereVolume.storagePolicyID** (string)
+
+    Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+
+  - **vsphereVolume.storagePolicyName** (string)
+
+    Storage Policy Based Management (SPBM) profile name.
+
+### Beta level {#Beta level}
+
+
+- **csi** (CSIVolumeSource)
+
+  CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+
+  <a name="CSIVolumeSource"></a>
+  *Represents a source location of a volume to mount, managed by an external CSI driver*
+
+  - **csi.driver** (string), required
+
+    Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
+
+  - **csi.fsType** (string)
+
+    Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
+
+  - **csi.nodePublishSecretRef** (<a href="{{< ref "../common-definitions/local-object-reference#LocalObjectReference" >}}">LocalObjectReference</a>)
+
+    NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
+
+  - **csi.readOnly** (boolean)
+
+    Specifies a read-only configuration for the volume. Defaults to false (read/write).
+
+  - **csi.volumeAttributes** (map[string]string)
+
+    VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
+
+### Alpha level {#Alpha level}
+
+
+- **ephemeral** (EphemeralVolumeSource)
+
+  Ephemeral represents a volume that is handled by a cluster storage driver (Alpha feature). The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+  
+  Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+     tracking are needed,
+  c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+     a PersistentVolumeClaim (see EphemeralVolumeSource for more
+     information on the connection between this volume type
+     and PersistentVolumeClaim).
+  
+  Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+  
+  Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+  
+  A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+
+  <a name="EphemeralVolumeSource"></a>
+  *Represents an ephemeral volume that is handled by a normal storage driver.*
+
+  - **ephemeral.readOnly** (boolean)
+
+    Specifies a read-only configuration for the volume. Defaults to false (read/write).
+
+  - **ephemeral.volumeClaimTemplate** (PersistentVolumeClaimTemplate)
+
+    Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `\<pod name>-\<volume name>` where `\<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+    
+    An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+    
+    This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+    
+    Required, must not be nil.
+
+    <a name="PersistentVolumeClaimTemplate"></a>
+    *PersistentVolumeClaimTemplate is used to produce PersistentVolumeClaim objects as part of an EphemeralVolumeSource.*
+
+  - **ephemeral.volumeClaimTemplate.spec** (<a href="{{< ref "../config-and-storage-resources/persistent-volume-claim-v1#PersistentVolumeClaimSpec" >}}">PersistentVolumeClaimSpec</a>), required
+
+    The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
+
+  - **ephemeral.volumeClaimTemplate.metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+    May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+
+### Deprecated {#Deprecated}
+
+
+- **gitRepo** (GitRepoVolumeSource)
+
+  GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.
+
+  <a name="GitRepoVolumeSource"></a>
+  *Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.
+  
+  DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.*
+
+  - **gitRepo.repository** (string), required
+
+    Repository URL
+
+  - **gitRepo.directory** (string)
+
+    Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
+
+  - **gitRepo.revision** (string)
+
+    Commit hash for the specified revision.
+
+
+

--- a/content/en/docs/reference/kubernetes-api/extend-resources/_index.md
+++ b/content/en/docs/reference/kubernetes-api/extend-resources/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Extend Resources"
+weight: 7
+---

--- a/content/en/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1.md
+++ b/content/en/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1.md
@@ -1,0 +1,859 @@
+---
+api_metadata:
+  apiVersion: "apiextensions.k8s.io/v1"
+  import: "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+  kind: "CustomResourceDefinition"
+content_type: "api_reference"
+description: "CustomResourceDefinition represents a resource that should be exposed on the API server."
+title: "CustomResourceDefinition"
+weight: 1
+---
+
+`apiVersion: apiextensions.k8s.io/v1`
+
+`import "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"`
+
+
+## CustomResourceDefinition {#CustomResourceDefinition}
+
+CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format \<.spec.name>.\<.spec.group>.
+
+<hr>
+
+- **apiVersion**: apiextensions.k8s.io/v1
+
+
+- **kind**: CustomResourceDefinition
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+
+- **spec** (<a href="{{< ref "../extend-resources/custom-resource-definition-v1#CustomResourceDefinitionSpec" >}}">CustomResourceDefinitionSpec</a>), required
+
+  spec describes how the user wants the resources to appear
+
+- **status** (<a href="{{< ref "../extend-resources/custom-resource-definition-v1#CustomResourceDefinitionStatus" >}}">CustomResourceDefinitionStatus</a>)
+
+  status indicates the actual state of the CustomResourceDefinition
+
+
+
+
+
+## CustomResourceDefinitionSpec {#CustomResourceDefinitionSpec}
+
+CustomResourceDefinitionSpec describes how a user wants their resource to appear
+
+<hr>
+
+- **group** (string), required
+
+  group is the API group of the defined custom resource. The custom resources are served under `/apis/\<group>/...`. Must match the name of the CustomResourceDefinition (in the form `\<names.plural>.\<group>`).
+
+- **names** (CustomResourceDefinitionNames), required
+
+  names specify the resource and kind names for the custom resource.
+
+  <a name="CustomResourceDefinitionNames"></a>
+  *CustomResourceDefinitionNames indicates the names to serve this CustomResourceDefinition*
+
+  - **names.kind** (string), required
+
+    kind is the serialized kind of the resource. It is normally CamelCase and singular. Custom resource instances will use this value as the `kind` attribute in API calls.
+
+  - **names.plural** (string), required
+
+    plural is the plural name of the resource to serve. The custom resources are served under `/apis/\<group>/\<version>/.../\<plural>`. Must match the name of the CustomResourceDefinition (in the form `\<names.plural>.\<group>`). Must be all lowercase.
+
+  - **names.categories** ([]string)
+
+    categories is a list of grouped resources this custom resource belongs to (e.g. 'all'). This is published in API discovery documents, and used by clients to support invocations like `kubectl get all`.
+
+  - **names.listKind** (string)
+
+    listKind is the serialized kind of the list for this resource. Defaults to "`kind`List".
+
+  - **names.shortNames** ([]string)
+
+    shortNames are short names for the resource, exposed in API discovery documents, and used by clients to support invocations like `kubectl get \<shortname>`. It must be all lowercase.
+
+  - **names.singular** (string)
+
+    singular is the singular name of the resource. It must be all lowercase. Defaults to lowercased `kind`.
+
+- **scope** (string), required
+
+  scope indicates whether the defined custom resource is cluster- or namespace-scoped. Allowed values are `Cluster` and `Namespaced`.
+
+- **versions** ([]CustomResourceDefinitionVersion), required
+
+  versions is the list of all API versions of the defined custom resource. Version names are used to compute the order in which served versions are listed in API discovery. If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version), then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
+
+  <a name="CustomResourceDefinitionVersion"></a>
+  *CustomResourceDefinitionVersion describes a version for CRD.*
+
+  - **versions.name** (string), required
+
+    name is the version name, e.g. “v1”, “v2beta1”, etc. The custom resources are served under this version at `/apis/\<group>/\<version>/...` if `served` is true.
+
+  - **versions.served** (boolean), required
+
+    served is a flag enabling/disabling this version from being served via REST APIs
+
+  - **versions.storage** (boolean), required
+
+    storage indicates this version should be used when persisting custom resources to storage. There must be exactly one version with storage=true.
+
+  - **versions.additionalPrinterColumns** ([]CustomResourceColumnDefinition)
+
+    additionalPrinterColumns specifies additional columns returned in Table output. See https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables for details. If no columns are specified, a single column displaying the age of the custom resource is used.
+
+    <a name="CustomResourceColumnDefinition"></a>
+    *CustomResourceColumnDefinition specifies a column for server side printing.*
+
+  - **versions.additionalPrinterColumns.jsonPath** (string), required
+
+    jsonPath is a simple JSON path (i.e. with array notation) which is evaluated against each custom resource to produce the value for this column.
+
+  - **versions.additionalPrinterColumns.name** (string), required
+
+    name is a human readable name for the column.
+
+  - **versions.additionalPrinterColumns.type** (string), required
+
+    type is an OpenAPI type definition for this column. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.
+
+  - **versions.additionalPrinterColumns.description** (string)
+
+    description is a human readable description of this column.
+
+  - **versions.additionalPrinterColumns.format** (string)
+
+    format is an optional OpenAPI type definition for this column. The 'name' format is applied to the primary identifier column to assist in clients identifying column is the resource name. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.
+
+  - **versions.additionalPrinterColumns.priority** (int32)
+
+    priority is an integer defining the relative importance of this column compared to others. Lower numbers are considered higher priority. Columns that may be omitted in limited space scenarios should be given a priority greater than 0.
+
+  - **versions.deprecated** (boolean)
+
+    deprecated indicates this version of the custom resource API is deprecated. When set to true, API requests to this version receive a warning header in the server response. Defaults to false.
+
+  - **versions.deprecationWarning** (string)
+
+    deprecationWarning overrides the default warning returned to API clients. May only be set when `deprecated` is true. The default warning indicates this version is deprecated and recommends use of the newest served version of equal or greater stability, if one exists.
+
+  - **versions.schema** (CustomResourceValidation)
+
+    schema describes the schema used for validation, pruning, and defaulting of this version of the custom resource.
+
+    <a name="CustomResourceValidation"></a>
+    *CustomResourceValidation is a list of validation methods for CustomResources.*
+
+  - **versions.schema.openAPIV3Schema** (<a href="{{< ref "../common-definitions/json-schema-props#JSONSchemaProps" >}}">JSONSchemaProps</a>)
+
+    openAPIV3Schema is the OpenAPI v3 schema to use for validation and pruning.
+
+  - **versions.subresources** (CustomResourceSubresources)
+
+    subresources specify what subresources this version of the defined custom resource have.
+
+    <a name="CustomResourceSubresources"></a>
+    *CustomResourceSubresources defines the status and scale subresources for CustomResources.*
+
+  - **versions.subresources.scale** (CustomResourceSubresourceScale)
+
+    scale indicates the custom resource should serve a `/scale` subresource that returns an `autoscaling/v1` Scale object.
+
+    <a name="CustomResourceSubresourceScale"></a>
+    *CustomResourceSubresourceScale defines how to serve the scale subresource for CustomResources.*
+
+  - **versions.subresources.scale.specReplicasPath** (string), required
+
+    specReplicasPath defines the JSON path inside of a custom resource that corresponds to Scale `spec.replicas`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.spec`. If there is no value under the given path in the custom resource, the `/scale` subresource will return an error on GET.
+
+  - **versions.subresources.scale.statusReplicasPath** (string), required
+
+    statusReplicasPath defines the JSON path inside of a custom resource that corresponds to Scale `status.replicas`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.status`. If there is no value under the given path in the custom resource, the `status.replicas` value in the `/scale` subresource will default to 0.
+
+  - **versions.subresources.scale.labelSelectorPath** (string)
+
+    labelSelectorPath defines the JSON path inside of a custom resource that corresponds to Scale `status.selector`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.status` or `.spec`. Must be set to work with HorizontalPodAutoscaler. The field pointed by this JSON path must be a string field (not a complex selector struct) which contains a serialized label selector in string form. More info: https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions#scale-subresource If there is no value under the given path in the custom resource, the `status.selector` value in the `/scale` subresource will default to the empty string.
+
+  - **versions.subresources.status** (CustomResourceSubresourceStatus)
+
+    status indicates the custom resource should serve a `/status` subresource. When enabled: 1. requests to the custom resource primary endpoint ignore changes to the `status` stanza of the object. 2. requests to the custom resource `/status` subresource ignore changes to anything other than the `status` stanza of the object.
+
+    <a name="CustomResourceSubresourceStatus"></a>
+    *CustomResourceSubresourceStatus defines how to serve the status subresource for CustomResources. Status is represented by the `.status` JSON path inside of a CustomResource. When set, * exposes a /status subresource for the custom resource * PUT requests to the /status subresource take a custom resource object, and ignore changes to anything except the status stanza * PUT/POST/PATCH requests to the custom resource ignore changes to the status stanza*
+
+- **conversion** (CustomResourceConversion)
+
+  conversion defines conversion settings for the CRD.
+
+  <a name="CustomResourceConversion"></a>
+  *CustomResourceConversion describes how to convert different versions of a CR.*
+
+  - **conversion.strategy** (string), required
+
+    strategy specifies how custom resources are converted between versions. Allowed values are: - `None`: The converter only change the apiVersion and would not touch any other field in the custom resource. - `Webhook`: API Server will call to an external webhook to do the conversion. Additional information
+      is needed for this option. This requires spec.preserveUnknownFields to be false, and spec.conversion.webhook to be set.
+
+  - **conversion.webhook** (WebhookConversion)
+
+    webhook describes how to call the conversion webhook. Required when `strategy` is set to `Webhook`.
+
+    <a name="WebhookConversion"></a>
+    *WebhookConversion describes how to call a conversion webhook*
+
+  - **conversion.webhook.conversionReviewVersions** ([]string), required
+
+    conversionReviewVersions is an ordered list of preferred `ConversionReview` versions the Webhook expects. The API server will use the first version in the list which it supports. If none of the versions specified in this list are supported by API server, conversion will fail for the custom resource. If a persisted Webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail.
+
+  - **conversion.webhook.clientConfig** (WebhookClientConfig)
+
+    clientConfig is the instructions for how to call the webhook if strategy is `Webhook`.
+
+    <a name="WebhookClientConfig"></a>
+    *WebhookClientConfig contains the information to make a TLS connection with the webhook.*
+
+  - **conversion.webhook.clientConfig.caBundle** ([]byte)
+
+    caBundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate. If unspecified, system trust roots on the apiserver are used.
+
+  - **conversion.webhook.clientConfig.service** (ServiceReference)
+
+    service is a reference to the service for this webhook. Either service or url must be specified.
+    
+    If the webhook is running within the cluster, then you should use `service`.
+
+    <a name="ServiceReference"></a>
+    *ServiceReference holds a reference to Service.legacy.k8s.io*
+
+  - **conversion.webhook.clientConfig.service.name** (string), required
+
+    name is the name of the service. Required
+
+  - **conversion.webhook.clientConfig.service.namespace** (string), required
+
+    namespace is the namespace of the service. Required
+
+  - **conversion.webhook.clientConfig.service.path** (string)
+
+    path is an optional URL path at which the webhook will be contacted.
+
+  - **conversion.webhook.clientConfig.service.port** (int32)
+
+    port is an optional service port at which the webhook will be contacted. `port` should be a valid port number (1-65535, inclusive). Defaults to 443 for backward compatibility.
+
+  - **conversion.webhook.clientConfig.url** (string)
+
+    url gives the location of the webhook, in standard URL form (`scheme://host:port/path`). Exactly one of `url` or `service` must be specified.
+    
+    The `host` should not refer to a service running in the cluster; use the `service` field instead. The host might be resolved via external DNS in some apiservers (e.g., `kube-apiserver` cannot resolve in-cluster DNS as that would be a layering violation). `host` may also be an IP address.
+    
+    Please note that using `localhost` or `127.0.0.1` as a `host` is risky unless you take great care to run this webhook on all hosts which run an apiserver which might need to make calls to this webhook. Such installs are likely to be non-portable, i.e., not easy to turn up in a new cluster.
+    
+    The scheme must be "https"; the URL must begin with "https://".
+    
+    A path is optional, and if present may be any string permissible in a URL. You may use the path to pass an arbitrary string to the webhook, for example, a cluster identifier.
+    
+    Attempting to use a user or basic auth e.g. "user:password@" is not allowed. Fragments ("#...") and query parameters ("?...") are not allowed, either.
+
+- **preserveUnknownFields** (boolean)
+
+  preserveUnknownFields indicates that object fields which are not specified in the OpenAPI schema should be preserved when persisting to storage. apiVersion, kind, metadata and known fields inside metadata are always preserved. This field is deprecated in favor of setting `x-preserve-unknown-fields` to true in `spec.versions[*].schema.openAPIV3Schema`. See https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#pruning-versus-preserving-unknown-fields for details.
+
+
+
+
+
+## CustomResourceDefinitionStatus {#CustomResourceDefinitionStatus}
+
+CustomResourceDefinitionStatus indicates the state of the CustomResourceDefinition
+
+<hr>
+
+- **acceptedNames** (CustomResourceDefinitionNames)
+
+  acceptedNames are the names that are actually being used to serve discovery. They may be different than the names in spec.
+
+  <a name="CustomResourceDefinitionNames"></a>
+  *CustomResourceDefinitionNames indicates the names to serve this CustomResourceDefinition*
+
+  - **acceptedNames.kind** (string), required
+
+    kind is the serialized kind of the resource. It is normally CamelCase and singular. Custom resource instances will use this value as the `kind` attribute in API calls.
+
+  - **acceptedNames.plural** (string), required
+
+    plural is the plural name of the resource to serve. The custom resources are served under `/apis/\<group>/\<version>/.../\<plural>`. Must match the name of the CustomResourceDefinition (in the form `\<names.plural>.\<group>`). Must be all lowercase.
+
+  - **acceptedNames.categories** ([]string)
+
+    categories is a list of grouped resources this custom resource belongs to (e.g. 'all'). This is published in API discovery documents, and used by clients to support invocations like `kubectl get all`.
+
+  - **acceptedNames.listKind** (string)
+
+    listKind is the serialized kind of the list for this resource. Defaults to "`kind`List".
+
+  - **acceptedNames.shortNames** ([]string)
+
+    shortNames are short names for the resource, exposed in API discovery documents, and used by clients to support invocations like `kubectl get \<shortname>`. It must be all lowercase.
+
+  - **acceptedNames.singular** (string)
+
+    singular is the singular name of the resource. It must be all lowercase. Defaults to lowercased `kind`.
+
+- **conditions** ([]CustomResourceDefinitionCondition)
+
+  conditions indicate state for particular aspects of a CustomResourceDefinition
+
+  <a name="CustomResourceDefinitionCondition"></a>
+  *CustomResourceDefinitionCondition contains details for the current condition of this pod.*
+
+  - **conditions.status** (string), required
+
+    status is the status of the condition. Can be True, False, Unknown.
+
+  - **conditions.type** (string), required
+
+    type is the type of the condition. Types include Established, NamesAccepted and Terminating.
+
+  - **conditions.lastTransitionTime** (Time)
+
+    lastTransitionTime last time the condition transitioned from one status to another.
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **conditions.message** (string)
+
+    message is a human-readable message indicating details about last transition.
+
+  - **conditions.reason** (string)
+
+    reason is a unique, one-word, CamelCase reason for the condition's last transition.
+
+- **storedVersions** ([]string)
+
+  storedVersions lists all versions of CustomResources that were ever persisted. Tracking these versions allows a migration path for stored versions in etcd. The field is mutable so a migration controller can finish a migration to another version (ensuring no old objects are left in storage), and then remove the rest of the versions from this list. Versions may not be removed from `spec.versions` while they exist in this list.
+
+
+
+
+
+## CustomResourceDefinitionList {#CustomResourceDefinitionList}
+
+CustomResourceDefinitionList is a list of CustomResourceDefinition objects.
+
+<hr>
+
+- **apiVersion**: apiextensions.k8s.io/v1
+
+
+- **kind**: CustomResourceDefinitionList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+
+- **items** ([]<a href="{{< ref "../extend-resources/custom-resource-definition-v1#CustomResourceDefinition" >}}">CustomResourceDefinition</a>), required
+
+  items list individual CustomResourceDefinition objects
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified CustomResourceDefinition
+
+#### HTTP Request
+
+GET /apis/apiextensions.k8s.io/v1/customresourcedefinitions/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CustomResourceDefinition
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../extend-resources/custom-resource-definition-v1#CustomResourceDefinition" >}}">CustomResourceDefinition</a>): OK
+
+401: Unauthorized
+
+
+### `get` read status of the specified CustomResourceDefinition
+
+#### HTTP Request
+
+GET /apis/apiextensions.k8s.io/v1/customresourcedefinitions/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CustomResourceDefinition
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../extend-resources/custom-resource-definition-v1#CustomResourceDefinition" >}}">CustomResourceDefinition</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind CustomResourceDefinition
+
+#### HTTP Request
+
+GET /apis/apiextensions.k8s.io/v1/customresourcedefinitions
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../extend-resources/custom-resource-definition-v1#CustomResourceDefinitionList" >}}">CustomResourceDefinitionList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a CustomResourceDefinition
+
+#### HTTP Request
+
+POST /apis/apiextensions.k8s.io/v1/customresourcedefinitions
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../extend-resources/custom-resource-definition-v1#CustomResourceDefinition" >}}">CustomResourceDefinition</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../extend-resources/custom-resource-definition-v1#CustomResourceDefinition" >}}">CustomResourceDefinition</a>): OK
+
+201 (<a href="{{< ref "../extend-resources/custom-resource-definition-v1#CustomResourceDefinition" >}}">CustomResourceDefinition</a>): Created
+
+202 (<a href="{{< ref "../extend-resources/custom-resource-definition-v1#CustomResourceDefinition" >}}">CustomResourceDefinition</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified CustomResourceDefinition
+
+#### HTTP Request
+
+PUT /apis/apiextensions.k8s.io/v1/customresourcedefinitions/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CustomResourceDefinition
+
+
+- **body**: <a href="{{< ref "../extend-resources/custom-resource-definition-v1#CustomResourceDefinition" >}}">CustomResourceDefinition</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../extend-resources/custom-resource-definition-v1#CustomResourceDefinition" >}}">CustomResourceDefinition</a>): OK
+
+201 (<a href="{{< ref "../extend-resources/custom-resource-definition-v1#CustomResourceDefinition" >}}">CustomResourceDefinition</a>): Created
+
+401: Unauthorized
+
+
+### `update` replace status of the specified CustomResourceDefinition
+
+#### HTTP Request
+
+PUT /apis/apiextensions.k8s.io/v1/customresourcedefinitions/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CustomResourceDefinition
+
+
+- **body**: <a href="{{< ref "../extend-resources/custom-resource-definition-v1#CustomResourceDefinition" >}}">CustomResourceDefinition</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../extend-resources/custom-resource-definition-v1#CustomResourceDefinition" >}}">CustomResourceDefinition</a>): OK
+
+201 (<a href="{{< ref "../extend-resources/custom-resource-definition-v1#CustomResourceDefinition" >}}">CustomResourceDefinition</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified CustomResourceDefinition
+
+#### HTTP Request
+
+PATCH /apis/apiextensions.k8s.io/v1/customresourcedefinitions/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CustomResourceDefinition
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../extend-resources/custom-resource-definition-v1#CustomResourceDefinition" >}}">CustomResourceDefinition</a>): OK
+
+401: Unauthorized
+
+
+### `patch` partially update status of the specified CustomResourceDefinition
+
+#### HTTP Request
+
+PATCH /apis/apiextensions.k8s.io/v1/customresourcedefinitions/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CustomResourceDefinition
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../extend-resources/custom-resource-definition-v1#CustomResourceDefinition" >}}">CustomResourceDefinition</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a CustomResourceDefinition
+
+#### HTTP Request
+
+DELETE /apis/apiextensions.k8s.io/v1/customresourcedefinitions/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CustomResourceDefinition
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of CustomResourceDefinition
+
+#### HTTP Request
+
+DELETE /apis/apiextensions.k8s.io/v1/customresourcedefinitions
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/extend-resources/mutating-webhook-configuration-v1.md
+++ b/content/en/docs/reference/kubernetes-api/extend-resources/mutating-webhook-configuration-v1.md
@@ -1,0 +1,599 @@
+---
+api_metadata:
+  apiVersion: "admissionregistration.k8s.io/v1"
+  import: "k8s.io/api/admissionregistration/v1"
+  kind: "MutatingWebhookConfiguration"
+content_type: "api_reference"
+description: "MutatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and may change the object."
+title: "MutatingWebhookConfiguration"
+weight: 2
+---
+
+`apiVersion: admissionregistration.k8s.io/v1`
+
+`import "k8s.io/api/admissionregistration/v1"`
+
+
+## MutatingWebhookConfiguration {#MutatingWebhookConfiguration}
+
+MutatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and may change the object.
+
+<hr>
+
+- **apiVersion**: admissionregistration.k8s.io/v1
+
+
+- **kind**: MutatingWebhookConfiguration
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+
+- **webhooks** ([]MutatingWebhook)
+
+  *Patch strategy: merge on key `name`*
+  
+  Webhooks is a list of webhooks and the affected resources and operations.
+
+  <a name="MutatingWebhook"></a>
+  *MutatingWebhook describes an admission webhook and the resources and operations it applies to.*
+
+  - **webhooks.admissionReviewVersions** ([]string), required
+
+    AdmissionReviewVersions is an ordered list of preferred `AdmissionReview` versions the Webhook expects. API server will try to use first version in the list which it supports. If none of the versions specified in this list supported by API server, validation will fail for this object. If a persisted webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail and be subject to the failure policy.
+
+  - **webhooks.clientConfig** (WebhookClientConfig), required
+
+    ClientConfig defines how to communicate with the hook. Required
+
+    <a name="WebhookClientConfig"></a>
+    *WebhookClientConfig contains the information to make a TLS connection with the webhook*
+
+  - **webhooks.clientConfig.caBundle** ([]byte)
+
+    `caBundle` is a PEM encoded CA bundle which will be used to validate the webhook's server certificate. If unspecified, system trust roots on the apiserver are used.
+
+  - **webhooks.clientConfig.service** (ServiceReference)
+
+    `service` is a reference to the service for this webhook. Either `service` or `url` must be specified.
+    
+    If the webhook is running within the cluster, then you should use `service`.
+
+    <a name="ServiceReference"></a>
+    *ServiceReference holds a reference to Service.legacy.k8s.io*
+
+  - **webhooks.clientConfig.service.name** (string), required
+
+    `name` is the name of the service. Required
+
+  - **webhooks.clientConfig.service.namespace** (string), required
+
+    `namespace` is the namespace of the service. Required
+
+  - **webhooks.clientConfig.service.path** (string)
+
+    `path` is an optional URL path which will be sent in any request to this service.
+
+  - **webhooks.clientConfig.service.port** (int32)
+
+    If specified, the port on the service that hosting webhook. Default to 443 for backward compatibility. `port` should be a valid port number (1-65535, inclusive).
+
+  - **webhooks.clientConfig.url** (string)
+
+    `url` gives the location of the webhook, in standard URL form (`scheme://host:port/path`). Exactly one of `url` or `service` must be specified.
+    
+    The `host` should not refer to a service running in the cluster; use the `service` field instead. The host might be resolved via external DNS in some apiservers (e.g., `kube-apiserver` cannot resolve in-cluster DNS as that would be a layering violation). `host` may also be an IP address.
+    
+    Please note that using `localhost` or `127.0.0.1` as a `host` is risky unless you take great care to run this webhook on all hosts which run an apiserver which might need to make calls to this webhook. Such installs are likely to be non-portable, i.e., not easy to turn up in a new cluster.
+    
+    The scheme must be "https"; the URL must begin with "https://".
+    
+    A path is optional, and if present may be any string permissible in a URL. You may use the path to pass an arbitrary string to the webhook, for example, a cluster identifier.
+    
+    Attempting to use a user or basic auth e.g. "user:password@" is not allowed. Fragments ("#...") and query parameters ("?...") are not allowed, either.
+
+  - **webhooks.name** (string), required
+
+    The name of the admission webhook. Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where "imagepolicy" is the name of the webhook, and kubernetes.io is the name of the organization. Required.
+
+  - **webhooks.sideEffects** (string), required
+
+    SideEffects states whether this webhook has side effects. Acceptable values are: None, NoneOnDryRun (webhooks created via v1beta1 may also specify Some or Unknown). Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission change and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some.
+
+  - **webhooks.failurePolicy** (string)
+
+    FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Fail.
+
+  - **webhooks.matchPolicy** (string)
+
+    matchPolicy defines how the "rules" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent".
+    
+    - Exact: match a request only if it exactly matches a specified rule. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the webhook.
+    
+    - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the webhook.
+    
+    Defaults to "Equivalent"
+
+  - **webhooks.namespaceSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
+
+    NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.
+    
+    For example, to run the webhook on any objects whose namespace is not associated with "runlevel" of "0" or "1";  you will set the selector as follows: "namespaceSelector": {
+      "matchExpressions": [
+        {
+          "key": "runlevel",
+          "operator": "NotIn",
+          "values": [
+            "0",
+            "1"
+          ]
+        }
+      ]
+    }
+    
+    If instead you want to only run the webhook on any objects whose namespace is associated with the "environment" of "prod" or "staging"; you will set the selector as follows: "namespaceSelector": {
+      "matchExpressions": [
+        {
+          "key": "environment",
+          "operator": "In",
+          "values": [
+            "prod",
+            "staging"
+          ]
+        }
+      ]
+    }
+    
+    See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more examples of label selectors.
+    
+    Default to the empty LabelSelector, which matches everything.
+
+  - **webhooks.objectSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
+
+    ObjectSelector decides whether to run the webhook based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the webhook, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.
+
+  - **webhooks.reinvocationPolicy** (string)
+
+    reinvocationPolicy indicates whether this webhook should be called multiple times as part of a single admission evaluation. Allowed values are "Never" and "IfNeeded".
+    
+    Never: the webhook will not be called more than once in a single admission evaluation.
+    
+    IfNeeded: the webhook will be called at least one additional time as part of the admission evaluation if the object being admitted is modified by other admission plugins after the initial webhook call. Webhooks that specify this option *must* be idempotent, able to process objects they previously admitted. Note: * the number of additional invocations is not guaranteed to be exactly one. * if additional invocations result in further modifications to the object, webhooks are not guaranteed to be invoked again. * webhooks that use this option may be reordered to minimize the number of additional invocations. * to validate an object after all mutations are guaranteed complete, use a validating admission webhook instead.
+    
+    Defaults to "Never".
+
+  - **webhooks.rules** ([]RuleWithOperations)
+
+    Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule. However, in order to prevent ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks from putting the cluster in a state which cannot be recovered from without completely disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.
+
+    <a name="RuleWithOperations"></a>
+    *RuleWithOperations is a tuple of Operations and Resources. It is recommended to make sure that all the tuple expansions are valid.*
+
+  - **webhooks.rules.apiGroups** ([]string)
+
+    APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+
+  - **webhooks.rules.apiVersions** ([]string)
+
+    APIVersions is the API versions the resources belong to. '*' is all versions. If '*' is present, the length of the slice must be one. Required.
+
+  - **webhooks.rules.operations** ([]string)
+
+    Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or * for all of those operations and any future admission operations that are added. If '*' is present, the length of the slice must be one. Required.
+
+  - **webhooks.rules.resources** ([]string)
+
+    Resources is a list of resources this rule applies to.
+    
+    For example: 'pods' means pods. 'pods/log' means the log subresource of pods. '*' means all resources, but not subresources. 'pods/*' means all subresources of pods. '*/scale' means all scale subresources. '*/*' means all resources and their subresources.
+    
+    If wildcard is present, the validation rule will ensure resources do not overlap with each other.
+    
+    Depending on the enclosing object, subresources might not be allowed. Required.
+
+  - **webhooks.rules.scope** (string)
+
+    scope specifies the scope of this rule. Valid values are "Cluster", "Namespaced", and "*" "Cluster" means that only cluster-scoped resources will match this rule. Namespace API objects are cluster-scoped. "Namespaced" means that only namespaced resources will match this rule. "*" means that there are no scope restrictions. Subresources match the scope of their parent resource. Default is "*".
+
+  - **webhooks.timeoutSeconds** (int32)
+
+    TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 10 seconds.
+
+
+
+
+
+## MutatingWebhookConfigurationList {#MutatingWebhookConfigurationList}
+
+MutatingWebhookConfigurationList is a list of MutatingWebhookConfiguration.
+
+<hr>
+
+- **apiVersion**: admissionregistration.k8s.io/v1
+
+
+- **kind**: MutatingWebhookConfigurationList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+- **items** ([]<a href="{{< ref "../extend-resources/mutating-webhook-configuration-v1#MutatingWebhookConfiguration" >}}">MutatingWebhookConfiguration</a>), required
+
+  List of MutatingWebhookConfiguration.
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified MutatingWebhookConfiguration
+
+#### HTTP Request
+
+GET /apis/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the MutatingWebhookConfiguration
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../extend-resources/mutating-webhook-configuration-v1#MutatingWebhookConfiguration" >}}">MutatingWebhookConfiguration</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind MutatingWebhookConfiguration
+
+#### HTTP Request
+
+GET /apis/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../extend-resources/mutating-webhook-configuration-v1#MutatingWebhookConfigurationList" >}}">MutatingWebhookConfigurationList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a MutatingWebhookConfiguration
+
+#### HTTP Request
+
+POST /apis/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../extend-resources/mutating-webhook-configuration-v1#MutatingWebhookConfiguration" >}}">MutatingWebhookConfiguration</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../extend-resources/mutating-webhook-configuration-v1#MutatingWebhookConfiguration" >}}">MutatingWebhookConfiguration</a>): OK
+
+201 (<a href="{{< ref "../extend-resources/mutating-webhook-configuration-v1#MutatingWebhookConfiguration" >}}">MutatingWebhookConfiguration</a>): Created
+
+202 (<a href="{{< ref "../extend-resources/mutating-webhook-configuration-v1#MutatingWebhookConfiguration" >}}">MutatingWebhookConfiguration</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified MutatingWebhookConfiguration
+
+#### HTTP Request
+
+PUT /apis/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the MutatingWebhookConfiguration
+
+
+- **body**: <a href="{{< ref "../extend-resources/mutating-webhook-configuration-v1#MutatingWebhookConfiguration" >}}">MutatingWebhookConfiguration</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../extend-resources/mutating-webhook-configuration-v1#MutatingWebhookConfiguration" >}}">MutatingWebhookConfiguration</a>): OK
+
+201 (<a href="{{< ref "../extend-resources/mutating-webhook-configuration-v1#MutatingWebhookConfiguration" >}}">MutatingWebhookConfiguration</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified MutatingWebhookConfiguration
+
+#### HTTP Request
+
+PATCH /apis/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the MutatingWebhookConfiguration
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../extend-resources/mutating-webhook-configuration-v1#MutatingWebhookConfiguration" >}}">MutatingWebhookConfiguration</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a MutatingWebhookConfiguration
+
+#### HTTP Request
+
+DELETE /apis/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the MutatingWebhookConfiguration
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of MutatingWebhookConfiguration
+
+#### HTTP Request
+
+DELETE /apis/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/extend-resources/validating-webhook-configuration-v1.md
+++ b/content/en/docs/reference/kubernetes-api/extend-resources/validating-webhook-configuration-v1.md
@@ -1,0 +1,589 @@
+---
+api_metadata:
+  apiVersion: "admissionregistration.k8s.io/v1"
+  import: "k8s.io/api/admissionregistration/v1"
+  kind: "ValidatingWebhookConfiguration"
+content_type: "api_reference"
+description: "ValidatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and object without changing it."
+title: "ValidatingWebhookConfiguration"
+weight: 3
+---
+
+`apiVersion: admissionregistration.k8s.io/v1`
+
+`import "k8s.io/api/admissionregistration/v1"`
+
+
+## ValidatingWebhookConfiguration {#ValidatingWebhookConfiguration}
+
+ValidatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and object without changing it.
+
+<hr>
+
+- **apiVersion**: admissionregistration.k8s.io/v1
+
+
+- **kind**: ValidatingWebhookConfiguration
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+
+- **webhooks** ([]ValidatingWebhook)
+
+  *Patch strategy: merge on key `name`*
+  
+  Webhooks is a list of webhooks and the affected resources and operations.
+
+  <a name="ValidatingWebhook"></a>
+  *ValidatingWebhook describes an admission webhook and the resources and operations it applies to.*
+
+  - **webhooks.admissionReviewVersions** ([]string), required
+
+    AdmissionReviewVersions is an ordered list of preferred `AdmissionReview` versions the Webhook expects. API server will try to use first version in the list which it supports. If none of the versions specified in this list supported by API server, validation will fail for this object. If a persisted webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail and be subject to the failure policy.
+
+  - **webhooks.clientConfig** (WebhookClientConfig), required
+
+    ClientConfig defines how to communicate with the hook. Required
+
+    <a name="WebhookClientConfig"></a>
+    *WebhookClientConfig contains the information to make a TLS connection with the webhook*
+
+  - **webhooks.clientConfig.caBundle** ([]byte)
+
+    `caBundle` is a PEM encoded CA bundle which will be used to validate the webhook's server certificate. If unspecified, system trust roots on the apiserver are used.
+
+  - **webhooks.clientConfig.service** (ServiceReference)
+
+    `service` is a reference to the service for this webhook. Either `service` or `url` must be specified.
+    
+    If the webhook is running within the cluster, then you should use `service`.
+
+    <a name="ServiceReference"></a>
+    *ServiceReference holds a reference to Service.legacy.k8s.io*
+
+  - **webhooks.clientConfig.service.name** (string), required
+
+    `name` is the name of the service. Required
+
+  - **webhooks.clientConfig.service.namespace** (string), required
+
+    `namespace` is the namespace of the service. Required
+
+  - **webhooks.clientConfig.service.path** (string)
+
+    `path` is an optional URL path which will be sent in any request to this service.
+
+  - **webhooks.clientConfig.service.port** (int32)
+
+    If specified, the port on the service that hosting webhook. Default to 443 for backward compatibility. `port` should be a valid port number (1-65535, inclusive).
+
+  - **webhooks.clientConfig.url** (string)
+
+    `url` gives the location of the webhook, in standard URL form (`scheme://host:port/path`). Exactly one of `url` or `service` must be specified.
+    
+    The `host` should not refer to a service running in the cluster; use the `service` field instead. The host might be resolved via external DNS in some apiservers (e.g., `kube-apiserver` cannot resolve in-cluster DNS as that would be a layering violation). `host` may also be an IP address.
+    
+    Please note that using `localhost` or `127.0.0.1` as a `host` is risky unless you take great care to run this webhook on all hosts which run an apiserver which might need to make calls to this webhook. Such installs are likely to be non-portable, i.e., not easy to turn up in a new cluster.
+    
+    The scheme must be "https"; the URL must begin with "https://".
+    
+    A path is optional, and if present may be any string permissible in a URL. You may use the path to pass an arbitrary string to the webhook, for example, a cluster identifier.
+    
+    Attempting to use a user or basic auth e.g. "user:password@" is not allowed. Fragments ("#...") and query parameters ("?...") are not allowed, either.
+
+  - **webhooks.name** (string), required
+
+    The name of the admission webhook. Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where "imagepolicy" is the name of the webhook, and kubernetes.io is the name of the organization. Required.
+
+  - **webhooks.sideEffects** (string), required
+
+    SideEffects states whether this webhook has side effects. Acceptable values are: None, NoneOnDryRun (webhooks created via v1beta1 may also specify Some or Unknown). Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission change and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some.
+
+  - **webhooks.failurePolicy** (string)
+
+    FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Fail.
+
+  - **webhooks.matchPolicy** (string)
+
+    matchPolicy defines how the "rules" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent".
+    
+    - Exact: match a request only if it exactly matches a specified rule. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the webhook.
+    
+    - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the webhook.
+    
+    Defaults to "Equivalent"
+
+  - **webhooks.namespaceSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
+
+    NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.
+    
+    For example, to run the webhook on any objects whose namespace is not associated with "runlevel" of "0" or "1";  you will set the selector as follows: "namespaceSelector": {
+      "matchExpressions": [
+        {
+          "key": "runlevel",
+          "operator": "NotIn",
+          "values": [
+            "0",
+            "1"
+          ]
+        }
+      ]
+    }
+    
+    If instead you want to only run the webhook on any objects whose namespace is associated with the "environment" of "prod" or "staging"; you will set the selector as follows: "namespaceSelector": {
+      "matchExpressions": [
+        {
+          "key": "environment",
+          "operator": "In",
+          "values": [
+            "prod",
+            "staging"
+          ]
+        }
+      ]
+    }
+    
+    See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels for more examples of label selectors.
+    
+    Default to the empty LabelSelector, which matches everything.
+
+  - **webhooks.objectSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
+
+    ObjectSelector decides whether to run the webhook based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the webhook, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.
+
+  - **webhooks.rules** ([]RuleWithOperations)
+
+    Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule. However, in order to prevent ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks from putting the cluster in a state which cannot be recovered from without completely disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.
+
+    <a name="RuleWithOperations"></a>
+    *RuleWithOperations is a tuple of Operations and Resources. It is recommended to make sure that all the tuple expansions are valid.*
+
+  - **webhooks.rules.apiGroups** ([]string)
+
+    APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+
+  - **webhooks.rules.apiVersions** ([]string)
+
+    APIVersions is the API versions the resources belong to. '*' is all versions. If '*' is present, the length of the slice must be one. Required.
+
+  - **webhooks.rules.operations** ([]string)
+
+    Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or * for all of those operations and any future admission operations that are added. If '*' is present, the length of the slice must be one. Required.
+
+  - **webhooks.rules.resources** ([]string)
+
+    Resources is a list of resources this rule applies to.
+    
+    For example: 'pods' means pods. 'pods/log' means the log subresource of pods. '*' means all resources, but not subresources. 'pods/*' means all subresources of pods. '*/scale' means all scale subresources. '*/*' means all resources and their subresources.
+    
+    If wildcard is present, the validation rule will ensure resources do not overlap with each other.
+    
+    Depending on the enclosing object, subresources might not be allowed. Required.
+
+  - **webhooks.rules.scope** (string)
+
+    scope specifies the scope of this rule. Valid values are "Cluster", "Namespaced", and "*" "Cluster" means that only cluster-scoped resources will match this rule. Namespace API objects are cluster-scoped. "Namespaced" means that only namespaced resources will match this rule. "*" means that there are no scope restrictions. Subresources match the scope of their parent resource. Default is "*".
+
+  - **webhooks.timeoutSeconds** (int32)
+
+    TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 10 seconds.
+
+
+
+
+
+## ValidatingWebhookConfigurationList {#ValidatingWebhookConfigurationList}
+
+ValidatingWebhookConfigurationList is a list of ValidatingWebhookConfiguration.
+
+<hr>
+
+- **apiVersion**: admissionregistration.k8s.io/v1
+
+
+- **kind**: ValidatingWebhookConfigurationList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+- **items** ([]<a href="{{< ref "../extend-resources/validating-webhook-configuration-v1#ValidatingWebhookConfiguration" >}}">ValidatingWebhookConfiguration</a>), required
+
+  List of ValidatingWebhookConfiguration.
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified ValidatingWebhookConfiguration
+
+#### HTTP Request
+
+GET /apis/admissionregistration.k8s.io/v1/validatingwebhookconfigurations/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ValidatingWebhookConfiguration
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../extend-resources/validating-webhook-configuration-v1#ValidatingWebhookConfiguration" >}}">ValidatingWebhookConfiguration</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind ValidatingWebhookConfiguration
+
+#### HTTP Request
+
+GET /apis/admissionregistration.k8s.io/v1/validatingwebhookconfigurations
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../extend-resources/validating-webhook-configuration-v1#ValidatingWebhookConfigurationList" >}}">ValidatingWebhookConfigurationList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a ValidatingWebhookConfiguration
+
+#### HTTP Request
+
+POST /apis/admissionregistration.k8s.io/v1/validatingwebhookconfigurations
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../extend-resources/validating-webhook-configuration-v1#ValidatingWebhookConfiguration" >}}">ValidatingWebhookConfiguration</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../extend-resources/validating-webhook-configuration-v1#ValidatingWebhookConfiguration" >}}">ValidatingWebhookConfiguration</a>): OK
+
+201 (<a href="{{< ref "../extend-resources/validating-webhook-configuration-v1#ValidatingWebhookConfiguration" >}}">ValidatingWebhookConfiguration</a>): Created
+
+202 (<a href="{{< ref "../extend-resources/validating-webhook-configuration-v1#ValidatingWebhookConfiguration" >}}">ValidatingWebhookConfiguration</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified ValidatingWebhookConfiguration
+
+#### HTTP Request
+
+PUT /apis/admissionregistration.k8s.io/v1/validatingwebhookconfigurations/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ValidatingWebhookConfiguration
+
+
+- **body**: <a href="{{< ref "../extend-resources/validating-webhook-configuration-v1#ValidatingWebhookConfiguration" >}}">ValidatingWebhookConfiguration</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../extend-resources/validating-webhook-configuration-v1#ValidatingWebhookConfiguration" >}}">ValidatingWebhookConfiguration</a>): OK
+
+201 (<a href="{{< ref "../extend-resources/validating-webhook-configuration-v1#ValidatingWebhookConfiguration" >}}">ValidatingWebhookConfiguration</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified ValidatingWebhookConfiguration
+
+#### HTTP Request
+
+PATCH /apis/admissionregistration.k8s.io/v1/validatingwebhookconfigurations/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ValidatingWebhookConfiguration
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../extend-resources/validating-webhook-configuration-v1#ValidatingWebhookConfiguration" >}}">ValidatingWebhookConfiguration</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a ValidatingWebhookConfiguration
+
+#### HTTP Request
+
+DELETE /apis/admissionregistration.k8s.io/v1/validatingwebhookconfigurations/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ValidatingWebhookConfiguration
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of ValidatingWebhookConfiguration
+
+#### HTTP Request
+
+DELETE /apis/admissionregistration.k8s.io/v1/validatingwebhookconfigurations
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/policies-resources/_index.md
+++ b/content/en/docs/reference/kubernetes-api/policies-resources/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Policies Resources"
+weight: 6
+---

--- a/content/en/docs/reference/kubernetes-api/policies-resources/limit-range-v1.md
+++ b/content/en/docs/reference/kubernetes-api/policies-resources/limit-range-v1.md
@@ -1,0 +1,577 @@
+---
+api_metadata:
+  apiVersion: "v1"
+  import: "k8s.io/api/core/v1"
+  kind: "LimitRange"
+content_type: "api_reference"
+description: "LimitRange sets resource usage limits for each kind of resource in a Namespace."
+title: "LimitRange"
+weight: 1
+---
+
+`apiVersion: v1`
+
+`import "k8s.io/api/core/v1"`
+
+
+## LimitRange {#LimitRange}
+
+LimitRange sets resource usage limits for each kind of resource in a Namespace.
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: LimitRange
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **spec** (<a href="{{< ref "../policies-resources/limit-range-v1#LimitRangeSpec" >}}">LimitRangeSpec</a>)
+
+  Spec defines the limits enforced. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+
+
+
+
+## LimitRangeSpec {#LimitRangeSpec}
+
+LimitRangeSpec defines a min/max usage limit for resources that match on kind.
+
+<hr>
+
+- **limits** ([]LimitRangeItem), required
+
+  Limits is the list of LimitRangeItem objects that are enforced.
+
+  <a name="LimitRangeItem"></a>
+  *LimitRangeItem defines a min/max usage limit for any resource that matches on kind.*
+
+  - **limits.type** (string), required
+
+    Type of resource that this limit applies to.
+
+  - **limits.default** (map[string]<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    Default resource requirement limit value by resource name if resource limit is omitted.
+
+  - **limits.defaultRequest** (map[string]<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    DefaultRequest is the default resource requirement request value by resource name if resource request is omitted.
+
+  - **limits.max** (map[string]<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    Max usage constraints on this kind by resource name.
+
+  - **limits.maxLimitRequestRatio** (map[string]<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    MaxLimitRequestRatio if specified, the named resource must have a request and limit that are both non-zero where limit divided by request is less than or equal to the enumerated value; this represents the max burst for the named resource.
+
+  - **limits.min** (map[string]<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    Min usage constraints on this kind by resource name.
+
+
+
+
+
+## LimitRangeList {#LimitRangeList}
+
+LimitRangeList is a list of LimitRange items.
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: LimitRangeList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+- **items** ([]<a href="{{< ref "../policies-resources/limit-range-v1#LimitRange" >}}">LimitRange</a>), required
+
+  Items is a list of LimitRange objects. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified LimitRange
+
+#### HTTP Request
+
+GET /api/v1/namespaces/{namespace}/limitranges/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the LimitRange
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/limit-range-v1#LimitRange" >}}">LimitRange</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind LimitRange
+
+#### HTTP Request
+
+GET /api/v1/namespaces/{namespace}/limitranges
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/limit-range-v1#LimitRangeList" >}}">LimitRangeList</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind LimitRange
+
+#### HTTP Request
+
+GET /api/v1/limitranges
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/limit-range-v1#LimitRangeList" >}}">LimitRangeList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a LimitRange
+
+#### HTTP Request
+
+POST /api/v1/namespaces/{namespace}/limitranges
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../policies-resources/limit-range-v1#LimitRange" >}}">LimitRange</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/limit-range-v1#LimitRange" >}}">LimitRange</a>): OK
+
+201 (<a href="{{< ref "../policies-resources/limit-range-v1#LimitRange" >}}">LimitRange</a>): Created
+
+202 (<a href="{{< ref "../policies-resources/limit-range-v1#LimitRange" >}}">LimitRange</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified LimitRange
+
+#### HTTP Request
+
+PUT /api/v1/namespaces/{namespace}/limitranges/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the LimitRange
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../policies-resources/limit-range-v1#LimitRange" >}}">LimitRange</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/limit-range-v1#LimitRange" >}}">LimitRange</a>): OK
+
+201 (<a href="{{< ref "../policies-resources/limit-range-v1#LimitRange" >}}">LimitRange</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified LimitRange
+
+#### HTTP Request
+
+PATCH /api/v1/namespaces/{namespace}/limitranges/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the LimitRange
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/limit-range-v1#LimitRange" >}}">LimitRange</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a LimitRange
+
+#### HTTP Request
+
+DELETE /api/v1/namespaces/{namespace}/limitranges/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the LimitRange
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of LimitRange
+
+#### HTTP Request
+
+DELETE /api/v1/namespaces/{namespace}/limitranges
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/policies-resources/network-policy-v1.md
+++ b/content/en/docs/reference/kubernetes-api/policies-resources/network-policy-v1.md
@@ -1,0 +1,672 @@
+---
+api_metadata:
+  apiVersion: "networking.k8s.io/v1"
+  import: "k8s.io/api/networking/v1"
+  kind: "NetworkPolicy"
+content_type: "api_reference"
+description: "NetworkPolicy describes what network traffic is allowed for a set of Pods."
+title: "NetworkPolicy"
+weight: 3
+---
+
+`apiVersion: networking.k8s.io/v1`
+
+`import "k8s.io/api/networking/v1"`
+
+
+## NetworkPolicy {#NetworkPolicy}
+
+NetworkPolicy describes what network traffic is allowed for a set of Pods
+
+<hr>
+
+- **apiVersion**: networking.k8s.io/v1
+
+
+- **kind**: NetworkPolicy
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **spec** (<a href="{{< ref "../policies-resources/network-policy-v1#NetworkPolicySpec" >}}">NetworkPolicySpec</a>)
+
+  Specification of the desired behavior for this NetworkPolicy.
+
+
+
+
+
+## NetworkPolicySpec {#NetworkPolicySpec}
+
+NetworkPolicySpec provides the specification of a NetworkPolicy
+
+<hr>
+
+- **podSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>), required
+
+  Selects the pods to which this NetworkPolicy object applies. The array of ingress rules is applied to any pods selected by this field. Multiple network policies can select the same set of pods. In this case, the ingress rules for each are combined additively. This field is NOT optional and follows standard label selector semantics. An empty podSelector matches all pods in this namespace.
+
+- **policyTypes** ([]string)
+
+  List of rule types that the NetworkPolicy relates to. Valid options are "Ingress", "Egress", or "Ingress,Egress". If this field is not specified, it will default based on the existence of Ingress or Egress rules; policies that contain an Egress section are assumed to affect Egress, and all policies (whether or not they contain an Ingress section) are assumed to affect Ingress. If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ]. Likewise, if you want to write a policy that specifies that no egress is allowed, you must specify a policyTypes value that include "Egress" (since such a policy would not include an Egress section and would otherwise default to just [ "Ingress" ]). This field is beta-level in 1.8
+
+- **ingress** ([]NetworkPolicyIngressRule)
+
+  List of ingress rules to be applied to the selected pods. Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod (and cluster policy otherwise allows the traffic), OR if the traffic source is the pod's local node, OR if the traffic matches at least one ingress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy does not allow any traffic (and serves solely to ensure that the pods it selects are isolated by default)
+
+  <a name="NetworkPolicyIngressRule"></a>
+  *NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.*
+
+  - **ingress.from** ([]NetworkPolicyPeer)
+
+    List of sources which should be able to access the pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all sources (traffic not restricted by source). If this field is present and contains at least one item, this rule allows traffic only if the traffic matches at least one item in the from list.
+
+    <a name="NetworkPolicyPeer"></a>
+    *NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of fields are allowed*
+
+  - **ingress.from.ipBlock** (IPBlock)
+
+    IPBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be.
+
+    <a name="IPBlock"></a>
+    *IPBlock describes a particular CIDR (Ex. "192.168.1.1/24","2001:db9::/64") that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs that should not be included within this rule.*
+
+  - **ingress.from.ipBlock.cidr** (string), required
+
+    CIDR is a string representing the IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+
+  - **ingress.from.ipBlock.except** ([]string)
+
+    Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64" Except values will be rejected if they are outside the CIDR range
+
+  - **ingress.from.namespaceSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
+
+    Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces.
+    
+    If PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector.
+
+  - **ingress.from.podSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
+
+    This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods.
+    
+    If NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy's own Namespace.
+
+  - **ingress.ports** ([]NetworkPolicyPort)
+
+    List of ports which should be made accessible on the pods selected for this rule. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.
+
+    <a name="NetworkPolicyPort"></a>
+    *NetworkPolicyPort describes a port to allow traffic on*
+
+  - **ingress.ports.port** (IntOrString)
+
+    The port on the given protocol. This can either be a numerical or named port on a pod. If this field is not provided, this matches all port names and numbers.
+
+    <a name="IntOrString"></a>
+    *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
+
+  - **ingress.ports.protocol** (string)
+
+    The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+
+- **egress** ([]NetworkPolicyEgressRule)
+
+  List of egress rules to be applied to the selected pods. Outgoing traffic is allowed if there are no NetworkPolicies selecting the pod (and cluster policy otherwise allows the traffic), OR if the traffic matches at least one egress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy limits all outgoing traffic (and serves solely to ensure that the pods it selects are isolated by default). This field is beta-level in 1.8
+
+  <a name="NetworkPolicyEgressRule"></a>
+  *NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to. This type is beta-level in 1.8*
+
+  - **egress.to** ([]NetworkPolicyPeer)
+
+    List of destinations for outgoing traffic of pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all destinations (traffic not restricted by destination). If this field is present and contains at least one item, this rule allows traffic only if the traffic matches at least one item in the to list.
+
+    <a name="NetworkPolicyPeer"></a>
+    *NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of fields are allowed*
+
+  - **egress.to.ipBlock** (IPBlock)
+
+    IPBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be.
+
+    <a name="IPBlock"></a>
+    *IPBlock describes a particular CIDR (Ex. "192.168.1.1/24","2001:db9::/64") that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs that should not be included within this rule.*
+
+  - **egress.to.ipBlock.cidr** (string), required
+
+    CIDR is a string representing the IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+
+  - **egress.to.ipBlock.except** ([]string)
+
+    Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64" Except values will be rejected if they are outside the CIDR range
+
+  - **egress.to.namespaceSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
+
+    Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces.
+    
+    If PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector.
+
+  - **egress.to.podSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
+
+    This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods.
+    
+    If NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy's own Namespace.
+
+  - **egress.ports** ([]NetworkPolicyPort)
+
+    List of destination ports for outgoing traffic. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.
+
+    <a name="NetworkPolicyPort"></a>
+    *NetworkPolicyPort describes a port to allow traffic on*
+
+  - **egress.ports.port** (IntOrString)
+
+    The port on the given protocol. This can either be a numerical or named port on a pod. If this field is not provided, this matches all port names and numbers.
+
+    <a name="IntOrString"></a>
+    *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
+
+  - **egress.ports.protocol** (string)
+
+    The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+
+
+
+
+
+## NetworkPolicyList {#NetworkPolicyList}
+
+NetworkPolicyList is a list of NetworkPolicy objects.
+
+<hr>
+
+- **apiVersion**: networking.k8s.io/v1
+
+
+- **kind**: NetworkPolicyList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **items** ([]<a href="{{< ref "../policies-resources/network-policy-v1#NetworkPolicy" >}}">NetworkPolicy</a>), required
+
+  Items is a list of schema objects.
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified NetworkPolicy
+
+#### HTTP Request
+
+GET /apis/networking.k8s.io/v1/namespaces/{namespace}/networkpolicies/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the NetworkPolicy
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/network-policy-v1#NetworkPolicy" >}}">NetworkPolicy</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind NetworkPolicy
+
+#### HTTP Request
+
+GET /apis/networking.k8s.io/v1/namespaces/{namespace}/networkpolicies
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/network-policy-v1#NetworkPolicyList" >}}">NetworkPolicyList</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind NetworkPolicy
+
+#### HTTP Request
+
+GET /apis/networking.k8s.io/v1/networkpolicies
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/network-policy-v1#NetworkPolicyList" >}}">NetworkPolicyList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a NetworkPolicy
+
+#### HTTP Request
+
+POST /apis/networking.k8s.io/v1/namespaces/{namespace}/networkpolicies
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../policies-resources/network-policy-v1#NetworkPolicy" >}}">NetworkPolicy</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/network-policy-v1#NetworkPolicy" >}}">NetworkPolicy</a>): OK
+
+201 (<a href="{{< ref "../policies-resources/network-policy-v1#NetworkPolicy" >}}">NetworkPolicy</a>): Created
+
+202 (<a href="{{< ref "../policies-resources/network-policy-v1#NetworkPolicy" >}}">NetworkPolicy</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified NetworkPolicy
+
+#### HTTP Request
+
+PUT /apis/networking.k8s.io/v1/namespaces/{namespace}/networkpolicies/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the NetworkPolicy
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../policies-resources/network-policy-v1#NetworkPolicy" >}}">NetworkPolicy</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/network-policy-v1#NetworkPolicy" >}}">NetworkPolicy</a>): OK
+
+201 (<a href="{{< ref "../policies-resources/network-policy-v1#NetworkPolicy" >}}">NetworkPolicy</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified NetworkPolicy
+
+#### HTTP Request
+
+PATCH /apis/networking.k8s.io/v1/namespaces/{namespace}/networkpolicies/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the NetworkPolicy
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/network-policy-v1#NetworkPolicy" >}}">NetworkPolicy</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a NetworkPolicy
+
+#### HTTP Request
+
+DELETE /apis/networking.k8s.io/v1/namespaces/{namespace}/networkpolicies/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the NetworkPolicy
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of NetworkPolicy
+
+#### HTTP Request
+
+DELETE /apis/networking.k8s.io/v1/namespaces/{namespace}/networkpolicies
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/policies-resources/pod-disruption-budget-v1beta1.md
+++ b/content/en/docs/reference/kubernetes-api/policies-resources/pod-disruption-budget-v1beta1.md
@@ -1,0 +1,738 @@
+---
+api_metadata:
+  apiVersion: "policy/v1beta1"
+  import: "k8s.io/api/policy/v1beta1"
+  kind: "PodDisruptionBudget"
+content_type: "api_reference"
+description: "PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods."
+title: "PodDisruptionBudget v1beta1"
+weight: 4
+---
+
+`apiVersion: policy/v1beta1`
+
+`import "k8s.io/api/policy/v1beta1"`
+
+
+## PodDisruptionBudget {#PodDisruptionBudget}
+
+PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods
+
+<hr>
+
+- **apiVersion**: policy/v1beta1
+
+
+- **kind**: PodDisruptionBudget
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+
+- **spec** (<a href="{{< ref "../policies-resources/pod-disruption-budget-v1beta1#PodDisruptionBudgetSpec" >}}">PodDisruptionBudgetSpec</a>)
+
+  Specification of the desired behavior of the PodDisruptionBudget.
+
+- **status** (<a href="{{< ref "../policies-resources/pod-disruption-budget-v1beta1#PodDisruptionBudgetStatus" >}}">PodDisruptionBudgetStatus</a>)
+
+  Most recently observed status of the PodDisruptionBudget.
+
+
+
+
+
+## PodDisruptionBudgetSpec {#PodDisruptionBudgetSpec}
+
+PodDisruptionBudgetSpec is a description of a PodDisruptionBudget.
+
+<hr>
+
+- **maxUnavailable** (IntOrString)
+
+  An eviction is allowed if at most "maxUnavailable" pods selected by "selector" are unavailable after the eviction, i.e. even in absence of the evicted pod. For example, one can prevent all voluntary evictions by specifying 0. This is a mutually exclusive setting with "minAvailable".
+
+  <a name="IntOrString"></a>
+  *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
+
+- **minAvailable** (IntOrString)
+
+  An eviction is allowed if at least "minAvailable" pods selected by "selector" will still be available after the eviction, i.e. even in the absence of the evicted pod.  So for example you can prevent all voluntary evictions by specifying "100%".
+
+  <a name="IntOrString"></a>
+  *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
+
+- **selector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
+
+  Label query over pods whose evictions are managed by the disruption budget.
+
+
+
+
+
+## PodDisruptionBudgetStatus {#PodDisruptionBudgetStatus}
+
+PodDisruptionBudgetStatus represents information about the status of a PodDisruptionBudget. Status may trail the actual state of a system.
+
+<hr>
+
+- **currentHealthy** (int32), required
+
+  current number of healthy pods
+
+- **desiredHealthy** (int32), required
+
+  minimum desired number of healthy pods
+
+- **disruptionsAllowed** (int32), required
+
+  Number of pod disruptions that are currently allowed.
+
+- **expectedPods** (int32), required
+
+  total number of pods counted by this disruption budget
+
+- **disruptedPods** (map[string]Time)
+
+  DisruptedPods contains information about pods whose eviction was processed by the API server eviction subresource handler but has not yet been observed by the PodDisruptionBudget controller. A pod will be in this map from the time when the API server processed the eviction request to the time when the pod is seen by PDB controller as having been marked for deletion (or after a timeout). The key in the map is the name of the pod and the value is the time when the API server processed the eviction request. If the deletion didn't occur and a pod is still there it will be removed from the list automatically by PodDisruptionBudget controller after some time. If everything goes smooth this map should be empty for the most of the time. Large number of entries in the map may indicate problems with pod deletions.
+
+  <a name="Time"></a>
+  *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+- **observedGeneration** (int64)
+
+  Most recent generation observed when updating this PDB status. DisruptionsAllowed and other status information is valid only if observedGeneration equals to PDB's object generation.
+
+
+
+
+
+## PodDisruptionBudgetList {#PodDisruptionBudgetList}
+
+PodDisruptionBudgetList is a collection of PodDisruptionBudgets.
+
+<hr>
+
+- **apiVersion**: policy/v1beta1
+
+
+- **kind**: PodDisruptionBudgetList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+
+- **items** ([]<a href="{{< ref "../policies-resources/pod-disruption-budget-v1beta1#PodDisruptionBudget" >}}">PodDisruptionBudget</a>), required
+
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified PodDisruptionBudget
+
+#### HTTP Request
+
+GET /apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PodDisruptionBudget
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/pod-disruption-budget-v1beta1#PodDisruptionBudget" >}}">PodDisruptionBudget</a>): OK
+
+401: Unauthorized
+
+
+### `get` read status of the specified PodDisruptionBudget
+
+#### HTTP Request
+
+GET /apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PodDisruptionBudget
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/pod-disruption-budget-v1beta1#PodDisruptionBudget" >}}">PodDisruptionBudget</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind PodDisruptionBudget
+
+#### HTTP Request
+
+GET /apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/pod-disruption-budget-v1beta1#PodDisruptionBudgetList" >}}">PodDisruptionBudgetList</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind PodDisruptionBudget
+
+#### HTTP Request
+
+GET /apis/policy/v1beta1/poddisruptionbudgets
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/pod-disruption-budget-v1beta1#PodDisruptionBudgetList" >}}">PodDisruptionBudgetList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a PodDisruptionBudget
+
+#### HTTP Request
+
+POST /apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../policies-resources/pod-disruption-budget-v1beta1#PodDisruptionBudget" >}}">PodDisruptionBudget</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/pod-disruption-budget-v1beta1#PodDisruptionBudget" >}}">PodDisruptionBudget</a>): OK
+
+201 (<a href="{{< ref "../policies-resources/pod-disruption-budget-v1beta1#PodDisruptionBudget" >}}">PodDisruptionBudget</a>): Created
+
+202 (<a href="{{< ref "../policies-resources/pod-disruption-budget-v1beta1#PodDisruptionBudget" >}}">PodDisruptionBudget</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified PodDisruptionBudget
+
+#### HTTP Request
+
+PUT /apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PodDisruptionBudget
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../policies-resources/pod-disruption-budget-v1beta1#PodDisruptionBudget" >}}">PodDisruptionBudget</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/pod-disruption-budget-v1beta1#PodDisruptionBudget" >}}">PodDisruptionBudget</a>): OK
+
+201 (<a href="{{< ref "../policies-resources/pod-disruption-budget-v1beta1#PodDisruptionBudget" >}}">PodDisruptionBudget</a>): Created
+
+401: Unauthorized
+
+
+### `update` replace status of the specified PodDisruptionBudget
+
+#### HTTP Request
+
+PUT /apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PodDisruptionBudget
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../policies-resources/pod-disruption-budget-v1beta1#PodDisruptionBudget" >}}">PodDisruptionBudget</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/pod-disruption-budget-v1beta1#PodDisruptionBudget" >}}">PodDisruptionBudget</a>): OK
+
+201 (<a href="{{< ref "../policies-resources/pod-disruption-budget-v1beta1#PodDisruptionBudget" >}}">PodDisruptionBudget</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified PodDisruptionBudget
+
+#### HTTP Request
+
+PATCH /apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PodDisruptionBudget
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/pod-disruption-budget-v1beta1#PodDisruptionBudget" >}}">PodDisruptionBudget</a>): OK
+
+401: Unauthorized
+
+
+### `patch` partially update status of the specified PodDisruptionBudget
+
+#### HTTP Request
+
+PATCH /apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PodDisruptionBudget
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/pod-disruption-budget-v1beta1#PodDisruptionBudget" >}}">PodDisruptionBudget</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a PodDisruptionBudget
+
+#### HTTP Request
+
+DELETE /apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PodDisruptionBudget
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of PodDisruptionBudget
+
+#### HTTP Request
+
+DELETE /apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/policies-resources/pod-security-policy-v1beta1.md
+++ b/content/en/docs/reference/kubernetes-api/policies-resources/pod-security-policy-v1beta1.md
@@ -1,0 +1,710 @@
+---
+api_metadata:
+  apiVersion: "policy/v1beta1"
+  import: "k8s.io/api/policy/v1beta1"
+  kind: "PodSecurityPolicy"
+content_type: "api_reference"
+description: "PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container."
+title: "PodSecurityPolicy v1beta1"
+weight: 5
+---
+
+`apiVersion: policy/v1beta1`
+
+`import "k8s.io/api/policy/v1beta1"`
+
+
+## PodSecurityPolicy {#PodSecurityPolicy}
+
+PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container.
+
+<hr>
+
+- **apiVersion**: policy/v1beta1
+
+
+- **kind**: PodSecurityPolicy
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **spec** (<a href="{{< ref "../policies-resources/pod-security-policy-v1beta1#PodSecurityPolicySpec" >}}">PodSecurityPolicySpec</a>)
+
+  spec defines the policy enforced.
+
+
+
+
+
+## PodSecurityPolicySpec {#PodSecurityPolicySpec}
+
+PodSecurityPolicySpec defines the policy enforced.
+
+<hr>
+
+- **runAsUser** (RunAsUserStrategyOptions), required
+
+  runAsUser is the strategy that will dictate the allowable RunAsUser values that may be set.
+
+  <a name="RunAsUserStrategyOptions"></a>
+  *RunAsUserStrategyOptions defines the strategy type and any options used to create the strategy.*
+
+  - **runAsUser.rule** (string), required
+
+    rule is the strategy that will dictate the allowable RunAsUser values that may be set.
+
+  - **runAsUser.ranges** ([]IDRange)
+
+    ranges are the allowed ranges of uids that may be used. If you would like to force a single uid then supply a single range with the same start and end. Required for MustRunAs.
+
+    <a name="IDRange"></a>
+    *IDRange provides a min/max of an allowed range of IDs.*
+
+  - **runAsUser.ranges.max** (int64), required
+
+    max is the end of the range, inclusive.
+
+  - **runAsUser.ranges.min** (int64), required
+
+    min is the start of the range, inclusive.
+
+- **runAsGroup** (RunAsGroupStrategyOptions)
+
+  RunAsGroup is the strategy that will dictate the allowable RunAsGroup values that may be set. If this field is omitted, the pod's RunAsGroup can take any value. This field requires the RunAsGroup feature gate to be enabled.
+
+  <a name="RunAsGroupStrategyOptions"></a>
+  *RunAsGroupStrategyOptions defines the strategy type and any options used to create the strategy.*
+
+  - **runAsGroup.rule** (string), required
+
+    rule is the strategy that will dictate the allowable RunAsGroup values that may be set.
+
+  - **runAsGroup.ranges** ([]IDRange)
+
+    ranges are the allowed ranges of gids that may be used. If you would like to force a single gid then supply a single range with the same start and end. Required for MustRunAs.
+
+    <a name="IDRange"></a>
+    *IDRange provides a min/max of an allowed range of IDs.*
+
+  - **runAsGroup.ranges.max** (int64), required
+
+    max is the end of the range, inclusive.
+
+  - **runAsGroup.ranges.min** (int64), required
+
+    min is the start of the range, inclusive.
+
+- **fsGroup** (FSGroupStrategyOptions), required
+
+  fsGroup is the strategy that will dictate what fs group is used by the SecurityContext.
+
+  <a name="FSGroupStrategyOptions"></a>
+  *FSGroupStrategyOptions defines the strategy type and options used to create the strategy.*
+
+  - **fsGroup.ranges** ([]IDRange)
+
+    ranges are the allowed ranges of fs groups.  If you would like to force a single fs group then supply a single range with the same start and end. Required for MustRunAs.
+
+    <a name="IDRange"></a>
+    *IDRange provides a min/max of an allowed range of IDs.*
+
+  - **fsGroup.ranges.max** (int64), required
+
+    max is the end of the range, inclusive.
+
+  - **fsGroup.ranges.min** (int64), required
+
+    min is the start of the range, inclusive.
+
+  - **fsGroup.rule** (string)
+
+    rule is the strategy that will dictate what FSGroup is used in the SecurityContext.
+
+- **supplementalGroups** (SupplementalGroupsStrategyOptions), required
+
+  supplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext.
+
+  <a name="SupplementalGroupsStrategyOptions"></a>
+  *SupplementalGroupsStrategyOptions defines the strategy type and options used to create the strategy.*
+
+  - **supplementalGroups.ranges** ([]IDRange)
+
+    ranges are the allowed ranges of supplemental groups.  If you would like to force a single supplemental group then supply a single range with the same start and end. Required for MustRunAs.
+
+    <a name="IDRange"></a>
+    *IDRange provides a min/max of an allowed range of IDs.*
+
+  - **supplementalGroups.ranges.max** (int64), required
+
+    max is the end of the range, inclusive.
+
+  - **supplementalGroups.ranges.min** (int64), required
+
+    min is the start of the range, inclusive.
+
+  - **supplementalGroups.rule** (string)
+
+    rule is the strategy that will dictate what supplemental groups is used in the SecurityContext.
+
+- **seLinux** (SELinuxStrategyOptions), required
+
+  seLinux is the strategy that will dictate the allowable labels that may be set.
+
+  <a name="SELinuxStrategyOptions"></a>
+  *SELinuxStrategyOptions defines the strategy type and any options used to create the strategy.*
+
+  - **seLinux.rule** (string), required
+
+    rule is the strategy that will dictate the allowable labels that may be set.
+
+  - **seLinux.seLinuxOptions** (SELinuxOptions)
+
+    seLinuxOptions required to run as; required for MustRunAs More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+
+    <a name="SELinuxOptions"></a>
+    *SELinuxOptions are the labels to be applied to the container*
+
+  - **seLinux.seLinuxOptions.level** (string)
+
+    Level is SELinux level label that applies to the container.
+
+  - **seLinux.seLinuxOptions.role** (string)
+
+    Role is a SELinux role label that applies to the container.
+
+  - **seLinux.seLinuxOptions.type** (string)
+
+    Type is a SELinux type label that applies to the container.
+
+  - **seLinux.seLinuxOptions.user** (string)
+
+    User is a SELinux user label that applies to the container.
+
+- **readOnlyRootFilesystem** (boolean)
+
+  readOnlyRootFilesystem when set to true will force containers to run with a read only root file system.  If the container specifically requests to run with a non-read only root file system the PSP should deny the pod. If set to false the container may run with a read only root file system if it wishes but it will not be forced to.
+
+- **privileged** (boolean)
+
+  privileged determines if a pod can request to be run as privileged.
+
+- **allowPrivilegeEscalation** (boolean)
+
+  allowPrivilegeEscalation determines if a pod can request to allow privilege escalation. If unspecified, defaults to true.
+
+- **defaultAllowPrivilegeEscalation** (boolean)
+
+  defaultAllowPrivilegeEscalation controls the default setting for whether a process can gain more privileges than its parent process.
+
+- **allowedCSIDrivers** ([]AllowedCSIDriver)
+
+  AllowedCSIDrivers is an allowlist of inline CSI drivers that must be explicitly set to be embedded within a pod spec. An empty value indicates that any CSI driver can be used for inline ephemeral volumes. This is a beta field, and is only honored if the API server enables the CSIInlineVolume feature gate.
+
+  <a name="AllowedCSIDriver"></a>
+  *AllowedCSIDriver represents a single inline CSI Driver that is allowed to be used.*
+
+  - **allowedCSIDrivers.name** (string), required
+
+    Name is the registered name of the CSI driver
+
+- **allowedCapabilities** ([]string)
+
+  allowedCapabilities is a list of capabilities that can be requested to add to the container. Capabilities in this field may be added at the pod author's discretion. You must not list a capability in both allowedCapabilities and requiredDropCapabilities.
+
+- **requiredDropCapabilities** ([]string)
+
+  requiredDropCapabilities are the capabilities that will be dropped from the container.  These are required to be dropped and cannot be added.
+
+- **defaultAddCapabilities** ([]string)
+
+  defaultAddCapabilities is the default set of capabilities that will be added to the container unless the pod spec specifically drops the capability.  You may not list a capability in both defaultAddCapabilities and requiredDropCapabilities. Capabilities added here are implicitly allowed, and need not be included in the allowedCapabilities list.
+
+- **allowedFlexVolumes** ([]AllowedFlexVolume)
+
+  allowedFlexVolumes is an allowlist of Flexvolumes.  Empty or nil indicates that all Flexvolumes may be used.  This parameter is effective only when the usage of the Flexvolumes is allowed in the "volumes" field.
+
+  <a name="AllowedFlexVolume"></a>
+  *AllowedFlexVolume represents a single Flexvolume that is allowed to be used.*
+
+  - **allowedFlexVolumes.driver** (string), required
+
+    driver is the name of the Flexvolume driver.
+
+- **allowedHostPaths** ([]AllowedHostPath)
+
+  allowedHostPaths is an allowlist of host paths. Empty indicates that all host paths may be used.
+
+  <a name="AllowedHostPath"></a>
+  *AllowedHostPath defines the host volume conditions that will be enabled by a policy for pods to use. It requires the path prefix to be defined.*
+
+  - **allowedHostPaths.pathPrefix** (string)
+
+    pathPrefix is the path prefix that the host volume must match. It does not support `*`. Trailing slashes are trimmed when validating the path prefix with a host path.
+    
+    Examples: `/foo` would allow `/foo`, `/foo/` and `/foo/bar` `/foo` would not allow `/food` or `/etc/foo`
+
+  - **allowedHostPaths.readOnly** (boolean)
+
+    when set to true, will allow host volumes matching the pathPrefix only if all volume mounts are readOnly.
+
+- **allowedProcMountTypes** ([]string)
+
+  AllowedProcMountTypes is an allowlist of allowed ProcMountTypes. Empty or nil indicates that only the DefaultProcMountType may be used. This requires the ProcMountType feature flag to be enabled.
+
+- **allowedUnsafeSysctls** ([]string)
+
+  allowedUnsafeSysctls is a list of explicitly allowed unsafe sysctls, defaults to none. Each entry is either a plain sysctl name or ends in "*" in which case it is considered as a prefix of allowed sysctls. Single * means all unsafe sysctls are allowed. Kubelet has to allowlist all allowed unsafe sysctls explicitly to avoid rejection.
+  
+  Examples: e.g. "foo/*" allows "foo/bar", "foo/baz", etc. e.g. "foo.*" allows "foo.bar", "foo.baz", etc.
+
+- **forbiddenSysctls** ([]string)
+
+  forbiddenSysctls is a list of explicitly forbidden sysctls, defaults to none. Each entry is either a plain sysctl name or ends in "*" in which case it is considered as a prefix of forbidden sysctls. Single * means all sysctls are forbidden.
+  
+  Examples: e.g. "foo/*" forbids "foo/bar", "foo/baz", etc. e.g. "foo.*" forbids "foo.bar", "foo.baz", etc.
+
+- **hostIPC** (boolean)
+
+  hostIPC determines if the policy allows the use of HostIPC in the pod spec.
+
+- **hostNetwork** (boolean)
+
+  hostNetwork determines if the policy allows the use of HostNetwork in the pod spec.
+
+- **hostPID** (boolean)
+
+  hostPID determines if the policy allows the use of HostPID in the pod spec.
+
+- **hostPorts** ([]HostPortRange)
+
+  hostPorts determines which host port ranges are allowed to be exposed.
+
+  <a name="HostPortRange"></a>
+  *HostPortRange defines a range of host ports that will be enabled by a policy for pods to use.  It requires both the start and end to be defined.*
+
+  - **hostPorts.max** (int32), required
+
+    max is the end of the range, inclusive.
+
+  - **hostPorts.min** (int32), required
+
+    min is the start of the range, inclusive.
+
+- **runtimeClass** (RuntimeClassStrategyOptions)
+
+  runtimeClass is the strategy that will dictate the allowable RuntimeClasses for a pod. If this field is omitted, the pod's runtimeClassName field is unrestricted. Enforcement of this field depends on the RuntimeClass feature gate being enabled.
+
+  <a name="RuntimeClassStrategyOptions"></a>
+  *RuntimeClassStrategyOptions define the strategy that will dictate the allowable RuntimeClasses for a pod.*
+
+  - **runtimeClass.allowedRuntimeClassNames** ([]string), required
+
+    allowedRuntimeClassNames is an allowlist of RuntimeClass names that may be specified on a pod. A value of "*" means that any RuntimeClass name is allowed, and must be the only item in the list. An empty list requires the RuntimeClassName field to be unset.
+
+  - **runtimeClass.defaultRuntimeClassName** (string)
+
+    defaultRuntimeClassName is the default RuntimeClassName to set on the pod. The default MUST be allowed by the allowedRuntimeClassNames list. A value of nil does not mutate the Pod.
+
+- **volumes** ([]string)
+
+  volumes is an allowlist of volume plugins. Empty indicates that no volumes may be used. To allow all volumes you may use '*'.
+
+
+
+
+
+## PodSecurityPolicyList {#PodSecurityPolicyList}
+
+PodSecurityPolicyList is a list of PodSecurityPolicy objects.
+
+<hr>
+
+- **apiVersion**: policy/v1beta1
+
+
+- **kind**: PodSecurityPolicyList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **items** ([]<a href="{{< ref "../policies-resources/pod-security-policy-v1beta1#PodSecurityPolicy" >}}">PodSecurityPolicy</a>), required
+
+  items is a list of schema objects.
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified PodSecurityPolicy
+
+#### HTTP Request
+
+GET /apis/policy/v1beta1/podsecuritypolicies/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PodSecurityPolicy
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/pod-security-policy-v1beta1#PodSecurityPolicy" >}}">PodSecurityPolicy</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind PodSecurityPolicy
+
+#### HTTP Request
+
+GET /apis/policy/v1beta1/podsecuritypolicies
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/pod-security-policy-v1beta1#PodSecurityPolicyList" >}}">PodSecurityPolicyList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a PodSecurityPolicy
+
+#### HTTP Request
+
+POST /apis/policy/v1beta1/podsecuritypolicies
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../policies-resources/pod-security-policy-v1beta1#PodSecurityPolicy" >}}">PodSecurityPolicy</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/pod-security-policy-v1beta1#PodSecurityPolicy" >}}">PodSecurityPolicy</a>): OK
+
+201 (<a href="{{< ref "../policies-resources/pod-security-policy-v1beta1#PodSecurityPolicy" >}}">PodSecurityPolicy</a>): Created
+
+202 (<a href="{{< ref "../policies-resources/pod-security-policy-v1beta1#PodSecurityPolicy" >}}">PodSecurityPolicy</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified PodSecurityPolicy
+
+#### HTTP Request
+
+PUT /apis/policy/v1beta1/podsecuritypolicies/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PodSecurityPolicy
+
+
+- **body**: <a href="{{< ref "../policies-resources/pod-security-policy-v1beta1#PodSecurityPolicy" >}}">PodSecurityPolicy</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/pod-security-policy-v1beta1#PodSecurityPolicy" >}}">PodSecurityPolicy</a>): OK
+
+201 (<a href="{{< ref "../policies-resources/pod-security-policy-v1beta1#PodSecurityPolicy" >}}">PodSecurityPolicy</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified PodSecurityPolicy
+
+#### HTTP Request
+
+PATCH /apis/policy/v1beta1/podsecuritypolicies/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PodSecurityPolicy
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/pod-security-policy-v1beta1#PodSecurityPolicy" >}}">PodSecurityPolicy</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a PodSecurityPolicy
+
+#### HTTP Request
+
+DELETE /apis/policy/v1beta1/podsecuritypolicies/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PodSecurityPolicy
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/pod-security-policy-v1beta1#PodSecurityPolicy" >}}">PodSecurityPolicy</a>): OK
+
+202 (<a href="{{< ref "../policies-resources/pod-security-policy-v1beta1#PodSecurityPolicy" >}}">PodSecurityPolicy</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of PodSecurityPolicy
+
+#### HTTP Request
+
+DELETE /apis/policy/v1beta1/podsecuritypolicies
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/policies-resources/resource-quota-v1.md
+++ b/content/en/docs/reference/kubernetes-api/policies-resources/resource-quota-v1.md
@@ -1,0 +1,738 @@
+---
+api_metadata:
+  apiVersion: "v1"
+  import: "k8s.io/api/core/v1"
+  kind: "ResourceQuota"
+content_type: "api_reference"
+description: "ResourceQuota sets aggregate quota restrictions enforced per namespace."
+title: "ResourceQuota"
+weight: 2
+---
+
+`apiVersion: v1`
+
+`import "k8s.io/api/core/v1"`
+
+
+## ResourceQuota {#ResourceQuota}
+
+ResourceQuota sets aggregate quota restrictions enforced per namespace
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: ResourceQuota
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **spec** (<a href="{{< ref "../policies-resources/resource-quota-v1#ResourceQuotaSpec" >}}">ResourceQuotaSpec</a>)
+
+  Spec defines the desired quota. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+- **status** (<a href="{{< ref "../policies-resources/resource-quota-v1#ResourceQuotaStatus" >}}">ResourceQuotaStatus</a>)
+
+  Status defines the actual enforced quota and its current usage. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+
+
+
+
+## ResourceQuotaSpec {#ResourceQuotaSpec}
+
+ResourceQuotaSpec defines the desired hard limits to enforce for Quota.
+
+<hr>
+
+- **hard** (map[string]<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+  hard is the set of desired hard limits for each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/
+
+- **scopeSelector** (ScopeSelector)
+
+  scopeSelector is also a collection of filters like scopes that must match each object tracked by a quota but expressed using ScopeSelectorOperator in combination with possible values. For a resource to match, both scopes AND scopeSelector (if specified in spec), must be matched.
+
+  <a name="ScopeSelector"></a>
+  *A scope selector represents the AND of the selectors represented by the scoped-resource selector requirements.*
+
+  - **scopeSelector.matchExpressions** ([]ScopedResourceSelectorRequirement)
+
+    A list of scope selector requirements by scope of the resources.
+
+    <a name="ScopedResourceSelectorRequirement"></a>
+    *A scoped-resource selector requirement is a selector that contains values, a scope name, and an operator that relates the scope name and values.*
+
+  - **scopeSelector.matchExpressions.operator** (string), required
+
+    Represents a scope's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist.
+
+  - **scopeSelector.matchExpressions.scopeName** (string), required
+
+    The name of the scope that the selector applies to.
+
+  - **scopeSelector.matchExpressions.values** ([]string)
+
+    An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+
+- **scopes** ([]string)
+
+  A collection of filters that must match each object tracked by a quota. If not specified, the quota matches all objects.
+
+
+
+
+
+## ResourceQuotaStatus {#ResourceQuotaStatus}
+
+ResourceQuotaStatus defines the enforced hard limits and observed use.
+
+<hr>
+
+- **hard** (map[string]<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+  Hard is the set of enforced hard limits for each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/
+
+- **used** (map[string]<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+  Used is the current observed total usage of the resource in the namespace.
+
+
+
+
+
+## ResourceQuotaList {#ResourceQuotaList}
+
+ResourceQuotaList is a list of ResourceQuota items.
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: ResourceQuotaList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+- **items** ([]<a href="{{< ref "../policies-resources/resource-quota-v1#ResourceQuota" >}}">ResourceQuota</a>), required
+
+  Items is a list of ResourceQuota objects. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified ResourceQuota
+
+#### HTTP Request
+
+GET /api/v1/namespaces/{namespace}/resourcequotas/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ResourceQuota
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/resource-quota-v1#ResourceQuota" >}}">ResourceQuota</a>): OK
+
+401: Unauthorized
+
+
+### `get` read status of the specified ResourceQuota
+
+#### HTTP Request
+
+GET /api/v1/namespaces/{namespace}/resourcequotas/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ResourceQuota
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/resource-quota-v1#ResourceQuota" >}}">ResourceQuota</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind ResourceQuota
+
+#### HTTP Request
+
+GET /api/v1/namespaces/{namespace}/resourcequotas
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/resource-quota-v1#ResourceQuotaList" >}}">ResourceQuotaList</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind ResourceQuota
+
+#### HTTP Request
+
+GET /api/v1/resourcequotas
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/resource-quota-v1#ResourceQuotaList" >}}">ResourceQuotaList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a ResourceQuota
+
+#### HTTP Request
+
+POST /api/v1/namespaces/{namespace}/resourcequotas
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../policies-resources/resource-quota-v1#ResourceQuota" >}}">ResourceQuota</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/resource-quota-v1#ResourceQuota" >}}">ResourceQuota</a>): OK
+
+201 (<a href="{{< ref "../policies-resources/resource-quota-v1#ResourceQuota" >}}">ResourceQuota</a>): Created
+
+202 (<a href="{{< ref "../policies-resources/resource-quota-v1#ResourceQuota" >}}">ResourceQuota</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified ResourceQuota
+
+#### HTTP Request
+
+PUT /api/v1/namespaces/{namespace}/resourcequotas/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ResourceQuota
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../policies-resources/resource-quota-v1#ResourceQuota" >}}">ResourceQuota</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/resource-quota-v1#ResourceQuota" >}}">ResourceQuota</a>): OK
+
+201 (<a href="{{< ref "../policies-resources/resource-quota-v1#ResourceQuota" >}}">ResourceQuota</a>): Created
+
+401: Unauthorized
+
+
+### `update` replace status of the specified ResourceQuota
+
+#### HTTP Request
+
+PUT /api/v1/namespaces/{namespace}/resourcequotas/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ResourceQuota
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../policies-resources/resource-quota-v1#ResourceQuota" >}}">ResourceQuota</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/resource-quota-v1#ResourceQuota" >}}">ResourceQuota</a>): OK
+
+201 (<a href="{{< ref "../policies-resources/resource-quota-v1#ResourceQuota" >}}">ResourceQuota</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified ResourceQuota
+
+#### HTTP Request
+
+PATCH /api/v1/namespaces/{namespace}/resourcequotas/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ResourceQuota
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/resource-quota-v1#ResourceQuota" >}}">ResourceQuota</a>): OK
+
+401: Unauthorized
+
+
+### `patch` partially update status of the specified ResourceQuota
+
+#### HTTP Request
+
+PATCH /api/v1/namespaces/{namespace}/resourcequotas/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ResourceQuota
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/resource-quota-v1#ResourceQuota" >}}">ResourceQuota</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a ResourceQuota
+
+#### HTTP Request
+
+DELETE /api/v1/namespaces/{namespace}/resourcequotas/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ResourceQuota
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../policies-resources/resource-quota-v1#ResourceQuota" >}}">ResourceQuota</a>): OK
+
+202 (<a href="{{< ref "../policies-resources/resource-quota-v1#ResourceQuota" >}}">ResourceQuota</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of ResourceQuota
+
+#### HTTP Request
+
+DELETE /api/v1/namespaces/{namespace}/resourcequotas
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/services-resources/_index.md
+++ b/content/en/docs/reference/kubernetes-api/services-resources/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Services Resources"
+weight: 2
+---

--- a/content/en/docs/reference/kubernetes-api/services-resources/endpoint-slice-v1beta1.md
+++ b/content/en/docs/reference/kubernetes-api/services-resources/endpoint-slice-v1beta1.md
@@ -1,0 +1,618 @@
+---
+api_metadata:
+  apiVersion: "discovery.k8s.io/v1beta1"
+  import: "k8s.io/api/discovery/v1beta1"
+  kind: "EndpointSlice"
+content_type: "api_reference"
+description: "EndpointSlice represents a subset of the endpoints that implement a service."
+title: "EndpointSlice v1beta1"
+weight: 3
+---
+
+`apiVersion: discovery.k8s.io/v1beta1`
+
+`import "k8s.io/api/discovery/v1beta1"`
+
+
+## EndpointSlice {#EndpointSlice}
+
+EndpointSlice represents a subset of the endpoints that implement a service. For a given service there may be multiple EndpointSlice objects, selected by labels, which must be joined to produce the full set of endpoints.
+
+<hr>
+
+- **apiVersion**: discovery.k8s.io/v1beta1
+
+
+- **kind**: EndpointSlice
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata.
+
+- **addressType** (string), required
+
+  addressType specifies the type of address carried by this EndpointSlice. All addresses in this slice must be the same type. This field is immutable after creation. The following address types are currently supported: * IPv4: Represents an IPv4 Address. * IPv6: Represents an IPv6 Address. * FQDN: Represents a Fully Qualified Domain Name.
+
+- **endpoints** ([]Endpoint), required
+
+  *Atomic: will be replaced during a merge*
+  
+  endpoints is a list of unique endpoints in this slice. Each slice may include a maximum of 1000 endpoints.
+
+  <a name="Endpoint"></a>
+  *Endpoint represents a single logical "backend" implementing a service.*
+
+  - **endpoints.addresses** ([]string), required
+
+    *Set: unique values will be kept during a merge*
+    
+    addresses of this endpoint. The contents of this field are interpreted according to the corresponding EndpointSlice addressType field. Consumers must handle different types of addresses in the context of their own capabilities. This must contain at least one address but no more than 100.
+
+  - **endpoints.conditions** (EndpointConditions)
+
+    conditions contains information about the current status of the endpoint.
+
+    <a name="EndpointConditions"></a>
+    *EndpointConditions represents the current condition of an endpoint.*
+
+  - **endpoints.conditions.ready** (boolean)
+
+    ready indicates that this endpoint is prepared to receive traffic, according to whatever system is managing the endpoint. A nil value indicates an unknown state. In most cases consumers should interpret this unknown state as ready. For compatibility reasons, ready should never be "true" for terminating endpoints.
+
+  - **endpoints.conditions.serving** (boolean)
+
+    serving is identical to ready except that it is set regardless of the terminating state of endpoints. This condition should be set to true for a ready endpoint that is terminating. If nil, consumers should defer to the ready condition. This field can be enabled with the EndpointSliceTerminatingCondition feature gate.
+
+  - **endpoints.conditions.terminating** (boolean)
+
+    terminating indicates that this endpoint is terminating. A nil value indicates an unknown state. Consumers should interpret this unknown state to mean that the endpoint is not terminating. This field can be enabled with the EndpointSliceTerminatingCondition feature gate.
+
+  - **endpoints.hostname** (string)
+
+    hostname of this endpoint. This field may be used by consumers of endpoints to distinguish endpoints from each other (e.g. in DNS names). Multiple endpoints which use the same hostname should be considered fungible (e.g. multiple A values in DNS). Must be lowercase and pass DNS Label (RFC 1123) validation.
+
+  - **endpoints.nodeName** (string)
+
+    nodeName represents the name of the Node hosting this endpoint. This can be used to determine endpoints local to a Node. This field can be enabled with the EndpointSliceNodeName feature gate.
+
+  - **endpoints.targetRef** (<a href="{{< ref "../common-definitions/object-reference#ObjectReference" >}}">ObjectReference</a>)
+
+    targetRef is a reference to a Kubernetes object that represents this endpoint.
+
+  - **endpoints.topology** (map[string]string)
+
+    topology contains arbitrary topology information associated with the endpoint. These key/value pairs must conform with the label format. https://kubernetes.io/docs/concepts/overview/working-with-objects/labels Topology may include a maximum of 16 key/value pairs. This includes, but is not limited to the following well known keys: * kubernetes.io/hostname: the value indicates the hostname of the node
+      where the endpoint is located. This should match the corresponding
+      node label.
+    * topology.kubernetes.io/zone: the value indicates the zone where the
+      endpoint is located. This should match the corresponding node label.
+    * topology.kubernetes.io/region: the value indicates the region where the
+      endpoint is located. This should match the corresponding node label.
+    This field is deprecated and will be removed in future api versions.
+
+- **ports** ([]EndpointPort)
+
+  *Atomic: will be replaced during a merge*
+  
+  ports specifies the list of network ports exposed by each endpoint in this slice. Each port must have a unique name. When ports is empty, it indicates that there are no defined ports. When a port is defined with a nil port value, it indicates "all ports". Each slice may include a maximum of 100 ports.
+
+  <a name="EndpointPort"></a>
+  *EndpointPort represents a Port used by an EndpointSlice*
+
+  - **ports.port** (int32)
+
+    The port number of the endpoint. If this is not specified, ports are not restricted and must be interpreted in the context of the specific consumer.
+
+  - **ports.protocol** (string)
+
+    The IP protocol for this port. Must be UDP, TCP, or SCTP. Default is TCP.
+
+  - **ports.name** (string)
+
+    The name of this port. All ports in an EndpointSlice must have a unique name. If the EndpointSlice is dervied from a Kubernetes service, this corresponds to the Service.ports[].name. Name must either be an empty string or pass DNS_LABEL validation: * must be no more than 63 characters long. * must consist of lower case alphanumeric characters or '-'. * must start and end with an alphanumeric character. Default is empty string.
+
+  - **ports.appProtocol** (string)
+
+    The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+
+
+
+
+
+## EndpointSliceList {#EndpointSliceList}
+
+EndpointSliceList represents a list of endpoint slices
+
+<hr>
+
+- **apiVersion**: discovery.k8s.io/v1beta1
+
+
+- **kind**: EndpointSliceList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata.
+
+- **items** ([]<a href="{{< ref "../services-resources/endpoint-slice-v1beta1#EndpointSlice" >}}">EndpointSlice</a>), required
+
+  List of endpoint slices
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified EndpointSlice
+
+#### HTTP Request
+
+GET /apis/discovery.k8s.io/v1beta1/namespaces/{namespace}/endpointslices/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the EndpointSlice
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/endpoint-slice-v1beta1#EndpointSlice" >}}">EndpointSlice</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind EndpointSlice
+
+#### HTTP Request
+
+GET /apis/discovery.k8s.io/v1beta1/namespaces/{namespace}/endpointslices
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/endpoint-slice-v1beta1#EndpointSliceList" >}}">EndpointSliceList</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind EndpointSlice
+
+#### HTTP Request
+
+GET /apis/discovery.k8s.io/v1beta1/endpointslices
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/endpoint-slice-v1beta1#EndpointSliceList" >}}">EndpointSliceList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create an EndpointSlice
+
+#### HTTP Request
+
+POST /apis/discovery.k8s.io/v1beta1/namespaces/{namespace}/endpointslices
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../services-resources/endpoint-slice-v1beta1#EndpointSlice" >}}">EndpointSlice</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/endpoint-slice-v1beta1#EndpointSlice" >}}">EndpointSlice</a>): OK
+
+201 (<a href="{{< ref "../services-resources/endpoint-slice-v1beta1#EndpointSlice" >}}">EndpointSlice</a>): Created
+
+202 (<a href="{{< ref "../services-resources/endpoint-slice-v1beta1#EndpointSlice" >}}">EndpointSlice</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified EndpointSlice
+
+#### HTTP Request
+
+PUT /apis/discovery.k8s.io/v1beta1/namespaces/{namespace}/endpointslices/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the EndpointSlice
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../services-resources/endpoint-slice-v1beta1#EndpointSlice" >}}">EndpointSlice</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/endpoint-slice-v1beta1#EndpointSlice" >}}">EndpointSlice</a>): OK
+
+201 (<a href="{{< ref "../services-resources/endpoint-slice-v1beta1#EndpointSlice" >}}">EndpointSlice</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified EndpointSlice
+
+#### HTTP Request
+
+PATCH /apis/discovery.k8s.io/v1beta1/namespaces/{namespace}/endpointslices/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the EndpointSlice
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/endpoint-slice-v1beta1#EndpointSlice" >}}">EndpointSlice</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete an EndpointSlice
+
+#### HTTP Request
+
+DELETE /apis/discovery.k8s.io/v1beta1/namespaces/{namespace}/endpointslices/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the EndpointSlice
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of EndpointSlice
+
+#### HTTP Request
+
+DELETE /apis/discovery.k8s.io/v1beta1/namespaces/{namespace}/endpointslices
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/services-resources/endpoints-v1.md
+++ b/content/en/docs/reference/kubernetes-api/services-resources/endpoints-v1.md
@@ -1,0 +1,626 @@
+---
+api_metadata:
+  apiVersion: "v1"
+  import: "k8s.io/api/core/v1"
+  kind: "Endpoints"
+content_type: "api_reference"
+description: "Endpoints is a collection of endpoints that implement the actual service."
+title: "Endpoints"
+weight: 2
+---
+
+`apiVersion: v1`
+
+`import "k8s.io/api/core/v1"`
+
+
+## Endpoints {#Endpoints}
+
+Endpoints is a collection of endpoints that implement the actual service. Example:
+  Name: "mysvc",
+  Subsets: [
+    {
+      Addresses: [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],
+      Ports: [{"name": "a", "port": 8675}, {"name": "b", "port": 309}]
+    },
+    {
+      Addresses: [{"ip": "10.10.3.3"}],
+      Ports: [{"name": "a", "port": 93}, {"name": "b", "port": 76}]
+    },
+ ]
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: Endpoints
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **subsets** ([]EndpointSubset)
+
+  The set of all endpoints is the union of all subsets. Addresses are placed into subsets according to the IPs they share. A single address with multiple ports, some of which are ready and some of which are not (because they come from different containers) will result in the address being displayed in different subsets for the different ports. No address will appear in both Addresses and NotReadyAddresses in the same subset. Sets of addresses and ports that comprise a service.
+
+  <a name="EndpointSubset"></a>
+  *EndpointSubset is a group of addresses with a common set of ports. The expanded set of endpoints is the Cartesian product of Addresses x Ports. For example, given:
+    {
+      Addresses: [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],
+      Ports:     [{"name": "a", "port": 8675}, {"name": "b", "port": 309}]
+    }
+  The resulting set of endpoints can be viewed as:
+      a: [ 10.10.1.1:8675, 10.10.2.2:8675 ],
+      b: [ 10.10.1.1:309, 10.10.2.2:309 ]*
+
+  - **subsets.addresses** ([]EndpointAddress)
+
+    IP addresses which offer the related ports that are marked as ready. These endpoints should be considered safe for load balancers and clients to utilize.
+
+    <a name="EndpointAddress"></a>
+    *EndpointAddress is a tuple that describes single IP address.*
+
+  - **subsets.addresses.ip** (string), required
+
+    The IP of this endpoint. May not be loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24). IPv6 is also accepted but not fully supported on all platforms. Also, certain kubernetes components, like kube-proxy, are not IPv6 ready.
+
+  - **subsets.addresses.hostname** (string)
+
+    The Hostname of this endpoint
+
+  - **subsets.addresses.nodeName** (string)
+
+    Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.
+
+  - **subsets.addresses.targetRef** (<a href="{{< ref "../common-definitions/object-reference#ObjectReference" >}}">ObjectReference</a>)
+
+    Reference to object providing the endpoint.
+
+  - **subsets.notReadyAddresses** ([]EndpointAddress)
+
+    IP addresses which offer the related ports but are not currently marked as ready because they have not yet finished starting, have recently failed a readiness check, or have recently failed a liveness check.
+
+    <a name="EndpointAddress"></a>
+    *EndpointAddress is a tuple that describes single IP address.*
+
+  - **subsets.notReadyAddresses.ip** (string), required
+
+    The IP of this endpoint. May not be loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24). IPv6 is also accepted but not fully supported on all platforms. Also, certain kubernetes components, like kube-proxy, are not IPv6 ready.
+
+  - **subsets.notReadyAddresses.hostname** (string)
+
+    The Hostname of this endpoint
+
+  - **subsets.notReadyAddresses.nodeName** (string)
+
+    Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.
+
+  - **subsets.notReadyAddresses.targetRef** (<a href="{{< ref "../common-definitions/object-reference#ObjectReference" >}}">ObjectReference</a>)
+
+    Reference to object providing the endpoint.
+
+  - **subsets.ports** ([]EndpointPort)
+
+    Port numbers available on the related IP addresses.
+
+    <a name="EndpointPort"></a>
+    *EndpointPort is a tuple that describes a single port.*
+
+  - **subsets.ports.port** (int32), required
+
+    The port number of the endpoint.
+
+  - **subsets.ports.protocol** (string)
+
+    The IP protocol for this port. Must be UDP, TCP, or SCTP. Default is TCP.
+
+  - **subsets.ports.name** (string)
+
+    The name of this port.  This must match the 'name' field in the corresponding ServicePort. Must be a DNS_LABEL. Optional only if one port is defined.
+
+  - **subsets.ports.appProtocol** (string)
+
+    The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. This is a beta field that is guarded by the ServiceAppProtocol feature gate and enabled by default.
+
+
+
+
+
+## EndpointsList {#EndpointsList}
+
+EndpointsList is a list of endpoints.
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: EndpointsList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+- **items** ([]<a href="{{< ref "../services-resources/endpoints-v1#Endpoints" >}}">Endpoints</a>), required
+
+  List of endpoints.
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified Endpoints
+
+#### HTTP Request
+
+GET /api/v1/namespaces/{namespace}/endpoints/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Endpoints
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/endpoints-v1#Endpoints" >}}">Endpoints</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind Endpoints
+
+#### HTTP Request
+
+GET /api/v1/namespaces/{namespace}/endpoints
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/endpoints-v1#EndpointsList" >}}">EndpointsList</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind Endpoints
+
+#### HTTP Request
+
+GET /api/v1/endpoints
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/endpoints-v1#EndpointsList" >}}">EndpointsList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create Endpoints
+
+#### HTTP Request
+
+POST /api/v1/namespaces/{namespace}/endpoints
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../services-resources/endpoints-v1#Endpoints" >}}">Endpoints</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/endpoints-v1#Endpoints" >}}">Endpoints</a>): OK
+
+201 (<a href="{{< ref "../services-resources/endpoints-v1#Endpoints" >}}">Endpoints</a>): Created
+
+202 (<a href="{{< ref "../services-resources/endpoints-v1#Endpoints" >}}">Endpoints</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified Endpoints
+
+#### HTTP Request
+
+PUT /api/v1/namespaces/{namespace}/endpoints/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Endpoints
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../services-resources/endpoints-v1#Endpoints" >}}">Endpoints</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/endpoints-v1#Endpoints" >}}">Endpoints</a>): OK
+
+201 (<a href="{{< ref "../services-resources/endpoints-v1#Endpoints" >}}">Endpoints</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified Endpoints
+
+#### HTTP Request
+
+PATCH /api/v1/namespaces/{namespace}/endpoints/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Endpoints
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/endpoints-v1#Endpoints" >}}">Endpoints</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete Endpoints
+
+#### HTTP Request
+
+DELETE /api/v1/namespaces/{namespace}/endpoints/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Endpoints
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of Endpoints
+
+#### HTTP Request
+
+DELETE /api/v1/namespaces/{namespace}/endpoints
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/services-resources/ingress-class-v1.md
+++ b/content/en/docs/reference/kubernetes-api/services-resources/ingress-class-v1.md
@@ -1,0 +1,451 @@
+---
+api_metadata:
+  apiVersion: "networking.k8s.io/v1"
+  import: "k8s.io/api/networking/v1"
+  kind: "IngressClass"
+content_type: "api_reference"
+description: "IngressClass represents the class of the Ingress, referenced by the Ingress Spec."
+title: "IngressClass"
+weight: 5
+---
+
+`apiVersion: networking.k8s.io/v1`
+
+`import "k8s.io/api/networking/v1"`
+
+
+## IngressClass {#IngressClass}
+
+IngressClass represents the class of the Ingress, referenced by the Ingress Spec. The `ingressclass.kubernetes.io/is-default-class` annotation can be used to indicate that an IngressClass should be considered default. When a single IngressClass resource has this annotation set to true, new Ingress resources without a class specified will be assigned this default class.
+
+<hr>
+
+- **apiVersion**: networking.k8s.io/v1
+
+
+- **kind**: IngressClass
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **spec** (<a href="{{< ref "../services-resources/ingress-class-v1#IngressClassSpec" >}}">IngressClassSpec</a>)
+
+  Spec is the desired state of the IngressClass. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+
+
+
+
+## IngressClassSpec {#IngressClassSpec}
+
+IngressClassSpec provides information about the class of an Ingress.
+
+<hr>
+
+- **controller** (string)
+
+  Controller refers to the name of the controller that should handle this class. This allows for different "flavors" that are controlled by the same controller. For example, you may have different Parameters for the same implementing controller. This should be specified as a domain-prefixed path no more than 250 characters in length, e.g. "acme.io/ingress-controller". This field is immutable.
+
+- **parameters** (<a href="{{< ref "../common-definitions/typed-local-object-reference#TypedLocalObjectReference" >}}">TypedLocalObjectReference</a>)
+
+  Parameters is a link to a custom resource containing additional configuration for the controller. This is optional if the controller does not require extra parameters.
+
+
+
+
+
+## IngressClassList {#IngressClassList}
+
+IngressClassList is a collection of IngressClasses.
+
+<hr>
+
+- **apiVersion**: networking.k8s.io/v1
+
+
+- **kind**: IngressClassList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata.
+
+- **items** ([]<a href="{{< ref "../services-resources/ingress-class-v1#IngressClass" >}}">IngressClass</a>), required
+
+  Items is the list of IngressClasses.
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified IngressClass
+
+#### HTTP Request
+
+GET /apis/networking.k8s.io/v1/ingressclasses/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the IngressClass
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/ingress-class-v1#IngressClass" >}}">IngressClass</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind IngressClass
+
+#### HTTP Request
+
+GET /apis/networking.k8s.io/v1/ingressclasses
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/ingress-class-v1#IngressClassList" >}}">IngressClassList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create an IngressClass
+
+#### HTTP Request
+
+POST /apis/networking.k8s.io/v1/ingressclasses
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../services-resources/ingress-class-v1#IngressClass" >}}">IngressClass</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/ingress-class-v1#IngressClass" >}}">IngressClass</a>): OK
+
+201 (<a href="{{< ref "../services-resources/ingress-class-v1#IngressClass" >}}">IngressClass</a>): Created
+
+202 (<a href="{{< ref "../services-resources/ingress-class-v1#IngressClass" >}}">IngressClass</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified IngressClass
+
+#### HTTP Request
+
+PUT /apis/networking.k8s.io/v1/ingressclasses/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the IngressClass
+
+
+- **body**: <a href="{{< ref "../services-resources/ingress-class-v1#IngressClass" >}}">IngressClass</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/ingress-class-v1#IngressClass" >}}">IngressClass</a>): OK
+
+201 (<a href="{{< ref "../services-resources/ingress-class-v1#IngressClass" >}}">IngressClass</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified IngressClass
+
+#### HTTP Request
+
+PATCH /apis/networking.k8s.io/v1/ingressclasses/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the IngressClass
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/ingress-class-v1#IngressClass" >}}">IngressClass</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete an IngressClass
+
+#### HTTP Request
+
+DELETE /apis/networking.k8s.io/v1/ingressclasses/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the IngressClass
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of IngressClass
+
+#### HTTP Request
+
+DELETE /apis/networking.k8s.io/v1/ingressclasses
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/services-resources/ingress-v1.md
+++ b/content/en/docs/reference/kubernetes-api/services-resources/ingress-v1.md
@@ -1,0 +1,892 @@
+---
+api_metadata:
+  apiVersion: "networking.k8s.io/v1"
+  import: "k8s.io/api/networking/v1"
+  kind: "Ingress"
+content_type: "api_reference"
+description: "Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend."
+title: "Ingress"
+weight: 4
+---
+
+`apiVersion: networking.k8s.io/v1`
+
+`import "k8s.io/api/networking/v1"`
+
+
+## Ingress {#Ingress}
+
+Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
+
+<hr>
+
+- **apiVersion**: networking.k8s.io/v1
+
+
+- **kind**: Ingress
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **spec** (<a href="{{< ref "../services-resources/ingress-v1#IngressSpec" >}}">IngressSpec</a>)
+
+  Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+- **status** (<a href="{{< ref "../services-resources/ingress-v1#IngressStatus" >}}">IngressStatus</a>)
+
+  Status is the current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+
+
+
+
+## IngressSpec {#IngressSpec}
+
+IngressSpec describes the Ingress the user wishes to exist.
+
+<hr>
+
+- **defaultBackend** (IngressBackend)
+
+  DefaultBackend is the backend that should handle requests that don't match any rule. If Rules are not specified, DefaultBackend must be specified. If DefaultBackend is not set, the handling of requests that do not match any of the rules will be up to the Ingress controller.
+
+  <a name="IngressBackend"></a>
+  *IngressBackend describes all endpoints for a given service and port.*
+
+  - **defaultBackend.resource** (<a href="{{< ref "../common-definitions/typed-local-object-reference#TypedLocalObjectReference" >}}">TypedLocalObjectReference</a>)
+
+    Resource is an ObjectRef to another Kubernetes resource in the namespace of the Ingress object. If resource is specified, a service.Name and service.Port must not be specified. This is a mutually exclusive setting with "Service".
+
+  - **defaultBackend.service** (IngressServiceBackend)
+
+    Service references a Service as a Backend. This is a mutually exclusive setting with "Resource".
+
+    <a name="IngressServiceBackend"></a>
+    *IngressServiceBackend references a Kubernetes Service as a Backend.*
+
+  - **defaultBackend.service.name** (string), required
+
+    Name is the referenced service. The service must exist in the same namespace as the Ingress object.
+
+  - **defaultBackend.service.port** (ServiceBackendPort)
+
+    Port of the referenced service. A port name or port number is required for a IngressServiceBackend.
+
+    <a name="ServiceBackendPort"></a>
+    *ServiceBackendPort is the service port being referenced.*
+
+  - **defaultBackend.service.port.name** (string)
+
+    Name is the name of the port on the Service. This is a mutually exclusive setting with "Number".
+
+  - **defaultBackend.service.port.number** (int32)
+
+    Number is the numerical port number (e.g. 80) on the Service. This is a mutually exclusive setting with "Name".
+
+- **ingressClassName** (string)
+
+  IngressClassName is the name of the IngressClass cluster resource. The associated IngressClass defines which controller will implement the resource. This replaces the deprecated `kubernetes.io/ingress.class` annotation. For backwards compatibility, when that annotation is set, it must be given precedence over this field. The controller may emit a warning if the field and annotation have different values. Implementations of this API should ignore Ingresses without a class specified. An IngressClass resource may be marked as default, which can be used to set a default value for this field. For more information, refer to the IngressClass documentation.
+
+- **rules** ([]IngressRule)
+
+  *Atomic: will be replaced during a merge*
+  
+  A list of host rules used to configure the Ingress. If unspecified, or no rule matches, all traffic is sent to the default backend.
+
+  <a name="IngressRule"></a>
+  *IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.*
+
+  - **rules.host** (string)
+
+    Host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the "host" part of the URI as defined in RFC 3986: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to
+       the IP in the Spec of the parent Ingress.
+    2. The `:` delimiter is not respected because ports are not allowed.
+    	  Currently the port of an Ingress is implicitly :80 for http and
+    	  :443 for https.
+    Both these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue.
+    
+    Host can be "precise" which is a domain name without the terminating dot of a network host (e.g. "foo.bar.com") or "wildcard", which is a domain name prefixed with a single wildcard label (e.g. "*.foo.com"). The wildcard character '*' must appear by itself as the first DNS label and matches only a single label. You cannot have a wildcard label by itself (e.g. Host == "*"). Requests will be matched against the Host field in the following way: 1. If Host is precise, the request matches this rule if the http host header is equal to Host. 2. If Host is a wildcard, then the request matches this rule if the http host header is to equal to the suffix (removing the first label) of the wildcard rule.
+
+  - **rules.http** (HTTPIngressRuleValue)
+
+
+    <a name="HTTPIngressRuleValue"></a>
+    *HTTPIngressRuleValue is a list of http selectors pointing to backends. In the example: http://<host>/<path>?<searchpart> -> backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.*
+
+  - **rules.http.paths** ([]HTTPIngressPath), required
+
+    *Atomic: will be replaced during a merge*
+    
+    A collection of paths that map requests to backends.
+
+    <a name="HTTPIngressPath"></a>
+    *HTTPIngressPath associates a path with a backend. Incoming urls matching the path are forwarded to the backend.*
+
+  - **rules.http.paths.backend** (IngressBackend), required
+
+    Backend defines the referenced service endpoint to which the traffic will be forwarded to.
+
+    <a name="IngressBackend"></a>
+    *IngressBackend describes all endpoints for a given service and port.*
+
+  - **rules.http.paths.backend.resource** (<a href="{{< ref "../common-definitions/typed-local-object-reference#TypedLocalObjectReference" >}}">TypedLocalObjectReference</a>)
+
+    Resource is an ObjectRef to another Kubernetes resource in the namespace of the Ingress object. If resource is specified, a service.Name and service.Port must not be specified. This is a mutually exclusive setting with "Service".
+
+  - **rules.http.paths.backend.service** (IngressServiceBackend)
+
+    Service references a Service as a Backend. This is a mutually exclusive setting with "Resource".
+
+    <a name="IngressServiceBackend"></a>
+    *IngressServiceBackend references a Kubernetes Service as a Backend.*
+
+  - **rules.http.paths.backend.service.name** (string), required
+
+    Name is the referenced service. The service must exist in the same namespace as the Ingress object.
+
+  - **rules.http.paths.backend.service.port** (ServiceBackendPort)
+
+    Port of the referenced service. A port name or port number is required for a IngressServiceBackend.
+
+    <a name="ServiceBackendPort"></a>
+    *ServiceBackendPort is the service port being referenced.*
+
+  - **rules.http.paths.backend.service.port.name** (string)
+
+    Name is the name of the port on the Service. This is a mutually exclusive setting with "Number".
+
+  - **rules.http.paths.backend.service.port.number** (int32)
+
+    Number is the numerical port number (e.g. 80) on the Service. This is a mutually exclusive setting with "Name".
+
+  - **rules.http.paths.path** (string)
+
+    Path is matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986. Paths must begin with a '/'. When unspecified, all paths from incoming requests are matched.
+
+  - **rules.http.paths.pathType** (string)
+
+    PathType determines the interpretation of the Path matching. PathType can be one of the following values: * Exact: Matches the URL path exactly. * Prefix: Matches based on a URL path prefix split by '/'. Matching is
+      done on a path element by element basis. A path element refers is the
+      list of labels in the path split by the '/' separator. A request is a
+      match for path p if every p is an element-wise prefix of p of the
+      request path. Note that if the last element of the path is a substring
+      of the last element in request path, it is not a match (e.g. /foo/bar
+      matches /foo/bar/baz, but does not match /foo/barbaz).
+    * ImplementationSpecific: Interpretation of the Path matching is up to
+      the IngressClass. Implementations can treat this as a separate PathType
+      or treat it identically to Prefix or Exact path types.
+    Implementations are required to support all path types.
+
+- **tls** ([]IngressTLS)
+
+  *Atomic: will be replaced during a merge*
+  
+  TLS configuration. Currently the Ingress only supports a single TLS port, 443. If multiple members of this list specify different hosts, they will be multiplexed on the same port according to the hostname specified through the SNI TLS extension, if the ingress controller fulfilling the ingress supports SNI.
+
+  <a name="IngressTLS"></a>
+  *IngressTLS describes the transport layer security associated with an Ingress.*
+
+  - **tls.hosts** ([]string)
+
+    *Atomic: will be replaced during a merge*
+    
+    Hosts are a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.
+
+  - **tls.secretName** (string)
+
+    SecretName is the name of the secret used to terminate TLS traffic on port 443. Field is left optional to allow TLS routing based on SNI hostname alone. If the SNI host in a listener conflicts with the "Host" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing.
+
+
+
+
+
+## IngressStatus {#IngressStatus}
+
+IngressStatus describe the current state of the Ingress.
+
+<hr>
+
+- **loadBalancer** (LoadBalancerStatus)
+
+  LoadBalancer contains the current status of the load-balancer.
+
+  <a name="LoadBalancerStatus"></a>
+  *LoadBalancerStatus represents the status of a load-balancer.*
+
+  - **loadBalancer.ingress** ([]LoadBalancerIngress)
+
+    Ingress is a list containing ingress points for the load-balancer. Traffic intended for the service should be sent to these ingress points.
+
+    <a name="LoadBalancerIngress"></a>
+    *LoadBalancerIngress represents the status of a load-balancer ingress point: traffic intended for the service should be sent to an ingress point.*
+
+  - **loadBalancer.ingress.hostname** (string)
+
+    Hostname is set for load-balancer ingress points that are DNS based (typically AWS load-balancers)
+
+  - **loadBalancer.ingress.ip** (string)
+
+    IP is set for load-balancer ingress points that are IP based (typically GCE or OpenStack load-balancers)
+
+  - **loadBalancer.ingress.ports** ([]PortStatus)
+
+    *Atomic: will be replaced during a merge*
+    
+    Ports is a list of records of service ports If used, every port defined in the service should have an entry in it
+
+    <a name="PortStatus"></a>
+    **
+
+  - **loadBalancer.ingress.ports.port** (int32), required
+
+    Port is the port number of the service port of which status is recorded here
+
+  - **loadBalancer.ingress.ports.protocol** (string), required
+
+    Protocol is the protocol of the service port of which status is recorded here The supported values are: "TCP", "UDP", "SCTP"
+
+  - **loadBalancer.ingress.ports.error** (string)
+
+    Error is to record the problem with the service port The format of the error shall comply with the following rules: - built-in error values shall be specified in this file and those shall use
+      CamelCase names
+    - cloud provider specific error values must have names that comply with the
+      format foo.example.com/CamelCase.
+
+
+
+
+
+## IngressList {#IngressList}
+
+IngressList is a collection of Ingress.
+
+<hr>
+
+- **apiVersion**: networking.k8s.io/v1
+
+
+- **kind**: IngressList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **items** ([]<a href="{{< ref "../services-resources/ingress-v1#Ingress" >}}">Ingress</a>), required
+
+  Items is the list of Ingress.
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified Ingress
+
+#### HTTP Request
+
+GET /apis/networking.k8s.io/v1/namespaces/{namespace}/ingresses/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Ingress
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/ingress-v1#Ingress" >}}">Ingress</a>): OK
+
+401: Unauthorized
+
+
+### `get` read status of the specified Ingress
+
+#### HTTP Request
+
+GET /apis/networking.k8s.io/v1/namespaces/{namespace}/ingresses/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Ingress
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/ingress-v1#Ingress" >}}">Ingress</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind Ingress
+
+#### HTTP Request
+
+GET /apis/networking.k8s.io/v1/namespaces/{namespace}/ingresses
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/ingress-v1#IngressList" >}}">IngressList</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind Ingress
+
+#### HTTP Request
+
+GET /apis/networking.k8s.io/v1/ingresses
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/ingress-v1#IngressList" >}}">IngressList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create an Ingress
+
+#### HTTP Request
+
+POST /apis/networking.k8s.io/v1/namespaces/{namespace}/ingresses
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../services-resources/ingress-v1#Ingress" >}}">Ingress</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/ingress-v1#Ingress" >}}">Ingress</a>): OK
+
+201 (<a href="{{< ref "../services-resources/ingress-v1#Ingress" >}}">Ingress</a>): Created
+
+202 (<a href="{{< ref "../services-resources/ingress-v1#Ingress" >}}">Ingress</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified Ingress
+
+#### HTTP Request
+
+PUT /apis/networking.k8s.io/v1/namespaces/{namespace}/ingresses/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Ingress
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../services-resources/ingress-v1#Ingress" >}}">Ingress</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/ingress-v1#Ingress" >}}">Ingress</a>): OK
+
+201 (<a href="{{< ref "../services-resources/ingress-v1#Ingress" >}}">Ingress</a>): Created
+
+401: Unauthorized
+
+
+### `update` replace status of the specified Ingress
+
+#### HTTP Request
+
+PUT /apis/networking.k8s.io/v1/namespaces/{namespace}/ingresses/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Ingress
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../services-resources/ingress-v1#Ingress" >}}">Ingress</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/ingress-v1#Ingress" >}}">Ingress</a>): OK
+
+201 (<a href="{{< ref "../services-resources/ingress-v1#Ingress" >}}">Ingress</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified Ingress
+
+#### HTTP Request
+
+PATCH /apis/networking.k8s.io/v1/namespaces/{namespace}/ingresses/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Ingress
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/ingress-v1#Ingress" >}}">Ingress</a>): OK
+
+401: Unauthorized
+
+
+### `patch` partially update status of the specified Ingress
+
+#### HTTP Request
+
+PATCH /apis/networking.k8s.io/v1/namespaces/{namespace}/ingresses/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Ingress
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/ingress-v1#Ingress" >}}">Ingress</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete an Ingress
+
+#### HTTP Request
+
+DELETE /apis/networking.k8s.io/v1/namespaces/{namespace}/ingresses/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Ingress
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of Ingress
+
+#### HTTP Request
+
+DELETE /apis/networking.k8s.io/v1/namespaces/{namespace}/ingresses
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/services-resources/service-v1.md
+++ b/content/en/docs/reference/kubernetes-api/services-resources/service-v1.md
@@ -1,0 +1,825 @@
+---
+api_metadata:
+  apiVersion: "v1"
+  import: "k8s.io/api/core/v1"
+  kind: "Service"
+content_type: "api_reference"
+description: "Service is a named abstraction of software service (for example, mysql) consisting of local port (for example 3306) that the proxy listens on, and the selector that determines which pods will answer requests sent through the proxy."
+title: "Service"
+weight: 1
+---
+
+`apiVersion: v1`
+
+`import "k8s.io/api/core/v1"`
+
+
+## Service {#Service}
+
+Service is a named abstraction of software service (for example, mysql) consisting of local port (for example 3306) that the proxy listens on, and the selector that determines which pods will answer requests sent through the proxy.
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: Service
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **spec** (<a href="{{< ref "../services-resources/service-v1#ServiceSpec" >}}">ServiceSpec</a>)
+
+  Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+- **status** (<a href="{{< ref "../services-resources/service-v1#ServiceStatus" >}}">ServiceStatus</a>)
+
+  Most recently observed status of the service. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+
+
+
+
+## ServiceSpec {#ServiceSpec}
+
+ServiceSpec describes the attributes that a user creates on a service.
+
+<hr>
+
+- **selector** (map[string]string)
+
+  Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/
+
+- **ports** ([]ServicePort)
+
+  *Patch strategy: merge on key `port`*
+  
+  *Map: unique values on keys `port, protocol` will be kept during a merge*
+  
+  The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+
+  <a name="ServicePort"></a>
+  *ServicePort contains information on service's port.*
+
+  - **ports.port** (int32), required
+
+    The port that will be exposed by this service.
+
+  - **ports.targetPort** (IntOrString)
+
+    Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
+
+    <a name="IntOrString"></a>
+    *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
+
+  - **ports.protocol** (string)
+
+    The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+
+  - **ports.name** (string)
+
+    The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+
+  - **ports.nodePort** (int32)
+
+    The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+
+  - **ports.appProtocol** (string)
+
+    The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. This is a beta field that is guarded by the ServiceAppProtocol feature gate and enabled by default.
+
+- **type** (string)
+
+  type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+
+- **ipFamilies** ([]string)
+
+  *Atomic: will be replaced during a merge*
+  
+  IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service, and is gated by the "IPv6DualStack" feature gate.  This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail.  This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service.  Valid values are "IPv4" and "IPv6".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to "headless" services.  This field will be wiped when updating a Service to type ExternalName.
+  
+  This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
+
+- **ipFamilyPolicy** (string)
+
+  IPFamilyPolicy represents the dual-stack-ness requested or required by this Service, and is gated by the "IPv6DualStack" feature gate.  If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field.  This field will be wiped when updating a service to type ExternalName.
+
+- **clusterIP** (string)
+
+  clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be blank) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address. Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+
+- **clusterIPs** ([]string)
+
+  *Atomic: will be replaced during a merge*
+  
+  ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address.  Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value.
+  
+  Unless the "IPv6DualStack" feature gate is enabled, this field is limited to one value, which must be the same as the clusterIP field.  If the feature gate is enabled, this field may hold a maximum of two entries (dual-stack IPs, in either order).  These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+
+- **externalIPs** ([]string)
+
+  externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
+
+- **sessionAffinity** (string)
+
+  Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+
+- **loadBalancerIP** (string)
+
+  Only applies to Service Type: LoadBalancer LoadBalancer will get created with the IP specified in this field. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.
+
+- **loadBalancerSourceRanges** ([]string)
+
+  If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/
+
+- **externalName** (string)
+
+  externalName is the external reference that discovery mechanisms will return as an alias for this service (e.g. a DNS CNAME record). No proxying will be involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires Type to be
+
+- **externalTrafficPolicy** (string)
+
+  externalTrafficPolicy denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. "Local" preserves the client source IP and avoids a second hop for LoadBalancer and Nodeport type services, but risks potentially imbalanced traffic spreading. "Cluster" obscures the client source IP and may cause a second hop to another node, but should have good overall load-spreading.
+
+- **healthCheckNodePort** (int32)
+
+  healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type).
+
+- **publishNotReadyAddresses** (boolean)
+
+  publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.
+
+- **sessionAffinityConfig** (SessionAffinityConfig)
+
+  sessionAffinityConfig contains the configurations of session affinity.
+
+  <a name="SessionAffinityConfig"></a>
+  *SessionAffinityConfig represents the configurations of session affinity.*
+
+  - **sessionAffinityConfig.clientIP** (ClientIPConfig)
+
+    clientIP contains the configurations of Client IP based session affinity.
+
+    <a name="ClientIPConfig"></a>
+    *ClientIPConfig represents the configurations of Client IP based session affinity.*
+
+  - **sessionAffinityConfig.clientIP.timeoutSeconds** (int32)
+
+    timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && \<=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+
+- **topologyKeys** ([]string)
+
+  topologyKeys is a preference-order list of topology keys which implementations of services should use to preferentially sort endpoints when accessing this Service, it can not be used at the same time as externalTrafficPolicy=Local. Topology keys must be valid label keys and at most 16 keys may be specified. Endpoints are chosen based on the first topology key with available backends. If this field is specified and all entries have no backends that match the topology of the client, the service has no backends for that client and connections should fail. The special value "*" may be used to mean "any topology". This catch-all value, if used, only makes sense as the last value in the list. If this is not specified or empty, no topology constraints will be applied. This field is alpha-level and is only honored by servers that enable the ServiceTopology feature.
+
+- **allocateLoadBalancerNodePorts** (boolean)
+
+  allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.  Default is "true". It may be set to "false" if the cluster load-balancer does not rely on NodePorts. allocateLoadBalancerNodePorts may only be set for services with type LoadBalancer and will be cleared if the type is changed to any other type. This field is alpha-level and is only honored by servers that enable the ServiceLBNodePortControl feature.
+
+
+
+
+
+## ServiceStatus {#ServiceStatus}
+
+ServiceStatus represents the current status of a service.
+
+<hr>
+
+- **conditions** ([]Condition)
+
+  *Patch strategy: merge on key `type`*
+  
+  *Map: unique values on key type will be kept during a merge*
+  
+  Current service state
+
+  <a name="Condition"></a>
+  *Condition contains details for one aspect of the current state of this API Resource.*
+
+  - **conditions.lastTransitionTime** (Time), required
+
+    lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **conditions.message** (string), required
+
+    message is a human readable message indicating details about the transition. This may be an empty string.
+
+  - **conditions.reason** (string), required
+
+    reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+
+  - **conditions.status** (string), required
+
+    status of the condition, one of True, False, Unknown.
+
+  - **conditions.type** (string), required
+
+    type of condition in CamelCase or in foo.example.com/CamelCase.
+
+  - **conditions.observedGeneration** (int64)
+
+    observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+
+- **loadBalancer** (LoadBalancerStatus)
+
+  LoadBalancer contains the current status of the load-balancer, if one is present.
+
+  <a name="LoadBalancerStatus"></a>
+  *LoadBalancerStatus represents the status of a load-balancer.*
+
+  - **loadBalancer.ingress** ([]LoadBalancerIngress)
+
+    Ingress is a list containing ingress points for the load-balancer. Traffic intended for the service should be sent to these ingress points.
+
+    <a name="LoadBalancerIngress"></a>
+    *LoadBalancerIngress represents the status of a load-balancer ingress point: traffic intended for the service should be sent to an ingress point.*
+
+  - **loadBalancer.ingress.hostname** (string)
+
+    Hostname is set for load-balancer ingress points that are DNS based (typically AWS load-balancers)
+
+  - **loadBalancer.ingress.ip** (string)
+
+    IP is set for load-balancer ingress points that are IP based (typically GCE or OpenStack load-balancers)
+
+  - **loadBalancer.ingress.ports** ([]PortStatus)
+
+    *Atomic: will be replaced during a merge*
+    
+    Ports is a list of records of service ports If used, every port defined in the service should have an entry in it
+
+    <a name="PortStatus"></a>
+    **
+
+  - **loadBalancer.ingress.ports.port** (int32), required
+
+    Port is the port number of the service port of which status is recorded here
+
+  - **loadBalancer.ingress.ports.protocol** (string), required
+
+    Protocol is the protocol of the service port of which status is recorded here The supported values are: "TCP", "UDP", "SCTP"
+
+  - **loadBalancer.ingress.ports.error** (string)
+
+    Error is to record the problem with the service port The format of the error shall comply with the following rules: - built-in error values shall be specified in this file and those shall use
+      CamelCase names
+    - cloud provider specific error values must have names that comply with the
+      format foo.example.com/CamelCase.
+
+
+
+
+
+## ServiceList {#ServiceList}
+
+ServiceList holds a list of services.
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: ServiceList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+- **items** ([]<a href="{{< ref "../services-resources/service-v1#Service" >}}">Service</a>), required
+
+  List of services
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified Service
+
+#### HTTP Request
+
+GET /api/v1/namespaces/{namespace}/services/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Service
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/service-v1#Service" >}}">Service</a>): OK
+
+401: Unauthorized
+
+
+### `get` read status of the specified Service
+
+#### HTTP Request
+
+GET /api/v1/namespaces/{namespace}/services/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Service
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/service-v1#Service" >}}">Service</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind Service
+
+#### HTTP Request
+
+GET /api/v1/namespaces/{namespace}/services
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/service-v1#ServiceList" >}}">ServiceList</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind Service
+
+#### HTTP Request
+
+GET /api/v1/services
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/service-v1#ServiceList" >}}">ServiceList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a Service
+
+#### HTTP Request
+
+POST /api/v1/namespaces/{namespace}/services
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../services-resources/service-v1#Service" >}}">Service</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/service-v1#Service" >}}">Service</a>): OK
+
+201 (<a href="{{< ref "../services-resources/service-v1#Service" >}}">Service</a>): Created
+
+202 (<a href="{{< ref "../services-resources/service-v1#Service" >}}">Service</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified Service
+
+#### HTTP Request
+
+PUT /api/v1/namespaces/{namespace}/services/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Service
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../services-resources/service-v1#Service" >}}">Service</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/service-v1#Service" >}}">Service</a>): OK
+
+201 (<a href="{{< ref "../services-resources/service-v1#Service" >}}">Service</a>): Created
+
+401: Unauthorized
+
+
+### `update` replace status of the specified Service
+
+#### HTTP Request
+
+PUT /api/v1/namespaces/{namespace}/services/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Service
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../services-resources/service-v1#Service" >}}">Service</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/service-v1#Service" >}}">Service</a>): OK
+
+201 (<a href="{{< ref "../services-resources/service-v1#Service" >}}">Service</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified Service
+
+#### HTTP Request
+
+PATCH /api/v1/namespaces/{namespace}/services/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Service
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/service-v1#Service" >}}">Service</a>): OK
+
+401: Unauthorized
+
+
+### `patch` partially update status of the specified Service
+
+#### HTTP Request
+
+PATCH /api/v1/namespaces/{namespace}/services/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Service
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../services-resources/service-v1#Service" >}}">Service</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a Service
+
+#### HTTP Request
+
+DELETE /api/v1/namespaces/{namespace}/services/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Service
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/workloads-resources/_index.md
+++ b/content/en/docs/reference/kubernetes-api/workloads-resources/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Workloads Resources"
+weight: 1
+---

--- a/content/en/docs/reference/kubernetes-api/workloads-resources/container.md
+++ b/content/en/docs/reference/kubernetes-api/workloads-resources/container.md
@@ -1,0 +1,774 @@
+---
+api_metadata:
+  apiVersion: ""
+  import: "k8s.io/api/core/v1"
+  kind: "Container"
+content_type: "api_reference"
+description: "A single application container that you want to run within a pod."
+title: "Container"
+weight: 2
+---
+
+
+
+`import "k8s.io/api/core/v1"`
+
+
+## Container {#Container}
+
+A single application container that you want to run within a pod.
+
+<hr>
+
+- **name** (string), required
+
+  Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
+
+
+
+### Image
+
+
+- **image** (string)
+
+  Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.
+
+- **imagePullPolicy** (string)
+
+  Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+### Entrypoint
+
+
+- **command** ([]string)
+
+  Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+
+- **args** ([]string)
+
+  Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+
+- **workingDir** (string)
+
+  Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+
+### Ports
+
+
+- **ports** ([]ContainerPort)
+
+  *Patch strategy: merge on key `containerPort`*
+  
+  *Map: unique values on keys `containerPort, protocol` will be kept during a merge*
+  
+  List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
+
+  <a name="ContainerPort"></a>
+  *ContainerPort represents a network port in a single container.*
+
+  - **ports.containerPort** (int32), required
+
+    Number of port to expose on the pod's IP address. This must be a valid port number, 0 \< x \< 65536.
+
+  - **ports.hostIP** (string)
+
+    What host IP to bind the external port to.
+
+  - **ports.hostPort** (int32)
+
+    Number of port to expose on the host. If specified, this must be a valid port number, 0 \< x \< 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
+
+  - **ports.name** (string)
+
+    If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
+
+  - **ports.protocol** (string)
+
+    Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+### Environment variables
+
+
+- **env** ([]EnvVar)
+
+  *Patch strategy: merge on key `name`*
+  
+  List of environment variables to set in the container. Cannot be updated.
+
+  <a name="EnvVar"></a>
+  *EnvVar represents an environment variable present in a Container.*
+
+  - **env.name** (string), required
+
+    Name of the environment variable. Must be a C_IDENTIFIER.
+
+  - **env.value** (string)
+
+    Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
+
+  - **env.valueFrom** (EnvVarSource)
+
+    Source for the environment variable's value. Cannot be used if value is not empty.
+
+    <a name="EnvVarSource"></a>
+    *EnvVarSource represents a source for the value of an EnvVar.*
+
+  - **env.valueFrom.configMapKeyRef** (ConfigMapKeySelector)
+
+    Selects a key of a ConfigMap.
+
+    <a name="ConfigMapKeySelector"></a>
+    *Selects a key from a ConfigMap.*
+
+  - **env.valueFrom.configMapKeyRef.key** (string), required
+
+    The key to select.
+
+  - **env.valueFrom.configMapKeyRef.name** (string)
+
+    Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+  - **env.valueFrom.configMapKeyRef.optional** (boolean)
+
+    Specify whether the ConfigMap or its key must be defined
+
+  - **env.valueFrom.fieldRef** (<a href="{{< ref "../common-definitions/object-field-selector#ObjectFieldSelector" >}}">ObjectFieldSelector</a>)
+
+    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['\<KEY>']`, `metadata.annotations['\<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+
+  - **env.valueFrom.resourceFieldRef** (<a href="{{< ref "../common-definitions/resource-field-selector#ResourceFieldSelector" >}}">ResourceFieldSelector</a>)
+
+    Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+
+  - **env.valueFrom.secretKeyRef** (SecretKeySelector)
+
+    Selects a key of a secret in the pod's namespace
+
+    <a name="SecretKeySelector"></a>
+    *SecretKeySelector selects a key of a Secret.*
+
+  - **env.valueFrom.secretKeyRef.key** (string), required
+
+    The key of the secret to select from.  Must be a valid secret key.
+
+  - **env.valueFrom.secretKeyRef.name** (string)
+
+    Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+  - **env.valueFrom.secretKeyRef.optional** (boolean)
+
+    Specify whether the Secret or its key must be defined
+
+- **envFrom** ([]EnvFromSource)
+
+  List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
+
+  <a name="EnvFromSource"></a>
+  *EnvFromSource represents the source of a set of ConfigMaps*
+
+  - **envFrom.configMapRef** (ConfigMapEnvSource)
+
+    The ConfigMap to select from
+
+    <a name="ConfigMapEnvSource"></a>
+    *ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.
+    
+    The contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.*
+
+  - **envFrom.configMapRef.name** (string)
+
+    Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+  - **envFrom.configMapRef.optional** (boolean)
+
+    Specify whether the ConfigMap must be defined
+
+  - **envFrom.prefix** (string)
+
+    An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+
+  - **envFrom.secretRef** (SecretEnvSource)
+
+    The Secret to select from
+
+    <a name="SecretEnvSource"></a>
+    *SecretEnvSource selects a Secret to populate the environment variables with.
+    
+    The contents of the target Secret's Data field will represent the key-value pairs as environment variables.*
+
+  - **envFrom.secretRef.name** (string)
+
+    Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+  - **envFrom.secretRef.optional** (boolean)
+
+    Specify whether the Secret must be defined
+
+### Volumes
+
+
+- **volumeMounts** ([]VolumeMount)
+
+  *Patch strategy: merge on key `mountPath`*
+  
+  Pod volumes to mount into the container's filesystem. Cannot be updated.
+
+  <a name="VolumeMount"></a>
+  *VolumeMount describes a mounting of a Volume within a container.*
+
+  - **volumeMounts.mountPath** (string), required
+
+    Path within the container at which the volume should be mounted.  Must not contain ':'.
+
+  - **volumeMounts.name** (string), required
+
+    This must match the Name of a Volume.
+
+  - **volumeMounts.mountPropagation** (string)
+
+    mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+
+  - **volumeMounts.readOnly** (boolean)
+
+    Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+
+  - **volumeMounts.subPath** (string)
+
+    Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+
+  - **volumeMounts.subPathExpr** (string)
+
+    Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+
+- **volumeDevices** ([]VolumeDevice)
+
+  *Patch strategy: merge on key `devicePath`*
+  
+  volumeDevices is the list of block devices to be used by the container.
+
+  <a name="VolumeDevice"></a>
+  *volumeDevice describes a mapping of a raw block device within a container.*
+
+  - **volumeDevices.devicePath** (string), required
+
+    devicePath is the path inside of the container that the device will be mapped to.
+
+  - **volumeDevices.name** (string), required
+
+    name must match the name of a persistentVolumeClaim in the pod
+
+### Resources
+
+
+- **resources** (ResourceRequirements)
+
+  Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+
+  <a name="ResourceRequirements"></a>
+  *ResourceRequirements describes the compute resource requirements.*
+
+  - **resources.limits** (map[string]<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+
+  - **resources.requests** (map[string]<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+
+### Lifecycle
+
+
+- **lifecycle** (Lifecycle)
+
+  Actions that the management system should take in response to container lifecycle events. Cannot be updated.
+
+  <a name="Lifecycle"></a>
+  *Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.*
+
+  - **lifecycle.postStart** (Handler)
+
+    PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+
+    <a name="Handler"></a>
+    *Handler defines a specific action that should be taken*
+
+  - **lifecycle.postStart.exec** (<a href="{{< ref "../common-definitions/exec-action#ExecAction" >}}">ExecAction</a>)
+
+    One and only one of the following should be specified. Exec specifies the action to take.
+
+  - **lifecycle.postStart.httpGet** (<a href="{{< ref "../common-definitions/http-get-action#HTTPGetAction" >}}">HTTPGetAction</a>)
+
+    HTTPGet specifies the http request to perform.
+
+  - **lifecycle.postStart.tcpSocket** (<a href="{{< ref "../common-definitions/tcp-socket-action#TCPSocketAction" >}}">TCPSocketAction</a>)
+
+    TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported
+
+  - **lifecycle.preStop** (Handler)
+
+    PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod's termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+
+    <a name="Handler"></a>
+    *Handler defines a specific action that should be taken*
+
+  - **lifecycle.preStop.exec** (<a href="{{< ref "../common-definitions/exec-action#ExecAction" >}}">ExecAction</a>)
+
+    One and only one of the following should be specified. Exec specifies the action to take.
+
+  - **lifecycle.preStop.httpGet** (<a href="{{< ref "../common-definitions/http-get-action#HTTPGetAction" >}}">HTTPGetAction</a>)
+
+    HTTPGet specifies the http request to perform.
+
+  - **lifecycle.preStop.tcpSocket** (<a href="{{< ref "../common-definitions/tcp-socket-action#TCPSocketAction" >}}">TCPSocketAction</a>)
+
+    TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported
+
+- **terminationMessagePath** (string)
+
+  Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.
+
+- **terminationMessagePolicy** (string)
+
+  Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+- **livenessProbe** (Probe)
+
+  Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+  <a name="Probe"></a>
+  *Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.*
+
+  - **livenessProbe.exec** (<a href="{{< ref "../common-definitions/exec-action#ExecAction" >}}">ExecAction</a>)
+
+    One and only one of the following should be specified. Exec specifies the action to take.
+
+  - **livenessProbe.httpGet** (<a href="{{< ref "../common-definitions/http-get-action#HTTPGetAction" >}}">HTTPGetAction</a>)
+
+    HTTPGet specifies the http request to perform.
+
+  - **livenessProbe.tcpSocket** (<a href="{{< ref "../common-definitions/tcp-socket-action#TCPSocketAction" >}}">TCPSocketAction</a>)
+
+    TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported
+
+  - **livenessProbe.initialDelaySeconds** (int32)
+
+    Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+  - **livenessProbe.periodSeconds** (int32)
+
+    How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+
+  - **livenessProbe.timeoutSeconds** (int32)
+
+    Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+  - **livenessProbe.failureThreshold** (int32)
+
+    Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+
+  - **livenessProbe.successThreshold** (int32)
+
+    Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+
+- **readinessProbe** (Probe)
+
+  Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+  <a name="Probe"></a>
+  *Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.*
+
+  - **readinessProbe.exec** (<a href="{{< ref "../common-definitions/exec-action#ExecAction" >}}">ExecAction</a>)
+
+    One and only one of the following should be specified. Exec specifies the action to take.
+
+  - **readinessProbe.httpGet** (<a href="{{< ref "../common-definitions/http-get-action#HTTPGetAction" >}}">HTTPGetAction</a>)
+
+    HTTPGet specifies the http request to perform.
+
+  - **readinessProbe.tcpSocket** (<a href="{{< ref "../common-definitions/tcp-socket-action#TCPSocketAction" >}}">TCPSocketAction</a>)
+
+    TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported
+
+  - **readinessProbe.initialDelaySeconds** (int32)
+
+    Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+  - **readinessProbe.periodSeconds** (int32)
+
+    How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+
+  - **readinessProbe.timeoutSeconds** (int32)
+
+    Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+  - **readinessProbe.failureThreshold** (int32)
+
+    Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+
+  - **readinessProbe.successThreshold** (int32)
+
+    Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+
+### Security Context
+
+
+- **securityContext** (SecurityContext)
+
+  Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+
+  <a name="SecurityContext"></a>
+  *SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.*
+
+  - **securityContext.runAsUser** (int64)
+
+    The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+
+  - **securityContext.runAsNonRoot** (boolean)
+
+    Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+
+  - **securityContext.runAsGroup** (int64)
+
+    The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+
+  - **securityContext.readOnlyRootFilesystem** (boolean)
+
+    Whether this container has a read-only root filesystem. Default is false.
+
+  - **securityContext.procMount** (string)
+
+    procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
+
+  - **securityContext.privileged** (boolean)
+
+    Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
+
+  - **securityContext.allowPrivilegeEscalation** (boolean)
+
+    AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
+
+  - **securityContext.capabilities** (Capabilities)
+
+    The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+
+    <a name="Capabilities"></a>
+    *Adds and removes POSIX capabilities from running containers.*
+
+  - **securityContext.capabilities.add** ([]string)
+
+    Added capabilities
+
+  - **securityContext.capabilities.drop** ([]string)
+
+    Removed capabilities
+
+  - **securityContext.seccompProfile** (SeccompProfile)
+
+    The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.
+
+    <a name="SeccompProfile"></a>
+    *SeccompProfile defines a pod/container's seccomp profile settings. Only one profile source may be set.*
+
+  - **securityContext.seccompProfile.type** (string), required
+
+    type indicates which kind of seccomp profile will be applied. Valid options are:
+    
+    Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+  - **securityContext.seccompProfile.localhostProfile** (string)
+
+    localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+
+  - **securityContext.seLinuxOptions** (SELinuxOptions)
+
+    The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+
+    <a name="SELinuxOptions"></a>
+    *SELinuxOptions are the labels to be applied to the container*
+
+  - **securityContext.seLinuxOptions.level** (string)
+
+    Level is SELinux level label that applies to the container.
+
+  - **securityContext.seLinuxOptions.role** (string)
+
+    Role is a SELinux role label that applies to the container.
+
+  - **securityContext.seLinuxOptions.type** (string)
+
+    Type is a SELinux type label that applies to the container.
+
+  - **securityContext.seLinuxOptions.user** (string)
+
+    User is a SELinux user label that applies to the container.
+
+  - **securityContext.windowsOptions** (WindowsSecurityContextOptions)
+
+    The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+
+    <a name="WindowsSecurityContextOptions"></a>
+    *WindowsSecurityContextOptions contain Windows-specific options and credentials.*
+
+  - **securityContext.windowsOptions.gmsaCredentialSpec** (string)
+
+    GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
+
+  - **securityContext.windowsOptions.gmsaCredentialSpecName** (string)
+
+    GMSACredentialSpecName is the name of the GMSA credential spec to use.
+
+  - **securityContext.windowsOptions.runAsUserName** (string)
+
+    The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+
+### Debugging
+
+
+- **stdin** (boolean)
+
+  Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
+
+- **stdinOnce** (boolean)
+
+  Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
+
+- **tty** (boolean)
+
+  Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
+
+### Beta level
+
+
+- **startupProbe** (Probe)
+
+  StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+  <a name="Probe"></a>
+  *Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.*
+
+  - **startupProbe.exec** (<a href="{{< ref "../common-definitions/exec-action#ExecAction" >}}">ExecAction</a>)
+
+    One and only one of the following should be specified. Exec specifies the action to take.
+
+  - **startupProbe.httpGet** (<a href="{{< ref "../common-definitions/http-get-action#HTTPGetAction" >}}">HTTPGetAction</a>)
+
+    HTTPGet specifies the http request to perform.
+
+  - **startupProbe.tcpSocket** (<a href="{{< ref "../common-definitions/tcp-socket-action#TCPSocketAction" >}}">TCPSocketAction</a>)
+
+    TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported
+
+  - **startupProbe.initialDelaySeconds** (int32)
+
+    Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+  - **startupProbe.periodSeconds** (int32)
+
+    How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+
+  - **startupProbe.timeoutSeconds** (int32)
+
+    Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+  - **startupProbe.failureThreshold** (int32)
+
+    Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+
+  - **startupProbe.successThreshold** (int32)
+
+    Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+
+
+
+## ContainerStatus {#ContainerStatus}
+
+ContainerStatus contains details for the current status of this container.
+
+<hr>
+
+- **name** (string), required
+
+  This must be a DNS_LABEL. Each container in a pod must have a unique name. Cannot be updated.
+
+- **image** (string), required
+
+  The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images
+
+- **imageID** (string), required
+
+  ImageID of the container's image.
+
+- **containerID** (string)
+
+  Container's ID in the format 'docker://\<container_id>'.
+
+- **state** (ContainerState)
+
+  Details about the container's current condition.
+
+  <a name="ContainerState"></a>
+  *ContainerState holds a possible state of container. Only one of its members may be specified. If none of them is specified, the default one is ContainerStateWaiting.*
+
+  - **state.running** (ContainerStateRunning)
+
+    Details about a running container
+
+    <a name="ContainerStateRunning"></a>
+    *ContainerStateRunning is a running state of a container.*
+
+  - **state.running.startedAt** (Time)
+
+    Time at which the container was last (re-)started
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **state.terminated** (ContainerStateTerminated)
+
+    Details about a terminated container
+
+    <a name="ContainerStateTerminated"></a>
+    *ContainerStateTerminated is a terminated state of a container.*
+
+  - **state.terminated.containerID** (string)
+
+    Container's ID in the format 'docker://\<container_id>'
+
+  - **state.terminated.exitCode** (int32), required
+
+    Exit status from the last termination of the container
+
+  - **state.terminated.startedAt** (Time)
+
+    Time at which previous execution of the container started
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **state.terminated.finishedAt** (Time)
+
+    Time at which the container last terminated
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **state.terminated.message** (string)
+
+    Message regarding the last termination of the container
+
+  - **state.terminated.reason** (string)
+
+    (brief) reason from the last termination of the container
+
+  - **state.terminated.signal** (int32)
+
+    Signal from the last termination of the container
+
+  - **state.waiting** (ContainerStateWaiting)
+
+    Details about a waiting container
+
+    <a name="ContainerStateWaiting"></a>
+    *ContainerStateWaiting is a waiting state of a container.*
+
+  - **state.waiting.message** (string)
+
+    Message regarding why the container is not yet running.
+
+  - **state.waiting.reason** (string)
+
+    (brief) reason the container is not yet running.
+
+- **lastState** (ContainerState)
+
+  Details about the container's last termination condition.
+
+  <a name="ContainerState"></a>
+  *ContainerState holds a possible state of container. Only one of its members may be specified. If none of them is specified, the default one is ContainerStateWaiting.*
+
+  - **lastState.running** (ContainerStateRunning)
+
+    Details about a running container
+
+    <a name="ContainerStateRunning"></a>
+    *ContainerStateRunning is a running state of a container.*
+
+  - **lastState.running.startedAt** (Time)
+
+    Time at which the container was last (re-)started
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **lastState.terminated** (ContainerStateTerminated)
+
+    Details about a terminated container
+
+    <a name="ContainerStateTerminated"></a>
+    *ContainerStateTerminated is a terminated state of a container.*
+
+  - **lastState.terminated.containerID** (string)
+
+    Container's ID in the format 'docker://\<container_id>'
+
+  - **lastState.terminated.exitCode** (int32), required
+
+    Exit status from the last termination of the container
+
+  - **lastState.terminated.startedAt** (Time)
+
+    Time at which previous execution of the container started
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **lastState.terminated.finishedAt** (Time)
+
+    Time at which the container last terminated
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **lastState.terminated.message** (string)
+
+    Message regarding the last termination of the container
+
+  - **lastState.terminated.reason** (string)
+
+    (brief) reason from the last termination of the container
+
+  - **lastState.terminated.signal** (int32)
+
+    Signal from the last termination of the container
+
+  - **lastState.waiting** (ContainerStateWaiting)
+
+    Details about a waiting container
+
+    <a name="ContainerStateWaiting"></a>
+    *ContainerStateWaiting is a waiting state of a container.*
+
+  - **lastState.waiting.message** (string)
+
+    Message regarding why the container is not yet running.
+
+  - **lastState.waiting.reason** (string)
+
+    (brief) reason the container is not yet running.
+
+- **ready** (boolean), required
+
+  Specifies whether the container has passed its readiness probe.
+
+- **restartCount** (int32), required
+
+  The number of times the container has been restarted, currently based on the number of dead containers that have not yet been removed. Note that this is calculated from dead containers. But those containers are subject to garbage collection. This value will get capped at 5 by GC.
+
+- **started** (boolean)
+
+  Specifies whether the container has passed its startup probe. Initialized as false, becomes true after startupProbe is considered successful. Resets to false when the container is restarted, or if kubelet loses state temporarily. Is always true when no startupProbe is defined.
+
+
+
+
+

--- a/content/en/docs/reference/kubernetes-api/workloads-resources/controller-revision-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workloads-resources/controller-revision-v1.md
@@ -1,0 +1,570 @@
+---
+api_metadata:
+  apiVersion: "apps/v1"
+  import: "k8s.io/api/apps/v1"
+  kind: "ControllerRevision"
+content_type: "api_reference"
+description: "ControllerRevision implements an immutable snapshot of state data."
+title: "ControllerRevision"
+weight: 9
+---
+
+`apiVersion: apps/v1`
+
+`import "k8s.io/api/apps/v1"`
+
+
+## ControllerRevision {#ControllerRevision}
+
+ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
+
+<hr>
+
+- **apiVersion**: apps/v1
+
+
+- **kind**: ControllerRevision
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **revision** (int64), required
+
+  Revision indicates the revision of the state represented by Data.
+
+- **data** (RawExtension)
+
+  Data is the serialized representation of the state.
+
+  <a name="RawExtension"></a>
+  *RawExtension is used to hold extensions in external versions.
+  
+  To use this, make a field which has RawExtension as its type in your external, versioned struct, and Object in your internal struct. You also need to register your various plugin types.
+  
+  // Internal package: type MyAPIObject struct {
+  	runtime.TypeMeta `json:",inline"`
+  	MyPlugin runtime.Object `json:"myPlugin"`
+  } type PluginA struct {
+  	AOption string `json:"aOption"`
+  }
+  
+  // External package: type MyAPIObject struct {
+  	runtime.TypeMeta `json:",inline"`
+  	MyPlugin runtime.RawExtension `json:"myPlugin"`
+  } type PluginA struct {
+  	AOption string `json:"aOption"`
+  }
+  
+  // On the wire, the JSON will look something like this: {
+  	"kind":"MyAPIObject",
+  	"apiVersion":"v1",
+  	"myPlugin": {
+  		"kind":"PluginA",
+  		"aOption":"foo",
+  	},
+  }
+  
+  So what happens? Decode first uses json or yaml to unmarshal the serialized data into your external MyAPIObject. That causes the raw JSON to be stored, but not unpacked. The next step is to copy (using pkg/conversion) into the internal struct. The runtime package's DefaultScheme has conversion functions installed which will unpack the JSON stored in RawExtension, turning it into the correct object type, and storing it in the Object. (TODO: In the case where the object is of an unknown type, a runtime.Unknown object will be created and stored.)*
+
+
+
+
+
+## ControllerRevisionList {#ControllerRevisionList}
+
+ControllerRevisionList is a resource containing a list of ControllerRevision objects.
+
+<hr>
+
+- **apiVersion**: apps/v1
+
+
+- **kind**: ControllerRevisionList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **items** ([]<a href="{{< ref "../workloads-resources/controller-revision-v1#ControllerRevision" >}}">ControllerRevision</a>), required
+
+  Items is the list of ControllerRevisions
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified ControllerRevision
+
+#### HTTP Request
+
+GET /apis/apps/v1/namespaces/{namespace}/controllerrevisions/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ControllerRevision
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/controller-revision-v1#ControllerRevision" >}}">ControllerRevision</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind ControllerRevision
+
+#### HTTP Request
+
+GET /apis/apps/v1/namespaces/{namespace}/controllerrevisions
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/controller-revision-v1#ControllerRevisionList" >}}">ControllerRevisionList</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind ControllerRevision
+
+#### HTTP Request
+
+GET /apis/apps/v1/controllerrevisions
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/controller-revision-v1#ControllerRevisionList" >}}">ControllerRevisionList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a ControllerRevision
+
+#### HTTP Request
+
+POST /apis/apps/v1/namespaces/{namespace}/controllerrevisions
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/controller-revision-v1#ControllerRevision" >}}">ControllerRevision</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/controller-revision-v1#ControllerRevision" >}}">ControllerRevision</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/controller-revision-v1#ControllerRevision" >}}">ControllerRevision</a>): Created
+
+202 (<a href="{{< ref "../workloads-resources/controller-revision-v1#ControllerRevision" >}}">ControllerRevision</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified ControllerRevision
+
+#### HTTP Request
+
+PUT /apis/apps/v1/namespaces/{namespace}/controllerrevisions/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ControllerRevision
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/controller-revision-v1#ControllerRevision" >}}">ControllerRevision</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/controller-revision-v1#ControllerRevision" >}}">ControllerRevision</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/controller-revision-v1#ControllerRevision" >}}">ControllerRevision</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified ControllerRevision
+
+#### HTTP Request
+
+PATCH /apis/apps/v1/namespaces/{namespace}/controllerrevisions/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ControllerRevision
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/controller-revision-v1#ControllerRevision" >}}">ControllerRevision</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a ControllerRevision
+
+#### HTTP Request
+
+DELETE /apis/apps/v1/namespaces/{namespace}/controllerrevisions/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ControllerRevision
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of ControllerRevision
+
+#### HTTP Request
+
+DELETE /apis/apps/v1/namespaces/{namespace}/controllerrevisions
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/workloads-resources/cron-job-v1beta1.md
+++ b/content/en/docs/reference/kubernetes-api/workloads-resources/cron-job-v1beta1.md
@@ -1,0 +1,746 @@
+---
+api_metadata:
+  apiVersion: "batch/v1beta1"
+  import: "k8s.io/api/batch/v1beta1"
+  kind: "CronJob"
+content_type: "api_reference"
+description: "CronJob represents the configuration of a single cron job."
+title: "CronJob v1beta1"
+weight: 12
+---
+
+`apiVersion: batch/v1beta1`
+
+`import "k8s.io/api/batch/v1beta1"`
+
+
+## CronJob {#CronJob}
+
+CronJob represents the configuration of a single cron job.
+
+<hr>
+
+- **apiVersion**: batch/v1beta1
+
+
+- **kind**: CronJob
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **spec** (<a href="{{< ref "../workloads-resources/cron-job-v1beta1#CronJobSpec" >}}">CronJobSpec</a>)
+
+  Specification of the desired behavior of a cron job, including the schedule. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+- **status** (<a href="{{< ref "../workloads-resources/cron-job-v1beta1#CronJobStatus" >}}">CronJobStatus</a>)
+
+  Current status of a cron job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+
+
+
+
+## CronJobSpec {#CronJobSpec}
+
+CronJobSpec describes how the job execution will look like and when it will actually run.
+
+<hr>
+
+- **jobTemplate** (JobTemplateSpec), required
+
+  Specifies the job that will be created when executing a CronJob.
+
+  <a name="JobTemplateSpec"></a>
+  *JobTemplateSpec describes the data a Job should have when created from a template*
+
+  - **jobTemplate.metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+    Standard object's metadata of the jobs created from this template. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+  - **jobTemplate.spec** (<a href="{{< ref "../workloads-resources/job-v1#JobSpec" >}}">JobSpec</a>)
+
+    Specification of the desired behavior of the job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+- **schedule** (string), required
+
+  The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
+
+- **concurrencyPolicy** (string)
+
+  Specifies how to treat concurrent executions of a Job. Valid values are: - "Allow" (default): allows CronJobs to run concurrently; - "Forbid": forbids concurrent runs, skipping next run if previous run hasn't finished yet; - "Replace": cancels currently running job and replaces it with a new one
+
+- **startingDeadlineSeconds** (int64)
+
+  Optional deadline in seconds for starting the job if it misses scheduled time for any reason.  Missed jobs executions will be counted as failed ones.
+
+- **suspend** (boolean)
+
+  This flag tells the controller to suspend subsequent executions, it does not apply to already started executions.  Defaults to false.
+
+- **successfulJobsHistoryLimit** (int32)
+
+  The number of successful finished jobs to retain. This is a pointer to distinguish between explicit zero and not specified. Defaults to 3.
+
+- **failedJobsHistoryLimit** (int32)
+
+  The number of failed finished jobs to retain. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.
+
+
+
+
+
+## CronJobStatus {#CronJobStatus}
+
+CronJobStatus represents the current state of a cron job.
+
+<hr>
+
+- **active** ([]<a href="{{< ref "../common-definitions/object-reference#ObjectReference" >}}">ObjectReference</a>)
+
+  A list of pointers to currently running jobs.
+
+- **lastScheduleTime** (Time)
+
+  Information when was the last time the job was successfully scheduled.
+
+  <a name="Time"></a>
+  *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+
+
+
+
+## CronJobList {#CronJobList}
+
+CronJobList is a collection of cron jobs.
+
+<hr>
+
+- **apiVersion**: batch/v1beta1
+
+
+- **kind**: CronJobList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **items** ([]<a href="{{< ref "../workloads-resources/cron-job-v1beta1#CronJob" >}}">CronJob</a>), required
+
+  items is the list of CronJobs.
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified CronJob
+
+#### HTTP Request
+
+GET /apis/batch/v1beta1/namespaces/{namespace}/cronjobs/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CronJob
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/cron-job-v1beta1#CronJob" >}}">CronJob</a>): OK
+
+401: Unauthorized
+
+
+### `get` read status of the specified CronJob
+
+#### HTTP Request
+
+GET /apis/batch/v1beta1/namespaces/{namespace}/cronjobs/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CronJob
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/cron-job-v1beta1#CronJob" >}}">CronJob</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind CronJob
+
+#### HTTP Request
+
+GET /apis/batch/v1beta1/namespaces/{namespace}/cronjobs
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/cron-job-v1beta1#CronJobList" >}}">CronJobList</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind CronJob
+
+#### HTTP Request
+
+GET /apis/batch/v1beta1/cronjobs
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/cron-job-v1beta1#CronJobList" >}}">CronJobList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a CronJob
+
+#### HTTP Request
+
+POST /apis/batch/v1beta1/namespaces/{namespace}/cronjobs
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/cron-job-v1beta1#CronJob" >}}">CronJob</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/cron-job-v1beta1#CronJob" >}}">CronJob</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/cron-job-v1beta1#CronJob" >}}">CronJob</a>): Created
+
+202 (<a href="{{< ref "../workloads-resources/cron-job-v1beta1#CronJob" >}}">CronJob</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified CronJob
+
+#### HTTP Request
+
+PUT /apis/batch/v1beta1/namespaces/{namespace}/cronjobs/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CronJob
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/cron-job-v1beta1#CronJob" >}}">CronJob</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/cron-job-v1beta1#CronJob" >}}">CronJob</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/cron-job-v1beta1#CronJob" >}}">CronJob</a>): Created
+
+401: Unauthorized
+
+
+### `update` replace status of the specified CronJob
+
+#### HTTP Request
+
+PUT /apis/batch/v1beta1/namespaces/{namespace}/cronjobs/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CronJob
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/cron-job-v1beta1#CronJob" >}}">CronJob</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/cron-job-v1beta1#CronJob" >}}">CronJob</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/cron-job-v1beta1#CronJob" >}}">CronJob</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified CronJob
+
+#### HTTP Request
+
+PATCH /apis/batch/v1beta1/namespaces/{namespace}/cronjobs/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CronJob
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/cron-job-v1beta1#CronJob" >}}">CronJob</a>): OK
+
+401: Unauthorized
+
+
+### `patch` partially update status of the specified CronJob
+
+#### HTTP Request
+
+PATCH /apis/batch/v1beta1/namespaces/{namespace}/cronjobs/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CronJob
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/cron-job-v1beta1#CronJob" >}}">CronJob</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a CronJob
+
+#### HTTP Request
+
+DELETE /apis/batch/v1beta1/namespaces/{namespace}/cronjobs/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CronJob
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of CronJob
+
+#### HTTP Request
+
+DELETE /apis/batch/v1beta1/namespaces/{namespace}/cronjobs
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/workloads-resources/cron-job-v2alpha1.md
+++ b/content/en/docs/reference/kubernetes-api/workloads-resources/cron-job-v2alpha1.md
@@ -1,0 +1,746 @@
+---
+api_metadata:
+  apiVersion: "batch/v2alpha1"
+  import: "k8s.io/api/batch/v2alpha1"
+  kind: "CronJob"
+content_type: "api_reference"
+description: "CronJob represents the configuration of a single cron job."
+title: "CronJob v2alpha1"
+weight: 13
+---
+
+`apiVersion: batch/v2alpha1`
+
+`import "k8s.io/api/batch/v2alpha1"`
+
+
+## CronJob {#CronJob}
+
+CronJob represents the configuration of a single cron job.
+
+<hr>
+
+- **apiVersion**: batch/v2alpha1
+
+
+- **kind**: CronJob
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **spec** (<a href="{{< ref "../workloads-resources/cron-job-v2alpha1#CronJobSpec" >}}">CronJobSpec</a>)
+
+  Specification of the desired behavior of a cron job, including the schedule. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+- **status** (<a href="{{< ref "../workloads-resources/cron-job-v2alpha1#CronJobStatus" >}}">CronJobStatus</a>)
+
+  Current status of a cron job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+
+
+
+
+## CronJobSpec {#CronJobSpec}
+
+CronJobSpec describes how the job execution will look like and when it will actually run.
+
+<hr>
+
+- **jobTemplate** (JobTemplateSpec), required
+
+  Specifies the job that will be created when executing a CronJob.
+
+  <a name="JobTemplateSpec"></a>
+  *JobTemplateSpec describes the data a Job should have when created from a template*
+
+  - **jobTemplate.metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+    Standard object's metadata of the jobs created from this template. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+  - **jobTemplate.spec** (<a href="{{< ref "../workloads-resources/job-v1#JobSpec" >}}">JobSpec</a>)
+
+    Specification of the desired behavior of the job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+- **schedule** (string), required
+
+  The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
+
+- **concurrencyPolicy** (string)
+
+  Specifies how to treat concurrent executions of a Job. Valid values are: - "Allow" (default): allows CronJobs to run concurrently; - "Forbid": forbids concurrent runs, skipping next run if previous run hasn't finished yet; - "Replace": cancels currently running job and replaces it with a new one
+
+- **failedJobsHistoryLimit** (int32)
+
+  The number of failed finished jobs to retain. This is a pointer to distinguish between explicit zero and not specified.
+
+- **startingDeadlineSeconds** (int64)
+
+  Optional deadline in seconds for starting the job if it misses scheduled time for any reason.  Missed jobs executions will be counted as failed ones.
+
+- **successfulJobsHistoryLimit** (int32)
+
+  The number of successful finished jobs to retain. This is a pointer to distinguish between explicit zero and not specified.
+
+- **suspend** (boolean)
+
+  This flag tells the controller to suspend subsequent executions, it does not apply to already started executions.  Defaults to false.
+
+
+
+
+
+## CronJobStatus {#CronJobStatus}
+
+CronJobStatus represents the current state of a cron job.
+
+<hr>
+
+- **active** ([]<a href="{{< ref "../common-definitions/object-reference#ObjectReference" >}}">ObjectReference</a>)
+
+  A list of pointers to currently running jobs.
+
+- **lastScheduleTime** (Time)
+
+  Information when was the last time the job was successfully scheduled.
+
+  <a name="Time"></a>
+  *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+
+
+
+
+## CronJobList {#CronJobList}
+
+CronJobList is a collection of cron jobs.
+
+<hr>
+
+- **apiVersion**: batch/v2alpha1
+
+
+- **kind**: CronJobList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **items** ([]<a href="{{< ref "../workloads-resources/cron-job-v2alpha1#CronJob" >}}">CronJob</a>), required
+
+  items is the list of CronJobs.
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified CronJob
+
+#### HTTP Request
+
+GET /apis/batch/v2alpha1/namespaces/{namespace}/cronjobs/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CronJob
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/cron-job-v2alpha1#CronJob" >}}">CronJob</a>): OK
+
+401: Unauthorized
+
+
+### `get` read status of the specified CronJob
+
+#### HTTP Request
+
+GET /apis/batch/v2alpha1/namespaces/{namespace}/cronjobs/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CronJob
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/cron-job-v2alpha1#CronJob" >}}">CronJob</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind CronJob
+
+#### HTTP Request
+
+GET /apis/batch/v2alpha1/namespaces/{namespace}/cronjobs
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/cron-job-v2alpha1#CronJobList" >}}">CronJobList</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind CronJob
+
+#### HTTP Request
+
+GET /apis/batch/v2alpha1/cronjobs
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/cron-job-v2alpha1#CronJobList" >}}">CronJobList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a CronJob
+
+#### HTTP Request
+
+POST /apis/batch/v2alpha1/namespaces/{namespace}/cronjobs
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/cron-job-v2alpha1#CronJob" >}}">CronJob</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/cron-job-v2alpha1#CronJob" >}}">CronJob</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/cron-job-v2alpha1#CronJob" >}}">CronJob</a>): Created
+
+202 (<a href="{{< ref "../workloads-resources/cron-job-v2alpha1#CronJob" >}}">CronJob</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified CronJob
+
+#### HTTP Request
+
+PUT /apis/batch/v2alpha1/namespaces/{namespace}/cronjobs/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CronJob
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/cron-job-v2alpha1#CronJob" >}}">CronJob</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/cron-job-v2alpha1#CronJob" >}}">CronJob</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/cron-job-v2alpha1#CronJob" >}}">CronJob</a>): Created
+
+401: Unauthorized
+
+
+### `update` replace status of the specified CronJob
+
+#### HTTP Request
+
+PUT /apis/batch/v2alpha1/namespaces/{namespace}/cronjobs/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CronJob
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/cron-job-v2alpha1#CronJob" >}}">CronJob</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/cron-job-v2alpha1#CronJob" >}}">CronJob</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/cron-job-v2alpha1#CronJob" >}}">CronJob</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified CronJob
+
+#### HTTP Request
+
+PATCH /apis/batch/v2alpha1/namespaces/{namespace}/cronjobs/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CronJob
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/cron-job-v2alpha1#CronJob" >}}">CronJob</a>): OK
+
+401: Unauthorized
+
+
+### `patch` partially update status of the specified CronJob
+
+#### HTTP Request
+
+PATCH /apis/batch/v2alpha1/namespaces/{namespace}/cronjobs/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CronJob
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/cron-job-v2alpha1#CronJob" >}}">CronJob</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a CronJob
+
+#### HTTP Request
+
+DELETE /apis/batch/v2alpha1/namespaces/{namespace}/cronjobs/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the CronJob
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of CronJob
+
+#### HTTP Request
+
+DELETE /apis/batch/v2alpha1/namespaces/{namespace}/cronjobs
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/workloads-resources/daemon-set-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workloads-resources/daemon-set-v1.md
@@ -1,0 +1,805 @@
+---
+api_metadata:
+  apiVersion: "apps/v1"
+  import: "k8s.io/api/apps/v1"
+  kind: "DaemonSet"
+content_type: "api_reference"
+description: "DaemonSet represents the configuration of a daemon set."
+title: "DaemonSet"
+weight: 10
+---
+
+`apiVersion: apps/v1`
+
+`import "k8s.io/api/apps/v1"`
+
+
+## DaemonSet {#DaemonSet}
+
+DaemonSet represents the configuration of a daemon set.
+
+<hr>
+
+- **apiVersion**: apps/v1
+
+
+- **kind**: DaemonSet
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **spec** (<a href="{{< ref "../workloads-resources/daemon-set-v1#DaemonSetSpec" >}}">DaemonSetSpec</a>)
+
+  The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+- **status** (<a href="{{< ref "../workloads-resources/daemon-set-v1#DaemonSetStatus" >}}">DaemonSetStatus</a>)
+
+  The current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+
+
+
+
+## DaemonSetSpec {#DaemonSetSpec}
+
+DaemonSetSpec is the specification of a daemon set.
+
+<hr>
+
+- **selector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>), required
+
+  A label query over pods that are managed by the daemon set. Must match in order to be controlled. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+
+- **template** (<a href="{{< ref "../workloads-resources/pod-template-v1#PodTemplateSpec" >}}">PodTemplateSpec</a>), required
+
+  An object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
+
+- **minReadySeconds** (int32)
+
+  The minimum number of seconds for which a newly created DaemonSet pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready).
+
+- **updateStrategy** (DaemonSetUpdateStrategy)
+
+  An update strategy to replace existing DaemonSet pods with new pods.
+
+  <a name="DaemonSetUpdateStrategy"></a>
+  *DaemonSetUpdateStrategy is a struct used to control the update strategy for a DaemonSet.*
+
+  - **updateStrategy.type** (string)
+
+    Type of daemon set update. Can be "RollingUpdate" or "OnDelete". Default is RollingUpdate.
+
+  - **updateStrategy.rollingUpdate** (RollingUpdateDaemonSet)
+
+    Rolling update config params. Present only if type = "RollingUpdate".
+
+    <a name="RollingUpdateDaemonSet"></a>
+    *Spec to control the desired behavior of daemon set rolling update.*
+
+  - **updateStrategy.rollingUpdate.maxUnavailable** (IntOrString)
+
+    The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0. Default value is 1. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their pods stopped for an update at any given time. The update starts by stopping at most 30% of those DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are available, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update.
+
+    <a name="IntOrString"></a>
+    *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
+
+- **revisionHistoryLimit** (int32)
+
+  The number of old history to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.
+
+
+
+
+
+## DaemonSetStatus {#DaemonSetStatus}
+
+DaemonSetStatus represents the current status of a daemon set.
+
+<hr>
+
+- **numberReady** (int32), required
+
+  The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.
+
+- **numberAvailable** (int32)
+
+  The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available (ready for at least spec.minReadySeconds)
+
+- **numberUnavailable** (int32)
+
+  The number of nodes that should be running the daemon pod and have none of the daemon pod running and available (ready for at least spec.minReadySeconds)
+
+- **numberMisscheduled** (int32), required
+
+  The number of nodes that are running the daemon pod, but are not supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
+
+- **desiredNumberScheduled** (int32), required
+
+  The total number of nodes that should be running the daemon pod (including nodes correctly running the daemon pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
+
+- **currentNumberScheduled** (int32), required
+
+  The number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
+
+- **updatedNumberScheduled** (int32)
+
+  The total number of nodes that are running updated daemon pod
+
+- **collisionCount** (int32)
+
+  Count of hash collisions for the DaemonSet. The DaemonSet controller uses this field as a collision avoidance mechanism when it needs to create the name for the newest ControllerRevision.
+
+- **conditions** ([]DaemonSetCondition)
+
+  *Patch strategy: merge on key `type`*
+  
+  Represents the latest available observations of a DaemonSet's current state.
+
+  <a name="DaemonSetCondition"></a>
+  *DaemonSetCondition describes the state of a DaemonSet at a certain point.*
+
+  - **conditions.status** (string), required
+
+    Status of the condition, one of True, False, Unknown.
+
+  - **conditions.type** (string), required
+
+    Type of DaemonSet condition.
+
+  - **conditions.lastTransitionTime** (Time)
+
+    Last time the condition transitioned from one status to another.
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **conditions.message** (string)
+
+    A human readable message indicating details about the transition.
+
+  - **conditions.reason** (string)
+
+    The reason for the condition's last transition.
+
+- **observedGeneration** (int64)
+
+  The most recent generation observed by the daemon set controller.
+
+
+
+
+
+## DaemonSetList {#DaemonSetList}
+
+DaemonSetList is a collection of daemon sets.
+
+<hr>
+
+- **apiVersion**: apps/v1
+
+
+- **kind**: DaemonSetList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **items** ([]<a href="{{< ref "../workloads-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>), required
+
+  A list of daemon sets.
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified DaemonSet
+
+#### HTTP Request
+
+GET /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the DaemonSet
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>): OK
+
+401: Unauthorized
+
+
+### `get` read status of the specified DaemonSet
+
+#### HTTP Request
+
+GET /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the DaemonSet
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind DaemonSet
+
+#### HTTP Request
+
+GET /apis/apps/v1/namespaces/{namespace}/daemonsets
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/daemon-set-v1#DaemonSetList" >}}">DaemonSetList</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind DaemonSet
+
+#### HTTP Request
+
+GET /apis/apps/v1/daemonsets
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/daemon-set-v1#DaemonSetList" >}}">DaemonSetList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a DaemonSet
+
+#### HTTP Request
+
+POST /apis/apps/v1/namespaces/{namespace}/daemonsets
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>): Created
+
+202 (<a href="{{< ref "../workloads-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified DaemonSet
+
+#### HTTP Request
+
+PUT /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the DaemonSet
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>): Created
+
+401: Unauthorized
+
+
+### `update` replace status of the specified DaemonSet
+
+#### HTTP Request
+
+PUT /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the DaemonSet
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified DaemonSet
+
+#### HTTP Request
+
+PATCH /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the DaemonSet
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>): OK
+
+401: Unauthorized
+
+
+### `patch` partially update status of the specified DaemonSet
+
+#### HTTP Request
+
+PATCH /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the DaemonSet
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/daemon-set-v1#DaemonSet" >}}">DaemonSet</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a DaemonSet
+
+#### HTTP Request
+
+DELETE /apis/apps/v1/namespaces/{namespace}/daemonsets/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the DaemonSet
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of DaemonSet
+
+#### HTTP Request
+
+DELETE /apis/apps/v1/namespaces/{namespace}/daemonsets
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/workloads-resources/deployment-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workloads-resources/deployment-v1.md
@@ -1,0 +1,825 @@
+---
+api_metadata:
+  apiVersion: "apps/v1"
+  import: "k8s.io/api/apps/v1"
+  kind: "Deployment"
+content_type: "api_reference"
+description: "Deployment enables declarative updates for Pods and ReplicaSets."
+title: "Deployment"
+weight: 7
+---
+
+`apiVersion: apps/v1`
+
+`import "k8s.io/api/apps/v1"`
+
+
+## Deployment {#Deployment}
+
+Deployment enables declarative updates for Pods and ReplicaSets.
+
+<hr>
+
+- **apiVersion**: apps/v1
+
+
+- **kind**: Deployment
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object metadata.
+
+- **spec** (<a href="{{< ref "../workloads-resources/deployment-v1#DeploymentSpec" >}}">DeploymentSpec</a>)
+
+  Specification of the desired behavior of the Deployment.
+
+- **status** (<a href="{{< ref "../workloads-resources/deployment-v1#DeploymentStatus" >}}">DeploymentStatus</a>)
+
+  Most recently observed status of the Deployment.
+
+
+
+
+
+## DeploymentSpec {#DeploymentSpec}
+
+DeploymentSpec is the specification of the desired behavior of the Deployment.
+
+<hr>
+
+- **selector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>), required
+
+  Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment. It must match the pod template's labels.
+
+- **template** (<a href="{{< ref "../workloads-resources/pod-template-v1#PodTemplateSpec" >}}">PodTemplateSpec</a>), required
+
+  Template describes the pods that will be created.
+
+- **replicas** (int32)
+
+  Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.
+
+- **minReadySeconds** (int32)
+
+  Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)
+
+- **strategy** (DeploymentStrategy)
+
+  *Patch strategy: retainKeys*
+  
+  The deployment strategy to use to replace existing pods with new ones.
+
+  <a name="DeploymentStrategy"></a>
+  *DeploymentStrategy describes how to replace existing pods with new ones.*
+
+  - **strategy.type** (string)
+
+    Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+
+  - **strategy.rollingUpdate** (RollingUpdateDeployment)
+
+    Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.
+
+    <a name="RollingUpdateDeployment"></a>
+    *Spec to control the desired behavior of rolling update.*
+
+  - **strategy.rollingUpdate.maxSurge** (IntOrString)
+
+    The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.
+
+    <a name="IntOrString"></a>
+    *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
+
+  - **strategy.rollingUpdate.maxUnavailable** (IntOrString)
+
+    The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.
+
+    <a name="IntOrString"></a>
+    *IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.*
+
+- **revisionHistoryLimit** (int32)
+
+  The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.
+
+- **progressDeadlineSeconds** (int32)
+
+  The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Note that progress will not be estimated during the time a deployment is paused. Defaults to 600s.
+
+- **paused** (boolean)
+
+  Indicates that the deployment is paused.
+
+
+
+
+
+## DeploymentStatus {#DeploymentStatus}
+
+DeploymentStatus is the most recently observed status of the Deployment.
+
+<hr>
+
+- **replicas** (int32)
+
+  Total number of non-terminated pods targeted by this deployment (their labels match the selector).
+
+- **availableReplicas** (int32)
+
+  Total number of available pods (ready for at least minReadySeconds) targeted by this deployment.
+
+- **readyReplicas** (int32)
+
+  Total number of ready pods targeted by this deployment.
+
+- **unavailableReplicas** (int32)
+
+  Total number of unavailable pods targeted by this deployment. This is the total number of pods that are still required for the deployment to have 100% available capacity. They may either be pods that are running but not yet available or pods that still have not been created.
+
+- **updatedReplicas** (int32)
+
+  Total number of non-terminated pods targeted by this deployment that have the desired template spec.
+
+- **collisionCount** (int32)
+
+  Count of hash collisions for the Deployment. The Deployment controller uses this field as a collision avoidance mechanism when it needs to create the name for the newest ReplicaSet.
+
+- **conditions** ([]DeploymentCondition)
+
+  *Patch strategy: merge on key `type`*
+  
+  Represents the latest available observations of a deployment's current state.
+
+  <a name="DeploymentCondition"></a>
+  *DeploymentCondition describes the state of a deployment at a certain point.*
+
+  - **conditions.status** (string), required
+
+    Status of the condition, one of True, False, Unknown.
+
+  - **conditions.type** (string), required
+
+    Type of deployment condition.
+
+  - **conditions.lastTransitionTime** (Time)
+
+    Last time the condition transitioned from one status to another.
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **conditions.lastUpdateTime** (Time)
+
+    The last time this condition was updated.
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **conditions.message** (string)
+
+    A human readable message indicating details about the transition.
+
+  - **conditions.reason** (string)
+
+    The reason for the condition's last transition.
+
+- **observedGeneration** (int64)
+
+  The generation observed by the deployment controller.
+
+
+
+
+
+## DeploymentList {#DeploymentList}
+
+DeploymentList is a list of Deployments.
+
+<hr>
+
+- **apiVersion**: apps/v1
+
+
+- **kind**: DeploymentList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata.
+
+- **items** ([]<a href="{{< ref "../workloads-resources/deployment-v1#Deployment" >}}">Deployment</a>), required
+
+  Items is the list of Deployments.
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified Deployment
+
+#### HTTP Request
+
+GET /apis/apps/v1/namespaces/{namespace}/deployments/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Deployment
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/deployment-v1#Deployment" >}}">Deployment</a>): OK
+
+401: Unauthorized
+
+
+### `get` read status of the specified Deployment
+
+#### HTTP Request
+
+GET /apis/apps/v1/namespaces/{namespace}/deployments/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Deployment
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/deployment-v1#Deployment" >}}">Deployment</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind Deployment
+
+#### HTTP Request
+
+GET /apis/apps/v1/namespaces/{namespace}/deployments
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/deployment-v1#DeploymentList" >}}">DeploymentList</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind Deployment
+
+#### HTTP Request
+
+GET /apis/apps/v1/deployments
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/deployment-v1#DeploymentList" >}}">DeploymentList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a Deployment
+
+#### HTTP Request
+
+POST /apis/apps/v1/namespaces/{namespace}/deployments
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/deployment-v1#Deployment" >}}">Deployment</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/deployment-v1#Deployment" >}}">Deployment</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/deployment-v1#Deployment" >}}">Deployment</a>): Created
+
+202 (<a href="{{< ref "../workloads-resources/deployment-v1#Deployment" >}}">Deployment</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified Deployment
+
+#### HTTP Request
+
+PUT /apis/apps/v1/namespaces/{namespace}/deployments/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Deployment
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/deployment-v1#Deployment" >}}">Deployment</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/deployment-v1#Deployment" >}}">Deployment</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/deployment-v1#Deployment" >}}">Deployment</a>): Created
+
+401: Unauthorized
+
+
+### `update` replace status of the specified Deployment
+
+#### HTTP Request
+
+PUT /apis/apps/v1/namespaces/{namespace}/deployments/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Deployment
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/deployment-v1#Deployment" >}}">Deployment</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/deployment-v1#Deployment" >}}">Deployment</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/deployment-v1#Deployment" >}}">Deployment</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified Deployment
+
+#### HTTP Request
+
+PATCH /apis/apps/v1/namespaces/{namespace}/deployments/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Deployment
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/deployment-v1#Deployment" >}}">Deployment</a>): OK
+
+401: Unauthorized
+
+
+### `patch` partially update status of the specified Deployment
+
+#### HTTP Request
+
+PATCH /apis/apps/v1/namespaces/{namespace}/deployments/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Deployment
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/deployment-v1#Deployment" >}}">Deployment</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a Deployment
+
+#### HTTP Request
+
+DELETE /apis/apps/v1/namespaces/{namespace}/deployments/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Deployment
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of Deployment
+
+#### HTTP Request
+
+DELETE /apis/apps/v1/namespaces/{namespace}/deployments
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/workloads-resources/ephemeral-container.md
+++ b/content/en/docs/reference/kubernetes-api/workloads-resources/ephemeral-container.md
@@ -1,0 +1,571 @@
+---
+api_metadata:
+  apiVersion: ""
+  import: "k8s.io/api/core/v1"
+  kind: "EphemeralContainer"
+content_type: "api_reference"
+description: "An EphemeralContainer is a container that may be added temporarily to an existing pod for user-initiated activities such as debugging."
+title: "EphemeralContainer"
+weight: 3
+---
+
+
+
+`import "k8s.io/api/core/v1"`
+
+
+An EphemeralContainer is a container that may be added temporarily to an existing pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a pod is removed or restarted. If an ephemeral container causes a pod to exceed its resource allocation, the pod may be evicted. Ephemeral containers may not be added by directly updating the pod spec. They must be added via the pod's ephemeralcontainers subresource, and they will appear in the pod spec once added. This is an alpha feature enabled by the EphemeralContainers feature flag.
+
+<hr>
+
+- **name** (string), required
+
+  Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.
+
+- **targetContainerName** (string)
+
+  If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container is run in whatever namespaces are shared for the pod. Note that the container runtime must support this feature.
+
+
+
+### Image {#Image}
+
+
+- **image** (string)
+
+  Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+
+- **imagePullPolicy** (string)
+
+  Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+### Entrypoint {#Entrypoint}
+
+
+- **command** ([]string)
+
+  Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+
+- **args** ([]string)
+
+  Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+
+- **workingDir** (string)
+
+  Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+
+### Environment variables {#Environment variables}
+
+
+- **env** ([]EnvVar)
+
+  *Patch strategy: merge on key `name`*
+  
+  List of environment variables to set in the container. Cannot be updated.
+
+  <a name="EnvVar"></a>
+  *EnvVar represents an environment variable present in a Container.*
+
+  - **env.name** (string), required
+
+    Name of the environment variable. Must be a C_IDENTIFIER.
+
+  - **env.value** (string)
+
+    Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
+
+  - **env.valueFrom** (EnvVarSource)
+
+    Source for the environment variable's value. Cannot be used if value is not empty.
+
+    <a name="EnvVarSource"></a>
+    *EnvVarSource represents a source for the value of an EnvVar.*
+
+  - **env.valueFrom.configMapKeyRef** (ConfigMapKeySelector)
+
+    Selects a key of a ConfigMap.
+
+    <a name="ConfigMapKeySelector"></a>
+    *Selects a key from a ConfigMap.*
+
+  - **env.valueFrom.configMapKeyRef.key** (string), required
+
+    The key to select.
+
+  - **env.valueFrom.configMapKeyRef.name** (string)
+
+    Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+  - **env.valueFrom.configMapKeyRef.optional** (boolean)
+
+    Specify whether the ConfigMap or its key must be defined
+
+  - **env.valueFrom.fieldRef** (<a href="{{< ref "../common-definitions/object-field-selector#ObjectFieldSelector" >}}">ObjectFieldSelector</a>)
+
+    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['\<KEY>']`, `metadata.annotations['\<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+
+  - **env.valueFrom.resourceFieldRef** (<a href="{{< ref "../common-definitions/resource-field-selector#ResourceFieldSelector" >}}">ResourceFieldSelector</a>)
+
+    Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+
+  - **env.valueFrom.secretKeyRef** (SecretKeySelector)
+
+    Selects a key of a secret in the pod's namespace
+
+    <a name="SecretKeySelector"></a>
+    *SecretKeySelector selects a key of a Secret.*
+
+  - **env.valueFrom.secretKeyRef.key** (string), required
+
+    The key of the secret to select from.  Must be a valid secret key.
+
+  - **env.valueFrom.secretKeyRef.name** (string)
+
+    Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+  - **env.valueFrom.secretKeyRef.optional** (boolean)
+
+    Specify whether the Secret or its key must be defined
+
+- **envFrom** ([]EnvFromSource)
+
+  List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
+
+  <a name="EnvFromSource"></a>
+  *EnvFromSource represents the source of a set of ConfigMaps*
+
+  - **envFrom.configMapRef** (ConfigMapEnvSource)
+
+    The ConfigMap to select from
+
+    <a name="ConfigMapEnvSource"></a>
+    *ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.
+    
+    The contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.*
+
+  - **envFrom.configMapRef.name** (string)
+
+    Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+  - **envFrom.configMapRef.optional** (boolean)
+
+    Specify whether the ConfigMap must be defined
+
+  - **envFrom.prefix** (string)
+
+    An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+
+  - **envFrom.secretRef** (SecretEnvSource)
+
+    The Secret to select from
+
+    <a name="SecretEnvSource"></a>
+    *SecretEnvSource selects a Secret to populate the environment variables with.
+    
+    The contents of the target Secret's Data field will represent the key-value pairs as environment variables.*
+
+  - **envFrom.secretRef.name** (string)
+
+    Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+  - **envFrom.secretRef.optional** (boolean)
+
+    Specify whether the Secret must be defined
+
+### Volumes {#Volumes}
+
+
+- **volumeMounts** ([]VolumeMount)
+
+  *Patch strategy: merge on key `mountPath`*
+  
+  Pod volumes to mount into the container's filesystem. Cannot be updated.
+
+  <a name="VolumeMount"></a>
+  *VolumeMount describes a mounting of a Volume within a container.*
+
+  - **volumeMounts.mountPath** (string), required
+
+    Path within the container at which the volume should be mounted.  Must not contain ':'.
+
+  - **volumeMounts.name** (string), required
+
+    This must match the Name of a Volume.
+
+  - **volumeMounts.mountPropagation** (string)
+
+    mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+
+  - **volumeMounts.readOnly** (boolean)
+
+    Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+
+  - **volumeMounts.subPath** (string)
+
+    Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+
+  - **volumeMounts.subPathExpr** (string)
+
+    Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+
+- **volumeDevices** ([]VolumeDevice)
+
+  *Patch strategy: merge on key `devicePath`*
+  
+  volumeDevices is the list of block devices to be used by the container.
+
+  <a name="VolumeDevice"></a>
+  *volumeDevice describes a mapping of a raw block device within a container.*
+
+  - **volumeDevices.devicePath** (string), required
+
+    devicePath is the path inside of the container that the device will be mapped to.
+
+  - **volumeDevices.name** (string), required
+
+    name must match the name of a persistentVolumeClaim in the pod
+
+### Lifecycle {#Lifecycle}
+
+
+- **terminationMessagePath** (string)
+
+  Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.
+
+- **terminationMessagePolicy** (string)
+
+  Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+### Debugging {#Debugging}
+
+
+- **stdin** (boolean)
+
+  Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
+
+- **stdinOnce** (boolean)
+
+  Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
+
+- **tty** (boolean)
+
+  Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
+
+### Not allowed {#Not allowed}
+
+
+- **ports** ([]ContainerPort)
+
+  Ports are not allowed for ephemeral containers.
+
+  <a name="ContainerPort"></a>
+  *ContainerPort represents a network port in a single container.*
+
+  - **ports.containerPort** (int32), required
+
+    Number of port to expose on the pod's IP address. This must be a valid port number, 0 \< x \< 65536.
+
+  - **ports.hostIP** (string)
+
+    What host IP to bind the external port to.
+
+  - **ports.hostPort** (int32)
+
+    Number of port to expose on the host. If specified, this must be a valid port number, 0 \< x \< 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
+
+  - **ports.name** (string)
+
+    If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
+
+  - **ports.protocol** (string)
+
+    Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+- **resources** (ResourceRequirements)
+
+  Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.
+
+  <a name="ResourceRequirements"></a>
+  *ResourceRequirements describes the compute resource requirements.*
+
+  - **resources.limits** (map[string]<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+
+  - **resources.requests** (map[string]<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+
+- **lifecycle** (Lifecycle)
+
+  Lifecycle is not allowed for ephemeral containers.
+
+  <a name="Lifecycle"></a>
+  *Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.*
+
+  - **lifecycle.postStart** (Handler)
+
+    PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+
+    <a name="Handler"></a>
+    *Handler defines a specific action that should be taken*
+
+  - **lifecycle.postStart.exec** (<a href="{{< ref "../common-definitions/exec-action#ExecAction" >}}">ExecAction</a>)
+
+    One and only one of the following should be specified. Exec specifies the action to take.
+
+  - **lifecycle.postStart.httpGet** (<a href="{{< ref "../common-definitions/http-get-action#HTTPGetAction" >}}">HTTPGetAction</a>)
+
+    HTTPGet specifies the http request to perform.
+
+  - **lifecycle.postStart.tcpSocket** (<a href="{{< ref "../common-definitions/tcp-socket-action#TCPSocketAction" >}}">TCPSocketAction</a>)
+
+    TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported
+
+  - **lifecycle.preStop** (Handler)
+
+    PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod's termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+
+    <a name="Handler"></a>
+    *Handler defines a specific action that should be taken*
+
+  - **lifecycle.preStop.exec** (<a href="{{< ref "../common-definitions/exec-action#ExecAction" >}}">ExecAction</a>)
+
+    One and only one of the following should be specified. Exec specifies the action to take.
+
+  - **lifecycle.preStop.httpGet** (<a href="{{< ref "../common-definitions/http-get-action#HTTPGetAction" >}}">HTTPGetAction</a>)
+
+    HTTPGet specifies the http request to perform.
+
+  - **lifecycle.preStop.tcpSocket** (<a href="{{< ref "../common-definitions/tcp-socket-action#TCPSocketAction" >}}">TCPSocketAction</a>)
+
+    TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported
+
+- **livenessProbe** (Probe)
+
+  Probes are not allowed for ephemeral containers.
+
+  <a name="Probe"></a>
+  *Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.*
+
+  - **livenessProbe.exec** (<a href="{{< ref "../common-definitions/exec-action#ExecAction" >}}">ExecAction</a>)
+
+    One and only one of the following should be specified. Exec specifies the action to take.
+
+  - **livenessProbe.httpGet** (<a href="{{< ref "../common-definitions/http-get-action#HTTPGetAction" >}}">HTTPGetAction</a>)
+
+    HTTPGet specifies the http request to perform.
+
+  - **livenessProbe.tcpSocket** (<a href="{{< ref "../common-definitions/tcp-socket-action#TCPSocketAction" >}}">TCPSocketAction</a>)
+
+    TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported
+
+  - **livenessProbe.initialDelaySeconds** (int32)
+
+    Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+  - **livenessProbe.periodSeconds** (int32)
+
+    How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+
+  - **livenessProbe.timeoutSeconds** (int32)
+
+    Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+  - **livenessProbe.failureThreshold** (int32)
+
+    Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+
+  - **livenessProbe.successThreshold** (int32)
+
+    Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+
+- **readinessProbe** (Probe)
+
+  Probes are not allowed for ephemeral containers.
+
+  <a name="Probe"></a>
+  *Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.*
+
+  - **readinessProbe.exec** (<a href="{{< ref "../common-definitions/exec-action#ExecAction" >}}">ExecAction</a>)
+
+    One and only one of the following should be specified. Exec specifies the action to take.
+
+  - **readinessProbe.httpGet** (<a href="{{< ref "../common-definitions/http-get-action#HTTPGetAction" >}}">HTTPGetAction</a>)
+
+    HTTPGet specifies the http request to perform.
+
+  - **readinessProbe.tcpSocket** (<a href="{{< ref "../common-definitions/tcp-socket-action#TCPSocketAction" >}}">TCPSocketAction</a>)
+
+    TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported
+
+  - **readinessProbe.initialDelaySeconds** (int32)
+
+    Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+  - **readinessProbe.periodSeconds** (int32)
+
+    How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+
+  - **readinessProbe.timeoutSeconds** (int32)
+
+    Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+  - **readinessProbe.failureThreshold** (int32)
+
+    Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+
+  - **readinessProbe.successThreshold** (int32)
+
+    Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+
+- **securityContext** (SecurityContext)
+
+  SecurityContext is not allowed for ephemeral containers.
+
+  <a name="SecurityContext"></a>
+  *SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.*
+
+  - **securityContext.runAsUser** (int64)
+
+    The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+
+  - **securityContext.runAsNonRoot** (boolean)
+
+    Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+
+  - **securityContext.runAsGroup** (int64)
+
+    The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+
+  - **securityContext.readOnlyRootFilesystem** (boolean)
+
+    Whether this container has a read-only root filesystem. Default is false.
+
+  - **securityContext.procMount** (string)
+
+    procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
+
+  - **securityContext.privileged** (boolean)
+
+    Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
+
+  - **securityContext.allowPrivilegeEscalation** (boolean)
+
+    AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
+
+  - **securityContext.capabilities** (Capabilities)
+
+    The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+
+    <a name="Capabilities"></a>
+    *Adds and removes POSIX capabilities from running containers.*
+
+  - **securityContext.capabilities.add** ([]string)
+
+    Added capabilities
+
+  - **securityContext.capabilities.drop** ([]string)
+
+    Removed capabilities
+
+  - **securityContext.seccompProfile** (SeccompProfile)
+
+    The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.
+
+    <a name="SeccompProfile"></a>
+    *SeccompProfile defines a pod/container's seccomp profile settings. Only one profile source may be set.*
+
+  - **securityContext.seccompProfile.type** (string), required
+
+    type indicates which kind of seccomp profile will be applied. Valid options are:
+    
+    Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+  - **securityContext.seccompProfile.localhostProfile** (string)
+
+    localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+
+  - **securityContext.seLinuxOptions** (SELinuxOptions)
+
+    The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+
+    <a name="SELinuxOptions"></a>
+    *SELinuxOptions are the labels to be applied to the container*
+
+  - **securityContext.seLinuxOptions.level** (string)
+
+    Level is SELinux level label that applies to the container.
+
+  - **securityContext.seLinuxOptions.role** (string)
+
+    Role is a SELinux role label that applies to the container.
+
+  - **securityContext.seLinuxOptions.type** (string)
+
+    Type is a SELinux type label that applies to the container.
+
+  - **securityContext.seLinuxOptions.user** (string)
+
+    User is a SELinux user label that applies to the container.
+
+  - **securityContext.windowsOptions** (WindowsSecurityContextOptions)
+
+    The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+
+    <a name="WindowsSecurityContextOptions"></a>
+    *WindowsSecurityContextOptions contain Windows-specific options and credentials.*
+
+  - **securityContext.windowsOptions.gmsaCredentialSpec** (string)
+
+    GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
+
+  - **securityContext.windowsOptions.gmsaCredentialSpecName** (string)
+
+    GMSACredentialSpecName is the name of the GMSA credential spec to use.
+
+  - **securityContext.windowsOptions.runAsUserName** (string)
+
+    The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+
+- **startupProbe** (Probe)
+
+  Probes are not allowed for ephemeral containers.
+
+  <a name="Probe"></a>
+  *Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.*
+
+  - **startupProbe.exec** (<a href="{{< ref "../common-definitions/exec-action#ExecAction" >}}">ExecAction</a>)
+
+    One and only one of the following should be specified. Exec specifies the action to take.
+
+  - **startupProbe.httpGet** (<a href="{{< ref "../common-definitions/http-get-action#HTTPGetAction" >}}">HTTPGetAction</a>)
+
+    HTTPGet specifies the http request to perform.
+
+  - **startupProbe.tcpSocket** (<a href="{{< ref "../common-definitions/tcp-socket-action#TCPSocketAction" >}}">TCPSocketAction</a>)
+
+    TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported
+
+  - **startupProbe.initialDelaySeconds** (int32)
+
+    Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+  - **startupProbe.periodSeconds** (int32)
+
+    How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+
+  - **startupProbe.timeoutSeconds** (int32)
+
+    Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+  - **startupProbe.failureThreshold** (int32)
+
+    Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+
+  - **startupProbe.successThreshold** (int32)
+
+    Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+
+
+

--- a/content/en/docs/reference/kubernetes-api/workloads-resources/horizontal-pod-autoscaler-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workloads-resources/horizontal-pod-autoscaler-v1.md
@@ -1,0 +1,750 @@
+---
+api_metadata:
+  apiVersion: "autoscaling/v1"
+  import: "k8s.io/api/autoscaling/v1"
+  kind: "HorizontalPodAutoscaler"
+content_type: "api_reference"
+description: "configuration of a horizontal pod autoscaler."
+title: "HorizontalPodAutoscaler"
+weight: 14
+---
+
+`apiVersion: autoscaling/v1`
+
+`import "k8s.io/api/autoscaling/v1"`
+
+
+## HorizontalPodAutoscaler {#HorizontalPodAutoscaler}
+
+configuration of a horizontal pod autoscaler.
+
+<hr>
+
+- **apiVersion**: autoscaling/v1
+
+
+- **kind**: HorizontalPodAutoscaler
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **spec** (<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscalerSpec" >}}">HorizontalPodAutoscalerSpec</a>)
+
+  behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
+
+- **status** (<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscalerStatus" >}}">HorizontalPodAutoscalerStatus</a>)
+
+  current information about the autoscaler.
+
+
+
+
+
+## HorizontalPodAutoscalerSpec {#HorizontalPodAutoscalerSpec}
+
+specification of a horizontal pod autoscaler.
+
+<hr>
+
+- **maxReplicas** (int32), required
+
+  upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
+
+- **scaleTargetRef** (CrossVersionObjectReference), required
+
+  reference to scaled resource; horizontal pod autoscaler will learn the current resource consumption and will set the desired number of pods by using its Scale subresource.
+
+  <a name="CrossVersionObjectReference"></a>
+  *CrossVersionObjectReference contains enough information to let you identify the referred resource.*
+
+  - **scaleTargetRef.kind** (string), required
+
+    Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+
+  - **scaleTargetRef.name** (string), required
+
+    Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
+
+  - **scaleTargetRef.apiVersion** (string)
+
+    API version of the referent
+
+- **minReplicas** (int32)
+
+  minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down.  It defaults to 1 pod.  minReplicas is allowed to be 0 if the alpha feature gate HPAScaleToZero is enabled and at least one Object or External metric is configured.  Scaling is active as long as at least one metric value is available.
+
+- **targetCPUUtilizationPercentage** (int32)
+
+  target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.
+
+
+
+
+
+## HorizontalPodAutoscalerStatus {#HorizontalPodAutoscalerStatus}
+
+current status of a horizontal pod autoscaler
+
+<hr>
+
+- **currentReplicas** (int32), required
+
+  current number of replicas of pods managed by this autoscaler.
+
+- **desiredReplicas** (int32), required
+
+  desired number of replicas of pods managed by this autoscaler.
+
+- **currentCPUUtilizationPercentage** (int32)
+
+  current average CPU utilization over all pods, represented as a percentage of requested CPU, e.g. 70 means that an average pod is using now 70% of its requested CPU.
+
+- **lastScaleTime** (Time)
+
+  last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed.
+
+  <a name="Time"></a>
+  *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+- **observedGeneration** (int64)
+
+  most recent generation observed by this autoscaler.
+
+
+
+
+
+## HorizontalPodAutoscalerList {#HorizontalPodAutoscalerList}
+
+list of horizontal pod autoscaler objects.
+
+<hr>
+
+- **apiVersion**: autoscaling/v1
+
+
+- **kind**: HorizontalPodAutoscalerList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata.
+
+- **items** ([]<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>), required
+
+  list of horizontal pod autoscaler objects.
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified HorizontalPodAutoscaler
+
+#### HTTP Request
+
+GET /apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the HorizontalPodAutoscaler
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): OK
+
+401: Unauthorized
+
+
+### `get` read status of the specified HorizontalPodAutoscaler
+
+#### HTTP Request
+
+GET /apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the HorizontalPodAutoscaler
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind HorizontalPodAutoscaler
+
+#### HTTP Request
+
+GET /apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscalerList" >}}">HorizontalPodAutoscalerList</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind HorizontalPodAutoscaler
+
+#### HTTP Request
+
+GET /apis/autoscaling/v1/horizontalpodautoscalers
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscalerList" >}}">HorizontalPodAutoscalerList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a HorizontalPodAutoscaler
+
+#### HTTP Request
+
+POST /apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): Created
+
+202 (<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified HorizontalPodAutoscaler
+
+#### HTTP Request
+
+PUT /apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the HorizontalPodAutoscaler
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): Created
+
+401: Unauthorized
+
+
+### `update` replace status of the specified HorizontalPodAutoscaler
+
+#### HTTP Request
+
+PUT /apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the HorizontalPodAutoscaler
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified HorizontalPodAutoscaler
+
+#### HTTP Request
+
+PATCH /apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the HorizontalPodAutoscaler
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): OK
+
+401: Unauthorized
+
+
+### `patch` partially update status of the specified HorizontalPodAutoscaler
+
+#### HTTP Request
+
+PATCH /apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the HorizontalPodAutoscaler
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v1#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a HorizontalPodAutoscaler
+
+#### HTTP Request
+
+DELETE /apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the HorizontalPodAutoscaler
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of HorizontalPodAutoscaler
+
+#### HTTP Request
+
+DELETE /apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/workloads-resources/horizontal-pod-autoscaler-v2beta2.md
+++ b/content/en/docs/reference/kubernetes-api/workloads-resources/horizontal-pod-autoscaler-v2beta2.md
@@ -1,0 +1,1302 @@
+---
+api_metadata:
+  apiVersion: "autoscaling/v2beta2"
+  import: "k8s.io/api/autoscaling/v2beta2"
+  kind: "HorizontalPodAutoscaler"
+content_type: "api_reference"
+description: "HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified."
+title: "HorizontalPodAutoscaler v2beta2"
+weight: 15
+---
+
+`apiVersion: autoscaling/v2beta2`
+
+`import "k8s.io/api/autoscaling/v2beta2"`
+
+
+## HorizontalPodAutoscaler {#HorizontalPodAutoscaler}
+
+HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
+
+<hr>
+
+- **apiVersion**: autoscaling/v2beta2
+
+
+- **kind**: HorizontalPodAutoscaler
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **spec** (<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v2beta2#HorizontalPodAutoscalerSpec" >}}">HorizontalPodAutoscalerSpec</a>)
+
+  spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
+
+- **status** (<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v2beta2#HorizontalPodAutoscalerStatus" >}}">HorizontalPodAutoscalerStatus</a>)
+
+  status is the current information about the autoscaler.
+
+
+
+
+
+## HorizontalPodAutoscalerSpec {#HorizontalPodAutoscalerSpec}
+
+HorizontalPodAutoscalerSpec describes the desired functionality of the HorizontalPodAutoscaler.
+
+<hr>
+
+- **maxReplicas** (int32), required
+
+  maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up. It cannot be less that minReplicas.
+
+- **scaleTargetRef** (CrossVersionObjectReference), required
+
+  scaleTargetRef points to the target resource to scale, and is used to the pods for which metrics should be collected, as well as to actually change the replica count.
+
+  <a name="CrossVersionObjectReference"></a>
+  *CrossVersionObjectReference contains enough information to let you identify the referred resource.*
+
+  - **scaleTargetRef.kind** (string), required
+
+    Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+
+  - **scaleTargetRef.name** (string), required
+
+    Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
+
+  - **scaleTargetRef.apiVersion** (string)
+
+    API version of the referent
+
+- **minReplicas** (int32)
+
+  minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down.  It defaults to 1 pod.  minReplicas is allowed to be 0 if the alpha feature gate HPAScaleToZero is enabled and at least one Object or External metric is configured.  Scaling is active as long as at least one metric value is available.
+
+- **behavior** (HorizontalPodAutoscalerBehavior)
+
+  behavior configures the scaling behavior of the target in both Up and Down directions (scaleUp and scaleDown fields respectively). If not set, the default HPAScalingRules for scale up and scale down are used.
+
+  <a name="HorizontalPodAutoscalerBehavior"></a>
+  *HorizontalPodAutoscalerBehavior configures the scaling behavior of the target in both Up and Down directions (scaleUp and scaleDown fields respectively).*
+
+  - **behavior.scaleDown** (HPAScalingRules)
+
+    scaleDown is scaling policy for scaling Down. If not set, the default value is to allow to scale down to minReplicas pods, with a 300 second stabilization window (i.e., the highest recommendation for the last 300sec is used).
+
+    <a name="HPAScalingRules"></a>
+    *HPAScalingRules configures the scaling behavior for one direction. These Rules are applied after calculating DesiredReplicas from metrics for the HPA. They can limit the scaling velocity by specifying scaling policies. They can prevent flapping by specifying the stabilization window, so that the number of replicas is not set instantly, instead, the safest value from the stabilization window is chosen.*
+
+  - **behavior.scaleDown.policies** ([]HPAScalingPolicy)
+
+    policies is a list of potential scaling polices which can be used during scaling. At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid
+
+    <a name="HPAScalingPolicy"></a>
+    *HPAScalingPolicy is a single policy which must hold true for a specified past interval.*
+
+  - **behavior.scaleDown.policies.type** (string), required
+
+    Type is used to specify the scaling policy.
+
+  - **behavior.scaleDown.policies.value** (int32), required
+
+    Value contains the amount of change which is permitted by the policy. It must be greater than zero
+
+  - **behavior.scaleDown.policies.periodSeconds** (int32), required
+
+    PeriodSeconds specifies the window of time for which the policy should hold true. PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
+
+  - **behavior.scaleDown.selectPolicy** (string)
+
+    selectPolicy is used to specify which policy should be used. If not set, the default value MaxPolicySelect is used.
+
+  - **behavior.scaleDown.stabilizationWindowSeconds** (int32)
+
+    StabilizationWindowSeconds is the number of seconds for which past recommendations should be considered while scaling up or scaling down. StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour). If not set, use the default values: - For scale up: 0 (i.e. no stabilization is done). - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
+
+  - **behavior.scaleUp** (HPAScalingRules)
+
+    scaleUp is scaling policy for scaling Up. If not set, the default value is the higher of:
+      * increase no more than 4 pods per 60 seconds
+      * double the number of pods per 60 seconds
+    No stabilization is used.
+
+    <a name="HPAScalingRules"></a>
+    *HPAScalingRules configures the scaling behavior for one direction. These Rules are applied after calculating DesiredReplicas from metrics for the HPA. They can limit the scaling velocity by specifying scaling policies. They can prevent flapping by specifying the stabilization window, so that the number of replicas is not set instantly, instead, the safest value from the stabilization window is chosen.*
+
+  - **behavior.scaleUp.policies** ([]HPAScalingPolicy)
+
+    policies is a list of potential scaling polices which can be used during scaling. At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid
+
+    <a name="HPAScalingPolicy"></a>
+    *HPAScalingPolicy is a single policy which must hold true for a specified past interval.*
+
+  - **behavior.scaleUp.policies.type** (string), required
+
+    Type is used to specify the scaling policy.
+
+  - **behavior.scaleUp.policies.value** (int32), required
+
+    Value contains the amount of change which is permitted by the policy. It must be greater than zero
+
+  - **behavior.scaleUp.policies.periodSeconds** (int32), required
+
+    PeriodSeconds specifies the window of time for which the policy should hold true. PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
+
+  - **behavior.scaleUp.selectPolicy** (string)
+
+    selectPolicy is used to specify which policy should be used. If not set, the default value MaxPolicySelect is used.
+
+  - **behavior.scaleUp.stabilizationWindowSeconds** (int32)
+
+    StabilizationWindowSeconds is the number of seconds for which past recommendations should be considered while scaling up or scaling down. StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour). If not set, use the default values: - For scale up: 0 (i.e. no stabilization is done). - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
+
+- **metrics** ([]MetricSpec)
+
+  metrics contains the specifications for which to use to calculate the desired replica count (the maximum replica count across all metrics will be used).  The desired replica count is calculated multiplying the ratio between the target value and the current value by the current number of pods.  Ergo, metrics used must decrease as the pod count is increased, and vice-versa.  See the individual metric source types for more information about how each type of metric must respond. If not set, the default metric will be set to 80% average CPU utilization.
+
+  <a name="MetricSpec"></a>
+  *MetricSpec specifies how to scale based on a single metric (only `type` and one other matching field should be set at once).*
+
+  - **metrics.type** (string), required
+
+    type is the type of metric source.  It should be one of "ContainerResource", "External", "Object", "Pods" or "Resource", each mapping to a matching field in the object. Note: "ContainerResource" type is available on when the feature-gate HPAContainerMetrics is enabled
+
+  - **metrics.containerResource** (ContainerResourceMetricSource)
+
+    container resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source. This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.
+
+    <a name="ContainerResourceMetricSource"></a>
+    *ContainerResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.  Only one "target" type should be set.*
+
+  - **metrics.containerResource.container** (string), required
+
+    container is the name of the container in the pods of the scaling target
+
+  - **metrics.containerResource.name** (string), required
+
+    name is the name of the resource in question.
+
+  - **metrics.containerResource.target** (MetricTarget), required
+
+    target specifies the target value for the given metric
+
+    <a name="MetricTarget"></a>
+    *MetricTarget defines the target value, average value, or average utilization of a specific metric*
+
+  - **metrics.containerResource.target.type** (string), required
+
+    type represents whether the metric type is Utilization, Value, or AverageValue
+
+  - **metrics.containerResource.target.averageUtilization** (int32)
+
+    averageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods. Currently only valid for Resource metric source type
+
+  - **metrics.containerResource.target.averageValue** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    averageValue is the target value of the average of the metric across all relevant pods (as a quantity)
+
+  - **metrics.containerResource.target.value** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    value is the target value of the metric (as a quantity).
+
+  - **metrics.external** (ExternalMetricSource)
+
+    external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).
+
+    <a name="ExternalMetricSource"></a>
+    *ExternalMetricSource indicates how to scale on a metric not associated with any Kubernetes object (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).*
+
+  - **metrics.external.metric** (MetricIdentifier), required
+
+    metric identifies the target metric by name and selector
+
+    <a name="MetricIdentifier"></a>
+    *MetricIdentifier defines the name and optionally selector for a metric*
+
+  - **metrics.external.metric.name** (string), required
+
+    name is the name of the given metric
+
+  - **metrics.external.metric.selector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
+
+    selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.
+
+  - **metrics.external.target** (MetricTarget), required
+
+    target specifies the target value for the given metric
+
+    <a name="MetricTarget"></a>
+    *MetricTarget defines the target value, average value, or average utilization of a specific metric*
+
+  - **metrics.external.target.type** (string), required
+
+    type represents whether the metric type is Utilization, Value, or AverageValue
+
+  - **metrics.external.target.averageUtilization** (int32)
+
+    averageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods. Currently only valid for Resource metric source type
+
+  - **metrics.external.target.averageValue** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    averageValue is the target value of the average of the metric across all relevant pods (as a quantity)
+
+  - **metrics.external.target.value** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    value is the target value of the metric (as a quantity).
+
+  - **metrics.object** (ObjectMetricSource)
+
+    object refers to a metric describing a single kubernetes object (for example, hits-per-second on an Ingress object).
+
+    <a name="ObjectMetricSource"></a>
+    *ObjectMetricSource indicates how to scale on a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).*
+
+  - **metrics.object.describedObject** (CrossVersionObjectReference), required
+
+
+    <a name="CrossVersionObjectReference"></a>
+    *CrossVersionObjectReference contains enough information to let you identify the referred resource.*
+
+  - **metrics.object.describedObject.kind** (string), required
+
+    Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+
+  - **metrics.object.describedObject.name** (string), required
+
+    Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
+
+  - **metrics.object.describedObject.apiVersion** (string)
+
+    API version of the referent
+
+  - **metrics.object.metric** (MetricIdentifier), required
+
+    metric identifies the target metric by name and selector
+
+    <a name="MetricIdentifier"></a>
+    *MetricIdentifier defines the name and optionally selector for a metric*
+
+  - **metrics.object.metric.name** (string), required
+
+    name is the name of the given metric
+
+  - **metrics.object.metric.selector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
+
+    selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.
+
+  - **metrics.object.target** (MetricTarget), required
+
+    target specifies the target value for the given metric
+
+    <a name="MetricTarget"></a>
+    *MetricTarget defines the target value, average value, or average utilization of a specific metric*
+
+  - **metrics.object.target.type** (string), required
+
+    type represents whether the metric type is Utilization, Value, or AverageValue
+
+  - **metrics.object.target.averageUtilization** (int32)
+
+    averageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods. Currently only valid for Resource metric source type
+
+  - **metrics.object.target.averageValue** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    averageValue is the target value of the average of the metric across all relevant pods (as a quantity)
+
+  - **metrics.object.target.value** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    value is the target value of the metric (as a quantity).
+
+  - **metrics.pods** (PodsMetricSource)
+
+    pods refers to a metric describing each pod in the current scale target (for example, transactions-processed-per-second).  The values will be averaged together before being compared to the target value.
+
+    <a name="PodsMetricSource"></a>
+    *PodsMetricSource indicates how to scale on a metric describing each pod in the current scale target (for example, transactions-processed-per-second). The values will be averaged together before being compared to the target value.*
+
+  - **metrics.pods.metric** (MetricIdentifier), required
+
+    metric identifies the target metric by name and selector
+
+    <a name="MetricIdentifier"></a>
+    *MetricIdentifier defines the name and optionally selector for a metric*
+
+  - **metrics.pods.metric.name** (string), required
+
+    name is the name of the given metric
+
+  - **metrics.pods.metric.selector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
+
+    selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.
+
+  - **metrics.pods.target** (MetricTarget), required
+
+    target specifies the target value for the given metric
+
+    <a name="MetricTarget"></a>
+    *MetricTarget defines the target value, average value, or average utilization of a specific metric*
+
+  - **metrics.pods.target.type** (string), required
+
+    type represents whether the metric type is Utilization, Value, or AverageValue
+
+  - **metrics.pods.target.averageUtilization** (int32)
+
+    averageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods. Currently only valid for Resource metric source type
+
+  - **metrics.pods.target.averageValue** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    averageValue is the target value of the average of the metric across all relevant pods (as a quantity)
+
+  - **metrics.pods.target.value** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    value is the target value of the metric (as a quantity).
+
+  - **metrics.resource** (ResourceMetricSource)
+
+    resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
+
+    <a name="ResourceMetricSource"></a>
+    *ResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.  Only one "target" type should be set.*
+
+  - **metrics.resource.name** (string), required
+
+    name is the name of the resource in question.
+
+  - **metrics.resource.target** (MetricTarget), required
+
+    target specifies the target value for the given metric
+
+    <a name="MetricTarget"></a>
+    *MetricTarget defines the target value, average value, or average utilization of a specific metric*
+
+  - **metrics.resource.target.type** (string), required
+
+    type represents whether the metric type is Utilization, Value, or AverageValue
+
+  - **metrics.resource.target.averageUtilization** (int32)
+
+    averageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods. Currently only valid for Resource metric source type
+
+  - **metrics.resource.target.averageValue** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    averageValue is the target value of the average of the metric across all relevant pods (as a quantity)
+
+  - **metrics.resource.target.value** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    value is the target value of the metric (as a quantity).
+
+
+
+
+
+## HorizontalPodAutoscalerStatus {#HorizontalPodAutoscalerStatus}
+
+HorizontalPodAutoscalerStatus describes the current status of a horizontal pod autoscaler.
+
+<hr>
+
+- **conditions** ([]HorizontalPodAutoscalerCondition), required
+
+  conditions is the set of conditions required for this autoscaler to scale its target, and indicates whether or not those conditions are met.
+
+  <a name="HorizontalPodAutoscalerCondition"></a>
+  *HorizontalPodAutoscalerCondition describes the state of a HorizontalPodAutoscaler at a certain point.*
+
+  - **conditions.status** (string), required
+
+    status is the status of the condition (True, False, Unknown)
+
+  - **conditions.type** (string), required
+
+    type describes the current condition
+
+  - **conditions.lastTransitionTime** (Time)
+
+    lastTransitionTime is the last time the condition transitioned from one status to another
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **conditions.message** (string)
+
+    message is a human-readable explanation containing details about the transition
+
+  - **conditions.reason** (string)
+
+    reason is the reason for the condition's last transition.
+
+- **currentReplicas** (int32), required
+
+  currentReplicas is current number of replicas of pods managed by this autoscaler, as last seen by the autoscaler.
+
+- **desiredReplicas** (int32), required
+
+  desiredReplicas is the desired number of replicas of pods managed by this autoscaler, as last calculated by the autoscaler.
+
+- **currentMetrics** ([]MetricStatus)
+
+  currentMetrics is the last read state of the metrics used by this autoscaler.
+
+  <a name="MetricStatus"></a>
+  *MetricStatus describes the last-read state of a single metric.*
+
+  - **currentMetrics.type** (string), required
+
+    type is the type of metric source.  It will be one of "ContainerResource", "External", "Object", "Pods" or "Resource", each corresponds to a matching field in the object. Note: "ContainerResource" type is available on when the feature-gate HPAContainerMetrics is enabled
+
+  - **currentMetrics.containerResource** (ContainerResourceMetricStatus)
+
+    container resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
+
+    <a name="ContainerResourceMetricStatus"></a>
+    *ContainerResourceMetricStatus indicates the current value of a resource metric known to Kubernetes, as specified in requests and limits, describing a single container in each pod in the current scale target (e.g. CPU or memory).  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.*
+
+  - **currentMetrics.containerResource.container** (string), required
+
+    Container is the name of the container in the pods of the scaling target
+
+  - **currentMetrics.containerResource.current** (MetricValueStatus), required
+
+    current contains the current value for the given metric
+
+    <a name="MetricValueStatus"></a>
+    *MetricValueStatus holds the current value for a metric*
+
+  - **currentMetrics.containerResource.current.averageUtilization** (int32)
+
+    currentAverageUtilization is the current value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
+
+  - **currentMetrics.containerResource.current.averageValue** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    averageValue is the current value of the average of the metric across all relevant pods (as a quantity)
+
+  - **currentMetrics.containerResource.current.value** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    value is the current value of the metric (as a quantity).
+
+  - **currentMetrics.containerResource.name** (string), required
+
+    Name is the name of the resource in question.
+
+  - **currentMetrics.external** (ExternalMetricStatus)
+
+    external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).
+
+    <a name="ExternalMetricStatus"></a>
+    *ExternalMetricStatus indicates the current value of a global metric not associated with any Kubernetes object.*
+
+  - **currentMetrics.external.current** (MetricValueStatus), required
+
+    current contains the current value for the given metric
+
+    <a name="MetricValueStatus"></a>
+    *MetricValueStatus holds the current value for a metric*
+
+  - **currentMetrics.external.current.averageUtilization** (int32)
+
+    currentAverageUtilization is the current value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
+
+  - **currentMetrics.external.current.averageValue** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    averageValue is the current value of the average of the metric across all relevant pods (as a quantity)
+
+  - **currentMetrics.external.current.value** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    value is the current value of the metric (as a quantity).
+
+  - **currentMetrics.external.metric** (MetricIdentifier), required
+
+    metric identifies the target metric by name and selector
+
+    <a name="MetricIdentifier"></a>
+    *MetricIdentifier defines the name and optionally selector for a metric*
+
+  - **currentMetrics.external.metric.name** (string), required
+
+    name is the name of the given metric
+
+  - **currentMetrics.external.metric.selector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
+
+    selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.
+
+  - **currentMetrics.object** (ObjectMetricStatus)
+
+    object refers to a metric describing a single kubernetes object (for example, hits-per-second on an Ingress object).
+
+    <a name="ObjectMetricStatus"></a>
+    *ObjectMetricStatus indicates the current value of a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).*
+
+  - **currentMetrics.object.current** (MetricValueStatus), required
+
+    current contains the current value for the given metric
+
+    <a name="MetricValueStatus"></a>
+    *MetricValueStatus holds the current value for a metric*
+
+  - **currentMetrics.object.current.averageUtilization** (int32)
+
+    currentAverageUtilization is the current value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
+
+  - **currentMetrics.object.current.averageValue** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    averageValue is the current value of the average of the metric across all relevant pods (as a quantity)
+
+  - **currentMetrics.object.current.value** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    value is the current value of the metric (as a quantity).
+
+  - **currentMetrics.object.describedObject** (CrossVersionObjectReference), required
+
+
+    <a name="CrossVersionObjectReference"></a>
+    *CrossVersionObjectReference contains enough information to let you identify the referred resource.*
+
+  - **currentMetrics.object.describedObject.kind** (string), required
+
+    Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+
+  - **currentMetrics.object.describedObject.name** (string), required
+
+    Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
+
+  - **currentMetrics.object.describedObject.apiVersion** (string)
+
+    API version of the referent
+
+  - **currentMetrics.object.metric** (MetricIdentifier), required
+
+    metric identifies the target metric by name and selector
+
+    <a name="MetricIdentifier"></a>
+    *MetricIdentifier defines the name and optionally selector for a metric*
+
+  - **currentMetrics.object.metric.name** (string), required
+
+    name is the name of the given metric
+
+  - **currentMetrics.object.metric.selector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
+
+    selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.
+
+  - **currentMetrics.pods** (PodsMetricStatus)
+
+    pods refers to a metric describing each pod in the current scale target (for example, transactions-processed-per-second).  The values will be averaged together before being compared to the target value.
+
+    <a name="PodsMetricStatus"></a>
+    *PodsMetricStatus indicates the current value of a metric describing each pod in the current scale target (for example, transactions-processed-per-second).*
+
+  - **currentMetrics.pods.current** (MetricValueStatus), required
+
+    current contains the current value for the given metric
+
+    <a name="MetricValueStatus"></a>
+    *MetricValueStatus holds the current value for a metric*
+
+  - **currentMetrics.pods.current.averageUtilization** (int32)
+
+    currentAverageUtilization is the current value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
+
+  - **currentMetrics.pods.current.averageValue** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    averageValue is the current value of the average of the metric across all relevant pods (as a quantity)
+
+  - **currentMetrics.pods.current.value** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    value is the current value of the metric (as a quantity).
+
+  - **currentMetrics.pods.metric** (MetricIdentifier), required
+
+    metric identifies the target metric by name and selector
+
+    <a name="MetricIdentifier"></a>
+    *MetricIdentifier defines the name and optionally selector for a metric*
+
+  - **currentMetrics.pods.metric.name** (string), required
+
+    name is the name of the given metric
+
+  - **currentMetrics.pods.metric.selector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
+
+    selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.
+
+  - **currentMetrics.resource** (ResourceMetricStatus)
+
+    resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
+
+    <a name="ResourceMetricStatus"></a>
+    *ResourceMetricStatus indicates the current value of a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.*
+
+  - **currentMetrics.resource.current** (MetricValueStatus), required
+
+    current contains the current value for the given metric
+
+    <a name="MetricValueStatus"></a>
+    *MetricValueStatus holds the current value for a metric*
+
+  - **currentMetrics.resource.current.averageUtilization** (int32)
+
+    currentAverageUtilization is the current value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
+
+  - **currentMetrics.resource.current.averageValue** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    averageValue is the current value of the average of the metric across all relevant pods (as a quantity)
+
+  - **currentMetrics.resource.current.value** (<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+    value is the current value of the metric (as a quantity).
+
+  - **currentMetrics.resource.name** (string), required
+
+    Name is the name of the resource in question.
+
+- **lastScaleTime** (Time)
+
+  lastScaleTime is the last time the HorizontalPodAutoscaler scaled the number of pods, used by the autoscaler to control how often the number of pods is changed.
+
+  <a name="Time"></a>
+  *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+- **observedGeneration** (int64)
+
+  observedGeneration is the most recent generation observed by this autoscaler.
+
+
+
+
+
+## HorizontalPodAutoscalerList {#HorizontalPodAutoscalerList}
+
+HorizontalPodAutoscalerList is a list of horizontal pod autoscaler objects.
+
+<hr>
+
+- **apiVersion**: autoscaling/v2beta2
+
+
+- **kind**: HorizontalPodAutoscalerList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  metadata is the standard list metadata.
+
+- **items** ([]<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v2beta2#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>), required
+
+  items is the list of horizontal pod autoscaler objects.
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified HorizontalPodAutoscaler
+
+#### HTTP Request
+
+GET /apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the HorizontalPodAutoscaler
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v2beta2#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): OK
+
+401: Unauthorized
+
+
+### `get` read status of the specified HorizontalPodAutoscaler
+
+#### HTTP Request
+
+GET /apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the HorizontalPodAutoscaler
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v2beta2#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind HorizontalPodAutoscaler
+
+#### HTTP Request
+
+GET /apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v2beta2#HorizontalPodAutoscalerList" >}}">HorizontalPodAutoscalerList</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind HorizontalPodAutoscaler
+
+#### HTTP Request
+
+GET /apis/autoscaling/v2beta2/horizontalpodautoscalers
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v2beta2#HorizontalPodAutoscalerList" >}}">HorizontalPodAutoscalerList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a HorizontalPodAutoscaler
+
+#### HTTP Request
+
+POST /apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v2beta2#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v2beta2#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v2beta2#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): Created
+
+202 (<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v2beta2#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified HorizontalPodAutoscaler
+
+#### HTTP Request
+
+PUT /apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the HorizontalPodAutoscaler
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v2beta2#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v2beta2#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v2beta2#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): Created
+
+401: Unauthorized
+
+
+### `update` replace status of the specified HorizontalPodAutoscaler
+
+#### HTTP Request
+
+PUT /apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the HorizontalPodAutoscaler
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v2beta2#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v2beta2#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v2beta2#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified HorizontalPodAutoscaler
+
+#### HTTP Request
+
+PATCH /apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the HorizontalPodAutoscaler
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v2beta2#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): OK
+
+401: Unauthorized
+
+
+### `patch` partially update status of the specified HorizontalPodAutoscaler
+
+#### HTTP Request
+
+PATCH /apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the HorizontalPodAutoscaler
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/horizontal-pod-autoscaler-v2beta2#HorizontalPodAutoscaler" >}}">HorizontalPodAutoscaler</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a HorizontalPodAutoscaler
+
+#### HTTP Request
+
+DELETE /apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the HorizontalPodAutoscaler
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of HorizontalPodAutoscaler
+
+#### HTTP Request
+
+DELETE /apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/workloads-resources/job-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workloads-resources/job-v1.md
@@ -1,0 +1,802 @@
+---
+api_metadata:
+  apiVersion: "batch/v1"
+  import: "k8s.io/api/batch/v1"
+  kind: "Job"
+content_type: "api_reference"
+description: "Job represents the configuration of a single job."
+title: "Job"
+weight: 11
+---
+
+`apiVersion: batch/v1`
+
+`import "k8s.io/api/batch/v1"`
+
+
+## Job {#Job}
+
+Job represents the configuration of a single job.
+
+<hr>
+
+- **apiVersion**: batch/v1
+
+
+- **kind**: Job
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **spec** (<a href="{{< ref "../workloads-resources/job-v1#JobSpec" >}}">JobSpec</a>)
+
+  Specification of the desired behavior of a job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+- **status** (<a href="{{< ref "../workloads-resources/job-v1#JobStatus" >}}">JobStatus</a>)
+
+  Current status of a job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+
+
+
+
+## JobSpec {#JobSpec}
+
+JobSpec describes how the job execution will look like.
+
+<hr>
+
+
+
+### Replicas
+
+
+- **template** (<a href="{{< ref "../workloads-resources/pod-template-v1#PodTemplateSpec" >}}">PodTemplateSpec</a>), required
+
+  Describes the pod that will be created when executing a job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+
+- **parallelism** (int32)
+
+  Specifies the maximum desired number of pods the job should run at any given time. The actual number of pods running in steady state will be less than this number when ((.spec.completions - .status.successful) \< .spec.parallelism), i.e. when the work left to do is less than max parallelism. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+
+### Lifecycle
+
+
+- **completions** (int32)
+
+  Specifies the desired number of successfully finished pods the job should be run with.  Setting to nil means that the success of any pod signals the success of all pods, and allows parallelism to have any positive value.  Setting to 1 means that parallelism is limited to 1 and the success of that pod signals the success of the job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+
+- **backoffLimit** (int32)
+
+  Specifies the number of retries before marking this job failed. Defaults to 6
+
+- **activeDeadlineSeconds** (int64)
+
+  Specifies the duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer
+
+- **ttlSecondsAfterFinished** (int32)
+
+  ttlSecondsAfterFinished limits the lifetime of a Job that has finished execution (either Complete or Failed). If this field is set, ttlSecondsAfterFinished after the Job finishes, it is eligible to be automatically deleted. When the Job is being deleted, its lifecycle guarantees (e.g. finalizers) will be honored. If this field is unset, the Job won't be automatically deleted. If this field is set to zero, the Job becomes eligible to be deleted immediately after it finishes. This field is alpha-level and is only honored by servers that enable the TTLAfterFinished feature.
+
+### Selector
+
+
+- **selector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
+
+  A label query over pods that should match the pod count. Normally, the system sets this field for you. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+
+- **manualSelector** (boolean)
+
+  manualSelector controls generation of pod labels and pod selectors. Leave `manualSelector` unset unless you are certain what you are doing. When false or unset, the system pick labels unique to this job and appends those labels to the pod template.  When true, the user is responsible for picking unique labels and specifying the selector.  Failure to pick a unique label may cause this and other jobs to not function correctly.  However, You may see `manualSelector=true` in jobs that were created with the old `extensions/v1beta1` API. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#specifying-your-own-pod-selector
+
+
+
+## JobStatus {#JobStatus}
+
+JobStatus represents the current state of a Job.
+
+<hr>
+
+- **startTime** (Time)
+
+  Represents time when the job was acknowledged by the job controller. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.
+
+  <a name="Time"></a>
+  *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+- **completionTime** (Time)
+
+  Represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC. The completion time is only set when the job finishes successfully.
+
+  <a name="Time"></a>
+  *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+- **active** (int32)
+
+  The number of actively running pods.
+
+- **failed** (int32)
+
+  The number of pods which reached phase Failed.
+
+- **succeeded** (int32)
+
+  The number of pods which reached phase Succeeded.
+
+- **conditions** ([]JobCondition)
+
+  *Patch strategy: merge on key `type`*
+  
+  The latest available observations of an object's current state. When a job fails, one of the conditions will have type == "Failed". More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+
+  <a name="JobCondition"></a>
+  *JobCondition describes current state of a job.*
+
+  - **conditions.status** (string), required
+
+    Status of the condition, one of True, False, Unknown.
+
+  - **conditions.type** (string), required
+
+    Type of job condition, Complete or Failed.
+
+  - **conditions.lastProbeTime** (Time)
+
+    Last time the condition was checked.
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **conditions.lastTransitionTime** (Time)
+
+    Last time the condition transit from one status to another.
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **conditions.message** (string)
+
+    Human readable message indicating details about last transition.
+
+  - **conditions.reason** (string)
+
+    (brief) reason for the condition's last transition.
+
+
+
+
+
+## JobList {#JobList}
+
+JobList is a collection of jobs.
+
+<hr>
+
+- **apiVersion**: batch/v1
+
+
+- **kind**: JobList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **items** ([]<a href="{{< ref "../workloads-resources/job-v1#Job" >}}">Job</a>), required
+
+  items is the list of Jobs.
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified Job
+
+#### HTTP Request
+
+GET /apis/batch/v1/namespaces/{namespace}/jobs/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Job
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/job-v1#Job" >}}">Job</a>): OK
+
+401: Unauthorized
+
+
+### `get` read status of the specified Job
+
+#### HTTP Request
+
+GET /apis/batch/v1/namespaces/{namespace}/jobs/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Job
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/job-v1#Job" >}}">Job</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind Job
+
+#### HTTP Request
+
+GET /apis/batch/v1/namespaces/{namespace}/jobs
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/job-v1#JobList" >}}">JobList</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind Job
+
+#### HTTP Request
+
+GET /apis/batch/v1/jobs
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/job-v1#JobList" >}}">JobList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a Job
+
+#### HTTP Request
+
+POST /apis/batch/v1/namespaces/{namespace}/jobs
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/job-v1#Job" >}}">Job</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/job-v1#Job" >}}">Job</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/job-v1#Job" >}}">Job</a>): Created
+
+202 (<a href="{{< ref "../workloads-resources/job-v1#Job" >}}">Job</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified Job
+
+#### HTTP Request
+
+PUT /apis/batch/v1/namespaces/{namespace}/jobs/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Job
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/job-v1#Job" >}}">Job</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/job-v1#Job" >}}">Job</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/job-v1#Job" >}}">Job</a>): Created
+
+401: Unauthorized
+
+
+### `update` replace status of the specified Job
+
+#### HTTP Request
+
+PUT /apis/batch/v1/namespaces/{namespace}/jobs/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Job
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/job-v1#Job" >}}">Job</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/job-v1#Job" >}}">Job</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/job-v1#Job" >}}">Job</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified Job
+
+#### HTTP Request
+
+PATCH /apis/batch/v1/namespaces/{namespace}/jobs/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Job
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/job-v1#Job" >}}">Job</a>): OK
+
+401: Unauthorized
+
+
+### `patch` partially update status of the specified Job
+
+#### HTTP Request
+
+PATCH /apis/batch/v1/namespaces/{namespace}/jobs/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Job
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/job-v1#Job" >}}">Job</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a Job
+
+#### HTTP Request
+
+DELETE /apis/batch/v1/namespaces/{namespace}/jobs/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Job
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of Job
+
+#### HTTP Request
+
+DELETE /apis/batch/v1/namespaces/{namespace}/jobs
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/workloads-resources/pod-template-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workloads-resources/pod-template-v1.md
@@ -1,0 +1,554 @@
+---
+api_metadata:
+  apiVersion: "v1"
+  import: "k8s.io/api/core/v1"
+  kind: "PodTemplate"
+content_type: "api_reference"
+description: "PodTemplate describes a template for creating copies of a predefined pod."
+title: "PodTemplate"
+weight: 4
+---
+
+`apiVersion: v1`
+
+`import "k8s.io/api/core/v1"`
+
+
+## PodTemplate {#PodTemplate}
+
+PodTemplate describes a template for creating copies of a predefined pod.
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: PodTemplate
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **template** (<a href="{{< ref "../workloads-resources/pod-template-v1#PodTemplateSpec" >}}">PodTemplateSpec</a>)
+
+  Template defines the pods that will be created from this pod template. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+
+
+
+
+## PodTemplateSpec {#PodTemplateSpec}
+
+PodTemplateSpec describes the data a pod should have when created from a template
+
+<hr>
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **spec** (<a href="{{< ref "../workloads-resources/pod-v1#PodSpec" >}}">PodSpec</a>)
+
+  Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+
+
+
+
+## PodTemplateList {#PodTemplateList}
+
+PodTemplateList is a list of PodTemplates.
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: PodTemplateList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+- **items** ([]<a href="{{< ref "../workloads-resources/pod-template-v1#PodTemplate" >}}">PodTemplate</a>), required
+
+  List of pod templates
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified PodTemplate
+
+#### HTTP Request
+
+GET /api/v1/namespaces/{namespace}/podtemplates/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PodTemplate
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/pod-template-v1#PodTemplate" >}}">PodTemplate</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind PodTemplate
+
+#### HTTP Request
+
+GET /api/v1/namespaces/{namespace}/podtemplates
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/pod-template-v1#PodTemplateList" >}}">PodTemplateList</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind PodTemplate
+
+#### HTTP Request
+
+GET /api/v1/podtemplates
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/pod-template-v1#PodTemplateList" >}}">PodTemplateList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a PodTemplate
+
+#### HTTP Request
+
+POST /api/v1/namespaces/{namespace}/podtemplates
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/pod-template-v1#PodTemplate" >}}">PodTemplate</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/pod-template-v1#PodTemplate" >}}">PodTemplate</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/pod-template-v1#PodTemplate" >}}">PodTemplate</a>): Created
+
+202 (<a href="{{< ref "../workloads-resources/pod-template-v1#PodTemplate" >}}">PodTemplate</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified PodTemplate
+
+#### HTTP Request
+
+PUT /api/v1/namespaces/{namespace}/podtemplates/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PodTemplate
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/pod-template-v1#PodTemplate" >}}">PodTemplate</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/pod-template-v1#PodTemplate" >}}">PodTemplate</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/pod-template-v1#PodTemplate" >}}">PodTemplate</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified PodTemplate
+
+#### HTTP Request
+
+PATCH /api/v1/namespaces/{namespace}/podtemplates/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PodTemplate
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/pod-template-v1#PodTemplate" >}}">PodTemplate</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a PodTemplate
+
+#### HTTP Request
+
+DELETE /api/v1/namespaces/{namespace}/podtemplates/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PodTemplate
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/pod-template-v1#PodTemplate" >}}">PodTemplate</a>): OK
+
+202 (<a href="{{< ref "../workloads-resources/pod-template-v1#PodTemplate" >}}">PodTemplate</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of PodTemplate
+
+#### HTTP Request
+
+DELETE /api/v1/namespaces/{namespace}/podtemplates
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/workloads-resources/pod-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workloads-resources/pod-v1.md
@@ -1,0 +1,1270 @@
+---
+api_metadata:
+  apiVersion: "v1"
+  import: "k8s.io/api/core/v1"
+  kind: "Pod"
+content_type: "api_reference"
+description: "Pod is a collection of containers that can run on a host."
+title: "Pod"
+weight: 1
+---
+
+`apiVersion: v1`
+
+`import "k8s.io/api/core/v1"`
+
+
+## Pod {#Pod}
+
+Pod is a collection of containers that can run on a host. This resource is created by clients and scheduled onto hosts.
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: Pod
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **spec** (<a href="{{< ref "../workloads-resources/pod-v1#PodSpec" >}}">PodSpec</a>)
+
+  Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+- **status** (<a href="{{< ref "../workloads-resources/pod-v1#PodStatus" >}}">PodStatus</a>)
+
+  Most recently observed status of the pod. This data may not be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+
+
+
+
+## PodSpec {#PodSpec}
+
+PodSpec is a description of a pod.
+
+<hr>
+
+
+
+### Containers
+
+
+- **containers** ([]<a href="{{< ref "../workloads-resources/container#Container" >}}">Container</a>), required
+
+  *Patch strategy: merge on key `name`*
+  
+  List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.
+
+- **initContainers** ([]<a href="{{< ref "../workloads-resources/container#Container" >}}">Container</a>)
+
+  *Patch strategy: merge on key `name`*
+  
+  List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+
+- **imagePullSecrets** ([]<a href="{{< ref "../common-definitions/local-object-reference#LocalObjectReference" >}}">LocalObjectReference</a>)
+
+  *Patch strategy: merge on key `name`*
+  
+  ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+
+- **enableServiceLinks** (boolean)
+
+  EnableServiceLinks indicates whether information about services should be injected into pod's environment variables, matching the syntax of Docker links. Optional: Defaults to true.
+
+### Volumes
+
+
+- **volumes** ([]<a href="{{< ref "../config-and-storage-resources/volume#Volume" >}}">Volume</a>)
+
+  *Patch strategies: retainKeys, merge on key `name`*
+  
+  List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes
+
+### Scheduling
+
+
+- **nodeSelector** (map[string]string)
+
+  NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+
+- **nodeName** (string)
+
+  NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.
+
+- **affinity** (Affinity)
+
+  If specified, the pod's scheduling constraints
+
+  <a name="Affinity"></a>
+  *Affinity is a group of affinity scheduling rules.*
+
+  - **affinity.nodeAffinity** (<a href="{{< ref "../common-definitions/node-affinity#NodeAffinity" >}}">NodeAffinity</a>)
+
+    Describes node affinity scheduling rules for the pod.
+
+  - **affinity.podAffinity** (<a href="{{< ref "../common-definitions/pod-affinity#PodAffinity" >}}">PodAffinity</a>)
+
+    Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+
+  - **affinity.podAntiAffinity** (<a href="{{< ref "../common-definitions/pod-anti-affinity#PodAntiAffinity" >}}">PodAntiAffinity</a>)
+
+    Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+
+- **tolerations** ([]Toleration)
+
+  If specified, the pod's tolerations.
+
+  <a name="Toleration"></a>
+  *The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.*
+
+  - **tolerations.key** (string)
+
+    Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+
+  - **tolerations.operator** (string)
+
+    Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+  - **tolerations.value** (string)
+
+    Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+
+  - **tolerations.effect** (string)
+
+    Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+  - **tolerations.tolerationSeconds** (int64)
+
+    TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+
+- **schedulerName** (string)
+
+  If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.
+
+- **runtimeClassName** (string)
+
+  RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md This is a beta feature as of Kubernetes v1.14.
+
+- **priorityClassName** (string)
+
+  If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
+
+- **priority** (int32)
+
+  The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.
+
+### Lifecycle
+
+
+- **restartPolicy** (string)
+
+  Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+
+- **terminationGracePeriodSeconds** (int64)
+
+  Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.
+
+- **activeDeadlineSeconds** (int64)
+
+  Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.
+
+- **readinessGates** ([]PodReadinessGate)
+
+  If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md
+
+  <a name="PodReadinessGate"></a>
+  *PodReadinessGate contains the reference to a pod condition*
+
+  - **readinessGates.conditionType** (string), required
+
+    ConditionType refers to a condition in the pod's condition list with matching type.
+
+### Hostname and Name resolution
+
+
+- **hostname** (string)
+
+  Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.
+
+- **setHostnameAsFQDN** (boolean)
+
+  If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default). In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname). In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters to FQDN. If a pod does not have FQDN, this has no effect. Default to false.
+
+- **subdomain** (string)
+
+  If specified, the fully qualified Pod hostname will be "\<hostname>.\<subdomain>.\<pod namespace>.svc.\<cluster domain>". If not specified, the pod will not have a domainname at all.
+
+- **hostAliases** ([]HostAlias)
+
+  *Patch strategy: merge on key `ip`*
+  
+  HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.
+
+  <a name="HostAlias"></a>
+  *HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.*
+
+  - **hostAliases.hostnames** ([]string)
+
+    Hostnames for the above IP address.
+
+  - **hostAliases.ip** (string)
+
+    IP address of the host file entry.
+
+- **dnsConfig** (PodDNSConfig)
+
+  Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
+
+  <a name="PodDNSConfig"></a>
+  *PodDNSConfig defines the DNS parameters of a pod in addition to those generated from DNSPolicy.*
+
+  - **dnsConfig.nameservers** ([]string)
+
+    A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
+
+  - **dnsConfig.options** ([]PodDNSConfigOption)
+
+    A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.
+
+    <a name="PodDNSConfigOption"></a>
+    *PodDNSConfigOption defines DNS resolver options of a pod.*
+
+  - **dnsConfig.options.name** (string)
+
+    Required.
+
+  - **dnsConfig.options.value** (string)
+
+
+  - **dnsConfig.searches** ([]string)
+
+    A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
+
+- **dnsPolicy** (string)
+
+  Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+
+### Hosts namespaces
+
+
+- **hostNetwork** (boolean)
+
+  Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.
+
+- **hostPID** (boolean)
+
+  Use the host's pid namespace. Optional: Default to false.
+
+- **hostIPC** (boolean)
+
+  Use the host's ipc namespace. Optional: Default to false.
+
+- **shareProcessNamespace** (boolean)
+
+  Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.
+
+### Service account
+
+
+- **serviceAccountName** (string)
+
+  ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+
+- **automountServiceAccountToken** (boolean)
+
+  AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
+
+### Security context
+
+
+- **securityContext** (PodSecurityContext)
+
+  SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.
+
+  <a name="PodSecurityContext"></a>
+  *PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.*
+
+  - **securityContext.runAsUser** (int64)
+
+    The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+
+  - **securityContext.runAsNonRoot** (boolean)
+
+    Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+
+  - **securityContext.runAsGroup** (int64)
+
+    The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+
+  - **securityContext.supplementalGroups** ([]int64)
+
+    A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.
+
+  - **securityContext.fsGroup** (int64)
+
+    A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+    
+    1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+    
+    If unset, the Kubelet will not modify the ownership and permissions of any volume.
+
+  - **securityContext.fsGroupChangePolicy** (string)
+
+    fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+
+  - **securityContext.seccompProfile** (SeccompProfile)
+
+    The seccomp options to use by the containers in this pod.
+
+    <a name="SeccompProfile"></a>
+    *SeccompProfile defines a pod/container's seccomp profile settings. Only one profile source may be set.*
+
+  - **securityContext.seccompProfile.type** (string), required
+
+    type indicates which kind of seccomp profile will be applied. Valid options are:
+    
+    Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+  - **securityContext.seccompProfile.localhostProfile** (string)
+
+    localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+
+  - **securityContext.seLinuxOptions** (SELinuxOptions)
+
+    The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+
+    <a name="SELinuxOptions"></a>
+    *SELinuxOptions are the labels to be applied to the container*
+
+  - **securityContext.seLinuxOptions.level** (string)
+
+    Level is SELinux level label that applies to the container.
+
+  - **securityContext.seLinuxOptions.role** (string)
+
+    Role is a SELinux role label that applies to the container.
+
+  - **securityContext.seLinuxOptions.type** (string)
+
+    Type is a SELinux type label that applies to the container.
+
+  - **securityContext.seLinuxOptions.user** (string)
+
+    User is a SELinux user label that applies to the container.
+
+  - **securityContext.sysctls** ([]Sysctl)
+
+    Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch.
+
+    <a name="Sysctl"></a>
+    *Sysctl defines a kernel parameter to be set*
+
+  - **securityContext.sysctls.name** (string), required
+
+    Name of a property to set
+
+  - **securityContext.sysctls.value** (string), required
+
+    Value of a property to set
+
+  - **securityContext.windowsOptions** (WindowsSecurityContextOptions)
+
+    The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+
+    <a name="WindowsSecurityContextOptions"></a>
+    *WindowsSecurityContextOptions contain Windows-specific options and credentials.*
+
+  - **securityContext.windowsOptions.gmsaCredentialSpec** (string)
+
+    GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
+
+  - **securityContext.windowsOptions.gmsaCredentialSpecName** (string)
+
+    GMSACredentialSpecName is the name of the GMSA credential spec to use.
+
+  - **securityContext.windowsOptions.runAsUserName** (string)
+
+    The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+
+### Beta level
+
+
+- **overhead** (map[string]<a href="{{< ref "../common-definitions/quantity#Quantity" >}}">Quantity</a>)
+
+  Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.
+
+- **topologySpreadConstraints** ([]TopologySpreadConstraint)
+
+  *Patch strategy: merge on key `topologyKey`*
+  
+  *Map: unique values on keys `topologyKey, whenUnsatisfiable` will be kept during a merge*
+  
+  TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.
+
+  <a name="TopologySpreadConstraint"></a>
+  *TopologySpreadConstraint specifies how to spread matching pods among the given topology.*
+
+  - **topologySpreadConstraints.maxSkew** (int32), required
+
+    MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It's a required field. Default value is 1 and 0 is not allowed.
+
+  - **topologySpreadConstraints.topologyKey** (string), required
+
+    TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each \<key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
+
+  - **topologySpreadConstraints.whenUnsatisfiable** (string), required
+
+    WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+      but giving higher precedence to topologies that would help reduce the
+      skew.
+    A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assigment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+
+  - **topologySpreadConstraints.labelSelector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>)
+
+    LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+
+### Alpha level
+
+
+- **ephemeralContainers** ([]<a href="{{< ref "../workloads-resources/ephemeral-container#EphemeralContainer" >}}">EphemeralContainer</a>)
+
+  *Patch strategy: merge on key `name`*
+  
+  List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is alpha-level and is only honored by servers that enable the EphemeralContainers feature.
+
+- **preemptionPolicy** (string)
+
+  PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is beta-level, gated by the NonPreemptingPriority feature-gate.
+
+### Deprecated
+
+
+- **serviceAccount** (string)
+
+  DeprecatedServiceAccount is a depreciated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.
+
+
+
+## PodStatus {#PodStatus}
+
+PodStatus represents information about the status of a pod. Status may trail the actual state of a system, especially if the node that hosts the pod cannot contact the control plane.
+
+<hr>
+
+- **nominatedNodeName** (string)
+
+  nominatedNodeName is set only when this pod preempts other pods on the node, but it cannot be scheduled right away as preemption victims receive their graceful termination periods. This field does not guarantee that the pod will be scheduled on this node. Scheduler may decide to place the pod elsewhere if other nodes become available sooner. Scheduler may also decide to give the resources on this node to a higher priority pod that is created after preemption. As a result, this field may be different than PodSpec.nodeName when the pod is scheduled.
+
+- **hostIP** (string)
+
+  IP address of the host to which the pod is assigned. Empty if not yet scheduled.
+
+- **startTime** (Time)
+
+  RFC 3339 date and time at which the object was acknowledged by the Kubelet. This is before the Kubelet pulled the container image(s) for the pod.
+
+  <a name="Time"></a>
+  *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+- **phase** (string)
+
+  The phase of a Pod is a simple, high-level summary of where the Pod is in its lifecycle. The conditions array, the reason and message fields, and the individual container status arrays contain more detail about the pod's status. There are five possible phase values:
+  
+  Pending: The pod has been accepted by the Kubernetes system, but one or more of the container images has not been created. This includes time before being scheduled as well as time spent downloading images over the network, which could take a while. Running: The pod has been bound to a node, and all of the containers have been created. At least one container is still running, or is in the process of starting or restarting. Succeeded: All containers in the pod have terminated in success, and will not be restarted. Failed: All containers in the pod have terminated, and at least one container has terminated in failure. The container either exited with non-zero status or was terminated by the system. Unknown: For some reason the state of the pod could not be obtained, typically due to an error in communicating with the host of the pod.
+  
+  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-phase
+
+- **message** (string)
+
+  A human readable message indicating details about why the pod is in this condition.
+
+- **reason** (string)
+
+  A brief CamelCase message indicating details about why the pod is in this state. e.g. 'Evicted'
+
+- **podIP** (string)
+
+  IP address allocated to the pod. Routable at least within the cluster. Empty if not yet allocated.
+
+- **podIPs** ([]PodIP)
+
+  *Patch strategy: merge on key `ip`*
+  
+  podIPs holds the IP addresses allocated to the pod. If this field is specified, the 0th entry must match the podIP field. Pods may be allocated at most 1 value for each of IPv4 and IPv6. This list is empty if no IPs have been allocated yet.
+
+  <a name="PodIP"></a>
+  *IP address information for entries in the (plural) PodIPs field. Each entry includes:
+     IP: An IP address allocated to the pod. Routable at least within the cluster.*
+
+  - **podIPs.ip** (string)
+
+    ip is an IP address (IPv4 or IPv6) assigned to the pod
+
+- **conditions** ([]PodCondition)
+
+  *Patch strategy: merge on key `type`*
+  
+  Current service state of pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions
+
+  <a name="PodCondition"></a>
+  *PodCondition contains details for the current condition of this pod.*
+
+  - **conditions.status** (string), required
+
+    Status is the status of the condition. Can be True, False, Unknown. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions
+
+  - **conditions.type** (string), required
+
+    Type is the type of the condition. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions
+
+  - **conditions.lastProbeTime** (Time)
+
+    Last time we probed the condition.
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **conditions.lastTransitionTime** (Time)
+
+    Last time the condition transitioned from one status to another.
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **conditions.message** (string)
+
+    Human-readable message indicating details about last transition.
+
+  - **conditions.reason** (string)
+
+    Unique, one-word, CamelCase reason for the condition's last transition.
+
+- **qosClass** (string)
+
+  The Quality of Service (QOS) classification assigned to the pod based on resource requirements See PodQOSClass type for available QOS classes More info: https://git.k8s.io/community/contributors/design-proposals/node/resource-qos.md
+
+- **initContainerStatuses** ([]<a href="{{< ref "../workloads-resources/container#ContainerStatus" >}}">ContainerStatus</a>)
+
+  The list has one entry per init container in the manifest. The most recent successful init container will have ready = true, the most recently started container will have startTime set. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status
+
+- **containerStatuses** ([]<a href="{{< ref "../workloads-resources/container#ContainerStatus" >}}">ContainerStatus</a>)
+
+  The list has one entry per container in the manifest. Each entry is currently the output of `docker inspect`. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status
+
+- **ephemeralContainerStatuses** ([]<a href="{{< ref "../workloads-resources/container#ContainerStatus" >}}">ContainerStatus</a>)
+
+  Status for any ephemeral containers that have run in this pod. This field is alpha-level and is only populated by servers that enable the EphemeralContainers feature.
+
+
+
+
+
+## PodList {#PodList}
+
+PodList is a list of Pods.
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: PodList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+- **items** ([]<a href="{{< ref "../workloads-resources/pod-v1#Pod" >}}">Pod</a>), required
+
+  List of pods. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified Pod
+
+#### HTTP Request
+
+GET /api/v1/namespaces/{namespace}/pods/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Pod
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/pod-v1#Pod" >}}">Pod</a>): OK
+
+401: Unauthorized
+
+
+### `get` read log of the specified Pod
+
+#### HTTP Request
+
+GET /api/v1/namespaces/{namespace}/pods/{name}/log
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Pod
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **container** (*in query*): string
+
+  The container for which to stream logs. Defaults to only container if there is one container in the pod.
+
+
+- **follow** (*in query*): boolean
+
+  Follow the log stream of the pod. Defaults to false.
+
+
+- **insecureSkipTLSVerifyBackend** (*in query*): boolean
+
+  insecureSkipTLSVerifyBackend indicates that the apiserver should not confirm the validity of the serving certificate of the backend it is connecting to.  This will make the HTTPS connection between the apiserver and the backend insecure. This means the apiserver cannot verify the log data it is receiving came from the real kubelet.  If the kubelet is configured to verify the apiserver's TLS credentials, it does not mean the connection to the real kubelet is vulnerable to a man in the middle attack (e.g. an attacker could not intercept the actual log data coming from the real kubelet).
+
+
+- **limitBytes** (*in query*): integer
+
+  If set, the number of bytes to read from the server before terminating the log output. This may not display a complete final line of logging, and may return slightly more or slightly less than the specified limit.
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **previous** (*in query*): boolean
+
+  Return previous terminated container logs. Defaults to false.
+
+
+- **sinceSeconds** (*in query*): integer
+
+  A relative time in seconds before the current time from which to show logs. If this value precedes the time a pod was started, only logs since the pod start will be returned. If this value is in the future, no logs will be returned. Only one of sinceSeconds or sinceTime may be specified.
+
+
+- **tailLines** (*in query*): integer
+
+  If set, the number of lines from the end of the logs to show. If not specified, logs are shown from the creation of the container or sinceSeconds or sinceTime
+
+
+- **timestamps** (*in query*): boolean
+
+  If true, add an RFC3339 or RFC3339Nano timestamp at the beginning of every line of log output. Defaults to false.
+
+
+
+#### Response
+
+
+200 (string): OK
+
+401: Unauthorized
+
+
+### `get` read status of the specified Pod
+
+#### HTTP Request
+
+GET /api/v1/namespaces/{namespace}/pods/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Pod
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/pod-v1#Pod" >}}">Pod</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind Pod
+
+#### HTTP Request
+
+GET /api/v1/namespaces/{namespace}/pods
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/pod-v1#PodList" >}}">PodList</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind Pod
+
+#### HTTP Request
+
+GET /api/v1/pods
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/pod-v1#PodList" >}}">PodList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a Pod
+
+#### HTTP Request
+
+POST /api/v1/namespaces/{namespace}/pods
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/pod-v1#Pod" >}}">Pod</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/pod-v1#Pod" >}}">Pod</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/pod-v1#Pod" >}}">Pod</a>): Created
+
+202 (<a href="{{< ref "../workloads-resources/pod-v1#Pod" >}}">Pod</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified Pod
+
+#### HTTP Request
+
+PUT /api/v1/namespaces/{namespace}/pods/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Pod
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/pod-v1#Pod" >}}">Pod</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/pod-v1#Pod" >}}">Pod</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/pod-v1#Pod" >}}">Pod</a>): Created
+
+401: Unauthorized
+
+
+### `update` replace status of the specified Pod
+
+#### HTTP Request
+
+PUT /api/v1/namespaces/{namespace}/pods/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Pod
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/pod-v1#Pod" >}}">Pod</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/pod-v1#Pod" >}}">Pod</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/pod-v1#Pod" >}}">Pod</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified Pod
+
+#### HTTP Request
+
+PATCH /api/v1/namespaces/{namespace}/pods/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Pod
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/pod-v1#Pod" >}}">Pod</a>): OK
+
+401: Unauthorized
+
+
+### `patch` partially update status of the specified Pod
+
+#### HTTP Request
+
+PATCH /api/v1/namespaces/{namespace}/pods/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Pod
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/pod-v1#Pod" >}}">Pod</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a Pod
+
+#### HTTP Request
+
+DELETE /api/v1/namespaces/{namespace}/pods/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the Pod
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/pod-v1#Pod" >}}">Pod</a>): OK
+
+202 (<a href="{{< ref "../workloads-resources/pod-v1#Pod" >}}">Pod</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of Pod
+
+#### HTTP Request
+
+DELETE /api/v1/namespaces/{namespace}/pods
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/workloads-resources/priority-class-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workloads-resources/priority-class-v1.md
@@ -1,0 +1,445 @@
+---
+api_metadata:
+  apiVersion: "scheduling.k8s.io/v1"
+  import: "k8s.io/api/scheduling/v1"
+  kind: "PriorityClass"
+content_type: "api_reference"
+description: "PriorityClass defines mapping from a priority class name to the priority integer value."
+title: "PriorityClass"
+weight: 16
+---
+
+`apiVersion: scheduling.k8s.io/v1`
+
+`import "k8s.io/api/scheduling/v1"`
+
+
+## PriorityClass {#PriorityClass}
+
+PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
+
+<hr>
+
+- **apiVersion**: scheduling.k8s.io/v1
+
+
+- **kind**: PriorityClass
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **value** (int32), required
+
+  The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.
+
+- **description** (string)
+
+  description is an arbitrary string that usually provides guidelines on when this priority class should be used.
+
+- **globalDefault** (boolean)
+
+  globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.
+
+- **preemptionPolicy** (string)
+
+  PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is beta-level, gated by the NonPreemptingPriority feature-gate.
+
+
+
+
+
+## PriorityClassList {#PriorityClassList}
+
+PriorityClassList is a collection of priority classes.
+
+<hr>
+
+- **apiVersion**: scheduling.k8s.io/v1
+
+
+- **kind**: PriorityClassList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **items** ([]<a href="{{< ref "../workloads-resources/priority-class-v1#PriorityClass" >}}">PriorityClass</a>), required
+
+  items is the list of PriorityClasses
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified PriorityClass
+
+#### HTTP Request
+
+GET /apis/scheduling.k8s.io/v1/priorityclasses/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PriorityClass
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/priority-class-v1#PriorityClass" >}}">PriorityClass</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind PriorityClass
+
+#### HTTP Request
+
+GET /apis/scheduling.k8s.io/v1/priorityclasses
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/priority-class-v1#PriorityClassList" >}}">PriorityClassList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a PriorityClass
+
+#### HTTP Request
+
+POST /apis/scheduling.k8s.io/v1/priorityclasses
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../workloads-resources/priority-class-v1#PriorityClass" >}}">PriorityClass</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/priority-class-v1#PriorityClass" >}}">PriorityClass</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/priority-class-v1#PriorityClass" >}}">PriorityClass</a>): Created
+
+202 (<a href="{{< ref "../workloads-resources/priority-class-v1#PriorityClass" >}}">PriorityClass</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified PriorityClass
+
+#### HTTP Request
+
+PUT /apis/scheduling.k8s.io/v1/priorityclasses/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PriorityClass
+
+
+- **body**: <a href="{{< ref "../workloads-resources/priority-class-v1#PriorityClass" >}}">PriorityClass</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/priority-class-v1#PriorityClass" >}}">PriorityClass</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/priority-class-v1#PriorityClass" >}}">PriorityClass</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified PriorityClass
+
+#### HTTP Request
+
+PATCH /apis/scheduling.k8s.io/v1/priorityclasses/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PriorityClass
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/priority-class-v1#PriorityClass" >}}">PriorityClass</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a PriorityClass
+
+#### HTTP Request
+
+DELETE /apis/scheduling.k8s.io/v1/priorityclasses/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the PriorityClass
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of PriorityClass
+
+#### HTTP Request
+
+DELETE /apis/scheduling.k8s.io/v1/priorityclasses
+
+#### Parameters
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/workloads-resources/replica-set-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workloads-resources/replica-set-v1.md
@@ -1,0 +1,764 @@
+---
+api_metadata:
+  apiVersion: "apps/v1"
+  import: "k8s.io/api/apps/v1"
+  kind: "ReplicaSet"
+content_type: "api_reference"
+description: "ReplicaSet ensures that a specified number of pod replicas are running at any given time."
+title: "ReplicaSet"
+weight: 6
+---
+
+`apiVersion: apps/v1`
+
+`import "k8s.io/api/apps/v1"`
+
+
+## ReplicaSet {#ReplicaSet}
+
+ReplicaSet ensures that a specified number of pod replicas are running at any given time.
+
+<hr>
+
+- **apiVersion**: apps/v1
+
+
+- **kind**: ReplicaSet
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **spec** (<a href="{{< ref "../workloads-resources/replica-set-v1#ReplicaSetSpec" >}}">ReplicaSetSpec</a>)
+
+  Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+- **status** (<a href="{{< ref "../workloads-resources/replica-set-v1#ReplicaSetStatus" >}}">ReplicaSetStatus</a>)
+
+  Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+
+
+
+
+## ReplicaSetSpec {#ReplicaSetSpec}
+
+ReplicaSetSpec is the specification of a ReplicaSet.
+
+<hr>
+
+- **selector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>), required
+
+  Selector is a label query over pods that should match the replica count. Label keys and values that must match in order to be controlled by this replica set. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+
+- **template** (<a href="{{< ref "../workloads-resources/pod-template-v1#PodTemplateSpec" >}}">PodTemplateSpec</a>)
+
+  Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
+
+- **replicas** (int32)
+
+  Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller
+
+- **minReadySeconds** (int32)
+
+  Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)
+
+
+
+
+
+## ReplicaSetStatus {#ReplicaSetStatus}
+
+ReplicaSetStatus represents the current status of a ReplicaSet.
+
+<hr>
+
+- **replicas** (int32), required
+
+  Replicas is the most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller
+
+- **availableReplicas** (int32)
+
+  The number of available replicas (ready for at least minReadySeconds) for this replica set.
+
+- **readyReplicas** (int32)
+
+  The number of ready replicas for this replica set.
+
+- **fullyLabeledReplicas** (int32)
+
+  The number of pods that have labels matching the labels of the pod template of the replicaset.
+
+- **conditions** ([]ReplicaSetCondition)
+
+  *Patch strategy: merge on key `type`*
+  
+  Represents the latest available observations of a replica set's current state.
+
+  <a name="ReplicaSetCondition"></a>
+  *ReplicaSetCondition describes the state of a replica set at a certain point.*
+
+  - **conditions.status** (string), required
+
+    Status of the condition, one of True, False, Unknown.
+
+  - **conditions.type** (string), required
+
+    Type of replica set condition.
+
+  - **conditions.lastTransitionTime** (Time)
+
+    The last time the condition transitioned from one status to another.
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **conditions.message** (string)
+
+    A human readable message indicating details about the transition.
+
+  - **conditions.reason** (string)
+
+    The reason for the condition's last transition.
+
+- **observedGeneration** (int64)
+
+  ObservedGeneration reflects the generation of the most recently observed ReplicaSet.
+
+
+
+
+
+## ReplicaSetList {#ReplicaSetList}
+
+ReplicaSetList is a collection of ReplicaSets.
+
+<hr>
+
+- **apiVersion**: apps/v1
+
+
+- **kind**: ReplicaSetList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+- **items** ([]<a href="{{< ref "../workloads-resources/replica-set-v1#ReplicaSet" >}}">ReplicaSet</a>), required
+
+  List of ReplicaSets. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified ReplicaSet
+
+#### HTTP Request
+
+GET /apis/apps/v1/namespaces/{namespace}/replicasets/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ReplicaSet
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/replica-set-v1#ReplicaSet" >}}">ReplicaSet</a>): OK
+
+401: Unauthorized
+
+
+### `get` read status of the specified ReplicaSet
+
+#### HTTP Request
+
+GET /apis/apps/v1/namespaces/{namespace}/replicasets/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ReplicaSet
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/replica-set-v1#ReplicaSet" >}}">ReplicaSet</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind ReplicaSet
+
+#### HTTP Request
+
+GET /apis/apps/v1/namespaces/{namespace}/replicasets
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/replica-set-v1#ReplicaSetList" >}}">ReplicaSetList</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind ReplicaSet
+
+#### HTTP Request
+
+GET /apis/apps/v1/replicasets
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/replica-set-v1#ReplicaSetList" >}}">ReplicaSetList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a ReplicaSet
+
+#### HTTP Request
+
+POST /apis/apps/v1/namespaces/{namespace}/replicasets
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/replica-set-v1#ReplicaSet" >}}">ReplicaSet</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/replica-set-v1#ReplicaSet" >}}">ReplicaSet</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/replica-set-v1#ReplicaSet" >}}">ReplicaSet</a>): Created
+
+202 (<a href="{{< ref "../workloads-resources/replica-set-v1#ReplicaSet" >}}">ReplicaSet</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified ReplicaSet
+
+#### HTTP Request
+
+PUT /apis/apps/v1/namespaces/{namespace}/replicasets/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ReplicaSet
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/replica-set-v1#ReplicaSet" >}}">ReplicaSet</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/replica-set-v1#ReplicaSet" >}}">ReplicaSet</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/replica-set-v1#ReplicaSet" >}}">ReplicaSet</a>): Created
+
+401: Unauthorized
+
+
+### `update` replace status of the specified ReplicaSet
+
+#### HTTP Request
+
+PUT /apis/apps/v1/namespaces/{namespace}/replicasets/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ReplicaSet
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/replica-set-v1#ReplicaSet" >}}">ReplicaSet</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/replica-set-v1#ReplicaSet" >}}">ReplicaSet</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/replica-set-v1#ReplicaSet" >}}">ReplicaSet</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified ReplicaSet
+
+#### HTTP Request
+
+PATCH /apis/apps/v1/namespaces/{namespace}/replicasets/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ReplicaSet
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/replica-set-v1#ReplicaSet" >}}">ReplicaSet</a>): OK
+
+401: Unauthorized
+
+
+### `patch` partially update status of the specified ReplicaSet
+
+#### HTTP Request
+
+PATCH /apis/apps/v1/namespaces/{namespace}/replicasets/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ReplicaSet
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/replica-set-v1#ReplicaSet" >}}">ReplicaSet</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a ReplicaSet
+
+#### HTTP Request
+
+DELETE /apis/apps/v1/namespaces/{namespace}/replicasets/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ReplicaSet
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of ReplicaSet
+
+#### HTTP Request
+
+DELETE /apis/apps/v1/namespaces/{namespace}/replicasets
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/workloads-resources/replication-controller-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workloads-resources/replication-controller-v1.md
@@ -1,0 +1,764 @@
+---
+api_metadata:
+  apiVersion: "v1"
+  import: "k8s.io/api/core/v1"
+  kind: "ReplicationController"
+content_type: "api_reference"
+description: "ReplicationController represents the configuration of a replication controller."
+title: "ReplicationController"
+weight: 5
+---
+
+`apiVersion: v1`
+
+`import "k8s.io/api/core/v1"`
+
+
+## ReplicationController {#ReplicationController}
+
+ReplicationController represents the configuration of a replication controller.
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: ReplicationController
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  If the Labels of a ReplicationController are empty, they are defaulted to be the same as the Pod(s) that the replication controller manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **spec** (<a href="{{< ref "../workloads-resources/replication-controller-v1#ReplicationControllerSpec" >}}">ReplicationControllerSpec</a>)
+
+  Spec defines the specification of the desired behavior of the replication controller. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+- **status** (<a href="{{< ref "../workloads-resources/replication-controller-v1#ReplicationControllerStatus" >}}">ReplicationControllerStatus</a>)
+
+  Status is the most recently observed status of the replication controller. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+
+
+
+
+## ReplicationControllerSpec {#ReplicationControllerSpec}
+
+ReplicationControllerSpec is the specification of a replication controller.
+
+<hr>
+
+- **selector** (map[string]string)
+
+  Selector is a label query over pods that should match the Replicas count. If Selector is empty, it is defaulted to the labels present on the Pod template. Label keys and values that must match in order to be controlled by this replication controller, if empty defaulted to labels on Pod template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+
+- **template** (<a href="{{< ref "../workloads-resources/pod-template-v1#PodTemplateSpec" >}}">PodTemplateSpec</a>)
+
+  Template is the object that describes the pod that will be created if insufficient replicas are detected. This takes precedence over a TemplateRef. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
+
+- **replicas** (int32)
+
+  Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#what-is-a-replicationcontroller
+
+- **minReadySeconds** (int32)
+
+  Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)
+
+
+
+
+
+## ReplicationControllerStatus {#ReplicationControllerStatus}
+
+ReplicationControllerStatus represents the current status of a replication controller.
+
+<hr>
+
+- **replicas** (int32), required
+
+  Replicas is the most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#what-is-a-replicationcontroller
+
+- **availableReplicas** (int32)
+
+  The number of available replicas (ready for at least minReadySeconds) for this replication controller.
+
+- **readyReplicas** (int32)
+
+  The number of ready replicas for this replication controller.
+
+- **fullyLabeledReplicas** (int32)
+
+  The number of pods that have labels matching the labels of the pod template of the replication controller.
+
+- **conditions** ([]ReplicationControllerCondition)
+
+  *Patch strategy: merge on key `type`*
+  
+  Represents the latest available observations of a replication controller's current state.
+
+  <a name="ReplicationControllerCondition"></a>
+  *ReplicationControllerCondition describes the state of a replication controller at a certain point.*
+
+  - **conditions.status** (string), required
+
+    Status of the condition, one of True, False, Unknown.
+
+  - **conditions.type** (string), required
+
+    Type of replication controller condition.
+
+  - **conditions.lastTransitionTime** (Time)
+
+    The last time the condition transitioned from one status to another.
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **conditions.message** (string)
+
+    A human readable message indicating details about the transition.
+
+  - **conditions.reason** (string)
+
+    The reason for the condition's last transition.
+
+- **observedGeneration** (int64)
+
+  ObservedGeneration reflects the generation of the most recently observed replication controller.
+
+
+
+
+
+## ReplicationControllerList {#ReplicationControllerList}
+
+ReplicationControllerList is a collection of replication controllers.
+
+<hr>
+
+- **apiVersion**: v1
+
+
+- **kind**: ReplicationControllerList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+  Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+- **items** ([]<a href="{{< ref "../workloads-resources/replication-controller-v1#ReplicationController" >}}">ReplicationController</a>), required
+
+  List of replication controllers. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified ReplicationController
+
+#### HTTP Request
+
+GET /api/v1/namespaces/{namespace}/replicationcontrollers/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ReplicationController
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/replication-controller-v1#ReplicationController" >}}">ReplicationController</a>): OK
+
+401: Unauthorized
+
+
+### `get` read status of the specified ReplicationController
+
+#### HTTP Request
+
+GET /api/v1/namespaces/{namespace}/replicationcontrollers/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ReplicationController
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/replication-controller-v1#ReplicationController" >}}">ReplicationController</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind ReplicationController
+
+#### HTTP Request
+
+GET /api/v1/namespaces/{namespace}/replicationcontrollers
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/replication-controller-v1#ReplicationControllerList" >}}">ReplicationControllerList</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind ReplicationController
+
+#### HTTP Request
+
+GET /api/v1/replicationcontrollers
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/replication-controller-v1#ReplicationControllerList" >}}">ReplicationControllerList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a ReplicationController
+
+#### HTTP Request
+
+POST /api/v1/namespaces/{namespace}/replicationcontrollers
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/replication-controller-v1#ReplicationController" >}}">ReplicationController</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/replication-controller-v1#ReplicationController" >}}">ReplicationController</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/replication-controller-v1#ReplicationController" >}}">ReplicationController</a>): Created
+
+202 (<a href="{{< ref "../workloads-resources/replication-controller-v1#ReplicationController" >}}">ReplicationController</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified ReplicationController
+
+#### HTTP Request
+
+PUT /api/v1/namespaces/{namespace}/replicationcontrollers/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ReplicationController
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/replication-controller-v1#ReplicationController" >}}">ReplicationController</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/replication-controller-v1#ReplicationController" >}}">ReplicationController</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/replication-controller-v1#ReplicationController" >}}">ReplicationController</a>): Created
+
+401: Unauthorized
+
+
+### `update` replace status of the specified ReplicationController
+
+#### HTTP Request
+
+PUT /api/v1/namespaces/{namespace}/replicationcontrollers/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ReplicationController
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/replication-controller-v1#ReplicationController" >}}">ReplicationController</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/replication-controller-v1#ReplicationController" >}}">ReplicationController</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/replication-controller-v1#ReplicationController" >}}">ReplicationController</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified ReplicationController
+
+#### HTTP Request
+
+PATCH /api/v1/namespaces/{namespace}/replicationcontrollers/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ReplicationController
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/replication-controller-v1#ReplicationController" >}}">ReplicationController</a>): OK
+
+401: Unauthorized
+
+
+### `patch` partially update status of the specified ReplicationController
+
+#### HTTP Request
+
+PATCH /api/v1/namespaces/{namespace}/replicationcontrollers/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ReplicationController
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/replication-controller-v1#ReplicationController" >}}">ReplicationController</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a ReplicationController
+
+#### HTTP Request
+
+DELETE /api/v1/namespaces/{namespace}/replicationcontrollers/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the ReplicationController
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of ReplicationController
+
+#### HTTP Request
+
+DELETE /api/v1/namespaces/{namespace}/replicationcontrollers
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/workloads-resources/stateful-set-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workloads-resources/stateful-set-v1.md
@@ -1,0 +1,810 @@
+---
+api_metadata:
+  apiVersion: "apps/v1"
+  import: "k8s.io/api/apps/v1"
+  kind: "StatefulSet"
+content_type: "api_reference"
+description: "StatefulSet represents a set of pods with consistent identities."
+title: "StatefulSet"
+weight: 8
+---
+
+`apiVersion: apps/v1`
+
+`import "k8s.io/api/apps/v1"`
+
+
+## StatefulSet {#StatefulSet}
+
+StatefulSet represents a set of pods with consistent identities. Identities are defined as:
+ - Network: A single stable DNS and hostname.
+ - Storage: As many VolumeClaims as requested.
+The StatefulSet guarantees that a given network identity will always map to the same storage identity.
+
+<hr>
+
+- **apiVersion**: apps/v1
+
+
+- **kind**: StatefulSet
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+
+- **spec** (<a href="{{< ref "../workloads-resources/stateful-set-v1#StatefulSetSpec" >}}">StatefulSetSpec</a>)
+
+  Spec defines the desired identities of pods in this set.
+
+- **status** (<a href="{{< ref "../workloads-resources/stateful-set-v1#StatefulSetStatus" >}}">StatefulSetStatus</a>)
+
+  Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.
+
+
+
+
+
+## StatefulSetSpec {#StatefulSetSpec}
+
+A StatefulSetSpec is the specification of a StatefulSet.
+
+<hr>
+
+- **serviceName** (string), required
+
+  serviceName is the name of the service that governs this StatefulSet. This service must exist before the StatefulSet, and is responsible for the network identity of the set. Pods get DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local where "pod-specific-string" is managed by the StatefulSet controller.
+
+- **selector** (<a href="{{< ref "../common-definitions/label-selector#LabelSelector" >}}">LabelSelector</a>), required
+
+  selector is a label query over pods that should match the replica count. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+
+- **template** (<a href="{{< ref "../workloads-resources/pod-template-v1#PodTemplateSpec" >}}">PodTemplateSpec</a>), required
+
+  template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet.
+
+- **replicas** (int32)
+
+  replicas is the desired number of replicas of the given Template. These are replicas in the sense that they are instantiations of the same Template, but individual replicas also have a consistent identity. If unspecified, defaults to 1.
+
+- **updateStrategy** (StatefulSetUpdateStrategy)
+
+  updateStrategy indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.
+
+  <a name="StatefulSetUpdateStrategy"></a>
+  *StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.*
+
+  - **updateStrategy.type** (string)
+
+    Type indicates the type of the StatefulSetUpdateStrategy. Default is RollingUpdate.
+
+  - **updateStrategy.rollingUpdate** (RollingUpdateStatefulSetStrategy)
+
+    RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.
+
+    <a name="RollingUpdateStatefulSetStrategy"></a>
+    *RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.*
+
+  - **updateStrategy.rollingUpdate.partition** (int32)
+
+    Partition indicates the ordinal at which the StatefulSet should be partitioned. Default value is 0.
+
+- **podManagementPolicy** (string)
+
+  podManagementPolicy controls how pods are created during initial scale up, when replacing pods on nodes, or when scaling down. The default policy is `OrderedReady`, where pods are created in increasing order (pod-0, then pod-1, etc) and the controller will wait until each pod is ready before continuing. When scaling down, the pods are removed in the opposite order. The alternative policy is `Parallel` which will create pods in parallel to match the desired scale without waiting, and on scale down will delete all pods at once.
+
+- **revisionHistoryLimit** (int32)
+
+  revisionHistoryLimit is the maximum number of revisions that will be maintained in the StatefulSet's revision history. The revision history consists of all revisions not represented by a currently applied StatefulSetSpec version. The default value is 10.
+
+- **volumeClaimTemplates** ([]<a href="{{< ref "../config-and-storage-resources/persistent-volume-claim-v1#PersistentVolumeClaim" >}}">PersistentVolumeClaim</a>)
+
+  volumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name.
+
+
+
+
+
+## StatefulSetStatus {#StatefulSetStatus}
+
+StatefulSetStatus represents the current state of a StatefulSet.
+
+<hr>
+
+- **replicas** (int32), required
+
+  replicas is the number of Pods created by the StatefulSet controller.
+
+- **readyReplicas** (int32)
+
+  readyReplicas is the number of Pods created by the StatefulSet controller that have a Ready Condition.
+
+- **currentReplicas** (int32)
+
+  currentReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by currentRevision.
+
+- **updatedReplicas** (int32)
+
+  updatedReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by updateRevision.
+
+- **collisionCount** (int32)
+
+  collisionCount is the count of hash collisions for the StatefulSet. The StatefulSet controller uses this field as a collision avoidance mechanism when it needs to create the name for the newest ControllerRevision.
+
+- **conditions** ([]StatefulSetCondition)
+
+  *Patch strategy: merge on key `type`*
+  
+  Represents the latest available observations of a statefulset's current state.
+
+  <a name="StatefulSetCondition"></a>
+  *StatefulSetCondition describes the state of a statefulset at a certain point.*
+
+  - **conditions.status** (string), required
+
+    Status of the condition, one of True, False, Unknown.
+
+  - **conditions.type** (string), required
+
+    Type of statefulset condition.
+
+  - **conditions.lastTransitionTime** (Time)
+
+    Last time the condition transitioned from one status to another.
+
+    <a name="Time"></a>
+    *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **conditions.message** (string)
+
+    A human readable message indicating details about the transition.
+
+  - **conditions.reason** (string)
+
+    The reason for the condition's last transition.
+
+- **currentRevision** (string)
+
+  currentRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
+
+- **updateRevision** (string)
+
+  updateRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
+
+- **observedGeneration** (int64)
+
+  observedGeneration is the most recent generation observed for this StatefulSet. It corresponds to the StatefulSet's generation, which is updated on mutation by the API Server.
+
+
+
+
+
+## StatefulSetList {#StatefulSetList}
+
+StatefulSetList is a collection of StatefulSets.
+
+<hr>
+
+- **apiVersion**: apps/v1
+
+
+- **kind**: StatefulSetList
+
+
+- **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
+
+
+- **items** ([]<a href="{{< ref "../workloads-resources/stateful-set-v1#StatefulSet" >}}">StatefulSet</a>), required
+
+
+
+
+
+
+## Operations {#Operations}
+
+
+
+<hr>
+
+
+
+
+
+
+### `get` read the specified StatefulSet
+
+#### HTTP Request
+
+GET /apis/apps/v1/namespaces/{namespace}/statefulsets/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the StatefulSet
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/stateful-set-v1#StatefulSet" >}}">StatefulSet</a>): OK
+
+401: Unauthorized
+
+
+### `get` read status of the specified StatefulSet
+
+#### HTTP Request
+
+GET /apis/apps/v1/namespaces/{namespace}/statefulsets/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the StatefulSet
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/stateful-set-v1#StatefulSet" >}}">StatefulSet</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind StatefulSet
+
+#### HTTP Request
+
+GET /apis/apps/v1/namespaces/{namespace}/statefulsets
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/stateful-set-v1#StatefulSetList" >}}">StatefulSetList</a>): OK
+
+401: Unauthorized
+
+
+### `list` list or watch objects of kind StatefulSet
+
+#### HTTP Request
+
+GET /apis/apps/v1/statefulsets
+
+#### Parameters
+
+
+- **allowWatchBookmarks** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#allowWatchBookmarks" >}}">allowWatchBookmarks</a>
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+- **watch** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#watch" >}}">watch</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/stateful-set-v1#StatefulSetList" >}}">StatefulSetList</a>): OK
+
+401: Unauthorized
+
+
+### `create` create a StatefulSet
+
+#### HTTP Request
+
+POST /apis/apps/v1/namespaces/{namespace}/statefulsets
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/stateful-set-v1#StatefulSet" >}}">StatefulSet</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/stateful-set-v1#StatefulSet" >}}">StatefulSet</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/stateful-set-v1#StatefulSet" >}}">StatefulSet</a>): Created
+
+202 (<a href="{{< ref "../workloads-resources/stateful-set-v1#StatefulSet" >}}">StatefulSet</a>): Accepted
+
+401: Unauthorized
+
+
+### `update` replace the specified StatefulSet
+
+#### HTTP Request
+
+PUT /apis/apps/v1/namespaces/{namespace}/statefulsets/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the StatefulSet
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/stateful-set-v1#StatefulSet" >}}">StatefulSet</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/stateful-set-v1#StatefulSet" >}}">StatefulSet</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/stateful-set-v1#StatefulSet" >}}">StatefulSet</a>): Created
+
+401: Unauthorized
+
+
+### `update` replace status of the specified StatefulSet
+
+#### HTTP Request
+
+PUT /apis/apps/v1/namespaces/{namespace}/statefulsets/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the StatefulSet
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../workloads-resources/stateful-set-v1#StatefulSet" >}}">StatefulSet</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/stateful-set-v1#StatefulSet" >}}">StatefulSet</a>): OK
+
+201 (<a href="{{< ref "../workloads-resources/stateful-set-v1#StatefulSet" >}}">StatefulSet</a>): Created
+
+401: Unauthorized
+
+
+### `patch` partially update the specified StatefulSet
+
+#### HTTP Request
+
+PATCH /apis/apps/v1/namespaces/{namespace}/statefulsets/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the StatefulSet
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/stateful-set-v1#StatefulSet" >}}">StatefulSet</a>): OK
+
+401: Unauthorized
+
+
+### `patch` partially update status of the specified StatefulSet
+
+#### HTTP Request
+
+PATCH /apis/apps/v1/namespaces/{namespace}/statefulsets/{name}/status
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the StatefulSet
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/patch#Patch" >}}">Patch</a>, required
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldManager** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldManager" >}}">fieldManager</a>
+
+
+- **force** (*in query*): boolean
+
+  <a href="{{< ref "../common-parameters/common-parameters#force" >}}">force</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../workloads-resources/stateful-set-v1#StatefulSet" >}}">StatefulSet</a>): OK
+
+401: Unauthorized
+
+
+### `delete` delete a StatefulSet
+
+#### HTTP Request
+
+DELETE /apis/apps/v1/namespaces/{namespace}/statefulsets/{name}
+
+#### Parameters
+
+
+- **name** (*in path*): string, required
+
+  name of the StatefulSet
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+202 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): Accepted
+
+401: Unauthorized
+
+
+### `deletecollection` delete collection of StatefulSet
+
+#### HTTP Request
+
+DELETE /apis/apps/v1/namespaces/{namespace}/statefulsets
+
+#### Parameters
+
+
+- **namespace** (*in path*): string, required
+
+  <a href="{{< ref "../common-parameters/common-parameters#namespace" >}}">namespace</a>
+
+
+- **body**: <a href="{{< ref "../common-definitions/delete-options#DeleteOptions" >}}">DeleteOptions</a>
+
+  
+
+
+- **continue** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#continue" >}}">continue</a>
+
+
+- **dryRun** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#dryRun" >}}">dryRun</a>
+
+
+- **fieldSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#fieldSelector" >}}">fieldSelector</a>
+
+
+- **gracePeriodSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#gracePeriodSeconds" >}}">gracePeriodSeconds</a>
+
+
+- **labelSelector** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#labelSelector" >}}">labelSelector</a>
+
+
+- **limit** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#limit" >}}">limit</a>
+
+
+- **pretty** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#pretty" >}}">pretty</a>
+
+
+- **propagationPolicy** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#propagationPolicy" >}}">propagationPolicy</a>
+
+
+- **resourceVersion** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersion" >}}">resourceVersion</a>
+
+
+- **resourceVersionMatch** (*in query*): string
+
+  <a href="{{< ref "../common-parameters/common-parameters#resourceVersionMatch" >}}">resourceVersionMatch</a>
+
+
+- **timeoutSeconds** (*in query*): integer
+
+  <a href="{{< ref "../common-parameters/common-parameters#timeoutSeconds" >}}">timeoutSeconds</a>
+
+
+
+#### Response
+
+
+200 (<a href="{{< ref "../common-definitions/status#Status" >}}">Status</a>): OK
+
+401: Unauthorized
+

--- a/content/en/docs/reference/labels-annotations-taints.md
+++ b/content/en/docs/reference/labels-annotations-taints.md
@@ -1,7 +1,7 @@
 ---
 title: Well-Known Labels, Annotations and Taints
 content_type: concept
-weight: 60
+weight: 20
 ---
 
 <!-- overview -->

--- a/static/_redirects
+++ b/static/_redirects
@@ -201,6 +201,8 @@
 /docs/reference/generated/kubernetes-api/v1.17/    https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/  301
 /docs/reference/generated/kubernetes-api/v1.18/    https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/  301
 
+/docs/reference/kubernetes-api/api-index/ /docs/reference 301
+
 /docs/reporting-security-issues/     /security/ 301
 
 /docs/roadmap/     https://github.com/kubernetes/kubernetes/milestones/ 301


### PR DESCRIPTION
This pull request implements https://github.com/kubernetes/website/issues/23809

## Generating Markdown files

The goal of this PR is to generate Markdown files for the API reference, with the help of https://github.com/kubernetes-sigs/reference-docs/tree/master/gen-resourcesdocs. The result is visible at https://deploy-preview-23294--kubernetes-io-master-staging.netlify.app/docs/reference/kubernetes-api/

