### PR TITLE
Fix missing command in helm search statement

### DIFF
--- a/content/en/docs/tasks/service-catalog/install-service-catalog-using-helm.md
+++ b/content/en/docs/tasks/service-catalog/install-service-catalog-using-helm.md
@@ -39,7 +39,7 @@ helm repo add svc-cat https://svc-catalog-charts.storage.googleapis.com
 Check to make sure that it installed successfully by executing the following command:
 
 ```shell
-helm search service-catalog
+helm search repo service-catalog
 ```
 
 If the installation was successful, the command should output the following:


### PR DESCRIPTION
helm search requires either hub or repo command after seach.

```
kejones@jetson-nano-1:~/Kubernetes$ helm version
version.BuildInfo{Version:"v3.1.0", GitCommit:"b29d20baf09943e134c2fa5e1e1cab3bf93315fa", GitTreeState:"clean", GoVersion:"go1.13.7"}
```

```
kejones@jetson-nano-1:~/Kubernetes$ helm search service-catalog

Search provides the ability to search for Helm charts in the various places
they can be stored including the Helm Hub and repositories you have added. Use
search subcommands to search different locations for charts.

Usage:
  helm search [command]

Available Commands:
  hub         search for charts in the Helm Hub or an instance of Monocular
  repo        search repositories for a keyword in charts
```

```
kejones@jetson-nano-1:~/Kubernetes$ helm search repo service-catalog
NAME                	CHART VERSION	APP VERSION	DESCRIPTION                                       
svc-cat/catalog     	0.3.0        	           	service-catalog webhook server and controller-m...
svc-cat/catalog-v0.2	0.2.3        	           	service-catalog API server and controller-manag...
```
