### PR TITLE
Add page for analytics dashboard

### DIFF
--- a/content/en/docs/contribute/analytics.md
+++ b/content/en/docs/contribute/analytics.md
@@ -1,5 +1,5 @@
 ---
-title: Viewing site analytics
+title: Viewing Site Analytics
 content_type: concept
 weight: 100
 card:
@@ -20,6 +20,6 @@ This dashboard is built using Google Data Studio and shows information collected
 
 ### Using the dashboard
 
-By default, the dashboard will show all collected analytics for the past 30 days. Use the date selector to see data from a different date range. Other filtering options allow you to view data based on user location, the device used to access the site, the translation of the docs used, and more.
+By default, the dashboard shows all collected analytics for the past 30 days. Use the date selector to see data from a different date range. Other filtering options allow you to view data based on user location, the device used to access the site, the translation of the docs used, and more.
 
  If you notice an issue with this dashboard, or would like to request any improvements, please [open an issue](https://github.com/kubernetes/website/issues/new/choose).

--- a/content/en/docs/contribute/analytics.md
+++ b/content/en/docs/contribute/analytics.md
@@ -1,0 +1,25 @@
+---
+title: Viewing site analytics
+content_type: concept
+weight: 100
+card:
+  name: contribute
+  weight: 100
+---
+
+<!-- overview -->
+
+This page contains information about the kubernetes.io analytics dashboard.
+
+
+<!-- body -->
+
+[View the dashboard.](https://datastudio.google.com/u/0/reporting/fede2672-b2fd-402a-91d2-7473bdb10f04/page/567IC/edit)
+
+This dashboard is built using Google Data Studio and shows information collected on kubernetes.io using Google Analytics.
+
+### Using the dashboard
+
+By default, the dashboard will show all collected analytics for the past 30 days. Use the date selector to see data from a different date range. Other filtering options allow you to view data based on user location, the device used to access the site, the translation of the docs used, and more.
+
+ If you notice an issue with this dashboard, or would like to request any improvements, please open an issue.

--- a/content/en/docs/contribute/analytics.md
+++ b/content/en/docs/contribute/analytics.md
@@ -14,7 +14,7 @@ This page contains information about the kubernetes.io analytics dashboard.
 
 <!-- body -->
 
-[View the dashboard.](https://datastudio.google.com/u/0/reporting/fede2672-b2fd-402a-91d2-7473bdb10f04/page/567IC/edit)
+[View the dashboard](https://datastudio.google.com/reporting/fede2672-b2fd-402a-91d2-7473bdb10f04).
 
 This dashboard is built using Google Data Studio and shows information collected on kubernetes.io using Google Analytics.
 
@@ -22,4 +22,4 @@ This dashboard is built using Google Data Studio and shows information collected
 
 By default, the dashboard will show all collected analytics for the past 30 days. Use the date selector to see data from a different date range. Other filtering options allow you to view data based on user location, the device used to access the site, the translation of the docs used, and more.
 
- If you notice an issue with this dashboard, or would like to request any improvements, please open an issue.
+ If you notice an issue with this dashboard, or would like to request any improvements, please [open an issue](https://github.com/kubernetes/website/issues/new/choose).


### PR DESCRIPTION
Fixes #27360 

This PR adds new page that links to the google data studio dashboard that shows the analytics data for kubernetes.io. More information about this report can be found in the issue. 

This report has been shared with k8s-sig-docs-leads@googlegroups.com with edit permissions. 

Open question
* Where to put more info about maintaining the report?
