### PR TITLE
Add meaning of Kubernetes to "What is Kubernetes" overview

### DIFF
--- a/content/en/docs/concepts/overview/what-is-kubernetes.md
+++ b/content/en/docs/concepts/overview/what-is-kubernetes.md
@@ -88,7 +88,9 @@ Kubernetes:
 * Does not provide nor adopt any comprehensive machine configuration, maintenance, management, or self-healing systems.
 * Additionally, Kubernetes is not a mere orchestration system. In fact, it eliminates the need for orchestration. The technical definition of orchestration is execution of a defined workflow: first do A, then B, then C. In contrast, Kubernetes comprises a set of independent, composable control processes that continuously drive the current state towards the provided desired state. It shouldn't matter how you get from A to C. Centralized control is also not required. This results in a system that is easier to use and more powerful, robust, resilient, and extensible.
 
+## The meaning of Kubernetes or K8s
 
+The name **Kubernetes** is derived from the Greek language and translates to *helmsman* or *pilot*. *K8s* as an abbreviation results from counting the eight letters between the "K" and the "s".
 
 ## {{% heading "whatsnext" %}}
 


### PR DESCRIPTION
I noticed that while the German "What is Kubernetes" page has a tiny section about the meaning of Kubernetes in it at the end, the English counterpart lacks this info. I want to add it.

Fixes [#25639](https://github.com/kubernetes/website/issues/25639)