### PR TITLE
Promote Pod Disruption Budgets to GA

### DIFF
--- a/content/en/docs/concepts/workloads/pods/disruptions.md
+++ b/content/en/docs/concepts/workloads/pods/disruptions.md
@@ -90,7 +90,7 @@ disruptions, if any, to expect.
 
 ## Pod disruption budgets
 
-{{< feature-state for_k8s_version="v1.5" state="beta" >}}
+{{< feature-state for_k8s_version="v1.21" state="stable" >}}
 
 Kubernetes offers features to help you run highly available applications even when you
 introduce frequent voluntary disruptions.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -145,8 +145,6 @@ different Kubernetes components.
 | `NonPreemptingPriority` | `false` | Alpha | 1.15 | 1.18 |
 | `NonPreemptingPriority` | `true` | Beta | 1.19 | |
 | `PodDeletionCost` | `false` | Alpha | 1.21 | |
-| `PodDisruptionBudget` | `false` | Alpha | 1.3 | 1.4 |
-| `PodDisruptionBudget` | `true` | Beta | 1.5 | |
 | `PodAffinityNamespaceSelector` | `false` | Alpha | 1.21 | |
 | `PodOverhead` | `false` | Alpha | 1.16 | 1.17 |
 | `PodOverhead` | `true` | Beta | 1.18 |  |
@@ -299,6 +297,9 @@ different Kubernetes components.
 | `PersistentLocalVolumes` | `false` | Alpha | 1.7 | 1.9 |
 | `PersistentLocalVolumes` | `true` | Beta | 1.10 | 1.13 |
 | `PersistentLocalVolumes` | `true` | GA | 1.14 | - |
+| `PodDisruptionBudget` | `false` | Alpha | 1.3 | 1.4 |
+| `PodDisruptionBudget` | `true` | Beta | 1.5 | 1.20 |
+| `PodDisruptionBudget` | `true` | GA | 1.21 | - |
 | `PodPriority` | `false` | Alpha | 1.8 | 1.10 |
 | `PodPriority` | `true` | Beta | 1.11 | 1.13 |
 | `PodPriority` | `true` | GA | 1.14 | - |

--- a/content/en/docs/tasks/run-application/configure-pdb.md
+++ b/content/en/docs/tasks/run-application/configure-pdb.md
@@ -2,11 +2,12 @@
 title: Specifying a Disruption Budget for your Application
 content_type: task
 weight: 110
+min-kubernetes-server-version: v1.21
 ---
 
 <!-- overview -->
 
-{{< feature-state for_k8s_version="v1.5" state="beta" >}}
+{{< feature-state for_k8s_version="v1.21" state="stable" >}}
 
 This page shows how to limit the number of concurrent disruptions
 that your application experiences, allowing for higher availability
@@ -16,6 +17,8 @@ nodes.
 
 
 ## {{% heading "prerequisites" %}}
+
+{{< version-check >}}
 
 * You are the owner of an application running on a Kubernetes cluster that requires
   high availability.
@@ -112,9 +115,9 @@ of the number of pods from that set that can be unavailable after the eviction.
 It can be either an absolute number or a percentage.
 
 {{< note >}}
-For versions 1.8 and earlier: When creating a `PodDisruptionBudget`
-object using the `kubectl` command line tool, the `minAvailable` field has a
-default value of 1 if neither `minAvailable` nor `maxUnavailable` is specified.
+The behavior for an empty selector differs between the policy/v1beta1 and policy/v1 APIs for
+PodDisruptionBudgets. For policy/v1beta1 an empty selector matches zero pods, while
+for policy/v1 an empty selector matches every pod in the namespace.
 {{< /note >}}
 
 You can specify only one of `maxUnavailable` and `minAvailable` in a single `PodDisruptionBudget`. 
@@ -160,7 +163,7 @@ Example PDB Using minAvailable:
 
 {{< codenew file="policy/zookeeper-pod-disruption-budget-minavailable.yaml" >}}
 
-Example PDB Using maxUnavailable (Kubernetes 1.7 or higher):
+Example PDB Using maxUnavailable:
 
 {{< codenew file="policy/zookeeper-pod-disruption-budget-maxunavailable.yaml" >}}
 
@@ -206,7 +209,7 @@ You can get more information about the status of a PDB with this command:
 kubectl get poddisruptionbudgets zk-pdb -o yaml
 ```
 ```yaml
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   annotations:

--- a/content/en/examples/application/zookeeper/zookeeper.yaml
+++ b/content/en/examples/application/zookeeper/zookeeper.yaml
@@ -27,7 +27,7 @@ spec:
   selector:
     app: zk
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: zk-pdb

--- a/content/en/examples/policy/zookeeper-pod-disruption-budget-maxunavailable.yaml
+++ b/content/en/examples/policy/zookeeper-pod-disruption-budget-maxunavailable.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: zk-pdb

--- a/content/en/examples/policy/zookeeper-pod-disruption-budget-minavailable.yaml
+++ b/content/en/examples/policy/zookeeper-pod-disruption-budget-minavailable.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: zk-pdb


### PR DESCRIPTION
PR to update documentation after PDBs have been promoted to GA.

KEP: https://github.com/kubernetes/enhancements/blob/master/keps/sig-apps/85-Graduate-PDB-to-Stable/README.md
Issue: https://github.com/kubernetes/enhancements/issues/85
PR: https://github.com/kubernetes/kubernetes/pull/99290
