### PR TITLE
Add mention of kubectl BuildKit CLI plugin to dockershim faq

### DIFF
--- a/content/en/blog/_posts/2020-12-02-dockershim-faq.md
+++ b/content/en/blog/_posts/2020-12-02-dockershim-faq.md
@@ -141,13 +141,14 @@ runtime where possible.
 Another thing to look out for is anything expecting to run for system maintenance
 or nested inside a container when building images will no longer work. For the
 former, you can use the [`crictl`][cr] tool as a drop-in replacement (see [mapping from docker cli to crictl](https://kubernetes.io/docs/tasks/debug-application-cluster/crictl/#mapping-from-docker-cli-to-crictl)) and for the
-latter you can use newer container build options like [img], [buildah], or
-[kaniko] that don’t require Docker.
+latter you can use newer container build options like [img], [buildah],
+[kaniko], or [buildkit-cli-for-kubectl] that don’t require Docker.
 
 [cr]: https://github.com/kubernetes-sigs/cri-tools
 [img]: https://github.com/genuinetools/img
 [buildah]: https://github.com/containers/buildah
 [kaniko]: https://github.com/GoogleContainerTools/kaniko
+[buildkit-cli-for-kubectl]: https://github.com/vmware-tanzu/buildkit-cli-for-kubectl
 
 For containerd, you can start with their [documentation] to see what configuration
 options are available as you migrate things over.


### PR DESCRIPTION
The buildkit-cli-for-kubectl project aims to provide a drop-in replacement for
`docker build` with compatible UX.  Some users looking to migrate off
dockershim may find this CLI plugin useful.

Signed-off-by: Daniel Hiltgen <hiltgend@vmware.com>