### PR TITLE
Fixed a small field name spelling mistake.

### DIFF
--- a/content/en/examples/access/certificate-signing-request/clusterrole-sign.yaml
+++ b/content/en/examples/access/certificate-signing-request/clusterrole-sign.yaml
@@ -21,7 +21,7 @@ rules:
   - certificates.k8s.io
   resources:
   - signers
-  resourceName:
+  resourceNames:
   - example.com/my-signer-name # example.com/* can be used to authorize for all signers in the 'example.com' domain
   verbs:
   - sign


### PR DESCRIPTION
`resourceName` is incorrect and fails upon apply/install. `resourceNames` is the correct file name.