### PR TITLE
[ko] Update task tookls and network in dev-1.21-ko.2

### DIFF
--- a/content/ko/docs/tasks/network/validate-dual-stack.md
+++ b/content/ko/docs/tasks/network/validate-dual-stack.md
@@ -1,4 +1,8 @@
 ---
+
+
+
+
 min-kubernetes-server-version: v1.20
 title: IPv4/IPv6 이중 스택 검증
 content_type: task
@@ -36,9 +40,10 @@ a00:100::/24
 ```
 단일 IPv4 블록과 단일 IPv6 블록이 할당되어야 한다.
 
-노드가 IPv4 및 IPv6 인터페이스를 가지고 있는지 검증한다. (노드 이름을 클러스터의 검증된 노드로 대체한다. 본 예제에서 노드 이름은 k8s-linuxpool1-34450317-0) 이다.
+노드가 IPv4 및 IPv6 인터페이스를 가지고 있는지 검증한다. 노드 이름을 클러스터의 검증된 노드로 대체한다. 본 예제에서 노드 이름은 `k8s-linuxpool1-34450317-0` 이다.
+
 ```shell
-kubectl get nodes k8s-linuxpool1-34450317-0 -o go-template --template='{{range .status.addresses}}{{printf "%s: %s \n" .type .address}}{{end}}'
+kubectl get nodes k8s-linuxpool1-34450317-0 -o go-template --template='{{range .status.addresses}}{{printf "%s: %s\n" .type .address}}{{end}}'
 ```
 ```
 Hostname: k8s-linuxpool1-34450317-0
@@ -48,9 +53,10 @@ InternalIP: 2001:1234:5678:9abc::5
 
 ### 파드 어드레싱 검증
 
-파드가 IPv4 및 IPv6 주소를 할당받았는지 검증한다. (파드 이름을 클러스터에서 검증된 파드로 대체한다. 본 예제에서 파드 이름은 pod01 이다.)
+파드가 IPv4 및 IPv6 주소를 할당받았는지 검증한다. 파드 이름을 클러스터에서 검증된 파드로 대체한다. 본 예제에서 파드 이름은 `pod01` 이다.
+
 ```shell
-kubectl get pods pod01 -o go-template --template='{{range .status.podIPs}}{{printf "%s \n" .ip}}{{end}}'
+kubectl get pods pod01 -o go-template --template='{{range .status.podIPs}}{{printf "%s\n" .ip}}{{end}}'
 ```
 ```
 10.244.1.4
@@ -68,6 +74,7 @@ a00:100::4
 ```
 
 다음 커맨드는 컨테이너 내 `MY_POD_IPS` 환경 변수의 값을 출력한다. 해당 값은 파드의 IPv4 및 IPv6 주소를 나타내는 쉼표로 구분된 목록이다.
+
 ```shell
 kubectl exec -it pod01 -- set | grep MY_POD_IPS
 ```
@@ -225,3 +232,4 @@ kubectl get svc -l app=MyApp
 ```shell
 NAME         TYPE           CLUSTER-IP   EXTERNAL-IP        PORT(S)        AGE
 my-service   LoadBalancer   fd00::7ebc   2603:1030:805::5   80:30790/TCP   35s
+```

--- a/content/ko/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/ko/docs/tasks/tools/install-kubectl-linux.md
@@ -12,24 +12,17 @@ card:
 
 ## {{% heading "prerequisites" %}}
 
-클러스터의 마이너(minor) 버전 차이 내에 있는 kubectl 버전을 사용해야 한다.
-예를 들어, v1.2 클라이언트는 v1.1, v1.2 및 v1.3의 마스터와 함께 작동해야 한다.
+클러스터의 마이너(minor) 버전 차이 내에 있는 kubectl 버전을 사용해야 한다. 예를 들어, v{{< skew latestVersion >}} 클라이언트는 v{{< skew prevMinorVersion >}}, v{{< skew latestVersion >}}, v{{< skew nextMinorVersion >}}의 컨트롤 플레인과 연동될 수 있다.
 최신 버전의 kubectl을 사용하면 예기치 않은 문제를 피할 수 있다.
 
 ## 리눅스에 kubectl 설치
 
 다음과 같은 방법으로 리눅스에 kubectl을 설치할 수 있다.
 
-- [{{% heading "prerequisites" %}}](#시작하기-전에)
-- [리눅스에 kubectl 설치](#리눅스에-kubectl-설치)
-  - [리눅스에서 curl을 사용하여 kubectl 바이너리 설치]{#install-kubectl-binary-with-curl-on-linux}
-  - [기본 패키지 관리 도구를 사용하여 설치]{#install-using-native-package-management}
-  - [다른 패키지 관리 도구를 사용하여 설치]{#install-using-other-package-management}
-  - [Google Cloud SDK를 사용하여 설치]{#install-on-linux-as-part-of-the-google-cloud-sdk}
-- [kubectl 구성 확인](#kubectl-구성-확인)
-- [선택적 kubectl 구성](#선택적-kubectl-구성)
-  - [셸 자동 완성 활성화](#셸-자동-완성-활성화)
-- [{{% heading "whatsnext" %}}](#다음-내용)
+- [리눅스에 curl을 사용하여 kubectl 바이너리 설치](#install-kubectl-binary-with-curl-on-linux)
+- [기본 패키지 관리 도구를 사용하여 설치](#install-using-native-package-management)
+- [다른 패키지 관리 도구를 사용하여 설치](#install-using-other-package-management)
+- [리눅스에 Google Cloud SDK를 사용하여 설치](#install-on-linux-as-part-of-the-google-cloud-sdk)
 
 ### 리눅스에서 curl을 사용하여 kubectl 바이너리 설치 {#install-kubectl-binary-with-curl-on-linux}
 
@@ -158,7 +151,6 @@ yum install -y kubectl
 
 ```shell
 snap install kubectl --classic
-
 kubectl version --client
 ```
 
@@ -169,7 +161,6 @@ kubectl version --client
 
 ```shell
 brew install kubectl
-
 kubectl version --client
 ```
 
@@ -177,7 +168,7 @@ kubectl version --client
 
 {{< /tabs >}}
 
-### Google Cloud SDK를 사용하여 설치 {#install-on-linux-as-part-of-the-google-cloud-sdk}
+### 리눅스에 Google Cloud SDK를 사용하여 설치 {#install-on-linux-as-part-of-the-google-cloud-sdk}
 
 {{< include "included/install-kubectl-gcloud.md" >}}
 

--- a/content/ko/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/ko/docs/tasks/tools/install-kubectl-macos.md
@@ -12,8 +12,7 @@ card:
 
 ## {{% heading "prerequisites" %}}
 
-클러스터의 마이너(minor) 버전 차이 내에 있는 kubectl 버전을 사용해야 한다.
-예를 들어, v1.2 클라이언트는 v1.1, v1.2 및 v1.3의 마스터와 함께 작동해야 한다.
+클러스터의 마이너(minor) 버전 차이 내에 있는 kubectl 버전을 사용해야 한다. 예를 들어, v{{< skew latestVersion >}} 클라이언트는 v{{< skew prevMinorVersion >}}, v{{< skew latestVersion >}}, v{{< skew nextMinorVersion >}}의 컨트롤 플레인과 연동될 수 있다.
 최신 버전의 kubectl을 사용하면 예기치 않은 문제를 피할 수 있다.
 
 ## macOS에 kubectl 설치
@@ -29,17 +28,28 @@ card:
 
 1. 최신 릴리스를 다운로드한다.
 
-   ```bash
+   {{< tabs name="download_binary_macos" >}}
+   {{< tab name="Intel" codelang="bash" >}}
    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl"
-   ```
+   {{< /tab >}}
+   {{< tab name="Apple Silicon" codelang="bash" >}}
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/arm64/kubectl"
+   {{< /tab >}}
+   {{< /tabs >}}
 
    {{< note >}}
    특정 버전을 다운로드하려면, `$(curl -L -s https://dl.k8s.io/release/stable.txt)` 명령 부분을 특정 버전으로 바꾼다.
 
-   예를 들어, macOS에서 버전 {{< param "fullversion" >}}을 다운로드하려면, 다음을 입력한다.
+   예를 들어, Intel macOS에 버전 {{< param "fullversion" >}}을 다운로드하려면, 다음을 입력한다.
 
    ```bash
-   curl -LO https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/darwin/amd64/kubectl
+   curl -LO "https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/darwin/amd64/kubectl"
+   ```
+
+   Apple Silicon의 macOS라면, 다음을 입력한다.
+
+   ```bash
+   curl -LO "https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/darwin/arm64/kubectl"
    ```
 
    {{< /note >}}
@@ -48,9 +58,14 @@ card:
 
    kubectl 체크섬 파일을 다운로드한다.
 
-   ```bash
-   curl -LO "https://dl.k8s.io/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl.sha256"
-   ```
+   {{< tabs name="download_checksum_macos" >}}
+   {{< tab name="Intel" codelang="bash" >}}
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl.sha256"
+   {{< /tab >}}
+   {{< tab name="Apple Silicon" codelang="bash" >}}
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/arm64/kubectl.sha256"
+   {{< /tab >}}
+   {{< /tabs >}}
 
    kubectl 바이너리를 체크섬 파일을 통해 검증한다.
 

--- a/content/ko/docs/tasks/tools/install-kubectl-windows.md
+++ b/content/ko/docs/tasks/tools/install-kubectl-windows.md
@@ -12,8 +12,7 @@ card:
 
 ## {{% heading "prerequisites" %}}
 
-클러스터의 마이너(minor) 버전 차이 내에 있는 kubectl 버전을 사용해야 한다.
-예를 들어, v1.2 클라이언트는 v1.1, v1.2 및 v1.3의 마스터와 함께 작동해야 한다.
+클러스터의 마이너(minor) 버전 차이 내에 있는 kubectl 버전을 사용해야 한다. 예를 들어, v{{< skew latestVersion >}} 클라이언트는 v{{< skew prevMinorVersion >}}, v{{< skew latestVersion >}}, v{{< skew nextMinorVersion >}}의 컨트롤 플레인과 연동될 수 있다.
 최신 버전의 kubectl을 사용하면 예기치 않은 문제를 피할 수 있다.
 
 ## 윈도우에 kubectl 설치
@@ -21,9 +20,8 @@ card:
 다음과 같은 방법으로 윈도우에 kubectl을 설치할 수 있다.
 
 - [윈도우에서 curl을 사용하여 kubectl 바이너리 설치](#install-kubectl-binary-with-curl-on-windows)
-- [PSGallery에서 PowerShell로 설치](#install-with-powershell-from-psgallery)
 - [Chocolatey 또는 Scoop을 사용하여 윈도우에 설치](#install-on-windows-using-chocolatey-or-scoop)
-- [Google Cloud SDK를 사용하여 설치](#install-on-windows-as-part-of-the-google-cloud-sdk)
+- [윈도우에서 Google Cloud SDK를 사용하여 설치](#install-on-windows-as-part-of-the-google-cloud-sdk)
 
 
 ### 윈도우에서 curl을 사용하여 kubectl 바이너리 설치 {#install-kubectl-binary-with-curl-on-windows}
@@ -74,33 +72,6 @@ card:
 {{< note >}}
 [윈도우용 도커 데스크톱](https://docs.docker.com/docker-for-windows/#kubernetes)은 자체 버전의 `kubectl` 을 `PATH` 에 추가한다.
 도커 데스크톱을 이전에 설치한 경우, 도커 데스크톱 설치 프로그램에서 추가한 `PATH` 항목 앞에 `PATH` 항목을 배치하거나 도커 데스크톱의 `kubectl` 을 제거해야 할 수도 있다.
-{{< /note >}}
-
-### PSGallery에서 PowerShell로 설치 {#install-with-powershell-from-psgallery}
-
-윈도우에서 [Powershell Gallery](https://www.powershellgallery.com/) 패키지 관리자를 사용하는 경우, Powershell로 kubectl을 설치하고 업데이트할 수 있다.
-
-1. 설치 명령을 실행한다(`DownloadLocation` 을 지정해야 한다).
-
-   ```powershell
-   Install-Script -Name install-kubectl -Scope CurrentUser -Force
-   install-kubectl.ps1 [-DownloadLocation <path>]
-   ```
-
-   {{< note >}}
-   `DownloadLocation` 을 지정하지 않으면, `kubectl` 은 사용자의 `temp` 디렉터리에 설치된다.
-   {{< /note >}}
-
-   설치 프로그램은 `$HOME/.kube` 를 생성하고 구성 파일을 작성하도록 지시한다.
-
-1. 설치한 버전이 최신 버전인지 확인한다.
-
-   ```powershell
-   kubectl version --client
-   ```
-
-{{< note >}}
-설치 업데이트는 1 단계에서 나열한 두 명령을 다시 실행하여 수행한다.
 {{< /note >}}
 
 ### Chocolatey 또는 Scoop을 사용하여 윈도우에 설치 {#install-on-windows-using-chocolatey-or-scoop}
@@ -156,7 +127,7 @@ card:
 메모장과 같은 텍스트 편집기를 선택하여 구성 파일을 편집한다.
 {{< /note >}}
 
-### Google Cloud SDK를 사용하여 설치 {#install-on-windows-as-part-of-the-google-cloud-sdk}
+### 윈도우에서 Google Cloud SDK를 사용하여 설치 {#install-on-windows-as-part-of-the-google-cloud-sdk}
 
 {{< include "included/install-kubectl-gcloud.md" >}}
 


### PR DESCRIPTION
Related issue: #27764

Update outdated translation for following Korean doc.

1. [ ] M32.  `content/en/docs/tasks/network/validate-dual-stack.md`  | 7(+XS) 4(-)
1. [ ] M33.  `content/en/docs/tasks/tools/install-kubectl-linux.md`  | 1(+XS) 2(-)
1. [ ] M34.  `content/en/docs/tasks/tools/install-kubectl-macos.md`  | 25(+S) 10(-)
1. [ ] M35.  `content/en/docs/tasks/tools/install-kubectl-windows.md`  | 1(+XS) 30(-)