### PR TITLE
Adjust yaml indentation on allowedHostPaths example

### DIFF
--- a/content/en/docs/concepts/policy/pod-security-policy.md
+++ b/content/en/docs/concepts/policy/pod-security-policy.md
@@ -465,9 +465,9 @@ For example:
 
 ```yaml
   allowedHostPaths:
-  # This allows "/foo", "/foo/", "/foo/bar" etc., but
-  # disallows "/fool", "/etc/foo" etc.
-  # "/foo/../" is never valid.
+    # This allows "/foo", "/foo/", "/foo/bar" etc., but
+    # disallows "/fool", "/etc/foo" etc.
+    # "/foo/../" is never valid.
     - pathPrefix: "/foo"
       readOnly: true # only allow read-only mounts
 ```

--- a/content/en/docs/concepts/policy/pod-security-policy.md
+++ b/content/en/docs/concepts/policy/pod-security-policy.md
@@ -464,12 +464,12 @@ allowed prefix, and a `readOnly` field indicating it must be mounted read-only.
 For example:
 
 ```yaml
-allowedHostPaths:
+  allowedHostPaths:
   # This allows "/foo", "/foo/", "/foo/bar" etc., but
   # disallows "/fool", "/etc/foo" etc.
   # "/foo/../" is never valid.
-  - pathPrefix: "/foo"
-    readOnly: true # only allow read-only mounts
+    - pathPrefix: "/foo"
+      readOnly: true # only allow read-only mounts
 ```
 
 {{< warning >}}There are many ways a container with unrestricted access to the host


### PR DESCRIPTION
allowedHostPaths is an attribute inside spec: of PSP, so the sample needs to be shifted to match the YAML.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
