### PR TITLE
Update docs for ServiceAccountIssuerDiscovery beta

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -142,7 +142,8 @@ different Kubernetes components.
 | `ServiceAppProtocol` | `true` | Beta | 1.19 | |
 | `ServerSideApply` | `false` | Alpha | 1.14 | 1.15 |
 | `ServerSideApply` | `true` | Beta | 1.16 | |
-| `ServiceAccountIssuerDiscovery` | `false` | Alpha | 1.18 | |
+| `ServiceAccountIssuerDiscovery` | `false` | Alpha | 1.18 | 1.19 |
+| `ServiceAccountIssuerDiscovery` | `true` | Beta | 1.20 | |
 | `ServiceAppProtocol` | `false` | Alpha | 1.18 | |
 | `ServiceNodeExclusion` | `false` | Alpha | 1.8 | 1.18 |
 | `ServiceNodeExclusion` | `true` | Beta | 1.19 | |

--- a/content/en/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-service-account.md
@@ -324,7 +324,7 @@ The application is responsible for reloading the token when it rotates. Periodic
 
 ## Service Account Issuer Discovery
 
-{{< feature-state for_k8s_version="v1.18" state="alpha" >}}
+{{< feature-state for_k8s_version="v1.20" state="beta" >}}
 
 The Service Account Issuer Discovery feature is enabled by enabling the
 `ServiceAccountIssuerDiscovery` [feature gate](/docs/reference/command-line-tools-reference/feature-gates)


### PR DESCRIPTION
ServiceAccountIssuerDiscovery is going beta in 1.20.
This updates the feature status in docs.

Enhancement: https://github.com/kubernetes/enhancements/issues/1393

This PR replaces: https://github.com/kubernetes/website/pull/21593
