### PR TITLE
remove misleading instructions in kubeadm setup docs

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -304,13 +304,6 @@ or `/etc/default/kubelet`(`/etc/sysconfig/kubelet` for RPMs), please remove it a
 (stored in `/var/lib/kubelet/config.yaml` by default).
 {{< /note >}}
 
-Restarting the kubelet is required:
-
-```bash
-sudo systemctl daemon-reload
-sudo systemctl restart kubelet
-```
-
 The automatic detection of cgroup driver for other container runtimes
 like CRI-O and containerd is work in progress.
 


### PR DESCRIPTION
There is no need to restart the kubelet as part of configuring kubeadm to set the cgroup driver. At this point in the setup instructions, the kubernetes cluster isn't even up and running yet, as kubeadm init hasn't been run.  The previous step even says the kubelet is in a crashloop waiting for kubeadm.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
