### PR TITLE
ja: Update docs/setup/production-environment/on-premises-vm/cloudstack.md follow v1.18 of the original text

### DIFF
--- a/content/ja/docs/setup/production-environment/on-premises-vm/cloudstack.md
+++ b/content/ja/docs/setup/production-environment/on-premises-vm/cloudstack.md
@@ -7,7 +7,7 @@ content_type: concept
 
 [CloudStack](https://cloudstack.apache.org/) is a software to build public and private clouds based on hardware virtualization principles (traditional IaaS). To deploy Kubernetes on CloudStack there are several possibilities depending on the Cloud being used and what images are made available. CloudStack also has a vagrant plugin available, hence Vagrant could be used to deploy Kubernetes either using the existing shell provisioner or using new Salt based recipes.
 
-[CoreOS](http://coreos.com) templates for CloudStack are built [nightly](http://stable.release.core-os.net/amd64-usr/current/). CloudStack operators need to [register](http://docs.cloudstack.apache.org/projects/cloudstack-administration/en/latest/templates.html) this template in their cloud before proceeding with these Kubernetes deployment instructions.
+[CoreOS](https://coreos.com) templates for CloudStack are built [nightly](https://stable.release.core-os.net/amd64-usr/current/). CloudStack operators need to [register](https://docs.cloudstack.apache.org/projects/cloudstack-administration/en/latest/templates.html) this template in their cloud before proceeding with these Kubernetes deployment instructions.
 
 This guide uses a single [Ansible playbook](https://github.com/apachecloudstack/k8s), which is completely automated and can deploy Kubernetes on a CloudStack based Cloud using CoreOS images. The playbook, creates an ssh key pair, creates a security group and associated rules and finally starts coreOS instances configured via cloud-init.
 


### PR DESCRIPTION
I updated the `content/ja/docs/setup/production-environment/on-premises-vm/cloudstack.md` to follow v1.18 of the original (English) text.

The following link is the differences between v1.17 and v1.18:
https://gist.github.com/inductor/d0fad60f7e28e6429f65b15735665418

This PR fixes this issue:
https://github.com/kubernetes/website/issues/26505
