### PR TITLE
Limited resources in quota when scoped for priority class.

### DIFF
--- a/content/en/docs/concepts/policy/resource-quotas.md
+++ b/content/en/docs/concepts/policy/resource-quotas.md
@@ -208,6 +208,19 @@ field in the quota spec.
 
 A quota is matched and consumed only if `scopeSelector` in the quota spec selects the pod.
 
+When quota is scoped for priority class using `scopeSelector` field, quota object is restricted to track only following resources:
+
+* `pods`
+* `cpu`
+* `memory`
+* `ephemeral-storage`
+* `limits.cpu`
+* `limits.memory`
+* `limits.ephemeral-storage`
+* `requests.cpu`
+* `requests.memory`
+* `requests.ephemeral-storage`
+
 This example creates a quota object and matches it with pods at specific priorities. The example
 works as follows:
 


### PR DESCRIPTION

This PR brings in documentation around small but important limitation of resource quota object scoped for  priority class.
When quota object is created for priority class, we only enforce limited set of resources. This PR lists those resources.

If quota object is created with priority class scope, k8s has no validation around allowed resources. Eventually the quota object gets created but resources not in the above list will never be enforced and counted towards usage.


Github issue: https://github.com/kubernetes/website/issues/23626