### PR TITLE
Decreate Quobyte's in-tree plugin

### DIFF
--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -922,17 +922,14 @@ receive updates for those volume sources.
 
 ### quobyte
 
-A `quobyte` volume allows an existing [Quobyte](https://www.quobyte.com) volume to
-be mounted into your Pod.
-
-{{< note >}}
-You must have your own Quobyte setup and running with the volumes
-created before you can use it.
-{{< /note >}}
+**Quobyte's in-tree plugin is deprecated.** Use
+[Quobyte CSI](https://github.com/quobyte/quobyte-csi#quobyte-csi) in place
+of `quobyte` in-tree plugin.
 
 Quobyte supports the {{< glossary_tooltip text="Container Storage Interface" term_id="csi" >}}.
-CSI is the recommended plugin to use Quobyte volumes inside Kubernetes. Quobyte's
-GitHub project has [instructions](https://github.com/quobyte/quobyte-csi#quobyte-csi) for deploying Quobyte using CSI, along with examples.
+Quobyte CSI plugin enalbes the usage of Quobyte volumes inside Kubernetes. Quobyte's
+GitHub project has [instructions](https://github.com/quobyte/quobyte-csi#quobyte-csi) to deploy
+the plugin and usage examples.
 
 ### rbd
 


### PR DESCRIPTION
Quobyte CSI replaces the deprecated in-tree plugin.
This patch updates the documentation and points the
quobyte volume section to Quobyte's CSI driver/plugin.

deprecation PR: https://github.com/kubernetes/kubernetes/issues/100900