### PR TITLE
Move CSIVolumeFSGroupPolicy to beta

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -81,7 +81,8 @@ different Kubernetes components.
 | `CSIMigrationvSphereComplete` | `false` | Beta | 1.19 | |
 | `CSIServiceAccountToken` | `false` | Alpha | 1.20 | |
 | `CSIStorageCapacity` | `false` | Alpha | 1.19 | |
-| `CSIVolumeFSGroupPolicy` | `false` | Alpha | 1.19 | |
+| `CSIVolumeFSGroupPolicy` | `false` | Alpha | 1.19 | 1.19 |
+| `CSIVolumeFSGroupPolicy` | `true` | Beta | 1.20 | |
 | `ConfigurableFSGroupPolicy` | `false` | Alpha | 1.18 | 1.19 |
 | `ConfigurableFSGroupPolicy` | `true` | Beta | 1.20 | |
 | `CronJobControllerV2` | `false` | Alpha | 1.20 | |


### PR DESCRIPTION
The CSIVolumeFSGroupPolicy feature is moving to beta in k8s 1.20. This PR updates the featureGate accordingly.

PRs:
https://github.com/kubernetes/kubernetes/pull/95739

Issues:
https://github.com/kubernetes/enhancements/issues/1682

/milestone 1.20