### PR TITLE
Clean up case study images in content/zh/case-studies

### DIFF
--- a/content/zh/case-studies/adform/index.html
+++ b/content/zh/case-studies/adform/index.html
@@ -12,7 +12,7 @@ quote: >
   Kubernetes enabled the self-healing and immutable infrastructure. We can do faster releases, so our developers are really happy. They can ship our features faster than before, and that makes our clients happier.
 ---
 
-<div class="banner1 desktop" style="background-image: url('/images/CaseStudy_adform_banner1.jpg')">
+<div class="banner1 desktop" style="background-image: url('/images/case-studies/adform/banner1.jpg')">
   <h1> CASE STUDY:<img src="/images/adform_logo.png" style="width:15%;margin-bottom:0%" class="header_logo"><br> <div class="subhead">Improving Performance and Morale with Cloud Native
 
 </div></h1>
@@ -66,7 +66,7 @@ The company has a large infrastructure: <a href="https://www.openstack.org/">Ope
 
 </div>
 </section>
-<div class="banner3" style="background-image: url('/images/CaseStudy_adform_banner3.jpg')">
+<div class="banner3" style="background-image: url('/images/case-studies/adform/banner3.jpg')">
   <div class="banner3text">
     "The fact that Cloud Native Computing Foundation incubated Kubernetes was a really big point for us because it was vendor neutral. And we can see that a community really gathers around it. Everyone shares their experiences, their knowledge, and the fact that it’s open source, you can contribute."<span style="font-size:14px;letter-spacing:0.12em;padding-top:20px;text-transform:uppercase;line-height:14px"><br><br>— Edgaras Apšega, IT Systems Engineer, Adform</span>
   </div>
@@ -83,7 +83,7 @@ The first production cluster was launched in the spring of 2018, and is now up t
 
 </div>
 </section>
-<div class="banner4" style="background-image: url('/images/CaseStudy_adform_banner4.jpg')">
+<div class="banner4" style="background-image: url('/images/case-studies/adform/banner4.jpg')">
   <div class="banner4text">
 "Releases are really nice for them, because they just push their code to Git and that’s it. They don’t have to worry about their virtual machines anymore." <span style="font-size:14px;letter-spacing:0.12em;padding-top:20px;text-transform:uppercase;line-height:14px"><br><br>— Andrius Cibulskis, IT Systems Engineer, Adform</span>
   </div>

--- a/content/zh/case-studies/ant-financial/index.html
+++ b/content/zh/case-studies/ant-financial/index.html
@@ -7,7 +7,7 @@ css: /css/style_case_studies.css
 featured: false
 ---
 
-<div class="banner1" style="background-image: url('/images/CaseStudy_antfinancial_banner1.jpg')">
+<div class="banner1" style="background-image: url('/images/case-studies/antfinancial/banner1.jpg')">
   <h1> CASE STUDY:<img src="/images/antfinancial_logo.png" class="header_logo" style="width:20%;margin-bottom:-2.5%"><br> <div class="subhead" style="margin-top:1%">Ant Financial’s Hypergrowth Strategy Using Kubernetes
 
 </div></h1>
@@ -50,7 +50,7 @@ featured: false
   To address those challenges and provide reliable and consistent services to its customers, Ant Financial embraced <a href="https://www.docker.com/">Docker</a> containerization in 2014. But they soon realized that they needed an orchestration solution for some tens-of-thousands-of-node clusters in the company’s data centers.
 </div>
 </section>
-<div class="banner3" style="background-image: url('/images/CaseStudy_antfinancial_banner3.jpg')">
+<div class="banner3" style="background-image: url('/images/case-studies/antfinancial/banner3.jpg')">
   <div class="banner3text">
     "On Double 11 this year, we had plenty of nodes on Kubernetes, but compared to the whole scale of our infrastructure, this is still in progress."<br style="height:25px"><span style="font-size:14px;letter-spacing:2px;text-transform:uppercase;margin-top:5% !important;"><br>- RANGER YU, GLOBAL TECHNOLOGY PARTNERSHIP & DEVELOPMENT, ANT FINANCIAL</span>
 
@@ -65,7 +65,7 @@ featured: false
   All core financial systems were containerized by November 2017, and the migration to Kubernetes is ongoing. Ant’s platform also leverages a number of other CNCF projects, including <a href="https://prometheus.io/">Prometheus</a>, <a href="https://opentracing.io/">OpenTracing</a>, <a href="https://coreos.com/etcd/">etcd</a> and <a href="https://coredns.io/">CoreDNS</a>.  “On Double 11 this year, we had plenty of nodes on Kubernetes, but compared to the whole scale of our infrastructure, this is still in progress,” says Ranger Yu, Global Technology Partnership & Development.
 </div>
 </section>
-<div class="banner4" style="background-image: url('/images/CaseStudy_antfinancial_banner4.jpg')">
+<div class="banner4" style="background-image: url('/images/case-studies/antfinancial/banner4.jpg')">
   <div class="banner4text">
   "We’re very grateful for CNCF and this amazing technology, which we need as we continue to scale globally. We’re definitely embracing the community and open source more in the future." <br style="height:25px"><span style="font-size:14px;letter-spacing:2px;text-transform:uppercase;margin-top:5% !important;"><br>- HAOJIE HANG, PRODUCT MANAGEMENT, ANT FINANCIAL</span>
   </div>

--- a/content/zh/case-studies/appdirect/index.html
+++ b/content/zh/case-studies/appdirect/index.html
@@ -12,7 +12,7 @@ quote: >
    We made the right decisions at the right time. Kubernetes and the cloud native technologies are now seen as the de facto ecosystem.
 ---
 
-<div class="banner1" style="background-image: url('/images/CaseStudy_appdirect_banner1.jpg')">
+<div class="banner1" style="background-image: url('/images/case-studies/appdirect/banner1.jpg')">
   <h1> CASE STUDY:<img src="/images/appdirect_logo.png" class="header_logo" style="margin-bottom:-2%"><br> <div class="subhead" style="margin-top:1%;font-size:0.5em">AppDirect: How AppDirect Supported the 10x Growth of Its Engineering Staff with Kubernetess
 </div></h1>
 
@@ -53,7 +53,7 @@ quote: >
 
 </div>
 </section>
-<div class="banner3" style="background-image: url('/images/CaseStudy_appdirect_banner3.jpg')">
+<div class="banner3" style="background-image: url('/images/case-studies/appdirect/banner3.jpg')">
   <div class="banner3text">
   "We made the right decisions at the right time. Kubernetes and the cloud native technologies are now seen as the de facto ecosystem. We know where to focus our efforts in order to tackle the new wave of challenges we face as we scale out. The community is so active and vibrant, which is a great complement to our awesome internal team."<br style="height:25px"><span style="font-size:14px;letter-spacing:2px;text-transform:uppercase;margin-top:5% !important;"><br>- Alexandre Gervais, Staff Software Developer, AppDirect
 </span>
@@ -69,7 +69,7 @@ quote: >
   Lacerte’s strategy ultimately worked because of the very real impact the Kubernetes platform has had to deployment time. Due to less dependency on custom-made, brittle shell scripts with SCP commands, time to deploy a new version has shrunk from 4 hours to a few minutes. Additionally, the company invested a lot of effort to make things self-service for developers. "Onboarding a new service doesn’t require <a href="https://www.atlassian.com/software/jira">Jira</a> tickets or meeting with three different teams," says Lacerte. Today, the company sees 1,600 deployments per week, compared to 1-30 before.
 </div>
 </section>
-<div class="banner4" style="background-image: url('/images/CaseStudy_appdirect_banner4.jpg');width:100%;">
+<div class="banner4" style="background-image: url('/images/case-studies/appdirect/banner4.jpg');width:100%;">
   <div class="banner4text">
   "I think our velocity would have slowed down a lot if we didn’t have this new infrastructure."<br style="height:25px"><span style="font-size:14px;letter-spacing:2px;text-transform:uppercase;margin-top:5% !important;"><br>- Pierre-Alexandre Lacerte, Director of Software Development, AppDirect</span>
   </div>

--- a/content/zh/case-studies/bose/index.html
+++ b/content/zh/case-studies/bose/index.html
@@ -11,7 +11,7 @@ quote: >
    The CNCF Landscape quickly explains what’s going on in all the different areas from storage to cloud providers to automation and so forth. This is our shopping cart to build a cloud infrastructure. We can go choose from the different aisles.
 ---
 
-<div class="banner1" style="background-image: url('/images/CaseStudy_bose_banner1.jpg')">
+<div class="banner1" style="background-image: url('/images/case-studies/bose/banner1.jpg')">
   <h1> CASE STUDY:<img src="/images/bose_logo.png" class="header_logo" style="width:20%;margin-bottom:-1.2%"><br> <div class="subhead" style="margin-top:1%">Bose: Supporting Rapid Development for Millions of IoT Products With Kubernetes
 
 </div></h1>
@@ -56,7 +56,7 @@ From the beginning, the team knew it wanted a microservices architecture and pla
 
 </div>
 </section>
-<div class="banner3" style="background-image: url('/images/CaseStudy_bose_banner3.jpg')">
+<div class="banner3" style="background-image: url('/images/case-studies/bose/banner3.jpg')">
   <div class="banner3text">
     "Everybody on the team thinks in terms of automation, leaning out the processes, getting things done as quickly as possible. When you step back and look at what it means for a 50-plus-year-old speaker company to have that sort of culture, it really is quite incredible, and I think the tools that we use and the foundation that we’ve built with them is a huge piece of that."<br style="height:25px"><span style="font-size:14px;letter-spacing:2px;text-transform:uppercase;margin-top:5% !important;"><br>- Dylan O’Mahony, Cloud Architecture Manager, Bose</span>
 
@@ -70,7 +70,7 @@ From the beginning, the team knew it wanted a microservices architecture and pla
 
 </div>
 </section>
-<div class="banner4" style="background-image: url('/images/CaseStudy_bose_banner4.jpg');width:100%">
+<div class="banner4" style="background-image: url('/images/case-studies/bose/banner4.jpg');width:100%">
   <div class="banner4text">
   "The CNCF Landscape quickly explains what’s going on in all the different areas from storage to cloud providers to automation and so forth. This is our shopping cart to build a cloud infrastructure. We can go choose from the different aisles." <br style="height:25px"><span style="font-size:14px;letter-spacing:2px;text-transform:uppercase;margin-top:5% !important;"><br>- Josh West, Lead Cloud Engineer, Bose</span>
   </div>

--- a/content/zh/case-studies/capital-one/index.html
+++ b/content/zh/case-studies/capital-one/index.html
@@ -5,7 +5,7 @@ cid: caseStudies
 css: /css/style_case_studies.css
 ---
 
-<div class="banner1 desktop" style="background-image: url('/images/CaseStudy_capitalone_banner1.jpg')">
+<div class="banner1 desktop" style="background-image: url('/images/case-studies/capitalone/banner1.jpg')">
   <h1> CASE STUDY:<img src="/images/capitalone-logo.png" style="margin-bottom:-2%" class="header_logo"><br> <div class="subhead">Supporting Fast Decisioning Applications with Kubernetes
 
 </div></h1>
@@ -55,7 +55,7 @@ css: /css/style_case_studies.css
 
 </div>
 </section>
-<div class="banner3" style="background-image: url('/images/CaseStudy_capitalone_banner3.jpg')">
+<div class="banner3" style="background-image: url('/images/case-studies/capitalone/banner3.jpg')">
   <div class="banner3text">
     "We want to provide the tools in the same ecosystem, in a consistent way, rather than have a large custom snowflake ecosystem where every tool needs its own custom deployment. Kubernetes gives us the ability to bring all of these together, so the richness of the open source and even the license community dealing with big data can be corralled."
 
@@ -69,7 +69,7 @@ css: /css/style_case_studies.css
 
 </div>
 </section>
-<div class="banner4" style="background-image: url('/images/CaseStudy_capitalone_banner4.jpg')">
+<div class="banner4" style="background-image: url('/images/case-studies/capitalone/banner4.jpg')">
   <div class="banner4text">
     With Kubernetes, "a team can come to us and we can have them up and running with a basic decisioning app in a fortnight, which before would have taken a whole quarter, if not longer. Kubernetes is a manifold productivity multiplier."
   </div>

--- a/content/zh/case-studies/cern/index.html
+++ b/content/zh/case-studies/cern/index.html
@@ -7,7 +7,7 @@ css: /css/style_case_studies.css
 logo: cern_featured_logo.png
 ---
 
-<div class="banner1" style="background-image: url('/images/CaseStudy_cern_banner1.jpg')">
+<div class="banner1" style="background-image: url('/images/case-studies/cern/banner1.jpg')">
   <h1> CASE STUDY: CERN<br> <div class="subhead" style="margin-top:1%">CERN: Processing Petabytes of Data More Efficiently with Kubernetes
 
 </div></h1>
@@ -52,7 +52,7 @@ logo: cern_featured_logo.png
 
 </div>
 </section>
-<div class="banner3" style="background-image: url('/images/CaseStudy_cern_banner3.jpg')">
+<div class="banner3" style="background-image: url('/images/case-studies/cern/banner3.jpg')">
   <div class="banner3text">
     "Before, the tendency was always: ‘I need this, I get a couple of developers, and I implement it.’ Right now it’s ‘I need this, I’m sure other people also need this, so I’ll go and ask around.’ The CNCF is a good source because there’s a very large catalog of applications available. It’s very hard right now to justify developing a new product in-house. There is really no real reason to keep doing that. It’s much easier for us to try it out, and if we see it’s a good solution, we try to reach out to the community and start working with that community." <br style="height:25px"><span style="font-size:14px;letter-spacing:2px;text-transform:uppercase;margin-top:5% !important;"><br>- Ricardo Rocha, Software Engineer, CERN</span>
 
@@ -66,7 +66,7 @@ logo: cern_featured_logo.png
 
 </div>
 </section>
-<div class="banner4" style="background-image: url('/images/CaseStudy_cern_banner4.jpg')">
+<div class="banner4" style="background-image: url('/images/case-studies/cern/banner4.jpg')">
   <div class="banner4text">
   "With Kubernetes, there’s a well-established technology and a big community that we can contribute to. It allows us to do our physics analysis without having to focus so much on the lower level software. This is just exciting. We are looking forward to keep contributing to the community and collaborating with everyone."<br style="height:25px"><span style="font-size:14px;letter-spacing:2px;text-transform:uppercase;margin-top:5% !important;"><br>- Ricardo Rocha, Software Engineer, CERN</span>
   </div>

--- a/content/zh/case-studies/chinaunicom/index.html
+++ b/content/zh/case-studies/chinaunicom/index.html
@@ -12,7 +12,7 @@ quote: >
    Kubernetes has improved our experience using cloud infrastructure. There is currently no alternative technology that can replace it.
 ---
 
-<div class="banner1" style="background-image: url('/images/CaseStudy_chinaunicom_banner1.jpg')">
+<div class="banner1" style="background-image: url('/images/case-studies/chinaunicom/banner1.jpg')">
   <h1> CASE STUDY:<img src="/images/chinaunicom_logo.png" class="header_logo" style="width:25%;margin-bottom:-1%"><br> <div class="subhead" style="margin-top:1%;line-height:1.4em">China Unicom: How China Unicom Leveraged Kubernetes to Boost Efficiency<br>and Lower IT&nbsp;Costs
 
 </div></h1>
@@ -55,7 +55,7 @@ quote: >
 
 </div>
 </section>
-<div class="banner3" style="background-image: url('/images/CaseStudy_chinaunicom_banner3.jpg');width:100%;padding-left:0;">
+<div class="banner3" style="background-image: url('/images/case-studies/chinaunicom/banner3.jpg');width:100%;padding-left:0;">
   <div class="banner3text">
     "We could never imagine we can achieve this scalability in such a short time."<br style="height:25px"><span style="font-size:14px;letter-spacing:2px;text-transform:uppercase;margin-top:5% !important;"><br>- Chengyu Zhang, Group Leader of Platform Technology R&D, China Unicom</span>
 
@@ -69,7 +69,7 @@ quote: >
 
 </div>
 </section>
-<div class="banner4" style="background-image: url('/images/CaseStudy_chinaunicom_banner4.jpg');width:100%">
+<div class="banner4" style="background-image: url('/images/case-studies/chinaunicom/banner4.jpg');width:100%">
   <div class="banner4text">
   "This technology is relatively complicated, but as long as developers get used to it, they can enjoy all the benefits." <br style="height:25px"><span style="font-size:14px;letter-spacing:2px;text-transform:uppercase;margin-top:5% !important;"><br>- Jie Jia, Member of Platform Technology R&D, China Unicom</span>
   </div>

--- a/content/zh/case-studies/city-of-montreal/index.html
+++ b/content/zh/case-studies/city-of-montreal/index.html
@@ -7,7 +7,7 @@ css: /css/style_case_studies.css
 featured: false
 ---
 
-<div class="banner1" style="background-image: url('/images/CaseStudy_montreal_banner1.jpg')">
+<div class="banner1" style="background-image: url('/images/case-studies/montreal/banner1.jpg')">
   <h1> CASE STUDY:<img src="/images/montreal_logo.png" class="header_logo" style="width:20%;margin-bottom:-1.2%"><br> <div class="subhead" style="margin-top:1%">City of Montréal - How the City of Montréal Is Modernizing Its 30-Year-Old, Siloed&nbsp;Architecture&nbsp;with&nbsp;Kubernetes
 
 </div></h1>
@@ -50,7 +50,7 @@ featured: false
   The first step to modernize the architecture was containerization. “We based our effort on the new trends; we understood the benefits of immutability and deployments without downtime and such things,” says Solutions Architect Marc Khouzam. The team started with a small Docker farm with four or five servers, with Rancher for providing access to the Docker containers and their logs and Jenkins for deployment.
 </div>
 </section>
-<div class="banner3" style="background-image: url('/images/CaseStudy_montreal_banner3.jpg')">
+<div class="banner3" style="background-image: url('/images/case-studies/montreal/banner3.jpg')">
   <div class="banner3text">
     "Getting a project running in Kubernetes is entirely dependent on how long you need to program the actual software. It’s no longer dependent on deployment. Deployment is so fast that it’s negligible."<br style="height:25px"><span style="font-size:14px;letter-spacing:2px;text-transform:uppercase;margin-top:5% !important;"><br>- MARC KHOUZAM, SOLUTIONS ARCHITECT, CITY OF MONTRÉAL</span>
 
@@ -65,7 +65,7 @@ featured: false
   Another important factor in the decision was vendor neutrality. “As a government entity, it is essential for us to be neutral in our selection of products and providers,” says Thibault. “The independence of the Cloud Native Computing Foundation from any company provides this.”
 </div>
 </section>
-<div class="banner4" style="background-image: url('/images/CaseStudy_montreal_banner4.jpg')">
+<div class="banner4" style="background-image: url('/images/case-studies/montreal/banner4.jpg')">
   <div class="banner4text">
   "Kubernetes has been great. It’s been stable, and it provides us with elasticity, resilience, and robustness. While re-architecting for Kubernetes, we also benefited from the monitoring and logging aspects, with centralized logging, Prometheus logging, and Grafana dashboards. We have enhanced visibility of what’s being deployed." <br style="height:25px"><span style="font-size:14px;letter-spacing:2px;text-transform:uppercase;margin-top:5% !important;"><br>- MORGAN MARTINET, ENTERPRISE ARCHITECT, CITY OF MONTRÉAL</span>
   </div>

--- a/content/zh/case-studies/netease/index.html
+++ b/content/zh/case-studies/netease/index.html
@@ -6,11 +6,11 @@ css: /css/style_case_studies.css
 ---
 
 
-<!-- <div class="banner1" style="background-image: url('/images/CaseStudy_netease_banner1.jpg')">
+<!-- <div class="banner1" style="background-image: url('/images/case-studies/netease/banner1.jpg')">
   <h1> CASE STUDY:<img src="/images/netease_logo.png" class="header_logo" style="width:22%;margin-bottom:-1%"><br> <div class="subhead" style="margin-top:1%"> How NetEase Leverages Kubernetes to Support Internet Business Worldwide</div></h1>
 
 </div> -->
-<div class="banner1" style="background-image: url('/images/CaseStudy_netease_banner1.jpg')">
+<div class="banner1" style="background-image: url('/images/case-studies/netease/banner1.jpg')">
   <h1> 案例研究：<img src="/images/netease_logo.png" class="header_logo" style="width:22%;margin-bottom:-1%"><br> <div class="subhead" style="margin-top:1%"> 网易如何利用 Kubernetes 支持在全球的互联网业务</div></h1>
 
 </div>
@@ -55,7 +55,7 @@ css: /css/style_case_studies.css
 在考虑构建自己的业务流程解决方案后，网易决定将其私有云平台建立在 <a href="https://kubernetes.io/">Kubernetes</a> 的基础上。这项技术来自谷歌，这一事实让团队有信心，它能够跟上网易的规模。“经过2到3个月的评估，我们相信它能满足我们的需求，”冯长健说。
 </div>
 </section>
-<div class="banner3" style="background-image: url('/images/CaseStudy_netease_banner3.jpg')">
+<div class="banner3" style="background-image: url('/images/case-studies/netease/banner3.jpg')">
   <div class="banner3text">
     <!-- "We leveraged the programmability of Kubernetes so that we can build a platform to satisfy the needs of our internal customers for upgrades and deployment." -->
 “我们利用 Kubernetes 的可编程性，构建一个平台，以满足内部客户对升级和部署的需求。”<br style="height:25px"><span style="font-size:14px;letter-spacing:2px;text-transform:uppercase;margin-top:5% !important;"><br>- 冯长健,网易云和容器托管平台架构师</span>
@@ -71,7 +71,7 @@ css: /css/style_case_studies.css
 团队正在继续改进。例如，企业的电子商务部分需要利用混合部署，过去需要使用两个单独的平台：基础架构即服务平台和 Kubernetes 平台。最近，网易创建了一个跨平台应用程序，支持将两者同时使用单命令部署。
 </div>
 </section>
-<div class="banner4" style="background-image: url('/images/CaseStudy_netease_banner4.jpg')">
+<div class="banner4" style="background-image: url('/images/case-studies/netease/banner4.jpg')">
   <div class="banner4text">
     <!-- "As long as a company has a mature team and enough developers, I think Kubernetes is a very good technology that can help them."<span style="font-size:14px;letter-spacing:2px;text-transform:uppercase;margin-top:5% !important;"><br><br>- Li Lanqing, Kubernetes Developer, NetEase</span> -->
 “只要公司拥有成熟的团队和足够的开发人员，我认为 Kubernetes 是一个很好的有所助力的技术。”<span style="font-size:14px;letter-spacing:2px;text-transform:uppercase;margin-top:5% !important;"><br><br>- 李兰青, 网易 Kubernetes 开发人员</span>

--- a/content/zh/case-studies/nordstrom/index.html
+++ b/content/zh/case-studies/nordstrom/index.html
@@ -5,14 +5,14 @@ cid: caseStudies
 css: /css/style_case_studies.css
 ---
 
-<!-- <div class="banner1" style="background-image: url('/images/CaseStudy_nordstrom_banner1.jpg')">
+<!-- <div class="banner1" style="background-image: url('/images/case-studies/nordstrom/banner1.jpg')">
   <h1> CASE STUDY:<img src="/images/nordstrom_logo.png" class="header_logo" style="margin-bottom:-1.5% !important;width:20% !important;"><br> <div class="subhead">Finding Millions in Potential Savings in a Tough Retail Climate
 
 </div></h1>
 
 </div> -->
 
-<div class="banner1" style="background-image: url('/images/CaseStudy_nordstrom_banner1.jpg')">
+<div class="banner1" style="background-image: url('/images/case-studies/nordstrom/banner1.jpg')">
   <h1> 案例研究:<img src="/images/nordstrom_logo.png" class="header_logo" style="margin-bottom:-1.5% !important;width:20% !important;"><br> <div class="subhead">在艰难的零售环境下寻找数百万的潜在成本节约
 
 
@@ -87,7 +87,7 @@ Nordstrom 希望提高其技术运营的效率和速度，其中包括 Nordstrom
 但是，新环境仍然需要很长时间才能出现，因此下一步是在云中工作。如今，Nordstrom  Technology 已经构建了一个企业平台，允许公司的1500 名开发人员在云中部署以 Docker 容器身份运行的应用程序，这些应用程序由 Kubernetes 进行编排。
 </div>
 </section>
-<div class="banner3" style="background-image: url('/images/CaseStudy_nordstrom_banner3.jpg')">
+<div class="banner3" style="background-image: url('/images/case-studies/nordstrom/banner3.jpg')">
 <div class="banner3text">
 <!-- "We made a bet that Kubernetes was going to take off, informed by early indicators of community support and project velocity, so we rebuilt our system with Kubernetes at the core," -->
 “了解到早期的社区支持和项目迭代指标，我们肯定 Kubernetes 一定会成功的，因此我们以 Kubernetes 为核心重建了我们的系统。”
@@ -108,7 +108,7 @@ Nordstrom 首次尝试在集群上调度容器，是基于 CoreOS fleet 的原�
 对于加入的团队来说,这些好处是立竿见影的。Grigoriu 说：“在我们的 Kubernetes 集群中运行的团队喜欢这样一个事实，即他们担心的问题更少，他们不需要管理基础设施或操作系统。早期使用者喜欢 Kubernetes 的声明特性，让他们不得不处理的面积减少。
 </div>
 </section>
-<div class="banner4" style="background-image: url('/images/CaseStudy_nordstrom_banner4.jpg')">
+<div class="banner4" style="background-image: url('/images/case-studies/nordstrom/banner4.jpg')">
   <div class="banner4text">
  <!-- "Teams running on our Kubernetes cluster loved the fact that they had fewer issues to worry about. They didn’t need to manage infrastructure or operating systems," says Grigoriu. "Early adopters loved the declarative nature of Kubernetes. They loved the reduced surface area they had to deal with." -->
 Grigoriu 说：“在我们的 Kubernetes 集群中运行的团队喜欢这样一个事实，即他们担心的问题更少，他们不需要管理基础设施或操作系统。早期使用者喜欢 Kubernetes 的声明特性，让他们不得不处理的面积减少。”

--- a/content/zh/case-studies/squarespace/index.html
+++ b/content/zh/case-studies/squarespace/index.html
@@ -14,13 +14,13 @@ css: /css/style_case_studies.css
 ---
 -->
 
-<!-- <div class="banner1 desktop" style="background-image: url('/images/CaseStudy_squarespace_banner1.jpg')">
+<!-- <div class="banner1 desktop" style="background-image: url('/images/case-studies/squarespace/banner1.jpg')">
   <h1> CASE STUDY:<img src="/images/squarespace_logo.png" class="header_logo"><br>
     <div class="subhead">Squarespace: Gaining Productivity and Resilience with Kubernetes</div>
   </h1>
 </div> -->
 
-<div class="banner1 desktop" style="background-image: url('/images/CaseStudy_squarespace_banner1.jpg')">
+<div class="banner1 desktop" style="background-image: url('/images/case-studies/squarespace/banner1.jpg')">
   <h1> 案例分析：<img src="/images/squarespace_logo.png" class="header_logo"><br>
     <div class="subhead">Squarespace: 借力 Kubernetes 提升效率和可靠性</div>
   </h1>
@@ -113,7 +113,7 @@ Kubernetes 也同样提升了可靠性：“如果一个节点宕掉，马上会
 </div>
 </section>
 
-<div class="banner3" style="background-image: url('/images/CaseStudy_squarespace_banner3.jpg')">
+<div class="banner3" style="background-image: url('/images/case-studies/squarespace/banner3.jpg')">
   <!-- <div class="banner3text">
     After experimenting with another container orchestration platform and "breaking it in very painful ways,"
     Lynch says, the team began experimenting with Kubernetes in mid-2016 and found that it "answered all the questions that we had."
@@ -157,7 +157,7 @@ Kubernetes 也同样提升了可靠性：“如果一个节点宕掉，马上会
 
 </div>
 </section>
-<div class="banner4" style="background-image: url('/images/CaseStudy_squarespace_banner4.jpg')">
+<div class="banner4" style="background-image: url('/images/case-studies/squarespace/banner4.jpg')">
   <div class="banner4text">
   <!-- "We switched to Kubernetes, a new world....It allowed us to streamline our process, so we can now easily create an entire microservice project from templates,"
   Lynch says. And the whole process takes only five minutes, an almost 85% reduction in time compared to their VM deployment. -->


### PR DESCRIPTION
Fix broken images in case study pages, part of #22086 as a follow up from #22636 for ZH.

xref #23708

/kind cleanup
/area web-development