### PR TITLE
kubeadm: add instruction to check kubelet status

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
@@ -50,7 +50,7 @@ this example.
 
 
 1. Configure the kubelet to be a service manager for etcd.
-  
+
    {{< note >}}You must do this on every host where etcd should be running.{{< /note >}}
     Since etcd was created first, you must override the service priority by creating a new unit file
     that has higher precedence than the kubeadm-provided kubelet unit file.
@@ -66,6 +66,12 @@ this example.
 
     systemctl daemon-reload
     systemctl restart kubelet
+    ```
+
+    Check the kubelet status to ensure it is running.
+
+    ```sh
+    systemctl status kubelet
     ```
 
 1. Create configuration files for kubeadm.


### PR DESCRIPTION
kubelet can fail to start due to various reason, e.g mismatching cgroup
drivers. Add this step to save user having to go back and check when
found etcd cluster is not running successfully.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
