### PR TITLE
switch New York Times case study to use youtube shortcode (ko)

### DIFF
--- a/content/ko/case-studies/newyorktimes/index.html
+++ b/content/ko/case-studies/newyorktimes/index.html
@@ -26,9 +26,9 @@ case_study_details:
 
 <p>Speed of delivery increased. Some of the legacy VM-based deployments took 45 minutes; with Kubernetes, that time was "just a few seconds to a couple of minutes," says Engineering Manager Brian Balser. Adds Li: "Teams that used to deploy on weekly schedules or had to coordinate schedules with the infrastructure team now deploy their updates independently, and can do it daily when necessary." Adopting Cloud Native Computing Foundation technologies allows for a more unified approach to deployment across the engineering staff, and portability for the company.</p>
 
-{{< case-studies/quote author="Deep Kapadia, Executive Director, Engineering at The New York Times">}}
-<iframe style="padding:1%:" width="380" height="215" src="https://www.youtube.com/embed/DqS_IPw-c6o" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
-<iframe style="padding:1%:" width="380" height="215" src="https://www.youtube.com/embed/Tm4VfJtOHt8" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+{{< case-studies/quote author="Deep Kapadia, Executive Director, Engineering at The New York Times" >}}
+{{< youtube DqS_IPw-c6o youtube-quote-sm >}}
+{{< youtube Tm4VfJtOHt8 youtube-quote-sm >}}
 <br>
 "I think once you get over the initial hump, things get a lot easier and actually a lot faster."
 {{< /case-studies/quote >}}


### PR DESCRIPTION
issue https://github.com/kubernetes/website/issues/25124