### PR TITLE
HTTP Probe - Update documentation about default headers

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -381,9 +381,9 @@ and the Pod's `hostNetwork` field is true. Then `host`, under `httpGet`, should 
 to 127.0.0.1. If your pod relies on virtual hosts, which is probably the more common
 case, you should not use `host`, but rather set the `Host` header in `httpHeaders`.
 
-For an HTTP probe, the kubelet sends three request headers in addition to the mandatory `Host` header:
-`User-Agent`, `Accept-Encoding` and `Accept`. The default values for these headers are `kube-probe/{{< skew latestVersion >}}`
-(where `{{< skew latestVersion >}}` is the version of the kubelet ), `gzip` and `*/*` respectively.
+For an HTTP probe, the kubelet sends two request headers in addition to the mandatory `Host` header:
+`User-Agent`, and `Accept`. The default values for these headers are `kube-probe/{{< skew latestVersion >}}`
+(where `{{< skew latestVersion >}}` is the version of the kubelet ), and `*/*` respectively.
 
 You can override the default headers by defining `.httpHeaders` for the probe; for example
 


### PR DESCRIPTION
Hello,
This PR is updates the documentation about default headers when using http probes given that this pr was accepted and merged

https://github.com/kubernetes/kubernetes/pull/96127

Please take look, thank you 