### PR TITLE
docs: add resource types reference page

### DIFF
--- a/content/en/docs/reference/resource-types/_index.md
+++ b/content/en/docs/reference/resource-types/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Resource Types
+title: Kubernetes Resource Management Types
 content_type: reference
 ---
 
@@ -15,64 +15,76 @@ cluster.
 See [Kubernetes Scheduler](/docs/concepts/scheduling-eviction/kube-scheduler/) and [Requests and Limits](/docs/concepts/configuration/manage-resources-containers/#requests-and-limits) for more details.
 
 <!-- body -->
+## Resource Types
 
-## CPU 
+### CPU
 The `cpu` resource represents CPU in cores and can be specified as either a decimal (e.g. `1`, `0.5`) or as millicores (e.g. `500m`, `1000m`). `0.5` = `500m`.
 
-You can request or limit the `cpu` resource for Pods and their containers, and any for object that embeds a [Pod template](/docs/concepts/workloads/pods/#pod-templates).
+You can request or limit the `cpu` resource for Pods and their containers, and any for object that
+embeds a [Pod template](/docs/concepts/workloads/pods/#pod-templates).
 
 When the cpu limit is reached, the Pod is throttled.
 
-See [Meaning of CPU](/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu) for more details on what CPU means in kubernetes.
+See [Meaning of CPU](/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu) for
+more details on what CPU means in kubernetes.
 
-## Memory
-The `memory` resource represents memory in bytes and is specified with a number and a binary suffix. e.g. `500Mi` = `500MiB` = `500 * 1024 * 1024`. 
+### Memory
+The `memory` resource represents memory in bytes and is specified with a number and a binary
+suffix. e.g. `500Mi` = `500MiB` = `500 * 1024 * 1024`.
 
-You can request or limit the `memory` resource in Pods and their containers, and any object that embeds a Pod template.
+You can request or limit the `memory` resource in Pods and their containers, and any object that
+embeds a Pod template.
 
-In contrast with cpu, when the memory limit is reached, the 
-Pod is killed.
+If a container or Pod tries to use more memory than the configured limit, the
+container runtime and / or host operating system kernel typically intervenes by
+stopping a process in that Pod. That mechanism is called
+“out of memory kill”, and is different from how CPU resource limits are handled
+(CPU limits are enforced using time-slicing, whereas memory limits are enforced
+by stopping containers that try to violate them).
 
 See [Meaning of Memory](/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory) for more details on what memory means in kubernetes.
 
-## Storage 
-The `storage` resource represents volume size in bytes and is specified with a number and a binary suffix. e.g. `500Gi` = `500GiB` = `500 * 1024 * 1024 * 1024`
+### Storage
+The `storage` resource represents volume size in bytes and is specified with a number and a binary
+suffix. e.g. `500Gi` = `500GiB` = `500 * 1024 * 1024 * 1024`
 
-You can use the `storage` resource in a [PersistentVolumeClaim](/docs/concepts/storage/persistent-volumes/#introduction).
+You can use the `storage` resource in a
+{{< glossary_tooltip text="PersistentVolumeClaim" term_id="persistent-volume-claim" >}}.
 
-## Huge pages
+### Huge pages {#hugepages-all}
 
-On Kubernetes v1.14 and newer you can request the `hugepages-*` 
-resource. Huge pages are a Linux-specific feature where the node 
-kernel allocates blocks of memory that are much larger than the 
-default page size.
+Huge pages are a Linux-specific feature where the node
+kernel allocates blocks of memory that are much larger than the
+default page size. You can set requests or limits for particular sizes
+of huge page.
 
 You cannot overcommit `hugepages-*` resources. This is different from the `memory` and `cpu` resources.
 
 You request huge pages with a combination of two binary
-suffixes. The first is part of the resource name in the request: 
-e.g. `hugepages-2Mi`. It specifies the size of the pages. The second part is the value of allocatable pages e.g. `80Mi`. 
+suffixes. The first is part of the resource name in the request:
+e.g. `hugepages-2Mi`. It specifies the size of the pages. The second part is the value of allocatable pages e.g. `80Mi`.
 
-## Ephemeral storage
+### Ephemeral storage
 
-Ephemeral storage is storage provided to pods that has no 
+Ephemeral storage is storage provided to pods that has no
 long-term guarantee of durability. Empheral Storage is in beta.
-Empheral storage is represented in bytes and is specified with a 
-number and a binary suffix. e.g. `500Mi` = `500MiB` = `500 * 1024 * 1024`. 
+Empheral storage is represented in bytes and is specified with a
+number and a binary suffix. e.g. `500Mi` = `500MiB` = `500 * 1024 * 1024`.
 
 You can specify the `ephemeral-storage` resource in Pods and any object that embeds a Pod template.
 
 See [Local ephemeral storage](/docs/concepts/configuration/manage-resources-containers/#local-ephemeral-storage) for more details.
 
-## Extended Resources
+### Extended Resources
 
-Extended resources are fully-qualified resource names outside the kubernetes.io domain. 
-They allow cluster operators to advertise and users to consume the non-Kubernetes-built-in resources.
+Extended resources are fully-qualified resource names outside the kubernetes.io domain.
+They allow cluster operators to advertise and users to consume the non-Kubernetes-built-in
+resources.
 
 See [Extended Resources](/docs/concepts/configuration/manage-resources-containers/#extended-resources) for more information.
 
 ## Examples
-### CPU and memory
+### CPU and memory  {#example-cpu-memory}
 
 ```yaml
 apiVersion: v1
@@ -89,7 +101,7 @@ spec:
     memory: 500Mi
 ```
 
-### Storage
+### Storage {#example-storage}
 
 ```yaml
 apiVersion: v1
@@ -102,7 +114,7 @@ spec:
     storage: 20Gi
 ```
 
-### Huge pages
+### Huge pages {#example-hugepages}
 ```yaml
 apiVersion: v1
 kind: Pod
@@ -116,7 +128,7 @@ spec:
     hugepages-2Mi: 100Mi
 ```
 
-### Ephemeral Storage
+### Ephemeral storage {#example-ephemeral-storage}
 
 ```yaml
 apiVersion: v1

--- a/content/en/docs/reference/resource-types/_index.md
+++ b/content/en/docs/reference/resource-types/_index.md
@@ -42,7 +42,8 @@ stopping a process in that Pod. That mechanism is called
 (CPU limits are enforced using time-slicing, whereas memory limits are enforced
 by stopping containers that try to violate them).
 
-See [Meaning of Memory](/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory) for more details on what memory means in kubernetes.
+See [Meaning of Memory](/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory)
+for more details on what memory means in kubernetes.
 
 ### Storage
 The `storage` resource represents volume size in bytes and is specified with a number and a binary

--- a/content/en/docs/reference/resource-types/_index.md
+++ b/content/en/docs/reference/resource-types/_index.md
@@ -16,6 +16,7 @@ Resource requests on Pods are an integral part of scheduling and
 limiting and managing resource consumption in a Kubernetes 
 cluster. 
 See [Kubernetes Scheduler](/docs/concepts/scheduling-eviction/kube-scheduler/) and [Requests and Limits](/docs/concepts/configuration/manage-resources-containers/#requests-and-limits) for more details.
+
 ## CPU 
 The `cpu` resource represents CPU in cores and can be specified as either a decimal (e.g. `1`, `0.5`) or as millicores (e.g. `500m`, `1000m`). `0.5` = `500m`.
 

--- a/content/en/docs/reference/resource-types/_index.md
+++ b/content/en/docs/reference/resource-types/_index.md
@@ -9,24 +9,62 @@ This page provides information on the different resource types you can request, 
 
 <!-- body -->
 
-There are 3 different resource types: `cpu`, `memory`, and `storage`.
+There are several different resource types: `cpu`, `memory`, `storage`, `hugepages-*`, and `emphemeral-storage`.
 
+
+Resource requests on Pods are an integral part of scheduling and 
+limiting and managing resource consumption in a Kubernetes 
+cluster. 
+See [Kubernetes Scheduler](/docs/concepts/scheduling-eviction/kube-scheduler/) and [Requests and Limits](/docs/concepts/configuration/manage-resources-containers/#requests-and-limits) for more details.
 ## CPU 
 The `cpu` resource represents CPU in cores and can be specified as either a decimal (e.g. `1`, `0.5`) or as millicores (e.g. `500m`, `1000m`). `0.5` = `500m`.
 
-You can request or limit the `cpu` resource for Pods and their containers, and any for object that embeds a [Pod template](https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates).
+You can request or limit the `cpu` resource for Pods and their containers, and any for object that embeds a [Pod template](/docs/concepts/workloads/pods/#pod-templates).
+
+When the cpu limit is reached, the Pod is throttled.
+
+See [Meaning of CPU](/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu) for more details on what CPU means in kubernetes.
 
 ## Memory
 The `memory` resource represents memory in bytes and is specified with a number and a binary suffix. e.g. `500Mi` = `500MiB` = `500 * 1024 * 1024`. 
 
-You can use the memory resource in Pods and any object that embeds a Pod template.
+You can request or limit the `memory` resource in Pods and their containers, and any object that embeds a Pod template.
+
+In contrast with cpu, when the memory limit is reached, the 
+Pod is killed.
+
+See [Meaning of Memory](/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory) for more details on what memory means in kubernetes.
 
 ## Storage 
 The `storage` resource represents volume size in bytes and is specified with a number and a binary suffix. e.g. `500Gi` = `500GiB` = `500 * 1024 * 1024 * 1024`
 
-You can use the `storage` resource in a PersistentVolumeClaim.
+You can use the `storage` resource in a [PersistentVolumeClaim](/docs/concepts/storage/persistent-volumes/#introduction).
 
-Examples: 
+## Huge pages
+
+On Kubernetes v1.14 and newer you can request the `hugepages-*` 
+resource. Huge pages are a Linux-specific feature where the node 
+kernel allocates blocks of memory that are much larger than the 
+default page size.
+
+You cannot overcommit `hugepages-*` resources. This is different from the `memory` and `cpu` resources.
+
+You request huge pages with a combination of two binary
+suffixes. The first is part of the resource name in the request: 
+e.g. `hugepages-2Mi`. It specifies the size of the pages. The second part is the value of allocatable pages e.g. `80Mi`. 
+
+## Emphemeral storage
+
+Emphemeral storage is storage provided to pods that has no 
+long-term gurantee of durablity. Empheral Storage is in beta. 
+Empheral storage is represented in bytes and is specified with a 
+number and a binary suffix. e.g. `500Mi` = `500MiB` = `500 * 1024 * 1024`. 
+
+You can specify the `ephemeral-storage` resource in Pods and any object that embeds a Pod template.
+
+See [Local emphemeral storage](/docs/concepts/configuration/manage-resources-containers/#local-ephemeral-storage) for more details.
+
+## Examples
 ### CPU and memory
 
 ```yaml
@@ -55,4 +93,33 @@ spec:
   ...
   requests:
     storage: 20Gi
+```
+
+### Huge pages
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  ...
+spec:
+  ...
+  requests:
+    hugepages-2Mi: 80Mi
+  limits:
+    hugepages-2Mi: 100Mi
+```
+
+### Emphemeral Storage
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  ...
+spec:
+  ...
+  requests:
+    emphemeral-storage: 100Mi
+  limits:
+    emphemeral-storage: 500Mi
 ```

--- a/content/en/docs/reference/resource-types/_index.md
+++ b/content/en/docs/reference/resource-types/_index.md
@@ -1,10 +1,11 @@
 ---
 title: Resource Types
+content_type: reference
 ---
 
 <!-- overview -->
 
-This section provides information on the different resource types you can request, built into Kubernetes.
+This page provides information on the different resource types you can request, built into Kubernetes.
 
 <!-- body -->
 
@@ -13,7 +14,7 @@ There are 3 different resource types: `cpu`, `memory`, and `storage`.
 ## CPU 
 The `cpu` resource represents CPU in cores and can be specified as either a decimal (e.g. `1`, `0.5`) or as millicores (e.g. `500m`, `1000m`). `0.5` = `500m`.
 
-You can use the cpu resource in Pods and any object that embeds a Pod template.
+You can request or limit the `cpu` resource for Pods and their containers, and any for object that embeds a [Pod template](https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates).
 
 ## Memory
 The `memory` resource represents memory in bytes and is specified with a number and a binary suffix. e.g. `500Mi` = `500MiB` = `500 * 1024 * 1024`. 
@@ -23,10 +24,10 @@ You can use the memory resource in Pods and any object that embeds a Pod templat
 ## Storage 
 The `storage` resource represents volume size in bytes and is specified with a number and a binary suffix. e.g. `500Gi` = `500GiB` = `500 * 1024 * 1024 * 1024`
 
-You can use the storage resource in PersistentVolumeClaims.
+You can use the `storage` resource in a PersistentVolumeClaim.
 
 Examples: 
-### CPU and Memory
+### CPU and memory
 
 ```yaml
 apiVersion: v1

--- a/content/en/docs/reference/resource-types/_index.md
+++ b/content/en/docs/reference/resource-types/_index.md
@@ -1,0 +1,57 @@
+---
+title: Resource Types
+---
+
+<!-- overview -->
+
+This section provides information on the different resource types you can request, built into Kubernetes.
+
+<!-- body -->
+
+There are 3 different resource types: `cpu`, `memory`, and `storage`.
+
+## CPU 
+The `cpu` resource represents CPU in cores and can be specified as either a decimal (e.g. `1`, `0.5`) or as millicores (e.g. `500m`, `1000m`). `0.5` = `500m`.
+
+You can use the cpu resource in Pods and any object that embeds a Pod template.
+
+## Memory
+The `memory` resource represents memory in bytes and is specified with a number and a binary suffix. e.g. `500Mi` = `500MiB` = `500 * 1024 * 1024`. 
+
+You can use the memory resource in Pods and any object that embeds a Pod template.
+
+## Storage 
+The `storage` resource represents volume size in bytes and is specified with a number and a binary suffix. e.g. `500Gi` = `500GiB` = `500 * 1024 * 1024 * 1024`
+
+You can use the storage resource in PersistentVolumeClaims.
+
+Examples: 
+### CPU and Memory
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  ...
+spec:
+  ...
+  requests:
+    cpu: 500m
+    memory: 250Mi
+  limits:
+    cpu: 700m
+    memory: 500Mi
+```
+
+### Storage
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  ...
+spec:
+  ...
+  requests:
+    storage: 20Gi
+```

--- a/content/en/docs/reference/resource-types/_index.md
+++ b/content/en/docs/reference/resource-types/_index.md
@@ -64,6 +64,13 @@ You can specify the `ephemeral-storage` resource in Pods and any object that emb
 
 See [Local ephemeral storage](/docs/concepts/configuration/manage-resources-containers/#local-ephemeral-storage) for more details.
 
+## Extended Resources
+
+Extended resources are fully-qualified resource names outside the kubernetes.io domain. 
+They allow cluster operators to advertise and users to consume the non-Kubernetes-built-in resources.
+
+See [Extended Resources](/docs/concepts/configuration/manage-resources-containers/#extended-resources) for more information.
+
 ## Examples
 ### CPU and memory
 

--- a/content/en/docs/reference/resource-types/_index.md
+++ b/content/en/docs/reference/resource-types/_index.md
@@ -7,15 +7,14 @@ content_type: reference
 
 This page provides information on the different resource types you can request, built into Kubernetes.
 
-<!-- body -->
-
-There are several different resource types: `cpu`, `memory`, `storage`, `hugepages-*`, and `emphemeral-storage`.
-
+There are several different resource types: `cpu`, `memory`, `storage`, `hugepages-*`, and `ephemeral-storage`.
 
 Resource requests on Pods are an integral part of scheduling and 
 limiting and managing resource consumption in a Kubernetes 
 cluster. 
 See [Kubernetes Scheduler](/docs/concepts/scheduling-eviction/kube-scheduler/) and [Requests and Limits](/docs/concepts/configuration/manage-resources-containers/#requests-and-limits) for more details.
+
+<!-- body -->
 
 ## CPU 
 The `cpu` resource represents CPU in cores and can be specified as either a decimal (e.g. `1`, `0.5`) or as millicores (e.g. `500m`, `1000m`). `0.5` = `500m`.
@@ -54,16 +53,16 @@ You request huge pages with a combination of two binary
 suffixes. The first is part of the resource name in the request: 
 e.g. `hugepages-2Mi`. It specifies the size of the pages. The second part is the value of allocatable pages e.g. `80Mi`. 
 
-## Emphemeral storage
+## Ephemeral storage
 
-Emphemeral storage is storage provided to pods that has no 
-long-term gurantee of durablity. Empheral Storage is in beta. 
+Ephemeral storage is storage provided to pods that has no 
+long-term guarantee of durability. Empheral Storage is in beta.
 Empheral storage is represented in bytes and is specified with a 
 number and a binary suffix. e.g. `500Mi` = `500MiB` = `500 * 1024 * 1024`. 
 
 You can specify the `ephemeral-storage` resource in Pods and any object that embeds a Pod template.
 
-See [Local emphemeral storage](/docs/concepts/configuration/manage-resources-containers/#local-ephemeral-storage) for more details.
+See [Local ephemeral storage](/docs/concepts/configuration/manage-resources-containers/#local-ephemeral-storage) for more details.
 
 ## Examples
 ### CPU and memory
@@ -110,7 +109,7 @@ spec:
     hugepages-2Mi: 100Mi
 ```
 
-### Emphemeral Storage
+### Ephemeral Storage
 
 ```yaml
 apiVersion: v1
@@ -120,7 +119,7 @@ metadata:
 spec:
   ...
   requests:
-    emphemeral-storage: 100Mi
+    ephemeral-storage: 100Mi
   limits:
-    emphemeral-storage: 500Mi
+    ephemeral-storage: 500Mi
 ```


### PR DESCRIPTION
Going off of what was discussed in #22298, I created a new
page to describe the different resource types available in Kubernetes.

I only included the resource names that had the `v1.ResourceName` type excluding
`ephemeral-storage` because it was labeled as alpha.

I wasn't sure how the `v1.ResourceName` towards the [bottom](https://github.com/kubernetes/kubernetes/blob/b2ecd1b3a3192fbbe2b9e348e095326f51dc43dd/staging/src/k8s.io/api/core/v1/types.go#L5568)
of the files were used so I did not include them.

I'm looking to see if I'm headed in the right direction. 

I'm still going through the style [guide](https://kubernetes.io/docs/contribute/style/style-guide/).

Closes #22298

