### PR TITLE
Fix typo in Debug Running Pods task for 1.20

### DIFF
--- a/content/en/docs/tasks/debug-application-cluster/debug-running-pod.md
+++ b/content/en/docs/tasks/debug-application-cluster/debug-running-pod.md
@@ -229,7 +229,7 @@ Sometimes it's useful to change the command for a container, for example to
 add a debugging flag or because the application is crashing.
 
 To simulate a crashing application, use `kubectl run` to create a container
-that immediately exists:
+that immediately exits:
 
 ```
 kubectl run --image=busybox myapp -- false


### PR DESCRIPTION
Fixes a single word typo in the Debug Running Pods task.