### PR TITLE
Consuming extended resources - Correction of a value

### DIFF
--- a/content/en/docs/concepts/configuration/manage-resources-containers.md
+++ b/content/en/docs/concepts/configuration/manage-resources-containers.md
@@ -560,7 +560,7 @@ available amount is simultaneously allocated to Pods.
 
 The API server restricts quantities of extended resources to whole numbers.
 Examples of _valid_ quantities are `3`, `3000m` and `3Ki`. Examples of
-_invalid_ quantities are `0.5` and `1500m`.
+_invalid_ quantities are `0.5` and `1.500m`.
 
 {{< note >}}
 Extended resources replace Opaque Integer Resources.


### PR DESCRIPTION
1500 is a whole number. I think 1.500m could be an invalid quantity and a correct answer for this example.