### PR TITLE
Update Japanese localization on concepts/overview/working-with-objects/labels.md

### DIFF
--- a/content/ja/docs/concepts/overview/working-with-objects/labels.md
+++ b/content/ja/docs/concepts/overview/working-with-objects/labels.md
@@ -155,6 +155,7 @@ partition
 * 第2の例では、キーが`tier`で、値が`frontend`と`backend`以外のもの、そして`tier`キーを持たないリソースを全て選択します。  
 * 第3の例では、`partition`というキーをもつラベルを全て選択し、値はチェックしません。  
 * 第4の例では、`partition`というキーを持たないラベルを全て選択し、値はチェックしません。  
+
 同様に、コンマセパレーターは、_AND_ オペレーターと同様にふるまいます。そのため、`partition`と`environment`キーの値がともに`qa`でないラベルを選択するには、`partition,environment notin (qa)`と記述することで可能です。  
 *集合ベース* のラベルセレクターは、`environment=production`という記述が`environment in (production)`と等しいため、一般的な等価形式となります。 `!=`と`notin`も同様に等価となります。  
 

--- a/content/ja/docs/concepts/overview/working-with-objects/labels.md
+++ b/content/ja/docs/concepts/overview/working-with-objects/labels.md
@@ -151,10 +151,10 @@ partition
 !partition
 ```
 
-最初の例では、キーが`environment`で、値が`production`か`qa`に等しいリソースを全て選択します。  
-第2の例では、キーが`tier`で、値が`frontend`と`backend`以外のもの、そして`tier`キーを持たないリソースを全て選択します。  
-第3の例では、`partition`というキーをもつラベルを全て選択し、値はチェックしません。  
-第4の例では、`partition`というキーを持たないラベルを全て選択し、値はチェックしません。  
+* 最初の例では、キーが`environment`で、値が`production`か`qa`に等しいリソースを全て選択します。  
+* 第2の例では、キーが`tier`で、値が`frontend`と`backend`以外のもの、そして`tier`キーを持たないリソースを全て選択します。  
+* 第3の例では、`partition`というキーをもつラベルを全て選択し、値はチェックしません。  
+* 第4の例では、`partition`というキーを持たないラベルを全て選択し、値はチェックしません。  
 同様に、コンマセパレーターは、_AND_ オペレーターと同様にふるまいます。そのため、`partition`と`environment`キーの値がともに`qa`でないラベルを選択するには、`partition,environment notin (qa)`と記述することで可能です。  
 *集合ベース* のラベルセレクターは、`environment=production`という記述が`environment in (production)`と等しいため、一般的な等価形式となります。 `!=`と`notin`も同様に等価となります。  
 
@@ -198,7 +198,7 @@ kubectl get pods -l 'environment,environment notin (frontend)'
 ```
 
 ### APIオブジェクトに参照を設定する
-[`Service`](/ja/docs/concepts/services-networking/service/) と [`ReplicationController`](/docs/concepts/workloads/controllers/replicationcontroller/)のような、いくつかのKubernetesオブジェクトでは、ラベルセレクターを[Pod](/ja/docs/concepts/workloads/pods/pod/)のような他のリソースのセットを指定するのにも使われます。  
+[`Service`](/ja/docs/concepts/services-networking/service/) と [`ReplicationController`](/docs/concepts/workloads/controllers/replicationcontroller/)のような、いくつかのKubernetesオブジェクトでは、ラベルセレクターを[Pod](/ja/docs/concepts/workloads/pods/)のような他のリソースのセットを指定するのにも使われます。  
 
 #### ServiceとReplicationController
 `Service`が対象とするPodの集合は、ラベルセレクターによって定義されます。  


### PR DESCRIPTION
**What this PR does / why we need it:**
content/ja/docs/concepts/overview/working-with-objects/labels.md is outdated.

File to update
https://github.com/kubernetes/website/tree/dev-1.19-ja.1/content/ja/docs/concepts/overview/working-with-objects/labels.md

Original
https://github.com/kubernetes/website/tree/release-1.19/content/en/docs/concepts/overview/working-with-objects/labels.md

diff between translated and v1.19
https://gist.github.com/da8d3b849aebd02969921ef3650ead01

**Which issue(s) this PR fixes:**
#26875 
