### PR TITLE
Improvement in Configure Service Accounts for Pods Task

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-service-account.md
@@ -167,8 +167,8 @@ The output is similar to this:
 Name:           build-robot-secret
 Namespace:      default
 Labels:         <none>
-Annotations:    kubernetes.io/service-account.name=build-robot
-                kubernetes.io/service-account.uid=da68f9c6-9d26-11e7-b84e-002dc52800da
+Annotations:    kubernetes.io/service-account.name: build-robot
+                kubernetes.io/service-account.uid: da68f9c6-9d26-11e7-b84e-002dc52800da
 
 Type:   kubernetes.io/service-account-token
 


### PR DESCRIPTION

When performing  Configure Service Accounts for Pods task. Here is my obsevation:
After creating the service account (build-robot) when I checked it by running `kubectl get serviceaccounts/build-robot -o yaml` i found that it also show `annotations` field under metadata. and on describing the secrets(build-robot-secret)  `kubectl describe secrets/build-robot-secret` then in annotations `:` is used instead of `=`

Improve these things in the task.