### PR TITLE
Sync with English version and Update Deprecated URL

### DIFF
--- a/content/zh/docs/tutorials/services/source-ip.md
+++ b/content/zh/docs/tutorials/services/source-ip.md
@@ -199,7 +199,7 @@ graph LR;
   node2-->client;
   node2-. SNAT .->node1[节点 1];
   node1-. SNAT .->node2;
-  node1-->endpoint(Endpoint);
+  node1-->endpoint(端点);
 
   classDef plain fill:#ddd,stroke:#fff,stroke-width:4px,color:#000;
   classDef k8s fill:#326ce5,stroke:#fff,stroke-width:4px,color:#fff;

--- a/content/zh/docs/tutorials/services/source-ip.md
+++ b/content/zh/docs/tutorials/services/source-ip.md
@@ -134,7 +134,7 @@ ip addr
        valid_lft forever preferred_lft forever
 ```
 
-然后使用 `wget` 去请求本地Web服务器
+然后使用 `wget` 去请求本地 Web 服务器
 ```shell
 # 用名为"clusterip"的服务的IPv4地址替换"10.0.170.92"
 

--- a/content/zh/docs/tutorials/services/source-ip.md
+++ b/content/zh/docs/tutorials/services/source-ip.md
@@ -250,7 +250,7 @@ client_address=104.132.1.79
 graph TD;
   client --> node1[节点 1];
   client(client) --x node2[节点 2];
-  node1 --> endpoint(endpoint);
+  node1 --> endpoint(端点);
   endpoint --> node1;
 
   classDef plain fill:#ddd,stroke:#fff,stroke-width:4px,color:#000;
@@ -403,4 +403,3 @@ $ kubectl delete deployment source-ip-app
 
 
 * 进一步学习 [通过 services 连接应用](/zh/docs/concepts/services-networking/connect-applications-service/)
-

--- a/content/zh/docs/tutorials/services/source-ip.md
+++ b/content/zh/docs/tutorials/services/source-ip.md
@@ -116,6 +116,7 @@ If you don't see a command prompt, try pressing enter.
 
 ```shell
 # 在终端内使用"kubectl run"执行
+
 ip addr
 ```
 ```
@@ -136,7 +137,8 @@ ip addr
 然后使用`wget`去请求本地Web服务器
 ```shell
 # 用名为"clusterip"的服务的IPv4地址替换"10.0.170.92"
-# wget -qO - 10.0.170.92
+
+wget -qO - 10.0.170.92
 ```
 ```
 CLIENT VALUES:

--- a/content/zh/docs/tutorials/services/source-ip.md
+++ b/content/zh/docs/tutorials/services/source-ip.md
@@ -136,7 +136,7 @@ ip addr
 
 然后使用 `wget` 去请求本地 Web 服务器
 ```shell
-# 用名为"clusterip"的服务的IPv4地址替换"10.0.170.92"
+# 用名为 "clusterip" 的服务的 IPv4 地址替换 "10.0.170.92"
 
 wget -qO - 10.0.170.92
 ```

--- a/content/zh/docs/tutorials/services/source-ip.md
+++ b/content/zh/docs/tutorials/services/source-ip.md
@@ -367,7 +367,7 @@ __跨平台支持__
 2. 使用一个包转发器，因此从客户端发送到负载均衡器 VIP 的请求在拥有客户端源 IP 地址的节点终止，而不被中间代理。
 
 
-第一类负载均衡器必须使用一种它和后端之间约定的协议来和真实的客户端 IP 通信，例如 HTTP [X-FORWARDED-FOR](https://en.wikipedia.org/wiki/X-Forwarded-For) 头，或者 [proxy 协议](http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt)。
+第一类负载均衡器必须使用一种它和后端之间约定的协议来和真实的客户端 IP 通信，例如 HTTP [X-FORWARDED-FOR](https://en.wikipedia.org/wiki/X-Forwarded-For) 头，或者 [proxy 协议](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)。
 第二类负载均衡器可以通过简单的在保存于 Service 的 `service.spec.healthCheckNodePort` 字段上创建一个 HTTP 健康检查点来使用上面描述的特性。
 
 

--- a/content/zh/docs/tutorials/services/source-ip.md
+++ b/content/zh/docs/tutorials/services/source-ip.md
@@ -195,15 +195,15 @@ client_address=10.240.0.3
 
 {{< mermaid >}}
 graph LR;
-  client(client)-->node2[Node 2];
+  client(client)-->node2[节点 2];
   node2-->client;
-  node2-. SNAT .->node1[Node 1];
+  node2-. SNAT .->node1[节点 1];
   node1-. SNAT .->node2;
   node1-->endpoint(Endpoint);
 
   classDef plain fill:#ddd,stroke:#fff,stroke-width:4px,color:#000;
   classDef k8s fill:#326ce5,stroke:#fff,stroke-width:4px,color:#fff;
-  class 节点1,节点2,endpoint k8s;
+  class node1,node2,endpoint k8s;
   class client plain;
 {{</ mermaid >}}
 
@@ -248,14 +248,14 @@ client_address=104.132.1.79
 
 {{< mermaid >}}
 graph TD;
-  client --> node1[Node 1];
-  client(client) --x node2[Node 2];
+  client --> node1[节点 1];
+  client(client) --x node2[节点 2];
   node1 --> endpoint(endpoint);
   endpoint --> node1;
 
   classDef plain fill:#ddd,stroke:#fff,stroke-width:4px,color:#000;
   classDef k8s fill:#326ce5,stroke:#fff,stroke-width:4px,color:#fff;
-  class 节点1,节点2,endpoint k8s;
+  class node1,node2,endpoint k8s;
   class client plain;
 {{</ mermaid >}}
 

--- a/content/zh/docs/tutorials/services/source-ip.md
+++ b/content/zh/docs/tutorials/services/source-ip.md
@@ -112,7 +112,7 @@ Waiting for pod default/busybox to be running, status is Pending, pod ready: fal
 If you don't see a command prompt, try pressing enter.
 ```
 
-然后你可以在Pod内运行命令：
+然后你可以在 Pod 内运行命令：
 
 ```shell
 # 在终端内使用"kubectl run"执行
@@ -134,7 +134,7 @@ ip addr
        valid_lft forever preferred_lft forever
 ```
 
-然后使用`wget`去请求本地Web服务器
+然后使用 `wget` 去请求本地Web服务器
 ```shell
 # 用名为"clusterip"的服务的IPv4地址替换"10.0.170.92"
 
@@ -203,7 +203,7 @@ graph LR;
 
   classDef plain fill:#ddd,stroke:#fff,stroke-width:4px,color:#000;
   classDef k8s fill:#326ce5,stroke:#fff,stroke-width:4px,color:#fff;
-  class node1,node2,endpoint k8s;
+  class 节点1,节点2,endpoint k8s;
   class client plain;
 {{</ mermaid >}}
 
@@ -255,7 +255,7 @@ graph TD;
 
   classDef plain fill:#ddd,stroke:#fff,stroke-width:4px,color:#000;
   classDef k8s fill:#326ce5,stroke:#fff,stroke-width:4px,color:#fff;
-  class node1,node2,endpoint k8s;
+  class 节点1,节点2,endpoint k8s;
   class client plain;
 {{</ mermaid >}}
 


### PR DESCRIPTION
1. Update Deprecated URL to Fix #26693
http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt is deprecated and 403 Forbidden
change it to 
https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt

2. Remove Load Balancer Link as English Version did to Fix #26689

3. Sync with English Version:
```
diff --git a/content/en/docs/tutorials/services/source-ip.md b/content/en/docs/tutorials/services/source-ip.md
index e6b1feead..4ed574e15 100644
--- a/content/en/docs/tutorials/services/source-ip.md
+++ b/content/en/docs/tutorials/services/source-ip.md
@@ -150,7 +150,7 @@ ip addr

 …then use `wget` to query the local webserver
 ```shell
-# Replace 10.0.170.92 with the Pod's IPv4 address
+# Replace "10.0.170.92" with the IPv4 address of the Service named "clusterip"
 wget -qO - 10.0.170.92
 ```
```
@@ -206,18 +206,19 @@ Note that these are not the correct client IPs, they're cluster internal IPs. Th

 Visually:

-```
-          client
-             \ ^
-              \ \
-               v \
-   node 1 <--- node 2
-    | ^   SNAT
-    | |   --->
-    v |
- endpoint
-```
+{{< mermaid >}}
+graph LR;
+  client(client)-->node2[Node 2];
+  node2-->client;
+  node2-. SNAT .->node1[Node 1];
+  node1-. SNAT .->node2;
+  node1-->endpoint(Endpoint);

+  classDef plain fill:#ddd,stroke:#fff,stroke-width:4px,color:#000;
+  classDef k8s fill:#326ce5,stroke:#fff,stroke-width:4px,color:#fff;
+  class node1,node2,endpoint k8s;
+  class client plain;
+{{</ mermaid >}}

 To avoid this, Kubernetes has a feature to
 [preserve the client source IP](/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip).
@@ -261,17 +262,18 @@ This is what happens:

 Visually:

-```
-        client
-       ^ /   \
-      / /     \
-     / v       X
-   node 1     node 2
-    ^ |
-    | |
-    | v
- endpoint
-```
+{{< mermaid >}}
+graph TD;
+  client --> node1[Node 1];
+  client(client) --x node2[Node 2];
+  node1 --> endpoint(endpoint);
+  endpoint --> node1;
+
+  classDef plain fill:#ddd,stroke:#fff,stroke-width:4px,color:#000;
+  classDef k8s fill:#326ce5,stroke:#fff,stroke-width:4px,color:#fff;
+  class node1,node2,endpoint k8s;
+  class client plain;
+{{</ mermaid >}}



@@ -324,17 +326,7 @@ deliberately failing health checks.

 Visually:

-```
-                      client
-                        |
-                      lb VIP
-                     / ^
-                    v /
-health check --->   node 1   node 2 <--- health check
-        200  <---   ^ |             ---> 500
-                    | V
-                 endpoint
-```
+![Source IP with externalTrafficPolicy](/images/docs/sourceip-externaltrafficpolicy.svg)

 You can test this by setting the annotation:

@@ -420,7 +412,7 @@ protocol between the loadbalancer and backend to communicate the true client IP
 such as the HTTP [Forwarded](https://tools.ietf.org/html/rfc7239#section-5.2)
 or [X-FORWARDED-FOR](https://en.wikipedia.org/wiki/X-Forwarded-For)
 headers, or the
-[proxy protocol](http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt).
+[proxy protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt).
 Load balancers in the second category can leverage the feature described above
 by creating an HTTP health check pointing at the port stored in
 the `service.spec.healthCheckNodePort` field on the Service.
@@ -447,6 +439,4 @@ kubectl delete deployment source-ip-app
 ## {{% heading "whatsnext" %}}

 * Learn more about [connecting applications via services](/docs/concepts/services-networking/connect-applications-service/)
-* Read how to [Create an External Load Balancer](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/)
-
-
```

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
