### PR TITLE
Update kops versioned download URLs

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kops.md
+++ b/content/en/docs/setup/production-environment/tools/kops.md
@@ -56,10 +56,10 @@ To download a specific version, replace the following portion of the command wit
 $(curl -s https://api.github.com/repos/kubernetes/kops/releases/latest | grep tag_name | cut -d '"' -f 4)
 ```
 
-For example, to download kops version v1.15.0 type:
+For example, to download kops version v1.20.0 type:
 
 ```shell
-curl -LO  https://github.com/kubernetes/kops/releases/download/1.15.0/kops-darwin-amd64
+curl -LO https://github.com/kubernetes/kops/releases/download/v1.20.0/kops-darwin-amd64
 ```
 
 Make the kops binary executable.
@@ -94,10 +94,10 @@ To download a specific version of kops, replace the following portion of the com
 $(curl -s https://api.github.com/repos/kubernetes/kops/releases/latest | grep tag_name | cut -d '"' -f 4)
 ```
 
-For example, to download kops version v1.15.0 type:
+For example, to download kops version v1.20.0 type:
 
 ```shell
-curl -LO  https://github.com/kubernetes/kops/releases/download/1.15.0/kops-linux-amd64
+curl -LO https://github.com/kubernetes/kops/releases/download/v1.20.0/kops-linux-amd64
 ```
 
 Make the kops binary executable


### PR DESCRIPTION
Recent kops releases started including a `v` prefix in their tags and GitHub releases.
This updates the instructions to a more recent kops version and includes that prefix in the URL.

See https://github.com/kubernetes/kops/releases/tag/v1.20.0