### PR TITLE
correct the version of beta annotation for storage

### DIFF
--- a/content/en/docs/concepts/storage/dynamic-provisioning.md
+++ b/content/en/docs/concepts/storage/dynamic-provisioning.md
@@ -80,7 +80,7 @@ parameters:
 Users request dynamically provisioned storage by including a storage class in
 their `PersistentVolumeClaim`. Before Kubernetes v1.6, this was done via the
 `volume.beta.kubernetes.io/storage-class` annotation. However, this annotation
-is deprecated since v1.6. Users now can and should instead use the
+is deprecated since v1.9. Users now can and should instead use the
 `storageClassName` field of the `PersistentVolumeClaim` object. The value of
 this field must match the name of a `StorageClass` configured by the
 administrator (see [below](#enabling-dynamic-provisioning)).


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/blob/7a94debba5f8c21bbf8b42b2a7f1d5e974ddb837/CHANGELOG/CHANGELOG-1.9.md#storage-2

> Before Kubernetes v1.6, this was done via the
> `volume.beta.kubernetes.io/storage-class` annotation. However, this annotation
> is deprecated since v1.9. Users now can and should instead use the
> `storageClassName` field of the `PersistentVolumeClaim` object.


- 1.6: StorageClassName attribute has been added to PersistentVolume and PersistentVolumeClaim objects and should be used instead of annotation volume.beta.kubernetes.io/storage-class. The beta annotation is still working in this release, however it will be removed in a future release. (#42128, @jsafrane)
- 1.9: The volume.beta.kubernetes.io/storage-class annotation is deprecated. It will be removed in a future release. For the StorageClass API object, use v1, and in place of the annotation use v1.PersistentVolumeClaim.Spec.StorageClassName and v1.PersistentVolume.Spec.StorageClassName instead. (#53580, @xiangpengzhao)

maybe removed later.