### PR TITLE
Remove ServiceAccount Secret automounting section

### DIFF
--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -801,11 +801,6 @@ field set to that of the service account.
 See [Add ImagePullSecrets to a service account](/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account)
  for a detailed explanation of that process.
 
-### Automatic mounting of manually created Secrets
-
-Manually created secrets (for example, one containing a token for accessing a GitHub account)
-can be automatically attached to pods based on their service account.
-
 ## Details
 
 ### Restrictions


### PR DESCRIPTION
The "Automatic mounting of manually created Secrets" section of the
Secrets documentation previously suggesting using PodPresets. PodPresets
have been removed, there is no alternate facility described, and it's
unclear if auto-mounting secrets based on associations with
ServiceAccounts was ever supported. Accordingly, the section should be
removed.

Fixes #26378