### PR TITLE
Fix AKA for node-pressure eviction glossary item

### DIFF
--- a/content/en/docs/reference/glossary/node-pressure-eviction.md
+++ b/content/en/docs/reference/glossary/node-pressure-eviction.md
@@ -6,7 +6,8 @@ full_link: /docs/concepts/scheduling-eviction/node-pressure-eviction/
 short_description: >
   Node-pressure eviction is the process by which the kubelet proactively fails
   pods to reclaim resources on nodes.
-aka: kubelet eviction
+aka:
+- kubelet eviction
 tags:
 - operation
 ---


### PR DESCRIPTION
Fix an [incorrect](https://kubernetes.io/docs/reference/glossary/?all=true#term-node-pressure-eviction) `aka:` field in a glossary item.

Fixup for PR #27739