### PR TITLE
renamed incorrect word in Portuguese

### DIFF
--- a/content/pt/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
+++ b/content/pt/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
@@ -31,7 +31,7 @@ weight: 10
                 Assim que o seu cluster Kubernetes estiver em execução você pode implementar seu aplicativo em contêiners nele.
                 Para fazer isso, você precisa criar uma configuração do tipo <b> Deployment </b> do Kubernetes. O Deployment define como criar e 
                 atualizar instâncias do seu aplicativo. Depois de criar um Deployment, o Master do Kubernetes
-                agenda as instâncias do aplicativo incluídas nesse Deployment para ser executado em nós individuais do CLuster.
+                agenda as instâncias do aplicativo incluídas nesse Deployment para ser executado em nós individuais do Cluster.
                 </p>
 
                 <p> Depois que as instâncias do aplicativo são criadas, um Controlador do Kubernetes Deployment monitora continuamente essas instâncias. 


### PR DESCRIPTION
The word CLuster is incorrect in Portuguese, so I renamed it then!