### PR TITLE
Revert banner after KubeCon

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -157,7 +157,7 @@ github_repo = "https://github.com/kubernetes/website"
 # param for displaying an announcement block on every page.
 # See /i18n/en.toml for message text and title.
 announcement = true
-announcement_bg = "#3d4cb7" # choose a dark color – text is white
+announcement_bg = "#000000" #choose a dark color – text is white
 
 #Searching
 k8s_search = true

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,10 +1,10 @@
 # i18n strings for the English (main) site.
 # NOTE: Please keep the entries in alphabetical order when editing
 [announcement_title]
-other = "<img src=\"/images/kccnc-na-virtual-2020-white.svg\" style=\"float: right; height: 80px;\" /><a href=\"https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/?utm_source=kuberntes.io&utm_medium=search&utm_campaign=KC_CNC_Virtual\">KubeCon + CloudNativeCon NA 2020</a> <em>virtual</em>."
+other = "Black lives matter."
 
 [announcement_message]
-other = "4 days of incredible opportunities to collaborate, learn, and share with the entire community!<br />November 17 – 20 2020"
+other = "We stand in solidarity with the Black community.<br/>Racism is unacceptable.<br/> It conflicts with the [core values of the Kubernetes project](https://git.k8s.io/community/values.md) and our community does not tolerate it."
 
 [caution]
 other = "Caution:"


### PR DESCRIPTION
This reverts PR #24714, because KubeCon NA 2020 is over.