### PR TITLE
Updating EndpointSlice docs for 1.20

### DIFF
--- a/content/en/docs/concepts/services-networking/endpoint-slices.md
+++ b/content/en/docs/concepts/services-networking/endpoint-slices.md
@@ -95,6 +95,16 @@ EndpointSlices support three address types:
 
 ### Topology information {#topology}
 
+{{< feature-state for_k8s_version="v1.20" state="deprecated" >}}
+
+{{< note >}}
+The topology field in EndpointSlices has been deprecated and will be removed in
+a future release. A new `nodeName` field will be used instead of setting
+`kubernetes.io/hostname` in topology. It was determined that other topology
+fields covering zone and region would be better represented as EndpointSlice
+labels that would apply to all endpoints within the EndpointSlice.
+{{< /note >}}
+
 Each endpoint within an EndpointSlice can contain relevant topology information.
 This is used to indicate where an endpoint is, containing information about the
 corresponding Node, zone, and region. When the values are available, the

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -103,8 +103,10 @@ different Kubernetes components.
 | `EndpointSlice` | `false` | Alpha | 1.16 | 1.16 |
 | `EndpointSlice` | `false` | Beta | 1.17 | |
 | `EndpointSlice` | `true` | Beta | 1.18 | |
+| `EndpointSliceNodeName` | `false` | Alpha | 1.20 | |
 | `EndpointSliceProxying` | `false` | Alpha | 1.18 | 1.18 |
 | `EndpointSliceProxying` | `true` | Beta | 1.19 | |
+| `EndpointSliceTerminating` | `false` | Alpha | 1.20 | |
 | `EphemeralContainers` | `false` | Alpha | 1.16 | |
 | `ExpandCSIVolumes` | `false` | Alpha | 1.14 | 1.15 |
 | `ExpandCSIVolumes` | `true` | Beta | 1.16 | |
@@ -479,6 +481,9 @@ Each feature gate is designed for enabling/disabling a specific feature:
    if user namespace remapping is enabled in the Docker daemon.
 - `EndpointSlice`: Enables Endpoint Slices for more scalable and extensible
    network endpoints. See [Enabling Endpoint Slices](/docs/tasks/administer-cluster/enabling-endpointslices/).
+- `EndpointSliceNodeName`: Enables EndpointSlice `nodeName` field.
+- `EndpointSliceTerminating`: Enables EndpointSlice `terminating` and `serving`
+   condition fields.
 - `EndpointSliceProxying`: When this feature gate is enabled, kube-proxy running
    on Linux will use EndpointSlices as the primary data source instead of
    Endpoints, enabling scalability and performance improvements. See

--- a/content/en/docs/tasks/administer-cluster/enabling-endpointslices.md
+++ b/content/en/docs/tasks/administer-cluster/enabling-endpointslices.md
@@ -31,9 +31,11 @@ resources instead of a single large Endpoints resource.
 {{< feature-state for_k8s_version="v1.17" state="beta" >}}
 
 {{< note >}}
-Although EndpointSlices may eventually replace Endpoints, many Kubernetes
-components still rely on Endpoints. For now, enabling EndpointSlices should be
-seen as an addition to Endpoints in a cluster, not a replacement for them.
+The EndpointSlice resource was designed to address shortcomings in a earlier
+resource: Endpoints. Some Kubernetes components and third-party applications
+continue to use and rely on Endpoints. Whilst that remains the case,
+EndpointSlices should be seen as an addition to Endpoints in a cluster, not as
+an outright replacement.
 {{< /note >}}
 
 EndpointSlice functionality in Kubernetes is made up of several different
@@ -60,13 +62,23 @@ components, most are enabled by default:
   gate](/docs/reference/command-line-tools-reference/feature-gates/) on
   kube-proxy.
 
+
+## API fields
+
+Some fields in the EndpointSlice API are feature-gated.
+
+- The `EndpointSliceNodeName` feature gate controls access to the `nodeName`
+  field. This is an alpha feature that is disabled by default.
+- The `EndpointSliceTerminating` feature gate controls access to the `serving`
+  and `terminating` condition fields. This is an alpha feature that is disabled
+  by default.
+
 ## Using EndpointSlices
 
 With EndpointSlices fully enabled in your cluster, you should see corresponding
 EndpointSlice resources for each Endpoints resource. In addition to supporting
-existing Endpoints functionality, EndpointSlices include new bits of information
-such as topology. They will allow for greater scalability and extensibility of
-network endpoints in your cluster.
+existing Endpoints functionality, EndpointSlices will allow for greater
+scalability and extensibility of network endpoints in your cluster.
 
 ## {{% heading "whatsnext" %}}
 


### PR DESCRIPTION
This covers https://github.com/kubernetes/enhancements/issues/752 and the changes that were implemented in https://github.com/kubernetes/kubernetes/pull/96440. It also overlaps a bit with https://github.com/kubernetes/website/pull/24927.

/sig network