### PR TITLE
kubeadm will default it to systemd in 1.22

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver.md
@@ -33,10 +33,8 @@ driver of the kubelet.
 
 {{< note >}}
 
-{{< feature-state for_k8s_version="v1.21" state="stable" >}}
-
-If the user is not setting the `cgroupDriver` field under `KubeletConfiguration`,
-`kubeadm init` will default it to `systemd`.
+In v1.22, if the user is not setting the `cgroupDriver` field under `KubeletConfiguration`,
+`kubeadm` will default it to `systemd`.
 {{< /note >}}
 
 A minimal example of configuring the field explicitly:


### PR DESCRIPTION
According to https://github.com/kubernetes/kubernetes/pull/102133#issuecomment-844264623.

After https://github.com/kubernetes/kubernetes/pull/102133 is merged, kubeadm 1.22 will default to systemd.
- kubeadm 1.21: only `kubeadm init`  will default to systemd.
