### PR TITLE
Updating dockershim FAQ with Mirantis announcement

### DIFF
--- a/content/en/blog/_posts/2020-12-02-dockershim-faq.md
+++ b/content/en/blog/_posts/2020-12-02-dockershim-faq.md
@@ -47,6 +47,15 @@ and other ecosystem groups to ensure a smooth transition and will evaluate thing
 as the situation evolves.
 
 
+### Can I still use dockershim after it is removed from Kubernetes?
+
+Update:
+[Mirantis and Docker have committed to maintaining the dockershim][mirantis] after
+it is removed from Kubernetes.
+
+[mirantis]: https://www.mirantis.com/blog/mirantis-to-take-over-support-of-kubernetes-dockershim-2/
+
+
 ### Will my existing Docker images still work?
 
 Yes, the images produced from `docker build` will work with all CRI implementations.


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

The dockershim FAQ is missing a key detail, that 2 days after the FAQ was posted, Mirantis and Docker committed to maintaining it. Since users arrive at the FAQ from being one of the top hits on Google, it seems useful to include this missing detail. Thanks to @bridgetkromhout for sending me here and I hope everyone's having a great KubeCon EU.
