### PR TITLE
Update SIG-docs-ja reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -120,10 +120,11 @@ aliases:
     - bells17
     # cstoku
     - inductor
+    - kakts
     - makocchi-git
     # MasayaAoyama
     - nasa9084
-    - oke-py
+    # oke-py
   sig-docs-ko-owners: # Admins for Korean content
     - ClaudiaJKang
     - gochist


### PR DESCRIPTION
# Summary

* @oke-py leaves temporarily due to sick, he will come back after treatment
* @kakts joined as a new reviewer
  * c.f.
    * https://github.com/kubernetes/website/pulls?q=is%3Apr+assignee%3Akakts+is%3Aclosed
    * https://github.com/kubernetes/website/pulls?q=is%3Apr+is%3Aclosed+author%3Akakts