### PR TITLE
Match API reference to version of Kubernetes we're documenting

### DIFF
--- a/content/en/docs/reference/_index.md
+++ b/content/en/docs/reference/_index.md
@@ -19,7 +19,7 @@ This section of the Kubernetes documentation contains references.
 ## API Reference
 
 * [Kubernetes API Overview](/docs/reference/using-api/api-overview/) - Overview of the API for Kubernetes.
-* [Kubernetes API Reference {{< latest-version >}}](/docs/reference/generated/kubernetes-api/{{< latest-version >}}/)
+* [Kubernetes API Reference {{< param "version" >}}](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/)
 
 ## API Client Libraries
 


### PR DESCRIPTION
Backport of PR #25552 to docs for Kubernetes v1.18 [[preview](https://deploy-preview-25574--k8s-v1-18.netlify.app/docs/reference/)]