### PR TITLE
Fix the translation about Source IP for Services with Type=LoadBalancer

### DIFF
--- a/content/ja/docs/tutorials/services/source-ip.md
+++ b/content/ja/docs/tutorials/services/source-ip.md
@@ -272,7 +272,7 @@ graph TD;
 
 ## `Type=LoadBalancer`を使用したServiceでの送信元IP
 
-[`Type=LoadBalancer`](/ja/docs/concepts/services-networking/service/#loadbalancer)を使用したServiceに送られたパケットは、デフォルトでは送信元のNATは行われません。`Ready`状態にあるすべてのスケジュール可能なKubernetesのNodeは、ロードバランサーからのトラフィックを受付可能であるためです。そのため、エンドポイントが存在しないノードにパケットが到達した場合、システムはエンドポイントが*存在する*ノードにパケットをプロシキーします。このとき、(前のセクションで説明したように)パケットの送信元IPがノードのIPに置換されます。
+[`Type=LoadBalancer`](/ja/docs/concepts/services-networking/service/#loadbalancer)を使用したServiceに送られたパケットは、デフォルトで送信元のNATが行われます。`Ready`状態にあるすべてのスケジュール可能なKubernetesのNodeは、ロードバランサーからのトラフィックを受付可能であるためです。そのため、エンドポイントが存在しないノードにパケットが到達した場合、システムはエンドポイントが*存在する*ノードにパケットをプロシキーします。このとき、(前のセクションで説明したように)パケットの送信元IPがノードのIPに置換されます。
 
 ロードバランサー経由でsource-ip-appを公開することで、これをテストできます。
 


### PR DESCRIPTION
Type=LoadBalancerを使用したServiceでの送信元IPに関する記述の序文の翻訳が逆になっていました。
誤：Type=LoadBalancerを使用したServiceに送られたパケットは、デフォルトでは送信元のNATは行われません。
正：Type=LoadBalancerを使用したServiceに送られたパケットは、デフォルトで送信元のNATが行われます。