### PR TITLE
Add object to glossary

### DIFF
--- a/content/en/docs/reference/glossary/object.md
+++ b/content/en/docs/reference/glossary/object.md
@@ -1,0 +1,19 @@
+---
+title: Object
+id: object
+date: 2020-10-12
+full_link: https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#kubernetes-objects
+short_description: >
+   A entity in the Kubernetes system, representing part of the state of your cluster.
+aka: 
+tags:
+- fundamental
+---
+An entity in the Kubernetes system. The Kubernetes API uses these entities to represent the state
+of your cluster.
+<!--more-->
+A Kubernetes object is typically a “record of intent”—once you create the object, the Kubernetes
+{{< glossary_tooltip text="control plane" term_id="control-plane" >}} works constantly to ensure
+that the item it represents actually exists.
+By creating an object, you're effectively telling the Kubernetes system what you want that part of
+your cluster's workload to look like; this is your cluster's desired state.


### PR DESCRIPTION
Let's define _object_ in the glossary, linking to https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/

[[preview](https://deploy-preview-24528--kubernetes-io-master-staging.netlify.app/docs/reference/glossary/?fundamental=true#term-object)]