### PR TITLE
Run Hugo as user "hugo" in local dev container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,6 @@ RUN mkdir -p /usr/local/src && \
 
 WORKDIR /src
 
+USER hugo:hugo
+
 EXPOSE 1313

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ container-build: module-check
 	$(CONTAINER_RUN) $(CONTAINER_IMAGE) hugo --minify
 
 container-serve: module-check
-	$(CONTAINER_RUN) --mount type=tmpfs,destination=/src/resources,tmpfs-mode=0755 -p 1313:1313 $(CONTAINER_IMAGE) hugo server --buildFuture --bind 0.0.0.0
+	$(CONTAINER_RUN) --mount type=tmpfs,destination=/src/resources,tmpfs-mode=0777 -p 1313:1313 $(CONTAINER_IMAGE) hugo server --buildFuture --bind 0.0.0.0
 
 test-examples:
 	scripts/test_examples.sh install


### PR DESCRIPTION
When previewing locally using `make container-serve`, run the Hugo process as user `hugo` inside that container.
(The build process already creates that user).