### PR TITLE
fr: Replace redirect links of kubeadm

### DIFF
--- a/content/fr/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
+++ b/content/fr/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
@@ -140,7 +140,7 @@ kubeadm init <args>
 ### Plus d'information
 
 Pour plus d'informations sur les arguments de `kubeadm init`, voir le
-[guide de référence kubeadm](/docs/reference/setup-tools/kubeadm/kubeadm/).
+[guide de référence kubeadm](/docs/reference/setup-tools/kubeadm/).
 
 Pour une liste complète des options de configuration, voir la
 [documentation du fichier de configuration](/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file).


### PR DESCRIPTION
/docs/reference/setup-tools/kubeadm/kubeadm/ is redirected to /docs/reference/setup-tools/kubeadm/
This replaces the redirect links of kubeadm with the direct links.

NOTE: The pull request for `en` language has been already merged as https://github.com/kubernetes/website/pull/26919