### PR TITLE
Fix link to nodeport Service type

### DIFF
--- a/content/en/docs/reference/kubernetes-api/service-resources/service-v1.md
+++ b/content/en/docs/reference/kubernetes-api/service-resources/service-v1.md
@@ -96,7 +96,7 @@ ServiceSpec describes the attributes that a user creates on a service.
 
   - **ports.nodePort** (int32)
 
-    The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+    The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#nodeport
 
   - **ports.appProtocol** (string)
 


### PR DESCRIPTION
This will correct the link to the Nodeport service type's section in the Service concept document.
