### PR TITLE
Proposed hugo archetype to fix issue #27843

### DIFF
--- a/archetypes/blog-post.md
+++ b/archetypes/blog-post.md
@@ -1,0 +1,61 @@
+---
+layout: blog
+title: "{{ replace .Name "-" " " | title }}"
+date: {{ .Date }}
+draft: true
+slug: <seo-friendly-version-of-title-separated-by-dashes>
+---
+
+**Author:** <your name> (<your organization name>), <another author's name> (<their organization>)
+
+<!--  
+Instructions:
+- Replace these instructions and the following text with your content.
+- Replace `<angle bracket placeholders>` with actual values. For example, you would update `date: <yyyy>-<mm>-<dd>` to look something like `date: 2021-10-21`.
+- For convenience, use third-party tools to author and collaborate on your content.
+- To save time and effort in reviews, check your content's spelling, grammar, and style before contributing.
+- Feel free to ask for assistance in the Kubernetes Slack channel, [#sig-docs-blog](https://kubernetes.slack.com/archives/CJDHVD54J).
+-->
+
+Replace this first line of your content with one to three sentences that summarize the blog post.
+
+## This is a section heading
+
+To help the reader, organize your content into sections that contain about three to six paragraphs.
+
+If you're documenting commands, separate the commands from the outputs, like this:
+
+1. Verify that the Secret exists by running the following command:
+
+      ```shell
+      kubectl get secrets
+      ```
+
+      The response should be like this:
+
+      ```shell
+      NAME                    TYPE                                  DATA   AGE
+      mysql-pass-c57bb4t7mf   Opaque                                1      9s
+      ```
+
+You're free to create any sections you like. Below are a few common patterns we see at the end of blog posts.
+
+## What’s next?
+
+This optional section describes the future of the thing you've just described in the post.
+
+## How can I learn more?
+
+This optional section provides links to more information. Please avoid promoting and over-represent your organization.
+
+## How do I get involved?
+
+An optional section that links to resources for readers to get involved, and acknowledgments of individual contributors, such as:
+
+* [The name of a channel on Slack, #a-channel](https://<a-workspace>.slack.com/messages/<a-channel>)
+
+* [A link to a "contribute" page with more information](<https://github.com/kubernetes/community/blob/master/sig-storage/README.md#contact>).
+
+* Acknowledgements and thanks to the contributors. <person's name> ([<github id>](https://github.com/<github id>)) who did X, Y, and Z.
+
+* Those interested in getting involved with the design and development of <project>, join the [<name of the SIG>](https://github.com/project/community/tree/master/<sig-group>). We’re rapidly growing and always welcome new contributors.


### PR DESCRIPTION
This PR provides a [Hugo archetype](https://gohugo.io/content-management/archetypes/) for users to create new blog posts. After we discuss, improve, and merge this archetype, we will create a separate PR providing instructions for contributors to use it. 

As @nate-double-u suggested, "It might be good to add some information about this archetype (and how to use it) to the [Submitting blog posts and case studies](https://kubernetes.io/docs/contribute/new-content/blogs-case-studies/) page. (Maybe under the [Technical Considerations for submitting a blog post](https://kubernetes.io/docs/contribute/new-content/blogs-case-studies/#technical-considerations-for-submitting-a-blog-post) section?)"