### PR TITLE
Update redirect destination for out-of-resource page

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -262,7 +262,7 @@
 /docs/tasks/administer-cluster/quota-memory-cpu-namespace/     /docs/tasks/administer-cluster/manage-resources/quota-memory-cpu-namespace/ 301
 /docs/tasks/administer-cluster/quota-pod-namespace/     /docs/tasks/administer-cluster/manage-resources/quota-pod-namespace/ 301
 /docs/tasks/administer-cluster/reserve-compute-resources/out-of-resource.md     /docs/tasks/administer-cluster/out-of-resource/ 301
-/docs/tasks/administer-cluster/out-of-resource/     /docs/concepts/scheduling-eviction/pod-eviction/ 301
+/docs/tasks/administer-cluster/out-of-resource/     /docs/concepts/scheduling-eviction/node-pressure-eviction/ 301
 /docs/tasks/administer-cluster/romana-network-policy/     /docs/tasks/administer-cluster/network-policy-provider/romana-network-policy/ 301
 /docs/tasks/administer-cluster/running-cloud-controller.md     /docs/tasks/administer-cluster/running-cloud-controller/ 301
 /docs/tasks/administer-cluster/share-configuration/     /docs/tasks/access-application-cluster/configure-access-multiple-clusters/ 301


### PR DESCRIPTION
Fixes #28076 

Corrected an invalid redirect link for the new Node-pressure Eviction page. 

/assign
/sig docs
/review @sftim 
