### PR TITLE
Remove deprecated "--algorithm-provider" flag

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/kube-scheduler.md
+++ b/content/en/docs/reference/command-line-tools-reference/kube-scheduler.md
@@ -58,13 +58,6 @@ kube-scheduler [flags]
 </tr>
 
 <tr>
-<td colspan="2">--algorithm-provider string</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>DEPRECATED: the scheduling algorithm provider to use, this sets the default plugins for component config profiles. Choose one of: ClusterAutoscalerProvider | DefaultProvider</p></td>
-</tr>
-
-<tr>
 <td colspan="2">--allow-metric-labels stringToString&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: []</td>
 </tr>
 <tr>
@@ -166,7 +159,7 @@ kube-scheduler [flags]
 <td colspan="2">--config string</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>The path to the configuration file. The following flags can overwrite fields in this file:<br/>--algorithm-provider<br/>--policy-config-file<br/>--policy-configmap<br/>--policy-configmap-namespace</p></td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>The path to the configuration file. The following flags can overwrite fields in this file:<br/>--policy-config-file<br/>--policy-configmap<br/>--policy-configmap-namespace</p></td>
 </tr>
 
 <tr>

--- a/content/zh/docs/reference/command-line-tools-reference/kube-scheduler.md
+++ b/content/zh/docs/reference/command-line-tools-reference/kube-scheduler.md
@@ -66,19 +66,6 @@ DEPRECATED: the IP address on which to listen for the --port port (set to 0.0.0.
 </tr>
 
 <tr>
-<td colspan="2">--algorithm-provider string</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-DEPRECATED: the scheduling algorithm provider to use, this sets the default plugins for component config profiles. Choose one of: ClusterAutoscalerProvider | DefaultProvider
--->
-已弃用: 要使用的调度算法驱动，此标志设置组件配置框架的默认插件。
-可选值：ClusterAutoscalerProvider | DefaultProvider
-</td>
-</tr>
-
-<tr>
 <td colspan="2">--alsologtostderr</td>
 </tr>
 <tr>
@@ -248,7 +235,7 @@ If set, any request presenting a client certificate signed by one of the authori
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-The path to the configuration file. The following flags can overwrite fields in this file:<br/>  --address<br/>  --port<br/>  --use-legacy-policy-config<br/>  --policy-configmap<br/>  --policy-config-file<br/>  --algorithm-provider
+The path to the configuration file. The following flags can overwrite fields in this file:<br/>  --address<br/>  --port<br/>  --use-legacy-policy-config<br/>  --policy-configmap<br/>  --policy-config-file
 -->
 配置文件的路径。以下标志会覆盖此文件中的值：<br/>
 --address<br/>
@@ -256,7 +243,6 @@ The path to the configuration file. The following flags can overwrite fields in 
 --use-legacy-policy-config<br/>
 --policy-configmap<br/>
 --policy-config-file<br/>
---algorithm-provider
 </td>
 </tr>
 


### PR DESCRIPTION
The flag --algorithm-provider has been verified deprecated since 1.17 and will be move since 1.22.

Related issues:  https://github.com/kubernetes/kubernetes/issues/102151
Related pr: https://github.com/kubernetes/kubernetes/pull/102239

@roycaihw Hi, here is the pr that remove --algorithm-provider flag in related doc.
This flag used to set the default plugins for component config profiles, if flag is ClusterAutoscalerProvider, compare to DefaultProvider, it will replace score plugin NodeResourcesLeastAllocated with NodeResourcesMostAllocated.

