### PR TITLE
Adding AKO (Avi Kubernetes Operator) to the list of ingress controllers

### DIFF
--- a/content/en/docs/concepts/services-networking/ingress-controllers.md
+++ b/content/en/docs/concepts/services-networking/ingress-controllers.md
@@ -27,6 +27,7 @@ Kubernetes as a project currently supports and maintains [GCE](https://git.k8s.i
   controller with [community](https://www.getambassador.io/docs) or 
   [commercial](https://www.getambassador.io/pro/) support from [Datawire](https://www.datawire.io/).
 * [AppsCode Inc.](https://appscode.com) offers support and maintenance for the most widely used [HAProxy](https://www.haproxy.org/) based ingress controller [Voyager](https://appscode.com/products/voyager). 
+* [Avi Kubernetes Operator](https://github.com/vmware/load-balancer-and-ingress-services-for-kubernetes) provides L4-L7 load-balancing using [VMware NSX Advanced Loadbalancer](https://avinetworks.com/).
 * [AWS ALB Ingress Controller](https://github.com/kubernetes-sigs/aws-alb-ingress-controller) enables ingress using the [AWS Application Load Balancer](https://aws.amazon.com/elasticloadbalancing/).
 * [Contour](https://projectcontour.io/) is an [Envoy](https://www.envoyproxy.io/) based ingress controller
   provided and supported by VMware.


### PR DESCRIPTION
This adds AKO (Avi Kubernetes Operator) to the list of available ingress controllers listed in [this document](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/). AKO is open-sourced by VMware at [https://github.com/vmware/load-balancer-and-ingress-services-for-kubernetes](https://github.com/vmware/load-balancer-and-ingress-services-for-kubernetes).
