### PR TITLE
Documenting new default headers in HTTP probes

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -336,6 +336,8 @@ liveness. Minimum value is 1.
 try `failureThreshold` times before giving up. Giving up in case of liveness probe means restarting the container. In case of readiness probe the Pod will be marked Unready.
 Defaults to 3. Minimum value is 1.
 
+### HTTP probes
+
 [HTTP probes](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#httpgetaction-v1-core)
 have additional fields that can be set on `httpGet`:
 
@@ -356,6 +358,36 @@ Here's one scenario where you would set it. Suppose the container listens on 127
 and the Pod's `hostNetwork` field is true. Then `host`, under `httpGet`, should be set
 to 127.0.0.1. If your pod relies on virtual hosts, which is probably the more common
 case, you should not use `host`, but rather set the `Host` header in `httpHeaders`.
+
+For an HTTP probe, the kubelet sends three request headers in addition to the mandatory `Host` header:
+`User-Agent`, `Accept-Encoding` and `Accept`. The default values for these headers are `kube-probe/{{< skew latestVersion >}}`
+(where `{{< skew latestVersion >}}` is the version of the kubelet ), `gzip` and `*/*` respectively.
+
+You can override the default headers by defining `.httpHeaders` for the probe; for example
+
+```yaml
+livenessProbe:
+  httpHeaders:
+    Accept: application/json
+
+startupProbe:
+  httpHeaders:
+    User-Agent: MyUserAgent
+```
+
+You can also remove these two headers by defining them with an empty value.
+
+```yaml
+livenessProbe:
+  httpHeaders:
+    Accept: ""
+
+startupProbe:
+  httpHeaders:
+    User-Agent: ""
+```
+
+### TCP probes
 
 For a TCP probe, the kubelet makes the probe connection at the node, not in the pod, which
 means that you can not use a service name in the `host` parameter since the kubelet is unable


### PR DESCRIPTION
Hello, 
This PR is adding documentation about default headers when using http probes and including the changes being proposed in 

https://github.com/kubernetes/kubernetes/pull/95641 

This is my first PR in this repo so please kindly help me to get through it

<!-- 🛈

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
