### PR TITLE
remove command from output block

### DIFF
--- a/content/en/docs/tasks/run-application/run-stateless-application-deployment.md
+++ b/content/en/docs/tasks/run-application/run-stateless-application-deployment.md
@@ -51,7 +51,6 @@ a Deployment that runs the nginx:1.14.2 Docker image:
 
     The output is similar to this:
 
-        user@computer:~/website$ kubectl describe deployment nginx-deployment
         Name:     nginx-deployment
         Namespace:    default
         CreationTimestamp:  Tue, 30 Aug 2016 18:11:37 -0700


### PR DESCRIPTION
This line does not meet "[Separate commands from output](https://kubernetes.io/docs/contribute/style/style-guide/#separate-commands-from-output)" style guide. 