### PR TITLE
Deprecated and remove '--use-api' for kubeadm cert renewal

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
@@ -170,14 +170,14 @@ controllerManager:
 
 ### Create certificate signing requests (CSR)
 
-You can create the certificate signing requests for the Kubernetes certificates API with `kubeadm certs renew --use-api`.
+You can create the certificate signing requests for the Kubernetes certificates API with `kubeadm certs renew`.
 
 If you set up an external signer such as [cert-manager](https://github.com/jetstack/cert-manager), certificate signing requests (CSRs) are automatically approved.
 Otherwise, you must manually approve certificates with the [`kubectl certificate`](/docs/setup/best-practices/certificates/) command.
 The following kubeadm command outputs the name of the certificate to approve, then blocks and waits for approval to occur:
 
 ```shell
-sudo kubeadm certs renew apiserver --use-api &
+sudo kubeadm certs renew apiserver &
 ```
 The output is similar to this:
 ```

--- a/content/ko/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
+++ b/content/ko/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
@@ -168,14 +168,14 @@ controllerManager:
 
 ### 인증서 서명 요청(CSR) 생성
 
-`kubeadm certs renew --use-api` 로 쿠버네티스 인증서 API에 대한 인증서 서명 요청을 만들 수 있다.
+`kubeadm certs renew` 로 쿠버네티스 인증서 API에 대한 인증서 서명 요청을 만들 수 있다.
 
 [cert-manager](https://github.com/jetstack/cert-manager)와 같은 외부 서명자를 설정하면, 인증서 서명 요청(CSR)이 자동으로 승인된다.
 그렇지 않으면, [`kubectl certificate`](/ko/docs/setup/best-practices/certificates/) 명령을 사용하여 인증서를 수동으로 승인해야 한다.
 다음의 kubeadm 명령은 승인할 인증서 이름을 출력한 다음, 승인이 발생하기를 차단하고 기다린다.
 
 ```shell
-sudo kubeadm certs renew apiserver --use-api &
+sudo kubeadm certs renew apiserver &
 ```
 출력 결과는 다음과 비슷하다.
 ```

--- a/content/zh/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
+++ b/content/zh/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
@@ -325,11 +325,11 @@ controllerManager:
 <!-- 
 ### Create certificate signing requests (CSR)
 
-You can create the certificate signing requests for the Kubernetes certificates API with `kubeadm alpha certs renew --use-api`. 
+You can create the certificate signing requests for the Kubernetes certificates API with `kubeadm alpha certs renew`. 
 -->
 ### 创建证书签名请求 (CSR)
 
-你可以用 `kubeadm alpha certs renew --use-api` 为 Kubernetes 证书 API 创建一个证书签名请求。
+你可以用 `kubeadm alpha certs renew` 为 Kubernetes 证书 API 创建一个证书签名请求。
 
 <!--
 If you set up an external signer such as [cert-manager](https://github.com/jetstack/cert-manager), certificate signing requests (CSRs) are automatically approved.
@@ -343,7 +343,7 @@ The following kubeadm command outputs the name of the certificate to approve, th
 以下 kubeadm 命令输出要批准的证书名称，然后阻塞等待批准发生：
 
 ```shell
-sudo kubeadm alpha certs renew apiserver --use-api &
+sudo kubeadm alpha certs renew apiserver &
 ```
 
 <!--


### PR DESCRIPTION
Deprecated and remove '--use-api' for kubeadm cert renewal.

link to https://github.com/kubernetes/kubeadm/issues/2047