### PR TITLE
Add kubelet config reference

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/kubelet-config.v1beta1.md
+++ b/content/en/docs/reference/command-line-tools-reference/kubelet-config.v1beta1.md
@@ -1,0 +1,1552 @@
+
+
+
+
+
+---
+title: kubelet.config.k8s.io/v1beta1
+content_type: tool-reference
+---
+
+
+## Resource Types 
+
+
+  
+- [KubeletConfiguration](#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
+- [SerializedNodeConfigSource](#kubelet-config-k8s-io-v1beta1-SerializedNodeConfigSource)
+  
+  
+    
+
+
+### `KubeletConfiguration`     {#kubelet-config-k8s-io-v1beta1-KubeletConfiguration}
+    
+
+
+<p>KubeletConfiguration contains the configuration for the Kubelet</p>
+
+
+<table class="table table-striped">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code></br>string</td><td><code>kubelet.config.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>kind</code></br>string</td><td><code>KubeletConfiguration</code></td></tr>
+    
+
+  
+  
+<tr><td style="white-space: pre"><code>enableServer</code><span style="color:blue;">&ast;</span></br>
+<code>bool</code>
+</td>
+<td><p>enableServer enables Kubelet's secured server.
+Note: Kubelet's insecure port is controlled by the readOnlyPort option.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Default: true</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>staticPodPath</code></br>
+<code>string</code>
+</td>
+<td><p>staticPodPath is the path to the directory containing local (static) pods to
+run, or the path to a single static pod file.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+the set of static pods specified at the new path may be different than the
+ones the Kubelet initially started with, and this may disrupt your node.
+Default: &quot;&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>syncFrequency</code></br>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td><p>syncFrequency is the max period between synchronizing running
+containers and config.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+shortening this duration may have a negative performance impact, especially
+as the number of Pods on the node increases. Alternatively, increasing this
+duration will result in longer refresh times for ConfigMaps and Secrets.
+Default: &quot;1m&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>fileCheckFrequency</code></br>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td><p>fileCheckFrequency is the duration between checking config files for
+new data
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+shortening the duration will cause the Kubelet to reload local Static Pod
+configurations more frequently, which may have a negative performance impact.
+Default: &quot;20s&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>httpCheckFrequency</code></br>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td><p>httpCheckFrequency is the duration between checking http for new data
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+shortening the duration will cause the Kubelet to poll staticPodURL more
+frequently, which may have a negative performance impact.
+Default: &quot;20s&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>staticPodURL</code></br>
+<code>string</code>
+</td>
+<td><p>staticPodURL is the URL for accessing static pods to run
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+the set of static pods specified at the new URL may be different than the
+ones the Kubelet initially started with, and this may disrupt your node.
+Default: &quot;&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>staticPodURLHeader</code></br>
+<code>map[string][]string</code>
+</td>
+<td><p>staticPodURLHeader is a map of slices with HTTP headers to use when accessing the podURL
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt the ability to read the latest set of static pods from StaticPodURL.
+Default: nil</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>address</code></br>
+<code>string</code>
+</td>
+<td><p>address is the IP address for the Kubelet to serve on (set to 0.0.0.0
+for all interfaces).
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Default: &quot;0.0.0.0&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>port</code></br>
+<code>int32</code>
+</td>
+<td><p>port is the port for the Kubelet to serve on.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Default: 10250</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>readOnlyPort</code></br>
+<code>int32</code>
+</td>
+<td><p>readOnlyPort is the read-only port for the Kubelet to serve on with
+no authentication/authorization.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Default: 0 (disabled)</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>tlsCertFile</code></br>
+<code>string</code>
+</td>
+<td><p>tlsCertFile is the file containing x509 Certificate for HTTPS. (CA cert,
+if any, concatenated after server cert). If tlsCertFile and
+tlsPrivateKeyFile are not provided, a self-signed certificate
+and key are generated for the public address and saved to the directory
+passed to the Kubelet's --cert-dir flag.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Default: &quot;&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>tlsPrivateKeyFile</code></br>
+<code>string</code>
+</td>
+<td><p>tlsPrivateKeyFile is the file containing x509 private key matching tlsCertFile
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Default: &quot;&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>tlsCipherSuites</code></br>
+<code>[]string</code>
+</td>
+<td><p>TLSCipherSuites is the list of allowed cipher suites for the server.
+Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Default: nil</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>tlsMinVersion</code></br>
+<code>string</code>
+</td>
+<td><p>TLSMinVersion is the minimum TLS version supported.
+Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Default: &quot;&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>rotateCertificates</code></br>
+<code>bool</code>
+</td>
+<td><p>rotateCertificates enables client certificate rotation. The Kubelet will request a
+new certificate from the certificates.k8s.io API. This requires an approver to approve the
+certificate signing requests.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+disabling it may disrupt the Kubelet's ability to authenticate with the API server
+after the current certificate expires.
+Default: false</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>serverTLSBootstrap</code></br>
+<code>bool</code>
+</td>
+<td><p>serverTLSBootstrap enables server certificate bootstrap. Instead of self
+signing a serving certificate, the Kubelet will request a certificate from
+the certificates.k8s.io API. This requires an approver to approve the
+certificate signing requests. The RotateKubeletServerCertificate feature
+must be enabled.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+disabling it will stop the renewal of Kubelet server certificates, which can
+disrupt components that interact with the Kubelet server in the long term,
+due to certificate expiration.
+Default: false</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>authentication</code></br>
+<a href="#kubelet-config-k8s-io-v1beta1-KubeletAuthentication"><code>KubeletAuthentication</code></a>
+</td>
+<td><p>authentication specifies how requests to the Kubelet's server are authenticated
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Defaults:
+anonymous:
+enabled: false
+webhook:
+enabled: true
+cacheTTL: &quot;2m&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>authorization</code></br>
+<a href="#kubelet-config-k8s-io-v1beta1-KubeletAuthorization"><code>KubeletAuthorization</code></a>
+</td>
+<td><p>authorization specifies how requests to the Kubelet's server are authorized
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Defaults:
+mode: Webhook
+webhook:
+cacheAuthorizedTTL: &quot;5m&quot;
+cacheUnauthorizedTTL: &quot;30s&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>registryPullQPS</code></br>
+<code>int32</code>
+</td>
+<td><p>registryPullQPS is the limit of registry pulls per second.
+Set to 0 for no limit.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact scalability by changing the amount of traffic produced
+by image pulls.
+Default: 5</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>registryBurst</code></br>
+<code>int32</code>
+</td>
+<td><p>registryBurst is the maximum size of bursty pulls, temporarily allows
+pulls to burst to this number, while still not exceeding registryPullQPS.
+Only used if registryPullQPS &gt; 0.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact scalability by changing the amount of traffic produced
+by image pulls.
+Default: 10</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>eventRecordQPS</code></br>
+<code>int32</code>
+</td>
+<td><p>eventRecordQPS is the maximum event creations per second. If 0, there
+is no limit enforced.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact scalability by changing the amount of traffic produced by
+event creations.
+Default: 5</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>eventBurst</code></br>
+<code>int32</code>
+</td>
+<td><p>eventBurst is the maximum size of a burst of event creations, temporarily
+allows event creations to burst to this number, while still not exceeding
+eventRecordQPS. Only used if eventRecordQPS &gt; 0.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact scalability by changing the amount of traffic produced by
+event creations.
+Default: 10</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>enableDebuggingHandlers</code></br>
+<code>bool</code>
+</td>
+<td><p>enableDebuggingHandlers enables server endpoints for log access
+and local running of containers and commands, including the exec,
+attach, logs, and portforward features.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+disabling it may disrupt components that interact with the Kubelet server.
+Default: true</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>enableContentionProfiling</code></br>
+<code>bool</code>
+</td>
+<td><p>enableContentionProfiling enables lock contention profiling, if enableDebuggingHandlers is true.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+enabling it may carry a performance impact.
+Default: false</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>healthzPort</code></br>
+<code>int32</code>
+</td>
+<td><p>healthzPort is the port of the localhost healthz endpoint (set to 0 to disable)
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that monitor Kubelet health.
+Default: 10248</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>healthzBindAddress</code></br>
+<code>string</code>
+</td>
+<td><p>healthzBindAddress is the IP address for the healthz server to serve on
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that monitor Kubelet health.
+Default: &quot;127.0.0.1&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>oomScoreAdj</code></br>
+<code>int32</code>
+</td>
+<td><p>oomScoreAdj is The oom-score-adj value for kubelet process. Values
+must be within the range [-1000, 1000].
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact the stability of nodes under memory pressure.
+Default: -999</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>clusterDomain</code></br>
+<code>string</code>
+</td>
+<td><p>clusterDomain is the DNS domain for this cluster. If set, kubelet will
+configure all containers to search this domain in addition to the
+host's search domains.
+Dynamic Kubelet Config (beta): Dynamically updating this field is not recommended,
+as it should be kept in sync with the rest of the cluster.
+Default: &quot;&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>clusterDNS</code></br>
+<code>[]string</code>
+</td>
+<td><p>clusterDNS is a list of IP addresses for the cluster DNS server. If set,
+kubelet will configure all containers to use this for DNS resolution
+instead of the host's DNS servers.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+changes will only take effect on Pods created after the update. Draining
+the node is recommended before changing this field.
+Default: nil</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>streamingConnectionIdleTimeout</code></br>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td><p>streamingConnectionIdleTimeout is the maximum time a streaming connection
+can be idle before the connection is automatically closed.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact components that rely on infrequent updates over streaming
+connections to the Kubelet server.
+Default: &quot;4h&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>nodeStatusUpdateFrequency</code></br>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td><p>nodeStatusUpdateFrequency is the frequency that kubelet computes node
+status. If node lease feature is not enabled, it is also the frequency that
+kubelet posts node status to master.
+Note: When node lease feature is not enabled, be cautious when changing the
+constant, it must work with nodeMonitorGracePeriod in nodecontroller.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact node scalability, and also that the node controller's
+nodeMonitorGracePeriod must be set to N*NodeStatusUpdateFrequency,
+where N is the number of retries before the node controller marks
+the node unhealthy.
+Default: &quot;10s&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>nodeStatusReportFrequency</code></br>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td><p>nodeStatusReportFrequency is the frequency that kubelet posts node
+status to master if node status does not change. Kubelet will ignore this
+frequency and post node status immediately if any change is detected. It is
+only used when node lease feature is enabled. nodeStatusReportFrequency's
+default value is 1m. But if nodeStatusUpdateFrequency is set explicitly,
+nodeStatusReportFrequency's default value will be set to
+nodeStatusUpdateFrequency for backward compatibility.
+Default: &quot;1m&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>nodeLeaseDurationSeconds</code></br>
+<code>int32</code>
+</td>
+<td><p>nodeLeaseDurationSeconds is the duration the Kubelet will set on its corresponding Lease,
+when the NodeLease feature is enabled. This feature provides an indicator of node
+health by having the Kubelet create and periodically renew a lease, named after the node,
+in the kube-node-lease namespace. If the lease expires, the node can be considered unhealthy.
+The lease is currently renewed every 10s, per KEP-0009. In the future, the lease renewal interval
+may be set based on the lease duration.
+Requires the NodeLease feature gate to be enabled.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+decreasing the duration may reduce tolerance for issues that temporarily prevent
+the Kubelet from renewing the lease (e.g. a short-lived network issue).
+Default: 40</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>imageMinimumGCAge</code></br>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td><p>imageMinimumGCAge is the minimum age for an unused image before it is
+garbage collected.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may trigger or delay garbage collection, and may change the image overhead
+on the node.
+Default: &quot;2m&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>imageGCHighThresholdPercent</code></br>
+<code>int32</code>
+</td>
+<td><p>imageGCHighThresholdPercent is the percent of disk usage after which
+image garbage collection is always run. The percent is calculated as
+this field value out of 100.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may trigger or delay garbage collection, and may change the image overhead
+on the node.
+Default: 85</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>imageGCLowThresholdPercent</code></br>
+<code>int32</code>
+</td>
+<td><p>imageGCLowThresholdPercent is the percent of disk usage before which
+image garbage collection is never run. Lowest disk usage to garbage
+collect to. The percent is calculated as this field value out of 100.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may trigger or delay garbage collection, and may change the image overhead
+on the node.
+Default: 80</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>volumeStatsAggPeriod</code></br>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td><p>How frequently to calculate and cache volume disk usage for all pods
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+shortening the period may carry a performance impact.
+Default: &quot;1m&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>kubeletCgroups</code></br>
+<code>string</code>
+</td>
+<td><p>kubeletCgroups is the absolute name of cgroups to isolate the kubelet in
+Dynamic Kubelet Config (beta): This field should not be updated without a full node
+reboot. It is safest to keep this value the same as the local config.
+Default: &quot;&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>systemCgroups</code></br>
+<code>string</code>
+</td>
+<td><p>systemCgroups is absolute name of cgroups in which to place
+all non-kernel processes that are not already in a container. Empty
+for no container. Rolling back the flag requires a reboot.
+Dynamic Kubelet Config (beta): This field should not be updated without a full node
+reboot. It is safest to keep this value the same as the local config.
+Default: &quot;&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>cgroupRoot</code></br>
+<code>string</code>
+</td>
+<td><p>cgroupRoot is the root cgroup to use for pods. This is handled by the
+container runtime on a best effort basis.
+Dynamic Kubelet Config (beta): This field should not be updated without a full node
+reboot. It is safest to keep this value the same as the local config.
+Default: &quot;&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>cgroupsPerQOS</code></br>
+<code>bool</code>
+</td>
+<td><p>Enable QoS based Cgroup hierarchy: top level cgroups for QoS Classes
+And all Burstable and BestEffort pods are brought up under their
+specific top level QoS cgroup.
+Dynamic Kubelet Config (beta): This field should not be updated without a full node
+reboot. It is safest to keep this value the same as the local config.
+Default: true</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>cgroupDriver</code></br>
+<code>string</code>
+</td>
+<td><p>driver that the kubelet uses to manipulate cgroups on the host (cgroupfs or systemd)
+Dynamic Kubelet Config (beta): This field should not be updated without a full node
+reboot. It is safest to keep this value the same as the local config.
+Default: &quot;cgroupfs&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>cpuManagerPolicy</code></br>
+<code>string</code>
+</td>
+<td><p>CPUManagerPolicy is the name of the policy to use.
+Requires the CPUManager feature gate to be enabled.
+Dynamic Kubelet Config (beta): This field should not be updated without a full node
+reboot. It is safest to keep this value the same as the local config.
+Default: &quot;none&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>cpuManagerReconcilePeriod</code></br>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td><p>CPU Manager reconciliation period.
+Requires the CPUManager feature gate to be enabled.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+shortening the period may carry a performance impact.
+Default: &quot;10s&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>topologyManagerPolicy</code></br>
+<code>string</code>
+</td>
+<td><p>TopologyManagerPolicy is the name of the policy to use.
+Policies other than &quot;none&quot; require the TopologyManager feature gate to be enabled.
+Dynamic Kubelet Config (beta): This field should not be updated without a full node
+reboot. It is safest to keep this value the same as the local config.
+Default: &quot;none&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>qosReserved</code></br>
+<code>map[string]string</code>
+</td>
+<td><p>qosReserved is a set of resource name to percentage pairs that specify
+the minimum percentage of a resource reserved for exclusive use by the
+guaranteed QoS tier.
+Currently supported resources: &quot;memory&quot;
+Requires the QOSReserved feature gate to be enabled.
+Dynamic Kubelet Config (beta): This field should not be updated without a full node
+reboot. It is safest to keep this value the same as the local config.
+Default: nil</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>runtimeRequestTimeout</code></br>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td><p>runtimeRequestTimeout is the timeout for all runtime requests except long running
+requests - pull, logs, exec and attach.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Default: &quot;2m&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>hairpinMode</code></br>
+<code>string</code>
+</td>
+<td><p>hairpinMode specifies how the Kubelet should configure the container
+bridge for hairpin packets.
+Setting this flag allows endpoints in a Service to loadbalance back to
+themselves if they should try to access their own Service. Values:
+&quot;promiscuous-bridge&quot;: make the container bridge promiscuous.
+&quot;hairpin-veth&quot;:       set the hairpin flag on container veth interfaces.
+&quot;none&quot;:               do nothing.
+Generally, one must set --hairpin-mode=hairpin-veth to achieve hairpin NAT,
+because promiscuous-bridge assumes the existence of a container bridge named cbr0.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may require a node reboot, depending on the network plugin.
+Default: &quot;promiscuous-bridge&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>maxPods</code></br>
+<code>int32</code>
+</td>
+<td><p>maxPods is the number of pods that can run on this Kubelet.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+changes may cause Pods to fail admission on Kubelet restart, and may change
+the value reported in Node.Status.Capacity[v1.ResourcePods], thus affecting
+future scheduling decisions. Increasing this value may also decrease performance,
+as more Pods can be packed into a single node.
+Default: 110</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>podCIDR</code></br>
+<code>string</code>
+</td>
+<td><p>The CIDR to use for pod IP addresses, only used in standalone mode.
+In cluster mode, this is obtained from the master.
+Dynamic Kubelet Config (beta): This field should always be set to the empty default.
+It should only set for standalone Kubelets, which cannot use Dynamic Kubelet Config.
+Default: &quot;&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>podPidsLimit</code></br>
+<code>int64</code>
+</td>
+<td><p>PodPidsLimit is the maximum number of pids in any pod.
+Requires the SupportPodPidsLimit feature gate to be enabled.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+lowering it may prevent container processes from forking after the change.
+Default: -1</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>resolvConf</code></br>
+<code>string</code>
+</td>
+<td><p>ResolverConfig is the resolver configuration file used as the basis
+for the container DNS resolution configuration.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+changes will only take effect on Pods created after the update. Draining
+the node is recommended before changing this field.
+Default: &quot;/etc/resolv.conf&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>runOnce</code></br>
+<code>bool</code>
+</td>
+<td><p>RunOnce causes the Kubelet to check the API server once for pods,
+run those in addition to the pods specified by static pod files, and exit.
+Default: false</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>cpuCFSQuota</code></br>
+<code>bool</code>
+</td>
+<td><p>cpuCFSQuota enables CPU CFS quota enforcement for containers that
+specify CPU limits.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+disabling it may reduce node stability.
+Default: true</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>cpuCFSQuotaPeriod</code></br>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td><p>CPUCFSQuotaPeriod is the CPU CFS quota period value, cpu.cfs_period_us.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+limits set for containers will result in different cpu.cfs_quota settings. This
+will trigger container restarts on the node being reconfigured.
+Default: &quot;100ms&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>nodeStatusMaxImages</code></br>
+<code>int32</code>
+</td>
+<td><p>nodeStatusMaxImages caps the number of images reported in Node.Status.Images.
+Note: If -1 is specified, no cap will be applied. If 0 is specified, no image is returned.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+different values can be reported on node status.
+Default: 50</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>maxOpenFiles</code></br>
+<code>int64</code>
+</td>
+<td><p>maxOpenFiles is Number of files that can be opened by Kubelet process.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact the ability of the Kubelet to interact with the node's filesystem.
+Default: 1000000</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>contentType</code></br>
+<code>string</code>
+</td>
+<td><p>contentType is contentType of requests sent to apiserver.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact the ability for the Kubelet to communicate with the API server.
+If the Kubelet loses contact with the API server due to a change to this field,
+the change cannot be reverted via dynamic Kubelet config.
+Default: &quot;application/vnd.kubernetes.protobuf&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>kubeAPIQPS</code></br>
+<code>int32</code>
+</td>
+<td><p>kubeAPIQPS is the QPS to use while talking with kubernetes apiserver
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact scalability by changing the amount of traffic the Kubelet
+sends to the API server.
+Default: 5</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>kubeAPIBurst</code></br>
+<code>int32</code>
+</td>
+<td><p>kubeAPIBurst is the burst to allow while talking with kubernetes apiserver
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact scalability by changing the amount of traffic the Kubelet
+sends to the API server.
+Default: 10</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>serializeImagePulls</code></br>
+<code>bool</code>
+</td>
+<td><p>serializeImagePulls when enabled, tells the Kubelet to pull images one
+at a time. We recommend <em>not</em> changing the default value on nodes that
+run docker daemon with version  &lt; 1.9 or an Aufs storage backend.
+Issue #10959 has more details.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact the performance of image pulls.
+Default: true</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>evictionHard</code></br>
+<code>map[string]string</code>
+</td>
+<td><p>Map of signal names to quantities that defines hard eviction thresholds. For example: {&quot;memory.available&quot;: &quot;300Mi&quot;}.
+To explicitly disable, pass a 0% or 100% threshold on an arbitrary resource.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may trigger or delay Pod evictions.
+Default:
+memory.available:  &quot;100Mi&quot;
+nodefs.available:  &quot;10%&quot;
+nodefs.inodesFree: &quot;5%&quot;
+imagefs.available: &quot;15%&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>evictionSoft</code></br>
+<code>map[string]string</code>
+</td>
+<td><p>Map of signal names to quantities that defines soft eviction thresholds.
+For example: {&quot;memory.available&quot;: &quot;300Mi&quot;}.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may trigger or delay Pod evictions, and may change the allocatable reported
+by the node.
+Default: nil</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>evictionSoftGracePeriod</code></br>
+<code>map[string]string</code>
+</td>
+<td><p>Map of signal names to quantities that defines grace periods for each soft eviction signal.
+For example: {&quot;memory.available&quot;: &quot;30s&quot;}.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may trigger or delay Pod evictions.
+Default: nil</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>evictionPressureTransitionPeriod</code></br>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td><p>Duration for which the kubelet has to wait before transitioning out of an eviction pressure condition.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+lowering it may decrease the stability of the node when the node is overcommitted.
+Default: &quot;5m&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>evictionMaxPodGracePeriod</code></br>
+<code>int32</code>
+</td>
+<td><p>Maximum allowed grace period (in seconds) to use when terminating pods in
+response to a soft eviction threshold being met. This value effectively caps
+the Pod's TerminationGracePeriodSeconds value during soft evictions.
+Note: Due to issue #64530, the behavior has a bug where this value currently just
+overrides the grace period during soft eviction, which can increase the grace
+period from what is set on the Pod. This bug will be fixed in a future release.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+lowering it decreases the amount of time Pods will have to gracefully clean
+up before being killed during a soft eviction.
+Default: 0</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>evictionMinimumReclaim</code></br>
+<code>map[string]string</code>
+</td>
+<td><p>Map of signal names to quantities that defines minimum reclaims, which describe the minimum
+amount of a given resource the kubelet will reclaim when performing a pod eviction while
+that resource is under pressure. For example: {&quot;imagefs.available&quot;: &quot;2Gi&quot;}
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may change how well eviction can manage resource pressure.
+Default: nil</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>podsPerCore</code></br>
+<code>int32</code>
+</td>
+<td><p>podsPerCore is the maximum number of pods per core. Cannot exceed MaxPods.
+If 0, this field is ignored.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+changes may cause Pods to fail admission on Kubelet restart, and may change
+the value reported in Node.Status.Capacity[v1.ResourcePods], thus affecting
+future scheduling decisions. Increasing this value may also decrease performance,
+as more Pods can be packed into a single node.
+Default: 0</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>enableControllerAttachDetach</code></br>
+<code>bool</code>
+</td>
+<td><p>enableControllerAttachDetach enables the Attach/Detach controller to
+manage attachment/detachment of volumes scheduled to this node, and
+disables kubelet from executing any attach/detach operations
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+changing which component is responsible for volume management on a live node
+may result in volumes refusing to detach if the node is not drained prior to
+the update, and if Pods are scheduled to the node before the
+volumes.kubernetes.io/controller-managed-attach-detach annotation is updated by the
+Kubelet. In general, it is safest to leave this value set the same as local config.
+Default: true</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>protectKernelDefaults</code></br>
+<code>bool</code>
+</td>
+<td><p>protectKernelDefaults, if true, causes the Kubelet to error if kernel
+flags are not as it expects. Otherwise the Kubelet will attempt to modify
+kernel flags to match its expectation.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+enabling it may cause the Kubelet to crash-loop if the Kernel is not configured as
+Kubelet expects.
+Default: false</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>makeIPTablesUtilChains</code></br>
+<code>bool</code>
+</td>
+<td><p>If true, Kubelet ensures a set of iptables rules are present on host.
+These rules will serve as utility rules for various components, e.g. KubeProxy.
+The rules will be created based on IPTablesMasqueradeBit and IPTablesDropBit.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+disabling it will prevent the Kubelet from healing locally misconfigured iptables rules.
+Default: true</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>iptablesMasqueradeBit</code></br>
+<code>int32</code>
+</td>
+<td><p>iptablesMasqueradeBit is the bit of the iptables fwmark space to mark for SNAT
+Values must be within the range [0, 31]. Must be different from other mark bits.
+Warning: Please match the value of the corresponding parameter in kube-proxy.
+TODO: clean up IPTablesMasqueradeBit in kube-proxy
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it needs to be coordinated with other components, like kube-proxy, and the update
+will only be effective if MakeIPTablesUtilChains is enabled.
+Default: 14</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>iptablesDropBit</code></br>
+<code>int32</code>
+</td>
+<td><p>iptablesDropBit is the bit of the iptables fwmark space to mark for dropping packets.
+Values must be within the range [0, 31]. Must be different from other mark bits.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it needs to be coordinated with other components, like kube-proxy, and the update
+will only be effective if MakeIPTablesUtilChains is enabled.
+Default: 15</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>featureGates</code></br>
+<code>map[string]bool</code>
+</td>
+<td><p>featureGates is a map of feature names to bools that enable or disable alpha/experimental
+features. This field modifies piecemeal the built-in default values from
+&quot;k8s.io/kubernetes/pkg/features/kube_features.go&quot;.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider the
+documentation for the features you are enabling or disabling. While we
+encourage feature developers to make it possible to dynamically enable
+and disable features, some changes may require node reboots, and some
+features may require careful coordination to retroactively disable.
+Default: nil</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>failSwapOn</code></br>
+<code>bool</code>
+</td>
+<td><p>failSwapOn tells the Kubelet to fail to start if swap is enabled on the node.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+setting it to true will cause the Kubelet to crash-loop if swap is enabled.
+Default: true</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>containerLogMaxSize</code></br>
+<code>string</code>
+</td>
+<td><p>A quantity defines the maximum size of the container log file before it is rotated.
+For example: &quot;5Mi&quot; or &quot;256Ki&quot;.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may trigger log rotation.
+Default: &quot;10Mi&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>containerLogMaxFiles</code></br>
+<code>int32</code>
+</td>
+<td><p>Maximum number of container log files that can be present for a container.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+lowering it may cause log files to be deleted.
+Default: 5</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>configMapAndSecretChangeDetectionStrategy</code></br>
+<a href="#kubelet-config-k8s-io-v1beta1-ResourceChangeDetectionStrategy"><code>ResourceChangeDetectionStrategy</code></a>
+</td>
+<td><p>ConfigMapAndSecretChangeDetectionStrategy is a mode in which
+config map and secret managers are running.
+Default: &quot;Watch&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>systemReserved</code></br>
+<code>map[string]string</code>
+</td>
+<td><p>systemReserved is a set of ResourceName=ResourceQuantity (e.g. cpu=200m,memory=150G)
+pairs that describe resources reserved for non-kubernetes components.
+Currently only cpu and memory are supported.
+See http://kubernetes.io/docs/user-guide/compute-resources for more detail.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may not be possible to increase the reserved resources, because this
+requires resizing cgroups. Always look for a NodeAllocatableEnforced event
+after updating this field to ensure that the update was successful.
+Default: nil</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>kubeReserved</code></br>
+<code>map[string]string</code>
+</td>
+<td><p>A set of ResourceName=ResourceQuantity (e.g. cpu=200m,memory=150G) pairs
+that describe resources reserved for kubernetes system components.
+Currently cpu, memory and local storage for root file system are supported.
+See http://kubernetes.io/docs/user-guide/compute-resources for more detail.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may not be possible to increase the reserved resources, because this
+requires resizing cgroups. Always look for a NodeAllocatableEnforced event
+after updating this field to ensure that the update was successful.
+Default: nil</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>reservedSystemCPUs</code><span style="color:blue;">&ast;</span></br>
+<code>string</code>
+</td>
+<td><p>This ReservedSystemCPUs option specifies the cpu list reserved for the host level system threads and kubernetes related threads.
+This provide a &quot;static&quot; CPU list rather than the &quot;dynamic&quot; list by system-reserved and kube-reserved.
+This option overwrites CPUs provided by system-reserved and kube-reserved.</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>showHiddenMetricsForVersion</code></br>
+<code>string</code>
+</td>
+<td><p>The previous version for which you want to show hidden metrics.
+Only the previous minor version is meaningful, other values will not be allowed.
+The format is <!-- raw HTML omitted -->.<!-- raw HTML omitted -->, e.g.: '1.16'.
+The purpose of this format is make sure you have the opportunity to notice if the next release hides additional metrics,
+rather than being surprised when they are permanently removed in the release after that.
+Default: &quot;&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>systemReservedCgroup</code></br>
+<code>string</code>
+</td>
+<td><p>This flag helps kubelet identify absolute name of top level cgroup used to enforce <code>SystemReserved</code> compute resource reservation for OS system daemons.
+Refer to <a href="https://git.k8s.io/community/contributors/design-proposals/node/node-allocatable.md">Node Allocatable</a> doc for more information.
+Dynamic Kubelet Config (beta): This field should not be updated without a full node
+reboot. It is safest to keep this value the same as the local config.
+Default: &quot;&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>kubeReservedCgroup</code></br>
+<code>string</code>
+</td>
+<td><p>This flag helps kubelet identify absolute name of top level cgroup used to enforce <code>KubeReserved</code> compute resource reservation for Kubernetes node system daemons.
+Refer to <a href="https://git.k8s.io/community/contributors/design-proposals/node/node-allocatable.md">Node Allocatable</a> doc for more information.
+Dynamic Kubelet Config (beta): This field should not be updated without a full node
+reboot. It is safest to keep this value the same as the local config.
+Default: &quot;&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>enforceNodeAllocatable</code></br>
+<code>[]string</code>
+</td>
+<td><p>This flag specifies the various Node Allocatable enforcements that Kubelet needs to perform.
+This flag accepts a list of options. Acceptable options are <code>none</code>, <code>pods</code>, <code>system-reserved</code> &amp; <code>kube-reserved</code>.
+If <code>none</code> is specified, no other options may be specified.
+Refer to <a href="https://git.k8s.io/community/contributors/design-proposals/node/node-allocatable.md">Node Allocatable</a> doc for more information.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+removing enforcements may reduce the stability of the node. Alternatively, adding
+enforcements may reduce the stability of components which were using more than
+the reserved amount of resources; for example, enforcing kube-reserved may cause
+Kubelets to OOM if it uses more than the reserved resources, and enforcing system-reserved
+may cause system daemons to OOM if they use more than the reserved resources.
+Default: [&quot;pods&quot;]</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>allowedUnsafeSysctls</code></br>
+<code>[]string</code>
+</td>
+<td><p>A comma separated whitelist of unsafe sysctls or sysctl patterns (ending in <em>).
+Unsafe sysctl groups are kernel.shm</em>, kernel.msg*, kernel.sem, fs.mqueue.*, and net.*.
+These sysctls are namespaced but not allowed by default.  For example: &quot;kernel.msg*,net.ipv4.route.min_pmtu&quot;
+Default: []</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>volumePluginDir</code></br>
+<code>string</code>
+</td>
+<td><p>volumePluginDir is the full path of the directory in which to search
+for additional third party volume plugins.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that changing
+the volumePluginDir may disrupt workloads relying on third party volume plugins.
+Default: &quot;/usr/libexec/kubernetes/kubelet-plugins/volume/exec/&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>providerID</code></br>
+<code>string</code>
+</td>
+<td><p>providerID, if set, sets the unique id of the instance that an external provider (i.e. cloudprovider)
+can use to identify a specific node.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact the ability of the Kubelet to interact with cloud providers.
+Default: &quot;&quot;</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>kernelMemcgNotification</code></br>
+<code>bool</code>
+</td>
+<td><p>kernelMemcgNotification, if set, the kubelet will integrate with the kernel memcg notification
+to determine if memory eviction thresholds are crossed rather than polling.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact the way Kubelet interacts with the kernel.
+Default: false</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>logging</code><span style="color:blue;">&ast;</span></br>
+<a href="#LoggingConfiguration"><code>LoggingConfiguration</code></a>
+</td>
+<td><p>Logging specifies the options of logging.
+Refer <a href="https://github.com/kubernetes/component-base/blob/master/logs/options.go">Logs Options</a> for more information.
+Defaults:
+Format: text</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>enableSystemLogHandler</code></br>
+<code>bool</code>
+</td>
+<td><p>enableSystemLogHandler enables system logs via web interface host:port/logs/
+Default: true</p>
+</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+### `SerializedNodeConfigSource`     {#kubelet-config-k8s-io-v1beta1-SerializedNodeConfigSource}
+    
+
+
+<p>SerializedNodeConfigSource allows us to serialize v1.NodeConfigSource.
+This type is used internally by the Kubelet for tracking checkpointed dynamic configs.
+It exists in the kubeletconfig API group because it is classified as a versioned input to the Kubelet.</p>
+
+
+<table class="table table-striped">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code></br>string</td><td><code>kubelet.config.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>kind</code></br>string</td><td><code>SerializedNodeConfigSource</code></td></tr>
+    
+
+  
+  
+<tr><td style="white-space: pre"><code>source</code></br>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#nodeconfigsource-v1-core"><code>core/v1.NodeConfigSource</code></a>
+</td>
+<td><p>Source is the source that we are serializing</p>
+</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+### `HairpinMode`     {#kubelet-config-k8s-io-v1beta1-HairpinMode}
+    
+(Alias of `string`)
+
+<p>HairpinMode denotes how the kubelet should configure networking to handle
+hairpin packets.</p>
+
+
+
+    
+
+
+### `KubeletAnonymousAuthentication`     {#kubelet-config-k8s-io-v1beta1-KubeletAnonymousAuthentication}
+    
+
+
+
+**Appears in:**
+
+- [KubeletAuthentication](#kubelet-config-k8s-io-v1beta1-KubeletAuthentication)
+
+
+<table class="table table-striped">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td style="white-space: pre"><code>enabled</code></br>
+<code>bool</code>
+</td>
+<td><p>enabled allows anonymous requests to the kubelet server.
+Requests that are not rejected by another authentication method are treated as anonymous requests.
+Anonymous requests have a username of system:anonymous, and a group name of system:unauthenticated.</p>
+</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+### `KubeletAuthentication`     {#kubelet-config-k8s-io-v1beta1-KubeletAuthentication}
+    
+
+
+
+**Appears in:**
+
+- [KubeletConfiguration](#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
+
+
+<table class="table table-striped">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td style="white-space: pre"><code>x509</code></br>
+<a href="#kubelet-config-k8s-io-v1beta1-KubeletX509Authentication"><code>KubeletX509Authentication</code></a>
+</td>
+<td><p>x509 contains settings related to x509 client certificate authentication</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>webhook</code></br>
+<a href="#kubelet-config-k8s-io-v1beta1-KubeletWebhookAuthentication"><code>KubeletWebhookAuthentication</code></a>
+</td>
+<td><p>webhook contains settings related to webhook bearer token authentication</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>anonymous</code></br>
+<a href="#kubelet-config-k8s-io-v1beta1-KubeletAnonymousAuthentication"><code>KubeletAnonymousAuthentication</code></a>
+</td>
+<td><p>anonymous contains settings related to anonymous authentication</p>
+</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+### `KubeletAuthorization`     {#kubelet-config-k8s-io-v1beta1-KubeletAuthorization}
+    
+
+
+
+**Appears in:**
+
+- [KubeletConfiguration](#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
+
+
+<table class="table table-striped">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td style="white-space: pre"><code>mode</code></br>
+<a href="#kubelet-config-k8s-io-v1beta1-KubeletAuthorizationMode"><code>KubeletAuthorizationMode</code></a>
+</td>
+<td><p>mode is the authorization mode to apply to requests to the kubelet server.
+Valid values are AlwaysAllow and Webhook.
+Webhook mode uses the SubjectAccessReview API to determine authorization.</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>webhook</code></br>
+<a href="#kubelet-config-k8s-io-v1beta1-KubeletWebhookAuthorization"><code>KubeletWebhookAuthorization</code></a>
+</td>
+<td><p>webhook contains settings related to Webhook authorization.</p>
+</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+### `KubeletAuthorizationMode`     {#kubelet-config-k8s-io-v1beta1-KubeletAuthorizationMode}
+    
+(Alias of `string`)
+
+
+**Appears in:**
+
+- [KubeletAuthorization](#kubelet-config-k8s-io-v1beta1-KubeletAuthorization)
+
+
+
+    
+
+
+### `KubeletWebhookAuthentication`     {#kubelet-config-k8s-io-v1beta1-KubeletWebhookAuthentication}
+    
+
+
+
+**Appears in:**
+
+- [KubeletAuthentication](#kubelet-config-k8s-io-v1beta1-KubeletAuthentication)
+
+
+<table class="table table-striped">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td style="white-space: pre"><code>enabled</code></br>
+<code>bool</code>
+</td>
+<td><p>enabled allows bearer token authentication backed by the tokenreviews.authentication.k8s.io API</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>cacheTTL</code></br>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td><p>cacheTTL enables caching of authentication results</p>
+</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+### `KubeletWebhookAuthorization`     {#kubelet-config-k8s-io-v1beta1-KubeletWebhookAuthorization}
+    
+
+
+
+**Appears in:**
+
+- [KubeletAuthorization](#kubelet-config-k8s-io-v1beta1-KubeletAuthorization)
+
+
+<table class="table table-striped">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td style="white-space: pre"><code>cacheAuthorizedTTL</code></br>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td><p>cacheAuthorizedTTL is the duration to cache 'authorized' responses from the webhook authorizer.</p>
+</td>
+</tr>
+    
+  
+<tr><td style="white-space: pre"><code>cacheUnauthorizedTTL</code></br>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td><p>cacheUnauthorizedTTL is the duration to cache 'unauthorized' responses from the webhook authorizer.</p>
+</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+### `KubeletX509Authentication`     {#kubelet-config-k8s-io-v1beta1-KubeletX509Authentication}
+    
+
+
+
+**Appears in:**
+
+- [KubeletAuthentication](#kubelet-config-k8s-io-v1beta1-KubeletAuthentication)
+
+
+<table class="table table-striped">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td style="white-space: pre"><code>clientCAFile</code></br>
+<code>string</code>
+</td>
+<td><p>clientCAFile is the path to a PEM-encoded certificate bundle. If set, any request presenting a client certificate
+signed by one of the authorities in the bundle is authenticated with a username corresponding to the CommonName,
+and groups corresponding to the Organization in the client certificate.</p>
+</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+### `ResourceChangeDetectionStrategy`     {#kubelet-config-k8s-io-v1beta1-ResourceChangeDetectionStrategy}
+    
+(Alias of `string`)
+
+
+**Appears in:**
+
+- [KubeletConfiguration](#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
+<p>ResourceChangeDetectionStrategy denotes a mode in which internal
+managers (secret, configmap) are discovering object changes.</p>
+
+
+
+    
+  
+  
+    
+
+### `LoggingConfiguration`     {#LoggingConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeletConfiguration](#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
+<p>LoggingConfiguration contains logging options</p>
+
+
+<table class="table table-striped">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td style="white-space: pre"><code>format</code><span style="color:blue;">&ast;</span></br>
+<code>string</code>
+</td>
+<td><p>Format Flag specifies the structure of log messages.
+default value of format is <code>text</code>
+Refer <a href="https://github.com/kubernetes/component-base/blob/master/logs/options.go">Logs Options</a> for more information.</p>
+</td>
+</tr>
+    
+  
+</tbody>
+</table>


### PR DESCRIPTION
This is a reference for kubelet config generated from
github.com/tengqm/genref tool using the following command:

```
./genref -format markdown -include kubelet-config
```