### PR TITLE
Modified the output when retrieving Secrets.

### DIFF
--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-config-file.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-config-file.md
@@ -131,6 +131,8 @@ The output is similar to:
 
 ```yaml
 apiVersion: v1
+data:
+  config.yaml: YXBpVXJsOiAiaHR0cHM6Ly9teS5hcGkuY29tL2FwaS92MSIKdXNlcm5hbWU6IHt7dXNlcm5hbWV9fQpwYXNzd29yZDoge3twYXNzd29yZH19
 kind: Secret
 metadata:
   creationTimestamp: 2018-11-15T20:40:59Z
@@ -139,8 +141,6 @@ metadata:
   resourceVersion: "7225"
   uid: c280ad2e-e916-11e8-98f2-025000000001
 type: Opaque
-data:
-  config.yaml: YXBpVXJsOiAiaHR0cHM6Ly9teS5hcGkuY29tL2FwaS92MSIKdXNlcm5hbWU6IHt7dXNlcm5hbWV9fQpwYXNzd29yZDoge3twYXNzd29yZH19
 ```
 
 The commands `kubectl get` and `kubectl describe` avoid showing the contents of a `Secret` by
@@ -168,6 +168,8 @@ Results in the following Secret:
 
 ```yaml
 apiVersion: v1
+data:
+  username: YWRtaW5pc3RyYXRvcg==
 kind: Secret
 metadata:
   creationTimestamp: 2018-11-15T20:46:46Z
@@ -176,8 +178,6 @@ metadata:
   resourceVersion: "7579"
   uid: 91460ecb-e917-11e8-98f2-025000000001
 type: Opaque
-data:
-  username: YWRtaW5pc3RyYXRvcg==
 ```
 
 Where `YWRtaW5pc3RyYXRvcg==` decodes to `administrator`.


### PR DESCRIPTION
Modified the output when we retrieving the secrets through `kubectl get secrets <secrets_name>  -o yaml` in [Managing Secret using Configuration File ](https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-config-file/#check-the-secret)
When we run this command the data field should show after apiversion.