### PR TITLE
Add note shortcode to 'Debugging Kubernetes nodes with crictl'

### DIFF
--- a/content/en/docs/tasks/debug-application-cluster/crictl.md
+++ b/content/en/docs/tasks/debug-application-cluster/crictl.md
@@ -360,7 +360,9 @@ for more information.
 
 The exact versions for below mapping table are for docker cli v1.40 and crictl v1.19.0. Please note that the list is not exhaustive. For example, it doesn't include experimental commands of docker cli.
 
+{{< note >}}
 Warn: the output format of CRICTL is similar to Docker CLI, despite some missing columns for some CLI. Make sure to check output for the specific command if your script output parsing.
+{{< /note >}}
 
 ### Retrieve Debugging Information
 


### PR DESCRIPTION
Fixes [k/website issue 25504](https://github.com/kubernetes/website/issues/25504)
Add note shortcode to 'Debugging Kubernetes nodes with crictl'
