### PR TITLE
id: Replace redirect links of kubeadm

### DIFF
--- a/content/id/docs/concepts/cluster-administration/cloud-providers.md
+++ b/content/id/docs/concepts/cluster-administration/cloud-providers.md
@@ -11,7 +11,7 @@ Laman ini akan menjelaskan bagaimana cara mengelola Kubernetes yang berjalan pad
 
 <!-- body -->
 ### Kubeadm
-[Kubeadm](/docs/reference/setup-tools/kubeadm/kubeadm/) merupakan salah satu cara yang banyak digunakan untuk membuat klaster Kubernetes.
+[Kubeadm](/docs/reference/setup-tools/kubeadm/) merupakan salah satu cara yang banyak digunakan untuk membuat klaster Kubernetes.
 Kubeadm memiliki beragam opsi untuk mengatur konfigurasi spesifik untuk penyedia layanan cloud. Salah satu contoh yang biasa digunakan pada penyedia cloud *in-tree* yang dapat diatur dengan kubeadm adalah sebagai berikut:
 
 ```yaml

--- a/content/id/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
+++ b/content/id/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
@@ -134,7 +134,7 @@ tidak didukung oleh kubeadm.
 
 ### Informasi lebih lanjut
 
-Untuk informasi lebih lanjut mengenai argumen-argumen `kubeadm init`, lihat [panduan referensi kubeadm](/docs/reference/setup-tools/kubeadm/kubeadm/).
+Untuk informasi lebih lanjut mengenai argumen-argumen `kubeadm init`, lihat [panduan referensi kubeadm](/docs/reference/setup-tools/kubeadm/).
 
 Untuk daftar pengaturan konfigurasi yang lengkap, lihat [dokumentasi berkas konfigurasi](/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file).
 
@@ -569,7 +569,7 @@ opsinya.
 * Pastikan klaster berjalan dengan benar menggunakan [Sonobuoy](https://github.com/heptio/sonobuoy)
 * <a id="lifecycle" />Lihat [Memperbaharui klaster kubeadm](/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/)
   untuk detail mengenai pembaruan klaster menggunakan `kubeadm`.
-* Pelajari penggunaan `kubeadm` lebih lanjut pada [dokumentasi referensi kubeadm](/docs/reference/setup-tools/kubeadm/kubeadm)
+* Pelajari penggunaan `kubeadm` lebih lanjut pada [dokumentasi referensi kubeadm](/docs/reference/setup-tools/kubeadm)
 * Pelajari lebih lanjut mengenai [konsep-konsep](/docs/concepts/) Kubernetes dan [`kubectl`](/docs/user-guide/kubectl-overview/).
 * Lihat halaman [Cluster Networking](/id/docs/concepts/cluster-administration/networking/) untuk daftar
 _add-on_ jaringan Pod yang lebih banyak.


### PR DESCRIPTION
/docs/reference/setup-tools/kubeadm/kubeadm/ is redirected to /docs/reference/setup-tools/kubeadm/
This replaces the redirect links of kubeadm with the direct links.

NOTE: The pull request for `en` language has been already merged as https://github.com/kubernetes/website/pull/26919
