### PR TITLE
Fix start tutorial button url for french version

### DIFF
--- a/content/fr/docs/tutorials/kubernetes-basics/_index.html
+++ b/content/fr/docs/tutorials/kubernetes-basics/_index.html
@@ -108,7 +108,7 @@ card:
 
     <div class="row">
       <div class="col-md-12">
-        <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro/" role="button">Lancer le tutoriel<span class="btn__next">›</span></a>
+        <a class="btn btn-lg btn-success" href="/fr/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro/" role="button">Lancer le tutoriel<span class="btn__next">›</span></a>
       </div>
     </div>
 


### PR DESCRIPTION
fix the href attribute of the start tutorial button in the french documentation
