### PR TITLE
v1.16_upgrade, add notes for upgrading additional control plane nodes

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -277,6 +277,10 @@ sudo kubeadm upgrade apply
 
 Also `sudo kubeadm upgrade plan` is not needed.
 
+{{< note >}}
+If you're using the kubeadm support for certificate management, please add `--certificate-renewal=true` to the `kubeadm upgrade node` command line. [bug issue](https://github.com/kubernetes/kubeadm/issues/1818)
+{{</ note >}}
+
 ### Upgrade kubelet and kubectl
 
 1.  Upgrade the kubelet and kubectl on all control plane nodes:


### PR DESCRIPTION
this pr is for the issue https://github.com/kubernetes/kubernetes/issues/95386

the problem is when upgrading from v1.15 to v1.16, on additional control plane nodes, renew certs would not run automatically , which is different with first control plane node.