### PR TITLE
Add link to KubeCon Virtual EU 2021

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -44,6 +44,11 @@ Kubernetes is open source giving you the freedom to take advantage of on-premise
         <br>
         <br>
         <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/?utm_source=kubernetes.io&utm_medium=nav&utm_campaign=kccncna20" button id="desktopKCButton">Attend KubeCon NA virtually on November 17-20, 2020</a>
+        <br>
+        <br>
+        <br>
+        <br>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/?utm_source=kubernetes.io&utm_medium=nav&utm_campaign=kccnceu21" button id="desktopKCButton">Attend KubeCon EU virtually on May 4 – 7, 2021</a>
 </div>
 <div id="videoPlayer">
     <iframe data-url="https://www.youtube.com/embed/H06qrNmGqyE?autoplay=1" frameborder="0" allowfullscreen></iframe>


### PR DESCRIPTION
This PR adds link to KubeCon Virtual EU 2021 in the index.html

![image](https://user-images.githubusercontent.com/20236173/98108434-48a14180-1edf-11eb-8e95-1f0a318e0fbc.png)
