### PR TITLE
Fixed deprecated delete cascade 'false' value

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/garbage-collection.md
+++ b/content/en/docs/concepts/workloads/controllers/garbage-collection.md
@@ -150,14 +150,16 @@ curl -X DELETE localhost:8080/apis/apps/v1/namespaces/default/replicasets/my-rep
 ```
 
 kubectl also supports cascading deletion.
-To delete dependents automatically using kubectl, set `--cascade` to true.  To
-orphan dependents, set `--cascade` to false. The default value for `--cascade`
-is true.
+
+To delete dependents in the foreground using kubectl, set `--cascade=foreground`.  To
+orphan dependents, set `--cascade=orphan`. 
+
+The default behavior is to delete dependents in the background i.e. no `--cascade` option or `--cascade=background`.
 
 Here's an example that orphans the dependents of a ReplicaSet:
 
 ```shell
-kubectl delete replicaset my-repset --cascade=false
+kubectl delete replicaset my-repset --cascade=orphan
 ```
 
 ### Additional note on Deployments

--- a/content/en/docs/concepts/workloads/controllers/garbage-collection.md
+++ b/content/en/docs/concepts/workloads/controllers/garbage-collection.md
@@ -154,7 +154,8 @@ kubectl also supports cascading deletion.
 To delete dependents in the foreground using kubectl, set `--cascade=foreground`.  To
 orphan dependents, set `--cascade=orphan`. 
 
-The default behavior is to delete dependents in the background i.e. no `--cascade` option or `--cascade=background`.
+The default behavior is to delete the dependents in the background which is the
+behavior when `--cascade` is omitted or explicitly set to `background`.
 
 Here's an example that orphans the dependents of a ReplicaSet:
 

--- a/content/en/docs/concepts/workloads/controllers/replicaset.md
+++ b/content/en/docs/concepts/workloads/controllers/replicaset.md
@@ -283,7 +283,7 @@ curl -X DELETE  'localhost:8080/apis/apps/v1/namespaces/default/replicasets/fron
 
 ### Deleting just a ReplicaSet
 
-You can delete a ReplicaSet without affecting any of its Pods using [`kubectl delete`](/docs/reference/generated/kubectl/kubectl-commands#delete) with the `--cascade=false` option.
+You can delete a ReplicaSet without affecting any of its Pods using [`kubectl delete`](/docs/reference/generated/kubectl/kubectl-commands#delete) with the `--cascade=orphan` option.
 When using the REST API or the `client-go` library, you must set `propagationPolicy` to `Orphan`.
 For example:
 ```shell


### PR DESCRIPTION
`kubectl delete --cascade=false` is now deprecated in favor of `kubectl delete --cascade=orphan`

