### PR TITLE
Update ingress apiVersion on  kubernetes.io/docs/tasks/access-applica…

### DIFF
--- a/content/en/examples/service/networking/example-ingress.yaml
+++ b/content/en/examples/service/networking/example-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: example-ingress


### PR DESCRIPTION
Update ingress apiVersion on  https://kubernetes.io/docs/tasks/access-application-cluster/ingress-minikube/

NOTE: networking.k8s.io/v1 is available in Kubernetes v1.19+