### PR TITLE
Add keyboard shortcut for quick search access

### DIFF
--- a/layouts/partials/search-input.html
+++ b/layouts/partials/search-input.html
@@ -26,5 +26,6 @@
     placeholder="&#xf002 {{ T "ui_search_placeholder" }}"
     aria-label="{{ T "ui_search_placeholder" }}"
     autocomplete="off"
+    accesskey="/"
   >
 {{ end }}


### PR DESCRIPTION
Hi! First of all, thank you for creating this amazing project Kubernetes and it's comprehensive well organized documentation.

Rationale for this particular PR:
A lot of websites offer quick search access via direct keyboard shortcuts. For example YouTube and GitHub offer <kbd>/</kbd> as a shortcut.
It would be really useful for the online Kubernetes Docs to have the same feature in order to make searching more convenient.

So basically this PR will allow quick jump to the online Kubernetes Docs search bar.
Depending on which OS/browser platform the user is, it will map to shortcuts like <kbd>Alt</kbd> + <kbd>/</kbd> or <kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd>/</kbd>, etc.
Additional information: [accesskey attribute (MDN reference)](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/accesskey).