### PR TITLE
Clean up reference section

### DIFF
--- a/content/en/docs/reference/_index.md
+++ b/content/en/docs/reference/_index.md
@@ -6,7 +6,9 @@ linkTitle: "Reference"
 main_menu: true
 weight: 70
 content_type: concept
+no_list: true
 ---
+
 
 <!-- overview -->
 
@@ -16,11 +18,17 @@ This section of the Kubernetes documentation contains references.
 
 <!-- body -->
 
-## API Reference
+## Standardized Glossary
+
+* [Glossary](/docs/reference/glossary/) -  a comprehensive, standardized list of Kubernetes terminology
+
+
 
 * [Kubernetes API Reference](/docs/reference/kubernetes-api/)
 * [One-page API Reference for Kubernetes {{< param "version" >}}](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/)
 * [Using The Kubernetes API](/docs/reference/using-api/) - overview of the API for Kubernetes.
+* [API access control](/docs/reference/access-authn-authz/) - details on how Kubernetes controls API access
+* [Well-Known Labels, Annotations and Taints](/docs/reference/kubernetes-api/labels-annotations-taints/)
 
 ## API Client Libraries
 
@@ -32,22 +40,28 @@ client libraries:
 - [Kubernetes Python client library](https://github.com/kubernetes-client/python)
 - [Kubernetes Java client library](https://github.com/kubernetes-client/java)
 - [Kubernetes JavaScript client library](https://github.com/kubernetes-client/javascript)
+- [Kubernetes Dotnet client library](https://github.com/kubernetes-client/csharp)
+- [Kubernetes Haskell Client library](https://github.com/kubernetes-client/haskell)
 
-## CLI Reference
+## CLI
 
 * [kubectl](/docs/reference/kubectl/overview/) - Main CLI tool for running commands and managing Kubernetes clusters.
     * [JSONPath](/docs/reference/kubectl/jsonpath/) - Syntax guide for using [JSONPath expressions](https://goessner.net/articles/JsonPath/) with kubectl.
 * [kubeadm](/docs/reference/setup-tools/kubeadm/) - CLI tool to easily provision a secure Kubernetes cluster.
 
-## Components Reference
+## Components
 
 * [kubelet](/docs/reference/command-line-tools-reference/kubelet/) - The primary *node agent* that runs on each node. The kubelet takes a set of PodSpecs and ensures that the described containers are running and healthy.
 * [kube-apiserver](/docs/reference/command-line-tools-reference/kube-apiserver/) - REST API that validates and configures data for API objects such as  pods, services, replication controllers.
 * [kube-controller-manager](/docs/reference/command-line-tools-reference/kube-controller-manager/) - Daemon that embeds the core control loops shipped with Kubernetes.
 * [kube-proxy](/docs/reference/command-line-tools-reference/kube-proxy/) - Can do simple TCP/UDP stream forwarding or round-robin TCP/UDP forwarding across a set of back-ends.
-* [kube-scheduler](/docs/reference/command-line-tools-reference/kube-scheduler/) - Scheduler that manages availability, performance, and capacity.
-  * [kube-scheduler Policies](/docs/reference/scheduling/policies)
-  * [kube-scheduler Profiles](/docs/reference/scheduling/config#profiles)
+* [kube-scheduler](/docs/reference/command-line-tools-reference/kube-scheduler/) - Scheduler that manages availability, performance, and capacity.  
+  
+## Scheduling
+
+* [Scheduler Policies](/docs/reference/scheduling/policies)
+* [Scheduler Profiles](/docs/reference/scheduling/config#profiles)
+
 
 ## Design Docs
 

--- a/content/en/docs/reference/_index.md
+++ b/content/en/docs/reference/_index.md
@@ -18,7 +18,7 @@ This section of the Kubernetes documentation contains references.
 
 <!-- body -->
 
-## Standardized Glossary
+## API Reference
 
 * [Glossary](/docs/reference/glossary/) -  a comprehensive, standardized list of Kubernetes terminology
 
@@ -30,7 +30,7 @@ This section of the Kubernetes documentation contains references.
 * [API access control](/docs/reference/access-authn-authz/) - details on how Kubernetes controls API access
 * [Well-Known Labels, Annotations and Taints](/docs/reference/kubernetes-api/labels-annotations-taints/)
 
-## API Client Libraries
+## Officially supported client libraries
 
 To call the Kubernetes API from a programming language, you can use
 [client libraries](/docs/reference/using-api/client-libraries/). Officially supported

--- a/content/en/docs/reference/access-authn-authz/_index.md
+++ b/content/en/docs/reference/access-authn-authz/_index.md
@@ -1,6 +1,6 @@
 ---
 title: API Access Control
-weight: 20
+weight: 15
 no_list: true
 ---
 

--- a/content/en/docs/reference/command-line-tools-reference/_index.md
+++ b/content/en/docs/reference/command-line-tools-reference/_index.md
@@ -1,4 +1,4 @@
 ---
-title: Command line tools reference
+title: Component tools
 weight: 60
 ---

--- a/content/en/docs/reference/glossary/index.md
+++ b/content/en/docs/reference/glossary/index.md
@@ -2,7 +2,7 @@
 approvers:
 - chenopis
 - abiogenesis-now
-title: Standardized Glossary
+title: Glossary
 layout: glossary
 noedit: true
 default_active_tag: fundamental

--- a/content/en/docs/reference/issues-security/_index.md
+++ b/content/en/docs/reference/issues-security/_index.md
@@ -1,4 +1,4 @@
 ---
 title: Kubernetes Issues and Security
-weight: 10
+weight: 40
 ---

--- a/content/en/docs/reference/kubectl/_index.md
+++ b/content/en/docs/reference/kubectl/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "CLI"
+title: "kubectl"
 weight: 60
 ---
 

--- a/content/en/docs/reference/kubectl/_index.md
+++ b/content/en/docs/reference/kubectl/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "kubectl CLI"
+title: "CLI"
 weight: 60
 ---
 

--- a/content/en/docs/reference/setup-tools/_index.md
+++ b/content/en/docs/reference/setup-tools/_index.md
@@ -1,4 +1,4 @@
 ---
-title: Setup tools reference
+title: Setup tools
 weight: 50
 ---

--- a/content/en/docs/reference/tools/_index.md
+++ b/content/en/docs/reference/tools/_index.md
@@ -1,8 +1,10 @@
 ---
+title: Other Tools
 reviewers:
 - janetkuo
-title: Tools
 content_type: concept
+weight: 80
+no_list: true
 ---
 
 <!-- overview -->
@@ -10,13 +12,6 @@ Kubernetes contains several built-in tools to help you work with the Kubernetes 
 
 
 <!-- body -->
-## Kubectl
-
-[`kubectl`](/docs/tasks/tools/install-kubectl/) is the command line tool for Kubernetes. It controls the Kubernetes cluster manager.
-
-## Kubeadm
-
-[`kubeadm`](/docs/setup/production-environment/tools/kubeadm/install-kubeadm/) is the command line tool for easily provisioning a secure Kubernetes cluster on top of physical or cloud servers or virtual machines (currently in alpha).
 
 ## Minikube
 

--- a/content/en/docs/reference/using-api/_index.md
+++ b/content/en/docs/reference/using-api/_index.md
@@ -1,11 +1,12 @@
 ---
-title: Kubernetes API Overview
+title: API Overview
 reviewers:
 - erictune
 - lavalamp
 - jbeda
 content_type: concept
 weight: 10
+no_list: true
 card:
   name: reference
   weight: 50


### PR DESCRIPTION
Fix and changes with respect to the issue - Tidy reference section
#22385

Proposed solution mentioned there

- make sure that every item in the left-hand navigation is referenced in the main text of the reference section (not counting the autogenerated list)
 **For this , I tried restructure based on my own preference and combined what is mentioned I already did a PR with quite hundreds of files changes which is recommended to be split and to address for other locals.Kindly help me refer a PR for such kind i can have a look and try or I can take a screenshot of my proposed changes (UI pages and content links) and I will attach it here.**

- set no_list: true in the front matter of content/en/docs/reference/_index.md
  **(Done)**