### PR TITLE
Apply the common blue style to buttons under .main class

### DIFF
--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -88,6 +88,20 @@ footer {
   }
 }
 
+main {
+  .button {
+    display: inline-block;
+    border-radius: 6px;
+    padding: 6px 20px;
+    line-height: 1.3rem;
+    color: white;
+    background-color: $blue;
+    text-decoration: none;
+    font-size: 1rem;
+    border: 0px;
+  }
+}
+
 // HEADER
 
 #hamburger {


### PR DESCRIPTION
**What this PR change?**

Change the style of the gray buttons under tasks/ pages. These buttons were blue until v1.17 (see for the screenshot in  #22892) while currently any style is not applied to them. This PR let them blue using the same style as https://kubernetes.io/docs/home/. :blue_heart: 

**Before**

![Screenshot from 2020-11-05 20-37-54](https://user-images.githubusercontent.com/1425259/98237741-b9f8f700-1fa8-11eb-88a0-fb7597ea2c6a.png)

**After**

![Screenshot from 2020-11-05 20-37-30](https://user-images.githubusercontent.com/1425259/98237802-d432d500-1fa8-11eb-9d5f-42e314f415bd.png)

**Related Issue**

#22892