### PR TITLE
Fix the position of the abbreviation text "CNCF" on the page /ja/docs/home/

### DIFF
--- a/content/ja/docs/home/_index.md
+++ b/content/ja/docs/home/_index.md
@@ -18,7 +18,7 @@ menu:
 description: >
   Kubernetesは、コンテナ化されたアプリケーションの展開、スケーリング、また管理を自動化するためのオープンソースコンテナプラットフォームです。このオープンソースプロジェクトは、Cloud Native Computing Foundationによってホストされています。
 overview: >
-  Kubernetesは、コンテナ化されたアプリケーションの展開、スケーリング、また管理を自動化するためのオープンソースコンテナプラットフォームです。このオープンソースプロジェクトは、Cloud Native Computing Foundationによってホストされています(<a href="https://www.cncf.io/about">CNCF</a>)。
+  Kubernetesは、コンテナ化されたアプリケーションの展開、スケーリング、また管理を自動化するためのオープンソースコンテナプラットフォームです。このオープンソースプロジェクトは、Cloud Native Computing Foundation(<a href="https://www.cncf.io/about">CNCF</a>)によってホストされています。
 cards:
 - name: concepts
   title: "基本を理解する"


### PR DESCRIPTION
現在、https://kubernetes.io/ja/docs/home/ の冒頭の文章は以下のようになっています。

> Cloud Native Computing Foundationによってホストされています(CNCF)。

一方、原文( https://kubernetes.io/docs/home/ )では次のようになっています。

> The open source project is hosted by the Cloud Native Computing Foundation (CNCF).

"(CNCF)" は "Cloud Native Computing Foundation" の直後に来るのが正しいので、次のように修正します。

> Cloud Native Computing Foundation(CNCF)によってホストされています。

