### PR TITLE
Fix spelling in authentication.md

### DIFF
--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -443,7 +443,7 @@ current-context: webhook
 contexts:
 - context:
     cluster: name-of-remote-authn-service
-    user: name-of-api-sever
+    user: name-of-api-server
   name: webhook
 ```
 


### PR DESCRIPTION
Rename `name-of-api-sever` to `name-of-api-server`.
