### PR TITLE
Clarify what must be the same

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/quality-service-pod.md
+++ b/content/en/docs/tasks/configure-pod-container/quality-service-pod.md
@@ -51,7 +51,6 @@ For a Pod to be given a QoS class of Guaranteed:
 * For every Container in the Pod, the CPU limit must equal the CPU request.
 
 These restrictions apply to init containers and app containers equally.
-* Every Container, including init containers, in the Pod must have a CPU limit and a CPU request, and the two values must be the same.
 
 Here is the configuration file for a Pod that has one Container. The Container has a memory limit and a
 memory request, both equal to 200 MiB. The Container has a CPU limit and a CPU request, both equal to 700 milliCPU:
@@ -274,7 +273,6 @@ kubectl delete namespace qos-example
 * [Configure Quotas for API Objects](/docs/tasks/administer-cluster/quota-api-object/)
 
 * [Control Topology Management policies on a node](/docs/tasks/administer-cluster/topology-manager/)
-
 
 
 

--- a/content/en/docs/tasks/configure-pod-container/quality-service-pod.md
+++ b/content/en/docs/tasks/configure-pod-container/quality-service-pod.md
@@ -45,8 +45,8 @@ kubectl create namespace qos-example
 
 For a Pod to be given a QoS class of Guaranteed:
 
-* Every Container, including init containers, in the Pod must have a memory limit and a memory request, and they must be the same.
-* Every Container, including init containers, in the Pod must have a CPU limit and a CPU request, and they must be the same.
+* Every Container, including init containers, in the Pod must have a memory limit and a memory request, and the two values must be the same.
+* Every Container, including init containers, in the Pod must have a CPU limit and a CPU request, and the two values must be the same.
 
 Here is the configuration file for a Pod that has one Container. The Container has a memory limit and a
 memory request, both equal to 200 MiB. The Container has a CPU limit and a CPU request, both equal to 700 milliCPU:

--- a/content/en/docs/tasks/configure-pod-container/quality-service-pod.md
+++ b/content/en/docs/tasks/configure-pod-container/quality-service-pod.md
@@ -45,7 +45,12 @@ kubectl create namespace qos-example
 
 For a Pod to be given a QoS class of Guaranteed:
 
-* Every Container, including init containers, in the Pod must have a memory limit and a memory request, and the two values must be the same.
+* Every Container in the Pod must have a memory limit and a memory request.
+* For every Container in the Pod, the memory limit must equal the memory request.
+* Every Container in the Pod must have a CPU limit and a CPU request.
+* For every Container in the Pod, the CPU limit must equal the CPU request.
+
+These restrictions apply to init containers and app containers equally.
 * Every Container, including init containers, in the Pod must have a CPU limit and a CPU request, and the two values must be the same.
 
 Here is the configuration file for a Pod that has one Container. The Container has a memory limit and a
@@ -269,7 +274,6 @@ kubectl delete namespace qos-example
 * [Configure Quotas for API Objects](/docs/tasks/administer-cluster/quota-api-object/)
 
 * [Control Topology Management policies on a node](/docs/tasks/administer-cluster/topology-manager/)
-
 
 
 


### PR DESCRIPTION
When reading these sentences, I thought that each pod must have the same values as each other pod. In other words, pod1's memory limit must equal pod2's memory limit.

It looks like I misunderstood; "must be the same" means that the limit and request values on each individual pod must match.

Clarify what "must be the same".