### PR TITLE
fix cronjob code for examples

### DIFF
--- a/content/en/examples/application/job/cronjob.yaml
+++ b/content/en/examples/application/job/cronjob.yaml
@@ -12,7 +12,7 @@ spec:
           - name: hello
             image: busybox
             imagePullPolicy: IfNotPresent
-            args:
+            command:
             - /bin/sh
             - -c
             - date; echo Hello from the Kubernetes cluster

--- a/content/id/examples/application/job/cronjob.yaml
+++ b/content/id/examples/application/job/cronjob.yaml
@@ -11,7 +11,7 @@ spec:
           containers:
           - name: hello
             image: busybox
-            args:
+            command:
             - /bin/sh
             - -c
             - date; echo Hello from the Kubernetes cluster

--- a/content/ja/examples/application/job/cronjob.yaml
+++ b/content/ja/examples/application/job/cronjob.yaml
@@ -11,7 +11,7 @@ spec:
           containers:
           - name: hello
             image: busybox
-            args:
+            command:
             - /bin/sh
             - -c
             - date; echo Hello from the Kubernetes cluster

--- a/content/ko/examples/application/job/cronjob.yaml
+++ b/content/ko/examples/application/job/cronjob.yaml
@@ -12,7 +12,7 @@ spec:
           - name: hello
             image: busybox
             imagePullPolicy: IfNotPresent
-            args:
+            command:
             - /bin/sh
             - -c
             - date; echo Hello from the Kubernetes cluster

--- a/content/zh/examples/application/job/cronjob.yaml
+++ b/content/zh/examples/application/job/cronjob.yaml
@@ -12,7 +12,7 @@ spec:
           - name: hello
             image: busybox
             imagePullPolicy: IfNotPresent
-            args:
+            command:
             - /bin/sh
             - -c
             - date; echo Hello from the Kubernetes cluster


### PR DESCRIPTION
Code examples for `cronjob` includes the `args` parameter instead `command` what might result more difficult to understand for newbies.

IMHO, `command` is better in this context.