### PR TITLE
Fix ko glossary managed service title

### DIFF
--- a/content/ko/docs/reference/glossary/managed-service.md
+++ b/content/ko/docs/reference/glossary/managed-service.md
@@ -1,5 +1,5 @@
 ---
-title: 매니지드 서비스
+title: 매니지드 서비스(Managed Service)
 id: managed-service
 date: 2018-04-12
 full_link:


### PR DESCRIPTION
Fix ko glossary managed service title.

For the terms in reference/glossary, 
Korean l10n team guides to provide original English term
in the title of document.