### PR TITLE
exec credential provider: cluster info details

### DIFF
--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -895,7 +895,9 @@ clusters:
     extensions:
     - name: client.authentication.k8s.io/exec # reserved extension name for per cluster exec config
       extension:
-        some-config-per-cluster: config-data  # arbitrary config
+        arbitrary: config
+        this: can be provided via the KUBERNETES_EXEC_INFO environment variable upon setting provideClusterInfo
+        you: ["can", "put", "anything", "here"]
 contexts:
 - name: my-cluster
   context:
@@ -994,7 +996,9 @@ example of the aforementioned `KUBERNETES_EXEC_INFO` environment variable.
       "server": "https://172.17.4.100:6443",
       "certificate-authority-data": "LS0t...",
       "config": {
-        "some-config-per-cluster": "config-data"
+        "arbitrary": "config",
+        "this": "can be provided via the KUBERNETES_EXEC_INFO environment variable upon setting provideClusterInfo",
+        "you": ["can", "put", "anything", "here"]
       }
     }
   }

--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -882,11 +882,20 @@ users:
         On Fedora: dnf install example-client-go-exec-plugin
 
         ...
+
+      # Whether or not to provide cluster information, which could potentially contain
+      # very large CA data, to this exec plugin as a part of the KUBERNETES_EXEC_INFO
+      # environment variable.
+      provideClusterInfo: true
 clusters:
 - name: my-cluster
   cluster:
     server: "https://172.17.4.100:6443"
     certificate-authority: "/etc/kubernetes/ca.pem"
+    extensions:
+    - name: client.authentication.k8s.io/exec # reserved extension name for per cluster exec config
+      extension:
+        some-config-per-cluster: config-data  # arbitrary config
 contexts:
 - name: my-cluster
   context:
@@ -968,3 +977,26 @@ RFC3339 timestamp. Presence or absence of an expiry has the following impact:
 }
 ```
 
+The plugin can optionally be called with an environment variable, `KUBERNETES_EXEC_INFO`,
+that contains information about the cluster for which this plugin is obtaining
+credentials. This information can be used to perform cluster-specific credential
+acquisition logic. In order to enable this behavior, the `provideClusterInfo` field must
+be set on the exec user field in the
+[kubeconfig](/docs/concepts/configuration/organize-cluster-access-kubeconfig/). Here is an
+example of the aforementioned `KUBERNETES_EXEC_INFO` environment variable.
+
+```json
+{
+  "apiVersion": "client.authentication.k8s.io/v1beta1",
+  "kind": "ExecCredential",
+  "spec": {
+    "cluster": {
+      "server": "https://172.17.4.100:6443",
+      "certificate-authority-data": "LS0t...",
+      "config": {
+        "some-config-per-cluster": "config-data"
+      }
+    }
+  }
+}
+```


### PR DESCRIPTION
Signed-off-by: Andrew Keesler akeesler@vmware.com

Notes:

* Roughly, this feature provides a way for an exec credential plugin to obtain information about the cluster for which it is supposed to be obtaining credentials.
* This feature is targeted at `1.20`.
* This feature was approved for `1.20` as a part of this KEP PR: https://github.com/kubernetes/enhancements/pull/2096.
* This k/k PR is, as of the time of writing this PR comment, in review: https://github.com/kubernetes/kubernetes/pull/95489/.

KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/541-external-credential-providers