### PR TITLE
[zh] Sync web page for tasks

### DIFF
--- a/content/zh/docs/tasks/access-application-cluster/configure-access-multiple-clusters.md
+++ b/content/zh/docs/tasks/access-application-cluster/configure-access-multiple-clusters.md
@@ -211,7 +211,7 @@ for the pathnames of the certificate files. You need to change these to the actu
 of certificate files in your environment.
 
 Sometimes you may want to use Base64-encoded data embedded here instead of separate
-certificate files; in that case you need add the suffix `-data` to the keys, for example,
+certificate files; in that case you need to add the suffix `-data` to the keys, for example,
 `certificate-authority-data`, `client-certificate-data`, `client-key-data`.
 -->
 其中的 `fake-ca-file`、`fake-cert-file` 和 `fake-key-file` 是证书文件路径名的占位符。

--- a/content/zh/docs/tasks/debug-application-cluster/debug-pod-replication-controller.md
+++ b/content/zh/docs/tasks/debug-application-cluster/debug-pod-replication-controller.md
@@ -79,7 +79,7 @@ case you can try several things:
 
 * Add more nodes to the cluster.
 
-* [Terminate unneeded pods](/docs/concepts/workloads/pods/#pod-termination)
+* [Terminate unneeded pods](/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination)
   to make room for pending pods.
 
 * Check that the pod is not larger than your nodes. For example, if all

--- a/content/zh/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch.md
+++ b/content/zh/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch.md
@@ -657,6 +657,17 @@ and
 和
 [`kubectl apply`](/docs/reference/generated/kubectl/kubectl-commands/#apply)。
 
+
+<!--
+{{< note >}}
+Strategic merge patch is not supported for custom resources.
+{{< /note >}}
+-->
+{{< note >}}
+定制资源不支持策略性合并 patch。
+{{< /note >}}
+
+
 ## {{% heading "whatsnext" %}}
 
 <!--


### PR DESCRIPTION
Sync web page for part of the items in umbrella issue:
[zh] Umbrella issue: pages out of sync in tasks section #26178

Misc Batch 2 (S)

 content/zh/docs/tasks/debug-application-cluster/debug-pod-replication-controller.md
 content/zh/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch.md
 content/zh/docs/tasks/access-application-cluster/configure-access-multiple-clusters.md

Note:
* The following items are already updated. No need to change.
   content/zh/docs/tasks/tools/_index.md
   content/zh/docs/tasks/manage-kubernetes-objects/kustomization.md
*  The following item contains huge changes, probably a lot of Chinese content is missing in last translation. I will open a separate PR for it.
   content/zh/docs/tasks/administer-cluster/nodelocaldns.md

