### PR TITLE
Samples for direct debugging from a pod

### DIFF
--- a/content/en/docs/tasks/debug-application-cluster/debug-service.md
+++ b/content/en/docs/tasks/debug-application-cluster/debug-service.md
@@ -23,10 +23,23 @@ sees.  The simplest way to do this is to run an interactive busybox Pod:
 ```none
 kubectl run -it --rm --restart=Never busybox --image=gcr.io/google-containers/busybox sh
 ```
-
 {{< note >}}
 If you don't see a command prompt, try pressing enter.
 {{< /note >}}
+
+Alternatively you can run the command directly from the pod. For example, let us say we wish to run nslookup for an existing service `servicesample` and store the output in nslookupout.txt. Then the command will be 
+
+```none
+kubectl run test-nslookup --image=busybox:1.28 --rm -it --restart=Never  -- nslookup servicesample > nslookupout.txt
+```
+
+Suppose you want to perform nslookup against an existing pod itself (say the pod ip is 10.244.1.13 in the default namespace), then the command would be 
+
+```none
+kubectl run test-nslookup --image=busybox:1.28 --rm -it --restart=Never  -- nslookup 10-244-1-13.default.pod > nslookupout.txt
+```
+
+Note that in this case, we have provided the automatically assigned service name of the pod with ip address specified with a '-' instead of '.'. 
 
 If you already have a running Pod that you prefer to use, you can run a
 command in it using:

--- a/content/en/docs/tasks/debug-application-cluster/debug-service.md
+++ b/content/en/docs/tasks/debug-application-cluster/debug-service.md
@@ -33,7 +33,7 @@ Alternatively you can run the command directly from the pod. For example, let us
 kubectl run test-nslookup --image=busybox:1.28 --rm -it --restart=Never  -- nslookup servicesample > nslookupout.txt
 ```
 
-Suppose you want to perform nslookup against an existing pod itself (say the pod ip is 10.244.1.13 in the default namespace), then the command would be 
+Suppose you want to perform nslookup against an existing pod itself. If the example pod's IPv4 address is 10.244.1.13, and the pod is in the `default` namespace, then you run:
 
 ```none
 kubectl run test-nslookup --image=busybox:1.28 --rm -it --restart=Never  -- nslookup 10-244-1-13.default.pod > nslookupout.txt
@@ -741,5 +741,4 @@ Contact us on
 
 Visit [troubleshooting document](/docs/tasks/debug-application-cluster/troubleshooting/)
 for more information.
-
 

--- a/content/en/docs/tasks/debug-application-cluster/debug-service.md
+++ b/content/en/docs/tasks/debug-application-cluster/debug-service.md
@@ -27,7 +27,7 @@ kubectl run -it --rm --restart=Never busybox --image=gcr.io/google-containers/bu
 If you don't see a command prompt, try pressing enter.
 {{< /note >}}
 
-Alternatively you can run the command directly from the pod. For example, let us say we wish to run nslookup for an existing service `servicesample` and store the output in nslookupout.txt. Then the command will be 
+Alternatively you can run the command directly from the pod. For example, let us say you wish to run `nslookup `for an existing Service named `servicesample`, and will store the output in `nslookupout.txt`. A command that achieves this is:
 
 ```none
 kubectl run test-nslookup --image=busybox:1.28 --rm -it --restart=Never  -- nslookup servicesample > nslookupout.txt
@@ -741,4 +741,3 @@ Contact us on
 
 Visit [troubleshooting document](/docs/tasks/debug-application-cluster/troubleshooting/)
 for more information.
-


### PR DESCRIPTION
Added two examples of how can we run command it the pod directly against a running service/pod and redirect the output for further debugging.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
