### PR TITLE
i18n(zh): fix kubectl reference link issue

### DIFF
--- a/content/zh/docs/tutorials/hello-minikube.md
+++ b/content/zh/docs/tutorials/hello-minikube.md
@@ -207,7 +207,7 @@ Pod runs a Container based on the provided Docker image.
 <!--
     {{< note >}}For more information about `kubectl`commands, see the [kubectl overview](/docs/user-guide/kubectl-overview/).{{< /note >}}
 -->
-   {{< note >}}有关 kubectl 命令的更多信息，请参阅 [kubectl 概述](/zh/docs/user-guide/kubectl-overview/)。{{< /note >}}
+   {{< note >}}有关 kubectl 命令的更多信息，请参阅 [kubectl 概述](/zh/docs/reference/kubectl/overview/)。{{< /note >}}
 
 <!--
 ## Create a Service


### PR DESCRIPTION
/language zh
/assign @chenrui333

Closes #24367 

update `/zh/docs/user-guide/kubectl-overview/`
to `/zh/docs/reference/kubectl/overview/`

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

-->
