### PR TITLE
fixed  demo deployment create command

### DIFF
--- a/content/zh/docs/tutorials/services/source-ip.md
+++ b/content/zh/docs/tutorials/services/source-ip.md
@@ -35,7 +35,7 @@ Kubernetes 集群中运行的应用通过 Service 抽象来互相查找、通信
 你必须拥有一个正常工作的 Kubernetes 1.5 集群来运行此文档中的示例。该示例使用一个简单的 nginx webserver，通过一个HTTP消息头返回它接收到请求的源IP。你可以像下面这样创建它：
 
 ```console
-kubectl run source-ip-app --image=k8s.gcr.io/echoserver:1.4
+kubectl create deployment source-ip-app --image=k8s.gcr.io/echoserver:1.4
 ```
 输出结果为
 ```


### PR DESCRIPTION
when use  `kubectl run source-ip-app --image=k8s.gcr.io/echoserver:1.4` . it will be create a pod, the output is: `pod/source-ip-app created`,  but the svc will find `deployment` when use `kubectl expose deployment source-ip-app --name=clusterip --port=80 --target-port=8080`

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
