### PR TITLE
Update maximum digital ocean volume mounts

### DIFF
--- a/content/en/docs/concepts/storage/storage-limits.md
+++ b/content/en/docs/concepts/storage/storage-limits.md
@@ -32,6 +32,7 @@ that can be attached to a Node:
   <tr><td><a href="https://aws.amazon.com/ebs/">Amazon Elastic Block Store (EBS)</a></td><td>39</td></tr>
   <tr><td><a href="https://cloud.google.com/persistent-disk/">Google Persistent Disk</a></td><td>16</td></tr>
   <tr><td><a href="https://azure.microsoft.com/en-us/services/storage/main-disks/">Microsoft Azure Disk Storage</a></td><td>16</td></tr>
+  <tr><td><a href="https://www.digitalocean.com/docs/volumes/">DigitalOcean Block Storage</a></td><td>7</td></tr>
 </table>
 
 ## Custom limits


### PR DESCRIPTION
I've updated the maximum mountable volume counts for Digital Ocean.

See also here (this has also been confirmed by their email support):

> https://www.digitalocean.com/docs/volumes/
> You can attach a maximum of 7 volumes to any one node or Droplet, and this limit cannot be changed.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
