### PR TITLE
Set code owners for /.github

### DIFF
--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+- sig-docs-en-reviews # Defined in OWNERS_ALIASES
+
+approvers:
+- sig-docs-en-owners # Defined in OWNERS_ALIASES

--- a/.github/workflows/OWNERS
+++ b/.github/workflows/OWNERS
@@ -1,0 +1,11 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# When modifying this file, consider the security implications of
+# allowing listed reviewers / approvals to modify or remove any
+# configured GitHub Actions.
+
+reviewers:
+- sig-docs-leads
+
+approvers:
+- sig-docs-leads


### PR DESCRIPTION
Granting people the ability to write into `/.github/workflows` can provide some measure of privilege escalation, so lock down access there.