### PR TITLE
Clarify requirements for “Using Source IP” tutorial

### DIFF
--- a/content/en/includes/task-tutorial-prereqs.md
+++ b/content/en/includes/task-tutorial-prereqs.md
@@ -1,7 +1,7 @@
 You need to have a Kubernetes cluster, and the kubectl command-line tool must
-be configured to communicate with your cluster. If you do not already have a
+be configured to communicate with your cluster. It is recommended to run this tutorial on a cluster with at least two nodes that are not acting as control plane hosts. If you do not already have a
 cluster, you can create one by using
-[minikube](/docs/tasks/tools/#minikube)
+[minikube](https://minikube.sigs.k8s.io/docs/tutorials/multi_node/)
 or you can use one of these Kubernetes playgrounds:
 
 * [Katacoda](https://www.katacoda.com/courses/kubernetes/playground)


### PR DESCRIPTION
Updated `pre-requisites` section of [Using Source IP](https://kubernetes.io/docs/tutorials/services/source-ip) tutorial to make requirement of a multi-node cluster clear.

Fixes: #27162 
