### PR TITLE
Fix issue with links to already translated ko documents

### DIFF
--- a/content/ko/docs/concepts/architecture/control-plane-node-communication.md
+++ b/content/ko/docs/concepts/architecture/control-plane-node-communication.md
@@ -16,7 +16,7 @@ aliases:
 
 ## 노드에서 컨트롤 플레인으로의 통신
 쿠버네티스에는 "허브 앤 스포크(hub-and-spoke)" API 패턴을 가지고 있다. 노드(또는 노드에서 실행되는 파드들)의 모든 API 사용은 API 서버에서 종료된다(다른 컨트롤 플레인 컴포넌트 중 어느 것도 원격 서비스를 노출하도록 설계되지 않았다). API 서버는 하나 이상의 클라이언트 [인증](/docs/reference/access-authn-authz/authentication/) 형식이 활성화된 보안 HTTPS 포트(일반적으로 443)에서 원격 연결을 수신하도록 구성된다.
-특히 [익명의 요청](/docs/reference/access-authn-authz/authentication/#anonymous-requests) 또는 [서비스 어카운트 토큰](/docs/reference/access-authn-authz/authentication/#service-account-tokens)이 허용되는 경우, 하나 이상의 [권한 부여](/docs/reference/access-authn-authz/authorization/) 형식을 사용해야 한다.
+특히 [익명의 요청](/docs/reference/access-authn-authz/authentication/#anonymous-requests) 또는 [서비스 어카운트 토큰](/docs/reference/access-authn-authz/authentication/#service-account-tokens)이 허용되는 경우, 하나 이상의 [권한 부여](/ko/docs/reference/access-authn-authz/authorization/) 형식을 사용해야 한다.
 
 노드는 유효한 클라이언트 자격 증명과 함께 API 서버에 안전하게 연결할 수 있도록 클러스터에 대한 공개 루트 인증서로 프로비전해야 한다. 예를 들어, 기본 GKE 배포에서, kubelet에 제공되는 클라이언트 자격 증명은 클라이언트 인증서 형식이다. kubelet 클라이언트 인증서의 자동 프로비저닝은 [kubelet TLS 부트스트랩](/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/)을 참고한다.
 

--- a/content/ko/docs/concepts/cluster-administration/_index.md
+++ b/content/ko/docs/concepts/cluster-administration/_index.md
@@ -47,11 +47,11 @@ no_list: true
 
 * [쿠버네티스 컨테이너 환경](/ko/docs/concepts/containers/container-environment/)은 쿠버네티스 노드에서 Kubelet으로 관리하는 컨테이너에 대한 환경을 설명한다.
 
-* [쿠버네티스 API에 대한 접근 제어](/docs/reference/access-authn-authz/controlling-access/)는 사용자와 서비스 어카운트에 대한 권한을 설정하는 방법을 설명한다.
+* [쿠버네티스 API에 대한 접근 제어](/ko/docs/reference/access-authn-authz/controlling-access/)는 사용자와 서비스 어카운트에 대한 권한을 설정하는 방법을 설명한다.
 
 * [인증](/docs/reference/access-authn-authz/authentication/)은 다양한 인증 옵션을 포함한 쿠버네티스에서의 인증에 대해 설명한다.
 
-* [인가](/docs/reference/access-authn-authz/authorization/)는 인증과는 별개로, HTTP 호출 처리 방법을 제어한다.
+* [인가](/ko/docs/reference/access-authn-authz/authorization/)는 인증과는 별개로, HTTP 호출 처리 방법을 제어한다.
 
 * [어드미션 컨트롤러 사용하기](/docs/reference/access-authn-authz/admission-controllers/)는 인증과 권한 부여 후 쿠버네티스 API 서버에 대한 요청을 가로채는 플러그인에 대해 설명한다.
 

--- a/content/ko/docs/concepts/containers/runtime-class.md
+++ b/content/ko/docs/concepts/containers/runtime-class.md
@@ -77,7 +77,7 @@ handler: myconfiguration  # 상응하는 CRI 설정의 이름임
 {{< note >}}
 런타임클래스 쓰기 작업(create/update/patch/delete)은
 클러스터 관리자로 제한할 것을 권장한다. 이것은 일반적으로 기본 설정이다.
-더 자세한 정보는 [권한 개요](/docs/reference/access-authn-authz/authorization/)를 참고한다.
+더 자세한 정보는 [권한 개요](/ko/docs/reference/access-authn-authz/authorization/)를 참고한다.
 {{< /note >}}
 
 ## 사용

--- a/content/ko/docs/concepts/extend-kubernetes/_index.md
+++ b/content/ko/docs/concepts/extend-kubernetes/_index.md
@@ -126,7 +126,7 @@ API를 추가해도 기존 API(예: 파드)의 동작에 직접 영향을 미치
 
 ### API 접근 익스텐션
 
-요청이 쿠버네티스 API 서버에 도달하면 먼저 인증이 되고, 그런 다음 승인된 후 다양한 유형의 어드미션 컨트롤이 적용된다. 이 흐름에 대한 자세한 내용은 [쿠버네티스 API에 대한 접근 제어](/docs/reference/access-authn-authz/controlling-access/)를 참고하길 바란다.
+요청이 쿠버네티스 API 서버에 도달하면 먼저 인증이 되고, 그런 다음 승인된 후 다양한 유형의 어드미션 컨트롤이 적용된다. 이 흐름에 대한 자세한 내용은 [쿠버네티스 API에 대한 접근 제어](/ko/docs/reference/access-authn-authz/controlling-access/)를 참고하길 바란다.
 
 이러한 각 단계는 익스텐션 포인트를 제공한다.
 

--- a/content/ko/docs/concepts/extend-kubernetes/extend-cluster.md
+++ b/content/ko/docs/concepts/extend-kubernetes/extend-cluster.md
@@ -127,7 +127,7 @@ API를 추가해도 기존 API(예: 파드)의 동작에 직접 영향을 미치
 
 ### API 접근 익스텐션
 
-요청이 쿠버네티스 API 서버에 도달하면 먼저 인증이 되고, 그런 다음 승인된 후 다양한 유형의 어드미션 컨트롤이 적용된다. 이 흐름에 대한 자세한 내용은 [쿠버네티스 API에 대한 접근 제어](/docs/reference/access-authn-authz/controlling-access/)를 참고하길 바란다.
+요청이 쿠버네티스 API 서버에 도달하면 먼저 인증이 되고, 그런 다음 승인된 후 다양한 유형의 어드미션 컨트롤이 적용된다. 이 흐름에 대한 자세한 내용은 [쿠버네티스 API에 대한 접근 제어](/ko/docs/reference/access-authn-authz/controlling-access/)를 참고하길 바란다.
 
 이러한 각 단계는 익스텐션 포인트를 제공한다.
 

--- a/content/ko/docs/concepts/policy/pod-security-policy.md
+++ b/content/ko/docs/concepts/policy/pod-security-policy.md
@@ -138,7 +138,7 @@ RBAC 바인딩에 대한 자세한 예는,
 ### 문제 해결
 
 - [컨트롤러 관리자](/docs/reference/command-line-tools-reference/kube-controller-manager/)는
-[보안 API 포트](/docs/reference/access-authn-authz/controlling-access/)에 대해 실행해야 하며,
+[보안 API 포트](/ko/docs/reference/access-authn-authz/controlling-access/)에 대해 실행해야 하며,
 슈퍼유저 권한이 없어야 한다. 그렇지 않으면 요청이 인증 및 권한 부여 모듈을 우회하고,
 모든 파드시큐리티폴리시 오브젝트가 허용되며
 사용자는 특권있는 컨테이너를 만들 수 있다. 컨트롤러 관리자 권한 구성에 대한 자세한

--- a/content/ko/docs/concepts/security/overview.md
+++ b/content/ko/docs/concepts/security/overview.md
@@ -147,7 +147,7 @@ TLS를 통한 접근 | 코드가 TCP를 통해 통신해야 한다면, 미리 �
 * [파드 보안 표준](/docs/concepts/security/pod-security-standards/)
 * [파드에 대한 네트워크 정책](/ko/docs/concepts/services-networking/network-policies/)
 * [클러스터 보안](/docs/tasks/administer-cluster/securing-a-cluster/)
-* [API 접근 통제](/docs/reference/access-authn-authz/controlling-access/)
+* [API 접근 통제](/ko/docs/reference/access-authn-authz/controlling-access/)
 * 컨트롤 플레인을 위한 [전송 데이터 암호화](/docs/tasks/tls/managing-tls-in-a-cluster/)
 * [Rest에서 데이터 암호화](/docs/tasks/administer-cluster/encrypt-data/)
 * [쿠버네티스 시크릿](/ko/docs/concepts/configuration/secret/)

--- a/content/ko/docs/concepts/storage/persistent-volumes.md
+++ b/content/ko/docs/concepts/storage/persistent-volumes.md
@@ -25,7 +25,7 @@ _퍼시스턴트볼륨클레임_ (PVC)은 사용자의 스토리지에 대한 �
 
 퍼시스턴트볼륨클레임을 사용하면 사용자가 추상화된 스토리지 리소스를 사용할 수 있지만, 다른 문제들 때문에 성능과 같은 다양한 속성을 가진 퍼시스턴트볼륨이 필요한 경우가 일반적이다. 클러스터 관리자는 사용자에게 해당 볼륨의 구현 방법에 대한 세부 정보를 제공하지 않고 단순히 크기와 접근 모드와는 다른 방식으로 다양한 퍼시스턴트볼륨을 제공할 수 있어야 한다. 이러한 요구에는 _스토리지클래스_ 리소스가 있다.
 
-[실습 예제와 함께 상세한 내용](/docs/tasks/configure-pod-container/configure-persistent-volume-storage/)을 참고하길 바란다.
+[실습 예제와 함께 상세한 내용](/ko/docs/tasks/configure-pod-container/configure-persistent-volume-storage/)을 참고하길 바란다.
 
 ## 볼륨과 클레임 라이프사이클
 
@@ -755,8 +755,8 @@ spec:
   ## {{% heading "whatsnext" %}}
 
 
-* [퍼시스턴트볼륨 생성](/docs/tasks/configure-pod-container/configure-persistent-volume-storage/#create-a-persistentvolume)에 대해 자세히 알아보기
-* [퍼시스턴트볼륨클레임 생성](/docs/tasks/configure-pod-container/configure-persistent-volume-storage/#create-a-persistentvolumeclaim)에 대해 자세히 알아보기
+* [퍼시스턴트볼륨 생성](/ko/docs/tasks/configure-pod-container/configure-persistent-volume-storage/#퍼시스턴트볼륨-생성하기)에 대해 자세히 알아보기
+* [퍼시스턴트볼륨클레임 생성](/ko/docs/tasks/configure-pod-container/configure-persistent-volume-storage/#퍼시스턴트볼륨클레임-생성하기)에 대해 자세히 알아보기
 * [퍼시스턴트 스토리지 설계 문서](https://git.k8s.io/community/contributors/design-proposals/storage/persistent-storage.md) 읽어보기
 
 ### 참고

--- a/content/ko/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/ko/docs/concepts/workloads/controllers/cron-jobs.md
@@ -44,7 +44,7 @@ kube-controller-manager 컨테이너에 설정된 시간대는
 
 {{< codenew file="application/job/cronjob.yaml" >}}
 
-([크론잡으로 자동화된 작업 실행하기](/docs/tasks/job/automated-tasks-with-cron-jobs/)는
+([크론잡으로 자동화된 작업 실행하기](/ko/docs/tasks/job/automated-tasks-with-cron-jobs/)는
 이 예시를 더 자세히 설명한다.)
 
 ## 크론잡의 한계 {#cron-job-limitations}
@@ -85,4 +85,4 @@ Cannot determine if job needs to be started. Too many missed start time (> 100).
 크론잡 `schedule` 필드의 포맷을 문서화 한다.
 
 크론잡 생성과 작업에 대한 지침과 크론잡 매니페스트의
-예는 [크론잡으로 자동화된 작업 실행하기](/docs/tasks/job/automated-tasks-with-cron-jobs/)를 참조한다.
+예는 [크론잡으로 자동화된 작업 실행하기](/ko/docs/tasks/job/automated-tasks-with-cron-jobs/)를 참조한다.

--- a/content/ko/docs/concepts/workloads/controllers/job.md
+++ b/content/ko/docs/concepts/workloads/controllers/job.md
@@ -346,7 +346,7 @@ spec:
 | -------------------------------------------------------------------- |:-----------------:|:---------------------------:|:-------------------:|:-------------------:|
 | [잡 템플릿 확장](/ko/docs/tasks/job/parallel-processing-expansion/)            |                   |                             |          ✓          |          ✓          |
 | [작업 항목 당 파드가 있는 큐](/docs/tasks/job/coarse-parallel-processing-work-queue/)   |         ✓         |                             |      때때로      |          ✓          |
-| [가변 파드 수를 가진 큐](/docs/tasks/job/fine-parallel-processing-work-queue/)  |         ✓         |             ✓               |                     |          ✓          |
+| [가변 파드 수를 가진 큐](/ko/docs/tasks/job/fine-parallel-processing-work-queue/)  |         ✓         |             ✓               |                     |          ✓          |
 | 정적 작업이 할당된 단일 잡                               |         ✓         |                             |          ✓          |                     |
 
 `.spec.completions` 로 완료를 지정할 때, 잡 컨트롤러에 의해 생성된 각 파드는
@@ -362,7 +362,7 @@ spec:
 | -------------------------------------------------------------------- |:-------------------:|:--------------------:|
 | [잡 템플릿 확장](/ko/docs/tasks/job/parallel-processing-expansion/)           |          1          |     1이어야 함      |
 | [작업 항목 당 파드가 있는 큐](/docs/tasks/job/coarse-parallel-processing-work-queue/)   |          W          |        any           |
-| [가변 파드 수를 가진 큐](/docs/tasks/job/fine-parallel-processing-work-queue/)  |          1          |        any           |
+| [가변 파드 수를 가진 큐](/ko/docs/tasks/job/fine-parallel-processing-work-queue/)  |          1          |        any           |
 | 정적 작업이 할당된 단일 잡                               |          W          |        any           |
 
 

--- a/content/ko/docs/reference/access-authn-authz/authorization.md
+++ b/content/ko/docs/reference/access-authn-authz/authorization.md
@@ -11,7 +11,7 @@ weight: 60
 
 <!-- body -->
 쿠버네티스에서는 사용자의 요청이 인가(접근 권한을 부여) 받기 전에 사용자가 인증(로그인)되어야 한다.
-인증에 대한 자세한 내용은 [쿠버네티스 API 접근 제어하기](/docs/reference/access-authn-authz/controlling-access/)를
+인증에 대한 자세한 내용은 [쿠버네티스 API 접근 제어하기](/ko/docs/reference/access-authn-authz/controlling-access/)를
 참고한다.
 
 쿠버네티스는 REST API 요청에 공통적인 속성을 요구한다.
@@ -42,7 +42,7 @@ weight: 60
  * **extra** - 인증 계층에서 제공하는 문자열 값에 대한 임의의 문자열 키 맵.
  * **API** - 요청이 API 리소스에 대한 것인지 여부.
  * **Request path** - `/api` 또는 `/healthz`와 같이 다양한 리소스가 아닌 엔드포인트의 경로.
- * **API request verb** - `get`, `list`, `create`, `update`, `patch`, `watch`, `delete`, `deletecollection`과 같은 리소스 요청에 사용하는 API 동사. 리소스 API 엔드포인트의 요청 동사를 결정하려면 [요청 동사 결정](/docs/reference/access-authn-authz/authorization/#determine-the-request-verb)을 참고한다.
+ * **API request verb** - `get`, `list`, `create`, `update`, `patch`, `watch`, `delete`, `deletecollection`과 같은 리소스 요청에 사용하는 API 동사. 리소스 API 엔드포인트의 요청 동사를 결정하려면 [요청 동사 결정](/ko/docs/reference/access-authn-authz/authorization/#요청-동사-결정)을 참고한다.
  * **HTTP request verb** - `get`, `post`, `put`, `delete`처럼 소문자 HTTP 메서드는 리소스가 아닌 요청에 사용한다.
  * **Resource** - 접근 중인 리소스의 ID 또는 이름(리소스 요청만 해당) -- `get`, `update`, `patch`, `delete` 동사를 사용하는 리소스 요청의 경우 리소스 이름을 지정해야 한다.
  * **Subresource** - 접근 중인 하위 리소스(리소스 요청만 해당).
@@ -197,5 +197,5 @@ status:
 
 ## {{% heading "whatsnext" %}}
 
-* 인증에 대한 자세한 내용은 [쿠버네티스 API 접근 제어하기](/docs/reference/access-authn-authz/controlling-access/)에서 **인증**을 참조한다.
+* 인증에 대한 자세한 내용은 [쿠버네티스 API 접근 제어하기](/ko/docs/reference/access-authn-authz/controlling-access/)에서 **인증**을 참조한다.
 * 어드미션 제어에 대한 자세한 내용은 [어드미션 컨트롤러 사용하기](/docs/reference/access-authn-authz/admission-controllers/)를 참조한다.

--- a/content/ko/docs/reference/access-authn-authz/controlling-access.md
+++ b/content/ko/docs/reference/access-authn-authz/controlling-access.md
@@ -11,7 +11,7 @@ weight: 5
 <!-- body -->
 사용자는 `kubectl`, 클라이언트 라이브러리
 또는 REST 요청을 통해
-[API에 접근한다](/docs/tasks/access-application-cluster/access-cluster/).
+[API에 접근한다](/ko/docs/tasks/access-application-cluster/access-cluster/).
 사용자와 쿠버네티스 서비스 어카운트 모두 API에 접근할 수 있다.
 요청이 API에 도달하면,
 다음 다이어그램에 설명된 몇 가지 단계를 거친다.
@@ -159,4 +159,3 @@ GCE(구글 컴퓨트 엔진) 및 다른 클라우드 제공자에서 `kube-up.sh
 API 서버는 포트 443에서 서비스한다.
 GCE에서는 외부 HTTPS가 API에 접근할 수 있도록 프로젝트에서 방화벽 규칙이 구성된다.
 이외에 클러스터 설정 방법은 다양하다.
-

--- a/content/ko/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
+++ b/content/ko/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
@@ -81,7 +81,7 @@ API 및 kubectl의 관점에서, 윈도우 컨테이너는 리눅스 기반 컨�
   * 레플리카셋(ReplicaSet)
   * 레플리케이션컨트롤러(ReplicationController)
   * 디플로이먼트(Deployment)
-  * 스테이트풀셋(StatefulSet)	
+  * 스테이트풀셋(StatefulSet)
   * 데몬셋(DaemonSet)
   * 잡(Job)
   * 크론잡(CronJob)
@@ -198,7 +198,7 @@ CSI 노드 플러그인(특히 블록 디바이스 또는 공유 파일시스템
 윈도우에서는 다음 IPAM 옵션이 지원된다.
 
 * [호스트-로컬](https://github.com/containernetworking/plugins/tree/master/plugins/ipam/host-local)
-* HNS IPAM(Inbox 플랫폼 IPAM, 이것은 IPAM이 설정되지 않은 경우 폴백(fallback)이다) 
+* HNS IPAM(Inbox 플랫폼 IPAM, 이것은 IPAM이 설정되지 않은 경우 폴백(fallback)이다)
 * [Azure-vnet-ipam](https://github.com/Azure/azure-container-networking/blob/master/docs/ipam.md)(azure-cni 전용)
 
 ##### 로드 밸런싱과 서비스
@@ -255,9 +255,9 @@ CSI 노드 플러그인(특히 블록 디바이스 또는 공유 파일시스템
 
 윈도우에는 리눅스처럼 out-of-memory 프로세스 킬러가 없다. 윈도우는 항상 모든 사용자 모드 메모리 할당을 가상으로 처리하며 페이지 파일은 필수이다. 결과적으로 윈도우는 리눅스와 같은 방식으로 메모리 부족 상태에 도달하지 않고, 메모리 부족(OOM)으로 인한 종료 대신 페이지를 디스크로 처리한다. 메모리가 과도하게 프로비저닝되고 모든 실제 메모리가 고갈되면, 페이징으로 인해 성능이 저하될 수 있다.
 
-2단계 프로세스를 통해 적절한 범위 내에서 메모리 사용량을 유지할 수 있다. 먼저, kubelet 파라미터 `--kubelet-reserve` 그리고/또는 `--system-reserve`를 사용하여 노드(컨테이너 외부)의 메모리 사용량을 고려한다. 이렇게 하면 [노드 할당(NodeAllocatable)](/docs/tasks/administer-cluster/reserve-compute-resources/#node-allocatable)이 줄어든다. 워크로드를 배포할 때 컨테이너에 리소스 제한을 사용(limits만 설정하거나 limits이 requests과 같아야 함)한다. 또한 NodeAllocatable에서 빼고 노드가 가득차면 스케줄러가 더 많은 파드를 추가하지 못하도록 한다. 
+2단계 프로세스를 통해 적절한 범위 내에서 메모리 사용량을 유지할 수 있다. 먼저, kubelet 파라미터 `--kubelet-reserve` 그리고/또는 `--system-reserve`를 사용하여 노드(컨테이너 외부)의 메모리 사용량을 고려한다. 이렇게 하면 [노드 할당(NodeAllocatable)](/docs/tasks/administer-cluster/reserve-compute-resources/#node-allocatable)이 줄어든다. 워크로드를 배포할 때 컨테이너에 리소스 제한을 사용(limits만 설정하거나 limits이 requests과 같아야 함)한다. 또한 NodeAllocatable에서 빼고 노드가 가득차면 스케줄러가 더 많은 파드를 추가하지 못하도록 한다.
 
-오버 프로비저닝을 방지하는 모범 사례는 윈도우, 도커 및 쿠버네티스 프로세스를 고려하여 최소 2GB의 시스템 예약 메모리로 kubelet을 구성하는 것이다. 
+오버 프로비저닝을 방지하는 모범 사례는 윈도우, 도커 및 쿠버네티스 프로세스를 고려하여 최소 2GB의 시스템 예약 메모리로 kubelet을 구성하는 것이다.
 
 플래그의 동작은 아래에 설명된대로 다르게 동작한다.
 
@@ -581,7 +581,7 @@ PodSecurityContext 필드는 윈도우에서 작동하지 않는다. 참조를 �
 1. DNS 확인(resolution)이 제대로 작동하지 않는다.
 
     이 [섹션](#dns-limitations)에서 윈도우에 대한 DNS 제한을 확인한다.
-    
+
 1. `kubectl port-forward`가 "unable to do port forwarding: wincat not found"로 실패한다.
 
     이는 쿠버네티스 1.15 및 pause 인프라 컨테이너 `mcr.microsoft.com/k8s/core/pause:1.2.0`에서 구현되었다. 해당 버전 또는 최신 버전을 사용해야 한다.
@@ -666,15 +666,13 @@ spec:
 
 ### kubeadm 및 클러스터 API를 사용한 배포
 
-Kubeadm은 사용자가 쿠버네티스 클러스터를 배포하기 위한 사실상의 표준이 
-되고 있다. kubeadm의 윈도우 노드 지원은 현재 작업 중이지만 
-[여기](/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes/)에서 가이드를 사용할 수 있다.
-또한 윈도우 노드가 적절하게 프로비저닝되도록 클러스터 API에 
+Kubeadm은 사용자가 쿠버네티스 클러스터를 배포하기 위한 사실상의 표준이
+되고 있다. kubeadm의 윈도우 노드 지원은 현재 작업 중이지만
+[여기](/ko/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes/)에서 가이드를 사용할 수 있다.
+또한 윈도우 노드가 적절하게 프로비저닝되도록 클러스터 API에
 투자하고 있다.
 
 ### 몇 가지 기타 주요 기능
 * 그룹 관리 서비스 어카운트(Service Accounts)에 대한 베타 지원
 * 더 많은 CNI
 * 더 많은 스토리지 플러그인
-
-

--- a/content/ko/docs/tasks/access-application-cluster/access-cluster.md
+++ b/content/ko/docs/tasks/access-application-cluster/access-cluster.md
@@ -149,8 +149,8 @@ root 인증서를 사용하려면 특수한 설정을 필요로 할 것이다.
 
 localhost에서 제공되거나 방화벽으로 보호되는 몇몇 클러스터들에서는 apiserver가 인증을
 요구하지 않지만 이는 표준이 아니다.
-[Configuring Access to the API](/docs/reference/access-authn-authz/controlling-access/)
-는 클러스터 관리자가 이를 어떻게 구성할 수 있는지를 설명한다.
+[API에 대한 접근 구성](/ko/docs/reference/access-authn-authz/controlling-access/)은
+클러스터 관리자가 이를 어떻게 구성할 수 있는지를 설명한다.
 이 방식들은 미래의 고가용성 지원과 충돌될 수 있다.
 
 ## API에 프로그래밍 방식으로 접근
@@ -375,4 +375,3 @@ redirect 기능은 deprecated되고 제거 되었다. 대신 (아래의) proxy�
 
 일반적으로 쿠버네티스 사용자들은 처음 두 타입이 아닌 다른 방식은 고려할 필요가 없지만 클러스터 관리자는
 나머지 타입을 적절하게 구성해줘야 한다.
-

--- a/content/ko/docs/tasks/administer-cluster/access-cluster-api.md
+++ b/content/ko/docs/tasks/administer-cluster/access-cluster-api.md
@@ -148,7 +148,7 @@ http 클라이언트가 루트 인증서를 사용하도록 하려면 특별한 
 
 일부 클러스터에서, API 서버는 인증이 필요하지 않다.
 로컬 호스트에서 제공되거나, 방화벽으로 보호될 수 있다. 이에 대한 표준은
-없다. [API에 대한 접근 구성](/docs/reference/access-authn-authz/controlling-access/)은
+없다. [API에 대한 접근 구성](/ko/docs/reference/access-authn-authz/controlling-access/)은
 클러스터 관리자가 이를 구성하는 방법에 대해 설명한다. 이러한 접근 방식은 향후
 고 가용성 지원과 충돌할 수 있다.
 


### PR DESCRIPTION
Closes #24156 

**Problem:**
The following documents contain the document links which are already translated into Korean:
- [x] content/ko/docs/concepts/architecture/control-plane-node-communication.md
- [x] content/ko/docs/concepts/cluster-administration/_index.md
- [x] content/ko/docs/concepts/containers/runtime-class.md
- [x] content/ko/docs/concepts/extend-kubernetes/_index.md
- [x] content/ko/docs/concepts/extend-kubernetes/extend-cluster.md
- [x] content/ko/docs/concepts/policy/pod-security-policy.md
- [x] content/ko/docs/concepts/security/overview.md
- [x] content/ko/docs/concepts/storage/persistent-volumes.md
- [x] content/ko/docs/concepts/workloads/controllers/cron-jobs.md
- [x] content/ko/docs/concepts/workloads/controllers/job.md
- [x] content/ko/docs/reference/access-authn-authz/authorization.md
- [x] content/ko/docs/reference/access-authn-authz/controlling-access.md
- [x] content/ko/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
- [x] content/ko/docs/tasks/access-application-cluster/access-cluster.md
- [x] content/ko/docs/tasks/administer-cluster/access-cluster-api.md

**Proposed Solution:**
Update the document links to the Korean translated documents.