### PR TITLE
es: Fix output of 'kubectl rollout status'

### DIFF
--- a/content/es/docs/concepts/workloads/controllers/deployment.md
+++ b/content/es/docs/concepts/workloads/controllers/deployment.md
@@ -109,7 +109,7 @@ Para ver el estado del Deployment, ejecuta el comando `kubectl rollout status de
 
 ```shell
 Waiting for rollout to finish: 2 out of 3 new replicas have been updated...
-deployment.apps/nginx-deployment successfully rolled out
+deployment "nginx-deployment" successfully rolled out
 ```
 
 Ejecuta de nuevo el comando `kubectl get deployments` unos segundos más tarde:
@@ -195,7 +195,7 @@ kubectl rollout status deployment.v1.apps/nginx-deployment
 ```
 ```
 Waiting for rollout to finish: 2 out of 3 new replicas have been updated...
-deployment.apps/nginx-deployment successfully rolled out
+deployment "nginx-deployment" successfully rolled out
 ```
 
 Cuando el despliegue funciona, puede que quieras `obtener` el Deployment:
@@ -803,7 +803,7 @@ kubectl rollout status deployment.v1.apps/nginx-deployment
 ```
 ```
 Waiting for rollout to finish: 2 of 3 updated replicas are available...
-deployment.apps/nginx-deployment successfully rolled out
+deployment "nginx-deployment" successfully rolled out
 $ echo $?
 0
 ```


### PR DESCRIPTION
This is the same fix as https://github.com/kubernetes/website/commit/6e93717597113c726cbcf8a7059e47f23e3e8a64 for es.

If running `kubectl rollout status` command, the output is like:
```
  deployment "nginx-deployment" successfully rolled out
```

The corresponding kubectl code also shows it according to https://github.com/kubernetes/kubectl/blob/e95e378e5972064b177a8e71eac2803f55c8c5df/pkg/polymorphichelpers/rollout_status.go#L89
