### PR TITLE
Add reference for client-authentication v1beta1

### DIFF
--- a/content/en/docs/reference/_index.md
+++ b/content/en/docs/reference/_index.md
@@ -66,6 +66,10 @@ client libraries:
 
 * [kube-proxy configuration (v1alpha1)](/docs/reference/config-api/kube-proxy-config.v1alpha1/)
 
+## Config APIs
+
+* [Client authentication API (v1beta1)](/docs/reference/config-api/client-authentication.v1beta1/)
+
 ## Design Docs
 
 An archive of the design docs for Kubernetes functionality. Good starting points are

--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -955,7 +955,8 @@ When run from an interactive session, `stdin` is exposed directly to the plugin.
 [TTY check](https://godoc.org/golang.org/x/crypto/ssh/terminal#IsTerminal) to determine if it's
 appropriate to prompt a user interactively.
 
-To use bearer token credentials, the plugin returns a token in the status of the `ExecCredential`.
+To use bearer token credentials, the plugin returns a token in the status of the
+[`ExecCredential`](/docs/reference/config-api/client-authentication.v1beta1/#client-authentication-k8s-io-v1beta1-ExecCredential)
 
 ```json
 {
@@ -1005,6 +1006,7 @@ RFC3339 timestamp. Presence or absence of an expiry has the following impact:
   }
 }
 ```
+
 To enable the exec plugin to obtain cluster-specific information, set `provideClusterInfo` on the `user.exec`
 field in the [kubeconfig](/docs/concepts/configuration/organize-cluster-access-kubeconfig/).
 The plugin will then be supplied with an environment variable, `KUBERNETES_EXEC_INFO`.
@@ -1029,3 +1031,8 @@ The following `ExecCredential` manifest describes a cluster information sample.
   }
 }
 ```
+
+## {{% heading "whatsnext" %}}
+
+* Read the [client authentication reference (v1beta1)](/docs/reference/config-api/client-authentication.v1beta1/)
+

--- a/content/en/docs/reference/config-api/client-authentication.v1beta1.md
+++ b/content/en/docs/reference/config-api/client-authentication.v1beta1.md
@@ -1,0 +1,252 @@
+---
+title: Client Authentication (v1beta1)
+content_type: tool-reference
+package: client.authentication.k8s.io/v1beta1
+auto_generated: true
+---
+
+
+## Resource Types 
+
+
+- [ExecCredential](#client-authentication-k8s-io-v1beta1-ExecCredential)
+  
+    
+
+
+## `ExecCredential`     {#client-authentication-k8s-io-v1beta1-ExecCredential}
+    
+
+
+
+
+ExecCredential is used by exec-based plugins to communicate credentials to
+HTTP transports.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>client.authentication.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>ExecCredential</code></td></tr>
+    
+
+  
+  
+<tr><td><code>spec</code> <B>[Required]</B><br/>
+<a href="#client-authentication-k8s-io-v1beta1-ExecCredentialSpec"><code>ExecCredentialSpec</code></a>
+</td>
+<td>
+   Spec holds information passed to the plugin by the transport.</td>
+</tr>
+    
+  
+<tr><td><code>status</code><br/>
+<a href="#client-authentication-k8s-io-v1beta1-ExecCredentialStatus"><code>ExecCredentialStatus</code></a>
+</td>
+<td>
+   Status is filled in by the plugin and holds the credentials that the transport
+should use to contact the API.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `Cluster`     {#client-authentication-k8s-io-v1beta1-Cluster}
+    
+
+
+
+**Appears in:**
+
+- [ExecCredentialSpec](#client-authentication-k8s-io-v1beta1-ExecCredentialSpec)
+
+
+Cluster contains information to allow an exec plugin to communicate
+with the kubernetes cluster being authenticated to.
+
+To ensure that this struct contains everything someone would need to communicate
+with a kubernetes cluster (just like they would via a kubeconfig), the fields
+should shadow "k8s.io/client-go/tools/clientcmd/api/v1".Cluster, with the exception
+of CertificateAuthority, since CA data will always be passed to the plugin as bytes.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>server</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Server is the address of the kubernetes cluster (https://hostname:port).</td>
+</tr>
+    
+  
+<tr><td><code>tls-server-name</code><br/>
+<code>string</code>
+</td>
+<td>
+   TLSServerName is passed to the server for SNI and is used in the client to
+check server certificates against. If ServerName is empty, the hostname
+used to contact the server is used.</td>
+</tr>
+    
+  
+<tr><td><code>insecure-skip-tls-verify</code><br/>
+<code>bool</code>
+</td>
+<td>
+   InsecureSkipTLSVerify skips the validity check for the server's certificate.
+This will make your HTTPS connections insecure.</td>
+</tr>
+    
+  
+<tr><td><code>certificate-authority-data</code><br/>
+<code>[]byte</code>
+</td>
+<td>
+   CAData contains PEM-encoded certificate authority certificates.
+If empty, system roots should be used.</td>
+</tr>
+    
+  
+<tr><td><code>proxy-url</code><br/>
+<code>string</code>
+</td>
+<td>
+   ProxyURL is the URL to the proxy to be used for all requests to this
+cluster.</td>
+</tr>
+    
+  
+<tr><td><code>config</code><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/runtime/#RawExtension"><code>k8s.io/apimachinery/pkg/runtime.RawExtension</code></a>
+</td>
+<td>
+   Config holds additional config data that is specific to the exec
+plugin with regards to the cluster being authenticated to.
+
+This data is sourced from the clientcmd Cluster object's
+extensions[client.authentication.k8s.io/exec] field:
+
+clusters:
+- name: my-cluster
+  cluster:
+    ...
+    extensions:
+    - name: client.authentication.k8s.io/exec  # reserved extension name for per cluster exec config
+      extension:
+        audience: 06e3fbd18de8  # arbitrary config
+
+In some environments, the user config may be exactly the same across many clusters
+(i.e. call this exec plugin) minus some details that are specific to each cluster
+such as the audience.  This field allows the per cluster config to be directly
+specified with the cluster info.  Using this field to store secret data is not
+recommended as one of the prime benefits of exec plugins is that no secrets need
+to be stored directly in the kubeconfig.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ExecCredentialSpec`     {#client-authentication-k8s-io-v1beta1-ExecCredentialSpec}
+    
+
+
+
+**Appears in:**
+
+- [ExecCredential](#client-authentication-k8s-io-v1beta1-ExecCredential)
+
+
+ExecCredentialSpec holds request and runtime specific information provided by
+the transport.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>cluster</code><br/>
+<a href="#client-authentication-k8s-io-v1beta1-Cluster"><code>Cluster</code></a>
+</td>
+<td>
+   Cluster contains information to allow an exec plugin to communicate with the
+kubernetes cluster being authenticated to. Note that Cluster is non-nil only
+when provideClusterInfo is set to true in the exec provider config (i.e.,
+ExecConfig.ProvideClusterInfo).</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ExecCredentialStatus`     {#client-authentication-k8s-io-v1beta1-ExecCredentialStatus}
+    
+
+
+
+**Appears in:**
+
+- [ExecCredential](#client-authentication-k8s-io-v1beta1-ExecCredential)
+
+
+ExecCredentialStatus holds credentials for the transport to use.
+
+Token and ClientKeyData are sensitive fields. This data should only be
+transmitted in-memory between client and exec plugin process. Exec plugin
+itself should at least be protected via file permissions.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>expirationTimestamp</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta"><code>meta/v1.Time</code></a>
+</td>
+<td>
+   ExpirationTimestamp indicates a time when the provided credentials expire.</td>
+</tr>
+    
+  
+<tr><td><code>token</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Token is a bearer token used by the client for request authentication.</td>
+</tr>
+    
+  
+<tr><td><code>clientCertificateData</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   PEM-encoded client TLS certificates (including intermediates, if any).</td>
+</tr>
+    
+  
+<tr><td><code>clientKeyData</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   PEM-encoded private key for the above certificate.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+  


### PR DESCRIPTION
This is a reference for client authentication API generated from kubernetes-sigs/reference-docs/genref tool.
More specifically, it is generated using the following command:

```shell
./genref -format markdown -include client-authentication
```

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
