### PR TITLE
moved drain the node step to after call kubeadm upgrade step for worker nodes

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -231,6 +231,14 @@ without compromising the minimum required capacity for running your workloads.
 {{% /tab %}}
 {{< /tabs >}}
 
+### Call "kubeadm upgrade"
+
+-  For worker nodes this upgrades the local kubelet configuration:
+
+    ```shell
+    sudo kubeadm upgrade node
+    ```
+
 ### Drain the node
 
 -  Prepare the node for maintenance by marking it unschedulable and evicting the workloads:
@@ -238,14 +246,6 @@ without compromising the minimum required capacity for running your workloads.
     ```shell
     # replace <node-to-drain> with the name of your node you are draining
     kubectl drain <node-to-drain> --ignore-daemonsets
-    ```
-
-### Call "kubeadm upgrade"
-
--  For worker nodes this upgrades the local kubelet configuration:
-
-    ```shell
-    sudo kubeadm upgrade node
     ```
 
 ### Upgrade kubelet and kubectl


### PR DESCRIPTION
Description - Updating upgrade kubeadm docs to move drain node step in Upgrade worker nodes section [#25732](https://github.com/kubernetes/website/issues/25732)

Moved the "Drain the node" step to after "Call kubeadm upgrade" step in Upgrading worker nodes section in the Upgrading kubeadm docs to be consistent with Upgrading the control-plane nodes and to ensure draining nodes is preformed before applying maintenance to nodes when updating kubelet/kubectl and restarting the kubelet service