### PR TITLE
Fix content/en/docs/tutorials/stateless-application/guestbook.md

### DIFF
--- a/content/en/docs/tutorials/stateless-application/guestbook.md
+++ b/content/en/docs/tutorials/stateless-application/guestbook.md
@@ -49,13 +49,14 @@ The manifest file, included below, specifies a Deployment controller that runs a
 1. Launch a terminal window in the directory you downloaded the manifest files.
 1. Apply the MongoDB Deployment from the `mongo-deployment.yaml` file:
 
+      <!---
+      for local testing of the content via relative file path
+      kubectl apply -f ./content/en/examples/application/guestbook/mongo-deployment.yaml
+      -->
+
       ```shell
       kubectl apply -f https://k8s.io/examples/application/guestbook/mongo-deployment.yaml
       ```
-<!---
-for local testing of the content via relative file path
-kubectl apply -f ./content/en/examples/application/guestbook/mongo-deployment.yaml
--->
 
 1. Query the list of Pods to verify that the MongoDB Pod is running:
 
@@ -66,8 +67,8 @@ kubectl apply -f ./content/en/examples/application/guestbook/mongo-deployment.ya
       The response should be similar to this:
 
       ```shell
-      NAME                            READY     STATUS    RESTARTS   AGE
-      mongo-5cfd459dd4-lrcjb          1/1       Running   0          28s
+      NAME                     READY   STATUS    RESTARTS   AGE
+      mongo-75f59d57f4-w9gv8   1/1     Running   0          100s
       ```
 
 1. Run the following command to view the logs from the MongoDB Deployment:
@@ -84,14 +85,14 @@ The guestbook application needs to communicate to the MongoDB to write its data.
 
 1. Apply the MongoDB Service from the following `mongo-service.yaml` file:
 
+      <!---
+      for local testing of the content via relative file path
+      kubectl apply -f ./content/en/examples/application/guestbook/mongo-service.yaml
+      -->
+      
       ```shell
       kubectl apply -f https://k8s.io/examples/application/guestbook/mongo-service.yaml
       ```
-
-<!---
-for local testing of the content via relative file path
-kubectl apply -f ./content/en/examples/application/guestbook/mongo-service.yaml
--->
 
 1. Query the list of Services to verify that the MongoDB Service is running:
 
@@ -102,9 +103,9 @@ kubectl apply -f ./content/en/examples/application/guestbook/mongo-service.yaml
       The response should be similar to this:
 
       ```shell
-      NAME           TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)    AGE
-      kubernetes     ClusterIP   10.0.0.1     <none>        443/TCP    1m
-      mongo          ClusterIP   10.0.0.151   <none>        6379/TCP   8s
+      NAME         TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)     AGE
+      kubernetes   ClusterIP   10.96.0.1      <none>        443/TCP     7m7s
+      mongo        ClusterIP   10.96.30.147   <none>        27017/TCP   2m17s
       ```
 
 {{< note >}}
@@ -122,14 +123,14 @@ The guestbook application has a web frontend serving the HTTP requests written i
 
 1. Apply the frontend Deployment from the `frontend-deployment.yaml` file:
 
+      <!---
+      for local testing of the content via relative file path
+      kubectl apply -f ./content/en/examples/application/guestbook/frontend-deployment.yaml
+      -->
+
       ```shell
       kubectl apply -f https://k8s.io/examples/application/guestbook/frontend-deployment.yaml
       ```
-
-<!---
-for local testing of the content via relative file path
-kubectl apply -f ./content/en/examples/application/guestbook/frontend-deployment.yaml
--->
 
 1. Query the list of Pods to verify that the three frontend replicas are running:
 
@@ -140,10 +141,10 @@ kubectl apply -f ./content/en/examples/application/guestbook/frontend-deployment
       The response should be similar to this:
 
       ```
-      NAME                        READY     STATUS    RESTARTS   AGE
-      frontend-3823415956-dsvc5   1/1       Running   0          54s
-      frontend-3823415956-k22zn   1/1       Running   0          54s
-      frontend-3823415956-w9gbt   1/1       Running   0          54s
+      NAME                       READY   STATUS    RESTARTS   AGE
+      frontend-848d88c7c-hpf8z   1/1     Running   0          28s
+      frontend-848d88c7c-hwxg4   1/1     Running   0          28s
+      frontend-848d88c7c-njxgk   1/1     Running   0          28s
       ```
 
 ### Creating the Frontend Service
@@ -160,14 +161,14 @@ Some cloud providers, like Google Compute Engine or Google Kubernetes Engine, su
 
 1. Apply the frontend Service from the `frontend-service.yaml` file:
 
+      <!---
+      for local testing of the content via relative file path
+      kubectl apply -f ./content/en/examples/application/guestbook/frontend-service.yaml
+      -->
+      
       ```shell
       kubectl apply -f https://k8s.io/examples/application/guestbook/frontend-service.yaml
       ```
-
-<!---
-for local testing of the content via relative file path
-kubectl apply -f ./content/en/examples/application/guestbook/frontend-service.yaml
--->
 
 1. Query the list of Services to verify that the frontend Service is running:
 
@@ -178,10 +179,10 @@ kubectl apply -f ./content/en/examples/application/guestbook/frontend-service.ya
       The response should be similar to this:
 
       ```
-      NAME           TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)        AGE
-      frontend       ClusterIP   10.0.0.112   <none>       80/TCP   6s
-      kubernetes     ClusterIP   10.0.0.1     <none>        443/TCP        4m
-      mongo          ClusterIP   10.0.0.151   <none>        6379/TCP       2m
+      NAME         TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)     AGE
+      frontend     ClusterIP   10.96.35.36    <none>        80/TCP      23s
+      kubernetes   ClusterIP   10.96.0.1      <none>        443/TCP     9m17s
+      mongo        ClusterIP   10.96.30.147   <none>        27017/TCP   4m27s
       ```
 
 ### Viewing the Frontend Service via `kubectl port-forward`
@@ -214,8 +215,8 @@ If you deployed the `frontend-service.yaml` manifest with type: `LoadBalancer` y
       The response should be similar to this:
 
       ```
-      NAME       TYPE        CLUSTER-IP      EXTERNAL-IP        PORT(S)        AGE
-      frontend   ClusterIP   10.51.242.136   109.197.92.229     80:32372/TCP   1m
+      NAME       TYPE           CLUSTER-IP      EXTERNAL-IP        PORT(S)        AGE
+      frontend   LoadBalancer   10.96.35.36     109.197.92.229     80:32372/TCP   1m
       ```
 
 1. Copy the external IP address, and load the page in your browser to view your guestbook.
@@ -239,13 +240,13 @@ You can scale up or down as needed because your servers are defined as a Service
       The response should look similar to this:
 
       ```
-      NAME                            READY     STATUS    RESTARTS   AGE
-      frontend-3823415956-70qj5       1/1       Running   0          5s
-      frontend-3823415956-dsvc5       1/1       Running   0          54m
-      frontend-3823415956-k22zn       1/1       Running   0          54m
-      frontend-3823415956-w9gbt       1/1       Running   0          54m
-      frontend-3823415956-x2pld       1/1       Running   0          5s
-      mongo-1068406935-3lswp   1/1       Running   0          56m
+      NAME                       READY   STATUS    RESTARTS   AGE
+      frontend-848d88c7c-fnphh   1/1     Running   0          6s
+      frontend-848d88c7c-hpf8z   1/1     Running   0          10m
+      frontend-848d88c7c-hwxg4   1/1     Running   0          10m
+      frontend-848d88c7c-kb54g   1/1     Running   0          6s
+      frontend-848d88c7c-njxgk   1/1     Running   0          10m
+      mongo-75f59d57f4-w9gv8     1/1     Running   0          15m
       ```
 
 1. Run the following command to scale down the number of frontend Pods:
@@ -263,10 +264,10 @@ You can scale up or down as needed because your servers are defined as a Service
       The response should look similar to this:
 
       ```
-      NAME                            READY     STATUS    RESTARTS   AGE
-      frontend-3823415956-k22zn       1/1       Running   0          1h
-      frontend-3823415956-w9gbt       1/1       Running   0          1h
-      mongo-1068406935-3lswp   1/1       Running   0          1h
+      NAME                       READY   STATUS    RESTARTS   AGE
+      frontend-848d88c7c-hpf8z   1/1     Running   0          12m
+      frontend-848d88c7c-njxgk   1/1     Running   0          12m
+      mongo-75f59d57f4-w9gv8     1/1     Running   0          16m
       ```
 
 


### PR DESCRIPTION
Update "Deploying PHP Guestbook application with MongoDB" Tutorial to fix the following issues:
- Ordered lists with wrong indexes
- Wrong port of mongo service example
- Wrong output of "kubectl get service frontend" on LoadBalancer Service Type example.
- Formatting issues

Fix: #26765
Fix: #26732 

Preview: https://deploy-preview-26766--kubernetes-io-master-staging.netlify.app/docs/tutorials/stateless-application/guestbook/

/kind cleanup 
/language en 