### PR TITLE
Update selector for External metrics type

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -397,7 +397,7 @@ section to your HorizontalPodAutoscaler manifest to specify that you need one wo
   external:
     metric:
       name: queue_messages_ready
-      selector: "queue=worker_tasks"
+      selector: {matchLabels: {queue: worker_tasks}}
     target:
       type: AverageValue
       averageValue: 30


### PR DESCRIPTION
The documentation for the `selector` field is incorrect. It says that `selector` should be a string but it actually expects a map. The above change worked for my use case.
