### PR TITLE
Match API reference to version of Kubernetes we're documenting

### DIFF
--- a/content/en/docs/reference/_index.md
+++ b/content/en/docs/reference/_index.md
@@ -18,7 +18,7 @@ This section of the Kubernetes documentation contains references.
 
 ## API Reference
 
-* [Kubernetes API Reference {{< latest-version >}}](/docs/reference/generated/kubernetes-api/{{< latest-version >}}/)
+* [API Reference for Kubernetes v{{< param "version" >}}](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/)
 * [Using The Kubernetes API](/docs/reference/using-api/) - overview of the API for Kubernetes.
 
 ## API Client Libraries

--- a/content/en/docs/reference/_index.md
+++ b/content/en/docs/reference/_index.md
@@ -18,7 +18,7 @@ This section of the Kubernetes documentation contains references.
 
 ## API Reference
 
-* [API Reference for Kubernetes v{{< param "version" >}}](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/)
+* [API Reference for Kubernetes {{< param "version" >}}](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/)
 * [Using The Kubernetes API](/docs/reference/using-api/) - overview of the API for Kubernetes.
 
 ## API Client Libraries
@@ -53,5 +53,4 @@ client libraries:
 An archive of the design docs for Kubernetes functionality. Good starting points are
 [Kubernetes Architecture](https://git.k8s.io/community/contributors/design-proposals/architecture/architecture.md) and
 [Kubernetes Design Overview](https://git.k8s.io/community/contributors/design-proposals).
-
 


### PR DESCRIPTION
Once backported appropriately, this could be a fix for issue #25548