### PR TITLE
Update local Hugo development target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,10 +65,10 @@ container-image:
 		--build-arg HUGO_VERSION=$(HUGO_VERSION)
 
 container-build: module-check
-	$(CONTAINER_RUN) $(CONTAINER_IMAGE) hugo --minify
+	$(CONTAINER_RUN) --read-only $(CONTAINER_IMAGE) hugo --minify
 
 container-serve: module-check
-	$(CONTAINER_RUN) --mount type=tmpfs,destination=/src/resources,tmpfs-mode=0777 -p 1313:1313 $(CONTAINER_IMAGE) hugo server --buildFuture --bind 0.0.0.0
+	$(CONTAINER_RUN) --read-only --mount type=tmpfs,destination=/tmp,tmpfs-mode=01777 -p 1313:1313 $(CONTAINER_IMAGE) hugo server --buildFuture --bind 0.0.0.0 --destination /tmp/hugo --cleanDestinationDir
 
 test-examples:
 	scripts/test_examples.sh install

--- a/config.toml
+++ b/config.toml
@@ -33,6 +33,23 @@ enableGitInfo = true
 # Hindi is disabled because it's currently in development.
 disableLanguages = ["hi", "no"]
 
+[caches]
+ [caches.assets]
+  dir = ":cacheDir/_gen"
+  maxAge = -1
+ [caches.getcsv]
+  dir = ":cacheDir/:project"
+  maxAge = "60s"
+ [caches.getjson]
+  dir = ":cacheDir/:project"
+  maxAge = "60s"
+ [caches.images]
+  dir = ":cacheDir/_images"
+  maxAge = -1
+ [caches.modules]
+  dir = ":cacheDir/modules"
+  maxAge = -1
+
 [markup]
  [markup.goldmark]
    [markup.goldmark.extensions]


### PR DESCRIPTION
- mount `/tmp` as _tmpfs_
- configure Hugo to use `/tmp` for all caches
- configure Hugo to render into `/tmp`

Untested on macOS, but I think this is very likely to close #24396