### PR TITLE
Remove --replicas flag from namespaces doc

### DIFF
--- a/content/en/docs/tasks/administer-cluster/namespaces.md
+++ b/content/en/docs/tasks/administer-cluster/namespaces.md
@@ -194,7 +194,7 @@ This delete is asynchronous, so for a time you will see the namespace in the `Te
     To demonstrate this, let's spin up a simple Deployment and Pods in the `development` namespace.
 
     ```shell
-    kubectl create deployment snowflake --image=k8s.gcr.io/serve_hostname  -n=development --replicas=2
+    kubectl create deployment snowflake --image=k8s.gcr.io/serve_hostname -n=development
     ```
     We have just created a deployment whose replica size is 2 that is running the pod called `snowflake` with a basic container that just serves the hostname.
 


### PR DESCRIPTION
I was working through this guide with `kubectl@1.18.8` and got the following error:

```
Error: unknown flag: --replicas
See 'kubectl create deployment --help' for usage.
```

I thought maybe because my server version is 1.16 I should try the example from that version of the docs, but it only confirmed that this should option should not be used.

```
> kubectl run snowflake --image=k8s.gcr.io/serve_hostname --replicas=2
Flag --replicas has been deprecated, has no effect and will be removed in the future.
```

I presume I will need to add more to my commit for the document to be correct. Was having 2 replicas important for what this example is demonstrating? What else do I need to correct? Just thought I'd open this to start a conversation on how to improve this.