### PR TITLE
[WIP] Update outdated files in the dev-1.20-ko.3 branch (2)

### DIFF
--- a/content/ko/docs/concepts/workloads/pods/init-containers.md
+++ b/content/ko/docs/concepts/workloads/pods/init-containers.md
@@ -1,6 +1,4 @@
 ---
-
-
 title: 초기화 컨테이너
 content_type: concept
 weight: 40
@@ -133,6 +131,7 @@ spec:
 ```shell
 kubectl apply -f myapp.yaml
 ```
+출력은 다음과 유사하다.
 ```
 pod/myapp-pod created
 ```
@@ -141,6 +140,7 @@ pod/myapp-pod created
 ```shell
 kubectl get -f myapp.yaml
 ```
+출력은 다음과 유사하다.
 ```
 NAME        READY     STATUS     RESTARTS   AGE
 myapp-pod   0/1       Init:0/2   0          6m
@@ -150,6 +150,7 @@ myapp-pod   0/1       Init:0/2   0          6m
 ```shell
 kubectl describe -f myapp.yaml
 ```
+출력은 다음과 유사하다.
 ```
 Name:          myapp-pod
 Namespace:     default
@@ -224,6 +225,7 @@ spec:
 ```shell
 kubectl apply -f services.yaml
 ```
+출력은 다음과 유사하다.
 ```
 service/myservice created
 service/mydb created
@@ -235,6 +237,7 @@ service/mydb created
 ```shell
 kubectl get -f myapp.yaml
 ```
+출력은 다음과 유사하다.
 ```
 NAME        READY     STATUS    RESTARTS   AGE
 myapp-pod   1/1       Running   0          9m
@@ -257,7 +260,7 @@ myapp-pod   1/1       Running   0          9m
 
 파드는 모든 초기화 컨테이너가 성공되기 전까지 `Ready` 될 수 없다. 초기화 컨테이너의 포트는
 서비스 하에 합쳐지지 않는다. 초기화 중인 파드는 `Pending` 상태이지만
-`Initialized` 가 참이 되는 조건을 가져야 한다.
+`Initialized` 가 거짓이 되는 조건을 가져야 한다.
 
 만약 파드가 [재시작](#파드-재시작-이유)되었다면, 모든 초기화 컨테이너는
 반드시 다시 실행된다.
@@ -316,7 +319,6 @@ myapp-pod   1/1       Running   0          9m
 * 파드 내의 모든 컨테이너들이, 재시작을 강제하는 `restartPolicy` 가 항상(Always)으로 설정되어 있는,
   동안 종료되었다. 그리고 초기화 컨테이너의 완료 기록이 가비지 수집
   때문에 유실되었다.
-
 
 
 

--- a/content/ko/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/ko/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -85,6 +85,13 @@ UID로 정의된 특정 파드는 다른 노드로 절대 "다시 스케줄"되�
 `Failed`    | 파드에 있는 모든 컨테이너가 종료되었고, 적어도 하나 이상의 컨테이너가 실패로 종료되었다. 즉, 해당 컨테이너는 non-zero 상태로 빠져나왔거나(exited) 시스템에 의해서 종료(terminated)되었다.
 `Unknown`   | 어떤 이유에 의해서 파드의 상태를 얻을 수 없다. 이 단계는 일반적으로 파드가 실행되어야 하는 노드와의 통신 오류로 인해 발생한다.
 
+{{< note >}}
+파드가 삭제되면, 일부 kubectl 명령에서는 `Terminating` 으로 표시된다.
+이 `Terminating` 상태는 파드 단계 중 하나가 아니다.
+파드는 정상적으로 종료되는 기간이 부여되며, 기본값은 30초이다.
+`--force` 플래그를 사용하여 [파드를 강제 종료](/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination-forced)를 사용할 수 있습니다.
+{{< /note >}}
+
 노드가 죽거나 클러스터의 나머지와의 연결이 끊어지면, 쿠버네티스는
 손실된 노드의 모든 파드의 `phase` 를 Failed로 설정하는 정책을 적용한다.
 
@@ -326,7 +333,7 @@ kubelet은 실행 중인 컨테이너들에 대해서 선택적으로 세 가지
 컨테이너가 보통 `initialDelaySeconds + failureThreshold × periodSeconds`
 이후에 기동된다면, 스타트업 프로브가
 활성화 프로브와 같은 엔드포인트를 확인하도록 지정해야 한다.
-`periodSeconds`의 기본값은 30s 이다. 이 때 컨테이너가 활성화 프로브의
+`periodSeconds`의 기본값은 10초이다. 이 때 컨테이너가 활성화 프로브의
 기본값 변경 없이 기동되도록 하려면, `failureThreshold` 를 충분히 높게 설정해주어야
 한다. 그래야 데드락(deadlocks)을 방지하는데 도움이 된다.
 

--- a/content/ko/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/ko/docs/reference/command-line-tools-reference/feature-gates.md
@@ -166,7 +166,8 @@ kubelet과 같은 컴포넌트의 기능 게이트를 설정하려면, 기능 �
 | `StorageVersionHash` | `true` | 베타 | 1.15 | |
 | `Sysctls` | `true` | 베타 | 1.11 | |
 | `TTLAfterFinished` | `false` | 알파 | 1.12 | |
-| `TopologyManager` | `false` | 알파 | 1.16 | |
+| `TopologyManager` | `false` | 알파 | 1.16 | 1.17 |
+| `TopologyManager` | `true` | 베타 | 1.18 | |
 | `ValidateProxyRedirects` | `false` | 알파 | 1.12 | 1.13 |
 | `ValidateProxyRedirects` | `true` | 베타 | 1.14 | |
 | `WindowsEndpointSliceProxying` | `false` | 알파 | 1.19 | |

--- a/content/ko/docs/reference/kubectl/cheatsheet.md
+++ b/content/ko/docs/reference/kubectl/cheatsheet.md
@@ -190,6 +190,9 @@ kubectl get pods --show-labels
 JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}' \
  && kubectl get nodes -o jsonpath="$JSONPATH" | grep "Ready=True"
 
+# 외부 도구 없이 디코딩된 시크릿 출력
+kubectl get secret ${secret_name} -o go-template='{{range $k,$v := .data}}{{$k}}={{$v|base64decode}}{{"\n"}}{{end}}'
+
 # 파드에 의해 현재 사용되고 있는 모든 시크릿 목록 조회
 kubectl get pods -o json | jq '.items[].spec.containers[].env[]?.valueFrom.secretKeyRef.name' | grep -v null | sort | uniq
 
@@ -311,6 +314,7 @@ kubectl exec my-pod -- ls /                         # 기존 파드에서 명령
 kubectl exec --stdin --tty my-pod -- /bin/sh        # 실행 중인 파드로 대화형 셸 액세스(1 컨테이너 경우)
 kubectl exec my-pod -c my-container -- ls /         # 기존 파드에서 명령 실행(멀티-컨테이너 경우)
 kubectl top pod POD_NAME --containers               # 특정 파드와 해당 컨테이너에 대한 메트릭 표시
+kubectl top pod POD_NAME --sort-by=cpu              # 지정한 파드에 대한 메트릭을 표시하고 'cpu' 또는 'memory'별로 정렬
 ```
 
 ## 노드, 클러스터와 상호 작용
@@ -388,6 +392,7 @@ Kubectl 로그 상세 레벨(verbosity)은 `-v` 또는`--v` 플래그와 로그 
 `--v=2` | 서비스와 시스템의 중요한 변화와 관련이있는 중요한 로그 메시지에 대한 유용한 정상 상태 정보. 이는 대부분의 시스템에서 권장되는 기본 로그 수준이다.
 `--v=3` | 변경 사항에 대한 확장 정보.
 `--v=4` | 디버그 수준 상세화.
+`--v=5` | 트레이스 수준 상세화.
 `--v=6` | 요청한 리소스를 표시.
 `--v=7` | HTTP 요청 헤더를 표시.
 `--v=8` | HTTP 요청 내용을 표시.

--- a/content/ko/docs/reference/kubectl/conventions.md
+++ b/content/ko/docs/reference/kubectl/conventions.md
@@ -1,7 +1,5 @@
 ---
 title: kubectl 사용 규칙
-
-
 content_type: concept
 ---
 
@@ -36,24 +34,23 @@ content_type: concept
 {{< /note >}}
 
 #### 생성기
-`kubectl create --dry-run -o yaml`라는 kubectl 커맨드를 통해 다음과 같은 리소스를 생성 할 수 있다.
-```
-  clusterrole         클러스터롤(ClusterRole)를 생성한다.
-  clusterrolebinding  특정 클러스터롤에 대한 클러스터롤바인딩(ClusterRoleBinding)을 생성한다.
-  configmap           로컬 파일, 디렉토리 또는 문자 그대로의 값으로 컨피그맵(ConfigMap)을 생성한다.
-  cronjob             지정된 이름으로 크론잡(CronJob)을 생성한다.
-  deployment          지정된 이름으로 디플로이먼트(Deployment)를 생성한다.
-  job                 지정된 이름으로 잡(Job)을 생성한다.
-  namespace           지정된 이름으로 네임스페이스(Namespace)를 생성한다.
-  poddisruptionbudget 지정된 이름으로 pod disruption budget을 생성한다.
-  priorityclass       지정된 이름으로 프라이어리티클래스(PriorityClass)을 생성한다.
-  quota               지정된 이름으로 쿼터(Quota)를 생성한다.
-  role                단일 규칙으로 롤(Role)을 생성한다.
-  rolebinding         특정 롤 또는 클러스터롤에 대한 롤바인딩(RoleBinding)을 생성한다.
-  secret              지정된 하위 커맨드를 사용하여 시크릿(Secret)을 생성한다.
-  service             지정된 하위 커맨드를 사용하여 서비스(Service)를 생성한다.
-  serviceaccount      지정된 이름으로 서비스어카운트(ServiceAccount)을 생성한다.
-```
+`kubectl create --dry-run -o yaml`라는 kubectl 커맨드를 통해 다음과 같은 리소스를 생성할 수 있다.
+
+* `clusterrole`: 클러스터롤(ClusterRole)를 생성한다.
+* `clusterrolebinding`: 특정 클러스터롤에 대한 클러스터롤바인딩(ClusterRoleBinding)을 생성한다.
+* `configmap`: 로컬 파일, 디렉토리 또는 문자 그대로의 값으로 컨피그맵(ConfigMap)을 생성한다.
+* `cronjob`: 지정된 이름으로 크론잡(CronJob)을 생성한다.
+* `deployment`: 지정된 이름으로 디플로이먼트(Deployment)를 생성한다.
+* `job`: 지정된 이름으로 잡(Job)을 생성한다.
+* `namespace`: 지정된 이름으로 네임스페이스(Namespace)를 생성한다.
+* `poddisruptionbudget`: 지정된 이름으로 PodDisruptionBudget을 생성한다.
+* `priorityclass`: 지정된 이름으로 프라이어리티클래스(PriorityClass)을 생성한다.
+* `quota`: 지정된 이름으로 쿼터(Quota)를 생성한다.
+* `role`: 단일 규칙으로 롤(Role)을 생성한다.
+* `rolebinding`: 특정 롤 또는 클러스터롤에 대한 롤바인딩(RoleBinding)을 생성한다.
+* `secret`: 지정된 하위 커맨드를 사용하여 시크릿(Secret)을 생성한다.
+* `service`: 지정된 하위 커맨드를 사용하여 서비스(Service)를 생성한다.
+* `serviceaccount`: 지정된 이름으로 서비스어카운트(ServiceAccount)을 생성한다.
 
 ### `kubectl apply`
 

--- a/content/ko/docs/reference/kubectl/docker-cli-to-kubectl.md
+++ b/content/ko/docs/reference/kubectl/docker-cli-to-kubectl.md
@@ -1,9 +1,6 @@
 ---
 title: 도커 사용자를 위한 kubectl
 content_type: concept
-
-
-
 ---
 
 <!-- overview -->
@@ -37,16 +34,11 @@ kubectl:
 # nginx 실행하는 파드를 시작한다
 kubectl create deployment --image=nginx nginx-app
 ```
-
-```shell
-# nginx-app 에 env를 추가한다
-kubectl set env deployment/nginx-app  DOMAIN=cluster
-```
 ```
 deployment.apps/nginx-app created
 ```
 
-```
+```shell
 # nginx-app 에 env를 추가한다
 kubectl set env deployment/nginx-app  DOMAIN=cluster
 ```
@@ -369,4 +361,3 @@ Grafana is running at https://203.0.113.141/api/v1/namespaces/kube-system/servic
 Heapster is running at https://203.0.113.141/api/v1/namespaces/kube-system/services/monitoring-heapster/proxy
 InfluxDB is running at https://203.0.113.141/api/v1/namespaces/kube-system/services/monitoring-influxdb/proxy
 ```
-

--- a/content/ko/docs/setup/production-environment/container-runtimes.md
+++ b/content/ko/docs/setup/production-environment/container-runtimes.md
@@ -148,6 +148,44 @@ sudo containerd config default | sudo tee /etc/containerd/config.toml
 sudo systemctl restart containerd
 ```
 {{% /tab %}}
+{{% tab name="Debian 9+" %}}
+
+```shell
+# (containerd 설치)
+## 리포지터리 설정
+### HTTPS를 통해 리포지터리를 사용할 수 있도록 패키지 설치
+sudo apt-get update && sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common
+```
+
+```shell
+## 도커의 공식 GPG 키 추가
+curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key --keyring /etc/apt/trusted.gpg.d/docker.gpg add -
+```
+
+```shell
+## 도커 apt 리포지터리 추가
+sudo add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/debian \
+   $(lsb_release -cs) \
+   stable"
+```
+
+```shell
+## containerd 설치
+sudo apt-get update && sudo apt-get install -y containerd.io
+```
+
+```shell
+# 기본 containerd 구성 설정
+sudo mkdir -p /etc/containerd
+containerd config default | sudo tee /etc/containerd/config.toml
+```
+
+```shell
+# containerd 재시작
+sudo systemctl restart containerd
+```
+{{% /tab %}}
 {{% tab name="CentOS/RHEL 7.4+" %}}
 
 ```shell
@@ -230,12 +268,18 @@ kubeadm을 사용하는 경우,
 
 {{< note >}}
 CRI-O 메이저와 마이너 버전은 쿠버네티스 메이저와 마이너 버전이 일치해야 한다.
-더 자세한 정보는 [CRI-O 호환 매트릭스](https://github.com/cri-o/cri-o)를 본다.
+더 자세한 정보는 [CRI-O 호환 매트릭스](https://github.com/cri-o/cri-o#compatibility-matrix-cri-o--kubernetes)를 본다.
 {{< /note >}}
 
 필수 구성 요소를 설치하고 구성한다.
 
 ```shell
+# .conf 파일을 만들어 부팅 시 모듈을 로드한다
+cat <<EOF | sudo tee /etc/modules-load.d/crio.conf
+overlay
+br_netfilter
+EOF
+
 sudo modprobe overlay
 sudo modprobe br_netfilter
 
@@ -262,9 +306,9 @@ sudo sysctl --system
 
 <br />
 그런 다음, `$VERSION` 을 사용자의 쿠버네티스 버전과 일치하는 CRI-O 버전으로 설정한다.
-예를 들어, CRI-O 1.18을 설치하려면, `VERSION=1.18` 로 설정한다.
+예를 들어, CRI-O 1.20을 설치하려면, `VERSION=1.20` 로 설정한다.
 사용자의 설치를 특정 릴리스에 고정할 수 있다.
-버전 1.18.3을 설치하려면, `VERSION=1.18:1.18.3` 을 설정한다.
+버전 1.20.0을 설치하려면, `VERSION=1.20:1.20.0` 을 설정한다.
 <br />
 
 그런 다음, 아래를 실행한다.
@@ -298,9 +342,9 @@ sudo apt-get install cri-o cri-o-runc
 
 <br />
 그런 다음, `$VERSION` 을 사용자의 쿠버네티스 버전과 일치하는 CRI-O 버전으로 설정한다.
-예를 들어, CRI-O 1.18을 설치하려면, `VERSION=1.18` 로 설정한다.
+예를 들어, CRI-O 1.20을 설치하려면, `VERSION=1.20` 로 설정한다.
 사용자의 설치를 특정 릴리스에 고정할 수 있다.
-버전 1.18.3을 설치하려면, `VERSION=1.18:1.18.3` 을 설정한다.
+버전 1.20.0을 설치하려면, `VERSION=1.20:1.20.0` 을 설정한다.
 <br />
 
 그런 다음, 아래를 실행한다.
@@ -332,9 +376,9 @@ apt-get install cri-o cri-o-runc
 
 <br />
 그런 다음, `$VERSION` 을 사용자의 쿠버네티스 버전과 일치하는 CRI-O 버전으로 설정한다.
-예를 들어, CRI-O 1.18을 설치하려면, `VERSION=1.18` 로 설정한다.
+예를 들어, CRI-O 1.20을 설치하려면, `VERSION=1.20` 로 설정한다.
 사용자의 설치를 특정 릴리스에 고정할 수 있다.
-버전 1.18.3을 설치하려면, `VERSION=1.18:1.18.3` 을 설정한다.
+버전 1.20.0을 설치하려면, `VERSION=1.20:1.20.0` 을 설정한다.
 <br />
 
 그런 다음, 아래를 실행한다.
@@ -355,7 +399,7 @@ sudo zypper install cri-o
 {{% tab name="Fedora" %}}
 
 `$VERSION` 을 사용자의 쿠버네티스 버전과 일치하는 CRI-O 버전으로 설정한다.
-예를 들어, CRI-O 1.18을 설치하려면, `VERSION=1.18` 로 설정한다.
+예를 들어, CRI-O 1.20을 설치하려면, `VERSION=1.20` 로 설정한다.
 
 사용할 수 있는 버전을 찾으려면 다음을 실행한다.
 ```shell
@@ -379,10 +423,26 @@ sudo systemctl daemon-reload
 sudo systemctl start crio
 ```
 
-자세한 사항은 [CRI-O 설치 가이드](https://github.com/kubernetes-sigs/cri-o#getting-started)를
+자세한 사항은 [CRI-O 설치 가이드](https://github.com/cri-o/cri-o/blob/master/install.md)를
 참고한다.
 
 
+#### cgroup 드라이버
+
+CRI-O는 기본적으로 systemd cgroup 드라이버를 사용한다. `cgroupfs` cgroup 드라이버로
+전환하려면, `/etc/crio/crio.conf` 를 수정하거나 `/etc/crio/crio.conf.d/02-cgroup-manager.conf` 에
+드롭-인(drop-in) 구성을 배치한다. 예를 들면, 다음과 같다.
+
+```toml
+[crio.runtime]
+conmon_cgroup = "pod"
+cgroup_manager = "cgroupfs"
+```
+
+또한 `cgroupfs` 와 함께 CRI-O를 사용할 때 `pod` 값으로 설정해야 하는
+변경된 `conmon_cgroup` 에 유의한다. 일반적으로 kubelet(일반적으로 kubeadm을 통해 수행됨) 과
+CRI-O의 cgroup 드라이버 구성을 동기화 상태로
+유지해야 한다.
 
 ### 도커
 
@@ -423,6 +483,11 @@ sudo apt-get update && sudo apt-get install -y \
   containerd.io=1.2.13-2 \
   docker-ce=5:19.03.11~3-0~ubuntu-$(lsb_release -cs) \
   docker-ce-cli=5:19.03.11~3-0~ubuntu-$(lsb_release -cs)
+```
+
+```shell
+## /etc/docker 생성
+sudo mkdir /etc/docker
 ```
 
 ```shell

--- a/content/ko/docs/tasks/access-application-cluster/connecting-frontend-backend.md
+++ b/content/ko/docs/tasks/access-application-cluster/connecting-frontend-backend.md
@@ -6,17 +6,19 @@ weight: 70
 
 <!-- overview -->
 
-이 작업은 프론트엔드와 마이크로서비스 백엔드를 어떻게 생성하는지를
-설명한다. 백엔드 마이크로서비스는 인사하기(hello greeter)이다.
-프론트엔드와 백엔드는 쿠버네티스 {{< glossary_tooltip term_id="service" text="서비스" >}}
-오브젝트를 이용해 연결되어 있다.
+이 작업은 _프론트엔드_ 와 _백엔드_ 마이크로서비스를 어떻게 생성하는지를 설명한다. 백엔드
+마이크로서비스는 인사하기(hello greeter)이다. 프론트엔드는 nginx 및 쿠버네티스
+{{< glossary_tooltip term_id="service" text="서비스" >}} 오브젝트를 사용해 백엔드를 노출한다.
 
 ## {{% heading "objectives" %}}
 
-* {{< glossary_tooltip term_id="deployment" text="디플로이먼트(Deployment)" >}} 오브젝트를 사용해 마이크로서비스를 생성하고 실행한다.
-* 프론트엔드를 사용하여 백엔드로 트래픽을 전달한다.
-* 프론트엔드 애플리케이션을 백엔드 애플리케이션에 연결하기 위해
-  서비스 오브젝트를 사용한다.
+* {{< glossary_tooltip term_id="deployment" text="디플로이먼트(Deployment)" >}} 오브젝트를 사용해
+  샘플 `hello` 백엔드 마이크로서비스를 생성하고 실행한다.
+* 서비스 오브젝트를 사용하여 백엔드 마이크로서비스의 여러 복제본으로 트래픽을 보낸다.
+* 디플로이먼트 오브젝트를 사용하여 `nginx` 프론트엔드 마이크로서비스를 생성하고 실행한다.
+* 트래픽을 백엔드 마이크로서비스로 보내도록 프론트엔드 마이크로서비스를 구성한다.
+* `type=LoadBalancer` 의 서비스 오브젝트를 사용해 클러스터 외부에 프론트엔드 마이크로서비스를
+  노출한다.
 
 ## {{% heading "prerequisites" %}}
 
@@ -34,24 +36,24 @@ weight: 70
 백엔드는 인사하기라는 간단한 마이크로서비스이다. 여기에 백엔드 디플로이먼트
 구성 파일이 있다.
 
-{{< codenew file="service/access/hello.yaml" >}}
+{{< codenew file="service/access/backend-deployment.yaml" >}}
 
 백엔드 디플로이먼트를 생성한다.
 
 ```shell
-kubectl apply -f https://k8s.io/examples/service/access/hello.yaml
+kubectl apply -f https://k8s.io/examples/service/access/backend-deployment.yaml
 ```
 
 백엔드 디플로이먼트에 관한 정보를 본다.
 
 ```shell
-kubectl describe deployment hello
+kubectl describe deployment backend
 ```
 
 결과는 아래와 같다.
 
 ```
-Name:                           hello
+Name:                           backend
 Namespace:                      default
 CreationTimestamp:              Mon, 24 Oct 2016 14:21:02 -0700
 Labels:                         app=hello
@@ -59,7 +61,7 @@ Labels:                         app=hello
                                 track=stable
 Annotations:                    deployment.kubernetes.io/revision=1
 Selector:                       app=hello,tier=backend,track=stable
-Replicas:                       7 desired | 7 updated | 7 total | 7 available | 0 unavailable
+Replicas:                       3 desired | 3 updated | 3 total | 3 available | 0 unavailable
 StrategyType:                   RollingUpdate
 MinReadySeconds:                0
 RollingUpdateStrategy:          1 max unavailable, 1 max surge
@@ -80,14 +82,13 @@ Conditions:
   Available     True    MinimumReplicasAvailable
   Progressing   True    NewReplicaSetAvailable
 OldReplicaSets:                 <none>
-NewReplicaSet:                  hello-3621623197 (7/7 replicas created)
+NewReplicaSet:                  hello-3621623197 (3/3 replicas created)
 Events:
 ...
 ```
 
-## 백엔드 서비스 오브젝트 생성하기
-
-프론트엔드와 백엔드를 연결하는 방법은 백엔드
+## `hello` 서비스 오브젝트 생성하기
+프론트엔드에서 백엔드로 요청을 보내는 핵심은 백엔드
 서비스이다. 서비스는 백엔드 마이크로서비스에 언제든 도달하기 위해
 변하지 않는 IP 주소와 DNS 이름 항목을 생성한다. 서비스는
 트래픽을 보내는 파드를 찾기 위해
@@ -95,42 +96,49 @@ Events:
 
 먼저, 서비스 구성 파일을 살펴보자.
 
-{{< codenew file="service/access/hello-service.yaml" >}}
+{{< codenew file="service/access/backend-service.yaml" >}}
 
-구성 파일에서 서비스가 `app: hello` 과 `tier: backend` 레이블을 갖는
-파드에 트래픽을 보내는 것을 볼 수 있다.
+구성 파일에서 `hello` 라는 이름의 서비스가 `app: hello` 및 `tier: backend` 레이블을 갖는
+파드에 트래픽을 보내는는 것을 볼 수 있다.
 
-`hello` 서비스를 생성한다.
+백엔드 서비스를 생성한다.
 
 ```shell
-kubectl apply -f https://k8s.io/examples/service/access/hello-service.yaml
+kubectl apply -f https://k8s.io/examples/service/access/backend-service.yaml
 ```
 
-이 시점에서, 백엔드 디플로이먼트는 Running 중이며, 해당 백엔드로
-트래픽을 보내는 서비스를 갖고 있다.
+이 시점에서 `hello` 애플리케이션의 복제본 3개를 실행하는 `backend`
+디플로이먼트가 있고, 해당 백엔드로 트래픽을 보내는 서비스가 있다. 그러나, 이
+서비스는 클러스터 외부에서 사용할 수 없거나 확인할 수 없다.
 
 ## 프론트엔드 생성하기
 
-이제 백엔드가 있기 때문에 백엔드와 연결하는 프론트엔드를 생성할 수 있다.
-프론트엔드는 백엔드 서비스에서 제공된 DNS 이름을 사용해 백엔드 워커
-파드에 연결할 수 있다. DNS 이름은 "hello" 이고, 앞선
-서비스 구성 파일의 `name` 항목의 값이다.
+이제 백엔드를 실행했으므로, 클러스터 외부에서 접근할 수 있는
+프론트엔드를 만들고, 백엔드로의 요청을 프록시하여 백엔드에 연결할 수 있다.
 
-프론트엔드 디플로이먼트 안에 파드는 hello 백엔드 서비스를 찾도록
-구성된 nginx 이미지를 실행한다. 여기에 nginx 구성 파일이 있다.
+프론트엔드는 백엔드 서비스에 지정된 DNS 이름을 사용하여 백엔드
+워커 파드에 요청을 보낸다. DNS 이름은
+`examples/service/access/backend-service.yaml` 구성 파일의
+`name` 필드 값인 `hello` 이다.
 
-{{< codenew file="service/access/frontend.conf" >}}
+프론트엔드 디플로이먼트 안의 파드는 `hello` 백엔드 서비스에 대한 요청을
+프록시하도록 구성된 nginx 이미지를 실행한다. 다음은 nginx 구성 파일이다.
 
-백엔드와 같이, 프론트엔드는 디플로이먼트와 서비스를 갖고 있다.
-서비스의 구성은 `type: LoadBalancer` 이며, 이는 서비스가
-클라우드 공급자의 기본 로드 밸런서를 사용하는 것을 의미한다.
+백엔드와 같이, 프론트엔드는 디플로이먼트와 서비스를 갖고 있다. 백엔드
+서비스와 프론트엔드 서비스 간에 주목해야 할 중요한 차이점은 프론트엔드
+서비스의 구성에 `type: LoadBalancer` 가 있다는 것이다. 즉,
+서비스가 클라우드 공급자가 프로비저닝한 로드 밸런서를 사용하고
+클러스터 외부에서 접근할 수 있음을 의미한다.
 
-{{< codenew file="service/access/frontend.yaml" >}}
+{{< codenew file="service/access/frontend-service.yaml" >}}
+
+{{< codenew file="service/access/frontend-deployment.yaml" >}}
 
 프론트엔드 디플로이먼트와 서비스를 생성한다.
 
 ```shell
-kubectl apply -f https://k8s.io/examples/service/access/frontend.yaml
+kubectl apply -f https://k8s.io/examples/service/access/frontend-deployment.yaml
+kubectl apply -f https://k8s.io/examples/service/access/frontend-service.yaml
 ```
 
 결과는 두 리소스가 생성되었음을 확인한다.
@@ -196,17 +204,16 @@ curl http://${EXTERNAL_IP} # 앞의 예에서 본 EXTERNAL-IP로 수정한다
 서비스를 삭제하기 위해, 아래 명령어를 입력하자.
 
 ```shell
-kubectl delete services frontend hello
+kubectl delete services frontend backend
 ```
 
 백엔드와 프론트엔드 애플리케이션에서 실행 중인 디플로이먼트, 레플리카셋, 파드를 삭제하기 위해, 아래 명령어를 입력하자.
 
 ```shell
-kubectl delete deployment frontend hello
+kubectl delete deployment frontend backend
 ```
 
 ## {{% heading "whatsnext" %}}
 
 * [서비스](/ko/docs/concepts/services-networking/service/)에 대해 더 알아본다.
 * [컨피그맵](/docs/tasks/configure-pod-container/configure-pod-configmap/)에 대해 더 알아본다.
-

--- a/content/ko/docs/tasks/manage-kubernetes-objects/kustomization.md
+++ b/content/ko/docs/tasks/manage-kubernetes-objects/kustomization.md
@@ -392,8 +392,8 @@ spec:
       containers:
       - name: my-nginx
         resources:
-        limits:
-          memory: 512Mi
+          limits:
+            memory: 512Mi
 EOF
 
 cat <<EOF >./kustomization.yaml
@@ -424,11 +424,12 @@ spec:
     spec:
       containers:
       - image: nginx
-        limits:
-          memory: 512Mi
         name: my-nginx
         ports:
         - containerPort: 80
+        resources:
+          limits:
+            memory: 512Mi
 ```
 
 모든 리소스 또는 필드가 전략적 병합 패치를 지원하는 것은 아니다. 임의의 리소스 내 임의의 필드의 수정을 지원하기 위해,

--- a/content/ko/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
+++ b/content/ko/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
@@ -103,9 +103,7 @@ weight: 10
         <div class="row">
             <div class="col-md-8">
                 <p>
-                  첫 번째 디플로이먼트로, 도커 컨테이너로 패키지된 Node.js 애플리케이션을 사용해보자.
-                    (Node.js 애플리케이션을 작성하고 컨테이너를 활용해서 배포해보지 않았다면,
-                    <a href="/ko/docs/tutorials/hello-minikube/">Hello Minikube 튜토리얼</a>의 지시를 따른다.)</p>
+                  첫 번째 디플로이먼트로, NGINX를 사용해 모든 요청을 에코하는 도커 컨테이너에 패키지된 hello-node 애플리케이션을 사용해보자. (아직 hello-node 애플리케이션을 작성하고 컨테이너를 활용해서 배포해보지 않았다면, <a href="/docs/tutorials/hello-minikube/">Hello Minikube 튜토리얼</a>의 지시를 따른다.).                  
                 <p>
 
                  <p>이제 디플로이먼트를 이해했으니, 온라인 튜토리얼을 통해 우리의 첫 번째 애플리케이션을 배포해보자!</p>


### PR DESCRIPTION
Update outdated files in the upstream/dev-1.20-ko.3 branch.

### 16 files are updated
- [x]  M24.  `content/en/docs/reference/command-line-tools-reference/feature-gates.md`  | 2(+XS) 1(-)
- [x]  M25.  `content/en/docs/reference/kubectl/cheatsheet.md`  | 5(+XS) 0(-)
- [x]  M26.  `content/en/docs/reference/kubectl/conventions.md`  | 16(+S) 17(-)
- [x]  M27.  `content/en/docs/reference/kubectl/docker-cli-to-kubectl.md`  | 1(+XS) 6(-)
- [x]  M29.  `content/en/docs/setup/production-environment/container-runtimes.md`  | 75(+M) 11(-)
- [x]  M31.  `content/en/docs/tasks/access-application-cluster/connecting-frontend-backend.md`  | 51(+M) 40(-)
- [x]  M32.  `content/en/docs/tasks/manage-kubernetes-objects/kustomization.md`  | 5(+XS) 4(-)
- [x]  M33.  `content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html`  | 1(+XS) 3(-)
- [ ]  M34.  `content/en/examples/application/deployment.yaml`  | 1(+XS) 1(-)
- [ ]  M35.  `content/en/examples/application/guestbook/frontend-deployment.yaml`  | 1(+XS) 1(-)
- [ ]  M36.  `content/en/examples/application/guestbook/redis-master-deployment.yaml`  | 1(+XS) 1(-)
- [ ]  M37.  `content/en/examples/application/guestbook/redis-slave-deployment.yaml`  | 1(+XS) 1(-)
- [ ]  M38.  `content/en/examples/application/mysql/mysql-deployment.yaml`  | 1(+XS) 1(-)
- [ ]  M39.  `content/en/examples/application/wordpress/mysql-deployment.yaml`  | 1(+XS) 1(-)
- [ ]  M40.  `content/en/examples/application/wordpress/wordpress-deployment.yaml`  | 1(+XS) 1(-)
- [ ]  M41.  `content/en/examples/service/access/Dockerfile`  | 1(+XS) 1(-)
 
### 2 files are renamed
- [x]  R1.  R091 `content/en/examples/service/access/hello.yaml` -> `content/en/examples/service/access/backend-deployment.yaml`
- [x]  R2.  R095 `content/en/examples/service/access/hello-service.yaml` -> `content/en/examples/service/access/backend-service.yaml`

### 2 files are deleted
- [x]  D1.  `content/en/examples/service/access/frontend.conf`
- [x]  D2.  `content/en/examples/service/access/frontend.yaml`

### 2 files not updated which were already applied for Korean
- [x]  M28.  `content/en/docs/reference/scheduling/config.md`  | 1(+XS) 1(-)
- [x]  M30.  `content/en/docs/tasks/access-application-cluster/configure-access-multiple-clusters.md`  | 1(+XS) 1(-)