### PR TITLE
Remove usage of 'we' in kubelet-garbage-collection.md

### DIFF
--- a/content/en/docs/concepts/cluster-administration/kubelet-garbage-collection.md
+++ b/content/en/docs/concepts/cluster-administration/kubelet-garbage-collection.md
@@ -44,7 +44,7 @@ Default is 85%.
 2. `image-gc-low-threshold`, the percent of disk usage to which image garbage collection attempts
 to free. Default is 80%.
 
-We also allow users to customize garbage collection policy through the following kubelet flags:
+Users can customize garbage collection policy through the following kubelet flags:
 
 1. `minimum-container-ttl-duration`, minimum age for a finished container before it is
 garbage collected. Default is 0 minute, which means every finished container will be garbage collected.

--- a/content/en/docs/concepts/cluster-administration/kubelet-garbage-collection.md
+++ b/content/en/docs/concepts/cluster-administration/kubelet-garbage-collection.md
@@ -44,7 +44,7 @@ Default is 85%.
 2. `image-gc-low-threshold`, the percent of disk usage to which image garbage collection attempts
 to free. Default is 80%.
 
-Users can customize garbage collection policy through the following kubelet flags:
+Users can customize the garbage collection policy through the following kubelet flags:
 
 1. `minimum-container-ttl-duration`, minimum age for a finished container before it is
 garbage collected. Default is 0 minute, which means every finished container will be garbage collected.
@@ -83,5 +83,4 @@ Including:
 
 
 See [Configuring Out Of Resource Handling](/docs/tasks/administer-cluster/out-of-resource/) for more details.
-
 

--- a/content/en/docs/concepts/cluster-administration/kubelet-garbage-collection.md
+++ b/content/en/docs/concepts/cluster-administration/kubelet-garbage-collection.md
@@ -37,14 +37,14 @@ Containers that are not managed by kubelet are not subject to container garbage 
 
 ## User Configuration
 
-Users can adjust the following thresholds to tune image garbage collection with the following kubelet flags :
+You can adjust the following thresholds to tune image garbage collection with the following kubelet flags :
 
 1. `image-gc-high-threshold`, the percent of disk usage which triggers image garbage collection.
 Default is 85%.
 2. `image-gc-low-threshold`, the percent of disk usage to which image garbage collection attempts
 to free. Default is 80%.
 
-Users can customize the garbage collection policy through the following kubelet flags:
+You can customize the garbage collection policy through the following kubelet flags:
 
 1. `minimum-container-ttl-duration`, minimum age for a finished container before it is
 garbage collected. Default is 0 minute, which means every finished container will be garbage collected.


### PR DESCRIPTION
Remove usage of 'we' in kubelet-garbage-collection.md