### PR TITLE
Add docs about auth differences between Docker and Kubernetes

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
+++ b/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
@@ -28,7 +28,7 @@ docker login
 
 When prompted, enter your Docker username and password.
 
-The login process creates or updates a `config.json` file that holds an authorization token.
+The login process creates or updates a `config.json` file that holds an authorization token. Review [how Kubernetes interprets this file](/docs/concepts/containers/images#config-json). 
 
 View the `config.json` file:
 


### PR DESCRIPTION
The interpretation between Docker and Kubernetes varies when comparing
its implementations. This allows different use cases and should be
documented accordingly.

cc @wking