### PR TITLE
Clarify language regarding environment variable order

### DIFF
--- a/content/en/docs/tasks/inject-data-application/define-environment-variable-container.md
+++ b/content/en/docs/tasks/inject-data-application/define-environment-variable-container.md
@@ -70,8 +70,9 @@ override any environment variables specified in the container image.
 {{< /note >}}
 
 {{< note >}}
-The environment variables can reference each other, and cycles are possible,
-pay attention to the order before using
+Environment variables may reference each other, however ordering is important.
+Variables making use of others defined in the same context must come later in
+the list. Similarly, avoid circular references.
 {{< /note >}}
 
 ## Using environment variables inside of your config


### PR DESCRIPTION
This MR clarifies language regarding the ordering of environment variables set on a pod, specifically that variables defined in the same context must occur in the proper order to be interpolated.
