### PR TITLE
Modify Kompose Page: remove the up command

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/translate-compose-kubernetes.md
+++ b/content/en/docs/tasks/configure-pod-container/translate-compose-kubernetes.md
@@ -127,23 +127,7 @@ you need is an existing `docker-compose.yml` file.
             kompose.service.type: LoadBalancer
       ```
 
-2.  Run the `kompose up` command to deploy to Kubernetes directly, or skip to
-    the next step instead to generate a file to use with `kubectl`.
-
-      ```bash
-      $ kompose up
-      We are going to create Kubernetes Deployments, Services and PersistentVolumeClaims for your Dockerized application.
-      If you need different kind of resources, use the 'kompose convert' and 'kubectl apply -f' commands instead.
-
-      INFO Successfully created Service: redis          
-      INFO Successfully created Service: web            
-      INFO Successfully created Deployment: redis       
-      INFO Successfully created Deployment: web         
-
-      Your application has been deployed to Kubernetes. You can run 'kubectl get deployment,svc,pods,pvc' for details.
-      ```
-
-3.  To convert the `docker-compose.yml` file to files that you can use with
+2.  To convert the `docker-compose.yml` file to files that you can use with
     `kubectl`, run `kompose convert` and then `kubectl apply -f <output file>`.
 
       ```bash
@@ -168,7 +152,7 @@ you need is an existing `docker-compose.yml` file.
 
       Your deployments are running in Kubernetes.
 
-4.  Access your application.
+3.  Access your application.
 
       If you're already using `minikube` for your development process:
 


### PR DESCRIPTION
In [Translate Compose Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/translate-compose-kubernetes/), On step 2, It asks to use `kompose up` which isn't available. 

This PR remove the 2nd line.

Fixes: #26244 

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
