### PR TITLE
Clarified kubectl generators being deprecated

### DIFF
--- a/content/en/docs/reference/kubectl/conventions.md
+++ b/content/en/docs/reference/kubectl/conventions.md
@@ -32,7 +32,7 @@ For `kubectl run` to satisfy infrastructure as code:
 You can use the `--dry-run=client` flag to preview the object that would be sent to your cluster, without really submitting it.
 
 {{< note >}}
-All `kubectl` generators are deprecated. See the Kubernetes v1.17 documentation for a [list](https://v1-17.docs.kubernetes.io/docs/reference/kubectl/conventions/#generators) of generators and how they were used.
+All `kubectl run` generators are deprecated. See the Kubernetes v1.17 documentation for a [list](https://v1-17.docs.kubernetes.io/docs/reference/kubectl/conventions/#generators) of generators and how they were used.
 {{< /note >}}
 
 #### Generators


### PR DESCRIPTION
Changed "All kubectl generators are deprecated" to now read "All `kubectl run` generators are deprecated"

Previously it was not clear that it was only the generators used by `kubectl run` that are deprecated, not those used by `kubectl create`
