### PR TITLE
Replace redirect links and fix link to use localized page of reference/index

### DIFF
--- a/content/ja/docs/reference/_index.md
+++ b/content/ja/docs/reference/_index.md
@@ -16,7 +16,7 @@ content_type: concept
 
 ## APIリファレンス
 
-* [Kubernetes API概要](/docs/reference/using-api/api-overview/) - Kubernetes APIの概要です。
+* [Kubernetes API概要](/docs/reference/using-api/) - Kubernetes APIの概要です。
 * [Kubernetes APIリファレンス {{< latest-version >}}](/docs/reference/generated/kubernetes-api/{{< latest-version >}}/)
 
 ## APIクライアントライブラリー
@@ -30,9 +30,9 @@ content_type: concept
 
 ## CLIリファレンス
 
-* [kubectl](/docs/reference/kubectl/overview/) - コマンドの実行やKubernetesクラスターの管理に使う主要なCLIツールです。
+* [kubectl](/ja/docs/reference/kubectl/overview/) - コマンドの実行やKubernetesクラスターの管理に使う主要なCLIツールです。
     * [JSONPath](/ja/docs/reference/kubectl/jsonpath/) - kubectlで[JSONPath記法](https://goessner.net/articles/JsonPath/)を使うための構文ガイドです。
-* [kubeadm](/docs/reference/setup-tools/kubeadm/kubeadm/) - セキュアなKubernetesクラスターを簡単にプロビジョニングするためのCLIツールです。
+* [kubeadm](ja/docs/reference/setup-tools/kubeadm/) - セキュアなKubernetesクラスターを簡単にプロビジョニングするためのCLIツールです。
 
 ## コンポーネントリファレンス
 


### PR DESCRIPTION
This PR fixes the page https://kubernetes.io/ja/docs/reference/ 
* replaces the redirect link `/docs/reference/using-api/api-overview/` with  `/docs/reference/using-api/`
* replaces `/docs/reference/kubectl/overview/` with localized page `/ja/docs/reference/kubectl/overview/`
* replaces the redirect link `/docs/reference/setup-tools/kubeadm/kubeadm/` with `/docs/reference/setup-tools/kubeadm/`

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
