### PR TITLE
Update minor typo on healthz endpoint

### DIFF
--- a/content/en/docs/reference/using-api/health-checks.md
+++ b/content/en/docs/reference/using-api/health-checks.md
@@ -18,7 +18,7 @@ The Kubernetes API server provides 3 API endpoints (`healthz`, `livez` and `read
 The `healthz` endpoint is deprecated (since Kubernetes v1.16), and you should use the more specific `livez` and `readyz` endpoints instead.
 The `livez` endpoint can be used with the `--livez-grace-period` [flag](/docs/reference/command-line-tools-reference/kube-apiserver) to specify the startup duration.
 For a graceful shutdown you can specify the `--shutdown-delay-duration` [flag](/docs/reference/command-line-tools-reference/kube-apiserver) with the `/readyz` endpoint.
-Machines that check the `health`/`livez`/`readyz` of the API server should rely on the HTTP status code.
+Machines that check the `healthz`/`livez`/`readyz` of the API server should rely on the HTTP status code.
 A status code `200` indicates the API server is `healthy`/`live`/`ready`, depending of the called endpoint.
 The more verbose options shown below are intended to be used by human operators to debug their cluster or specially the state of the API server.
 


### PR DESCRIPTION
One character change to update the reference to the `healthz` endpoint.
