### PR TITLE
docs-fr: make the Ingress TLS example match EN version (example URL mainly)

### DIFF
--- a/content/fr/docs/concepts/services-networking/ingress.md
+++ b/content/fr/docs/concepts/services-networking/ingress.md
@@ -328,7 +328,7 @@ metadata:
 type: kubernetes.io/tls
 ```
 
-Référencer ce secret dans un Ingress indiquera au contrôleur d'Ingress de sécuriser le canal du client au load-balancer à l'aide de TLS. Vous devez vous assurer que le secret TLS que vous avez créé provenait d'un certificat contenant un Common Name (CN), aussi appelé nom de domaine pleinement qualifié (FQDN), pour `tlsexample.foo.com`.
+Référencer ce secret dans un Ingress indiquera au contrôleur d'Ingress de sécuriser le canal du client au load-balancer à l'aide de TLS. Vous devez vous assurer que le secret TLS que vous avez créé provenait d'un certificat contenant un Common Name (CN), aussi appelé nom de domaine pleinement qualifié (FQDN), pour `https-example.foo.com`.
 
 ```yaml
 apiVersion: networking.k8s.io/v1

--- a/content/fr/docs/concepts/services-networking/ingress.md
+++ b/content/fr/docs/concepts/services-networking/ingress.md
@@ -330,28 +330,8 @@ type: kubernetes.io/tls
 
 Référencer ce secret dans un Ingress indiquera au contrôleur d'Ingress de sécuriser le canal du client au load-balancer à l'aide de TLS. Vous devez vous assurer que le secret TLS que vous avez créé provenait d'un certificat contenant un Common Name (CN), aussi appelé nom de domaine pleinement qualifié (FQDN), pour `https-example.foo.com`.
 
-```yaml
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: tls-example-ingress
-spec:
-  tls:
-  - hosts:
-      - https-example.foo.com
-    secretName: testsecret-tls
-  rules:
-  - host: https-example.foo.com
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: service1
-            port:
-              number: 80
-```
+{{< codenew file="service/networking/tls-example-ingress.yaml" >}}
+
 
 {{< note >}}
 Les fonctionnalités TLS prisent en charge par les différents contrôleurs peuvent être différentes. Veuillez vous référer à la documentation sur

--- a/content/fr/docs/concepts/services-networking/ingress.md
+++ b/content/fr/docs/concepts/services-networking/ingress.md
@@ -328,7 +328,7 @@ metadata:
 type: kubernetes.io/tls
 ```
 
-Référencer ce secret dans un Ingress indiquera au contrôleur d'Ingress de sécuriser le canal du client au load-balancer à l'aide de TLS. Vous devez vous assurer que le secret TLS que vous avez créé provenait d'un certificat contenant un CN pour `tlsexample.foo.com`.
+Référencer ce secret dans un Ingress indiquera au contrôleur d'Ingress de sécuriser le canal du client au load-balancer à l'aide de TLS. Vous devez vous assurer que le secret TLS que vous avez créé provenait d'un certificat contenant un Common Name (CN), aussi appelé nom de domaine pleinement qualifié (FQDN), pour `tlsexample.foo.com`.
 
 ```yaml
 apiVersion: networking.k8s.io/v1

--- a/content/fr/docs/concepts/services-networking/ingress.md
+++ b/content/fr/docs/concepts/services-networking/ingress.md
@@ -328,7 +328,7 @@ metadata:
 type: kubernetes.io/tls
 ```
 
-Référencer ce secret dans un Ingress indiquera au contrôleur d'ingress de sécuriser le canal du client au load-balancer à l'aide de TLS. Vous devez vous assurer que le secret TLS que vous avez créé provenait d'un certificat contenant un CN pour `sslexample.foo.com`.
+Référencer ce secret dans un Ingress indiquera au contrôleur d'ingress de sécuriser le canal du client au load-balancer à l'aide de TLS. Vous devez vous assurer que le secret TLS que vous avez créé provenait d'un certificat contenant un CN pour `tlsexample.foo.com`.
 
 ```yaml
 apiVersion: networking.k8s.io/v1
@@ -338,10 +338,10 @@ metadata:
 spec:
   tls:
   - hosts:
-    - sslexample.foo.com
+    - tlsexample.foo.com
     secretName: testsecret-tls
   rules:
-    - host: sslexample.foo.com
+    - host: tlsexample.foo.com
       http:
         paths:
         - path: /

--- a/content/fr/docs/concepts/services-networking/ingress.md
+++ b/content/fr/docs/concepts/services-networking/ingress.md
@@ -338,19 +338,19 @@ metadata:
 spec:
   tls:
   - hosts:
-    - tlsexample.foo.com
+      - https-example.foo.com
     secretName: testsecret-tls
   rules:
-    - host: tlsexample.foo.com
-      http:
-        paths:
-        - path: /
-          pathType: Prefix
-          backend:
-            service:
-              name: service1
-              port:
-                number: 80
+  - host: https-example.foo.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: service1
+            port:
+              number: 80
 ```
 
 {{< note >}}

--- a/content/fr/docs/concepts/services-networking/ingress.md
+++ b/content/fr/docs/concepts/services-networking/ingress.md
@@ -328,7 +328,7 @@ metadata:
 type: kubernetes.io/tls
 ```
 
-Référencer ce secret dans un Ingress indiquera au contrôleur d'ingress de sécuriser le canal du client au load-balancer à l'aide de TLS. Vous devez vous assurer que le secret TLS que vous avez créé provenait d'un certificat contenant un CN pour `tlsexample.foo.com`.
+Référencer ce secret dans un Ingress indiquera au contrôleur d'Ingress de sécuriser le canal du client au load-balancer à l'aide de TLS. Vous devez vous assurer que le secret TLS que vous avez créé provenait d'un certificat contenant un CN pour `tlsexample.foo.com`.
 
 ```yaml
 apiVersion: networking.k8s.io/v1

--- a/content/fr/examples/service/networking/tls-example-ingress.yaml
+++ b/content/fr/examples/service/networking/tls-example-ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tls-example-ingress
+spec:
+  tls:
+  - hosts:
+      - https-example.foo.com
+    secretName: testsecret-tls
+  rules:
+  - host: https-example.foo.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: service1
+            port:
+              number: 80


### PR DESCRIPTION
This PR is a minor update to the Ingress documentation in French: the page is talking about TLS everywhere, but the example DNS record used remains `sslexample.foo.com`. This PR simply changes it to `tlsexample.foo.com` for more consistency. Noticed it thanks to @franck-cussac !
 
As suggested in <https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use> I tried to find a branch dedicated to the updates of the FR translation but didn't find any, so I'm filing this against master. Let me know if I should do something else!
