### PR TITLE
Remove outdated install-minikube.md file

### DIFF
--- a/content/ja/docs/tasks/tools/_index.md
+++ b/content/ja/docs/tasks/tools/_index.md
@@ -19,6 +19,8 @@ Kubernetesのコマンドラインツール`kubectl`を使用すると、Kuberne
 
 ツールのインストールについて知りたい場合は、公式の[Get Started!](https://minikube.sigs.k8s.io/docs/start/)のガイドに従ってください。
 
+<a class="btn btn-primary" href="https://minikube.sigs.k8s.io/docs/start/" role="button" aria-label="View minikube Get Started! Guide">minikube Get Started!ガイドを見る</a>
+
 Minikubeが起動したら、[サンプルアプリケーションの実行](/ja/docs/tutorials/hello-minikube/)を試すことができます。
 
 ## kind


### PR DESCRIPTION
Issue https://github.com/kubernetes/website/issues/26504

What I did
- removed tool/install-minikube.md file
- updated some files with a link to the removed install-minikube page
  - It seems like no Japanese translated page for ["minikube Get Started! Guide"](https://minikube.sigs.k8s.io/docs/start/) but I'll fix the url if exists

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
