### PR TITLE
delete a illegal code in fr/docs.

### DIFF
--- a/content/fr/docs/concepts/cluster-administration/logging.md
+++ b/content/fr/docs/concepts/cluster-administration/logging.md
@@ -82,7 +82,7 @@ conteneur a crashé.
 
 Si le Pod a plusieurs conteneurs, il faut spécifier le nom du conteneur dont on
 veut récupérer le journal d'évènement. Dans notre exemple le conteneur s'appelle
-`count` donc vous pouvez utiliser `kubectl logs counter count`. Plus de détails
+`count` donc vous pouvez utiliser `kubectl logs counter count`. Plus de détails
 dans la [documentation de `kubectl
 logs`] (/docs/reference/generated/kubectl/kubectl-commands#logs)
 


### PR DESCRIPTION
I found the illegal code in fr/docs. The character code is 0x1c.
When I saw it Chrome browser or Microsoft Edge browser, the character was displayed as rectangle.
I checked all files in fr/docs and I couldn't find the other.

Update files:
fr/docs/concepts/cluster-administration/logging.md