### PR TITLE
[zh] add missing links in/zh/docs/home/contribute

### DIFF
--- a/content/zh/docs/contribute/_index.md
+++ b/content/zh/docs/contribute/_index.md
@@ -6,7 +6,7 @@ main_menu: true
 no_list: true
 weight: 80
 card:
-  name: 贡献
+  name: contribute
   weight: 10
   title: 开始贡献
 ---

--- a/content/zh/docs/contribute/localization.md
+++ b/content/zh/docs/contribute/localization.md
@@ -3,7 +3,7 @@ title: 本地化 Kubernetes 文档
 content_type: concept
 weight: 50
 card:
-  name: 贡献
+  name: contribute
   weight: 50
   title: 翻译文档
 ---

--- a/content/zh/docs/contribute/new-content/new-features.md
+++ b/content/zh/docs/contribute/new-content/new-features.md
@@ -5,7 +5,7 @@ content_type: concept
 main_menu: true
 weight: 20
 card:
-  name: 贡献
+  name: contribute
   weight: 45
   title: 为发行版本撰写功能特性文档 
 ---

--- a/content/zh/docs/contribute/new-content/open-a-pr.md
+++ b/content/zh/docs/contribute/new-content/open-a-pr.md
@@ -3,7 +3,7 @@ title: 发起拉取请求（PR）
 content_type: concept
 weight: 10
 card:
-  name: 贡献
+  name: contribute
   weight: 40
 ---
 <!--

--- a/content/zh/docs/contribute/style/page-content-types.md
+++ b/content/zh/docs/contribute/style/page-content-types.md
@@ -3,7 +3,7 @@ title: 页面内容类型
 content_type: concept
 weight: 30
 card:
-  name: 贡献
+  name: contribute
   weight: 30
 ---
 <!--

--- a/content/zh/docs/contribute/suggesting-improvements.md
+++ b/content/zh/docs/contribute/suggesting-improvements.md
@@ -4,7 +4,7 @@ slug: suggest-improvements
 content_type: concept
 weight: 10
 card:
-  name: 贡献
+  name: contribute
   weight: 20
 ---
 <!--


### PR DESCRIPTION
**Problem:**
page of /docs/home in Chinese is different from English version. These direct link of below is missing:
```
Start contributing
Suggesting content improvements
Page content types
Opening a pull request
Documenting a feature for a release
Translating the docs
Participating in SIG Docs
```

**Proposed Solution:**
modify related posts' config, modify the `card.name` from "贡献" to "contribute"

**Page to Update:**
https://kubernetes.io/zh/docs/home/

**Related Issue:**
https://github.com/kubernetes/website/issues/23980