### PR TITLE
[zh] translate task/Install and Set Up kubectl on macOS

### DIFF
--- a/content/zh/docs/tasks/tools/included/install-kubectl-gcloud.md
+++ b/content/zh/docs/tasks/tools/included/install-kubectl-gcloud.md
@@ -1,0 +1,37 @@
+---
+title: "通过 gcloud 安装 kubectl"
+description: "用各个特定操作系统标签页中包含的 gcloud 指令片段安装 kubectl。"
+headless: true
+---
+<!-- 
+---
+title: "gcloud kubectl install"
+description: "How to install kubectl with gcloud snippet for inclusion in each OS-specific tab."
+headless: true
+---
+-->
+
+<!-- 
+You can install kubectl as part of the Google Cloud SDK.
+-->
+kubectl 可以作为 Google Cloud SDK 的一部分被安装。
+
+<!-- 
+1. Install the [Google Cloud SDK](https://cloud.google.com/sdk/).
+1. Run the `kubectl` installation command:
+-->
+1. 安装 [Google Cloud SDK](https://cloud.google.com/sdk/)。
+1. 运行安装 `kubectl` 的命令：
+
+   ```shell
+   gcloud components install kubectl
+   ```
+
+   <!-- 
+   1. Test to ensure the version you installed is up-to-date:
+   -->
+1. 验证一下，确保安装的是最新的版本：
+
+   ```shell
+   kubectl version --client
+   ```

--- a/content/zh/docs/tasks/tools/included/kubectl-whats-next.md
+++ b/content/zh/docs/tasks/tools/included/kubectl-whats-next.md
@@ -1,0 +1,27 @@
+---
+title: "后续内容"
+description: "安装 kubectl 之后，还可以做些什么？"
+headless: true
+---
+<!-- 
+---
+title: "What's next?"
+description: "What's next after installing kubectl."
+headless: true
+---
+-->
+
+<!-- 
+* [Install Minikube](https://minikube.sigs.k8s.io/docs/start/)
+* See the [getting started guides](/docs/setup/) for more about creating clusters.
+* [Learn how to launch and expose your application.](/docs/tasks/access-application-cluster/service-access-application-cluster/)
+* If you need access to a cluster you didn't create, see the
+  [Sharing Cluster Access document](/docs/tasks/access-application-cluster/configure-access-multiple-clusters/).
+* Read the [kubectl reference docs](/docs/reference/kubectl/kubectl/)
+-->
+* [安装 Minikube](https://minikube.sigs.k8s.io/docs/start/)
+* 有关创建集群的更多信息，请参阅[入门指南](/zh/docs/setup/).
+* [学习如何启动并对外公开你的应用程序。](/zh/docs/tasks/access-application-cluster/service-access-application-cluster/)
+* 如果你需要访问其他人创建的集群，请参阅
+  [共享集群接入文档](/zh/docs/tasks/access-application-cluster/configure-access-multiple-clusters/).
+* 阅读 [kubectl 参考文档](/zh/docs/reference/kubectl/kubectl/)

--- a/content/zh/docs/tasks/tools/included/optional-kubectl-configs-bash-mac.md
+++ b/content/zh/docs/tasks/tools/included/optional-kubectl-configs-bash-mac.md
@@ -1,0 +1,173 @@
+---
+title: "macOS 系统上的 bash 自动补全"
+description: "在 macOS 上实现 Bash 自动补全的一些可选配置。"
+headless: true
+---
+<!-- 
+---
+title: "bash auto-completion on macOS"
+description: "Some optional configuration for bash auto-completion on macOS."
+headless: true
+---
+ -->
+
+<!-- 
+### Introduction
+-->
+### 简介 
+
+<!-- 
+The kubectl completion script for Bash can be generated with `kubectl completion bash`. Sourcing this script in your shell enables kubectl completion.
+
+However, the kubectl completion script depends on [**bash-completion**](https://github.com/scop/bash-completion) which you thus have to previously install.
+-->
+kubectl 的 Bash 补全脚本可以通过 `kubectl completion bash` 命令生成。
+在你的 shell 中导入（Sourcing）这个脚本即可启用补全功能。
+
+此外，kubectl 补全脚本依赖于工具 [**bash-completion**](https://github.com/scop/bash-completion)，
+所以你必须先安装它。
+
+{{< warning>}}
+<!-- 
+There are two versions of bash-completion, v1 and v2. V1 is for Bash 3.2 (which is the default on macOS), and v2 is for Bash 4.1+. The kubectl completion script **doesn't work** correctly with bash-completion v1 and Bash 3.2. It requires **bash-completion v2** and **Bash 4.1+**. Thus, to be able to correctly use kubectl completion on macOS, you have to install and use Bash 4.1+ ([*instructions*](https://itnext.io/upgrading-bash-on-macos-7138bd1066ba)). The following instructions assume that you use Bash 4.1+ (that is, any Bash version of 4.1 or newer).
+-->
+bash-completion 有两个版本：v1 和 v2。v1 对应 Bash3.2（也是 macOS 的默认安装版本），v2 对应 Bash 4.1+。
+kubectl 的补全脚本**无法适配** bash-completion v1 和 Bash 3.2。
+必须为它配备  **bash-completion v2** 和 **Bash 4.1+**。
+有鉴于此，为了在 macOS 上使用 kubectl 补全功能，你必须要安装和使用 Bash 4.1+
+([*说明*](https://itnext.io/upgrading-bash-on-macos-7138bd1066ba))。
+后续说明假定你用的是 Bash 4.1+（也就是 Bash 4.1 或更新的版本）
+{{< /warning >}}
+
+<!-- 
+### Upgrade Bash
+-->
+### 升级 Bash
+
+<!-- 
+The instructions here assume you use Bash 4.1+. You can check your Bash's version by running:
+-->
+后续说明假定你已使用 Bash 4.1+。你可以运行以下命令检查 Bash 版本：
+
+```bash
+echo $BASH_VERSION
+```
+
+<!-- 
+If it is too old, you can install/upgrade it using Homebrew:
+-->
+如果版本太旧，可以用 Homebrew 安装/升级：
+
+```bash
+brew install bash
+```
+
+<!-- 
+Reload your shell and verify that the desired version is being used:
+-->
+重新加载 shell，并验证所需的版本已经生效：
+
+```bash
+echo $BASH_VERSION $SHELL
+```
+
+<!-- 
+Homebrew usually installs it at `/usr/local/bin/bash`.
+-->
+Homebrew 通常把它安装为 `/usr/local/bin/bash`。
+
+<!-- 
+### Install bash-completion
+-->
+### 安装 bash-completion
+
+
+{{< note >}}
+<!-- 
+As mentioned, these instructions assume you use Bash 4.1+, which means you will install bash-completion v2 (in contrast to Bash 3.2 and bash-completion v1, in which case kubectl completion won't work).
+-->
+如前所述，本说明假定你使用的 Bash 版本为 4.1+，这意味着你要安装 bash-completion v2
+（不同于 Bash 3.2 和 bash-completion v1，kubectl 的补全功能在该场景下无法工作）。
+{{< /note >}}
+
+<!-- 
+You can test if you have bash-completion v2 already installed with `type _init_completion`. If not, you can install it with Homebrew:
+-->
+你可以用命令 `type _init_completion` 测试 bash-completion v2 是否已经安装。
+如未安装，用 Homebrew 来安装它：
+
+```bash
+brew install bash-completion@2
+```
+
+<!-- 
+As stated in the output of this command, add the following to your `~/.bash_profile` file:
+-->
+如命令的输出信息所显示的，将如下内容添加到文件 `~/.bash_profile` 中：
+
+```bash
+export BASH_COMPLETION_COMPAT_DIR="/usr/local/etc/bash_completion.d"
+[[ -r "/usr/local/etc/profile.d/bash_completion.sh" ]] && . "/usr/local/etc/profile.d/bash_completion.sh"
+```
+
+<!-- 
+Reload your shell and verify that bash-completion v2 is correctly installed with `type _init_completion`.
+-->
+重新加载 shell，并用命令 `type _init_completion` 验证 bash-completion v2 已经恰当的安装。
+
+<!-- 
+### Enable kubectl autocompletion
+-->
+### 启用 kubectl 自动补全功能
+
+<!-- 
+You now have to ensure that the kubectl completion script gets sourced in all your shell sessions. There are multiple ways to achieve this:
+
+- Source the completion script in your `~/.bash_profile` file:
+-->
+你现在需要确保在所有的 shell 环境中均已导入（sourced） kubectl 的补全脚本，
+有若干种方法可以实现这一点：
+
+- 在文件 `~/.bash_profile` 中导入（Source）补全脚本：
+
+    ```bash
+    echo 'source <(kubectl completion bash)' >>~/.bash_profile
+    ```
+
+<!-- 
+- Add the completion script to the `/usr/local/etc/bash_completion.d` directory:
+-->
+- 将补全脚本添加到目录 `/usr/local/etc/bash_completion.d` 中：
+
+    ```bash
+    kubectl completion bash >/usr/local/etc/bash_completion.d/kubectl
+    ```
+
+<!-- 
+- If you have an alias for kubectl, you can extend shell completion to work with that alias:
+-->
+- 如果你为 kubectl 定义了别名，则可以扩展 shell 补全来兼容该别名：
+
+    ```bash
+    echo 'alias k=kubectl' >>~/.bash_profile
+    echo 'complete -F __start_kubectl k' >>~/.bash_profile
+    ```
+
+<!-- 
+- If you installed kubectl with Homebrew (as explained [above](#install-with-homebrew-on-macos)), then the kubectl completion script should already be in `/usr/local/etc/bash_completion.d/kubectl`. In that case, you don't need to do anything.
+-->
+- 如果你是用 Homebrew 安装的 kubectl（[如上所述](#install-with-homebrew-on-macos)），
+  那么 kubectl 补全脚本应该已经安装到目录 `/usr/local/etc/bash_completion.d/kubectl` 中了。
+  这种情况下，你什么都不需要做。
+
+   {{< note >}}
+   <!-- 
+   The Homebrew installation of bash-completion v2 sources all the files in the `BASH_COMPLETION_COMPAT_DIR` directory, that's why the latter two methods work.
+   -->
+   用 Hommbrew 安装的 bash-completion v2 会初始化 目录 `BASH_COMPLETION_COMPAT_DIR` 中的所有文件，这就是后两种方法能正常工作的原因。
+   {{< /note >}}
+
+<!-- 
+In any case, after reloading your shell, kubectl completion should be working.
+-->
+总之，重新加载 shell 之后，kubectl 补全功能将立即生效。

--- a/content/zh/docs/tasks/tools/included/optional-kubectl-configs-zsh.md
+++ b/content/zh/docs/tasks/tools/included/optional-kubectl-configs-zsh.md
@@ -1,0 +1,50 @@
+---
+title: "zsh 自动补全"
+description: "zsh 自动补全的一些可选配置"
+headless: true
+---
+<!-- 
+---
+title: "zsh auto-completion"
+description: "Some optional configuration for zsh auto-completion."
+headless: true
+---
+-->
+
+<!-- 
+The kubectl completion script for Zsh can be generated with the command `kubectl completion zsh`. Sourcing the completion script in your shell enables kubectl autocompletion.
+
+To do so in all your shell sessions, add the following to your `~/.zshrc` file:
+-->
+kubectl 通过命令 `kubectl completion zsh` 生成 Zsh 自动补全脚本。
+在 shell 中导入（Sourcing）该自动补全脚本，将启动 kubectl 自动补全功能。
+
+为了在所有的 shell 会话中实现此功能，请将下面内容加入到文件 `~/.zshrc` 中。
+
+```zsh
+source <(kubectl completion zsh)
+```
+
+<!-- 
+If you have an alias for kubectl, you can extend shell completion to work with that alias:
+-->
+如果你为 kubectl 定义了别名，可以扩展脚本补全，以兼容该别名。
+
+```zsh
+echo 'alias k=kubectl' >>~/.zshrc
+echo 'complete -F __start_kubectl k' >>~/.zshrc
+```
+
+<!-- 
+After reloading your shell, kubectl autocompletion should be working.
+
+If you get an error like `complete:13: command not found: compdef`, then add the following to the beginning of your `~/.zshrc` file:
+-->
+重新加载 shell 后，kubectl 自动补全功能将立即生效。
+
+如果你收到 `complete:13: command not found: compdef` 这样的错误提示，那请将下面内容添加到 `~/.zshrc` 文件的开头：
+
+```zsh
+autoload -Uz compinit
+compinit
+```

--- a/content/zh/docs/tasks/tools/included/verify-kubectl.md
+++ b/content/zh/docs/tasks/tools/included/verify-kubectl.md
@@ -1,0 +1,62 @@
+---
+title: "验证 kubectl 的安装效果"
+description: "如何验证 kubectl。"
+headless: true
+---
+<!-- 
+---
+title: "verify kubectl install"
+description: "How to verify kubectl."
+headless: true
+---
+ -->
+
+<!-- 
+In order for kubectl to find and access a Kubernetes cluster, it needs a
+[kubeconfig file](/docs/concepts/configuration/organize-cluster-access-kubeconfig/),
+which is created automatically when you create a cluster using
+[kube-up.sh](https://github.com/kubernetes/kubernetes/blob/master/cluster/kube-up.sh)
+or successfully deploy a Minikube cluster.
+By default, kubectl configuration is located at `~/.kube/config`.
+
+Check that kubectl is properly configured by getting the cluster state:
+ -->
+为了让 kubectl 能发现并访问 Kubernetes 集群，你需要一个
+[kubeconfig 文件](/docs/zh/concepts/configuration/organize-cluster-access-kubeconfig/)，
+该文件在
+[kube-up.sh](https://github.com/kubernetes/kubernetes/blob/master/cluster/kube-up.sh)
+创建集群时，或成功部署一个 Miniube 集群时，均会自动生成。
+通常，kubectl 的配置信息存放于文件 `~/.kube/config` 中。
+
+通过获取集群状态的方法，检查是否已恰当的配置了 kubectl：
+
+```shell
+kubectl cluster-info
+```
+
+<!-- 
+If you see a URL response, kubectl is correctly configured to access your cluster.
+
+If you see a message similar to the following, kubectl is not configured correctly or is not able to connect to a Kubernetes cluster.
+ -->
+如果返回一个 URL，则意味着 kubectl 成功的访问到了你的集群。
+
+如果你看到如下所示的消息，则代表 kubectl 配置出了问题，或无法连接到 Kubernetes 集群。
+
+```
+The connection to the server <server-name:port> was refused - did you specify the right host or port?
+（访问 <server-name:port> 被拒绝 - 你指定的主机和端口是否有误？）
+```
+
+<!-- 
+For example, if you are intending to run a Kubernetes cluster on your laptop (locally), you will need a tool like Minikube to be installed first and then re-run the commands stated above.
+
+If kubectl cluster-info returns the url response but you can't access your cluster, to check whether it is configured properly, use:
+ -->
+例如，如果你想在自己的笔记本上（本地）运行 Kubernetes 集群，你需要先安装一个 Minikube 这样的工具，然后再重新运行上面的命令。
+
+如果命令 `kubectl cluster-info` 返回了 url，但你还不能访问集群，那可以用以下命令来检查配置是否妥当：
+
+```shell
+kubectl cluster-info dump
+```

--- a/content/zh/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/zh/docs/tasks/tools/install-kubectl-macos.md
@@ -1,0 +1,263 @@
+---
+title: 在 macOS 系统上安装和设置 kubectl
+content_type: task
+weight: 10
+card:
+  name: tasks
+  weight: 20
+  title: 在 macOS 系统上安装 kubectl 
+---
+<!-- 
+---
+reviewers:
+- mikedanese
+title: Install and Set Up kubectl on macOS
+content_type: task
+weight: 10
+card:
+  name: tasks
+  weight: 20
+  title: Install kubectl on macOS
+---
+-->
+
+## {{% heading "prerequisites" %}}
+
+<!-- 
+You must use a kubectl version that is within one minor version difference of your cluster.
+For example, a v1.2 client should work with v1.1, v1.2, and v1.3 master.
+Using the latest version of kubectl helps avoid unforeseen issues.
+-->
+kubectl 版本和集群之间的差异必须在一个小版本号之内。
+例如：v1.2 版本的客户端只能与 v1.1、v1.2 和 v1.3 版本的集群一起工作。
+用最新版本的 kubectl 有助于避免不可预见的问题。
+
+<!-- 
+## Install kubectl on macOS
+-->
+## 在 macOS 系统上安装 kubectl {#install-kubectl-on-macos}
+
+<!-- 
+The following methods exist for installing kubectl on macOS:
+-->
+在 macOS 系统上安装 kubectl 有如下方法：
+
+- [{{% heading "prerequisites" %}}](#{{% heading "prerequisites" %}})
+- [在 macOS 系统上安装 kubectl](#install-kubectl-on-macos)
+  - [用 curl 在 macOS 系统上安装 kubectl](#install-kubectl-binary-with-curl-on-macos)
+  - [用 Homebrew 在 macOS 系统上安装](#install-with-homebrew-on-macos)
+  - [用 Macports 在 macOS 上安装](#install-with-macports-on-macos)
+  - [作为谷歌云 SDK 的一部分，在 macOS 上安装](#install-on-macos-as-part-of-the-google-cloud-sdk)
+- [验证 kubectl 配置](#verify-kubectl-configuration)
+- [可选的 kubectl 配置](#optional-kubectl-configurations)
+  - [启用 shell 自动补全功能](#enable-shell-autocompletion)
+- [{{% heading "whatsnext" %}}](#{{% heading "whatsnext" %}})
+
+<!-- 
+### Install kubectl binary with curl on macOS {#install-kubectl-binary-with-curl-on-macos}
+-->
+### 用 curl 在 macOS 系统上安装 kubectl {#install-kubectl-binary-with-curl-on-macos}
+
+<!-- 
+1. Download the latest release:
+-->
+1. 下载最新的发行版：
+
+   ```bash
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl"
+   ```
+
+   {{< note >}}
+   <!-- 
+   To download a specific version, replace the `$(curl -L -s https://dl.k8s.io/release/stable.txt)` portion of the command with the specific version.
+
+   For example, to download version {{< param "fullversion" >}} on macOS, type:
+   -->
+   如果需要下载某个指定的版本，用该指定版本号替换掉命令的这个部分：`$(curl -L -s https://dl.k8s.io/release/stable.txt)`。
+   例如：要在 macOS 系统中下载 {{< param "fullversion" >}} 版本，则输入：
+
+   ```bash
+   curl -LO https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/darwin/amd64/kubectl
+   ```
+
+   {{< /note >}}
+
+   <!-- 
+   1. Validate the binary (optional)
+
+   Download the kubectl checksum file:
+   -->
+1. 验证可执行文件（可选操作）
+
+   下载 kubectl 的校验和文件：
+
+   ```bash
+   curl -LO "https://dl.k8s.io/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl.sha256"
+   ```
+
+   <!-- 
+      Validate the kubectl binary against the checksum file:
+   -->
+   根据校验和文件，验证 kubectl：
+
+   ```bash
+   echo "$(<kubectl.sha256)  kubectl" | shasum -a 256 --check
+   ```
+   <!-- 
+   If valid, the output is:
+   -->
+   验证通过时，输出如下：
+
+   ```console
+   kubectl: OK
+   ```
+
+   <!-- 
+   If the check fails, `shasum` exits with nonzero status and prints output similar to:
+   -->
+   验证失败时，`shasum` 将以非零值退出，并打印如下输出：
+
+   ```
+   kubectl: FAILED
+   shasum: WARNING: 1 computed checksum did NOT match
+   ```
+
+   {{< note >}}
+   <!-- 
+   Download the same version of the binary and checksum.
+   -->
+   下载的 kubectl 与校验和文件版本要相同。
+   {{< /note >}}
+
+   <!-- 
+   1. Make the kubectl binary executable.
+   -->
+1. 将 kubectl 置为可执行文件：
+
+   ```bash
+   chmod +x ./kubectl
+   ```
+
+   <!-- 
+   1. Move the kubectl binary to a file location on your system `PATH`.
+   -->
+1. 将可执行文件 kubectl 移动到系统可寻址路径 `PATH` 内的一个位置：
+
+   ```bash
+   sudo mv ./kubectl /usr/local/bin/kubectl
+   sudo chown root: /usr/local/bin/kubectl
+   ```
+
+   <!-- 
+   1. Test to ensure the version you installed is up-to-date:
+   -->
+1. 测试一下，确保你安装的是最新的版本：
+
+   ```bash
+   kubectl version --client
+   ```
+
+<!-- 
+### Install with Homebrew on macOS {#install-with-homebrew-on-macos}
+-->
+### 用 Homebrew 在 macOS 系统上安装 {#install-with-homebrew-on-macos}
+
+<!-- 
+If you are on macOS and using [Homebrew](https://brew.sh/) package manager, you can install kubectl with Homebrew.
+-->
+如果你是 macOS 系统，且用的是 [Homebrew](https://brew.sh/) 包管理工具，
+则可以用 Homebrew 安装 kubectl。
+
+<!-- 
+1. Run the installation command:
+-->
+1. 运行安装命令：
+
+   ```bash
+   brew install kubectl 
+   ```
+
+   或
+
+   ```bash
+   brew install kubernetes-cli
+   ```
+
+   <!-- 
+   1. Test to ensure the version you installed is up-to-date:
+   -->
+1. 测试一下，确保你安装的是最新的版本：
+
+   ```bash
+   kubectl version --client
+   ```
+
+<!-- 
+### Install with Macports on macOS {#install-with-macports-on-macos}
+-->
+### 用 Macports 在 macOS 上安装 {#install-with-macports-on-macos}
+
+<!-- 
+If you are on macOS and using [Macports](https://macports.org/) package manager, you can install kubectl with Macports.
+-->
+如果你用的是 macOS，且用 [Macports](https://macports.org/) 包管理工具，则你可以用 Macports 安装kubectl。
+
+<!-- 
+1. Run the installation command:
+-->
+1. 运行安装命令：
+
+   ```bash
+   sudo port selfupdate
+   sudo port install kubectl
+   ```
+
+   <!-- 
+   1. Test to ensure the version you installed is up-to-date:
+   -->
+1. 测试一下，确保你安装的是最新的版本：
+
+   ```bash
+   kubectl version --client
+   ```
+
+<!-- 
+### Install on macOS as part of the Google Cloud SDK {#install-on-macos-as-part-of-the-google-cloud-sdk}
+-->
+### 作为谷歌云 SDK 的一部分，在 macOS 上安装 {#install-on-macos-as-part-of-the-google-cloud-sdk}
+
+{{< include "included/install-kubectl-gcloud.md" >}}
+
+<!-- 
+## Verify kubectl configuration {#verify-kubectl-configuration}
+-->
+## 验证 kubectl 配置 {#verify-kubectl-configuration}
+
+{{< include "included/verify-kubectl.md" >}}
+
+<!-- 
+## Optional kubectl configurations {#optional-kubectl-configurations}
+
+### Enable shell autocompletion {#enable-shell-autocompletion}
+-->
+## 可选的 kubectl 配置 {#optional-kubectl-configurations}
+
+### 启用 shell 自动补全功能 {#enable-shell-autocompletion}
+
+<!-- 
+kubectl provides autocompletion support for Bash and Zsh, which can save you a lot of typing.
+
+Below are the procedures to set up autocompletion for Bash and Zsh.
+-->
+kubectl 为 Bash 和 Zsh 提供自动补全功能，这可以节省许多输入的麻烦。
+
+下面是为 Bash 和 Zsh 设置自动补全功能的操作步骤。
+
+{{< tabs name="kubectl_autocompletion" >}}
+{{< tab name="Bash" include="included/optional-kubectl-configs-bash-mac.md" />}}
+{{< tab name="Zsh" include="included/optional-kubectl-configs-zsh.md" />}}
+{{< /tabs >}}
+
+## {{% heading "whatsnext" %}}
+
+{{< include "included/kubectl-whats-next.md" >}}


### PR DESCRIPTION
transalte following files into Chinese:
	 content/docs/tasks/tools/included/install-kubectl-gcloud.md
	content/docs/tasks/tools/included/kubectl-whats-next.md
	content/docs/tasks/tools/included/optional-kubectl-configs-bash-mac.md
	 content/docs/tasks/tools/included/optional-kubectl-configs-zsh.md
	content/docs/tasks/tools/included/verify-kubectl.md
	content/docs/tasks/tools/install-kubectl-macos.md

close #26946 