### PR TITLE
Correcting entry in Multiple Resource Types

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/field-selectors.md
+++ b/content/en/docs/concepts/overview/working-with-objects/field-selectors.md
@@ -48,7 +48,7 @@ kubectl get pods --field-selector=status.phase!=Running,spec.restartPolicy=Alway
 
 ## Multiple resource types
 
-You use field selectors across multiple resource types. This `kubectl` command selects all Statefulsets and Services that are not in the `default` namespace:
+You can use field selectors across multiple resource types. This `kubectl` command selects all Statefulsets and Services that are not in the `default` namespace:
 
 ```shell
 kubectl get statefulsets,services --all-namespaces --field-selector metadata.namespace!=default


### PR DESCRIPTION
We *can* use field selectors across multiple resource types. The field selectors can be used for single resource types too.
