### PR TITLE
Graduate multiple sizes huge pages to GA

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -125,8 +125,6 @@ different Kubernetes components.
 | `GracefulNodeShutdown` | `true` | Beta | 1.21 | |
 | `HPAContainerMetrics` | `false` | Alpha | 1.20 | |
 | `HPAScaleToZero` | `false` | Alpha | 1.16 | |
-| `HugePageStorageMediumSize` | `false` | Alpha | 1.18 | 1.18 |
-| `HugePageStorageMediumSize` | `true` | Beta | 1.19 | |
 | `IndexedJob` | `false` | Alpha | 1.21 | 1.21 |
 | `IndexedJob` | `true` | Beta | 1.22 | |
 | `JobTrackingWithFinalizers` | `false` | Alpha | 1.22 | |
@@ -293,6 +291,9 @@ different Kubernetes components.
 | `HugePages` | `false` | Alpha | 1.8 | 1.9 |
 | `HugePages` | `true` | Beta| 1.10 | 1.13 |
 | `HugePages` | `true` | GA | 1.14 | - |
+| `HugePageStorageMediumSize` | `false` | Alpha | 1.18 | 1.18 |
+| `HugePageStorageMediumSize` | `true` | Beta | 1.19 | 1.21 |
+| `HugePageStorageMediumSize` | `true` | GA | 1.22 | - |
 | `HyperVContainer` | `false` | Alpha | 1.10 | 1.19 |
 | `HyperVContainer` | `false` | Deprecated | 1.20 | - |
 | `ImmutableEphemeralVolumes` | `false` | Alpha | 1.18 | 1.18 |

--- a/content/en/docs/tasks/manage-hugepages/scheduling-hugepages.md
+++ b/content/en/docs/tasks/manage-hugepages/scheduling-hugepages.md
@@ -113,10 +113,4 @@ spec:
 - Huge page usage in a namespace is controllable via ResourceQuota similar
   to other compute resources like `cpu` or `memory` using the `hugepages-<size>`
   token.
-- Support of multiple sizes huge pages is feature gated. It can be
-  disabled with the `HugePageStorageMediumSize`
-  [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
-  on the {{< glossary_tooltip text="kubelet" term_id="kubelet" >}} and
-  {{< glossary_tooltip text="kube-apiserver" term_id="kube-apiserver" >}}
-  (`--feature-gates=HugePageStorageMediumSize=false`).
 


### PR DESCRIPTION
This PR is a part of PR series to graduate support for multiple sizes hugepages to GA.
 
Support for multiple sizes huge pages was implemented in 1.18 and graduated to beta in 1.19.
Community feedback was positive since then, so it's time to graduate it to GA.

k8s PR:  kubernetes/kubernetes#99144
KEP PR: kubernetes/enhancements#2534 