### PR TITLE
Fix "visible" translation in static-pod.md

### DIFF
--- a/content/zh/docs/tasks/configure-pod-container/static-pod.md
+++ b/content/zh/docs/tasks/configure-pod-container/static-pod.md
@@ -39,7 +39,7 @@ instead.
 
 kubelet 会尝试通过 Kubernetes API 服务器为每个静态 Pod 自动创建一个
 {{< glossary_tooltip text="镜像 Pod" term_id="mirror-pod" >}}。
-这意味着节点上运行的静态 Pod 对 API 服务来说是不可见的，但是不能通过 API 服务器来控制。
+这意味着节点上运行的静态 Pod 对 API 服务来说是可见的，但是不能通过 API 服务器来控制。
 
 {{< note >}}
 如果你在运行一个 Kubernetes 集群，并且在每个节点上都运行一个静态 Pod，


### PR DESCRIPTION
The translation of visible is wrong in the Chinese document, easily misleading

