### PR TITLE
Update reference link for API Group

### DIFF
--- a/content/en/docs/reference/glossary/api-group.md
+++ b/content/en/docs/reference/glossary/api-group.md
@@ -16,4 +16,4 @@ A set of related paths in Kubernetes API.
 <!--more-->
 You can enable or disable each API group by changing the configuration of your API server. You can also disable or enable paths to specific resources. API group makes it easier to extend the Kubernetes API. The API group is specified in a REST path and in the `apiVersion` field of a serialized object.
 
-* Read [API Group](/docs/concepts/overview/kubernetes-api/#api-groups) for more information.
+* Read [API Group](/docs/concepts/overview/kubernetes-api/#api-groups-and-versioning) for more information.


### PR DESCRIPTION
The old link "https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-groups" points to an nonexistent section of that page. The correct section should be "https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-groups-and-versioning" .


