### PR TITLE
Better description of Job execution

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -13,7 +13,7 @@ weight: 50
 
 <!-- overview -->
 
-A Job creates one or more Pods and ensures that a specified number of them successfully terminate.
+A Job creates one or more Pods and will continue to retry execution of the Pods until a specified number of them successfully terminate.
 As pods successfully complete, the Job tracks the successful completions.  When a specified number
 of successful completions is reached, the task (ie, Job) is complete.  Deleting a Job will clean up
 the Pods it created.


### PR DESCRIPTION
This PR is a small clarification on the description of the responsibilities of a Job. Kubernetes doesn't ensure that the Pods are successful, but the scheduler's responsibility is to continue retrying until success. Updating the docs with a slight wording change to more accurately reflect that a Job won't ensure success, but it will continue retrying until success.
