### PR TITLE
Replaced deprecated ReplicationController with JobController 

### DIFF
--- a/content/en/docs/concepts/overview/components.md
+++ b/content/en/docs/concepts/overview/components.md
@@ -51,11 +51,10 @@ the same machine, and do not run user containers on this machine. See
 
 {{< glossary_definition term_id="kube-controller-manager" length="all" >}}
 
-These controllers include:
+Some types of these controllers are:
 
   * Node controller: Responsible for noticing and responding when nodes go down.
-  * Replication controller: Responsible for maintaining the correct number of pods for every replication
-  controller object in the system.
+  * Job controller: Responsible for noticing tasks and creating Pods to run the tasks to completion
   * Endpoints controller: Populates the Endpoints object (that is, joins Services & Pods).
   * Service Account & Token controllers: Create default accounts and API access tokens for new namespaces.
 

--- a/content/en/docs/concepts/overview/components.md
+++ b/content/en/docs/concepts/overview/components.md
@@ -54,7 +54,8 @@ the same machine, and do not run user containers on this machine. See
 Some types of these controllers are:
 
   * Node controller: Responsible for noticing and responding when nodes go down.
-  * Job controller: Responsible for noticing tasks and creating Pods to run the tasks to completion
+  * Job controller: Watches for Job objects that represent one-off tasks, then creates
+    Pods to run those tasks to completion.
   * Endpoints controller: Populates the Endpoints object (that is, joins Services & Pods).
   * Service Account & Token controllers: Create default accounts and API access tokens for new namespaces.
 


### PR DESCRIPTION
Ref: https://github.com/kubernetes/website/issues/25658

Updated kube-controller-manager documentation to replace the ReplicationController example with JobController according to @sftim recommendation
