### PR TITLE
Corrected Docker(shim) UNIX domain socket file

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -122,7 +122,7 @@ The following table lists container runtimes and their associated socket paths:
 {{< table caption = "Container runtimes and their socket paths" >}}
 | Runtime    | Path to Unix domain socket        |
 |------------|-----------------------------------|
-| Docker     | `/var/run/docker.sock`            |
+| Docker     | `/var/run/dockershim.sock`        |
 | containerd | `/run/containerd/containerd.sock` |
 | CRI-O      | `/var/run/crio/crio.sock`         |
 {{< /table >}}


### PR DESCRIPTION
This page listed `/var/run/docker.sock` as the UNIX domain socket path for the Docker container runtime, but it's actually `/var/run/dockershim.sock`, as the kubelet documentation indicates as the default value for the `--container-runtime-endpoint` argument:

https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/

The socket file specified (`/var/run/docker.sock`) is where the Docker daemon listens for requests for the Docker API, not the CRI interface.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
