### PR TITLE
Env var are not updated after a secret update

### DIFF
--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -726,6 +726,11 @@ The output is similar to:
 1f2d1e2e67df
 ```
 
+#### Environment variables are not updated after a secret update
+
+If a container already consumes a Secret in an environment variable, a Secret update will not be seen by the container unless it is restarted.
+There are third party solutions for triggering restarts when secrets change.
+
 ## Immutable Secrets {#secret-immutable}
 
 {{< feature-state for_k8s_version="v1.19" state="beta" >}}


### PR DESCRIPTION
Hello,

If we mention that when we consume secret as volume, a secret update trigger container volume update: https://kubernetes.io/docs/concepts/configuration/secret/#mounted-secrets-are-updated-automatically

Nothing mentions that when we consume secret value from environment a secret update will not be cascaded.

I propose to mention this. What do you think?

Sylvain

I made some test here: https://github.com/scoulomb/myk8s/blob/master/Volumes/secret-doc-deep-dive.md