### PR TITLE
Update the example for kubectl port-forward

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
+++ b/content/en/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
@@ -152,7 +152,7 @@ for database debugging.
     or
 
     ```shell
-    kubectl port-forward service/redis-master 7000:6379
+    kubectl port-forward service/redis-master 7000:redis
     ```
 
     Any of the above commands works. The output is similar to this:

--- a/content/en/examples/application/guestbook/redis-master-service.yaml
+++ b/content/en/examples/application/guestbook/redis-master-service.yaml
@@ -8,7 +8,8 @@ metadata:
     tier: backend
 spec:
   ports:
-  - port: 6379
+  - name: redis
+    port: 6379
     targetPort: 6379
   selector:
     app: redis


### PR DESCRIPTION
Clarifies that `REMOTE_PORT` is interpreted as identifying a _Service_ port when provided `TYPE` is `service`.
Also, highlights support for specifying a named port as `REMOTE_PORT`.

Related to https://github.com/kubernetes/kubernetes/pull/95383 and https://github.com/kubernetes/kubectl/issues/947.