### PR TITLE
Update contribute/generate-ref-docs/quickstart.md

### DIFF
--- a/content/en/docs/contribute/generate-ref-docs/quickstart.md
+++ b/content/en/docs/contribute/generate-ref-docs/quickstart.md
@@ -156,13 +156,15 @@ You can run the `update-imported-docs` tool as follows:
 
 ```shell
 cd <web-base>/update-imported-docs
-./update-imported-docs <configuration-file.yml> <release-version>
+export GO111MODULE=auto
+./update-imported-docs.py <configuration-file.yml> <release-version>
 ```
 
 For example:
 
 ```shell
-./update-imported-docs reference.yml 1.17
+export GO111MODULE=auto
+./update-imported-docs.py reference.yml 1.17
 ```
 
 <!-- Revisit: is the release configuration used -->


### PR DESCRIPTION
- Update `content/en/docs/contribute/generate-ref-docs/quickstart.md`
  - Add a line `export GO111MODULE=auto` 
  (since if `GO111MODULE=on`, the `./update-imported-docs.py` will fail.)
  - Related issue: https://github.com/kubernetes-sigs/reference-docs/issues/217
- ~Update imported docs~
~(How-to: https://kubernetes.io/docs/contribute/generate-ref-docs/quickstart/)~
  - ~FYI: Imported docs are quite outdated.~
  ~For example: [`website/content/en/docs/reference/setup-tools/kubeadm/generated/`](https://github.com/kubernetes/website/tree/master/content/en/docs/reference/setup-tools/kubeadm/generated) last updated on **4 Dec 2020**~
  ![image](https://user-images.githubusercontent.com/46767780/112288288-8822cb80-8cd0-11eb-8ff8-d1ea500a5834.png)
- ~Somehow related with the PR #26979~