### PR TITLE
[de] Add missing git submodules init to german README.

### DIFF
--- a/README-de.md
+++ b/README-de.md
@@ -37,9 +37,10 @@ Um die Kubernetes-Website lokal laufen zu lassen, empfiehlt es sich, ein speziel
 
 > Wenn Sie die Website lieber lokal ohne Docker ausführen möchten, finden Sie weitere Informationen unter [Website lokal mit Hugo ausführen](#Die-Site-lokal-mit-Hugo-ausführen).
 
-Das benötigte Docsy Hugo Theme muss als git submodule installiert werden:
+Das benötigte [Docsy Hugo theme](https://github.com/google/docsy#readme) muss als git submodule installiert werden:
 
 ```
+#Füge das Docsy submodule hinzu
 git submodule update --init --recursive --depth 1
 ```
 
@@ -61,9 +62,13 @@ make container-serve
 
 Hugo-Installationsanweisungen finden Sie in der [offiziellen Hugo-Dokumentation](https://gohugo.io/getting-started/installing/). Stellen Sie sicher, dass Sie die Hugo-Version installieren, die in der Umgebungsvariablen `HUGO_VERSION` in der Datei [`netlify.toml`](netlify.toml#L9) angegeben ist.
 
-Das benötigte Docsy Hugo Theme muss als git submodule installiert werden:
+Das benötigte [Docsy Hugo theme](https://github.com/google/docsy#readme) muss als git submodule installiert werden:
 
 ```
+#Installiere die Abhängigkeiten
+yarn
+
+#Füge das Docsy submodule hinzu
 git submodule update --init --recursive --depth 1
 ```
 

--- a/README-de.md
+++ b/README-de.md
@@ -65,9 +65,6 @@ Hugo-Installationsanweisungen finden Sie in der [offiziellen Hugo-Dokumentation]
 Das benötigte [Docsy Hugo theme](https://github.com/google/docsy#readme) muss als git submodule installiert werden:
 
 ```
-#Installiere die Abhängigkeiten
-yarn
-
 #Füge das Docsy submodule hinzu
 git submodule update --init --recursive --depth 1
 ```
@@ -75,6 +72,8 @@ git submodule update --init --recursive --depth 1
 So führen Sie die Site lokal aus, wenn Sie Hugo installiert haben:
 
 ```bash
+# Installieren der JavaScript Abhängigkeiten
+npm ci
 make serve
 ```
 

--- a/README-de.md
+++ b/README-de.md
@@ -37,6 +37,12 @@ Um die Kubernetes-Website lokal laufen zu lassen, empfiehlt es sich, ein speziel
 
 > Wenn Sie die Website lieber lokal ohne Docker ausführen möchten, finden Sie weitere Informationen unter [Website lokal mit Hugo ausführen](#Die-Site-lokal-mit-Hugo-ausführen).
 
+Das benötigte Docsy Hugo Theme muss als git submodule installiert werden:
+
+```
+git submodule update --init --recursive --depth 1
+```
+
 Wenn Sie Docker [installiert](https://www.docker.com/get-started) haben, erstellen Sie das Docker-Image `kubernetes-hugo` lokal:
 
 ```bash
@@ -54,6 +60,12 @@ make container-serve
 ## Die Site lokal mit Hugo ausführen
 
 Hugo-Installationsanweisungen finden Sie in der [offiziellen Hugo-Dokumentation](https://gohugo.io/getting-started/installing/). Stellen Sie sicher, dass Sie die Hugo-Version installieren, die in der Umgebungsvariablen `HUGO_VERSION` in der Datei [`netlify.toml`](netlify.toml#L9) angegeben ist.
+
+Das benötigte Docsy Hugo Theme muss als git submodule installiert werden:
+
+```
+git submodule update --init --recursive --depth 1
+```
 
 So führen Sie die Site lokal aus, wenn Sie Hugo installiert haben:
 


### PR DESCRIPTION
I followed the German Readme to run the local development. Hugo could not compile the website. After reading the English Readme, I saw the missing git submodules init.

In this PR I add that missing submodules init. 