### PR TITLE
Update rbac.md

### DIFF
--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -514,13 +514,22 @@ subjects:
   namespace: kube-system
 ```
 
-For all service accounts in the "qa" namespace:
+For all service accounts in the "qa" group in any namespace:
 
 ```yaml
 subjects:
 - kind: Group
   name: system:serviceaccounts:qa
   apiGroup: rbac.authorization.k8s.io
+```
+For all service accounts in the "dev" group in the "development" namespace:
+
+```yaml
+subjects:
+- kind: Group
+  name: system:serviceaccounts:dev
+  apiGroup: rbac.authorization.k8s.io
+  namespace: development
 ```
 
 For all service accounts in any namespace:


### PR DESCRIPTION
The language "For all service accounts in the "qa" namespace" in the example is confusing namespaces and groups. Language fixed to disambiguate between group and namespace. An additional example provided which uses both the group ("dev") AND the namespace ("development") to further illustrate this point