### PR TITLE
fix: errors in base64 and sed commands

### DIFF
--- a/content/en/docs/tasks/tls/manual-rotation-of-ca-certificates.md
+++ b/content/en/docs/tasks/tls/manual-rotation-of-ca-certificates.md
@@ -51,12 +51,12 @@ Configurations with a single API server will experience unavailability while the
    If any pods are started before new CA is used by API servers, they will get this update and trust both old and new CAs.
 
    ```shell
-   base64_encoded_ca="$(base64 <path to file containing both old and new CAs>)"
+   base64_encoded_ca="$(base64 -w0 <path to file containing both old and new CAs>)"
 
    for namespace in $(kubectl get ns --no-headers | awk '{print $1}'); do
        for token in $(kubectl get secrets --namespace "$namespace" --field-selector type=kubernetes.io/service-account-token -o name); do
            kubectl get $token --namespace "$namespace" -o yaml | \
-             /bin/sed "s/\(ca.crt:\).*/\1 ${base64_encoded_ca}" | \
+             /bin/sed "s/\(ca.crt:\).*/\1 ${base64_encoded_ca}/" | \
              kubectl apply -f -
        done
    done
@@ -132,10 +132,10 @@ Configurations with a single API server will experience unavailability while the
 1. If your cluster is using bootstrap tokens to join nodes, update the ConfigMap `cluster-info` in the `kube-public` namespace with new CA.
 
    ```shell
-   base64_encoded_ca="$(base64 /etc/kubernetes/pki/ca.crt)"
+   base64_encoded_ca="$(base64 -w0 /etc/kubernetes/pki/ca.crt)"
 
    kubectl get cm/cluster-info --namespace kube-public -o yaml | \
-       /bin/sed "s/\(certificate-authority-data:\).*/\1 ${base64_encoded_ca}" | \
+       /bin/sed "s/\(certificate-authority-data:\).*/\1 ${base64_encoded_ca}/" | \
        kubectl apply -f -
    ```
 


### PR DESCRIPTION
Hello,

There are errors in the documentation to do the manual rotation of the cluster CA.

* All **base64** commands need `-w0` argument or else the **base64_encoded_ca** bash variable will contain space chars (" ") where newlines were
* All **sed** command are missing final "/" at the end of the expression. Command fails with the following error

```bash
/bin/sed: -e expression #1, char 95: unterminated `s' command
```
