### PR TITLE
Clarify use of QoS in eviction ranking

### DIFF
--- a/content/en/docs/concepts/configuration/pod-priority-preemption.md
+++ b/content/en/docs/concepts/configuration/pod-priority-preemption.md
@@ -353,20 +353,21 @@ the removal of the lowest priority Pods is not sufficient to allow the scheduler
 to schedule the preemptor Pod, or if the lowest priority Pods are protected by
 `PodDisruptionBudget`.
 
-The only component that considers both QoS and Pod priority is
-[kubelet out-of-resource eviction](/docs/tasks/administer-cluster/out-of-resource/).
-The kubelet ranks Pods for eviction first by whether or not their usage of the
-starved resource exceeds requests, then by Priority, and then by the consumption
-of the starved compute resource relative to the Pods' scheduling requests.
-See
-[evicting end-user pods](/docs/tasks/administer-cluster/out-of-resource/#evicting-end-user-pods)
+The kubelet uses Priority to determine pod order for [out-of-resource eviction](/docs/tasks/administer-cluster/out-of-resource/).
+You can use the QoS class to estimate the order in which pods are most likely
+to get evicted. The kubelet ranks pods for eviction based on the following factors:
+
+  1. Whether the starved resource usage exceeds requests
+  1. Pod Priority
+  1. Amount of resource usage relative to requests 
+
+See [evicting end-user pods](/docs/tasks/administer-cluster/out-of-resource/#evicting-end-user-pods)
 for more details.
 
 kubelet out-of-resource eviction does not evict Pods when their
 usage does not exceed their requests. If a Pod with lower priority is not
 exceeding its requests, it won't be evicted. Another Pod with higher priority
 that exceeds its requests may be evicted.
-
 
 ## {{% heading "whatsnext" %}}
 


### PR DESCRIPTION
Fixes #27753 

Affected section: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#interactions-of-pod-priority-and-qos

/sig docs
/language en
/do-not-merge work-in-progress
/review @dashpole 