### PR TITLE
Update DenyExecOnPrivileged and DenyEscalatingExec deprecation notice

### DIFF
--- a/content/en/docs/reference/access-authn-authz/admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/admission-controllers.md
@@ -176,7 +176,7 @@ The default value for `default-not-ready-toleration-seconds` and `default-unreac
 This admission controller will intercept all requests to exec a command in a pod if that pod has a privileged container.
 
 This functionality has been merged into [DenyEscalatingExec](#denyescalatingexec).
-The DenyExecOnPrivileged admission plugin is deprecated and will be removed in v1.18.
+The DenyExecOnPrivileged admission plugin is deprecated.
 
 Use of a policy-based admission plugin (like [PodSecurityPolicy](#podsecuritypolicy) or a custom admission plugin)
 which can be targeted at specific users or Namespaces and also protects against creation of overly privileged Pods
@@ -190,7 +190,7 @@ This admission controller will deny exec and attach commands to pods that run wi
 allow host access.  This includes pods that run as privileged, have access to the host IPC namespace, and
 have access to the host PID namespace.
 
-The DenyEscalatingExec admission plugin is deprecated and will be removed in v1.18.
+The DenyEscalatingExec admission plugin is deprecated.
 
 Use of a policy-based admission plugin (like [PodSecurityPolicy](#podsecuritypolicy) or a custom admission plugin)
 which can be targeted at specific users or Namespaces and also protects against creation of overly privileged Pods


### PR DESCRIPTION
Update DenyExecOnPrivileged and DenyEscalatingExec deprecation notice on the `master` (live) branch. Both previously stated that they were removed in 1.18 but they will be removed in 1.21
/assign @sftim 