### PR TITLE
Add envs example for secretGenerator.

### DIFF
--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
@@ -48,7 +48,19 @@ secretGenerator:
   - password=1f2d1e2e67df
 ```
 
-Note that in both cases, you don't need to base64 encode the values.
+You can also define the `secretGenerator` in the `kustomization.yaml`
+file by providing `.env` files.
+For example, the following `kustomization.yaml` file pulls in data from
+`.env.secret` file:
+
+```yaml
+secretGenerator:
+- name: db-user-pass
+  envs:
+  - .env.secret
+```
+
+Note that in all cases, you don't need to base64 encode the values.
 
 ## Create the Secret
 


### PR DESCRIPTION
The secretGenerator examples showed files, but didn't contain an example for envs which was ultimately what we were looking for. Hopefully this can help others looking to reference a .env file for secrets.