### PR TITLE
Clean up case study images in content/pt/case-studies

### DIFF
--- a/content/pt/case-studies/chinaunicom/index.html
+++ b/content/pt/case-studies/chinaunicom/index.html
@@ -12,7 +12,7 @@ quote: >
    O Kubernetes melhorou nossa experiência usando a infraestrutura de nuvem. Atualmente, não há tecnologia alternativa que possa substituí-lo.
 ---
 
-<div class="banner1" style="background-image: url('/images/CaseStudy_chinaunicom_banner1.jpg')">
+<div class="banner1" style="background-image: url('/images/case-studies/chinaunicom/banner1.jpg')">
   <h1> ESTUDO DE CASO:<img src="/images/chinaunicom_logo.png" class="header_logo" style="width:25%;margin-bottom:-1%"><br> <div class="subhead" style="margin-top:1%;line-height:1.4em">China Unicom: Como o Kubernetes alavancou a utilização de recursos, aumentando sua eficiência operacional e menores custos em TI
 
 </div></h1>
@@ -55,7 +55,7 @@ quote: >
 
 </div>
 </section>
-<div class="banner3" style="background-image: url('/images/CaseStudy_chinaunicom_banner3.jpg');width:100%;padding-left:0;">
+<div class="banner3" style="background-image: url('/images/case-studies/chinaunicom/banner3.jpg');width:100%;padding-left:0;">
   <div class="banner3text">
     "Nós nunca poderíamos imaginar que alcançaríamos essa escalabilidade em tão pouco tempo."<br style="height:25px"><span style="font-size:14px;letter-spacing:2px;text-transform:uppercase;margin-top:5% !important;"><br>- Chengyu Zhang, Líder do Grupo de Tecnologia de Plataforma de Pesquisa e Desenvolvimento, China Unicom</span>
 
@@ -68,7 +68,7 @@ quote: >
   "O Kubernetes melhorou nossa experiência usando a infraestrutura de nuvem", diz Zhang. "Atualmente, não há tecnologia alternativa que possa substituí-lo."
 </div>
 </section>
-<div class="banner4" style="background-image: url('/images/CaseStudy_chinaunicom_banner4.jpg');width:100%">
+<div class="banner4" style="background-image: url('/images/case-studies/chinaunicom/banner4.jpg');width:100%">
   <div class="banner4text">
     "Essa tecnologia é relativamente complicada, mas quando os desenvolvedores se acostumarem, eles poderão desfrutar de todos os benefícios." <br style="height:25px"> <span style = "font-size: 14px; letter-spacing: 2px; text-transform: uppercase; margin-top: 5%! important;"> <br> - Jie Jia , Membro da Plataforma de Tecnologia de I & D, China Unicom </ span>
   </div>


### PR DESCRIPTION
Fix broken images in case study pages, part of #22086 as a follow up from #22636 for PT.

/kind cleanup
/area web-development