### PR TITLE
Docs: Restore PR24605, update containerd systemd configuration

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -189,13 +189,15 @@ Start-Service containerd
 {{% /tab %}}
 {{< /tabs >}}
 
-#### systemd
+#### systemd {#containerd-systemd}
 
 To use the `systemd` cgroup driver in `/etc/containerd/config.toml` with `runc`, set
 
 ```
-[plugins.cri]
-systemd_cgroup = true
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+  ...
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+    SystemdCgroup = true
 ```
 
 When using kubeadm, manually configure the


### PR DESCRIPTION
This PR restores the updated containerd systemd configuration made in PR #24605, which were accidentally removed in #24530.
