### PR TITLE
Change `<meta name="robots">` content to "noindex, nofollow" when the print format mode

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -19,11 +19,12 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 {{ hugo.Generator }}
-{{ if eq (getenv "HUGO_ENV") "production" }}
+{{- $outputFormat := partial "outputformat.html" . -}}
+{{ if and (eq (getenv "HUGO_ENV") "production") (ne $outputFormat "print") -}}
 <META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
-{{ else }}
+{{ else -}}
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
-{{ end }}
+{{ end -}}
 {{ range .AlternativeOutputFormats -}}
 <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
 {{ end -}}

--- a/layouts/partials/outputformat.html
+++ b/layouts/partials/outputformat.html
@@ -1,0 +1,12 @@
+{{/* Return the current page outputformat */}}
+{{ $alts := newScratch }}
+{{ $format := "unknown" }}
+{{ range .AlternativeOutputFormats }}
+    {{ $alts.Set .Name true }}
+{{ end }}
+{{ range .OutputFormats }}
+    {{ if not ($alts.Get .Name) }}
+        {{ $format = .Name }}
+    {{ end }}
+{{ end }}
+{{ return $format }}


### PR DESCRIPTION
✅ Resolves #27690.

I used the latest [layouts/partials/head.html](https://github.com/google/docsy/blob/67eaa0fe6deb383abae8ec7ccf426e28f243147d/layouts/partials/head.html) and [layouts/partials/outputformat.html](https://github.com/google/docsy/blob/fb2e9c9647e02109b018921d356ad3a7bed10a26/layouts/partials/outputformat.html) of the upstream Docsy repository for this change. Both files are added when the print format mode was implemented (https://github.com/google/docsy/pull/356).

## How to check

### Normal document page

Page preview: https://deploy-preview-27807--kubernetes-io-master-staging.netlify.app/docs/home/

Check if the following `<meta>` tag in `<head>`:

```html
<meta name="ROBOTS" content="INDEX, FOLLOW">
```

The current pages contains the same tag on both the normal page and the print format page:
- https://kubernetes.io/docs/home/
- https://kubernetes.io/docs/home/_print/

### Print format mode page

Page preview: https://deploy-preview-27807--kubernetes-io-master-staging.netlify.app/docs/home/_print/

Check if the print format page has a new "noindex, nofollow" meta tag like this:

```html
<meta name="ROBOTS" content="NOINDEX, NOFOLLOW">
```