### PR TITLE
Skip crawling for new API documentation

### DIFF
--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -6,4 +6,8 @@ Disallow: /v1.1/
 Disallow: /404/
 Disallow: /404.html
 
+Allow: /docs/reference/kubernetes-api/api-index/
+Allow: /docs/reference/kubernetes-api/labels-annotations-taints/
+Disallow: /docs/reference/kubernetes-api/
+
 SITEMAP: {{ "sitemap.xml" | absLangURL }}


### PR DESCRIPTION
Small change to lay the path for merging PR #23294. Approach as per https://github.com/kubernetes/website/pull/23294#issuecomment-763108448 but I tweaked it based on what I think provides broadest compatibility: I want to cover many search engines both current and not.

This prepares for the launch of new API documentation, initially without indexing by search engines.
