### PR TITLE
Updating Barnie Makonda's permissions

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -27,7 +27,6 @@ aliases:
     - jimangel
     - kbarnard10
     - kbhawkey
-    - makoscafee
     - onlydole
     - savitharaghunathan
     - sftim
@@ -43,7 +42,6 @@ aliases:
     - jimangel
     - kbarnard10
     - kbhawkey
-    - makoscafee
     - onlydole
     - rajeshdeshpande02
     - sftim


### PR DESCRIPTION
I spoke with @makoscafee and he is busy for the foreseeable future. This PR removes his owner permissions and removes him from the PR Wrangler rotation. (I have updated the PR Wrangler wiki).

This PR helps keep SIG Docs OWNERS_ALIAS file up to date.

@makoscafee is 100% able (and encouraged) to return when his schedule permits. Using this PR as reference, he may request full reinstatement of permissions with a PR.

Thanks @makoscafee's for all of your contributions and I look forward to seeing you again!

/cc @kbarnard10 @zacharysarah 