### PR TITLE
State that no more than one handler is allowed per lifecycle event

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/attach-handler-lifecycle-event.md
+++ b/content/en/docs/tasks/configure-pod-container/attach-handler-lifecycle-event.md
@@ -9,7 +9,7 @@ weight: 140
 This page shows how to attach handlers to Container lifecycle events. Kubernetes supports
 the postStart and preStop events. Kubernetes sends the postStart event immediately
 after a Container is started, and it sends the preStop event immediately before the
-Container is terminated.
+Container is terminated. A Container may specify one handler per event.
 
 
 


### PR DESCRIPTION
PR summary:
- States that no more than one handler is allowed per life cycle event
- Fixes #25468 

Page preview: https://deploy-preview-25547--kubernetes-io-master-staging.netlify.app/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/