### PR TITLE
Redirects "Well-Known Labels, Annotations and Taints" page

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -203,6 +203,8 @@
 
 /docs/reference/kubernetes-api/api-index/ /docs/reference 301
 
+/docs/reference/kubernetes-api/labels-annotations-taints/ /docs/reference/labels-annotations-taints/ 301
+
 /docs/reporting-security-issues/     /security/ 301
 
 /docs/roadmap/     https://github.com/kubernetes/kubernetes/milestones/ 301


### PR DESCRIPTION
Fixes #26194 by redirecting "Well-Known Labels, Annotations and Taints" page to its new location.
Location change was introduced in #23294.
 
Redirects
https://deploy-preview-26218--kubernetes-io-master-staging.netlify.app/docs/reference/kubernetes-api/labels-annotations-taints/ 
to
https://deploy-preview-26218--kubernetes-io-master-staging.netlify.app/docs/reference/labels-annotations-taints/
