### PR TITLE
Update Japanese localization on concepts/overview/working-with-object…

### DIFF
--- a/content/ja/docs/concepts/overview/working-with-objects/kubernetes-objects.md
+++ b/content/ja/docs/concepts/overview/working-with-objects/kubernetes-objects.md
@@ -72,8 +72,8 @@ Kubernetesオブジェクトを`.yaml`ファイルに記載して作成する場
 
 
 
-* [Kubernetes API overview](/docs/reference/using-api/api-overview/)はこのページでは取り上げていない他のAPIについて説明します。
 * 最も重要、かつ基本的なKubernetesオブジェクト群を学びましょう、例えば、[Pod](/ja/docs/concepts/workloads/pods/)です。
 * Kubernetesの[コントローラー](/docs/concepts/architecture/controller/)を学びましょう。
+* [Using the Kubernetes API](/docs/reference/using-api/)はこのページでは取り上げていない他のAPIについて説明します。
 
 

--- a/content/ja/docs/concepts/overview/working-with-objects/kubernetes-objects.md
+++ b/content/ja/docs/concepts/overview/working-with-objects/kubernetes-objects.md
@@ -73,7 +73,6 @@ Kubernetesオブジェクトを`.yaml`ファイルに記載して作成する場
 
 
 * 最も重要、かつ基本的なKubernetesオブジェクト群を学びましょう、例えば、[Pod](/ja/docs/concepts/workloads/pods/)です。
-* Kubernetesの[コントローラー](/docs/concepts/architecture/controller/)を学びましょう。
+* Kubernetesの[コントローラー](/ja/docs/concepts/architecture/controller/)を学びましょう。
 * [Using the Kubernetes API](/docs/reference/using-api/)はこのページでは取り上げていない他のAPIについて説明します。
-
 


### PR DESCRIPTION
**What this PR does / why we need it:**
concepts/overview/working-with-objects/kubernetes-objects.md is outdated.

File to update
https://github.com/kubernetes/website/tree/dev-1.19-ja.1/content/ja/docs/concepts/overview/working-with-objects/kubernetes-objects.md

Original
https://github.com/kubernetes/website/tree/release-1.19/content/en/docs/concepts/overview/working-with-objects/kubernetes-objects.md

diff between translated and v1.19
https://gist.github.com/b02064fe97a59deabedf3a47732a47b8

**Which issue(s) this PR fixes:**
#26874 

**Notes**
Regading `docs/reference/using-api`, no Japanese doc found.
So this link refer English doc.