### PR TITLE
Remove mentions of kube-dns in kubeadm docs

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/implementation-details.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/implementation-details.md
@@ -436,12 +436,14 @@ A ServiceAccount for `kube-proxy` is created in the `kube-system` namespace; the
 
 #### DNS
 
-- In Kubernetes version 1.21 kube-dns usage with kubeadm has been removed
 - The CoreDNS service is named `kube-dns`. This is done to prevent any interruption
 in service when the user is switching the cluster DNS from kube-dns to CoreDNS
 the `--config` method described [here](/docs/reference/setup-tools/kubeadm/kubeadm-init-phase/#cmd-phase-addon)
 - A ServiceAccount for CoreDNS is created in the `kube-system` namespace.
 - The `coredns` ServiceAccount is bound to the privileges in the `system:coredns` ClusterRole
+
+- In Kubernetes version 1.21, support for using `kube-dns` with kubeadm is removed.
+You can use CoreDNS with kubeadm even when the related Service is named `kube-dns`.
 
 ## kubeadm join phases internal design
 

--- a/content/en/docs/reference/setup-tools/kubeadm/implementation-details.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/implementation-details.md
@@ -442,7 +442,7 @@ the `--config` method described [here](/docs/reference/setup-tools/kubeadm/kubea
 - A ServiceAccount for CoreDNS is created in the `kube-system` namespace.
 - The `coredns` ServiceAccount is bound to the privileges in the `system:coredns` ClusterRole
 
-- In Kubernetes version 1.21, support for using `kube-dns` with kubeadm is removed.
+- In Kubernetes version 1.21, support for using `kube-dns` with kubeadm was removed.
 You can use CoreDNS with kubeadm even when the related Service is named `kube-dns`.
 
 ## kubeadm join phases internal design

--- a/content/en/docs/reference/setup-tools/kubeadm/implementation-details.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/implementation-details.md
@@ -436,12 +436,12 @@ A ServiceAccount for `kube-proxy` is created in the `kube-system` namespace; the
 
 #### DNS
 
-- In Kubernetes version 1.18 kube-dns usage with kubeadm is deprecated and will be removed in a future release
+- In Kubernetes version 1.21 kube-dns usage with kubeadm has been removed
 - The CoreDNS service is named `kube-dns`. This is done to prevent any interruption
-in service when the user is switching the cluster DNS from kube-dns to CoreDNS or vice-versa
+in service when the user is switching the cluster DNS from kube-dns to CoreDNS
 the `--config` method described [here](/docs/reference/setup-tools/kubeadm/kubeadm-init-phase/#cmd-phase-addon)
-- A ServiceAccount for CoreDNS/kube-dns is created in the `kube-system` namespace.
-- The `kube-dns` ServiceAccount is bound to the privileges in the `system:kube-dns` ClusterRole
+- A ServiceAccount for CoreDNS is created in the `kube-system` namespace.
+- The `coredns` ServiceAccount is bound to the privileges in the `system:coredns` ClusterRole
 
 ## kubeadm join phases internal design
 

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-config.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-config.md
@@ -20,10 +20,6 @@ For more information navigate to
 [Using kubeadm init with a configuration file](/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file)
 or [Using kubeadm join with a configuration file](/docs/reference/setup-tools/kubeadm/kubeadm-join/#config-file).
 
-In Kubernetes v1.13.0 and later to list/pull kube-dns images instead of the CoreDNS image
-the `--config` method described [here](/docs/reference/setup-tools/kubeadm/kubeadm-init-phase/#cmd-phase-addon)
-has to be used.
-
 <!-- body -->
 ## kubeadm config view {#cmd-config-view}
 

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init-phase.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init-phase.md
@@ -143,25 +143,6 @@ install them selectively.
 {{< tab name="kube-proxy" include="generated/kubeadm_init_phase_addon_kube-proxy.md" />}}
 {{< /tabs >}}
 
-To use kube-dns instead of CoreDNS you have to pass a configuration file:
-
-```bash
-# for installing a DNS addon only
-kubeadm init phase addon coredns --config=someconfig.yaml
-```
-
-The file has to contain a [`dns`](https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2#DNS) field in[`ClusterConfiguration`](https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2#ClusterConfiguration)
-and also a type for the addon - `kube-dns` (default value is `CoreDNS`).
-
-```yaml
-apiVersion: kubeadm.k8s.io/v1beta2
-kind: ClusterConfiguration
-dns:
-  type: "kube-dns"
-```
-
-Please note that kube-dns usage with kubeadm is deprecated as of v1.18 and will be removed in a future release.
-
 For more details on each field in the `v1beta2` configuration you can navigate to our
 [API reference pages.] (https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2)
 

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -66,12 +66,10 @@ following steps:
 
 1. Installs a DNS server (CoreDNS) and the kube-proxy addon components via the API server.
    In Kubernetes version 1.11 and later CoreDNS is the default DNS server.
-   To install kube-dns instead of CoreDNS, the DNS addon has to be configured in the kubeadm `ClusterConfiguration`.
-   For more information about the configuration see the section `Using kubeadm init with a configuration file` below.
    Please note that although the DNS server is deployed, it will not be scheduled until CNI is installed.
 
    {{< warning >}}
-   kube-dns usage with kubeadm is deprecated as of v1.18 and will be removed in a future release.
+   kube-dns usage with kubeadm is deprecated as of v1.18 and is removed in v1.21.
    {{< /warning >}}
 
 ### Using init phases with kubeadm {#init-phases}

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-upgrade.md
@@ -20,8 +20,6 @@ For older versions of kubeadm, please refer to older documentation sets of the K
 
 You can use `kubeadm upgrade diff` to see the changes that would be applied to static pod manifests.
 
-To use kube-dns with upgrades in Kubernetes v1.13.0 and later please follow [this guide](/docs/reference/setup-tools/kubeadm/kubeadm-init-phase/#cmd-phase-addon).
-
 In Kubernetes v1.15.0 and later, `kubeadm upgrade apply` and `kubeadm upgrade node` will also
 automatically renew the kubeadm managed certificates on this node, including those stored in kubeconfig files.
 To opt-out, it is possible to pass the flag `--certificate-renewal=false`. For more details about certificate

--- a/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
@@ -149,7 +149,7 @@ Right after `kubeadm init` there should not be any pods in these states.
   MountFlags can interfere with volumes mounted by Kubernetes, and put the Pods in `CrashLoopBackOff` state.
   The error happens when Kubernetes does not find `var/run/secrets/kubernetes.io/serviceaccount` files.
 
-## `coredns` (or `kube-dns`) is stuck in the `Pending` state
+## `coredns` is stuck in the `Pending` state
 
 This is **expected** and part of the design. kubeadm is network provider-agnostic, so the admin
 should [install the pod network add-on](/docs/concepts/cluster-administration/addons/)

--- a/content/en/docs/tasks/administer-cluster/coredns.md
+++ b/content/en/docs/tasks/administer-cluster/coredns.md
@@ -36,7 +36,7 @@ For manual deployment or replacement of kube-dns, see the documentation at the
 
 In Kubernetes version 1.10 and later, you can also move to CoreDNS when you use `kubeadm` to upgrade
 a cluster that is using `kube-dns`. In this case, `kubeadm` will generate the CoreDNS configuration
-("Corefile") based upon the `kube-dns` ConfigMap, preserving configurations for federation,
+("Corefile") based upon the `kube-dns` ConfigMap, preserving configurations for
 stub domains, and upstream name server.
 
 If you are moving from kube-dns to CoreDNS, make sure to set the `CoreDNS` feature gate to `true`
@@ -46,8 +46,7 @@ kubeadm upgrade apply v1.11.0 --feature-gates=CoreDNS=true
 ```
 
 In Kubernetes version 1.13 and later the `CoreDNS` feature gate is removed and CoreDNS
-is used by default. Follow the guide outlined [here](/docs/reference/setup-tools/kubeadm/kubeadm-init-phase#cmd-phase-addon) if you want
-your upgraded cluster to use kube-dns.
+is used by default.
 
 In versions prior to 1.11 the Corefile will be **overwritten** by the one created during upgrade.
 **You should save your existing ConfigMap if you have customized it.** You may re-apply your
@@ -56,26 +55,7 @@ customizations after the new ConfigMap is up and running.
 If you are running CoreDNS in Kubernetes version 1.11 and later, during upgrade,
 your existing Corefile will be retained.
 
-
-### Installing kube-dns instead of CoreDNS with kubeadm
-
-{{< note >}}
-In Kubernetes 1.11, CoreDNS has graduated to General Availability (GA)
-and is installed by default.
-{{< /note >}}
-
-{{< warning >}}
-In Kubernetes 1.18, kube-dns usage with kubeadm has been deprecated and will be removed in a future version.
-{{< /warning >}}
-
-To install kube-dns on versions prior to 1.13, set the `CoreDNS` feature gate
-value to `false`:
-
-```
-kubeadm init --feature-gates=CoreDNS=false
-```
-
-For versions 1.13 and later, follow the guide outlined [here](/docs/reference/setup-tools/kubeadm/kubeadm-init-phase#cmd-phase-addon).
+In Kubernetes version 1.21, support for `kube-dns` is removed from kubeadm.
 
 ## Upgrading CoreDNS
 

--- a/content/en/docs/tasks/administer-cluster/dns-custom-nameservers.md
+++ b/content/en/docs/tasks/administer-cluster/dns-custom-nameservers.md
@@ -34,7 +34,7 @@ As of Kubernetes v1.12, CoreDNS is the recommended DNS Server, replacing kube-dn
 originally used kube-dns, you may still have `kube-dns` deployed rather than CoreDNS.
 
 {{< note >}}
-Both the CoreDNS and kube-dns Service are named `kube-dns` in the `metadata.name` field.  
+The CoreDNS Service is named `kube-dns` in the `metadata.name` field.  
 This is so that there is greater interoperability with workloads that relied on the legacy `kube-dns` Service name to resolve addresses internal to the cluster. Using a Service named `kube-dns` abstracts away the implementation detail of which DNS provider is running behind that common name.
 {{< /note >}}
 
@@ -179,17 +179,14 @@ During translation, all FQDN nameservers will be omitted from the CoreDNS config
 
 CoreDNS supports the features of kube-dns and more.
 A ConfigMap created for kube-dns to support `StubDomains`and `upstreamNameservers` translates to the `forward` plugin in CoreDNS.
-Similarly, the `Federations` plugin in kube-dns translates to the `federation` plugin in CoreDNS.
 
 ### Example
 
-This example ConfigMap for kube-dns specifies federations, stubdomains and upstreamnameservers:
+This example ConfigMap for kube-dns specifies stubdomains and upstreamnameservers:
 
 ```yaml
 apiVersion: v1
 data:
-  federations: |
-    {"foo" : "foo.feddomain.com"}
   stubDomains: |
     {"abc.com" : ["1.2.3.4"], "my.cluster.local" : ["2.3.4.5"]}
   upstreamNameservers: |
@@ -198,13 +195,6 @@ kind: ConfigMap
 ```
 
 The equivalent configuration in CoreDNS creates a Corefile:
-
-* For federations:
-```
-federation cluster.local {
-    foo foo.feddomain.com
-}
-```
 
 * For stubDomains:
 ```yaml

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -328,7 +328,7 @@ and post-upgrade manifest file for a certain component, a backup file for it wil
 - Makes sure the control plane images are available or available to pull to the machine.
 - Generates replacements and/or uses user supplied overwrites if component configs require version upgrades.
 - Upgrades the control plane components or rollbacks if any of them fails to come up.
-- Applies the new `kube-dns` and `kube-proxy` manifests and makes sure that all necessary RBAC rules are created.
+- Applies the new `CoreDNS` and `kube-proxy` manifests and makes sure that all necessary RBAC rules are created.
 - Creates new certificate and key files of the API server and backs up old files if they're about to expire in 180 days.
 
 `kubeadm upgrade node` does the following on additional control plane nodes:


### PR DESCRIPTION
Kubeadm is removing support for the deprecated kube-dns addon. This PR clears any mention of kube-dns from the kubeadm docs and also indicate that kube-dns is not supported from 1.21

Related to: kubernetes/kubeadm#1943