### PR TITLE
Update container-runtimes.md

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -122,7 +122,7 @@ sudo apt-get update && sudo apt-get install -y containerd.io
 ```shell
 # Configure containerd
 sudo mkdir -p /etc/containerd
-sudo containerd config default > /etc/containerd/config.toml
+sudo containerd config default | sudo tee /etc/containerd/config.toml
 ```
 
 ```shell


### PR DESCRIPTION
The current command on line 125 throws a permission error. The sudo elevation of rights applies to the containerd command, not the write (>) to a file owned by root.

This is the command as copied from the current page:
student@master:~$ **sudo containerd config default > /etc/containerd/config.toml**
-bash: /etc/containerd/config.toml: Permission denied

Instead leverage sudo tee. It works and no more error: 
student@master:~$ **containerd config default | sudo tee /etc/containerd/config.toml**
