### PR TITLE
add Antrea as network policy provider

### DIFF
--- a/content/en/docs/tasks/administer-cluster/declare-network-policy.md
+++ b/content/en/docs/tasks/administer-cluster/declare-network-policy.md
@@ -18,6 +18,7 @@ This document helps you get started using the Kubernetes [NetworkPolicy API](/do
 
 Make sure you've configured a network provider with network policy support. There are a number of network providers that support NetworkPolicy, including:
 
+* [Antrea](/docs/tasks/administer-cluster/network-policy-provider/antrea-network-policy/)
 * [Calico](/docs/tasks/administer-cluster/network-policy-provider/calico-network-policy/)
 * [Cilium](/docs/tasks/administer-cluster/network-policy-provider/cilium-network-policy/)
 * [Kube-router](/docs/tasks/administer-cluster/network-policy-provider/kube-router-network-policy/)

--- a/content/en/docs/tasks/administer-cluster/network-policy-provider/antrea-network-policy.md
+++ b/content/en/docs/tasks/administer-cluster/network-policy-provider/antrea-network-policy.md
@@ -1,0 +1,24 @@
+---
+title: Use Antrea for NetworkPolicy
+content_type: task
+weight: 10
+---
+
+<!-- overview -->
+This page shows how to install and use Antrea CNI plugin on Kubernetes.
+For background on Project Antrea, read the [Introduction to Antrea](https://antrea.io/docs/).
+
+## {{% heading "prerequisites" %}}
+
+You need to have a Kubernetes cluster. Follow the
+[kubeadm getting started guide](/docs/reference/setup-tools/kubeadm/) to bootstrap one.
+
+<!-- steps -->
+
+## Deploying Antrea with kubeadm
+
+Follow [Getting Started](https://github.com/vmware-tanzu/antrea/blob/main/docs/getting-started.md) guide to deploy Antrea for kubeadm.
+
+## {{% heading "whatsnext" %}}
+
+Once your cluster is running, you can follow the [Declare Network Policy](/docs/tasks/administer-cluster/declare-network-policy/) to try out Kubernetes NetworkPolicy.


### PR DESCRIPTION
Antrea is in K8S network addon list https://kubernetes.io/docs/concepts/cluster-administration/networking/#antrea now, since it's also a network provider, so add a simple intro page into network-policy-provider folder