### PR TITLE
Provide links back to "Production environment"

### DIFF
--- a/content/en/docs/setup/learning-environment/_index.md
+++ b/content/en/docs/setup/learning-environment/_index.md
@@ -31,3 +31,8 @@ Kubernetes, or for daily development work.
 You can follow the official
 [Get Started!](https://minikube.sigs.k8s.io/docs/start/) guide if your focus is
 on getting the tool installed.
+
+
+{{< note >}}
+For creating a production-quality Kubernetes cluster, look for documentation here [Production environment](/docs/setup/#production-environment)
+{{< /note >}}


### PR DESCRIPTION
Provide links back to "Production environment", when finished with "Learning environment"
fixes https://github.com/kubernetes/minikube/issues/11409