### PR TITLE
Use k8s more widely

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -8,7 +8,7 @@ sitemap:
 
 {{< blocks/section id="oceanNodes" >}}
 {{% blocks/feature image="flower" %}}
-[Kubernetes (K8s)]({{< relref "/docs/concepts/overview/what-is-kubernetes" >}}) is an open-source system for automating deployment, scaling, and management of containerized applications.
+[Kubernetes]({{< relref "/docs/concepts/overview/what-is-kubernetes" >}}), also known as K8s, is an open-source system for automating deployment, scaling, and management of containerized applications.
 
 It groups containers that make up an application into logical units for easy management and discovery. Kubernetes builds upon [15 years of experience of running production workloads at Google](http://queue.acm.org/detail.cfm?id=2898444), combined with best-of-breed ideas and practices from the community.
 {{% /blocks/feature %}}
@@ -28,7 +28,7 @@ Whether testing locally or running a global enterprise, Kubernetes flexibility g
 {{% /blocks/feature %}}
 
 {{% blocks/feature image="suitcase" %}}
-#### Run Anywhere
+#### Run K8s Anywhere
 
 Kubernetes is open source giving you the freedom to take advantage of on-premises, hybrid, or public cloud infrastructure, letting you effortlessly move workloads to where it matters to you.
 

--- a/content/en/docs/contribute/_index.md
+++ b/content/en/docs/contribute/_index.md
@@ -1,6 +1,6 @@
 ---
 content_type: concept
-title: Contribute to Kubernetes docs
+title: Contribute to K8s docs
 linktitle: Contribute
 main_menu: true
 no_list: true
@@ -8,7 +8,7 @@ weight: 80
 card:
   name: contribute
   weight: 10
-  title: Start contributing
+  title: Start contributing to K8s
 ---
 
 <!-- overview -->

--- a/content/en/docs/home/_index.md
+++ b/content/en/docs/home/_index.md
@@ -32,7 +32,7 @@ cards:
   button: "View Tutorials"
   button_path: "/docs/tutorials"
 - name: setup
-  title: "Set up a cluster"
+  title: "Set up a K8s cluster"
   description: "Get Kubernetes running based on your resources and needs."
   button: "Set up Kubernetes"
   button_path: "/docs/setup"
@@ -57,7 +57,7 @@ cards:
   button: Contribute to the docs
   button_path: /docs/contribute
 - name: release-notes
-  title: Release Notes
+  title: K8s Release Notes
   description: If you are installing Kubernetes or upgrading to the newest version, refer to the current release notes.
   button: "Download Kubernetes"
   button_path: "/docs/setup/release/notes"


### PR DESCRIPTION
Signed-off-by: Celeste Horgan <celeste@cncf.io>


Fuffilling a small request from @caniszczyk  filed here: https://github.com/cncf/techdocs/issues/7 

This uses "k8s" a little more widely on the website, ~for what I assume are SEO purposes :)~ so the CNCF can work on a k8s trademark