### PR TITLE
Revise “Supported Versions of the Kubernetes Documentation”

### DIFF
--- a/content/en/docs/home/supported-doc-versions.md
+++ b/content/en/docs/home/supported-doc-versions.md
@@ -1,30 +1,12 @@
 ---
-title: Supported Versions of the Kubernetes Documentation
-content_type: concept
+title: Available Documentation Versions
+content_type: custom
+layout: supported-versions
 card:
   name: about
   weight: 10
-  title: Supported Versions of the Documentation
+  title: Available Documentation Versions
 ---
-
-<!-- overview -->
 
 This website contains documentation for the current version of Kubernetes
 and the four previous versions of Kubernetes.
-
-
-
-<!-- body -->
-
-## Current version
-
-The current version is
-[{{< param "version" >}}](/).
-
-## Previous versions
-
-{{< versions-other >}}
-
-
-
-

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -54,6 +54,15 @@ other = "I AM..."
 [docs_label_users]
 other = "Users"
 
+[docs_version_current]
+other = "(this documentation)"
+
+[docs_version_latest_heading]
+other = "Latest version"
+
+[docs_version_other_heading]
+other = "Older versions"
+
 [examples_heading]
 other = "Examples"
 

--- a/layouts/docs/supported-versions.html
+++ b/layouts/docs/supported-versions.html
@@ -1,0 +1,39 @@
+{{ define "main" }}
+    <div class="td-content">
+    {{ partial "docs/content-page" (dict "ctx" . "page" .) }}
+    {{ $versions := .Page.Param "versions" }}
+    {{ $thisPageRelUri := .Page.RelPermalink }}
+    {{ $thisVersionArray := split (.Page.Param "version") "." }}
+    {{ $.Scratch.Set "version-class" (slice "placeholder") }}
+    {{/* "placeholder" is also used later to check whether we opened the <ul> */}}
+    {{ range $index, $version := $versions }}
+    {{ $.Scratch.Set "version-class" (slice "") }}
+    {{ $versionArray := split .version "." }}
+
+    {{ if eq $index 0 }}
+    <h2 id="version-latest">{{ T "docs_version_latest_heading" }}</h2>
+    <ul>
+    {{ $.Scratch.Set "version-class" ($.Scratch.Get "version-class" | append "version-latest" ) }}
+    {{ end }}
+    {{ if eq $index 1 }}
+    </ul>
+    <h2 id="versions-older">{{ T "docs_version_other_heading" }}</h2>
+    <ul>
+    {{ end }}
+
+    {{ if eq .version ( delimit $thisVersionArray "." ) }}
+    {{ $.Scratch.Set "version-class" ($.Scratch.Get "version-class" | append "version-current" ) }}
+    {{ end }}
+
+    <li class="{{ delimit ( $.Scratch.Get "version-class") " " }}">
+        <a href="{{ .url }}{{ $thisPageRelUri }}">{{ .version }}</a>
+        {{ if eq .version ( delimit $thisVersionArray "." ) }}
+        {{ T "docs_version_current" }}
+        {{ end }}
+    </li>
+    {{ end }}
+    {{ if ne (index ($.Scratch.Get "version-class") 0) "placeholder" }}
+    </ul>
+    {{ end }}
+
+{{ end }}

--- a/layouts/shortcodes/versions-other.html
+++ b/layouts/shortcodes/versions-other.html
@@ -1,3 +1,4 @@
+{{/* this shortcode is DEPRECATED */}}
 {{ $versions := .Page.Param "versions" }}
 {{ $thisVersion :=  .Page.Param "version" }}
 <ul>


### PR DESCRIPTION
Although https://k8s.io/docs/home/supported-doc-versions/ looks the way you might expect, https://v1-18.docs.kubernetes.io/docs/home/supported-doc-versions/ shows up wrongly, listing v1.19 as a _previous_ version. This change (targeting _master_, initially) switches from a shortcode to a custom layout with localized text [[preview](https://deploy-preview-23520--kubernetes-io-master-staging.netlify.app/docs/home/supported-doc-versions/)], that highlights both the latest documentation version and the one you're looking at.

Will help with issue #23512 once merged to _master_ and then backported to _release-1.18_.
Fixing older releases (v1.15 to v1.17) would need a slightly different change I think because those predate the switch to Docsy and removal of the `capture` shortcode.