### PR TITLE
docs: add partition field for EBS

### DIFF
--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -106,6 +106,8 @@ spec:
       fsType: ext4
 ```
 
+If the EBS volume is partitioned, you can supply the optional field `partition: "<partition number>"` to specify which parition to mount on.
+
 #### AWS EBS CSI migration
 
 {{< feature-state for_k8s_version="v1.17" state="beta" >}}


### PR DESCRIPTION
If the partition field is missed, the mounting process will fail because no partition specified.

```
mount: /var/lib/kubelet/plugins/kubernetes.io/aws-ebs/mounts/vol-<volume id>: wrong fs type, bad option, bad superblock on /dev/nvme3n1, missing codepage or helper program, or other error.
```
