### PR TITLE
api-reference shortcode + script to test links

### DIFF
--- a/content/en/docs/contribute/style/hugo-shortcodes/index.md
+++ b/content/en/docs/contribute/style/hugo-shortcodes/index.md
@@ -83,6 +83,33 @@ You can also include a full definition:
 which renders as:
 {{< glossary_definition term_id="cluster" length="all" >}}
 
+## Links to API Reference
+
+You can link to a page of the Kubernetes API reference using the `api-reference` shortcode, for example to the {{< api-reference page="workload-resources/pod-v1" >}} reference:
+
+```
+{{</* api-reference page="workload-resources/pod-v1" */>}}
+```
+
+The content of the `page` parameter is the suffix of the URL of the API reference page.
+
+
+You can link to a specific place into a page by specifying an `anchor` parameter, for example to the {{< api-reference page="workload-resources/pod-v1" anchor="PodSpec" >}} reference or the {{< api-reference page="workload-resources/pod-v1" anchor="environment-variables" >}} section of the page:
+
+```
+{{</* api-reference page="workload-resources/pod-v1" anchor="PodSpec" */>}}
+{{</* api-reference page="workload-resources/pod-v1" anchor="environment-variables" */>}}
+```
+
+
+You can change the text of the link by specifying a `text` parameter, for example by linking to the {{< api-reference page="workload-resources/pod-v1" anchor="environment-variables" text="Environment Variables">}} section of the page:
+
+```
+{{</* api-reference page="workload-resources/pod-v1" anchor="environment-variables" text="Environment Variable" */>}}
+```
+
+
+
 ## Table captions
 
 You can make tables more accessible to screen readers by adding a table caption. To add a [caption](https://www.w3schools.com/tags/tag_caption.asp) to a table, enclose the table with a `table` shortcode and specify the caption with the `caption` parameter.

--- a/layouts/shortcodes/api-reference.html
+++ b/layouts/shortcodes/api-reference.html
@@ -1,0 +1,7 @@
+{{ $base := "docs/reference/kubernetes-api" }}
+{{ $pageArg := .Get "page" }}
+{{ $anchorArg := .Get "anchor" }}
+{{ $textArg := .Get "text" }}
+{{ $page := site.GetPage "page" (printf "%s/%s" $base $pageArg) }}
+{{ $metadata := $page.Params.api_metadata }}
+<a href="{{ $page.URL }}{{if $anchorArg}}#{{ $anchorArg }}{{end}}">{{if $textArg}}{{ $textArg }}{{else if $anchorArg}}{{ $anchorArg }}{{else}}{{ $metadata.kind }}{{end}}</a>


### PR DESCRIPTION
This PR adds an `api-reference` shortcode to create link to the new API reference introduced in https://github.com/kubernetes/website/pull/23294.

## `api-reference` shortcode

A shortcode has been created, to help creating links to sections of the API Reference.

Attributes of the shortcode:

### `page`

`page` indicates the page to link to, by specifying the suffix of the URL after `docs/reference/kubernetes-api/`:
  `{{< api-reference page="workload-resources/pod-v1" >}}` will create a link to the page https://deploy-preview-26151--kubernetes-io-main-staging.netlify.app/docs/reference/kubernetes-api/workload-resources/pod-v1/

### `anchor`
an optional `anchor` indicates a fragment of the page to point to (the fragment can be the name of a Definition defined in this page, or a section):
- link to the `PodSpec` definition:  `{{< api-reference page="workload-resources/pod-v1" anchor="PodSpec" >}}` will link to the fragment of the page https://deploy-preview-26151--kubernetes-io-main-staging.netlify.app/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec
- link to the `Scheduling` section of Pod page: `{{< api-reference page="workload-resources/pod-v1" anchor="Scheduling" >}}` will link to the fragment of the page https://deploy-preview-26151--kubernetes-io-main-staging.netlify.app/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling

### `text`

By default, the text of the link is derived from the name of the linked page. For example, the shortcode `{{< api-reference page="workloads-resources/pod-v1" >}}` will generate a link with the text **Pod**.

You can specify the text of the link with the `text` attribute. For example, the shortcode `{{< api-reference page="workload-resources/pod-v1" text="the Pod resource" >}}`  will generate a link with the text **the Pod resource**.

## Checking the links

The script `scripts/linkchecker.py` checks that the links are correct.
