### PR TITLE
Mention API extensibility as a front-page feature

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/_index.md
+++ b/content/en/docs/concepts/extend-kubernetes/_index.md
@@ -7,6 +7,10 @@ reviewers:
 - lavalamp
 - cheftako
 - chenopis
+feature:
+  title: Designed for extensibility
+  description: >
+    Add features to your Kubernetes cluster without changing upstream source code.
 content_type: concept
 no_list: true
 ---


### PR DESCRIPTION
Kubernetes has really good options for extending and customizing its behavior. Mention these right on the front page.

/sig api-machinery
/language en

This will change the rendered content of https://kubernetes.io/ [[preview](https://deploy-preview-27392--kubernetes-io-master-staging.netlify.app/)]
/hold
for extra review.