### PR TITLE
Fix typo in worker.py example script

### DIFF
--- a/content/en/examples/application/job/redis/worker.py
+++ b/content/en/examples/application/job/redis/worker.py
@@ -8,7 +8,7 @@ host="redis"
 # import os
 # host = os.getenv("REDIS_SERVICE_HOST")
 
-q = rediswq.RedisWQ(name="job2", host="redis")
+q = rediswq.RedisWQ(name="job2", host=host)
 print("Worker with sessionID: " +  q.sessionID())
 print("Initial queue state: empty=" + str(q.empty()))
 while not q.empty():


### PR DESCRIPTION
I think, calling ```rediswq.RedisWQ()``` with a literal string as the ```host``` argument is a typo, because it would make the assignment nonsense at the beginning of the script. Furthermore, setting the host via environment variable in the comments works only correctly with this change. 
