### PR TITLE
Capitalize "nginx" on docs/concepts/services-networking/ingress-controllers

### DIFF
--- a/content/en/docs/concepts/services-networking/ingress-controllers.md
+++ b/content/en/docs/concepts/services-networking/ingress-controllers.md
@@ -14,7 +14,7 @@ are not started automatically with a cluster. Use this page to choose the ingres
 that best fits your cluster.
 
 Kubernetes as a project supports and maintains [AWS](https://github.com/kubernetes-sigs/aws-load-balancer-controller#readme), [GCE](https://git.k8s.io/ingress-gce/README.md#readme), and
-  [nginx](https://git.k8s.io/ingress-nginx/README.md#readme) ingress controllers.
+  [NGINX](https://git.k8s.io/ingress-nginx/README.md#readme) ingress controllers.
 
 
 <!-- body -->


### PR DESCRIPTION
This PR just capitalize the word `nginx`. Because the official representation of `nginx` is `NGINX`. 

Actually, `NGINX` is used in another place on this page (such as https://github.com/shuuji3/kubernetes-website/blob/patch-4/content/en/docs/concepts/services-networking/ingress-controllers.md#L47).

📄 Page preview: https://deploy-preview-27590--kubernetes-io-master-staging.netlify.app/docs/concepts/services-networking/ingress-controllers/