### PR TITLE
[zh] "/zh/docs/tutorials/stateless-application/expose-external-ip-address" page is outdate.

### DIFF
--- a/content/zh/docs/tutorials/stateless-application/expose-external-ip-address.md
+++ b/content/zh/docs/tutorials/stateless-application/expose-external-ip-address.md
@@ -20,23 +20,18 @@ external IP address.
 ## {{% heading "prerequisites" %}}
 
 <!--
- * Install [kubectl](/docs/tasks/tools/install-kubectl/).
-
- * Use a cloud provider like Google Kubernetes Engine or Amazon Web Services to
- create a Kubernetes cluster. This tutorial creates an
- [external load balancer](/docs/tasks/access-application-cluster/create-external-load-balancer/),
- which requires a cloud provider.
-
- * Configure `kubectl` to communicate with your Kubernetes API server. For
- instructions, see the documentation for your cloud provider.
+* Install [kubectl](/docs/tasks/tools/install-kubectl/).
+* Use a cloud provider like Google Kubernetes Engine or Amazon Web Services to
+  create a Kubernetes cluster. This tutorial creates an
+  [external load balancer](/docs/tasks/access-application-cluster/create-external-load-balancer/),
+  which requires a cloud provider.
+* Configure `kubectl` to communicate with your Kubernetes API server. For instructions, see the
+  documentation for your cloud provider.
 -->
-
  * 安装 [kubectl](/zh/docs/tasks/tools/install-kubectl/).
-
  * 使用 Google Kubernetes Engine 或 Amazon Web Services 等云供应商创建 Kubernetes 集群。
    本教程创建了一个[外部负载均衡器](/zh/docs/tasks/access-application-cluster/create-external-load-balancer/)，
    需要云供应商。
-
  * 配置 `kubectl` 与 Kubernetes API 服务器通信。有关说明，请参阅云供应商文档。
 
 ## {{% heading "objectives" %}}
@@ -68,7 +63,6 @@ external IP address.
    ```shell
    kubectl apply -f https://k8s.io/examples/service/load-balancer-example.yaml
    ```
-
    <!--
    The preceding command creates a
    {{< glossary_tooltip text="Deployment" term_id="deployment" >}}
@@ -128,9 +122,9 @@ external IP address.
    -->
    输出类似于：
 
-   ```
-   NAME         TYPE        CLUSTER-IP     EXTERNAL-IP      PORT(S)    AGE
-   my-service   ClusterIP   10.3.245.137   104.198.205.71   8080/TCP   54s
+   ```console
+   NAME         TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)    AGE
+   my-service   LoadBalancer   10.3.245.137   104.198.205.71   8080/TCP   54s
    ```
 
    <!--
@@ -162,12 +156,12 @@ external IP address.
    -->
    输出类似于：
 
-   ```
+   ```console
    Name:           my-service
    Namespace:      default
-   Labels:         run=load-balancer-example
+   Labels:         app.kubernetes.io/name=load-balancer-example
    Annotations:    <none>
-   Selector:       run=load-balancer-example
+   Selector:       app.kubernetes.io/name=load-balancer-example
    Type:           LoadBalancer
    IP:             10.3.245.137
    LoadBalancer Ingress:   104.198.205.71
@@ -207,7 +201,7 @@ external IP address.
    -->
    输出类似于：
 
-   ```
+   ```console
    NAME                         ...  IP         NODE
    hello-world-2895499144-1jaz9 ...  10.0.1.6   gke-cluster-1-default-pool-e0b8d269-1afc
    hello-world-2895499144-2e5uh ...  10.0.1.8   gke-cluster-1-default-pool-e0b8d269-1afc
@@ -241,7 +235,7 @@ external IP address.
    -->
    成功请求的响应是一条问候消息：
 
-   ```
+   ```shell
    Hello Kubernetes!
    ```
 


### PR DESCRIPTION
### This oupt is incorrect,the type should be LoadBalancer. Also zh-doc is outdate for this page.
![image](https://user-images.githubusercontent.com/35824522/103723413-f8447e00-500c-11eb-9ba4-8e05df26d75c.png)

```
ubuntu@master:~/website$  ./scripts/lsync.sh content/zh/docs/tutorials/stateless-application/expose-external-ip-address.md
diff --git a/content/en/docs/tutorials/stateless-application/expose-external-ip-address.md b/content/en/docs/tutorials/stateless-application/expose-external-ip-address.md
index 5babc2c0b..8368d2413 100644
--- a/content/en/docs/tutorials/stateless-application/expose-external-ip-address.md
+++ b/content/en/docs/tutorials/stateless-application/expose-external-ip-address.md
@@ -9,78 +9,73 @@ weight: 10
 This page shows how to create a Kubernetes Service object that exposes an
 external IP address.

-
-
-
 ## {{% heading "prerequisites" %}}

-
- * Install [kubectl](/docs/tasks/tools/install-kubectl/).
-
- * Use a cloud provider like Google Kubernetes Engine or Amazon Web Services to
- create a Kubernetes cluster. This tutorial creates an
- [external load balancer](/docs/tasks/access-application-cluster/create-external-load-balancer/),
- which requires a cloud provider.
-
- * Configure `kubectl` to communicate with your Kubernetes API server. For
- instructions, see the documentation for your cloud provider.
-
-
-
+* Install [kubectl](/docs/tasks/tools/install-kubectl/).
+* Use a cloud provider like Google Kubernetes Engine or Amazon Web Services to
+  create a Kubernetes cluster. This tutorial creates an
+  [external load balancer](/docs/tasks/access-application-cluster/create-external-load-balancer/),
+  which requires a cloud provider.
+* Configure `kubectl` to communicate with your Kubernetes API server. For instructions, see the
+  documentation for your cloud provider.

 ## {{% heading "objectives" %}}

-
 * Run five instances of a Hello World application.
 * Create a Service object that exposes an external IP address.
 * Use the Service object to access the running application.

-
-
-
 <!-- lessoncontent -->

 ## Creating a service for an application running in five pods

 1. Run a Hello World application in your cluster:

-{{< codenew file="service/load-balancer-example.yaml" >}}
-
-```shell
-kubectl apply -f https://k8s.io/examples/service/load-balancer-example.yaml
-```
-
+   {{< codenew file="service/load-balancer-example.yaml" >}}

-The preceding command creates a
-    {{< glossary_tooltip text="Deployment" term_id="deployment" >}}
-    and an associated
-    {{< glossary_tooltip term_id="replica-set" text="ReplicaSet" >}}.
-    The ReplicaSet has five
-    {{< glossary_tooltip text="Pods" term_id="pod" >}}
-    each of which runs the Hello World application.
+   ```shell
+   kubectl apply -f https://k8s.io/examples/service/load-balancer-example.yaml
+   ```
+   The preceding command creates a
+   {{< glossary_tooltip text="Deployment" term_id="deployment" >}}
+   and an associated
+   {{< glossary_tooltip term_id="replica-set" text="ReplicaSet" >}}.
+   The ReplicaSet has five
+   {{< glossary_tooltip text="Pods" term_id="pod" >}}
+   each of which runs the Hello World application.

 1. Display information about the Deployment:

-        kubectl get deployments hello-world
-        kubectl describe deployments hello-world
+    ```shell
+    kubectl get deployments hello-world
+    kubectl describe deployments hello-world
+    ```

 1. Display information about your ReplicaSet objects:

-        kubectl get replicasets
-        kubectl describe replicasets
+    ```shell
+    kubectl get replicasets
+    kubectl describe replicasets
+    ```

 1. Create a Service object that exposes the deployment:

-        kubectl expose deployment hello-world --type=LoadBalancer --name=my-service
+    ```shell
+    kubectl expose deployment hello-world --type=LoadBalancer --name=my-service
+    ```

 1. Display information about the Service:

-        kubectl get services my-service
+    ```shell
+    kubectl get services my-service
+    ```

-    The output is similar to this:
+    The output is similar to:

-        NAME         TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)    AGE
-        my-service   LoadBalancer   10.3.245.137   104.198.205.71   8080/TCP   54s
+    ```console
+    NAME         TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)    AGE
+    my-service   LoadBalancer   10.3.245.137   104.198.205.71   8080/TCP   54s
+    ```

     {{< note >}}

@@ -96,23 +91,27 @@ The preceding command creates a

 1. Display detailed information about the Service:

-        kubectl describe services my-service
-
-    The output is similar to this:
-
-        Name:           my-service
-        Namespace:      default
-        Labels:         app.kubernetes.io/name=load-balancer-example
-        Annotations:    <none>
-        Selector:       app.kubernetes.io/name=load-balancer-example
-        Type:           LoadBalancer
-        IP:             10.3.245.137
-        LoadBalancer Ingress:   104.198.205.71
-        Port:           <unset> 8080/TCP
-        NodePort:       <unset> 32377/TCP
-        Endpoints:      10.0.0.6:8080,10.0.1.6:8080,10.0.1.7:8080 + 2 more...
-        Session Affinity:   None
-        Events:         <none>
+    ```shell
+    kubectl describe services my-service
+    ```
+
+    The output is similar to:
+
+    ```console
+    Name:           my-service
+    Namespace:      default
+    Labels:         app.kubernetes.io/name=load-balancer-example
+    Annotations:    <none>
+    Selector:       app.kubernetes.io/name=load-balancer-example
+    Type:           LoadBalancer
+    IP:             10.3.245.137
+    LoadBalancer Ingress:   104.198.205.71
+    Port:           <unset> 8080/TCP
+    NodePort:       <unset> 32377/TCP
+    Endpoints:      10.0.0.6:8080,10.0.1.6:8080,10.0.1.7:8080 + 2 more...
+    Session Affinity:   None
+    Events:         <none>
+    ```

     Make a note of the external IP address (`LoadBalancer Ingress`) exposed by
     your service. In this example, the external IP address is 104.198.205.71.
@@ -124,21 +123,27 @@ The preceding command creates a
    addresses of the pods that are running the Hello World application. To
    verify these are pod addresses, enter this command:

-        kubectl get pods --output=wide
+    ```shell
+    kubectl get pods --output=wide
+    ```

-    The output is similar to this:
+    The output is similar to:

-        NAME                         ...  IP         NODE
-        hello-world-2895499144-1jaz9 ...  10.0.1.6   gke-cluster-1-default-pool-e0b8d269-1afc
-        hello-world-2895499144-2e5uh ...  10.0.1.8   gke-cluster-1-default-pool-e0b8d269-1afc
-        hello-world-2895499144-9m4h1 ...  10.0.0.6   gke-cluster-1-default-pool-e0b8d269-5v7a
-        hello-world-2895499144-o4z13 ...  10.0.1.7   gke-cluster-1-default-pool-e0b8d269-1afc
-        hello-world-2895499144-segjf ...  10.0.2.5   gke-cluster-1-default-pool-e0b8d269-cpuc
+    ```console
+    NAME                         ...  IP         NODE
+    hello-world-2895499144-1jaz9 ...  10.0.1.6   gke-cluster-1-default-pool-e0b8d269-1afc
+    hello-world-2895499144-2e5uh ...  10.0.1.8   gke-cluster-1-default-pool-e0b8d269-1afc
+    hello-world-2895499144-9m4h1 ...  10.0.0.6   gke-cluster-1-default-pool-e0b8d269-5v7a
+    hello-world-2895499144-o4z13 ...  10.0.1.7   gke-cluster-1-default-pool-e0b8d269-1afc
+    hello-world-2895499144-segjf ...  10.0.2.5   gke-cluster-1-default-pool-e0b8d269-cpuc
+    ```

 1. Use the external IP address (`LoadBalancer Ingress`) to access the Hello
    World application:

-        curl http://<external-ip>:<port>
+    ```shell
+    curl http://<external-ip>:<port>
+    ```

     where `<external-ip>` is the external IP address (`LoadBalancer Ingress`)
     of your Service, and `<port>` is the value of `Port` in your Service
@@ -148,29 +153,26 @@ The preceding command creates a

     The response to a successful request is a hello message:

-        Hello Kubernetes!
-
-
-
+    ```shell
+    Hello Kubernetes!
+    ```

 ## {{% heading "cleanup" %}}

-
 To delete the Service, enter this command:

-    kubectl delete services my-service
+```shell
+kubectl delete services my-service
+```

 To delete the Deployment, the ReplicaSet, and the Pods that are running
 the Hello World application, enter this command:

-    kubectl delete deployment hello-world
-
-
-
+```shell
+kubectl delete deployment hello-world
+```

 ## {{% heading "whatsnext" %}}

-
 Learn more about
 [connecting applications with services](/docs/concepts/services-networking/connect-applications-service/).
-

```