### PR TITLE
Fix links in tutorials section

### DIFF
--- a/content/zh/docs/tutorials/clusters/seccomp.md
+++ b/content/zh/docs/tutorials/clusters/seccomp.md
@@ -52,14 +52,14 @@ Kubernetes 允许你将加载到节点上的 seccomp 配置文件自动应用于
 <!--
 In order to complete all steps in this tutorial, you must install
 [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) and
-[kubectl](/doc/tasks/tools/install-kubectl/). This tutorial will show examples
+[kubectl](/docs/tasks/tools/install-kubectl/). This tutorial will show examples
 with both alpha (pre-v1.19) and generally available seccomp functionality, so
 make sure that your cluster is [configured
 correctly](https://kind.sigs.k8s.io/docs/user/quick-start/#setting-kubernetes-version)
 for the version you are using.
 -->
 为了完成本教程中的所有步骤，你必须安装 [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) 
-和 [kubectl](/zh/doc/tasks/tools/install-kubectl/)。本教程将显示同时具有 alpha（v1.19 之前的版本）
+和 [kubectl](/zh/docs/tasks/tools/install-kubectl/)。本教程将显示同时具有 alpha（v1.19 之前的版本）
 和通常可用的 seccomp 功能的示例，因此请确保为所使用的版本[正确配置](https://kind.sigs.k8s.io/docs/user/quick-start/#setting-kubernetes-version)了集群。
 
 <!-- steps -->

--- a/content/zh/docs/tutorials/configuration/configure-java-microservice/configure-java-microservice.md
+++ b/content/zh/docs/tutorials/configuration/configure-java-microservice/configure-java-microservice.md
@@ -34,7 +34,7 @@ Dockerfile、kubernetes.yml、Kubernetes ConfigMaps、和 Kubernetes Secrets。
 比如赋值给不同的容器中的不同环境变量。
 
 <!-- 
-ConfigMaps are API Objects that store non-confidential key-value pairs.  In the Interactive Tutorial you will learn how to use a ConfigMap to store the application's name.  For more information regarding ConfigMaps, you can find the documentation [here].
+ConfigMaps are API Objects that store non-confidential key-value pairs.  In the Interactive Tutorial you will learn how to use a ConfigMap to store the application's name.  For more information regarding ConfigMaps, you can find the documentation [here](/docs/tasks/configure-pod-container/configure-pod-configmap/).
 
 Although Secrets are also used to store key-value pairs, they differ from ConfigMaps in that they're intended for confidential/sensitive information and are stored using Base64 encoding.  This makes secrets the appropriate choice for storing such things as credentials, keys, and tokens, the former of which you'll do in the Interactive Tutorial.  For more information on Secrets, you can find the documentation [here](/docs/concepts/configuration/secret/).
 -->
@@ -90,4 +90,4 @@ CDI & MicroProfile 都会被用在互动教程中，
 ### [Start Interactive Tutorial](/docs/tutorials/configuration/configure-java-microservice/configure-java-microservice-interactive/) 
 -->
 ## 示例：使用 MicroProfile、ConfigMaps、Secrets 实现外部化应用配置
-### [启动互动教程](/docs/tutorials/configuration/configure-java-microservice/configure-java-microservice-interactive/) 
+### [启动互动教程](/zh/docs/tutorials/configuration/configure-java-microservice/configure-java-microservice-interactive/) 


### PR DESCRIPTION
Ref: #24681

And the doc [content/zh/docs/tutorials/stateful-application/cassandra.md](content/zh/docs/tutorials/stateful-application/cassandra.md) is out of date, I'll resync it in a new PR separately.