### PR TITLE
[ru] "kubectl for Docker Users" use "kubectl create deployment" command

### DIFF
--- a/content/ru/docs/reference/kubectl/docker-cli-to-kubectl.md
+++ b/content/ru/docs/reference/kubectl/docker-cli-to-kubectl.md
@@ -34,10 +34,18 @@ kubectl:
 
 ```shell
 # запустить под, в котором работает nginx
-kubectl run --image=nginx nginx-app --port=80 --env="DOMAIN=cluster"
+kubectl create deployment --image=nginx nginx-app
 ```
 ```
 deployment "nginx-app" created
+```
+
+```shell
+# add env to nginx-app
+kubectl set env deployment/nginx-app  DOMAIN=cluster
+```
+```
+deployment.apps/nginx-app env updated
 ```
 
 {{< note >}}
@@ -260,7 +268,7 @@ nginx-app    1/1     1            1           2m
 ```
 
 ```shell
-kubectl get po -l run=nginx-app
+kubectl get po -l app=nginx-app
 ```
 ```
 NAME                         READY     STATUS    RESTARTS   AGE
@@ -274,7 +282,7 @@ deployment "nginx-app" deleted
 ```
 
 ```shell
-kubectl get po -l run=nginx-app
+kubectl get po -l app=nginx-app
 # Return nothing
 ```
 


### PR DESCRIPTION
Before:
Example runs pod without creating deployment
```sh
kubectl run --image=nginx nginx-app --port=80
```
But later in document mentions:
```
deployment "nginx-app" created
```
After:
```sh
kubectl create deployment --image=nginx nginx-app
```
Pod is created with deployment. (Aligned with other language examples.)