### PR TITLE
Fix the "prerequisites" header

### DIFF
--- a/content/ja/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/ja/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -10,7 +10,7 @@ Horizontal Pod Autoscalerは、Deployment、ReplicaSetまたはStatefulSetとい
 
 このドキュメントはphp-apacheサーバーに対しHorizontal Pod Autoscalerを有効化するという例に沿ってウォークスルーで説明していきます。Horizontal Pod Autoscalerの動作についてのより詳細な情報を知りたい場合は、[Horizontal Pod Autoscalerユーザーガイド](/docs/tasks/run-application/horizontal-pod-autoscale/)をご覧ください。
 
-## {{% heading "前提条件" %}}
+## {{% heading "prerequisites" %}}
 
 この例ではバージョン1.2以上の動作するKubernetesクラスターおよびkubectlが必要です。
 [Metrics API](https://github.com/kubernetes/metrics)を介してメトリクスを提供するために、[Metrics server](https://github.com/kubernetes-sigs/metrics-server)によるモニタリングがクラスター内にデプロイされている必要があります。


### PR DESCRIPTION
This PR fixes the empty "prerequisites" header on this page: https://kubernetes.io/ja/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/.

The cause of this issue is that the "heading" partial parameter was translated, but it is not needed in this case.

Note: I'm targeting the `master` branch instead of `dev-1.19-ja.1` because the branch doesn't have this page. (ref. https://github.com/kubernetes/website/tree/dev-1.19-ja.1/content/ja/docs/tasks/run-application)