### PR TITLE
[zh] translate /zh/docs/tasks/configmap-secret/managing-secret-using-kustomize.md

### DIFF
--- a/content/zh/docs/tasks/configmap-secret/_index.md
+++ b/content/zh/docs/tasks/configmap-secret/_index.md
@@ -1,5 +1,5 @@
 ---
 title: "管理 Secrets"
 weight: 28
-description: 使用 Secrets 管理机密配置数据.
+description: 使用 Secrets 管理机密配置数据。
 ---

--- a/content/zh/docs/tasks/configmap-secret/managing-secret-using-config-file.md
+++ b/content/zh/docs/tasks/configmap-secret/managing-secret-using-config-file.md
@@ -202,9 +202,9 @@ or from being stored in a terminal log.
 To check the actual content of the encoded data, please refer to
 [decoding secret](/docs/tasks/configmap-secret/managing-secret-using-kubectl/#decoding-secret).
 -->
-命令 `kubectl get` 和 `kubectl describe` 默认情况不显示 `Secret` 的内容。
-这是为了防止 `Secret` 意外地暴露给旁观者，或者保存在终端日志中。
-检查编码数据的实际内容，请参考 [解码 secret](/zh/docs/tasks/configmap-secret/managing-secret-using-kubectl/#decoding-secret).
+命令 `kubectl get` 和 `kubectl describe` 默认不显示 `Secret` 的内容。
+这是为了防止 `Secret` 意外地暴露给旁观者或者保存在终端日志中。
+检查编码数据的实际内容，请参考[解码 secret](/zh/docs/tasks/configmap-secret/managing-secret-using-kubectl/#decoding-secret).
 
 <!-- 
 If a field, such as `username`, is specified in both `data` and `stringData`,
@@ -262,7 +262,7 @@ kubectl delete secret db-user-pass
 - Learn how to [manage Secret with the `kubectl` command](/docs/tasks/configmap-secret/managing-secret-using-kubectl/)
 - Learn how to [manage Secret using kustomizae](/docs/tasks/configmap-secret/managing-secret-using-kustomize/)
 -->
-- 阅读更多有关于 [Secret 概念](/zh/docs/concepts/configuration/secret/)
-- 了解如何 [使用 `kubectl` 命令管理 Secret](/zh/docs/tasks/configmap-secret/managing-secret-using-kubectl/)
-- 了解如何 [使用 kustomize 管理 Secret](/zh/docs/tasks/configmap-secret/managing-secret-using-kustomize/)
+- 进一步阅读 [Secret 概念](/zh/docs/concepts/configuration/secret/)
+- 了解如何[使用 `kubectl` 命令管理 Secret](/zh/docs/tasks/configmap-secret/managing-secret-using-kubectl/)
+- 了解如何[使用 kustomize 管理 Secret](/zh/docs/tasks/configmap-secret/managing-secret-using-kustomize/)
 

--- a/content/zh/docs/tasks/configmap-secret/managing-secret-using-config-file.md
+++ b/content/zh/docs/tasks/configmap-secret/managing-secret-using-config-file.md
@@ -2,7 +2,7 @@
 title: 使用配置文件管理 Secret
 content_type: task
 weight: 20
-description: 使用资源配置文件创建 Secret 对象
+description: 使用资源配置文件创建 Secret 对象。
 ---
 <!--  
 title: Managing Secret using Configuration File

--- a/content/zh/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
+++ b/content/zh/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
@@ -150,7 +150,7 @@ The commands `kubectl get` and `kubectl describe` avoid showing the contents
 of a `Secret` by default. This is to protect the `Secret` from being exposed
 accidentally to an onlooker, or from being stored in a terminal log.
 -->
-默认情况下，`kubectl get` 和 `kubectl describe` 命令可避免显示 `Secret` 的内容。
+`kubectl get` 和 `kubectl describe` 命令默认不显示 `Secret` 的内容。
 这是为了防止 `Secret` 被意外暴露给旁观者或存储在终端日志中。
 
 <!-- ## Decoding the Secret  {#decoding-secret} -->
@@ -206,6 +206,6 @@ kubectl delete secret db-user-pass
 - Learn how to [manage Secret using config file](/docs/tasks/configmap-secret/managing-secret-using-config-file/)
 - Learn how to [manage Secret using kustomize](/docs/tasks/configmap-secret/managing-secret-using-kustomize/)
 -->
-- 阅读更多有关 [Secret 概念](/zh/docs/concepts/configuration/secret/)
-- 了解如何 [使用配置文件管理 Secret](/zh/docs/tasks/configmap-secret/managing-secret-using-config-file/)
-- 了解如何 [使用 kustomize 管理 Secret](/zh/docs/tasks/configmap-secret/managing-secret-using-kustomize/)
+- 进一步阅读 [Secret 概念](/zh/docs/concepts/configuration/secret/)
+- 了解如何[使用配置文件管理 Secret](/zh/docs/tasks/configmap-secret/managing-secret-using-config-file/)
+- 了解如何[使用 kustomize 管理 Secret](/zh/docs/tasks/configmap-secret/managing-secret-using-kustomize/)

--- a/content/zh/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
+++ b/content/zh/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
@@ -1,0 +1,173 @@
+---
+title: 使用 Kustomize 管理 Secret
+content_type: task
+weight: 30
+description: 使用 kustomization.yaml 文件创建 Secret 对象。
+---
+<!-- 
+title: Managing Secret using Kustomize
+content_type: task
+weight: 30
+description: Creating Secret objects using kustomization.yaml file.
+-->
+
+<!-- overview -->
+
+<!--  
+Since Kubernetes v1.14, `kubectl` supports
+[managing objects using Kustomize](/docs/tasks/manage-kubernetes-objects/kustomization/).
+Kustomize provides resource Generators to create Secrets and ConfigMaps. The
+Kustomize generators should be specified in a `kustomization.yaml` file inside
+a directory. After generating the Secret, you can create the Secret on the API
+server with `kubectl apply`.
+-->
+从 kubernetes v1.14 开始，`kubectl` 支持[使用 Kustomize 管理对象](/zh/docs/tasks/manage-kubernetes-objects/kustomization/)。
+Kustomize 提供了资源生成器（Generators）来创建 Secret 和 ConfigMap。
+Kustomize 生成器应该在某个目录的 `kustomization.yaml` 文件中指定。
+生成 Secret 后，你可以使用 `kubectl apply` 在 API 服务器上创建该 Secret。
+## {{% heading "prerequisites" %}}
+
+{{< include "task-tutorial-prereqs.md" >}}
+
+<!-- steps -->
+
+<!-- ## Create the Kustomization file -->
+## 创建 Kustomization 文件    {#create-the-kustomization-file}
+
+<!--  
+You can generate a Secret by defining a `secretGenerator` in a
+`kustomization.yaml` file that references other existing files.
+For example, the following kustomization file references the
+`./username.txt` and the `./password.txt` files:
+-->
+你可以在 `kustomization.yaml` 中定义 `secreteGenerator`，并在定义中引用其他现成的文件，生成 Secret。
+例如：下面的 kustomization 文件 引用了 `./username.txt` 和 `./password.txt` 文件：
+
+```yaml
+secretGenerator:
+- name: db-user-pass
+  files:
+  - username.txt
+  - password.txt
+```
+
+<!--  
+You can also define the `secretGenerator` in the `kustomization.yaml`
+file by providing some literals.
+For example, the following `kustomization.yaml` file contains two literals
+for `username` and `password` respectively:
+-->
+你也可以在 `kustomization.yaml` 文件中指定一些字面量定义 `secretGenerator`。
+例如：下面的 `kustomization.yaml` 文件中包含了 `username` 和 `password` 两个字面量：
+
+```yaml
+secretGenerator:
+- name: db-user-pass
+  literals:
+  - username=admin
+  - password=1f2d1e2e67df
+```
+
+<!-- Note that in both cases, you don't need to base64 encode the values. -->
+注意，上面两种情况，你都不需要使用 base64 编码。
+
+<!-- ## Create the Secret -->
+## 创建 Secret    {#create-the-secret}
+
+<!-- Apply the directory containing the `kustomization.yaml` to create the Secret. -->
+使用 `kubectl apply` 命令应用包含 `kustomization.yaml` 文件的目录创建 Secret。
+
+```shell
+kubectl apply -k .
+```
+
+<!-- The output is similar to: -->
+输出类似于：
+
+```
+secret/db-user-pass-96mffmfh4k created
+```
+
+<!-- 
+Note that when a Secret is generated, the Secret name is created by hashing
+the Secret data and appending the hash value to the name. This ensures that
+a new Secret is generated each time the data is modified. 
+-->
+请注意，生成 Secret 时，Secret 的名称最终是由 `name` 字段和数据的哈希值拼接而成。
+
+<!-- ## Check the Secret created -->
+## 检查创建的 Secret    {#check-the-secret-created}
+
+<!-- You can check that the secret was created: -->
+你可以检查刚才创建的 Secret：
+
+```shell
+kubectl get secrets
+```
+
+<!-- The output is similar to: -->
+输出类似于：
+
+```
+NAME                             TYPE                                  DATA      AGE
+db-user-pass-96mffmfh4k          Opaque                                2         51s
+```
+
+<!-- You can view a description of the secret: -->
+你可以看到 Secret 的描述：
+
+```shell
+kubectl describe secrets/db-user-pass-96mffmfh4k
+```
+
+<!-- The output is similar to: -->
+输出类似于：
+
+```
+Name:            db-user-pass
+Namespace:       default
+Labels:          <none>
+Annotations:     <none>
+
+Type:            Opaque
+
+Data
+====
+password.txt:    12 bytes
+username.txt:    5 bytes
+```
+
+<!-- 
+The commands `kubectl get` and `kubectl describe` avoid showing the contents of a `Secret` by
+default. This is to protect the `Secret` from being exposed accidentally to an onlooker,
+or from being stored in a terminal log.
+To check the actual content of the encoded data, please refer to
+[decoding secret](/docs/tasks/configmap-secret/managing-secret-using-kubectl/#decoding-secret). 
+-->
+`kubectl get` 和 `kubectl describe` 命令默认不显示 `Secret` 的内容。
+这是为了防止 `Secret` 被意外暴露给旁观者或存储在终端日志中。
+检查编码后的实际内容，请参考[解码 secret](/zh/docs/tasks/configmap-secret/managing-secret-using-kubectl/#decoding-secret)。 
+-->
+
+
+<!-- ## Clean Up -->
+## 清理    {#clean-up}
+
+<!-- To delete the Secret you have just created: -->
+删除你刚才创建的 Secret：
+
+```shell
+kubectl delete secret db-user-pass-96mffmfh4k
+```
+
+<!-- Optional section; add links to information related to this topic. -->
+## {{% heading "whatsnext" %}}
+
+<!-- 
+- Read more about the [Secret concept](/docs/concepts/configuration/secret/)
+- Learn how to [manage Secret with the `kubectl` command](/docs/tasks/configmap-secret/managing-secret-using-kubectl/)
+- Learn how to [manage Secret using config file](/docs/tasks/configmap-secret/managing-secret-using-config-file/) 
+-->
+- 进一步阅读 [Secret 概念](/zh/docs/concepts/configuration/secret/)
+- 了解如何[使用 `kubectl` 命令管理 Secret](/zh/docs/tasks/configmap-secret/managing-secret-using-kubectl/)
+- 了解如何[使用配置文件管理 Secret](/zh/docs/tasks/configmap-secret/managing-secret-using-config-file/)

--- a/content/zh/docs/tasks/extend-kubectl/kubectl-plugins.md
+++ b/content/zh/docs/tasks/extend-kubectl/kubectl-plugins.md
@@ -1,6 +1,6 @@
 ---
 title: 用插件扩展 kubectl
-description: 通过创建和安装 kubectl 插件扩展 kubectl
+description: 通过创建和安装 kubectl 插件扩展 kubectl。
 content_type: task
 ---
 

--- a/content/zh/docs/tasks/extend-kubernetes/_index.md
+++ b/content/zh/docs/tasks/extend-kubernetes/_index.md
@@ -1,5 +1,5 @@
 ---
 title: "扩展 Kubernetes"
-description: 了解针对工作环境需要来调整 Kubernetes 集群的进阶方法
+description: 了解针对工作环境需要来调整 Kubernetes 集群的进阶方法。
 weight: 90
 ---

--- a/content/zh/docs/tasks/manage-gpus/scheduling-gpus.md
+++ b/content/zh/docs/tasks/manage-gpus/scheduling-gpus.md
@@ -1,7 +1,7 @@
 ---
 content_type: concept
 title: 调度 GPUs
-description: 配置和调度 GPU 成一类资源以供集群中节点使用
+description: 配置和调度 GPU 成一类资源以供集群中节点使用。
 ---
 <!--
 reviewers:

--- a/content/zh/docs/tasks/service-catalog/_index.md
+++ b/content/zh/docs/tasks/service-catalog/_index.md
@@ -1,5 +1,5 @@
 ---
 title: "安装服务目录"
 weight: 150
-description: 安装服务目录扩展 API 。
+description: 安装服务目录扩展 API。
 ---


### PR DESCRIPTION
fix https://github.com/kubernetes/website/issues/23934

**Problem:**
https://kubernetes.io/zh/docs/tasks/configmap-secret/  is missing in Chinese version. 
See https://kubernetes.io/docs/tasks/configmap-secret/ for more info.

**Proposed Solution:**
Add /docs/tasks/configmap-secret/ to zh version with three articles to be translated.

- [x ]  /zh/docs/tasks/configmap-secret/managing-secret-using-kustomize.md

**Page to Update:**
https://kubernetes.io/zh/docs/tasks/configmap-secret/managing-secret-using-kustomize