### PR TITLE
Improvement: Managing Secret using kubectl

### DIFF
--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
@@ -125,10 +125,10 @@ kubectl get secret db-user-pass -o jsonpath='{.data}'
 The output is similar to:
 
 ```json
-{"password.txt":"MWYyZDFlMmU2N2Rm","username.txt":"YWRtaW4="}
+{"password":"MWYyZDFlMmU2N2Rm","username":"YWRtaW4="}
 ```
 
-Now you can decode the `password.txt` data:
+Now you can decode the `password` data:
 
 ```shell
 echo 'MWYyZDFlMmU2N2Rm' | base64 --decode


### PR DESCRIPTION

To manage the uniformity  of the docs changing the `password.txt` and `username.txt` to `password` and `username` respectively in [Decoding the Secret](https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/#decoding-secret) of the task [Managing Secret using kubectl](https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-config-file/).