### PR TITLE
Explain the insecure by default nature of secrets

### DIFF
--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -24,6 +24,16 @@ a password, a token, or a key. Such information might otherwise be put in a
 Pod specification or in an image. Users can create Secrets and the system
 also creates some Secrets.
 
+{{< caution >}}
+Kubernetes Secrets are, by default, stored as unencrypted base64-encoded
+strings. By default they can be retrieved - as plain text - by anyone with API
+access, or anyone with access to Kubernetes' underlying data store, etcd. In
+order to safely use Secrets, we recommend you (at a minimum):
+
+1. [Enable Encryption at Rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/) for Secrets.
+2. [Enable RBAC rules that restrict reading and writing the Secret](https://kubernetes.io/docs/reference/access-authn-authz/authorization/). Be aware that secrets can be obtained implicitly by anyone with the permission to create a Pod.
+{{< /caution >}}
+
 <!-- body -->
 
 ## Overview of Secrets


### PR DESCRIPTION
This PR adds a paragraph explaining the insecure by default nature of k8s secrets, and points users at the documentation to turn on encryption at rest and RBAC.

I think a second page needs to be created showing the correct combination of RBAC rules for various cases, which should eventually replace the link to the RBAC documentation.

I believe this change is necessary - while it's possible to discover that secrets aren't secure by default by reading this page, you need to make it all the way to the bottom to do so. Even then, it's not explicitly stated that they are insecure. This paragraph fixes that. 
