### PR TITLE
VolumeSubpath is GA since 1.10

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -351,7 +351,7 @@ different Kubernetes components.
 | `VolumeScheduling` | `false` | Alpha | 1.9 | 1.9 |
 | `VolumeScheduling` | `true` | Beta | 1.10 | 1.12 |
 | `VolumeScheduling` | `true` | GA | 1.13 | - |
-| `VolumeSubpath` | `true` | GA | 1.13 | - |
+| `VolumeSubpath` | `true` | GA | 1.10 | - |
 | `VolumeSubpathEnvExpansion` | `false` | Alpha | 1.14 | 1.14 |
 | `VolumeSubpathEnvExpansion` | `true` | Beta | 1.15 | 1.16 |
 | `VolumeSubpathEnvExpansion` | `true` | GA | 1.17 | - |


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/issues/60813

Correct a feature gate version. The feature gate VolumeSubpath is GA since 1.10 for CVEs. 

Fixed versions:

- Fixed in v1.7.14 by kubernetes#61047
- Fixed in v1.8.9 by kubernetes#61046
- Fixed in v1.9.4 by kubernetes#61045
- Fixed in master by kubernetes#61044 (included in v1.10.0-beta.3, will be in v1.10.0)

It can be disabled even it is GA.

