### PR TITLE
docs: update containerd systemd configuration

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -472,11 +472,13 @@ Start-Service containerd
 
 ### systemd
 
-To use the `systemd` cgroup driver in `/etc/containerd/config.toml` set
+To use the `systemd` cgroup driver in `/etc/containerd/config.toml` with `runc` set
 
 ```
-[plugins.cri]
-systemd_cgroup = true
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+  ...
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+    SystemdCgroup = true
 ```
 When using kubeadm, manually configure the
 [cgroup driver for kubelet](/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#configure-cgroup-driver-used-by-kubelet-on-control-plane-node)


### PR DESCRIPTION
`systemd_cgroup = true` in `plugins."io.containerd.grpc.v1.cri"` is no longer
supported by containerd 1.3.x. Enabling it causes containerd to skip loading
the cri plugin.

Add the preferred setting to the container runtime configuration documentation.

Ref: https://github.com/containerd/containerd/issues/4574