### PR TITLE
Ensure valid SHA-256 checksum for JavaScript across platforms

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Declare files that will always have LF line endings on checkout.
+*.js text eol=lf
+
+# mark minified JavaScript as generated
+*.min.js linguist-generated=true


### PR DESCRIPTION
Create `.gitattributes` file.

fix #25414

1. Git will always convert line endings to LF on checkout
   > reference from [Configuring Git to handle line endings](https://docs.github.com/en/free-pro-team@latest/github/using-git/configuring-git-to-handle-line-endings#platform-windows)

2. Mark minified JavaScript as generated