### PR TITLE
Add [version-menu] section into i18n/zh.toml

### DIFF
--- a/i18n/zh.toml
+++ b/i18n/zh.toml
@@ -211,6 +211,9 @@ other = "您的 Kubernetes 服务器版本必须不低于版本 "
 [version_check_tocheck]
 other = "要获知版本信息，请输入 "
 
+[version_menu]
+other = "版本列表"
+
 [warning]
 other = "警告："
 


### PR DESCRIPTION
Fix issue that `Version` menu in the nav bar is still in English after change to Chinese.