### PR TITLE
ja: Fix output of 'kubectl rollout status'

### DIFF
--- a/content/ja/docs/concepts/workloads/controllers/deployment.md
+++ b/content/ja/docs/concepts/workloads/controllers/deployment.md
@@ -92,7 +92,7 @@ Deploymentによって作成されたReplicaSetを管理しないでください
   コマンドの実行結果は以下のとおりです。
   ```shell
   Waiting for rollout to finish: 2 out of 3 new replicas have been updated...
-  deployment.apps/nginx-deployment successfully rolled out
+  deployment "nginx-deployment" successfully rolled out
   ```
 
 4. 数秒後、再度`kubectl get deployments`を実行してください。コマンドの実行結果は以下のとおりです。
@@ -188,7 +188,7 @@ Deploymentを更新するには以下のステップに従ってください。
     ```
     もしくは
     ```
-    deployment.apps/nginx-deployment successfully rolled out
+    deployment "nginx-deployment" successfully rolled out
     ```
 
 更新されたDeploymentのさらなる情報を取得するには、以下を確認してください。
@@ -781,7 +781,7 @@ kubectl rollout status deployment.v1.apps/nginx-deployment
 実行結果は以下のとおりです。
 ```
 Waiting for rollout to finish: 2 of 3 updated replicas are available...
-deployment.apps/nginx-deployment successfully rolled out
+deployment "nginx-deployment" successfully rolled out
 $ echo $?
 0
 ```


### PR DESCRIPTION
This is the same fix as https://github.com/kubernetes/website/pull/24437 for ja content.

If running `kubectl rollout status` command, the output is like:
```
  deployment "nginx-deployment" successfully rolled out
```

The corresponding kubectl code also shows it according to https://github.com/kubernetes/kubectl/blob/e95e378e5972064b177a8e71eac2803f55c8c5df/pkg/polymorphichelpers/rollout_status.go#L89
