### PR TITLE
Fix incorrect guidance on enabling EventRateLimit

### DIFF
--- a/content/en/docs/reference/access-authn-authz/admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/admission-controllers.md
@@ -202,8 +202,6 @@ is recommended instead.
 This admission controller mitigates the problem where the API server gets flooded by
 event requests. The cluster admin can specify event rate limits by:
 
- * Ensuring that `eventratelimit.admission.k8s.io/v1alpha1=true` is included in the
-   `--runtime-config` flag for the API server;
  * Enabling the `EventRateLimit` admission controller;
  * Referencing an `EventRateLimit` configuration file from the file provided to the API
    server's command line flag `--admission-control-config-file`:


### PR DESCRIPTION
As highlighted by @liggitt [here](https://github.com/kubernetes/kubernetes/issues/62861#issuecomment-422901400), it is not necessary to set `--runtime-config` for this admission controller.

In fact, doing so makes the api-server to not start, as highlighted by a couple of users in this issues: (
https://github.com/kubernetes/kubernetes/issues/62861 https://github.com/kubernetes/kubernetes/issues/57030)

I have tested this new guidance on v1.19 and it works as desired.