### PR TITLE
shortcodes/skew.html: use .version instead of .latest

### DIFF
--- a/layouts/shortcodes/skew.html
+++ b/layouts/shortcodes/skew.html
@@ -2,7 +2,7 @@
 {{- $version := .Get 0 -}}
 
 <!-- strip "v" from latest verison  -->
-{{- $latestVersion := site.Params.latest -}}
+{{- $latestVersion := site.Params.version -}}
 {{- $latestVersion := (replace $latestVersion "v" "") -}}
 
 <!-- splits a string x.Xy into substrings separated by a "." delimiter  -->


### PR DESCRIPTION
The "skew" shortcodes should use the .version parameter
instead of the .latest parameter, to show examples
on pages for this particular k8s version and not for
the latest k8s version.

/sig cluster-lifecycle 
backport of https://github.com/kubernetes/website/pull/27540
fixes #27525