### PR TITLE
Add netpol endport documentation

### DIFF
--- a/content/en/docs/concepts/services-networking/network-policies.md
+++ b/content/en/docs/concepts/services-networking/network-policies.md
@@ -257,7 +257,7 @@ The following restrictions apply when using this field:
 * As an alpha feature, this is disabled by default. To enable endPort field at a cluster level, you (or your cluster administrator) will need to enable the `NetworkPolicyEndPort` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) for the API server with `--feature-gates=NetworkPolicyEndPort=true,…`.
 * The `endPort` field must be equal than or greater to `port` field.
 * `endPort` can only be defined if `port` is also defined.
-* When using `endPort` field, the `port` field must be numeric.
+* Both ports must be numeric.
 
 {{< note >}}
 Your cluster must be using a {{< glossary_tooltip text="CNI" term_id="cni" >}} plugin that

--- a/content/en/docs/concepts/services-networking/network-policies.md
+++ b/content/en/docs/concepts/services-networking/network-policies.md
@@ -225,7 +225,7 @@ You must be using a {{< glossary_tooltip text="CNI" term_id="cni" >}} plugin tha
 
 {{< feature-state for_k8s_version="v1.21" state="alpha" >}}
 
-When writing a Network Policy, you can target a range of Ports instead of a single port.
+When writing a NetworkPolicy, you can target a range of ports instead of a single port.
 
 This is achiveable with the usage of the `endPort` field, as the following example:
 
@@ -260,7 +260,8 @@ The following restrictions apply when using this field:
 * When using `endPort` field, the `port` field must be numeric.
 
 {{< note >}}
-You must be using a {{< glossary_tooltip text="CNI" term_id="cni" >}} plugin that supports endPort field in NetworkPolicies ports specification.
+Your cluster must be using a {{< glossary_tooltip text="CNI" term_id="cni" >}} plugin that
+supports the `endPort` field in NetworkPolicy specifications.
 {{< /note >}}
 
 ## What you can't do with network policies (at least, not yet)

--- a/content/en/docs/concepts/services-networking/network-policies.md
+++ b/content/en/docs/concepts/services-networking/network-policies.md
@@ -221,6 +221,48 @@ When the feature gate is enabled, you can set the `protocol` field of a NetworkP
 You must be using a {{< glossary_tooltip text="CNI" term_id="cni" >}} plugin that supports SCTP protocol NetworkPolicies.
 {{< /note >}}
 
+## Targeting a range of Ports
+
+{{< feature-state for_k8s_version="v1.21" state="alpha" >}}
+
+When writing a Network Policy, you can target a range of Ports instead of a single port.
+
+This is achiveable with the usage of the `endPort` field, as the following example:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: multi-port-egress
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      role: db
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 10.0.0.0/24
+    ports:
+    - protocol: TCP
+      port: 32000
+      endPort: 32768
+```
+
+The above rule will allow a Pod with label `db` on the namespace `default` to communicate with any IP within the range `10.0.0.0/24` if the target port is between the range 32000 and 32768.
+
+The following restrictions apply when using this field:
+* As an alpha feature, this is disabled by default. To enable endPort field at a cluster level, you (or your cluster administrator) will need to enable the `NetworkPolicyEndPort` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) for the API server with `--feature-gates=NetworkPolicyEndPort=true,…`.
+* The `endPort` field must be equal than or greater to `port` field.
+* `endPort` can only be defined if `port` is also defined.
+* When using `endPort` field, the `port` field must be numeric.
+
+{{< note >}}
+You must be using a {{< glossary_tooltip text="CNI" term_id="cni" >}} plugin that supports endPort field in NetworkPolicies ports specification.
+{{< /note >}}
+
 ## What you can't do with network policies (at least, not yet)
 
 As of Kubernetes 1.20, the following functionality does not exist in the NetworkPolicy API, but you might be able to implement workarounds using Operating System components (such as SELinux, OpenVSwitch, IPTables, and so on) or Layer 7 technologies (Ingress controllers, Service Mesh implementations) or admission controllers.  In case you are new to network security in Kubernetes, its worth noting that the following User Stories cannot (yet) be implemented using the NetworkPolicy API.  Some (but not all) of these user stories are actively being discussed for future releases of the NetworkPolicy API.
@@ -232,7 +274,6 @@ As of Kubernetes 1.20, the following functionality does not exist in the Network
 - Creation or management of "Policy requests" that are fulfilled by a third party.
 - Default policies which are applied to all namespaces or pods (there are some third party Kubernetes distributions and projects which can do this).
 - Advanced policy querying and reachability tooling.
-- The ability to target ranges of Ports in a single policy declaration.
 - The ability to log network security events (for example connections that are blocked or accepted).
 - The ability to explicitly deny policies (currently the model for NetworkPolicies are deny by default, with only the ability to add allow rules).
 - The ability to prevent loopback or incoming host traffic (Pods cannot currently block localhost access, nor do they have the ability to block access from their resident node).

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -135,6 +135,7 @@ different Kubernetes components.
 | `LocalStorageCapacityIsolation` | `true` | Beta | 1.10 | |
 | `LocalStorageCapacityIsolationFSQuotaMonitoring` | `false` | Alpha | 1.15 | |
 | `MixedProtocolLBService` | `false` | Alpha | 1.20 | |
+| `NetworkPolicyEndPort` | `false` | Alpha | 1.21 |  |
 | `NodeDisruptionExclusion` | `false` | Alpha | 1.16 | 1.18 |
 | `NodeDisruptionExclusion` | `true` | Beta | 1.19 | |
 | `NonPreemptingPriority` | `false` | Alpha | 1.15 | 1.18 |
@@ -657,6 +658,7 @@ Each feature gate is designed for enabling/disabling a specific feature:
   the volume mounter.
 - `MountPropagation`: Enable sharing volume mounted by one container to other containers or pods.
   For more details, please see [mount propagation](/docs/concepts/storage/volumes/#mount-propagation).
+- `NetworkPolicyEndPort`: Enable use of the field `endPort` in NetworkPolicy objects, allowing the selection of a port range instead of a single port.
 - `NodeDisruptionExclusion`: Enable use of the Node label `node.kubernetes.io/exclude-disruption`
   which prevents nodes from being evacuated during zone failures.
 - `NodeLease`: Enable the new Lease API to report node heartbeats, which could be used as a node health signal.


### PR DESCRIPTION
endPort field is going to be part of release v1.21 as per https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/2079-network-policy-port-range

While this still need to be supported by the CNIs and it's an alpha feature, it's worth to document it and remove from non supported features.