### PR TITLE
Fix label selector in Using Source IP tutorial

### DIFF
--- a/content/en/docs/tutorials/services/source-ip.md
+++ b/content/en/docs/tutorials/services/source-ip.md
@@ -425,7 +425,7 @@ the `service.spec.healthCheckNodePort` field on the Service.
 Delete the Services:
 
 ```shell
-kubectl delete svc -l run=source-ip-app
+kubectl delete svc -l app=source-ip-app
 ```
 
 Delete the Deployment, ReplicaSet and Pod:

--- a/content/ja/docs/tutorials/services/source-ip.md
+++ b/content/ja/docs/tutorials/services/source-ip.md
@@ -399,7 +399,7 @@ client_address=198.51.100.79
 Serviceを削除します。
 
 ```shell
-kubectl delete svc -l run=source-ip-app
+kubectl delete svc -l app=source-ip-app
 ```
 
 Deployment、ReplicaSet、Podを削除します。

--- a/content/ko/docs/tutorials/services/source-ip.md
+++ b/content/ko/docs/tutorials/services/source-ip.md
@@ -426,7 +426,7 @@ HTTP 헬스 체크를 생성하여
 서비스를 삭제한다.
 
 ```shell
-kubectl delete svc -l run=source-ip-app
+kubectl delete svc -l app=source-ip-app
 ```
 
 디플로이먼트, 레플리카셋 그리고 파드를 삭제한다.

--- a/content/zh/docs/tutorials/services/source-ip.md
+++ b/content/zh/docs/tutorials/services/source-ip.md
@@ -387,7 +387,7 @@ __跨平台支持__
 删除服务：
 
 ```console
-$ kubectl delete svc -l run=source-ip-app
+$ kubectl delete svc -l app=source-ip-app
 ```
 
 


### PR DESCRIPTION
Before:
```sh
controlplane $ kubectl delete svc -l run=source-ip-app
No resources found
```
```sh
k get svc --show-labels 
NAME           TYPE           CLUSTER-IP       EXTERNAL-IP   PORT(S)        AGE     LABELS
clusterip      ClusterIP      10.110.247.112   <none>        80/TCP         28m     app=source-ip-app
kubernetes     ClusterIP      10.96.0.1        <none>        443/TCP        49m     component=apiserver,provider=kubernetes
loadbalancer   LoadBalancer   10.111.123.206   <pending>     80:31111/TCP   9m59s   app=source-ip-app
nodeport       NodePort       10.108.129.31    <none>        80:32503/TCP   22m     app=source-ip-app
```
After:
```sh
controlplane $ kubectl delete svc -l app=source-ip-app
service "clusterip" deleted
service "loadbalancer" deleted
service "nodeport" deleted
```

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
