### PR TITLE
Fixes sidebar link for blog posts

### DIFF
--- a/layouts/partials/blog-meta-links.html
+++ b/layouts/partials/blog-meta-links.html
@@ -3,7 +3,7 @@
   <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}" title="{{ site.Title }}">
   <a class="widget-link" href="{{ .Permalink | safeURL }}"><div> <i class="fas fa-rss fab-icon"> </i> <span class="widget-link-text">RSS Feed</span></div> </a>
   {{ end -}}
-  <a class="widget-link" href="https://kubernetes.io/docs/contribute/start/#write-a-blog-post"><div> <i class="fa fa-edit fab-icon"></i> <span class="widget-link-text">Submit a Post</span></div></a>
+  <a class="widget-link" href="https://kubernetes.io/docs/contribute/new-content/blogs-case-studies/"><div> <i class="fa fa-edit fab-icon"></i> <span class="widget-link-text">Submit a Post</span></div></a>
   <a class="widget-link" href="https://twitter.com/kubernetesio"><div> <i class="fab fa-twitter-square fab-icon"> </i> <span class="widget-link-text"> @Kubernetesio</span></div></a>
   <a class="widget-link" href="https://github.com/kubernetes/kubernetes"><div> <i class="fab fa-github-square fab-icon"></i> <span class="widget-link-text"> on GitHub </span></div></a>
   <a class="widget-link" href="http://slack.k8s.io"><div><i class="fab fa-slack fab-icon"> </i> <span class="widget-link-text">#kubernetes-users </span></div></a>


### PR DESCRIPTION
Hi, website friends! I was trying to send a colleague a link for how to create a Kubernetes.io blog post. I followed the link on the right sidebar from https://kubernetes.io/blog/:

![image](https://user-images.githubusercontent.com/2104453/116465050-556d7500-a832-11eb-8cfb-d9fb8d62e192.png)

Unfortunately, https://kubernetes.io/docs/contribute/#write-a-blog-post is an old link and since the anchor doesn't go anywhere obvious, one needs to scroll down and hopefully find the link to the page one would actually want. (The `start` redirection doesn't help here, as the anchor is gone.)

After I found the `Submit a blog post or case study` item all the way at the end, I realized that's a better target for the sidebar's call to action, as it will take people to the actual thing they're looking for, just as the previous link would have (until it changed [sometime in the 1.18 release cycle](https://github.com/kubernetes/website/blob/dev-1.18/content/en/docs/contribute/start.md#write-a-blog-post)).


Signed-off-by: Bridget Kromhout <bridget@kromhout.org>
