### PR TITLE
Fix 1.21 doc reference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,4 +91,4 @@ clean-api-reference: ## Clean all directories in API reference directory, preser
 
 api-reference: clean-api-reference ## Build the API reference pages. go needed
 	cd api-ref-generator/gen-resourcesdocs && \
-		go run cmd/main.go kwebsite --config-dir config/v1.20/ --file api/v1.20/swagger.json --output-dir ../../content/en/docs/reference/kubernetes-api --templates templates
+		go run cmd/main.go kwebsite --config-dir config/v1.21/ --file api/v1.21/swagger.json --output-dir ../../content/en/docs/reference/kubernetes-api --templates templates


### PR DESCRIPTION
The PR https://github.com/kubernetes-sigs/reference-docs/pull/207 to prepare the 1.21 API reference doc has been merged, so this PR updates the `api-ref-generator` git submodule with the latest version.

Then, `make api-reference` has been run again, to cleanup some files remaining from the previous API reference release (it seems the merge of https://github.com/kubernetes/website/pull/23294 failed to remove these files).
