### PR TITLE
chore: fix an invalid location.hash

### DIFF
--- a/content/en/docs/tasks/run-application/force-delete-stateful-set-pod.md
+++ b/content/en/docs/tasks/run-application/force-delete-stateful-set-pod.md
@@ -46,7 +46,7 @@ before the kubelet deletes the name from the apiserver.
 
 Kubernetes (versions 1.5 or newer) will not delete Pods just because a Node is unreachable.
 The Pods running on an unreachable Node enter the 'Terminating' or 'Unknown' state after a
-[timeout](/docs/concepts/architecture/nodes/#node-condition).
+[timeout](/docs/concepts/architecture/nodes/#condition).
 Pods may also enter these states when the user attempts graceful deletion of a Pod
 on an unreachable Node.
 The only ways in which a Pod in such a state can be removed from the apiserver are as follows:


### PR DESCRIPTION
The correct link may be https://kubernetes.io/docs/concepts/architecture/nodes/#condition