### PR TITLE
Remove minion from germen nodes.md

### DIFF
--- a/content/de/docs/concepts/architecture/nodes.md
+++ b/content/de/docs/concepts/architecture/nodes.md
@@ -6,7 +6,7 @@ weight: 10
 
 <!-- overview -->
 
-Ein Knoten (Node in Englisch) ist eine Arbeitsmaschine in Kubernetes, früher als `minion` bekannt. Ein Node
+Ein Knoten (Node in Englisch) ist eine Arbeitsmaschine in Kubernetes. Ein Node
 kann je nach Cluster eine VM oder eine physische Maschine sein. Jeder Node enthält
 die für den Betrieb von [Pods](/docs/concepts/workloads/pods/pod/) notwendigen Dienste
 und wird von den Master-Komponenten verwaltet.


### PR DESCRIPTION
i've removed the `minion` from the german documentation. It is not present in the english one.
Yesterday i was sitting in a presentation and i was a little bit confused because the student sometimes talked about minions. Therefore i removed the half sentence to avoid confusion for others.
Maybe this should done in the other languages as well.