### PR TITLE
Change the page title from "Secrets" to "Secret"

### DIFF
--- a/content/ja/docs/concepts/configuration/secret.md
+++ b/content/ja/docs/concepts/configuration/secret.md
@@ -1,5 +1,5 @@
 ---
-title: Secrets
+title: Secret
 content_type: concept
 feature:
   title: Secretと構成管理


### PR DESCRIPTION
For Japanese documentation, we use the singular form for Secret resource. So we don't have to use the plural form for this page title, same as the article body doesn't.