### PR TITLE
Remove broken link to CSIStorageCapacity in API reference

### DIFF
--- a/content/en/docs/concepts/storage/storage-capacity.md
+++ b/content/en/docs/concepts/storage/storage-capacity.md
@@ -34,7 +34,7 @@ text="Container Storage Interface" term_id="csi" >}} (CSI) drivers and
 ## API
 
 There are two API extensions for this feature:
-- [CSIStorageCapacity](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#csistoragecapacity-v1alpha1-storage-k8s-io) objects:
+- CSIStorageCapacity objects:
   these get produced by a CSI driver in the namespace
   where the driver is installed. Each object contains capacity
   information for one storage class and defines which nodes have


### PR DESCRIPTION
Because the OpenAPI spec is extracted from an API Server configured with the default feature gates and the CSIStorageCapacity feature gate is disabled by default, this CSIStorageCapacity resource is not included in the API reference.

The API reference is based on the OpenAPI spec available at (1) generated by the script (2).

(1) https://github.com/kubernetes/kubernetes/tree/master/api/openapi-spec
(2) https://github.com/kubernetes/kubernetes/blob/master/hack/update-openapi-spec.sh

CC @pohly 