### PR TITLE
Fix the instruction to click the "Create an Issue" link on the contribute/suggest-improvements page

### DIFF
--- a/content/en/docs/contribute/suggesting-improvements.md
+++ b/content/en/docs/contribute/suggesting-improvements.md
@@ -24,7 +24,7 @@ of the Kubernetes community open a pull request with changes to resolve the issu
 
 If you want to suggest improvements to existing content, or notice an error, then open an issue.
 
-1. Go to the bottom of the page and click the **Create an Issue** button. This redirects you
+1. Click the **Create an issue** link on the right sidebar. This redirects you
  to a GitHub issue page pre-populated with some headers.
 2. Describe the issue or suggestion for improvement. Provide as many details as you can.
 3. Click **Submit new issue**.


### PR DESCRIPTION
The "Create an Issue" button had been moved from the bottom of the page to the right sidebar by #23227. But there remains the old description of the button on the [contribute/suggest-improvements](https://k8s.io/docs/contribute/suggest-improvements/) page. This PR fixes the instruction to click the button.

![Screenshot from 2020-09-15 11-48-47](https://user-images.githubusercontent.com/1425259/93159605-8092d080-f749-11ea-92db-3b357b2ddcd3.png)
We have a link on the right sidebar now.