### PR TITLE
Going emeritus, remove myself from WGs and SIGs

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -11,7 +11,7 @@ emeritus_approvers:
 # - jaredbhatti, commented out to disable PR assignments
 # - steveperry-53, commented out to disable PR assignments
 - stewart-yu 
-- zacharysarah
+# - zacharysarah, commented out to disable PR assignments
 
 labels:
 - sig/docs

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,7 +3,6 @@ aliases:
     - castrojo
     - kbarnard10
     - onlydole
-    - zacharysarah
     - mrbobbytables
   sig-docs-blog-reviewers: # Reviewers for blog content
     - castrojo
@@ -33,7 +32,6 @@ aliases:
     - sftim
     - steveperry-53
     - tengqm
-    - zacharysarah
     - zparnold
   sig-docs-en-reviews: # PR reviews for English content
     - bradtopol

--- a/content/en/docs/contribute/localization.md
+++ b/content/en/docs/contribute/localization.md
@@ -4,7 +4,6 @@ content_type: concept
 approvers:
 - remyleone
 - rlenferink
-- zacharysarah
 weight: 50
 card:
   name: contribute


### PR DESCRIPTION
This PR removes myself as an approver/reviewer in SIG Docs.

It's been a wonderful four years...and now it's time for something different. ❤️ 

Related PRs:
- https://github.com/kubernetes/community/pull/5733
- https://github.com/kubernetes/org/pull/2649

![so-long](https://user-images.githubusercontent.com/3210446/115466755-5b85a500-a1e5-11eb-8b17-c82f080857c0.jpeg)

