### PR TITLE
docs: DaemonSets can be configured to surge

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/daemonset.md
+++ b/content/en/docs/concepts/workloads/controllers/daemonset.md
@@ -187,6 +187,8 @@ them according to its `updateStrategy`.
 
 You can [perform a rolling update](/docs/tasks/manage-daemon/update-daemon-set/) on a DaemonSet.
 
+TODO: INSERT DOCUMENTATION ABOUT SURGE VS MAXUNAVAILABLE
+
 ## Alternatives to DaemonSet
 
 ### Init scripts


### PR DESCRIPTION
DaemonSets now support the MaxSurge option on their rolling update
strategy which allows two pods for the same daemonset to be running
at the same time on a node during an update. This allows a workload
to hand off traffic or responsibilities gracefully, instead of
having to take a per node outage during a rolling update.

This is documentation for the enhancement described at https://github.com/kubernetes/enhancements/issues/1591

Not yet implemented