### PR TITLE
Automatically add milestone to future release branches

### DIFF
--- a/.github/workflows/future-release-branch-labeler.yml
+++ b/.github/workflows/future-release-branch-labeler.yml
@@ -3,7 +3,7 @@ name: Future Release Branch Pull Request Labeler
 on:
   pull_request_target:
     branches:
-      - dev-[0-9].[0-9][0-9]
+      - dev-[0-9].[0-9]+
     types:
       - opened
       - reopened

--- a/.github/workflows/future-release-branch-labeler.yml
+++ b/.github/workflows/future-release-branch-labeler.yml
@@ -9,16 +9,6 @@ on:
       - reopened
 
 jobs:
-  add-hold-label:
-    runs-on: ubuntu-latest
-    steps:
-      - name:
-        run: |
-          curl --request PATCH \
-          --url ${{ github.event.pull_request.issue_url }} \
-          --header 'Authorization: token ${{ secrets.GITHUB_ACTIONS_TOKEN }}' \
-          --header 'Accept: application/vnd.github.v3+json' \
-          --data '{"labels": ["hold"]}'
   add-milestone:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/future-release-branch-labeler.yml
+++ b/.github/workflows/future-release-branch-labeler.yml
@@ -21,7 +21,7 @@ jobs:
           # grab the number associated with milestone not the name of milestone
           curl --request GET \
           --url 'https://api.github.com/repos/${{ github.repository }}/milestones' \
-          --header 'Authorization: token ${{ secrets.GITHUB_ACTIONS_TOKEN }}' \
+          --header 'Authorization: token ${{ secrets.FUTURE_RELEASE_BRANCH_LABEL_TOKEN }}' \
           --header 'Accept: application/vnd.github.v3+json' | \
           jq --arg milestone "$milestone" '.[] | select(.title==$milestone).number' > milestone_number.txt
 
@@ -29,6 +29,6 @@ jobs:
 
           curl --request PATCH \
           --url ${{ github.event.pull_request.issue_url }} \
-          --header 'Authorization: token ${{ secrets.GITHUB_ACTIONS_TOKEN }}' \
+          --header 'Authorization: token ${{ secrets.FUTURE_RELEASE_BRANCH_LABEL_TOKEN }}' \
           --header 'Accept: application/vnd.github.v3+json' \
           --data '{"milestone": "'"$milestone_number"'"}'

--- a/.github/workflows/future-release-branch-labeler.yml
+++ b/.github/workflows/future-release-branch-labeler.yml
@@ -24,7 +24,8 @@ jobs:
     steps:
       - name:
         run: |
-          # grab the version using the branch of the base repository
+          # determine the target release from the branch that this PR targets
+          # ignore first 4 characters ("dev-")
           milestone=${GITHUB_BASE_REF:4}
 
           # grab the number associated with milestone not the name of milestone

--- a/.github/workflows/future-release-branch-labeler.yml
+++ b/.github/workflows/future-release-branch-labeler.yml
@@ -34,7 +34,7 @@ jobs:
           --header 'Accept: application/vnd.github.v3+json' | \
           jq --arg milestone "$milestone" '.[] | select(.title==$milestone).number' > milestone_number.txt
 
-          milestone_number=$(cat milestone_number.txt)
+          milestone_number="$(cat milestone_number.txt)"
 
           curl --request PATCH \
           --url ${{ github.event.pull_request.issue_url }} \

--- a/.github/workflows/future-release-branch-labeler.yml
+++ b/.github/workflows/future-release-branch-labeler.yml
@@ -1,0 +1,43 @@
+name: Future Release Branch Pull Request Labeler
+
+on:
+  pull_request_target:
+    branches:
+      - dev-[0-9].[0-9][0-9]
+    types:
+      - opened
+      - reopened
+
+jobs:
+  add-hold-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name:
+        run: |
+          curl --request PATCH \
+          --url ${{ github.event.pull_request.issue_url }} \
+          --header 'Authorization: token ${{ secrets.GITHUB_ACTIONS_TOKEN }}' \
+          --header 'Accept: application/vnd.github.v3+json' \
+          --data '{"labels": ["hold"]}'
+  add-milestone:
+    runs-on: ubuntu-latest
+    steps:
+      - name:
+        run: |
+          # grab the version using the branch of the base repository
+          milestone=${GITHUB_BASE_REF:4}
+
+          # grab the number associated with milestone not the name of milestone
+          curl --request GET \
+          --url 'https://api.github.com/repos/${{ github.repository }}/milestones' \
+          --header 'Authorization: token ${{ secrets.GITHUB_ACTIONS_TOKEN }}' \
+          --header 'Accept: application/vnd.github.v3+json' | \
+          jq --arg milestone "$milestone" '.[] | select(.title==$milestone).number' > milestone_number.txt
+
+          milestone_number=$(cat milestone_number.txt)
+
+          curl --request PATCH \
+          --url ${{ github.event.pull_request.issue_url }} \
+          --header 'Authorization: token ${{ secrets.GITHUB_ACTIONS_TOKEN }}' \
+          --header 'Accept: application/vnd.github.v3+json' \
+          --data '{"milestone": "'"$milestone_number"'"}'


### PR DESCRIPTION
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

Relates to https://github.com/kubernetes/website/pull/24784. Separate PR created for the milestone functionality only based on https://github.com/kubernetes/website/pull/24784#issuecomment-719969830

Create a GitHub action to add a milestone `future-release` against the `dev-future-release` branch.

The GitHub action will only trigger for a branch that matches the following pattern: `dev-[0-9].[0-9]+`
The GitHub action will only trigger when a pull request first opens and when it reopens after closing.
The GitHub action will NOT trigger when the PR owner changes base from master to `dev-1.20`

To be able to successfully run the actions, a secret needs to be created in the `k/website repo`, named `FUTURE_RELEASE_BRANCH_LABEL_TOKEN` that contains a token that allows calling the GitHub API to add a milestone.

/hold
until the secret is created and to get feedback from @kubernetes/sig-docs-leads

/label tide/merge-method-squash