### PR TITLE
Clean up case study images in content/ko/case-studies

### DIFF
--- a/content/ko/case-studies/newyorktimes/index.html
+++ b/content/ko/case-studies/newyorktimes/index.html
@@ -5,7 +5,7 @@ cid: caseStudies
 css: /css/style_case_studies.css
 ---
 
-<div class="banner1" style="padding-left:8% !important;background-image: url('/images/CaseStudy_newyorktimes_banner1.jpg')">
+<div class="banner1" style="padding-left:8% !important;background-image: url('/images/case-studies/newyorktimes/banner1.jpg')">
   <h1> CASE STUDY:<img src="/images/newyorktimes_logo.png" class="header_logo"><br> <div class="subhead">The New York Times: From Print to the Web to Cloud Native
 
 </div></h1>
@@ -64,7 +64,7 @@ css: /css/style_case_studies.css
 
 </div>
 </section>
-<div class="banner3" style="background-image: url('/images/CaseStudy_newyorktimes_banner3.jpg')">
+<div class="banner3" style="background-image: url('/images/case-studies/newyorktimes/banner3.jpg')">
   <div class="banner3text">
   "We had some internal tooling that attempted to do what Kubernetes does for containers, but for VMs. We asked why are we building and maintaining these tools ourselves?"
   </div>
@@ -79,7 +79,7 @@ css: /css/style_case_studies.css
 
 </div>
 </section>
-<div class="banner4" style="background-image: url('/images/CaseStudy_newyorktimes_banner4.jpg')">
+<div class="banner4" style="background-image: url('/images/case-studies/newyorktimes/banner4.jpg')">
   <div class="banner4text">
     "Right now, every team is running a small Kubernetes cluster, but it would be nice if we could all live in a larger ecosystem," says Kapadia. "Then we can harness the power of things like service mesh proxies that can actually do a lot of instrumentation between microservices, or service-to-service orchestration. Those are the new things that we want to experiment with as we go forward."
 


### PR DESCRIPTION
Fix broken images in case study pages, part of #22086 as a follow up from #22636 for KO.

xref #23708

/kind cleanup
/area web-development

Note:
Slightly confused because none of the case studies are localized, maybe I'm looking at the wrong branch?