### PR TITLE
refactor volumes page into core, external

### DIFF
--- a/content/en/docs/concepts/storage/mount-propagation.md
+++ b/content/en/docs/concepts/storage/mount-propagation.md
@@ -1,0 +1,77 @@
+---
+reviewers:
+- saad-ali
+- jsafrane
+- thockin
+- msau42
+title: Mount Propagation
+content_type: concept
+weight: 40
+---
+
+<!-- overview -->
+
+Mount propagation allows for sharing a {{< glossary_tooltip text="volume" term_id="volume" >}} mounted
+by a container to other containers in the same {{< glossary_tooltip text="pod" term_id="pod" >}}, or even to other pods on the same {{< glossary_tooltip text="node" term_id="node" >}}.
+
+<!-- body -->
+
+Mount propagation of a volume is controlled by the `mountPropagation` field within `volumeMounts`.
+Its values are:
+
+* `None` (Default) - This volume mount does not receive any subsequent mounts
+  that are mounted to this volume or any of its subdirectories by the host.
+  In similar fashion, no mounts created by the container will be visible on
+  the host. This is the default mode.
+
+  This mode is equal to `private` mount propagation as described in the
+  [Linux kernel documentation](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt)
+
+* `HostToContainer` - This volume mount receives all subsequent mounts
+  that are mounted to this volume or any of its subdirectories.
+
+  In other words, if the host mounts anything inside the volume mount, the
+  container will see it mounted there.
+
+  Similarly, if any pod with `Bidirectional` mount propagation to the same
+  volume mounts anything there, the container with `HostToContainer` mount
+  propagation will see it.
+
+  This mode is equal to `rslave` mount propagation as described in the
+  [Linux kernel documentation](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt)
+
+* `Bidirectional` - This volume mount behaves the same as the `HostToContainer` mount. In addition, all volume mounts created by the container are propagated
+  back to the host and to all containers of all pods that use the same volume.
+
+  A typical use case for this mode is a pod with a FlexVolume or CSI driver or
+  a pod that needs to mount something on the host using a `hostPath` volume.
+
+  This mode is equal to `rshared` mount propagation as described in the
+  [Linux kernel documentation](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt)
+
+  {{< warning >}}
+  `Bidirectional` mount propagation can be dangerous. It can damage
+  the host operating system and therefore it is allowed only in privileged  
+   containers. Familiarity with Linux kernel behavior is strongly recommended.
+  {{< /warning >}}
+
+### Docker mount propagation configuration
+Before mount propagation can work properly on some deployments (CoreOS,
+RedHat/Centos, Ubuntu), mount share must be configured correctly in
+Docker as shown below.
+
+Edit your Docker's `systemd` service file. Set `MountFlags` as follows:
+```shell
+MountFlags=shared
+```
+
+Or, remove `MountFlags=slave` if present. Then restart the Docker daemon:
+
+```shell
+sudo systemctl daemon-reload
+sudo systemctl restart docker
+```
+
+## {{% heading "whatsnext" %}}
+
+Learn more about managing storage declaratively using [Persistent Volumes](docs/concepts/storage/persistent-volumes/).

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -11,228 +11,191 @@ weight: 10
 
 <!-- overview -->
 
-On-disk files in a container are ephemeral, which presents some problems for
-non-trivial applications when running in containers. One problem
-is the loss of files when a container crashes. The kubelet restarts the container
-but with a clean state. A second problem occurs when sharing files
-between containers running together in a `Pod`.
-The Kubernetes {{< glossary_tooltip text="volume" term_id="volume" >}} abstraction
-solves both of these problems.
+File storage is useful when building applications, such as to store state or cache data. Use _volumes_ to declaratively manage storage for containers. The Kubernetes {{< glossary_tooltip text="volume" term_id="volume" >}} abstraction allows files to persist even beyond the lifetime of a pod. Volumes also allow different containers within a pod to share storage and to access configuration.
+
 Familiarity with [Pods](/docs/concepts/workloads/pods/) is suggested.
 
 <!-- body -->
 
-## Background
+## Introduction
 
-Docker has a concept of
-[volumes](https://docs.docker.com/storage/), though it is
-somewhat looser and less managed. A Docker volume is a directory on
-disk or in another container. Docker provides volume
-drivers, but the functionality is somewhat limited.
+One use case for volumes is providing directories to pods, possibly with some data in it.  How that directory comes to be, the medium that backs it, and the contents of it are determined by the particular volume type used.
 
-Kubernetes supports many types of volumes. A {{< glossary_tooltip term_id="pod" text="Pod" >}}
-can use any number of volume types simultaneously.
-Ephemeral volume types have a lifetime of a pod, but persistent volumes exist beyond
-the lifetime of a pod. When a pod ceases to exist, Kubernetes destroys ephemeral volumes; 
-however, Kubernetes does not destroy persistent volumes. 
-For any kind of volume in a given pod, data is preserved across container restarts.
+Kubernetes supports a variety of different volume types, such as directories from the host system and NFS mounts. In addition to filesystem volumes, Kubernetes also supports persistent volumes in a [raw block access mode](/docs/concepts/storage/persistent-volumes/#raw-block-volume-support). 
 
-At its core, a volume is a directory, possibly with some data in it, which
-is accessible to the containers in a pod. How that directory comes to be, the
-medium that backs it, and the contents of it are determined by the particular
-volume type used.
+### Volume Lifecycle
 
-To use a volume, specify the volumes to provide for the Pod in `.spec.volumes`
-and declare where to mount those volumes into containers in `.spec.containers[*].volumeMounts`.
-A process in a container sees a filesystem view composed from their Docker
-image and volumes. The [Docker image](https://docs.docker.com/userguide/dockerimages/)
-is at the root of the filesystem hierarchy. Volumes mount at the specified paths within
-the image. Volumes can not mount onto other volumes or have hard links to
-other volumes. Each Container in the Pod's configuration must independently specify where to
-mount each volume.
+In a standard docker container, for example, the filesystem of a container is ephemeral. When a container is restarted or destroyed, modifications to the container filesystem are lost.  
 
-## Types of Volumes {#volume-types}
+A Kubernetes volume's lifecycle is tied to the *pod* that encloses it. The pod maintains the volume as different containers are started or stopped. Multiple volumes of any type may be connected to a pod. The [PersistentVolume](/docs/concepts/storage/persistent-volumes/) abstraction builds on the volume concept to let pods access storage that outlasts the lifetime of a pod. For example, a PersistentVolume may be a NFS mount or a Google Cloud Persistent Disk. 
 
-Kubernetes supports several types of volumes.
+Kubernetes also supports [Ephemeral volumes](docs/concepts/storage/ephemeral-volumes/), such as an emptyDir or a configMap. Some application need additional storage but don't care whether that data is stored persistently across restarts. 
+ 
+### Volume specification example
+ 
+First, specify a pod that will provide the volume. This example uses the `emptyDir` volume type, and includes mounting the volume. The [`emptyDir` volume type](#emptydir) is merely an empty directory, available for containers to mount. The contents will be lost when the pod is terminated or restarts. 
 
-### awsElasticBlockStore {#awselasticblockstore}
-
-An `awsElasticBlockStore` volume mounts an Amazon Web Services (AWS)
-[EBS volume](https://aws.amazon.com/ebs/) into your pod. Unlike
-`emptyDir`, which is erased when a pod is removed, the contents of an EBS
-volume are persisted and the volume is unmounted. This means that an
-EBS volume can be pre-populated with data, and that data can be shared between pods.
-
-{{< note >}}
-You must create an EBS volume by using `aws ec2 create-volume` or the AWS API before you can use it.
-{{< /note >}}
-
-There are some restrictions when using an `awsElasticBlockStore` volume:
-
-* the nodes on which pods are running must be AWS EC2 instances
-* those instances need to be in the same region and availability zone as the EBS volume
-* EBS only supports a single EC2 instance mounting a volume
-
-#### Creating an AWS EBS volume
-
-Before you can use an EBS volume with a pod, you need to create it.
-
-```shell
-aws ec2 create-volume --availability-zone=eu-west-1a --size=10 --volume-type=gp2
-```
-
-Make sure the zone matches the zone you brought up your cluster in. Check that the size and EBS volume
-type are suitable for your use.
-
-#### AWS EBS configuration example
+A `Pod`'s specification defines what `volumes` are available to containers in that pod through the `.spec.volumes` field.
 
 ```yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  name: test-ebs
+  name: sample-cache-pod
 spec:
-  containers:
-  - image: k8s.gcr.io/test-webserver
-    name: test-container
-    volumeMounts:
-    - mountPath: /test-ebs
-      name: test-volume
+  # other specification, including container definitions
   volumes:
-  - name: test-volume
-    # This AWS EBS volume must already exist.
-    awsElasticBlockStore:
-      volumeID: "<volume id>"
-      fsType: ext4
+    - name: cache-volume
+      emptyDir: {}
 ```
 
-If the EBS volume is partitioned, you can supply the optional field `partition: "<partition number>"` to specify which parition to mount on.
+Second, specify a mount point within each container via the
+`.spec.containers[*].volumeMounts` field. 
 
-#### AWS EBS CSI migration
-
-{{< feature-state for_k8s_version="v1.17" state="beta" >}}
-
-The `CSIMigration` feature for `awsElasticBlockStore`, when enabled, redirects
-all plugin operations from the existing in-tree plugin to the `ebs.csi.aws.com` Container
-Storage Interface (CSI) driver. In order to use this feature, the [AWS EBS CSI
-driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver)
-must be installed on the cluster and the `CSIMigration` and `CSIMigrationAWS`
-beta features must be enabled.
-
-#### AWS EBS CSI migration complete
-
-{{< feature-state for_k8s_version="v1.17" state="alpha" >}}
-
-To disable the `awsElasticBlockStore` storage plugin from being loaded by the controller manager
-and the kubelet, set the `CSIMigrationAWSComplete` flag to `true`. This feature requires the `ebs.csi.aws.com` Container Storage Interface (CSI) driver installed on all worker nodes.
-
-### azureDisk {#azuredisk}
-
-The `azureDisk` volume type mounts a Microsoft Azure [Data Disk](https://docs.microsoft.com/en-us/azure/aks/csi-storage-drivers) into a pod.
-
-For more details, see the [`azureDisk` volume plugin](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/azure_disk/README.md).
-
-#### azureDisk CSI migration
-
-{{< feature-state for_k8s_version="v1.19" state="beta" >}}
-
-The `CSIMigration` feature for `azureDisk`, when enabled, redirects all plugin operations
-from the existing in-tree plugin to the `disk.csi.azure.com` Container
-Storage Interface (CSI) Driver. In order to use this feature, the [Azure Disk CSI
-Driver](https://github.com/kubernetes-sigs/azuredisk-csi-driver)
-must be installed on the cluster and the `CSIMigration` and `CSIMigrationAzureDisk`
-features must be enabled.
-
-### azureFile {#azurefile}
-
-The `azureFile` volume type mounts a Microsoft Azure File volume (SMB 2.1 and 3.0)
-into a pod.
-
-For more details, see the [`azureFile` volume plugin](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/azure_file/README.md).
-
-#### azureFile CSI migration
-
-{{< feature-state for_k8s_version="v1.21" state="beta" >}}
-
-The `CSIMigration` feature for `azureFile`, when enabled, redirects all plugin operations
-from the existing in-tree plugin to the `file.csi.azure.com` Container
-Storage Interface (CSI) Driver. In order to use this feature, the [Azure File CSI
-Driver](https://github.com/kubernetes-sigs/azurefile-csi-driver)
-must be installed on the cluster and the `CSIMigration` and `CSIMigrationAzureFile`
-[feature gates](/docs/reference/command-line-tools-reference/feature-gates/) must be enabled.
-
-Azure File CSI driver does not support using same volume with different fsgroups, if Azurefile CSI migration is enabled, using same volume with different fsgroups won't be supported at all.
-
-### cephfs
-
-A `cephfs` volume allows an existing CephFS volume to be
-mounted into your Pod. Unlike `emptyDir`, which is erased when a pod is
-removed, the contents of a `cephfs` volume are preserved and the volume is merely
-unmounted. This means that a `cephfs` volume can be pre-populated with data, and
-that data can be shared between pods. The `cephfs` volume can be mounted by multiple
-writers simultaneously.
-
-{{< note >}}
-You must have your own Ceph server running with the share exported before you can use it.
-{{< /note >}}
-
-See the [CephFS example](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/volumes/cephfs/) for more details.
-
-### cinder
-
-{{< note >}}
-Kubernetes must be configured with the OpenStack cloud provider.
-{{< /note >}}
-
-The `cinder` volume type is used to mount the OpenStack Cinder volume into your pod.
-
-#### Cinder volume configuration example
+Volumes can not mount into other volumes, or have hard links to
+other volumes. Each container in the pod's configuration must independently specify where to mount each volume. 
 
 ```yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  name: test-cinder
+  name: sample-cache-pod
 spec:
-  containers:
-  - image: k8s.gcr.io/test-webserver
-    name: test-cinder-container
-    volumeMounts:
-    - mountPath: /test-cinder
-      name: test-volume
   volumes:
-  - name: test-volume
-    # This OpenStack volume must already exist.
-    cinder:
-      volumeID: "<volume id>"
-      fsType: ext4
+    [...]
+  containers:
+    - name: test
+      image: busybox
+      volumeMounts:
+        - name: cache-volume
+          mountPath: /var/cache
+
 ```
 
-#### OpenStack CSI migration
+## Specify subPaths on volumes {#using-subpath}
 
-{{< feature-state for_k8s_version="v1.21" state="beta" >}}
+The `volumeMounts.subPath` property mounts the subdirectory of the volume into the container. More specifically, The `volumeMounts.subPath` property specifies a sub-path inside the referenced volume instead of its root. For example, this property may be used to to share one volume for multiple uses in a single pod.
 
-The `CSIMigration` feature for Cinder is enabled by default in Kubernetes 1.21.
-It redirects all plugin operations from the existing in-tree plugin to the
-`cinder.csi.openstack.org` Container Storage Interface (CSI) Driver.
-[OpenStack Cinder CSI Driver](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/cinder-csi-plugin/using-cinder-csi-plugin.md)
-must be installed on the cluster.
-You can disable Cinder CSI migration for your cluster by setting the `CSIMigrationOpenStack` 
-[feature gate](/docs/reference/command-line-tools-reference/feature-gates/) to `false`.
-If you disable the `CSIMigrationOpenStack` feature, the in-tree Cinder volume plugin takes responsibility
-for all aspects of Cinder volume storage management.
+The following example shows how to configure a Pod with a LAMP stack (Linux Apache MySQL PHP)
+using a single, shared volume. This sample `subPath` configuration is not recommended
+for production use.
+
+The PHP application's code and assets map to the volume's `html` folder and
+the MySQL database is stored in the volume's `mysql` folder. For example:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-lamp-site
+spec:
+    containers:
+    - name: mysql
+      image: mysql
+      env:
+      # password in config yaml for testing only
+      # use a Kubernetes Secret in production
+      - name: MYSQL_ROOT_PASSWORD
+        value: "rootpasswd"
+      volumeMounts:
+      - mountPath: /var/lib/mysql
+        name: site-data
+        subPath: mysql
+    - name: php
+      image: php:7.0-apache
+      volumeMounts:
+      - mountPath: /var/www/html
+        name: site-data
+        subPath: html
+    volumes:
+    - name: site-data
+      persistentVolumeClaim:
+        claimName: my-lamp-site-data
+```
+
+Note: The password is defined in the config yaml, which is insecure. See Kubernetes Secrets for a secure solution.
+
+### Kubernetes core volume types {#volume-types-core}
+
+Kubernetes supports several types of volumes. Kubernetes core volume types are specialized volume types (mostly ephemeral) and are not used for general purpose persistent storage use cases. 
+
+Core Volume Types:
+
+   * [configMap](#configmap)
+   * [downwardAPI](#downwardapi)
+   * [emptyDir](#emptydir)
+   * [gitRepo (deprecated)](#gitrepo)
+   * [glusterfs](#glusterfs)
+   * [hostPath](#hostpath)
+   * [local](#local)
+   * [projected](#projected)
+   * [secret](#secret)
+
+
+### Storage plugins
+
+A [persistentVolumeClaim](#persistentvolumeclaim) is a declarative way to ask for storage, without preference for the underlying implementation. 
+
+This is powered by storage plugins. Kubernetes implements the {{< glossary_tooltip text="Container Storage Interface" term_id="csi" >}} (CSI),
+which lets developers implement storage plugins without needing to make changes to the code of
+Kubernetes itself. Visit
+[Kubernetes Container Storage Interface Documentation])(https://kubernetes-csi.github.io/docs/)
+to learn more about CSI. 
+
+In contrast to the CSI, some storage plugins are "in-tree" plugins. That is, storage technology specific code inserted into the code of Kubernetes itself, without using the CSI. The C  
+
+[FlexVolume](#flexvolume) is yet another mechanism for storage plugins. Unlike CSI, FlexVolume is
+more closely tied to Kubernetes and its storage implementation. FlexVolume was developed before CSI.
+
+Storage plugin interfaces:
+
+   * [CSI](#csi)
+   * [FlexVolume](#flexvolume)
+   * [persistentVolumeClaim](#persistentvolumeclaim)
+
+
+### General purpose volume types
+
+Kubernetes directly implements some volume types for communicating with externally managed volumes, such as AWS EBS or Azure Disk Storage. These volume types are described as in-tree storage plugins, and are used for general purpose persistent storage. 
+
+The CSI was introduced to standardize connectivity to externally managed volumes, such as cloud platform storage. However, Kubernetes still includes many volume types for connecting to specific cloud storage providers. 
+
+{{< note >}}
+Using in-tree plugins is not recommended. All new storage features are only supported for CSI volumes, and in-tree plugins are being replaced by their equivalent CSI drivers."
+{{< note >}}
+
+General Purpose  Volume Types:
+   * [awsElasticBlockStore](#awselasticblockstore)
+   * [azureDisk](#azuredisk)
+   * [azureFile](#azurefile)
+   * [cephfs](#cephfs)
+   * [cinder](#cinder)
+   * [fc (fibre channel)](#fc)
+   * [gcePersistentDisk](#gcepersistentdisk)
+   * [iscsi](#iscsi)
+   * [nfs](#nfs)
+   * [portworxVolume](#portworxvolume)
+   * [rbd](#rbd)
+   * [vsphereVolume](#vspherevolume)
+
+## Kubernetes core volume types
 
 ### configMap
 
-A [ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/)
-provides a way to inject configuration data into pods.
-The data stored in a ConfigMap can be referenced in a volume of type
-`configMap` and then consumed by containerized applications running in a pod.
+A [ConfigMap](/docs/concepts/configuration/configmap/) 
+exports configuration data to a pod's filesystem. A `configMap` volume references data stored in a `ConfigMap` object. Containerized applications use the data from the volume. 
+
+You must create a [ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/) 
+before you can use it.
+
+{{< note >}}
+A container using a ConfigMap as a [subPath](#using-subpath) volume mount does not receive ConfigMap updates.
+{{< /note >}}
 
 When referencing a ConfigMap, you provide the name of the ConfigMap in the
 volume. You can customize the path to use for a specific
 entry in the ConfigMap. The following configuration shows how to mount
-the `log-config` ConfigMap onto a Pod called `configmap-pod`:
+the `log-config` ConfigMap onto a pod called `configmap-pod`:
 
 ```yaml
 apiVersion: v1
@@ -256,19 +219,11 @@ spec:
 ```
 
 The `log-config` ConfigMap is mounted as a volume, and all contents stored in
-its `log_level` entry are mounted into the Pod at path `/etc/config/log_level`.
+its `log_level` entry are mounted into the pod at path `/etc/config/log_level`.
 Note that this path is derived from the volume's `mountPath` and the `path`
 keyed with `log_level`.
 
-{{< note >}}
-* You must create a [ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/)
-  before you can use it.
-
-* A container using a ConfigMap as a [`subPath`](#using-subpath) volume mount will not
-  receive ConfigMap updates.
-
-* Text data is exposed as files using the UTF-8 character encoding. For other character encodings, use `binaryData`.
-{{< /note >}}
+Values from ConfigMaps are exposed as text files, using UTF-8 character encoding. To use some other character encoding, or to store information that is not text, use the `binaryData` (rather than `data`) field in the ConfigMap.
 
 ### downwardAPI {#downwardapi}
 
@@ -276,23 +231,22 @@ A `downwardAPI` volume makes downward API data available to applications.
 It mounts a directory and writes the requested data in plain text files.
 
 {{< note >}}
-A container using the downward API as a [`subPath`](#using-subpath) volume mount will not
-receive downward API updates.
+A container using the downward API as a [`subPath`](#using-subpath) volume mount will not receive downward API updates.
 {{< /note >}}
 
 See the [downward API example](/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/) for more details.
 
 ### emptyDir {#emptydir}
 
-An `emptyDir` volume is first created when a Pod is assigned to a node, and
-exists as long as that Pod is running on that node. As the name says, the
-`emptyDir` volume is initially empty. All containers in the Pod can read and write the same
+An `emptyDir` volume is first created when a pod is assigned to a node, and
+exists as long as that pod is running on that node. As the name says, the
+`emptyDir` volume is initially empty. All containers in the pod can read and write the same
 files in the `emptyDir` volume, though that volume can be mounted at the same
-or different paths in each container. When a Pod is removed from a node for
+or different paths in each container. When a pod is removed from a node for
 any reason, the data in the `emptyDir` is deleted permanently.
 
 {{< note >}}
-A container crashing does *not* remove a Pod from a node. The data in an `emptyDir` volume
+A container crashing does *not* remove a pod from a node. The data in an `emptyDir` volume
 is safe across container crashes.
 {{< /note >}}
 
@@ -305,8 +259,8 @@ Some uses for an `emptyDir` are:
 
 Depending on your environment, `emptyDir` volumes are stored on whatever medium that backs the
 node such as disk or SSD, or network storage. However, if you set the `emptyDir.medium` field
-to `"Memory"`, Kubernetes mounts a tmpfs (RAM-backed filesystem) for you instead.
-While tmpfs is very fast, be aware that unlike disks, tmpfs is cleared on
+to `"Memory"`, Kubernetes mounts a `tmpfs` (RAM-backed filesystem) for you instead.
+While `tmpfs` is very fast, be aware that unlike disks, `tmpfs` is cleared on
 node reboot and any files you write count against your container's
 memory limit.
 
@@ -315,6 +269,17 @@ If the `SizeMemoryBackedVolumes` [feature gate](/docs/reference/command-line-too
 you can specify a size for memory backed volumes.  If no size is specified, memory
 backed volumes are sized to 50% of the memory on a Linux host.
 {{< /note>}}
+
+#### Resources
+
+//todo
+
+The storage media (such as Disk or SSD) of an `emptyDir` volume is determined by the medium of the filesystem holding the kubelet root dir (typically
+`/var/lib/kubelet`). There is no limit on how much space an `emptyDir` or
+`hostPath` volume can consume, and no isolation between containers or between
+pods.
+
+A container of a pod may request ephemeral storage in it's spec. For example, `spec.containers[].resources.requests.ephemeral-storage` may be specified and set to a requested amount of storage in bytes. This storage can be used for `emptyDir` volumes. Learn more about [managing resources for containers](/docs/concepts/configuration/manage-resources-containers/#setting-requests-and-limits-for-local-ephemeral-storage).
 
 #### emptyDir configuration example
 
@@ -335,160 +300,15 @@ spec:
     emptyDir: {}
 ```
 
-### fc (fibre channel) {#fc}
-
-An `fc` volume type allows an existing fibre channel block storage volume
-to mount in a Pod. You can specify single or multiple target world wide names (WWNs)
-using the parameter `targetWWNs` in your Volume configuration. If multiple WWNs are specified,
-targetWWNs expect that those WWNs are from multi-path connections.
-
-{{< note >}}
-You must configure FC SAN Zoning to allocate and mask those LUNs (volumes) to the target WWNs
-beforehand so that Kubernetes hosts can access them.
-{{< /note >}}
-
-See the [fibre channel example](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/fibre_channel) for more details.
-
-### flocker (deprecated) {#flocker}
-
-[Flocker](https://github.com/ClusterHQ/flocker) is an open-source, clustered
-container data volume manager. Flocker provides management
-and orchestration of data volumes backed by a variety of storage backends.
-
-A `flocker` volume allows a Flocker dataset to be mounted into a Pod. If the
-dataset does not already exist in Flocker, it needs to be first created with the Flocker
-CLI or by using the Flocker API. If the dataset already exists it will be
-reattached by Flocker to the node that the pod is scheduled. This means data
-can be shared between pods as required.
-
-{{< note >}}
-You must have your own Flocker installation running before you can use it.
-{{< /note >}}
-
-See the [Flocker example](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/flocker) for more details.
-
-### gcePersistentDisk
-
-A `gcePersistentDisk` volume mounts a Google Compute Engine (GCE)
-[persistent disk](https://cloud.google.com/compute/docs/disks) (PD) into your Pod.
-Unlike `emptyDir`, which is erased when a pod is removed, the contents of a PD are
-preserved and the volume is merely unmounted. This means that a PD can be
-pre-populated with data, and that data can be shared between pods.
-
-{{< note >}}
-You must create a PD using `gcloud` or the GCE API or UI before you can use it.
-{{< /note >}}
-
-There are some restrictions when using a `gcePersistentDisk`:
-
-* the nodes on which Pods are running must be GCE VMs
-* those VMs need to be in the same GCE project and zone as the persistent disk
-
-One feature of GCE persistent disk is concurrent read-only access to a persistent disk.
-A `gcePersistentDisk` volume permits multiple consumers to simultaneously
-mount a persistent disk as read-only. This means that you can pre-populate a PD with your dataset
-and then serve it in parallel from as many Pods as you need. Unfortunately,
-PDs can only be mounted by a single consumer in read-write mode. Simultaneous
-writers are not allowed.
-
-Using a GCE persistent disk with a Pod controlled by a ReplicaSet will fail unless
-the PD is read-only or the replica count is 0 or 1.
-
-#### Creating a GCE persistent disk {#gce-create-persistent-disk}
-
-Before you can use a GCE persistent disk with a Pod, you need to create it.
-
-```shell
-gcloud compute disks create --size=500GB --zone=us-central1-a my-data-disk
-```
-
-#### GCE persistent disk configuration example
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: test-pd
-spec:
-  containers:
-  - image: k8s.gcr.io/test-webserver
-    name: test-container
-    volumeMounts:
-    - mountPath: /test-pd
-      name: test-volume
-  volumes:
-  - name: test-volume
-    # This GCE PD must already exist.
-    gcePersistentDisk:
-      pdName: my-data-disk
-      fsType: ext4
-```
-
-#### Regional persistent disks
-
-The [Regional persistent disks](https://cloud.google.com/compute/docs/disks/#repds)
-feature allows the creation of persistent disks that are available in two zones
-within the same region. In order to use this feature, the volume must be provisioned
-as a PersistentVolume; referencing the volume directly from a pod is not supported.
-
-#### Manually provisioning a Regional PD PersistentVolume
-
-Dynamic provisioning is possible using a
-[StorageClass for GCE PD](/docs/concepts/storage/storage-classes/#gce).
-Before creating a PersistentVolume, you must create the persistent disk:
-
-```shell
-gcloud compute disks create --size=500GB my-data-disk
-  --region us-central1
-  --replica-zones us-central1-a,us-central1-b
-```
-
-#### Regional persistent disk configuration example
-
-```yaml
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: test-volume
-spec:
-  capacity:
-    storage: 400Gi
-  accessModes:
-  - ReadWriteOnce
-  gcePersistentDisk:
-    pdName: my-data-disk
-    fsType: ext4
-  nodeAffinity:
-    required:
-      nodeSelectorTerms:
-      - matchExpressions:
-        - key: failure-domain.beta.kubernetes.io/zone
-          operator: In
-          values:
-          - us-central1-a
-          - us-central1-b
-```
-
-#### GCE CSI migration
-
-{{< feature-state for_k8s_version="v1.17" state="beta" >}}
-
-The `CSIMigration` feature for GCE PD, when enabled, redirects all plugin operations
-from the existing in-tree plugin to the `pd.csi.storage.gke.io` Container
-Storage Interface (CSI) Driver. In order to use this feature, the [GCE PD CSI
-Driver](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver)
-must be installed on the cluster and the `CSIMigration` and `CSIMigrationGCE`
-beta features must be enabled.
-
 ### gitRepo (deprecated) {#gitrepo}
 
 {{< warning >}}
-The `gitRepo` volume type is deprecated. To provision a container with a git repo, mount an [EmptyDir](#emptydir) into an InitContainer that clones the repo using git, then mount the [EmptyDir](#emptydir) into the Pod's container.
+The `gitRepo` volume type is deprecated. To provision a container with a git repo, mount an [EmptyDir](#emptydir) into an InitContainer that clones the repo using git, then mount the [EmptyDir](#emptydir) into the pod's container.
 {{< /warning >}}
 
 A `gitRepo` volume is an example of a volume plugin. This plugin
 mounts an empty directory and clones a git repository into this directory
-for your Pod to use.
+for your pod to use.
 
 Here is an example of a `gitRepo` volume:
 
@@ -514,32 +334,29 @@ spec:
 ### glusterfs
 
 A `glusterfs` volume allows a [Glusterfs](https://www.gluster.org) (an open
-source networked filesystem) volume to be mounted into your Pod. Unlike
-`emptyDir`, which is erased when a Pod is removed, the contents of a
+source networked filesystem) volume to be mounted into your pod. Unlike
+`emptyDir`, which is erased when a pod is removed, the contents of a
 `glusterfs` volume are preserved and the volume is merely unmounted. This
 means that a glusterfs volume can be pre-populated with data, and that data can
 be shared between pods. GlusterFS can be mounted by multiple writers
 simultaneously.
 
-{{< note >}}
 You must have your own GlusterFS installation running before you can use it.
-{{< /note >}}
 
 See the [GlusterFS example](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/volumes/glusterfs) for more details.
 
 ### hostPath {#hostpath}
 
 A `hostPath` volume mounts a file or directory from the host node's filesystem
-into your Pod. This is not something that most Pods will need, but it offers a
-powerful escape hatch for some applications.
+into your pod. This volume type improperly breaks the boundary betwen host and container. However, it may be necessary in certain situations, such as testing or running legacy applications. 
 
 For example, some uses for a `hostPath` are:
 
 * running a container that needs access to Docker internals; use a `hostPath`
   of `/var/lib/docker`
 * running cAdvisor in a container; use a `hostPath` of `/sys`
-* allowing a Pod to specify whether a given `hostPath` should exist prior to the
-  Pod running, whether it should be created, and what it should exist as
+* allowing a pod to specify whether a given `hostPath` should exist prior to the
+  pod running, whether it should be created, and what it should exist as
 
 In addition to the required `path` property, you can optionally specify a `type` for a `hostPath` volume.
 
@@ -548,9 +365,9 @@ The supported values for field `type` are:
 | Value | Behavior |
 |:------|:---------|
 | | Empty string (default) is for backward compatibility, which means that no checks will be performed before mounting the hostPath volume. |
-| `DirectoryOrCreate` | If nothing exists at the given path, an empty directory will be created there as needed with permission set to 0755, having the same group and ownership with Kubelet. |
+| `DirectoryOrCreate` | If nothing exists at the given path, an empty directory is created there as needed with permission set to 0755, having the same group and ownership with Kubelet. |
 | `Directory` | A directory must exist at the given path |
-| `FileOrCreate` | If nothing exists at the given path, an empty file will be created there as needed with permission set to 0644, having the same group and ownership with Kubelet. |
+| `FileOrCreate` | If nothing exists at the given path, an empty file is be created there as needed with permission set to 0644, having the same group and ownership with Kubelet. |
 | `File` | A file must exist at the given path |
 | `Socket` | A UNIX socket must exist at the given path |
 | `CharDevice` | A character device must exist at the given path |
@@ -558,11 +375,11 @@ The supported values for field `type` are:
 
 Watch out when using this type of volume, because:
 
-* Pods with identical configuration (such as created from a PodTemplate) may
+* Pods with identical configuration (such as those created from a PodTemplate) may
   behave differently on different nodes due to different files on the nodes
 * The files or directories created on the underlying hosts are only writable by root. You
   either need to run your process as root in a
-  [privileged Container](/docs/tasks/configure-pod-container/security-context/) or modify the file
+  [privileged container](/docs/tasks/configure-pod-container/security-context/) or modify the file
   permissions on the host to be able to write to a `hostPath` volume
 
 #### hostPath configuration example
@@ -595,7 +412,7 @@ you can try to mount directories and files separately, as shown in the
 [`FileOrCreate`configuration](#hostpath-fileorcreate-example).
 {{< /caution >}}
 
-#### hostPath FileOrCreate configuration example {#hostpath-fileorcreate-example}
+####  hostPath FileOrCreate configuration example {#hostpath-fileorcreate-example}
 
 ```yaml
 apiVersion: v1
@@ -623,26 +440,6 @@ spec:
       type: FileOrCreate
 ```
 
-### iscsi
-
-An `iscsi` volume allows an existing iSCSI (SCSI over IP) volume to be mounted
-into your Pod. Unlike `emptyDir`, which is erased when a Pod is removed, the
-contents of an `iscsi` volume are preserved and the volume is merely
-unmounted. This means that an iscsi volume can be pre-populated with data, and
-that data can be shared between pods.
-
-{{< note >}}
-You must have your own iSCSI server running with the volume created before you can use it.
-{{< /note >}}
-
-A feature of iSCSI is that it can be mounted as read-only by multiple consumers
-simultaneously. This means that you can pre-populate a volume with your dataset
-and then serve it in parallel from as many Pods as you need. Unfortunately,
-iSCSI volumes can only be mounted by a single consumer in read-write mode.
-Simultaneous writers are not allowed.
-
-See the [iSCSI example](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/volumes/iscsi) for more details.
-
 ### local
 
 A `local` volume represents a mounted local storage device such as a disk,
@@ -651,8 +448,8 @@ partition or directory.
 Local volumes can only be used as a statically created PersistentVolume. Dynamic
 provisioning is not supported.
 
-Compared to `hostPath` volumes, `local` volumes are used in a durable and
-portable manner without manually scheduling pods to nodes. The system is aware
+Compared to `hostPath` volumes, `local` volumes are used in a *durable and
+portable manner* without manually scheduling pods to nodes. The system is aware
 of the volume's node constraints by looking at the node affinity on the PersistentVolume.
 
 However, `local` volumes are subject to the availability of the underlying
@@ -692,7 +489,7 @@ spec:
 
 You must set a PersistentVolume `nodeAffinity` when using `local` volumes.
 The Kubernetes scheduler uses the PersistentVolume `nodeAffinity` to schedule
-these Pods to the correct node.
+these pods to the correct node.
 
 PersistentVolume `volumeMode` can be set to "Block" (instead of the default
 value "Filesystem") to expose the local volume as a raw block device.
@@ -701,7 +498,7 @@ When using local volumes, it is recommended to create a StorageClass with
 `volumeBindingMode` set to `WaitForFirstConsumer`. For more details, see the
 local [StorageClass](/docs/concepts/storage/storage-classes/#local) example.
 Delaying volume binding ensures that the PersistentVolumeClaim binding decision
-will also be evaluated with any other node constraints the Pod may have,
+is evaluated with any other node constraints the Pod may have,
 such as node resource requirements, node selectors, Pod affinity, and Pod anti-affinity.
 
 An external static provisioner can be run separately for improved management of
@@ -716,70 +513,7 @@ user if the external static provisioner is not used to manage the volume
 lifecycle.
 {{< /note >}}
 
-### nfs
-
-An `nfs` volume allows an existing NFS (Network File System) share to be
-mounted into a Pod. Unlike `emptyDir`, which is erased when a Pod is
-removed, the contents of an `nfs` volume are preserved and the volume is merely
-unmounted. This means that an NFS volume can be pre-populated with data, and
-that data can be shared between pods. NFS can be mounted by multiple
-writers simultaneously.
-
-{{< note >}}
-You must have your own NFS server running with the share exported before you can use it.
-{{< /note >}}
-
-See the [NFS example](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/nfs) for more details.
-
-### persistentVolumeClaim {#persistentvolumeclaim}
-
-A `persistentVolumeClaim` volume is used to mount a
-[PersistentVolume](/docs/concepts/storage/persistent-volumes/) into a Pod. PersistentVolumeClaims
-are a way for users to "claim" durable storage (such as a GCE PersistentDisk or an
-iSCSI volume) without knowing the details of the particular cloud environment.
-
-See the information about [PersistentVolumes](/docs/concepts/storage/persistent-volumes/) for more
-details.
-
-### portworxVolume {#portworxvolume}
-
-A `portworxVolume` is an elastic block storage layer that runs hyperconverged with
-Kubernetes. [Portworx](https://portworx.com/use-case/kubernetes-storage/) fingerprints storage
-in a server, tiers based on capabilities, and aggregates capacity across multiple servers.
-Portworx runs in-guest in virtual machines or on bare metal Linux nodes.
-
-A `portworxVolume` can be dynamically created through Kubernetes or it can also
-be pre-provisioned and referenced inside a Pod.
-Here is an example Pod referencing a pre-provisioned Portworx volume:
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: test-portworx-volume-pod
-spec:
-  containers:
-  - image: k8s.gcr.io/test-webserver
-    name: test-container
-    volumeMounts:
-    - mountPath: /mnt
-      name: pxvol
-  volumes:
-  - name: pxvol
-    # This Portworx volume must already exist.
-    portworxVolume:
-      volumeID: "pxvol"
-      fsType: "<fs-type>"
-```
-
-{{< note >}}
-Make sure you have an existing PortworxVolume with name `pxvol`
-before using it in the Pod.
-{{< /note >}}
-
-For more details, see the [Portworx volume](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/portworx/README.md) examples.
-
-### projected
+### projected {#projected}
 
 A `projected` volume maps several existing volume sources into the same directory.
 
@@ -790,10 +524,11 @@ Currently, the following types of volume sources can be projected:
 * [`configMap`](#configmap)
 * `serviceAccountToken`
 
-All sources are required to be in the same namespace as the Pod. For more details,
+All sources are required to be in the same namespace as the pod. For more details,
 see the [all-in-one volume design document](https://github.com/kubernetes/community/blob/{{< param "githubbranch" >}}/contributors/design-proposals/node/all-in-one-volume.md).
 
 #### Example configuration with a secret, a downwardAPI, and a configMap {#example-configuration-secret-downwardapi-configmap}
+
 
 ```yaml
 apiVersion: v1
@@ -874,9 +609,9 @@ parameters are nearly the same with two exceptions:
   volume source. However, as illustrated above, you can explicitly set the `mode`
   for each individual projection.
 
-When the `TokenRequestProjection` feature is enabled, you can inject the token
+You can inject the token
 for the current [service account](/docs/reference/access-authn-authz/authentication/#service-account-tokens)
-into a Pod at a specified path. For example:
+into a pod at a specified path. For example:
 
 ```yaml
 apiVersion: v1
@@ -901,7 +636,7 @@ spec:
           path: token
 ```
 
-The example Pod has a projected volume containing the injected service account
+The example pod has a projected volume containing the injected service account
 token. This token can be used by a Pod's containers to access the Kubernetes API
 server. The `audience` field contains the intended audience of the
 token. A recipient of the token must identify itself with an identifier specified
@@ -909,7 +644,7 @@ in the audience of the token, and otherwise should reject the token. This field
 is optional and it defaults to the identifier of the API server.
 
 The `expirationSeconds` is the expected duration of validity of the service account
-token. It defaults to 1 hour and must be at least 10 minutes (600 seconds). An administrator
+token. It defaults to one hour and must be at least 10 minutes (600 seconds). An administrator
 can also limit its maximum value by specifying the `--service-account-max-token-expiration`
 option for the API server. The `path` field specifies a relative path to the mount point
 of the projected volume.
@@ -919,86 +654,7 @@ A container using a projected volume source as a [`subPath`](#using-subpath) vol
 receive updates for those volume sources.
 {{< /note >}}
 
-### quobyte
-
-A `quobyte` volume allows an existing [Quobyte](https://www.quobyte.com) volume to
-be mounted into your Pod.
-
-{{< note >}}
-You must have your own Quobyte setup and running with the volumes
-created before you can use it.
-{{< /note >}}
-
-Quobyte supports the {{< glossary_tooltip text="Container Storage Interface" term_id="csi" >}}.
-CSI is the recommended plugin to use Quobyte volumes inside Kubernetes. Quobyte's
-GitHub project has [instructions](https://github.com/quobyte/quobyte-csi#quobyte-csi) for deploying Quobyte using CSI, along with examples.
-
-### rbd
-
-An `rbd` volume allows a
-[Rados Block Device](https://docs.ceph.com/en/latest/rbd/) (RBD) volume to mount into your
-Pod. Unlike `emptyDir`, which is erased when a pod is removed, the contents of
-an `rbd` volume are preserved and the volume is unmounted. This
-means that a RBD volume can be pre-populated with data, and that data can
-be shared between pods.
-
-{{< note >}}
-You must have a Ceph installation running before you can use RBD.
-{{< /note >}}
-
-A feature of RBD is that it can be mounted as read-only by multiple consumers
-simultaneously. This means that you can pre-populate a volume with your dataset
-and then serve it in parallel from as many pods as you need. Unfortunately,
-RBD volumes can only be mounted by a single consumer in read-write mode.
-Simultaneous writers are not allowed.
-
-See the [RBD example](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/volumes/rbd)
-for more details.
-
-### scaleIO (deprecated) {#scaleio}
-
-ScaleIO is a software-based storage platform that uses existing hardware to
-create clusters of scalable shared block networked storage. The `scaleIO` volume
-plugin allows deployed pods to access existing ScaleIO
-volumes. For information about dynamically provisioning new volumes for
-persistent volume claims, see
-[ScaleIO persistent volumes](/docs/concepts/storage/persistent-volumes/#scaleio).
-
-{{< note >}}
-You must have an existing ScaleIO cluster already setup and
-running with the volumes created before you can use them.
-{{< /note >}}
-
-The following example is a Pod configuration with ScaleIO:
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: pod-0
-spec:
-  containers:
-  - image: k8s.gcr.io/test-webserver
-    name: pod-0
-    volumeMounts:
-    - mountPath: /test-pd
-      name: vol-0
-  volumes:
-  - name: vol-0
-    scaleIO:
-      gateway: https://localhost:443/api
-      system: scaleio
-      protectionDomain: sd0
-      storagePool: sp1
-      volumeName: vol-0
-      secretRef:
-        name: sio-secret
-      fsType: xfs
-```
-
-For further details, see the [ScaleIO](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/scaleio) examples.
-
-### secret
+### secret 
 
 A `secret` volume is used to pass sensitive information, such as passwords, to
 Pods. You can store secrets in the Kubernetes API and mount them as files for
@@ -1007,271 +663,24 @@ backed by tmpfs (a RAM-backed filesystem) so they are never written to
 non-volatile storage.
 
 {{< note >}}
-You must create a Secret in the Kubernetes API before you can use it.
-{{< /note >}}
-
-{{< note >}}
-A container using a Secret as a [`subPath`](#using-subpath) volume mount will not
-receive Secret updates.
+A container using a Secret as a [`subPath`](#using-subpath) volume mount doesn't receive Secret updates.
 {{< /note >}}
 
 For more details, see [Configuring Secrets](/docs/concepts/configuration/secret/).
 
-### storageOS {#storageos}
 
-A `storageos` volume allows an existing [StorageOS](https://www.storageos.com)
-volume to mount into your Pod.
+## Storage plugin interfaces
 
-StorageOS runs as a container within your Kubernetes environment, making local
-or attached storage accessible from any node within the Kubernetes cluster.
-Data can be replicated to protect against node failure. Thin provisioning and
-compression can improve utilization and reduce cost.
+The out-of-tree volume plugins include the Container Storage Interface (CSI)
+and FlexVolume. They enable storage vendors to create custom storage plugins. The main Kubernetes binary implements the CSI, and communicates with any external plugins. This keeps the main binary efficient, and allows users to choose their own storage plugins. 
 
-At its core, StorageOS provides block storage to containers, accessible from a file system.
+Before the introduction of CSI and FlexVolume, all volume plugins (like
+volume types listed above) were "in-tree" meaning they were built, linked,
+compiled, and shipped with the core Kubernetes binaries and extend the core
+Kubernetes API. This meant that adding a new storage system to Kubernetes (a
+volume plugin) required checking code into the core Kubernetes code repository.
 
-The StorageOS Container requires 64-bit Linux and has no additional dependencies.
-A free developer license is available.
-
-{{< caution >}}
-You must run the StorageOS container on each node that wants to
-access StorageOS volumes or that will contribute storage capacity to the pool.
-For installation instructions, consult the
-[StorageOS documentation](https://docs.storageos.com).
-{{< /caution >}}
-
-The following example is a Pod configuration with StorageOS:
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  labels:
-    name: redis
-    role: master
-  name: test-storageos-redis
-spec:
-  containers:
-    - name: master
-      image: kubernetes/redis:v1
-      env:
-        - name: MASTER
-          value: "true"
-      ports:
-        - containerPort: 6379
-      volumeMounts:
-        - mountPath: /redis-master-data
-          name: redis-data
-  volumes:
-    - name: redis-data
-      storageos:
-        # The `redis-vol01` volume must already exist within StorageOS in the `default` namespace.
-        volumeName: redis-vol01
-        fsType: ext4
-```
-
-For more information about StorageOS, dynamic provisioning, and PersistentVolumeClaims, see the
-[StorageOS examples](https://github.com/kubernetes/examples/blob/master/volumes/storageos).
-
-### vsphereVolume {#vspherevolume}
-
-{{< note >}}
-You must configure the Kubernetes vSphere Cloud Provider. For cloudprovider
-configuration, refer to the [vSphere Getting Started guide](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/).
-{{< /note >}}
-
-A `vsphereVolume` is used to mount a vSphere VMDK volume into your Pod.  The contents
-of a volume are preserved when it is unmounted. It supports both VMFS and VSAN datastore.
-
-{{< note >}}
-You must create vSphere VMDK volume using one of the following methods before using with a Pod.
-{{< /note >}}
-
-#### Creating a VMDK volume {#creating-vmdk-volume}
-
-Choose one of the following methods to create a VMDK.
-
-{{< tabs name="tabs_volumes" >}}
-{{% tab name="Create using vmkfstools" %}}
-First ssh into ESX, then use the following command to create a VMDK:
-
-```shell
-vmkfstools -c 2G /vmfs/volumes/DatastoreName/volumes/myDisk.vmdk
-```
-
-{{% /tab %}}
-{{% tab name="Create using vmware-vdiskmanager" %}}
-Use the following command to create a VMDK:
-
-```shell
-vmware-vdiskmanager -c -t 0 -s 40GB -a lsilogic myDisk.vmdk
-```
-
-{{% /tab %}}
-
-{{< /tabs >}}
-
-#### vSphere VMDK configuration example {#vsphere-vmdk-configuration}
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: test-vmdk
-spec:
-  containers:
-  - image: k8s.gcr.io/test-webserver
-    name: test-container
-    volumeMounts:
-    - mountPath: /test-vmdk
-      name: test-volume
-  volumes:
-  - name: test-volume
-    # This VMDK volume must already exist.
-    vsphereVolume:
-      volumePath: "[DatastoreName] volumes/myDisk"
-      fsType: ext4
-```
-
-For more information, see the [vSphere volume](https://github.com/kubernetes/examples/tree/master/staging/volumes/vsphere) examples.
-
-#### vSphere CSI migration {#vsphere-csi-migration}
-
-{{< feature-state for_k8s_version="v1.19" state="beta" >}}
-
-The `CSIMigration` feature for `vsphereVolume`, when enabled, redirects all plugin operations
-from the existing in-tree plugin to the `csi.vsphere.vmware.com` {{< glossary_tooltip text="CSI" term_id="csi" >}} driver. In order to use this feature, the
-[vSphere CSI driver](https://github.com/kubernetes-sigs/vsphere-csi-driver)
-must be installed on the cluster and the `CSIMigration` and `CSIMigrationvSphere`
-[feature gates](/docs/reference/command-line-tools-reference/feature-gates/) must be enabled.
-
-This also requires minimum vSphere vCenter/ESXi Version to be 7.0u1 and minimum HW Version to be VM version 15.
-
-{{< note >}}
-The following StorageClass parameters from the built-in `vsphereVolume` plugin are not supported by the vSphere CSI driver:
-
-* `diskformat`
-* `hostfailurestotolerate`
-* `forceprovisioning`
-* `cachereservation`
-* `diskstripes`
-* `objectspacereservation`
-* `iopslimit`
-
-Existing volumes created using these parameters will be migrated to the vSphere CSI driver,
-but new volumes created by the vSphere CSI driver will not be honoring these parameters.
-{{< /note >}}
-
-#### vSphere CSI migration complete {#vsphere-csi-migration-complete}
-
-{{< feature-state for_k8s_version="v1.19" state="beta" >}}
-
-To turn off the `vsphereVolume` plugin from being loaded by the controller manager and the kubelet, you need to set this feature flag to `true`. You must install a `csi.vsphere.vmware.com` {{< glossary_tooltip text="CSI" term_id="csi" >}} driver on all worker nodes.
-
-## Using subPath {#using-subpath}
-
-Sometimes, it is useful to share one volume for multiple uses in a single pod.
-The `volumeMounts.subPath` property specifies a sub-path inside the referenced volume
-instead of its root.
-
-The following example shows how to configure a Pod with a LAMP stack (Linux Apache MySQL PHP)
-using a single, shared volume. This sample `subPath` configuration is not recommended
-for production use.
-
-The PHP application's code and assets map to the volume's `html` folder and
-the MySQL database is stored in the volume's `mysql` folder. For example:
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: my-lamp-site
-spec:
-    containers:
-    - name: mysql
-      image: mysql
-      env:
-      - name: MYSQL_ROOT_PASSWORD
-        value: "rootpasswd"
-      volumeMounts:
-      - mountPath: /var/lib/mysql
-        name: site-data
-        subPath: mysql
-    - name: php
-      image: php:7.0-apache
-      volumeMounts:
-      - mountPath: /var/www/html
-        name: site-data
-        subPath: html
-    volumes:
-    - name: site-data
-      persistentVolumeClaim:
-        claimName: my-lamp-site-data
-```
-
-### Using subPath with expanded environment variables {#using-subpath-expanded-environment}
-
-{{< feature-state for_k8s_version="v1.17" state="stable" >}}
-
-Use the `subPathExpr` field to construct `subPath` directory names from
-downward API environment variables.
-The `subPath` and `subPathExpr` properties are mutually exclusive.
-
-In this example, a `Pod` uses `subPathExpr` to create a directory `pod1` within
-the `hostPath` volume `/var/log/pods`.
-The `hostPath` volume takes the `Pod` name from the `downwardAPI`.
-The host directory `/var/log/pods/pod1` is mounted at `/logs` in the container.
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: pod1
-spec:
-  containers:
-  - name: container1
-    env:
-    - name: POD_NAME
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: metadata.name
-    image: busybox
-    command: [ "sh", "-c", "while [ true ]; do echo 'Hello'; sleep 10; done | tee -a /logs/hello.txt" ]
-    volumeMounts:
-    - name: workdir1
-      mountPath: /logs
-      subPathExpr: $(POD_NAME)
-  restartPolicy: Never
-  volumes:
-  - name: workdir1
-    hostPath:
-      path: /var/log/pods
-```
-
-## Resources
-
-The storage media (such as Disk or SSD) of an `emptyDir` volume is determined by the
-medium of the filesystem holding the kubelet root dir (typically
-`/var/lib/kubelet`). There is no limit on how much space an `emptyDir` or
-`hostPath` volume can consume, and no isolation between containers or between
-pods.
-
-To learn about requesting space using a resource specification, see
-[how to manage resources](/docs/concepts/configuration/manage-resources-containers/).
-
-## Out-of-tree volume plugins
-
-The out-of-tree volume plugins include
-{{< glossary_tooltip text="Container Storage Interface" term_id="csi" >}} (CSI)
-and FlexVolume. These plugins enable storage vendors to create custom storage plugins
-without adding their plugin source code to the Kubernetes repository.
-
-Previously, all volume plugins were "in-tree". The "in-tree" plugins were built, linked, compiled,
-and shipped with the core Kubernetes binaries. This meant that adding a new storage system to
-Kubernetes (a volume plugin) required checking code into the core Kubernetes code repository.
-
-Both CSI and FlexVolume allow volume plugins to be developed independent of
-the Kubernetes code base, and deployed (installed) on Kubernetes clusters as
+CSI and FlexVolume allow volume plugin development independent of the Kubernetes code base. Both are deployed (installed) on Kubernetes clusters as
 extensions.
 
 For storage vendors looking to create an out-of-tree volume plugin, please refer
@@ -1279,28 +688,22 @@ to the [volume plugin FAQ](https://github.com/kubernetes/community/blob/master/s
 
 ### csi
 
-[Container Storage Interface](https://github.com/container-storage-interface/spec/blob/master/spec.md)
-(CSI) defines a standard interface for container orchestration systems (like
-Kubernetes) to expose arbitrary storage systems to their container workloads.
-
-Please read the [CSI design proposal](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/container-storage-interface.md) for more information.
-
-{{< note >}}
-Support for CSI spec versions 0.2 and 0.3 are deprecated in Kubernetes
-v1.13 and will be removed in a future release.
-{{< /note >}}
-
 {{< note >}}
 CSI drivers may not be compatible across all Kubernetes releases.
 Please check the specific CSI driver's documentation for supported
 deployments steps for each Kubernetes release and a compatibility matrix.
 {{< /note >}}
 
+The {{< glossary_tooltip text="Container Storage Interface" term_id="csi" >}} defines a standard interface for container orchestration systems (like Kubernetes) to expose arbitrary storage systems to their container workloads.
+
+Read the [CSI design proposal](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/container-storage-interface.md) or [CSI spec](https://github.com/container-storage-interface/spec/blob/master/spec.md) for more information.
+
+
 Once a CSI compatible volume driver is deployed on a Kubernetes cluster, users
 may use the `csi` volume type to attach or mount the volumes exposed by the
 CSI driver.
 
-A `csi` volume can be used in a Pod in three different ways:
+A `csi` volume can be used in a pod in three different ways:
 
 * through a reference to a [PersistentVolumeClaim](#persistentvolumeclaim)
 * with a [generic ephemeral volume](/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volume)
@@ -1321,7 +724,7 @@ persistent volume:
   `CreateVolumeResponse` by the CSI driver as defined in the [CSI spec](https://github.com/container-storage-interface/spec/blob/master/spec.md#createvolume).
   The value is passed as `volume_id` on all calls to the CSI volume driver when
   referencing the volume.
-* `readOnly`: An optional boolean value indicating whether the volume is to be
+* `readOnly`: An optional boolean value indicating whether the volume is
   "ControllerPublished" (attached) as read only. Default is false. This value is
   passed to the CSI driver via the `readonly` field in the
   `ControllerPublishVolumeRequest`.
@@ -1347,8 +750,7 @@ persistent volume:
 * `nodeStageSecretRef`: A reference to the secret object containing
   sensitive information to pass to the CSI driver to complete the CSI
   `NodeStageVolume` call. This field is optional, and may be empty if no secret
-  is required. If the Secret contains more than one secret, all secrets
-  are passed.
+  is required. If the secret object contains more than one secret value, all secrets are passed.
 * `nodePublishSecretRef`: A reference to the secret object containing
   sensitive information to pass to the CSI driver to complete the CSI
   `NodePublishVolume` call. This field is optional, and may be empty if no
@@ -1369,21 +771,20 @@ You can set up your
 
 {{< feature-state for_k8s_version="v1.16" state="beta" >}}
 
-You can directly configure CSI volumes within the Pod
+You can directly configure CSI volumes within the pod
 specification. Volumes specified in this way are ephemeral and do not
 persist across pod restarts. See [Ephemeral
 Volumes](/docs/concepts/storage/ephemeral-volumes/#csi-ephemeral-volume)
 for more information.
 
 For more information on how to develop a CSI driver, refer to the
-[kubernetes-csi documentation](https://kubernetes-csi.github.io/docs/)
+[kubernetes-csi documentation](https://kubernetes-csi.github.io/docs/).
 
 #### Migrating to CSI drivers from in-tree plugins
 
 {{< feature-state for_k8s_version="v1.17" state="beta" >}}
 
-The `CSIMigration` feature, when enabled, directs operations against existing in-tree
-plugins to corresponding CSI plugins (which are expected to be installed and configured).
+The `CSIMigration` feature, when enabled, directs operations against existing in-tree plugins to corresponding CSI plugins (which are expected to be installed and configured).  
 As a result, operators do not have to make any
 configuration changes to existing Storage Classes, PersistentVolumes or PersistentVolumeClaims
 (referring to in-tree plugins) when transitioning to a CSI driver that supersedes an in-tree plugin.
@@ -1391,85 +792,468 @@ configuration changes to existing Storage Classes, PersistentVolumes or Persiste
 The operations and features that are supported include:
 provisioning/delete, attach/detach, mount/unmount and resizing of volumes.
 
-In-tree plugins that support `CSIMigration` and have a corresponding CSI driver implemented
-are listed in [Types of Volumes](#volume-types).
+To learn more about migrating from an in-tree volume plugin to a CSI driver, 
+lookup the specific volume type under [Types of Volumes](#volume-types).
 
 ### flexVolume
 
 FlexVolume is an out-of-tree plugin interface that has existed in Kubernetes
-since version 1.2 (before CSI). It uses an exec-based model to interface with
+since version 1.2 (before CSI). FlexVolume is deprecated. CSI is the recommended way to develop storage plugins for Kubernetes. 
+
+It uses an exec-based model to interface with
 drivers. The FlexVolume driver binaries must be installed in a pre-defined volume
 plugin path on each node and in some cases the control plane nodes as well.
 
 Pods interact with FlexVolume drivers through the `flexvolume` in-tree volume plugin.
 For more details, see the [FlexVolume](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-storage/flexvolume.md) examples.
 
-## Mount propagation
+### persistentVolumeClaim {#persistentvolumeclaim}
 
-Mount propagation allows for sharing volumes mounted by a container to
-other containers in the same pod, or even to other pods on the same node.
+A `persistentVolumeClaim` volume is used to mount a
+[PersistentVolume](/docs/concepts/storage/persistent-volumes/) into a pod. Notably, the lifecycle of the `persistentVolumeClaim` is independent of the pod, suitable for stateful or data storage applications. PersistentVolumeClaims are a way for cluster developers to "claim" durable storage (such as a GCE PersistentDisk or an iSCSI volume) without knowing the details of the particular cloud environment.
 
-Mount propagation of a volume is controlled by the `mountPropagation` field
-in `Container.volumeMounts`. Its values are:
+See the information about [PersistentVolumes](/docs/concepts/storage/persistent-volumes/) for more
+details.
 
-* `None` - This volume mount will not receive any subsequent mounts
-  that are mounted to this volume or any of its subdirectories by the host.
-  In similar fashion, no mounts created by the container will be visible on
-  the host. This is the default mode.
+## General purpouse storage providers
 
-  This mode is equal to `private` mount propagation as described in the
-  [Linux kernel documentation](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt)
+### awsElasticBlockStore {#awselasticblockstore}
 
-* `HostToContainer` - This volume mount will receive all subsequent mounts
-  that are mounted to this volume or any of its subdirectories.
+An `awsElasticBlockStore` volume mounts a filesystem stored on an Amazon Web Services (AWS) _[EBS](https://aws.amazon.com/ebs/) volume_ into your pod.  Unlike `emptyDir`, which is erased when a pod is removed, the contents of an EBS
+volume are preserved and the volume is merely unmounted.  This means that an
+EBS volume can be pre-populated with data, and that data can be shared
+between pods.
 
-  In other words, if the host mounts anything inside the volume mount, the
-  container will see it mounted there.
+If you manually specify an `awsElasticBlockStore` volume, you must create an EBS volume using `aws ec2 create-volume` or the AWS API before you can use it.
 
-  Similarly, if any Pod with `Bidirectional` mount propagation to the same
-  volume mounts anything there, the container with `HostToContainer` mount
-  propagation will see it.
+Dynamic provisioning is a feature of the [AWS EBS CSI driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver). The [AWS EKS documentation](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html) provides more information on dynamic provisioning of EBS volumes.
 
-  This mode is equal to `rslave` mount propagation as described in the
-  [Linux kernel documentation](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt)
+There are some restrictions when using an `awsElasticBlockStore` volume:
 
-* `Bidirectional` - This volume mount behaves the same the `HostToContainer` mount.
-  In addition, all volume mounts created by the container will be propagated
-  back to the host and to all containers of all pods that use the same volume.
+* the nodes on which pods are running must be AWS EC2 instances
+* those instances need to be in the same region and availability-zone as the EBS volume
+* EBS only supports a single EC2 instance mounting a volume
 
-  A typical use case for this mode is a Pod with a FlexVolume or CSI driver or
-  a Pod that needs to mount something on the host using a `hostPath` volume.
+#### Creating an AWS EBS volume
 
-  This mode is equal to `rshared` mount propagation as described in the
-  [Linux kernel documentation](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt)
-
-  {{< warning >}}
-  `Bidirectional` mount propagation can be dangerous. It can damage
-  the host operating system and therefore it is allowed only in privileged
-  containers. Familiarity with Linux kernel behavior is strongly recommended.
-  In addition, any volume mounts created by containers in pods must be destroyed
-  (unmounted) by the containers on termination.
-  {{< /warning >}}
-
-### Configuration
-
-Before mount propagation can work properly on some deployments (CoreOS,
-RedHat/Centos, Ubuntu) mount share must be configured correctly in
-Docker as shown below.
-
-Edit your Docker's `systemd` service file. Set `MountFlags` as follows:
+Before you can use an EBS volume with a pod, you need to create it.
 
 ```shell
-MountFlags=shared
+aws ec2 create-volume --availability-zone=eu-west-1a --size=10 --volume-type=gp2
 ```
 
-Or, remove `MountFlags=slave` if present. Then restart the Docker daemon:
+Make sure the zone matches the zone where you want to mount that volume. Also check that the size and EBS volume type are suitable for your use.
+
+#### AWS EBS configuration example
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: webserver-using-aws-ebs
+spec:
+  containers:
+  - image: k8s.gcr.io/test-webserver
+    name: test-container
+    volumeMounts:
+    - mountPath: /test-ebs
+      name: test-volume
+  volumes:
+  - name: test-volume
+    # This AWS EBS volume must already exist.
+    awsElasticBlockStore:
+      volumeID: <volume-id>
+      fsType: ext4
+```
+
+If the EBS volume is partitioned, you can supply the optional field `partition: "<partition number>"` to specify which parition to mount on.
+
+#### AWS EBS CSI migration
+
+{{< feature-state for_k8s_version="v1.17" state="beta" >}}
+
+The `CSIMigration` feature for `awsElasticBlockStore`, when enabled, redirects
+all plugin operations from the existing in-tree plugin to the `ebs.csi.aws.com` Container
+Storage Interface (CSI) driver. In order to use this feature, the [AWS EBS CSI
+driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver)
+must be installed on the cluster and the `CSIMigration` and `CSIMigrationAWS`
+beta features must be enabled.
+
+#### AWS EBS CSI migration complete
+{{< feature-state for_k8s_version="v1.17" state="alpha" >}}
+
+To turn off the awsElasticBlockStore storage plugin from being loaded by controller manager and kubelet, you need to set this feature flag to true. This requires `ebs.csi.aws.com` Container Storage Interface (CSI) driver being installed on all worker nodes.
+
+### azureDisk {#azuredisk}
+
+The `azureDisk` volume type mounts a Microsoft Azure [Data Disk](https://docs.microsoft.com/en-us/azure/aks/csi-storage-driver) into a pod.
+
+For more details, see the [`azureDisk` volume plugin](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/azure_disk/README.md).
+
+#### azureDisk CSI migration
+
+{{< feature-state for_k8s_version="v1.21" state="beta" >}}
+
+The `CSIMigration` feature for `azureFile`, when enabled, redirects all plugin operations
+from the existing in-tree plugin to the `file.csi.azure.com` Container
+Storage Interface (CSI) Driver. In order to use this feature, the [Azure File CSI
+Driver](https://github.com/kubernetes-sigs/azurefile-csi-driver)
+must be installed on the cluster and the `CSIMigration` and `CSIMigrationAzureFile`
+[feature gates](/docs/reference/command-line-tools-reference/feature-gates/) must be enabled.
+
+Azure File CSI driver does not support using same volume with different fsgroups, if Azurefile CSI migration is enabled, using same volume with different fsgroups won't be supported at all.
+
+### azureFile {#azurefile}
+
+A `azureFile` volume type mounts a Microsoft Azure File volume (SMB 2.1 and 3.0)
+into a pod.
+
+For more details, see the [`azureFile` volume plugin](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/azure_file/README.md).
+
+#### azureFile CSI migration
+
+{{< feature-state for_k8s_version="v1.15" state="alpha" >}}
+
+The CSI Migration feature for azureFile, when enabled, redirects all plugin operations
+from the existing in-tree plugin to the `file.csi.azure.com` Container
+Storage Interface (CSI) Driver. In order to use this feature, the [Azure File CSI
+Driver](https://github.com/kubernetes-sigs/azurefile-csi-driver)
+must be installed on the cluster and the `CSIMigration` and `CSIMigrationAzureFile`
+Alpha features must be enabled.
+
+### cephfs
+
+A `cephfs` volume mounts an existing CephFS volume to your pod. CephFS can be mounted by multiple writers simultaneously.
+
+See the [CephFS example](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/volumes/cephfs/) for more details.
+
+### cinder {#cinder}
+
+{{< note >}}
+Kubernetes must be configured with the OpenStack cloud provider.
+{{< /note >}}
+
+The `cinder` volume type is used to mount the OpenStack Cinder volume into your pod. 
+
+#### Cinder volume configuration example
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-cinder
+spec:
+  containers:
+  - image: k8s.gcr.io/test-webserver
+    name: test-cinder-container
+    volumeMounts:
+    - mountPath: /test-cinder
+      name: test-volume
+  volumes:
+  - name: test-volume
+    # This OpenStack volume must already exist.
+    cinder:
+      volumeID: <volume-id>
+      fsType: ext4
+```
+
+#### OpenStack CSI migration
+
+{{< feature-state for_k8s_version="v1.21" state="beta" >}}
+
+The `CSIMigration` feature for Cinder is enabled by default in Kubernetes 1.21.
+It redirects all plugin operations from the existing in-tree plugin to the
+`cinder.csi.openstack.org` Container Storage Interface (CSI) Driver.
+[OpenStack Cinder CSI Driver](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/cinder-csi-plugin/using-cinder-csi-plugin.md)
+must be installed on the cluster.
+You can disable Cinder CSI migration for your cluster by setting the `CSIMigrationOpenStack` 
+[feature gate](/docs/reference/command-line-tools-reference/feature-gates/) to `false`.
+If you disable the `CSIMigrationOpenStack` feature, the in-tree Cinder volume plugin takes responsibility
+for all aspects of Cinder volume storage management.
+
+### fc (fibre channel) {#fc}
+
+An `fc` volume type allows an existing fibre channel block storage volume
+to mount in a pod. You can specify single or multiple target world wide names (WWNs)
+using the parameter `targetWWNs` in your Volume configuration. If multiple WWNs are specified,
+targetWWNs expect that those WWNs are from multi-path connections.
+
+You must configure FC SAN Zoning to allocate and mask those LUNs (volumes) to the target WWNs beforehand so that Kubernetes hosts can access them.
+
+See the [fibre channel example](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/fibre_channel) for more details.
+
+### gcePersistentDisk 
+
+A `gcePersistentDisk` volume mounts a Google Compute Engine (GCE)
+[persistent disk](https://cloud.google.com/compute/docs/disks) into your pod.  Unlike `emptyDir`, which is erased when a pod is removed, the contents of a PD are
+preserved and the volume is merely unmounted.  This means that a PD can be
+pre-populated with data, and that data can be shared between pods.
+
+{{< caution >}}
+You must create a PD using `gcloud` or the GCE API or UI before you can use it.
+{{< /caution >}}
+
+There are some restrictions when using a `gcePersistentDisk`:
+
+* the nodes on which pods are running must be GCE VMs
+* those VMs need to be in the same GCE project and zone as the persistent disk.
+
+One feature of GCE persistent disk is concurrent read-only access to a persistent disk.
+A `gcePersistentDisk` volume permits multiple consumers to simultaneously
+mount a persistent disk as read-only. This means that you can pre-populate a PD with your dataset
+and then serve it in parallel from as many Pods as you need. Unfortunately,
+PDs can only be mounted by a single consumer in read-write mode. Simultaneous
+writers are not allowed.
+
+Using a GCE persistent disk with a Pod controlled by a ReplicaSet will fail unless the PD is read-only or the replica count is 0 or 1.
+
+#### GCE persistent disk {#gce-create-persistent-disk}
+
+Before you can use a GCE persistent disk with a pod, you need to create it.
 
 ```shell
-sudo systemctl daemon-reload
-sudo systemctl restart docker
+gcloud compute disks create --size=500GB --zone=us-central1-a my-data-disk
 ```
+
+#### GCE persistent disk configuration example
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: webserver-using-gce-pd
+spec:
+  containers:
+  - image: k8s.gcr.io/test-webserver
+    name: test-container
+    volumeMounts:
+    - mountPath: /test-pd
+      name: test-volume
+  volumes:
+  - name: test-volume
+    # This GCE PD must already exist.
+    gcePersistentDisk:
+      pdName: my-data-disk
+      fsType: ext4
+```
+
+#### Regional Persistent Disks
+The [Regional Persistent Disks](https://cloud.google.com/compute/docs/disks/#repds) feature allows the creation of Persistent Disks that are available in two zones within the same region. In order to use this feature, the volume must be provisioned as a PersistentVolume; referencing the volume directly from a pod is not supported.
+
+#### Manually provisioning a Regional PD PersistentVolume
+Dynamic provisioning is possible using a [StorageClass for GCE PD](/docs/concepts/storage/storage-classes/#gce-pd).
+Before creating a PersistentVolume, you must create the PD:
+```shell
+gcloud compute disks create --size=500GB my-data-disk
+  --region us-central1
+  --replica-zones us-central1-a,us-central1-b
+```
+#### Regional persistent disk configuration example
+
+```yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: test-volume
+spec:
+  capacity:
+    storage: 400Gi
+  accessModes:
+  - ReadWriteOnce
+  gcePersistentDisk:
+    pdName: my-data-disk
+    fsType: ext4
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: failure-domain.beta.kubernetes.io/zone
+          operator: In
+          values:
+          - us-central1-a
+          - us-central1-b
+```
+
+#### GCE CSI migration
+
+{{< feature-state for_k8s_version="v1.17" state="beta" >}}
+
+The `CSIMigration` feature for GCE PD, when enabled, redirects all plugin operations
+from the existing in-tree plugin to the `pd.csi.storage.gke.io` Container
+Storage Interface (CSI) Driver. In order to use this feature, the [GCE PD CSI
+Driver](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver)
+must be installed on the cluster and the `CSIMigration` and `CSIMigrationGCE`
+beta features must be enabled.
+
+### iscsi
+
+An `iscsi` volume mounts existing iSCSI (SCSI over IP) volume to into your pod. Unlike `emptyDir`, which is erased when a pod is removed, the
+contents of an `iscsi` volume are preserved and the volume is merely
+unmounted. This means that an iSCSI volume can be pre-populated with data, and
+that data can be shared between pods.
+
+You must have your own iSCSI server running with the volume created before you can use it.
+
+A feature of iSCSI is that it can be mounted as read-only by multiple consumers
+simultaneously. This means that you can pre-populate a volume with your dataset
+and then serve it in parallel from as many pods as you need. Unfortunately,
+iSCSI volumes can only be mounted by a single consumer in read-write mode.
+Simultaneous writers are not allowed.
+
+See the [iSCSI example](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/volumes/iscsi) for more details.
+
+### nfs
+
+An `nfs` volume mounts an existing NFS (Network File System) share to into a pod. Unlike `emptyDir`, which is erased when a pod is
+removed, the contents of an `nfs` volume are preserved and the volume is merely
+unmounted. This means that an NFS volume can be pre-populated with data, and
+that data can be shared between pods. NFS can be mounted by multiple
+writers simultaneously.
+
+You must have your own NFS server running with the share exported before you can use it.
+
+See the [NFS example](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/nfs) for more details.
+
+### portworxVolume {#portworxvolume}
+
+A `portworxVolume` is an elastic block storage layer that runs hyperconverged with Kubernetes. [Portworx](https://portworx.com/use-case/kubernetes-storage/) fingerprints storage in a server, tiers based on capabilities,
+and aggregates capacity across multiple servers. Portworx runs in-guest in virtual machines or on bare metal Linux nodes.
+
+A `portworxVolume` can be dynamically created through Kubernetes or it can also
+be pre-provisioned and referenced inside a Kubernetes pod. Here is an example pod referencing a *pre-provisioned* PortworxVolume:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-portworx-volume-pod
+spec:
+  containers:
+  - image: k8s.gcr.io/test-webserver
+    name: test-container
+    volumeMounts:
+    - mountPath: /mnt
+      name: pxvol
+  volumes:
+  - name: pxvol
+    # This Portworx volume must already exist.
+    portworxVolume:
+      volumeID: "pxvol"
+      fsType: "<fs-type>"
+```
+
+More details and examples can be found [here](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/portworx/README.md).
+
+### rbd
+
+An `rbd` volume allows a
+[Rados Block Device](https://docs.ceph.com/en/latest/rbd/) (RBD) volume to mount into your
+Pod. Unlike `emptyDir`, which is erased when a pod is removed, the contents of
+an `rbd` volume are preserved and the volume is unmounted. This
+means that a RBD volume can be pre-populated with data, and that data can
+be shared between pods.
+
+You must have your own Ceph installation running before you can use RBD.
+
+A feature of RBD is that it can be mounted as read-only by multiple consumers
+simultaneously. This means that you can pre-populate a volume with your dataset
+and then serve it in parallel from as many pods as you need. Unfortunately,
+only a single consumer can mount an RBD volume in read-write mode.
+Simultaneous writers are not allowed.
+
+See the [RBD example](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/volumes/rbd)
+for more details.
+
+### vsphereVolume {#vspherevolume}
+
+A `vsphereVolume` is used to mount a VMWare vSphere VMDK Volume into your pod.  The contents of a volume are preserved when it is unmounted. It supports both VMFS and VSAN datastore.
+
+You must configure the Kubernetes vSphere Cloud Provider. For cloudprovider configruation, refer to the [vSphere Getting Started guide](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/).
+
+#### Creating a VMDK volume  {#creating-vmdk-volume}
+
+Choose one of the following methods to create a VMDK.
+
+{{< tabs name="tabs_volumes" >}}
+{{% tab name="Create using vmkfstools" %}}
+First ssh into ESX, then use the following command to create a VMDK:
+
+```shell
+vmkfstools -c 2G /vmfs/volumes/DatastoreName/volumes/myDisk.vmdk
+```
+{{% /tab %}}
+{{% tab name="Create using vmware-vdiskmanager" %}}
+Use the following command to create a VMDK:
+
+```shell
+vmware-vdiskmanager -c -t 0 -s 40GB -a lsilogic myDisk.vmdk
+```
+
+{{% /tab %}}
+
+{{< /tabs >}}
+
+
+#### vSphere VMDK configuration example {#vsphere-vmdk-configuration}
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-vmdk
+spec:
+  containers:
+  - image: k8s.gcr.io/test-webserver
+    name: test-container
+    volumeMounts:
+    - mountPath: /test-vmdk
+      name: test-volume
+  volumes:
+  - name: test-volume
+    # This VMDK volume must already exist.
+    vsphereVolume:
+      volumePath: "[DatastoreName] volumes/myDisk"
+      fsType: ext4
+```
+
+For more information, see the [vSphere volume]](https://github.com/kubernetes/examples/tree/master/staging/volumes/vsphere) examples.
+
+#### vSphere CSI migration {#vsphere-csi-migration}
+
+{{< feature-state for_k8s_version="v1.19" state="beta" >}}
+
+The `CSIMigration` feature for vsphereVolume, when enabled, redirects all plugin operations
+from the existing in-tree plugin to the `csi.vsphere.vmware.com` {{< glossary_tooltip text="CSI" term_id="csi" >}} driver. In order to use this feature, the [vSphere CSI
+Driver](https://github.com/kubernetes-sigs/vsphere-csi-driver)
+must be installed on the cluster and the `CSIMigration` and `CSIMigrationvSphere`
+[feature gates](/docs/reference/command-line-tools-reference/feature-gates/) must be enabled.
+
+This also requires minimum vSphere vCenter/ESXi Version to be 7.0u1 and minimum HW Version to be VM version 15.
+
+{{< note >}}
+The following StorageClass parameters from the built-in `vsphereVolume` plugin are not supported by the vSphere CSI driver:
+
+* `diskformat`
+* `hostfailurestotolerate`
+* `forceprovisioning`
+* `cachereservation`
+* `diskstripes`
+* `objectspacereservation`
+* `iopslimit`
+
+Existing volumes created using these parameters will be migrated to the vSphere CSI driver, but new volumes created by the vSphere CSI driver will not be honoring these parameters.
+{{< /note >}}
+
+#### vSphere CSI migration complete {#vsphere-csi-migration-complete}
+{{< feature-state for_k8s_version="v1.19" state="beta" >}}
+
+To turn off the `vsphereVolume` plugin from being loaded by the controller manager and the kubelet, you need to set this feature flag to `true`. You must install a `csi.vsphere.vmware.com` {{< glossary_tooltip text="CSI" term_id="csi" >}} driver on all worker nodes.
+
 
 ## {{% heading "whatsnext" %}}
 
-Follow an example of [deploying WordPress and MySQL with Persistent Volumes](/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/).
+Learn more about [Persistent Volumes](/docs/concepts/storage/persistent-volumes/) and managing storage declaratively.
+
+Learn about [mounting a sub-path of a volume based on an environment variable](docs/tasks/administer-cluster/subpath-env). 
+
+Learn about sharing a volume with multiple containers via [mount propagation](docs/concepts/storage/mount-propagation). 

--- a/content/en/docs/tasks/administer-cluster/subpath-env.md
+++ b/content/en/docs/tasks/administer-cluster/subpath-env.md
@@ -1,0 +1,63 @@
+---
+title: Using SubPath with Expanded Environment Variables 
+content_type: task
+min-kubernetes-server-version: v1.15
+---
+{{< feature-state for_k8s_version="v1.17" state="stable" >}}
+
+<!-- overview -->
+
+Use the `subPathExpr` field to construct `subPath` directory names from
+downward API environment variables. In other words, the `subPath` mounted by a pod may determined using variables, such as pod name. For example, you can create a folder for logs from each pod.
+
+The `subPath` and `subPathExpr` properties are mutually exclusive.
+
+## {{% heading "prerequisites" %}}
+
+{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+
+<!-- steps -->
+
+## Example manifest
+
+In this example, a pod uses `subPathExpr` to create a directory `pod1` within
+the `hostPath` volume `/var/log/pods`. All containers see this as simply `/logs`. Thus, logs may be collected from multiple pods in directories such as `/var/log/pods/pod1/` and `.../pods/pod2/`.
+
+First, the spec defines an environment variable `POD_NAME` using the _downward API_.
+
+Second, a subpath on the volume mount is defined using a `subPathExpr`. This allows the subpath to change based on environment variables. The subpath `pod1` is determined using an environment variable. 
+
+Overall, the host directory `/var/log/pods/pod1` is mounted at `/logs` in the container.
+
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1
+spec:
+  containers:
+  - name: container1
+    env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
+    image: busybox
+    command: [ "sh", "-c", "while [ true ]; do echo 'Hello'; sleep 10; done | tee -a /logs/hello.txt" ]
+    volumeMounts:
+    - name: workdir1
+      mountPath: /logs
+      subPathExpr: $(POD_NAME)
+  restartPolicy: Never
+  volumes:
+  - name: workdir1
+    hostPath:
+      path: /var/log/pods
+```
+
+## {{% heading "whatsnext" %}}
+
+* Learn more about [PersistentVolumeClaims] and automating the provisioning of volumes. (/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims).
+* Learn more about [Persistent Volumes] and managing storage declaratively. (/docs/concepts/storage/volumes/).


### PR DESCRIPTION
This PR is a rewrite of the concepts/storage/volumes page. I've reorganized it for improved readability.


re: Create two umbrella sections (persistent, ephemeral) for volume concept page #24726 

The previous list of volume types included a lot of different things. 

It's now broken up into two groups. I went with "core" and "external" -- but I'm open to feedback. 