### PR TITLE
Fix feature state for cluster-level default topology spread

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-topology-spread-constraints.md
+++ b/content/en/docs/concepts/workloads/pods/pod-topology-spread-constraints.md
@@ -284,8 +284,6 @@ There are some implicit conventions worth noting here:
 
 ### Cluster-level default constraints
 
-{{< feature-state for_k8s_version="v1.19" state="beta" >}}
-
 It is possible to set default topology spread constraints for a cluster. Default
 topology spread constraints are applied to a Pod if, and only if:
 


### PR DESCRIPTION
The configuration is part of the PodTopologySpread feature (previously known as `EvenPodsSpread`)

Do not confuse with `DefaultPodTopologySpread` feature that replaces the legacy `SelectorSpread` plugin with a system configuration for `PodTopologySpread` (#24852)

/sig scheduling

/kind bug