### PR TITLE
remove wrong example of 'kubectl create deployment'

### DIFF
--- a/static/docs/reference/generated/kubectl/kubectl-commands.html
+++ b/static/docs/reference/generated/kubectl/kubectl-commands.html
@@ -566,11 +566,6 @@ inspect them.</p>
 <pre class="code-block example"><code class="lang-shell">kubectl create deployment <span class="hljs-keyword">my</span>-dep <span class="hljs-comment">--image=busybox</span>
 </code></pre>
 <blockquote class="code-block example">
-<p> Create a deployment with command</p>
-</blockquote>
-<pre class="code-block example"><code class="lang-shell">kubectl create deployment <span class="hljs-keyword">my</span>-dep <span class="hljs-comment">--image=busybox -- date</span>
-</code></pre>
-<blockquote class="code-block example">
 <p> Create a deployment named my-dep that runs the nginx image with 3 replicas.</p>
 </blockquote>
 <pre class="code-block example"><code class="lang-shell">kubectl create deployment my-dep <span class="hljs-attribute">--image</span>=nginx <span class="hljs-attribute">--replicas</span>=3


### PR DESCRIPTION
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

-->

https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#-em-deployment-em-

Please check https://github.com/kubernetes/kubernetes/issues/94755#issuecomment-691776837 for more info.

```
[root@master-dce3 ~]# kubectl create deployment my-dep --image=busybox --help
Create a deployment with the specified name.

Aliases:
deployment, deploy

Examples:
  # Create a new deployment named my-dep that runs the busybox image.
  kubectl create deployment my-dep --image=busybox

Options:
      --allow-missing-template-keys=true: If true, ignore any errors in templates when a field or map key is missing in
the template. Only applies to golang and jsonpath output formats.
      --dry-run='none': Must be "none", "server", or "client". If client strategy, only print the object that would be
sent, without sending it. If server strategy, submit server-side request without persisting the resource.
      --image=[]: Image name to run.
  -o, --output='': Output format. One of:
json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-file.
      --save-config=false: If true, the configuration of current object will be saved in its annotation. Otherwise, the
annotation will be unchanged. This flag is useful when you want to perform kubectl apply on this object in the future.
      --template='': Template string or path to template file to use when -o=go-template, -o=go-template-file. The
template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
      --validate=true: If true, use a schema to validate the input before sending it

Usage:
  kubectl create deployment NAME --image=image [--dry-run=server|client|none] [options]

Use "kubectl options" for a list of global command-line options (applies to all commands).
```

