### PR TITLE
storageclass name in pvc needs to be empty to match pv

### DIFF
--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -185,25 +185,27 @@ If the PersistentVolume exists and has not reserved PersistentVolumeClaims throu
 The binding happens regardless of some volume matching criteria, including node affinity.
 The control plane still checks that [storage class](https://kubernetes.io/docs/concepts/storage/storage-classes/), access modes, and requested storage size are valid.
 
-```
+```yaml
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: foo-pvc
   namespace: foo
 spec:
+  storageClassName: "" # Empty string must be explicitly set otherwise default StorageClass will be set
   volumeName: foo-pv
   ...
 ```
 
 This method does not guarantee any binding privileges to the PersistentVolume. If other PersistentVolumeClaims could use the PV that you specify, you first need to reserve that storage volume. Specify the relevant PersistentVolumeClaim in the `claimRef` field of the PV so that other PVCs can not bind to it.
 
-```
+```yaml
 apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: foo-pv
 spec:
+  storageClassName: ""
   claimRef:
     name: foo-pvc
     namespace: foo


### PR DESCRIPTION
Fix example of reserving a pv so that the storageclass names match.