### PR TITLE
Update config.toml in dev-1.21 branch

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -185,23 +185,23 @@ docsbranch = "master"
 url = "https://kubernetes.io"
 
 [[params.versions]]
-fullversion = "v1.20.6"
+fullversion = "v1.20.5"
 version = "v1.20"
-githubbranch = "v1.20.6"
+githubbranch = "v1.20.5"
 docsbranch = "release-1.20"
 url = "https://v1-20.kubernetes.io"
 
 [[params.versions]]
-fullversion = "v1.19.10"
+fullversion = "v1.19.9"
 version = "v1.19"
-githubbranch = "v1.19.10"
+githubbranch = "v1.19.9"
 docsbranch = "release-1.19"
 url = "https://v1-19.docs.kubernetes.io"
 
 [[params.versions]]
-fullversion = "v1.18.18"
+fullversion = "v1.18.17"
 version = "v1.18"
-githubbranch = "v1.18.18"
+githubbranch = "v1.18.17"
 docsbranch = "release-1.18"
 url = "https://v1-18.docs.kubernetes.io"
 


### PR DESCRIPTION
Update the config.toml in the dev-1.21 branch. This is a cleanup PR, I previously used the patch versions with future target release dates in https://github.com/kubernetes/sig-release/blob/master/releases/patch-releases.md
/cc @annajung 
/kind cleanup