### PR TITLE
Update container-runtimes.md

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -236,6 +236,13 @@ For more information, see the [CRI-O compatibility matrix](https://github.com/cr
 Install and configure prerequisites:
 
 ```shell
+
+# Create the .conf file to load the modules at bootup
+cat <<EOF | sudo tee /etc/modules-load.d/crio.conf
+overlay
+br_netfilter
+EOF
+
 sudo modprobe overlay
 sudo modprobe br_netfilter
 


### PR DESCRIPTION
I propose that by adding the requisite modules to /etc/modules-load.d/ can help prevent issues with overlay and br_netfilter modules not loading after reboot.

**Problem:**
  - Modules do not persist reboots
  - Documentation states that they will persist across reboots.
  - Cluster will fail pre-flight if modules are not loaded

This is the way it is documented in the containerd installation prerequisites but appears missing from CRI-O. Modules do not appear to persist across reboots unless /etc/modules-load.d has a config reference to load at boot.

fixes #25878