### PR TITLE
Warn against default imagePullPolicy behaviour

### DIFF
--- a/content/en/docs/concepts/configuration/overview.md
+++ b/content/en/docs/concepts/configuration/overview.md
@@ -73,17 +73,19 @@ A desired state of an object is described by a Deployment, and if changes to tha
 
 ## Container Images
 
-The [imagePullPolicy](/docs/concepts/containers/images/#updating-images) and the tag of the image affect when the [kubelet](/docs/reference/command-line-tools-reference/kubelet/) attempts to pull the specified image.
+The [imagePullPolicy](/docs/concepts/containers/images/#updating-images) and the tag of the image affect when the [kubelet](/docs/reference/command-line-tools-reference/kubelet/) attempts to pull the specified image. For the most reliable results, always set `imagePullPolicy` explicitly, and do not rely on the default behavior.
 
 - `imagePullPolicy: IfNotPresent`: the image is pulled only if it is not already present locally.
 
 - `imagePullPolicy: Always`: every time the kubelet launches a container, the kubelet queries the container image registry to resolve the name to an image digest. If the kubelet has a container image with that exact digest cached locally, the kubelet uses its cached image; otherwise, the kubelet downloads (pulls) the image with the resolved digest, and uses that image to launch the container.
 
-- `imagePullPolicy` is omitted and either the image tag is `:latest` or it is omitted: `Always` is applied.
-
-- `imagePullPolicy` is omitted and the image tag is present but not `:latest`: `IfNotPresent` is applied.
-
 - `imagePullPolicy: Never`: the image is assumed to exist locally. No attempt is made to pull the image.
+
+- `imagePullPolicy` is omitted (not recommended):
+
+   - Either the image tag is `:latest` or it is omitted: the policy is set to `Always`, and will not be updated to `IfNotPresent` even if the image tag is changed.
+
+   - The image tag is present but not `:latest`: the policy is set to `IfNotPresent`, and will not be updated to `Always` even if the image tag is changed to `:latest`.
 
 {{< note >}}
 To make sure the container always uses the same version of the image, you can specify its [digest](https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier); replace `<image-name>:<tag>` with `<image-name>@<digest>` (for example, `image@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2`). The digest uniquely identifies a specific version of the image, so it is never updated by Kubernetes unless you change the digest value.
@@ -94,7 +96,7 @@ You should avoid using the `:latest` tag when deploying containers in production
 {{< /note >}}
 
 {{< note >}}
-The caching semantics of the underlying image provider make even `imagePullPolicy: Always` efficient. With Docker, for example, if the image already exists, the pull attempt is fast because all image layers are cached and no image download is needed.
+The caching semantics of the underlying image provider make even `imagePullPolicy: Always` efficient, as long as the registry is reliably accessible. With Docker, for example, if the image already exists, the pull attempt is fast because all image layers are cached and no image download is needed.
 {{< /note >}}
 
 ## Using kubectl


### PR DESCRIPTION
The `imagePullPolicy` field is set automatically based on the image tag if it's initially omitted, but it is not updated if the image tag later changes. This can lead to [confusing behaviour](https://itnext.io/defaults-are-hard-kubernetes-deployment-edition-3b11095792f2). This change attempts to warn users of this potential pitfall.