### PR TITLE
Fix links to flexVolume documentation

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/extend-cluster.md
+++ b/content/en/docs/concepts/extend-kubernetes/extend-cluster.md
@@ -74,7 +74,7 @@ failure.
 In the webhook model, Kubernetes makes a network request to a remote service.
 In the *Binary Plugin* model, Kubernetes executes a binary (program).
 Binary plugins are used by the kubelet (e.g.
-[Flex Volume Plugins](/docs/concepts/storage/volumes/#flexVolume)
+[Flex Volume Plugins](/docs/concepts/storage/volumes/#flexvolume)
 and [Network Plugins](/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/))
 and by kubectl.
 
@@ -161,7 +161,7 @@ After a request is authorized, if it is a write operation, it also goes through 
 
 ### Storage Plugins
 
-[Flex Volumes](/docs/concepts/storage/volumes/#flexVolume)
+[Flex Volumes](/docs/concepts/storage/volumes/#flexvolume)
 allow users to mount volume types without built-in support by having the
 Kubelet call a Binary Plugin to mount the volume.
 

--- a/content/ja/docs/concepts/extend-kubernetes/extend-cluster.md
+++ b/content/ja/docs/concepts/extend-kubernetes/extend-cluster.md
@@ -58,7 +58,7 @@ Kubernetes上でうまく動くクライアントプログラムを書くため�
 
 Webhookのモデルでは、Kubernetesは外部のサービスを呼び出します。
 *バイナリプラグイン* モデルでは、Kubernetesはバイナリ(プログラム)を実行します。
-バイナリプラグインはkubelet(例、[FlexVolumeプラグイン](/docs/concepts/storage/volumes/#flexVolume)、[ネットワークプラグイン](/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/))、またkubectlで利用されています。
+バイナリプラグインはkubelet(例、[FlexVolumeプラグイン](/docs/concepts/storage/volumes/#flexvolume)、[ネットワークプラグイン](/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/))、またkubectlで利用されています。
 
 下図は、それぞれの拡張ポイントが、Kubernetesのコントロールプレーンとどのように関わっているかを示しています。
 
@@ -134,7 +134,7 @@ Kubernetesはいくつかのビルトイン認証方式と、それらが要件�
 
 ### ストレージプラグイン
 
-[Flex Volumes](/docs/concepts/storage/volumes/#flexVolume)は、Kubeletがバイナリプラグインを呼び出してボリュームをマウントすることにより、ユーザーはビルトインのサポートなしでボリュームタイプをマウントすることを可能にします。
+[Flex Volumes](/docs/concepts/storage/volumes/#flexvolume)は、Kubeletがバイナリプラグインを呼び出してボリュームをマウントすることにより、ユーザーはビルトインのサポートなしでボリュームタイプをマウントすることを可能にします。
 
 ### デバイスプラグイン
 

--- a/content/ko/docs/concepts/extend-kubernetes/extend-cluster.md
+++ b/content/ko/docs/concepts/extend-kubernetes/extend-cluster.md
@@ -69,7 +69,7 @@ weight: 10
 웹훅 모델에서 쿠버네티스는 원격 서비스에 네트워크 요청을 한다.
 *바이너리 플러그인* 모델에서 쿠버네티스는 바이너리(프로그램)를 실행한다.
 바이너리 플러그인은 kubelet(예:
-[Flex Volume 플러그인](/ko/docs/concepts/storage/volumes/#flexVolume)과
+[Flex Volume 플러그인](/ko/docs/concepts/storage/volumes/#flexvolume)과
 [네트워크 플러그인](/ko/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/))과
 kubectl에서
 사용한다.
@@ -157,7 +157,7 @@ API를 추가해도 기존 API(예: 파드)의 동작에 직접 영향을 미치
 
 ### 스토리지 플러그인
 
-[Flex Volumes](/ko/docs/concepts/storage/volumes/#flexVolume)을 사용하면
+[Flex Volumes](/ko/docs/concepts/storage/volumes/#flexvolume)을 사용하면
 Kubelet이 바이너리 플러그인을 호출하여 볼륨을 마운트하도록 함으로써
 빌트인 지원 없이 볼륨 유형을 마운트 할 수 있다.
 


### PR DESCRIPTION


<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

A few links to the flexVolume documentation do not resolve correctly due
to case sensitivity in the page anchor. This updates those links to
resolve to the correct section of the volumes doc.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I believe this change would be acceptable to go directly to `master` based on my read of the [localization branching strategy](https://kubernetes.io/docs/contribute/localization/#branching-strategy), but I would be happy to break the language-specific changes into appropriate dev branches if needed :+1: 