### PR TITLE
Minor - Systemd enable command to enable CRI-O at boot time

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -420,8 +420,7 @@ Start CRI-O:
 
 ```shell
 sudo systemctl daemon-reload
-sudo systemctl enable crio
-sudo systemctl start crio
+sudo systemctl enable crio --now
 ```
 
 Refer to the [CRI-O installation guide](https://github.com/cri-o/cri-o/blob/master/install.md)

--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -420,6 +420,7 @@ Start CRI-O:
 
 ```shell
 sudo systemctl daemon-reload
+sudo systemctl enable crio
 sudo systemctl start crio
 ```
 


### PR DESCRIPTION
Added the line "sudo systemctl enable crio enable" to configure systemd to enable CRI-O at boot time, as shown in the CRI-O install.md doc: https://github.com/cri-o/cri-o/blob/master/install.md#user-content-starting-cri-o

This is my first ever github submission. I'm not sure what I am doing. Hoping this might help newbies who might loose time not understanding why cri-o is not running (after reboot or other).

Have a nice day!
