### PR TITLE
kubeadm: update create-cluster-kubeadm page as kubeadm will not do e2e tests against Calico CNI anymore

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
@@ -229,7 +229,7 @@ Cluster DNS (CoreDNS) will not start up before a network is installed.**
 {{< /caution >}}
 
 {{< note >}}
-Currently Calico is the only CNI plugin that the kubeadm project performs e2e tests against.
+Kubeadm should be CNI agnostic and the validation of CNI providers is out of the scope of our current e2e testing.
 If you find an issue related to a CNI plugin you should log a ticket in its respective issue
 tracker instead of the kubeadm or kubernetes issue trackers.
 {{< /note >}}


### PR DESCRIPTION
Update create-cluster-kubeadm page as kubeadm will not do e2e tests against Calico CNI anymore.

Ref: kubernetes/kubeadm#2420

/cc @neolit123 @aojea @fabriziopandini 