### PR TITLE
Update URL of krew plugin list

### DIFF
--- a/content/en/docs/tasks/extend-kubectl/kubectl-plugins.md
+++ b/content/en/docs/tasks/extend-kubectl/kubectl-plugins.md
@@ -32,7 +32,7 @@ using [Krew](https://krew.dev/). Krew is a plugin manager maintained by
 the Kubernetes SIG CLI community.
 
 {{< caution >}}
-Kubectl plugins available via the Krew [plugin index](https://index.krew.dev/)
+Kubectl plugins available via the Krew [plugin index](https://krew.sigs.k8s.io/plugins/)
 are not audited for security. You should install and run third-party plugins at your
 own risk, since they are arbitrary programs running on your machine.
 {{< /caution >}}
@@ -46,7 +46,7 @@ A warning will also be included for any valid plugin files that overlap each oth
 
 You can use [Krew](https://krew.dev/) to discover and install `kubectl`
 plugins from a community-curated
-[plugin index](https://index.krew.dev/).
+[plugin index](https://krew.sigs.k8s.io/plugins/).
 
 #### Limitations
 
@@ -354,7 +354,7 @@ package it, distribute it and deliver updates to your users.
 distribute your plugins. This way, you use a single packaging format for all
 target platforms (Linux, Windows, macOS etc) and deliver updates to your users.
 Krew also maintains a [plugin
-index](https://index.krew.dev/) so that other people can
+index](https://krew.sigs.k8s.io/plugins/) so that other people can
 discover your plugin and install it.
 
 


### PR DESCRIPTION
This PR update URL of the krew plugin list:
https://index.krew.dev/ → https://krew.sigs.k8s.io/plugins/

The krew plugin list had been moved from `README.md` on GitHub to the krew website by this PR: kubernetes-sigs/krew#658

Target page: https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/
Page preview: https://deploy-preview-25105--kubernetes-io-master-staging.netlify.app/docs/tasks/extend-kubectl/kubectl-plugins/

**How to test the change**
1. Search "plugin index" on the page
2. You should find 3 links
3. Click each link and check if the plugin list page is shown