### PR TITLE
[id] Fix typo on Web UI (Dashboard)

### DIFF
--- a/content/id/docs/tasks/access-application-cluster/web-ui-dashboard.md
+++ b/content/id/docs/tasks/access-application-cluster/web-ui-dashboard.md
@@ -94,11 +94,11 @@ Jika membutuhkan, kamu dapat membuka bagian **Advanced options** di mana kamu da
   Contoh:
 
   ```conf
-release=1.0
-tier=frontend
-environment=pod
-track=stable
-```
+  release=1.0
+  tier=frontend
+  environment=pod
+  track=stable
+  ```
 
 - **_Namespace_**: Kubernetes mendukung beberapa klaster virtual yang berjalan di atas klaster fisik yang sama. Klaster virtual ini disebut [Namespace](/docs/tasks/administer-cluster/namespaces/). Mereka mengizinkan kamu untuk mempartisi sumber daya ke beberapa grup yang diberi nama secara logis.
 


### PR DESCRIPTION
Fix typo that causes the "Web UI (Dashboard)" article not rendered properly in Bahasa Indonesia

/language id