### PR TITLE
Fix layout for deprecated url of cncf embed pages

### DIFF
--- a/layouts/shortcodes/cncf-landscape.html
+++ b/layouts/shortcodes/cncf-landscape.html
@@ -15,7 +15,7 @@ function updateLandscapeSource(button,shouldUpdateFragment) {
     } else {
       var landscapeElements = document.querySelectorAll("#landscape");
       let categories=button.dataset.landscapeTypes;
-      let link = "https://landscape.cncf.io/category="+encodeURIComponent(categories)+"&format=card-mode&grouping=category&embed=yes";
+      let link = "https://landscape.cncf.io/card-mode?category="+encodeURIComponent(categories)+"&grouping=category&embed=yes";
       landscapeElements[0].src = link;
     }
   }
@@ -58,9 +58,9 @@ document.addEventListener("DOMContentLoaded", function () {
 {{- end -}}
 <div id="frameHolder">
   {{ if ( .Get "category" ) }}
-  <iframe frameborder="0" id="landscape" scrolling="no" src="https://landscape.cncf.io/category={{ .Get "category" }}&format=card-mode&grouping=category&embed=yes" style="width: 1px; min-width: 100%"></iframe>
+  <iframe frameborder="0" id="landscape" scrolling="no" src="https://landscape.cncf.io/card-mode?category={{ .Get "category" }}&grouping=category&embed=yes" style="width: 1px; min-width: 100%"></iframe>
   {{ else }}
-  <iframe frameborder="0" id="landscape" scrolling="no" src="https://landscape.cncf.io/format=card-mode;embed=yes" style="width: 1px; min-width: 100%" title="CNCF Landscape"></iframe>
+  <iframe frameborder="0" id="landscape" scrolling="no" src="https://landscape.cncf.io/card-mode;embed=yes" style="width: 1px; min-width: 100%" title="CNCF Landscape"></iframe>
   {{ end }}
   <script src="https://landscape.cncf.io/iframeResizer.js"></script>
 </div>


### PR DESCRIPTION
Currently, following pages include embed page from https://landscape.cncf.io.
- https://kubernetes.io/docs/setup/production-environment/turnkey-solutions/
- https://kubernetes.io/partners/
- https://kubernetes.io/training/

We are using a layout (layouts/shortcodes/cncf-landscape.html)
to embed pages from landscape.cncf.io.

However, the URL the layout provides is deprecated by landscape.cncf.io. 
So, the related pages show a "URL deprecated warning" , like this.

> URL deprecated. The following URL should be used instead:
> https://landscape.cncf.io/card-mode?category=certified-kubernetes-hosted&grouping=category&embed=yes

![image](https://user-images.githubusercontent.com/5966944/109104422-46edd900-776f-11eb-8ed9-58fcd316927a.png)


This PR update the layout to fix outdated URL code.
