### PR TITLE
SCTP is stable as of 1.20

### DIFF
--- a/content/en/docs/concepts/services-networking/network-policies.md
+++ b/content/en/docs/concepts/services-networking/network-policies.md
@@ -212,9 +212,9 @@ This ensures that even pods that aren't selected by any other NetworkPolicy will
 
 ## SCTP support
 
-{{< feature-state for_k8s_version="v1.19" state="beta" >}}
+{{< feature-state for_k8s_version="v1.20" state="stable" >}}
 
-As a beta feature, this is enabled by default. To disable SCTP at a cluster level, you (or your cluster administrator) will need to disable the `SCTPSupport` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) for the API server with `--feature-gates=SCTPSupport=false,…`.
+As a stable feature, this is enabled by default. To disable SCTP at a cluster level, you (or your cluster administrator) will need to disable the `SCTPSupport` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) for the API server with `--feature-gates=SCTPSupport=false,…`.
 When the feature gate is enabled, you can set the `protocol` field of a NetworkPolicy to `SCTP`.
 
 {{< note >}}


### PR DESCRIPTION
SCTP has been stable since 1.20. I was showing this page to colleagues and noticed SCTP is still listed as beta; that is no longer accurate. This PR corrects the outdated info on this page. Supporting evidence:

- Mentioned in release blog: https://kubernetes.io/blog/2020/12/08/kubernetes-1-20-release-announcement/#graduated-to-stable
- Listed correctly (as SCTPSupport) on https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/ 

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>

