### PR TITLE
Include missing cert export step

### DIFF
--- a/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
+++ b/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
@@ -253,9 +253,10 @@ kubectl get csr/john -o yaml
 The certificate value is in Base64-encoded format under `status.certificate`.
 
 Export the issued certificate from the CertificateSigningRequest.
+This example assumes the key and certificate files are located at "/home/vagrant/work/".
 
 ```
-kubectl get csr john -o jsonpath='{.status.certificate}'| base64 -d > certificate.crt
+kubectl get csr john -o jsonpath='{.status.certificate}'| base64 -d > /home/vagrant/work/john.crt
 ```
 
 ### Create Role and RoleBinding
@@ -278,7 +279,6 @@ kubectl create rolebinding developer-binding-john --role=developer --user=john
 ### Add to kubeconfig
 
 The last step is to add this user into the kubeconfig file.
-This example assumes the key and certificate files are located at "/home/vagrant/work/".
 
 First, you need to add new credentials:
 

--- a/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
+++ b/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
@@ -196,8 +196,8 @@ O is the group that this user will belong to. You can refer to
 [RBAC](/docs/reference/access-authn-authz/rbac/) for standard groups.
 
 ```shell
-openssl genrsa -out john.key 2048
-openssl req -new -key john.key -out john.csr
+openssl genrsa -out myuser.key 2048
+openssl req -new -key myuser.key -out myuser.csr
 ```
 
 ### Create CertificateSigningRequest
@@ -209,7 +209,7 @@ cat <<EOF | kubectl apply -f -
 apiVersion: certificates.k8s.io/v1
 kind: CertificateSigningRequest
 metadata:
-  name: john
+  name: myuser
 spec:
   groups:
   - system:authenticated
@@ -224,7 +224,7 @@ Some points to note:
 
 - `usages` has to be '`client auth`'
 - `request` is the base64 encoded value of the CSR file content.
-  You can get the content using this command: ```cat john.csr | base64 | tr -d "\n"```
+  You can get the content using this command: ```cat myuser.csr | base64 | tr -d "\n"```
 
 ### Approve certificate signing request
 
@@ -239,7 +239,7 @@ kubectl get csr
 Approve the CSR:
 
 ```shell
-kubectl certificate approve john
+kubectl certificate approve myuser
 ```
 
 ### Get the certificate
@@ -247,16 +247,15 @@ kubectl certificate approve john
 Retrieve the certificate from the CSR:
 
 ```shell
-kubectl get csr/john -o yaml
+kubectl get csr/myuser -o yaml
 ```
 
 The certificate value is in Base64-encoded format under `status.certificate`.
 
 Export the issued certificate from the CertificateSigningRequest.
-This example assumes the key and certificate files are located at "/home/vagrant/work/".
 
 ```
-kubectl get csr john -o jsonpath='{.status.certificate}'| base64 -d > john.crt
+kubectl get csr myuser -o jsonpath='{.status.certificate}'| base64 -d > myuser.crt
 ```
 
 ### Create Role and RoleBinding
@@ -273,7 +272,7 @@ kubectl create role developer --verb=create --verb=get --verb=list --verb=update
 This is a sample command to create a RoleBinding for this new user:
 
 ```shell
-kubectl create rolebinding developer-binding-john --role=developer --user=john
+kubectl create rolebinding developer-binding-myuser --role=developer --user=myuser
 ```
 
 ### Add to kubeconfig
@@ -283,20 +282,20 @@ The last step is to add this user into the kubeconfig file.
 First, you need to add new credentials:
 
 ```
-kubectl config set-credentials john --client-key=/home/vagrant/work/john.key --client-certificate=/home/vagrant/work/john.crt --embed-certs=true
+kubectl config set-credentials myuser --client-key=myuser.key --client-certificate=myuser.crt --embed-certs=true
 
 ```
 
 Then, you need to add the context:
 
 ```
-kubectl config set-context john --cluster=kubernetes --user=john
+kubectl config set-context myuser --cluster=kubernetes --user=myuser
 ```
 
-To test it, change the context to `john`:
+To test it, change the context to `myuser`:
 
 ```
-kubectl config use-context john
+kubectl config use-context myuser
 ```
 
 ## Approval or rejection  {#approval-rejection}

--- a/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
+++ b/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
@@ -255,7 +255,7 @@ The certificate value is in Base64-encoded format under `status.certificate`.
 Export the issued certificate from the CertificateSigningRequest.
 
 ```
-kubectl get csr john -o jsonpath='{.status.certificate}'| base64 -d > /home/vagrant/work/john.crt
+kubectl get csr john -o jsonpath='{.status.certificate}'| base64 -d > certificate.crt
 ```
 
 ### Create Role and RoleBinding
@@ -444,4 +444,3 @@ status:
 * View the source code for the kube-controller-manager built in [approver](https://github.com/kubernetes/kubernetes/blob/32ec6c212ec9415f604ffc1f4c1f29b782968ff1/pkg/controller/certificates/approver/sarapprove.go)
 * For details of X.509 itself, refer to [RFC 5280](https://tools.ietf.org/html/rfc5280#section-3.1) section 3.1
 * For information on the syntax of PKCS#10 certificate signing requests, refer to [RFC 2986](https://tools.ietf.org/html/rfc2986)
-

--- a/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
+++ b/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
@@ -252,6 +252,12 @@ kubectl get csr/john -o yaml
 
 The certificate value is in Base64-encoded format under `status.certificate`.
 
+Export the issued certificate from the CertificateSigningRequest.
+
+```
+kubectl get csr john -o jsonpath='{.status.certificate}'| base64 -d > /home/vagrant/work/john.crt
+```
+
 ### Create Role and RoleBinding
 
 With the certificate created. it is time to define the Role and RoleBinding for

--- a/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
+++ b/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
@@ -256,7 +256,7 @@ Export the issued certificate from the CertificateSigningRequest.
 This example assumes the key and certificate files are located at "/home/vagrant/work/".
 
 ```
-kubectl get csr john -o jsonpath='{.status.certificate}'| base64 -d > /home/vagrant/work/john.crt
+kubectl get csr john -o jsonpath='{.status.certificate}'| base64 -d > john.crt
 ```
 
 ### Create Role and RoleBinding


### PR DESCRIPTION
Updating the instructions to include missing step of getting issued cert exported from kubernetes, decoded, and ready for kubeconfig setup.
