### PR TITLE
container-runtimes: fix 404 link to cgroup driver migration guide

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -59,7 +59,7 @@ configuration, or reinstall it using automation.
 
 ### Migrating to the `systemd` driver in kubeadm managed clusters
 
-Follow this [Migration guide](docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver)
+Follow this [Migration guide](/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver)
 if you wish to migrate to the `systemd` cgroup driver in existing kubeadm managed clusters.
 
 ## Container runtimes


### PR DESCRIPTION
The URL needs a leading '/', otherwise it points to:
https://kubernetes.io/docs/setup/production-environment/container-runtimes/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver

fixes https://github.com/kubernetes/website/issues/27516
/sig cluster-lifecycle