### PR TITLE
Added docs about container resource metric source for HPA

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -288,10 +288,15 @@ In the above example the HPA controller scales the target such that the average 
 in the `application` container of all the pods is 60%.
 
 {{< note >}}
-In case the name of a container targetted by an HPA has to be changed, it is recommended that before
-the deployment the HPA is updated to have both the new and old container names. This way HPA will always
-be able to able to calculate a recommendation for the scaling target. Once the rollout is done the old
-container name can be dropped from the HPA.
+If you change the name of a container that a HorizontalPodAutoscaler is tracking, you can
+make that change in a specific order to ensure scaling remains available and effective
+whilst the change is being applied. Before you update the resource that defines the container
+(such as a Deployment), you should update the associated HPA to track both the new and
+old container names. This way, the HPA is able to calculate a scaling recommendation
+throughout the update process.
+
+Once you have rolled out the container name change to the workload resource, tidy up by removing
+the old container name from the HPA specification.
 {{< /note >}}
 
 ## Support for multiple metrics

--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -266,10 +266,14 @@ pod usage is still within acceptable limits.
 
 {{< feature-state for_k8s_version="v1.20" state="alpha" >}}
 
-The HPA spec also supports a container metric source where the HPA can use the resource usage of
-individual containers to scale the target. The advantage of this approach is that different containers
-in the pod could use different scaling thresholds. However when a new container is added to the pod
-specification the HPA needs to be updated if the newly added container should also be used for
+`HorizontalPodAutoscaler` also supports a container metric source where the HPA can track the
+resource usage of individual containers across a set of Pods, in order to scale the target resource.
+This lets you configure scaling thresholds for the containers that matter most in a particular Pod.
+For example, if you have a web application and a logging sidecar, you can scale based on the resource
+use of the web application, ignoring the sidecar container and its resource use.
+
+If you revise the target resource to have a new Pod specification with a different set of containers,
+you should revise the HPA spec if that newly added container should also be used for
 scaling. If the specified container in the metric source is not present or only present in a subset
 of the pods then those pods are ignored and the recommendation is recalculated. See [Algorithm](#algorithm-details)
 for more details about the calculation. To use container resources for autoscaling define a metric
@@ -506,4 +510,3 @@ behavior:
 * Design documentation: [Horizontal Pod Autoscaling](https://git.k8s.io/community/contributors/design-proposals/autoscaling/horizontal-pod-autoscaler.md).
 * kubectl autoscale command: [kubectl autoscale](/docs/reference/generated/kubectl/kubectl-commands/#autoscale).
 * Usage example of [Horizontal Pod Autoscaler](/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/).
-

--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -237,7 +237,7 @@ usual.
 ## Support for resource metrics
 
 Any HPA target can be scaled based on the resource usage of the pods in the scaling target.
-When definining the pod specification the resource requests like `cpu` and `memory` should
+When defining the pod specification the resource requests like `cpu` and `memory` should
 be specified. This is used to determine the resource utilization and used by the HPA controller
 to scale the target up or down. To use resource utilization based scaling specify a metric source
 like this:


### PR DESCRIPTION
A new metric source going to be added tot the HPA in version 1.20. [PR](https://github.com/kubernetes/kubernetes/pull/90691)
This PR adds a section in the HPA  docs about the new source and how it differs from the existing metric source. 
