### PR TITLE
Updating docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -330,8 +330,8 @@ seconds. Minimum value is 1.
 * `timeoutSeconds`: Number of seconds after which the probe times out. Defaults
 to 1 second. Minimum value is 1.
 * `successThreshold`: Minimum consecutive successes for the probe to be
-considered successful after having failed. Defaults to 1. Must be 1 for
-liveness. Minimum value is 1.
+considered successful after having failed. Defaults to 1. Must be 1 for liveness
+and startup Probes. Minimum value is 1.
 * `failureThreshold`: When a probe fails, Kubernetes will
 try `failureThreshold` times before giving up. Giving up in case of liveness probe means restarting the container. In case of readiness probe the Pod will be marked Unready.
 Defaults to 3. Minimum value is 1.


### PR DESCRIPTION
Adding the `successThreshold` default value for the `startupProbe` in the *Configure Probes* section.

fixes: https://github.com/kubernetes/website/issues/24049