### PR TITLE
minikube 1.19.0 is namespace changed

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -44,13 +44,23 @@ This page shows you how to set up a simple Ingress which routes requests to Serv
 
 1. Verify that the NGINX Ingress controller is running
 
+    minikube version 1.18.1 or earlier
+    
     ```shell
     kubectl get pods -n kube-system
+    ```
+
+    minikube version 1.19.0 or later
+
+    ```shell
+    kubectl get pods -n ingress-nginx
     ```
 
     {{< note >}}This can take up to a minute.{{< /note >}}
 
     Output:
+    
+    minikube version 1.18.1 or earlier
 
     ```shell
     NAME                                        READY     STATUS    RESTARTS   AGE
@@ -60,6 +70,15 @@ This page shows you how to set up a simple Ingress which routes requests to Serv
     kubernetes-dashboard-5498ccf677-b8p5h       1/1       Running   0          2m
     nginx-ingress-controller-5984b97644-rnkrg   1/1       Running   0          1m
     storage-provisioner                         1/1       Running   0          2m
+    ```
+    
+    minikube version 1.19.0 or later
+
+    ```shell
+    NAME                                        READY   STATUS      RESTARTS   AGE
+    ingress-nginx-admission-create-ckgpj        0/1     Completed   0          15m
+    ingress-nginx-admission-patch-585xt         0/1     Completed   0          15m
+    ingress-nginx-controller-5d88495688-b4s8m   1/1     Running     0          15m
     ```
 
 ## Deploy a hello, world app


### PR DESCRIPTION
Ingress namespace is minikube 1.19.0 chage the status kube-system to ingress-nginx. 

https://github.com/kubernetes/minikube/blob/master/CHANGELOG.md#version-1190-beta0---2021-04-05
https://github.com/kubernetes/minikube/pull/10879

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

/ assign @onlydole