### PR TITLE
updated labels for cli command in the PHP Guestbook tutorial

### DIFF
--- a/content/en/docs/tutorials/stateless-application/guestbook.md
+++ b/content/en/docs/tutorials/stateless-application/guestbook.md
@@ -134,7 +134,7 @@ kubectl apply -f ./content/en/examples/application/guestbook/frontend-deployment
 1. Query the list of Pods to verify that the three frontend replicas are running:
 
       ```shell
-      kubectl get pods -l app=guestbook -l tier=frontend
+      kubectl get pods -l app.kubernetes.io/name=guestbook -l app.kubernetes.io/component=frontend
       ```
 
       The response should be similar to this:


### PR DESCRIPTION
I was going through the PHP Guestbook tutorial and noticed that one of the CLI commands needed its label references updated.
