### PR TITLE
Added step to create /etc/docker/ folder in Ubuntu instruction

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -408,6 +408,11 @@ sudo apt-get update && sudo apt-get install -y \
 ```
 
 ```shell
+## Create /etc/docker
+sudo mkdir /etc/docker
+```
+
+```shell
 # Set up the Docker daemon
 cat <<EOF | sudo tee /etc/docker/daemon.json
 {


### PR DESCRIPTION
The "Set up the Docker daemon" step fails because the initial files have not been created. I added the "Start Docker deamon to create initial files" step to deal with this. Tested this, works like a charm.