### PR TITLE
Shell script syntax highlighting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Try checking the current limit for open files:
 
 Then run the following commands:
 
-```
+```shell
 #!/bin/sh
 
 # These are the original gist links, linking to my gists now.


### PR DESCRIPTION
Shell script in section [Troubleshooting MacOS for too many open files
](https://github.com/kubernetes/website#troubleshooting-macos-for-too-many-open-files) could apply syntax highlighting.