### PR TITLE
Add sftim as blog reviewer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -10,6 +10,7 @@ aliases:
     - kbarnard10
     - mrbobbytables
     - onlydole
+    - sftim
   sig-docs-de-owners: # Admins for German content
     - bene2k1
     - mkorbi


### PR DESCRIPTION
This PR adds me (@sftim) as a reviewer for the Kubernetes blog.

/area blog
/cc onlydole

@kubernetes/sig-docs-blog-owners PTAL