### PR TITLE
Revise ingress controller list

### DIFF
--- a/content/en/docs/concepts/services-networking/ingress-controllers.md
+++ b/content/en/docs/concepts/services-networking/ingress-controllers.md
@@ -13,9 +13,8 @@ Unlike other types of controllers which run as part of the `kube-controller-mana
 are not started automatically with a cluster. Use this page to choose the ingress controller implementation 
 that best fits your cluster.
 
-Kubernetes as a project currently supports and maintains [GCE](https://git.k8s.io/ingress-gce/README.md) and
-  [nginx](https://git.k8s.io/ingress-nginx/README.md) controllers.
-  
+Kubernetes as a project supports and maintains [AWS](https://github.com/kubernetes-sigs/aws-load-balancer-controller#readme), [GCE](https://git.k8s.io/ingress-gce/README.md#readme), and
+  [nginx](https://git.k8s.io/ingress-nginx/README.md#readme) ingress controllers.
 
 
 <!-- body -->
@@ -24,31 +23,31 @@ Kubernetes as a project currently supports and maintains [GCE](https://git.k8s.i
 
 {{% thirdparty-content %}}
 
-* [AKS Application Gateway Ingress Controller](https://github.com/Azure/application-gateway-kubernetes-ingress) is an ingress controller that enables ingress to [AKS clusters](https://docs.microsoft.com/azure/aks/kubernetes-walkthrough-portal) using the [Azure Application Gateway](https://docs.microsoft.com/azure/application-gateway/overview).
-* [Ambassador](https://www.getambassador.io/) API Gateway is an [Envoy](https://www.envoyproxy.io) based ingress 
-  controller with [community](https://www.getambassador.io/docs) or 
-  [commercial](https://www.getambassador.io/pro/) support from [Datawire](https://www.datawire.io/).
-* [AppsCode Inc.](https://appscode.com) offers support and maintenance for the most widely used [HAProxy](https://www.haproxy.org/) based ingress controller [Voyager](https://appscode.com/products/voyager). 
-* [AWS Load Balancer Controller](https://github.com/kubernetes-sigs/aws-load-balancer-controller) (formerly known as AWS ALB Ingress Controller) enables ingress using [AWS Elastic Load Balancing](https://aws.amazon.com/elasticloadbalancing/).
-* [Contour](https://projectcontour.io/) is an [Envoy](https://www.envoyproxy.io/) based ingress controller
-  provided and supported by VMware.
-* Citrix provides an [Ingress Controller](https://github.com/citrix/citrix-k8s-ingress-controller) for its hardware (MPX), virtualized (VPX) and [free containerized (CPX) ADC](https://www.citrix.com/products/citrix-adc/cpx-express.html) for [baremetal](https://github.com/citrix/citrix-k8s-ingress-controller/tree/master/deployment/baremetal) and [cloud](https://github.com/citrix/citrix-k8s-ingress-controller/tree/master/deployment) deployments.
-* F5 Networks provides [support and maintenance](https://support.f5.com/csp/article/K86859508)
-  for the [F5 BIG-IP Container Ingress Services for Kubernetes](https://clouddocs.f5.com/containers/latest/userguide/kubernetes/).
-* [Gloo](https://gloo.solo.io) is an open-source ingress controller based on [Envoy](https://www.envoyproxy.io) which offers API Gateway functionality with enterprise support from [solo.io](https://www.solo.io).  
-* [HAProxy Ingress](https://haproxy-ingress.github.io) is a highly customizable community-driven ingress controller for HAProxy.
-* [HAProxy Technologies](https://www.haproxy.com/) offers support and maintenance for the [HAProxy Ingress Controller for Kubernetes](https://github.com/haproxytech/kubernetes-ingress). See the [official documentation](https://www.haproxy.com/documentation/hapee/1-9r1/traffic-management/kubernetes-ingress-controller/).
-* [Istio](https://istio.io/) based ingress controller
-  [Control Ingress Traffic](https://istio.io/docs/tasks/traffic-management/ingress/).
-* [Kong](https://konghq.com/) offers [community](https://discuss.konghq.com/c/kubernetes) or
-  [commercial](https://konghq.com/kong-enterprise/) support and maintenance for the
-  [Kong Ingress Controller for Kubernetes](https://github.com/Kong/kubernetes-ingress-controller).
-* [NGINX, Inc.](https://www.nginx.com/) offers support and maintenance for the
-  [NGINX Ingress Controller for Kubernetes](https://www.nginx.com/products/nginx/kubernetes-ingress-controller).
-* [Skipper](https://opensource.zalando.com/skipper/kubernetes/ingress-controller/) HTTP router and reverse proxy for service composition, including use cases like Kubernetes Ingress, designed as a library to build your custom proxy
-* [Traefik](https://github.com/traefik/traefik) is a fully featured ingress controller
-  ([Let's Encrypt](https://letsencrypt.org), secrets, http2, websocket), and it also comes with commercial
-  support by [Traefik Labs](https://traefik.io).
+* [AKS Application Gateway Ingress Controller](https://azure.github.io/application-gateway-kubernetes-ingress/) is an ingress controller that configures the [Azure Application Gateway](https://docs.microsoft.com/azure/application-gateway/overview).
+* [Ambassador](https://www.getambassador.io/) API Gateway is an [Envoy](https://www.envoyproxy.io)-based ingress
+  controller.
+* The [Citrix ingress controller](https://github.com/citrix/citrix-k8s-ingress-controller#readme) works with
+  Citrix Application Delivery Controller.
+* [Contour](https://projectcontour.io/) is an [Envoy](https://www.envoyproxy.io/) based ingress controller.
+* F5 BIG-IP [Container Ingress Services for Kubernetes](https://clouddocs.f5.com/containers/latest/userguide/kubernetes/)
+  lets you use an Ingress to configure F5 BIG-IP virtual servers.
+* [Gloo](https://gloo.solo.io) is an open-source ingress controller based on [Envoy](https://www.envoyproxy.io),
+  which offers API gateway functionality.
+* [HAProxy Ingress](https://haproxy-ingress.github.io/) is an ingress controller for
+  [HAProxy](http://www.haproxy.org/#desc).
+* The [HAProxy Ingress Controller for Kubernetes](https://github.com/haproxytech/kubernetes-ingress#readme)
+  is also an ingress controller for [HAProxy](http://www.haproxy.org/#desc).
+* [Istio Ingress](https://istio.io/latest/docs/tasks/traffic-management/ingress/kubernetes-ingress/)
+  is an [Istio](https://istio.io/) based ingress controller.
+* The [Kong Ingress Controller for Kubernetes](https://github.com/Kong/kubernetes-ingress-controller#readme)
+  is an ingress controller driving [Kong Gateway](https://konghq.com/kong/).
+* The [NGINX Ingress Controller for Kubernetes](https://www.nginx.com/products/nginx/kubernetes-ingress-controller)
+  works with the [NGINX](https://www.nginx.com/resources/glossary/nginx/) webserver (as a proxy).
+* [Skipper](https://opensource.zalando.com/skipper/kubernetes/ingress-controller/) HTTP router and reverse proxy for service composition, including use cases like Kubernetes Ingress, designed as a library to build your custom proxy.
+* The [Traefik Kubernetes Ingress provider](https://doc.traefik.io/traefik/providers/kubernetes-ingress/) is an
+  ingress controller for the [Traefik](https://traefik.io/traefik/) proxy.
+* [Voyager](https://appscode.com/products/voyager) is an ingress controller for
+  [HAProxy](http://www.haproxy.org/#desc).
 
 ## Using multiple Ingress controllers
 
@@ -73,4 +72,5 @@ Make sure you review your ingress controller's documentation to understand the c
 
 * Learn more about [Ingress](/docs/concepts/services-networking/ingress/).
 * [Set up Ingress on Minikube with the NGINX Controller](/docs/tasks/access-application-cluster/ingress-minikube).
+
 


### PR DESCRIPTION
Update https://k8s.io/docs/concepts/services-networking/ingress-controllers/ [[preview](https://deploy-preview-25026--kubernetes-io-master-staging.netlify.app/docs/concepts/services-networking/ingress-controllers/)]:

- note that AWS load balancer integration is now in-project
- sort alphabetically
- link to documentation for the product
- revise wording to always describe the ingress controller rather than
  the service / product that the ingress controller integrates with

/sig network