### PR TITLE
Add reference to AKS

### DIFF
--- a/content/en/blog/_posts/2020-12-02-dont-panic-kubernetes-and-docker.md
+++ b/content/en/blog/_posts/2020-12-02-dont-panic-kubernetes-and-docker.md
@@ -24,7 +24,7 @@ shouldn’t, use Docker as a development tool anymore. Docker is still a useful
 tool for building containers, and the images that result from running `docker
 build` can still run in your Kubernetes cluster. 
  
-If you’re using a managed Kubernetes service like GKE or EKS, you will need to
+If you’re using a managed Kubernetes service like GKE, EKS, or AKS (which [defaults to containerd](https://github.com/Azure/AKS/releases/tag/2020-11-16)) you will need to
 make sure your worker nodes are using a supported container runtime before
 Docker support is removed in a future version of Kubernetes. If you have node
 customizations you may need to update them based on your environment and runtime


### PR DESCRIPTION
Add a reference to AKS as a managed Kubernetes service. I know this blog was pulled together quickly and has tons of great content. It is just odd that AKS is not listed alongside GKE and EKS.