### PR TITLE
Rewording of paragraph about provideClusterInfo key on Authentication page

### DIFF
--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -1004,13 +1004,12 @@ RFC3339 timestamp. Presence or absence of an expiry has the following impact:
   }
 }
 ```
-To provide the plugin with information about the cluster for which it is
-obtaining credentials, the `provideClusterInfo` field can be set on the exec user
+To enable the exec plugin to obtain cluster-specific information, set `provideClusterInfo` on the `user.exec`
 field in the [kubeconfig](/docs/concepts/configuration/organize-cluster-access-kubeconfig/).
 The plugin will then be supplied with an environment variable, `KUBERNETES_EXEC_INFO`.
 Information from this environment variable can be used to perform cluster-specific
-credential acquisition logic. Here is an example of the aforementioned
-`KUBERNETES_EXEC_INFO` environment variable.
+credential acquisition logic.
+The following `ExecCredential` manifest describes a cluster information sample.
 
 ```json
 {

--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -1004,14 +1004,13 @@ RFC3339 timestamp. Presence or absence of an expiry has the following impact:
   }
 }
 ```
-
-The plugin can optionally be called with an environment variable, `KUBERNETES_EXEC_INFO`,
-that contains information about the cluster for which this plugin is obtaining
-credentials. This information can be used to perform cluster-specific credential
-acquisition logic. In order to enable this behavior, the `provideClusterInfo` field must
-be set on the exec user field in the
-[kubeconfig](/docs/concepts/configuration/organize-cluster-access-kubeconfig/). Here is an
-example of the aforementioned `KUBERNETES_EXEC_INFO` environment variable.
+To provide the plugin with information about the cluster for which it is
+obtaining credentials, the `provideClusterInfo` field can be set on the exec user
+field in the [kubeconfig](/docs/concepts/configuration/organize-cluster-access-kubeconfig/).
+The plugin will then be supplied with an environment variable, `KUBERNETES_EXEC_INFO`.
+Information from this environment variable can be used to perform cluster-specific
+credential acquisition logic. Here is an example of the aforementioned
+`KUBERNETES_EXEC_INFO` environment variable.
 
 ```json
 {


### PR DESCRIPTION
Reworded paragraph about provideClusterInfo flag to start with the higher level explanation of why it is used, then move on to the details.