### PR TITLE
Mention the range of time in which a kubelet might renew a certificate

### DIFF
--- a/content/en/docs/tasks/tls/certificate-rotation.md
+++ b/content/en/docs/tasks/tls/certificate-rotation.md
@@ -69,8 +69,9 @@ write that to disk, in the location specified by `--cert-dir`. Then the kubelet
 will use the new certificate to connect to the Kubernetes API.
 
 As the expiration of the signed certificate approaches, the kubelet will
-automatically issue a new certificate signing request, using the Kubernetes
-API. Again, the controller manager will automatically approve the certificate
+automatically issue a new certificate signing request, using the Kubernetes API. 
+This can happen at any point between 30% and 10% of the time remaining on the 
+certificate. Again, the controller manager will automatically approve the certificate
 request and attach a signed certificate to the certificate signing request. The
 kubelet will retrieve the new signed certificate from the Kubernetes API and
 write that to disk. Then it will update the connections it has to the


### PR DESCRIPTION
The docs don't mention when the kubelet will attempt to renew a certificate, which causes concern when one notices that certain certificates are being renewed and others are not. Including the time frame adds certainty, so that if an user notices a kubelet certificate expiring in less than 30d, they know something is misconfigured and should be looked at.

This information comes from Kubelet's source code: https://github.com/kubernetes/kubernetes/blob/f41def8d76660c94c4eca483ec6d3edde5deac89/staging/src/k8s.io/client-go/util/certificate/certificate_manager.go#L560-L565



