### PR TITLE
minikube 1.19.0 is Ingress namespace chaged

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -44,8 +44,16 @@ This page shows you how to set up a simple Ingress which routes requests to Serv
 
 1. Verify that the NGINX Ingress controller is running
 
+    minikube version 1.18.1 or earlier
+
     ```shell
     kubectl get pods -n kube-system
+    ```
+
+    minikube version 1.19.0 or later
+
+    ```shell
+    kubectl get pods -n ingress-nginx
     ```
 
     {{< note >}}This can take up to a minute.{{< /note >}}
@@ -54,12 +62,7 @@ This page shows you how to set up a simple Ingress which routes requests to Serv
 
     ```shell
     NAME                                        READY     STATUS    RESTARTS   AGE
-    default-http-backend-59868b7dd6-xb8tq       1/1       Running   0          1m
-    kube-addon-manager-minikube                 1/1       Running   0          3m
-    kube-dns-6dcb57bcc8-n4xd4                   3/3       Running   0          2m
-    kubernetes-dashboard-5498ccf677-b8p5h       1/1       Running   0          2m
     nginx-ingress-controller-5984b97644-rnkrg   1/1       Running   0          1m
-    storage-provisioner                         1/1       Running   0          2m
     ```
 
 ## Deploy a hello, world app


### PR DESCRIPTION
Ingress namespace is minikube 1.19.0 chage the status kube-system to ingress-nginx.
Since the output result has also changed, I decided to display only one line.
   
minikube 1.19.0 Upgrade ingress addon files according to upstream.
https://github.com/kubernetes/minikube/blob/master/CHANGELOG.md#version-1190-beta0---2021-04-05
https://github.com/kubernetes/minikube/pull/10879

Before
```
NAME                                        READY     STATUS    RESTARTS   AGE
default-http-backend-59868b7dd6-xb8tq       1/1       Running   0          1m
kube-addon-manager-minikube                 1/1       Running   0          3m
kube-dns-6dcb57bcc8-n4xd4                   3/3       Running   0          2m
kubernetes-dashboard-5498ccf677-b8p5h       1/1       Running   0          2m
nginx-ingress-controller-5984b97644-rnkrg   1/1       Running   0          1m
storage-provisioner                         1/1       Running   0          2m
```

After
```
NAME                                        READY   STATUS      RESTARTS   AGE
ingress-nginx-controller-75fbcbcc56-q7lg8   1/1     Running     0          4h41m
```

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
