### PR TITLE
Add WebhookAdmission reference

### DIFF
--- a/content/en/docs/concepts/configuration/configmap.md
+++ b/content/en/docs/concepts/configuration/configmap.md
@@ -224,7 +224,7 @@ When a ConfigMap currently consumed in a volume is updated, projected keys are e
 The kubelet checks whether the mounted ConfigMap is fresh on every periodic sync.
 However, the kubelet uses its local cache for getting the current value of the ConfigMap.
 The type of the cache is configurable using the `ConfigMapAndSecretChangeDetectionStrategy` field in
-the [KubeletConfiguration struct](/docs/reference/config-api/kubelet-config.v1beta1/)).
+the [KubeletConfiguration struct](/docs/reference/config-api/kubelet-config.v1beta1/).
 A ConfigMap can be either propagated by watch (default), ttl-based, or by redirecting
 all requests directly to the API server.
 As a result, the total delay from the moment when the ConfigMap is updated to the moment

--- a/content/en/docs/reference/_index.md
+++ b/content/en/docs/reference/_index.md
@@ -73,16 +73,11 @@ operator to use or manage a cluster.
 
 * [kubelet configuration (v1beta1)](/docs/reference/config-api/kubelet-config.v1beta1/)
 * [kube-scheduler configuration (v1beta1)](/docs/reference/config-api/kube-scheduler-config.v1beta1/)
+* [kube-scheduler policy reference (v1)](/docs/reference/config-api/kube-scheduler-policy-config.v1/)
 * [kube-proxy configuration (v1alpha1)](/docs/reference/config-api/kube-proxy-config.v1alpha1/)
 * [`audit.k8s.io/v1` API](/docs/reference/config-api/apiserver-audit.v1/)
-
-## Config APIs
-
 * [Client authentication API (v1beta1)](/docs/reference/config-api/client-authentication.v1beta1/)
-
-## Config APIs
-
-* [kube-scheduler policy reference (v1)](/docs/reference/config-api/kube-scheduler-policy-config.v1/)
+* [WebhookAdmission configuration (v1)](/docs/reference/config-api/apiserver-webhookadmission.v1/)
 
 ## Design Docs
 

--- a/content/en/docs/reference/access-authn-authz/extensible-admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/extensible-admission-controllers.md
@@ -147,7 +147,7 @@ webhooks:
 {{< /tabs >}}
 
 The scope field specifies if only cluster-scoped resources ("Cluster") or namespace-scoped
-resources ("Namespaced") will match this rule. "*" means that there are no scope restrictions.
+resources ("Namespaced") will match this rule. "&lowast;" means that there are no scope restrictions.
 
 {{< note >}}
 When using `clientConfig.service`, the server cert must be valid for
@@ -225,7 +225,7 @@ plugins:
 {{< /tabs >}}
 
 For more information about `AdmissionConfiguration`, see the
-[AdmissionConfiguration schema](https://github.com/kubernetes/kubernetes/blob/v1.17.0/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1/types.go#L27).
+[AdmissionConfiguration (v1) reference](/docs/reference/config-api/apiserver-webhookadmission.v1/).
 See the [webhook configuration](#webhook-configuration) section for details about each config field.
 
 * In the kubeConfig file, provide the credentials:

--- a/content/en/docs/reference/config-api/apiserver-webhookadmission.v1.md
+++ b/content/en/docs/reference/config-api/apiserver-webhookadmission.v1.md
@@ -1,0 +1,46 @@
+---
+title: WebhookAdmission Configuration (v1)
+content_type: tool-reference
+package: apiserver.config.k8s.io/v1
+auto_generated: true
+---
+Package v1 is the v1 version of the API.
+
+## Resource Types 
+
+
+- [WebhookAdmission](#apiserver-config-k8s-io-v1-WebhookAdmission)
+  
+    
+
+
+## `WebhookAdmission`     {#apiserver-config-k8s-io-v1-WebhookAdmission}
+    
+
+
+
+
+WebhookAdmission provides configuration for the webhook admission controller.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>apiserver.config.k8s.io/v1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>WebhookAdmission</code></td></tr>
+    
+
+  
+  
+<tr><td><code>kubeConfigFile</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   KubeConfigFile is the path to the kubeconfig file.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+  

--- a/content/en/docs/tasks/debug-application-cluster/audit.md
+++ b/content/en/docs/tasks/debug-application-cluster/audit.md
@@ -251,5 +251,7 @@ By default truncate is disabled in both `webhook` and `log`, a cluster administr
 ## {{% heading "whatsnext" %}}
 
 * Learn about [Mutating webhook auditing annotations](/docs/reference/access-authn-authz/extensible-admission-controllers/#mutating-webhook-auditing-annotations).
-* Read the [reference for `audit.k8s.io` API group](/docs/reference/config-api/apiserver-audit.v1/).
+* Learn more about [`Event`](/docs/reference/config-api/apiserver-audit.v1/#audit-k8s-io-v1-Event)
+  and the [`Policy`](/docs/reference/config-api/apiserver-audit.v1/#audit-k8s-io-v1-Policy)
+  resource types by reading the Audit configuration reference.
 


### PR DESCRIPTION
This adds a reference for WebhookAdmission config generated from kubernetes-sigs/reference-docs/genref tool.
More specifically, it is generated using the following command:

```shell
./genref -include apiserver-webhookadmission
```
