### PR TITLE
Disable announcement banner for v1.18 release (leaving banner on live site)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -129,7 +129,7 @@ githubWebsiteRaw = "raw.githubusercontent.com/kubernetes/website"
 
 # param for displaying an announcement block on every page.
 # See /i18n/en.toml for message text and title.
-announcement = true
+announcement = false
 announcement_bg = "#000000" #choose a dark color – text is white
 
 #Searching


### PR DESCRIPTION
Announcements should display on the live documentation. Disable the announcement that was showing at the moment the release branch was cut.

**This does _not_ remove the announcement from https://kubernetes.io/**

/kind cleanup
/cc @savitharaghunathan @jimangel @zacharysarah @kbarnard10 