### PR TITLE
Stale doc script first pass

### DIFF
--- a/scripts/git-file-history.sh
+++ b/scripts/git-file-history.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SEARCH_DIR='./content/en/docs'
+
+query_stale_files() {
+    # find markdown files in content/en/docs excluding _index.md, glossary, and reference files
+    SEARCH_FILES=($(find $SEARCH_DIR -name '*.md' -not -name '_index.md' -not -path '*/glossary/*' -not -path '*/reference/*'))
+    MOD_FILES=($(git log --since '6 months ago' --name-only --pretty=format: content/en/docs | sort  | uniq | awk '{print "./"$1}' ))
+
+    declare -a output=()
+    for i in "${SEARCH_FILES[@]}"; do
+        if [[ ! " ${MOD_FILES[@]} " =~ " $i " ]]; then
+            timestamp=$(git log -1 --pretty='format:%as' $i)
+            output+=("$timestamp $i")
+        fi
+    done
+
+    IFS=$'\n'
+    sorted=($(sort <<<"${output[*]}"))
+    unset IFS
+
+    for row in "${sorted[@]}"; do
+        echo "$row"
+    done
+}
+
+query_stale_files


### PR DESCRIPTION
This is a first pass at a script to generate potentially stale docs files.

Current implementation looks at:
- markdown files in `content/en/docs` (ignoring _index.md)
- have most-recent commit dates of more than one year ago

With the exception of glossary files (which can be ignored as well), the current output looks like:
```
2018-05-05 ./content/en/docs/reference/setup-tools/kubeadm/generated/README.md
2018-05-11 ./content/en/docs/reference/kubectl/kubectl-cmds.md
2018-08-16 ./content/en/docs/contribute/style/hugo-shortcodes/example2.md
2019-03-28 ./content/en/docs/reference/issues-security/issues.md
```