### PR TITLE
adjust table margin bottom

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -11,11 +11,6 @@ $announcement-size-adjustment: 8px;
       max-width: 100%;
     }
 
-    table {
-      margin-bottom: 1rem;
-      display: initial;
-    }
-
     @media only screen and (min-width: 768px) {
       padding-top: 2rem !important;
     }


### PR DESCRIPTION
Remove td-main table custom margin settings.
There is inadequate spacing between text that immediately follows a table element.