### PR TITLE
Update the run command to refer to pod creation

### DIFF
--- a/content/en/docs/tasks/manage-kubernetes-objects/imperative-command.md
+++ b/content/en/docs/tasks/manage-kubernetes-objects/imperative-command.md
@@ -37,7 +37,7 @@ The `kubectl` tool supports verb-driven commands for creating some of the most c
 object types. The commands are named to be recognizable to users unfamiliar with
 the Kubernetes object types.
 
-- `run`: Create a new Deployment object to run Containers in one or more Pods.
+- `run`: Create a new Pod to run a Container.
 - `expose`: Create a new Service object to load balance traffic across Pods.
 - `autoscale`: Create a new Autoscaler object to automatically horizontally scale a controller, such as a Deployment.
 


### PR DESCRIPTION
The "run" command refers to deployment creation and it should refer to pod creation

