### PR TITLE
Remove the KubeCon EU event from the landing page

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -41,11 +41,6 @@ Kubernetes is open source giving you the freedom to take advantage of on-premise
         <button id="desktopShowVideoButton" onclick="kub.showVideo()">Watch Video</button>
         <br>
         <br>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/?utm_source=kubernetes.io&utm_medium=nav&utm_campaign=kccnceu20" button id="desktopKCButton">Attend KubeCon EU virtually on August 17-20, 2020</a>
-        <br>
-        <br>
-        <br>
-        <br>
         <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/?utm_source=kubernetes.io&utm_medium=nav&utm_campaign=kccncna20" button id="desktopKCButton">Attend KubeCon NA virtually on November 17-20, 2020</a>
 </div>
 <div id="videoPlayer">


### PR DESCRIPTION
Says what it does, does what it says.

Preview link (scroll down the page): https://deploy-preview-23505--kubernetes-io-master-staging.netlify.app/