### PR TITLE
re-positioned drain/uncorden steps in kubeadm upgrade docs in release-1.16

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -47,7 +47,7 @@ The upgrade workflow at high level is the following:
 
 ## Determine which version to upgrade to
 
-1.  Find the latest stable 1.16 version:
+-  Find the latest stable 1.16 version:
 
     {{< tabs name="k8s_install_versions" >}}
     {{% tab name="Ubuntu, Debian or HypriotOS" %}}
@@ -67,7 +67,7 @@ The upgrade workflow at high level is the following:
 
 ### Upgrade the first control plane node
 
-1.  On your first control plane node, upgrade kubeadm:
+-  On your first control plane node, upgrade kubeadm:
 
     {{< tabs name="k8s_install_kubeadm_first_cp" >}}
     {{% tab name="Ubuntu, Debian or HypriotOS" %}}
@@ -82,19 +82,13 @@ The upgrade workflow at high level is the following:
     {{% /tab %}}
     {{< /tabs >}}
 
-1.  Verify that the download works and has the expected version:
+-  Verify that the download works and has the expected version:
 
     ```shell
     kubeadm version
     ```
 
-1.  Drain the control plane node:
-
-    ```shell
-    kubectl drain $MASTER --ignore-daemonsets
-    ```
-
-1.  On the control plane node, run:
+-  On the control plane node, run:
 
     ```shell
     sudo kubeadm upgrade plan
@@ -141,7 +135,7 @@ The upgrade workflow at high level is the following:
     For more information see the [certificate management guide](/docs/tasks/administer-cluster/kubeadm/kubeadm-certs).
     {{</ note >}}
 
-1.  Choose a version to upgrade to, and run the appropriate command. For example:
+-  Choose a version to upgrade to, and run the appropriate command. For example:
 
     ```shell
     sudo kubeadm upgrade apply v1.16.x
@@ -229,7 +223,7 @@ The upgrade workflow at high level is the following:
     [upgrade/kubelet] Now that your control plane is upgraded, please proceed with upgrading your kubelets if you haven't already done so.
     ```
 
-1.  Manually upgrade your CNI provider plugin.
+-  Manually upgrade your CNI provider plugin.
 
     Your Container Network Interface (CNI) provider may have its own upgrade instructions to follow.
     Check the [addons](/docs/concepts/cluster-administration/addons/) page to
@@ -255,15 +249,9 @@ The upgrade workflow at high level is the following:
       "plugins": [ ...
     ```
 
-1.  Uncordon the control plane node
-
-    ```shell
-    kubectl uncordon $MASTER
-    ```
-
 ### Upgrade additional control plane nodes
 
-1.  Same as the first control plane node but use:
+-  Same as the first control plane node but use:
 
 ```
 sudo kubeadm upgrade node
@@ -281,9 +269,17 @@ Also `sudo kubeadm upgrade plan` is not needed.
 If you're using the kubeadm support for certificate management, please add `--certificate-renewal=true` to the `kubeadm upgrade node` command line. [bug issue](https://github.com/kubernetes/kubeadm/issues/1818)
 {{</ note >}}
 
+###  Drain the control plane node
+
+- Prepare the node for maintenance by marking it unschedulable and evicting the workloads:
+
+    ```shell
+    kubectl drain $MASTER --ignore-daemonsets
+    ```
+
 ### Upgrade kubelet and kubectl
 
-1.  Upgrade the kubelet and kubectl on all control plane nodes:
+-  Upgrade the kubelet and kubectl on all control plane nodes:
 
     {{< tabs name="k8s_install_kubelet" >}}
     {{% tab name="Ubuntu, Debian or HypriotOS" %}}
@@ -298,10 +294,18 @@ If you're using the kubeadm support for certificate management, please add `--ce
     {{% /tab %}}
     {{< /tabs >}}
 
-1. Restart the kubelet
+- Restart the kubelet
 
     ```shell
     sudo systemctl restart kubelet
+    ```
+
+###  Uncordon the control plane node
+
+- Bring the node back online by marking it schedulable:
+
+    ```shell
+    kubectl uncordon $MASTER
     ```
 
 ## Upgrade worker nodes
@@ -311,7 +315,7 @@ without compromising the minimum required capacity for running your workloads.
 
 ### Upgrade kubeadm
 
-1.  Upgrade kubeadm on all worker nodes:
+-  Upgrade kubeadm on all worker nodes:
 
     {{< tabs name="k8s_install_kubeadm_worker_nodes" >}}
     {{% tab name="Ubuntu, Debian or HypriotOS" %}}
@@ -326,9 +330,17 @@ without compromising the minimum required capacity for running your workloads.
     {{% /tab %}}
     {{< /tabs >}}
 
+### Upgrade the kubelet configuration
+
+-  Call the following command:
+
+    ```shell
+    sudo kubeadm upgrade node
+    ```
+
 ### Drain the node
 
-1.  Prepare the node for maintenance by marking it unschedulable and evicting the workloads. Run:
+-  Prepare the node for maintenance by marking it unschedulable and evicting the workloads. Run:
 
     ```shell
     kubectl drain $NODE --ignore-daemonsets
@@ -342,17 +354,9 @@ without compromising the minimum required capacity for running your workloads.
     node/ip-172-31-85-18 drained
     ```
 
-### Upgrade the kubelet configuration
-
-1.  Call the following command:
-
-    ```shell
-    sudo kubeadm upgrade node
-    ```
-
 ### Upgrade kubelet and kubectl
 
-1.  Upgrade the kubelet and kubectl on all worker nodes:
+-  Upgrade the kubelet and kubectl on all worker nodes:
 
     {{< tabs name="k8s_kubelet_and_kubectl" >}}
     {{% tab name="Ubuntu, Debian or HypriotOS" %}}
@@ -367,7 +371,7 @@ without compromising the minimum required capacity for running your workloads.
     {{% /tab %}}
     {{< /tabs >}}
 
-1. Restart the kubelet
+- Restart the kubelet
 
     ```shell
     sudo systemctl restart kubelet
@@ -375,7 +379,7 @@ without compromising the minimum required capacity for running your workloads.
 
 ### Uncordon the node
 
-1.  Bring the node back online by marking it schedulable:
+-  Bring the node back online by marking it schedulable:
 
     ```shell
     kubectl uncordon $NODE


### PR DESCRIPTION
Description - Re-positioned the drain/uncorden steps in kubeadm upgrade docs in release-1.16 [#25732](https://github.com/kubernetes/website/issues/25732)

I have moved the `Drain the node` step to be placed after running `kubeadm upgrade` on contron-plane and worker nodes, also I moved the `Uncorden the node` step to after `Restart the kubelet` to keep inline with the current version of the docs and as per discussions in [#25732] to ensure consistency between doc versions.
