### PR TITLE
Fix glossary containers link

### DIFF
--- a/content/en/docs/concepts/workloads/pods/_index.md
+++ b/content/en/docs/concepts/workloads/pods/_index.md
@@ -15,7 +15,7 @@ card:
 _Pods_ are the smallest deployable units of computing that you can create and manage in Kubernetes.
 
 A _Pod_ (as in a pod of whales or pea pod) is a group of one or more
-[containers](/docs/concepts/containers/), with shared storage/network resources, and a specification
+{{< glossary_tooltip text="containers" term_id="container" >}}, with shared storage/network resources, and a specification
 for how to run the containers. A Pod's contents are always co-located and
 co-scheduled, and run in a shared context. A Pod models an
 application-specific "logical host": it contains one or more application

--- a/content/en/docs/reference/glossary/container.md
+++ b/content/en/docs/reference/glossary/container.md
@@ -2,7 +2,7 @@
 title: Container
 id: container
 date: 2018-04-12
-full_link: /docs/concepts/overview/what-is-kubernetes/#why-containers
+full_link: /docs/concepts/containers/
 short_description: >
   A lightweight and portable executable image that contains software and all of its dependencies.
 


### PR DESCRIPTION
An alternative fix for issue #24459.

- Revise glossary page for “container” to link to [/docs/concepts/containers/](https://k8s.io/docs/concepts/containers/).
- Then, revert the changes from PR #24579 so that the [Pods](https://k8s.io/docs/concepts/workloads/pods/) concept page again uses the glossary tooltip [[preview](https://deploy-preview-24587--kubernetes-io-master-staging.netlify.app/docs/concepts/workloads/pods/)].

