### PR TITLE
Fix link color and tab component styles

### DIFF
--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -42,6 +42,10 @@ $video-section-height: 200px;
 
 body {
   background-color: white;
+
+  a {
+    color: $blue;
+  }
 }
 
 section {

--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -20,6 +20,15 @@ $announcement-size-adjustment: 8px;
       padding-top: 2rem !important;
     }
   }
+
+  .ui-widget {
+    font-family: inherit;
+    font-size: inherit;
+  }
+
+  .ui-widget-content a {
+    color: $blue;
+  }
 }
 
 section {


### PR DESCRIPTION
Fixes #23504 as well as:
- Update link style across site to use consistent default color when appropriate (as defined in [/assets/scss/_skin.css#L1](https://github.com/kubernetes/website/blob/94b2f857bbef31cbfd3c8a433d8bb9aa572a4843/assets/scss/_skin.scss#L1))
- Update tab component font styles to match the rest of the document (the current one is inheriting styles from JQuery UI, which is also the cause of #23504)