### PR TITLE
Deleted reference to removed file

### DIFF
--- a/content/en/docs/contribute/generate-ref-docs/contribute-upstream.md
+++ b/content/en/docs/contribute/generate-ref-docs/contribute-upstream.md
@@ -134,7 +134,6 @@ Go to `<k8s-base>` and run these scripts:
 hack/update-generated-swagger-docs.sh
 hack/update-openapi-spec.sh
 hack/update-generated-protobuf.sh
-hack/update-api-reference-docs.sh
 ```
 
 Run `git status` to see what was generated.
@@ -143,8 +142,6 @@ Run `git status` to see what was generated.
 On branch master
 ...
     modified:   api/openapi-spec/swagger.json
-    modified:   api/swagger-spec/apps_v1.json
-    modified:   docs/api-reference/apps/v1/definitions.html
     modified:   staging/src/k8s.io/api/apps/v1/generated.proto
     modified:   staging/src/k8s.io/api/apps/v1/types.go
     modified:   staging/src/k8s.io/api/apps/v1/types_swagger_doc_generated.go


### PR DESCRIPTION
In the [contribute upstream guide](https://kubernetes.io/docs/contribute/generate-ref-docs/contribute-upstream/) one of the steps is to run `hack/update-api-reference-docs.sh`, this file does not exist in kubernetes/hack. @Priyankasaggu11929 kindly pointed me to the issue that removed the shell file: https://github.com/kubernetes/kubernetes/issues/38637#issue-195056333.

Related issue: https://github.com/kubernetes/website/issues/27982
