### PR TITLE
Replace legacy capture shortcodes

### DIFF
--- a/content/fr/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/fr/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -1,10 +1,10 @@
 ---
 title: Configurer les Liveness, Readiness et Startup Probes
-content_template: templates/task
+content_type: task
 weight: 110
 ---
 
-{{% capture overview %}}
+<!-- overview -->
 
 Cette page montre comment configurer les liveness, readiness et startup probes pour les conteneurs.
 
@@ -17,15 +17,11 @@ Le Kubelet utilise startup probes pour savoir quand une application d'un contene
 Si une telle probe est configurée, elle désactive les contrôles de liveness et readiness jusqu'à cela réussit, en s'assurant que ces probes n'interfèrent pas avec le démarrage de l'application.
 Cela peut être utilisé dans le cas des liveness checks sur les conteneurs à démarrage lent, en les évitant de se faire tuer par le Kubelet avant qu'ils ne soient opérationnels.
 
-{{% /capture %}}
-
-{{% capture prerequisites %}}
+## {{% heading "prerequisites" %}}
 
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
 
-{{% /capture %}}
-
-{{% capture steps %}}
+<!-- steps -->
 
 ## Définir une commande de liveness
 
@@ -281,9 +277,7 @@ Voici un scénario où vous le mettriez en place. Supposons que le conteneur éc
 
 Le Kubelet fait la connexion de la probe au noeud, pas dans le Pod, ce qui signifie que vous ne pouvez pas utiliser un nom de service dans le paramètre `host` puisque le Kubelet est incapable pour le résoudre.
 
-{{% /capture %}}
-
-{{% capture whatsnext %}}
+## {{% heading whatsnext %}}
 
 * Pour en savoir plus sur
 [Probes des Conteneurs](/docs/concepts/workloads/pods/pod-lifecycle/#container-probes).
@@ -293,7 +287,5 @@ Le Kubelet fait la connexion de la probe au noeud, pas dans le Pod, ce qui signi
 * [Pod](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#pod-v1-core)
 * [Container](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#container-v1-core)
 * [Probe](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#probe-v1-core)
-
-{{% /capture %}}
 
 

--- a/content/fr/docs/tasks/configure-pod-container/share-process-namespace.md
+++ b/content/fr/docs/tasks/configure-pod-container/share-process-namespace.md
@@ -1,11 +1,11 @@
 ---
 title: Partager l'espace de nommage des processus entre les conteneurs d'un Pod
 min-kubernetes-server-version: v1.10
-content_template: templates/task
+content_type: task
 weight: 160
 ---
 
-{{% capture overview %}}
+<!-- overview -->
 
 {{< feature-state state="stable" for_k8s_version="v1.17" >}}
 
@@ -13,15 +13,11 @@ Cette page montre comment configurer le partage de l'espace de noms d'un process
 
 Vous pouvez utiliser cette fonctionnalité pour configurer les conteneurs coopérants, comme un conteneur de sidecar de gestionnaire de journaux, ou pour dépanner les images de conteneurs qui n'incluent pas d'utilitaires de débogage comme un shell.
 
-{{% /capture %}}
-
-{{% capture prerequisites %}}
+## {{% heading prerequisites %}}
 
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
 
-{{% /capture %}}
-
-{{% capture steps %}}
+<!-- steps -->
 
 ## Configurer un Pod
 
@@ -83,10 +79,6 @@ events {
     worker_connections  1024;
 ```
 
-{{% /capture %}}
-
-{{% capture discussion %}}
-
 ## Comprendre le processus de partage de l'espace de nommage
 
 Les pods partagent de nombreuses ressources, il est donc logique qu'elles partagent également un espace de noms des processus. Pour certaines images de conteneur, on peut envisager de les isoler les uns des autres. Il est donc important de comprendre ces différences :
@@ -96,7 +88,4 @@ Les pods partagent de nombreuses ressources, il est donc logique qu'elles partag
 1. **Les processus sont visibles par les autres conteneurs du pod.**  Cela inclut tout les informations visibles dans `/proc`, comme les mots de passe passés en argument ou les variables d'environnement. Celles-ci ne sont protégées que par des permissions Unix régulières.
 
 1. **Les systèmes de fichiers des conteneurs sont visibles par les autres conteneurs du pod à travers le lien `/proc/$pid/root`.** Cela rend le débogage plus facile, mais cela signifie aussi que les secrets du système de fichiers ne sont protégés que par les permissions du système de fichiers.
-
-{{% /capture %}}
-
 


### PR DESCRIPTION
Generate pages without using legacy capture statements.

Fixup for PR #24566.
/kind cleanup

