### PR TITLE
Set sitemap priority for key pages

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -66,6 +66,10 @@ date = ["date", ":filename", "publishDate", "lastmod"]
 [permalinks]
 blog = "/:section/:year/:month/:day/:slug/"
 
+[sitemap]
+  filename = "sitemap.xml"
+  priority = 0.75
+
 # Be explicit about the output formats. We (currently) only want an RSS feed for the home page.
 [outputs]
 home = [ "HTML", "RSS", "HEADERS" ]

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -2,6 +2,8 @@
 title: "Production-Grade Container Orchestration"
 abstract: "Automated container deployment, scaling, and management"
 cid: home
+sitemap:
+  priority: 1.0
 ---
 
 {{< blocks/section id="oceanNodes" >}}

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -1,4 +1,6 @@
 ---
 linktitle: Kubernetes Documentation
 title: Documentation
+sitemap:
+  priority: 1.0
 ---

--- a/content/en/docs/concepts/overview/_index.md
+++ b/content/en/docs/concepts/overview/_index.md
@@ -2,4 +2,6 @@
 title: "Overview"
 weight: 20
 description: Get a high-level outline of Kubernetes and the components it is built from.
+sitemap:
+  priority: 0.9
 ---

--- a/content/en/docs/concepts/overview/what-is-kubernetes.md
+++ b/content/en/docs/concepts/overview/what-is-kubernetes.md
@@ -10,6 +10,8 @@ weight: 10
 card:
   name: concepts
   weight: 10
+sitemap:
+  priority: 0.9
 ---
 
 <!-- overview -->


### PR DESCRIPTION
Configure Docsy to set a default sitemap priority (0.75), and then override that for key pages.

See https://www.docsy.dev/docs/adding-content/content/#sitemap for details on how Docsy makes this work.

The very key pages get 1.0 priority; other good landing pages get 0.9 and the remaining pages have a default priority, 0.75.

Fixes #24148