### PR TITLE
[zh] translate kubeadm commands which are missing in zh version

### DIFF
--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_alpha_certs.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_alpha_certs.md
@@ -1,0 +1,55 @@
+
+<!-- ### Synopsis -->
+### 概要
+
+
+
+<!-- Commands related to handling kubernetes certificates -->
+与处理 kubernetes 证书相关的命令
+
+<!-- ### Options -->
+### 选项
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">-h, --help</td>
+</tr>
+<tr>
+<!-- <td></td><td style="line-height: 130%; word-wrap: break-word;">help for certs</td> -->
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><!-- help for certs-->certs 命令的帮助</td>
+</tr>
+
+</tbody>
+</table>
+
+
+
+<!-- ### Options inherited from parent commands -->
+### 继承于父命令的选项
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">--rootfs string</td>
+</tr>
+<tr>
+<!-- <td></td><td style="line-height: 130%; word-wrap: break-word;">[EXPERIMENTAL] The path to the 'real' host root filesystem.</td> -->
+<td></td><td style="line-height: 130%; word-wrap: break-word;">[实验] 到'真实'主机根文件系统的路径。</td>
+</tr>
+
+</tbody>
+</table>
+
+
+

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_alpha_certs_generate-csr.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_alpha_certs_generate-csr.md
@@ -1,0 +1,111 @@
+
+<!-- ### Synopsis -->
+### 概要
+
+<!-- 
+Generates keys and certificate signing requests (CSRs) for all the certificates required to run the control plane. This command also generates partial kubeconfig files with private key data in the  "users &gt; user &gt; client-key-data" field, and for each kubeconfig file an accompanying ".csr" file is created.
+-->
+为运行控制平面所需的所有证书生成密钥和证书签名请求（CSR）。该命令会生成部分 kubeconfig 文件，
+其中 "users &gt; user &gt; client-key-data" 字段包含私钥数据，并为每个 kubeconfig 文件创建一个随附的".csr"文件。
+
+<!--  
+This command is designed for use in [Kubeadm External CA Mode](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-certs/#external-ca-mode). It generates CSRs which you can then submit to your external certificate authority for signing.
+-->
+该命令设计用于 [Kubeadm 外部 CA 模式](https://kubernetes.io/zh/docs/tasks/administer-cluster/kubeadm/kubeadm-certs/#external-ca-mode)。 
+它生成 CSR，然后你可以将其提交给外部证书颁发机构进行签名。
+
+<!--  
+The PEM encoded signed certificates should then be saved alongside the key files, using ".crt" as the file extension, or in the case of kubeconfig files, the PEM encoded signed certificate should be base64 encoded and added to the kubeconfig file in the "users &gt; user &gt; client-certificate-data" field.
+-->
+然后，应使用 ".crt" 作为文件扩展名将 PEM 编码的签名证书与密钥文件一起保存，或者，对于 kubeconfig 文件，
+PEM 编码的签名证书应使用 base64 编码，并添加到 "users &gt; user &gt; client-certificate-data" 字段。
+
+```
+kubeadm alpha certs generate-csr [flags]
+```
+
+<!-- ### Examples -->
+### 示例
+
+<!-- 
+```
+  # The following command will generate keys and CSRs for all control-plane certificates and kubeconfig files:
+  kubeadm alpha certs generate-csr --kubeconfig-dir /tmp/etc-k8s --cert-dir /tmp/etc-k8s/pki
+```
+-->
+```
+  # 以下命令将为所有控制平面证书和 kubeconfig 文件生成密钥和 CSR :
+  kubeadm alpha certs generate-csr --kubeconfig-dir /tmp/etc-k8s --cert-dir /tmp/etc-k8s/pki
+```
+
+<!-- ### Options -->
+### 选项
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">--cert-dir string</td>
+</tr>
+<tr>
+<!-- <td></td><td style="line-height: 130%; word-wrap: break-word;">The path where to save the certificates</td> -->
+<td></td><td style="line-height: 130%; word-wrap: break-word;">保存证书的路径</td>
+</tr>
+
+<tr>
+<td colspan="2">--config string</td>
+</tr>
+<tr>
+<!-- <td></td><td style="line-height: 130%; word-wrap: break-word;">Path to a kubeadm configuration file.</td> -->
+<td></td><td style="line-height: 130%; word-wrap: break-word;">kubeadm 配置文件的路径。</td>
+</tr>
+
+<tr>
+<td colspan="2">-h, --help</td>
+</tr>
+<tr>
+<!-- <td></td><td style="line-height: 130%; word-wrap: break-word;">help for generate-csr</td> -->
+<td></td><td style="line-height: 130%; word-wrap: break-word;">generate-csr 命令的帮助</td>
+</tr>
+
+<tr>
+<!-- <td colspan="2">--kubeconfig-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/etc/kubernetes"</td> -->
+<td colspan="2">--kubeconfig-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值："/etc/kubernetes"</td>
+</tr>
+<tr>
+<!-- <td></td><td style="line-height: 130%; word-wrap: break-word;">The path where to save the kubeconfig file.</td> -->
+<td></td><td style="line-height: 130%; word-wrap: break-word;">保存 kubeconfig 文件的路径。</td>
+</tr>
+
+</tbody>
+</table>
+
+
+
+<!-- ### Options inherited from parent commands -->
+### 继承于父命令的选项
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">--rootfs string</td>
+</tr>
+<tr>
+<!-- <td></td><td style="line-height: 130%; word-wrap: break-word;">[EXPERIMENTAL] The path to the 'real' host root filesystem.</td> -->
+<td></td><td style="line-height: 130%; word-wrap: break-word;">[实验] 到'真实'主机根文件系统的路径。</td>
+</tr>
+
+</tbody>
+</table>
+
+
+

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_kubelet-finalize.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_kubelet-finalize.md
@@ -1,0 +1,71 @@
+
+<!-- ### Synopsis -->
+### 概要
+
+<!-- Updates settings relevant to the kubelet after TLS bootstrap -->
+TLS 引导后更新与 kubelet 相关的设置
+
+```
+kubeadm init phase kubelet-finalize [flags]
+```
+
+<!-- ### Examples -->
+### 示例
+
+<!--  
+```
+  # Updates settings relevant to the kubelet after TLS bootstrap
+  kubeadm init phase kubelet-finalize all --config
+```
+-->
+```
+  # 在 TLS 引导后更新与 kubelet 相关的设置
+  kubeadm init phase kubelet-finalize all --config
+```
+
+<!-- ### Options -->
+### 选项
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">-h, --help</td>
+</tr>
+<tr>
+<!-- <td></td><td style="line-height: 130%; word-wrap: break-word;">help for kubelet-finalize</td> -->
+<td></td><td style="line-height: 130%; word-wrap: break-word;">kubelet-finalize 操作的帮助命令</td>
+</tr>
+
+</tbody>
+</table>
+
+
+
+<!-- ### Options inherited from parent commands -->
+### 继承于父命令的选项
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">--rootfs string</td>
+</tr>
+<tr>
+<!-- <td></td><td style="line-height: 130%; word-wrap: break-word;">[EXPERIMENTAL] The path to the 'real' host root filesystem.</td> -->
+<td></td><td style="line-height: 130%; word-wrap: break-word;">[实验] 到'真实'主机根文件系统的路径。</td>
+</tr>
+
+</tbody>
+</table>
+
+
+

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_kubelet-finalize_all.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_kubelet-finalize_all.md
@@ -1,0 +1,89 @@
+
+<!-- ### Synopsis -->
+### 概要
+
+
+<!-- Run all kubelet-finalize phases -->
+运行所有 kubelet-finalize 阶段
+
+```
+kubeadm init phase kubelet-finalize all [flags]
+```
+
+<!-- ### Examples -->
+### 示例
+
+<!--  
+```
+  # Updates settings relevant to the kubelet after TLS bootstrap
+  kubeadm init phase kubelet-finalize all --config
+```
+-->
+```
+  # 在 TLS 引导后更新与 kubelet 相关的设置
+  kubeadm init phase kubelet-finalize all --config
+```
+
+<!-- ### Options -->
+### 选项
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<!-- <td colspan="2">--cert-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/etc/kubernetes/pki"</td> -->
+<td colspan="2">--cert-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值: "/etc/kubernetes/pki"</td>
+</tr>
+<tr>
+<!-- <td></td><td style="line-height: 130%; word-wrap: break-word;">The path where to save and store the certificates.</td> -->
+<td></td><td style="line-height: 130%; word-wrap: break-word;">保存和存储证书的路径。</td>
+</tr>
+
+<tr>
+<td colspan="2">--config string</td>
+</tr>
+<tr>
+<!-- <td></td><td style="line-height: 130%; word-wrap: break-word;">Path to a kubeadm configuration file.</td> -->
+<td></td><td style="line-height: 130%; word-wrap: break-word;">kubeadm 配置文件的路径。</td>
+</tr>
+
+<tr>
+<td colspan="2">-h, --help</td>
+</tr>
+<tr>
+<!-- <td></td><td style="line-height: 130%; word-wrap: break-word;">help for all</td> -->
+<td></td><td style="line-height: 130%; word-wrap: break-word;">all 操作的帮助命令</td>
+</tr>
+
+</tbody>
+</table>
+
+
+
+<!-- ### Options inherited from parent commands -->
+### 继承于父命令的选项
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">--rootfs string</td>
+</tr>
+<tr>
+<!-- <td></td><td style="line-height: 130%; word-wrap: break-word;">[EXPERIMENTAL] The path to the 'real' host root filesystem.</td> -->
+<td></td><td style="line-height: 130%; word-wrap: break-word;">[实验] 到'真实'主机根文件系统的路径。</td>
+</tr>
+
+</tbody>
+</table>
+
+
+

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_kubelet-finalize_experimental-cert-rotation.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_kubelet-finalize_experimental-cert-rotation.md
@@ -1,0 +1,75 @@
+
+<!-- ### Synopsis -->
+### 概要
+
+
+
+<!-- Enable kubelet client certificate rotation -->
+启用 kubelet 客户端证书轮换
+
+```
+kubeadm init phase kubelet-finalize experimental-cert-rotation [flags]
+```
+
+<!-- ### Options -->
+### 选项
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">--cert-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "/etc/kubernetes/pki"</td>
+</tr>
+<tr>
+<!-- <td></td><td style="line-height: 130%; word-wrap: break-word;">The path where to save and store the certificates.</td> -->
+<td></td><td style="line-height: 130%; word-wrap: break-word;">保存和存储证书的路径。</td>
+</tr>
+
+<tr>
+<td colspan="2">--config string</td>
+</tr>
+<tr>
+<!-- <td></td><td style="line-height: 130%; word-wrap: break-word;">Path to a kubeadm configuration file.</td> -->
+<td></td><td style="line-height: 130%; word-wrap: break-word;">kubeadm 配置文件的路径。</td>
+</tr>
+
+<tr>
+<td colspan="2">-h, --help</td>
+</tr>
+<tr>
+<!-- <td></td><td style="line-height: 130%; word-wrap: break-word;">help for experimental-cert-rotation</td> -->
+<td></td><td style="line-height: 130%; word-wrap: break-word;">experimental-cert-rotation 操作的帮助命令</td>
+</tr>
+
+</tbody>
+</table>
+
+
+
+<!-- ### Options inherited from parent commands -->
+### 继承于父命令的选项
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">--rootfs string</td>
+</tr>
+<tr>
+<!-- <td></td><td style="line-height: 130%; word-wrap: break-word;">[EXPERIMENTAL] The path to the 'real' host root filesystem.</td> -->
+<td></td><td style="line-height: 130%; word-wrap: break-word;">[实验] 到'真实'主机根文件系统的路径。</td>
+</tr>
+
+</tbody>
+</table>
+
+
+

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade_node_phase_preflight.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade_node_phase_preflight.md
@@ -1,0 +1,69 @@
+
+<!-- ### Synopsis -->
+### 概要
+
+
+<!-- Run pre-flight checks for kubeadm upgrade node. -->
+
+执行 kubeadm 升级节点的预检。
+
+```
+kubeadm upgrade node phase preflight [flags]
+```
+
+<!-- ### Options -->
+### 选项
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">-h, --help</td>
+</tr>
+<tr>
+<!-- <td></td><td style="line-height: 130%; word-wrap: break-word;">help for preflight</td> -->
+<td></td><td style="line-height: 130%; word-wrap: break-word;">preflight 操作的帮助命令</td>
+</tr>
+
+<tr>
+<td colspan="2">--ignore-preflight-errors stringSlice</td>
+</tr>
+<tr>
+<!-- 
+<td></td><td style="line-height: 130%; word-wrap: break-word;">A list of checks whose errors will be shown as warnings. Example: 'IsPrivilegedUser,Swap'. Value 'all' ignores errors from all checks.</td> 
+-->
+<td></td><td style="line-height: 130%; word-wrap: break-word;">错误将显示为警告的检查清单。示例：'IsPrivilegedUser,Swap'。值为'all'表示忽略所有检查的错误。</td>
+</tr>
+
+</tbody>
+</table>
+
+
+
+<!-- ### Options inherited from parent commands -->
+### 继承于父命令的选项
+
+   <table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">--rootfs string</td>
+</tr>
+<tr>
+<!-- <td></td><td style="line-height: 130%; word-wrap: break-word;">[EXPERIMENTAL] The path to the 'real' host root filesystem.</td> -->
+<td></td><td style="line-height: 130%; word-wrap: break-word;">[实验] 到'真实'主机根文件系统的路径。</td>
+</tr>
+
+</tbody>
+</table>
+
+
+


### PR DESCRIPTION
ref: https://github.com/kubernetes/website/issues/24486

this PR contains all files in docs/reference/setup-tools/kubeadm/generated
implementation-details.md will committed in other PR.