### PR TITLE
Use make-container serve by default

### DIFF
--- a/content/en/docs/contribute/generate-ref-docs/kubectl.md
+++ b/content/en/docs/contribute/generate-ref-docs/kubectl.md
@@ -230,11 +230,9 @@ Build the Kubernetes documentation in your local `<web-base>`.
 
 ```shell
 cd <web-base>
-make docker-serve
+git submodule update --init --recursive --depth 1 # if not already done
+make container-serve
 ```
-{{< note >}}
-The use of `make docker-serve` is deprecated. Please use `make container-serve` instead.
-{{< /note >}}
 
 View the [local preview](https://localhost:1313/docs/reference/generated/kubectl/kubectl-commands/).
 

--- a/content/en/docs/contribute/generate-ref-docs/kubernetes-api.md
+++ b/content/en/docs/contribute/generate-ref-docs/kubernetes-api.md
@@ -182,12 +182,9 @@ Verify the [local preview](http://localhost:1313/docs/reference/generated/kubern
 
 ```shell
 cd <web-base>
-make docker-serve
+git submodule update --init --recursive --depth 1 # if not already done
+make container-serve
 ```
-
-{{< note >}}
-The use of `make docker-serve` is deprecated. Please use `make container-serve` instead.
-{{< /note >}}
 
 ## Commit the changes
 


### PR DESCRIPTION
The switch from `make docker-serve` to `make container-serve` is far enough in the past that everyone should have a current `Makefile`. Update instructions so that `make container-serve` is the default.

Also, highlight the command to fetch and use submodules.