### PR TITLE
Add curl to required packages in kubectl install

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl.md
+++ b/content/en/docs/tasks/tools/install-kubectl.md
@@ -65,7 +65,7 @@ Using the latest version of kubectl helps avoid unforeseen issues.
 
 {{< tabs name="kubectl_install" >}}
 {{< tab name="Ubuntu, Debian or HypriotOS" codelang="bash" >}}
-sudo apt-get update && sudo apt-get install -y apt-transport-https gnupg2
+sudo apt-get update && sudo apt-get install -y apt-transport-https gnupg2 curl
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list
 sudo apt-get update


### PR DESCRIPTION
This is a really small change. 

While installing kubectl in Debian 10 minimal, curl is also not installed so copying/pasting the whole command ends in an error.

So the correction is to add curl to the required packages together with gnupg2 and apt-transport-https