### PR TITLE
modify link title

### DIFF
--- a/content/ja/docs/tasks/debug-application-cluster/debug-stateful-set.md
+++ b/content/ja/docs/tasks/debug-application-cluster/debug-stateful-set.md
@@ -27,7 +27,7 @@ StatefulSetに属し、ラベル`app=myapp`が設定されているすべてのP
 kubectl get pods -l app=myapp
 ```
 
-Podが長期間`Unknown`または`Terminating`の状態になっていることがわかった場合は、それらを処理する方法について[StatefulSet Podの強制削除](/ja/docs/tasks/run-application/delete-stateful-set/)タスクを参照してください。
+Podが長期間`Unknown`または`Terminating`の状態になっていることがわかった場合は、それらを処理する方法について[StatefulSetの削除](/ja/docs/tasks/run-application/delete-stateful-set/)タスクを参照してください。
 [Podのデバッグ](/docs/tasks/debug-application-cluster/debug-pod-replication-controller/)ガイドを使用して、StatefulSet内の個々のPodをデバッグできます。
 
 


### PR DESCRIPTION
ここで修正してもらっているのは少し違うので直しました。
ややこしいかもしれませんが、削除と強制削除は別ページです。
https://github.com/kubernetes/website/pull/23401#pullrequestreview-477789883

StatefulSetの削除
https://kubernetes.io/ja/docs/tasks/run-application/delete-stateful-set/

StatefulSet Podの強制削除
https://kubernetes.io/ja/docs/tasks/run-application/force-delete-stateful-set-pod/