### PR TITLE
OWNERS_ALIASES: add pi-victor as part of sig-docs-en-owners.

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -27,6 +27,7 @@ aliases:
     - kbarnard10
     - kbhawkey
     - onlydole
+    - pi-victor
     - reylejano
     - savitharaghunathan
     - sftim


### PR DESCRIPTION
As Docs RT lead, this is a request for approval rights for 1.22 release. This is part of the [handbook process](https://github.com/kubernetes/sig-release/blob/master/release-team/role-handbooks/docs/Release-Timeline.md#ensure-access-is-set-up).

/cc @jimangel @irvifa @sftim

p.s.: if it were after me, i'd rather not have this, but i'd have to burden someone else with the tasks that require approval.

Signed-off-by: Victor Palade <victor@cloudflavor.io>

