### PR TITLE
Tidy sysctl task page for GA

### DIFF
--- a/content/en/docs/tasks/administer-cluster/sysctl-cluster.md
+++ b/content/en/docs/tasks/administer-cluster/sysctl-cluster.md
@@ -7,17 +7,19 @@ content_type: task
 
 <!-- overview -->
 
+{{< feature-state for_k8s_version="v1.21" state="stable" >}}
+
 This document describes how to configure and use kernel parameters within a
 Kubernetes cluster using the {{< glossary_tooltip term_id="sysctl" >}}
 interface.
 
-
-
 ## {{% heading "prerequisites" %}}
 
 
-{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+{{< include "task-tutorial-prereqs.md" >}}
 
+For some steps, you also need to be able to reconfigure the command line
+options for the kubelets running on your cluster.
 
 
 <!-- steps -->

--- a/content/en/docs/tasks/administer-cluster/sysctl-cluster.md
+++ b/content/en/docs/tasks/administer-cluster/sysctl-cluster.md
@@ -167,6 +167,8 @@ to schedule those pods onto the right nodes.
 
 ## PodSecurityPolicy
 
+{{< feature-state for_k8s_version="v1.21" state="deprecated" >}}
+
 You can further control which sysctls can be set in pods by specifying lists of
 sysctls or sysctl patterns in the `forbiddenSysctls` and/or
 `allowedUnsafeSysctls` fields of the PodSecurityPolicy. A sysctl pattern ends


### PR DESCRIPTION
A fixup for #26981

- mark when the feature went stable, it's only just turned GA
- omit the version check (as all supported versions have had it on by default)
- highlight that PodSecurityPolicy is deprecated

/sig node
Cc: @reylejano 