### PR TITLE
Fix typo in en/docs/concepts/scheduling-eviction/scheduling-framework.md

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/scheduling-framework.md
+++ b/content/en/docs/concepts/scheduling-eviction/scheduling-framework.md
@@ -78,7 +78,7 @@ called for that node. Nodes may be evaluated concurrently.
 ### PostFilter {#post-filter}
 
 These plugins are called after Filter phase, but only when no feasible nodes
-were found for the node. Plugins are called in their configured order. If
+were found for the pod. Plugins are called in their configured order. If
 any postFilter plugin marks the node as `Schedulable`, the remaining plugins
 will not be called. A typical PostFilter implementation is preemption, which
 tries to make the pod schedulable by preempting other Pods.


### PR DESCRIPTION
Fixes description for Postfilter plugin. The plugin is called when no feasible nodes were found for the pod being scheduled.