### PR TITLE
volume stats agg period should be disabled when value is negative

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/kubelet.md
+++ b/content/en/docs/reference/command-line-tools-reference/kubelet.md
@@ -1364,7 +1364,7 @@ Insecure values: TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, TLS_ECDHE_ECDSA_WITH_R
 <td colspan="2">--volume-stats-agg-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: `1m0s`</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">Specifies interval for kubelet to calculate and cache the volume disk usage for all pods and volumes. To disable volume calculations, set to `0`. (DEPRECATED: This parameter should be set via the config file specified by the Kubelet's `--config` flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.)</td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">Specifies interval for kubelet to calculate and cache the volume disk usage for all pods and volumes. To disable volume calculations, set to a negative value. (DEPRECATED: This parameter should be set via the config file specified by the Kubelet's `--config` flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.)</td>
 </tr>
 </tbody>
 </table>

--- a/content/zh/docs/reference/command-line-tools-reference/kubelet.md
+++ b/content/zh/docs/reference/command-line-tools-reference/kubelet.md
@@ -2154,7 +2154,7 @@ comma-separated list of pattern=N settings for file-filtered logging
 <!--
 Specifies interval for kubelet to calculate and cache the volume disk usage for all pods and volumes. To disable volume calculations, set to 0. (default 1m0s) (DEPRECATED: This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.)
 -->
-指定 kubelet 计算和缓存所有 Pod 和卷的磁盘用量总值的时间间隔。要禁用磁盘用量计算，请设置为 0。（默认值为 1m0s）（已弃用：在 --config 指定的配置文件中进行设置。有关更多信息，请参阅 https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/。）
+指定 kubelet 计算和缓存所有 Pod 和卷的磁盘用量总值的时间间隔。要禁用磁盘用量计算，请设置为负数，如`-1s`。（默认值为 1m0s）（已弃用：在 --config 指定的配置文件中进行设置。有关更多信息，请参阅 https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/。）
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
fix https://github.com/kubernetes/kubernetes/issues/96674

1. When I set it to -1s, kubelet log showsVolume stats collection disabled. during startup.
2. When I set it to '0', kubelet log doesn't showsVolume stats collection disabled. during startup. (Not disabled)
3. When I set it to '1s', kubelet log doesn't showsVolume stats collection disabled. during startup.
4. When I don't set it, kubelet log doesn't showsVolume stats collection disabled. during startup.

The second result is not the same as the doc. 
```
To disable volume calculations, set to `0`.
```

you may check https://github.com/kubernetes/kubernetes/pull/96675 for more details.