### PR TITLE
Update certificate-signing-requests.md

### DIFF
--- a/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
+++ b/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
@@ -252,6 +252,12 @@ kubectl get csr/john -o yaml
 
 The certificate value is in Base64-encoded format under `status.certificate`.
 
+Generate certificate file:
+
+```shell
+kubectl get csr/john -o yaml |grep -E "^\s*certificate: \w+$"|awk '{print $NF}'|base64 -d > /home/vagrant/work/john.crt
+```
+
 ### Create Role and RoleBinding
 
 With the certificate created. it is time to define the Role and RoleBinding for


### PR DESCRIPTION
Some people will be confused about how the certificate file `/home/vagrant/work/john.crt` came from.
Add the Base64 decoding steps.
