### PR TITLE
Clarify stability level of admission plugins

### DIFF
--- a/content/en/docs/reference/access-authn-authz/admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/admission-controllers.md
@@ -565,6 +565,8 @@ Starting from 1.11, this admission controller is disabled by default.
 
 ### PodNodeSelector {#podnodeselector}
 
+{{< feature-state for_k8s_version="v1.5" state="alpha" >}}
+
 This admission controller defaults and limits what node selectors may be used within a namespace by reading a namespace annotation and a global configuration.
 
 #### Configuration File Format
@@ -674,6 +676,8 @@ See also [Pod Security Policy documentation](/docs/concepts/policy/pod-security-
 for more information.
 
 ### PodTolerationRestriction {#podtolerationrestriction}
+
+{{< feature-state for_k8s_version="v1.7" state="alpha" >}}
 
 The PodTolerationRestriction admission controller verifies any conflict between tolerations of a pod and the tolerations of its namespace.
 It rejects the pod request if there is a conflict.


### PR DESCRIPTION
cc @ahg-g 

These two admission plugins still require use of alpha annotations. Adding feature state indicates to clarify that.