### PR TITLE
Add the search box and the toggle section navigation

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -444,7 +444,7 @@ body.cid-community > #deprecation-warning > .deprecation-warning > * {
 .td-sidebar__inner {
   form.td-sidebar__search {
 
-    button.td-sidebar__toggle {
+    .td-sidebar__toggle {
       &:hover {
         color: #000000;
       }
@@ -481,10 +481,6 @@ main.content {
 /* BLOG */
 
 .td-blog {
-
-  .td-sidebar-nav {
-    max-height: calc(100vh - 8rem);
-  }
 
   .widget-link {
     margin-bottom: 1rem;

--- a/layouts/partials/blog-sidebar.html
+++ b/layouts/partials/blog-sidebar.html
@@ -5,6 +5,13 @@ sidebar-tree in use elsewhere on the site. */}}
 {{ $shouldDelayActive := ge (len .Site.Pages) 2000 }}
 
 <div id="td-sidebar-menu" class="td-sidebar__inner{{ if $shouldDelayActive }} d-none{{ end }}">
+
+  <form class="td-sidebar__search d-flex align-items-center">
+    {{ partial "search-input.html" . }}
+    <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fas fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-docs-nav" aria-expanded="false" aria-label="Toggle section navigation">
+    </button>
+  </form>
+  
   <nav class="collapse td-sidebar-nav pt-2 pl-4" id="td-section-nav">
     <!-- {{ if  (gt (len .Site.Home.Translations) 0) }}
     <div class="nav-item dropdown d-block d-lg-none">


### PR DESCRIPTION
✅ Resolves #20895.
📄 Page preview: https://deploy-preview-27689--kubernetes-io-master-staging.netlify.app/blog/

## Search box

This PR adds the search box to the blog page.

**Screenshot:**
<img width="859" alt="Screen Shot 2021-04-23 at 21 34 39" src="https://user-images.githubusercontent.com/1425259/115873192-9efa4080-a47d-11eb-8f19-292471c85e73.png">

## Toggle button

Also, this adds the toggle button on the right of the search box for the mobile page. Clicking the button expands the navigation menu. It's the same as the documentation pages. 

**Screenshot:**
<img width="391" alt="Screen Shot 2021-04-23 at 21 34 54" src="https://user-images.githubusercontent.com/1425259/115873262-b0434d00-a47d-11eb-8b69-ffb3742f7979.png">
<img width="387" alt="Screen Shot 2021-04-23 at 21 35 20" src="https://user-images.githubusercontent.com/1425259/115873255-ad485c80-a47d-11eb-9b60-f9fe60825238.png">

## How to test

1. Open the blog page (https://deploy-preview-27689--kubernetes-io-master-staging.netlify.app/blog).
2. Test search functionality with keywords you like.
3. Change to the mobile view.
4. Test search again.
5. Tap the toggle button and confirm to show the Table of Contents of the page.
