### PR TITLE
Fix coreos.com broken link for Operator pattern

### DIFF
--- a/content/en/docs/reference/glossary/cluster-operator.md
+++ b/content/en/docs/reference/glossary/cluster-operator.md
@@ -17,6 +17,6 @@ tags:
 Their primary responsibility is keeping a cluster up and running, which may involve periodic maintenance activities or upgrades.<br>
 
 {{< note >}}
-Cluster operators are different from the [Operator pattern](https://coreos.com/operators) that extends the Kubernetes API.
+Cluster operators are different from the [Operator pattern](https://www.openshift.com/learn/topics/operators) that extends the Kubernetes API.
 {{< /note >}}
 


### PR DESCRIPTION
Operator Pattern link was pointing to https://coreos.com/operator. This link was redirecting to the openshift.com homepage.
Provided new link on openshift.com pointing to Operator Pattern documentation.