### PR TITLE
Updating apiVersion for CertificateSigningRequest object

### DIFF
--- a/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
+++ b/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
@@ -108,7 +108,6 @@ Kubernetes provides built-in signers that each have a well-known `signerName`:
 
 1. `kubernetes.io/legacy-unknown`:  has no guarantees for trust at all. Some distributions may honor these as client
   certs, but that behavior is not standard Kubernetes behavior.
-  This signerName can only be requested in CertificateSigningRequests created via the `certificates.k8s.io/v1` API version.
   Never auto-approved by {{< glossary_tooltip term_id="kube-controller-manager" >}}.
     1. Trust distribution: None.  There is no standard trust or distribution for this signer in a Kubernetes cluster.
     1. Permitted subjects - any

--- a/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
+++ b/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
@@ -108,7 +108,7 @@ Kubernetes provides built-in signers that each have a well-known `signerName`:
 
 1. `kubernetes.io/legacy-unknown`:  has no guarantees for trust at all. Some distributions may honor these as client
   certs, but that behavior is not standard Kubernetes behavior.
-  This signerName can only be requested in CertificateSigningRequests created via the `certificates.k8s.io/v1beta1` API version.
+  This signerName can only be requested in CertificateSigningRequests created via the `certificates.k8s.io/v1` API version.
   Never auto-approved by {{< glossary_tooltip term_id="kube-controller-manager" >}}.
     1. Trust distribution: None.  There is no standard trust or distribution for this signer in a Kubernetes cluster.
     1. Permitted subjects - any
@@ -245,7 +245,7 @@ Create a CertificateSigningRequest and submit it to a Kubernetes Cluster via kub
 
 ```
 cat <<EOF | kubectl apply -f -
-apiVersion: certificates.k8s.io/v1beta1
+apiVersion: certificates.k8s.io/v1
 kind: CertificateSigningRequest
 metadata:
   name: john


### PR DESCRIPTION
**Issue detected**: There are two references to old apiVersion for CertificateSigningRequest object

**Ref**: CertificateSigningRequest API is promoted to certificates.k8s.io/v1 (https://kubernetes.io/docs/setup/release/notes/#api-change)

**Fix**: Replaced "certificates.k8s.io/v1beta1" by "certificates.k8s.io/v1"
