### PR TITLE
Clean up case study images in content/ja/case-studies

### DIFF
--- a/content/ja/case-studies/appdirect/index.html
+++ b/content/ja/case-studies/appdirect/index.html
@@ -12,7 +12,7 @@ quote: >
    私たちはたくさんの人からの関心を得るためにさまざまな戦略を試みています。Kubernetesとクラウドネイティブ技術は、いまやデファクトのエコシステムとみなされています。
 ---
 
-<div class="banner1" style="background-image: url('/images/CaseStudy_appdirect_banner1.jpg')">
+<div class="banner1" style="background-image: url('/images/case-studies/appdirect/banner1.jpg')">
 <h1>ケーススタディ：<img src="/images/appdirect_logo.png" class="header_logo" style="width:25%;margin-bottom:-1%"><br> <div class="subhead" style="margin-top:1%;font-size:0.5em">AppDirect：AppDirectはいかにしてKubernetessを活用し、エンジニアリングスタッフが10倍になるほどの成長を後押ししたのか<br>
 
 </div></h1>
@@ -47,14 +47,14 @@ quote: >
 <div class="fullcol">
   <h2><a href="https://www.appdirect.com/">AppDirect</a> は2009年以来、クラウドベースの製品やサービス向けのエンドツーエンドのeコマースプラットフォームによって、ComcastやGoDaddyといった組織がデジタルサプライチェーンをシンプルにすることに役立ってきました。</h2><br> 2014年にソフトウェア開発ディレクターのPierre-Alexandre Lacerteが働き始めたとき、AppDirectでは「tomcatベースのインフラにモノリシックなアプリケーションをデプロイしていて、リリースプロセス全体が必要以上に複雑なものとなっていました」と彼は振り返ります。「たくさんのマニュアルステップがありました。1人のエンジニアがある機能を構築し、Pull requestを作成、そしてQAもしくは別のエンジニアの手によってその機能を検証する、といった具合でした。さらにこれがマージされれば、また別の誰かがデプロイ作業の面倒をみることになるでしょう。そのため、提供までのパイプラインにボトルネックがいくつもありました。」<br><br> これと同時に、40人のエンジニアリングチームが大きくなっていくにつれ、その成長を後押しし加速する上でも、より良いインフラが必要となってくることに同社は気づいたのです。そのころプラットフォーム チームの一員であったLacerteには、<a href="https://nodejs.org/">Node.js</a> に <a href="http://spring.io/projects/spring-boot">Spring Boot Java</a>といった、異なるフレームワークや言語を使いたいといった声が複数のチームから聞こえてくるようになってきました。同社の成長とスピードを両立するには、(チームが自律的に動き、自らがデプロイし、稼働中のサービスに責任を持てるような)よりよいインフラやシステムがこの会社には必要だということに彼はすぐに気づいたのです。</div>
 </section>
-<div class="banner3" style="background-image: url('/images/CaseStudy_appdirect_banner3.jpg')">
+<div class="banner3" style="background-image: url('/images/case-studies/appdirect/banner3.jpg')">
   <div class="banner3text">「正しいタイミングで正しい判断ができました。Kubernetesとクラウドネイティブ技術は、いまやデファクトのエコシステムとみなされています。スケールアウトしていく中で直面する新たな難題に取り組むにはどこに注力すべきか、私たちはわかっています。このコミュニティはとても活発で、当社の優秀なチームをすばらしく補完してくれています。」<br style="height:25px"><span style="font-size:14px;letter-spacing:2px;text-transform:uppercase;margin-top:5% !important;"><br>-  AppDirect ソフトウェア開発者　Alexandre Gervais </span></div>
 </div>
 <section class="section3">
 <div class="fullcol">Lacerteは当初から言っていました。「私のアイデアは、チームがサービスをもっと高速にデプロイできる環境を作ろう、というものです。そうすれば彼らもこう言うでしょう『そうだよ、モノリスを建てるなんてもうしたくないしサービスを構築したいんだ』と」(Lacerteは2019年に同社を退社)。<br><br>Lacerteのグループは運用チームと連携することで同社の <a href="https://aws.amazon.com/">AWSのインフラ</a>により多くアクセスし、コントロールするようになりました。そして、いくつかのオーケストレーション技術のプロトタイプを作り始めたのです。「当時を振り返ると、Kubernetesはちょっとアンダーグラウンドというか、それほど知られていなかったように思います。」と彼は言います。「しかし、コミュニティやPull requestの数、GitHub上でのスピードなどをよく見てみると勢いが増してきていることがわかりました。他の技術よりも管理がはるかに簡単であることもわかりました。」彼らは、Kubernetes上で <a href="https://www.chef.io/">Chef</a> や<a href="https://www.terraform.io/">Terraform</a> によるプロビジョニングを用いながら最初のいくつかのサービスを開発しました。その後さらにサービスも、自動化されるところも増えました。「韓国、オーストラリア、ドイツ、そしてアメリカ、私たちのクラスターは世界中にあります。」とLacerteは言います。「自動化は私たちにとって極めて重要です。」今彼らは大部分で<a href="https://github.com/kubernetes/kops">Kops</a>を使っていて、いくつかのクラウドプロバイダーから提供されるマネージドKubernetesサービスも視野に入れていれています。<br><br> 今もモノリスは存在してはいますが、コミットや機能はどんどん少なくなってきています。あらゆるチームがこの新たなインフラ上でデプロイしていて、それらはサービスとして提供されるのが一般的です。今やAppDirectは本番環境で50以上のマイクロサービス、15のKubernetesクラスターをAWS上や世界中のオンプレミス環境で展開しています。<br><br> Kubernetesプラットフォームがデプロイ時間に非常に大きなインパクトを与えたことから、Lacerteの戦略が究極的に機能しました。カスタムメイドで不安定だった、SCPコマンドを用いたシェルスクリプトに対する依存性を弱めることで、新しいバージョンをデプロイする時間は4時間から数分にまで短縮されるようになったのです。こういったことに加え同社は、開発者たちが自らのサービスとして仕立て上げるよう、数多くの努力をしてきました。「新しいサービスを始めるのに、 <a href="https://www.atlassian.com/software/jira">Jira</a>のチケットや他のチームとのミーティングはもはや必要ないのです」とLacerteは言います。以前、週あたり1〜30だった同社のデプロイ数は、いまや週1,600デプロイにまでなっています。
 </div>
 </section>
-<div class="banner4" style="background-image: url('/images/CaseStudy_appdirect_banner4.jpg');width:100%;">
+<div class="banner4" style="background-image: url('/images/case-studies/appdirect/banner4.jpg');width:100%;">
   <div class="banner4text">「この新たなインフラがなければ、我々は大幅なスローダウンを強いられていたと思います。」<br style="height:25px"><span style="font-size:14px;letter-spacing:2px;text-transform:uppercase;margin-top:5% !important;"><br>-  AppDirect ソフトウェア開発 ディレクター Pierre-Alexandre Lacerte</span></div>
 </div>
 

--- a/content/ja/case-studies/chinaunicom/index.html
+++ b/content/ja/case-studies/chinaunicom/index.html
@@ -12,7 +12,7 @@ quote: >
    Kubernetesが私たちのクラウドインフラの経験値を上げてくれました。今のところ、これに代わる技術はありません。
 ---
 
-<div class="banner1" style="background-image: url('/images/CaseStudy_chinaunicom_banner1.jpg')">
+<div class="banner1" style="background-image: url('/images/case-studies/chinaunicom/banner1.jpg')">
 <h1>ケーススタディ：<img src="/images/chinaunicom_logo.png" class="header_logo" style="width:25%;margin-bottom:-1%"><br> <div class="subhead" style="margin-top:1%;line-height:1.4em">China Unicom社：KubernetesによるITコスト削減と効率性向上をいかにして実現したか<br>
 
 </div></h1>
@@ -57,7 +57,7 @@ quote: >
   そこで新しい技術、研究開発(R&amp;D)、およびプラットフォームの責務を担うZhangのチームは、IT管理におけるソリューションの探索を始めました。以前は完全な国営企業だったChina Unicomは、近年BAT(Baidu、Alibaba、Tencent)およびJD.comからの民間投資を受け、今は商用製品ではなくオープンソース技術を活用した社内開発に注力するようになりました。こういったこともあり、Zhangのチームはクラウドインフラのオープンソースオーケストレーションツールを探し始めたのです。
 </div>
 </section>
-<div class="banner3" style="background-image: url('/images/CaseStudy_chinaunicom_banner3.jpg');width:100%;padding-left:0;">
+<div class="banner3" style="background-image: url('/images/case-studies/chinaunicom/banner3.jpg');width:100%;padding-left:0;">
   <div class="banner3text">
         「これほどの短期間でここまでのスケーラビリティを達成できるとは思いもよりませんでした。」<span style="font-size:14px;letter-spacing:2px;text-transform:uppercase;margin-top:5% !important;"><br>- Chengyu Zhang、 China Unicom プラットフォーム技術R&amp;D グループリーダー</span></span>
 
@@ -73,7 +73,7 @@ quote: >
 
 </div>
 </section>
-<div class="banner4" style="background-image: url('/images/CaseStudy_chinaunicom_banner4.jpg');width:100%">
+<div class="banner4" style="background-image: url('/images/case-studies/chinaunicom/banner4.jpg');width:100%">
   <div class="banner4text">
     「この技術は比較的複雑ですが、開発者が慣れれば、恩恵をすべて享受できるのではないかと思います。」 <br style="height:25px"><span style="font-size:14px;letter-spacing:2px;text-transform:uppercase;margin-top:5% !important;"><br>-  Jie Jia、China Unicom プラットフォーム技術 R&amp;D</span>
   </div>

--- a/content/ja/case-studies/nav/index.html
+++ b/content/ja/case-studies/nav/index.html
@@ -11,7 +11,7 @@ quote: >
    コミュニティは非常に活発です。アイデアを出し合い、皆が直面する多くの類似課題について話すことができ、そして支援を得ることができます。私たちはさまざまな理由から同じ問題に取り組み、そこでお互いに助け合うことができる、そういう点が気に入っています。
 ---
 
-<div class="banner1" style="background-image: url('/images/CaseStudy_nav_banner1.jpg')">
+<div class="banner1" style="background-image: url('/images/case-studies/nav/banner1.jpg')">
   <h1>ケーススタディ：<img src="/images/nav_logo.png" class="header_logo" style="width:15%"><br><div class="subhead" style="margin-top:1%">スタートアップはどのようにしてKubernetesでインフラコストを50％も削減したのか</div></h1>
 
 </div>
@@ -54,7 +54,7 @@ quote: >
 
 </div>
 </section>
-<div class="banner3" style="background-image: url('/images/CaseStudy_nav_banner3.jpg')">
+<div class="banner3" style="background-image: url('/images/case-studies/nav/banner3.jpg')">
   <div class="banner3text"> 「コミュニティは非常に活発です。アイデアを出し合い、皆が直面する多くの類似課題について話すことができ、そして支援を得ることができます。私たちはさまざまな理由から同じ問題に取り組み、そこでお互いに助け合うことができる、そういう点が気に入っています。」<br style="height:25px"><span style="font-size:14px;letter-spacing:2px;text-transform:uppercase;margin-top:5% !important;"><br>- Travis Jeppson、Nav エンジニアリングディレクター</span></div>
 
 
@@ -65,7 +65,7 @@ quote: >
  Jeppsonの4人編成のエンジニアリングサービスチームは、Kubernetesを立ち上げ、稼働させるのに6ヶ月かけました（クラスターを動かすために <a href="http://kubespray.io/">Kubespray</a> を使いました）。そして、その後6ヶ月かけNavの25のマイクロサービスと一つのモノリシックな主要サービスのフルマイグレーションを完了させました。「すべて書き換えたり、止めることはできませんでした」と彼は言います。「稼働し、利用可能であり続けなければいけなかったですし、ダウンタイムがあってもをそれを最小にしなければなりませんでした。そのためパイプライン作成、メトリクスやロギングといったことについてよくわかるようになりました。さらにKubernetes自身についても習熟し、起動、アップグレード、サービス提供の仕方についてもわかるようになりました。そうして移行を少しずつ進めていきました。」
 </div>
 </section>
-<div class="banner4" style="background-image: url('/images/CaseStudy_nav_banner4.jpg')" style="width:100%">
+<div class="banner4" style="background-image: url('/images/case-studies/nav/banner4.jpg')" style="width:100%">
   <div class="banner4text">
 「Kubernetesは、これまで経験したことのない新たな自由とたくさんの価値をNavにもたらしてくれました。」 <br style="height:25px"><span style="font-size:14px;letter-spacing:2px;text-transform:uppercase;margin-top:5% !important;"><br>-  Travis Jeppson、Nav エンジニアリングディレクター</span>
  </div>

--- a/content/ja/case-studies/nordstrom/index.html
+++ b/content/ja/case-studies/nordstrom/index.html
@@ -5,7 +5,7 @@ cid: caseStudies
 css: /css/style_case_studies.css
 ---
 
-<div class="banner1" style="background-image: url('/images/CaseStudy_nordstrom_banner1.jpg')">
+<div class="banner1" style="background-image: url('/images/case-studies/nordstrom/banner1.jpg')">
   <h1> ケーススタディ:<img src="/images/nordstrom_logo.png" class="header_logo" style="margin-bottom:-1.5% !important;width:20% !important;"><br> <div class="subhead">厳しい小売環境下で数百万ドルのコスト削減を実現
 
 
@@ -57,7 +57,7 @@ css: /css/style_case_studies.css
 
 </div>
 </section>
-<div class="banner3" style="background-image: url('/images/CaseStudy_nordstrom_banner3.jpg')">
+<div class="banner3" style="background-image: url('/images/case-studies/nordstrom/banner3.jpg')">
   <div class="banner3text">
     「私たちはKubernetesに人気が出ることに賭けました。コミュニティのサポートとプロジェクトの速度の初期の指標に基づいて、Kubernetesを中心にシステムを再構築しました。」
   </div>
@@ -73,7 +73,7 @@ Kubernetesは多くの場合、マイクロサービスのプラットフォー�
 参加したチームにとってメリットはすぐに現れました。「Kubernetesクラスターを使っているチームは心配する問題が少ないという事実を気に入っていました。インフラストラクチャーやオペレーティングシステムを管理する必要はありませんでした。」とGrigoriu氏は言います。「初期の導入者は、Kubernetesの宣言的な性質を好んでいます。彼らは対処しなければならなかった領域が減少したことを好んでます。」
 </div>
 </section>
-<div class="banner4" style="background-image: url('/images/CaseStudy_nordstrom_banner4.jpg')">
+<div class="banner4" style="background-image: url('/images/case-studies/nordstrom/banner4.jpg')">
   <div class="banner4text">
  「Kubernetesクラスターを使っているチームは心配する問題が少ないという事実を気に入っていました。インフラストラクチャーやオペレーティングシステムを管理する必要はありませんでした。」とGrigoriu氏は言います。「初期の導入者は、Kubernetesの宣言的な性質を好んでいます。彼らは対処しなければならなかった領域が減少したことを好んでます。」
   </div>

--- a/content/ja/case-studies/sos/index.html
+++ b/content/ja/case-studies/sos/index.html
@@ -8,7 +8,7 @@ logo: sos_featured_logo.png
 ---
 
 
-<div class="banner1" style="background-image: url('/images/CaseStudy_sos_banner1.jpg')">
+<div class="banner1" style="background-image: url('/images/case-studies/sos/banner1.jpg')">
   <h1>ケーススタディ:<img src="/images/sos_logo.png" class="header_logo" style="width:20%;margin-bottom:-1.2%"><br> <div class="subhead" style="margin-top:1%">SOS International: Kubernetesを使ってコネクテッドな世界での緊急支援を提供
 
 </div></h1>
@@ -56,7 +56,7 @@ logo: sos_featured_logo.png
 
 </div>
 </section>
-<div class="banner3" style="background-image: url('/images/CaseStudy_sos_banner3.jpg')">
+<div class="banner3" style="background-image: url('/images/case-studies/sos/banner3.jpg')">
   <div class="banner3text">
  「私たちは新しいデジタルサービスを提供しなければなりませんが、古いものも移行する必要があります。そして、コアシステムをこのプラットフォーム上に構築された新しいシステムに変換する必要があります。この技術を選んだ理由の1つは古いデジタルサービスを変更しながら新しいサービスを構築できるからです。」
 
@@ -73,7 +73,7 @@ logo: sos_featured_logo.png
 プラットフォームは2018年春に公開されました。マイクロサービスアーキテクチャに基づく6つの未開発のプロジェクトが最初に開始されました。さらに、同社のJavaアプリケーションはすべて「リフト&シフト」移行を行っています。最初に稼働しているKubernetesベースのプロジェクトの一つがRemote Medical Treatmentです。これは顧客が音声、チャット、ビデオを介してSOSアラームセンターに連絡できるソリューションです。「完全なCI/CDパイプラインと最新のマイクロサービスアーキテクチャをすべて2つのOpenShiftクラスターセットアップで実行することに焦点を当てて、非常に短時間で開発できました。」とAhrentsen氏は言います。北欧諸国へのレスキュートラックの派遣に使用されるOnsite、および、レッカー車の追跡を可能にするFollow Your Truckも展開されています。
 </div>
 </section>
-<div class="banner4" style="background-image: url('/images/CaseStudy_sos_banner4.jpg');width:100%">
+<div class="banner4" style="background-image: url('/images/case-studies/sos/banner4.jpg');width:100%">
   <div class="banner4text">
  「ITプロフェッショナルが新しい技術を提供したという理由で我が社を選んでいたことが新人研修の時にわかりました。」
  <br style="height:25px"><span style="font-size:14px;letter-spacing:2px;text-transform:uppercase;margin-top:5% !important;"><br>- SOS International エンタープライズアーキテクチャ責任者 Martin Ahrentsen</span>

--- a/content/ja/case-studies/spotify/index.html
+++ b/content/ja/case-studies/spotify/index.html
@@ -11,7 +11,7 @@ quote: >
    Kubernetesを中心に成長した素晴らしいコミュニティを見て、その一部になりたかったのです。スピードの向上とコスト削減のメリットを享受し、ベストプラクティスとツールについて業界の他の企業と連携したいとも思いました。
 ---
 
-<div class="banner1" style="background-image: url('/images/CaseStudy_spotify_banner1.jpg')">
+<div class="banner1" style="background-image: url('/images/case-studies/spotify/banner1.jpg')">
   <h1> ケーススタディ：Spotify<br> <div class="subhead" style="margin-top:1%">Spotify：コンテナ技術のアーリーアダプターであるSpotifyは自社製オーケストレーションツールからKubernetesに移行しています
 
 </div></h1>
@@ -55,7 +55,7 @@ quote: >
 
 </div>
 </section>
-<div class="banner3" style="background-image: url('/images/CaseStudy_spotify_banner3.jpg')">
+<div class="banner3" style="background-image: url('/images/case-studies/spotify/banner3.jpg')">
   <div class="banner3text">
     「このコミュニティは、あらゆる技術への取り組みをより速く、より容易にしてくれることを強力に助けてくれました。そして、私たちの取り組みのすべてを検証することも助けてくれました。」 <br style="height:25px"><span style="font-size:14px;letter-spacing:2px;text-transform:uppercase;margin-top:5% !important;"><br>- Spotify ソフトウェアエンジニア、インフラおよびオペレーション担当、Dave Zolotusky</span>
 
@@ -81,7 +81,7 @@ Kubernetesで現在実行されている最も大きなサービスはアグリ�
 
 </div>
 </section>
-<div class="banner4" style="background-image: url('/images/CaseStudy_spotify_banner4.jpg')">
+<div class="banner4" style="background-image: url('/images/case-studies/spotify/banner4.jpg')">
   <div class="banner4text">
   「レガシーのインフラをサポートしたり連携するKubernetes APIやKubernetesの拡張性機能をたくさん使うことができたので、インテグレーションはシンプルで簡単なものでした」<br style="height:25px"><span style="font-size:14px;letter-spacing:2px;text-transform:uppercase;margin-top:5% !important;"><br>-  Spotify、Spotifyエンジニア、James Wen</span>
   </div>


### PR DESCRIPTION
Fix broken images in case study pages, part of #22086 as a follow up from #22636 for JA.

xref #23708 

/kind cleanup
/area web-development