### PR TITLE
Fix configuring containerd on Ubuntu 18.04/20.04

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -140,7 +140,7 @@ sudo apt-get update && sudo apt-get install -y containerd
 ```shell
 # Configure containerd
 sudo mkdir -p /etc/containerd
-sudo containerd config default > /etc/containerd/config.toml
+sudo containerd config default | sudo tee /etc/containerd/config.toml
 ```
 
 ```shell


### PR DESCRIPTION
When configuring containerd on Ubuntu 18.04+ and following the steps [mentioned here](https://kubernetes.io/docs/setup/production-environment/container-runtimes/#containerd) the user will run into a permission denied error.

```shell
ubuntu@control-plane:~$ sudo containerd config default > /etc/containerd/config.toml
-bash: /etc/containerd/config.toml: Permission denied
```
This PR fixes this  problem by providing an alternate command.