### PR TITLE
[ja] Update Chained selectors shell command to follow the English version

### DIFF
--- a/content/ja/docs/concepts/overview/working-with-objects/field-selectors.md
+++ b/content/ja/docs/concepts/overview/working-with-objects/field-selectors.md
@@ -46,7 +46,7 @@ kubectl get services  --all-namespaces --field-selector metadata.namespace!=defa
 下記の`kubectl`コマンドは、`status.phase`が`Runnning`でなく、かつ`spec.restartPolicy`フィールドが`Always`に等しいような全てのPodを選択します。  
 
 ```shell
-kubectl get statefulsets,services --all-namespaces --field-selector metadata.namespace!=default
+kubectl get pods --field-selector=status.phase!=Running,spec.restartPolicy=Always
 ```
 
 ## 複数のリソースタイプ


### PR DESCRIPTION
Let me propose change to follow the English version
https://github.com/kubernetes/website/blame/79c1ab1fd2836726379c3debef18e955faeedbb2/content/en/docs/concepts/overview/working-with-objects/field-selectors.md#L46