### PR TITLE
Add configuration java microservice link to tutorials index

### DIFF
--- a/content/en/docs/tutorials/_index.md
+++ b/content/en/docs/tutorials/_index.md
@@ -27,6 +27,8 @@ Before walking through each tutorial, you may want to bookmark the
 
 ## Configuration
 
+* [Example: Configuring a Java Microservice](/docs/tutorials/configuration/configure-java-microservice/)
+
 * [Configuring Redis Using a ConfigMap](/docs/tutorials/configuration/configure-redis-using-configmap/)
 
 ## Stateless Applications


### PR DESCRIPTION
There is page for example configuration for java microservice at [here](https://kubernetes.io/docs/tutorials/configuration/configure-java-microservice/), but that is not listed on [Tutorial index page](https://kubernetes.io/docs/tutorials/).
This PR adds link of `Example: Configuring a Java Microservice` to Tutorials index.
