### PR TITLE
Demonstrate how to use secure communication

### DIFF
--- a/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
+++ b/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
@@ -125,7 +125,16 @@ the URL schema.
 
 Similarly, to configure etcd with secure client communication, specify flags
 `--key-file=k8sclient.key` and `--cert-file=k8sclient.cert`, and use HTTPS as
-the URL schema.
+the URL schema. Here is an example on a client command that uses secure
+communication:
+
+```
+ETCDCTL_API=3 etcdctl --endpoints 10.2.0.9:2379 \
+--cert=/etc/kubernetes/pki/etcd/server.crt \
+--key=/etc/kubernetes/pki/etcd/server.key \
+--cacert=/etc/kubernetes/pki/etcd/ca.crt \
+member list
+```
 
 ### Limiting access of etcd clusters
 

--- a/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
+++ b/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
@@ -130,10 +130,10 @@ communication:
 
 ```
 ETCDCTL_API=3 etcdctl --endpoints 10.2.0.9:2379 \
---cert=/etc/kubernetes/pki/etcd/server.crt \
---key=/etc/kubernetes/pki/etcd/server.key \
---cacert=/etc/kubernetes/pki/etcd/ca.crt \
-member list
+  --cert=/etc/kubernetes/pki/etcd/server.crt \
+  --key=/etc/kubernetes/pki/etcd/server.key \
+  --cacert=/etc/kubernetes/pki/etcd/ca.crt \
+  member list
 ```
 
 ### Limiting access of etcd clusters


### PR DESCRIPTION
The page at https://kubernetes.io/docs/tasks/administer-cluster/configure-upgrade-etcd/ explains how to set up secure communication at etcd but does not provide an example on how to use the certificates.