### PR TITLE
Caution Note for ssh-auth Secrets

### DIFF
--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -271,6 +271,13 @@ However, using the builtin Secret type helps unify the formats of your credentia
 and the API server does verify if the required keys are provided in a Secret
 configuration.
 
+{{< caution >}}
+SSH private keys do not establish trusted communication between an SSH client and
+host server on their own. A secondary means of establishing trust is needed to
+mitigate "man in the middle" attacks, such as a `known_hosts` file added to a
+ConfigMap.
+{{< /caution >}}
+
 ### TLS secrets
 
 Kubernetes provides a builtin Secret type `kubernetes.io/tls` for to storing


### PR DESCRIPTION
Adds a `caution` note that SSH key pairs do not establish trust between
clients and servers. A secondary method is required to establish trust
between an SSH client and host server, such as fixed `known_hosts` file.
Clients which do not establish adequate trust are vulnerable to "man in
the middle" impersonation attacks.

Fixes #25497

Signed-off-by: Adam Kaplan <adam.kaplan@redhat.com>
