### PR TITLE
doc: update corefile

### DIFF
--- a/content/en/docs/tasks/administer-cluster/dns-debugging-resolution.md
+++ b/content/en/docs/tasks/administer-cluster/dns-debugging-resolution.md
@@ -222,7 +222,7 @@ data:
           fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153
-        proxy . /etc/resolv.conf
+        forward . /etc/resolv.conf
         cache 30
         loop
         reload


### PR DESCRIPTION
as title

# reference
https://github.com/istio/istio.io/issues/4715

This is due to the CoreDNS version 1.5.0 used by the image which does not support the "proxy" keyword anymore. It must be replaced by "forward" in order to the pod to boot properly.