### PR TITLE
Fix: Minor typo on portuguese operator page

### DIFF
--- a/content/pt/docs/concepts/extend-kubernetes/operator.md
+++ b/content/pt/docs/concepts/extend-kubernetes/operator.md
@@ -107,7 +107,7 @@ kubectl edit SampleDB/example-database # mudar manualmente algumas definições
 &hellip;e é isso! O Operador vai tomar conta de aplicar
 as mudanças assim como manter o serviço existente em boa forma.
 
-## Escrevendo o seu prórpio Operador {#escrevendo-operador}
+## Escrevendo o seu próprio Operador {#escrevendo-operador}
 
 Se não existir no ecosistema um Operador que implementa
 o comportamento que pretende, pode codificar o seu próprio.


### PR DESCRIPTION
This PR fixes a minor typo on the portuguese translation for Kubernetes operators. I haven't used a development branch as it doesn't exist one for portugueses.