### PR TITLE
pl: Replace redirect links of kubeadm

### DIFF
--- a/content/pl/docs/reference/_index.md
+++ b/content/pl/docs/reference/_index.md
@@ -33,7 +33,7 @@ biblioteki to:
 
 * [kubectl](/docs/reference/kubectl/overview/) - Główne narzędzie tekstowe (linii poleceń) do zarządzania klastrem Kubernetes.
   * [JSONPath](/docs/reference/kubectl/jsonpath/) - Podręcznik składni [wyrażeń JSONPath](https://goessner.net/articles/JsonPath/) dla kubectl.
-* [kubeadm](/docs/reference/setup-tools/kubeadm/kubeadm/) - Narzędzie tekstowe do łatwego budowania klastra Kubernetes spełniającego niezbędne wymogi bezpieczeństwa.
+* [kubeadm](/docs/reference/setup-tools/kubeadm/) - Narzędzie tekstowe do łatwego budowania klastra Kubernetes spełniającego niezbędne wymogi bezpieczeństwa.
 
 ## Dokumentacja komponentów
 


### PR DESCRIPTION
/docs/reference/setup-tools/kubeadm/kubeadm/ is redirected to /docs/reference/setup-tools/kubeadm/
This replaces the redirect links of kubeadm with the direct links.

NOTE: The pull request for `en` language has been already merged as https://github.com/kubernetes/website/pull/26919

