### PR TITLE
Fix examples for http probe headers

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -389,24 +389,32 @@ You can override the default headers by defining `.httpHeaders` for the probe; f
 
 ```yaml
 livenessProbe:
-  httpHeaders:
-    Accept: application/json
+  httpGet:
+    httpHeaders:
+      - name: Accept
+        value: application/json
 
 startupProbe:
-  httpHeaders:
-    User-Agent: MyUserAgent
+  httpGet:
+    httpHeaders:
+      - name: User-Agent
+        value: MyUserAgent
 ```
 
 You can also remove these two headers by defining them with an empty value.
 
 ```yaml
 livenessProbe:
-  httpHeaders:
-    Accept: ""
+  httpGet:
+    httpHeaders:
+      - name: Accept
+        value: ""
 
 startupProbe:
-  httpHeaders:
-    User-Agent: ""
+  httpGet:
+    httpHeaders:
+      - name: User-Agent
+        value: ""
 ```
 
 ### TCP probes


### PR DESCRIPTION
Fix incorrect examples for setting headers for HTTP probes.

1) HTTP headers are set on the httpGet action, not on the probe level
2) HTTP headers is an array of name/value pairs, not a map

See the following
```
type HTTPHeader struct {
	// The header field name
	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
	// The header field value
	Value string `json:"value" protobuf:"bytes,2,opt,name=value"`
}

// HTTPGetAction describes an action based on HTTP Get requests.
type HTTPGetAction struct {
...
	// Custom headers to set in the request. HTTP allows repeated headers.
	// +optional
	HTTPHeaders []HTTPHeader `json:"httpHeaders,omitempty" protobuf:"bytes,5,rep,name=httpHeaders"`
}
```