### PR TITLE
container-runtimes: add note about restarting containerd

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -147,7 +147,7 @@ Start a Powershell session, set `$Version` to the desired version (ex: `$Version
 {{% /tab %}}
 {{< /tabs >}}
 
-#### systemd {#containerd-systemd}
+#### Using the `systemd` cgroup driver {#containerd-systemd}
 
 To use the `systemd` cgroup driver in `/etc/containerd/config.toml` with `runc`, set
 
@@ -156,6 +156,12 @@ To use the `systemd` cgroup driver in `/etc/containerd/config.toml` with `runc`,
   ...
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
     SystemdCgroup = true
+```
+
+If you apply this change make sure to restart containerd again:
+
+```shell
+sudo systemctl restart containerd
 ```
 
 When using kubeadm, manually configure the


### PR DESCRIPTION
**note: targeting the `master` branch is accurate here.**

Add note about restarting containerd when the cgroup driver
is changed to "systemd".

fixes https://github.com/kubernetes/website/issues/27017

/sig node cluster-lifecycle
