### PR TITLE
Reword task page, remote access web UI dashboard

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/web-ui-dashboard.md
+++ b/content/en/docs/tasks/access-application-cluster/web-ui-dashboard.md
@@ -57,7 +57,27 @@ kubectl proxy
 
 Kubectl will make Dashboard available at http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/.
 
-The UI can _only_ be accessed from the machine where the command is executed. See `kubectl proxy --help` for more options.
+<!-- The above statement is implicit about accessing it local , so commenting and removing the below line.
+The UI can _only_ be accessed from the machine where the command is executed. 
+-->
+
+
+To make kubernetes dashboard accessible remote using SSH tunnel and configure proxy:
+
+Example:
+
+```
+ssh -L 8001:127.0.0.1:8001 user@remote
+
+kubectl proxy --address='0.0.0.0' --accept-hosts='^*$'
+
+```
+
+This will make the remote kubernetes dashboard accesible as http://localhost:8001
+
+kindly check `kubectl proxy --help` for more options.
+
+
 
 {{< note >}}
 Kubeconfig Authentication method does NOT support external identity providers or x509 certificate-based authentication.

--- a/content/en/docs/tasks/access-application-cluster/web-ui-dashboard.md
+++ b/content/en/docs/tasks/access-application-cluster/web-ui-dashboard.md
@@ -57,10 +57,6 @@ kubectl proxy
 
 Kubectl will make Dashboard available at http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/.
 
-<!-- The above statement is implicit about accessing it local , so commenting and removing the below line.
-The UI can _only_ be accessed from the machine where the command is executed. 
--->
-
 
 To make kubernetes dashboard accessible remote using SSH tunnel and configure proxy:
 
@@ -73,7 +69,7 @@ kubectl proxy --address='0.0.0.0' --accept-hosts='^*$'
 
 ```
 
-This will make the remote kubernetes dashboard accesible as http://localhost:8001
+This will make the remote Kubernetes dashboard accesible as http://localhost:8001.
 
 kindly check `kubectl proxy --help` for more options.
 


### PR DESCRIPTION
This change is made based on the issue -Remote SSH Forwarding Example: k8s.io/docs/tasks/access-application-cluster/web-ui-dashboard/#accessing-the-dashboard-ui #24027

Removed the content "The UI can _only_ be accessed from the machine where the command is executed."

Because in the previous line it has been mentioned as "Kubectl will make Dashboard available at http://localhost:8001/".
This is implicit to say it is accessible locally.

For other options and remote access , added and realigned the respective content and used its example command as mentioned in the issue.