### PR TITLE
[zh] update kube-controller-manager --leader-elect-resource-lock default value in Chinese version

### DIFF
--- a/content/zh/docs/reference/command-line-tools-reference/kube-controller-manager.md
+++ b/content/zh/docs/reference/command-line-tools-reference/kube-controller-manager.md
@@ -1176,7 +1176,7 @@ The interval between attempts by the acting master to renew a leadership slot be
 </tr>
 
 <tr>
-<td colspan="2">--leader-elect-resource-lock string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<!--Default:-->默认值："endpointsleases"</td>
+<td colspan="2">--leader-elect-resource-lock string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<!--Default:-->默认值："leases"</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">


### PR DESCRIPTION
[zh] update kube-controller-manager --leader-elect-resource-lock default value in Chinese version to `leases `

Closes #27642
