### PR TITLE
.editorconfig: turning off trim_trailing_whitespace for markdown files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,9 @@ charset = utf-8
 max_line_length = 80
 trim_trailing_whitespace = true
 
+[*.md]
+trim_trailing_whitespace = false
+
 [*.{css,html,js,json,sass,md,mmark,toml,yaml}]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
Adding `[*.md]` section to `.editorconfig`,  turning off `trim_trailing_whitespace` for markdown files.
fixes: https://github.com/kubernetes/website/issues/24731