### PR TITLE
ja: Make docs/setup/production-environment/windows/user-guide-windows-containhers.md follow v1.18 of the original text

### DIFF
--- a/content/ja/docs/setup/production-environment/windows/user-guide-windows-containers.md
+++ b/content/ja/docs/setup/production-environment/windows/user-guide-windows-containers.md
@@ -19,7 +19,7 @@ Windowsアプリケーションは、多くの組織で実行されるサービ�
 
 ## 始める前に
 
-* [Windows Serverを実行するマスターノードとワーカーノード](/ja/docs/setup/production-environment/windows/user-guide-windows-nodes/)を含むKubernetesクラスターを作成します
+* [Windows Serverを実行するマスターノードとワーカーノード](/ja/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes)を含むKubernetesクラスターを作成します
 * Kubernetes上にServiceとワークロードを作成してデプロイすることは、LinuxコンテナとWindowsコンテナ共に、ほぼ同じように動作することに注意してください。クラスターとのインタフェースとなる[Kubectlコマンド](/docs/reference/kubectl/overview/)も同じです。Windowsコンテナをすぐに体験できる例を以下セクションに用意しています。
 
 ## はじめに:Windowsコンテナのデプロイ


### PR DESCRIPTION
What would you like to be added
Update docs/setup/production-environment/windows/user-guide-windows-containers.md to follow v1.18 of the original (English) text.

Why is this needed
content/ja/docs/setup/production-environment/windows/user-guide-windows-containers.md is outdated.

Which issue(s) this PR fixes:
#26525 

other diff has been resolved in #23124