### PR TITLE
Wrong argument order for apt-key. Fails on Ubuntu 20.04.1 LTS

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -102,7 +102,7 @@ sudo apt-get update && sudo apt-get install -y apt-transport-https ca-certificat
 
 ```shell
 ## Add Docker's official GPG key
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add --keyring /etc/apt/trusted.gpg.d/docker.gpg -
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key --keyring /etc/apt/trusted.gpg.d/docker.gpg add -
 ```
 
 ```shell


### PR DESCRIPTION
This patch changes the order of the arguments for the apt-key command. The --keyring option to apt-key must come before the "add" command otherwise this step will fail. See the manual page of apt-key for correct syntax.