### PR TITLE
Fix some of the grammar

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -23,7 +23,7 @@ ConfigMaps allow you to decouple configuration artifacts from image content to k
 
 
 ## Create a ConfigMap
-You can use either `kubectl create configmap` or a ConfigMap generator in `kustomization.yaml` to create a ConfigMap. Note that `kubectl` starts to support `kustomization.yaml` since 1.14.
+You can use either `kubectl create configmap` or a ConfigMap generator in `kustomization.yaml` to create a ConfigMap. Note that `kubectl` supports `kustomization.yaml` as of version 1.14.
 
 ### Create a ConfigMap Using kubectl create configmap
 


### PR DESCRIPTION
The existing grammar is broken as "starts" is present-tense and "since" is past-tense.  This is a common mistake for people who speak other languages as their primary (I think French & German are common, but lots of languages use "since" this way).  In English you should either be saying "kubectl supports kustomization.yaml as of" or "kubectl started supporting kustomization.yaml as of".