### PR TITLE
fix duplicated content

### DIFF
--- a/content/zh/docs/contribute/style/hugo-shortcodes/index.md
+++ b/content/zh/docs/contribute/style/hugo-shortcodes/index.md
@@ -191,7 +191,6 @@ You can also include a full definition:
 
 <!--
 which renders as:
-{{< glossary_definition term_id="cluster" length="all" >}}
 -->
 呈现为： 
 {{< glossary_definition term_id="cluster" length="all" >}}


### PR DESCRIPTION
The circled content is supposed to be in the HTML comment.
![image](https://user-images.githubusercontent.com/8073696/109384319-fae59480-7926-11eb-86e5-9c8dd63a0b4c.png)
The mistake is caused by a nested comments in the `cluster` glossary_definition, see line 38-45 in content/zh/docs/reference/glossary/cluster.md.