### PR TITLE
Update nodes.md to remove ambiguity

### DIFF
--- a/content/en/docs/concepts/architecture/nodes.md
+++ b/content/en/docs/concepts/architecture/nodes.md
@@ -11,9 +11,10 @@ weight: 10
 
 Kubernetes runs your workload by placing containers into Pods to run on _Nodes_.
 A node may be a virtual or physical machine, depending on the cluster. Each node
-contains the services necessary to run
-{{< glossary_tooltip text="Pods" term_id="pod" >}}, managed by the
-{{< glossary_tooltip text="control plane" term_id="control-plane" >}}.
+is managed by the
+{{< glossary_tooltip text="control plane" term_id="control-plane" >}}
+and contains the services necessary to run
+{{< glossary_tooltip text="Pods" term_id="pod" >}}
 
 Typically you have several nodes in a cluster; in a learning or resource-limited
 environment, you might have just one.


### PR DESCRIPTION
I think the sentence 'Each node contains the services necessary to run Pods, managed by the control plane.' is a little bit ambiguous because it is not clear which word the 'managed' modifies.

I think it can be 'node', 'services', and even 'Pods' semantically, but I think it should be clear.

when I see this sentence translated by all the other languages, they are translated in many ways which are semantically different.

I thought the original intention is that 'managed' modifies 'node' and I made it clear.