### PR TITLE
Update macOS installation instructions

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/en/docs/tasks/tools/install-kubectl-macos.md
@@ -41,16 +41,18 @@ The following methods exist for installing kubectl on macOS:
    {{< note >}}
    To download a specific version, replace the `$(curl -L -s https://dl.k8s.io/release/stable.txt)` portion of the command with the specific version.
 
-   For example, to download version {{< param "fullversion" >}} on macOS, type:
+   For example, to download version {{< param "fullversion" >}} on Intel macOS, type:
 
-   {{< tabs name="download_binary_macos" >}}
-   {{< tab name="Intel" codelang="bash" >}}
+   ```bash
    curl -LO "https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/darwin/amd64/kubectl"
-   {{< /tab >}}
-   {{< tab name="Apple Silicon" codelang="bash" >}}
+   ```
+
+   And for macOS on Apple Silicon, type:
+
+   ```bash
    curl -LO "https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/darwin/arm64/kubectl"
-   {{< /tab >}}
-   {{< /tabs >}}
+   ```
+
    {{< /note >}}
 
 1. Validate the binary (optional)

--- a/content/en/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/en/docs/tasks/tools/install-kubectl-macos.md
@@ -29,14 +29,19 @@ The following methods exist for installing kubectl on macOS:
 
 1. Download the latest release:
 
-   ```bash
+   {{< tabs name="download_binary_macos" >}}
+   {{< tab name="Intel" codelang="bash" >}}
    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl"
-   ```
+   {{< /tab >}}
+   {{< tab name="Apple Silicon" codelang="bash" >}}
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/arm64/kubectl"
+   {{< /tab >}}
+   {{< /tabs >}}
 
    {{< note >}}
    To download a specific version, replace the `$(curl -L -s https://dl.k8s.io/release/stable.txt)` portion of the command with the specific version.
 
-   For example, to download version {{< param "fullversion" >}} on macOS, type:
+   For example, to download version {{< param "fullversion" >}} on Intel macOS, type:
 
    ```bash
    curl -LO https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/darwin/amd64/kubectl
@@ -48,10 +53,15 @@ The following methods exist for installing kubectl on macOS:
 
    Download the kubectl checksum file:
 
-   ```bash
-   curl -LO "https://dl.k8s.io/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl.sha256"
-   ```
-
+   {{< tabs name="download_checksum_macos" >}}
+   {{< tab name="Intel" codelang="bash" >}}
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl.sha256"
+   {{< /tab >}}
+   {{< tab name="Apple Silicon" codelang="bash" >}}
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/arm64/kubectl.sha256"
+   {{< /tab >}}
+   {{< /tabs >}}
+  
    Validate the kubectl binary against the checksum file:
 
    ```bash

--- a/content/en/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/en/docs/tasks/tools/install-kubectl-macos.md
@@ -41,12 +41,16 @@ The following methods exist for installing kubectl on macOS:
    {{< note >}}
    To download a specific version, replace the `$(curl -L -s https://dl.k8s.io/release/stable.txt)` portion of the command with the specific version.
 
-   For example, to download version {{< param "fullversion" >}} on Intel macOS, type:
+   For example, to download version {{< param "fullversion" >}} on macOS, type:
 
-   ```bash
-   curl -LO https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/darwin/amd64/kubectl
-   ```
-
+   {{< tabs name="download_binary_macos" >}}
+   {{< tab name="Intel" codelang="bash" >}}
+   curl -LO "https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/darwin/amd64/kubectl"
+   {{< /tab >}}
+   {{< tab name="Apple Silicon" codelang="bash" >}}
+   curl -LO "https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/darwin/arm64/kubectl"
+   {{< /tab >}}
+   {{< /tabs >}}
    {{< /note >}}
 
 1. Validate the binary (optional)


### PR DESCRIPTION
See https://github.com/kubernetes/website/issues/27511 

The URL given for downloading kubectl releases on macOS has amd64 hardcoded in. There's no indication that if you replace it with arm64 you will receive an arm64 binary. This should be reflected in the documentation for users of Apple Silicon Macs.