### PR TITLE
Deprecate and remove some storage plugins

### DIFF
--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -314,12 +314,9 @@ PersistentVolume types are implemented as plugins. Kubernetes currently supports
 * [`azureDisk`](/docs/concepts/storage/volumes/#azuredisk) - Azure Disk
 * [`azureFile`](/docs/concepts/storage/volumes/#azurefile) - Azure File
 * [`cephfs`](/docs/concepts/storage/volumes/#cephfs) - CephFS volume
-* [`cinder`](/docs/concepts/storage/volumes/#cinder) - Cinder (OpenStack block storage)
-  (**deprecated**)
 * [`csi`](/docs/concepts/storage/volumes/#csi) - Container Storage Interface (CSI)
 * [`fc`](/docs/concepts/storage/volumes/#fc) - Fibre Channel (FC) storage
 * [`flexVolume`](/docs/concepts/storage/volumes/#flexVolume) - FlexVolume
-* [`flocker`](/docs/concepts/storage/volumes/#flocker) - Flocker storage
 * [`gcePersistentDisk`](/docs/concepts/storage/volumes/#gcepersistentdisk) - GCE Persistent Disk
 * [`glusterfs`](/docs/concepts/storage/volumes/#glusterfs) - Glusterfs volume
 * [`hostPath`](/docs/concepts/storage/volumes/#hostpath) - HostPath volume
@@ -329,16 +326,27 @@ PersistentVolume types are implemented as plugins. Kubernetes currently supports
 * [`local`](/docs/concepts/storage/volumes/#local) - local storage devices
   mounted on nodes.
 * [`nfs`](/docs/concepts/storage/volumes/#nfs) - Network File System (NFS) storage
-* `photonPersistentDisk` - Photon controller persistent disk.
-  (This volume type no longer works since the removal of the corresponding
-  cloud provider.)
 * [`portworxVolume`](/docs/concepts/storage/volumes/#portworxvolume) - Portworx volume
-* [`quobyte`](/docs/concepts/storage/volumes/#quobyte) - Quobyte volume
 * [`rbd`](/docs/concepts/storage/volumes/#rbd) - Rados Block Device (RBD) volume
-* [`scaleIO`](/docs/concepts/storage/volumes/#scaleio) - ScaleIO volume
-  (**deprecated**)
-* [`storageos`](/docs/concepts/storage/volumes/#storageos) - StorageOS volume
 * [`vsphereVolume`](/docs/concepts/storage/volumes/#vspherevolume) - vSphere VMDK volume
+
+The following types of PersistentVolume are deprecated. This means that support is still available but will be removed in a future Kubernetes release.
+
+* [`cinder`](/docs/concepts/storage/volumes/#cinder) - Cinder (OpenStack block storage)
+  (**deprecated** in v1.18)
+* [`flocker`](/docs/concepts/storage/volumes/#flocker) - Flocker storage
+  (**deprecated** in v1.22)
+* [`quobyte`](/docs/concepts/storage/volumes/#quobyte) - Quobyte volume
+  (**deprecated** in v1.22)
+* [`storageos`](/docs/concepts/storage/volumes/#storageos) - StorageOS volume
+  (**deprecated** in v1.22)
+
+Older versions of Kubernetes also supported the following in-tree PersistentVolume types:
+
+* `photonPersistentDisk` - Photon controller persistent disk.
+  (**not available** after v1.15)
+* [`scaleIO`](/docs/concepts/storage/volumes/#scaleio) - ScaleIO volume
+  (**not available** after v1.21)
 
 ## Persistent Volumes
 
@@ -437,7 +445,6 @@ In the CLI, the access modes are abbreviated to:
 | RBD                  | &#x2713;               | &#x2713;              | -            |
 | VsphereVolume        | &#x2713;               | -                     | - (works when Pods are collocated)  |
 | PortworxVolume       | &#x2713;               | -                     | &#x2713;     |
-| ScaleIO              | &#x2713;               | &#x2713;              | -            |
 | StorageOS            | &#x2713;               | -                     | -            |
 
 ### Class

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -919,7 +919,7 @@ A container using a projected volume source as a [`subPath`](#using-subpath) vol
 receive updates for those volume sources.
 {{< /note >}}
 
-### quobyte
+### quobyte (deprecated) {#quobyte}
 
 A `quobyte` volume allows an existing [Quobyte](https://www.quobyte.com) volume to
 be mounted into your Pod.
@@ -955,49 +955,6 @@ Simultaneous writers are not allowed.
 See the [RBD example](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/volumes/rbd)
 for more details.
 
-### scaleIO (deprecated) {#scaleio}
-
-ScaleIO is a software-based storage platform that uses existing hardware to
-create clusters of scalable shared block networked storage. The `scaleIO` volume
-plugin allows deployed pods to access existing ScaleIO
-volumes. For information about dynamically provisioning new volumes for
-persistent volume claims, see
-[ScaleIO persistent volumes](/docs/concepts/storage/persistent-volumes/#scaleio).
-
-{{< note >}}
-You must have an existing ScaleIO cluster already setup and
-running with the volumes created before you can use them.
-{{< /note >}}
-
-The following example is a Pod configuration with ScaleIO:
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: pod-0
-spec:
-  containers:
-  - image: k8s.gcr.io/test-webserver
-    name: pod-0
-    volumeMounts:
-    - mountPath: /test-pd
-      name: vol-0
-  volumes:
-  - name: vol-0
-    scaleIO:
-      gateway: https://localhost:443/api
-      system: scaleio
-      protectionDomain: sd0
-      storagePool: sp1
-      volumeName: vol-0
-      secretRef:
-        name: sio-secret
-      fsType: xfs
-```
-
-For further details, see the [ScaleIO](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/scaleio) examples.
-
 ### secret
 
 A `secret` volume is used to pass sensitive information, such as passwords, to
@@ -1017,7 +974,7 @@ receive Secret updates.
 
 For more details, see [Configuring Secrets](/docs/concepts/configuration/secret/).
 
-### storageOS {#storageos}
+### storageOS (deprecated) {#storageos}
 
 A `storageos` volume allows an existing [StorageOS](https://www.storageos.com)
 volume to mount into your Pod.


### PR DESCRIPTION
Deprecate and remove some storage plugins:

Storage plugins removed:
- ScaleIO  
- https://github.com/kubernetes/kubernetes/pull/101685

Storage plugins deprecated:
- Flocker, StorageOS, Quobyte
- https://github.com/kubernetes/kubernetes/pull/101773
- https://github.com/kubernetes/kubernetes/pull/102186