### PR TITLE
[zh] Use apiversion networking.k8s.io/v1 for ingress in example

### DIFF
--- a/content/zh/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/zh/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -12,7 +12,7 @@ weight: 100
 <!-- overview -->
 
 <!--
-An [Ingress](/docs/concepts/services-networking/ingress/) is an API object that defines rules which allow external access 
+An [Ingress](/docs/concepts/services-networking/ingress/) is an API object that defines rules which allow external access
 to services in a cluster. An [Ingress controller](/docs/concepts/services-networking/ingress-controllers/) fulfills the rules set in the Ingress.
 
 This page shows you how to set up a simple Ingress which routes requests to Service web or web2 depending on the HTTP URI.
@@ -65,7 +65,7 @@ This page shows you how to set up a simple Ingress which routes requests to Serv
     minikube addons enable ingress
     ```
 
-<!--      
+<!--
 1. Verify that the NGINX Ingress controller is running
 -->
 2. 检查验证 NGINX Ingress 控制器处于运行状态：
@@ -104,39 +104,39 @@ This page shows you how to set up a simple Ingress which routes requests to Serv
 
    <!--Output:-->
    输出：
-    
+
    ```
    deployment.apps/web created
    ```
 
 <!--
-1. Expose the Deployment: 
+1. Expose the Deployment:
 -->
 2. 将 Deployment 暴露出来：
 
    ```shell
    kubectl expose deployment web --type=NodePort --port=8080
    ```
-    
+
    <!-- Output: -->
-   输出： 
-    
+   输出：
+
    ```
    service/web exposed
    ```
 
-<!--    
+<!--
 1. Verify the Service is created and is available on a node port:
 -->
 3. 验证 Service 已经创建，并且可能从节点端口访问：
 
    ```shell
    kubectl get service web
-   ``` 
-    
+   ```
+
    <!-- Output: -->
    输出：
-    
+
    ```shell
    NAME      TYPE       CLUSTER-IP       EXTERNAL-IP   PORT(S)          AGE
    web       NodePort   10.104.133.249   <none>        8080:31637/TCP   12m
@@ -150,14 +150,14 @@ This page shows you how to set up a simple Ingress which routes requests to Serv
    ```shell
    minikube service web --url
    ```
-    
+
    <!-- Output: -->
    输出：
-    
+
    ```shell
    http://172.17.0.15:31637
    ```
-    
+
    <!--
    Katacoda environment only: at the top of the terminal panel, click the plus sign, and then click **Select port to view on Host 1**. Enter the NodePort, in this case `31637`, and then click **Display Port**.
    -->
@@ -166,18 +166,18 @@ This page shows you how to set up a simple Ingress which routes requests to Serv
    然后点击 **Select port to view on Host 1**。
    输入节点和端口号（这里是`31637`），之后点击 **Display Port**。
    {{< /note >}}
-    
+
    <!-- Output: -->
    输出：
-    
+
    ```shell
    Hello, world!
    Version: 1.0.0
    Hostname: web-55b8c6998d-8k564
    ```
-  
-   <!--  
-   You can now access the sample app via the Minikube IP address and NodePort. The next step lets you access 
+
+   <!--
+   You can now access the sample app via the Minikube IP address and NodePort. The next step lets you access
    the app using the Ingress resource.
    -->
    你现在应该可以通过 Minikube 的 IP 地址和节点端口来访问示例应用了。
@@ -198,7 +198,7 @@ The following file is an Ingress resource that sends traffic to your Service via
 1. 根据下面的 YAML 创建文件 `example-ingress.yaml`：
 
    ```yaml
-   apiVersion: networking.k8s.io/v1beta1
+   apiVersion: networking.k8s.io/v1
    kind: Ingress
    metadata:
      name: example-ingress
@@ -210,32 +210,35 @@ The following file is an Ingress resource that sends traffic to your Service via
        http:
          paths:
          - path: /
+           pathType: Prefix
            backend:
-             serviceName: web
-             servicePort: 8080
+             service:
+               name: web
+               port:
+                 number: 8080
    ```
 
 <!--
 1. Create the Ingress resource by running the following command:
 -->
 2. 通过运行下面的命令创建 Ingress 资源：
-    
+
    ```shell
    kubectl apply -f example-ingress.yaml
    ```
-    
+
    <!-- Output: -->
    输出：
-    
+
    ```shell
    ingress.networking.k8s.io/example-ingress created
    ```
 <!--
-1. Verify the IP address is set: 
+1. Verify the IP address is set:
 -->
 3. 验证 IP 地址已被设置：
 
-   ```shell 
+   ```shell
    kubectl get ingress
    ```
 
@@ -243,12 +246,12 @@ The following file is an Ingress resource that sends traffic to your Service via
    {{< note >}}此操作可能需要几分钟时间。{{< /note >}}
 
    ```shell
-   NAME              HOSTS              ADDRESS       PORTS     AGE
-   example-ingress   hello-world.info   172.17.0.15   80        38s
+   NAME              CLASS    HOSTS              ADDRESS        PORTS   AGE
+   example-ingress   <none>   hello-world.info   172.17.0.15    80      38s
    ```
 
 <!--
-1. Add the following line to the bottom of the `/etc/hosts` file. 
+1. Add the following line to the bottom of the `/etc/hosts` file.
 -->
 4. 在 `/etc/hosts` 文件的末尾添加以下内容：
 
@@ -277,7 +280,7 @@ The following file is an Ingress resource that sends traffic to your Service via
 
    <!-- Output: -->
    输出：
-    
+
    ```shell
    Hello, world!
    Version: 1.0.0
@@ -305,12 +308,12 @@ The following file is an Ingress resource that sends traffic to your Service via
    ```
    <!-- Output: -->
    输出：
-    
+
    ```shell
    deployment.apps/web2 created
    ```
 
-<!--    
+<!--
 1. Expose the Deployment:
 -->
 2. 将 Deployment 暴露出来：
@@ -321,15 +324,15 @@ The following file is an Ingress resource that sends traffic to your Service via
 
    <!-- Output:  -->
    输出：
-    
+
    ```shell
    service/web2 exposed
    ```
 
-<!--    
+<!--
 ## Edit Ingress
 
-1. Edit the existing `example-ingress.yaml` and add the following lines:  
+1. Edit the existing `example-ingress.yaml` and add the following lines:
 -->
 ## 编辑 Ingress
 
@@ -338,9 +341,12 @@ The following file is an Ingress resource that sends traffic to your Service via
 
    ```yaml
      - path: /v2
+       pathType: Prefix
        backend:
-         serviceName: web2
-         servicePort: 8080
+         service:
+           name: web2
+           port:
+             number: 8080
    ```
 
 <!--
@@ -353,7 +359,7 @@ The following file is an Ingress resource that sends traffic to your Service via
    ```
 
    <!-- Output: -->
-   输出： 
+   输出：
 
    ```shell
    ingress.networking/example-ingress configured


### PR DESCRIPTION
There is a warning deprecation message for kubernetes v1.19:

```
Warning: networking.k8s.io/v1beta1 Ingress is deprecated in v1.19+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
```

Switched `apiVersion` in the example to `networking.k8s.io/v1`

Related prs: https://github.com/kubernetes/website/pull/24224 and https://github.com/kubernetes/website/pull/24225