### PR TITLE
Fixed variable substitution typo

### DIFF
--- a/content/en/docs/contribute/generate-ref-docs/kubernetes-api.md
+++ b/content/en/docs/contribute/generate-ref-docs/kubernetes-api.md
@@ -90,8 +90,8 @@ This section shows how to generate the
 For example:
 
 ```shell
-export K8S_WEBROOT=$(GOPATH)/src/github.com/<your-username>/website
-export K8S_ROOT=$(GOPATH)/src/k8s.io/kubernetes
+export K8S_WEBROOT=${GOPATH}/src/github.com/<your-username>/website
+export K8S_ROOT=${GOPATH}/src/k8s.io/kubernetes
 export K8S_RELEASE=1.17.0
 ```
 


### PR DESCRIPTION
I was following [a contribution guide](https://kubernetes.io/docs/contribute/generate-ref-docs/kubernetes-api/) and noticed two variable substitution mistakes. 
The rest of the docs is very clear, my compliments.