### PR TITLE
Don't mention kubeadm dual-stack as a site front page feature

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/dual-stack-support.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/dual-stack-support.md
@@ -1,7 +1,5 @@
 ---
 title: Dual-stack support with kubeadm
-feature:
-  title: Dual-stack support with kubeadm
 content_type: task
 weight: 110
 min-kubernetes-server-version: 1.21


### PR DESCRIPTION
kubeadm dual-stack is a nice feature, but we don't need to mention it on https://kubernetes.io/

[Preview](https://deploy-preview-27391--kubernetes-io-vnext-staging.netlify.app/) of the revised front page (compare to [_dev-1.21_ branch](https://deploy-preview-26153--kubernetes-io-vnext-staging.netlify.app/) front page).

Omit that mention.

/sig cluster-lifecycle
/milestone 1.21
/language en