### PR TITLE
Updated ingress.md TLS section

### DIFF
--- a/content/en/docs/concepts/services-networking/ingress.md
+++ b/content/en/docs/concepts/services-networking/ingress.md
@@ -413,6 +413,13 @@ secure the channel from the client to the load balancer using TLS. You need to m
 sure the TLS secret you created came from a certificate that contains a Common
 Name (CN), also known as a Fully Qualified Domain Name (FQDN) for `https-example.foo.com`.
 
+{{< note >}}
+Keep in mind that TLS will not work on the default rule because the
+certificates would have to be issued for all the possible sub-domains. Therefore,
+`hosts` in the `tls` section need to explicitly match the `host` in the `rules`
+section.
+{{< /note >}}
+
 {{< codenew file="service/networking/tls-example-ingress.yaml" >}}
 
 {{< note >}}


### PR DESCRIPTION
I missed the fact that for TLS to work, Ingress resource has to explicitly mention `host` from `rules` part. I thought that the default routing rule ( the one without `host` field ) would work as well. Only recently I realized that the certificates would have to contain all the possible sub-domains to work for default rule. Well, I wish to stop other "not so smart" people from missing that as well. It possibly is mentioned somewhere, but me, nor my colleagues, found it.
