### PR TITLE
Append `.git` to upstream URLs

### DIFF
--- a/content/en/docs/contribute/new-content/open-a-pr.md
+++ b/content/en/docs/contribute/new-content/open-a-pr.md
@@ -123,8 +123,8 @@ Make sure you have [git](https://git-scm.com/book/en/v2/Getting-Started-Installi
     ```bash
     origin	git@github.com:<github_username>/website.git (fetch)
     origin	git@github.com:<github_username>/website.git (push)
-    upstream	https://github.com/kubernetes/website (fetch)
-    upstream	https://github.com/kubernetes/website (push)
+    upstream	https://github.com/kubernetes/website.git (fetch)
+    upstream	https://github.com/kubernetes/website.git (push)
     ```
 
 6. Fetch commits from your fork's `origin/master` and `kubernetes/website`'s `upstream/master`:


### PR DESCRIPTION
The upstream URLs are missing the `.git` suffix. You can see this minor omission if you run the `git remote -v` command in your local `website` repo.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
