### PR TITLE
ja: Make docs/concepts/overview/working-with-objects/field-selectors.md follow v1.18 of the original text

### DIFF
--- a/content/ja/docs/concepts/overview/working-with-objects/field-selectors.md
+++ b/content/ja/docs/concepts/overview/working-with-objects/field-selectors.md
@@ -17,7 +17,7 @@ kubectl get pods --field-selector status.phase=Running
 ```
 
 {{< note >}}
-フィールドセレクターは本質的にリソースの _フィルター_ となります。デフォルトでは、セレクター/フィルターが指定されていない場合は、全てのタイプのリソースが取得されます。これは、以下の2つの`kubectl`クエリ`kubectl get pods`と`kubectl get pods --field-selector ""`が同じであることを意味します。  
+フィールドセレクターは本質的にリソースの _フィルター_ となります。デフォルトでは、セレクター/フィルターが指定されていない場合は、全てのタイプのリソースが取得されます。これは、`kubectl`クエリの`kubectl get pods`と`kubectl get pods --field-selector ""`が同じであることを意味します。  
 {{< /note >}}
 
 ## サポートされているフィールド

--- a/content/ja/docs/concepts/overview/working-with-objects/field-selectors.md
+++ b/content/ja/docs/concepts/overview/working-with-objects/field-selectors.md
@@ -17,12 +17,7 @@ kubectl get pods --field-selector status.phase=Running
 ```
 
 {{< note >}}
-フィールドセレクターは本質的にリソースの _フィルター_ となります。デフォルトでは、セレクター/フィルターが指定されていない場合は、全てのタイプのリソースが取得されます。これは、下記の2つの`kubectl`クエリが同じであることを意味します。  
-
-```shell
-kubectl get pods
-kubectl get pods --field-selector ""
-```
+フィールドセレクターは本質的にリソースの _フィルター_ となります。デフォルトでは、セレクター/フィルターが指定されていない場合は、全てのタイプのリソースが取得されます。これは、以下の2つの`kubectl`クエリ`kubectl get pods`と`kubectl get pods --field-selector ""`が同じであることを意味します。  
 {{< /note >}}
 
 ## サポートされているフィールド


### PR DESCRIPTION
updated japanese docs/concepts/overview/working-with-objects/field-selectors.md to follow v1.18 of the original text.
This fixes #23610 .