### PR TITLE
Adding shell-operator as another way to create operators

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/operator.md
+++ b/content/en/docs/concepts/extend-kubernetes/operator.md
@@ -119,6 +119,7 @@ Operator.
 * [Metacontroller](https://metacontroller.app/) along with WebHooks that
   you implement yourself
 * [Operator Framework](https://operatorframework.io)
+* [shell-operator](https://github.com/flant/shell-operator)
 
 ## {{% heading "whatsnext" %}}
 


### PR DESCRIPTION
[shell-operator](https://github.com/flant/shell-operator) ([demonstrated](https://www.youtube.com/watch?v=we0s4ETUBLc) at KubeCon EU 2020) is a 3rd-party tool to start creating K8s operators easily. Written in Golang itself, it provides a convenient framework to use scripts (in Bash, etc.) or other executables to implement the operator's logic. It has recently reached its v1.0.0 marking its readiness for a wider community.
