### PR TITLE
Fix secret FR translation error

### DIFF
--- a/content/fr/docs/concepts/configuration/secret.md
+++ b/content/fr/docs/concepts/configuration/secret.md
@@ -217,7 +217,7 @@ type: Opaque
 data:
   username: YWRtaW4=
 stringData:
-  username: administrator
+  username: administrateur
 ```
 
 Donnera le secret suivant:

--- a/content/fr/docs/concepts/configuration/secret.md
+++ b/content/fr/docs/concepts/configuration/secret.md
@@ -233,10 +233,10 @@ metadata:
   uid: 91460ecb-e917-11e8-98f2-025000000001
 type: Opaque
 data:
-  username: YWRtaW5pc3RyYXRvcg==
+  username: YWRtaW5pc3RyYXRldXI=
 ```
 
-Où `YWRtaW5pc3RyYXRvcg ==` décode en `administrateur`.
+Où `YWRtaW5pc3RyYXRldXI=` décode en `administrateur`.
 
 Les clés de `data` et `stringData` doivent être composées de caractères alphanumériques, '-', '_' ou '.'.
 


### PR DESCRIPTION
This PR fix an issue in the secret documentation. 

Translation was applied only on one of the two fields and therefore was incorrect. The yaml exposes a variable `username=administrator` and the translation refers to `administrateur`