### PR TITLE
Support canonical URIs for blog articles

### DIFF
--- a/content/en/blog/_posts/2020-10-01-contributing-to-the-development-guide/index.md
+++ b/content/en/blog/_posts/2020-10-01-contributing-to-the-development-guide/index.md
@@ -4,6 +4,7 @@ linkTitle: "Contributing to the Development Guide"
 Author: Erik L. Arneson
 Description: "A new contributor describes the experience of writing and submitting changes to the Kubernetes Development Guide."
 date: 2020-10-01
+canonicalUrl: https://www.kubernetes.dev/blog/2020/09/28/contributing-to-the-development-guide/
 resources:
 - src: "jorge-castro-code-of-conduct.jpg"
   title: "Jorge Castro announcing the Kubernetes Code of Conduct during a weekly SIG ContribEx meeting."

--- a/layouts/blog/baseof.html
+++ b/layouts/blog/baseof.html
@@ -4,6 +4,9 @@
     {{ partial "head.html" . }}
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
     <script defer src="https://use.fontawesome.com/releases/v5.0.6/js/all.js"></script>
+    {{ with .Params.canonicalUrl }}
+    <link rel="canonical" href="{{ . }}">
+    {{ end }}
   </head>
   <body class="td-{{ .Kind }} td-blog">
     <header>


### PR DESCRIPTION
 If a blog article has a canonical URI set, link to it.

This change lets us point search engines to the original article when we mirror them from https://k8s.dev/, and potentially from other sites too.

Compare [_preview_](https://deploy-preview-24333--kubernetes-io-master-staging.netlify.app/blog/2020/10/01/contributing-to-the-development-guide/) (view source to check) vs. [original](https://k8s.io/blog/2020/10/01/contributing-to-the-development-guide/).

/area blog
/area web-development