### PR TITLE
Additional details on the behaviour

### DIFF
--- a/content/en/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace.md
+++ b/content/en/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace.md
@@ -10,7 +10,9 @@ This page shows how to configure default CPU requests and limits for a namespace
 A Kubernetes cluster can be divided into namespaces. If a Container is created in a namespace
 that has a default CPU limit, and the Container does not specify its own CPU limit, then
 the Container is assigned the default CPU limit. Kubernetes assigns a default CPU request
-under certain conditions that are explained later in this topic.
+under certain conditions that are explained later in this topic. Kubernetes will also not allow 
+a pod creation if the pod requests more than the default CPU limit configured in the LimitRange 
+that is applied to the namespace where the pod creation request is made.
 
 
 


### PR DESCRIPTION
Added more details on Kubernetes behavior for a pod creation request, which is applicable when there is a LimitRange is applied with default CPU limits for a namespace.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
