### PR TITLE
Fix issue in lsync script

### DIFF
--- a/scripts/lsync.sh
+++ b/scripts/lsync.sh
@@ -23,7 +23,7 @@ fi
 # Last commit for the localized file
 LASTCOMMIT=`git log -n 1 --pretty=format:%h -- $LOCALIZED`
 
-git diff $LASTCOMMIT...HEAD $EN_VERSION
+git diff --exit-code $LASTCOMMIT...HEAD $EN_VERSION
 
 if [ "$?" -eq 0 ]; then
   echo "$LOCALIZED is still in sync"


### PR DESCRIPTION
According to 'git diff --help', the `--exist-code` flag can be used to
ensure that the command returns 0 when no difference is found.

fixes #24595