### PR TITLE
kubeadm reset unmounts /var/lib/kubelet

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
@@ -407,4 +407,12 @@ be advised that this is modifying a design principle of the Linux distribution.
 
 This error message is shown when upgrading a Kubernetes cluster with `kubeadm` in the case of running an external etcd. This is not a critical bug and happens because older versions of kubeadm perform a version check on the external etcd cluster. You can proceed with `kubeadm upgrade apply ...`. 
 
-This issue is fixed as of version 1.19. 
+This issue is fixed as of version 1.19.
+
+## `kubeadm reset` unmounts `/var/lib/kubelet`
+
+If `/var/lib/kubelet` is being mounted, performing a `kubeadm reset` will effectively unmount it.
+
+To workaround the issue, re-mount the `/var/lib/kubelet` directory after performing the `kubeadm reset` operation.
+
+This is a regression introduced in kubeadm 1.15. The issue is fixed in 1.20.


### PR DESCRIPTION
This is to document the behavior of `kubeadm reset` that unmounts `/var/lib/kubelet` (regression since 1.15).

cc: @neolit123 
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

-->
