### PR TITLE
fix note about alpha status of featuregate

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/security-context.md
+++ b/content/en/docs/tasks/configure-pod-container/security-context.md
@@ -176,7 +176,7 @@ securityContext:
   fsGroupChangePolicy: "OnRootMismatch"
 ```
 
-This is an alpha feature. To use it, enable the [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) `ConfigurableFSGroupPolicy` for the kube-api-server, the kube-controller-manager, and for the kubelet.
+This is feature is disabled by default in Kubernetes versions <= v1.19. To use it, enable the [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) `ConfigurableFSGroupPolicy` for the kube-api-server, the kube-controller-manager, and for the kubelet.
 
 {{< note >}}
 This field has no effect on ephemeral volume types such as

--- a/content/en/docs/tasks/configure-pod-container/security-context.md
+++ b/content/en/docs/tasks/configure-pod-container/security-context.md
@@ -151,7 +151,7 @@ exit
 
 {{< feature-state for_k8s_version="v1.20" state="beta" >}}
 
-By default, Kubernetes recursively changes ownership and permissions for the contents of each
+Support for ConfigurableFSGroupPolicy is now enabled by default. By default, Kubernetes recursively changes ownership and permissions for the contents of each
 volume to match the `fsGroup` specified in a Pod's `securityContext` when that volume is
 mounted.
 For large volumes, checking and changing ownership and permissions can take a lot of time,

--- a/content/en/docs/tasks/configure-pod-container/security-context.md
+++ b/content/en/docs/tasks/configure-pod-container/security-context.md
@@ -176,8 +176,6 @@ securityContext:
   fsGroupChangePolicy: "OnRootMismatch"
 ```
 
-This is feature is disabled by default in Kubernetes versions <= v1.19. To use it, enable the [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) `ConfigurableFSGroupPolicy` for the kube-api-server, the kube-controller-manager, and for the kubelet.
-
 {{< note >}}
 This field has no effect on ephemeral volume types such as
 [`secret`](/docs/concepts/storage/volumes/#secret),


### PR DESCRIPTION
`ConfigurableFSGroupPolicy` has been enabled by default and in beta status since kubernetes v1.20.  Updated the docs to reflect that.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
