### PR TITLE
Update Japanese localization on concepts/configuration/configmap.md

### DIFF
--- a/content/ja/docs/concepts/configuration/configmap.md
+++ b/content/ja/docs/concepts/configuration/configmap.md
@@ -188,7 +188,7 @@ data:
 immutable: true
 ```
 
-一度ConfigMapがイミュータブルに設定されると、この変更を元に戻したり、`data`または`binaryData`フィールドのコンテンツを変更することは*できません*。Configmapの削除と再作成のみ可能です。既存のPodは削除されたConfigMapのマウントポイントを保持するため、こうしたPodは再作成することをおすすめします。
+一度ConfigMapがイミュータブルに設定されると、この変更を元に戻したり、`data`または`binaryData`フィールドのコンテンツを変更することは*できません*。ConfigMapの削除と再作成のみ可能です。既存のPodは削除されたConfigMapのマウントポイントを保持するため、こうしたPodは再作成することをおすすめします。
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/ja/docs/concepts/configuration/configmap.md
+++ b/content/ja/docs/concepts/configuration/configmap.md
@@ -30,7 +30,7 @@ ConfigMapは、他のオブジェクトが使うための設定を保存でき�
 
 ConfigMapの名前は、有効な[DNSのサブドメイン名](/ja/docs/concepts/overview/working-with-objects/names#dns-subdomain-names)でなければなりません。
 
-`data`または` binaryData`フィールドの各キーは、英数字、`-`、`_`、または`.`で構成されている必要があります。`data`に格納されているキーは、`binaryData`フィールドのキーと重複することはできません。
+`data`または`binaryData`フィールドの各キーは、英数字、`-`、`_`、または`.`で構成されている必要があります。`data`に格納されているキーは、`binaryData`フィールドのキーと重複することはできません。
 
 v1.19以降、ConfigMapの定義に`immutable`フィールドを追加して、[イミュータブルなConfigMap](#configmap-immutable)を作成できます。
 

--- a/content/ja/docs/concepts/configuration/configmap.md
+++ b/content/ja/docs/concepts/configuration/configmap.md
@@ -26,7 +26,7 @@ ConfigMapは、大量のデータを保持するようには設計されてい�
 
 ## ConfigMapオブジェクト
 
-ConfigMapは、他のオブジェクトが使うための設定を保存できるAPI[オブジェクト](/ja/docs/concepts/overview/working-with-objects/kubernetes-objects/)です。ほとんどのKubernetesオブジェクトに`spec`セクションがあるのとは違い、ConfigMapには`data`および`binaryData`フィールドがあります。これらのフィールドは、キーとバリューのペアを値として受け入れます。`data`フィールドと` binaryData`フィールドはどちらもオプションです。`data`フィールドはUTF-8バイトシーケンスを含むように設計されていますが、` binaryData`フィールドはバイナリデータを含むように設計されています。
+ConfigMapは、他のオブジェクトが使うための設定を保存できるAPI[オブジェクト](/ja/docs/concepts/overview/working-with-objects/kubernetes-objects/)です。ほとんどのKubernetesオブジェクトに`spec`セクションがあるのとは違い、ConfigMapには`data`および`binaryData`フィールドがあります。これらのフィールドは、キーとバリューのペアを値として受け入れます。`data`フィールドと`binaryData`フィールドはどちらもオプションです。`data`フィールドはUTF-8バイトシーケンスを含むように設計されていますが、`binaryData`フィールドはバイナリデータを含むように設計されています。
 
 ConfigMapの名前は、有効な[DNSのサブドメイン名](/ja/docs/concepts/overview/working-with-objects/names#dns-subdomain-names)でなければなりません。
 


### PR DESCRIPTION
**What this PR does / why we need it:**
concepts/configuration/configmap.md is outdated.

File to update
https://github.com/kubernetes/website/tree/dev-1.19-ja.1/content/ja/docs/concepts/configuration/configmap.md

Original
https://github.com/kubernetes/website/tree/release-1.19/content/en/docs/concepts/configuration/configmap.md

diff between translated and v1.19
https://gist.github.com/e92f6d3b819b60295505744afabab6f9

**Which issue(s) this PR fixes:**
#26859 