### PR TITLE
content/en/docs/tasks/run-application/configure-pdb: Acceptable overlapping PDBs

### DIFF
--- a/content/en/docs/tasks/run-application/configure-pdb.md
+++ b/content/en/docs/tasks/run-application/configure-pdb.md
@@ -236,9 +236,6 @@ You can use a PDB with pods controlled by another type of controller, by an
 - only an integer value can be used with `.spec.minAvailable`, not a percentage.
 
 You can use a selector which selects a subset or superset of the pods belonging to a built-in
-controller.  However, when there are multiple PDBs in a namespace, you must be careful not
-to create PDBs whose selectors overlap.
-
-
-
-
+controller.  The eviction API will disallow eviction of any pod covered by multiple PDBs,
+so most users will want to avoid overlapping selectors.  One reasonable use of overlapping
+PDBs is when pods are being transitioned from one PDB to another.


### PR DESCRIPTION
The previous "must be careful not to create" wording was [making folks uncomfortable][1] about brief overlap periods while transitioning between two PDBs.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1861104#c29