### PR TITLE
remove images from dashboard blog page

### DIFF
--- a/content/en/blog/_posts/2021-03-09-The-Evolution-of-Kubernetes-Dashboard/index.md
+++ b/content/en/blog/_posts/2021-03-09-The-Evolution-of-Kubernetes-Dashboard/index.md
@@ -15,19 +15,6 @@ The initial idea behind the Kubernetes Dashboard project was to provide a web in
 
 The very [first commit](https://github.com/kubernetes/dashboard/commit/5861187fa807ac1cc2d9b2ac786afeced065076c) to the Kubernetes Dashboard was made by Filip Grządkowski from Google on 16th October 2015 – just a few months from the initial commit to the Kubernetes repository. Our initial commits go back to November 2015 ([Sebastian committed on 16 November 2015](https://github.com/kubernetes/dashboard/commit/09e65b6bb08c49b926253de3621a73da05e400fd); [Marcin committed on 23 November 2015](https://github.com/kubernetes/dashboard/commit/1da4b1c25ef040818072c734f71333f9b4733f55)). Since that time, we’ve become regular contributors to the project. For the next two years, we worked closely with the Googlers, eventually becoming main project maintainers ourselves.
 
-<!--
-{{< imgproc first-ui Fit "1000x900" >}}
-The First Version of the User Interface
-{{< /imgproc >}}
-
-{{< imgproc along-the-way-ui Fit "1000x900" >}}
-Prototype of the New User Interface
-{{< /imgproc >}}
-
-{{< imgproc current-ui Fit "1000x700" >}}
-The Current User Interface
-{{< /imgproc >}}
--->
 
 As you can see, the initial look and feel of the project were completely different from the current one. We have changed the design multiple times. The same has happened with the code itself.
 

--- a/content/en/blog/_posts/2021-03-09-The-Evolution-of-Kubernetes-Dashboard/index.md
+++ b/content/en/blog/_posts/2021-03-09-The-Evolution-of-Kubernetes-Dashboard/index.md
@@ -15,6 +15,7 @@ The initial idea behind the Kubernetes Dashboard project was to provide a web in
 
 The very [first commit](https://github.com/kubernetes/dashboard/commit/5861187fa807ac1cc2d9b2ac786afeced065076c) to the Kubernetes Dashboard was made by Filip Grządkowski from Google on 16th October 2015 – just a few months from the initial commit to the Kubernetes repository. Our initial commits go back to November 2015 ([Sebastian committed on 16 November 2015](https://github.com/kubernetes/dashboard/commit/09e65b6bb08c49b926253de3621a73da05e400fd); [Marcin committed on 23 November 2015](https://github.com/kubernetes/dashboard/commit/1da4b1c25ef040818072c734f71333f9b4733f55)). Since that time, we’ve become regular contributors to the project. For the next two years, we worked closely with the Googlers, eventually becoming main project maintainers ourselves.
 
+<!--
 {{< imgproc first-ui Fit "1000x900" >}}
 The First Version of the User Interface
 {{< /imgproc >}}
@@ -26,6 +27,7 @@ Prototype of the New User Interface
 {{< imgproc current-ui Fit "1000x700" >}}
 The Current User Interface
 {{< /imgproc >}}
+-->
 
 As you can see, the initial look and feel of the project were completely different from the current one. We have changed the design multiple times. The same has happened with the code itself.
 
@@ -55,14 +57,14 @@ The Kubernetes Dashboard has been growing and prospering for more than 5 years n
 
 ## The Kubernetes Dashboard in Numbers
 
-*   Initial commit made on October 16, 2015
-*   Over 100 million pulls from Dockerhub since the v2 release
-*   8 supported languages and the next 2 in progress
-*   Over 3360 closed PRs
-*   Over 2260 closed issues
-*   100% coverage of the supported core Kubernetes resources
-*   Over 9000 stars on GitHub
-*   Over 237 000 lines of code
+* Initial commit made on October 16, 2015
+* Over 100 million pulls from Dockerhub since the v2 release
+* 8 supported languages and the next 2 in progress
+* Over 3360 closed PRs
+* Over 2260 closed issues
+* 100% coverage of the supported core Kubernetes resources
+* Over 9000 stars on GitHub
+* Over 237 000 lines of code
 
 ## Join Us
 


### PR DESCRIPTION
Temporarily remove images in blog page.
The site if failing to build the page with image processing (large images).