### PR TITLE
ja: Fix the translation about nodeSelectorTerms of Node affinity

### DIFF
--- a/content/ja/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/ja/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -140,9 +140,9 @@ Nodeアフィニティでは、`In`、`NotIn`、`Exists`、`DoesNotExist`、`Gt`
 
 `nodeSelector`と`nodeAffinity`の両方を指定した場合、Podは**両方の**条件を満たすNodeにスケジュールされます。
 
-`nodeAffinity`内で複数の`nodeSelectorTerms`を指定した場合、Podは**全ての**`nodeSelectorTerms`を満たしたNodeへスケジュールされます。
+`nodeAffinity`内で複数の`nodeSelectorTerms`を指定した場合、Podは**いずれかの**`nodeSelectorTerms`を満たしたNodeへスケジュールされます。
 
-`nodeSelectorTerms`内で複数の`matchExpressions`を指定した場合にはPodは**いずれかの**`matchExpressions`を満たしたNodeへスケジュールされます。
+`nodeSelectorTerms`内で複数の`matchExpressions`を指定した場合にはPodは**全ての**`matchExpressions`を満たしたNodeへスケジュールされます。
 
 PodがスケジュールされたNodeのラベルを削除したり変更しても、Podは削除されません。
 言い換えると、アフィニティはPodをスケジュールする際にのみ考慮されます。


### PR DESCRIPTION
Node affinity の `nodeSelectorTerms` に関する記述で翻訳では真逆の説明がされています。

> If you specify multiple nodeSelectorTerms associated with nodeAffinity types, then the pod can be scheduled onto a node if one of the nodeSelectorTerms can be satisfied.

誤:  nodeAffinity内で複数のnodeSelectorTermsを指定した場合、Podは全てのnodeSelectorTermsを満たしたNodeへスケジュールされます。
正:  nodeAffinity内で複数のnodeSelectorTermsを指定した場合、PodはいずれかのnodeSelectorTermsを満たしたNodeへスケジュールされます。

> If you specify multiple matchExpressions associated with nodeSelectorTerms, then the pod can be scheduled onto a node only if all matchExpressions is satisfied.

誤:  nodeSelectorTerms内で複数のmatchExpressionsを指定した場合にはPodはいずれかのmatchExpressionsを満たしたNodeへスケジュールされます。
正:  nodeSelectorTerms内で複数のmatchExpressionsを指定した場合にはPodは全てのmatchExpressionsを満たしたNodeへスケジュールされます。

- https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
