### PR TITLE
Remove stale announcement

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -156,7 +156,7 @@ github_repo = "https://github.com/kubernetes/website"
 
 # param for displaying an announcement block on every page.
 # See /i18n/en.toml for message text and title.
-announcement = true
+announcement = false
 announcement_bg = "#000000" #choose a dark color – text is white
 
 #Searching


### PR DESCRIPTION
This announcement was live when the v1.19 release branch was made, but is no longer active. Remove it. _[[preview](https://deploy-preview-27274--k8s-v1-19.netlify.app/) vs [existing](https://v1-19.docs.kubernetes.io/)]_

(Since this release, we [updated](https://github.com/kubernetes/website/pull/25771) the mechanism for publishing announcements, but have not backported those changes).