### PR TITLE
fix anchor link to "What's next" heading in operator docs

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/operator.md
+++ b/content/en/docs/concepts/extend-kubernetes/operator.md
@@ -103,7 +103,7 @@ as well as keeping the existing service in good shape.
 ## Writing your own Operator {#writing-operator}
 
 If there isn't an Operator in the ecosystem that implements the behavior you
-want, you can code your own. In [What's next](#whats-next) you'll find a few
+want, you can code your own. In [What's next](#what-s-next) you'll find a few
 links to libraries and tools you can use to write your own cloud native
 Operator.
 


### PR DESCRIPTION
The "What's next" text link in https://kubernetes.io/docs/concepts/extend-kubernetes/operator/#writing-operator links to `#whats-next` (incorrect). It should link to `#what-s-next`.
