### PR TITLE
cpumanager: document cpu manager policy options

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/kubelet.md
+++ b/content/en/docs/reference/command-line-tools-reference/kubelet.md
@@ -281,7 +281,7 @@ kubelet [flags]
 <td colspan="2">--cpu-manager-policy-options strings</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">Comma-separated list of options to fine-tune the behavior of the CPU Manager policy to use. (DEPRECATED: This parameter should be set via the config file specified by the Kubelet's `--config` flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.)</td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">Comma-separated list of options to fine-tune the behavior of the selected CPU Manager policy. (DEPRECATED: This parameter should be set via the config file specified by the Kubelet's `--config` flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.)</td>
 </tr>
 
 <tr>
@@ -1241,5 +1241,4 @@ Insecure values: TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, TLS_ECDHE_ECDSA_WITH_R
 </tr>
 </tbody>
 </table>
-
 

--- a/content/en/docs/reference/command-line-tools-reference/kubelet.md
+++ b/content/en/docs/reference/command-line-tools-reference/kubelet.md
@@ -278,6 +278,13 @@ kubelet [flags]
 </tr>
 
 <tr>
+<td colspan="2">--cpu-manager-policy-options strings</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">Comma-separated list of options to fine-tune the behavior of the CPU Manager policy to use. (DEPRECATED: This parameter should be set via the config file specified by the Kubelet's `--config` flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.)</td>
+</tr>
+
+<tr>
 <td colspan="2">--cpu-manager-reconcile-period duration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: `10s`</td>
 </tr>
 <tr>

--- a/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
+++ b/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
@@ -58,6 +58,9 @@ frequency is set through a new Kubelet configuration value
 `--cpu-manager-reconcile-period`. If not specified, it defaults to the same
 duration as `--node-status-update-frequency`.
 
+The behavior of the static policy can be fine-tuned using the `--cpu-manager-policy-options` flag.
+The flag takes a comma-separated list of `key=value` policy options.
+
 ### None policy
 
 The `none` policy explicitly enables the existing default CPU
@@ -212,4 +215,14 @@ and `requests` are set equal to `limits` when not explicitly specified. And the
 container's resource limit for the CPU resource is an integer greater than or
 equal to one. The `nginx` container is granted 2 exclusive CPUs.
 
+#### Static policy options
 
+If the `full-pcpus-only` policy option is specified, the static policy will always allocate full physical cores.
+You can enable this option by adding `full-pcups-only=true` to the CPUManager policy options.
+By default, without this option, the static policy allocates CPUs using a topology-aware best-fit allocation.
+On SMT enabled systems, the policy can allocate individual virtual cores, which correspond to hardware threads.
+This can lead to different containers sharing the same physical cores; this behaviour in turn contributes
+to the [noisy neighbours problem](https://en.wikipedia.org/wiki/Cloud_computing_issues#Performance_interference_and_noisy_neighbors).
+With the option enabled, the pod will be admitted by the kubelet only if the CPU request of all its containers
+can be fulfilled by allocating full physical cores.
+If the pod does not pass the admission, it will be put in Failed state with the message `SMTAlignmentError`.


### PR DESCRIPTION
The enhancement https://github.com/kubernetes/enhancements/issues/2625
wants to add a new kubelet option to fine tune the behaviour of the
cpu manager policies, and to do so we add support for cpu manager policy
options themselves.

Signed-off-by: Francesco Romani <fromani@redhat.com>

