### PR TITLE
taint-and-toleration: Delete out-of-disk, add pid-pressure

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -210,9 +210,9 @@ are true. The following taints are built in:
    the NodeCondition `Ready` being "`False`".
  * `node.kubernetes.io/unreachable`: Node is unreachable from the node
    controller. This corresponds to the NodeCondition `Ready` being "`Unknown`".
- * `node.kubernetes.io/out-of-disk`: Node becomes out of disk.
  * `node.kubernetes.io/memory-pressure`: Node has memory pressure.
  * `node.kubernetes.io/disk-pressure`: Node has disk pressure.
+ * `node.kubernetes.io/pid-pressure`: Node has PID pressure.
  * `node.kubernetes.io/network-unavailable`: Node's network is unavailable.
  * `node.kubernetes.io/unschedulable`: Node is unschedulable.
  * `node.cloudprovider.kubernetes.io/uninitialized`: When the kubelet is started
@@ -275,7 +275,7 @@ tolerations to all daemons, to prevent DaemonSets from breaking.
 
   * `node.kubernetes.io/memory-pressure`
   * `node.kubernetes.io/disk-pressure`
-  * `node.kubernetes.io/out-of-disk` (*only for critical pods*)
+  * `node.kubernetes.io/pid-pressure` (1.14 or later)
   * `node.kubernetes.io/unschedulable` (1.10 or later)
   * `node.kubernetes.io/network-unavailable` (*host network only*)
 


### PR DESCRIPTION
Delete a reference to the `node.kubernetes.io/out-of-disk` taint, which Kubernetes 1.14 deleted (https://github.com/kubernetes/kubernetes/pull/67037/commits/8f87e71e0cc3a2b714291ecd7210dfd8f4de33d6).

Document that the DaemonSet controller adds a toleration for the `node.kubernetes.io/pid-pressure` taint since Kubernetes 1.14 (https://github.com/kubernetes/kubernetes/pull/67036/commits/ad6e3617d3e92f47fa0874ca258ffe31d1d2ff4c).

* `content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md`: Delete references to `node.kubernetes.io/out-of-disk` and document that the DaemonSet adds a toleration for `node.kubernetes.io/pid-pressure`.