### PR TITLE
Add a caution message on CronJob Controller workload if using startingDeadlineSeconds

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/en/docs/concepts/workloads/controllers/cron-jobs.md
@@ -62,7 +62,7 @@ and if `concurrencyPolicy` is set to `Allow`, the jobs will always run
 at least once.
 
 {{< caution >}}
-If `startingDeadlineSeconds` is set to a value less than 10 seconds, the CronJob may not be scheduled. This is because the CronJob controller checks things every 10 seconds.
+If `startingDeadlineSeconds` is set to a value less than 10 seconds, the CronJob may not be scheduled. This is because the CronJob controller checks things every 10 seconds. As an alpha feature, there is a V2 controller implementation with different behavior. The version 2 controller provides experimental performance improvements.
 {{< /caution >}}
 
 

--- a/content/en/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/en/docs/concepts/workloads/controllers/cron-jobs.md
@@ -62,7 +62,7 @@ and if `concurrencyPolicy` is set to `Allow`, the jobs will always run
 at least once.
 
 {{< caution >}}
-If `startingDeadlineSeconds` is set to a value less than 10 seconds, the CronJob may not be scheduled. This is because the CronJob controller checks things every 10 seconds. As an alpha feature, there is a V2 controller implementation with different behavior. The version 2 controller provides experimental performance improvements.
+If `startingDeadlineSeconds` is set to a value less than 10 seconds, the CronJob may not be scheduled. This is because the CronJob controller checks things every 10 seconds.
 {{< /caution >}}
 
 

--- a/content/en/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/en/docs/concepts/workloads/controllers/cron-jobs.md
@@ -61,6 +61,11 @@ If `startingDeadlineSeconds` is set to a large value or left unset (the default)
 and if `concurrencyPolicy` is set to `Allow`, the jobs will always run
 at least once.
 
+{{< caution >}}
+If `startingDeadlineSeconds` is set to a value less than 10 seconds, then the CronJob may not be scheduled. This is because Cronjob Controller checks things every 10 seconds by default.
+{{< /caution >}}
+
+
 For every CronJob, the CronJob {{< glossary_tooltip term_id="controller" >}} checks how many schedules it missed in the duration from its last scheduled time until now. If there are more than 100 missed schedules, then it does not start the job and logs the error
 
 ````

--- a/content/en/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/en/docs/concepts/workloads/controllers/cron-jobs.md
@@ -62,7 +62,7 @@ and if `concurrencyPolicy` is set to `Allow`, the jobs will always run
 at least once.
 
 {{< caution >}}
-If `startingDeadlineSeconds` is set to a value less than 10 seconds, then the CronJob may not be scheduled. This is because Cronjob Controller checks things every 10 seconds by default.
+If `startingDeadlineSeconds` is set to a value less than 10 seconds, the CronJob may not be scheduled. This is because the CronJob controller checks things every 10 seconds.
 {{< /caution >}}
 
 
@@ -95,5 +95,4 @@ documents the format of CronJob `schedule` fields.
 
 For instructions on creating and working with cron jobs, and for an example of CronJob
 manifest, see [Running automated tasks with cron jobs](/docs/tasks/job/automated-tasks-with-cron-jobs).
-
 


### PR DESCRIPTION
Add a caution message on CronJob page to advice about using a value less than 10 seconds for `startingDeadlineSeconds` property that may incur in not scheduling the Job.

Closes #23622
