### PR TITLE
zh: Fix output of 'kubectl rollout status'

### DIFF
--- a/content/zh/docs/concepts/workloads/controllers/deployment.md
+++ b/content/zh/docs/concepts/workloads/controllers/deployment.md
@@ -203,7 +203,7 @@ Follow the steps given below to create the above Deployment:
 
     ```
     Waiting for rollout to finish: 2 out of 3 new replicas have been updated...
-    deployment.apps/nginx-deployment successfully rolled out
+    deployment "nginx-deployment" successfully rolled out
     ```
 
 <!--
@@ -393,7 +393,7 @@ is changed, for example if the labels or container images of the template are up
    或者
 
    ```
-   deployment.apps/nginx-deployment successfully rolled out
+   deployment "nginx-deployment" successfully rolled out
    ```
 
 <!--
@@ -1439,7 +1439,7 @@ kubectl rollout status deployment.v1.apps/nginx-deployment
 
 ```shell
 Waiting for rollout to finish: 2 of 3 updated replicas are available...
-deployment.apps/nginx-deployment successfully rolled out
+deployment "nginx-deployment" successfully rolled out
 $ echo $?
 0
 ```


### PR DESCRIPTION
This is the same fix as https://github.com/kubernetes/website/commit/6e93717597113c726cbcf8a7059e47f23e3e8a64 for zh.

If running `kubectl rollout status` command, the output is like:
```
  deployment "nginx-deployment" successfully rolled out
```

The corresponding kubectl code also shows it according to https://github.com/kubernetes/kubectl/blob/e95e378e5972064b177a8e71eac2803f55c8c5df/pkg/polymorphichelpers/rollout_status.go#L89
