### PR TITLE
Fix formatting issue in Compute Resource Quota documentation

### DIFF
--- a/content/en/docs/concepts/policy/resource-quotas.md
+++ b/content/en/docs/concepts/policy/resource-quotas.md
@@ -76,8 +76,7 @@ The following resource types are supported:
 | `limits.memory` | Across all pods in a non-terminal state, the sum of memory limits cannot exceed this value. |
 | `requests.cpu` | Across all pods in a non-terminal state, the sum of CPU requests cannot exceed this value. |
 | `requests.memory` | Across all pods in a non-terminal state, the sum of memory requests cannot exceed this value. |
-| `hugepages-<size>` | Across all pods in a non-terminal state, the number of
-huge page requests of the specified size cannot exceed this value. |
+| `hugepages-<size>` | Across all pods in a non-terminal state, the number of huge page requests of the specified size cannot exceed this value. |
 | `cpu` | Same as `requests.cpu` |
 | `memory` | Same as `requests.memory` |
 


### PR DESCRIPTION
Fix a small formatting issue in the [Compute Resource Quota documentation table](https://kubernetes.io/docs/concepts/policy/resource-quotas/#compute-resource-quota) that causes the second half of the `hugepages-<size>` resource description to clip into it's own row. Included is a screenshot of the current state of the table in the page.

![image](https://user-images.githubusercontent.com/16110353/98403886-80fb6980-201e-11eb-9ff3-a420fdec7488.png)
