### PR TITLE
Fix example url for downloading specific version

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kops.md
+++ b/content/en/docs/setup/production-environment/tools/kops.md
@@ -59,7 +59,7 @@ $(curl -s https://api.github.com/repos/kubernetes/kops/releases/latest | grep ta
 For example, to download kops version v1.15.0 type:
 
 ```shell
-curl -LO  https://github.com/kubernetes/kops/releases/download/1.15.0/kops-darwin-amd64
+curl -LO  https://github.com/kubernetes/kops/releases/download/v1.15.0/kops-darwin-amd64
 ```
 
 Make the kops binary executable.


### PR DESCRIPTION
 - Fix example url in docs for downloading a specific kops version.