### PR TITLE
Improve configmap usage as pod command and args

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -532,7 +532,7 @@ This functionality is available in Kubernetes v1.6 and later.
 
 ## Use ConfigMap-defined environment variables in Pod commands
 
-You can use ConfigMap-defined environment variables in the `command` section of the Pod specification using the `$(VAR_NAME)` Kubernetes substitution syntax.
+You can use ConfigMap-defined environment variables in the `command` and `args` of a container using the `$(VAR_NAME)` Kubernetes substitution syntax.
 
 For example, the following Pod specification
 

--- a/content/en/examples/pods/pod-configmap-env-var-valueFrom.yaml
+++ b/content/en/examples/pods/pod-configmap-env-var-valueFrom.yaml
@@ -6,7 +6,7 @@ spec:
   containers:
     - name: test-container
       image: k8s.gcr.io/busybox
-      command: [ "/bin/sh", "-c", "echo $(SPECIAL_LEVEL_KEY) $(SPECIAL_TYPE_KEY)" ]
+      command: [ "/bin/echo", "$(SPECIAL_LEVEL_KEY) $(SPECIAL_TYPE_KEY)" ]
       env:
         - name: SPECIAL_LEVEL_KEY
           valueFrom:


### PR DESCRIPTION
Why this PR?

Here https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#use-configmap-defined-environment-variables-in-pod-commands

 - [1] In the given example we want to show `$(VAR_NAME)` usage of Kubernetes substitution syntax.
But as we use a shell (`/bin/sh`),  it would work without the k8s substitution syntax. 

Here is a proof

````
echo 'apiVersion: v1
kind: Pod
metadata:
  name: dapi-test-pod-123456
spec:
  containers:
    - name: test-container
      image: k8s.gcr.io/busybox
      command: [ "/bin/sh", "-c", "echo $SPECIAL_LEVEL_KEY $SPECIAL_TYPE_KEY" ]
      env:
        - name: SPECIAL_LEVEL_KEY
          valueFrom:
            configMapKeyRef:
              name: special-config
              key: SPECIAL_LEVEL
        - name: SPECIAL_TYPE_KEY
          valueFrom:
            configMapKeyRef:
              name: special-config
              key: SPECIAL_TYPE
  restartPolicy: Never' > test.yaml
kubectl apply -f test.yaml
````
output is

````
root@sylvain-hp:/home/sylvain# kubectl logs dapi-test-pod-123456
very charm
````

I propose to replace with a case where variable expansion is actually needed, to show the added value. 

- [2] We can use configmap defined environment var (and k8s substitution) not only in pod commands , but also args of container section

- [3] Finally it enables to be consistent with change proposed here: https://github.com/kubernetes/website/pull/25068/commits