### PR TITLE
Updating readme files to use the right make functions for build and serve

### DIFF
--- a/README-de.md
+++ b/README-de.md
@@ -40,13 +40,13 @@ Um die Kubernetes-Website lokal laufen zu lassen, empfiehlt es sich, ein speziel
 Wenn Sie Docker [installiert](https://www.docker.com/get-started) haben, erstellen Sie das Docker-Image `kubernetes-hugo` lokal:
 
 ```bash
-make docker-image
+make container-image
 ```
 
 Nachdem das Image erstellt wurde, können Sie die Site lokal ausführen:
 
 ```bash
-make docker-serve
+make container-serve
 ```
 
 Öffnen Sie Ihren Browser unter http://localhost:1313, um die Site anzuzeigen. Wenn Sie Änderungen an den Quelldateien vornehmen, aktualisiert Hugo die Site und erzwingt eine Browseraktualisierung.

--- a/README-es.md
+++ b/README-es.md
@@ -33,13 +33,13 @@ El método recomendado para levantar una copia local del sitio web kubernetes.io
 Una vez tenga Docker [configurado en su máquina](https://www.docker.com/get-started), puede construir la imagen de Docker `kubernetes-hugo` localmente ejecutando el siguiente comando en la raíz del repositorio:
 
 ```bash
-make docker-image
+make container-image
 ```
 
 Una vez tenga la imagen construida, puede levantar el sitio web ejecutando:
 
 ```bash
-make docker-serve
+make container-serve
 ```
 
 Abra su navegador y visite http://localhost:1313 para acceder a su copia local del sitio. A medida que vaya haciendo cambios en el código fuente, Hugo irá actualizando la página y forzará la actualización en el navegador.

--- a/README-fr.md
+++ b/README-fr.md
@@ -38,13 +38,13 @@ La façon recommandée d'exécuter le site web Kubernetes localement est d'utili
 Si vous avez Docker [up and running](https://www.docker.com/get-started), construisez l'image Docker `kubernetes-hugo' localement:
 
 ```bash
-make docker-image
+make container-image
 ```
 
 Une fois l'image construite, vous pouvez exécuter le site localement :
 
 ```bash
-make docker-serve
+make container-serve
 ```
 
 Ouvrez votre navigateur à l'adresse: http://localhost:1313 pour voir le site.

--- a/README-hi.md
+++ b/README-hi.md
@@ -41,13 +41,13 @@
 यदि आप [डॉकर](https://www.docker.com/get-started) चला रहे हैं, तो स्थानीय रूप से `कुबेरनेट्स-ह्यूगो` Docker image बनाएँ:
 
 ```bash
-make docker-image
+make container-image
 ```
 
 एक बार image बन जाने के बाद, आप साइट को स्थानीय रूप से चला सकते हैं:
 
 ```bash
-make docker-serve
+make container-serve
 ```
 
 साइट देखने के लिए अपने browser को `http://localhost:1313` पर खोलें। जैसा कि आप source फ़ाइलों में परिवर्तन करते हैं, Hugo साइट को अपडेट करता है और browser को refresh करने पर मजबूर करता है।

--- a/README-id.md
+++ b/README-id.md
@@ -30,13 +30,13 @@ Petunjuk yang disarankan untuk menjalankan Dokumentasi Kubernetes pada mesin lok
 Jika kamu sudah memiliki **Docker** [yang sudah dapat digunakan](https://www.docker.com/get-started), kamu dapat melakukan **build** `kubernetes-hugo` **Docker image** secara lokal:
 
 ```bash
-make docker-image
+make container-image
 ```
 
 Setelah **image** berhasil di-**build**, kamu dapat menjalankan website tersebut pada mesin lokal-mu:
 
 ```bash
-make docker-serve
+make container-serve
 ```
 
 Buka **browser** kamu ke http://localhost:1313 untuk melihat laman dokumentasi. Selama kamu melakukan penambahan konten, **Hugo** akan secara otomatis melakukan perubahan terhadap laman dokumentasi apabila **browser** melakukan proses **refresh**.

--- a/README-it.md
+++ b/README-it.md
@@ -30,13 +30,13 @@ Il modo consigliato per eseguire localmente il sito Web Kubernetes prevede l'uti
 Se hai Docker [attivo e funzionante](https://www.docker.com/get-started), crea l'immagine Docker `kubernetes-hugo` localmente:
 
 ```bash
-make docker-image
+make container-image
 ```
 
 Dopo aver creato l'immagine, è possibile eseguire il sito Web localmente:
 
 ```bash
-make docker-serve
+make container-serve
 ```
 
 Apri il tuo browser su http://localhost:1313 per visualizzare il sito Web. Mentre modifichi i file sorgenti, Hugo aggiorna automaticamente il sito Web e forza un aggiornamento della pagina visualizzata nel browser.

--- a/README-ko.md
+++ b/README-ko.md
@@ -41,13 +41,13 @@
 도커 [동작 및 실행](https://www.docker.com/get-started) 환경이 있는 경우, 로컬에서 `kubernetes-hugo` 도커 이미지를 빌드 합니다:
 
 ```bash
-make docker-image
+make container-image
 ```
 
 해당 이미지가 빌드 된 이후, 사이트를 로컬에서 실행할 수 있습니다:
 
 ```bash
-make docker-serve
+make container-serve
 ```
 
 브라우저에서 http://localhost:1313 를 열어 사이트를 살펴봅니다. 소스 파일에 변경 사항이 있을 때, Hugo는 사이트를 업데이트하고 브라우저를 강제로 새로고침합니다.

--- a/README-pl.md
+++ b/README-pl.md
@@ -49,13 +49,13 @@ choco install make
 Jeśli [zainstalowałeś i uruchomiłeś](https://www.docker.com/get-started) już Dockera, zbuduj obraz `kubernetes-hugo` lokalnie:
 
 ```bash
-make docker-image
+make container-image
 ```
 
 Po zbudowaniu obrazu, możesz uruchomić serwis lokalnie:
 
 ```bash
-make docker-serve
+make container-serve
 ```
 
 Aby obejrzeć zawartość serwisu otwórz w przeglądarce adres http://localhost:1313. Po każdej zmianie plików źródłowych, Hugo automatycznie aktualizuje stronę i odświeża jej widok w przeglądarce.

--- a/README-pt.md
+++ b/README-pt.md
@@ -35,13 +35,13 @@ A maneira recomendada de executar o site do Kubernetes localmente é executar um
 Se você tiver o Docker [em funcionamento](https://www.docker.com/get-started), crie a imagem do Docker do `kubernetes-hugo` localmente:
 
 ```bash
-make docker-image
+make container-image
 ```
 
 Depois que a imagem foi criada, você pode executar o site localmente:
 
 ```bash
-make docker-serve
+make container-serve
 ```
 
 Abra seu navegador para http://localhost:1313 para visualizar o site. Conforme você faz alterações nos arquivos de origem, Hugo atualiza o site e força a atualização do navegador.

--- a/README-vi.md
+++ b/README-vi.md
@@ -31,13 +31,13 @@ Cách được đề xuất để chạy trang web Kubernetes cục bộ là dù
 Nếu bạn có Docker đang [up và running](https://www.docker.com/get-started), build `kubernetes-hugo` Docker image cục bộ:
 
 ```bash
-make docker-image
+make container-image
 ```
 
 Khi image đã được built, bạn có thể chạy website cục bộ:
 
 ```bash
-make docker-serve
+make container-serve
 ```
 
 Mở trình duyệt và đến địa chỉ http://localhost:1313 để xem website. Khi bạn thay đổi các file nguồn, Hugo cập nhật website và buộc làm mới trình duyệt.


### PR DESCRIPTION
Hello,

this pull requests updates the readme files to use `container-image` and `container-serve` instead of `docker-image` and `docker-serve` for building the docker image and serving the content.

The docker-image and docker-serve are **deprecated** according `Makefile` line **50** and **58**.

Cheers Lars.
