### PR TITLE
fix example for customizing the control plane with scheduler flags

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/control-plane-flags.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/control-plane-flags.md
@@ -78,9 +78,13 @@ kind: ClusterConfiguration
 kubernetesVersion: v1.16.0
 scheduler:
   extraArgs:
-    bind-address: 0.0.0.0
-    config: /home/johndoe/schedconfig.yaml
-    kubeconfig: /home/johndoe/kubeconfig.yaml
+    config: /etc/kubernetes/scheduler-config.yaml
+  extraVolumes:
+    - name: schedulerconfig
+      hostPath: /home/johndoe/schedconfig.yaml
+      mountPath: /etc/kubernetes/scheduler-config.yaml
+      readOnly: true
+      pathType: "File"
 ```
 
 


### PR DESCRIPTION
Signed-off-by: wangyysde <net_use@bzhy.com>

The example at https://github.com/kubernetes/website/blob/master/content/en/docs/setup/production-environment/tools/kubeadm/control-plane-flags.md#scheduler-flags shows scheduler.extraArgs.config in the ClusterConfiguration being used without scheduler.extraVolumes. But kubeadm sets up the scheduler to run inside a pod, it is necessary to use scheduler.extraVolumes to mount the config file into the pod.
kubeconfig in the original example is simillar to config. If we keep this item in the sample, we should add more lines into the extraVolumes section. For the sake of simplicity, I use  feature-gates instead of kubeconfig.

Fix: #27816 
