### PR TITLE
Point glossary terms to Chinese pages if available.

### DIFF
--- a/content/zh/docs/reference/glossary/secret.md
+++ b/content/zh/docs/reference/glossary/secret.md
@@ -2,11 +2,11 @@
 title: Secret
 id: secret
 date: 2018-04-12
-full_link: /docs/concepts/configuration/secret/
+full_link: /zh/docs/concepts/configuration/secret/
 short_description: >
   Secret 用于存储敏感信息，如密码、OAuth 令牌和 SSH 密钥。
 
-aka: 
+aka:
 tags:
 - core-object
 - security
@@ -21,7 +21,7 @@ full_link: /docs/concepts/configuration/secret/
 short_description: >
   Stores sensitive information, such as passwords, OAuth tokens, and ssh keys.
 
-aka: 
+aka:
 tags:
 - core-object
 - security
@@ -34,7 +34,7 @@ tags:
 
  Secret 用于存储敏感信息，如密码、OAuth 令牌和 SSH 密钥。
 
-<!--more--> 
+<!--more-->
 
 <!--
 Allows for more control over how sensitive information is used and reduces the risk of accidental exposure, including [encryption](/docs/tasks/administer-cluster/encrypt-data/#ensure-all-secrets-are-encrypted) at rest.  A {{< glossary_tooltip text="Pod" term_id="pod" >}} references the secret as a file in a volume mount or by the kubelet pulling images for a pod. Secrets are great for confidential data and [ConfigMaps](/docs/tasks/configure-pod-container/configure-pod-configmap/) for non-confidential data.

--- a/content/zh/docs/reference/glossary/service-account.md
+++ b/content/zh/docs/reference/glossary/service-account.md
@@ -2,11 +2,11 @@
 title: 服务账户
 id: service-account
 date: 2018-04-12
-full_link: /docs/tasks/configure-pod-container/configure-service-account/
+full_link: /zh/docs/tasks/configure-pod-container/configure-service-account/
 short_description: >
   为在 Pod 中运行的进程提供标识。
 
-aka: 
+aka:
 tags:
 - fundamental
 - core-object
@@ -21,7 +21,7 @@ full_link: /docs/tasks/configure-pod-container/configure-service-account/
 short_description: >
   Provides an identity for processes that run in a Pod.
 
-aka: 
+aka:
 tags:
 - fundamental
 - core-object
@@ -33,11 +33,9 @@ tags:
 -->
 为在 {{< glossary_tooltip text="Pod" term_id="pod" >}} 中运行的进程提供标识。
 
-<!--more--> 
-  
-<!-- 
+<!--more-->
+
+<!--
 When processes inside Pods access the cluster, they are authenticated by the API server as a particular service account, for example, `default`. When you create a Pod, if you do not specify a service account, it is automatically assigned the default service account in the same namespace {{< glossary_tooltip text="Namespace" term_id="namespace" >}}.
 -->
 当 Pod 中的进程访问集群时，API 服务器将它们作为特定的服务帐户进行身份验证，例如 `default`。当您创建 Pod 时，如果您没有指定服务帐户，它将在相同的命名空间 {{< glossary_tooltip text="命名空间" term_id="namespace" >}} 中自动分配 default 服务账户。
-
-


### PR DESCRIPTION
1. Fix glossary term pages containing `full_link` which point to `en` pages while `zh` pages are available.
2. Normalize whitespace of these pages.

Updated terms:  `service-account` `secret`

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

-->
