### PR TITLE
id: Fix output of 'kubectl rollout status'

### DIFF
--- a/content/id/docs/concepts/workloads/controllers/deployment.md
+++ b/content/id/docs/concepts/workloads/controllers/deployment.md
@@ -96,7 +96,7 @@ Dalam contoh ini:
   3. Untuk melihat status rilis Deployment, jalankan `kubectl rollout status deployment.v1.apps/nginx-deployment`. Keluaran akan tampil seperti berikut:
     ```shell
     Waiting for rollout to finish: 2 out of 3 new replicas have been updated...
-    deployment.apps/nginx-deployment successfully rolled out
+    deployment "nginx-deployment" successfully rolled out
     ```
 
   4. Jalankan `kubectl get deployments` lagi beberapa saat kemudian. Keluaran akan tampil seperti berikut:
@@ -179,7 +179,7 @@ Ikuti langkah-langkah berikut untuk membarui Deployment:
     ```
     atau
     ```
-    deployment.apps/nginx-deployment successfully rolled out
+    deployment "nginx-deployment" successfully rolled out
     ```
 
 Untuk menampilkan detail lain dari Deployment yang terbaru:
@@ -826,7 +826,7 @@ kubectl rollout status deployment.v1.apps/nginx-deployment
 Keluaran akan tampil seperti berikut:
 ```
 Waiting for rollout to finish: 2 of 3 updated replicas are available...
-deployment.apps/nginx-deployment successfully rolled out
+deployment "nginx-deployment" successfully rolled out
 $ echo $?
 0
 ```


### PR DESCRIPTION
This is the same fix as https://github.com/kubernetes/website/commit/6e93717597113c726cbcf8a7059e47f23e3e8a64 for id.

If running `kubectl rollout status` command, the output is like:
```
  deployment "nginx-deployment" successfully rolled out
```

The corresponding kubectl code also shows it according to https://github.com/kubernetes/kubectl/blob/e95e378e5972064b177a8e71eac2803f55c8c5df/pkg/polymorphichelpers/rollout_status.go#L89
