### PR TITLE
added example linking to hostPath volume definition

### DIFF
--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -620,10 +620,10 @@ spec:
 
 PersistentVolumes binds are exclusive, and since PersistentVolumeClaims are namespaced objects, mounting claims with "Many" modes (`ROX`, `RWX`) is only possible within one namespace.
 
-### PersistentVolumes typed HostPath
+### PersistentVolumes typed `hostPath`
 
-A hostPath PersistentVolume uses a file or directory on the Node to emulate network-attached storage.
-See [an example of HostPath typed volume](/docs/tasks/configure-pod-container/configure-persistent-volume-storage/#create-a-persistentvolume).
+A `hostPath` PersistentVolume uses a file or directory on the Node to emulate network-attached storage.
+See [an example of `hostPath` typed volume](/docs/tasks/configure-pod-container/configure-persistent-volume-storage/#create-a-persistentvolume).
 
 ## Raw Block Volume Support
 

--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -620,6 +620,11 @@ spec:
 
 PersistentVolumes binds are exclusive, and since PersistentVolumeClaims are namespaced objects, mounting claims with "Many" modes (`ROX`, `RWX`) is only possible within one namespace.
 
+### PersistentVolumes typed HostPath
+
+A hostPath PersistentVolume uses a file or directory on the Node to emulate network-attached storage.
+See [an example of HostPath typed volume](/docs/tasks/configure-pod-container/configure-persistent-volume-storage/#create-a-persistentvolume).
+
 ## Raw Block Volume Support
 
 {{< feature-state for_k8s_version="v1.18" state="stable" >}}


### PR DESCRIPTION
# Problem

When looking at PersistenVolume documentation an example was hostPath was nowhere to be found but it was under a different page that is not obvious to the users. I saw this problem occurring with not only myself but also some other people too.

# Solution

This PR adds link to correct place in the docs where an example of such volume declaration can be found.


