### PR TITLE
Use configmap inside a k8s pod command, as entrypoint is docker specific

### DIFF
--- a/content/en/docs/concepts/configuration/configmap.md
+++ b/content/en/docs/concepts/configuration/configmap.md
@@ -88,7 +88,7 @@ data:
 There are four different ways that you can use a ConfigMap to configure
 a container inside a Pod:
 
-1. Command line arguments to the entrypoint of a container
+1. Inside a container command and args
 1. Environment variables for a container
 1. Add a file in read-only volume, for the application to read
 1. Write code to run inside the Pod that uses the Kubernetes API to read a ConfigMap


### PR DESCRIPTION
Change to say k8s Pod command rather than Docker Entrypoint which is container engine specific.
And to be aligned with

- https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#define-a-command-and-arguments-when-you-create-a-pod
> Note: The command field corresponds to entrypoint in some container runtimes. 
- https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#use-configmap-defined-environment-variables-in-pod-commands
> You can use ConfigMap-defined environment variables in the command section of the Pod.
