### PR TITLE
Add new make target `module-init` and update `module-check`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,11 @@ help: ## Show this help.
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 module-check:
-	@git submodule status --recursive | awk '/^[+-]/ {printf "\033[31mWARNING\033[0m Submodule not initialized: \033[34m%s\033[0m\n",$$2}' 1>&2
+	@git submodule status --recursive | awk '/^[+-]/ {err = 1; printf "\033[31mWARNING\033[0m Submodule not initialized: \033[34m%s\033[0m\n",$$2} END { if (err != 0) print "You need to run \033[32mmake module-init\033[0m to initialize missing modules first"; exit err }' 1>&2
+
+module-init:
+	@echo "Initializing submodules..." 1>&2
+	@git submodule update --init --recursive --depth 1
 
 all: build ## Build site with production settings and put deliverables in ./public
 


### PR DESCRIPTION
Currently when running `make serve` or something similar, we get just a warning says 
```
WARNING: Submodule not initialized: <module path>
```
Even if submodules are not initialized, we always go to the next steps and get failed.

Better if we could automatically initialize these submodules before build and serve.

-- Thanks to the advice from @kbhawkey 

This PR change the behavior of make target `module-check`. Now it will break the make process if submodules are not initialized. And also introduce a new make target `module-init`, which provides a way to initialize submodules.