### PR TITLE
Default Namespace labels

### DIFF
--- a/content/en/docs/concepts/services-networking/network-policies.md
+++ b/content/en/docs/concepts/services-networking/network-policies.md
@@ -264,6 +264,10 @@ Your cluster must be using a {{< glossary_tooltip text="CNI" term_id="cni" >}} p
 supports the `endPort` field in NetworkPolicy specifications.
 {{< /note >}}
 
+## Targeting a Namespace by its name
+
+As of Kubernetes v1.21, a default immutable label ``kubernetes.io/metadata.name`` with the namespace name will be added to all namespaces. While NetworkPolicy cannot target a namespace by its name with some object field, this label now can be used to target a specific namespace.
+
 ## What you can't do with network policies (at least, not yet)
 
 As of Kubernetes 1.20, the following functionality does not exist in the NetworkPolicy API, but you might be able to implement workarounds using Operating System components (such as SELinux, OpenVSwitch, IPTables, and so on) or Layer 7 technologies (Ingress controllers, Service Mesh implementations) or admission controllers.  In case you are new to network security in Kubernetes, its worth noting that the following User Stories cannot (yet) be implemented using the NetworkPolicy API.  Some (but not all) of these user stories are actively being discussed for future releases of the NetworkPolicy API.
@@ -271,7 +275,7 @@ As of Kubernetes 1.20, the following functionality does not exist in the Network
 - Forcing internal cluster traffic to go through a common gateway (this might be best served with a service mesh or other proxy).
 - Anything TLS related (use a service mesh or ingress controller for this).
 - Node specific policies (you can use CIDR notation for these, but you cannot target nodes by their Kubernetes identities specifically).
-- Targeting of namespaces or services by name (you can, however, target pods or namespaces by their {{< glossary_tooltip text="labels" term_id="label" >}}, which is often a viable workaround).
+- Targeting of services by name (you can, however, target pods or namespaces by their {{< glossary_tooltip text="labels" term_id="label" >}}, which is often a viable workaround).
 - Creation or management of "Policy requests" that are fulfilled by a third party.
 - Default policies which are applied to all namespaces or pods (there are some third party Kubernetes distributions and projects which can do this).
 - Advanced policy querying and reachability tooling.

--- a/content/en/docs/concepts/services-networking/network-policies.md
+++ b/content/en/docs/concepts/services-networking/network-policies.md
@@ -266,7 +266,10 @@ supports the `endPort` field in NetworkPolicy specifications.
 
 ## Targeting a Namespace by its name
 
-As of Kubernetes v1.21, a default immutable label ``kubernetes.io/metadata.name`` with the namespace name will be added to all namespaces. While NetworkPolicy cannot target a namespace by its name with some object field, this label now can be used to target a specific namespace.
+As of Kubernetes v1.21, an immutable label `kubernetes.io/metadata.name` is added to all
+namespaces. The value of the label is the namespace name. While NetworkPolicy cannot
+target a namespace by its name with some object field, this label now can be used to target
+a specific namespace.
 
 ## What you can't do with network policies (at least, not yet)
 

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -664,7 +664,7 @@ Each feature gate is designed for enabling/disabling a specific feature:
   the volume mounter.
 - `MountPropagation`: Enable sharing volume mounted by one container to other containers or pods.
   For more details, please see [mount propagation](/docs/concepts/storage/volumes/#mount-propagation).
-- `NamespaceDefaultLabelName`: Enable the behavior of APIServer creating a default label `kubernetes.io/metadata.name` containing the namespace name.
+- `NamespaceDefaultLabelName`: Enable the API Server to create a default label `kubernetes.io/metadata.name` in all namespaces containing the namespace name.
 - `NetworkPolicyEndPort`: Enable use of the field `endPort` in NetworkPolicy objects, allowing the selection of a port range instead of a single port.
 - `NodeDisruptionExclusion`: Enable use of the Node label `node.kubernetes.io/exclude-disruption`
   which prevents nodes from being evacuated during zone failures.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -134,6 +134,7 @@ different Kubernetes components.
 | `LocalStorageCapacityIsolation` | `true` | Beta | 1.10 | |
 | `LocalStorageCapacityIsolationFSQuotaMonitoring` | `false` | Alpha | 1.15 | |
 | `MixedProtocolLBService` | `false` | Alpha | 1.20 | |
+| `NamespaceDefaultLabelName` | `true` | Beta | 1.21 | |
 | `NetworkPolicyEndPort` | `false` | Alpha | 1.21 |  |
 | `NodeDisruptionExclusion` | `false` | Alpha | 1.16 | 1.18 |
 | `NodeDisruptionExclusion` | `true` | Beta | 1.19 | |
@@ -663,6 +664,7 @@ Each feature gate is designed for enabling/disabling a specific feature:
   the volume mounter.
 - `MountPropagation`: Enable sharing volume mounted by one container to other containers or pods.
   For more details, please see [mount propagation](/docs/concepts/storage/volumes/#mount-propagation).
+- `NamespaceDefaultLabelName`: Enable the behavior of APIServer creating a default label `kubernetes.io/metadata.name` containing the namespace name.
 - `NetworkPolicyEndPort`: Enable use of the field `endPort` in NetworkPolicy objects, allowing the selection of a port range instead of a single port.
 - `NodeDisruptionExclusion`: Enable use of the Node label `node.kubernetes.io/exclude-disruption`
   which prevents nodes from being evacuated during zone failures.

--- a/content/en/docs/reference/labels-annotations-taints.md
+++ b/content/en/docs/reference/labels-annotations-taints.md
@@ -36,7 +36,7 @@ Example: `kubernetes.io/metadata.name=mynamespace`
 
 Used on: Namespaces
 
-Kubernetes APIServer defaults this label to the namespace name. This label can be used with any namespace selector, as an example with NetworkPolicy objects.
+Kubernetes API Server defaults this label to the namespace name during admission. This label can be used with any namespace selector, as an example with NetworkPolicy objects.
 
 ## beta.kubernetes.io/arch (deprecated)
 

--- a/content/en/docs/reference/labels-annotations-taints.md
+++ b/content/en/docs/reference/labels-annotations-taints.md
@@ -30,6 +30,14 @@ Used on: Node
 
 The Kubelet populates this with `runtime.GOOS` as defined by Go. This can be handy if you are mixing operating systems in your cluster (for example: mixing Linux and Windows nodes).
 
+## kubernetes.io/metadata.name
+
+Example: `kubernetes.io/metadata.name=mynamespace`
+
+Used on: Namespaces
+
+Kubernetes APIServer defaults this label to the namespace name. This label can be used with any namespace selector, as an example with Network Policies.
+
 ## beta.kubernetes.io/arch (deprecated)
 
 This label has been deprecated. Please use `kubernetes.io/arch` instead.

--- a/content/en/docs/reference/labels-annotations-taints.md
+++ b/content/en/docs/reference/labels-annotations-taints.md
@@ -36,7 +36,7 @@ Example: `kubernetes.io/metadata.name=mynamespace`
 
 Used on: Namespaces
 
-Kubernetes APIServer defaults this label to the namespace name. This label can be used with any namespace selector, as an example with Network Policies.
+Kubernetes APIServer defaults this label to the namespace name. This label can be used with any namespace selector, as an example with NetworkPolicy objects.
 
 ## beta.kubernetes.io/arch (deprecated)
 
@@ -261,4 +261,3 @@ Sets this taint on a node to mark it as unusable, when kubelet is started with t
 Example: `node.cloudprovider.kubernetes.io/shutdown:NoSchedule`
 
 If a Node is in a cloud provider specified shutdown state, the Node gets tainted accordingly with `node.cloudprovider.kubernetes.io/shutdown` and the taint effect of `NoSchedule`.
-


### PR DESCRIPTION
This adds the docs for the default namespace labels, created by Kep kubernetes/enhancements#2161

