### PR TITLE
Add automatic site deploys

### DIFF
--- a/.github/workflows/netlify-periodic-build.yml
+++ b/.github/workflows/netlify-periodic-build.yml
@@ -1,0 +1,15 @@
+---
+name: Scheduled Netlify site build
+on:
+  schedule: # Build twice daily: shortly after midnight and noon (UTC)
+            # Offset is to be nice to the build service
+  - cron: '4 0,12 * * *'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Trigger build on Netlify
+      env:
+        TOKEN: ${{ secrets.NETLIFY_BUILD_HOOK_KEY }}
+      run: >-
+          curl -s -H "Accept: application/json" -H "Content-Type: application/json" -X POST -d "{}" "https://api.netlify.com/build_hooks/${TOKEN}"


### PR DESCRIPTION
Use GitHub Actions to trigger a Netlify deploy for the primary branch, twice per day.

This is part of the implementation for #25759. As well as helping to automate announcements, this change will help the blog team: it will become possible to approve future-dated blog articles and have them go out automatically.


/hold
As well as technical review and approval, this change requires co-ordination so that a [website admin](https://github.com/orgs/kubernetes/teams/website-admins) or other Kubernetes member with appropriate access can set `NETLIFY_BUILD_HOOK_KEY` as a secret for GitHub Actions.