### PR TITLE
update gitignore to include folder created by make container-serve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ resources/
 package-lock.json
 functions/
 node_modules/
+
+# Generated files when building with make container-build
+.config/
+.npm/


### PR DESCRIPTION
When I use `make container-serve` a bunch of folders are created that are not useful for version tracking and git is not ignoring them.