### PR TITLE
Explanation of autoscaling algorithm does not match with current k8s implementation

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -155,10 +155,8 @@ used.
 
 If multiple metrics are specified in a HorizontalPodAutoscaler, this
 calculation is done for each metric, and then the largest of the desired
-replica counts is chosen. If any of these metrics cannot be converted
-into a desired replica count (e.g. due to an error fetching the metrics
-from the metrics APIs) and a scale down is suggested by the metrics which
-can be fetched, scaling is skipped. This means that the HPA is still capable
+replica counts is chosen. If all of these metrics cannot be converted
+into a desired replica count, scaling is skipped. This means that the HPA is still capable
 of scaling up if one or more metrics give a `desiredReplicas` greater than
 the current value.
 


### PR DESCRIPTION


action was changed at https://github.com/kubernetes/kubernetes/commit/d55f037b7d84e61c81a6b8c20606bb06b6eb20f2 pkg/controller/podautoscaler/horizontal.go L278-281

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
