### PR TITLE
Update client-libraries.md

### DIFF
--- a/content/en/docs/reference/using-api/client-libraries.md
+++ b/content/en/docs/reference/using-api/client-libraries.md
@@ -72,7 +72,7 @@ their authors, not the Kubernetes team.
 | Ruby                 | [github.com/kontena/k8s-client](https://github.com/kontena/k8s-client) |
 | Rust                 | [github.com/clux/kube-rs](https://github.com/clux/kube-rs) |
 | Rust                 | [github.com/ynqa/kubernetes-rust](https://github.com/ynqa/kubernetes-rust) |
-| Scala                | [github.com/doriordan/skuber](https://github.com/doriordan/skuber) |
+| Scala                | [github.com/hagay3/skuber](https://github.com/hagay3/skuber) |
 | Scala                | [github.com/joan38/kubernetes-client](https://github.com/joan38/kubernetes-client) |
 | Swift                | [github.com/swiftkube/client](https://github.com/swiftkube/client) |
 | DotNet               | [github.com/tonnyeremin/kubernetes_gen](https://github.com/tonnyeremin/kubernetes_gen) |


### PR DESCRIPTION
New maintainer of kubernetes scala client - skuber.
skuber repo seems abandoned by doriordan.
I forked the repo and started to maintain it.
