### PR TITLE
Fix the typo of `-f` argument in scripts/linkchecker.py

### DIFF
--- a/scripts/linkchecker.py
+++ b/scripts/linkchecker.py
@@ -373,7 +373,7 @@ def parse_arguments():
     parser.add_argument("-f", dest="filter", default="/docs/**/*.md",
                         metavar="<FILTER>",
                         help=("File pattern to scan, e.g. '/docs/foo.md'. "
-                              "(default='/docs/foo/*.md')"))
+                              "(default='/docs/**/*.md')"))
     parser.add_argument("-n", "--no-color", action="store_true",
                         help="Suppress colored printing.")
 


### PR DESCRIPTION
The help document of the `scripts/linkchecker.py` tells us that the default value of the `-f` argument is `/docs/foo/*.md` but actual default value is `/docs/**/*.md` (as written in [line 373](https://github.com/kubernetes/website/pull/27599/files#diff-06647e4be1e17b6a76975aafa115be634ce8139731bc0a5b60c9f25c0703bd87R373)). This PR fixes this typo.