### PR TITLE
Match API reference to version of Kubernetes we're documenting

### DIFF
--- a/content/en/docs/reference/_index.md
+++ b/content/en/docs/reference/_index.md
@@ -18,7 +18,7 @@ This section of the Kubernetes documentation contains references.
 
 ## API Reference
 
-* [Kubernetes API Reference {{< latest-version >}}](/docs/reference/generated/kubernetes-api/{{< latest-version >}}/)
+* [API Reference for Kubernetes {{< param "version" >}}](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/)
 * [Using The Kubernetes API](/docs/reference/using-api/) - overview of the API for Kubernetes.
 
 ## API Client Libraries


### PR DESCRIPTION
Backport of PR #25552 to docs for Kubernetes v1.19 [[preview](https://deploy-preview-25572--k8s-v1-19.netlify.app/docs/reference/)]

Fixes #25548