### PR TITLE
Fix errors by linkchecker.py in tasks folder

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
@@ -170,7 +170,7 @@ controllerManager:
 
 ### Create certificate signing requests (CSR)
 
-See [Create CertificateSigningRequest](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/#create-certificatesigningrequest) for creating CSRs with the Kubernetes API.
+See [Create CertificateSigningRequest](/docs/reference/access-authn-authz/certificate-signing-requests/#create-certificatesigningrequest) for creating CSRs with the Kubernetes API.
 
 ## Renew certificates with external CA
 

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -37,7 +37,7 @@ The upgrade workflow at high level is the following:
 
 ### Additional information
 
-- [Draining nodes](https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/) before kubelet MINOR version
+- [Draining nodes](/docs/tasks/administer-cluster/safely-drain-node/) before kubelet MINOR version
   upgrades is required. In the case of control plane nodes, they could be running CoreDNS Pods or other critical workloads.
 - All containers are restarted after upgrade, because the container spec hash value is changed.
 

--- a/content/en/docs/tasks/tools/_index.md
+++ b/content/en/docs/tasks/tools/_index.md
@@ -17,9 +17,9 @@ and view logs. For more information including a complete list of kubectl operati
 kubectl is installable on a variety of Linux platforms, macOS and Windows. 
 Find your preferred operating system below.
 
-- [Install kubectl on Linux](install-kubectl-linux)
-- [Install kubectl on macOS](install-kubectl-macos)
-- [Install kubectl on Windows](install-kubectl-windows)
+- [Install kubectl on Linux](/docs/tasks/tools/install-kubectl-linux)
+- [Install kubectl on macOS](/docs/tasks/tools/install-kubectl-macos)
+- [Install kubectl on Windows](/docs/tasks/tools/install-kubectl-windows)
 
 ## kind
 


### PR DESCRIPTION
This PR fixes "`Should use relative paths` errors" which are shown by `scripts/linkchecker.py` on `en/docs/tasks/*`.

