### PR TITLE
Added Windows Containerd GMSA Updates

### DIFF
--- a/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
+++ b/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
@@ -188,15 +188,6 @@ also be used as the container runtime for Windows Kubernetes nodes.
 Learn how to
 [install ContainerD on a Windows](/docs/setup/production-environment/container-runtimes/#install-containerd).
 
-{{< caution >}}
-There is a [known limitation](/docs/tasks/configure-pod-container/configure-gmsa/#gmsa-limitations)
-when using GMSA with ContainerD to access Windows network shares which
-requires a kernel patch. Updates to address this limitation are currently
-available for Windows Server, Version 2004 and will be available for Windows
-Server 2019 in early 2021. Check for updates on the
-[Microsoft Windows Containers issue tracker](https://github.com/microsoft/Windows-Containers/issues/44).
-{{< /caution >}}
-
 #### Persistent Storage
 
 Kubernetes [volumes](/docs/concepts/storage/volumes/) enable complex


### PR DESCRIPTION
Added updates to instructions on installing and troubleshooting GMSA on Windows and Containerd to reflect the release of [kb5000822](https://support.microsoft.com/en-us/topic/march-9-2021-kb5000822-os-build-17763-1817-2eb6197f-e3b1-4f42-ab51-84345e063564) and the discovery of an [issue](https://github.com/kubernetes-sigs/windows-gmsa/issues/30) connecting to SMB shares via Hostname or FQDN

/sig windows
