### PR TITLE
Clarify that bind verb does not require resourceNames

### DIFF
--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -908,6 +908,8 @@ subjects:
   name: user-1
 ```
 
+Note that - as with any RBAC verb - you may omit `resourceNames` to allow `user-1` to grant other users _any_ ClusterRole in the namespace `user-1-namespace`.
+
 When bootstrapping the first roles and role bindings, it is necessary for the initial user to grant permissions they do not yet have.
 To bootstrap initial roles and role bindings:
 

--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -891,6 +891,7 @@ rules:
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["clusterroles"]
   verbs: ["bind"]
+  # omit resourceNames to allow binding any ClusterRole
   resourceNames: ["admin","edit","view"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -907,8 +908,6 @@ subjects:
   kind: User
   name: user-1
 ```
-
-Note that - as with any RBAC verb - you may omit `resourceNames` to allow `user-1` to grant other users _any_ ClusterRole in the namespace `user-1-namespace`.
 
 When bootstrapping the first roles and role bindings, it is necessary for the initial user to grant permissions they do not yet have.
 To bootstrap initial roles and role bindings:


### PR DESCRIPTION
This may be intuitive for most, but the existing phrasing read to me as if `bind` were a special-case verb that _required_ me to explicitly state which Roles or ClusterRoles it should apply to.

> You can only create/update a role binding if you […] or if you have been authorized to perform the bind verb on the **referenced** role.

> Grant them permissions needed to bind a particular role […] explicitly, by giving them permission to perform the bind verb on the  **particular** Role (or ClusterRole).