### PR TITLE
Write Vixie in title case

### DIFF
--- a/content/en/docs/tasks/job/automated-tasks-with-cron-jobs.md
+++ b/content/en/docs/tasks/job/automated-tasks-with-cron-jobs.md
@@ -146,7 +146,7 @@ All modifications to a cron job, especially its `.spec`, are applied only to the
 The `.spec.schedule` is a required field of the `.spec`.
 It takes a [Cron](https://en.wikipedia.org/wiki/Cron) format string, such as `0 * * * *` or `@hourly`, as schedule time of its jobs to be created and executed.
 
-The format also includes extended `vixie cron` step values. As explained in the
+The format also includes extended "Vixie cron" step values. As explained in the
 [FreeBSD manual](https://www.freebsd.org/cgi/man.cgi?crontab%285%29):
 
 > Step values can be	used in	conjunction with ranges.  Following a range


### PR DESCRIPTION
The surname Vixie (as in [Paul Vixie](https://www.circleid.com/members/620/)) should be in title case as it is a proper noun, even as part of the name of Vixie cron.

"vixie cron" (with a space in it) is not the name of any scheduling tool; there are tools named vixie-cron but that is different from the
existing text.

/kind cleanup