### PR TITLE
[ko] Update link href to translated page

### DIFF
--- a/content/ko/docs/reference/setup-tools/kubeadm/_index.md
+++ b/content/ko/docs/reference/setup-tools/kubeadm/_index.md
@@ -16,7 +16,7 @@ kubeadm은 실행 가능한 최소 클러스터를 시작하고 실행하는 데
 
 ## 설치 방법
 
-kubeadm을 설치하려면, [설치 가이드](/docs/setup/production-environment/tools/kubeadm/install-kubeadm)를 참고한다.
+kubeadm을 설치하려면, [설치 가이드](/ko/docs/setup/production-environment/tools/kubeadm/install-kubeadm/)를 참고한다.
 
 ## {{% heading "whatsnext" %}}
 


### PR DESCRIPTION
- Resolves #27121

> **Problem:**
> In https://kubernetes.io/ko/docs/reference/setup-tools/kubeadm/#%EC%84%A4%EC%B9%98-%EB%B0%A9%EB%B2%95 ,
> the link href is https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm (English).
> 
> The [Korean version](https://kubernetes.io/ko/docs/setup/production-environment/tools/kubeadm/install-kubeadm/) of https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm is
> recently added in #26837.
> 
> **Proposed Solution:**
> In https://github.com/kubernetes/website/edit/master/content/ko/docs/reference/setup-tools/kubeadm/_index.md ,
> 
> Before: `kubeadm을 설치하려면, [설치 가이드](/docs/setup/production-environment/tools/kubeadm/install-kubeadm)를 참고한다.`
> After: `kubeadm을 설치하려면, [설치 가이드](/ko/docs/setup/production-environment/tools/kubeadm/install-kubeadm/)를 참고한다.`
> 
> **Page to Update:**
> https://kubernetes.io/ko/docs/reference/setup-tools/kubeadm/

/language ko