### PR TITLE
manual-ca-rotation: adjust note for "--client-ca-file"

### DIFF
--- a/content/en/docs/tasks/tls/manual-rotation-of-ca-certificates.md
+++ b/content/en/docs/tasks/tls/manual-rotation-of-ca-certificates.md
@@ -38,9 +38,11 @@ Configurations with a single API server will experience unavailability while the
    Any service account created after this point will get secrets that include both old and new CAs.
 
    {{< note >}}
-   Remove the flag `--client-ca-file` from the *Kubernetes controller manager* configuration.
-   You can also replace the existing client CA file or change this configuration item to reference a new, updated CA.
-   [Issue 1350](https://github.com/kubernetes/kubeadm/issues/1350) tracks an issue with *Kubernetes controller manager* being unable to accept a CA bundle.
+   The files specified by the *Kubernetes controller manager* flags `--client-ca-file` and `--cluster-signing-cert-file`
+   cannot be CA bundles. If these flags and `--root-ca-file` point to the same `ca.crt` file which is now a
+   bundle (includes both old and new CA) you will face an error. To workaround this problem you can copy the new CA to a separate
+   file and make the flags `--client-ca-file` and `--cluster-signing-cert-file` point to the copy. Once `ca.crt` is no longer
+   a bundle you can restore the problem flags to point to `ca.crt` and delete the copy.
    {{< /note >}}
 
 1. Update all service account tokens to include both old and new CA certificates.

--- a/content/en/docs/tasks/tls/manual-rotation-of-ca-certificates.md
+++ b/content/en/docs/tasks/tls/manual-rotation-of-ca-certificates.md
@@ -33,12 +33,13 @@ Configurations with a single API server will experience unavailability while the
    (ex: `ca.crt`, `ca.key`, `front-proxy-ca.crt`, and `front-proxy-ca.key`)
    to all your control plane nodes in the Kubernetes certificates directory.
 
-1. Update *Kubernetes controller manager's* `--root-ca-file` to include both old and new CA and restart controller manager.
+1. Update {{< glossary_tooltip text="kube-controller-manager" term_id="kube-controller-manager" >}}'s `--root-ca-file` to
+   include both old and new CA. Then restart the component.
 
    Any service account created after this point will get secrets that include both old and new CAs.
 
    {{< note >}}
-   The files specified by the *Kubernetes controller manager* flags `--client-ca-file` and `--cluster-signing-cert-file`
+   The files specified by the kube-controller-manager flags `--client-ca-file` and `--cluster-signing-cert-file`
    cannot be CA bundles. If these flags and `--root-ca-file` point to the same `ca.crt` file which is now a
    bundle (includes both old and new CA) you will face an error. To workaround this problem you can copy the new CA to a separate
    file and make the flags `--client-ca-file` and `--cluster-signing-cert-file` point to the copy. Once `ca.crt` is no longer


### PR DESCRIPTION
manual-ca-rotation: adjust note for "--client-ca-file"

- Instead of telling the users to remove the --client-ca-file flag, tell them
that they can point to a copy of the new CA. Mention the same for
--cluster-signing-cert-file.
- Don't reference the kubeadm issue. If sig-auth has a tracking
issue for --client-ca-file / --cluster-signing-cert-file and bundles
we can add that at some point.

NOTE: would appreciate feedback on both the wording and proposed solution.

closes https://github.com/kubernetes/website/issues/23323