### PR TITLE
Optimize Chinese localization owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -147,27 +147,28 @@ aliases:
     - sftim
     - zacharysarah
   sig-docs-zh-owners: # Admins for Chinese content
-    - chenopis
+    # chenopis
     - chenrui333
-    - dchen1107
-    - haibinxie
-    - hanjiayao
-    - lichuqiang
+    # dchen1107
+    # haibinxie
+    # hanjiayao
+    # lichuqiang
     - SataQiu
     - tengqm
     - xiangpengzhao
     - xichengliudui
-    - zacharysarah
-    - zhangxiaoyu-zidif
+    # zacharysarah
+    # zhangxiaoyu-zidif
   sig-docs-zh-reviews: # PR reviews for Chinese content
     - chenrui333
+    - howieyuen
     - idealhack
     - SataQiu
     - tanjunchen
     - tengqm
     - xiangpengzhao
     - xichengliudui
-    - zhangxiaoyu-zidif
+    # zhangxiaoyu-zidif
     - pigletfly
   sig-docs-pt-owners: # Admins for Portuguese content
     - femrtnz


### PR DESCRIPTION
This PR tweaks the owner/reviewer list for Chinese localization in hope PRs are routed to currently active contributors. Names that are commented out rather than removed so that when these former contributors find cycles to resume their work on this project, we can easily add them back. The filtering of names is based on the PR commits and reviews during the past 6 months. 

Please do *NOT* interpret this action as a negative one. We always welcome all kinds of contributions from everyone. While we admit that the past year has been a difficult one for everyone, we must carry on. If your id is commented out and you do not agree with it, please leave a comment and resume your contribution to the community. We need help, as we always do.

This PR also nominates @howieyuen to the reviewers team for Chinese localization, who has been an active contributor lately.

@chenopis @dchen1107 @haibinxie @hanjiayao @lichuqiang @zhangxiaoyu-zidif 