### PR TITLE
Update dry-run flag

### DIFF
--- a/content/en/docs/reference/kubectl/conventions.md
+++ b/content/en/docs/reference/kubectl/conventions.md
@@ -29,14 +29,14 @@ For `kubectl run` to satisfy infrastructure as code:
 * Check in the script for an image that is heavily parameterized.
 * Switch to configuration files checked into source control for features that are needed, but not expressible via `kubectl run` flags.
 
-You can use the `--dry-run` flag to preview the object that would be sent to your cluster, without really submitting it.
+You can use the `--dry-run=client` flag to preview the object that would be sent to your cluster, without really submitting it.
 
 {{< note >}}
 All `kubectl` generators are deprecated. See the Kubernetes v1.17 documentation for a [list](https://v1-17.docs.kubernetes.io/docs/reference/kubectl/conventions/#generators) of generators and how they were used.
 {{< /note >}}
 
 #### Generators
-You can generate the following resources with a kubectl command, `kubectl create --dry-run -o yaml`:
+You can generate the following resources with a kubectl command, `kubectl create --dry-run=client -o yaml`:
 ```
   clusterrole         Create a ClusterRole.
   clusterrolebinding  Create a ClusterRoleBinding for a particular ClusterRole.


### PR DESCRIPTION
Since the flag `dry-run` is deprecated, in docs it should be replaced with `--dry-run=client`.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

-->
