### PR TITLE
Fix the text in the Mermaid diagram on the reference/access-authn-authz/authentication/ page

### DIFF
--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -301,8 +301,8 @@ sequenceDiagram
     deactivate kube
     activate api
     api ->> api: 5. Is JWT signature valid?
-    api ->> api: 6. Has the JWT expired?(iat+exp)
-    api ->> api: 7. user authorized?
+    api ->> api: 6. Has the JWT expired? (iat+exp)
+    api ->> api: 7. User authorized?
     api -->> kube: 8. Authorized: Perform<br>action and return result
     deactivate api
     activate kube


### PR DESCRIPTION
This PR fixes some text in the Mermaid diagram on [reference/access-authn-authz/authentication/](https://k8s.io/docs/reference/access-authn-authz/authentication/) is the follow-up PR for #25181.

Page preview: https://deploy-preview-25255--kubernetes-io-master-staging.netlify.app/docs/reference/access-authn-authz/authentication/#openid-connect-tokens