### PR TITLE
Operator: Exists missing

### DIFF
--- a/content/en/examples/controllers/daemonset.yaml
+++ b/content/en/examples/controllers/daemonset.yaml
@@ -18,6 +18,7 @@ spec:
       # this toleration is to have the daemonset runnable on master nodes
       # remove it if your masters can't run pods
       - key: node-role.kubernetes.io/master
+        operator: Exists
         effect: NoSchedule
       containers:
       - name: fluentd-elasticsearch


### PR DESCRIPTION
The Operator Exists is missing without this operator there will be no pod deployed on the master node.