### PR TITLE
lose `not` in Chinese translation text

### DIFF
--- a/content/zh/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/zh/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -169,7 +169,7 @@ scheduled onto the node (if it is not yet running on the node).
   则 Kubernetes 不会将 Pod 分配到该节点。
 * 如果未被过滤的污点中不存在 effect 值为 `NoSchedule` 的污点，
   但是存在 effect 值为 `PreferNoSchedule` 的污点，
-  则 Kubernetes 会 *尝试* 将 Pod 分配到该节点。
+  则 Kubernetes 会 *尝试* 不将 Pod 分配到该节点。
 * 如果未被过滤的污点中存在至少一个 effect 值为 `NoExecute` 的污点，
   则 Kubernetes 不会将 Pod 分配到该节点（如果 Pod 还未在节点上运行），
   或者将 Pod 从该节点驱逐（如果 Pod 已经在节点上运行）。


### PR DESCRIPTION
> Kubernetes will try to not schedule the pod onto the node

`not` is lost in Chinese translation text.