### PR TITLE
[ja] Use apiversion networking.k8s.io/v1 for ingress

### DIFF
--- a/content/ja/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/ja/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -135,7 +135,7 @@ weight: 100
 1. 以下の内容で`example-ingress.yaml`を作成します。
 
     ```yaml
-    apiVersion: networking.k8s.io/v1beta1
+    apiVersion: networking.k8s.io/v1
     kind: Ingress
     metadata:
       name: example-ingress
@@ -147,9 +147,12 @@ weight: 100
         http:
           paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: web
-              servicePort: 8080
+              service:
+                name: web
+                port:
+                  number: 8080
     ```
 
 1. 次のコマンドを実行して、Ingressリソースを作成します。
@@ -175,8 +178,8 @@ weight: 100
     {{< /note >}}
 
     ```shell
-    NAME              HOSTS              ADDRESS       PORTS     AGE
-    example-ingress   hello-world.info   172.17.0.15   80        38s
+    NAME              CLASS    HOSTS              ADDRESS        PORTS   AGE
+    example-ingress   <none>   hello-world.info   172.17.0.15    80      38s
     ```
 
 1. 次の行を`/etc/hosts`ファイルの最後に書きます。
@@ -241,9 +244,12 @@ weight: 100
 
     ```yaml
           - path: /v2
+            pathType: Prefix
             backend:
-              serviceName: web2
-              servicePort: 8080
+              service:
+                name: web2
+                port:
+                  number: 8080
     ```
 
 1. 次のコマンドで変更を適用します。

--- a/content/ja/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/ja/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -134,31 +134,12 @@ weight: 100
 
 1. 以下の内容で`example-ingress.yaml`を作成します。
 
-    ```yaml
-    apiVersion: networking.k8s.io/v1
-    kind: Ingress
-    metadata:
-      name: example-ingress
-      annotations:
-        nginx.ingress.kubernetes.io/rewrite-target: /$1
-    spec:
-      rules:
-      - host: hello-world.info
-        http:
-          paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: web
-                port:
-                  number: 8080
-    ```
+    {{< codenew file="service/networking/example-ingress.yaml" >}}
 
 1. 次のコマンドを実行して、Ingressリソースを作成します。
 
     ```shell
-    kubectl apply -f example-ingress.yaml
+    kubectl apply -f https://kubernetes.io/examples/service/networking/example-ingress.yaml
     ```
 
     出力は次のようになります。
@@ -306,6 +287,3 @@ weight: 100
 * [Ingress](/ja/docs/concepts/services-networking/ingress/)についてさらに学ぶ。
 * [Ingressコントローラー](/ja/docs/concepts/services-networking/ingress-controllers/)についてさらに学ぶ。
 * [Service](/ja/docs/concepts/services-networking/service/)についてさらに学ぶ。
-
-
-

--- a/content/ja/examples/service/networking/example-ingress.yaml
+++ b/content/ja/examples/service/networking/example-ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: example-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+spec:
+  rules:
+    - host: hello-world.info
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: web
+                port:
+                  number: 8080


### PR DESCRIPTION
There is a warning deprecation message for kubernetes v1.19:

```
Warning: networking.k8s.io/v1beta1 Ingress is deprecated in v1.19+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
```

Switched apiversion in the example to `networking.k8s.io/v1`

Related PRs https://github.com/kubernetes/website/pull/24075 and https://github.com/kubernetes/website/pull/24225

[Current English version](https://kubernetes.io/docs/tasks/access-application-cluster/ingress-minikube/)
[Current Japanese version](https://kubernetes.io/ja/docs/tasks/access-application-cluster/ingress-minikube/)