### PR TITLE
Omit “Edit this page” links for generated content

### DIFF
--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -1,0 +1,41 @@
+{{/* template adapted from Docsy theme */}}
+{{ if .Path }}
+  {{ $pathFormatted := replace .Path "\\" "/" }}
+  {{ $gh_repo := ($.Param "github_repo") }}
+  {{ $gh_subdir := ($.Param "github_subdir") }}
+  {{ $gh_project_repo := ($.Param "github_project_repo") }}
+  {{ $gh_branch := (default "master" ($.Param "github_branch")) }}
+  <div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
+  {{ if $gh_repo }}
+    {{ $gh_repo_path := printf "%s/content/%s" $gh_branch $pathFormatted }}
+    {{ if and ($gh_subdir) (.Site.Language.Lang) }}
+      {{ $gh_repo_path = printf "%s/%s/content/%s/%s" $gh_branch $gh_subdir ($.Site.Language.Lang) $pathFormatted }}
+    {{ else if .Site.Language.Lang }}
+      {{ $gh_repo_path = printf "%s/content/%s/%s" $gh_branch ($.Site.Language.Lang) $pathFormatted }}
+    {{ else if $gh_subdir }}
+      {{ $gh_repo_path = printf "%s/%s/content/%s" $gh_branch $gh_subdir $pathFormatted }}
+    {{ end }}
+    {{ $editURL := printf "%s/edit/%s" $gh_repo $gh_repo_path }}
+    {{ $createURL := printf "%s/edit/%s" $gh_repo $gh_repo_path }}
+    {{ $issuesURL := printf "%s/issues/new?title=%s" $gh_repo (htmlEscape $.Title )}}
+    {{ $newPageStub := resources.Get "stubs/new-page-template.md" }}
+    {{ $newPageQS := querify "value" $newPageStub.Content "filename" "change-me.md" | safeURL }}
+    {{ $newPageURL := printf "%s/new/%s?%s"  $gh_repo $gh_repo_path $newPageQS }}
+
+    {{ if not (.Param "auto_generated") }}
+    <a href="{{ $editURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
+    <a href="{{ $newPageURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_create_child_page" }}</a>
+    {{ end }}
+
+    <a href="{{ $issuesURL }}" target="_blank"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
+    {{ if $gh_project_repo }}
+      {{ $project_issueURL := printf "%s/issues/new" $gh_project_repo }}
+      <a href="{{ $project_issueURL }}" target="_blank"><i class="fas fa-tasks fa-fw"></i> {{ T "post_create_project_issue" }}</a>
+    {{ end }}
+
+  {{ end }}
+  {{ with .CurrentSection.AlternativeOutputFormats.Get "print" }}
+    <a id="print" href="{{ .Permalink | safeURL }}"><i class="fa fa-print fa-fw"></i> {{ T "print_entire_section" }}</a>
+  {{ end }}
+  </div>
+{{ end }}


### PR DESCRIPTION
Copy the page meta links template from Docsy and adapt it to only suggest editing pages when they aren't autogenerated.

Previews:
- [normal page #1](https://deploy-preview-27393--kubernetes-io-master-staging.netlify.app/docs/home/)
- [normal page #2](https://deploy-preview-27393--kubernetes-io-master-staging.netlify.app/docs/tutorials/clusters/apparmor/)
- [generated page](https://deploy-preview-27393--kubernetes-io-master-staging.netlify.app/docs/reference/config-api/kubelet-config.v1beta1/)