### PR TITLE
Fix for 23732

### DIFF
--- a/content/en/docs/concepts/configuration/configmap.md
+++ b/content/en/docs/concepts/configuration/configmap.md
@@ -212,7 +212,8 @@ As a result, the total delay from the moment when the ConfigMap is updated to th
 when new keys are projected to the Pod can be as long as the kubelet sync period + cache
 propagation delay, where the cache propagation delay depends on the chosen cache type
 (it equals to watch propagation delay, ttl of cache, or zero correspondingly).
-
+{{< note >}}
+ConfigMaps consumed as environment variables are not updated automatically and require a pod restart. 
 ## Immutable ConfigMaps {#configmap-immutable}
 
 {{< feature-state for_k8s_version="v1.19" state="beta" >}}

--- a/content/en/docs/concepts/configuration/configmap.md
+++ b/content/en/docs/concepts/configuration/configmap.md
@@ -212,7 +212,7 @@ As a result, the total delay from the moment when the ConfigMap is updated to th
 when new keys are projected to the Pod can be as long as the kubelet sync period + cache
 propagation delay, where the cache propagation delay depends on the chosen cache type
 (it equals to watch propagation delay, ttl of cache, or zero correspondingly).
-{{< note >}}
+
 ConfigMaps consumed as environment variables are not updated automatically and require a pod restart. 
 ## Immutable ConfigMaps {#configmap-immutable}
 


### PR DESCRIPTION
Explicitly specify that consumed as environment variables  require pod restart to refresh.
https://github.com/kubernetes/website/issues/23732
