### PR TITLE
[ko] Fix label selector in "kubectl for Docker Users"

### DIFF
--- a/content/ko/docs/reference/kubectl/docker-cli-to-kubectl.md
+++ b/content/ko/docs/reference/kubectl/docker-cli-to-kubectl.md
@@ -265,7 +265,7 @@ nginx-app    1/1     1            1           2m
 ```
 
 ```shell
-kubectl get po -l run=nginx-app
+kubectl get po -l app=nginx-app
 ```
 ```
 NAME                         READY     STATUS    RESTARTS   AGE
@@ -279,7 +279,7 @@ deployment "nginx-app" deleted
 ```
 
 ```shell
-kubectl get po -l run=nginx-app
+kubectl get po -l app=nginx-app
 # 아무것도 반환하지 않는다
 ```
 


### PR DESCRIPTION
Ref. #27414 
Before:
```sh
kubectl get po -l run=nginx-app
No resources found in default namespace.
```
Because:
```sh
kubectl get po --show-labels
NAME                         READY   STATUS    RESTARTS   AGE   LABELS
nginx-app-58cfd4c468-jx6qp   1/1     Running   0          17m   app=nginx-app,pod-template-hash=58cfd4c468
```
After:
```sh
kubectl get po -l app=nginx-app
NAME                         READY   STATUS    RESTARTS   AGE
nginx-app-58cfd4c468-jx6qp   1/1     Running   0          18m
```
