### PR TITLE
re-positioned drain/uncorden steps in kubeadm upgrade docs in release-1.17

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -92,13 +92,6 @@ The upgrade workflow at high level is the following:
     kubeadm version
     ```
 
-1.  Drain the control plane node:
-
-    ```shell
-    # replace <cp-node-name> with the name of your control plane node
-    kubectl drain <cp-node-name> --ignore-daemonsets
-    ```
-
 1.  On the control plane node, run:
 
     ```shell
@@ -242,13 +235,6 @@ The upgrade workflow at high level is the following:
 
     This step is not required on additional control plane nodes if the CNI provider runs as a DaemonSet.
 
-1.  Uncordon the control plane node:
-
-    ```shell
-    # replace <cp-node-name> with the name of your control plane node
-    kubectl uncordon <cp-node-name>
-    ```
-
 ### Upgrade additional control plane nodes
 
 1.  Same as the first control plane node but use:
@@ -264,6 +250,15 @@ sudo kubeadm upgrade apply
 ```
 
 Also `sudo kubeadm upgrade plan` is not needed.
+
+###  Drain the control plane node
+
+- Prepare the node for maintenance by marking it unschedulable and evicting the workloads:
+
+    ```shell
+    # replace <cp-node-name> with the name of your control plane node
+    kubectl drain <cp-node-name> --ignore-daemonsets
+    ```
 
 ### Upgrade kubelet and kubectl
 
@@ -292,6 +287,16 @@ Also `sudo kubeadm upgrade plan` is not needed.
     sudo systemctl restart kubelet
     ```
 
+###  Uncordon the control plane node
+
+- Bring the node back online by marking it schedulable
+
+    ```shell
+    # replace <cp-node-name> with the name of your control plane node
+    kubectl uncordon <cp-node-name>
+    ```
+
+
 ## Upgrade worker nodes
 
 The upgrade procedure on worker nodes should be executed one node at a time or few nodes at a time,
@@ -318,6 +323,14 @@ without compromising the minimum required capacity for running your workloads.
     {{% /tab %}}
     {{< /tabs >}}
 
+### Upgrade the kubelet configuration
+
+1.  Call the following command:
+
+    ```shell
+    sudo kubeadm upgrade node
+    ```
+
 ### Drain the node
 
 1.  Prepare the node for maintenance by marking it unschedulable and evicting the workloads:
@@ -333,14 +346,6 @@ without compromising the minimum required capacity for running your workloads.
     node/ip-172-31-85-18 cordoned
     WARNING: ignoring DaemonSet-managed Pods: kube-system/kube-proxy-dj7d7, kube-system/weave-net-z65qx
     node/ip-172-31-85-18 drained
-    ```
-
-### Upgrade the kubelet configuration
-
-1.  Call the following command:
-
-    ```shell
-    sudo kubeadm upgrade node
     ```
 
 ### Upgrade kubelet and kubectl


### PR DESCRIPTION
Description - Re-positioned the drain/uncorden steps in kubeadm upgrade docs in release-1.18 [#25732](https://github.com/kubernetes/website/issues/25732)

I have moved the `Drain the node` step to be placed after running `kubeadm upgrade` on contron-plane and worker nodes, also I moved the `Uncorden the node` step to after `Restart the kubelet` to keep inline with the current version of the docs and as per discussions in [#25732] to ensure consistency between doc versions.
