### PR TITLE
Update cheatsheet: add interacting with Deployments and Services

### DIFF
--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -317,6 +317,18 @@ kubectl top pod POD_NAME --containers               # Show metrics for a given p
 kubectl top pod POD_NAME --sort-by=cpu              # Show metrics for a given pod and sort it by 'cpu' or 'memory'
 ```
 
+## Interacting with Deployments and Services
+```bash
+kubectl logs deploy/my-deployment                         # dump Pod logs for a Deployment (single-container case)
+kubectl logs deploy/my-deployment -c my-container         # dump Pod logs for a Deployment (multi-container case)
+
+kubectl port-forward svc/my-service 5000                  # listen on local port 5000 and forward to port 5000 on Service backend
+kubectl port-forward svc/my-service 5000:my-service-port  # listen on local port 5000 and forward to Service target port with name <my-service-port>
+
+kubectl port-forward deploy/my-deployment 5000:6000       # listen on local port 5000 and forward to port 6000 on a Pod created by <my-deployment>
+kubectl exec deploy/my-deployment -- ls                   # run command in first Pod and first container in Deployment (single- or multi-container cases)
+```
+
 ## Interacting with Nodes and cluster
 
 ```bash


### PR DESCRIPTION
Deployments and services can be easier to interact with compared to pods. Generally pods aren't created directly but through other objects such as deployments, where the pod name is inherited from the replicaset.

I've personally found interacting with deployments or services to be easier because I can e.g. know the name of the deployment ahead of time, which isn't necessarily the case with pods. The syntax seemed to be different enough for deployments and services that it could warrant being added to the cheatsheet.