### PR TITLE
Fix a markup error on tasks/administer-cluster/running-cloud-controller

### DIFF
--- a/content/en/docs/tasks/administer-cluster/running-cloud-controller.md
+++ b/content/en/docs/tasks/administer-cluster/running-cloud-controller.md
@@ -11,7 +11,7 @@ content_type: concept
 
 {{< feature-state state="beta" for_k8s_version="v1.11" >}}
 
-Since cloud providers develop and release at a different pace compared to the Kubernetes project, abstracting the provider-specific code to the {{< glossary_tooltip text="`cloud-controller-manager`" term_id="cloud-controller-manager" >}} binary allows cloud vendors to evolve independently from the core Kubernetes code.
+Since cloud providers develop and release at a different pace compared to the Kubernetes project, abstracting the provider-specific code to the `{{< glossary_tooltip text="cloud-controller-manager" term_id="cloud-controller-manager" >}}` binary allows cloud vendors to evolve independently from the core Kubernetes code.
 
 The `cloud-controller-manager` can be linked to any cloud provider that satisfies [cloudprovider.Interface](https://github.com/kubernetes/cloud-provider/blob/master/cloud.go). For backwards compatibility, the [cloud-controller-manager](https://github.com/kubernetes/kubernetes/tree/master/cmd/cloud-controller-manager) provided in the core Kubernetes project uses the same cloud libraries as `kube-controller-manager`. Cloud providers already supported in Kubernetes core are expected to use the in-tree cloud-controller-manager to transition out of Kubernetes core.
 


### PR DESCRIPTION
This PR fixes a tiny markup error on [running-cloud-controller](https://k8s.io/docs/tasks/administer-cluster/running-cloud-controller/).

**Before**
![Screenshot from 2020-10-12 16-40-58](https://user-images.githubusercontent.com/1425259/95720131-c93b9c00-0cab-11eb-9686-29f4b691123d.png)

**After**

![Screenshot from 2020-10-12 16-40-38](https://user-images.githubusercontent.com/1425259/95720135-c9d43280-0cab-11eb-9e52-03533ff4a27d.png)
