### PR TITLE
Fix a markup error on concepts/workloads/controllers/garbage-collection

### DIFF
--- a/content/ja/docs/concepts/workloads/controllers/garbage-collection.md
+++ b/content/ja/docs/concepts/workloads/controllers/garbage-collection.md
@@ -124,7 +124,7 @@ kubectl delete replicaset my-repset --cascade=false
 
 ### Deploymentsに関する追記事項
 
-Kubernetes1.7以前では、Deploymentに対するカスケード削除において、作成されたReplicaSetだけでなく、それらのPodも削除するためには、ユーザーは`propagationPolicy: Foreground`と指定*しなくてはなりません* 。もしこのタイプの_propagationPolicy_ が使われなかった場合、そのReplicaSetは削除されますが、そのPodは削除されずみなしご状態になります。  
+Kubernetes1.7以前では、Deploymentに対するカスケード削除において、作成されたReplicaSetだけでなく、それらのPodも削除するためには、ユーザーは`propagationPolicy: Foreground`と指定*しなくてはなりません* 。もしこのタイプの*propagationPolicy*が使われなかった場合、そのReplicaSetは削除されますが、そのPodは削除されずみなしご状態になります。  
 さらなる詳細に関しては[kubeadm/#149](https://github.com/kubernetes/kubeadm/issues/149#issuecomment-284766613)を参照してください。
 
 ## 既知の問題について


### PR DESCRIPTION
This PR fixes a markup error on [this section](https://kubernetes.io/ja/docs/concepts/workloads/controllers/garbage-collection/#deployments%E3%81%AB%E9%96%A2%E3%81%99%E3%82%8B%E8%BF%BD%E8%A8%98%E4%BA%8B%E9%A0%85).

The text "もしこのタイプの_propagationPolicy_ が使われなかった場合" should be rendered as "もしこのタイプの*propagationPolicy*が使われなかった場合".