### PR TITLE
Fix ambiguity around behavior of preStop hook

### DIFF
--- a/content/en/docs/concepts/containers/container-lifecycle-hooks.md
+++ b/content/en/docs/concepts/containers/container-lifecycle-hooks.md
@@ -65,7 +65,7 @@ However, if the hook takes too long to run or hangs,
 the Container cannot reach a `running` state.
 
 `PreStop` hooks are not executed asynchronously from the signal
-to stop the Container–they hook must complete its execution before
+to stop the Container; the hook must complete its execution before
 the signal can be sent.
 If a `PreStop` hook hangs during execution,
 the Pod phase stays in a `Terminating` state and is killed after its `terminationGracePeriodSeconds` expires.

--- a/content/en/docs/concepts/containers/container-lifecycle-hooks.md
+++ b/content/en/docs/concepts/containers/container-lifecycle-hooks.md
@@ -38,7 +38,7 @@ No parameters are passed to the handler.
 
 This hook is called immediately before a container is terminated due to an API request or management event such as liveness probe failure, preemption, resource contention and others. A call to the preStop hook fails if the container is already in terminated or completed state.
 It is blocking, meaning it is synchronous,
-so it must complete before the signal to stop the Container can be sent.
+so it must complete before the signal to stop the container can be sent.
 No parameters are passed to the handler.
 
 A more detailed description of the termination behavior can be found in
@@ -130,5 +130,4 @@ Events:
 * Learn more about the [Container environment](/docs/concepts/containers/container-environment/).
 * Get hands-on experience
   [attaching handlers to Container lifecycle events](/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/).
-
 

--- a/content/en/docs/concepts/containers/container-lifecycle-hooks.md
+++ b/content/en/docs/concepts/containers/container-lifecycle-hooks.md
@@ -38,7 +38,7 @@ No parameters are passed to the handler.
 
 This hook is called immediately before a container is terminated due to an API request or management event such as liveness probe failure, preemption, resource contention and others. A call to the preStop hook fails if the container is already in terminated or completed state.
 It is blocking, meaning it is synchronous,
-so it must complete before the call to delete the container can be sent.
+so it must complete before the signal to stop the Container can be sent.
 No parameters are passed to the handler.
 
 A more detailed description of the termination behavior can be found in
@@ -64,10 +64,20 @@ the Container ENTRYPOINT and hook fire asynchronously.
 However, if the hook takes too long to run or hangs,
 the Container cannot reach a `running` state.
 
-The behavior is similar for a `PreStop` hook.
-If the hook hangs during execution,
-the Pod phase stays in a `Terminating` state and is killed after `terminationGracePeriodSeconds` of pod ends.
-If a `PostStart` or `PreStop` hook fails,
+`PreStop` hooks are not executed asynchronously from the signal
+to stop the Container–they hook must complete its execution before
+the signal can be sent.
+If a `PreStop` hook hangs during execution,
+the Pod phase stays in a `Terminating` state and is killed after its `terminationGracePeriodSeconds` expires.
+This grace period applies to the total time it takes for both
+the `PreStop` hook to execute and for the Container to stop normally.
+If, for example, `terminationGracePeriodSeconds` is 60, and the hook
+takes 55 seconds to complete, and the Container takes 10 seconds to stop
+normally after receiving the signal, then the Container will be killed
+before it can stop normally, since `terminationGracePeriodSeconds` is
+less than the total time (55+10) it takes for these two things to happen.
+
+If either a `PostStart` or `PreStop` hook fails,
 it kills the Container.
 
 Users should make their hook handlers as lightweight as possible.

--- a/content/en/docs/concepts/containers/container-lifecycle-hooks.md
+++ b/content/en/docs/concepts/containers/container-lifecycle-hooks.md
@@ -68,7 +68,8 @@ the Container cannot reach a `running` state.
 to stop the Container; the hook must complete its execution before
 the signal can be sent.
 If a `PreStop` hook hangs during execution,
-the Pod phase stays in a `Terminating` state and is killed after its `terminationGracePeriodSeconds` expires.
+the Pod's phase will be `Terminating` and remain there until the Pod is
+killed after its `terminationGracePeriodSeconds` expires.
 This grace period applies to the total time it takes for both
 the `PreStop` hook to execute and for the Container to stop normally.
 If, for example, `terminationGracePeriodSeconds` is 60, and the hook


### PR DESCRIPTION
When the previous paragraph says that postStart hooks are
fired asynchronously, and this paragraph says "the behavior is
much the same for preStop hooks," it reads as saying that
preStop hooks are fired asynchronously as well–which is not true.

It also seems prudent to give a concrete example of how
terminationGracePeriodSeconds applies to the total time it takes the
preStop hook and the container shutdown to happen.
