### PR TITLE
fr: Fix output of 'kubectl rollout status'

### DIFF
--- a/content/fr/docs/concepts/workloads/controllers/deployment.md
+++ b/content/fr/docs/concepts/workloads/controllers/deployment.md
@@ -116,7 +116,7 @@ Avant de commencer, assurez-vous que votre cluster Kubernetes est opérationnel.
 
    ```shell
    Waiting for rollout to finish: 2 out of 3 new replicas have been updated...
-   deployment.apps/nginx-deployment successfully rolled out
+   deployment "nginx-deployment" successfully rolled out
    ```
 
 1. Exécutez à nouveau `kubectl get deployments` quelques secondes plus tard.
@@ -223,7 +223,7 @@ Suivez les étapes ci-dessous pour mettre à jour votre déploiement:
     ou
 
     ```text
-    deployment.apps/nginx-deployment successfully rolled out
+    deployment "nginx-deployment" successfully rolled out
     ```
 
 Obtenez plus de détails sur votre déploiement mis à jour:
@@ -932,7 +932,7 @@ La sortie est similaire à ceci:
 
 ```text
 Waiting for rollout to finish: 2 of 3 updated replicas are available...
-deployment.apps/nginx-deployment successfully rolled out
+deployment "nginx-deployment" successfully rolled out
 $ echo $?
 0
 ```


### PR DESCRIPTION
This is the same fix as https://github.com/kubernetes/website/commit/6e93717597113c726cbcf8a7059e47f23e3e8a64 for fr.

If running `kubectl rollout status` command, the output is like:
```
  deployment "nginx-deployment" successfully rolled out
```

The corresponding kubectl code also shows it according to https://github.com/kubernetes/kubectl/blob/e95e378e5972064b177a8e71eac2803f55c8c5df/pkg/polymorphichelpers/rollout_status.go#L89
