### PR TITLE
[ja] Fix emphasis tags in ja/docs/concepts/services-networking/service.md

### DIFF
--- a/content/ja/docs/concepts/services-networking/service.md
+++ b/content/ja/docs/concepts/services-networking/service.md
@@ -95,7 +95,7 @@ Serviceは多くの場合、KubernetesのPodに対するアクセスを抽象化
 * Serviceを、異なる{{< glossary_tooltip term_id="namespace" >}}のServiceや他のクラスターのServiceに向ける場合
 * ワークロードをKubernetesに移行するとき、アプリケーションに対する処理をしながら、バックエンドの一部をKubernetesで実行する場合
 
-このような場合において、ユーザーはPodセレクター_なしで_ Serviceを定義できます。
+このような場合において、ユーザーはPodセレクター*なしで*Serviceを定義できます。
 
 ```yaml
 apiVersion: v1
@@ -882,7 +882,7 @@ Kubernetesは各Serviceに、それ自身のIPアドレスを割り当てるこ�
 ### ServiceのIPアドレス {#ips-and-vips}
 
 実際に固定された向き先であるPodのIPアドレスとは異なり、ServiceのIPは実際には単一のホストによって応答されません。
-その代わり、kube-proxyは必要な時に透過的にリダイレクトされる_仮想_ IPアドレスを定義するため、iptables(Linuxのパケット処理ロジック)を使用します。
+その代わり、kube-proxyは必要な時に透過的にリダイレクトされる*仮想*IPアドレスを定義するため、iptables(Linuxのパケット処理ロジック)を使用します。
 クライアントがVIPに接続する時、そのトラフィックは自動的に適切なEndpointsに転送されます。
 Service用の環境変数とDNSは、Serviceの仮想IPアドレス(とポート)の面において、自動的に生成されます。
 


### PR DESCRIPTION
This PR fixes emphasis tags which are not converted to `<em>` tag.

When using underscore as an emphasis tag, a blank character is required in both start and end. (with some exceptions ...)
If these blanks are undescribed, underscore is displayed with no change.

Generally, a blank character is not used between words in Japanese.
So, translators tend to use underscore without blank by mistake.

e.g.:
NG `通常_斜体_通常`
NG `通常_斜体_ 通常`
NG `通常 _斜体_通常`
OK `通常 _斜体_ 通常`

I think it is better to use asterisk instead of underscore in Japanese and other similar languages for the following reasons.
- Asterisk can be used as emphasis tag, too.
- When using asterisk, a blank character is not required. (e.g.: OK `通常*斜体*通常`)
- if underscore is used, unnecessary blanks between words are displayed in Web browser.

By the way, Japanese characters are not displayed as italic in Edge and Chrome by default font.
It is the specification of Meiryo font.
To confirm italic, it is necessary to change to other font or use Firefox.
