### PR TITLE
Update source-ip.md

### DIFF
--- a/content/en/docs/tutorials/services/source-ip.md
+++ b/content/en/docs/tutorials/services/source-ip.md
@@ -425,7 +425,7 @@ the `service.spec.healthCheckNodePort` field on the Service.
 Delete the Services:
 
 ```shell
-kubectl delete svc -l run=source-ip-app
+kubectl delete svc -l app=source-ip-app
 ```
 
 Delete the Deployment, ReplicaSet and Pod:


### PR DESCRIPTION
In v1.20.2, the command to delete svc is “kubectl delete svc -l app=source-ip-app”, the label not "run=source-ip-app"  in  the title of this "Cleaning up".

[root@demo ~]# kubectl get all --show-labels
NAME                                 READY   STATUS    RESTARTS   AGE   LABELS
pod/source-ip-app-54595b9cc9-s2r45   1/1     Running   0          32s   app=source-ip-app,pod-template-hash=54595b9cc9

NAME                 TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)        AGE     LABELS
service/clusterip    ClusterIP   10.99.78.154     <none>        80/TCP         5m56s   app=source-ip-app
service/kubernetes   ClusterIP   10.96.0.1        <none>        443/TCP        57m     component=apiserver,provider=kubernetes
service/nodeport     NodePort    10.107.251.119   <none>        80:31548/TCP   5m46s   app=source-ip-app

NAME                            READY   UP-TO-DATE   AVAILABLE   AGE    LABELS
deployment.apps/source-ip-app   1/1     1            1           6m3s   app=source-ip-app

NAME                                       DESIRED   CURRENT   READY   AGE    LABELS
replicaset.apps/source-ip-app-54595b9cc9   1         1         1       32s    app=source-ip-app,pod-template-hash=54595b9cc9
replicaset.apps/source-ip-app-86cd545f4c   0         0         0       6m3s   app=source-ip-app,pod-template-hash=86cd545f4c


