### PR TITLE
 Scheduling Policies mis-named predicate for NodeSelector #23862

### DIFF
--- a/content/en/docs/reference/scheduling/policies.md
+++ b/content/en/docs/reference/scheduling/policies.md
@@ -32,7 +32,7 @@ The following *predicates* implement filtering:
 - `PodFitsResources`: Checks if the Node has free resources (eg, CPU and Memory)
   to meet the requirement of the Pod.
 
-- `PodMatchNodeSelector`: Checks if a Pod's Node {{< glossary_tooltip term_id="selector" >}}
+- `MatchNodeSelector`: Checks if a Pod's Node {{< glossary_tooltip term_id="selector" >}}
    matches the Node's {{< glossary_tooltip text="label(s)" term_id="label" >}}.
 
 - `NoVolumeZoneConflict`: Evaluate if the {{< glossary_tooltip text="Volumes" term_id="volume" >}}


### PR DESCRIPTION
This resolves bug #23862 
Description: PodMatchNodeSelector is mislabelled, I believe it should be MatchNodeSelector
Solution: Replace the label with the correct one.