### PR TITLE
fix translation for "such as"

### DIFF
--- a/content/ja/docs/concepts/overview/working-with-objects/namespaces.md
+++ b/content/ja/docs/concepts/overview/working-with-objects/namespaces.md
@@ -79,7 +79,7 @@ kubectl config view --minify | grep namespace:
 
 ユーザーが[Service](/ja/docs/concepts/services-networking/service/)を作成するとき、Serviceは対応する[DNSエントリ](/ja/docs/concepts/services-networking/dns-pod-service/)を作成します。
 このエントリは`<service-name>.<namespace-name>.svc.cluster.local`という形式になり、これはもしあるコンテナがただ`<service-name>`を指定していた場合、Namespace内のローカルのServiceに対して名前解決されます。
-これはデベロップメント、ステージング、プロダクションといって複数のNamespaceをまたいで同じ設定を使う時に効果的です。
+これはデベロップメント、ステージング、プロダクションといった複数のNamespaceをまたいで同じ設定を使う時に効果的です。
 もしユーザーがNamespaceをまたいでアクセスしたい時、 完全修飾ドメイン名(FQDN)を指定する必要があります。
 
 ## すべてのオブジェクトはNamespaceに属しているとは限らない


### PR DESCRIPTION
In the context, "Development, Staging and Production" is example, so I think "といった" is appropriate.
