### PR TITLE
Fix issue with k8s.io/docs/reference/command-line-tools-reference/fea…

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -423,7 +423,7 @@ Each feature gate is designed for enabling/disabling a specific feature:
 - `CustomResourceWebhookConversion`: Enable webhook-based conversion
   on resources created from [CustomResourceDefinition](/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
   troubleshoot a running Pod.
-- `DisableAcceleratorUsageMetrics`: [Disable accelerator metrics collected by the kubelet](/docs/concepts/cluster-administration/monitoring.md).
+- `DisableAcceleratorUsageMetrics`: [Disable accelerator metrics collected by the kubelet](/docs/concepts/cluster-administration/system-metrics/).
 - `DevicePlugins`: Enable the [device-plugins](/docs/concepts/cluster-administration/device-plugins/)
   based resource provisioning on nodes.
 - `DefaultPodTopologySpread`: Enables the use of `PodTopologySpread` scheduling plugin to do
@@ -475,9 +475,6 @@ Each feature gate is designed for enabling/disabling a specific feature:
 - `LegacyNodeRoleBehavior`: When disabled, legacy behavior in service load balancers and node disruption will ignore the `node-role.kubernetes.io/master` label in favor of the feature-specific labels provided by `NodeDisruptionExclusion` and `ServiceNodeExclusion`.
 - `LocalStorageCapacityIsolation`: Enable the consumption of [local ephemeral storage](/docs/concepts/configuration/manage-compute-resources-container/) and also the `sizeLimit` property of an [emptyDir volume](/docs/concepts/storage/volumes/#emptydir).
 - `LocalStorageCapacityIsolationFSQuotaMonitoring`: When `LocalStorageCapacityIsolation` is enabled for [local ephemeral storage](/docs/concepts/configuration/manage-compute-resources-container/) and the backing filesystem for [emptyDir volumes](/docs/concepts/storage/volumes/#emptydir) supports project quotas and they are enabled, use project quotas to monitor [emptyDir volume](/docs/concepts/storage/volumes/#emptydir) storage consumption rather than filesystem walk for better performance and accuracy.
-  [local ephemeral storage](/docs/concepts/configuration/manage-resources-containers/) and the backing filesystem for
-  [emptyDir volumes](/docs/concepts/storage/volumes/#emptydir) supports project quotas and they are enabled, use project quotas to monitor
-  [emptyDir volume](/docs/concepts/storage/volumes/#emptydir) storage consumption rather than filesystem walk for better performance and accuracy.
 - `MountContainers`: Enable using utility containers on host as the volume mounter.
 - `MountPropagation`: Enable sharing volume mounted by one container to other containers or pods.
   For more details, please see [mount propagation](/docs/concepts/storage/volumes/#mount-propagation).


### PR DESCRIPTION
…ture-gates/

Closes #23678 

**Problem:**
Line 426: broken link
\- \`DisableAcceleratorUsageMetrics\`: \[Disable accelerator metrics collected by the kubelet\]\(/docs/concepts/cluster-administration/monitoring.md\).

Line 477: duplicated
\- \`LocalStorageCapacityIsolationFSQuotaMonitoring\`: When \`LocalStorageCapacityIsolation\` is enabled for \[local ephemeral storage\]\(/docs/concepts/configuration/manage-compute-resources-container/) and the backing filesystem for \[emptyDir volumes\]\(/docs/concepts/storage/volumes/#emptydir) supports project quotas and they are enabled, use project quotas to monitor \[emptyDir volume\]\(/docs/concepts/storage/volumes/#emptydir) storage consumption rather than filesystem walk for better performance and accuracy.
  _\[local ephemeral storage\]\(/docs/concepts/configuration/manage-resources-containers/) and the backing filesystem for
  \[emptyDir volumes\]\(/docs/concepts/storage/volumes/#emptydir) supports project quotas and they are enabled, use project quotas to monitor
  \[emptyDir volume\]\(/docs/concepts/storage/volumes/#emptydir) storage consumption rather than filesystem walk for better performance and accuracy._

**Proposed Solution:**

Line 426: 
\- \`DisableAcceleratorUsageMetrics\`: \[Disable accelerator metrics collected by the kubelet\]\(/docs/concepts/cluster-administration/system-metrics/).

Line 477:
\- \`LocalStorageCapacityIsolationFSQuotaMonitoring\`: When \`LocalStorageCapacityIsolation\` is enabled for \[local ephemeral storage\]\(/docs/concepts/configuration/manage-compute-resources-container/) and the backing filesystem for \[emptyDir volumes\]\(/docs/concepts/storage/volumes/#emptydir) supports project quotas and they are enabled, use project quotas to monitor \[emptyDir volume\]\(/docs/concepts/storage/volumes/#emptydir) storage consumption rather than filesystem walk for better performance and accuracy.

**Page to Update:**
https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/