### PR TITLE
Update invalid web page link for api group

### DIFF
--- a/content/en/docs/reference/glossary/api-group.md
+++ b/content/en/docs/reference/glossary/api-group.md
@@ -2,7 +2,7 @@
 title: API Group
 id: api-group
 date: 2019-09-02
-full_link: /docs/concepts/overview/kubernetes-api/#api-groups
+full_link: /docs/concepts/overview/kubernetes-api/#api-groups-and-versioning
 short_description: >
   A set of related paths in the Kubernetes API.
 

--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -337,7 +337,7 @@ kubectl taint nodes foo dedicated=special-user:NoSchedule
 
 ### Resource types
 
-List all supported resource types along with their shortnames, [API group](/docs/concepts/overview/kubernetes-api/#api-groups), whether they are [namespaced](/docs/concepts/overview/working-with-objects/namespaces), and [Kind](/docs/concepts/overview/working-with-objects/kubernetes-objects):
+List all supported resource types along with their shortnames, [API group](/docs/concepts/overview/kubernetes-api/#api-groups-and-versioning), whether they are [namespaced](/docs/concepts/overview/working-with-objects/namespaces), and [Kind](/docs/concepts/overview/working-with-objects/kubernetes-objects):
 
 ```bash
 kubectl api-resources


### PR DESCRIPTION
The old link "https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-groups" points to an nonexistent section of that page. 

The correct section should be
"https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-groups-and-versioning"
