### PR TITLE
add notes for that strategic merge patch is unsupported for CR

### DIFF
--- a/content/en/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch.md
+++ b/content/en/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch.md
@@ -445,6 +445,9 @@ and
 [kubectl apply](/docs/reference/generated/kubectl/kubectl-commands/#apply).
 
 
+{{< note >}}
+Strategic merge patch is not supported for custom resources.
+{{< /note >}}
 
 
 ## {{% heading "whatsnext" %}}


### PR DESCRIPTION
Per https://github.com/kubernetes/kubernetes/issues/97423#issuecomment-749312425,  strategic merge patch is unsupported for Custom Resource objects 
