### PR TITLE
[ko] Update link href to translated page

### DIFF
--- a/content/ko/docs/reference/setup-tools/kubeadm/_index.md
+++ b/content/ko/docs/reference/setup-tools/kubeadm/_index.md
@@ -16,15 +16,15 @@ kubeadm은 실행 가능한 최소 클러스터를 시작하고 실행하는 데
 
 ## 설치 방법
 
-kubeadm을 설치하려면, [설치 가이드](/docs/setup/production-environment/tools/kubeadm/install-kubeadm)를 참고한다.
+kubeadm을 설치하려면, [설치 가이드](/ko/docs/setup/production-environment/tools/kubeadm/install-kubeadm/)를 참고한다.
 
 ## {{% heading "whatsnext" %}}
 
-* [kubeadm init](/docs/reference/setup-tools/kubeadm/kubeadm-init): 쿠버네티스 컨트롤 플레인 노드를 부트스트랩한다.
-* [kubeadm join](/docs/reference/setup-tools/kubeadm/kubeadm-join): 쿠버네티스 워커(worker) 노드를 부트스트랩하고 클러스터에 조인시킨다.
-* [kubeadm upgrade](/docs/reference/setup-tools/kubeadm/kubeadm-upgrade): 쿠버네티스 클러스터를 새로운 버전으로 업그레이드한다.
-* [kubeadm config](/docs/reference/setup-tools/kubeadm/kubeadm-config): kubeadm v1.7.x 이하의 버전을 사용하여 클러스터를 초기화한 경우, `kubeadm upgrade` 를 위해 사용자의 클러스터를 구성한다.
-* [kubeadm token](/docs/reference/setup-tools/kubeadm/kubeadm-token): `kubeadm join` 을 위한 토큰을 관리한다.
-* [kubeadm reset](/docs/reference/setup-tools/kubeadm/kubeadm-reset): `kubeadm init` 또는 `kubeadm join` 에 의한 호스트의 모든 변경 사항을 되돌린다.
-* [kubeadm version](/docs/reference/setup-tools/kubeadm/kubeadm-version): kubeadm 버전을 출력한다.
-* [kubeadm alpha](/docs/reference/setup-tools/kubeadm/kubeadm-alpha): 커뮤니티에서 피드백을 수집하기 위해서 기능 미리 보기를 제공한다.
+* [kubeadm init](/docs/reference/setup-tools/kubeadm/kubeadm-init/): 쿠버네티스 컨트롤 플레인 노드를 부트스트랩한다.
+* [kubeadm join](/docs/reference/setup-tools/kubeadm/kubeadm-join/): 쿠버네티스 워커(worker) 노드를 부트스트랩하고 클러스터에 조인시킨다.
+* [kubeadm upgrade](/docs/reference/setup-tools/kubeadm/kubeadm-upgrade/): 쿠버네티스 클러스터를 새로운 버전으로 업그레이드한다.
+* [kubeadm config](/docs/reference/setup-tools/kubeadm/kubeadm-config/): kubeadm v1.7.x 이하의 버전을 사용하여 클러스터를 초기화한 경우, `kubeadm upgrade` 를 위해 사용자의 클러스터를 구성한다.
+* [kubeadm token](/docs/reference/setup-tools/kubeadm/kubeadm-token/): `kubeadm join` 을 위한 토큰을 관리한다.
+* [kubeadm reset](/docs/reference/setup-tools/kubeadm/kubeadm-reset/): `kubeadm init` 또는 `kubeadm join` 에 의한 호스트의 모든 변경 사항을 되돌린다.
+* [kubeadm version](/docs/reference/setup-tools/kubeadm/kubeadm-version/): kubeadm 버전을 출력한다.
+* [kubeadm alpha](/docs/reference/setup-tools/kubeadm/kubeadm-alpha/): 커뮤니티에서 피드백을 수집하기 위해서 기능 미리 보기를 제공한다.

--- a/content/ko/docs/reference/setup-tools/kubeadm/generated/_index.md
+++ b/content/ko/docs/reference/setup-tools/kubeadm/generated/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Kubeadm Generated"
+weight: 10
+toc_hide: true
+---
+

--- a/content/ko/docs/reference/tools.md
+++ b/content/ko/docs/reference/tools.md
@@ -16,7 +16,7 @@ content_type: concept
 
 ## Kubeadm
 
-[`kubeadm`](/docs/setup/production-environment/tools/kubeadm/install-kubeadm/)은 물리적 환경, 클라우드 서버, 또는 가상머신 상에서 안전한 쿠버네티스를 쉽게 프로비저닝하기 위한 커맨드라인 툴이다(현재는 알파 상태).
+[`kubeadm`](/ko/docs/setup/production-environment/tools/kubeadm/install-kubeadm/)은 물리적 환경, 클라우드 서버, 또는 가상머신 상에서 안전한 쿠버네티스를 쉽게 프로비저닝하기 위한 커맨드라인 툴이다(현재는 알파 상태).
 
 ## Minikube
 

--- a/content/ko/docs/setup/production-environment/container-runtimes.md
+++ b/content/ko/docs/setup/production-environment/container-runtimes.md
@@ -265,7 +265,7 @@ Start-Service containerd
 ```
 
 kubeadm을 사용하는 경우,
-[kubelet용 cgroup 드라이버](/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#configure-cgroup-driver-used-by-kubelet-on-control-plane-node)를 수동으로 구성한다.
+[kubelet용 cgroup 드라이버](/ko/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#컨트롤-플레인-노드에서-kubelet이-사용하는-cgroup-드라이버-구성)를 수동으로 구성한다.
 
 ### CRI-O
 

--- a/content/ko/docs/tasks/tools/_index.md
+++ b/content/ko/docs/tasks/tools/_index.md
@@ -53,7 +53,7 @@ kind를 시작하고 실행하기 위해 수행해야 하는 작업을 보여준
 {{< glossary_tooltip term_id="kubeadm" text="kubeadm" >}} 도구를 사용하여 쿠버네티스 클러스터를 만들고 관리할 수 있다.
 사용자 친화적인 방식으로 최소한의 실행 가능하고 안전한 클러스터를 설정하고 실행하는 데 필요한 작업을 수행한다.
 
-[kubeadm 설치](/docs/setup/production-environment/tools/kubeadm/install-kubeadm/) 페이지는 kubeadm 설치하는 방법을 보여준다.
+[kubeadm 설치](/ko/docs/setup/production-environment/tools/kubeadm/install-kubeadm/) 페이지는 kubeadm 설치하는 방법을 보여준다.
 설치가 끝나면, [클러스터 생성](/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/)이 가능하다.
 
-<a class="btn btn-primary" href="/docs/setup/production-environment/tools/kubeadm/install-kubeadm/" role="button" aria-label="kubeadm 설치 가이드 보기">kubeadm 설치 가이드 보기</a>
+<a class="btn btn-primary" href="/ko/docs/setup/production-environment/tools/kubeadm/install-kubeadm/" role="button" aria-label="kubeadm 설치 가이드 보기">kubeadm 설치 가이드 보기</a>


### PR DESCRIPTION
- Resolves #27121
- Replaces the PR #27122

> **Problem:**
> In https://kubernetes.io/ko/docs/reference/setup-tools/kubeadm/#%EC%84%A4%EC%B9%98-%EB%B0%A9%EB%B2%95 ,
> the link href is https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm (English).
> 
> The [Korean version](https://kubernetes.io/ko/docs/setup/production-environment/tools/kubeadm/install-kubeadm/) of https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm is
> recently added in #26837.
> 
> **Proposed Solution:**
> In https://github.com/kubernetes/website/edit/master/content/ko/docs/reference/setup-tools/kubeadm/_index.md ,
> 
> Before: `kubeadm을 설치하려면, [설치 가이드](/docs/setup/production-environment/tools/kubeadm/install-kubeadm)를 참고한다.`
> After: `kubeadm을 설치하려면, [설치 가이드](/ko/docs/setup/production-environment/tools/kubeadm/install-kubeadm/)를 참고한다.`
> 
> **Page to Update:**
> https://kubernetes.io/ko/docs/reference/setup-tools/kubeadm/

/language ko