### PR TITLE
"*-controller-manager" typo fix

### DIFF
--- a/content/en/blog/_posts/2021-04-08-cronjob-reaches-ga/index.md
+++ b/content/en/blog/_posts/2021-04-08-cronjob-reaches-ga/index.md
@@ -102,4 +102,4 @@ controllers. As mentioned before, the new controller is on by default starting
 from Kubernetes v1.21; if you want to check it out in the previous release (1.20),
 you can enable the `CronJobControllerV2`
 [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) 
-for the kube-controller-manger: `--feature-gate="CronJobControllerV2=true"`.
+for the kube-controller-manager: `--feature-gate="CronJobControllerV2=true"`.

--- a/content/en/examples/admin/cloud/ccm-example.yaml
+++ b/content/en/examples/admin/cloud/ccm-example.yaml
@@ -1,4 +1,4 @@
-# This is an example of how to setup cloud-controller-manger as a Daemonset in your cluster.
+# This is an example of how to setup cloud-controller-manager as a Daemonset in your cluster.
 # It assumes that your masters can run pods and has the role node-role.kubernetes.io/master
 # Note that this Daemonset will not work straight out of the box for your cloud, this is
 # meant to be a guideline.

--- a/content/ja/examples/admin/cloud/ccm-example.yaml
+++ b/content/ja/examples/admin/cloud/ccm-example.yaml
@@ -1,4 +1,4 @@
-# This is an example of how to setup cloud-controller-manger as a Daemonset in your cluster.
+# This is an example of how to setup cloud-controller-manager as a Daemonset in your cluster.
 # It assumes that your masters can run pods and has the role node-role.kubernetes.io/master
 # Note that this Daemonset will not work straight out of the box for your cloud, this is
 # meant to be a guideline.

--- a/content/zh/examples/admin/cloud/ccm-example.yaml
+++ b/content/zh/examples/admin/cloud/ccm-example.yaml
@@ -1,4 +1,4 @@
-# This is an example of how to setup cloud-controller-manger as a Daemonset in your cluster.
+# This is an example of how to setup cloud-controller-manager as a Daemonset in your cluster.
 # It assumes that your masters can run pods and has the role node-role.kubernetes.io/master
 # Note that this Daemonset will not work straight out of the box for your cloud, this is
 # meant to be a guideline.


### PR DESCRIPTION
I noticed a typo in a recent blog post, and a similar typo appears in
the comments for some examples. This PR corrects these typos.

I see https://kubernetes.io/docs/contribute/new-content/overview/#languages-per-pr but I'm not sure if it applies since I'm changing English-language comments. If this needs to be PRed separately regardless of not needing language-specific review, please let me know. Thanks!

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>

