### PR TITLE
Add ID translation for Scale You App tutorial

### DIFF
--- a/content/id/docs/tutorials/_index.md
+++ b/content/id/docs/tutorials/_index.md
@@ -18,7 +18,7 @@ Sebelum melangkah lebih lanjut ke tutorial, sebaiknya tandai dulu halaman [Kamus
 
 ## Prinsip Dasar
 
-* [Prinsip Dasar Kubernetes](/docs/tutorials/kubernetes-basics/) merupakan tutorial yang sangat interaktif, membantu kamu mengerti apa itu sistem Kubernetes dan beberapa fitur Kubernetes yang umum digunakan.
+* [Prinsip Dasar Kubernetes](/id/docs/tutorials/kubernetes-basics/) merupakan tutorial yang sangat interaktif, membantu kamu mengerti apa itu sistem Kubernetes dan beberapa fitur Kubernetes yang umum digunakan.
 
 * [Mikroservis yang Scalable dengan Kubernetes (Udacity)](https://www.udacity.com/course/scalable-microservices-with-kubernetes--ud615)
 

--- a/content/id/docs/tutorials/kubernetes-basics/_index.html
+++ b/content/id/docs/tutorials/kubernetes-basics/_index.html
@@ -89,17 +89,17 @@ card:
             </div>
             <div class="col-md-4">
               <div class="thumbnail">
-                <a href="/docs/tutorials/kubernetes-basics/scale/scale-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_05.svg?v=1469803628347" alt=""></a>
+                <a href="/id/docs/tutorials/kubernetes-basics/scale/scale-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_05.svg?v=1469803628347" alt=""></a>
                 <div class="caption">
-                  <a href="/docs/tutorials/kubernetes-basics/scale/scale-intro/"><h5>5. Penyekalaan naik aplikasimu</h5></a>
+                  <a href="/id/docs/tutorials/kubernetes-basics/scale/scale-intro/"><h5>5. Penyekalaan naik aplikasimu</h5></a>
                 </div>
               </div>
             </div>
             <div class="col-md-4">
               <div class="thumbnail">
-                <a href="/docs/tutorials/kubernetes-basics/update/update-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_06.svg?v=1469803628347" alt=""></a>
+                <a href="/id/docs/tutorials/kubernetes-basics/update/update-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_06.svg?v=1469803628347" alt=""></a>
                 <div class="caption">
-                  <a href="/docs/tutorials/kubernetes-basics/update/update-intro/"><h5>6. Memperbarui aplikasimu</h5></a>
+                  <a href="/id/docs/tutorials/kubernetes-basics/update/update-intro/"><h5>6. Memperbarui aplikasimu</h5></a>
                 </div>
               </div>
             </div>

--- a/content/id/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive.html
+++ b/content/id/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive.html
@@ -25,7 +25,7 @@ weight: 20
         </div>
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/" role="button">Lanjut ke Modul 2<span class="btn__next">›</span></a>
+                <a class="btn btn-lg btn-success" href="/id/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/" role="button">Lanjut ke Modul 2<span class="btn__next">›</span></a>
             </div>
         </div>
 

--- a/content/id/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive.html
+++ b/content/id/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive.html
@@ -31,7 +31,7 @@ weight: 20
                 Untuk berinteraksi dengan Terminal, silahkan gunakan desktop/tablet.
             </div>
 
-            <div class="katacoda__box" id="inline-terminal-1" data-katacoda-lang="id" data-katacoda-id="kubernetes-bootcamp/7" data-katacoda-color="326de6" data-katacoda-secondary="273d6d" data-katacoda-hideintro="false" data-katacoda-font="Roboto" data-katacoda-fontheader="Roboto Slab" data-katacoda-prompt="Kubernetes Bootcamp Terminal" style="height: 600px;">
+            <div class="katacoda__box" id="inline-terminal-1" data-katacoda-lang="id" data-katacoda-id="kubernetes-bootcamp/7" data-katacoda-color="326de6" data-katacoda-secondary="273d6d" data-katacoda-hideintro="false" data-katacoda-prompt="Kubernetes Bootcamp Terminal" style="height: 600px;">
             </div>
 
         </div>

--- a/content/id/docs/tutorials/kubernetes-basics/explore/explore-interactive.html
+++ b/content/id/docs/tutorials/kubernetes-basics/explore/explore-interactive.html
@@ -24,7 +24,7 @@ weight: 20
                 Untuk berinteraksi dengan Terminal, tolong gunakan dalam desktop/tablet
             </div>
 
-            <div class="katacoda__box" id="inline-terminal-1" data-katacoda-lang="id" data-katacoda-id="kubernetes-bootcamp/4" data-katacoda-color="326de6" data-katacoda-secondary="273d6d" data-katacoda-hideintro="false" data-katacoda-font="Roboto" data-katacoda-fontheader="Roboto Slab" data-katacoda-prompt="Kubernetes Bootcamp Terminal" style="height: 600px;">
+            <div class="katacoda__box" id="inline-terminal-1" data-katacoda-lang="id" data-katacoda-id="kubernetes-bootcamp/4" data-katacoda-color="326de6" data-katacoda-secondary="273d6d" data-katacoda-hideintro="false" data-katacoda-prompt="Kubernetes Bootcamp Terminal" style="height: 600px;">
             </div>
         </div>
         <div class="row">

--- a/content/id/docs/tutorials/kubernetes-basics/expose/expose-interactive.html
+++ b/content/id/docs/tutorials/kubernetes-basics/expose/expose-interactive.html
@@ -21,7 +21,7 @@ weight: 20
             <div class="katacoda__alert">
                 Untuk berinteraksi dengan Terminal, harap gunakan desktop/tablet
             </div>
-            <div class="katacoda__box" id="inline-terminal-1" data-katacoda-lang="id" data-katacoda-id="kubernetes-bootcamp/8" data-katacoda-color="326de6" data-katacoda-secondary="273d6d" data-katacoda-hideintro="false" data-katacoda-font="Roboto" data-katacoda-fontheader="Roboto Slab" data-katacoda-prompt="Kubernetes Bootcamp Terminal" style="height: 600px;">
+            <div class="katacoda__box" id="inline-terminal-1" data-katacoda-lang="id" data-katacoda-id="kubernetes-bootcamp/8" data-katacoda-color="326de6" data-katacoda-secondary="273d6d" data-katacoda-hideintro="false" data-katacoda-prompt="Kubernetes Bootcamp Terminal" style="height: 600px;">
             </div>
         </div>
         <div class="row">

--- a/content/id/docs/tutorials/kubernetes-basics/scale/_index.md
+++ b/content/id/docs/tutorials/kubernetes-basics/scale/_index.md
@@ -1,0 +1,4 @@
+---
+title: Penyekalaan Aplikasimu
+weight: 50
+---

--- a/content/id/docs/tutorials/kubernetes-basics/scale/scale-interactive.html
+++ b/content/id/docs/tutorials/kubernetes-basics/scale/scale-interactive.html
@@ -21,7 +21,7 @@ weight: 20
             <div class="katacoda__alert">
                 Untuk berinteraksi dengan Terminal, harap gunakan desktop/tablet
             </div>
-            <div class="katacoda__box" id="inline-terminal-1" data-katacoda-lang="id" data-katacoda-id="kubernetes-bootcamp/5" data-katacoda-color="326de6" data-katacoda-secondary="273d6d" data-katacoda-hideintro="false" data-katacoda-font="Roboto" data-katacoda-fontheader="Roboto Slab" data-katacoda-prompt="Kubernetes Bootcamp Terminal" style="height: 600px;">
+            <div class="katacoda__box" id="inline-terminal-1" data-katacoda-lang="id" data-katacoda-id="kubernetes-bootcamp/5" data-katacoda-color="326de6" data-katacoda-secondary="273d6d" data-katacoda-hideintro="false" data-katacoda-prompt="Kubernetes Bootcamp Terminal" style="height: 600px;">
             </div>
         </div>
         <div class="row">

--- a/content/id/docs/tutorials/kubernetes-basics/scale/scale-interactive.html
+++ b/content/id/docs/tutorials/kubernetes-basics/scale/scale-interactive.html
@@ -1,5 +1,5 @@
 ---
-title: Tutorial Interaktif - Mengekspos Aplikasimu
+title: Tutorial Interaktif - Penyekalaan Aplikasimu
 weight: 20
 ---
 
@@ -21,16 +21,18 @@ weight: 20
             <div class="katacoda__alert">
                 Untuk berinteraksi dengan Terminal, harap gunakan desktop/tablet
             </div>
-            <div class="katacoda__box" id="inline-terminal-1" data-katacoda-lang="id" data-katacoda-id="kubernetes-bootcamp/8" data-katacoda-color="326de6" data-katacoda-secondary="273d6d" data-katacoda-hideintro="false" data-katacoda-font="Roboto" data-katacoda-fontheader="Roboto Slab" data-katacoda-prompt="Kubernetes Bootcamp Terminal" style="height: 600px;">
+            <div class="katacoda__box" id="inline-terminal-1" data-katacoda-lang="id" data-katacoda-id="kubernetes-bootcamp/5" data-katacoda-color="326de6" data-katacoda-secondary="273d6d" data-katacoda-hideintro="false" data-katacoda-font="Roboto" data-katacoda-fontheader="Roboto Slab" data-katacoda-prompt="Kubernetes Bootcamp Terminal" style="height: 600px;">
             </div>
         </div>
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/id/docs/tutorials/kubernetes-basics/scale/scale-intro/" role="button">Lanjutkan ke Modul 5<span class="btn__next">›</span></a>
+                <a class="btn btn-lg btn-success" href="/id/docs/tutorials/kubernetes-basics/update/update-intro/" role="button">Lanjutkan ke Modul 6<span class="btn__next">›</span></a>
             </div>
         </div>
 
     </main>
+
+<a class="scrolltop" href="#top"></a>
 
 </div>
 

--- a/content/id/docs/tutorials/kubernetes-basics/scale/scale-intro.html
+++ b/content/id/docs/tutorials/kubernetes-basics/scale/scale-intro.html
@@ -1,0 +1,121 @@
+---
+title: Menjalankan Multipel Instans dari Aplikasimu
+weight: 10
+---
+
+<!DOCTYPE html>
+
+<html lang="id">
+
+<body>
+
+<link href="/docs/tutorials/kubernetes-basics/public/css/styles.css" rel="stylesheet">
+
+<div class="layout" id="top">
+
+    <main class="content">
+
+        <div class="row">
+
+     <div class="col-md-8">
+          <h3>Tujuan</h3>
+                <ul>
+                    <li>Penyekalaan aplikasi menggunakan kubectl.</li>
+                </ul>
+            </div>
+
+            <div class="col-md-8">
+       <h3>Penyekalaan sebuah Aplikasi</h3>
+
+            <p>Di modul-modul sebelumnya kita telah membuat <a href="/id/docs/concepts/workloads/controllers/deployment/">Deployment</a>, dan mengeksposnya secara publik via <a href="/id/docs/concepts/services-networking/service/">Service</a>. Deployment yang dibuat itu hanya satu Pod yang menjalankan aplikasi kita. Ketika kunjungan meningkat, kita perlu menyekalakan (<i>scale</i>) aplikasi kita untuk mengikuti tingkat permintaan pengguna.</p>
+
+            <p><b>Penyekalaan</b> dapat dicapai dengan mengubah nilai replicas dalam Deployment</p>
+
+            </div>
+            <div class="col-md-4">
+                <div class="content__box content__box_lined">
+                    <h3>Ringkasan:</h3>
+                    <ul>
+                        <li>Penyekalaan sebuah Deployment</li>
+                    </ul>
+                </div>
+                <div class="content__box content__box_fill">
+                    <p><i> Kamu dapat dari awal memulai Deployment dengan multipel instans menggunakan parameter --replicas pada perintah kubectl create deployment</i></p>
+                </div>
+            </div>
+        </div>
+        <br>
+
+        <div class="row">
+            <div class="col-md-8">
+                <h2 style="color: #3771e3;">Ikhtisar Penyekalaan</h2>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-md-1"></div>
+            <div class="col-md-8">
+                <div id="myCarousel" class="carousel" data-ride="carousel" data-interval="3000">
+                    <ol class="carousel-indicators">
+                        <li data-target="#myCarousel" data-slide-to="0" class="active"></li>
+                        <li data-target="#myCarousel" data-slide-to="1"></li>
+                    </ol>
+                      <div class="carousel-inner" role="listbox">
+                        <div class="item carousel-item active">
+                          <img src="/docs/tutorials/kubernetes-basics/public/images/module_05_scaling1.svg">
+                        </div>
+
+                        <div class="item carousel-item">
+                          <img src="/docs/tutorials/kubernetes-basics/public/images/module_05_scaling2.svg">
+                        </div>
+                      </div>
+
+                      <a class="left carousel-control" href="#myCarousel" role="button" data-slide="prev">
+                        <span class="sr-only ">Sebelumnya</span>
+                      </a>
+                      <a class="right carousel-control" href="#myCarousel" role="button" data-slide="next">
+                        <span class="sr-only">Selanjutnya</span>
+                      </a>
+
+                    </div>
+            </div>
+        </div>
+
+        <br>
+
+        <div class="row">
+            <div class="col-md-8">
+
+                <p>Perluasan skala Deployment akan memastikan Pod baru dibuat dan dijadwalkan ke Node-Node dengan sumber daya yang tersedia. Penyekalaan akan meningkatkan jumlah Pod ke keadaan yang diinginkan. Kubernetes juga mendukung <a href="/id/docs/tasks/run-application/horizontal-pod-autoscale/"><i>autoscaling</i></a> Pod, tetapi itu di luar cakupan tutorial ini. Penyekalaan ke nol juga dimungkinkan, dan tindakan ini akan mengakhiri semua Pod pada Deployment tersebut.</p>
+
+                <p>Menjalankan beberapa instans dari aplikasi akan membutuhkan cara untuk mendistribusikan kunjungan ke semuanya. Service punya penyeimbang beban terintegrasi yang akan mendistribusikan kujungan jaringan ke semua Pod dari sebuah Deployment yang diekspos. Service akan terus-menerus memonitor Pod-Pod yang berjalan menggunakan Endpoints, untuk memastikan kunjungan hanya dikirim kepada Pod yang tersedia.</p>
+
+            </div>
+            <div class="col-md-4">
+                <div class="content__box content__box_fill">
+                    <p><i>Penyekalaan dapat dicapai dengan mengubah jumlah replicas pada sebuah Deployment.</i></p>
+                </div>
+            </div>
+        </div>
+
+        <br>
+
+        <div class="row">
+            <div class="col-md-8">
+                <p>Sewaktu kamu punya multipel instans dari aplikasi berjalan, kamu akan dapat melakukan pembaruan bertahap tanpa perhentian. Kita akan akan membahas hal tersebut pada modul selanjutnya. Sekarang, mari kita pergi ke terminal daring dan menyekalakan aplikasi kita.</p>
+            </div>
+        </div>
+        <br>
+
+        <div class="row">
+            <div class="col-md-12">
+                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/scale/scale-interactive/" role="button"> Mulai Tutorial Interaktif <span class="btn__next">›</span></a>
+            </div>
+        </div>
+
+    </main>
+
+</div>
+
+</body>
+</html>

--- a/content/id/docs/tutorials/kubernetes-basics/scale/scale-intro.html
+++ b/content/id/docs/tutorials/kubernetes-basics/scale/scale-intro.html
@@ -27,7 +27,7 @@ weight: 10
             <div class="col-md-8">
        <h3>Penyekalaan sebuah Aplikasi</h3>
 
-            <p>Di modul-modul sebelumnya kita telah membuat <a href="/id/docs/concepts/workloads/controllers/deployment/">Deployment</a>, dan mengeksposnya secara publik via <a href="/id/docs/concepts/services-networking/service/">Service</a>. Deployment yang dibuat itu hanya satu Pod yang menjalankan aplikasi kita. Ketika kunjungan meningkat, kita perlu menyekalakan (<i>scale</i>) aplikasi kita untuk mengikuti tingkat permintaan pengguna.</p>
+            <p>Di modul-modul sebelumnya kita telah membuat <a href="/id/docs/concepts/workloads/controllers/deployment/">Deployment</a>, dan mengeksposnya secara publik via <a href="/id/docs/concepts/services-networking/service/">Service</a>. Deployment tersebut hanya membuat satu Pod untuk menjalankan aplikasi kita. Ketika kunjungan meningkat, kita perlu  melakukan penyekalaan (<i>scale</i>) aplikasi kita untuk mengikuti tingkat permintaan pengguna.</p>
 
             <p><b>Penyekalaan</b> dapat dicapai dengan mengubah nilai replicas dalam Deployment</p>
 
@@ -40,7 +40,7 @@ weight: 10
                     </ul>
                 </div>
                 <div class="content__box content__box_fill">
-                    <p><i> Kamu dapat dari awal memulai Deployment dengan multipel instans menggunakan parameter --replicas pada perintah kubectl create deployment</i></p>
+                    <p><i> Kamu dapat membuat Deployment dengan beberapa instans sekaligus dari awal dengan menggunakan parameter --replicas pada perintah kubectl create deployment</i></p>
                 </div>
             </div>
         </div>
@@ -88,7 +88,7 @@ weight: 10
 
                 <p>Perluasan skala Deployment akan memastikan Pod baru dibuat dan dijadwalkan ke Node-Node dengan sumber daya yang tersedia. Penyekalaan akan meningkatkan jumlah Pod ke keadaan yang diinginkan. Kubernetes juga mendukung <a href="/id/docs/tasks/run-application/horizontal-pod-autoscale/"><i>autoscaling</i></a> Pod, tetapi itu di luar cakupan tutorial ini. Penyekalaan ke nol juga dimungkinkan, dan tindakan ini akan mengakhiri semua Pod pada Deployment tersebut.</p>
 
-                <p>Menjalankan beberapa instans dari aplikasi akan membutuhkan cara untuk mendistribusikan kunjungan ke semuanya. Service punya penyeimbang beban terintegrasi yang akan mendistribusikan kujungan jaringan ke semua Pod dari sebuah Deployment yang diekspos. Service akan terus-menerus memonitor Pod-Pod yang berjalan menggunakan Endpoints, untuk memastikan kunjungan hanya dikirim kepada Pod yang tersedia.</p>
+                <p>Menjalankan beberapa instans dari aplikasi akan membutuhkan cara untuk mendistribusikan trafik ke semuanya. Service memiliki penyeimbang beban terintegrasi yang akan mendistribusikan trafik jaringan ke semua Pod dari sebuah Deployment yang diekspos. Service akan terus memonitor Pod-Pod yang berjalan menggunakan Endpoints, untuk memastikan trafik hanya dikirim ke Pod yang tersedia.</p>
 
             </div>
             <div class="col-md-4">
@@ -102,14 +102,14 @@ weight: 10
 
         <div class="row">
             <div class="col-md-8">
-                <p>Sewaktu kamu punya multipel instans dari aplikasi berjalan, kamu akan dapat melakukan pembaruan bertahap tanpa perhentian. Kita akan akan membahas hal tersebut pada modul selanjutnya. Sekarang, mari kita pergi ke terminal daring dan menyekalakan aplikasi kita.</p>
+                <p>Sewaktu kamu memiliki multipel instans dari aplikasi yang berjalan, kamu akan bisa melakukan pembaruan bertahap tanpa henti. Kita akan akan membahas hal tersebut pada modul selanjutnya. Sekarang, mari kita pergi ke terminal daring dan melakukan penyekalaan terhadap aplikasi kita.</p>
             </div>
         </div>
         <br>
 
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/scale/scale-interactive/" role="button"> Mulai Tutorial Interaktif <span class="btn__next">›</span></a>
+                <a class="btn btn-lg btn-success" href="/id/docs/tutorials/kubernetes-basics/scale/scale-interactive/" role="button"> Mulai Tutorial Interaktif <span class="btn__next">›</span></a>
             </div>
         </div>
 


### PR DESCRIPTION
This PR is part of #22296 , translating `/docs/tutorials/kubernetes-basics/scale/` into Bahasa Indonesia. Also, update links and katakoda embed for other id k8s basic tutorials.

Notes:
 - instance : instans ([RSNI3](https://github.com/jk8s/sig-docs-id-localization-how-tos/blob/master/resources/RSNI-glossarium.pdf))
 - "replicas" are not translated since it is kubectl paramenter / Deployment field
 - scale out : perluasan skala
 - multiple : multipel https://kbbi.kemdikbud.go.id/entri/multipel
 - traffic : kunjungan https://twitter.com/ivanlanin/status/19299826772480000

/language id
