### PR TITLE
Remove statement about future of namespaces

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/namespaces.md
+++ b/content/en/docs/concepts/overview/working-with-objects/namespaces.md
@@ -28,9 +28,6 @@ resource can only be in one namespace.
 
 Namespaces are a way to divide cluster resources between multiple users (via [resource quota](/docs/concepts/policy/resource-quotas/)).
 
-In future versions of Kubernetes, objects in the same namespace will have the same
-access control policies by default.
-
 It is not necessary to use multiple namespaces just to separate slightly different
 resources, such as different versions of the same software: use
 [labels](/docs/concepts/overview/working-with-objects/labels) to distinguish


### PR DESCRIPTION
Remove
> In future versions of Kubernetes, objects in the same namespace will have the same access control policies by default.

from https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/

We usually [avoid statements about the future](https://kubernetes.io/docs/contribute/style/style-guide/#avoid-statements-about-the-future) in the documentation. [KEPs](https://github.com/kubernetes/enhancements/) are the right home to discuss what _might_ be in future Kubernetes, and this namespace feature doesn't seem to be confirmed on a roadmap.

/kind cleanup