### PR TITLE
Update triage/support label in for-approvers doc

### DIFF
--- a/content/en/docs/contribute/review/for-approvers.md
+++ b/content/en/docs/contribute/review/for-approvers.md
@@ -190,7 +190,7 @@ close the issue without fixing.
 
 Some docs issues are actually issues with the underlying code, or requests for
 assistance when something, for example a tutorial, doesn't work.
-For issues unrelated to docs, close the issue with the `triage/support` label and a comment
+For issues unrelated to docs, close the issue with the `kind/support` label and a comment
 directing the requester to support venues (Slack, Stack Overflow) and, if
 relevant, the repository to file an issue for bugs with features (`kubernetes/kubernetes`
 is a great place to start).


### PR DESCRIPTION
Follow-up to 5878a2a73dfb24c82af54ef2a4406c3de1fe4834

Last doc to migrate from triage/support -> kind/support


I missed this yesterday 🤦 I had it open in my IDE and forgot to save. >_<


