### PR TITLE
Fix typo in container restart policy doc

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -142,7 +142,7 @@ The `restartPolicy` applies to all containers in the Pod. `restartPolicy` only
 refers to restarts of the containers by the kubelet on the same node. After containers
 in a Pod exit, the kubelet restarts them with an exponential back-off delay (10s, 20s,
 40s, …), that is capped at five minutes. Once a container has executed for 10 minutes
-without any problems, the kubelet resets the restart backoff timer forthat container.
+without any problems, the kubelet resets the restart backoff timer for that container.
 
 ## Pod conditions
 


### PR DESCRIPTION
Issue: https://github.com/kubernetes/website/issues/25041

Description: Missing space in the word "forthat", it should be "for that".

Fix: Fixed the missing space in "forthat" under the topic "Container restart policy".

Doc link: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy