### PR TITLE
Remove duplicate link in container/securityContext

### DIFF
--- a/content/en/docs/reference/kubernetes-api/workloads-resources/container.md
+++ b/content/en/docs/reference/kubernetes-api/workloads-resources/container.md
@@ -414,7 +414,7 @@ A single application container that you want to run within a pod.
 
 - **securityContext** (SecurityContext)
 
-  Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  Security options the pod should run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 
   <a name="SecurityContext"></a>
   *SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.*


### PR DESCRIPTION
Two links were listed to provide more info about security context in the [container documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core).

One of the links now permanently redirects (301 status code) to the other, so this change removes the outdated link.