### PR TITLE
Add comments for the commands using container in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ docker-serve:
 	@echo -e "$(CCRED)**** The use of docker-serve is deprecated. Use container-serve instead. ****$(CCEND)"
 	$(MAKE) container-serve
 
-container-image:
+container-image: ## Build a container image for the preview of the website
 	$(CONTAINER_ENGINE) build . \
 		--network=host \
 		--tag $(CONTAINER_IMAGE) \
@@ -67,7 +67,7 @@ container-image:
 container-build: module-check
 	$(CONTAINER_RUN) --read-only --mount type=tmpfs,destination=/tmp,tmpfs-mode=01777 $(CONTAINER_IMAGE) sh -c "npm ci && hugo --minify"
 
-container-serve: module-check
+container-serve: module-check ## Boot the development server using container. Run `make container-image` before this.
 	$(CONTAINER_RUN) --read-only --mount type=tmpfs,destination=/tmp,tmpfs-mode=01777 -p 1313:1313 $(CONTAINER_IMAGE) hugo server --buildFuture --bind 0.0.0.0 --destination /tmp/hugo --cleanDestinationDir
 
 test-examples:


### PR DESCRIPTION
By adding the commends to each make command, the help description is shown when we run `make` command without arguments. This should help users to understand the appropriate commands to run.

The help messages for `container-image` and `container-serve` will be added by this change.

**Example**

```shell
$ make
help                 Show this help.
all                  Build site with production settings and put deliverables in ./public
build                Build site with production settings and put deliverables in ./public
build-preview        Build site with drafts and future posts enabled
deploy-preview       Deploy preview site via netlify
production-build     Build the production site and ensure that noindex headers aren't added
non-production-build Build the non-production site, which adds noindex headers to prevent indexing
serve                Boot the development server.
container-image      Build a container image for the preview of the website
container-serve      Boot the development server using container. Run `make container-image` before this.
```

I welcome amending the words because I'm not a native speaker.