### PR TITLE
Improve the lsync script

### DIFF
--- a/scripts/lsync.sh
+++ b/scripts/lsync.sh
@@ -3,27 +3,37 @@
 # This script checks if the English version of a page has changed since a localized
 # page has been committed.
 
-if [ "$#" -ne 1 ] || ! [ -f "$1" ]; then
-  echo -e "\nThis script checks if the English version of a page has changed since a "
-  echo -e "localized page has been committed.\n"
+if [ "$#" -ne 1 ] ; then
+  echo -e "\nThis script checks if the English version of a page has changed since a " >&2
+  echo -e "localized page has been committed.\n" >&2
   echo -e "Usage:\n\t$0 <PATH>\n" >&2
   echo -e "Example:\n\t$0 content/zh/docs/concepts/_index.md\n" >&2
   exit 1
 fi
 
+# Check if path exists, and whether it is a directory or a file
+if [ ! -e "$1" ] ; then
+  echo "Path not found: '$1'" >&2
+  exit 2
+elif [ -d "$1" ] ; then
+  IS_DIR=1
+  EXTRA_FLAGS="--stat"
+else
+  IS_DIR=0
+fi
 LOCALIZED="$1"
 
 # Try get the English version
 EN_VERSION=`echo $LOCALIZED | sed "s/content\/..\//content\/en\//g"`
-if ! [ -f $EN_VERSION ]; then
+if [ $IS_DIR -eq 1 -a ! -e $EN_VERSION ]; then
   echo "$EN_VERSION has been removed."
-  exit 2
+  exit 3
 fi
 
-# Last commit for the localized file
+# Last commit for the localized path
 LASTCOMMIT=`git log -n 1 --pretty=format:%h -- $LOCALIZED`
 
-git diff --exit-code $LASTCOMMIT...HEAD $EN_VERSION
+git diff --exit-code $EXTRA_FLAGS $LASTCOMMIT...HEAD $EN_VERSION
 
 if [ "$?" -eq 0 ]; then
   echo "$LOCALIZED is still in sync"


### PR DESCRIPTION

This PR improves the lsync script so that it can handle directories
(recursively). For example, you can run the following command to find
the detailed changes that are out of sync:

```
./scripts/lsync content/zh/docs/concepts/_index.md
```

and you can run the following command to identify how many files are
out of sync under a given directory:

```
> ./scripts/lsync content/zh/docs/concepts/

content/en/docs/concepts/architecture/control-plane-node-communication.md        |  2 +-
 content/en/docs/concepts/architecture/controller.md                              | 10 ++++++++++
 content/en/docs/concepts/cluster-administration/logging.md                       |  4 ++--
 content/en/docs/concepts/cluster-administration/system-metrics.md                |  2 +-
 content/en/docs/concepts/configuration/pod-priority-preemption.md                |  2 +-
 content/en/docs/concepts/containers/runtime-class.md                             |  2 +-
 content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md |  2 +-
 content/en/docs/concepts/extend-kubernetes/operator.md                           |  2 +-
 content/en/docs/concepts/extend-kubernetes/service-catalog.md                    |  2 +-
 content/en/docs/concepts/overview/kubernetes-api.md                              |  2 +-
 content/en/docs/concepts/overview/what-is-kubernetes.md                          |  3 +--
 content/en/docs/concepts/overview/working-with-objects/labels.md                 |  2 +-
 content/en/docs/concepts/scheduling-eviction/kube-scheduler.md                   |  4 ++--
 content/en/docs/concepts/services-networking/dual-stack.md                       |  2 +-
 content/en/docs/concepts/storage/ephemeral-volumes.md                            | 11 +++++------
 content/en/docs/concepts/storage/persistent-volumes.md                           |  2 +-
 content/en/docs/concepts/storage/storage-classes.md                              |  2 +-
 content/en/docs/concepts/storage/volumes.md                                      |  5 ++---
 content/en/docs/concepts/workloads/_index.md                                     |  2 +-
 content/en/docs/concepts/workloads/controllers/replicaset.md                     |  4 ++--
 content/en/docs/concepts/workloads/pods/_index.md                                |  4 ++--
 content/en/docs/concepts/workloads/pods/pod-lifecycle.md                         |  3 ++-

```

Related: #24419
