### PR TITLE
MacOS should be macOS in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ make serve
 
 This will start the local Hugo server on port 1313. Open up your browser to http://localhost:1313 to view the website. As you make changes to the source files, Hugo updates the website and forces a browser refresh.
 
-### Troubleshooting MacOS for too many open files
+### Troubleshooting macOS for too many open files
 
-If you run `make serve` on MacOS and receive the following error:
+If you run `make serve` on macOS and receive the following error:
 
 ```
 ERROR 2020/08/01 19:09:18 Error: listen tcp 127.0.0.1:1313: socket: too many open files
@@ -92,7 +92,7 @@ sudo chown root:wheel /Library/LaunchDaemons/limit.maxproc.plist
 sudo launchctl load -w /Library/LaunchDaemons/limit.maxfiles.plist
 ```
 
-This works for Catalina as well as Mojave MacOS.
+This works for Catalina as well as Mojave macOS.
 
 
 # Get involved with SIG Docs


### PR DESCRIPTION
`MacOS` should be `macOS` in README.md