### PR TITLE
Update Kubespray page

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubespray.md
+++ b/content/en/docs/setup/production-environment/tools/kubespray.md
@@ -13,12 +13,13 @@ Kubespray is a composition of [Ansible](https://docs.ansible.com/) playbooks, [i
 * a highly available cluster
 * composable attributes
 * support for most popular Linux distributions
-  * Container Linux by CoreOS
+  * Ubuntu 16.04, 18.04, 20.04
+  * CentOS/RHEL/Oracle Linux 7, 8
   * Debian Buster, Jessie, Stretch, Wheezy
-  * Ubuntu 16.04, 18.04
-  * CentOS/RHEL/Oracle Linux 7
-  * Fedora 28
+  * Fedora 31, 32
+  * Fedora CoreOS
   * openSUSE Leap 15
+  * Flatcar Container Linux by Kinvolk
 * continuous integration tests
 
 To choose a tool which best fits your use case, read [this comparison](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/comparisons.md) to
@@ -32,8 +33,8 @@ To choose a tool which best fits your use case, read [this comparison](https://g
 
 Provision servers with the following [requirements](https://github.com/kubernetes-sigs/kubespray#requirements):
 
-* **Ansible v2.7.8 and python-netaddr is installed on the machine that will run Ansible commands**
-* **Jinja 2.9 (or newer) is required to run the Ansible Playbooks**
+* **Ansible v2.9 and python-netaddr is installed on the machine that will run Ansible commands**
+* **Jinja 2.11 (or newer) is required to run the Ansible Playbooks**
 * The target servers must have access to the Internet in order to pull docker images. Otherwise, additional configuration is required ([See Offline Environment](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/offline-environment.md))
 * The target servers are configured to allow **IPv4 forwarding**
 * **Your ssh key must be copied** to all the servers part of your inventory


### PR DESCRIPTION
Update the Kubespray page.

Latest release dropped support for CoreOS but added Oracle Linux 8, Ubuntu 20.04 etc...

See https://github.com/kubernetes-sigs/kubespray/ for more info.