### PR TITLE
Change links for localized tutorials in Polish

### DIFF
--- a/content/pl/docs/tutorials/_index.md
+++ b/content/pl/docs/tutorials/_index.md
@@ -18,11 +18,11 @@ Przed zapoznaniem się z samouczkami warto stworzyć zakładkę do
 
 ## Podstawy
 
-* [Podstawy Kubernetes](/docs/tutorials/kubernetes-basics/) to interaktywny samouczek, który pomoże zrozumieć system Kubernetes i wypróbować jego podstawowe możliwości.
+* [Podstawy Kubernetesa (PL)](/pl/docs/tutorials/kubernetes-basics/) to interaktywny samouczek, który pomoże zrozumieć system Kubernetes i wypróbować jego podstawowe możliwości.
 
 * [Introduction to Kubernetes (edX)](https://www.edx.org/course/introduction-kubernetes-linuxfoundationx-lfs158x#)
 
-* [Hello Minikube](/docs/tutorials/hello-minikube/)
+* [Hello Minikube (PL)](/pl/docs/tutorials/hello-minikube/)
 
 ## Konfiguracja
 

--- a/content/pl/docs/tutorials/kubernetes-basics/_index.html
+++ b/content/pl/docs/tutorials/kubernetes-basics/_index.html
@@ -1,6 +1,6 @@
 ---
 title: Naucz się podstaw
-linkTitle: Podstawy Kubernetes
+linkTitle: Podstawy Kubernetesa
 weight: 10
 card:
   name: tutorials
@@ -22,7 +22,7 @@ card:
 
     <div class="row">
       <div class="col-md-9">
-        <h2>Podstawy Kubernetes</h2>
+        <h2>Podstawy Kubernetesa</h2>
         <p>Ten samouczek poprowadzi Cię przez podstawy systemu zarządzania zadaniami na klastrze Kubernetes. W każdym module znajdziesz najważniejsze informacje o głównych pojęciach i funkcjonalnościach Kubernetes oraz interaktywny samouczek online. Dzięki samouczkom nauczysz się zarządzać prostym klasterem i skonteneryzowanymi aplikacjami uruchamianymi na tym klastrze.</p>
         <p>Nauczysz się, jak:</p>
         <ul>


### PR DESCRIPTION
Localized links in a page body are not automatically detected/created. Thus this manual change.
