### PR TITLE
Update Japanese localization on tutorials/stateful-application/mysql-…

### DIFF
--- a/content/ja/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
+++ b/content/ja/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
@@ -188,8 +188,8 @@ kubectl apply -k ./
       結果は次のようになるはずです。
 
       ```
-      NAME        TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)        AGE
-      wordpress   ClusterIP   10.0.0.89    <pending>     80:32406/TCP   4m
+      NAME        TYPE            CLUSTER-IP   EXTERNAL-IP   PORT(S)        AGE
+      wordpress   LoadBalancer    10.0.0.89    <pending>     80:32406/TCP   4m
       ```
 
       {{< note >}}


### PR DESCRIPTION
**What this PR does / why we need it:**
content/ja/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md is outdated.

File to update
https://github.com/kubernetes/website/blob/dev-1.18-ja.1/content/ja/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md

Original
https://github.com/kubernetes/website/blob/fb6364d/content/en/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md

diff between translated and v1.18
https://gist.github.com/b098655f7e7e2409f4d6b6119e78a918

**Which issue(s) this PR fixes:**
#23320 

**Special notes for your reviewer:**
None