### PR TITLE
Add overview page for docker-compose to k8s migration

### DIFF
--- a/content/en/docs/tutorials/_index.md
+++ b/content/en/docs/tutorials/_index.md
@@ -62,6 +62,10 @@ Before walking through each tutorial, you may want to bookmark the
 * [Apply Pod Security Standards at Cluster level](/docs/tutorials/security/cluster-level-pss/)
 * [Apply Pod Security Standards at Namespace level](/docs/tutorials/security/ns-level-pss/)
 
+## Migrating to Kubernetes from compose
+
+* [Overview](/docs/tutorials/compose-migration/)
+
 ## {{% heading "whatsnext" %}}
 
 If you would like to write a tutorial, see

--- a/content/en/docs/tutorials/compose-migration/_index.md
+++ b/content/en/docs/tutorials/compose-migration/_index.md
@@ -1,0 +1,49 @@
+---
+title: Migrating from compose workflows to Kubernetes
+weight: 60
+---
+
+## Disclaimer
+
+The [compose specification](https://github.com/compose-spec/compose-spec) is evolving, this documentation aims to cover the latest version of this compose specification.
+We will assume that we are talking about the latest compose specifications which the v3 at this time of writing.
+If your compose files at not at the latest version specification, we suggest you try to upgrade to the latest spec version first. 
+
+## Differences between compose specification and Kubernetes specification
+
+A set of workflows defined using the compose specification cannot be automated translated to a unique set of Kubernetes objects.
+While some notions are very similar, there is not a single way to translate concepts from compose to Kubernetes.
+There is no direct equivalence for many concepts of compose in Kubernetes.
+
+Also, you have features that are available in the compose specifications that do not have a clear equivalent in Kubernetes.
+
+Therefore, these content are only there to be suggestions and not a definitive and absolute guide.
+
+There is an [ongoing work](https://github.com/compose-spec/compose-spec/blob/wip_kube_mapping/KUBERNETES_MAPPING.md) on the compose specification side to give some information about compose to Kubernetes mapping.
+
+## Stateful and stateless workloads
+
+One of the first step to migrate from compose to Kubernetes is to analyze among the different components of the compose files the sub-systems that are stateless, and the one that are stateful.
+
+### Stateless applications
+
+Stateless applications is one which depends on no persistent storage.
+The only thing your cluster is responsible for is the code, and other static content, being hosted on it.
+That's it, no changing databases, no writes and no left over files when the pod is deleted.
+
+Stateless components are often migrated as [Deployment](/docs/concepts/workloads/controllers/deployment/) objects in Kubernetes.
+
+### Stateful applications
+
+Stateful applications save data to persistent disk storage for use by the server, by clients, and by other applications.
+An example of a stateful application is a database or key-value store to which data is saved and retrieved by other applications.
+In the case of compose, this data could be persisted either on disk or on a different host.
+
+Stateful applications can use [StatefulSet](/docs/concepts/workloads/controllers/statefulset/) objects to migrate.
+
+## Tools
+
+Some tools provide support to create automated translation from compose to Kubernetes.
+Be aware that automated translations don't always work as there is no exact mapping:
+
+- [Kompose](https://kompose.io/) (To get started, checkout [this tutorial](/docs/tasks/configure-pod-container/translate-compose-kubernetes/))

--- a/content/en/docs/tutorials/compose-migration/_index.md
+++ b/content/en/docs/tutorials/compose-migration/_index.md
@@ -5,13 +5,13 @@ weight: 60
 
 ## Disclaimer
 
-The [compose specification](https://github.com/compose-spec/compose-spec) is evolving, this documentation aims to cover the latest version of this compose specification.
+The [compose specification](https://github.com/compose-spec/compose-spec) is evolving. This documentation aims to cover the latest version of this compose specification.
 We will assume that we are talking about the latest compose specifications which the v3 at this time of writing.
-If your compose files at not at the latest version specification, we suggest you try to upgrade to the latest spec version first. 
+If your compose files are not at the latest version specification, we suggest you try to upgrade to the latest spec version first. 
 
 ## Differences between compose specification and Kubernetes specification
 
-A set of workflows defined using the compose specification cannot be automated translated to a unique set of Kubernetes objects.
+A set of workflows defined using the compose specification cannot be automatically translated to a unique set of Kubernetes objects.
 While some notions are very similar, there is not a single way to translate concepts from compose to Kubernetes.
 There is no direct equivalence for many concepts of compose in Kubernetes.
 
@@ -27,7 +27,7 @@ One of the first step to migrate from compose to Kubernetes is to analyze among 
 
 ### Stateless applications
 
-Stateless applications is one which depends on no persistent storage.
+A stateless application is one which depends on no persistent storage.
 The only thing your cluster is responsible for is the code, and other static content, being hosted on it.
 That's it, no changing databases, no writes and no left over files when the pod is deleted.
 


### PR DESCRIPTION
This PR adds an overview page for a set of tutorials about how to migrate a compose-based workflow to Kubernetes. 
Relevant issue: https://github.com/kubernetes/website/issues/27271 