### PR TITLE
Remove feature-state tag for categories for CRDs

### DIFF
--- a/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
+++ b/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
@@ -1129,8 +1129,6 @@ resources that have the scale subresource enabled.
 
 ### Categories
 
-{{< feature-state state="beta" for_k8s_version="v1.10" >}}
-
 Categories is a list of grouped resources the custom resource belongs to (eg. `all`).
 You can use `kubectl get <category-name>` to list the resources belonging to the category.
 


### PR DESCRIPTION
The `Categories` field for CRDs was documented as beta in 1.10 in #7439
mainly because CRDs were in beta back then.

The `feature-state` tag for this section was added in #2754, however
this section doesn't need a `feature-state` tag because the field is not
gated by any feature gate:

https://github.com/kubernetes/kubernetes/blob/90851a0fb5bbb6f02b3c22715f9f91609f8ee438/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/types.go#L247-L251

It is now safe to remove the feature-state tag. Moreover, CRDs are now
GA so the beta state is not accurate.

/assign @sftim 