### PR TITLE
Update Quobyte StorageClass reference

### DIFF
--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -548,52 +548,8 @@ parameters:
 
 ### Quobyte
 
-```yaml
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-   name: slow
-provisioner: kubernetes.io/quobyte
-parameters:
-    quobyteAPIServer: "http://138.68.74.142:7860"
-    registry: "138.68.74.142:7861"
-    adminSecretName: "quobyte-admin-secret"
-    adminSecretNamespace: "kube-system"
-    user: "root"
-    group: "root"
-    quobyteConfig: "BASE"
-    quobyteTenant: "DEFAULT"
-```
-
-* `quobyteAPIServer`: API Server of Quobyte in the format
-  `"http(s)://api-server:7860"`
-* `registry`: Quobyte registry to use to mount the volume. You can specify the
-  registry as ``<host>:<port>`` pair or if you want to specify multiple
-  registries, put a comma between them.
-  ``<host1>:<port>,<host2>:<port>,<host3>:<port>``.
-  The host can be an IP address or if you have a working DNS you can also
-  provide the DNS names.
-* `adminSecretNamespace`: The namespace for `adminSecretName`.
-  Default is "default".
-* `adminSecretName`: secret that holds information about the Quobyte user and
-  the password to authenticate against the API server. The provided secret
-  must have type "kubernetes.io/quobyte" and the keys `user` and `password`,
-  for example:
-
-    ```shell
-    kubectl create secret generic quobyte-admin-secret \
-      --type="kubernetes.io/quobyte" --from-literal=user='admin' --from-literal=password='opensesame' \
-      --namespace=kube-system
-    ```
-
-* `user`: maps all access to this user. Default is "root".
-* `group`: maps all access to this group. Default is "nfsnobody".
-* `quobyteConfig`: use the specified configuration to create the volume. You
-  can create a new configuration or modify an existing one with the Web
-  console or the quobyte CLI. Default is "BASE".
-* `quobyteTenant`: use the specified tenant ID to create/delete the volume.
-  This Quobyte tenant has to be already present in Quobyte.
-  Default is "DEFAULT".
+An [example](https://github.com/quobyte/quobyte-csi/blob/master/example/StorageClass.yaml)
+ Quobyte `StorageClass` can be found at the Quobyte CSI repository.
 
 ### Azure Disk
 


### PR DESCRIPTION
Quobyte no longer recommends usage of in-tree plugin, instead
uses CSI driver. The current StorageClass example is based
on the in-tree plugin and out-dated. This patch points to the
example StorageClass available at the Quobyte CSI repository.

In response to https://github.com/kubernetes/website/pull/27631#issuecomment-823884333, posting it on `dev-1.22` branch
