### PR TITLE
Add auto_generated metadata

### DIFF
--- a/content/en/docs/reference/kubernetes-api/authentication-resources/_index.md
+++ b/content/en/docs/reference/kubernetes-api/authentication-resources/_index.md
@@ -1,4 +1,17 @@
 ---
 title: "Authentication Resources"
 weight: 4
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
+

--- a/content/en/docs/reference/kubernetes-api/authentication-resources/certificate-signing-request-v1.md
+++ b/content/en/docs/reference/kubernetes-api/authentication-resources/certificate-signing-request-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "CertificateSigningRequest objects provide a mechanism to obtain x509 certificates by submitting a certificate signing request, and having it asynchronously approved and issued."
 title: "CertificateSigningRequest"
 weight: 4
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: certificates.k8s.io/v1`
 

--- a/content/en/docs/reference/kubernetes-api/authentication-resources/service-account-v1.md
+++ b/content/en/docs/reference/kubernetes-api/authentication-resources/service-account-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "ServiceAccount binds together: * a name, understood by users, and perhaps by peripheral systems, for an identity * a principal that can be authenticated and authorized * a set of secrets."
 title: "ServiceAccount"
 weight: 1
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: v1`
 

--- a/content/en/docs/reference/kubernetes-api/authentication-resources/token-request-v1.md
+++ b/content/en/docs/reference/kubernetes-api/authentication-resources/token-request-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "TokenRequest requests a token for a given service account."
 title: "TokenRequest"
 weight: 2
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: authentication.k8s.io/v1`
 

--- a/content/en/docs/reference/kubernetes-api/authentication-resources/token-review-v1.md
+++ b/content/en/docs/reference/kubernetes-api/authentication-resources/token-review-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "TokenReview attempts to authenticate a token to a known user."
 title: "TokenReview"
 weight: 3
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: authentication.k8s.io/v1`
 

--- a/content/en/docs/reference/kubernetes-api/authorization-resources/_index.md
+++ b/content/en/docs/reference/kubernetes-api/authorization-resources/_index.md
@@ -1,4 +1,17 @@
 ---
 title: "Authorization Resources"
 weight: 5
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
+

--- a/content/en/docs/reference/kubernetes-api/authorization-resources/cluster-role-binding-v1.md
+++ b/content/en/docs/reference/kubernetes-api/authorization-resources/cluster-role-binding-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "ClusterRoleBinding references a ClusterRole, but not contain it."
 title: "ClusterRoleBinding"
 weight: 6
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: rbac.authorization.k8s.io/v1`
 

--- a/content/en/docs/reference/kubernetes-api/authorization-resources/cluster-role-v1.md
+++ b/content/en/docs/reference/kubernetes-api/authorization-resources/cluster-role-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding."
 title: "ClusterRole"
 weight: 5
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: rbac.authorization.k8s.io/v1`
 

--- a/content/en/docs/reference/kubernetes-api/authorization-resources/local-subject-access-review-v1.md
+++ b/content/en/docs/reference/kubernetes-api/authorization-resources/local-subject-access-review-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace."
 title: "LocalSubjectAccessReview"
 weight: 1
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: authorization.k8s.io/v1`
 

--- a/content/en/docs/reference/kubernetes-api/authorization-resources/role-binding-v1.md
+++ b/content/en/docs/reference/kubernetes-api/authorization-resources/role-binding-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "RoleBinding references a role, but does not contain it."
 title: "RoleBinding"
 weight: 8
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: rbac.authorization.k8s.io/v1`
 

--- a/content/en/docs/reference/kubernetes-api/authorization-resources/role-v1.md
+++ b/content/en/docs/reference/kubernetes-api/authorization-resources/role-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding."
 title: "Role"
 weight: 7
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: rbac.authorization.k8s.io/v1`
 

--- a/content/en/docs/reference/kubernetes-api/authorization-resources/self-subject-access-review-v1.md
+++ b/content/en/docs/reference/kubernetes-api/authorization-resources/self-subject-access-review-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "SelfSubjectAccessReview checks whether or the current user can perform an action."
 title: "SelfSubjectAccessReview"
 weight: 2
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: authorization.k8s.io/v1`
 

--- a/content/en/docs/reference/kubernetes-api/authorization-resources/self-subject-rules-review-v1.md
+++ b/content/en/docs/reference/kubernetes-api/authorization-resources/self-subject-rules-review-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "SelfSubjectRulesReview enumerates the set of actions the current user can perform within a namespace."
 title: "SelfSubjectRulesReview"
 weight: 3
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: authorization.k8s.io/v1`
 

--- a/content/en/docs/reference/kubernetes-api/authorization-resources/subject-access-review-v1.md
+++ b/content/en/docs/reference/kubernetes-api/authorization-resources/subject-access-review-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "SubjectAccessReview checks whether or not a user or group can perform an action."
 title: "SubjectAccessReview"
 weight: 4
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: authorization.k8s.io/v1`
 

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/_index.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/_index.md
@@ -1,4 +1,17 @@
 ---
 title: "Cluster Resources"
 weight: 8
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
+

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/api-service-v1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/api-service-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "APIService represents a server for a particular GroupVersion."
 title: "APIService"
 weight: 4
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: apiregistration.k8s.io/v1`
 

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/binding-v1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/binding-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "Binding ties one object to another; for example, a pod is bound to a node by a scheduler."
 title: "Binding"
 weight: 9
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: v1`
 

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/component-status-v1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/component-status-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "ComponentStatus (and ComponentStatusList) holds the cluster validation info."
 title: "ComponentStatus"
 weight: 10
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: v1`
 

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/event-v1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/event-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "Event is a report of an event somewhere in the cluster."
 title: "Event"
 weight: 3
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: events.k8s.io/v1`
 

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/flow-schema-v1beta1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/flow-schema-v1beta1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "FlowSchema defines the schema of a group of flows."
 title: "FlowSchema v1beta1"
 weight: 7
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: flowcontrol.apiserver.k8s.io/v1beta1`
 

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/lease-v1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/lease-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "Lease defines a lease concept."
 title: "Lease"
 weight: 5
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: coordination.k8s.io/v1`
 

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/namespace-v1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/namespace-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "Namespace provides a scope for Names."
 title: "Namespace"
 weight: 2
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: v1`
 

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/node-v1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/node-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "Node is a worker node in Kubernetes."
 title: "Node"
 weight: 1
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: v1`
 

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/priority-level-configuration-v1beta1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/priority-level-configuration-v1beta1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "PriorityLevelConfiguration represents the configuration of a priority level."
 title: "PriorityLevelConfiguration v1beta1"
 weight: 8
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: flowcontrol.apiserver.k8s.io/v1beta1`
 

--- a/content/en/docs/reference/kubernetes-api/cluster-resources/runtime-class-v1.md
+++ b/content/en/docs/reference/kubernetes-api/cluster-resources/runtime-class-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "RuntimeClass defines a class of container runtime supported in the cluster."
 title: "RuntimeClass"
 weight: 6
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: node.k8s.io/v1`
 

--- a/content/en/docs/reference/kubernetes-api/common-definitions/_index.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/_index.md
@@ -1,4 +1,17 @@
 ---
 title: "Common Definitions"
 weight: 9
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
+

--- a/content/en/docs/reference/kubernetes-api/common-definitions/delete-options.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/delete-options.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "DeleteOptions may be provided when deleting an API object."
 title: "DeleteOptions"
 weight: 1
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 
 

--- a/content/en/docs/reference/kubernetes-api/common-definitions/label-selector.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/label-selector.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "A label selector is a label query over a set of resources."
 title: "LabelSelector"
 weight: 2
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 
 

--- a/content/en/docs/reference/kubernetes-api/common-definitions/list-meta.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/list-meta.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "ListMeta describes metadata that synthetic resources must have, including lists and various status objects."
 title: "ListMeta"
 weight: 3
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 
 

--- a/content/en/docs/reference/kubernetes-api/common-definitions/local-object-reference.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/local-object-reference.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace."
 title: "LocalObjectReference"
 weight: 4
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 
 

--- a/content/en/docs/reference/kubernetes-api/common-definitions/node-selector-requirement.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/node-selector-requirement.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values."
 title: "NodeSelectorRequirement"
 weight: 5
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 
 

--- a/content/en/docs/reference/kubernetes-api/common-definitions/object-field-selector.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/object-field-selector.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "ObjectFieldSelector selects an APIVersioned field of an object."
 title: "ObjectFieldSelector"
 weight: 6
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 
 

--- a/content/en/docs/reference/kubernetes-api/common-definitions/object-meta.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/object-meta.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create."
 title: "ObjectMeta"
 weight: 7
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 
 

--- a/content/en/docs/reference/kubernetes-api/common-definitions/object-reference.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/object-reference.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "ObjectReference contains enough information to let you inspect or modify the referred object."
 title: "ObjectReference"
 weight: 8
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 
 

--- a/content/en/docs/reference/kubernetes-api/common-definitions/patch.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/patch.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body."
 title: "Patch"
 weight: 9
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 
 

--- a/content/en/docs/reference/kubernetes-api/common-definitions/quantity.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/quantity.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "Quantity is a fixed-point representation of a number."
 title: "Quantity"
 weight: 10
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 
 

--- a/content/en/docs/reference/kubernetes-api/common-definitions/resource-field-selector.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/resource-field-selector.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "ResourceFieldSelector represents container resources (cpu, memory) and their output format."
 title: "ResourceFieldSelector"
 weight: 11
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 
 

--- a/content/en/docs/reference/kubernetes-api/common-definitions/status.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/status.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "Status is a return value for calls that don't return other objects."
 title: "Status"
 weight: 12
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 
 

--- a/content/en/docs/reference/kubernetes-api/common-definitions/typed-local-object-reference.md
+++ b/content/en/docs/reference/kubernetes-api/common-definitions/typed-local-object-reference.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "TypedLocalObjectReference contains enough information to let you locate the typed referenced object inside the same namespace."
 title: "TypedLocalObjectReference"
 weight: 13
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 
 

--- a/content/en/docs/reference/kubernetes-api/common-parameters/common-parameters.md
+++ b/content/en/docs/reference/kubernetes-api/common-parameters/common-parameters.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: ""
 title: "Common Parameters"
 weight: 10
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 
 

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/_index.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/_index.md
@@ -1,4 +1,17 @@
 ---
 title: "Config and Storage Resources"
 weight: 3
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
+

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/config-map-v1.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/config-map-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "ConfigMap holds configuration data for pods to consume."
 title: "ConfigMap"
 weight: 1
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: v1`
 

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/csi-driver-v1.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/csi-driver-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "CSIDriver captures information about a Container Storage Interface (CSI) volume driver deployed on the cluster."
 title: "CSIDriver"
 weight: 8
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: storage.k8s.io/v1`
 

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/csi-node-v1.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/csi-node-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "CSINode holds information about all CSI drivers installed on a node."
 title: "CSINode"
 weight: 9
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: storage.k8s.io/v1`
 

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/csi-storage-capacity-v1beta1.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/csi-storage-capacity-v1beta1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "CSIStorageCapacity stores the result of one CSI GetCapacity call."
 title: "CSIStorageCapacity v1beta1"
 weight: 10
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: storage.k8s.io/v1beta1`
 

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "PersistentVolumeClaim is a user's request for and claim to a persistent volume."
 title: "PersistentVolumeClaim"
 weight: 4
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: v1`
 

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "PersistentVolume (PV) is a storage resource provisioned by an administrator."
 title: "PersistentVolume"
 weight: 5
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: v1`
 

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/secret-v1.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/secret-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "Secret holds secret data of a certain type."
 title: "Secret"
 weight: 2
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: v1`
 

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/storage-class-v1.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/storage-class-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned."
 title: "StorageClass"
 weight: 6
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: storage.k8s.io/v1`
 

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/volume-attachment-v1.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/volume-attachment-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node."
 title: "VolumeAttachment"
 weight: 7
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: storage.k8s.io/v1`
 

--- a/content/en/docs/reference/kubernetes-api/config-and-storage-resources/volume.md
+++ b/content/en/docs/reference/kubernetes-api/config-and-storage-resources/volume.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "Volume represents a named volume in a pod that may be accessed by any container in the pod."
 title: "Volume"
 weight: 3
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 
 

--- a/content/en/docs/reference/kubernetes-api/extend-resources/_index.md
+++ b/content/en/docs/reference/kubernetes-api/extend-resources/_index.md
@@ -1,4 +1,17 @@
 ---
 title: "Extend Resources"
 weight: 7
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
+

--- a/content/en/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1.md
+++ b/content/en/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "CustomResourceDefinition represents a resource that should be exposed on the API server."
 title: "CustomResourceDefinition"
 weight: 1
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: apiextensions.k8s.io/v1`
 

--- a/content/en/docs/reference/kubernetes-api/extend-resources/mutating-webhook-configuration-v1.md
+++ b/content/en/docs/reference/kubernetes-api/extend-resources/mutating-webhook-configuration-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "MutatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and may change the object."
 title: "MutatingWebhookConfiguration"
 weight: 2
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: admissionregistration.k8s.io/v1`
 

--- a/content/en/docs/reference/kubernetes-api/extend-resources/validating-webhook-configuration-v1.md
+++ b/content/en/docs/reference/kubernetes-api/extend-resources/validating-webhook-configuration-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "ValidatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and object without changing it."
 title: "ValidatingWebhookConfiguration"
 weight: 3
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: admissionregistration.k8s.io/v1`
 

--- a/content/en/docs/reference/kubernetes-api/policy-resources/_index.md
+++ b/content/en/docs/reference/kubernetes-api/policy-resources/_index.md
@@ -1,4 +1,17 @@
 ---
 title: "Policy Resources"
 weight: 6
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
+

--- a/content/en/docs/reference/kubernetes-api/policy-resources/limit-range-v1.md
+++ b/content/en/docs/reference/kubernetes-api/policy-resources/limit-range-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "LimitRange sets resource usage limits for each kind of resource in a Namespace."
 title: "LimitRange"
 weight: 1
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: v1`
 

--- a/content/en/docs/reference/kubernetes-api/policy-resources/network-policy-v1.md
+++ b/content/en/docs/reference/kubernetes-api/policy-resources/network-policy-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "NetworkPolicy describes what network traffic is allowed for a set of Pods."
 title: "NetworkPolicy"
 weight: 3
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: networking.k8s.io/v1`
 

--- a/content/en/docs/reference/kubernetes-api/policy-resources/pod-disruption-budget-v1.md
+++ b/content/en/docs/reference/kubernetes-api/policy-resources/pod-disruption-budget-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods."
 title: "PodDisruptionBudget"
 weight: 4
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: policy/v1`
 

--- a/content/en/docs/reference/kubernetes-api/policy-resources/pod-security-policy-v1beta1.md
+++ b/content/en/docs/reference/kubernetes-api/policy-resources/pod-security-policy-v1beta1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container."
 title: "PodSecurityPolicy v1beta1"
 weight: 5
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: policy/v1beta1`
 

--- a/content/en/docs/reference/kubernetes-api/policy-resources/resource-quota-v1.md
+++ b/content/en/docs/reference/kubernetes-api/policy-resources/resource-quota-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "ResourceQuota sets aggregate quota restrictions enforced per namespace."
 title: "ResourceQuota"
 weight: 2
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: v1`
 

--- a/content/en/docs/reference/kubernetes-api/service-resources/_index.md
+++ b/content/en/docs/reference/kubernetes-api/service-resources/_index.md
@@ -1,4 +1,17 @@
 ---
 title: "Service Resources"
 weight: 2
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
+

--- a/content/en/docs/reference/kubernetes-api/service-resources/endpoint-slice-v1.md
+++ b/content/en/docs/reference/kubernetes-api/service-resources/endpoint-slice-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "EndpointSlice represents a subset of the endpoints that implement a service."
 title: "EndpointSlice"
 weight: 3
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: discovery.k8s.io/v1`
 

--- a/content/en/docs/reference/kubernetes-api/service-resources/endpoints-v1.md
+++ b/content/en/docs/reference/kubernetes-api/service-resources/endpoints-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "Endpoints is a collection of endpoints that implement the actual service."
 title: "Endpoints"
 weight: 2
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: v1`
 

--- a/content/en/docs/reference/kubernetes-api/service-resources/ingress-class-v1.md
+++ b/content/en/docs/reference/kubernetes-api/service-resources/ingress-class-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "IngressClass represents the class of the Ingress, referenced by the Ingress Spec."
 title: "IngressClass"
 weight: 5
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: networking.k8s.io/v1`
 

--- a/content/en/docs/reference/kubernetes-api/service-resources/ingress-v1.md
+++ b/content/en/docs/reference/kubernetes-api/service-resources/ingress-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend."
 title: "Ingress"
 weight: 4
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: networking.k8s.io/v1`
 

--- a/content/en/docs/reference/kubernetes-api/service-resources/service-v1.md
+++ b/content/en/docs/reference/kubernetes-api/service-resources/service-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "Service is a named abstraction of software service (for example, mysql) consisting of local port (for example 3306) that the proxy listens on, and the selector that determines which pods will answer requests sent through the proxy."
 title: "Service"
 weight: 1
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: v1`
 

--- a/content/en/docs/reference/kubernetes-api/workload-resources/_index.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/_index.md
@@ -1,4 +1,17 @@
 ---
 title: "Workload Resources"
 weight: 1
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
+

--- a/content/en/docs/reference/kubernetes-api/workload-resources/controller-revision-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/controller-revision-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "ControllerRevision implements an immutable snapshot of state data."
 title: "ControllerRevision"
 weight: 8
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: apps/v1`
 

--- a/content/en/docs/reference/kubernetes-api/workload-resources/cron-job-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/cron-job-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "CronJob represents the configuration of a single cron job."
 title: "CronJob"
 weight: 11
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: batch/v1`
 

--- a/content/en/docs/reference/kubernetes-api/workload-resources/daemon-set-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/daemon-set-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "DaemonSet represents the configuration of a daemon set."
 title: "DaemonSet"
 weight: 9
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: apps/v1`
 

--- a/content/en/docs/reference/kubernetes-api/workload-resources/deployment-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/deployment-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "Deployment enables declarative updates for Pods and ReplicaSets."
 title: "Deployment"
 weight: 6
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: apps/v1`
 

--- a/content/en/docs/reference/kubernetes-api/workload-resources/ephemeral-containers-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/ephemeral-containers-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "A list of ephemeral containers used with the Pod ephemeralcontainers subresource."
 title: "EphemeralContainers"
 weight: 2
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: v1`
 

--- a/content/en/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "configuration of a horizontal pod autoscaler."
 title: "HorizontalPodAutoscaler"
 weight: 12
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: autoscaling/v1`
 

--- a/content/en/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2beta2.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2beta2.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified."
 title: "HorizontalPodAutoscaler v2beta2"
 weight: 13
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: autoscaling/v2beta2`
 

--- a/content/en/docs/reference/kubernetes-api/workload-resources/job-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/job-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "Job represents the configuration of a single job."
 title: "Job"
 weight: 10
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: batch/v1`
 

--- a/content/en/docs/reference/kubernetes-api/workload-resources/pod-template-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/pod-template-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "PodTemplate describes a template for creating copies of a predefined pod."
 title: "PodTemplate"
 weight: 3
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: v1`
 

--- a/content/en/docs/reference/kubernetes-api/workload-resources/pod-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/pod-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "Pod is a collection of containers that can run on a host."
 title: "Pod"
 weight: 1
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: v1`
 

--- a/content/en/docs/reference/kubernetes-api/workload-resources/priority-class-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/priority-class-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "PriorityClass defines mapping from a priority class name to the priority integer value."
 title: "PriorityClass"
 weight: 14
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: scheduling.k8s.io/v1`
 

--- a/content/en/docs/reference/kubernetes-api/workload-resources/replica-set-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/replica-set-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "ReplicaSet ensures that a specified number of pod replicas are running at any given time."
 title: "ReplicaSet"
 weight: 5
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: apps/v1`
 

--- a/content/en/docs/reference/kubernetes-api/workload-resources/replication-controller-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/replication-controller-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "ReplicationController represents the configuration of a replication controller."
 title: "ReplicationController"
 weight: 4
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: v1`
 

--- a/content/en/docs/reference/kubernetes-api/workload-resources/stateful-set-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/stateful-set-v1.md
@@ -7,7 +7,19 @@ content_type: "api_reference"
 description: "StatefulSet represents a set of pods with consistent identities."
 title: "StatefulSet"
 weight: 7
+auto_generated: true
 ---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
 
 `apiVersion: apps/v1`
 


### PR DESCRIPTION
Related to #27509 

Add the `auto_generated: true` metadata to the generated files for the API specs, so the *Edit this page* link is not visible (when featue is implemented).

Also add some comment in the source of the file to indicate the file is auto-generated.

Example at https://deploy-preview-27603--kubernetes-io-master-staging.netlify.app/docs/reference/kubernetes-api/workload-resources/pod-v1/