### PR TITLE
[docs] fix client-go example

### DIFF
--- a/content/en/docs/tasks/administer-cluster/access-cluster-api.md
+++ b/content/en/docs/tasks/administer-cluster/access-cluster-api.md
@@ -171,6 +171,8 @@ The Go client can use the same [kubeconfig file](/docs/concepts/configuration/or
 as the kubectl CLI does to locate and authenticate to the API server. See this [example](https://git.k8s.io/client-go/examples/out-of-cluster-client-configuration/main.go):
 
 ```golang
+package main
+
 import (
   "fmt"
   "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/content/en/docs/tasks/administer-cluster/access-cluster-api.md
+++ b/content/en/docs/tasks/administer-cluster/access-cluster-api.md
@@ -174,6 +174,7 @@ as the kubectl CLI does to locate and authenticate to the API server. See this [
 package main
 
 import (
+  "context"
   "fmt"
   "k8s.io/apimachinery/pkg/apis/meta/v1"
   "k8s.io/client-go/kubernetes"
@@ -187,7 +188,7 @@ func main() {
   // creates the clientset
   clientset, _ := kubernetes.NewForConfig(config)
   // access the API to list pods
-  pods, _ := clientset.CoreV1().Pods("").List(v1.ListOptions{})
+  pods, _ := clientset.CoreV1().Pods("").List(context.TODO(), v1.ListOptions{})
   fmt.Printf("There are %d pods in the cluster\n", len(pods.Items))
 }
 ```

--- a/content/ko/docs/tasks/administer-cluster/access-cluster-api.md
+++ b/content/ko/docs/tasks/administer-cluster/access-cluster-api.md
@@ -177,6 +177,7 @@ Go 클라이언트는 kubectl CLI가 API 서버를 찾아 인증하기 위해 �
 package main
 
 import (
+  "context"
   "fmt"
   "k8s.io/apimachinery/pkg/apis/meta/v1"
   "k8s.io/client-go/kubernetes"
@@ -190,7 +191,7 @@ func main() {
   // clientset을 생성한다
   clientset, _ := kubernetes.NewForConfig(config)
   // 파드를 나열하기 위해 API에 접근한다
-  pods, _ := clientset.CoreV1().Pods("").List(v1.ListOptions{})
+  pods, _ := clientset.CoreV1().Pods("").List(context.TODO(), v1.ListOptions{})
   fmt.Printf("There are %d pods in the cluster\n", len(pods.Items))
 }
 ```

--- a/content/ko/docs/tasks/administer-cluster/access-cluster-api.md
+++ b/content/ko/docs/tasks/administer-cluster/access-cluster-api.md
@@ -174,6 +174,8 @@ Go 클라이언트는 kubectl CLI가 API 서버를 찾아 인증하기 위해 �
 사용할 수 있다. 이 [예제](https://git.k8s.io/client-go/examples/out-of-cluster-client-configuration/main.go)를 참고한다.
 
 ```golang
+package main
+
 import (
   "fmt"
   "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/content/zh/docs/tasks/administer-cluster/access-cluster-api.md
+++ b/content/zh/docs/tasks/administer-cluster/access-cluster-api.md
@@ -277,6 +277,8 @@ Go 客户端可以使用与 kubectl 命令行工具相同的
 [例子](https://git.k8s.io/client-go/examples/out-of-cluster-client-configuration/main.go)：
 
 ```golang
+package main
+
 import (
    "fmt"
    "k8s.io/client-go/1.4/kubernetes"

--- a/content/zh/docs/tasks/administer-cluster/access-cluster-api.md
+++ b/content/zh/docs/tasks/administer-cluster/access-cluster-api.md
@@ -282,9 +282,9 @@ package main
 import (
    "context"
    "fmt"
-   "k8s.io/client-go/1.4/kubernetes"
-   "k8s.io/client-go/1.4/pkg/api/v1"
-   "k8s.io/client-go/1.4/tools/clientcmd"
+   "k8s.io/apimachinery/pkg/apis/meta/v1"
+   "k8s.io/client-go/kubernetes"
+   "k8s.io/client-go/tools/clientcmd"
 )
 
 func main() {

--- a/content/zh/docs/tasks/administer-cluster/access-cluster-api.md
+++ b/content/zh/docs/tasks/administer-cluster/access-cluster-api.md
@@ -280,6 +280,7 @@ Go 客户端可以使用与 kubectl 命令行工具相同的
 package main
 
 import (
+   "context"
    "fmt"
    "k8s.io/client-go/1.4/kubernetes"
    "k8s.io/client-go/1.4/pkg/api/v1"
@@ -293,7 +294,7 @@ func main() {
   // creates the clientset
   clientset, _ := kubernetes.NewForConfig(config)
   // access the API to list pods
-  pods, _ := clientset.CoreV1().Pods("").List(v1.ListOptions{})
+  pods, _ := clientset.CoreV1().Pods("").List(context.TODO(), v1.ListOptions{})
   fmt.Printf("There are %d pods in the cluster\n", len(pods.Items))
 }
 ```


### PR DESCRIPTION
- [en]: Add package main to client-go example 
- [ko]: Add package main to client-go example
- [zh]: Add package main to client-go example 
- [en]: add missing context module for the go example
- [ko]: add missing context module for the go example
- [zh]: add missing context module for the go example
- [zh] fix import examples for the client-go