### PR TITLE
Fix experimental flag example

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping.md
+++ b/content/en/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping.md
@@ -243,7 +243,7 @@ for example:
 The validity duration of signed certificates can be configured with flag:
 
 ```
---experimental-cluster-signing-duration
+--cluster-signing-duration
 ```
 
 ### Approval


### PR DESCRIPTION
`--experimental-cluster-signing-duration`  is deprecated and renamed to `--cluster-signing-duration`.

Refer [code here](https://github.com/kubernetes/kubernetes/blob/f0dfa55de5d8e234acd0fe7cd42667ec88703318/cmd/kube-controller-manager/app/options/csrsigningcontroller.go#L48-L50).