### PR TITLE
Replace the sequence diagram on authentication page using Mermaid

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -71,6 +71,22 @@ body.td-404 main .error-details {
   max-width: 80%;
   border: 1px solid rgb(222, 226, 230);
   border-radius: 5px;
+  margin-bottom: 1rem;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+
+  // mermaid diagram - sequence diagram
+  .actor {
+    fill: #326ce5 !important;
+  }
+  text.actor {
+    font-size: 18px !important;
+    stroke: white !important;
+    fill: white !important;
+  }
+  .activation0 {
+    fill: #c9e9ec !important;
+  }
 }
 
 /* HEADER */

--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -282,7 +282,33 @@ from the OAuth2 [token response](https://openid.net/specs/openid-connect-core-1_
 as a bearer token.  See [above](#putting-a-bearer-token-in-a-request) for how the token
 is included in a request.
 
-![Kubernetes OpenID Connect Flow](/images/docs/admin/k8s_oidc_login.svg)
+{{< mermaid >}}
+sequenceDiagram
+    participant user as User
+    participant idp as Identity Provider
+    participant kube as Kubectl
+    participant api as API Server
+
+    user ->> idp: 1. Login to IdP
+    activate idp
+    idp -->> user: 2. Provide access_token,<br>id_token, and refresh_token
+    deactivate idp
+    activate user
+    user ->> kube: 3. Call Kubectl<br>with --token being the id_token<br>OR add tokens to .kube/config
+    deactivate user
+    activate kube
+    kube ->> api: 4. Authorization: Bearer...
+    deactivate kube
+    activate api
+    api ->> api: 5. Is JWT signature valid?
+    api ->> api: 6. Has the JWT expired?(iat+exp)
+    api ->> api: 7. user authorized?
+    api -->> kube: 8. Authorized: Perform<br>action and return result
+    deactivate api
+    activate kube
+    kube --x user: 9. Return result
+    deactivate kube
+{{< /mermaid >}}
 
 1.  Login to your identity provider
 2.  Your identity provider will provide you with an `access_token`, `id_token` and a `refresh_token`


### PR DESCRIPTION
Fixes #25179.

This PR replaces the sequence diagram on [authentication page](https://kubernetes.io/docs/reference/access-authn-authz/authentication/) with the one by [mermaid](https://mermaid-js.github.io/mermaid/#/sequenceDiagram). This is the follow-up of #25168.

**Preview**
https://deploy-preview-25181--kubernetes-io-master-staging.netlify.app/docs/reference/access-authn-authz/authentication/#openid-connect-tokens

**Screenshot**
above: current diagram
below: new diagram using Mermaid

![Screenshot from 2020-11-23 14-12-08](https://user-images.githubusercontent.com/1425259/99930870-f775c680-2d95-11eb-94bb-7e2720f08592.png)

**Comments**
I'm not sure both cross representation (×) at the last reply has the same meaning.