### PR TITLE
Add missing --type merge for retainkeys examples

### DIFF
--- a/content/zh/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch.md
+++ b/content/zh/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch.md
@@ -452,10 +452,10 @@ spec:
 
 {{< tabs name="kubectl_retainkeys_example" >}}
 {{{< tab name="Bash" codelang="bash" >}}
-kubectl patch deployment retainkeys-demo --patch "$(cat patch-file-no-retainkeys.yaml)"
+kubectl patch deployment retainkeys-demo --type merge --patch "$(cat patch-file-no-retainkeys.yaml)"
 {{< /tab >}}
 {{< tab name="PowerShell" codelang="posh" >}}
-kubectl patch deployment retainkeys-demo --patch $(Get-Content patch-file-no-retainkeys.yaml -Raw)
+kubectl patch deployment retainkeys-demo --type merge --patch $(Get-Content patch-file-no-retainkeys.yaml -Raw)
 {{< /tab >}}}
 {{< /tabs >}}
 
@@ -499,10 +499,10 @@ Patch your Deployment again with this new patch:
 
 {{< tabs name="kubectl_retainkeys2_example" >}}
 {{{< tab name="Bash" codelang="bash" >}}
-kubectl patch deployment retainkeys-demo --patch "$(cat patch-file-retainkeys.yaml)"
+kubectl patch deployment retainkeys-demo --type merge --patch "$(cat patch-file-retainkeys.yaml)"
 {{< /tab >}}
 {{< tab name="PowerShell" codelang="posh" >}}
-kubectl patch deployment retainkeys-demo --patch $(Get-Content patch-file-retainkeys.yaml -Raw)
+kubectl patch deployment retainkeys-demo --type merge --patch $(Get-Content patch-file-retainkeys.yaml -Raw)
 {{< /tab >}}}
 {{< /tabs >}}
 


### PR DESCRIPTION
add missing "--type merge"  in retainkeys examples
ref: https://github.com/kubernetes/website/pull/27806/files
Fix #27805
