### PR TITLE
[es] Update content/es/docs/reference/glossary/limitrange.md

### DIFF
--- a/content/es/docs/reference/glossary/limitrange.md
+++ b/content/es/docs/reference/glossary/limitrange.md
@@ -20,4 +20,4 @@ Proporciona restricciones para limitar el consumo de recursos por {{< glossary_t
 
 <!--more-->
 
-LimitRange limita la cantidad de objetos que se pueden crear por su tipo (vease {{< glossary_tooltip text="Workloads" term_id="workload" >}}), así como la cantidad de recursos informáticos que pueden ser requeridos/consumidos por {{< glossary_tooltip text="Pods" term_id="pod" >}} individuales en un espacio de nombres.
+LimitRange limita la cantidad de objetos que se pueden crear por tipo, así como la cantidad de recursos informáticos que pueden ser requeridos/consumidos por {{< glossary_tooltip text="Pods" term_id="pod" >}} o {{< glossary_tooltip text="Contenedores" term_id="container" >}} individuales en un espacio de nombres.

--- a/content/es/docs/reference/glossary/limitrange.md
+++ b/content/es/docs/reference/glossary/limitrange.md
@@ -20,4 +20,4 @@ Proporciona restricciones para limitar el consumo de recursos por {{< glossary_t
 
 <!--more-->
 
-LimitRange limita la cantidad de objetos que se pueden crear por tipo, así como la cantidad de recursos informáticos que pueden ser requeridos/consumidos por {{< glossary_tooltip text="Pods" term_id="pod" >}} o {{< glossary_tooltip text="Contenedores" term_id="container" >}} individuales en un espacio de nombres.
+LimitRange limita la cantidad de objetos que se pueden crear por tipo, así como la cantidad de recursos informáticos que pueden ser requeridos/consumidos por {{< glossary_tooltip text="Pods" term_id="pod" >}} o {{< glossary_tooltip text="Contenedores" term_id="container" >}} individuales en un {{< glossary_tooltip text="Namespace" term_id="namespace" >}}.


### PR DESCRIPTION
/language/es

Description:
Update / fix, extended definition for LimitRange in glossary

Why?:
Because a misconception that I had and I forgot to fix it before the merge

/assign @raelga 
(He dejado información extra como comentario en este mensaje pero no sé si se podrá leer aquí.)

<!-- 
Extra Notes:
    Last week, I worked in a fork that I deleted today (after a successful merge a few days ago) because I was working on master.
Hopefully this way I will not have any trouble to work on different branches and ask for pull requests in parallel, 
while keeping the fork master up to date.
    I checked the page in my local build after push the changes but not before: 
* No new changes were added.
* The site and the update looked good.
-->
