### PR TITLE
Update “Auditing” concept

### DIFF
--- a/content/en/docs/tasks/debug-application-cluster/audit.md
+++ b/content/en/docs/tasks/debug-application-cluster/audit.md
@@ -154,16 +154,14 @@ volumeMounts:
 finally the hostPath:
 
 ```
-- name: audit
-  hostPath:
+- hostPath:
     path: /etc/kubernetes/audit-policy.yaml
     type: File
-
-- name: audit-log
-  hostPath:
+  name: audit
+- hostPath:
     path: /var/log/audit.log
     type: FileOrCreate
-    
+  name: audit-log   
 ```
 
 


### PR DESCRIPTION
Fixed the - hostPath example info for setting up the audit logs. It avoids making the kube-apiserver unresponsive when enabling the audit logs.

It was:
- name: audit
  hostPath:
    path: /etc/kubernetes/audit-policy.yaml
    type: File

- name: audit-log
  hostPath:
    path: /var/log/audit.log
    type: FileOrCreate

Now it is:

- hostPath:
    path: /etc/kubernetes/audit-policy.yaml
    type: File
  name: audit
- hostPath:
    path: /var/log/audit.log
    type: FileOrCreate
  name: audit-log

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
