### PR TITLE
Use port number in “Use Port Forwarding to Access Applications in a Cluster”

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
+++ b/content/en/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
@@ -152,7 +152,7 @@ for database debugging.
     or
 
     ```shell
-    kubectl port-forward service/redis-master 7000:redis
+    kubectl port-forward service/redis-master 7000:6379
     ```
 
     Any of the above commands works. The output is similar to this:


### PR DESCRIPTION
Fix #26457

Preview: https://deploy-preview-26632--kubernetes-io-master-staging.netlify.app/docs/tasks/access-application-cluster/port-forward-access-application-cluster/

/language en