### PR TITLE
Set sticky bit for tmpfs in local container dev Hugo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ container-build: module-check
 	$(CONTAINER_RUN) $(CONTAINER_IMAGE) hugo --minify
 
 container-serve: module-check
-	$(CONTAINER_RUN) --mount type=tmpfs,destination=/src/resources,tmpfs-mode=0777 -p 1313:1313 $(CONTAINER_IMAGE) hugo server --buildFuture --bind 0.0.0.0
+	$(CONTAINER_RUN) --mount type=tmpfs,destination=/src/resources,tmpfs-mode=01777 -p 1313:1313 $(CONTAINER_IMAGE) hugo server --buildFuture --bind 0.0.0.0
 
 test-examples:
 	scripts/test_examples.sh install


### PR DESCRIPTION
My version of PR #24406:

- make the tmpfs have the [sticky bit](https://en.wikipedia.org/wiki/Sticky_bit) set so that ownership works OK
- tested with Docker (locally, Ubuntu 20.04)
- tested with Podman (locally, Ubuntu 20.04)