### PR TITLE
clarify: add that binaryData is base64-encoded

### DIFF
--- a/content/en/docs/concepts/configuration/configmap.md
+++ b/content/en/docs/concepts/configuration/configmap.md
@@ -43,7 +43,7 @@ Kubernetes objects that have a `spec`, a ConfigMap has `data` and `binaryData`
 fields. These fields accept key-value pairs as their values.  Both the `data`
 field and the `binaryData` are optional. The `data` field is designed to
 contain UTF-8 byte sequences while the `binaryData` field is designed to
-contain binary data.
+contain binary data as base64-encoded strings.
 
 The name of a ConfigMap must be a valid
 [DNS subdomain name](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names).


### PR DESCRIPTION
This PR clarifies how binaryData in what format the `binaryData` field in configmaps should be filled.

This information can come handy if one would want to manually add binaryData to a configmap.

I copied the wording over from the secrets page, not sure if that is the best wording: 
> [The values for all keys in the data field have to be base64-encoded strings.](https://kubernetes.io/docs/concepts/configuration/secret/#overview-of-secrets)


Edit: I had to reread up on https://github.com/kubernetes/kubernetes/pull/57938, but I'm now rather certain that binaryData is base64 represented in the API.