### PR TITLE
Update PR template to include a requirment for release related docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,12 +14,11 @@
  Use the default base branch, “master”, if you're documenting existing
  features in the English localization.
 
- If you're working on a different localization (not English), or you
- are documenting a feature that will be part of a future release, see
+ If you're working on a different localization (not English), see
  https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
  for advice.
 
- Use the next release branch, "dev-x.xx", if you're documenting a feature for
- a release. If applicable, please also include links to k/k and k/enhancement.
+ If you're documenting a feature that will be part of a future release, see
+ https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
 
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,4 +19,7 @@
  https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
  for advice.
 
+ Use the next release branch, "dev-x.xx", if you're documenting a feature for
+ a release. If applicable, please also include links to k/k and k/enhancement.
+
 -->

--- a/content/en/docs/contribute/new-content/new-features.md
+++ b/content/en/docs/contribute/new-content/new-features.md
@@ -98,7 +98,8 @@ deadlines.
 1. Open a pull request against the
 `dev-{{< skew nextMinorVersion >}}` branch in the `kubernetes/website` repository, with a small
 commit that you will amend later.
-2. Use the Prow command `/milestone {{< skew nextMinorVersion >}}` to
+2. Edit the pull request description to include links to `k/k` PR(s) and `k/enhancement` issue(s).
+3. Use the Prow command `/milestone {{< skew nextMinorVersion >}}` to
 assign the PR to the relevant milestone. This alerts the docs person managing
 this release that the feature docs are coming.
 


### PR DESCRIPTION
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), or you
 are documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

-->

Sig Release docs team often has to track down both `k/enhancement` and `k/k` prs related to the doc when it's not shared by the PR owner. Therefore, I like to add a section in the PR template to remind folks about the PR requirements related to the release. (pointing to dev branch and including `k/k`, `k/enhancement` links).

During the sig docs meeting, I mentioned creating a separate pull request template, but I think that would just create unnecessary complications since we somehow need to enforce all owners to modify the links to add `?template=templatename` at the end of the URL. Therefore, I have decided to add on to the current PR template. 

@celestehorgan also brought up an idea about automating this process
```
- If a k/website PR mentions a k/k issue (or, ideally, PR)
- Then prow applies hold  on the k/w PR
- And once the k/k PR is merged, it removes hold ?
```
I will follow up with someone who is more familiar with prow to see if this is possible! 

Regardless of automation, I think a reminder in the PR template could be beneficial.

/hold 
for feedback from @sftim @jimangel @irvifa 

cc @reylejano-rxm @eagleusb @SomtochiAma @kcmartin 