### PR TITLE
Get node output to list for scp

### DIFF
--- a/content/en/docs/concepts/containers/images.md
+++ b/content/en/docs/concepts/containers/images.md
@@ -121,8 +121,8 @@ example, run these on your desktop/laptop:
    1. Run `docker login [server]` for each set of credentials you want to use.  This updates `$HOME/.docker/config.json` on your PC.
    1. View `$HOME/.docker/config.json` in an editor to ensure it contains just the credentials you want to use.
    1. Get a list of your nodes; for example:
-      - if you want the names: `nodes=$( kubectl get nodes -o jsonpath='{range.items[*].metadata}{.name} {end}' )`
-      - if you want to get the IP addresses: `nodes=$( kubectl get nodes -o jsonpath='{range .items[*].status.addresses[?(@.type=="ExternalIP")]}{.address} {end}' )`
+      - if you want the names: `nodes=($( kubectl get nodes -o jsonpath='{range.items[*].metadata}{.name} {end}' ))`
+      - if you want to get the IP addresses: `nodes=($( kubectl get nodes -o jsonpath='{range .items[*].status.addresses[?(@.type=="ExternalIP")]}{.address} {end}' ))`
    1. Copy your local `.docker/config.json` to one of the search paths list above.
       - for example, to test this out: `for n in $nodes; do scp ~/.docker/config.json root@"$n":/var/lib/kubelet/config.json; done`
 

--- a/content/zh/docs/concepts/containers/images.md
+++ b/content/zh/docs/concepts/containers/images.md
@@ -258,9 +258,9 @@ example, run these on your desktop/laptop:
    使用的凭据信息。
 1. 获得节点列表；例如：
 
-   - 如果想要节点名称：`nodes=$(kubectl get nodes -o jsonpath='{range.items[*].metadata}{.name} {end}')`
+   - 如果想要节点名称：`nodes=($(kubectl get nodes -o jsonpath='{range.items[*].metadata}{.name} {end}'))`
 
-   - 如果想要节点 IP ，`nodes=$(kubectl get nodes -o jsonpath='{range .items[*].status.addresses[?(@.type=="ExternalIP")]}{.address} {end}')`
+   - 如果想要节点 IP ，`nodes=($(kubectl get nodes -o jsonpath='{range .items[*].status.addresses[?(@.type=="ExternalIP")]}{.address} {end}'))`
 
 1. 将本地的 `.docker/config.json` 拷贝到所有节点，放入如上所列的目录之一：
    - 例如，可以试一下：`for n in $nodes; do scp ~/.docker/config.json root@"$n":/var/lib/kubelet/config.json; done`


### PR DESCRIPTION
This change allows users to use `nodes` directly for the following scp command.