### PR TITLE
Add description of replica controller scaledown sort logic

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/replicaset.md
+++ b/content/en/docs/concepts/workloads/controllers/replicaset.md
@@ -310,6 +310,17 @@ assuming that the number of replicas is not also changed).
 A ReplicaSet can be easily scaled up or down by simply updating the `.spec.replicas` field. The ReplicaSet controller
 ensures that a desired number of Pods with a matching label selector are available and operational.
 
+When scaling down, the ReplicaSet controller chooses which pods to delete by sorting the available pods to
+prioritize scaling down pods based on the following general algorithm:
+ 1. Pending (and unschedulable) pods are scaled down first
+ 2. If controller.kubernetes.io/pod-deletion-cost annotation is set, then
+    the pod with the lower value will come first.
+ 3. Pods on nodes with more replicas come before pods on nodes with fewer replicas.
+ 4. If the pods' creation times differ, the pod that was created more recently
+    comes before the older pod (the creation times are bucketed on an integer log scale)
+    
+If all of the above match, then selection is random.
+
 ### ReplicaSet as a Horizontal Pod Autoscaler Target
 
 A ReplicaSet can also be a target for


### PR DESCRIPTION
This copies the description from the replica controller's internal scale-down logic (https://github.com/damemi/kubernetes/blob/a8d105ab724ccdb45b4ff380d84fd356e833991e/pkg/controller/controller_utils.go#L787-L815) 

This was prompted as part of https://github.com/kubernetes/enhancements/issues/2185 and https://github.com/kubernetes/kubernetes/pull/99212