### PR TITLE
Update LogarithmicScaleDown featuregate docs

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -137,6 +137,7 @@ different Kubernetes components.
 | `LocalStorageCapacityIsolation` | `true` | Beta | 1.10 | |
 | `LocalStorageCapacityIsolationFSQuotaMonitoring` | `false` | Alpha | 1.15 | |
 | `LogarithmicScaleDown` | `false` | Alpha | 1.21 | |
+| `LogarithmicScaleDown` | `true` | Beta | 1.22 | |
 | `KubeletPodResourcesGetAllocatable` | `false` | Alpha | 1.21 | |
 | `MixedProtocolLBService` | `false` | Alpha | 1.20 | |
 | `NamespaceDefaultLabelName` | `true` | Beta | 1.21 | |


### PR DESCRIPTION
Ref https://github.com/kubernetes/enhancements/issues/2185
This updates the `LogarithmicScaleDown` feature gate documentation to reflect its 1.22 Beta status

PR to make this change: https://github.com/kubernetes/kubernetes/pull/101767