### PR TITLE
Remove automatic index from tutorials list

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/_index.html
+++ b/content/en/docs/tutorials/kubernetes-basics/_index.html
@@ -1,6 +1,7 @@
 ---
 title: Learn Kubernetes Basics
 linkTitle: Learn Kubernetes Basics
+no_list: true
 weight: 10
 card:
   name: tutorials


### PR DESCRIPTION
Added `no_list: true` to remove automatic index from tutorials list

Issue #25118

Please review
Thank you in advance