### PR TITLE
Revise skew shortcode

### DIFF
--- a/content/en/docs/concepts/services-networking/network-policies.md
+++ b/content/en/docs/concepts/services-networking/network-policies.md
@@ -287,7 +287,7 @@ standardized label to target a specific namespace.
 
 ## What you can't do with network policies (at least, not yet)
 
-As of Kubernetes {{< skew latestVersion >}}, the following functionality does not exist in the NetworkPolicy API, but you might be able to implement workarounds using Operating System components (such as SELinux, OpenVSwitch, IPTables, and so on) or Layer 7 technologies (Ingress controllers, Service Mesh implementations) or admission controllers.  In case you are new to network security in Kubernetes, its worth noting that the following User Stories cannot (yet) be implemented using the NetworkPolicy API.
+As of Kubernetes {{< skew currentVersion >}}, the following functionality does not exist in the NetworkPolicy API, but you might be able to implement workarounds using Operating System components (such as SELinux, OpenVSwitch, IPTables, and so on) or Layer 7 technologies (Ingress controllers, Service Mesh implementations) or admission controllers.  In case you are new to network security in Kubernetes, its worth noting that the following User Stories cannot (yet) be implemented using the NetworkPolicy API.
 
 - Forcing internal cluster traffic to go through a common gateway (this might be best served with a service mesh or other proxy).
 - Anything TLS related (use a service mesh or ingress controller for this).

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -9,12 +9,12 @@ weight: 20
 <!-- overview -->
 
 This page explains how to upgrade a Kubernetes cluster created with kubeadm from version
-{{< skew latestVersionAddMinor -1 >}}.x to version {{< skew latestVersion >}}.x, and from version
-{{< skew latestVersion >}}.x to {{< skew latestVersion >}}.y (where `y > x`). Skipping MINOR versions
+{{< skew currentVersionAddMinor -1 >}}.x to version {{< skew currentVersion >}}.x, and from version
+{{< skew currentVersion >}}.x to {{< skew currentVersion >}}.y (where `y > x`). Skipping MINOR versions
 when upgrading is unsupported.
 
-To see information about upgrading clusters created using older versions of kubeadm,
-please refer to following pages instead:
+To see information about upgrading clusters created using other versions of kubeadm,
+please refer to the following list:
 
 - [Upgrading a kubeadm cluster from {{< skew latestVersionAddMinor -2 >}} to {{< skew latestVersionAddMinor -1 >}}](https://v{{< skew latestVersionAddMinor -1 "-" >}}.docs.kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/)
 - [Upgrading a kubeadm cluster from {{< skew latestVersionAddMinor -3 >}} to {{< skew latestVersionAddMinor -2 >}}](https://v{{< skew latestVersionAddMinor -2 "-" >}}.docs.kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/)
@@ -45,19 +45,19 @@ The upgrade workflow at high level is the following:
 
 ## Determine which version to upgrade to
 
-Find the latest stable {{< skew latestVersion >}} version using the OS package manager:
+Find the latest stable {{< skew currentVersion >}} version using the OS package manager:
 
 {{< tabs name="k8s_install_versions" >}}
 {{% tab name="Ubuntu, Debian or HypriotOS" %}}
     apt update
     apt-cache madison kubeadm
-    # find the latest {{< skew latestVersion >}} version in the list
-    # it should look like {{< skew latestVersion >}}.x-00, where x is the latest patch
+    # find the latest {{< skew currentVersion >}} version in the list
+    # it should look like {{< skew currentVersion >}}.x-00, where x is the latest patch
 {{% /tab %}}
 {{% tab name="CentOS, RHEL or Fedora" %}}
     yum list --showduplicates kubeadm --disableexcludes=kubernetes
-    # find the latest {{< skew latestVersion >}} version in the list
-    # it should look like {{< skew latestVersion >}}.x-0, where x is the latest patch
+    # find the latest {{< skew currentVersion >}} version in the list
+    # it should look like {{< skew currentVersion >}}.x-0, where x is the latest patch
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -74,18 +74,18 @@ Pick a control plane node that you wish to upgrade first. It must have the `/etc
 
 {{< tabs name="k8s_install_kubeadm_first_cp" >}}
 {{% tab name="Ubuntu, Debian or HypriotOS" %}}
-    # replace x in {{< skew latestVersion >}}.x-00 with the latest patch version
+    # replace x in {{< skew currentVersion >}}.x-00 with the latest patch version
     apt-mark unhold kubeadm && \
-    apt-get update && apt-get install -y kubeadm={{< skew latestVersion >}}.x-00 && \
+    apt-get update && apt-get install -y kubeadm={{< skew currentVersion >}}.x-00 && \
     apt-mark hold kubeadm
     -
     # since apt-get version 1.1 you can also use the following method
     apt-get update && \
-    apt-get install -y --allow-change-held-packages kubeadm={{< skew latestVersion >}}.x-00
+    apt-get install -y --allow-change-held-packages kubeadm={{< skew currentVersion >}}.x-00
 {{% /tab %}}
 {{% tab name="CentOS, RHEL or Fedora" %}}
-    # replace x in {{< skew latestVersion >}}.x-0 with the latest patch version
-    yum install -y kubeadm-{{< skew latestVersion >}}.x-0 --disableexcludes=kubernetes
+    # replace x in {{< skew currentVersion >}}.x-0 with the latest patch version
+    yum install -y kubeadm-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -120,13 +120,13 @@ Failing to do so will cause `kubeadm upgrade apply` to exit with an error and no
 
     ```shell
     # replace x with the patch version you picked for this upgrade
-    sudo kubeadm upgrade apply v{{< skew latestVersion >}}.x
+    sudo kubeadm upgrade apply v{{< skew currentVersion >}}.x
     ```
 
     Once the command finishes you should see:
 
     ```
-    [upgrade/successful] SUCCESS! Your cluster was upgraded to "v{{< skew latestVersion >}}.x". Enjoy!
+    [upgrade/successful] SUCCESS! Your cluster was upgraded to "v{{< skew currentVersion >}}.x". Enjoy!
 
     [upgrade/kubelet] Now that your control plane is upgraded, please proceed with upgrading your kubelets if you haven't already done so.
     ```
@@ -171,20 +171,20 @@ Also calling `kubeadm upgrade plan` and upgrading the CNI provider plugin is no 
 {{< tabs name="k8s_install_kubelet" >}}
 {{< tab name="Ubuntu, Debian or HypriotOS" >}}
     <pre>
-    # replace x in {{< skew latestVersion >}}.x-00 with the latest patch version
+    # replace x in {{< skew currentVersion >}}.x-00 with the latest patch version
     apt-mark unhold kubelet kubectl && \
-    apt-get update && apt-get install -y kubelet={{< skew latestVersion >}}.x-00 kubectl={{< skew latestVersion >}}.x-00 && \
+    apt-get update && apt-get install -y kubelet={{< skew currentVersion >}}.x-00 kubectl={{< skew currentVersion >}}.x-00 && \
     apt-mark hold kubelet kubectl
     -
     # since apt-get version 1.1 you can also use the following method
     apt-get update && \
-    apt-get install -y --allow-change-held-packages kubelet={{< skew latestVersion >}}.x-00 kubectl={{< skew latestVersion >}}.x-00
+    apt-get install -y --allow-change-held-packages kubelet={{< skew currentVersion >}}.x-00 kubectl={{< skew currentVersion >}}.x-00
     </pre>
 {{< /tab >}}
 {{< tab name="CentOS, RHEL or Fedora" >}}
     <pre>
-    # replace x in {{< skew latestVersion >}}.x-0 with the latest patch version
-    yum install -y kubelet-{{< skew latestVersion >}}.x-0 kubectl-{{< skew latestVersion >}}.x-0 --disableexcludes=kubernetes
+    # replace x in {{< skew currentVersion >}}.x-0 with the latest patch version
+    yum install -y kubelet-{{< skew currentVersion >}}.x-0 kubectl-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
     </pre>
 {{< /tab >}}
 {{< /tabs >}}
@@ -216,18 +216,18 @@ without compromising the minimum required capacity for running your workloads.
 
 {{< tabs name="k8s_install_kubeadm_worker_nodes" >}}
 {{% tab name="Ubuntu, Debian or HypriotOS" %}}
-    # replace x in {{< skew latestVersion >}}.x-00 with the latest patch version
+    # replace x in {{< skew currentVersion >}}.x-00 with the latest patch version
     apt-mark unhold kubeadm && \
-    apt-get update && apt-get install -y kubeadm={{< skew latestVersion >}}.x-00 && \
+    apt-get update && apt-get install -y kubeadm={{< skew currentVersion >}}.x-00 && \
     apt-mark hold kubeadm
     -
     # since apt-get version 1.1 you can also use the following method
     apt-get update && \
-    apt-get install -y --allow-change-held-packages kubeadm={{< skew latestVersion >}}.x-00
+    apt-get install -y --allow-change-held-packages kubeadm={{< skew currentVersion >}}.x-00
 {{% /tab %}}
 {{% tab name="CentOS, RHEL or Fedora" %}}
-    # replace x in {{< skew latestVersion >}}.x-0 with the latest patch version
-    yum install -y kubeadm-{{< skew latestVersion >}}.x-0 --disableexcludes=kubernetes
+    # replace x in {{< skew currentVersion >}}.x-0 with the latest patch version
+    yum install -y kubeadm-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -254,18 +254,18 @@ without compromising the minimum required capacity for running your workloads.
 
 {{< tabs name="k8s_kubelet_and_kubectl" >}}
 {{% tab name="Ubuntu, Debian or HypriotOS" %}}
-    # replace x in {{< skew latestVersion >}}.x-00 with the latest patch version
+    # replace x in {{< skew currentVersion >}}.x-00 with the latest patch version
     apt-mark unhold kubelet kubectl && \
-    apt-get update && apt-get install -y kubelet={{< skew latestVersion >}}.x-00 kubectl={{< skew latestVersion >}}.x-00 && \
+    apt-get update && apt-get install -y kubelet={{< skew currentVersion >}}.x-00 kubectl={{< skew currentVersion >}}.x-00 && \
     apt-mark hold kubelet kubectl
     -
     # since apt-get version 1.1 you can also use the following method
     apt-get update && \
-    apt-get install -y --allow-change-held-packages kubelet={{< skew latestVersion >}}.x-00 kubectl={{< skew latestVersion >}}.x-00
+    apt-get install -y --allow-change-held-packages kubelet={{< skew currentVersion >}}.x-00 kubectl={{< skew currentVersion >}}.x-00
 {{% /tab %}}
 {{% tab name="CentOS, RHEL or Fedora" %}}
-    # replace x in {{< skew latestVersion >}}.x-0 with the latest patch version
-    yum install -y kubelet-{{< skew latestVersion >}}.x-0 kubectl-{{< skew latestVersion >}}.x-0 --disableexcludes=kubernetes
+    # replace x in {{< skew currentVersion >}}.x-0 with the latest patch version
+    yum install -y kubelet-{{< skew currentVersion >}}.x-0 kubectl-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/releases/version-skew-policy.md
+++ b/content/en/releases/version-skew-policy.md
@@ -23,7 +23,7 @@ Specific cluster deployment tools may place additional restrictions on version s
 Kubernetes versions are expressed as **x.y.z**, where **x** is the major version, **y** is the minor version, and **z** is the patch version, following [Semantic Versioning](https://semver.org/) terminology.
 For more information, see [Kubernetes Release Versioning](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md#kubernetes-release-versioning).
 
-The Kubernetes project maintains release branches for the most recent three minor releases ({{< skew latestVersion >}}, {{< skew prevMinorVersion >}}, {{< skew oldestMinorVersion >}}).  Kubernetes 1.19 and newer receive approximately 1 year of patch support. Kubernetes 1.18 and older received approximately 9 months of patch support.
+The Kubernetes project maintains release branches for the most recent three minor releases ({{< skew latestVersion >}}, {{< skew latestVersionAddMinor -1 >}}, {{< skew latestVersionAddMinor -2 >}}).  Kubernetes 1.19 and newer receive approximately 1 year of patch support. Kubernetes 1.18 and older received approximately 9 months of patch support.
 
 Applicable fixes, including security fixes, may be backported to those three release branches, depending on severity and feasibility.
 Patch releases are cut from those branches at a [regular cadence](https://git.k8s.io/sig-release/releases/patch-releases.md#cadence), plus additional urgent releases, when required.
@@ -40,8 +40,8 @@ In [highly-available (HA) clusters](/docs/setup/production-environment/tools/kub
 
 Example:
 
-* newest `kube-apiserver` is at **{{< skew latestVersion >}}**
-* other `kube-apiserver` instances are supported at **{{< skew latestVersion >}}** and **{{< skew prevMinorVersion >}}**
+* newest `kube-apiserver` is at **{{< skew currentVersion >}}**
+* other `kube-apiserver` instances are supported at **{{< skew currentVersion >}}** and **{{< skew currentVersionAddMinor -1 >}}**
 
 ### kubelet
 
@@ -49,8 +49,8 @@ Example:
 
 Example:
 
-* `kube-apiserver` is at **{{< skew latestVersion >}}**
-* `kubelet` is supported at **{{< skew latestVersion >}}**, **{{< skew prevMinorVersion >}}**, and **{{< skew oldestMinorVersion >}}**
+* `kube-apiserver` is at **{{< skew currentVersion >}}**
+* `kubelet` is supported at **{{< skew currentVersion >}}**, **{{< skew currentVersionAddMinor -1 >}}**, and **{{< skew currentVersionAddMinor -2 >}}**
 
 {{< note >}}
 If version skew exists between `kube-apiserver` instances in an HA cluster, this narrows the allowed `kubelet` versions.
@@ -58,8 +58,8 @@ If version skew exists between `kube-apiserver` instances in an HA cluster, this
 
 Example:
 
-* `kube-apiserver` instances are at **{{< skew latestVersion >}}** and **{{< skew prevMinorVersion >}}**
-* `kubelet` is supported at **{{< skew prevMinorVersion >}}**, and **{{< skew oldestMinorVersion >}}** (**{{< skew latestVersion >}}** is not supported because that would be newer than the `kube-apiserver` instance at version **{{< skew prevMinorVersion >}}**)
+* `kube-apiserver` instances are at **{{< skew currentVersion >}}** and **{{< skew currentVersionAddMinor -1 >}}**
+* `kubelet` is supported at **{{< skew currentVersionAddMinor -1 >}}**, and **{{< skew currentVersionAddMinor -2 >}}** (**{{< skew currentVersion >}}** is not supported because that would be newer than the `kube-apiserver` instance at version **{{< skew currentVersionAddMinor -1 >}}**)
 
 ### kube-controller-manager, kube-scheduler, and cloud-controller-manager
 
@@ -67,8 +67,8 @@ Example:
 
 Example:
 
-* `kube-apiserver` is at **{{< skew latestVersion >}}**
-* `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager` are supported at **{{< skew latestVersion >}}** and **{{< skew prevMinorVersion >}}**
+* `kube-apiserver` is at **{{< skew currentVersion >}}**
+* `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager` are supported at **{{< skew currentVersion >}}** and **{{< skew currentVersionAddMinor -1 >}}**
 
 {{< note >}}
 If version skew exists between `kube-apiserver` instances in an HA cluster, and these components can communicate with any `kube-apiserver` instance in the cluster (for example, via a load balancer), this narrows the allowed versions of these components.
@@ -76,9 +76,9 @@ If version skew exists between `kube-apiserver` instances in an HA cluster, and 
 
 Example:
 
-* `kube-apiserver` instances are at **{{< skew latestVersion >}}** and **{{< skew prevMinorVersion >}}**
+* `kube-apiserver` instances are at **{{< skew currentVersion >}}** and **{{< skew currentVersionAddMinor -1 >}}**
 * `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager` communicate with a load balancer that can route to any `kube-apiserver` instance
-* `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager` are supported at **{{< skew prevMinorVersion >}}** (**{{< skew latestVersion >}}** is not supported because that would be newer than the `kube-apiserver` instance at version **{{< skew prevMinorVersion >}}**)
+* `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager` are supported at **{{< skew currentVersionAddMinor -1 >}}** (**{{< skew currentVersion >}}** is not supported because that would be newer than the `kube-apiserver` instance at version **{{< skew currentVersionAddMinor -1 >}}**)
 
 ### kubectl
 
@@ -86,8 +86,8 @@ Example:
 
 Example:
 
-* `kube-apiserver` is at **{{< skew latestVersion >}}**
-* `kubectl` is supported at **{{< skew nextMinorVersion >}}**, **{{< skew latestVersion >}}**, and **{{< skew prevMinorVersion >}}**
+* `kube-apiserver` is at **{{< skew currentVersion >}}**
+* `kubectl` is supported at **{{< skew nextMinorVersion >}}**, **{{< skew currentVersion >}}**, and **{{< skew currentVersionAddMinor -1 >}}**
 
 {{< note >}}
 If version skew exists between `kube-apiserver` instances in an HA cluster, this narrows the supported `kubectl` versions.
@@ -95,27 +95,27 @@ If version skew exists between `kube-apiserver` instances in an HA cluster, this
 
 Example:
 
-* `kube-apiserver` instances are at **{{< skew latestVersion >}}** and **{{< skew prevMinorVersion >}}**
-* `kubectl` is supported at **{{< skew latestVersion >}}** and **{{< skew prevMinorVersion >}}** (other versions would be more than one minor version skewed from one of the `kube-apiserver` components)
+* `kube-apiserver` instances are at **{{< skew currentVersion >}}** and **{{< skew currentVersionAddMinor -1 >}}**
+* `kubectl` is supported at **{{< skew currentVersion >}}** and **{{< skew currentVersionAddMinor -1 >}}** (other versions would be more than one minor version skewed from one of the `kube-apiserver` components)
 
 ## Supported component upgrade order
 
 The supported version skew between components has implications on the order in which components must be upgraded.
-This section describes the order in which components must be upgraded to transition an existing cluster from version **{{< skew prevMinorVersion >}}** to version **{{< skew latestVersion >}}**.
+This section describes the order in which components must be upgraded to transition an existing cluster from version **{{< skew currentVersionAddMinor -1 >}}** to version **{{< skew currentVersion >}}**.
 
 ### kube-apiserver
 
 Pre-requisites:
 
-* In a single-instance cluster, the existing `kube-apiserver` instance is **{{< skew prevMinorVersion >}}**
-* In an HA cluster, all `kube-apiserver` instances are at **{{< skew prevMinorVersion >}}** or **{{< skew latestVersion >}}** (this ensures maximum skew of 1 minor version between the oldest and newest `kube-apiserver` instance)
-* The `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager` instances that communicate with this server are at version **{{< skew prevMinorVersion >}}** (this ensures they are not newer than the existing API server version, and are within 1 minor version of the new API server version)
-* `kubelet` instances on all nodes are at version **{{< skew prevMinorVersion >}}** or **{{< skew oldestMinorVersion >}}** (this ensures they are not newer than the existing API server version, and are within 2 minor versions of the new API server version)
+* In a single-instance cluster, the existing `kube-apiserver` instance is **{{< skew currentVersionAddMinor -1 >}}**
+* In an HA cluster, all `kube-apiserver` instances are at **{{< skew currentVersionAddMinor -1 >}}** or **{{< skew currentVersion >}}** (this ensures maximum skew of 1 minor version between the oldest and newest `kube-apiserver` instance)
+* The `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager` instances that communicate with this server are at version **{{< skew currentVersionAddMinor -1 >}}** (this ensures they are not newer than the existing API server version, and are within 1 minor version of the new API server version)
+* `kubelet` instances on all nodes are at version **{{< skew currentVersionAddMinor -1 >}}** or **{{< skew currentVersionAddMinor -2 >}}** (this ensures they are not newer than the existing API server version, and are within 2 minor versions of the new API server version)
 * Registered admission webhooks are able to handle the data the new `kube-apiserver` instance will send them:
-  * `ValidatingWebhookConfiguration` and `MutatingWebhookConfiguration` objects are updated to include any new versions of REST resources added in **{{< skew latestVersion >}}** (or use the [`matchPolicy: Equivalent` option](/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-matchpolicy) available in v1.15+)
-  * The webhooks are able to handle any new versions of REST resources that will be sent to them, and any new fields added to existing versions in **{{< skew latestVersion >}}**
+  * `ValidatingWebhookConfiguration` and `MutatingWebhookConfiguration` objects are updated to include any new versions of REST resources added in **{{< skew currentVersion >}}** (or use the [`matchPolicy: Equivalent` option](/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-matchpolicy) available in v1.15+)
+  * The webhooks are able to handle any new versions of REST resources that will be sent to them, and any new fields added to existing versions in **{{< skew currentVersion >}}**
 
-Upgrade `kube-apiserver` to **{{< skew latestVersion >}}**
+Upgrade `kube-apiserver` to **{{< skew currentVersion >}}**
 
 {{< note >}}
 Project policies for [API deprecation](/docs/reference/using-api/deprecation-policy/) and
@@ -127,17 +127,17 @@ require `kube-apiserver` to not skip minor versions when upgrading, even in sing
 
 Pre-requisites:
 
-* The `kube-apiserver` instances these components communicate with are at **{{< skew latestVersion >}}** (in HA clusters in which these control plane components can communicate with any `kube-apiserver` instance in the cluster, all `kube-apiserver` instances must be upgraded before upgrading these components)
+* The `kube-apiserver` instances these components communicate with are at **{{< skew currentVersion >}}** (in HA clusters in which these control plane components can communicate with any `kube-apiserver` instance in the cluster, all `kube-apiserver` instances must be upgraded before upgrading these components)
 
-Upgrade `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager` to **{{< skew latestVersion >}}**
+Upgrade `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager` to **{{< skew currentVersion >}}**
 
 ### kubelet
 
 Pre-requisites:
 
-* The `kube-apiserver` instances the `kubelet` communicates with are at **{{< skew latestVersion >}}**
+* The `kube-apiserver` instances the `kubelet` communicates with are at **{{< skew currentVersion >}}**
 
-Optionally upgrade `kubelet` instances to **{{< skew latestVersion >}}** (or they can be left at **{{< skew prevMinorVersion >}}** or **{{< skew oldestMinorVersion >}}**)
+Optionally upgrade `kubelet` instances to **{{< skew currentVersion >}}** (or they can be left at **{{< skew currentVersionAddMinor -1 >}}** or **{{< skew currentVersionAddMinor -2 >}}**)
 
 {{< note >}}
 Before performing a minor version `kubelet` upgrade, [drain](/docs/tasks/administer-cluster/safely-drain-node/) pods from that node.
@@ -159,7 +159,7 @@ Running a cluster with `kubelet` instances that are persistently two minor versi
 
 Example:
 
-If `kube-proxy` version is **{{< skew oldestMinorVersion >}}**:
+If `kube-proxy` version is **{{< skew currentVersionAddMinor -2 >}}**:
 
-* `kubelet` version must be at the same minor version as **{{< skew oldestMinorVersion >}}**.
-* `kube-apiserver` version must be between **{{< skew oldestMinorVersion >}}** and **{{< skew latestVersion >}}**, inclusive.
+* `kubelet` version must be at the same minor version as **{{< skew currentVersionAddMinor -2 >}}**.
+* `kube-apiserver` version must be between **{{< skew currentVersionAddMinor -2 >}}** and **{{< skew currentVersion >}}**, inclusive.

--- a/layouts/shortcodes/skew.html
+++ b/layouts/shortcodes/skew.html
@@ -1,64 +1,92 @@
-<!-- capture version from first argument in "skew" -->
+{{/* capture version from first argument in "skew" */}}
 {{- $version := .Get 0 -}}
 
-<!-- strip "v" from latest verison  -->
+{{/* strip "v" from latest and current version  */}}
+{{- $currentVersion := site.Params.version -}}
+{{- $currentVersion := (replace $currentVersion "v" "") -}}
 {{- $latestVersion := site.Params.latest -}}
 {{- $latestVersion := (replace $latestVersion "v" "") -}}
 
-<!-- splits a string x.Xy into substrings separated by a "." delimiter  -->
-{{- $versionArray := split $latestVersion "." -}}
+{{/* splits a string x.Xy into substrings separated by a "." delimiter  */}}
+{{- $versionArrayCurrent := split $currentVersion "." -}}
 
-<!-- capture minorVersion ("Xy") in a variable -->
-{{- $minorVersion := int (index $versionArray 1) -}}
+{{/* capture minorVersion ("Xy") in a variable */}}
+{{- $minorVersionCurrent := int (index $versionArrayCurrent 1) -}}
 
-<!-- increment latest 1 minor number for "nextMinorVerison" -->
-{{- $nextMinorVersion := add $minorVersion 1 -}}
+{{/* splits a string x.Xy into substrings separated by a "." delimiter  */}}
+{{- $versionArrayLatest := split $latestVersion "." -}}
 
-<!-- subtract latest 1 minor number for "prevMinorVerison" -->
-{{- $prevMinorVersion := sub $minorVersion 1 -}}
+{{/* capture minorVersion ("Xy") in a variable */}}
+{{- $minorVersionLatest := int (index $versionArrayLatest 1) -}}
 
-<!-- subtract latest 2 minor numbers for "oldestMinorVerison" -->
-{{- $oldestMinorVersion := sub $minorVersion 2 -}}
+{{/* increment latest 1 minor number for "nextMinorVerison" */}}
+{{- $nextMinorVersionLatest := add $minorVersionLatest 1 -}}
 
-<!-- output nextMinorVersion based on captured arg -->
+{{/* subtract latest 1 minor number for "prevMinorVerison" */}}
+{{- $prevMinorVersionLatest := sub $minorVersionLatest 1 -}}
+
+{{/* subtract latest 2 minor numbers for "oldestMinorVerison" */}}
+{{- $oldestMinorVersionLatest := sub $minorVersionLatest 2 -}}
+
+{{/* output nextMinorVersion based on captured arg */}}
 {{- if eq $version "nextMinorVersion" -}}
-    {{- $nextMinorVersion := printf "%s.%d" (index $versionArray 0) $nextMinorVersion -}}
+    {{- $nextMinorVersion := printf "%s.%d" (index $versionArrayLatest 0) $nextMinorVersionLatest -}}
     {{- $nextMinorVersion -}}
 {{- end -}}
 
-<!-- output latestVersion based on captured arg -->
+{{/* output latestVersion based on captured arg */}}
 {{- if eq $version "latestVersion" -}}
     {{- $latestVersion -}}
 {{- end -}}
 
-<!-- output prevMinorVersion based on captured arg -->
+{{/* output prevMinorVersion based on captured arg */}}
 {{- if eq $version "prevMinorVersion" -}}
-    {{- $prevMinorVersion := printf "%s.%d" (index $versionArray 0) $prevMinorVersion -}}
+    {{- $prevMinorVersion := printf "%s.%d" (index $versionArrayLatest 0) $prevMinorVersionLatest -}}
     {{- $prevMinorVersion -}}
 {{- end -}}
 
-<!-- output oldestMinorVersion based on captured arg -->
+{{/* output oldestMinorVersion based on captured arg */}}
 {{- if eq $version "oldestMinorVersion" -}}
-    {{- $oldestMinorVersion := printf "%s.%d" (index $versionArray 0) $oldestMinorVersion -}}
+    {{- $oldestMinorVersion := printf "%s.%d" (index $versionArrayLatest 0) $oldestMinorVersionLatest -}}
     {{- $oldestMinorVersion -}}
 {{- end -}}
-
-<!-- output latestVersionAddMinor based on captured args -->
+{{/* output latestVersionAddMinor based on captured args */}}
 {{- if eq $version "latestVersionAddMinor" -}}
     {{- $seperator := .Get 2 -}}
     {{- if eq $seperator "" -}}
         {{- $seperator = "." -}}
     {{- end -}}
     {{- $latestVersionAddMinor := int (.Get 1) -}}
-    {{- $latestVersionAddMinor = add $minorVersion $latestVersionAddMinor -}}
-    {{- $latestVersionAddMinor = printf "%s%s%d" (index $versionArray 0) $seperator $latestVersionAddMinor -}}
+    {{- $latestVersionAddMinor = add $minorVersionLatest $latestVersionAddMinor -}}
+    {{- $latestVersionAddMinor = printf "%s%s%d" (index $versionArrayLatest 0) $seperator $latestVersionAddMinor -}}
     {{- $latestVersionAddMinor -}}
 {{- end -}}
-<!--
+
+{{/* output currentVersion based on captured arg */}}
+{{- if eq $version "currentVersion" -}}
+    {{- $currentVersion -}}
+{{- end -}}
+
+{{/* output currentVersionAddMinor based on captured args */}}
+{{- if eq $version "currentVersionAddMinor" -}}
+    {{- $seperator := .Get 2 -}}
+    {{- if eq $seperator "" -}}
+        {{- $seperator = "." -}}
+    {{- end -}}
+    {{- $currentVersionAddMinor := int (.Get 1) -}}
+    {{- $currentVersionAddMinor = add $minorVersionCurrent $currentVersionAddMinor -}}
+    {{- $currentVersionAddMinor = printf "%s%s%d" (index $versionArrayCurrent 0) $seperator $currentVersionAddMinor -}}
+    {{- $currentVersionAddMinor -}}
+{{- end -}}
+{{/*
 example shortcode use:
 - skew nextMinorVersion
-- skew latestVersion
+- skew currentVersion
 - skew prevMinorVersion
 - skew oldestMinorVersion
+- skew latestVersion
+- skew latestVersionAddMinor +1 "-"
 - skew latestVersionAddMinor -1 "-"
--->
+- skew currentVersionAddMinor +1 "-"
+- skew currentVersionAddMinor -1 "-"
+*/}}


### PR DESCRIPTION
Revise the `skew` shortcode so that `latestVersion` now means the latest known Kubernetes release, whereas
`currentVersion` means the one that we're rendering documentation for.

Also provide `currentVersionAddMinor`, by analogy with the existing
`latestVersionAddMinor`.

After this change, `{{< skew latestVersion >}}` continues to render to represent the Kubernetes release, whereas `{{< skew currentVersion >}}` means the one that we're rendering documentation for.

- [Preview](https://deploy-preview-27542--kubernetes-io-main-staging.netlify.app/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/) of _Upgrading kubeadm clusters_
- [Preview](https://deploy-preview-27542--kubernetes-io-main-staging.netlify.app/docs/setup/release/version-skew-policy/) of _Kubernetes version and version skew support policy_

BTW originally I had the revised comment format in a separate commit, but I squashed it out whilst chasing some errant whitepace.

Relevant to #27525 and #27526