### PR TITLE
Update docs/setup/production-environment/turnkey/gce.md to follow v1.18 of the original text

### DIFF
--- a/content/ja/docs/setup/production-environment/turnkey/gce.md
+++ b/content/ja/docs/setup/production-environment/turnkey/gce.md
@@ -144,7 +144,7 @@ Some of the pods may take a few seconds to start up (during this time they'll sh
 
 ### いくつかの例の実行
 
-Then, see [a simple nginx example](/docs/tasks/run-application/run-stateless-application-deployment/) to try out your new cluster.
+Then, see [a simple nginx example](/ja/docs/tasks/run-application/run-stateless-application-deployment/) to try out your new cluster.
 
 For more complete applications, please look in the [examples directory](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/).  The [guestbook example](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/guestbook/) is a good "getting started" walkthrough.
 
@@ -214,5 +214,4 @@ field values:
 IaaS Provider        | Config. Mgmt | OS     | Networking  | Docs                                              | Conforms | Support Level
 -------------------- | ------------ | ------ | ----------  | ---------------------------------------------     | ---------| ----------------------------
 GCE                  | Saltstack    | Debian | GCE         | [docs](/ja/docs/setup/production-environment/turnkey/gce/)                                    |   | Project
-
 

--- a/content/ja/docs/setup/production-environment/turnkey/gce.md
+++ b/content/ja/docs/setup/production-environment/turnkey/gce.md
@@ -93,7 +93,7 @@ gcloud components install kubectl
 
 {{< note >}}
 The kubectl version bundled with `gcloud` may be older than the one
-downloaded by the get.k8s.io install script. See [Installing kubectl](/docs/tasks/tools/install-kubectl/)
+The [kubectl](/ja/docs/reference/kubectl/kubectl/) tool controls the Kubernetes cluster
 document to see how you can set up the latest `kubectl` on your workstation.
 {{< /note >}}
 
@@ -214,7 +214,6 @@ field values:
 IaaS Provider        | Config. Mgmt | OS     | Networking  | Docs                                              | Conforms | Support Level
 -------------------- | ------------ | ------ | ----------  | ---------------------------------------------     | ---------| ----------------------------
 GCE                  | Saltstack    | Debian | GCE         | [docs](/ja/docs/setup/production-environment/turnkey/gce/)                                    |   | Project
-
 
 
 

--- a/content/ja/docs/setup/production-environment/turnkey/gce.md
+++ b/content/ja/docs/setup/production-environment/turnkey/gce.md
@@ -67,7 +67,7 @@ cluster/kube-up.sh
 If you want more than one cluster running in your project, want to use a different name, or want a different number of worker nodes, see the `<kubernetes>/cluster/gce/config-default.sh` file for more fine-grained configuration before you start up your cluster.
 
 If you run into trouble, please see the section on [troubleshooting](/ja/docs/setup/production-environment/turnkey/gce/#troubleshooting), post to the
-[Kubernetes Forum](https://discuss.kubernetes.io), or come ask questions on [Slack](/docs/troubleshooting/#slack).
+[Kubernetes Forum](https://discuss.kubernetes.io), or come ask questions on `#gke` Slack channel.
 
 The next few steps will show you:
 
@@ -80,7 +80,7 @@ The next few steps will show you:
 
 The cluster startup script will leave you with a running cluster and a `kubernetes` directory on your workstation.
 
-The [kubectl](/docs/user-guide/kubectl/) tool controls the Kubernetes cluster
+The [kubectl](/docs/reference/kubectl/kubectl/) tool controls the Kubernetes cluster
 manager.  It lets you inspect your cluster resources, create, delete, and update
 components, and much more. You will use it to look at your new cluster and bring
 up example apps.
@@ -93,7 +93,7 @@ gcloud components install kubectl
 
 {{< note >}}
 The kubectl version bundled with `gcloud` may be older than the one
-downloaded by the get.k8s.io install script. See [Installing kubectl](/docs/tasks/kubectl/install/)
+downloaded by the get.k8s.io install script. See [Installing kubectl](/docs/tasks/tools/install-kubectl/)
 document to see how you can set up the latest `kubectl` on your workstation.
 {{< /note >}}
 
@@ -107,7 +107,7 @@ Once `kubectl` is in your path, you can use it to look at your cluster. E.g., ru
 kubectl get --all-namespaces services
 ```
 
-should show a set of [services](/docs/user-guide/services) that look something like this:
+should show a set of [services](/docs/concepts/services-networking/service/) that look something like this:
 
 ```shell
 NAMESPACE     NAME          TYPE             CLUSTER_IP       EXTERNAL_IP       PORT(S)        AGE
@@ -117,7 +117,7 @@ kube-system   kube-ui       ClusterIP        10.0.0.3         <none>            
 ...
 ```
 
-Similarly, you can take a look at the set of [pods](/docs/user-guide/pods) that were created during cluster startup.
+Similarly, you can take a look at the set of [pods](/docs/concepts/workloads/pods/) that were created during cluster startup.
 You can do this via the
 
 ```shell
@@ -144,7 +144,7 @@ Some of the pods may take a few seconds to start up (during this time they'll sh
 
 ### いくつかの例の実行
 
-Then, see [a simple nginx example](/docs/user-guide/simple-nginx) to try out your new cluster.
+Then, see [a simple nginx example](/docs/tasks/run-application/run-stateless-application-deployment/) to try out your new cluster.
 
 For more complete applications, please look in the [examples directory](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/).  The [guestbook example](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/guestbook/) is a good "getting started" walkthrough.
 
@@ -216,9 +216,5 @@ IaaS Provider        | Config. Mgmt | OS     | Networking  | Docs               
 GCE                  | Saltstack    | Debian | GCE         | [docs](/ja/docs/setup/production-environment/turnkey/gce/)                                    |   | Project
 
 
-## 参考文献
-
-Please see the [Kubernetes docs](/ja/docs/) for more details on administering
-and using a Kubernetes cluster.
 
 

--- a/content/ja/docs/setup/production-environment/turnkey/gce.md
+++ b/content/ja/docs/setup/production-environment/turnkey/gce.md
@@ -117,7 +117,7 @@ kube-system   kube-ui       ClusterIP        10.0.0.3         <none>            
 ...
 ```
 
-Similarly, you can take a look at the set of [pods](/docs/concepts/workloads/pods/) that were created during cluster startup.
+Similarly, you can take a look at the set of [pods](/ja/docs/concepts/workloads/pods/) that were created during cluster startup.
 You can do this via the
 
 ```shell
@@ -214,6 +214,5 @@ field values:
 IaaS Provider        | Config. Mgmt | OS     | Networking  | Docs                                              | Conforms | Support Level
 -------------------- | ------------ | ------ | ----------  | ---------------------------------------------     | ---------| ----------------------------
 GCE                  | Saltstack    | Debian | GCE         | [docs](/ja/docs/setup/production-environment/turnkey/gce/)                                    |   | Project
-
 
 


### PR DESCRIPTION
I updated the `content/ja/docs/setup/production-environment/turnkey/gce.md` to follow v1.18 of the original (English) text.

The following link is the differences between v1.17 and v1.18:
https://gist.github.com/inductor/c5961124a77fff385810347dba45a651

This PR fixes this issue:
#26519