### PR TITLE
Fix Common Name in Ingress TLS docs to match the name used in example.

### DIFF
--- a/content/en/docs/concepts/services-networking/ingress.md
+++ b/content/en/docs/concepts/services-networking/ingress.md
@@ -411,7 +411,7 @@ type: kubernetes.io/tls
 Referencing this secret in an Ingress tells the Ingress controller to
 secure the channel from the client to the load balancer using TLS. You need to make
 sure the TLS secret you created came from a certificate that contains a Common
-Name (CN), also known as a Fully Qualified Domain Name (FQDN) for `sslexample.foo.com`.
+Name (CN), also known as a Fully Qualified Domain Name (FQDN) for `https-example.foo.com`.
 
 {{< codenew file="service/networking/tls-example-ingress.yaml" >}}
 


### PR DESCRIPTION
Ingress documentation mentions `sslexample.foo.com` as the example FQDN, while the [example yaml](https://github.com/kubernetes/website/blob/master/content/en/examples/service/networking/tls-example-ingress.yaml) right below it uses `https-example.foo.com`. 

This has been changed in the commit updating the ingress documentation to 1.19. Before the `sslexample.foo.com` domain was used in the example yaml as well.
Have a look at this diff https://github.com/kubernetes/website/commit/51f6e23f3521f82eaf01e3e3f2b933a6e0b0fc1d#diff-1627c406f91b4f139248c522b1b7cd18L404.

I changed the example FQDN to match the one in the example yaml.
