### PR TITLE
[zh] sync changes in docs/reference/setup-tools/kubeadm/generated/ directory

### DIFF
--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_images_list.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_images_list.md
@@ -29,6 +29,37 @@ kubeadm config images list [flags]
 <tbody>
 
 <tr>
+<td colspan="2">
+<!-- --allow-missing-template-keys&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true -->
+--allow-missing-template-keys&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值：true
+</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<!-- 
+If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
+-->
+如果设置为 true，则在模板中缺少字段或哈希表的键时忽略模板中的任何错误。
+仅适用于 golang 和 jsonpath 输出格式。
+</td>
+</tr>
+
+<tr>
+<td colspan="2">
+<!-- -o, --experimental-output string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "text" -->
+-o, --experimental-output string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值："text"
+</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<!--  
+Output format. One of: text|json|yaml|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file.
+-->
+输出格式：text|json|yaml|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file 其中之一
+</td>
+</tr>
+
+<tr>
 <td colspan="2">--config string</td>
 </tr>
 <tr>
@@ -48,7 +79,10 @@ kubeadm 配置文件的路径。
 <!--
 A set of key=value pairs that describe feature gates for various features. Options are:<br/>IPv6DualStack=true|false (ALPHA - default=false)
 -->
-一组键值对（key=value），用于描述各种特征。选项有：<br/>Auditing=true|false (ALPHA - 默认值=false)<br/>CoreDNS=true|false (默认值=true)<br/>DynamicKubeletConfig=true|false (BETA - 默认值=false)
+一组键值对（key=value），用于描述各种特征。选项是：
+<br/>Auditing=true|false (ALPHA - 默认=false)
+<br/>CoreDNS=true|false (默认=true)
+<br/>DynamicKubeletConfig=true|false (BETA - 默认=false)
 </td>
 </tr>
 
@@ -61,6 +95,19 @@ A set of key=value pairs that describe feature gates for various features. Optio
 help for list
 -->
 list 操作的帮助命令
+</td>
+</tr>
+
+<tr>
+<td colspan="2">
+<!-- --image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "k8s.gcr.io" -->
+--image-repository string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值："k8s.gcr.io"
+</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<!-- Choose a container registry to pull control plane images from -->
+选择要从中拉取控制平面镜像的容器仓库
 </td>
 </tr>
 

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init.md
@@ -18,40 +18,42 @@ The "init" command executes the following phases:
 "init" 命令执行以下阶段：
 
 ```
-preflight                  Run pre-flight checks
-kubelet-start              Write kubelet settings and (re)start the kubelet
-certs                      Certificate generation
-  /ca                        Generate the self-signed Kubernetes CA to provision identities for other Kubernetes components
-  /apiserver                 Generate the certificate for serving the Kubernetes API
-  /apiserver-kubelet-client  Generate the certificate for the API server to connect to kubelet
-  /front-proxy-ca            Generate the self-signed CA to provision identities for front proxy
-  /front-proxy-client        Generate the certificate for the front proxy client
-  /etcd-ca                   Generate the self-signed CA to provision identities for etcd
-  /etcd-server               Generate the certificate for serving etcd
-  /etcd-peer                 Generate the certificate for etcd nodes to communicate with each other
-  /etcd-healthcheck-client   Generate the certificate for liveness probes to healthcheck etcd
-  /apiserver-etcd-client     Generate the certificate the apiserver uses to access etcd
-  /sa                        Generate a private key for signing service account tokens along with its public key
-kubeconfig                 Generate all kubeconfig files necessary to establish the control plane and the admin kubeconfig file
-  /admin                     Generate a kubeconfig file for the admin to use and for kubeadm itself
-  /kubelet                   Generate a kubeconfig file for the kubelet to use *only* for cluster bootstrapping purposes
-  /controller-manager        Generate a kubeconfig file for the controller manager to use
-  /scheduler                 Generate a kubeconfig file for the scheduler to use
-control-plane              Generate all static Pod manifest files necessary to establish the control plane
-  /apiserver                 Generates the kube-apiserver static Pod manifest
-  /controller-manager        Generates the kube-controller-manager static Pod manifest
-  /scheduler                 Generates the kube-scheduler static Pod manifest
-etcd                       Generate static Pod manifest file for local etcd
-  /local                     Generate the static Pod manifest file for a local, single-node local etcd instance
-upload-config              Upload the kubeadm and kubelet configuration to a ConfigMap
-  /kubeadm                   Upload the kubeadm ClusterConfiguration to a ConfigMap
-  /kubelet                   Upload the kubelet component config to a ConfigMap
-upload-certs               Upload certificates to kubeadm-certs
-mark-control-plane         Mark a node as a control-plane
-bootstrap-token            Generates bootstrap tokens used to join a node to a cluster
-addon                      Install required addons for passing Conformance tests
-  /coredns                   Install the CoreDNS addon to a Kubernetes cluster
-  /kube-proxy                Install the kube-proxy addon to a Kubernetes cluster
+preflight                    Run pre-flight checks
+certs                        Certificate generation
+  /ca                          Generate the self-signed Kubernetes CA to provision identities for other Kubernetes components
+  /apiserver                   Generate the certificate for serving the Kubernetes API
+  /apiserver-kubelet-client    Generate the certificate for the API server to connect to kubelet
+  /front-proxy-ca              Generate the self-signed CA to provision identities for front proxy
+  /front-proxy-client          Generate the certificate for the front proxy client
+  /etcd-ca                     Generate the self-signed CA to provision identities for etcd
+  /etcd-server                 Generate the certificate for serving etcd
+  /etcd-peer                   Generate the certificate for etcd nodes to communicate with each other
+  /etcd-healthcheck-client     Generate the certificate for liveness probes to healthcheck etcd
+  /apiserver-etcd-client       Generate the certificate the apiserver uses to access etcd
+  /sa                          Generate a private key for signing service account tokens along with its public key
+kubeconfig                   Generate all kubeconfig files necessary to establish the control plane and the admin kubeconfig file
+  /admin                       Generate a kubeconfig file for the admin to use and for kubeadm itself
+  /kubelet                     Generate a kubeconfig file for the kubelet to use *only* for cluster bootstrapping purposes
+  /controller-manager          Generate a kubeconfig file for the controller manager to use
+  /scheduler                   Generate a kubeconfig file for the scheduler to use
+kubelet-start                Write kubelet settings and (re)start the kubelet
+control-plane                Generate all static Pod manifest files necessary to establish the control plane
+  /apiserver                   Generates the kube-apiserver static Pod manifest
+  /controller-manager          Generates the kube-controller-manager static Pod manifest
+  /scheduler                   Generates the kube-scheduler static Pod manifest
+etcd                         Generate static Pod manifest file for local etcd
+  /local                       Generate the static Pod manifest file for a local, single-node local etcd instance
+upload-config                Upload the kubeadm and kubelet configuration to a ConfigMap
+  /kubeadm                     Upload the kubeadm ClusterConfiguration to a ConfigMap
+  /kubelet                     Upload the kubelet component config to a ConfigMap
+upload-certs                 Upload certificates to kubeadm-certs
+mark-control-plane           Mark a node as a control-plane
+bootstrap-token              Generates bootstrap tokens used to join a node to a cluster
+kubelet-finalize             Updates settings relevant to the kubelet after TLS bootstrap
+  /experimental-cert-rotation  Enable kubelet client certificate rotation
+addon                        Install required addons for passing Conformance tests
+  /coredns                     Install the CoreDNS addon to a Kubernetes cluster
+  /kube-proxy                  Install the kube-proxy addon to a Kubernetes cluster
 ```
 
 ```
@@ -190,14 +192,18 @@ Don't apply any changes; just output what would be done.
 </tr>
 
 <tr>
-<td colspan="2">-k, --experimental-kustomize string</td>
+<td colspan="2">--experimental-patches string</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-The path where kustomize patches for static pod manifests are stored.
+<!--  
+Path to a directory that contains files named "target[suffix][+patchtype].extension". For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "patchtype" can be one of "strategic", "merge" or "json" and they match the patch formats supported by kubectl. The default "patchtype" is "strategic". "extension" must be either "json" or "yaml". "suffix" is an optional string that can be used to determine which patches are applied first alpha-numerically.
 -->
-用于存储 kustomize 为静态 pod 清单所提供的补丁的路径。
+包含名为 "target[suffix][+patchtype].extension" 的文件的目录路径。
+例如，"kube-apiserver0+merge.yaml" 或仅仅是 "etcd.json"。
+"patchtype" 可以是 "strategic"、"merge" 或 "json" 之一，并且它们与 kubectl 支持的补丁格式匹配。
+默认的 "patchtype" 为 "strategic"。 "extension" 必须为 "json" 或 "yaml"。 
+"suffix" 是一个可选字符串，可用于确定首先按字母顺序应用哪些补丁。
 </td>
 </tr>
 

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_apiserver-etcd-client.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_apiserver-etcd-client.md
@@ -66,27 +66,6 @@ kubeadm 配置文件的路径。
 </tr>
 
 <tr>
-<td colspan="2">--csr-dir string</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!-- The path to output the CSRs and private keys to -->
-输出 CSR 和私钥的路径
-</td>
-</td>
-</tr>
-
-<tr>
-<td colspan="2">--csr-only</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!-- Create CSRs instead of generating certificates -->
-创建 CSR 而不是生成证书
-</td>
-</tr>
-
-<tr>
 <td colspan="2">-h, --help</td>
 </tr>
 <tr>

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_apiserver-kubelet-client.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_apiserver-kubelet-client.md
@@ -70,30 +70,6 @@ kubeadm 配置文件路径。
 </tr>
 
 <tr>
-<td colspan="2">--csr-dir string</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-The path to output the CSRs and private keys to
--->
-输出 CSR 和私钥的路径
-</td>
-</tr>
-
-<tr>
-<td colspan="2">--csr-only</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-Create CSRs instead of generating certificates
--->
-创建 CSR 而不是生成证书
-</td>
-</tr>
-
-<tr>
 <td colspan="2">-h, --help</td>
 </tr>
 <tr>

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_apiserver.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_apiserver.md
@@ -112,30 +112,6 @@ Specify a stable IP address or DNS name for the control plane.
 </tr>
 
 <tr>
-<td colspan="2">--csr-dir string</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-The path to output the CSRs and private keys to
--->
-输出 CSR 和私钥的路径
-</td>
-</tr>
-
-<tr>
-<td colspan="2">--csr-only</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-Create CSRs instead of generating certificates
--->
-创建 CSR 而不是生成证书
-</td>
-</tr>
-
-<tr>
 <td colspan="2">-h, --help</td>
 </tr>
 <tr>

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-healthcheck-client.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-healthcheck-client.md
@@ -70,27 +70,6 @@ kubeadm 配置文件的路径。
 </tr>
 
 <tr>
-<td colspan="2">--csr-dir string</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-The path to output the CSRs and private keys to
--->
-CSR 和私钥的输出路径
-</td>
-</tr>
-
-<tr>
-<td colspan="2">--csr-only</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
-创建 CSR 而不是生成证书
-</td>
-</tr>
-
-<tr>
 <td colspan="2">-h, --help</td>
 </tr>
 <tr>

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-peer.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-peer.md
@@ -72,26 +72,6 @@ kubeadm 配置文件的路径。
 </tr>
 
 <tr>
-<td colspan="2">--csr-dir string</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!-- The path to output the CSRs and private keys to -->
-输出 CSR 和私钥的路径
-</td>
-</tr>
-
-<tr>
-<td colspan="2">--csr-only</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!-- Create CSRs instead of generating certificates -->
-创建 CSR 而不是生成证书
-</td>
-</tr>
-
-<tr>
 <td colspan="2">-h, --help</td>
 </tr>
 <tr>

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-server.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-server.md
@@ -71,30 +71,6 @@ kubeadm 配置文件的路径。
 </tr>
 
 <tr>
-<td colspan="2">--csr-dir string</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-The path to output the CSRs and private keys to
--->
-输出 CSR 和私钥的路径
-</td>
-</tr>
-
-<tr>
-<td colspan="2">--csr-only</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-Create CSRs instead of generating certificates
--->
-创建 CSR 而不是生成证书
-</td>
-</tr>
-
-<tr>
 <td colspan="2">-h, --help</td>
 </tr>
 <tr>

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_front-proxy-client.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_front-proxy-client.md
@@ -61,30 +61,6 @@ kubeadm 配置文件的路径。
 </tr>
 
 <tr>
-<td colspan="2">--csr-dir string</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-The path to output the CSRs and private keys to
--->
-输出 CSR 和私钥的路径
-</td>
-</tr>
-
-<tr>
-<td colspan="2">--csr-only</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-Create CSRs instead of generating certificates
--->
-创建 CSR 而不是生成证书
-</td>
-</tr>
-
-<tr>
 <td colspan="2">-h, --help</td>
 </tr>
 <tr>

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_all.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_all.md
@@ -142,26 +142,16 @@ A set of extra flags to pass to the Controller Manager or override default ones 
 </tr>
 
 <tr>
-<td colspan="2">-k, --experimental-kustomize string</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-The path where kustomize patches for static pod manifests are stored.
--->
-用于存储 kustomize 为静态 pod 清单所提供的补丁的路径。
-</td>
-</tr>
-
-<tr>
 <td colspan="2">--feature-gates string</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-A set of key=value pairs that describe feature gates for various features. Options are:<br/>IPv6DualStack=true|false (ALPHA - default=false)
+A set of key=value pairs that describe feature gates for various features. Options are:<br/>IPv6DualStack=true|false (ALPHA - default=false)<br/>PublicKeysECDSA=true|false (ALPHA - default=false)
 -->
-一组用来描述各种功能特性的键值（key=value）对。选项是：<br/>IPv6DualStack=true|false (ALPHA - default=false)
+一组用来描述各种功能特性的键值（key=value）对。选项是：
+<br/>IPv6DualStack=true|false (ALPHA - 默认=false)
+<br/>PublicKeysECDSA=true|false (ALPHA - 默认=false)
 </td>
 </tr>
 

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_apiserver.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_apiserver.md
@@ -110,26 +110,16 @@ Specify a stable IP address or DNS name for the control plane.
 </tr>
 
 <tr>
-<td colspan="2">-k, --experimental-kustomize string</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-The path where kustomize patches for static pod manifests are stored.
--->
-用于存储 kustomize 为静态 pod 清单所提供的补丁的路径。
-</td>
-</tr>
-
-<tr>
 <td colspan="2">--feature-gates string</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-A set of key=value pairs that describe feature gates for various features. Options are:<br/>IPv6DualStack=true|false (ALPHA - default=false)
+A set of key=value pairs that describe feature gates for various features. Options are:<br/>IPv6DualStack=true|false (ALPHA - default=false)<br/>PublicKeysECDSA=true|false (ALPHA - default=false)
 -->
-一组键值对，用于描述各种特征的特征事项。选项是：<br/>IPv6DualStack=true|false (ALPHA - default=false)
+一组键值对，用于描述各种特征的特征事项。选项是：
+<br/>IPv6DualStack=true|false (ALPHA - 默认=false)
+<br/>PublicKeysECDSA=true|false (ALPHA - 默认=false)
 </td>
 </tr>
 

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_controller-manager.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_controller-manager.md
@@ -70,18 +70,6 @@ A set of extra flags to pass to the Controller Manager or override default ones 
 </tr>
 
 <tr>
-<td colspan="2">-k, --experimental-kustomize string</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-The path where kustomize patches for static pod manifests are stored.
--->
-用于存储 kustomize 为静态 pod 清单所提供的补丁的路径。
-</td>
-</tr>
-
-<tr>
 <td colspan="2">-h, --help</td>
 </tr>
 <tr>

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_scheduler.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_scheduler.md
@@ -58,18 +58,6 @@ kubeadm 配置文件的路径。
 </tr>
 
 <tr>
-<td colspan="2">-k, --experimental-kustomize string</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-The path where kustomize patches for static pod manifests are stored.
--->
-用于存储 kustomize 为静态 pod 清单所提供的补丁的路径。
-</td>
-</tr>
-
-<tr>
 <td colspan="2">-h, --help</td>
 </tr>
 <tr>

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_etcd_local.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_etcd_local.md
@@ -75,12 +75,18 @@ kubeadm 配置文件的路径。
 </tr>
 
 <tr>
-<td colspan="2">-k, --experimental-kustomize string</td>
+<td colspan="2">--experimental-patches string</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!-- The path where kustomize patches for static pod manifests are stored.  -->
-用于存储 kustomize 为静态 pod 清单所提供的补丁的路径。
+<!--  
+Path to a directory that contains files named "target[suffix][+patchtype].extension". For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "patchtype" can be one of "strategic", "merge" or "json" and they match the patch formats supported by kubectl. The default "patchtype" is "strategic". "extension" must be either "json" or "yaml". "suffix" is an optional string that can be used to determine which patches are applied first alpha-numerically.
+-->
+包含名为 "target[suffix][+patchtype].extension" 的文件的目录的路径。
+例如，"kube-apiserver0+merge.yaml" 或仅仅是 "etcd.json"。
+"patchtype" 可以是 "strategic"、"merge" 或 "json" 之一，并且它们与 kubectl 支持的补丁格式匹配。
+默认的 "patchtype" 为 "strategic"。 "extension" 必须为 "json" 或 "yaml"。 
+"suffix" 是一个可选字符串，可用于确定首先按字母顺序应用哪些补丁。
 </td>
 </tr>
 

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_join.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_join.md
@@ -7,8 +7,8 @@
 <!--
 When joining a kubeadm initialized cluster, we need to establish
 bidirectional trust. This is split into discovery (having the Node
-trust the Kubernetes Control Plane) and TLS bootstrap (having the Kubernetes
-Control Plane trust the Node).
+trust the Kubernetes Control Plane) and TLS bootstrap (having the
+Kubernetes Control Plane trust the Node).
 -->
 
 当节点加入 kubeadm 初始化的集群时，我们需要建立双向信任。
@@ -21,7 +21,7 @@ provide a file - a subset of the standard kubeconfig file. This file
 can be a local file or downloaded via an HTTPS URL. The forms are
 kubeadm join --discovery-token abcdef.1234567890abcdef 1.2.3.4:6443,
 kubeadm join --discovery-file path/to/file.conf, or kubeadm join
---discovery-file `https://url/file.conf`. Only one form can be used. If
+--discovery-file https://url/file.conf. Only one form can be used. If
 the discovery information is loaded from a URL, HTTPS must be used.
 Also, in that case the host installed CA bundle is used to verify
 the connection.
@@ -39,7 +39,9 @@ the connection.
 <!--
 If you use a shared token for discovery, you should also pass the
 --discovery-token-ca-cert-hash flag to validate the public key of the
-root certificate authority (CA) presented by the Kubernetes Control Plane. The value of this flag is specified as "&lt;hash-type&gt;:&lt;hex-encoded-value&gt;",where the supported hash type is "sha256". The hash is calculated over
+root certificate authority (CA) presented by the Kubernetes Control Plane.
+The value of this flag is specified as "&lt;hash-type&gt;:&lt;hex-encoded-value&gt;",
+where the supported hash type is "sha256". The hash is calculated over
 the bytes of the Subject Public Key Info (SPKI) object (as in RFC7469).
 This value is available in the output of "kubeadm init" or can be
 calculated using standard tools. The --discovery-token-ca-cert-hash flag
@@ -241,14 +243,18 @@ For token-based discovery, allow joining without --discovery-token-ca-cert-hash 
 </tr>
 
 <tr>
-<td colspan="2">-k, --experimental-kustomize string</td>
+<td colspan="2">--experimental-patches string</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-The path where kustomize patches for static pod manifests are stored.
+<!--  
+Path to a directory that contains files named "target[suffix][+patchtype].extension". For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "patchtype" can be one of "strategic", "merge" or "json" and they match the patch formats supported by kubectl. The default "patchtype" is "strategic". "extension" must be either "json" or "yaml". "suffix" is an optional string that can be used to determine which patches are applied first alpha-numerically.
 -->
-用于存储 kustomize 为静态 pod 清单所提供的补丁的路径。
+包含名为 "target[suffix][+patchtype].extension" 的文件的目录的路径。
+例如，"kube-apiserver0+merge.yaml" 或仅仅是 "etcd.json"。
+"patchtype" 可以是 "strategic"、"merge" 或 "json" 之一，并且它们与 kubectl 支持的补丁格式匹配。
+默认的 "patchtype" 为 "strategic"。 "extension" 必须为 "json" 或 "yaml"。 
+"suffix" 是一个可选字符串，可用于确定首先按字母顺序应用哪些补丁。
 </td>
 </tr>
 

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_join_phase_control-plane-join_etcd.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_join_phase_control-plane-join_etcd.md
@@ -65,14 +65,18 @@ Create a new control plane instance on this node
 </tr>
 
 <tr>
-<td colspan="2">-k, --experimental-kustomize string</td>
+<td colspan="2">--experimental-patches string</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-The path where kustomize patches for static pod manifests are stored.
+<!--  
+Path to a directory that contains files named "target[suffix][+patchtype].extension". For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "patchtype" can be one of "strategic", "merge" or "json" and they match the patch formats supported by kubectl. The default "patchtype" is "strategic". "extension" must be either "json" or "yaml". "suffix" is an optional string that can be used to determine which patches are applied first alpha-numerically.
 -->
-用于存储 kustomize 为静态 pod 清单所提供的补丁的路径。
+包含名为 "target[suffix][+patchtype].extension" 的文件的目录的路径。
+例如，"kube-apiserver0+merge.yaml" 或仅仅是 "etcd.json"。
+"patchtype" 可以是"strategic"、"merge" 或 "json" 之一，并且它们与 kubectl 支持的补丁格式匹配。
+默认的 "patchtype" 为 "strategic"。 "extension" 必须为 "json" 或 "yaml"。 
+"suffix" 是一个可选字符串，可用于确定首先按字母顺序应用哪些补丁。
 </td>
 </tr>
 

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_join_phase_control-plane-prepare_all.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_join_phase_control-plane-prepare_all.md
@@ -142,14 +142,18 @@ For token-based discovery, allow joining without --discovery-token-ca-cert-hash 
 </tr>
 
 <tr>
-<td colspan="2">-k, --experimental-kustomize string</td>
+<td colspan="2">--experimental-patches string</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-The path where kustomize patches for static pod manifests are stored.
+<!--  
+Path to a directory that contains files named "target[suffix][+patchtype].extension". For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "patchtype" can be one of "strategic", "merge" or "json" and they match the patch formats supported by kubectl. The default "patchtype" is "strategic". "extension" must be either "json" or "yaml". "suffix" is an optional string that can be used to determine which patches are applied first alpha-numerically.
 -->
-用于存储 kustomize 为静态 pod 清单所提供的补丁的路径。
+包含名为 "target[suffix][+patchtype].extension" 的文件的目录的路径。
+例如，"kube-apiserver0+merge.yaml" 或仅仅是 "etcd.json"。
+"patchtype" 可以是 "strategic"、"merge" 或 "json" 之一，并且它们与 kubectl 支持的补丁格式匹配。
+默认的 "patchtype" 为 "strategic"。 "extension" 必须为 "json" 或 "yaml"。 
+"suffix" 是一个可选字符串，可用于确定首先按字母顺序应用哪些补丁。
 </td>
 </tr>
 

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_join_phase_control-plane-prepare_control-plane.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_join_phase_control-plane-prepare_control-plane.md
@@ -82,14 +82,18 @@ Create a new control plane instance on this node
 </tr>
 
 <tr>
-<td colspan="2">-k, --experimental-kustomize string</td>
+<td colspan="2">--experimental-patches string</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-The path where kustomize patches for static pod manifests are stored.
+<!--  
+Path to a directory that contains files named "target[suffix][+patchtype].extension". For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "patchtype" can be one of "strategic", "merge" or "json" and they match the patch formats supported by kubectl. The default "patchtype" is "strategic". "extension" must be either "json" or "yaml". "suffix" is an optional string that can be used to determine which patches are applied first alpha-numerically.
 -->
-用于存储 kustomize 为静态 pod 清单所提供的补丁的路径。
+包含名为 "target[suffix][+patchtype].extension" 的文件的目录的路径。
+例如，"kube-apiserver0+merge.yaml" 或仅仅是 "etcd.json"。
+"patchtype" 可以是 "strategic"、"merge" 或 "json" 之一，并且它们与 kubectl 支持的补丁格式匹配。
+默认的 "patchtype" 为 "strategic"。 "extension" 必须为 "json" 或 "yaml"。 
+"suffix" 是一个可选字符串，可用于确定首先按字母顺序应用哪些补丁。
 </td>
 </tr>
 

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_token_list.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_token_list.md
@@ -28,6 +28,37 @@ kubeadm token list [flags]
 <tbody>
 
 <tr>
+<td colspan="2">
+<!-- --allow-missing-template-keys&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true -->
+--allow-missing-template-keys&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值：true
+</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<!-- 
+If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
+-->
+如果设置为 true，则在模板中缺少字段或哈希表的键时忽略模板中的任何错误。
+仅适用于 golang 和 jsonpath 输出格式。
+</td>
+</tr>
+
+<tr>
+<td colspan="2">
+<!-- -o, --experimental-output string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "text" -->
+-o, --experimental-output string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值："text"
+</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<!--  
+Output format. One of: text|json|yaml|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file.
+-->
+输出格式：text|json|yaml|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file 其中之一
+</td>
+</tr>
+
+<tr>
 <td colspan="2">-h, --help</td>
 </tr>
 <tr>

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade_apply.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade_apply.md
@@ -106,14 +106,18 @@ Perform the upgrade of etcd.
 </tr>
 
 <tr>
-<td colspan="2">-k, --experimental-kustomize string</td>
+<td colspan="2">--experimental-patches string</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-The path where kustomize patches for static pod manifests are stored.
+<!--  
+Path to a directory that contains files named "target[suffix][+patchtype].extension". For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "patchtype" can be one of "strategic", "merge" or "json" and they match the patch formats supported by kubectl. The default "patchtype" is "strategic". "extension" must be either "json" or "yaml". "suffix" is an optional string that can be used to determine which patches are applied first alpha-numerically.
 -->
-用于存储 kustomize 为静态 pod 清单所提供的补丁的路径。
+包含名为 "target[suffix][+patchtype].extension" 的文件的目录的路径。
+例如，"kube-apiserver0+merge.yaml" 或仅仅是 "etcd.json"。
+"patchtype" 可以是 "strategic"、"merge" 或 "json" 之一，并且它们与 kubectl 支持的补丁格式匹配。
+默认的 "patchtype" 为 "strategic"。 "extension" 必须为 "json" 或 "yaml"。 
+"suffix" 是一个可选字符串，可用于确定首先按字母顺序应用哪些补丁。
 </td>
 </tr>
 
@@ -125,7 +129,9 @@ The path where kustomize patches for static pod manifests are stored.
 <!--
 A set of key=value pairs that describe feature gates for various features. Options are:<br/>IPv6DualStack=true|false (ALPHA - default=false)
 -->
-一组键值对，用于描述各种功能。选项包括：<br/>IPv6DualStack=true|false (ALPHA - 默认值=false)
+一组键值对，用于描述各种功能。选项包括：
+<br/>IPv6DualStack=true|false (ALPHA - 默认=false)
+<br/>PublicKeysECDSA=true|false (ALPHA - 默认=false)
 </td>
 </tr>
 
@@ -162,23 +168,6 @@ apply 操作的帮助命令
 A list of checks whose errors will be shown as warnings. Example: 'IsPrivilegedUser,Swap'. Value 'all' ignores errors from all checks.
 -->
 错误将显示为警告的检查列表；例如：'IsPrivilegedUser,Swap'。取值为 'all' 时将忽略检查中的所有错误。
-</td>
-</tr>
-
-<tr>
-<td colspan="2">
-<!--
---image-pull-timeout duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 15m0s
--->
---image-pull-timeout duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;默认值：15m0s
-</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-The maximum amount of time to wait for the control plane pods to be downloaded.
--->
-等待控制面板 pod 下载的最长时间。
 </td>
 </tr>
 

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade_node.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade_node.md
@@ -19,12 +19,14 @@ The "node" command executes the following phases:
 
 <!--
 ```
+preflight       Run upgrade node pre-flight checks
 control-plane   Upgrade the control plane instance deployed on this node, if any
 kubelet-config  Upgrade the kubelet configuration for this node
 ```
 -->
 
 ```
+preflight       执行节点升级前检查
 control-plane   如果存在的话，升级部署在该节点上的管理面实例
 kubelet-config  更新该节点上的 kubelet 配置
 ```
@@ -87,14 +89,18 @@ Perform the upgrade of etcd.
 </tr>
 
 <tr>
-<td colspan="2">-k, --experimental-kustomize string</td>
+<td colspan="2">--experimental-patches string</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-The path where kustomize patches for static pod manifests are stored.
+<!--  
+Path to a directory that contains files named "target[suffix][+patchtype].extension". For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "patchtype" can be one of "strategic", "merge" or "json" and they match the patch formats supported by kubectl. The default "patchtype" is "strategic". "extension" must be either "json" or "yaml". "suffix" is an optional string that can be used to determine which patches are applied first alpha-numerically.
 -->
-用于存储 kustomize 为静态 pod 清单所提供的补丁的路径。
+包含名为 "target[suffix][+patchtype].extension" 的文件的目录的路径。
+例如，"kube-apiserver0+merge.yaml" 或仅仅是 "etcd.json"。
+"patchtype" 可以是 "strategic"、"merge" 或 "json" 之一，并且它们与 kubectl 支持的补丁格式匹配。
+默认的 "patchtype" 为 "strategic"。 "extension" 必须为 "json" 或 "yaml"。 
+"suffix" 是一个可选字符串，可用于确定首先按字母顺序应用哪些补丁。
 </td>
 </tr>
 

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade_node_phase_control-plane.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade_node_phase_control-plane.md
@@ -62,10 +62,19 @@ kubeadm upgrade node phase control-plane [flags]
 -->
 
 <tr>
-<td colspan="2">-k, --experimental-kustomize string</td>
+<td colspan="2">--experimental-patches string</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">用于存储 kustomize 为静态 pod 清单所提供的补丁的路径。</td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<!--  
+Path to a directory that contains files named "target[suffix][+patchtype].extension". For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "patchtype" can be one of "strategic", "merge" or "json" and they match the patch formats supported by kubectl. The default "patchtype" is "strategic". "extension" must be either "json" or "yaml". "suffix" is an optional string that can be used to determine which patches are applied first alpha-numerically.
+-->
+包含名为 "target[suffix][+patchtype].extension" 的文件的目录的路径。
+例如，"kube-apiserver0+merge.yaml" 或仅仅是 "etcd.json"。
+"patchtype" 可以是 "strategic"、"merge" 或 "json" 之一，并且它们与 kubectl 支持的补丁格式匹配。
+默认的 "patchtype" 为 "strategic"。 "extension" 必须为 "json" 或 "yaml"。 
+"suffix" 是一个可选字符串，可用于确定首先按字母顺序应用哪些补丁。
+</td>
 </tr>
 
 <!--


### PR DESCRIPTION
ref: https://github.com/kubernetes/website/issues/25247
sync files below, 22 in total
```
1	1	content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_token_list.md
2	2	content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_join_phase_control-plane-join_etcd.md
2	2	content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_join_phase_control-plane-prepare_all.md
1	1	content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_config_images_list.md
10	2	content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade_node.md
3	3	content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init.md
0	14	content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-healthcheck-client.md
0	7	content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_scheduler.md
0	7	content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_all.md
0	14	content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_apiserver-kubelet-client.md
2	2	content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade_node_phase_control-plane.md
0	14	content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-peer.md
0	7	content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_apiserver.md
2	2	content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_join_phase_control-plane-prepare_control-plane.md
0	14	content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_apiserver.md
0	7	content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_control-plane_controller-manager.md
2	9	content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_upgrade_apply.md
2	2	content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_etcd_local.md
0	14	content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_apiserver-etcd-client.md
0	14	content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_front-proxy-client.md
2	2	content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_join.md
0	14	content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_etcd-server.md
```