### PR TITLE
Add default storageclass annotation

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints.md
+++ b/content/en/docs/reference/labels-annotations-taints.md
@@ -188,6 +188,14 @@ When a single IngressClass resource has this annotation set to `"true"`, new Ing
 
 {{< note >}} Starting in v1.18, this annotation is deprecated in favor of `spec.ingressClassName`. {{< /note >}}
 
+## storageclass.kubernetes.io//is-default-class
+
+Example: `storageclass.kubernetes.io//is-default-class: true`
+
+Used on: StorageClass
+
+When a single StorageClass resource has this annotation set to `"true"`, new Physical Volume Claim resource without a class specified will be assigned this default class.
+
 ## alpha.kubernetes.io/provided-node-ip
 
 Example: `alpha.kubernetes.io/provided-node-ip: "10.0.0.1"`

--- a/content/en/docs/reference/labels-annotations-taints.md
+++ b/content/en/docs/reference/labels-annotations-taints.md
@@ -188,9 +188,9 @@ When a single IngressClass resource has this annotation set to `"true"`, new Ing
 
 {{< note >}} Starting in v1.18, this annotation is deprecated in favor of `spec.ingressClassName`. {{< /note >}}
 
-## storageclass.kubernetes.io//is-default-class
+## storageclass.kubernetes.io/is-default-class
 
-Example: `storageclass.kubernetes.io//is-default-class: true`
+Example: `storageclass.kubernetes.io/is-default-class=true`
 
 Used on: StorageClass
 
@@ -261,4 +261,3 @@ Sets this taint on a node to mark it as unusable, when kubelet is started with t
 Example: `node.cloudprovider.kubernetes.io/shutdown:NoSchedule`
 
 If a Node is in a cloud provider specified shutdown state, the Node gets tainted accordingly with `node.cloudprovider.kubernetes.io/shutdown` and the taint effect of `NoSchedule`.
-


### PR DESCRIPTION
Current well known annotations, labels, etc does not contain the storageclass default annotation.
