### PR TITLE
Update content/en/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro.html to to use the "control plane" terminology

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro.html
+++ b/content/en/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro.html
@@ -33,7 +33,7 @@ weight: 10
                 </p>
                 <p>A Kubernetes cluster consists of two types of resources:
                     <ul>
-                        <li>The <b>Master</b> coordinates the cluster</li>
+                        <li>The <b>Control Plane</b> coordinates the cluster</li>
                         <li><b>Nodes</b> are the workers that run applications</li>
                     </ul>
                 </p>
@@ -71,22 +71,22 @@ weight: 10
 
         <div class="row">
             <div class="col-md-8">
-                <p><b>The Master is responsible for managing the cluster.</b> The master coordinates all activities in your cluster, such as scheduling applications, maintaining applications' desired state, scaling applications, and rolling out new updates.</p>
-                <p><b>A node is a VM or a physical computer that serves as a worker machine in a Kubernetes cluster.</b> Each node has a Kubelet, which is an agent for managing the node and communicating with the Kubernetes master. The node should also have tools for handling container operations, such as containerd or Docker. A Kubernetes cluster that handles production traffic should have a minimum of three nodes.</p>
+                <p><b>The Control Plane is responsible for managing the cluster.</b> The Control Plane coordinates all activities in your cluster, such as scheduling applications, maintaining applications' desired state, scaling applications, and rolling out new updates.</p>
+                <p><b>A node is a VM or a physical computer that serves as a worker machine in a Kubernetes cluster.</b> Each node has a Kubelet, which is an agent for managing the node and communicating with the Kubernetes control plane. The node should also have tools for handling container operations, such as containerd or Docker. A Kubernetes cluster that handles production traffic should have a minimum of three nodes.</p>
 
             </div>
             <div class="col-md-4">
                 <div class="content__box content__box_fill">
-                    <p><i>Masters manage the cluster and the nodes that are used to host the running applications.</i></p>
+                    <p><i>Control Planes manage the cluster and the nodes that are used to host the running applications.</i></p>
                 </div>
             </div>
         </div>
 
         <div class="row">
             <div class="col-md-8">
-                <p>When you deploy applications on Kubernetes, you tell the master to start the application containers. The master schedules the containers to run on the cluster's nodes. <b>The nodes communicate with the master using the <a href="/docs/concepts/overview/kubernetes-api/">Kubernetes API</a></b>, which the master exposes. End users can also use the Kubernetes API directly to interact with the cluster.</p>
+                <p>When you deploy applications on Kubernetes, you tell the control plane to start the application containers. The control plane schedules the containers to run on the cluster's nodes. <b>The nodes communicate with the control plane using the <a href="/docs/concepts/overview/kubernetes-api/">Kubernetes API</a></b>, which the control plane exposes. End users can also use the Kubernetes API directly to interact with the cluster.</p>
 
-                <p>A Kubernetes cluster can be deployed on either physical or virtual machines. To get started with Kubernetes development, you can use Minikube.  Minikube is a lightweight Kubernetes implementation that creates a VM on your local machine and deploys a simple cluster containing only one node. Minikube is available for Linux, macOS, and Windows systems. The Minikube CLI provides basic bootstrapping operations for working with your cluster, including start, stop, status, and delete. For this tutorial, however, you'll use a provided online terminal with Minikube pre-installed.</p>
+                <p>A Kubernetes cluster can be deployed on either physical or virtual machines. To get started with Kubernetes development, you can use Minikube. Minikube is a lightweight Kubernetes implementation that creates a VM on your local machine and deploys a simple cluster containing only one node. Minikube is available for Linux, macOS, and Windows systems. The Minikube CLI provides basic bootstrapping operations for working with your cluster, including start, stop, status, and delete. For this tutorial, however, you'll use a provided online terminal with Minikube pre-installed.</p>
 
                 <p>Now that you know what Kubernetes is, let's go to the online tutorial and start our first cluster!</p>
 


### PR DESCRIPTION
Update content/en/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro.html to to use the "control plane" terminology.

Fix:  #26640
Ref: #21621

Preview: https://deploy-preview-26645--kubernetes-io-master-staging.netlify.app/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro/

/language en