### PR TITLE
Fix relnotes.k8s.io link

### DIFF
--- a/content/en/releases/notes.md
+++ b/content/en/releases/notes.md
@@ -10,4 +10,4 @@ sitemap:
 
 Release notes can be found by reading the [Changelog](https://github.com/kubernetes/kubernetes/tree/master/CHANGELOG) that matches your Kubernetes version. View the changelog for {{< skew latestVersion >}} on [GitHub](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-{{< skew latestVersion >}}.md).
 
-Alternately, release notes can be searched and filtered online at: [relnotes.k8s.io](relnotes.k8s.io). View filtered release notes for {{< skew latestVersion >}} on [relnotes.k8s.io](https://relnotes.k8s.io/?releaseVersions={{< skew latestVersion >}}.0).
+Alternately, release notes can be searched and filtered online at: [relnotes.k8s.io](https://relnotes.k8s.io). View filtered release notes for {{< skew latestVersion >}} on [relnotes.k8s.io](https://relnotes.k8s.io/?releaseVersions={{< skew latestVersion >}}.0).


### PR DESCRIPTION
It was pointing to `https://kubernetes.io/releases/notes/relnotes.k8s.io`. I'm assuming that adding the scheme will fix it.

/assign @jimangel 