### PR TITLE
Deprecate and remove storage plugins

### DIFF
--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -320,6 +320,7 @@ PersistentVolume types are implemented as plugins. Kubernetes currently supports
 * [`fc`](/docs/concepts/storage/volumes/#fc) - Fibre Channel (FC) storage
 * [`flexVolume`](/docs/concepts/storage/volumes/#flexVolume) - FlexVolume
 * [`flocker`](/docs/concepts/storage/volumes/#flocker) - Flocker storage
+  (**deprecated**)
 * [`gcePersistentDisk`](/docs/concepts/storage/volumes/#gcepersistentdisk) - GCE Persistent Disk
 * [`glusterfs`](/docs/concepts/storage/volumes/#glusterfs) - Glusterfs volume
 * [`hostPath`](/docs/concepts/storage/volumes/#hostpath) - HostPath volume
@@ -329,15 +330,12 @@ PersistentVolume types are implemented as plugins. Kubernetes currently supports
 * [`local`](/docs/concepts/storage/volumes/#local) - local storage devices
   mounted on nodes.
 * [`nfs`](/docs/concepts/storage/volumes/#nfs) - Network File System (NFS) storage
-* `photonPersistentDisk` - Photon controller persistent disk.
-  (This volume type no longer works since the removal of the corresponding
-  cloud provider.)
 * [`portworxVolume`](/docs/concepts/storage/volumes/#portworxvolume) - Portworx volume
 * [`quobyte`](/docs/concepts/storage/volumes/#quobyte) - Quobyte volume
-* [`rbd`](/docs/concepts/storage/volumes/#rbd) - Rados Block Device (RBD) volume
-* [`scaleIO`](/docs/concepts/storage/volumes/#scaleio) - ScaleIO volume
   (**deprecated**)
+* [`rbd`](/docs/concepts/storage/volumes/#rbd) - Rados Block Device (RBD) volume
 * [`storageos`](/docs/concepts/storage/volumes/#storageos) - StorageOS volume
+  (**deprecated**)
 * [`vsphereVolume`](/docs/concepts/storage/volumes/#vspherevolume) - vSphere VMDK volume
 
 ## Persistent Volumes
@@ -437,7 +435,6 @@ In the CLI, the access modes are abbreviated to:
 | RBD                  | &#x2713;               | &#x2713;              | -            |
 | VsphereVolume        | &#x2713;               | -                     | - (works when Pods are collocated)  |
 | PortworxVolume       | &#x2713;               | -                     | &#x2713;     |
-| ScaleIO              | &#x2713;               | &#x2713;              | -            |
 | StorageOS            | &#x2713;               | -                     | -            |
 
 ### Class

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -121,10 +121,10 @@ beta features must be enabled.
 
 #### AWS EBS CSI migration complete
 
-{{< feature-state for_k8s_version="v1.17" state="alpha" >}}
+{{< feature-state for_k8s_version="v1.21" state="alpha" >}}
 
 To disable the `awsElasticBlockStore` storage plugin from being loaded by the controller manager
-and the kubelet, set the `CSIMigrationAWSComplete` flag to `true`. This feature requires the `ebs.csi.aws.com` Container Storage Interface (CSI) driver installed on all worker nodes.
+and the kubelet, set the `InTreePluginAWSUnregister` flag to `true`.
 
 ### azureDisk {#azuredisk}
 
@@ -462,7 +462,7 @@ spec:
     required:
       nodeSelectorTerms:
       - matchExpressions:
-        - key: failure-domain.beta.kubernetes.io/zone
+        - key: topology.kubernetes.io/zone
           operator: In
           values:
           - us-central1-a
@@ -479,6 +479,13 @@ Storage Interface (CSI) Driver. In order to use this feature, the [GCE PD CSI
 Driver](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver)
 must be installed on the cluster and the `CSIMigration` and `CSIMigrationGCE`
 beta features must be enabled.
+
+#### GCE CSI migration complete
+
+{{< feature-state for_k8s_version="v1.21" state="alpha" >}}
+
+To disable the `gcePersistentDisk` storage plugin from being loaded by the controller manager
+and the kubelet, set the `InTreePluginGCEUnregister` flag to `true`.
 
 ### gitRepo (deprecated) {#gitrepo}
 
@@ -919,7 +926,7 @@ A container using a projected volume source as a [`subPath`](#using-subpath) vol
 receive updates for those volume sources.
 {{< /note >}}
 
-### quobyte
+### quobyte (deprecated)
 
 A `quobyte` volume allows an existing [Quobyte](https://www.quobyte.com) volume to
 be mounted into your Pod.
@@ -955,49 +962,6 @@ Simultaneous writers are not allowed.
 See the [RBD example](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/volumes/rbd)
 for more details.
 
-### scaleIO (deprecated) {#scaleio}
-
-ScaleIO is a software-based storage platform that uses existing hardware to
-create clusters of scalable shared block networked storage. The `scaleIO` volume
-plugin allows deployed pods to access existing ScaleIO
-volumes. For information about dynamically provisioning new volumes for
-persistent volume claims, see
-[ScaleIO persistent volumes](/docs/concepts/storage/persistent-volumes/#scaleio).
-
-{{< note >}}
-You must have an existing ScaleIO cluster already setup and
-running with the volumes created before you can use them.
-{{< /note >}}
-
-The following example is a Pod configuration with ScaleIO:
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: pod-0
-spec:
-  containers:
-  - image: k8s.gcr.io/test-webserver
-    name: pod-0
-    volumeMounts:
-    - mountPath: /test-pd
-      name: vol-0
-  volumes:
-  - name: vol-0
-    scaleIO:
-      gateway: https://localhost:443/api
-      system: scaleio
-      protectionDomain: sd0
-      storagePool: sp1
-      volumeName: vol-0
-      secretRef:
-        name: sio-secret
-      fsType: xfs
-```
-
-For further details, see the [ScaleIO](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/scaleio) examples.
-
 ### secret
 
 A `secret` volume is used to pass sensitive information, such as passwords, to
@@ -1017,7 +981,7 @@ receive Secret updates.
 
 For more details, see [Configuring Secrets](/docs/concepts/configuration/secret/).
 
-### storageOS {#storageos}
+### storageOS (deprecated) {#storageos}
 
 A `storageos` volume allows an existing [StorageOS](https://www.storageos.com)
 volume to mount into your Pod.
@@ -1165,7 +1129,7 @@ but new volumes created by the vSphere CSI driver will not be honoring these par
 
 {{< feature-state for_k8s_version="v1.19" state="beta" >}}
 
-To turn off the `vsphereVolume` plugin from being loaded by the controller manager and the kubelet, you need to set this feature flag to `true`. You must install a `csi.vsphere.vmware.com` {{< glossary_tooltip text="CSI" term_id="csi" >}} driver on all worker nodes.
+To turn off the `vsphereVolume` plugin from being loaded by the controller manager and the kubelet, you need to set `InTreePluginvSphereUnregister` feature flag to `true`. You must install a `csi.vsphere.vmware.com` {{< glossary_tooltip text="CSI" term_id="csi" >}} driver on all worker nodes.
 
 ## Using subPath {#using-subpath}
 


### PR DESCRIPTION
Deprecate and remove some storage plugins:

Storage plugins removed:
- ScaleIO  
- https://github.com/kubernetes/kubernetes/pull/101685

Storage plugins deprecated:
- Flocker, StorageOS, Quobyte
- https://github.com/kubernetes/kubernetes/pull/101773
- https://github.com/kubernetes/kubernetes/pull/102186