### PR TITLE
Add a mapping table from docker cli to crictl in crictl debugging doc

### DIFF
--- a/content/en/blog/_posts/2020-12-02-dockershim-faq.md
+++ b/content/en/blog/_posts/2020-12-02-dockershim-faq.md
@@ -140,7 +140,7 @@ runtime where possible.
 
 Another thing to look out for is anything expecting to run for system maintenance
 or nested inside a container when building images will no longer work. For the
-former, you can use the [`crictl`][cr] tool as a drop-in replacement and for the
+former, you can use the [`crictl`][cr] tool as a drop-in replacement (see [mapping from docker cli to crictl](https://kubernetes.io/docs/tasks/debug-application-cluster/crictl/#mapping-from-docker-cli-to-crictl)) and for the
 latter you can use newer container build options like [img], [buildah], or
 [kaniko] that don’t require Docker.
 

--- a/content/en/docs/tasks/debug-application-cluster/crictl.md
+++ b/content/en/docs/tasks/debug-application-cluster/crictl.md
@@ -367,15 +367,15 @@ Warn: the output format of CRICTL is similar to Docker CLI, despite some missing
 {{< table caption="mapping from docker cli to crictl - retrieve debugging information" >}}
 docker cli | crictl | Description | Unsupported Features
 -- | -- | -- | --
-attach | attach | Attach to a running container | `--detach-keys`, `--sig-proxy`
-exec | exec | Run a command in a running container | `--privileged`, `--user`, `--detach-keys`
-images | images | List images |  
-info | info | Display system-wide information |  
-inspect | inspectinspecti | Return low-level information on a container, image or task |  
-logs | logs | Fetch the logs of a container | `--details`
-ps | ps | List containers |  
-stats | stats | Display a live stream of container(s) resource usage statistics | Column: NET/BLOCK I/O, PIDs
-version | version | Show the runtime (Docker, ContainerD, or others) version information |  
+`attach` | `attach` | Attach to a running container | `--detach-keys`, `--sig-proxy`
+`exec` | `exec` | Run a command in a running container | `--privileged`, `--user`, `--detach-keys`
+`images` | `images` | List images |  
+`info` | `info` | Display system-wide information |  
+`inspect` | `inspect`, `inspecti` | Return low-level information on a container, image or task |  
+`logs` | `logs` | Fetch the logs of a container | `--details`
+`ps` | `ps` | List containers |  
+`stats` | `stats` | Display a live stream of container(s) resource usage statistics | Column: NET/BLOCK I/O, PIDs
+`version` | `version` | Show the runtime (Docker, ContainerD, or others) version information |  
 {{< /table >}}
 
 ### Perform Changes
@@ -383,15 +383,15 @@ version | version | Show the runtime (Docker, ContainerD, or others) version inf
 {{< table caption="mapping from docker cli to crictl - perform changes" >}}
 docker cli | crictl | Description | Unsupported Features
 -- | -- | -- | --
-create | create | Create a new container |  
-kill | stop (timeout = 0) | Kill one or more running container | `--signal`
-pull | pull | Pull an image or a repository from a registry | `--all-tags`, `--disable-content-trust`
-rm | rm | Remove one or more containers |  
-rmi | rmi | Remove one or more images |  
-run | run | Run a command in a new container |  
-start | start | Start one or more stopped containers | `--detach-keys`
-stop | stop | Stop one or more running containers |  
-update | update | Update configuration of one or more containers | `--restart`, `--blkio-weight` and some other resource limit not supported by CRI.
+`create` | `create` | Create a new container |  
+`kill` | `stop` (timeout = 0) | Kill one or more running container | `--signal`
+`pull` | `pull` | Pull an image or a repository from a registry | `--all-tags`, `--disable-content-trust`
+`rm` | `rm` | Remove one or more containers |  
+`rmi` | `rmi` | Remove one or more images |  
+`run` | `run` | Run a command in a new container |  
+`start` | `start` | Start one or more stopped containers | `--detach-keys`
+`stop` | `stop` | Stop one or more running containers |  
+`update` | `update` | Update configuration of one or more containers | `--restart`, `--blkio-weight` and some other resource limit not supported by CRI.
 {{< /table >}}
 
 ### Supported only in crictl
@@ -399,11 +399,11 @@ update | update | Update configuration of one or more containers | `--restart`, 
 {{< table caption="mapping from docker cli to crictl - supported only in crictl" >}}
 crictl | Description
 -- | --
-imagefsinfo | Return image filesystem info
-inspectp | Display the status of one or more pods
-port-forward | Forward local port to a pod
-pods | List pods
-runp | Run a new pod
-rmp | Remove one or more pods
-stopp | Stop one or more running pods
+`imagefsinfo` | Return image filesystem info
+`inspectp` | Display the status of one or more pods
+`port-forward` | Forward local port to a pod
+`pods` | List pods
+`runp` | Run a new pod
+`rmp` | Remove one or more pods
+`stopp` | Stop one or more running pods
 {{< /table >}}

--- a/content/en/docs/tasks/debug-application-cluster/crictl.md
+++ b/content/en/docs/tasks/debug-application-cluster/crictl.md
@@ -364,35 +364,39 @@ Warn: the output format of CRICTL is similar to Docker CLI, despite some missing
 
 ### Retrieve Debugging Information
 
-
+{{< table caption="mapping from docker cli to crictl - retrieve debugging information" >}}
 docker cli | crictl | Description | Unsupported Features
 -- | -- | -- | --
-attach | attach | Attach to a running container | --detach-keys, --sig-proxy
-exec | exec | Run a command in a running container | --privileged, --user, --detach-keys
+attach | attach | Attach to a running container | `--detach-keys`, `--sig-proxy`
+exec | exec | Run a command in a running container | `--privileged`, `--user`, `--detach-keys`
 images | images | List images |  
 info | info | Display system-wide information |  
 inspect | inspectinspecti | Return low-level information on a container, image or task |  
-logs | logs | Fetch the logs of a container | --details
+logs | logs | Fetch the logs of a container | `--details`
 ps | ps | List containers |  
 stats | stats | Display a live stream of container(s) resource usage statistics | Column: NET/BLOCK I/O, PIDs
 version | version | Show the runtime (Docker, ContainerD, or others) version information |  
+{{< /table >}}
 
 ### Perform Changes
 
+{{< table caption="mapping from docker cli to crictl - perform changes" >}}
 docker cli | crictl | Description | Unsupported Features
 -- | -- | -- | --
 create | create | Create a new container |  
-kill | stop (timeout = 0) | Kill one or more running container | --signal
-pull | pull | Pull an image or a repository from a registry | --all-tags, --disable-content-trust
+kill | stop (timeout = 0) | Kill one or more running container | `--signal`
+pull | pull | Pull an image or a repository from a registry | `--all-tags`, `--disable-content-trust`
 rm | rm | Remove one or more containers |  
 rmi | rmi | Remove one or more images |  
 run | run | Run a command in a new container |  
-start | start | Start one or more stopped containers | --detach-keys
+start | start | Start one or more stopped containers | `--detach-keys`
 stop | stop | Stop one or more running containers |  
-update | update | Update configuration of one or more containers | --restart, --blkio-weight and some other resource limit not supported by CRI.
+update | update | Update configuration of one or more containers | `--restart`, `--blkio-weight` and some other resource limit not supported by CRI.
+{{< /table >}}
 
 ### Supported only in crictl
 
+{{< table caption="mapping from docker cli to crictl - supported only in crictl" >}}
 crictl | Description
 -- | --
 imagefsinfo | Return image filesystem info
@@ -402,3 +406,4 @@ pods | List pods
 runp | Run a new pod
 rmp | Remove one or more pods
 stopp | Stop one or more running pods
+{{< /table >}}

--- a/content/en/docs/tasks/debug-application-cluster/crictl.md
+++ b/content/en/docs/tasks/debug-application-cluster/crictl.md
@@ -356,4 +356,49 @@ CONTAINER ID        IMAGE               CREATED              STATE              
 See [kubernetes-sigs/cri-tools](https://github.com/kubernetes-sigs/cri-tools)
 for more information.
 
+## Mapping from docker cli to crictl
 
+The exact versions for below mapping table are for docker cli v1.40 and crictl v1.19.0. Please note that the list is not exhaustive. For example, it doesn't include experimental commands of docker cli.
+
+Warn: the output format of CRICTL is similar to Docker CLI, despite some missing columns for some CLI. Make sure to check output for the specific command if your script output parsing.
+
+### Retrieve Debugging Information
+
+
+docker cli | crictl | Description | Unsupported Features
+-- | -- | -- | --
+attach | attach | Attach to a running container | --detach-keys, --sig-proxy
+exec | exec | Run a command in a running container | --privileged, --user, --detach-keys
+images | images | List images |  
+info | info | Display system-wide information |  
+inspect | inspectinspecti | Return low-level information on a container, image or task |  
+logs | logs | Fetch the logs of a container | --details
+ps | ps | List containers |  
+stats | stats | Display a live stream of container(s) resource usage statistics | Column: NET/BLOCK I/O, PIDs
+version | version | Show the runtime (Docker, ContainerD, or others) version information |  
+
+### Perform Changes
+
+docker cli | crictl | Description | Unsupported Features
+-- | -- | -- | --
+create | create | Create a new container |  
+kill | stop (timeout = 0) | Kill one or more running container | --signal
+pull | pull | Pull an image or a repository from a registry | --all-tags, --disable-content-trust
+rm | rm | Remove one or more containers |  
+rmi | rmi | Remove one or more images |  
+run | run | Run a command in a new container |  
+start | start | Start one or more stopped containers | --detach-keys
+stop | stop | Stop one or more running containers |  
+update | update | Update configuration of one or more containers | --restart, --blkio-weight and some other resource limit not supported by CRI.
+
+### Supported only in crictl
+
+crictl | Description
+-- | --
+imagefsinfo | Return image filesystem info
+inspectp | Display the status of one or more pods
+port-forward | Forward local port to a pod
+pods | List pods
+runp | Run a new pod
+rmp | Remove one or more pods
+stopp | Stop one or more running pods


### PR DESCRIPTION
Signed-off-by: Qiutong Song <songqt01@gmail.com>

Add a mapping table from docker cli to crictl in crictl debugging doc. This table serves as a convenient reference when users want to use crictl. This is important especially if users are going to use ContainerD as the container runtime. 
