### PR TITLE
Tidy list of generators for “kubectl create”

### DIFF
--- a/content/en/docs/reference/kubectl/conventions.md
+++ b/content/en/docs/reference/kubectl/conventions.md
@@ -40,19 +40,19 @@ You can generate the following resources with a kubectl command, `kubectl create
 
 * `clusterrole`: Create a ClusterRole.
 * `clusterrolebinding`: Create a ClusterRoleBinding for a particular ClusterRole.
-* `configmap`: Create a configmap from a local file, directory or literal value.
-* `cronjob`: Create a cronjob with the specified name.
-* `deployment`: Create a deployment with the specified name.
-* `job`: Create a job with the specified name.
-* `namespace`: Create a namespace with the specified name.
-* `poddisruptionbudget`: Create a pod disruption budget with the specified name.
-* `priorityclass`: Create a priorityclass with the specified name.
-* `quota`: Create a quota with the specified name.
-* `role`: Create a role with single rule.
+* `configmap`: Create a ConfigMap from a local file, directory or literal value.
+* `cronjob`: Create a CronJob with the specified name.
+* `deployment`: Create a Deployment with the specified name.
+* `job`: Create a Job with the specified name.
+* `namespace`: Create a Namespace with the specified name.
+* `poddisruptionbudget`: Create a PodDisruptionBudget with the specified name.
+* `priorityclass`: Create a PriorityClass with the specified name.
+* `quota`: Create a Quota with the specified name.
+* `role`: Create a Role with single rule.
 * `rolebinding`: Create a RoleBinding for a particular Role or ClusterRole.
-* `secret`: Create a secret using specified subcommand.
-* `service`: Create a service using specified subcommand.
-* `serviceaccount`: Create a service account with the specified name.
+* `secret`: Create a Secret using specified subcommand.
+* `service`: Create a Service using specified subcommand.
+* `serviceaccount`: Create a ServiceAccount with the specified name.
 
 ### `kubectl apply`
 

--- a/content/en/docs/reference/kubectl/conventions.md
+++ b/content/en/docs/reference/kubectl/conventions.md
@@ -37,23 +37,22 @@ All `kubectl run` generators are deprecated. See the Kubernetes v1.17 documentat
 
 #### Generators
 You can generate the following resources with a kubectl command, `kubectl create --dry-run=client -o yaml`:
-```
-  clusterrole         Create a ClusterRole.
-  clusterrolebinding  Create a ClusterRoleBinding for a particular ClusterRole.
-  configmap           Create a configmap from a local file, directory or literal value.
-  cronjob             Create a cronjob with the specified name.
-  deployment          Create a deployment with the specified name.
-  job                 Create a job with the specified name.
-  namespace           Create a namespace with the specified name.
-  poddisruptionbudget Create a pod disruption budget with the specified name.
-  priorityclass       Create a priorityclass with the specified name.
-  quota               Create a quota with the specified name.
-  role                Create a role with single rule.
-  rolebinding         Create a RoleBinding for a particular Role or ClusterRole.
-  secret              Create a secret using specified subcommand.
-  service             Create a service using specified subcommand.
-  serviceaccount      Create a service account with the specified name.
-```
+
+* `clusterrole`: Create a ClusterRole.
+* `clusterrolebinding`: Create a ClusterRoleBinding for a particular ClusterRole.
+* `configmap`: Create a configmap from a local file, directory or literal value.
+* `cronjob`: Create a cronjob with the specified name.
+* `deployment`: Create a deployment with the specified name.
+* `job`: Create a job with the specified name.
+* `namespace`: Create a namespace with the specified name.
+* `poddisruptionbudget`: Create a pod disruption budget with the specified name.
+* `priorityclass`: Create a priorityclass with the specified name.
+* `quota`: Create a quota with the specified name.
+* `role`: Create a role with single rule.
+* `rolebinding`: Create a RoleBinding for a particular Role or ClusterRole.
+* `secret`: Create a secret using specified subcommand.
+* `service`: Create a service using specified subcommand.
+* `serviceaccount`: Create a service account with the specified name.
 
 ### `kubectl apply`
 


### PR DESCRIPTION
As mentioned in issue #25501.  I've kept the generators as monospaced within the unordered list as I've noticed it used as a style elsewhere, but of course can change if preferred.
