### PR TITLE
Fix false Object in persistentVolumeClaim explanation

### DIFF
--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -756,8 +756,8 @@ See the [NFS example](https://github.com/kubernetes/examples/tree/{{< param "git
 ### persistentVolumeClaim {#persistentvolumeclaim}
 
 A `persistentVolumeClaim` volume is used to mount a
-[PersistentVolume](/docs/concepts/storage/persistent-volumes/) into a Pod.  PersistentVolumes are a
-way for users to "claim" durable storage (such as a GCE PersistentDisk or an
+[PersistentVolume](/docs/concepts/storage/persistent-volumes/) into a Pod. PersistentVolumeClaims
+are a way for users to "claim" durable storage (such as a GCE PersistentDisk or an
 iSCSI volume) without knowing the details of the particular cloud environment.
 
 See the [PersistentVolumes example](/docs/concepts/storage/persistent-volumes/) for more


### PR DESCRIPTION
The [persistentVolumeClaim explanation](https://kubernetes.io/docs/concepts/storage/volumes/#persistentvolumeclaim) was contradictory. I've changed it, since PersistentVolumeClaims are an abstraction layer for PersistentVolumes, which in turn _"capture[..] the details of the implementation of the storage"_.
