### PR TITLE
Update connect-applications-service.md

### DIFF
--- a/content/en/docs/concepts/services-networking/connect-applications-service.md
+++ b/content/en/docs/concepts/services-networking/connect-applications-service.md
@@ -360,7 +360,7 @@ spec:
   ports:
   - name: http
     nodePort: 31704
-    port: 8080
+    port: 80
     protocol: TCP
     targetPort: 80
   - name: https


### PR DESCRIPTION
The targetPort and Port were mixed up, I believe. Are they purposely trying to obfuscate nginx deployment port 80 to 8080 inside the cluster? Why would you want to do that?
If your nginx is 8080 internally and you wish to expose it on 80 inside the cluster, than port: 8080 with targetPort: 80 would seem more correct. However, previous configuration seems to indicate that nginx is running on 80 and 443 internally.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
