### PR TITLE
modify the kubectl as a tool

### DIFF
--- a/content/zh/docs/concepts/overview/kubernetes-api.md
+++ b/content/zh/docs/concepts/overview/kubernetes-api.md
@@ -35,7 +35,7 @@ API 服务器负责提供 HTTP API，以供用户、集群中的不同部分和�
 Kubernetes API 使你可以查询和操纵 Kubernetes API
 中对象（例如：Pod、Namespace、ConfigMap 和 Event）的状态。
 
-大部分操作都可以通过 [kubectl](/zh/docs/reference/kubectl/overview/) 命令行接口或
+大部分操作都可以通过 [kubectl](/zh/docs/reference/kubectl/overview/) 命令行工具或
 类似 [kubeadm](/zh/docs/reference/setup-tools/kubeadm/) 这类命令行工具来执行，
 这些工具在背后也是调用 API。不过，你也可以使用 REST 调用来访问这些 API。
 


### PR DESCRIPTION
Signed-off-by: timyinshi <shiguangyin@inspur.com>

/kind bug
/sig docs

the kubectl is a tool,not interface
