### PR TITLE
Update Ubuntu/Debian installation instructions to use Signed-By option

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -89,134 +89,102 @@ EOF
 sudo sysctl --system
 ```
 
-Install containerd:
+Install `containerd`:
 
 {{< tabs name="tab-cri-containerd-installation" >}}
 {{% tab name="Ubuntu 16.04" %}}
 
-```shell
-# (Install containerd)
-## Set up the repository
-### Install packages to allow apt to use a repository over HTTPS
-sudo apt-get update && sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common
-```
+1. Setup the [Docker Engine repository for Ubuntu](https://docs.docker.com/engine/install/ubuntu/#set-up-the-repository)
 
-```shell
-## Add Docker's official GPG key
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key --keyring /etc/apt/trusted.gpg.d/docker.gpg add -
-```
+2. Install `containerd`:
 
-```shell
-## Add Docker apt repository.
-sudo add-apt-repository \
-    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-    $(lsb_release -cs) \
-    stable"
-```
+   ```shell
+   sudo apt-get update && sudo apt-get install -y containerd.io
+   ```
 
-```shell
-## Install containerd
-sudo apt-get update && sudo apt-get install -y containerd.io
-```
+3. Configure `containerd`:
 
-```shell
-# Configure containerd
-sudo mkdir -p /etc/containerd
-containerd config default | sudo tee /etc/containerd/config.toml
-```
+   ```shell
+   sudo mkdir -p /etc/containerd
+   containerd config default | sudo tee /etc/containerd/config.toml
+   ```
 
-```shell
-# Restart containerd
-sudo systemctl restart containerd
-```
+4. Restart `containerd`:
+
+   ```shell
+   sudo systemctl restart containerd
+   ```
+
 {{% /tab %}}
 {{% tab name="Ubuntu 18.04/20.04" %}}
 
-```shell
-# (Install containerd)
-sudo apt-get update && sudo apt-get install -y containerd
-```
+1. Install `containerd`:
 
-```shell
-# Configure containerd
-sudo mkdir -p /etc/containerd
-containerd config default | sudo tee /etc/containerd/config.toml
-```
+   ```shell
+   sudo apt-get update && sudo apt-get install -y containerd
+   ```
 
-```shell
-# Restart containerd
-sudo systemctl restart containerd
-```
+2. Configure `containerd`:
+
+   ```shell
+   sudo mkdir -p /etc/containerd
+   containerd config default | sudo tee /etc/containerd/config.toml
+   ```
+
+3. Restart `containerd`:
+
+   ```shell
+   sudo systemctl restart containerd
+   ```
+
 {{% /tab %}}
 {{% tab name="Debian 9+" %}}
 
-```shell
-# (Install containerd)
-## Set up the repository
-### Install packages to allow apt to use a repository over HTTPS
-sudo apt-get update && sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common
-```
+1. Setup the [Docker Engine repository for Debian](https://docs.docker.com/engine/install/debian/#set-up-the-repository)
 
-```shell
-## Add Docker's official GPG key
-curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key --keyring /etc/apt/trusted.gpg.d/docker.gpg add -
-```
+2. Install `containerd`:
 
-```shell
-## Add Docker apt repository.
-sudo add-apt-repository \
-   "deb [arch=amd64] https://download.docker.com/linux/debian \
-   $(lsb_release -cs) \
-   stable"
-```
+   ```shell
+   sudo apt-get update && sudo apt-get install -y containerd.io
+   ```
 
-```shell
-## Install containerd
-sudo apt-get update && sudo apt-get install -y containerd.io
-```
+3. Configure `containerd`:
 
-```shell
-# Set default containerd configuration
-sudo mkdir -p /etc/containerd
-containerd config default | sudo tee /etc/containerd/config.toml
-```
+   ```shell
+   sudo mkdir -p /etc/containerd
+   containerd config default | sudo tee /etc/containerd/config.toml
+   ```
 
-```shell
-# Restart containerd
-sudo systemctl restart containerd
-```
+4. Restart `containerd`:
+
+   ```shell
+   sudo systemctl restart containerd
+   ```
+
 {{% /tab %}}
 {{% tab name="CentOS/RHEL 7.4+" %}}
 
-```shell
-# (Install containerd)
-## Set up the repository
-### Install required packages
-sudo yum install -y yum-utils device-mapper-persistent-data lvm2
-```
+1. Setup the [Docker Engine repository for CentOS/RHEL](https://docs.docker.com/engine/install/centos/#set-up-the-repository)
 
-```shell
-## Add docker repository
-sudo yum-config-manager \
-    --add-repo \
-    https://download.docker.com/linux/centos/docker-ce.repo
-```
+2. Install `containerd`:
 
-```shell
-## Install containerd
-sudo yum update -y && sudo yum install -y containerd.io
-```
+   ```shell
+   sudo yum update -y && sudo yum install -y containerd.io
+   ```
 
-```shell
-## Configure containerd
-sudo mkdir -p /etc/containerd
-containerd config default | sudo tee /etc/containerd/config.toml
-```
+3. Configure `containerd`:
 
-```shell
-# Restart containerd
-sudo systemctl restart containerd
-```
+   ```shell
+   sudo mkdir -p /etc/containerd
+   containerd config default | sudo tee /etc/containerd/config.toml
+   ```
+
+4. Restart `containerd`:
+
+   ```shell
+   sudo systemctl restart containerd
+   ```
+
 {{% /tab %}}
 {{% tab name="Windows (PowerShell)" %}}
 
@@ -224,33 +192,35 @@ sudo systemctl restart containerd
 Start a Powershell session, set `$Version` to the desired version (ex: `$Version=1.4.3`), and then run the following commands:
 <br />
 
-```powershell
-# (Install containerd)
-# Download containerd
-curl.exe -L https://github.com/containerd/containerd/releases/download/v$Version/containerd-$Version-windows-amd64.tar.gz -o containerd-windows-amd64.tar.gz
-tar.exe xvf .\containerd-windows-amd64.tar.gz
-```
+1. Download `containerd`:
 
-```powershell
-# Extract and configure
-Copy-Item -Path ".\bin\" -Destination "$Env:ProgramFiles\containerd" -Recurse -Force
-cd $Env:ProgramFiles\containerd\
-.\containerd.exe config default | Out-File config.toml -Encoding ascii
+   ```powershell
+   curl.exe -L https://github.com/containerd/containerd/releases/download/v$Version/containerd-$Version-windows-amd64.tar.gz -o containerd-windows-amd64.tar.gz
+   tar.exe xvf .\containerd-windows-amd64.tar.gz
+   ```
 
-# Review the configuration. Depending on setup you may want to adjust:
-# - the sandbox_image (Kubernetes pause image)
-# - cni bin_dir and conf_dir locations
-Get-Content config.toml
+2. Extract and configure:
 
-# (Optional - but highly recommended) Exclude containerd from Windows Defender Scans
-Add-MpPreference -ExclusionProcess "$Env:ProgramFiles\containerd\containerd.exe" 
-```
+   ```powershell
+   Copy-Item -Path ".\bin\" -Destination "$Env:ProgramFiles\containerd" -Recurse -Force
+   cd $Env:ProgramFiles\containerd\
+   .\containerd.exe config default | Out-File config.toml -Encoding ascii
 
-```powershell
-# Start containerd
-.\containerd.exe --register-service
-Start-Service containerd
-```
+   # Review the configuration. Depending on setup you may want to adjust:
+   # - the sandbox_image (Kubernetes pause image)
+   # - cni bin_dir and conf_dir locations
+   Get-Content config.toml
+
+   # (Optional - but highly recommended) Exclude containerd from Windows Defender Scans
+   Add-MpPreference -ExclusionProcess "$Env:ProgramFiles\containerd\containerd.exe"
+   ```
+
+3. Start `containerd`:
+
+   ```powershell
+   .\containerd.exe --register-service
+   Start-Service containerd
+   ```
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -465,120 +435,92 @@ Use the following commands to install Docker on your system:
 {{< tabs name="tab-cri-docker-installation" >}}
 {{% tab name="Ubuntu 16.04+" %}}
 
-```shell
-# (Install Docker CE)
-## Set up the repository:
-### Install packages to allow apt to use a repository over HTTPS
-sudo apt-get update && sudo apt-get install -y \
-  apt-transport-https ca-certificates curl software-properties-common gnupg2
-```
+1. Setup the [Docker Engine repository for Ubuntu](https://docs.docker.com/engine/install/ubuntu/#set-up-the-repository)
 
-```shell
-# Add Docker's official GPG key:
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key --keyring /etc/apt/trusted.gpg.d/docker.gpg add -
-```
+2. Install Docker CE:
 
-```shell
-# Add the Docker apt repository:
-sudo add-apt-repository \
-  "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-  $(lsb_release -cs) \
-  stable"
-```
+   ```shell
+   sudo apt-get update && sudo apt-get install -y \
+     containerd.io=1.2.13-2 \
+     docker-ce=5:19.03.11~3-0~ubuntu-$(lsb_release -cs) \
+     docker-ce-cli=5:19.03.11~3-0~ubuntu-$(lsb_release -cs)
+   ```
 
-```shell
-# Install Docker CE
-sudo apt-get update && sudo apt-get install -y \
-  containerd.io=1.2.13-2 \
-  docker-ce=5:19.03.11~3-0~ubuntu-$(lsb_release -cs) \
-  docker-ce-cli=5:19.03.11~3-0~ubuntu-$(lsb_release -cs)
-```
+3. Set up the Docker daemon:
 
-```shell
-## Create /etc/docker
-sudo mkdir /etc/docker
-```
+   ```shell
+   sudo mkdir /etc/docker
+   cat <<EOF | sudo tee /etc/docker/daemon.json
+   {
+     "exec-opts": ["native.cgroupdriver=systemd"],
+     "log-driver": "json-file",
+     "log-opts": {
+       "max-size": "100m"
+     },
+     "storage-driver": "overlay2"
+   }
+   EOF
+   ```
 
-```shell
-# Set up the Docker daemon
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-  "exec-opts": ["native.cgroupdriver=systemd"],
-  "log-driver": "json-file",
-  "log-opts": {
-    "max-size": "100m"
-  },
-  "storage-driver": "overlay2"
-}
-EOF
-```
+4. Create `/etc/systemd/system/docker.service.d`:
 
-```shell
-# Create /etc/systemd/system/docker.service.d
-sudo mkdir -p /etc/systemd/system/docker.service.d
-```
+   ```shell
+   sudo mkdir -p /etc/systemd/system/docker.service.d
+   ```
 
-```shell
-# Restart Docker
-sudo systemctl daemon-reload
-sudo systemctl restart docker
-```
+5. Restart Docker:
+
+   ```shell
+   sudo systemctl daemon-reload
+   sudo systemctl restart docker
+   ```
+
 {{% /tab %}}
 {{% tab name="CentOS/RHEL 7.4+" %}}
 
-```shell
-# (Install Docker CE)
-## Set up the repository
-### Install required packages
-sudo yum install -y yum-utils device-mapper-persistent-data lvm2
-```
+1. Setup the [Docker Engine repository for CentOS/RHEL](https://docs.docker.com/engine/install/centos/#set-up-the-repository)
 
-```shell
-## Add the Docker repository
-sudo yum-config-manager --add-repo \
-  https://download.docker.com/linux/centos/docker-ce.repo
-```
+2. Install Docker CE:
 
-```shell
-# Install Docker CE
-sudo yum update -y && sudo yum install -y \
-  containerd.io-1.2.13 \
-  docker-ce-19.03.11 \
-  docker-ce-cli-19.03.11
-```
+   ```shell
+   sudo yum update -y && sudo yum install -y \
+     containerd.io-1.2.13 \
+     docker-ce-19.03.11 \
+     docker-ce-cli-19.03.11
+   ```
 
-```shell
-## Create /etc/docker
-sudo mkdir /etc/docker
-```
+3. Set up the Docker daemon:
 
-```shell
-# Set up the Docker daemon
-cat <<EOF | sudo tee /etc/docker/daemon.json
-{
-  "exec-opts": ["native.cgroupdriver=systemd"],
-  "log-driver": "json-file",
-  "log-opts": {
-    "max-size": "100m"
-  },
-  "storage-driver": "overlay2",
-  "storage-opts": [
-    "overlay2.override_kernel_check=true"
-  ]
-}
-EOF
-```
+   ```shell
+   sudo mkdir /etc/docker
+   cat <<EOF | sudo tee /etc/docker/daemon.json
+   {
+     "exec-opts": ["native.cgroupdriver=systemd"],
+     "log-driver": "json-file",
+     "log-opts": {
+       "max-size": "100m"
+     },
+     "storage-driver": "overlay2",
+     "storage-opts": [
+       "overlay2.override_kernel_check=true"
+     ]
+   }
+   EOF
+   ```
 
-```shell
-# Create /etc/systemd/system/docker.service.d
-sudo mkdir -p /etc/systemd/system/docker.service.d
-```
+4. Create `/etc/systemd/system/docker.service.d`:
 
-```shell
-# Restart Docker
-sudo systemctl daemon-reload
-sudo systemctl restart docker
-```
+   ```shell
+   sudo mkdir -p /etc/systemd/system/docker.service.d
+   ```
+
+5. Restart Docker:
+
+   ```shell
+   sudo systemctl daemon-reload
+   sudo systemctl restart docker
+   ```
+
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -92,37 +92,9 @@ sudo sysctl --system
 Install containerd:
 
 {{< tabs name="tab-cri-containerd-installation" >}}
-{{% tab name="Ubuntu 16.04" %}}
+{{% tab name="Linux" %}}
 
-1. Setup the [Docker Engine repository for Ubuntu](https://docs.docker.com/engine/install/ubuntu/#set-up-the-repository)
-
-2. Install containerd:
-
-   ```shell
-   sudo apt-get update && sudo apt-get install -y containerd.io
-   ```
-
-3. Configure containerd:
-
-   ```shell
-   sudo mkdir -p /etc/containerd
-   containerd config default | sudo tee /etc/containerd/config.toml
-   ```
-
-4. Restart containerd:
-
-   ```shell
-   sudo systemctl restart containerd
-   ```
-
-{{% /tab %}}
-{{% tab name="Ubuntu 18.04/20.04" %}}
-
-1. Install containerd:
-
-   ```shell
-   sudo apt-get update && sudo apt-get install -y containerd
-   ```
+1. Install the `containerd.io` package from the official Docker repositories. Instructions for setting up the Docker repository for your respective Linux distribution and installing the `containerd.io` package can be found at [Install Docker Engine](https://docs.docker.com/engine/install/#server).
 
 2. Configure containerd:
 
@@ -138,59 +110,9 @@ Install containerd:
    ```
 
 {{% /tab %}}
-{{% tab name="Debian 9+" %}}
-
-1. Setup the [Docker Engine repository for Debian](https://docs.docker.com/engine/install/debian/#set-up-the-repository)
-
-2. Install containerd:
-
-   ```shell
-   sudo apt-get update && sudo apt-get install -y containerd.io
-   ```
-
-3. Configure containerd:
-
-   ```shell
-   sudo mkdir -p /etc/containerd
-   containerd config default | sudo tee /etc/containerd/config.toml
-   ```
-
-4. Restart containerd:
-
-   ```shell
-   sudo systemctl restart containerd
-   ```
-
-{{% /tab %}}
-{{% tab name="CentOS/RHEL 7.4+" %}}
-
-1. Setup the [Docker Engine repository for CentOS/RHEL](https://docs.docker.com/engine/install/centos/#set-up-the-repository)
-
-2. Install containerd:
-
-   ```shell
-   sudo yum update -y && sudo yum install -y containerd.io
-   ```
-
-3. Configure containerd:
-
-   ```shell
-   sudo mkdir -p /etc/containerd
-   containerd config default | sudo tee /etc/containerd/config.toml
-   ```
-
-4. Restart containerd:
-
-   ```shell
-   sudo systemctl restart containerd
-   ```
-
-{{% /tab %}}
 {{% tab name="Windows (PowerShell)" %}}
 
-<br />
 Start a Powershell session, set `$Version` to the desired version (ex: `$Version=1.4.3`), and then run the following commands:
-<br />
 
 1. Download containerd:
 
@@ -425,28 +347,9 @@ in sync.
 
 ### Docker
 
-On each of your nodes, install Docker CE.
+1. On each of your nodes, install the Docker for your Linux distribution as per [Install Docker Engine](https://docs.docker.com/engine/install/#server)
 
-The Kubernetes release notes list which versions of Docker are compatible
-with that version of Kubernetes.
-
-Use the following commands to install Docker on your system:
-
-{{< tabs name="tab-cri-docker-installation" >}}
-{{% tab name="Ubuntu 16.04+" %}}
-
-1. Setup the [Docker Engine repository for Ubuntu](https://docs.docker.com/engine/install/ubuntu/#set-up-the-repository)
-
-2. Install Docker CE:
-
-   ```shell
-   sudo apt-get update && sudo apt-get install -y \
-     containerd.io=1.2.13-2 \
-     docker-ce=5:19.03.11~3-0~ubuntu-$(lsb_release -cs) \
-     docker-ce-cli=5:19.03.11~3-0~ubuntu-$(lsb_release -cs)
-   ```
-
-3. Set up the Docker daemon:
+2. Configure the Docker daemon, in particular to use systemd for the management of the container’s cgroups.
 
    ```shell
    sudo mkdir /etc/docker
@@ -462,73 +365,20 @@ Use the following commands to install Docker on your system:
    EOF
    ```
 
-4. Create `/etc/systemd/system/docker.service.d`:
+   {{< note >}}
+   `overlay2` is the preferred storage driver for systems running Linux kernel version 4.0 or higher, or RHEL or CentOS using version 3.10.0-514 and above.
+   {{< /note >}}
+
+3. Restart Docker and enable on boot:
 
    ```shell
-   sudo mkdir -p /etc/systemd/system/docker.service.d
-   ```
-
-5. Restart Docker:
-
-   ```shell
+   sudo systemctl enable docker
    sudo systemctl daemon-reload
    sudo systemctl restart docker
    ```
 
-{{% /tab %}}
-{{% tab name="CentOS/RHEL 7.4+" %}}
-
-1. Setup the [Docker Engine repository for CentOS/RHEL](https://docs.docker.com/engine/install/centos/#set-up-the-repository)
-
-2. Install Docker CE:
-
-   ```shell
-   sudo yum update -y && sudo yum install -y \
-     containerd.io-1.2.13 \
-     docker-ce-19.03.11 \
-     docker-ce-cli-19.03.11
-   ```
-
-3. Set up the Docker daemon:
-
-   ```shell
-   sudo mkdir /etc/docker
-   cat <<EOF | sudo tee /etc/docker/daemon.json
-   {
-     "exec-opts": ["native.cgroupdriver=systemd"],
-     "log-driver": "json-file",
-     "log-opts": {
-       "max-size": "100m"
-     },
-     "storage-driver": "overlay2",
-     "storage-opts": [
-       "overlay2.override_kernel_check=true"
-     ]
-   }
-   EOF
-   ```
-
-4. Create `/etc/systemd/system/docker.service.d`:
-
-   ```shell
-   sudo mkdir -p /etc/systemd/system/docker.service.d
-   ```
-
-5. Restart Docker:
-
-   ```shell
-   sudo systemctl daemon-reload
-   sudo systemctl restart docker
-   ```
-
-{{% /tab %}}
-{{< /tabs >}}
-
-If you want the `docker` service to start on boot, run the following command:
-
-```shell
-sudo systemctl enable docker
-```
-
-Refer to the [official Docker installation guides](https://docs.docker.com/engine/installation/)
-for more information.
+{{< note >}}
+For more information refer to
+  - [Configure the Docker daemon](https://docs.docker.com/config/daemon/)
+  - [Control Docker with systemd](https://docs.docker.com/config/daemon/systemd/)
+{{< /note >}}

--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -63,7 +63,7 @@ configuration, or reinstall it using automation.
 
 ### containerd
 
-This section contains the necessary steps to use `containerd` as CRI runtime.
+This section contains the necessary steps to use containerd as CRI runtime.
 
 Use the following commands to install Containerd on your system:
 
@@ -89,27 +89,27 @@ EOF
 sudo sysctl --system
 ```
 
-Install `containerd`:
+Install containerd:
 
 {{< tabs name="tab-cri-containerd-installation" >}}
 {{% tab name="Ubuntu 16.04" %}}
 
 1. Setup the [Docker Engine repository for Ubuntu](https://docs.docker.com/engine/install/ubuntu/#set-up-the-repository)
 
-2. Install `containerd`:
+2. Install containerd:
 
    ```shell
    sudo apt-get update && sudo apt-get install -y containerd.io
    ```
 
-3. Configure `containerd`:
+3. Configure containerd:
 
    ```shell
    sudo mkdir -p /etc/containerd
    containerd config default | sudo tee /etc/containerd/config.toml
    ```
 
-4. Restart `containerd`:
+4. Restart containerd:
 
    ```shell
    sudo systemctl restart containerd
@@ -118,20 +118,20 @@ Install `containerd`:
 {{% /tab %}}
 {{% tab name="Ubuntu 18.04/20.04" %}}
 
-1. Install `containerd`:
+1. Install containerd:
 
    ```shell
    sudo apt-get update && sudo apt-get install -y containerd
    ```
 
-2. Configure `containerd`:
+2. Configure containerd:
 
    ```shell
    sudo mkdir -p /etc/containerd
    containerd config default | sudo tee /etc/containerd/config.toml
    ```
 
-3. Restart `containerd`:
+3. Restart containerd:
 
    ```shell
    sudo systemctl restart containerd
@@ -142,20 +142,20 @@ Install `containerd`:
 
 1. Setup the [Docker Engine repository for Debian](https://docs.docker.com/engine/install/debian/#set-up-the-repository)
 
-2. Install `containerd`:
+2. Install containerd:
 
    ```shell
    sudo apt-get update && sudo apt-get install -y containerd.io
    ```
 
-3. Configure `containerd`:
+3. Configure containerd:
 
    ```shell
    sudo mkdir -p /etc/containerd
    containerd config default | sudo tee /etc/containerd/config.toml
    ```
 
-4. Restart `containerd`:
+4. Restart containerd:
 
    ```shell
    sudo systemctl restart containerd
@@ -166,20 +166,20 @@ Install `containerd`:
 
 1. Setup the [Docker Engine repository for CentOS/RHEL](https://docs.docker.com/engine/install/centos/#set-up-the-repository)
 
-2. Install `containerd`:
+2. Install containerd:
 
    ```shell
    sudo yum update -y && sudo yum install -y containerd.io
    ```
 
-3. Configure `containerd`:
+3. Configure containerd:
 
    ```shell
    sudo mkdir -p /etc/containerd
    containerd config default | sudo tee /etc/containerd/config.toml
    ```
 
-4. Restart `containerd`:
+4. Restart containerd:
 
    ```shell
    sudo systemctl restart containerd
@@ -192,7 +192,7 @@ Install `containerd`:
 Start a Powershell session, set `$Version` to the desired version (ex: `$Version=1.4.3`), and then run the following commands:
 <br />
 
-1. Download `containerd`:
+1. Download containerd:
 
    ```powershell
    curl.exe -L https://github.com/containerd/containerd/releases/download/v$Version/containerd-$Version-windows-amd64.tar.gz -o containerd-windows-amd64.tar.gz
@@ -215,7 +215,7 @@ Start a Powershell session, set `$Version` to the desired version (ex: `$Version
    Add-MpPreference -ExclusionProcess "$Env:ProgramFiles\containerd\containerd.exe"
    ```
 
-3. Start `containerd`:
+3. Start containerd:
 
    ```powershell
    .\containerd.exe --register-service

--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -180,13 +180,13 @@ For more information on version skews, see:
 
    ```shell
    sudo apt-get update
-   sudo apt-get install -y apt-transport-https ca-certificates wget
+   sudo apt-get install -y apt-transport-https ca-certificates curl
    ```
 
 2. Download the Google Cloud public signing key:
 
    ```shell
-   sudo wget -O /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+   sudo curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
    ```
 
 3. Add the Kubernetes `apt` repository:
@@ -195,7 +195,7 @@ For more information on version skews, see:
    echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
    ```
 
-4. Update `apt` package index, install `kubelet`, `kubeadm` and `kubectl`, and pin their version:
+4. Update `apt` package index, install kubelet, kubeadm and kubectl, and pin their version:
 
    ```shell
    sudo apt-get update

--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -175,16 +175,34 @@ For more information on version skews, see:
 
 {{< tabs name="k8s_install" >}}
 {{% tab name="Debian-based distributions" %}}
-```bash
-sudo apt-get update && sudo apt-get install -y apt-transport-https curl
-curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-cat <<EOF | sudo tee /etc/apt/sources.list.d/kubernetes.list
-deb https://apt.kubernetes.io/ kubernetes-xenial main
-EOF
-sudo apt-get update
-sudo apt-get install -y kubelet kubeadm kubectl
-sudo apt-mark hold kubelet kubeadm kubectl
-```
+
+1. Update the `apt` package index and install packages needed to use the Kubernetes `apt` repository:
+
+   ```shell
+   sudo apt-get update
+   sudo apt-get install -y apt-transport-https ca-certificates wget
+   ```
+
+2. Download the Google Cloud public signing key:
+
+   ```shell
+   sudo wget -O /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+   ```
+
+3. Add the Kubernetes `apt` repository:
+
+   ```shell
+   echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+   ```
+
+4. Update `apt` package index, install `kubelet`, `kubeadm` and `kubectl`, and pin their version:
+
+   ```shell
+   sudo apt-get update
+   sudo apt-get install -y kubelet kubeadm kubectl
+   sudo apt-mark hold kubelet kubeadm kubectl
+   ```
+
 {{% /tab %}}
 {{% tab name="Red Hat-based distributions" %}}
 ```bash

--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -100,19 +100,19 @@ For example, to download version {{< param "fullversion" >}} on Linux, type:
 ### Install using native package management
 
 {{< tabs name="kubectl_install" >}}
-{{% tab name="Ubuntu, Debian or HypriotOS" %}}
+{{% tab name="Debian-based distributions" %}}
 
 1. Update the `apt` package index and install packages needed to use the Kubernetes `apt` repository:
 
    ```shell
    sudo apt-get update
-   sudo apt-get install -y apt-transport-https ca-certificates wget
+   sudo apt-get install -y apt-transport-https ca-certificates curl
    ```
 
 2. Download the Google Cloud public signing key:
 
    ```shell
-   sudo wget -O /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+   sudo curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
    ```
 
 3. Add the Kubernetes `apt` repository:
@@ -121,7 +121,7 @@ For example, to download version {{< param "fullversion" >}} on Linux, type:
    echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
    ```
 
-4. Update `apt` package index with the new repository and install `kubectl`:
+4. Update `apt` package index with the new repository and install kubectl:
 
    ```shell
    sudo apt-get update
@@ -130,7 +130,8 @@ For example, to download version {{< param "fullversion" >}} on Linux, type:
 
 {{% /tab %}}
 
-{{< tab name="CentOS, RHEL or Fedora" codelang="bash" >}}cat <<EOF > /etc/yum.repos.d/kubernetes.repo
+{{< tab name="Red Hat-based distributions" codelang="bash" >}}
+cat <<EOF > /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
 baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64

--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -100,13 +100,35 @@ For example, to download version {{< param "fullversion" >}} on Linux, type:
 ### Install using native package management
 
 {{< tabs name="kubectl_install" >}}
-{{< tab name="Ubuntu, Debian or HypriotOS" codelang="bash" >}}
-sudo apt-get update && sudo apt-get install -y apt-transport-https gnupg2 curl
-curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list
-sudo apt-get update
-sudo apt-get install -y kubectl
-{{< /tab >}}
+{{% tab name="Ubuntu, Debian or HypriotOS" %}}
+
+1. Update the `apt` package index and install packages needed to use the Kubernetes `apt` repository:
+
+   ```shell
+   sudo apt-get update
+   sudo apt-get install -y apt-transport-https ca-certificates wget
+   ```
+
+2. Download the Google Cloud public signing key:
+
+   ```shell
+   sudo wget -O /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+   ```
+
+3. Add the Kubernetes `apt` repository:
+
+   ```shell
+   echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+   ```
+
+4. Update `apt` package index with the new repository and install `kubectl`:
+
+   ```shell
+   sudo apt-get update
+   sudo apt-get install -y kubectl
+   ```
+
+{{% /tab %}}
 
 {{< tab name="CentOS, RHEL or Fedora" codelang="bash" >}}cat <<EOF > /etc/yum.repos.d/kubernetes.repo
 [kubernetes]


### PR DESCRIPTION
This updates the kubectl/kubeadm installation instructions on Ubuntu/Debian to:

1. Replace the use of `apt-key` to install the Kubernetes package signing key with `curl`. `apt-key` has been deprecated and will be last available in Debian 11 and Ubuntu 22.04.
2. Writes the package signing keys to `/usr/share/keyrings/kubernetes-archive-keyring.gpg` as per https://wiki.debian.org/DebianRepository/UseThirdParty. Note that it is no longer recommended to write or add keys to `/etc/apt/trusted.gpg` or `/etc/apt/trusted.gpg.d/`
3. Makes use of the `signed-by` option to the repo `/etc/apt/sources.list.d/kubernetes.list`

This PR also updates the `containerd.io` / `docker-ce` (Container runtimes) repository setup instructions. The instructions which previously duplicated an outdated set of instructions from Docker now refer to the respective OS distribution instructions at https://docs.docker.com/engine/install/ which has already been updated to best practice.

Note that I have left the CRI-O Installation instructions as the installation instructions at https://cri-o.io still makes use `apt-key add -`.

Resolves #26906 

References:
- https://wiki.debian.org/DebianRepository/UseThirdParty
- https://askubuntu.com/questions/1286545/what-commands-exactly-should-replace-the-deprecated-apt-key/1307181#1307181
- https://www.linuxuprising.com/2021/01/apt-key-is-deprecated-how-to-add.html
- https://github.com/docker/docker.github.io/issues/11625#issuecomment-751388087