### PR TITLE
re-positioned drain/uncorden steps in kubeadm upgrade docs in release-1.18

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -91,13 +91,6 @@ Find the latest stable 1.18 version:
     kubeadm version
     ```
 
--  Drain the control plane node:
-
-    ```shell
-    # replace <cp-node-name> with the name of your control plane node
-    kubectl drain <cp-node-name> --ignore-daemonsets
-    ```
-
 -   On the control plane node, run:
 
     ```shell
@@ -244,13 +237,6 @@ For more information see the [certificate management guide](/docs/tasks/administ
 
     This step is not required on additional control plane nodes if the CNI provider runs as a DaemonSet.
 
--  Uncordon the control plane node:
-
-    ```shell
-    # replace <cp-node-name> with the name of your control plane node
-    kubectl uncordon <cp-node-name>
-    ```
-
 ### Upgrade additional control plane nodes
 
 Same as the first control plane node but use:
@@ -266,6 +252,15 @@ sudo kubeadm upgrade apply
 ```
 
 Also `sudo kubeadm upgrade plan` is not needed.
+
+###  Drain the control plane node
+
+- Prepare the node for maintenance by marking it unschedulable and evicting the workloads:
+
+    ```shell
+    # replace <cp-node-name> with the name of your control plane node
+    kubectl drain <cp-node-name> --ignore-daemonsets
+    ```
 
 ### Upgrade kubelet and kubectl
 
@@ -295,6 +290,15 @@ sudo systemctl daemon-reload
 sudo systemctl restart kubelet
 ```
 
+###  Uncordon the control plane node
+
+- Bring the node back online by marking it schedulable:
+
+    ```shell
+    # replace <cp-node-name> with the name of your control plane node
+    kubectl uncordon <cp-node-name>
+    ```
+
 ## Upgrade worker nodes
 
 The upgrade procedure on worker nodes should be executed one node at a time or few nodes at a time,
@@ -321,6 +325,14 @@ without compromising the minimum required capacity for running your workloads.
 {{% /tab %}}
 {{< /tabs >}}
 
+### Upgrade the kubelet configuration
+
+-  Call the following command:
+
+    ```shell
+    sudo kubeadm upgrade node
+    ```
+
 ### Drain the node
 
 -  Prepare the node for maintenance by marking it unschedulable and evicting the workloads:
@@ -336,14 +348,6 @@ without compromising the minimum required capacity for running your workloads.
     node/ip-172-31-85-18 cordoned
     WARNING: ignoring DaemonSet-managed Pods: kube-system/kube-proxy-dj7d7, kube-system/weave-net-z65qx
     node/ip-172-31-85-18 drained
-    ```
-
-### Upgrade the kubelet configuration
-
--  Call the following command:
-
-    ```shell
-    sudo kubeadm upgrade node
     ```
 
 ### Upgrade kubelet and kubectl


### PR DESCRIPTION
Description - Re-positioned the drain/uncorden steps in kubeadm upgrade docs in release-1.18 [#25732](https://github.com/kubernetes/website/issues/25732)

I have moved the `Drain the node` step to be placed after running `kubeadm upgrade` on contron-plane and worker nodes, also I moved the `Uncorden the node` step to after `Restart the kubelet` to keep inline with the current version of the docs and as per discussions in [#25732] to ensure consistency between doc versions.
