### PR TITLE
Redirect to correct 1.19 release blog date

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -20,6 +20,7 @@
 /vi/docs/     /vi/docs/home/ 301!
 /zh/docs/     /zh/docs/home/ 301!
 /blog/2018/03/kubernetes-1.10-stabilizing-storage-security-networking/     /blog/2018/03/26/kubernetes-1.10-stabilizing-storage-security-networking/     301!
+/blog/2020/08/25/kubernetes-release-1.19-accentuate-the-paw-sitive/     /blog/2020/08/26/kubernetes-release-1.19-accentuate-the-paw-sitive/     301!
 /docs/admin/     /docs/concepts/cluster-administration/ 301
 /docs/admin/add-ons/     /docs/concepts/cluster-administration/addons/ 301
 /docs/admin/addons/     /docs/concepts/cluster-administration/addons/ 301


### PR DESCRIPTION
Resolves a 404 in an uneditable link from the official project twitter account: https://twitter.com/kubernetesio/status/1298722760189833220