### PR TITLE
Enhance diff_l10n_branches script output

### DIFF
--- a/scripts/diff_l10n_branches.py
+++ b/scripts/diff_l10n_branches.py
@@ -13,17 +13,17 @@ Outdated files in the {{ r_commit }} branch.
 
 ### {{ files_to_be_modified | count }} files to be modified 
 {% for m_file in files_to_be_modified -%}
-  1. [ ] {{ m_file.filepath }} {{ m_file.shortstat }}
+  1. [ ] {{ m_file.fileindex }} `{{ m_file.filepath }}` {{ m_file.stat }}
 {% endfor %}
 
 ### {{ files_to_be_renamed | count }} files to be renamed  
 {% for r_file in files_to_be_renamed -%}
-  1. [ ] {{ r_file.diff_status_letter }} {{ r_file.src_filepath }} -> {{ r_file.dest_filepath }}
+  1. [ ] {{ r_file.fileindex }} {{ r_file.diff_status_letter }} `{{ r_file.src_filepath }}` -> `{{ r_file.dest_filepath }}`
 {% endfor %}
 
 ### {{ files_to_be_deleted | count }} files to be deleted 
 {% for d_file in files_to_be_deleted -%}
-  1. [ ] {{ d_file }}
+  1. [ ] {{ d_file.fileindex }} `{{ d_file.filepath }}`
 {% endfor %}
 
 ## Proposed Solution
@@ -51,18 +51,23 @@ vi {{ files_to_be_modified.0.filepath | replace(src_lang_path, l10n_lang_path) }
 
 ## Pages to Update
 
+Pages in {{ l10n_lang_path }}
+
 """
 
 files_to_be_deleted = []
 files_to_be_renamed = []
 files_to_be_modified = []
 
+index_to_be_deleted = 0
+index_to_be_renamed = 0
+index_to_be_modified = 0
 
-def git_diff(filepath, l_commit, r_commit, shortstat=False):
+def git_diff(filepath, l_commit, r_commit, stat=False):
     cmd = ["git", "diff", l_commit, r_commit, "--", filepath]
 
-    if shortstat:
-        cmd = ["git", "diff", l_commit, r_commit, "--shortstat", "--", filepath]
+    if stat:
+        cmd = ["git", "diff", l_commit, r_commit, "--stat", "--", filepath]
 
     return subprocess.check_output(cmd).decode("UTF-8").strip()
 
@@ -78,18 +83,70 @@ def process_diff_status(diff_status, l_commit, r_commit, src_lang_path,
     status_letter = diff_status[0]
     filepath = diff_status[1]
 
+    size_xs = 10
+    size_s = 30
+    size_m = 100
+    size_l = 500
+    size_xl = 1000
+
     if git_exists(r_commit, filepath.replace(src_lang_path, l10n_lang_path)):
         if status_letter == 'D':
-            files_to_be_deleted.append(filepath)
+            global index_to_be_deleted
+            index_to_be_deleted += 1
+            fileindex = "D" + str(index_to_be_deleted) + '. '
+            deleted = {"fileindex": fileindex,
+                        "filepath": filepath }
+            files_to_be_deleted.append(deleted)
         elif status_letter.startswith('R'):
-            replaced = {"diff_status_letter": diff_status[0],
+            global index_to_be_renamed
+            index_to_be_renamed += 1
+            fileindex = "R" + str(index_to_be_renamed) + '. '
+            replaced = {"fileindex": fileindex,
+                        "diff_status_letter": diff_status[0],
                         "src_filepath": diff_status[1],
                         "dest_filepath": diff_status[2]}
             files_to_be_renamed.append(replaced)
         elif status_letter == 'M':
-            modified = {"filepath": filepath,
-                        "shortstat": git_diff(filepath, l_commit, r_commit,
-                                              shortstat=True),
+            global index_to_be_modified
+            index_to_be_modified += 1
+            diff_string = git_diff(filepath, l_commit, r_commit, stat=True)
+            diff_string_tmp= diff_string.split("|") 
+            diff_string_r = diff_string_tmp[1]
+
+            res = [int(i) for i in diff_string_r.split() if i.isdigit()] 
+            if len(res) < 4 :
+                res.append(0)
+
+            insertions = res[2]
+            deletions = res[3]
+
+            bold_condition = size_m
+            if insertions < size_xs :
+                insertion_size = "XS"
+            elif insertions < size_s :
+                insertion_size = "S"
+            elif insertions < size_m :
+                insertion_size = "M"
+            elif insertions < size_l :
+                insertion_size = "L"
+            elif insertions < size_xl :
+                insertion_size = "XL"
+            else :
+                insertion_size = "XXL"
+
+            stat_output =  str(insertions) + "(+" + insertion_size + ") "  + str(deletions) + "(-)"
+
+            if insertions >= bold_condition :
+                fileindex = "**M" + str(index_to_be_modified)  + ".** "
+                stat_output = "**" + stat_output + "**"
+            else :
+                fileindex = "M" + str(index_to_be_modified)  + ". "
+                
+            stat_output =  " | " + stat_output
+
+            modified = {"fileindex": fileindex,
+                        "filepath": filepath,
+                        "stat": stat_output,
                         "diff": git_diff(filepath, l_commit, r_commit)}
             files_to_be_modified.append(modified)
 


### PR DESCRIPTION
`script/diff_l10n_branches.py` script generates a report of outdated contents in content/<l10n-lang> directory by comparing two l10n team milestone branches. (for example, https://github.com/kubernetes/website/issues/25521)

This PR enhances output of the diff_l10n_branches script.

With this PR, we can easily check **Index of outdated files** and **Size of changed amount** (if the changes is larger than Size/L, highlight.

Usage example:
`$ scripts/diff_l10n_branches.py ko upstream/dev-1.19-ko.6 upstream/dev-1.20-ko.1`


#### output of existing diff_l10n_branches.py
1. [ ] content/en/docs/setup/production-environment/container-runtimes.md 1 file changed, 3 insertions(+), 3 deletions(-)
1. [ ] content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md 1 file changed, 34 insertions(+), 65 deletions(-)
1. [ ] content/en/docs/setup/production-environment/windows/user-guide-windows-containers.md 1 file changed, 2 insertions(+), 2 deletions(-)
1. [ ] content/en/docs/setup/release/notes.md 1 file changed, 1656 insertions(+), 2119 deletions(-)
1. [ ] content/en/docs/tasks/administer-cluster/highly-available-master.md 1 file changed, 33 insertions(+)
1. [ ] content/en/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes.md 1 file changed, 74 insertions(+), 19 deletions(-)

#### (after revision) output of enhanced diff_l10n_branches.py 
1. [ ] M41.  `content/en/docs/setup/production-environment/container-runtimes.md`  | 3(+XS) 3(-)
1. [ ] M42.  `content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md`  | 34(+M) 65(-)
1. [ ] M43.  `content/en/docs/setup/production-environment/windows/user-guide-windows-containers.md`  | 2(+XS) 2(-)
1. [ ] **M44.**  `content/en/docs/setup/release/notes.md`  | **1656(+XXL) 2119(-)**
1. [ ] M45.  `content/en/docs/tasks/administer-cluster/highly-available-master.md`  | 33(+M) 0(-)
1. [ ] M46.  `content/en/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes.md`  | 74(+M) 19(-)
