### PR TITLE
Fix image positioning on homepage, tablet

### DIFF
--- a/assets/scss/_tablet.scss
+++ b/assets/scss/_tablet.scss
@@ -77,7 +77,6 @@ $feature-box-div-width: 45%;
       position: relative;
       clear: both;
       display: table;
-      height: 160px;
 
       .content {
         display: table-cell;
@@ -124,6 +123,7 @@ $feature-box-div-width: 45%;
           position: relative;
           display: block;
           float: none;
+          text-align: center;
           max-width: 100%;
           transform: none;
         }


### PR DESCRIPTION
On homepage (https://kubernetes.io) with Chrome web browser.

Before: 
<img width="1230" alt="Screen Shot 2021-04-04 at 6 20 07 PM" src="https://user-images.githubusercontent.com/22407953/113522996-11f55300-9573-11eb-824c-082de5bccbdf.png">


After: 
<img width="1229" alt="Screen Shot 2021-04-04 at 6 20 24 PM" src="https://user-images.githubusercontent.com/22407953/113522991-0ace4500-9573-11eb-8d40-f9d87d8f2157.png">

Let me know if there's another way I should do this
