### PR TITLE
Update misleading webhook authentication documentation

### DIFF
--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -457,7 +457,7 @@ clusters:
   - name: name-of-remote-authn-service
     cluster:
       certificate-authority: /path/to/ca.pem         # CA for verifying the remote service.
-      server: https://authn.example.com/authenticate # URL of remote service to query. Must use 'https'.
+      server: https://authn.example.com/authenticate # URL of remote service to query. 'https' recommended for production.
 
 # users refers to the API server's webhook configuration.
 users:
@@ -474,6 +474,8 @@ contexts:
     user: name-of-api-server
   name: webhook
 ```
+
+Refer to [Cluster Struct](https://github.com/kubernetes/kubernetes/blob/2b8cac754c88900ea3ad91d6c3f0997b602a3051/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/types.go#L63) for more configuration options.
 
 When a client attempts to authenticate with the API server using a bearer token as discussed [above](#putting-a-bearer-token-in-a-request),
 the authentication webhook POSTs a JSON-serialized `TokenReview` object containing the token to the remote service.

--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -475,8 +475,6 @@ contexts:
   name: webhook
 ```
 
-Refer to [Cluster Struct](https://github.com/kubernetes/kubernetes/blob/2b8cac754c88900ea3ad91d6c3f0997b602a3051/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/types.go#L63) for more configuration options.
-
 When a client attempts to authenticate with the API server using a bearer token as discussed [above](#putting-a-bearer-token-in-a-request),
 the authentication webhook POSTs a JSON-serialized `TokenReview` object containing the token to the remote service.
 


### PR DESCRIPTION
Update misleading information that HTTPS is required and link to self-documented code to find more edge-case configuration options.

HTTPS is not required for the Webhook Authentication, but definitely is recommended. Was also a bit of a pain to hunt down additional configurations - figured a link to the struct would be handy for those with edge cases instead of spelling them all out directly in the doc site.