### PR TITLE
Update kubeadm-upgrade.md

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -247,6 +247,7 @@ without compromising the minimum required capacity for running your workloads.
     # replace <node-to-drain> with the name of your node you are draining
     kubectl drain <node-to-drain> --ignore-daemonsets
     ```
+    This should be run from control plane.
 
 ### Upgrade kubelet and kubectl
 
@@ -284,6 +285,7 @@ without compromising the minimum required capacity for running your workloads.
     # replace <node-to-drain> with the name of your node
     kubectl uncordon <node-to-drain>
     ```
+    This should be run from control plane.
 
 ## Verify the status of the cluster
 


### PR DESCRIPTION
Added "This should be run from control plane." at worker node upgrade portion
Added 1)
https://v1-19.docs.kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/#drain-the-node
Added 2)
https://v1-19.docs.kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/#uncordon-the-node
