### PR TITLE
[WIP] All Enhancement proposals in single webpage | KEPs

### DIFF
--- a/content/en/keps/_index.md
+++ b/content/en/keps/_index.md
@@ -1,13 +1,16 @@
 ---
 linktitle: KEPs
 title: KEPs
-
 ---
 
-
-<!-- overview -->
-Data taken from Enhancements tracking repo for Kubernetes: https://github.com/kubernetes/enhancements
-<!-- body -->
+<div class="container ">
+	<div class="row mx-md-n5  px-md-5">
+		<!-- overview -->
+		Data taken from Enhancements tracking repo for Kubernetes:
+		<a href="https://github.com/kubernetes/enhancements">kubernetes/enhancements</a>
+		<!-- body -->
+	</div>
+</div>
 
 ## KEPs
 

--- a/content/en/keps/_index.md
+++ b/content/en/keps/_index.md
@@ -4,7 +4,7 @@ title: KEPs
 ---
 
 <div class="container ">
-	<div class="row mx-md-n5  px-md-5">
+	<div class="mt-2 col-md-12">
 		<!-- overview -->
 		Data taken from Enhancements tracking repo for Kubernetes:
 		<a href="https://github.com/kubernetes/enhancements">kubernetes/enhancements</a>
@@ -12,7 +12,11 @@ title: KEPs
 	</div>
 </div>
 
-## KEPs
+<div class="container ">
+	<h3 class="mt-2 col-md-12">
+		KEP List:
+	</h3>
+</div>
 
 {{< keps-data >}}
 

--- a/content/en/keps/_index.md
+++ b/content/en/keps/_index.md
@@ -1,0 +1,15 @@
+---
+linktitle: KEPs
+title: KEPs
+
+---
+
+
+<!-- overview -->
+Data taken from Enhancements tracking repo for Kubernetes: https://github.com/kubernetes/enhancements
+<!-- body -->
+
+## KEPs
+
+{{< keps-data >}}
+

--- a/data/keps/keps_data.yaml
+++ b/data/keps/keps_data.yaml
@@ -1,0 +1,8518 @@
+keps:
+- id: ""
+  prnumber: ""
+  name: 1027-api-unions
+  title: Union types
+  kep_number: "1027"
+  authors: ['@apelisse']
+  owning_sig: sig-api-machinery
+  reviewers: ['@sttts', '@lavalamp', '@thockin', '@DirectXMan12']
+  approvers: ['@lavalamp']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-03-25"
+  last-updated: "2019-03-25"
+  status: implementable
+  see-also:
+    - /keps/sig-api-machinery/0006-apply.md
+  replaces:
+    - https://docs.google.com/document/d/1lrV-P25ZTWukixE9ZWyvchfFR0NE2eCHlObiCUgNQGQ
+  stage: alpha
+  latest-milestone: "1.15"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1040-priority-and-fairness
+  title: Priority and Fairness for API Server Requests
+  kep_number: "1040"
+  authors: ['@MikeSpreitzer', '@yue9944882', '@wojtek-t']
+  owning_sig: sig-api-machinery
+  participating-sigs: [wg-multitenancy, sig-scheduling]
+  reviewers: ['@deads2k', '@lavalamp', '@ahg-g', '@wojtek-t']
+  approvers: ['@deads2k', '@lavalamp']
+  prr-approvers: ['@wojtek-t']
+  creation-date: "2019-02-28"
+  last-updated: ""
+  status: implementable
+  stage: beta
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.18
+      beta: v1.20
+      stable: v1.23
+  feature-gates:
+    - name: APIPriorityAndFairness
+      components:
+        - kube-apiserver
+  disable-supported: true
+  metrics:
+    - apiserver_flowcontrol_rejected_requests_total
+    - apiserver_flowcontrol_dispatched_requests_total
+    - apiserver_flowcontrol_current_inqueue_requests
+    - apiserver_flowcontrol_request_queue_length_after_enqueue
+    - apiserver_flowcontrol_request_concurrency_limit
+    - apiserver_flowcontrol_current_executing_requests
+    - apiserver_flowcontrol_request_wait_duration_seconds
+    - apiserver_flowcontrol_request_execution_seconds
+- id: ""
+  prnumber: ""
+  name: 1101-immutable-fields
+  title: Immutable Fields
+  kep_number: "1101"
+  authors: ['@apelisse', '@sttts']
+  owning_sig: sig-api-machinery
+  participating-sigs: [sig-api-machinery]
+  reviewers: ['@erictune', '@jpbetz', '@liggitt', '@logicalhan', '@p0lyn0mial']
+  approvers: ['@liggitt', '@deads2k']
+  prr-approvers: []
+  editor: '@sttts'
+  creation-date: "2019-06-03"
+  last-updated: "2019-10-01"
+  status: provisional
+  see-also:
+    - /keps/sig-api-machinery/0006-apply.md
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1152-less-object-serializations
+  title: Less object serializations
+  kep_number: "1152"
+  authors: ['@wojtek-t']
+  owning_sig: sig-api-machinery
+  participating-sigs: [sig-scalability]
+  reviewers: ['@jpbetz', '@justinsb', '@smarterclayton']
+  approvers: ['@deads2k', '@lavalamp']
+  prr-approvers: []
+  creation-date: "2019-03-27"
+  last-updated: "2019-10-10"
+  status: implemented
+  see-also:
+    - TODO
+  replaces:
+    - n/a
+  superseded-by:
+    - n/a
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1164-remove-selflink
+  title: Deprecate and remove SelfLink
+  kep_number: "1164"
+  authors: ['@wojtek-t']
+  owning_sig: sig-api-machinery
+  participating-sigs: [sig-scalability]
+  reviewers: ['@liggitt', '@smarterclayton']
+  approvers: ['@lavalamp', '@deads2k']
+  prr-approvers: ['@deads2k']
+  creation-date: "2019-07-11"
+  last-updated: "2019-07-24"
+  status: implementable
+  stage: beta
+  latest-milestone: v1.20
+  milestone:
+      alpha: v1.16
+      beta: v1.20
+      stable: v1.21
+  feature-gates:
+    - name: RemoveSelfLink
+      components:
+        - kube-apiserver
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1281-network-proxy
+  title: API Server Network Proxy
+  kep_number: "1281"
+  authors: ['@cheftako', '@anfernee']
+  owning_sig: sig-api-machinery
+  participating-sigs: [sig-network, sig-cloud-provider]
+  reviewers: [TBD, '@lavalamp', '@deads2k', '@bowei', '@andrewsykim', '@justinsb',
+      '@krousey', '@khenidak', '@mikedanese']
+  approvers: ['@deads2k - For Kube API Server portion of KEP', '@bowei - For networking/proxy
+          portion of KEP']
+  prr-approvers: []
+  editor: '@calebamiles'
+  creation-date: "2019-02-25"
+  last-updated: "2020-01-15"
+  status: implementable
+  see-also:
+    - https://goo.gl/qiARUK - Network Proxy design proposal
+    - https://goo.gl/ipwDkX - Explicit API server to node communications
+    - https://github.com/kubernetes-sigs/apiserver-network-proxy - Reference implementations
+      of API Server Network Proxy
+  stage: alpha
+  latest-milestone: "1.16"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1295-insecure-backend-proxy
+  title: Insecure Backend Proxy
+  kep_number: "1295"
+  authors: ['@deads2k']
+  owning_sig: sig-api-machinery
+  participating-sigs: [sig-api-machinery, sig-auth, sig-cli]
+  reviewers: ['@sttts', '@cheftako', '@liggitt', '@soltysh']
+  approvers: ['@lavalamp', '@mikedanese']
+  prr-approvers: ['@johnbelamaric', '@wojtek-t']
+  creation-date: "2019-09-27"
+  last-updated: ""
+  status: implemented
+  stage: stable
+  latest-milestone: v1.21
+  milestone:
+      alpha: ""
+      beta: v1.17
+      stable: v1.21
+  feature-gates:
+    - name: AllowInsecureBackendProxy
+      components:
+        - kube-apiserver
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1601-client-go-context
+  title: Context support in k8s.io/client-go
+  kep_number: "1601"
+  authors: ['@mikedanese', '@maleck13']
+  owning_sig: sig-api-machinery
+  participating-sigs: [sig-api-machinery]
+  reviewers: []
+  approvers: ['@deads2k', '@liggitt', '@lavalamp']
+  prr-approvers: []
+  creation-date: "2020-01-23"
+  last-updated: "2020-01-23"
+  status: implementable
+  stage: beta
+  latest-milestone: "1.18"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1623-standardize-conditions
+  title: KEP Template
+  kep_number: "1623"
+  authors: ['@deads2k']
+  owning_sig: sig-api-machinery
+  participating-sigs: [sig-api-machinery, sig-apps, sig-architecture]
+  reviewers: ['@lavalamp', '@smarterclayton']
+  approvers: ['@derekwaynecarr', '@liggitt']
+  prr-approvers: []
+  creation-date: "2020-03-23"
+  last-updated: ""
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1693-warnings
+  title: Warning mechanism for use of deprecated APIs
+  kep_number: "1693"
+  authors: ['@liggitt']
+  owning_sig: sig-api-machinery
+  participating-sigs: [sig-architecture, sig-cli, sig-instrumentation]
+  reviewers: ['@lavalamp', '@deads2k', '@seans3', '@logicalhan']
+  approvers: ['@lavalamp', '@smarterclayton']
+  prr-approvers: ['@ehashman']
+  creation-date: "2020-04-16"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - /keps/sig-architecture/1635-prevent-permabeta
+  stage: stable
+  latest-milestone: v1.22
+  milestone:
+      alpha: ""
+      beta: v1.19
+      stable: v1.22
+  feature-gates:
+    - name: WarningHeaders
+      components:
+        - kube-apiserver
+  disable-supported: true
+  metrics:
+    - apiserver_requested_deprecated_apis
+- id: ""
+  prnumber: ""
+  name: 1872-manifest-based-admission-webhooks
+  title: Manifest based registration of Admission webhooks
+  kep_number: "1872"
+  authors: ['@vivekbagade']
+  owning_sig: sig-api-machinery
+  participating-sigs: [sig-instrumentation]
+  reviewers: ['@liggitt', '@deads2k', '@wojtek-t', '@JeremyOT']
+  approvers: ['@liggitt', '@deads2k']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2020-04-21"
+  last-updated: "2020-07-23"
+  status: provisional
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1904-efficient-watch-resumption
+  title: Efficient watch resumption after kube-apiserver reboot
+  kep_number: "1904"
+  authors: ['@wojtek-t']
+  owning_sig: sig-api-machinery
+  participating-sigs: [sig-scalability]
+  reviewers: ['@jpbetz']
+  approvers: ['@deads2k', '@lavalamp']
+  prr-approvers: ['@deads2k']
+  creation-date: "2020-07-23"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - /keps/sig-api-machinery/20191210-consistent-reads-from-cache.md
+  stage: beta
+  latest-milestone: v1.21
+  milestone:
+      alpha: v1.20
+      beta: v1.21
+      stable: v1.23
+  feature-gates:
+    - name: EfficientWatchResumption
+      components:
+        - kube-apiserver
+  disable-supported: true
+  metrics:
+    - etcd_bookmark_counts
+- id: ""
+  prnumber: ""
+  name: 1929-built-in-default
+  title: Built-in declarative defaults
+  kep_number: "1929"
+  authors: [apelisse]
+  owning_sig: sig-api-machinery
+  reviewers: [jpbetz, lavalamp, sttts, kensipe]
+  approvers: [TBD]
+  prr-approvers: [deads2k]
+  creation-date: "2020-08-04"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - /keps/sig-api-machinery/20190426-crd-defaulting.md
+  stage: stable
+  latest-milestone: v1.20
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: v1.20
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1965-kube-apiserver-identity
+  title: kube-apiserver identity
+  kep_number: "1965"
+  authors: ['@roycaihw']
+  owning_sig: sig-api-machinery
+  reviewers: ['@caesarxuchao', '@lavalamp', '@MikeSpreitzer', '@deads2k']
+  approvers: ['@lavalamp', '@deads2k']
+  prr-approvers: []
+  creation-date: "2020-09-02"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - https://docs.google.com/document/d/1ed7miqlFY7-9lZxE7gzoyx_MFQCtFEDqtcKMpaAmHys/edit?usp=sharing
+  stage: alpha
+  latest-milestone: v1.20
+  milestone:
+      alpha: v1.20
+      beta: v1.21
+      stable: v1.22
+  feature-gates:
+    - name: APIServerIdentity
+      components:
+        - kube-apiserver
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2155-clientgo-apply
+  title: Client-go Apply
+  kep_number: "2155"
+  authors: ['@jpbetz']
+  owning_sig: sig-api-machinery
+  reviewers: ['@apelisse', '@kwiesmueller']
+  approvers: ['@deads2k', '@lavalamp']
+  prr-approvers: ['@deads2k']
+  creation-date: "2020-11-16"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - /keps/sig-api-machinery/0006-apply.md
+  stage: stable
+  latest-milestone: v1.21
+  milestone:
+      alpha: v1.21
+      beta: v1.21
+      stable: v1.21
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2161-apiserver-default-labels
+  title: Immutable label selectors for all namespaces
+  kep_number: "2161"
+  authors: ['@thockin', '@jayunit100', '@rikatz', '@abhiraut', '@andrewsykim']
+  owning_sig: sig-api-machinery
+  participating-sigs: [sig-api-machinery, sig-network]
+  reviewers: ['@liggitt', '@nikhita', '@thockin', '@deads2k']
+  approvers: ['@liggitt', '@deads2k']
+  prr-approvers: ['@deads2k']
+  creation-date: "2020-11-22"
+  last-updated: ""
+  status: implemented
+  stage: stable
+  latest-milestone: v1.22
+  milestone:
+      alpha: ""
+      beta: v1.21
+      stable: v1.22
+  feature-gates:
+    - name: NamespaceDefaultLabelName
+      components:
+        - kube-apiserver
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2330-migrating-api-objects-to-latest-storage-version
+  title: Migrating API objects to latest storage version
+  kep_number: "2330"
+  authors: ['@xuchao']
+  owning_sig: sig-api-machinery
+  reviewers: ['@deads2k', '@yliaog', '@lavalamp']
+  approvers: ['@deads2k', '@lavalamp']
+  prr-approvers: []
+  creation-date: "2018-08-06"
+  last-updated: "2019-03-19"
+  status: implementable
+  stage: alpha
+  latest-milestone: "1.14"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2332-pruning-for-custom-resources
+  title: Pruning for Custom Resources
+  kep_number: "2332"
+  authors: ['@sttts']
+  owning_sig: sig-api-machinery
+  participating-sigs: [sig-api-machinery]
+  reviewers: ['@deads2k', '@lavalamp', '@liggitt', '@erictune', '@mbohlool', '@apelisse']
+  approvers: ['@deads2k', '@lavalamp']
+  prr-approvers: []
+  editor: '@sttts'
+  creation-date: "2018-07-31"
+  last-updated: "2019-04-30"
+  status: implemented
+  see-also:
+    - https://github.com/kubernetes/enhancements/pull/1002
+    - /keps/sig-api-machinery/20180415-crds-to-ga.md
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2333-legacyflags-kflag
+  title: legacyflags
+  kep_number: "2333"
+  authors: ['@mtaufen']
+  owning_sig: sig-api-machinery
+  participating-sigs: [sig-architecture, sig-cluster-lifecycle, wg-component-standard]
+  reviewers: ['@kubernetes/wg-component-standard']
+  approvers: ['@luxas', '@sttts']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-01-29"
+  last-updated: "2019-04-02"
+  status: provisional
+  see-also:
+    - KEP-32
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2334-graduate-server-side-get-and-partial-objects-to-GA
+  title: Graduate Server-side Get and Partial Objects to GA
+  kep_number: "2334"
+  authors: ['@smarterclayton']
+  owning_sig: sig-api-machinery
+  participating-sigs: [sig-cli]
+  reviewers: ['@lavalamp', '@soltysh', '@liggitt']
+  approvers: ['@liggitt', '@pwittrock']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-03-22"
+  last-updated: "2019-03-22"
+  status: implementable
+  see-also:
+    - https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/server-get.md
+  stage: alpha
+  latest-milestone: "1.15"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2335-vanilla-crd-openapi-subset-structural-schemas
+  title: 'Vanilla CRD OpenAPI Subset: Structural Schemas'
+  kep_number: "2335"
+  authors: ['@sttts', '@mbohlool']
+  owning_sig: sig-api-machinery
+  participating-sigs: [sig-api-machinery]
+  reviewers: ['@liggitt', '@apelisse', '@mbohlool', '@DirectXMan12']
+  approvers: ['@lavalamp', '@deads2k']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-04-25"
+  last-updated: "2019-05-09"
+  status: implemented
+  see-also:
+    - /keps/sig-api-machinery/20180415-crds-to-ga.md
+    - https://github.com/kubernetes/enhancements/pull/926
+    - https://github.com/kubernetes/enhancements/pull/709
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2336-OwnerReference-resource-field
+  title: OwnerReference Resource Field
+  kep_number: "2336"
+  authors: ['@deads2k']
+  owning_sig: sig-api-machinery
+  participating-sigs: [sig-api-machinery]
+  reviewers: ['@sttts', '@caesarxuchao', '@liggitt']
+  approvers: ['@caesarxuchao', '@lavalamp']
+  prr-approvers: []
+  editor: '@deads2k'
+  creation-date: "2019-06-07"
+  last-updated: "2019-06-12"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2337-k8s.io-group-protection
+  title: k8s.io Group Protection
+  kep_number: "2337"
+  authors: ['@deads2k']
+  owning_sig: sig-api-machinery
+  participating-sigs: [sig-api-machinery, sig-architecture]
+  reviewers: ['@sttts', '@jpbetz', '@liggitt']
+  approvers: ['@liggitt', '@sttts']
+  prr-approvers: []
+  editor: '@deads2k'
+  creation-date: "2019-06-12"
+  last-updated: "2019-07-03"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2338-graduate-API-gzip-compression-support-to-GA
+  title: Graduate API gzip compression support to GA
+  kep_number: "2338"
+  authors: ['@smarterclayton']
+  owning_sig: sig-api-machinery
+  participating-sigs: [sig-cli]
+  reviewers: ['@lavalamp', '@liggitt']
+  approvers: ['@liggitt', '@lavalamp']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-03-22"
+  last-updated: "2019-03-22"
+  status: implementable
+  see-also:
+    - https://github.com/kubernetes/kubernetes/issues/44164
+  stage: beta
+  latest-milestone: "1.16"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2339-storageversion-api-for-ha-api-servers
+  title: StorageVersion API for HA API servers
+  kep_number: "2339"
+  authors: ['@xuchao']
+  owning_sig: sig-api-machinery
+  reviewers: ['@deads2k', '@yliaog', '@lavalamp']
+  approvers: ['@deads2k', '@lavalamp']
+  prr-approvers: []
+  creation-date: "2019-08-22"
+  last-updated: "2019-08-22"
+  status: implementable
+  stage: alpha
+  latest-milestone: "1.17"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2340-Consistent-reads-from-cache
+  title: Consistent Reads from Cache
+  kep_number: "2340"
+  authors: ['@jpbetz', '@wojtek-t']
+  owning_sig: sig-api-machinery
+  participating-sigs: [sig-scalability]
+  reviewers: ['@wojtek-t', '@jingyih']
+  approvers: ['@lavalamp', '@deads2k', '@wojtek-t']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-12-10"
+  last-updated: "2020-02-19"
+  status: provisional
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2341-enabling-clients-to-tell-if-resource-endpoints-serve-the-same-set-of-objects
+  title: Enabling clients to tell if resource endpoints serve the same set of objects
+  kep_number: "2341"
+  authors: ['@xuchao']
+  owning_sig: sig-api-machinery
+  reviewers: ['@deads2k', '@lavalamp']
+  approvers: ['@deads2k', '@lavalamp']
+  prr-approvers: []
+  creation-date: "2018-10-12"
+  last-updated: "2018-12-17"
+  status: provisional
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2342-exposing-hashed-storage-versions-via-the-discovery-API
+  title: exposing hashed storage versions via the discovery API
+  kep_number: "2342"
+  authors: ['@xuchao']
+  owning_sig: sig-api-machinery
+  reviewers: ['@deads2k', '@lavalamp']
+  approvers: ['@deads2k', '@lavalamp']
+  prr-approvers: []
+  creation-date: "2019-01-02"
+  last-updated: "2019-01-04"
+  status: provisional
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2343-automated-storage-version-migration-with-storage-version-hash
+  title: Automated Storage Version Migration with Storage Version Hash
+  kep_number: "2343"
+  authors: ['@xuchao']
+  owning_sig: sig-api-machinery
+  reviewers: ['@deads2k', '@yliaog']
+  approvers: ['@deads2k', '@lavalamp']
+  prr-approvers: []
+  creation-date: "2019-01-23"
+  last-updated: "2019-01-23"
+  status: provisional
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2523-consistent-resource-versions-semantics
+  title: consistent-resource-version-semantics
+  kep_number: "2523"
+  authors: ['@jpbetz']
+  owning_sig: sig-api-machinery
+  reviewers: ['@lavalamp', '@wojtek-t']
+  approvers: ['@lavalamp', '@deads2k']
+  prr-approvers: []
+  creation-date: "2020-03-09"
+  last-updated: "2020-04-02"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2558-publish-version-openapi
+  title: Publish versioning information in OpenAPI
+  kep_number: "2558"
+  authors: ['@nikhita']
+  owning_sig: sig-api-machinery
+  participating-sigs: [sig-architecture]
+  reviewers: ['@thockin', '@apelisse', '@sttts', '@roycaihw']
+  approvers: ['@thockin', '@apelisse']
+  prr-approvers: ['@deads2k']
+  creation-date: "2021-03-07"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - https://groups.google.com/g/kubernetes-sig-architecture/c/UmPwm-J3ztE/m/QckZWJAABQAJ
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.22
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 365-paginated-lists
+  title: Paginated API Lists
+  kep_number: "365"
+  authors: ['@smarterclayton']
+  owning_sig: sig-api-machinery
+  participating-sigs: [sig-scalability]
+  reviewers: ['@liggitt']
+  approvers: ['@deads2k', '@lavalamp']
+  prr-approvers: ['@wojtek-t']
+  creation-date: "2017-08-29"
+  last-updated: ""
+  status: implemented
+  stage: beta
+  latest-milestone: v1.9
+  milestone:
+      alpha: v1.8
+      beta: v1.9
+      stable: ""
+  feature-gates:
+    - name: APIListChunking
+      components:
+        - kube-apiserver
+  disable-supported: true
+  metrics:
+    - apiserver_request_duration_seconds
+- id: ""
+  prnumber: ""
+  name: 492-admission-webhooks
+  title: Graduate Admission Webhooks to GA
+  kep_number: "492"
+  authors: ['@mbohlool']
+  owning_sig: sig-api-machinery
+  reviewers: ['@liggitt', '@deads2k']
+  approvers: ['@liggitt', '@deads2k']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-01-27"
+  last-updated: "2019-02-04"
+  status: implemented
+  see-also:
+    - '[Admission Control Webhook Beta Design Doc](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/admission-control-webhooks.md)'
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 555-server-side-apply
+  title: Apply
+  kep_number: "555"
+  authors: ['@lavalamp']
+  owning_sig: sig-api-machinery
+  participating-sigs: [sig-api-machinery, sig-cli]
+  reviewers: ['@pwittrock', '@erictune']
+  approvers: ['@bgrant0607']
+  prr-approvers: ['@deads2k']
+  editor: TBD
+  creation-date: "2018-03-28"
+  last-updated: "2021-02-21"
+  status: implementable
+  see-also:
+    - n/a
+  replaces:
+    - n/a
+  superseded-by:
+    - n/a
+  stage: stable
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.14
+      beta: v1.16
+      stable: v1.22
+  feature-gates:
+    - name: ServerSideApply
+      components:
+        - kube-apiserver
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 575-crd-defaulting
+  title: Defaulting for Custom Resources
+  kep_number: "575"
+  authors: ['@sttts']
+  owning_sig: sig-api-machinery
+  participating-sigs: [sig-api-machinery]
+  reviewers: ['@deads2k', '@lavalamp', '@liggitt', '@mbohlool', '@apelisse']
+  approvers: ['@deads2k', '@lavalamp']
+  prr-approvers: []
+  editor: '@sttts'
+  creation-date: "2019-04-26"
+  last-updated: "2019-07-29"
+  status: implemented
+  see-also:
+    - /keps/sig-api-machinery/20180731-crd-pruning.md
+    - /keps/sig-api-machinery/20190425-structural-openapi.md
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 576-dry-run
+  title: Dry-run
+  kep_number: "576"
+  authors: ['@apelisse']
+  owning_sig: sig-api-machinery
+  participating-sigs: [sig-api-machinery, sig-cli]
+  reviewers: ['@lavalamp', '@deads2k']
+  approvers: ['@erictune']
+  prr-approvers: []
+  editor: apelisse
+  creation-date: "2018-06-21"
+  last-updated: "2020-03-23"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 598-crd-conversion-webhook
+  title: CustomResourceDefinition Conversion Webhook
+  kep_number: "598"
+  authors: ['@mbohlool', '@erictune']
+  owning_sig: sig-api-machinery
+  reviewers: ['@lavalamp', '@deads2k', '@sttts', '@liggitt']
+  approvers: ['@lavalamp', '@deads2k']
+  prr-approvers: []
+  creation-date: "2019-04-25"
+  last-updated: "2019-04-25"
+  status: implemented
+  replaces:
+    - (https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/customresource-conversion-webhook.md)
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 692-crd-openapi-schema
+  title: Publish CRD OpenAPI
+  kep_number: "692"
+  authors: ['@roycaihw']
+  owning_sig: sig-api-machinery
+  reviewers: ['@apelisse', '@liggitt', '@mbohlool', '@sttts']
+  approvers: ['@liggitt', '@sttts']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-02-07"
+  last-updated: "2019-02-13"
+  status: implemented
+  see-also:
+    - '[Validation for CustomResources design doc](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/customresources-validation.md)'
+  stage: stable
+  latest-milestone: "1.19"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 95-custom-resource-definitions
+  title: Graduate CustomResourceDefinitions to GA
+  kep_number: "95"
+  authors: ['@jpbetz', '@roycaihw', '@sttts']
+  owning_sig: sig-api-machinery
+  participating-sigs: [sig-api-machinery, sig-architecture]
+  reviewers: ['@deads2k', '@lavalamp', '@liggitt', '@mbohlool', '@sttts']
+  approvers: ['@deads2k', '@lavalamp']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2018-04-15"
+  last-updated: "2018-04-24"
+  status: implementable
+  see-also:
+    - '[Umbrella Issue](https://github.com/kubernetes/kubernetes/issues/58682)'
+    - '[Vanilla OpenAPI Subset Design](https://docs.google.com/document/d/1pcGlbmw-2Y0JJs9hsYnSBXamgG9TfWtHY6eh80zSTd8)'
+    - '[Pruning for CustomResources KEP](https://github.com/kubernetes/enhancements/pull/709)'
+    - '[Defaulting for Custom Resources KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20190426-crd-defaulting.md)'
+  stage: stable
+  latest-milestone: "1.16"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 956-watch-bookmark
+  title: Watch Bookmark
+  kep_number: "956"
+  authors: ['@wojtek-t']
+  owning_sig: sig-api-machinery
+  participating-sigs: [sig-scalability]
+  reviewers: ['@jpbetz']
+  approvers: ['@deads2k', '@lavalamp']
+  prr-approvers: []
+  creation-date: "2019-02-06"
+  last-updated: "2019-04-30"
+  status: implemented
+  see-also:
+    - https://github.com/kubernetes/kubernetes/issues/73585
+  replaces:
+    - n/a
+  superseded-by:
+    - n/a
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1591-daemonset-surge
+  title: Allow DaemonSets to surge during update like Deployments
+  kep_number: "1591"
+  authors: ['@smarterclayton']
+  owning_sig: sig-apps
+  participating-sigs: [sig-scheduling, sig-node]
+  reviewers: ['@kow3ns', '@janetkuo', '@soltysh']
+  approvers: ['@kow3ns', '@janetkuo', '@soltysh']
+  prr-approvers: ['@deads2k', '@ehashman']
+  editor: TBD
+  creation-date: "2020-03-02"
+  last-updated: "2020-05-06"
+  status: implementable
+  stage: beta
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.21
+      beta: v1.22
+      stable: v1.24
+  feature-gates:
+    - name: DaemonSetUpdateSurge
+      components:
+        - kube-apiserver
+        - kube-controller-manager
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1847-autoremove-statefulset-pvcs
+  title: Auto delete PVCs created by StatefulSet
+  kep_number: "1847"
+  authors: ['@kk-src', '@dsu-igeek', '@mattcary']
+  owning_sig: sig-apps
+  participating-sigs: [sig-storage]
+  reviewers: ['@kow3ns', '@xing-yang', '@msau42', '@janetkuo']
+  approvers: ['@msau42', '@janetkuo']
+  prr-approvers: ['@wojtek-t']
+  creation-date: "2020-06-04"
+  last-updated: ""
+  status: implementable
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.22
+      beta: v1.23
+      stable: v1.24
+  feature-gates:
+    - name: StatefulSetAutoDeletePVC
+      components:
+        - kube-controller-manager
+        - kube-apiserver
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 19-Graduate-CronJob-to-Stable
+  title: Graduate CronJob to Stable
+  kep_number: "19"
+  authors: ['@barney-s', '@soltysh']
+  owning_sig: sig-apps
+  participating-sigs: [sig-scalability]
+  reviewers: ['@liggitt', '@kow3ns', '@janetkuo', “@mortent”, '@wojtek-t']
+  approvers: ['@kow3ns', '@janetkuo', '@liggitt', '@wojtek-t']
+  prr-approvers: ['@wojtek-t']
+  creation-date: "2019-04-18"
+  last-updated: ""
+  status: implementable
+  replaces:
+    - https://github.com/kubernetes/community/blob/master/contributors/design-proposals/apps/cronjob.md
+  stage: stable
+  latest-milestone: v1.21
+  milestone:
+      alpha: v1.4
+      beta: v1.8
+      stable: v1.21
+  feature-gates:
+    - name: CronJobControllerV2
+      components:
+        - kube-controller-manager
+  disable-supported: true
+  metrics:
+    - cronjob_controller_rate_limiter_use
+    - cronjob_job_creation_skew
+    - workqueue_depth
+    - workqueue_retries
+    - workqueue_adds_total
+- id: ""
+  prnumber: ""
+  name: 2185-random-pod-select-on-replicaset-downscale
+  title: Random Pod Selection on ReplicaSet Downscale
+  kep_number: "2185"
+  authors: ['@alculquicondor', '@damemi']
+  owning_sig: sig-apps
+  participating-sigs: [sig-scheduling]
+  reviewers: ['@janetkuo', '@ahg-g', '@kow3ns', '@soltysh']
+  approvers: ['@janetkuo', '@kow3ns']
+  prr-approvers: [wojtek-t, '@wojtek-t']
+  creation-date: "2020-12-15"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - /keps/sig-apps/1828-delete-priority-annotations
+  stage: beta
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.21
+      beta: v1.22
+      stable: v1.23
+  feature-gates:
+    - name: LogarithmicScaleDown
+      components:
+        - kube-controller-manager
+  disable-supported: true
+  metrics:
+    - TBD
+- id: ""
+  prnumber: ""
+  name: 2214-indexed-job
+  title: Indexed Job
+  kep_number: "2214"
+  authors: ['@alculquicondor']
+  owning_sig: sig-apps
+  reviewers: ['@erictune', '@ahg', '@liggitt']
+  approvers: ['@soltysh', '@janetkuo']
+  prr-approvers: ['@wojtek-t']
+  creation-date: "2020-12-29"
+  last-updated: ""
+  status: implemented
+  stage: beta
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.21
+      beta: v1.22
+      stable: v1.23
+  feature-gates:
+    - name: IndexedJob
+      components:
+        - kube-apiserver
+        - kube-controller-manager
+  disable-supported: true
+  metrics:
+    - job_sync_duration_seconds
+    - job_sync_total
+    - job_finished_total
+- id: ""
+  prnumber: ""
+  name: 2232-suspend-jobs
+  title: Suspend Job
+  kep_number: "2232"
+  authors: ['@adtac']
+  owning_sig: sig-apps
+  reviewers: ['@soltysh', '@ahg', '@alculquicondor', TBD]
+  approvers: ['@janetkuo', TBD]
+  prr-approvers: ['@wojtek-t']
+  creation-date: "2020-01-06"
+  last-updated: ""
+  status: implementable
+  stage: beta
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.21
+      beta: v1.22
+      stable: v1.24
+  feature-gates:
+    - name: SuspendJob
+      components:
+        - kube-apiserver
+        - kube-controller-manager
+  disable-supported: true
+  metrics:
+    - job_sync_duration_seconds
+    - job_sync_total
+- id: ""
+  prnumber: ""
+  name: 2255-pod-cost
+  title: ReplicaSet Pod Deletion Cost
+  kep_number: "2255"
+  authors: ['@drbugfinder-work', '@ahg-g', '@alculquicondor']
+  owning_sig: sig-apps
+  reviewers: ['@ahg-g', '@janetkuo', '@alculquicondor']
+  approvers: ['@janetkuo']
+  prr-approvers: ['@wojtek-t']
+  creation-date: "2021-01-12"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - https://github.com/kubernetes/kubernetes/issues/45509
+    - https://github.com/kubernetes/kubernetes/issues/4301
+  stage: beta
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.21
+      beta: v1.22
+      stable: v1.24
+  feature-gates:
+    - name: ReplicaSetPodDeletionCost
+      components:
+        - kube-controller-manager
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2307-job-tracking-without-lingering-pods
+  title: Job tracking without lingering Pods
+  kep_number: "2307"
+  authors: ['@alculquicondor']
+  owning_sig: sig-apps
+  reviewers: ['@erictune', '@lavalamp', '@soltysh']
+  approvers: ['@janetkuo']
+  prr-approvers: ['@wojtek-t']
+  creation-date: "2020-01-21"
+  last-updated: ""
+  status: implementable
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.22
+      beta: v1.23
+      stable: v1.25
+  feature-gates:
+    - name: JobTrackingWithFinalizers
+      components:
+        - kube-apiserver
+        - kube-controller-manager
+  disable-supported: true
+  metrics:
+    - TBD
+- id: ""
+  prnumber: ""
+  name: 2360-optional-service-environment-variables
+  title: Optional Service Environment Variables
+  kep_number: "2360"
+  authors: ['@bradhoekstra', '@kongslund']
+  owning_sig: sig-apps
+  reviewers: [TBD]
+  approvers: [TBD]
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2018-09-25"
+  last-updated: "2018-09-25"
+  status: provisional
+  see-also:
+    - https://github.com/kubernetes/community/pull/1249
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2599-minreadyseconds-for-statefulsets
+  title: minReadySeconds for StatefulSets
+  kep_number: "2599"
+  authors: ['@ravisantoshgudimetla']
+  owning_sig: sig-apps
+  participating-sigs: [sig-apps]
+  reviewers: ['@soltysh']
+  approvers: ['@soltysh']
+  prr-approvers: ['@ehashman']
+  creation-date: "2021-04-07"
+  last-updated: "2021-04-12"
+  status: implementable
+  see-also:
+    - https://github.com/kubernetes/kubernetes/issues/65098
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.22
+      beta: v1.23
+      stable: v1.25
+  feature-gates:
+    - name: StatefulSetMinReadySeconds
+      components:
+        - kube-controller-manager
+        - kube-apiserver
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 592-ttl-after-finish
+  title: TTL After Finished
+  kep_number: "592"
+  authors: ['@janetkuo', '@ahg-g']
+  owning_sig: sig-apps
+  participating-sigs: [sig-api-machinery]
+  reviewers: ['@enisoc', '@tnozicka']
+  approvers: ['@kow3ns']
+  prr-approvers: ['@wojtek-t']
+  creation-date: "2018-08-16"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - n/a
+  replaces:
+    - n/a
+  superseded-by:
+    - n/a
+  stage: beta
+  latest-milestone: v1.21
+  milestone:
+      alpha: v1.12
+      beta: v1.21
+      stable: v1.23
+  feature-gates:
+    - name: TTLAfterFinished
+      components:
+        - kube-apiserver
+        - kube-controller-manager
+  disable-supported: true
+  metrics:
+    - ttl_after_finished_controller_rate_limiter_use
+    - ttl_after_finished_controller_time_to_deletion_seconds
+    - workqueue_adds_total{name=ttl_jobs_to_delete}
+    - workqueue_depth{name=ttl_jobs_to_delete}
+    - workqueue_queue_duration_seconds{name=ttl_jobs_to_delete}
+    - workqueue_retries_total{name=ttl_jobs_to_delete}
+- id: ""
+  prnumber: ""
+  name: 706-portable-service-definitions
+  title: Portable Service Definitions
+  kep_number: "706"
+  authors: ['@mattfarina']
+  owning_sig: sig-apps
+  participating-sigs: [sig-service-catalog]
+  reviewers: ['@carolynvs', '@kibbles-n-bytes', '@duglin', '@jboyd01', '@prydonius',
+      '@kow3ns']
+  approvers: ['@mattfarina', '@prydonius', '@kow3ns']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2018-11-13"
+  last-updated: "2018-11-19"
+  status: provisional
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 85-Graduate-PDB-to-Stable
+  title: KEP Template
+  kep_number: "85"
+  authors: ['@bsalamat', '@mortent']
+  owning_sig: sig-apps
+  participating-sigs: [sig-scheduling]
+  reviewers: ['@liggitt', '@kow3ns', '@soltysh', '@janetkuo', '@wojtek-t']
+  approvers: ['@kow3ns', '@liggitt', '@wojtek-t']
+  prr-approvers: ['@wojtek-t']
+  creation-date: "2019-03-18"
+  last-updated: ""
+  status: implemented
+  stage: stable
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.4
+      beta: v1.5
+      stable: v1.21
+  feature-gates:
+    - name: PodDisruptionBudget
+      components:
+        - kube-controller-manager
+        - scheduler
+  disable-supported: true
+  metrics:
+    - workqueue_depth
+    - workqueue_retries
+    - workqueue_adds_total
+- id: ""
+  prnumber: ""
+  name: 961-maxunavailable-for-statefulset
+  title: Implement maxUnavailable for StatefulSets
+  kep_number: "961"
+  authors: ['@krmayankk']
+  owning_sig: sig-apps
+  participating-sigs: [sig-apps]
+  reviewers: ['@janetkuo', '@kow3ns']
+  approvers: ['@janetkuo', '@kow3ns']
+  prr-approvers: ['@wojtek-t']
+  editor: TBD
+  creation-date: "2018-12-29"
+  last-updated: "2021-05-06"
+  status: implementable
+  see-also:
+    - n/a
+  replaces:
+    - n/a
+  superseded-by:
+    - n/a
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.22
+      beta: v1.23
+      stable: v1.24
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 981-poddisruptionbudget-for-custom-resources
+  title: pdb-support-for-custom-resources-with-scale-subresource
+  kep_number: "981"
+  authors: ['@mortent']
+  owning_sig: sig-apps
+  participating-sigs: [sig-scheduling, sig-autoscaling]
+  reviewers: ['@kow3ns', '@janetkuo']
+  approvers: ['@kow3ns', '@janetkuo']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-04-12"
+  last-updated: "2019-04-12"
+  status: implemented
+  stage: stable
+  latest-milestone: "1.15"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 0000-kep-process
+  title: Kubernetes Enhancement Proposal Process
+  kep_number: "0000"
+  authors: ['@calebamiles', '@jbeda']
+  owning_sig: sig-architecture
+  reviewers: ['@timothysc']
+  approvers: ['@bgrant0607']
+  prr-approvers: []
+  editor: '@jbeda'
+  creation-date: "2017-08-22"
+  last-updated: "2020-02-18"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1143-node-role-labels
+  title: Appropriate use of node-role labels
+  kep_number: "1143"
+  authors: ['@smarterclayton']
+  owning_sig: sig-architecture
+  participating-sigs: [sig-api-machinery, sig-network, sig-node, sig-testing]
+  reviewers: ['@lavalamp', '@derekwaynecarr', '@liggitt']
+  approvers: ['@thockin', '@derekwaynecarr']
+  prr-approvers: ['@wojtek-t']
+  creation-date: "2019-07-16"
+  last-updated: "2021-04-02"
+  status: implemented
+  stage: stable
+  latest-milestone: v1.21
+  milestone:
+      alpha: v1.16
+      beta: v1.19
+      stable: v1.21
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1194-prod-readiness
+  title: Production Readiness Review Process
+  kep_number: "1194"
+  authors: ['@johnbelamaric']
+  owning_sig: sig-architecture
+  participating-sigs: [sig-release]
+  reviewers: ['@derekwaynecarr', '@vishh', '@justaugustus', '@alejandrox1', '@wojtek-t',
+      '@deads2k']
+  approvers: ['@derekwaynecarr', '@dims']
+  prr-approvers: []
+  creation-date: "2019-07-31"
+  last-updated: "2020-12-15"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1333-conformance-without-beta
+  title: Ensure Conformance Tests Do Not Require Beta APIs or Features
+  kep_number: "1333"
+  authors: ['@liggitt']
+  owning_sig: sig-architecture
+  participating-sigs: [sig-testing, sig-api-machinery]
+  reviewers: ['@deads2k', '@bentheelder', '@timothysc', '@smarterclayton', '@johnbelamaric']
+  approvers: ['@timothysc', '@smarterclayton', '@johnbelamaric']
+  prr-approvers: []
+  creation-date: "2019-10-23"
+  last-updated: "2019-10-23"
+  status: implementable
+  see-also:
+    - /keps/sig-architecture/20190412-conformance-behaviors.md
+  stage: beta
+  latest-milestone: "1.19"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1618-conformance-profiles
+  title: Conformance Profiles
+  kep_number: "1618"
+  authors: ['@johnbelamaric', '@jefftree']
+  owning_sig: sig-architecture
+  reviewers: ['@hh', '@smarterclayton', '@spiffxp']
+  approvers: ['@johnbelamaric', '@smarterclayton']
+  prr-approvers: []
+  creation-date: "2020-03-18"
+  last-updated: ""
+  status: provisional
+  see-also:
+    - /keps/sig-architecture/20190412-conformance-behaviors.md
+    - https://docs.google.com/document/d/1QAXp1xCXh1Bj2Bj-lEzwIVaSQvJRuTwQG7xT2q3me58/edit
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1635-prevent-permabeta
+  title: Require Transition from Beta
+  kep_number: "1635"
+  authors: ['@deads2k']
+  owning_sig: sig-architecture
+  participating-sigs: [sig-api-machinery, sig-apps, sig-architecture, sig-auth, sig-instrumentation,
+      sig-network, sig-node, sig-scheduling]
+  reviewers: ['@bgrant0607', '@liggitt', '@smarterclayton']
+  approvers: ['@derekwaynecarr', '@johnbelamaric']
+  prr-approvers: []
+  creation-date: "2019-10-01"
+  last-updated: ""
+  status: implemented
+  stage: ""
+  latest-milestone: v1.19
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: v1.19
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1659-standard-topology-labels
+  title: Standard Topology Labels
+  kep_number: "1659"
+  authors: ['@thockin']
+  owning_sig: sig-architecture
+  participating-sigs: [sig-cloud-provider, sig-network, sig-scheduling]
+  reviewers: ['@andrewsykim']
+  approvers: ['@ahg-g']
+  prr-approvers: ['@johnbelamaric']
+  creation-date: "2020-03-31"
+  last-updated: ""
+  status: implemented
+  stage: stable
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 617-improve-kep-implementation
+  title: Enhance KEP implementation
+  kep_number: "617"
+  authors: ['@calebamiles', '@deads2k', '@derekwaynecarr', '@jdumars', '@johnbelamaric',
+      '@justaugustus', '@thockin']
+  owning_sig: sig-architecture
+  reviewers: ['@erictune', '@idvoretskyi', '@spiffxp', '@timothysc']
+  approvers: ['@bgrant0607', '@jbeda']
+  prr-approvers: []
+  creation-date: "2018-09-08"
+  last-updated: ""
+  status: provisional
+  see-also:
+    - /keps/0001-kubernetes-enhancement-proposal-process.md
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 917-go-modules
+  title: go modules
+  kep_number: "917"
+  authors: ['@liggitt']
+  owning_sig: sig-architecture
+  participating-sigs: [sig-api-machinery, sig-release, sig-testing]
+  reviewers: ['@sttts', '@lavalamp']
+  approvers: ['@smarterclayton', '@thockin']
+  prr-approvers: []
+  creation-date: "2019-03-19"
+  last-updated: "2019-11-01"
+  status: implemented
+  stage: stable
+  latest-milestone: "1.15"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 960-conformance-behaviors
+  title: Behavior-driven Conformance Testing
+  kep_number: "960"
+  authors: ['@johnbelamaric', '@hh', '@spiffxp', '@jefftree']
+  owning_sig: sig-architecture
+  participating-sigs: [sig-testing]
+  reviewers: ['@timothysc', '@spiffxp', '@alejandrox1', '@johnschnake']
+  approvers: ['@bgrant0607', '@smarterclayton']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-04-12"
+  last-updated: "2020-07-28"
+  status: withdrawn
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1205-bound-service-account-tokens
+  title: Bound Service Account Tokens
+  kep_number: "1205"
+  authors: ['@mikedanese', '@zshihang']
+  owning_sig: sig-auth
+  participating-sigs: [sig-auth, sig-storage]
+  reviewers: ['@liggitt']
+  approvers: ['@liggitt']
+  prr-approvers: ['@deads2k']
+  creation-date: "2019-08-06"
+  last-updated: "2021-04-29"
+  status: implementable
+  replaces:
+    - /keps/sig-storage/2451-service-account-token-volumes
+  stage: stable
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.13
+      beta: v1.21
+      stable: v1.22
+  feature-gates:
+    - name: TokenRequest
+      components:
+        - kube-apiserver
+        - kube-controller-manager
+    - name: TokenRequestProjection
+      components:
+        - kube-apiserver
+        - kubelet
+    - name: RootCAConfigMap
+      components:
+        - kube-controller-manager
+    - name: BoundServiceAccountTokenVolume
+      components:
+        - kube-apiserver
+  disable-supported: false
+  metrics:
+    - serviceaccount_stale_tokens_total
+    - serviceaccount_valid_tokens_total
+- id: ""
+  prnumber: ""
+  name: 1314-node-restriction-pods
+  title: Extended NodeRestrictions for Pods
+  kep_number: "1314"
+  authors: [tallclair]
+  owning_sig: sig-auth
+  participating-sigs: [sig-node, sig-cluster-lifecycle]
+  reviewers: [derekwaynecarr, neolit123, deads2k]
+  approvers: [liggitt, derekwaynecarr, neolit123, deads2k]
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-09-16"
+  last-updated: ""
+  status: implementable
+  stage: alpha
+  latest-milestone: "1.17"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1393-oidc-discovery
+  title: Service Account signing key retrieval
+  kep_number: "1393"
+  authors: ['@mikedanese', '@cceckman', '@mtaufen']
+  owning_sig: sig-auth
+  participating-sigs: [sig-auth]
+  reviewers: ['@liggitt', '@enj', '@micahhausler', '@ericchiang']
+  approvers: ['@liggitt', '@enj', '@micahhausler', '@ericchiang']
+  prr-approvers: ['@johnbelamaric']
+  editor: TBD
+  creation-date: "2018-06-26"
+  last-updated: "2020-01-25"
+  status: implemented
+  replaces:
+    - https://github.com/kubernetes/community/pull/2314/
+  stage: stable
+  latest-milestone: v1.21
+  milestone:
+      alpha: v1.18
+      beta: v1.20
+      stable: v1.21
+  feature-gates:
+    - name: ServiceAccountIssuerDiscovery
+      components:
+        - kube-apiserver
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1513-certificate-signing-request
+  title: Certificates API
+  kep_number: "1513"
+  authors: ['@mikedanese', '@deads2k']
+  owning_sig: sig-auth
+  reviewers: ['@liggitt', '@smarterclayton', '@munnerz']
+  approvers: ['@liggitt', '@smarterclayton']
+  prr-approvers: []
+  creation-date: "2019-06-07"
+  last-updated: "2020-09-14"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1687-hierarchical-namespaces-subproject
+  title: Hierarchical Namespace Controller As A Subproject
+  kep_number: "1687"
+  authors: ['@rjbez17', '@adrianludwin']
+  owning_sig: sig-auth
+  participating-sigs: [sig-auth]
+  reviewers: ['@mikedanese', '@liggitt']
+  approvers: ['@mikedanese', '@deads2k', '@liggitt']
+  prr-approvers: []
+  creation-date: "2020-04-14"
+  last-updated: "2021-01-06"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2579-psp-replacement
+  title: PSP Replacement Policy
+  kep_number: "2579"
+  authors: ['@tallclair', '@liggitt']
+  owning_sig: sig-auth
+  participating-sigs: [sig-security, sig-windows, sig-node, sig-instrumentation]
+  reviewers: ['@mrunalp', '@dashpole', '@marosset', '@ritazh']
+  approvers: ['@deads2k', '@enj', '@IanColdwater', '@mikedanese', '@tabbysable']
+  prr-approvers: ['@deads2k']
+  creation-date: "2021-03-19"
+  last-updated: ""
+  status: implementable
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.22
+      beta: TBD
+      stable: TBD
+  feature-gates:
+    - name: PodSecurity
+      components:
+        - kube-apiserver (PodSecurity admission plugin)
+  disable-supported: true
+  metrics:
+    - TBD
+- id: ""
+  prnumber: ""
+  name: 266-kubelet-client-certificate-bootstrap-rotation
+  title: Kubelet client certificate bootstrap and rotation
+  kep_number: "266"
+  authors: ['@jcbsmpsn', '@liggitt']
+  owning_sig: sig-auth
+  participating-sigs: [sig-auth, sig-node]
+  reviewers: ['@smarterclayton', '@mikedanese']
+  approvers: ['@smarterclayton', '@mikedanese', '@johnbelamaric']
+  prr-approvers: []
+  creation-date: "2017-06-27"
+  last-updated: ""
+  status: implemented
+  see-also:
+    - /keps/sig-auth/20190607-certificates-api.md
+  replaces:
+    - https://github.com/kubernetes/community/pull/768
+  stage: ""
+  latest-milestone: v1.19
+  milestone:
+      alpha: v1.4
+      beta: v1.8
+      stable: v1.19
+  feature-gates:
+    - name: RotateKubeletClientCertificate
+      components:
+        - kubelet
+  disable-supported: true
+  metrics:
+    - kubelet_certificate_manager_client_expiration_seconds
+    - kubelet_certificate_manager_client_expiration_renew_errors
+- id: ""
+  prnumber: ""
+  name: 279-limit-node-access
+  title: Bounding Self-Labeling Kubelets
+  kep_number: "279"
+  authors: ['@mikedanese', '@liggitt']
+  owning_sig: sig-auth
+  participating-sigs: [sig-node, sig-storage]
+  reviewers: ['@saad-ali', '@tallclair']
+  approvers: ['@thockin', '@smarterclayton']
+  prr-approvers: []
+  creation-date: "2017-08-14"
+  last-updated: "2020-05-01"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 541-external-credential-providers
+  title: External credential providers
+  kep_number: "541"
+  authors: ['@awly', '@enj']
+  owning_sig: sig-auth
+  participating-sigs: [sig-cli, sig-api-machinery]
+  reviewers: ['@liggitt', '@mikedanese']
+  approvers: ['@liggitt', '@mikedanese']
+  prr-approvers: ['@deads2k']
+  creation-date: "2019-07-11"
+  last-updated: ""
+  status: implementable
+  stage: beta
+  latest-milestone: v1.21
+  milestone:
+      alpha: v1.10
+      beta: v1.11
+      stable: v1.22
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 600-dynamic-audit-configuration
+  title: Dynamic Audit Configuration
+  kep_number: "600"
+  authors: ['@pbarker']
+  owning_sig: sig-auth
+  participating-sigs: [sig-api-machinery]
+  reviewers: ['@tallclair', '@yliaog', '@caesarxuchao', '@liggitt']
+  approvers: ['@tallclair', '@liggitt', '@yliaog']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2018-05-18"
+  last-updated: "2018-07-31"
+  status: withdrawn
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 740-service-account-external-signing
+  title: Support external signing of service account keys
+  kep_number: "740"
+  authors: ['@micahhausler']
+  owning_sig: sig-auth
+  reviewers: ['@mikedanese', '@liggit', '@tallclair']
+  approvers: ['@mikedanese', '@liggit', '@tallclair']
+  prr-approvers: []
+  editor: '@micahhausler'
+  creation-date: "2019-01-16"
+  last-updated: "2019-05-17"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 789-harden-default-discover-bindings
+  title: Harden Default RBAC Discovery ClusterRole(Binding)s
+  kep_number: "789"
+  authors: ['@dekkagaijin']
+  owning_sig: sig-auth
+  participating-sigs: [sig-auth, sig-api-machinery]
+  reviewers: ['@liggitt', '@tallclair', '@deads2k']
+  approvers: ['@liggitt', '@tallclair', '@deads2k']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-01-28"
+  last-updated: "2019-01-31"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 117-hpa-metrics-specificity
+  title: Enhance HPA Metrics Specificity
+  kep_number: "117"
+  authors: ['@directxman12']
+  owning_sig: sig-autoscaling
+  participating-sigs: [sig-instrumentation]
+  reviewers: ['@brancz', '@maciekpytel']
+  approvers: ['@brancz', '@maciekpytel', '@directxman12']
+  prr-approvers: []
+  editor: '@directxman12'
+  creation-date: "2018-04-19"
+  last-updated: "2018-04-19"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1610-container-resource-autoscaling
+  title: Container Resource based Autoscaling
+  kep_number: "1610"
+  authors: ['@arjunrn']
+  owning_sig: sig-autoscaling
+  reviewers: ['@josephburnett', '@mwielgus', '@gjtempleton']
+  approvers: ['@josephburnett', '@gjtempleton']
+  prr-approvers: []
+  creation-date: "2020-02-18"
+  last-updated: "2020-11-03"
+  status: implementable
+  stage: alpha
+  latest-milestone: "1.20"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2702-graduate-hpa-api-to-GA
+  title: Graduate HPA v2beta2 API to GA
+  kep_number: "2702"
+  authors: ['@supriya-premkumar', '@josephburnett']
+  owning_sig: sig-autoscaling
+  reviewers: ['@josephburnett', '@gjtempleton']
+  approvers: ['@josephburnett', '@gjtempleton']
+  prr-approvers: ['@johnbelamaric']
+  creation-date: "2021-05-10"
+  last-updated: "2021-05-10"
+  status: implementable
+  stage: stable
+  latest-milestone: v1.22
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: v1.22
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 853-configurable-hpa-scale-velocity
+  title: Configurable scale up/down velocity for HPA
+  kep_number: "853"
+  authors: ['@gliush', '@arjunrn']
+  owning_sig: sig-autoscaling
+  reviewers: ['@mwielgus', '@josephburnett']
+  approvers: ['@mwielgus', '@josephburnett']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-03-07"
+  last-updated: "2020-01-29"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1020-kubectl-staging
+  title: Move Kubectl Code into Staging
+  kep_number: "1020"
+  authors: ['@seans3', '@soltysh']
+  owning_sig: sig-cli
+  reviewers: ['@pwittrock', '@liggitt']
+  approvers: ['@pwittrock']
+  prr-approvers: ['@deads2k']
+  creation-date: "2019-04-09"
+  last-updated: ""
+  status: implemented
+  stage: stable
+  latest-milestone: v1.20
+  milestone:
+      alpha: v1.15
+      beta: v1.19
+      stable: v1.20
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1440-kubectl-events
+  title: Kubectl events
+  kep_number: "1440"
+  authors: ['@hpandeycodeit']
+  owning_sig: sig-cli
+  participating-sigs: [sig-cli]
+  reviewers: ['@soltysh', '@pwittrock']
+  approvers: ['@soltysh', '@pwittrock']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-10-08"
+  last-updated: "2020-01-27"
+  status: implementable
+  see-also:
+    - https://docs.google.com/document/d/1w-HRLtMncDAL_yQQJdHDasyCZRdJTOV1N6y22fGsKkY/edit#
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1441-kubectl-debug
+  title: kubectl debug
+  kep_number: "1441"
+  authors: ['@verb']
+  owning_sig: sig-cli
+  participating-sigs: [sig-cli, sig-node]
+  reviewers: ['@aylei', '@soltysh']
+  approvers: ['@pwittrock', '@soltysh']
+  prr-approvers: ['@johnbelamaric']
+  creation-date: "2019-08-05"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - /keps/sig-node/20190212-ephemeral-containers.md
+    - /keps/sig-release/20190316-rebase-images-to-distroless.md
+  stage: beta
+  latest-milestone: v1.20
+  milestone:
+      alpha: v1.18
+      beta: v1.20
+      stable: v1.22
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1802-kustomize-components
+  title: Kustomize Components
+  kep_number: "1802"
+  authors: ['@apyrgio', '@ioandr', '@pgpx']
+  owning_sig: sig-cli
+  participating-sigs: [sig-cli]
+  reviewers: ['@pwittrock', '@monopole']
+  approvers: ['@pwittrock', '@monopole']
+  prr-approvers: []
+  creation-date: "2020-05-20"
+  last-updated: "2020-05-20"
+  status: implemented
+  stage: alpha
+  latest-milestone: v1.19
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2206-openapi-features-in-kustomize
+  title: OpenAPI Features in Kustomize
+  kep_number: "2206"
+  authors: ['@natasha41575']
+  owning_sig: sig-cli
+  participating-sigs: [sig-cli]
+  reviewers: ['@monopole', '@pwittrock']
+  approvers: ['@monopole', '@pwittrock']
+  prr-approvers: []
+  creation-date: "2020-12-21"
+  last-updated: "2020-01-15"
+  status: implemented
+  stage: beta
+  latest-milestone: "1.22"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2227-kubectl-default-container
+  title: kubectl default container
+  kep_number: "2227"
+  authors: ['@pacoxu']
+  owning_sig: sig-cli
+  reviewers: ['@dougsland', '@eddiezane', '@soltysh', '@howardjohn', '@rikatz']
+  approvers: ['@soltysh', '@rikatz']
+  prr-approvers: ['@johnbelamaric', '@deads2k']
+  creation-date: "2020-12-16"
+  last-updated: "2021-03-10"
+  status: implementable
+  stage: alpha
+  latest-milestone: v1.21
+  milestone:
+      alpha: v1.21
+      beta: v1.23
+      stable: v1.25
+  feature-gates: []
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2257-kui
+  title: Kui Graphical Terminal Enhancements
+  kep_number: "2257"
+  authors: ['@starpit', '@myan9', '@paulcastro']
+  owning_sig: sig-cli
+  participating-sigs: [sig-cli]
+  reviewers: ['@pwittrock', '@soltysh']
+  approvers: ['@pwittrock', '@soltysh']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-11-14"
+  last-updated: "2021-01-12"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: base
+  title: ""
+  kep_number: ""
+  authors: []
+  owning_sig: ""
+  reviewers: []
+  approvers: []
+  prr-approvers: []
+  creation-date: ""
+  last-updated: ""
+  status: ""
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: resources
+  title: ""
+  kep_number: ""
+  authors: []
+  owning_sig: ""
+  reviewers: []
+  approvers: []
+  prr-approvers: []
+  creation-date: ""
+  last-updated: ""
+  status: ""
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: composition
+  title: ""
+  kep_number: ""
+  authors: []
+  owning_sig: ""
+  reviewers: []
+  approvers: []
+  prr-approvers: []
+  creation-date: ""
+  last-updated: ""
+  status: ""
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: kustomization
+  title: ""
+  kep_number: ""
+  authors: []
+  owning_sig: ""
+  reviewers: []
+  approvers: []
+  prr-approvers: []
+  creation-date: ""
+  last-updated: ""
+  status: ""
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: builtins-base
+  title: ""
+  kep_number: ""
+  authors: []
+  owning_sig: ""
+  reviewers: []
+  approvers: []
+  prr-approvers: []
+  creation-date: ""
+  last-updated: ""
+  status: ""
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: resources
+  title: ""
+  kep_number: ""
+  authors: []
+  owning_sig: ""
+  reviewers: []
+  approvers: []
+  prr-approvers: []
+  creation-date: ""
+  last-updated: ""
+  status: ""
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: prod-integration-base
+  title: ""
+  kep_number: ""
+  authors: []
+  owning_sig: ""
+  reviewers: []
+  approvers: []
+  prr-approvers: []
+  creation-date: ""
+  last-updated: ""
+  status: ""
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: prod-plugin-transformation
+  title: ""
+  kep_number: ""
+  authors: []
+  owning_sig: ""
+  reviewers: []
+  approvers: []
+  prr-approvers: []
+  creation-date: ""
+  last-updated: ""
+  status: ""
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: plugins-base
+  title: ""
+  kep_number: ""
+  authors: []
+  owning_sig: ""
+  reviewers: []
+  approvers: []
+  prr-approvers: []
+  creation-date: ""
+  last-updated: ""
+  status: ""
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: plugins-base
+  title: ""
+  kep_number: ""
+  authors: []
+  owning_sig: ""
+  reviewers: []
+  approvers: []
+  prr-approvers: []
+  creation-date: ""
+  last-updated: ""
+  status: ""
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: plugins-base
+  title: ""
+  kep_number: ""
+  authors: []
+  owning_sig: ""
+  reviewers: []
+  approvers: []
+  prr-approvers: []
+  creation-date: ""
+  last-updated: ""
+  status: ""
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: plugins-base
+  title: ""
+  kep_number: ""
+  authors: []
+  owning_sig: ""
+  reviewers: []
+  approvers: []
+  prr-approvers: []
+  creation-date: ""
+  last-updated: ""
+  status: ""
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2299-kustomize-plugin-composition
+  title: Kustomize Plugin Composition API
+  kep_number: "2299"
+  authors: ['@knverey', '@campoy']
+  owning_sig: sig-cli
+  participating-sigs: [sig-cli]
+  reviewers: ['@monopole', '@pwittrock']
+  approvers: ['@monopole', '@pwittrock']
+  prr-approvers: []
+  creation-date: "2021-01-20"
+  last-updated: ""
+  status: provisional
+  see-also:
+    - /keps/sig-cli/993-kustomize-generators-transformers
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2377-Kustomize
+  title: Kustomize
+  kep_number: "2377"
+  authors: ['@pwittrock', '@monopole']
+  owning_sig: sig-cli
+  participating-sigs: [sig-cli]
+  reviewers: ['@droot']
+  approvers: ['@soltysh']
+  prr-approvers: []
+  editor: '@droot'
+  creation-date: "2018-05-05"
+  last-updated: "2019-01-09"
+  status: implemented
+  see-also:
+    - n/a
+  replaces:
+    - kinflate
+  superseded-by:
+    - /keps/sig-cli/2386-kustomize-subcommand-integration/
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2379-kubectl-plugins
+  title: Kubectl Plugins
+  kep_number: "2379"
+  authors: ['@juanvallejo']
+  owning_sig: sig-cli
+  participating-sigs: [sig-cli]
+  reviewers: ['@pwittrock', '@deads2k', '@liggitt', '@soltysh']
+  approvers: ['@pwittrock', '@soltysh']
+  prr-approvers: []
+  editor: juanvallejo
+  creation-date: "2018-07-24"
+  last-updated: "2010-02-26"
+  status: implemented
+  see-also:
+    - n/a
+  replaces:
+    - https://github.com/kubernetes/community/blob/master/contributors/design-proposals/cli/kubectl-extension.md
+    - https://github.com/kubernetes/community/pull/481
+  superseded-by:
+    - n/a
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2380-data-driven-commands-for-kubectl
+  title: Data Driven Commands for Kubectl
+  kep_number: "2380"
+  authors: ['@pwittrock']
+  owning_sig: sig-cli
+  reviewers: ['@soltysh', '@juanvallejo', '@seans3 ']
+  approvers: ['@soltysh']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2018-11-13"
+  last-updated: "2018-11-13"
+  status: provisional
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2381-future-of-kubectl-cp
+  title: future-of-kubectl-cp
+  kep_number: "2381"
+  authors: ['@sallyom']
+  owning_sig: sig-cli
+  participating-sigs: [sig-usability]
+  reviewers: ['@liggitt', '@brendandburns']
+  approvers: ['@pwittrock', '@soltysh']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-09-20"
+  last-updated: "2019-09-20"
+  status: provisional
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2382-kustomize-exec-secret-generator
+  title: Kustomize Exec Secret Generator
+  kep_number: "2382"
+  authors: ['@pwittrock']
+  owning_sig: sig-cli
+  reviewers: ['@anguslees', '@Liujingfang1', '@sethpollack']
+  approvers: ['@monopole']
+  prr-approvers: []
+  editor: '@pwittrock'
+  creation-date: "2019-03-12"
+  last-updated: "2019-03-12"
+  status: implementable
+  see-also:
+    - /keps/sig-cli/2385-kustomize-secret-generator-plugins/
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2383-extend-kustomize-patches-to-multiple-targets
+  title: Extend Kustomize Patches to Multiple Targets
+  kep_number: "2383"
+  authors: ['@Liujingfang1']
+  owning_sig: sig-cli
+  participating-sigs: [sig-apps]
+  reviewers: ['@pwittrock', '@mengqiy']
+  approvers: ['@monopole']
+  prr-approvers: []
+  editor: '@Liujingfang1'
+  creation-date: "2019-03-14"
+  last-updated: "2019-03-18"
+  status: implemented
+  stage: beta
+  latest-milestone: "1.16"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2384-kustomize-file-processing-integration
+  title: Kustomize File Processing Integration
+  kep_number: "2384"
+  authors: ['@pwittrock']
+  owning_sig: sig-cli
+  participating-sigs: [sig-cli]
+  reviewers: ['@liggitt', '@seans3', '@soltysh', '@monopole']
+  approvers: ['@liggitt', '@seans3', '@soltysh', '@monopole']
+  prr-approvers: []
+  editor: '@pwittrock'
+  creation-date: "2019-01-17"
+  last-updated: "2019-03-18"
+  status: implemented
+  see-also:
+    - /keps/sig-cli/2386-kustomize-subcommand-integration/
+  superseded-by:
+    - n/a
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2385-kustomize-secret-generator-plugins
+  title: Kustomize Secret Generator Plugins
+  kep_number: "2385"
+  authors: ['@sethpollack']
+  owning_sig: sig-cli
+  participating-sigs: [sig-apps, sig-architecture]
+  reviewers: ['@monopole', '@Liujingfang1']
+  approvers: ['@monopole', '@Liujingfang1', '@pwittrock']
+  prr-approvers: []
+  editor: '@sethpollack'
+  creation-date: "2019-02-04"
+  last-updated: "2019-02-04"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2386-kustomize-subcommand-integration
+  title: Kustomize Subcommand Integration
+  kep_number: "2386"
+  authors: ['@Liujingfang1']
+  owning_sig: sig-cli
+  participating-sigs: [sig-cli]
+  reviewers: ['@liggitt', '@seans3', '@soltysh']
+  approvers: ['@liggitt', '@seans3', '@soltysh']
+  prr-approvers: []
+  editor: '@pwittrock'
+  creation-date: "2018-11-07"
+  last-updated: "2019-02-15"
+  status: implemented
+  see-also:
+    - '[kustomize](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/workflows.md)'
+    - /keps/sig-cli/2384-kustomize-file-processing-integration/
+  replaces:
+    - 0008-kustomize.md
+  superseded-by:
+    - n/a
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2590-kubectl-subresource
+  title: Kubectl Subresource Support
+  kep_number: "2590"
+  authors: ['@nikhita', '@ykakarap']
+  owning_sig: sig-cli
+  participating-sigs: [sig-arch]
+  reviewers: ['@soltysh']
+  approvers: ['@soltysh']
+  prr-approvers: ['@johnbelamaric']
+  creation-date: "2021-04-06"
+  last-updated: "2021-04-06"
+  status: implementable
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.22
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 491-kubectl-diff
+  title: kubectl-diff
+  kep_number: "491"
+  authors: ['@apelisse', '@julianvmodesto']
+  owning_sig: sig-cli
+  participating-sigs: [sig-api-machinery]
+  reviewers: [TBD]
+  approvers: [TBD]
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2020-01-15"
+  last-updated: "2020-03-23"
+  status: implemented
+  see-also:
+    - /keps/sig-api-machinery/0015-dry-run.md
+    - /keps/sig-api-machinery/0006-apply.md
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 859-kubectl-headers
+  title: Kubectl Commands In Headers
+  kep_number: "859"
+  authors: ['@pwittrock', '@seans3']
+  owning_sig: sig-cli
+  participating-sigs: [sig-api-machinery]
+  reviewers: ['@deads2k', '@kow3ns', '@lavalamp']
+  approvers: ['@soltysh']
+  prr-approvers: ['@deads2k', '@johnbelamaric']
+  editor: TBD
+  creation-date: "2019-02-22"
+  last-updated: "2019-05-11"
+  status: implementable
+  stage: beta
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.21
+      beta: v1.22
+      stable: v1.24
+  feature-gates:
+    - name: kubectl-commands-in-headers
+      components:
+        - kubectl
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 993-kustomize-generators-transformers
+  title: Kustomize Generators and Transformers
+  kep_number: "993"
+  authors: ['@pwittrock']
+  owning_sig: sig-cli
+  reviewers: ['@droot', '@sethpollack']
+  approvers: ['@monopole']
+  prr-approvers: []
+  creation-date: "2019-03-25"
+  last-updated: "2019-04-30"
+  status: implemented
+  see-also:
+    - /keps/sig-cli/2299-kustomize-plugin-composition
+  stage: alpha
+  latest-milestone: "1.20"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1179-building-without-in-tree-providers
+  title: Building Kubernetes Without In-Tree Cloud Providers
+  kep_number: "1179"
+  authors: ['@BenTheElder']
+  owning_sig: sig-cloud-provider
+  participating-sigs: [sig-release, sig-testing]
+  reviewers: ['@spiffxp', '@cheftako', '@andrewsykim', '@stephenaugustus']
+  approvers: ['@cheftako', '@andrewsykim', '@spiffxp', '@stephenaugustus']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-07-29"
+  last-updated: "2020-05-08"
+  status: implemented
+  see-also:
+    - /keps/sig-cloud-provider/20190125-removing-in-tree-providers.md
+    - /keps/sig-cloud-provider/20180530-cloud-controller-manager.md
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1771-versioning-policy-for-external-cloud-providers
+  title: Versioning Policy for External Cloud Providers
+  kep_number: "1771"
+  authors: ['@andrewsykim']
+  owning_sig: sig-cloud-provider
+  participating-sigs: [sig-release]
+  reviewers: ['@cheftako']
+  approvers: ['@cheftako']
+  prr-approvers: []
+  creation-date: "2020-04-29"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - /kep/sig-cloud-provider/20190125-removing-in-tree-providers.md
+    - /kep/sig-cloud-provider/20180530-cloud-controller-manager.md
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1959-service-lb-class-field
+  title: Service Type=LoadBalancer Class Field
+  kep_number: "1959"
+  authors: ['@andrewsykim']
+  owning_sig: sig-cloud-provider
+  participating-sigs: [sig-network]
+  reviewers: ['@bowei', '@cheftako', '@thockin']
+  approvers: ['@bowei', '@cheftako', '@thockin']
+  prr-approvers: ['@johnbelamaric']
+  creation-date: "2020-11-02"
+  last-updated: ""
+  status: implementable
+  stage: beta
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.21
+      beta: v1.22
+      stable: ""
+  feature-gates:
+    - name: ServiceLoadBalancerClass
+      components:
+        - kube-apiserver
+        - kube-controller-manager
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2025-extend-konnectivity-for-both-directions
+  title: Extending Apiserver Network Proxy to handle traffic originated from Node
+      network
+  kep_number: "2025"
+  authors: ['@irozzo-1A', '@youssefazrak']
+  owning_sig: sig-cloud-provider
+  participating-sigs: [sig-network]
+  reviewers: ['@cheftako', '@anfernee', '@caesarxuchao', '@Jefftree', '@andrewsykim']
+  approvers: [TBD]
+  prr-approvers: [deads2k, '@deads2k']
+  creation-date: "2020-09-28"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - keps/sig-api-machinery/20190226-network-proxy.md
+  stage: alpha
+  latest-milestone: v1.21
+  milestone:
+      alpha: v1.21
+      beta: v1.22
+      stable: v1.24
+  feature-gates:
+    - name: EnableClusterToMasterTraffic
+      components:
+        - konnectivity-server
+        - konnectivity-agent
+  disable-supported: true
+  metrics:
+    - TBD
+- id: ""
+  prnumber: ""
+  name: 2133-out-of-tree-credential-provider
+  title: Out-of-Tree Credential Providers
+  kep_number: "2133"
+  authors: ['@mcrute', '@nckturner']
+  owning_sig: sig-cloud-provider
+  participating-sigs: [sig-node, sig-auth]
+  reviewers: ['@andrewsykim', '@cheftako', '@tallclair', '@mikedanese']
+  approvers: ['@andrewsykim', '@cheftako', '@tallclair', '@mikedanese']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-10-04"
+  last-updated: "2019-12-10"
+  status: replaced
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2390-reporting-conformance-test-results-to-testgrid
+  title: Reporting Conformance Test Results to Testgrid
+  kep_number: "2390"
+  authors: ['@andrewsykim']
+  owning_sig: sig-cloud-provider
+  participating-sigs: [sig-testing, sig-release]
+  reviewers: [TBD]
+  approvers: [TBD]
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2018-06-06"
+  last-updated: "2018-11-16"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2392-cloud-controller-manager
+  title: Cloud Controller Manager
+  kep_number: "2392"
+  authors: ['@cheftako', '@calebamiles', '@hogepodge']
+  owning_sig: sig-api-machinery
+  participating-sigs: [sig-cloud-provider, sig-storage]
+  reviewers: ['@andrewsykim', '@calebamiles', '@hogepodge', '@jagosan']
+  approvers: ['@thockin']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2018-01-09"
+  last-updated: "2019-04-10"
+  status: provisional
+  replaces:
+    - contributors/design-proposals/cloud-provider/cloud-provider-refactoring.md
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2393-cloud-provider-documentation
+  title: Cloud Provider Documentation
+  kep_number: "2393"
+  authors: ['@d-nishi', '@hogepodge', '@andrewsykim']
+  owning_sig: sig-cloud-provider
+  participating-sigs: [sig-docs, sig-cluster-lifecycle]
+  reviewers: ['@andrewsykim', '@calebamiles', '@hogepodge', '@jagosan']
+  approvers: ['@andrewsykim', '@hogepodge', '@jagosan']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2018-07-31"
+  last-updated: "2019-02-12"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2394-support-out-of-tree-AWS-cloud-provider
+  title: Support Out-of-Tree AWS Cloud Provider
+  kep_number: "2394"
+  authors: ['@andrewsykim']
+  owning_sig: sig-cloud-provider
+  reviewers: [TBD]
+  approvers: [TBD]
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-01-25"
+  last-updated: "2019-01-25"
+  status: provisional
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2395-removing-in-tree-cloud-providers
+  title: Removing In-Tree Cloud Providers
+  kep_number: "2395"
+  authors: ['@andrewsykim', '@cheftako']
+  owning_sig: sig-cloud-provider
+  participating-sigs: [sig-apps, sig-api-machinery, sig-network, sig-storage]
+  reviewers: ['@andrewsykim', '@cheftako', '@d-nishi', '@dims', '@hogepodge', '@mcrute',
+      '@steward-yu']
+  approvers: ['@thockin', '@liggit']
+  prr-approvers: ['@wojtek-t']
+  editor: TBD
+  creation-date: "2018-12-18"
+  last-updated: "2019-04-11"
+  status: implementable
+  stage: alpha
+  latest-milestone: v1.21
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates:
+    - name: DisableCloudProviders
+      components:
+        - kubelet
+        - kube-apiserver
+        - kube-controller-manager
+    - name: DisableKubeletCloudCredentialProviders
+      components:
+        - kubelet
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2436-controller-manager-leader-migration
+  title: Controller Manager Leader Migration
+  kep_number: "2436"
+  authors: ['@andrewsykim', '@jiahuif']
+  owning_sig: sig-cloud-provider
+  participating-sigs: [sig-api-machinery]
+  reviewers: ['@cheftako', '@nckturner', '@andrewsykim']
+  approvers: ['@cheftako']
+  prr-approvers: ['@deads2k']
+  creation-date: "2019-04-22"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - /keps/sig-cloud-provider/20180530-cloud-controller-manager.md
+  stage: beta
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.21
+      beta: v1.22
+      stable: v1.23
+  feature-gates:
+    - name: ControllerManagerLeaderMigration
+      components:
+        - cloud-controller-manager
+        - kube-controller-manager
+  disable-supported: true
+  metrics:
+    - leader_active
+- id: ""
+  prnumber: ""
+  name: 668-out-of-tree-gce
+  title: Support Out-of-Tree GCE Cloud Provider
+  kep_number: "668"
+  authors: ['@andrewsykim']
+  owning_sig: sig-cloud-provider
+  reviewers: [TBD]
+  approvers: [TBD]
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-01-25"
+  last-updated: "2019-01-25"
+  status: provisional
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 669-out-of-tree-openstack
+  title: Support Out-of-Tree OpenStack Cloud Provider
+  kep_number: "669"
+  authors: ['@andrewsykim', '@adisky']
+  owning_sig: sig-cloud-provider
+  reviewers: ['@lingxiankong', '@chrigl', '@ramineni', '@kendallnelson']
+  approvers: [TBD]
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-01-25"
+  last-updated: "2019-01-25"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 670-out-of-tree-vsphere
+  title: Support Out-of-Tree vSphere Cloud Provider
+  kep_number: "670"
+  authors: ['@frapposelli', '@andrewsykim']
+  owning_sig: sig-cloud-provider
+  reviewers: ['@frapposelli', '@cantbewong', '@andrewsykim', '@dvonthenen']
+  approvers: ['@frapposelli', '@cantbewong', '@andrewsykim', '@dvonthenen']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-01-25"
+  last-updated: "2020-04-09"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 671-out-of-tree-ibm
+  title: Support Out-of-Tree IBM Cloud Provider
+  kep_number: "671"
+  authors: ['@andrewsykim']
+  owning_sig: sig-cloud-provider
+  reviewers: [TBD]
+  approvers: [TBD]
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-01-25"
+  last-updated: "2019-01-25"
+  status: provisional
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 837-cloud-provider-labels
+  title: Promoting Cloud Provider Labels to GA
+  kep_number: "837"
+  authors: ['@andrewsykim']
+  owning_sig: sig-cloud-provider
+  participating-sigs: [sig-node, sig-storage]
+  reviewers: ['@dims', '@liggit', '@msau42', '@saad-ali', '@thockin']
+  approvers: ['@thockin', '@liggit']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-02-15"
+  last-updated: "2019-02-15"
+  status: implementable
+  see-also:
+    - /keps/sig-node/20190130-node-os-arch-labels.md
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2328-ccm-instance-metadata
+  title: Support Instance Metadata Service with Cloud Controller Manager
+  kep_number: "2328"
+  authors: ['@feiskyer']
+  owning_sig: sig-cloud-provider
+  reviewers: ['@andrewsykim', '@jagosan']
+  approvers: ['@andrewsykim']
+  prr-approvers: []
+  editor: '@feiskyer'
+  creation-date: "2019-07-22"
+  last-updated: "2021-01-26"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 586-azure-availability-zones
+  title: Azure Availability Zones
+  kep_number: "586"
+  authors: ['@feiskyer']
+  owning_sig: sig-cloud-provider
+  participating-sigs: [sig-storage]
+  reviewers: ['@khenidak', '@colemickens']
+  approvers: ['@brendanburns']
+  prr-approvers: []
+  editor: '@feiskyer'
+  creation-date: "2018-07-11"
+  last-updated: "2018-09-29"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 604-cross-resource-group-nodes
+  title: Cross resource group nodes
+  kep_number: "604"
+  authors: ['@feiskyer']
+  owning_sig: sig-cloud-provider
+  reviewers: ['@khenidak', '@justaugustus']
+  approvers: ['@brendanburns']
+  prr-approvers: []
+  editor: '@feiskyer'
+  creation-date: "2018-08-09"
+  last-updated: "2018-09-29"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 667-out-of-tree-azure
+  title: Support Out-of-Tree Azure Cloud Provider
+  kep_number: "667"
+  authors: ['@andrewsykim', '@dstrebel', '@feiskyer']
+  owning_sig: sig-cloud-provider
+  reviewers: ['@dstrebel', '@justaugustus', '@khenidak', '@feiskyer']
+  approvers: ['@feiskyer', '@khenidak', '@hogepodge', '@jagosan']
+  prr-approvers: []
+  editor: '@feiskyer'
+  creation-date: "2019-01-29"
+  last-updated: "2020-09-29"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 0000-cloud-provider-template
+  title: Cloud Provider Template
+  kep_number: "0000"
+  authors: ['@janedoe']
+  owning_sig: sig-cloud-provider
+  participating-sigs: [sig-aaa, sig-bbb]
+  reviewers: [TBD, '@alicedoe']
+  approvers: ['@andrewsykim', '@hogepodge', '@jagosan']
+  prr-approvers: []
+  editor: TBD
+  creation-date: yyyy-mm-dd
+  last-updated: yyyy-mm-dd
+  status: provisional
+  see-also:
+    - KEP-1
+    - KEP-2
+  replaces:
+    - KEP-3
+  superseded-by:
+    - KEP-100
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2530-alibaba-cloud
+  title: Cloud Provider for Alibaba Cloud
+  kep_number: "2530"
+  authors: ['@aoxn']
+  owning_sig: sig-cloud-provider
+  reviewers: ['@andrewsykim']
+  approvers: ['@andrewsykim', '@hogepodge', '@jagosan']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2018-06-20"
+  last-updated: "2018-06-20"
+  status: provisional
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2531-baidu-cloud
+  title: Cloud Provider for BaiduCloud
+  kep_number: "2531"
+  authors: ['@tizhou86']
+  owning_sig: sig-cloud-provider
+  reviewers: ['@andrewsykim', '@cheftako']
+  approvers: ['@andrewsykim', '@cheftako', '@hogepodge', '@jagosan']
+  prr-approvers: []
+  creation-date: "2020-02-25"
+  last-updated: "2020-02-25"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2532-huawei-cloud
+  title: Cloud Provider For HUAWEI CLOUD
+  kep_number: "2532"
+  authors: ['@RainbowMango']
+  owning_sig: sig-cloud-provider
+  reviewers: ['@andrewsykim', '@cheftako']
+  approvers: ['@andrewsykim', '@cheftako']
+  prr-approvers: []
+  creation-date: "2019-12-06"
+  last-updated: "2020-02-26"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2492-Addons-via-Operators
+  title: Addons via Operators
+  kep_number: "2492"
+  authors: ['@justinsb']
+  owning_sig: sig-cluster-lifecycle
+  reviewers: ['@luxas', '@roberthbailey', '@timothysc']
+  approvers: ['@timothysc']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-01-28"
+  last-updated: "2019-03-11"
+  status: provisional
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2494-Manifest-Bundle
+  title: Manifest Bundle
+  kep_number: "2494"
+  authors: ['@ecordell']
+  owning_sig: sig-cluster-lifecycle
+  participating-sigs: [sig-cluster-lifecycle, sig-api-machinery]
+  reviewers: [TBD]
+  approvers: [TBD]
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2020-01-21"
+  last-updated: "2020-02-06"
+  status: provisional
+  see-also:
+    - /keps/sig-cluster-lifecycle/addons/2492-Addons-via-Operators/
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2495-Kubernetes-Cluster-Management-API
+  title: Kubernetes Cluster Management API
+  kep_number: "2495"
+  authors: ['@roberthbailey', '@pipejakob']
+  owning_sig: sig-cluster-lifecycle
+  reviewers: ['@justinsb', '@timothysc']
+  approvers: ['@justinsb', '@timothysc']
+  prr-approvers: []
+  editor: '@justinsb'
+  creation-date: "2018-01-19"
+  last-updated: "2019-04-04"
+  status: provisional
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2496-etcdadm
+  title: etcdadm
+  kep_number: "2496"
+  authors: ['@justinsb']
+  owning_sig: sig-cluster-lifecycle
+  reviewers: ['@roberthbailey', '@timothysc']
+  approvers: ['@roberthbailey', '@timothysc']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2018-10-22"
+  last-updated: "2018-10-22"
+  status: provisional
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1755-communicating-a-local-registry
+  title: Standard for communicating a local registry
+  kep_number: "1755"
+  authors: ['@nicks']
+  owning_sig: sig-cluster-lifecycle
+  reviewers: ['@neolit123']
+  approvers: ['@timothysc', '@justinsb', '@neolit123']
+  prr-approvers: []
+  creation-date: "2020-05-08"
+  last-updated: ""
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2497-Kubernetes-Image-Builder
+  title: Kubernetes Image Builder
+  kep_number: "2497"
+  authors: ['@timothysc', '@moshloop']
+  owning_sig: sig-cluster-lifecycle
+  reviewers: ['@justinsb', '@luxas', '@astrieanna']
+  approvers: ['@justinsb', '@timothysc', '@luxas']
+  prr-approvers: []
+  editor: '@timothysc'
+  creation-date: "2019-06-11"
+  last-updated: "2019-07-05"
+  status: provisional
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1177-kubeadm-with-kustomize
+  title: Advanced configurations with kubeadm (Kustomize)
+  kep_number: "1177"
+  authors: ['@fabriziopandini']
+  owning_sig: sig-cluster-lifecycle
+  participating-sigs: [sig-cluster-lifecycle]
+  reviewers: ['@neolit123', '@rosti', '@ereslibre', '@detiber', '@vincepri', '@chuckha']
+  approvers: ['@timothysc', '@luxas']
+  prr-approvers: []
+  editor: '@fabriziopandini'
+  creation-date: "2019-07-22"
+  last-updated: "2020-09-18"
+  status: replaced
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1381-component-config
+  title: kubeadm component config management
+  kep_number: "1381"
+  authors: ['@rosti']
+  owning_sig: sig-cluster-lifecycle
+  participating-sigs: [sig-cluster-lifecycle]
+  reviewers: ['@fabriziopandini', '@neolit123', '@ereslibre', '@yastij']
+  approvers: ['@timothysc']
+  prr-approvers: []
+  editor: '@rosti'
+  creation-date: "2019-09-25"
+  last-updated: "2020-04-29"
+  status: implementable
+  see-also:
+    - /keps/sig-cluster-lifecycle/kubeadm/0023-kubeadm-config.md
+    - /keps/sig-cluster-lifecycle/kubeadm/20190722-Advanced-configurations-with-kubeadm-(Kustomize).md
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1739-customization-with-patches
+  title: kubeadm customization with patches
+  kep_number: "1739"
+  authors: ['@neolit123']
+  owning_sig: sig-cluster-lifecycle
+  participating-sigs: [sig-cluster-lifecycle]
+  reviewers: ['@fabriziopandini', '@rosti']
+  approvers: ['@fabriziopandini']
+  prr-approvers: []
+  creation-date: "2020-05-04"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - /keps/sig-cluster-lifecycle/kubeadm/20190722-Advanced-configurations-with-kubeadm-(Kustomize).md
+  replaces:
+    - /keps/sig-cluster-lifecycle/kubeadm/20190722-Advanced-configurations-with-kubeadm-(Kustomize).md
+  stage: alpha
+  latest-milestone: v1.19
+  milestone:
+      alpha: v1.19
+      beta: v1.20
+      stable: v1.22
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2067-rename-master-label-taint
+  title: Rename the kubeadm "master" label and taint
+  kep_number: "2067"
+  authors: ['@neolit123']
+  owning_sig: sig-cluster-lifecycle
+  participating-sigs: [sig-cluster-lifecycle]
+  reviewers: ['@fabriziopandini']
+  approvers: ['@fabriziopandini']
+  prr-approvers: []
+  creation-date: "2020-10-03"
+  last-updated: ""
+  status: implementable
+  stage: alpha
+  latest-milestone: v1.20
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2498-Kubeadm-Config-versioning
+  title: Kubeadm Config versioning
+  kep_number: "2498"
+  authors: ['@liztio']
+  owning_sig: sig-cluster-lifecycle
+  reviewers: ['@timothysc']
+  approvers: [TBD]
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2018-04-12"
+  last-updated: "2018-04-12"
+  status: provisional
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2500-kubeadm-join-control-plane-workflow
+  title: kubeadm join --control-plane workflow
+  kep_number: "2500"
+  authors: ['@fabriziopandini']
+  owning_sig: sig-cluster-lifecycle
+  reviewers: ['@chuckha', '@detiber', '@luxas']
+  approvers: ['@luxas', '@timothysc']
+  prr-approvers: []
+  editor: '@fabriziopandini'
+  creation-date: "2018-01-28"
+  last-updated: "2019-04-18"
+  status: provisional
+  see-also:
+    - KEP 0004
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2501-kubeadm-phases-to-beta
+  title: kubeadm phases to beta
+  kep_number: "2501"
+  authors: ['@fabriziopandini']
+  owning_sig: sig-cluster-lifecycle
+  reviewers: ['@chuckha', '@detiber', '@liztio', '@neolit123']
+  approvers: ['@luxas', '@timothysc']
+  prr-approvers: []
+  editor: '@fabriziopandini'
+  creation-date: "2018-03-16"
+  last-updated: "2019-01-22"
+  status: provisional
+  see-also:
+    - KEP 0008
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2502-Certificates-copy-for-join-control-plane
+  title: Certificates copy for join --control-plane
+  kep_number: "2502"
+  authors: ['@fabriziopandini']
+  owning_sig: sig-cluster-lifecycle
+  reviewers: ['@neolit123', '@detiber', '@mattmoyer', '@chuckha', '@liztio']
+  approvers: ['@timothysc', '@luxas']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-01-22"
+  last-updated: "2019-04-18"
+  status: implementable
+  see-also:
+    - KEP-0015
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2503-Artifact-Generation
+  title: Artifact Generation
+  kep_number: "2503"
+  authors: ['@klaven', '@ncdc']
+  owning_sig: sig-cluster-lifecycle
+  participating-sigs: [sig-cluster-lifecycle, sig-release]
+  reviewers: ['@ncdc', '@hoegaarden', “@neolit123”, “@ixdy”]
+  approvers: ['@timothysc']
+  prr-approvers: []
+  editor: '@Klaven'
+  creation-date: "2019-02-15"
+  last-updated: "2019-02-27"
+  status: implementable
+  see-also:
+    - https://github.com/kubernetes/enhancements/pull/843
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2504-kubeadm-machine-output
+  title: kubeadm-machine-output
+  kep_number: "2504"
+  authors: ['@akutz', '@bart0sh']
+  owning_sig: sig-cluster-lifecycle
+  reviewers: ['@justinsb', '@tstromberg', '@timothysc', '@mtaufen', '@rosti', '@randomvariable',
+      '@fabriziopandini', '@neolit123']
+  approvers: ['@timothysc', '@neolit123', '@fabriziopandini']
+  prr-approvers: []
+  creation-date: "2019-05-06"
+  last-updated: "2019-05-29"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2505-Kubeadm-operator
+  title: Kubeadm operator
+  kep_number: "2505"
+  authors: ['@fabriziopandini']
+  owning_sig: sig-cluster-lifecycle
+  participating-sigs: [sig-cluster-lifecycle]
+  reviewers: ['@neolit123', '@rosti', '@ereslibre', '@detiber', '@vincepri', '@yastij',
+      '@chuckha']
+  approvers: ['@timothysc', '@luxas']
+  prr-approvers: []
+  editor: '@fabriziopandini'
+  creation-date: "2019-09-16"
+  last-updated: "2019-09-28"
+  status: provisional
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2506-Remove-ClusterStatus-from-kubeadm-config
+  title: Remove ClusterStatus from kubeadm-config
+  kep_number: "2506"
+  authors: ['@fabriziopandini']
+  owning_sig: sig-cluster-lifecycle
+  participating-sigs: [sig-cluster-lifecycle]
+  reviewers: ['@neolit123', '@rosti', '@ereslibre', '@ncdc']
+  approvers: ['@timothysc']
+  prr-approvers: []
+  editor: '@fabriziopandini'
+  creation-date: "2019-11-25"
+  last-updated: "2019-11-25"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2568-kubeadm-non-root-control-plane
+  title: Run control-plane as non-root in kubeadm.
+  kep_number: "2568"
+  authors: ['@vinayakankugoyal']
+  owning_sig: sig-cluster-lifecycle
+  participating-sigs: [sig-security]
+  reviewers: ['@neolit123', '@fabriziopandini', '@randomvariable', '@vincepri', '@PushkarJ']
+  approvers: ['@neolit123', '@fabriziopandini']
+  prr-approvers: ['@ehashman']
+  creation-date: "2021-03-13"
+  last-updated: ""
+  status: implementable
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.22
+      beta: TBD
+      stable: TBD
+  feature-gates:
+    - name: kubeadmRootlessControlPlane
+      components:
+        - kubeadm
+  disable-supported: true
+  metrics:
+    - TBD
+- id: ""
+  prnumber: ""
+  name: 378-bootstrap-checkpointing
+  title: Kubernetes Bootstrap Checkpointing Proposal
+  kep_number: "378"
+  authors: ['@timothysc']
+  owning_sig: sig-cluster-lifecycle
+  participating-sigs: [sig-node]
+  reviewers: ['@yujuhong', '@luxas', '@roberthbailey']
+  approvers: ['@yujuhong', '@roberthbailey']
+  prr-approvers: []
+  editor: '@timothysc'
+  creation-date: "2017-10-20"
+  last-updated: "2018-01-23"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 970-kubeadm-config
+  title: Kubeadm config file graduation
+  kep_number: "970"
+  authors: ['@fabriziopandini', '@luxas', '@rosti', '@neolit123']
+  owning_sig: sig-cluster-lifecycle
+  reviewers: ['@chuckha', '@detiber', '@liztio']
+  approvers: ['@luxas', '@timothysc', '@fabriziopandini', '@neolit123']
+  prr-approvers: []
+  editor: '@neolit123'
+  creation-date: "2018-08-01"
+  last-updated: "2021-04-15"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 995-kubeadm-windows
+  title: kubeadm-for-windows
+  kep_number: "995"
+  authors: ['@benmoss', '@gab-satchi', '@ksubrmnn', '@neolit123', '@patricklang']
+  owning_sig: sig-windows
+  participating-sigs: [sig-windows, sig-cluster-lifecycle]
+  reviewers: ['@timothysc', '@michmike', '@fabriziopandini', '@rosti']
+  approvers: ['@timothysc']
+  prr-approvers: []
+  editor: '@ksubrmnn'
+  creation-date: "2019-04-24"
+  last-updated: "2019-04-24"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 115-componentconfig
+  title: Moving ComponentConfig API types to staging repos
+  kep_number: "115"
+  authors: ['@luxas', '@sttts']
+  owning_sig: sig-cluster-lifecycle
+  participating-sigs: [sig-api-machinery, sig-node, sig-network, sig-scheduling, sig-cloud-provider]
+  reviewers: ['@thockin', '@liggitt', '@wojtek-t', '@stewart-yu', '@dixudx']
+  approvers: ['@thockin', '@jbeda', '@deads2k']
+  prr-approvers: []
+  editor: '@luxas'
+  creation-date: "2018-07-07"
+  last-updated: "2018-08-10"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 783-component-base
+  title: Create a `k8s.io/component-base` repo
+  kep_number: "783"
+  authors: ['@luxas', '@sttts']
+  owning_sig: sig-cluster-lifecycle
+  participating-sigs: [sig-api-machinery, sig-cloud-provider]
+  reviewers: ['@thockin', '@jbeda', '@bgrant0607', '@smarterclayton', '@liggitt',
+      '@lavalamp', '@andrewsykim', '@cblecker']
+  approvers: ['@thockin', '@jbeda', '@bgrant0607', '@smarterclayton']
+  prr-approvers: []
+  editor: '@luxas'
+  creation-date: "2018-11-27"
+  last-updated: "2018-12-10"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 0000-community-forum
+  title: A community forum for Kubernetes
+  kep_number: "0000"
+  authors: ['@castrojo']
+  owning_sig: sig-contributor-experience
+  reviewers: ['@jberkus', '@joebeda', '@cblecker']
+  approvers: ['@parispittman', '@grodrigues3']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2018-04-03"
+  last-updated: "2018-04-17"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1553-issue-triage
+  title: Issue Triage Workflow and Automation
+  kep_number: "1553"
+  authors: ['@justaugustus', '@mrbobbytables', '@nikhita']
+  owning_sig: sig-contributor-experience
+  participating-sigs: [sig-release]
+  reviewers: ['@alejandrox1', '@mrbobbytables', '@logicalhan', '@smourapina', '@thockin']
+  approvers: ['@cblecker', '@nikhita']
+  prr-approvers: []
+  creation-date: "2020-02-15"
+  last-updated: ""
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2225-contributor-site
+  title: Contributor Site
+  kep_number: "2225"
+  authors: ['@jbeda']
+  owning_sig: sig-contributor-experience
+  participating-sigs: [sig-architecture, sig-docs]
+  reviewers: ['@castrojo']
+  approvers: ['@parispittman', '@mrbobbytables']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2018-02-19"
+  last-updated: "2021-01-04"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1326-third-party-content-in-docs
+  title: doc-policies-for-third-party-content
+  kep_number: "1326"
+  authors: ['@aimeeu', '@jimangel', '@sftim', '@zacharysarah']
+  owning_sig: sig-docs
+  reviewers: ['@jaredbhatti', '@kbarnard10']
+  approvers: ['@cblecker', '@derekwaynecarr', '@dims']
+  prr-approvers: []
+  editor: '@zacharysarah'
+  creation-date: "2019-10-20"
+  last-updated: "2019-10-20"
+  status: provisional
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1013-metrics-watch-api
+  title: Watch support for metrics APIs
+  kep_number: "1013"
+  authors: ['@x13n']
+  owning_sig: sig-instrumentation
+  participating-sigs: [sig-autoscaling]
+  reviewers: [TBD]
+  approvers: [TBD]
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-04-25"
+  last-updated: "2019-04-29"
+  status: provisional
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1206-metrics-overhaul
+  title: Kubernetes Metrics Overhaul
+  kep_number: "1206"
+  authors: ['@brancz', '@ehashman']
+  owning_sig: sig-instrumentation
+  reviewers: ['@piosz', '@DirectXMan12']
+  approvers: ['@piosz', '@DirectXMan12']
+  prr-approvers: []
+  editor: '@DirectXMan12'
+  creation-date: "2018-11-06"
+  last-updated: "2019-03-21"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1209-metrics-stability
+  title: Metrics Stability Framework
+  kep_number: "1209"
+  authors: ['@logicalhan', '@RainbowMango', '@solodov', '@serathius']
+  owning_sig: sig-instrumentation
+  participating-sigs: [sig-api-machinery, sig-node, sig-scheduling, sig-cluster-lifecycle,
+      sig-cloud-provider, sig-testing]
+  reviewers: ['@brancz', '@x13n', '@DirectXMan12', '@lavalamp', '@dashpole', '@ehashman',
+      '@mml', '@sttts', '@bsalamat', '@andrewsykim']
+  approvers: ['@brancz']
+  prr-approvers: ['@johnbelamaric']
+  creation-date: "2019-04-04"
+  last-updated: ""
+  status: implemented
+  see-also:
+    - /keps/sig-instrumentation/1206-metrics-overhaul
+  stage: stable
+  latest-milestone: v1.21
+  milestone:
+      alpha: v1.15
+      beta: v1.17
+      stable: v1.21
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1602-structured-logging
+  title: Structured Logging
+  kep_number: "1602"
+  authors: ['@serathius', '@44past4', '@DirectXMan12', '@ehashman']
+  owning_sig: sig-instrumentation
+  participating-sigs: [sig-architecture]
+  reviewers: ['@dims', '@mtaufen', '@derekwaynecarr']
+  approvers: ['@brancz', '@thockin']
+  prr-approvers: ['@wojtek-t', '@johnbelamaric']
+  creation-date: "2019-11-15"
+  last-updated: ""
+  status: implementable
+  stage: beta
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.19
+      beta: v1.22
+      stable: v1.23
+  feature-gates: []
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1748-pod-resource-metrics
+  title: Expose Pod Resource Request Metrics
+  kep_number: "1748"
+  authors: ['@smarterclayton']
+  owning_sig: sig-instrumentation
+  participating-sigs: [sig-node, sig-scheduling]
+  reviewers: ['@brancz', '@dashpole', '@ehashman']
+  approvers: ['@brancz', '@dashpole', '@ahg-g']
+  prr-approvers: ['@johnbelamaric']
+  creation-date: "2020-07-30"
+  last-updated: ""
+  status: implementable
+  stage: beta
+  latest-milestone: v1.21
+  milestone:
+      alpha: v1.20
+      beta: v1.21
+      stable: v1.22
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2305-metrics-cardinality-enforcement
+  title: Dynamic Cardinality Enforcement
+  kep_number: "2305"
+  authors: ['@logicalhan', '@lilic', '@yoyinzyc']
+  owning_sig: sig-instrumentation
+  participating-sigs: [sig-instrumentation]
+  reviewers: ['@dashpole', '@brancz', '@ehashman', '@x13n']
+  approvers: ['@ehashman']
+  prr-approvers: ['@johnbelamaric']
+  creation-date: "2020-04-15"
+  last-updated: "2021-02-08"
+  status: implementable
+  stage: alpha
+  latest-milestone: v1.21
+  milestone:
+      alpha: v1.21
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 383-new-event-api-ga-graduation
+  title: New Event API GA Graduation
+  kep_number: "383"
+  authors: ['@gmarek', '@chelseychen']
+  owning_sig: sig-instrumentation
+  participating-sigs: [sig-instrumentation, sig-scalability, sig-architecture]
+  reviewers: ['@yastij', '@wojtek-t']
+  approvers: ['@brancz']
+  prr-approvers: ['@wojtek-t']
+  creation-date: "2019-01-31"
+  last-updated: "2021-02-03"
+  status: implementable
+  stage: stable
+  latest-milestone: v1.19
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: v1.19
+  feature-gates: []
+  disable-supported: true
+  metrics:
+    - apiserver_requests_total
+- id: ""
+  prnumber: ""
+  name: 647-apiserver-tracing
+  title: APIServer Tracing
+  kep_number: "647"
+  authors: ['@Monkeyanator', '@dashpole', '@logicalhan']
+  owning_sig: sig-instrumentation
+  participating-sigs: [sig-architecture, sig-api-machinery, sig-scalability]
+  reviewers: ['@logicalhan', '@caesarxuchao']
+  approvers: ['@brancz', '@lavalamp']
+  prr-approvers: ['@wojtek-t']
+  creation-date: "2018-12-04"
+  last-updated: "2020-10-14"
+  status: implementable
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.22
+      beta: ""
+      stable: ""
+  feature-gates:
+    - name: APIServerTracing
+      components: []
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1645-multi-cluster-services-api
+  title: Multi-Cluster Services API
+  kep_number: "1645"
+  authors: ['@jeremyot']
+  owning_sig: sig-multicluster
+  participating-sigs: [sig-network]
+  reviewers: ['@johnbelamaric', '@janetkuo', '@danwinship', '@deads2k', '@liggitt']
+  approvers: ['@pmorie', '@thockin']
+  prr-approvers: []
+  creation-date: "2020-03-30"
+  last-updated: ""
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2149-clusterid
+  title: ClusterID for ClusterSet Identification
+  kep_number: "2149"
+  authors: ['@jeremyot', '@lauralorenz']
+  owning_sig: sig-multicluster
+  reviewers: ['@mikedanese']
+  approvers: ['@pmorie']
+  prr-approvers: []
+  creation-date: "2020-11-13"
+  last-updated: ""
+  status: provisional
+  see-also:
+    - /keps/sig-multicluster/1645-multi-cluster-services-api
+  stage: alpha
+  latest-milestone: v1.20
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 0752-endpointslices
+  title: EndpointSlice API
+  kep_number: "752"
+  authors: ['@freehan', '@robscott', '@swetharepakula']
+  owning_sig: sig-network
+  reviewers: ['@bowei', '@thockin', '@wojtek-t', '@johnbelamaric']
+  approvers: ['@bowei', '@thockin']
+  prr-approvers: ['@wojtek-t']
+  creation-date: "2019-06-01"
+  last-updated: "2021-05-04"
+  status: implementable
+  see-also:
+    - https://docs.google.com/document/d/1sLJfolOeEVzK5oOviRmtHOHmke8qtteljQPaDUEukxY/edit#
+  stage: stable
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.16
+      beta: v1.17
+      stable: v1.21
+  feature-gates:
+    - name: EndpointSlice
+      components:
+        - kube-apiserver
+        - kube-controller-manager
+    - name: EndpointSliceProxying
+      components:
+        - kube-proxy
+    - name: WindowsEndpointSliceProxying
+      components:
+        - kube-proxy
+  disable-supported: true
+  metrics:
+    - endpoint_slice_controller/endpoints_added_per_sync
+    - endpoint_slice_controller/endpoints_removed_per_sync
+    - endpoint_slice_controller/endpoints_desired
+    - endpoint_slice_controller/num_endpoint_slices
+    - endpoint_slice_controller/desired_endpoint_slices
+    - endpoint_slice_controller/changes
+- id: ""
+  prnumber: ""
+  name: 1024-nodelocal-cache-dns
+  title: NodeLocal DNS Cache
+  kep_number: "1024"
+  authors: ['@prameshj']
+  owning_sig: sig-network
+  reviewers: ['@bowei', '@thockin', '@johnbelamaric', '@sdodson']
+  approvers: ['@bowei', '@thockin']
+  prr-approvers: []
+  creation-date: "2019-04-24"
+  last-updated: "2020-09-23"
+  status: implemented
+  see-also:
+    - /keps/sig-network/0030-nodelocal-dns-cache.md
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1435-mixed-protocol-lb
+  title: Different protocols in the same service definition with type=loadbalancer
+  kep_number: "1435"
+  authors: ['@laszlo.janosi1@gmail.com']
+  owning_sig: sig-network
+  participating-sigs: [sig-cloud-provider]
+  reviewers: ['@thockin', '@dcbw', '@andrewsykim']
+  approvers: ['@thockin']
+  prr-approvers: []
+  creation-date: "2020-01-03"
+  last-updated: ""
+  status: implementable
+  replaces:
+    - /keps/sig-network/ 20200103-mixed-protocol-lb
+  stage: alpha
+  latest-milestone: v1.20
+  milestone:
+      alpha: v1.20
+      beta: v1.21
+      stable: v1.22
+  feature-gates:
+    - name: MixedProtocolLBSVC
+      components:
+        - kube-apiserver
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1453-ingress-api
+  title: Graduate Ingress API to GA
+  kep_number: "1453"
+  authors: ['@bowei', '@cmluciano', '@robscott']
+  owning_sig: sig-network
+  reviewers: ['@aledbf']
+  approvers: ['@caseydavenport', '@ligitt', '@thockin']
+  prr-approvers: ['@wojtek-t']
+  creation-date: yyyy-mm-dd
+  last-updated: ""
+  status: implemented
+  replaces:
+    - '/keps/sig-network/20190125-ingress-api-group.md '
+  stage: stable
+  latest-milestone: v1.19
+  milestone:
+      alpha: ""
+      beta: v1.1
+      stable: v1.19
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1507-app-protocol
+  title: Adding AppProtocol to Services and Endpoints
+  kep_number: "1507"
+  authors: ['@robscott']
+  owning_sig: sig-network
+  reviewers: ['@thockin', '@dcbw']
+  approvers: ['@thockin', '@dcbw']
+  prr-approvers: ['@deads2k']
+  creation-date: "2019-12-27"
+  last-updated: "2021-02-05"
+  status: implementable
+  see-also:
+    - /keps/sig-network/20190603-EndpointSlice-API.md
+    - https://github.com/kubernetes/kubernetes/issues/40244
+  stage: stable
+  latest-milestone: v1.21
+  milestone:
+      alpha: v1.18
+      beta: v1.19
+      stable: v1.20
+  feature-gates:
+    - name: ServiceAppProtocol
+      components:
+        - kube-apiserver
+        - kube-controller-manager
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1611-network-policy-validation
+  title: Rearchitecting NetworkPolicy tests with a DSL for better upstream test coverage
+  kep_number: "1611"
+  authors: ['@jayunit100', '@abhiraut', '@sedefsavas', '@McCodeman', '@mattfenwick']
+  owning_sig: sig-network
+  reviewers: [bowei@, TBD]
+  approvers: [TBD]
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2020-02-04"
+  last-updated: "2020-5-01"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1669-graceful-termination-local-external-traffic-policy
+  title: Graceful Termination for Local External Traffic Policy
+  kep_number: "1669"
+  authors: ['@andrewsykim']
+  owning_sig: sig-network
+  participating-sigs: [sig-scalability]
+  reviewers: ['@thockin', '@wojtek-t', '@smarterclayton']
+  approvers: ['@thockin']
+  prr-approvers: ['@johnbelamaric', '@wojtek-t']
+  creation-date: "2020-04-07"
+  last-updated: "2020-04-07"
+  status: implementable
+  see-also:
+    - /keps/sig-network/1672-tracking-terminating-endpoints/README.md
+    - https://github.com/kubernetes/kubernetes/issues/85643
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.22
+      beta: ""
+      stable: ""
+  feature-gates:
+    - name: ProxyTerminatingEndpoints
+      components:
+        - kube-proxy
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1672-tracking-terminating-endpoints
+  title: Tracking Terminating Endpoints in EndpointSlice
+  kep_number: "1672"
+  authors: ['@andrewsykim']
+  owning_sig: sig-network
+  participating-sigs: [sig-scalability]
+  reviewers: ['@thockin', '@robscott', '@freehan', '@smarterclayton', '@wojtek-t']
+  approvers: ['@thockin']
+  prr-approvers: ['@wojtek-t']
+  creation-date: "2020-04-07"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - /kep/sig-network/20190603-EndpointSlice-API.md
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.20
+      beta: ""
+      stable: ""
+  feature-gates:
+    - name: EndpointSliceTerminatingCondition
+      components:
+        - kube-apiserver
+        - kube-controller-manager
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1860-kube-proxy-IP-node-binding
+  title: Make Kubernetes aware of the load balancer behaviour
+  kep_number: "1860"
+  authors: ['@Sh4d1']
+  owning_sig: sig-network
+  participating-sigs: [sig-cloud-provider]
+  reviewers: ['@thockin', '@cheftako', '@MorrisLaw']
+  approvers: ['@thockin', '@andrewsykim']
+  prr-approvers: []
+  creation-date: ""
+  last-updated: ""
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: v1.21
+      beta: v1.22
+      stable: ""
+  feature-gates:
+    - name: LoadBalancerIPMode
+      components:
+        - kube-apiserver
+        - kube-proxy
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1864-disable-lb-node-ports
+  title: Optionally Disable Node Ports for Service Type=LoadBalancer
+  kep_number: "1864"
+  authors: ['@andrewsykim']
+  owning_sig: sig-network
+  participating-sigs: [sig-cloud-provider]
+  reviewers: ['@thockin', '@uablrek', '@rikatz']
+  approvers: ['@thockin']
+  prr-approvers: ['@johnbelamaric']
+  creation-date: "2020-06-21"
+  last-updated: ""
+  status: implementable
+  stage: beta
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.20
+      beta: v1.22
+      stable: v1.23
+  feature-gates:
+    - name: ServiceLBNodePortControl
+      components:
+        - kube-apiserver
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2079-network-policy-port-range
+  title: Allow a Network Policy to contemplate a set of ports in a single rule
+  kep_number: "2079"
+  authors: ['@rikatz']
+  owning_sig: sig-network
+  reviewers: ['@andrewsykim', '@abhiraut', '@danwinship']
+  approvers: ['@thockin']
+  prr-approvers: ['@wojtek-t']
+  creation-date: "2020-10-08"
+  last-updated: ""
+  status: implementable
+  stage: beta
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.21
+      beta: v1.22
+      stable: v1.23
+  feature-gates:
+    - name: NetworkPolicyEndPort
+      components:
+        - kube-apiserver
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2086-service-internal-traffic-policy
+  title: Service Internal Traffic Policy
+  kep_number: "2086"
+  authors: ['@andrewsykim']
+  owning_sig: sig-network
+  reviewers: [robscott, thockin]
+  approvers: ['@thockin']
+  prr-approvers: ['@johnbelamaric', '@wojtek-t']
+  creation-date: "2020-10-07"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - /keps/sig-network/2004-topology-aware-subsetting
+    - /keps/sig-network/20181024-service-topology.md
+  stage: beta
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.21
+      beta: v1.22
+      stable: v1.23
+  feature-gates:
+    - name: ServiceInternalTrafficPolicy
+      components:
+        - kube-apiserver
+        - kube-proxy
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2200-externalips-admission
+  title: Block ExternalIPs via Admission Control
+  kep_number: "2200"
+  authors: ['@thockin']
+  owning_sig: sig-network
+  participating-sigs: [sig-auth, sig-security, sig-api-machinery]
+  reviewers: ['@IanColdwater', '@tabbysable']
+  approvers: ['@tallclair', '@lavalamp']
+  prr-approvers: ['@johnbelamaric']
+  creation-date: "2020-12-07"
+  last-updated: ""
+  status: implemented
+  see-also:
+    - https://github.com/kubernetes/kubernetes/issues/97110
+  stage: stable
+  latest-milestone: v1.21
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: v1.21
+  feature-gates: []
+  disable-supported: true
+  metrics:
+    - apiserver_admission_controller_admission_duration_seconds_bucket{name="DenyServiceExternalIPs",
+      ...}
+- id: ""
+  prnumber: ""
+  name: 2365-ingressclass-namespaced-params
+  title: IngressClass Namespaced Params
+  kep_number: "2365"
+  authors: ['@robscott']
+  owning_sig: sig-network
+  reviewers: ['@danehans', '@cmluciano', '@hbagdi', '@bowei']
+  approvers: ['@thockin']
+  prr-approvers: ['@johnbelamaric']
+  creation-date: "2021-01-28"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - /keps/sig-network/1453-ingress-api
+  stage: beta
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.21
+      beta: v1.22
+      stable: v1.23
+  feature-gates:
+    - name: IngressClassNamespacedParams
+      components:
+        - kube-apiserver
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2433-topology-aware-hints
+  title: Topology Aware Hints
+  kep_number: "2433"
+  authors: ['@robscott']
+  owning_sig: sig-network
+  reviewers: ['@andrewsykim', '@bowei', '@dcbw', '@thockin']
+  approvers: ['@thockin', '@wojtek-t']
+  prr-approvers: ['@wojtek-t']
+  creation-date: "2021-02-04"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - https://docs.google.com/document/d/1ZzUoFY1SrdjVefl7gVOJZJLt1I1LHttw8pcX95nlgMY/edit?usp=sharing
+    - github.com/kubernetes/enhancements/blob/master/keps/sig-network/2004-topology-aware-subsetting
+    - github.com/kubernetes/enhancements/blob/master/keps/sig-network/2030-topology-aware-proxying
+    - github.com/kubernetes/enhancements/blob/master/keps/sig-network/2086-service-internal-traffic-policy
+  replaces:
+    - github.com/kubernetes/enhancements/tree/master/keps/sig-network/536-topology-aware-routing
+  stage: beta
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.21
+      beta: v1.22
+      stable: v1.24
+  feature-gates:
+    - name: TopologyAwareHints
+      components:
+        - kube-controller-manager
+        - kube-proxy
+  disable-supported: true
+  metrics:
+    - endpoint_slice_controller/endpointslices_changed_per_sync
+    - endpoint_slice_controller/syncs
+- id: ""
+  prnumber: ""
+  name: 2447-Make-kube-proxy-service-abstraction-optional
+  title: Make kube-proxy service abstraction optional
+  kep_number: "2447"
+  authors: ['@bradhoekstra']
+  owning_sig: sig-network
+  reviewers: ['@freehan']
+  approvers: ['@thockin']
+  prr-approvers: []
+  editor: '@bradhoekstra'
+  creation-date: "2018-10-17"
+  last-updated: "2018-11-12"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2448-Remove-kube-proxy-automatic-clean-up-logic
+  title: Remove kube-proxy's automatic clean up logic
+  kep_number: "2448"
+  authors: ['@vllry']
+  owning_sig: sig-network
+  reviewers: ['@andrewsykim']
+  approvers: ['@bowei', '@thockin']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2018-03-24"
+  last-updated: "2018-04-02"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2449-move-externalDNS-out-of-kubernetes-incubator
+  title: Move ExternalDNS out of Kubernetes incubator
+  kep_number: "2449"
+  authors: ['@njuettner']
+  owning_sig: sig-network
+  reviewers: []
+  approvers: []
+  prr-approvers: []
+  creation-date: ""
+  last-updated: ""
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2450-Remove-knowledge-of-pod-cluster-CIDR-from-iptables-rules
+  title: Remove knowledge of pod cluster CIDR from iptables rules
+  kep_number: "2450"
+  authors: ['@satyasm']
+  owning_sig: sig-network
+  reviewers: ['@thockin', '@caseydavenport', '@mikespreitzer', '@aojea', '@fasaxc',
+      '@squeed', '@bowei', '@dcbw', '@darwinship']
+  approvers: ['@thockin']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-11-04"
+  last-updated: "2019-11-27"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2595-expanded-dns-config
+  title: Expanded DNS Configuration
+  kep_number: "2595"
+  authors: ['@gjkim42']
+  owning_sig: sig-network
+  participating-sigs: [sig-node]
+  reviewers: ['@thockin', '@liggitt', '@aojea', '@sftim']
+  approvers: ['@thockin']
+  prr-approvers: ['@johnbelamaric']
+  creation-date: "2021-04-02"
+  last-updated: ""
+  status: implementable
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.22
+      beta: x.y
+      stable: ""
+  feature-gates:
+    - name: ExpandedDNSConfig
+      components:
+        - kube-apiserver
+        - kubelet
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 265-ipvs-based-load-balancing
+  title: IPVS Load Balancing Mode in Kubernetes
+  kep_number: "265"
+  authors: ['@rramkumar1']
+  owning_sig: sig-network
+  reviewers: ['@thockin', '@m1093782566']
+  approvers: ['@thockin', '@m1093782566']
+  prr-approvers: []
+  editor: '@thockin'
+  creation-date: "2018-03-21"
+  last-updated: "2019-06-27"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 427-coredns
+  title: Graduate CoreDNS to GA
+  kep_number: "427"
+  authors: ['@johnbelamaric', '@rajansandeep']
+  owning_sig: sig-network
+  participating-sigs: [sig-cluster-lifecycle]
+  reviewers: ['@bowei', '@thockin']
+  approvers: ['@thockin']
+  prr-approvers: []
+  editor: '@rajansandeep'
+  creation-date: "2018-03-21"
+  last-updated: "2018-05-18"
+  status: provisional
+  see-also:
+    - https://github.com/kubernetes/community/pull/2167
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 504-configurable-pod-dns
+  title: Configurable Pod DNS
+  kep_number: "504"
+  authors: ['@MrHohn']
+  owning_sig: sig-network
+  participating-sigs: [sig-network]
+  reviewers: ['@thockin', '@bowei']
+  approvers: ['@thockin', '@bowei']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-01-18"
+  last-updated: "2019-02-11"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 506-ipv6
+  title: graduate-ipv6-to-beta
+  kep_number: "506"
+  authors: ['@aojea']
+  owning_sig: sig-network
+  reviewers: ['@bentheelder', '@andrewsykim', '@khenidak']
+  approvers: ['@lachie83', '@thockin']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-07-14"
+  last-updated: "2019-07-27"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 536-topology-aware-routing
+  title: Topology-aware service routing
+  kep_number: "536"
+  authors: ['@m1093782566', '@andrewsykim']
+  owning_sig: sig-network
+  reviewers: ['@thockin', '@johnbelamaric']
+  approvers: ['@thockin']
+  prr-approvers: []
+  creation-date: "2018-10-24"
+  last-updated: "2021-05-12"
+  status: replaced
+  stage: ""
+  latest-milestone: v1.22
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 563-dual-stack
+  title: Kubernetes Dual-stack Support
+  kep_number: "563"
+  authors: ['@leblancd', '@rpothier', '@lachie83', '@khenidak', '@feiskyer', '@bridgetkromhout']
+  owning_sig: sig-network
+  participating-sigs: [sig-cluster-lifecycle]
+  reviewers: ['@danwinship']
+  approvers: ['@thockin']
+  prr-approvers: ['@johnbelamaric']
+  editor: TBD
+  creation-date: "2018-05-21"
+  last-updated: "2021-05-03"
+  status: implementable
+  stage: beta
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.20
+      beta: v1.21
+      stable: v1.23
+  feature-gates:
+    - name: IPv6DualStack
+      components:
+        - kube-apiserver
+        - kube-controller-manager
+        - kubelet
+        - kube-proxy
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 566-coredns-default
+  title: Switch CoreDNS to the default DNS
+  kep_number: "566"
+  authors: ['@johnbelamaric', '@rajansandeep']
+  owning_sig: sig-network
+  participating-sigs: [sig-cluster-lifecycle]
+  reviewers: ['@bowei', '@thockin']
+  approvers: ['@thockin']
+  prr-approvers: []
+  editor: '@rajansandeep'
+  creation-date: "2018-05-18"
+  last-updated: "2018-05-18"
+  status: provisional
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 580-pod-readiness-gates
+  title: Pod Ready++
+  kep_number: "580"
+  authors: [freehan@]
+  owning_sig: sig-network
+  participating-sigs: [sig-node, sig-cli]
+  reviewers: [thockin@, dchen1107@]
+  approvers: [thockin@, dchen1107@]
+  prr-approvers: []
+  editor: freehan@
+  creation-date: "2018-04-01"
+  last-updated: "2018-04-01"
+  status: provisional
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 614-SCTP-support
+  title: SCTP support
+  kep_number: "614"
+  authors: ['@janosi']
+  owning_sig: sig-network
+  reviewers: ['@danwinship', '@thockin']
+  approvers: ['@thockin']
+  prr-approvers: []
+  creation-date: "2018-06-14"
+  last-updated: ""
+  status: implemented
+  stage: stable
+  latest-milestone: v1.20
+  milestone:
+      alpha: v1.12
+      beta: v1.19
+      stable: v1.20
+  feature-gates:
+    - name: SCTPSupport
+      components:
+        - kube-apiserver
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 758-ingress-api-group
+  title: Graduate Ingress to GA
+  kep_number: "758"
+  authors: ['@bowei']
+  owning_sig: sig-network
+  reviewers: ['@aledbf']
+  approvers: ['@thockin', '@caseydavenport']
+  prr-approvers: []
+  creation-date: "2018-01-25"
+  last-updated: "2018-04-25"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 784-kube-proxy-component-config
+  title: Kube-Proxy ComponentConfig graduation
+  kep_number: "784"
+  authors: ['@rosti']
+  owning_sig: sig-network
+  participating-sigs: [sig-cluster-lifecycle, sig-api-machinery, wg-component-standard]
+  reviewers: ['@luxas', '@mtaufen', '@sttts']
+  approvers: ['@thockin']
+  prr-approvers: []
+  editor: '@rosti'
+  creation-date: "2019-06-13"
+  last-updated: ""
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 980-load-balancer-finalizers
+  title: Finalizer Protection for Service LoadBalancers
+  kep_number: "980"
+  authors: ['@MrHohn']
+  owning_sig: sig-network
+  participating-sigs: [sig-cloud-provider]
+  reviewers: ['@andrewsykim', '@bowei', '@jhorwit2', '@jiatongw']
+  approvers: ['@andrewsykim', '@bowei', '@thockin']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-04-23"
+  last-updated: "2020-01-06"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1029-ephemeral-storage-quotas
+  title: Quotas for Ephemeral Storage
+  kep_number: "1029"
+  authors: ['@RobertKrawitz']
+  owning_sig: sig-node
+  participating-sigs: [sig-node]
+  reviewers: ['@dashpole', '@derekwaynecarr']
+  approvers: ['@dchen1107', '@derekwaynecarr']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2018-09-06"
+  last-updated: "2019-06-04"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1287-in-place-update-pod-resources
+  title: In-place Update of Pod Resources
+  kep_number: "1287"
+  authors: ['@kgolab', '@bskiba', '@schylek', '@vinaykul']
+  owning_sig: sig-node
+  participating-sigs: [sig-autoscaling, sig-scheduling]
+  reviewers: ['@bsalamat', '@dashpole', '@derekwaynecarr', '@dchen1107', '@ahg-g',
+      '@k82cn']
+  approvers: ['@dchen1107', '@derekwaynecarr', '@ahg-g', '@mwielgus']
+  prr-approvers: ['@ehashman']
+  creation-date: "2018-11-06"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - /keps/sig-node/2273-kubelet-container-resources-cri-api-changes
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.22
+      beta: v1.23
+      stable: v1.25
+  feature-gates:
+    - name: InPlacePodVerticalScaling
+      components:
+        - kube-apiserver
+        - kube-scheduler
+        - kubelet
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 135-seccomp
+  title: Seccomp to GA
+  kep_number: "135"
+  authors: ['@tallclair', '@pjbgf']
+  owning_sig: sig-node
+  participating-sigs: [sig-api-machinery, sig-auth]
+  reviewers: ['@liggitt', '@derekwaynecarr', '@dchen1107', '@mrunalp']
+  approvers: ['@liggitt', '@derekwaynecarr']
+  prr-approvers: []
+  editor: '@saschagrunert'
+  creation-date: "2019-07-17"
+  last-updated: ""
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1539-hugepages
+  title: HugePages
+  kep_number: "1539"
+  authors: ['@derekwaynecarr', '@sjenning', '@PiotrProkop']
+  owning_sig: sig-node
+  participating-sigs: [sig-scheduling]
+  reviewers: ['@vishnu']
+  approvers: ['@dawnchen']
+  prr-approvers: ['@ehashman']
+  editor: Derek Carr
+  creation-date: "2019-01-29"
+  last-updated: "2021-05-12"
+  status: implemented
+  stage: stable
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.18
+      beta: v1.19
+      stable: v1.22
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1547-building-kubelet-without-docker
+  title: Building a Dockerless Kubelet
+  kep_number: "1547"
+  authors: ['@mattjmcnaughton']
+  owning_sig: sig-node
+  participating-sigs: [sig-testing, sig-release, sig-cluster-lifecycle]
+  reviewers: ['@dims', '@BenTheElder', TBD]
+  approvers: ['@derekwaynecarr', '@dchen1107']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2020-02-05"
+  last-updated: "2020-05-11"
+  status: implemented
+  see-also:
+    - /keps/sig-cloud-provider/20190729-building-without-in-tree-providers.md
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1558-streaming-proxy-redirects
+  title: Cleaning up container streaming requests
+  kep_number: "1558"
+  authors: ['@tallclair']
+  owning_sig: sig-node
+  participating-sigs: [sig-api-machinery]
+  reviewers: ['@Random-Liu', '@yujuhong', '@mrunalp', '@derekwaynecarr']
+  approvers: ['@Random-Liu', '@derekwaynecarr']
+  prr-approvers: ['@johnbelamaric']
+  creation-date: "2019-12-05"
+  last-updated: "2021-05-11"
+  status: implementable
+  replaces:
+    - https://docs.google.com/document/d/1OE_QoInPlVCK9rMAx9aybRmgFiVjHpJCHI9LrfdNM_s/edit#heading=h.4yfjiw58o8d3
+  stage: stable
+  latest-milestone: "1.22"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 166-taint-based-eviction
+  title: Promote Taint Based Evictions to GA
+  kep_number: "166"
+  authors: ['@damemi']
+  owning_sig: sig-node
+  participating-sigs: [sig-scheduling]
+  reviewers: ['@Huang-Wei']
+  approvers: [sig-node, sig-cloud-provider]
+  prr-approvers: []
+  creation-date: "2020-01-14"
+  last-updated: "2020-03-23"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1769-memory-manager
+  title: Memory Manager
+  kep_number: "1769"
+  authors: ['@bg-chun', '@cezaryzukowski', '@cynepco3hahue']
+  owning_sig: sig-node
+  reviewers: ['@klueska', '@derekwaynecarr']
+  approvers: ['@derekwaynecarr']
+  prr-approvers: ['@deads2k']
+  creation-date: "2020-02-03"
+  last-updated: "2021-05-11"
+  status: implementable
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.21
+      beta: v1.22
+      stable: v1.23
+  feature-gates:
+    - name: MemoryManager
+      components:
+        - kubelet
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1797-configure-fqdn-as-hostname-for-pods
+  title: Configure FQDN as Hostname for Pods
+  kep_number: "1797"
+  authors: ['@javidiaz', '@clrkio', '@kochut']
+  owning_sig: sig-node
+  participating-sigs: [sig-network, sig-node]
+  reviewers: ['@thockin', '@marosset', '@dashpole', '@wojtek-t']
+  approvers: ['@dchen1107']
+  prr-approvers: ['@wojtek-t']
+  creation-date: "2020-05-18"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - N/A
+  replaces:
+    - N/A
+  stage: stable
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.19
+      beta: v1.20
+      stable: v1.22
+  feature-gates:
+    - name: setHostnameAsFQDN
+      components:
+        - kubelet
+        - kube-apiserver
+  disable-supported: true
+  metrics:
+    - run_podsandbox_errors_total
+- id: ""
+  prnumber: ""
+  name: 1867-disable-accelerator-usage-metrics
+  title: Disable AcceleratorUsage Metrics
+  kep_number: "1867"
+  authors: ['@RenaudWasTaken']
+  owning_sig: sig-node
+  reviewers: [dashpole, derekwaynecarr, dawnchen]
+  approvers: [dashpole, derekwaynecarr, dawnchen]
+  prr-approvers: [deads2k, johnbelamaric, wojtek-t]
+  creation-date: "2020-06-18"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - /keps/sig-node/606-compute-device-assignment
+  stage: beta
+  latest-milestone: v1.20
+  milestone:
+      alpha: v1.19
+      beta: v1.20
+      stable: v1.22
+  feature-gates:
+    - name: DisableAcceleratorUsageMetrics
+      components:
+        - kubelet
+  disable-supported: true
+  metrics:
+    - N/A
+- id: ""
+  prnumber: ""
+  name: 1898-hardened-exec
+  title: Hardening exec endpoints against SSRF
+  kep_number: "1898"
+  authors: ['@tallclair']
+  owning_sig: sig-node
+  participating-sigs: [sig-api-machinery, sig-auth]
+  reviewers: [derekwaynecarr, liggitt, sftim]
+  approvers: [derekwaynecarr, liggitt]
+  prr-approvers: [deads2k]
+  creation-date: "2020-07-08"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - /keps/sig-node/20191205-container-streaming-requests.md
+  stage: alpha
+  latest-milestone: v1.20
+  milestone:
+      alpha: v1.20
+      beta: ""
+      stable: ""
+  feature-gates:
+    - name: HardenedExecRequests
+      components:
+        - kube-apiserver
+    - name: DeprecatedKubeletStreamingAPI
+      components:
+        - kubelet
+  disable-supported: true
+  metrics:
+    - TBD
+- id: ""
+  prnumber: ""
+  name: 1967-size-memory-backed-volumes
+  title: Size memory backed volumes
+  kep_number: "1967"
+  authors: ['@derekwaynecarr']
+  owning_sig: sig-node
+  participating-sigs: [sig-storage]
+  reviewers: ['@dashpole']
+  approvers: ['@dashpole']
+  prr-approvers: [johnbelamaric, '@johnbelamaric']
+  creation-date: "2020-09-03"
+  last-updated: ""
+  status: implementable
+  stage: beta
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.20
+      beta: v1.22
+      stable: v1.23
+  feature-gates:
+    - name: SizeMemoryBackedVolumes
+      components:
+        - kubelet
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1972-kubelet-exec-probe-timeouts
+  title: Kubelet Exec Probe Timeouts
+  kep_number: "1972"
+  authors: ['@andrewsykim', '@SergeyKanzhelev']
+  owning_sig: sig-node
+  reviewers: ['@dchen1107', '@derekwaynecarr']
+  approvers: ['@dchen1107', '@derekwaynecarr']
+  prr-approvers: []
+  creation-date: "2020-09-08"
+  last-updated: ""
+  status: implemented
+  stage: stable
+  latest-milestone: v1.20
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: v1.20
+  feature-gates:
+    - name: ExecProbeTimeouts
+      components:
+        - kubelet
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2000-graceful-node-shutdown
+  title: Graceful Node Shutdown
+  kep_number: "2000"
+  authors: [bobbypage, mrunalp]
+  owning_sig: sig-node
+  reviewers: ['@SergeyKanzhelev', '@karan']
+  approvers: ['@dchen1107', '@derekwaynecarr']
+  prr-approvers: ['@johnbelamaric']
+  creation-date: "2020-09-21"
+  last-updated: ""
+  status: implementable
+  stage: beta
+  latest-milestone: v1.21
+  milestone:
+      alpha: v1.20
+      beta: v1.21
+      stable: ""
+  feature-gates:
+    - name: GracefulNodeShutdown
+      components:
+        - kubelet
+  disable-supported: true
+  metrics:
+    - N/A
+- id: ""
+  prnumber: ""
+  name: 2033-kubelet-in-userns-aka-rootless
+  title: Rootless mode
+  kep_number: "2033"
+  authors: ['@AkihiroSuda']
+  owning_sig: sig-node
+  reviewers: ['@derekwaynecarr', '@dchen1107', '@mattjmcnaughton', '@giuseppe', '@ehashman',
+      '@mrunalp', '@dims', '@sftim']
+  approvers: [TBD]
+  prr-approvers: ['@ehashman']
+  creation-date: "2019-06-04"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - https://github.com/kubernetes/enhancements/pull/1370
+  replaces:
+    - https://github.com/kubernetes/enhancements/pull/1084
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.22
+      beta: ""
+      stable: ""
+  feature-gates:
+    - name: KubeletInUserNamespace
+      components:
+        - kubelet
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2040-kubelet-cri
+  title: Kubelet CRI support
+  kep_number: "2040"
+  authors: ['@mrunalp', '@mikebrow']
+  owning_sig: sig-node
+  reviewers: ['@derekwaynecarr', '@dchen1107']
+  approvers: ['@derekwaynecarr', '@dchen1107']
+  prr-approvers: ['@deads2k']
+  creation-date: "2020-09-30"
+  last-updated: ""
+  status: implementable
+  stage: beta
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.5
+      beta: v1.22
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics:
+    - N/A
+- id: ""
+  prnumber: ""
+  name: 2043-pod-resource-concrete-assigments
+  title: Kubelet endpoint for pod resource assignment
+  kep_number: "1884"
+  authors: ['@dashpole', '@vikaschoudhary16', '@renaudwastaken', '@fromanirh', '@alexeyperevalov']
+  owning_sig: sig-node
+  reviewers: ['@derekwaynecarr', '@renaudwastaken', '@dashpole']
+  approvers: ['@sig-node-leads']
+  prr-approvers: []
+  creation-date: "2018-07-19"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - keps/sig-node/606-compute-device-assignment/
+  stage: stable
+  latest-milestone: "0.0"
+  milestone:
+      alpha: v1.13
+      beta: v1.15
+      stable: v1.21
+  feature-gates:
+    - name: KubeletPodResources
+      components:
+        - kubelet
+  disable-supported: false
+  metrics:
+    - pod_resources_endpoint_requests_total
+- id: ""
+  prnumber: ""
+  name: 2053-downward-api-hugepages
+  title: Downward API HugePages
+  kep_number: "2053"
+  authors: ['@derekwaynecarr']
+  owning_sig: sig-node
+  reviewers: ['@dashpole', '@sjenning']
+  approvers: ['@dashpole', '@sjenning', '@dchen1107']
+  prr-approvers: [deads2k, johnbelamaric, wojtek-t, '@johnbelamaric']
+  creation-date: "2020-06-18"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - /keps/sig-node/20190129-hugepages.md
+  stage: beta
+  latest-milestone: v1.21
+  milestone:
+      alpha: v1.20
+      beta: v1.21
+      stable: v1.22
+  feature-gates:
+    - name: DownwardAPIHugePages
+      components:
+        - kube-apiserver
+  disable-supported: true
+  metrics:
+    - N/A
+- id: ""
+  prnumber: ""
+  name: 2129-remove-cadvisor-json-metrics
+  title: Disable cAdvisor json Metrics
+  kep_number: "2129"
+  authors: ['@dashpole']
+  owning_sig: sig-node
+  participating-sigs: [sig-instrumentation]
+  reviewers: [derekwaynecarr, dawnchen]
+  approvers: [derekwaynecarr, dawnchen]
+  prr-approvers: ['@johnbelamaric']
+  creation-date: "2020-10-04"
+  last-updated: ""
+  status: implementable
+  stage: stable
+  latest-milestone: v1.21
+  milestone:
+      alpha: v1.21
+      beta: v1.21
+      stable: v1.21
+  feature-gates: []
+  disable-supported: false
+  metrics:
+    - N/A
+- id: ""
+  prnumber: ""
+  name: 213-run-as-group
+  title: RunAsGroup support in PodSpec and PodSecurityPolicy
+  kep_number: "213"
+  authors: ['@krmayankk']
+  owning_sig: sig-node
+  participating-sigs: [sig-auth]
+  reviewers: ['@tallclair', '@mrunalp']
+  approvers: ['@liggitt', '@derekwaynecarr']
+  prr-approvers: ['@johnbelamaric']
+  editor: TBD
+  creation-date: "2017-06-21"
+  last-updated: "2021-02-04"
+  status: implementable
+  stage: stable
+  latest-milestone: v1.21
+  milestone:
+      alpha: v1.10
+      beta: v1.14
+      stable: v1.21
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2133-kubelet-credential-providers
+  title: Kubelet Credential Providers
+  kep_number: "2133"
+  authors: ['@andrewsykim']
+  owning_sig: sig-node
+  participating-sigs: [sig-auth, sig-cloud-provider]
+  reviewers: ['@cheftako', '@liggitt', '@derekwaynecarr']
+  approvers: ['@cheftako', '@liggitt', '@derekwaynecarr']
+  prr-approvers: ['@deads2k']
+  creation-date: "2020-11-12"
+  last-updated: ""
+  status: implementable
+  replaces:
+    - /keps/sig-cloud-provider/20191004-out-of-tree-credential-providers.md
+  stage: beta
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.20
+      beta: v1.22
+      stable: v1.24
+  feature-gates:
+    - name: KubeletCredentialProviders
+      components:
+        - kubelet
+  disable-supported: true
+  metrics:
+    - kubelet_credential_provider_plugin_errors
+    - kubelet_credential_provider_plugin_duration
+- id: ""
+  prnumber: ""
+  name: 2221-remove-dockershim
+  title: Removing dockershim from kubelet
+  kep_number: "2221"
+  authors: ['@resouer', '@dims']
+  owning_sig: sig-node
+  reviewers: ['@yujuhong', '@dchen1107', '@derekwaynecarr', '@dashpole', '@sjennning']
+  approvers: ['@dchen1107', '@derekwaynecarr']
+  prr-approvers: [johnbelamaric]
+  creation-date: "2020-09-14"
+  last-updated: ""
+  status: implementable
+  stage: alpha
+  latest-milestone: v1.20
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2238-liveness-probe-grace-period
+  title: Liveness Probe Grace Period
+  kep_number: "2238"
+  authors: ['@ehashman']
+  owning_sig: sig-node
+  participating-sigs: [sig-node]
+  reviewers: ['@matthyx', '@dims', '@derekwaynecarr', '@smarterclayton']
+  approvers: ['@derekwaynecarr']
+  prr-approvers: ['@johnbelamaric']
+  creation-date: "2021-01-07"
+  last-updated: ""
+  status: implementable
+  stage: beta
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.21
+      beta: v1.22
+      stable: v1.25
+  feature-gates:
+    - name: ProbeTerminationGracePeriod
+      components:
+        - kube-apiserver
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2254-cgroup-v2
+  title: cgroups v2
+  kep_number: "2254"
+  authors: ['@giuseppe']
+  owning_sig: sig-node
+  participating-sigs: [sig-architecture]
+  reviewers: ['@yujuhong', '@dchen1107', '@derekwaynecarr']
+  approvers: ['@yujuhong', '@dchen1107', '@derekwaynecarr']
+  prr-approvers: ['@johnbelamaric']
+  editor: Giuseppe Scrivano
+  creation-date: "2019-11-18"
+  last-updated: "2019-11-18"
+  status: implementable
+  stage: beta
+  latest-milestone: v1.22
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2273-kubelet-container-resources-cri-api-changes
+  title: Container Resources CRI API Changes for Pod Vertical Scaling
+  kep_number: "2273"
+  authors: ['@vinaykul', '@quinton-hoole']
+  owning_sig: sig-node
+  reviewers: ['@Random-Liu', '@yujuhong', '@PatrickLang']
+  approvers: ['@dchen1107', '@derekwaynecarr']
+  prr-approvers: ['@ehashman']
+  creation-date: "2019-10-25"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - /keps/sig-node/1287-in-place-update-pod-resources
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.22
+      beta: v1.23
+      stable: v1.25
+  feature-gates:
+    - name: InPlacePodVerticalScaling
+      components:
+        - kubelet
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2371-cri-pod-container-stats
+  title: cAdvisor-less, CRI-full Container and Pod Stats
+  kep_number: "2371"
+  authors: ['@haircommander', '@bobbypage']
+  owning_sig: sig-node
+  reviewers: ['@derekwaynecarr', '@mrunalp', '@ehashman', '@marosset', TODO containerd
+          reviewer]
+  approvers: ['@dchen1107']
+  prr-approvers: ['@ehashman']
+  editor: TBD
+  creation-date: "2021-01-27"
+  last-updated: "2021-05-12"
+  status: implementable
+  see-also:
+    - TODO
+  replaces:
+    - TODO/N/A?
+  superseded-by:
+    - N/A
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2400-node-swap
+  title: Node system swap support
+  kep_number: "2400"
+  authors: ['@ehashman', '@ike-ma']
+  owning_sig: sig-node
+  participating-sigs: [sig-node]
+  reviewers: ['@SergeyKanzhelev', '@anguslees', '@deads2k', '@sftim']
+  approvers: ['@derekwaynecarr', '@dchen1107']
+  prr-approvers: ['@deads2k']
+  creation-date: "2021-04-06"
+  last-updated: ""
+  status: implementable
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.22
+      beta: v1.23
+      stable: v1.24
+  feature-gates:
+    - name: NodeSwapEnabled
+      components:
+        - kube-apiserver
+        - kubelet
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2403-pod-resources-allocatable-resources
+  title: Extend kubelet pod resource assignment endpoint to return allocatable resources
+  kep_number: "2403"
+  authors: ['@fromanirh', '@alexeyperevalov']
+  owning_sig: sig-node
+  reviewers: ['@derekwaynecarr', '@renaudwastaken']
+  approvers: ['@sig-node-leads']
+  prr-approvers: ['@johnbelamaric']
+  creation-date: "2021-02-02"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - keps/sig-node/606-compute-device-assignment/
+    - keps/sig-node/2043-pod-resource-concrete-assigments/
+  stage: alpha
+  latest-milestone: v1.21
+  milestone:
+      alpha: v1.21
+      beta: v1.22
+      stable: v1.23
+  feature-gates:
+    - name: KubeletPodResourcesGetAllocatable
+      components:
+        - kubelet
+  disable-supported: false
+  metrics:
+    - pod_resources_endpoint_requests_total
+    - pod_resources_endpoint_requests_list
+    - pod_resources_endpoint_requests_get_allocatable
+    - pod_resources_endpoint_errors_list
+    - pod_resources_endpoint_errors_get_allocatable
+- id: ""
+  prnumber: ""
+  name: 2411-cri-container-log-rotation
+  title: CRI Container Log Rotation
+  kep_number: "2411"
+  authors: ['@umohnani8']
+  owning_sig: sig-node
+  participating-sigs: [sig-instrumentation, sig-storage]
+  reviewers: ['@mrunalp', '@SergeyKanzhelev']
+  approvers: ['@mrunalp', '@derekwaynecarr']
+  prr-approvers: ['@deads2k']
+  creation-date: "2018-01-25"
+  last-updated: ""
+  status: implemented
+  stage: stable
+  latest-milestone: v1.21
+  milestone:
+      alpha: v1.10
+      beta: v1.11
+      stable: v1.21
+  feature-gates:
+    - name: CRIContainerLogRotation
+      components:
+        - kubelet
+  disable-supported: true
+  metrics:
+    - N/A
+- id: ""
+  prnumber: ""
+  name: 2413-seccomp-by-default
+  title: Seccomp by default
+  kep_number: "2413"
+  authors: ['@mrunalp', '@saschagrunert']
+  owning_sig: sig-node
+  participating-sigs: [sig-security]
+  reviewers: ['@mrunalp', '@tallclair']
+  approvers: ['@mrunalp']
+  prr-approvers: ['@deads2k']
+  creation-date: "2021-02-03"
+  last-updated: ""
+  status: implementable
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.22
+      beta: v1.23
+      stable: v1.26
+  feature-gates:
+    - name: SeccompDefault
+      components:
+        - kubelet
+  disable-supported: true
+  metrics:
+    - N/A
+- id: ""
+  prnumber: ""
+  name: 2570-memory-qos
+  title: Memory QoS
+  kep_number: "2570"
+  authors: ['@xiaoxubeii']
+  owning_sig: sig-node
+  reviewers: ['@derekwaynecarr', '@bobbypage', '@mrunalp', '@giuseppe']
+  approvers: ['@derekwaynecarr']
+  prr-approvers: ['@johnbelamaric']
+  editor: TBD
+  creation-date: "2021-03-14"
+  last-updated: ""
+  status: implementable
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.22
+      beta: ""
+      stable: ""
+  feature-gates:
+    - name: MemoryQoS
+      components:
+        - kubelet
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2625-cpumanager-policies-thread-placement
+  title: SMT aware cpumanager policy
+  kep_number: "2625"
+  authors: ['@fromanirh', '@swatisehgal']
+  owning_sig: sig-node
+  reviewers: ['@klueska']
+  approvers: ['@sig-node-leads']
+  prr-approvers: ['@johnbelamaric']
+  creation-date: "2021-04-14"
+  last-updated: ""
+  status: implementable
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.22
+      beta: v1.23
+      stable: v1.25
+  feature-gates:
+    - name: CPUManagerPolicyOptions
+      components:
+        - kubelet
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2712-pod-priority-based-graceful-node-shutdown
+  title: Pod Priority Based Graceful Node Shutdown
+  kep_number: "2712"
+  authors: [mrunalp, bobbypage]
+  owning_sig: sig-node
+  reviewers: ['@derekwaynecarr', '@SergeyKanzhelev']
+  approvers: ['@derekwaynecarr']
+  prr-approvers: ['@deads2k']
+  creation-date: "2021-05-11"
+  last-updated: ""
+  status: implementable
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.22
+      beta: ""
+      stable: ""
+  feature-gates:
+    - name: PodPriorityBasedGracefulNodeShutdown
+      components:
+        - kubelet
+  disable-supported: true
+  metrics:
+    - N/A
+- id: ""
+  prnumber: ""
+  name: 2727-grpc-probe
+  title: Add gRPC probe to Pod.Spec.Container.{Liveness,Readiness,Startup}Probe
+  kep_number: "2727"
+  authors: ['@bowei', '@PxyUp']
+  owning_sig: sig-node
+  participating-sigs: [sig-node, sig-network]
+  reviewers: ['@thockin', '@mrunalp', '@SergeyKanzhelev']
+  approvers: ['@thockin']
+  prr-approvers: ['@johnbelarmic', '@johnbelamaric']
+  creation-date: "2020-04-04"
+  last-updated: ""
+  status: implementable
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 277-ephemeral-containers
+  title: Ephemeral Containers
+  kep_number: "277"
+  authors: ['@verb']
+  owning_sig: sig-node
+  participating-sigs: [sig-auth, sig-node]
+  reviewers: ['@yujuhong']
+  approvers: ['@dchen1107', '@liggitt']
+  prr-approvers: ['@johnbelamaric']
+  creation-date: "2019-02-12"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - /keps/sig-cli/1441-kubectl-debug
+  stage: beta
+  latest-milestone: v1.21
+  milestone:
+      alpha: v1.16
+      beta: v1.21
+      stable: v1.23
+  feature-gates:
+    - name: EphemeralContainers
+      components:
+        - kube-apiserver
+        - kubelet
+  disable-supported: true
+  metrics:
+    - kubelet_container_errors_total
+- id: ""
+  prnumber: ""
+  name: 281-dynamic-kubelet-configuration
+  title: Dynamic Kubelet Configuration
+  kep_number: "281"
+  authors: ['@mtaufen']
+  owning_sig: sig-node
+  reviewers: ['@lavalamp', '@liggitt', '@thockin', '@dchen1107', '@alejandroEsc']
+  approvers: ['@dchen1107', '@derekwaynecarr']
+  prr-approvers: ['@johnbelamaric']
+  creation-date: "2017-04-26"
+  last-updated: ""
+  status: implemented (beta)
+  stage: beta (deprecated)
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.8
+      beta: v1.11
+      stable: never
+  feature-gates: []
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 34-sysctl-fields
+  title: Protomote sysctl annotations to fields
+  kep_number: "34"
+  authors: ['@ingvagabund']
+  owning_sig: sig-node
+  participating-sigs: [sig-node, sig-auth]
+  reviewers: ['@sjenning', '@derekwaynecarr']
+  approvers: ['@derekwaynecarr']
+  prr-approvers: ['@johnbelamaric']
+  creation-date: "2018-04-30"
+  last-updated: "2021-04-08"
+  status: implemented
+  stage: stable
+  latest-milestone: v1.21
+  milestone:
+      alpha: v1.4
+      beta: v1.11
+      stable: v1.21
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 375-cpu-manager
+  title: CPU Manager
+  kep_number: "375"
+  authors: ['@ConnorDoyle', '@flyingcougar', '@sjenning']
+  owning_sig: sig-node
+  participating-sigs: [sig-node]
+  reviewers: ['@derekwaynecarr']
+  approvers: ['@dawnchen', '@derekwaynecarr']
+  prr-approvers: []
+  editor: Connor Doyle
+  creation-date: "2017-05-23"
+  last-updated: "2017-05-23"
+  status: implementable
+  replaces:
+    - ' kubernetes/community/contributors/design-proposals/node/cpu-manager.md'
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 495-pod-pid-namespace
+  title: Shared PID Namespace
+  kep_number: "495"
+  authors: ['@verb']
+  owning_sig: sig-node
+  participating-sigs: [sig-node]
+  reviewers: ['@yujuhong']
+  approvers: ['@dchen1107']
+  prr-approvers: []
+  editor: N/A
+  creation-date: "2016-12-21"
+  last-updated: "2019-09-30"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 585-runtime-class
+  title: Runtime Class
+  kep_number: "585"
+  authors: ['@tallclair']
+  owning_sig: sig-node
+  participating-sigs: [sig-architecture]
+  reviewers: ['@dchen1107', '@derekwaynecarr', '@yujuhong']
+  approvers: ['@dchen1107', '@derekwaynecarr']
+  prr-approvers: []
+  creation-date: "2018-06-19"
+  last-updated: ""
+  status: implemented
+  stage: stable
+  latest-milestone: v1.20
+  milestone:
+      alpha: v1.12
+      beta: v1.14
+      stable: v1.20
+  feature-gates:
+    - name: RuntimeClass
+      components:
+        - kubelet
+  disable-supported: false
+  metrics:
+    - RunPodSandboxErrors
+    - RunPodSandboxDuration
+- id: ""
+  prnumber: ""
+  name: 589-efficient-node-heartbeats
+  title: Efficient Node Heartbeat
+  kep_number: "589"
+  authors: ['@wojtek-t', 'with input from @bgrant0607, @dchen1107, @yujuhong, @lavalamp']
+  owning_sig: sig-node
+  participating-sigs: [sig-scalability, sig-api-machinery, sig-scheduling]
+  reviewers: ['@deads2k', '@lavalamp']
+  approvers: ['@dchen1107', '@derekwaynecarr']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2018-04-27"
+  last-updated: "2018-04-27"
+  status: implemented
+  see-also:
+    - https://github.com/kubernetes/kubernetes/issues/14733
+    - https://github.com/kubernetes/kubernetes/pull/14735
+  replaces:
+    - n/a
+  superseded-by:
+    - n/a
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 606-compute-device-assignment
+  title: Kubelet endpoint for device assignment observation details
+  kep_number: "606"
+  authors: ['@dashpole', '@vikaschoudhary16', '@renaudwastaken']
+  owning_sig: sig-node
+  reviewers: ['@thockin', '@derekwaynecarr', '@dchen1107', '@vishh']
+  approvers: ['@sig-node-leads']
+  prr-approvers: []
+  creation-date: "2018-07-19"
+  last-updated: ""
+  status: implemented
+  stage: stable
+  latest-milestone: v1.20
+  milestone:
+      alpha: v1.13
+      beta: v1.15
+      stable: v1.20
+  feature-gates:
+    - name: KubeletPodResources
+      components:
+        - kubelet
+        - kube-controller-manager
+  disable-supported: false
+  metrics:
+    - pod_resources_endpoint_requests_total
+- id: ""
+  prnumber: ""
+  name: 688-pod-overhead
+  title: Pod Overhead
+  kep_number: "688"
+  authors: ['@egernst']
+  owning_sig: sig-node
+  participating-sigs: [sig-scheduling, sig-autoscaling, sig-windows]
+  reviewers: ['@tallclair', '@derekwaynecarr', '@dchen1107']
+  approvers: ['@dchen1107', '@derekwaynecarr']
+  prr-approvers: []
+  editor: Eric Ernst
+  creation-date: "2019-02-26"
+  last-updated: "2020-10-27"
+  status: implemented (beta)
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 693-topology-manager
+  title: Node Topology Manager
+  kep_number: "693"
+  authors: ['@ConnorDoyle', '@balajismaniam', '@lmdaly']
+  owning_sig: sig-node
+  participating-sigs: [sig-node]
+  reviewers: ['@vikasc', '@derekwaynecarr', '@jeremyeder', '@RenaudWasTaken', '@klueska',
+      '@nolancon']
+  approvers: ['@dawnchen', '@derekwaynecarr']
+  prr-approvers: []
+  editor: Louise Daly
+  creation-date: "2019-01-30"
+  last-updated: "2019-01-30"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 727-resource-metrics-endpoint
+  title: Kubelet Resource Metrics Endpoint
+  kep_number: "727"
+  authors: ['@dashpole']
+  owning_sig: sig-node
+  participating-sigs: [sig-instrumentation]
+  reviewers: [DirectXMan12, tallclair]
+  approvers: [dchen1107, brancz]
+  prr-approvers: []
+  creation-date: "2019-01-24"
+  last-updated: "2019-02-21"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 753-sidecar-containers
+  title: Sidecar Containers
+  kep_number: "753"
+  authors: ['@joseph-irving', '@rata']
+  owning_sig: sig-apps
+  participating-sigs: [sig-apps, sig-node]
+  reviewers: ['@fejta', '@sjenning', '@SergeyKanzhelev']
+  approvers: ['@enisoc', '@kow3ns', '@derekwaynecarr', '@dchen1107']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2018-05-14"
+  last-updated: "2020-06-24"
+  status: provisional
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 757-pid-limiting
+  title: Pid Limiting
+  kep_number: "757"
+  authors: ['@derekwaynecarr', '@dims']
+  owning_sig: sig-node
+  reviewers: ['@dashpole']
+  approvers: ['@dashpole', '@dchen1107']
+  prr-approvers: []
+  editor: Derek Carr
+  creation-date: "2019-01-29"
+  last-updated: "2019-03-05"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 793-node-os-arch-labels
+  title: Promote Node Operating System & Architecture labels to GA
+  kep_number: "793"
+  authors: ['@yujuhong']
+  owning_sig: sig-node
+  participating-sigs: [sig-node]
+  reviewers: ['@liggitt']
+  approvers: ['@dchen1107']
+  prr-approvers: []
+  editor: Yu-Ju Hong
+  creation-date: "2019-01-30"
+  last-updated: "2019-01-30"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 950-liveness-probe-holdoff
+  title: Add pod-startup liveness-probe holdoff for slow-starting pods
+  kep_number: "950"
+  authors: ['@matthyx']
+  owning_sig: sig-node
+  participating-sigs: [sig-apps, sig-architecture]
+  reviewers: ['@thockin']
+  approvers: ['@derekwaynecarr', '@thockin']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-02-21"
+  last-updated: "2020-09-16"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 0000-anago-to-krel-migration
+  title: Anago to Krel Migration
+  kep_number: "0000"
+  authors: ['@saschagrunert']
+  owning_sig: sig-release
+  reviewers: ['@justaugustus']
+  approvers: ['@justaugustus']
+  prr-approvers: []
+  creation-date: "2020-09-22"
+  last-updated: ""
+  status: implemented
+  stage: ""
+  latest-milestone: v1.20
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1498-kubernetes-yearly-support-period
+  title: Kubernetes Yearly Support Period
+  kep_number: "1498"
+  authors: ['@imkin', '@liggitt', '@tpepper', '@jberkus', '@youngnick']
+  owning_sig: sig-release
+  participating-sigs: [sig-architecture, sig-testing, sig-release, sig-api-machinery,
+      sig-node, sig-cli]
+  reviewers: ['@quinton_hoole']
+  approvers: ['@justaugustus', '@spiffxp', '@bgrant', '@deads2k', '@dchen1107', '@pwittrock']
+  prr-approvers: []
+  creation-date: "2020-01-22"
+  last-updated: ""
+  status: implemented
+  stage: ""
+  latest-milestone: v1.19
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1729-rebase-images-to-distroless
+  title: Rebase Kubernetes Main Master and Node Images to Distroless/static
+  kep_number: "1729"
+  authors: ['@yuwenma']
+  owning_sig: sig-release
+  participating-sigs: [sig-release, sig-cloud-provider]
+  reviewers: ['@tallclair']
+  approvers: ['@tallclair']
+  prr-approvers: []
+  editor: yuwenma
+  creation-date: "2019-03-16"
+  last-updated: "2019-03-21"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1731-publishing-packages
+  title: Publishing kubernetes packages
+  kep_number: "1731"
+  authors: ['@hoegaarden']
+  owning_sig: sig-release
+  participating-sigs: [sig-cluster-lifecycle]
+  reviewers: ['@timothysc', '@sumitranr', '@Klaven', '@ncdc', '@ixdy', “@neolit123”]
+  approvers: ['@spiffxp', '@tpepper']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-02-19"
+  last-updated: "2019-02-27"
+  status: provisional
+  see-also:
+    - https://github.com/kubernetes/enhancements/pull/858
+    - /keps/sig-release/20190121-artifact-management.md
+    - /keps/sig-release/k8s-image-promoter.md
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1732-artifact-management
+  title: Kubernetes Community Artifact Serving
+  kep_number: "1732"
+  authors: ['@brendandburns']
+  owning_sig: sig-release
+  participating-sigs: [sig-architecture, sig-contributor-experience, sig-testing]
+  reviewers: ['@justinsb', '@dims']
+  approvers: ['@dims']
+  prr-approvers: []
+  editor: '@brendandburns'
+  creation-date: "2019-01-23"
+  last-updated: "2019-01-31"
+  status: provisional
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1733-release-notes
+  title: Release Notes Improvements
+  kep_number: "1733"
+  authors: ['@jeefy', '@saschagrunert']
+  owning_sig: sig-release
+  participating-sigs: [sig-contributor-experience, sig-docs]
+  reviewers: ['@spiffxp', '@marpaia']
+  approvers: ['@calebamiles', '@tpepper', '@justaugustus']
+  prr-approvers: []
+  editor: '@saschagrunert'
+  creation-date: "2019-03-31"
+  last-updated: "2021-01-12"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1734-k8s-image-promoter
+  title: Image Promoter
+  kep_number: "1734"
+  authors: ['@javier-b-perez']
+  owning_sig: sig-release
+  participating-sigs: [wg-k8s-infra]
+  reviewers: ['@AishSundar', '@BenTheElder', '@dims', '@listx']
+  approvers: ['@thockin']
+  prr-approvers: []
+  creation-date: "2018-09-05"
+  last-updated: "2018-11-14"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2572-release-cadence
+  title: Defining the Kubernetes Release Cadence
+  kep_number: "2572"
+  authors: ['@kikisdeliveryservice', '@jeremyrickard', '@jberkus', '@justaugustus',
+      '@LappleApple', '@saschagrunert']
+  owning_sig: sig-release
+  participating-sigs: [sig-architecture, sig-testing]
+  reviewers: ['@ehashman', '@hasheddan']
+  approvers: ['@BenTheElder', '@derekwaynecarr', '@dims', '@johnbelamaric', '@LappleApple',
+      '@saschagrunert', '@spiffxp', '@stevekuznetsov']
+  prr-approvers: ['@johnbelamaric']
+  creation-date: "2021-01-21"
+  last-updated: ""
+  status: implementable
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.22
+      beta: v1.23
+      stable: v1.26
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1258-default-pod-topology-spread
+  title: Default Pod Topology Spread
+  kep_number: "1258"
+  authors: ['@alculquicondor']
+  owning_sig: sig-scheduling
+  reviewers: ['@ahg-g', '@Huang-Wei']
+  approvers: ['@ahg-g', '@Huang-Wei']
+  prr-approvers: ['@wojtek-t']
+  creation-date: "2019-09-26"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - /keps/sig-scheduling/895-pod-topology-spread
+  stage: beta
+  latest-milestone: v1.20
+  milestone:
+      alpha: v1.19
+      beta: v1.20
+      stable: v1.22
+  feature-gates:
+    - name: DefaultPodTopologySpread
+      components:
+        - kube-scheduler
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1451-multi-scheduling-profiles
+  title: Multi Scheduling Profiles
+  kep_number: "1451"
+  authors: ['@alculquicondor', '@ahg-g']
+  owning_sig: sig-scheduling
+  reviewers: ['@Huang-Wei', '@liggitt']
+  approvers: ['@Huang-Wei']
+  prr-approvers: ['@wojtek-t']
+  creation-date: "2020-01-14"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - /keps/sig-scheduling/20180409-scheduling-framework.md
+    - /keps/sig-scheduling/20190226-default-even-pod-spreading.md
+    - /keps/sig-scheduling/785-scheduler-component-config-api
+  stage: beta
+  latest-milestone: v1.19
+  milestone:
+      alpha: v1.18
+      beta: v1.19
+      stable: v1.22
+  feature-gates: []
+  disable-supported: false
+  metrics:
+    - schedule_attempts_total
+    - e2e_scheduling_duration_seconds
+    - scheduling_algorithm_duration_seconds
+    - scheduling_algorithm_preemption_evaluation_seconds
+    - binding_duration_seconds
+- id: ""
+  prnumber: ""
+  name: 1819-scheduler-extender
+  title: Scheduler Extender
+  kep_number: "1819"
+  authors: ['@ravigadde']
+  owning_sig: sig-scheduling
+  reviewers: ['@ahg-g', '@Huang-Wei']
+  approvers: ['@ahg-g', '@Huang-Wei']
+  prr-approvers: ['@wojtek-t']
+  creation-date: "2020-05-28"
+  last-updated: ""
+  status: implemented
+  replaces:
+    - https://github.com/cofyc/community/blob/master/contributors/design-proposals/scheduling/scheduler_extender.md
+  stage: stable
+  latest-milestone: v1.19
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1923-prefer-nominated-node
+  title: Prefer Nominated Node
+  kep_number: "1923"
+  authors: ['@chendave']
+  owning_sig: sig-scheduling
+  participating-sigs: [sig-scheduling]
+  reviewers: ['@alculquicondor', '@Huang-Wei', '@ahg-g']
+  approvers: ['@Huang-Wei', '@ahg-g']
+  prr-approvers: ['@wojtek-t']
+  creation-date: "2020-09-29"
+  last-updated: ""
+  status: implementable
+  stage: beta
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.21
+      beta: v1.22
+      stable: v1.24
+  feature-gates:
+    - name: PreferNominatedNode
+      components:
+        - kube-scheduler
+  disable-supported: true
+  metrics:
+    - scheduler_framework_extension_point_duration_seconds{extension_point="Filter"}
+- id: ""
+  prnumber: ""
+  name: 2249-pod-affinity-namespace-selector
+  title: Namespace Selector for Pod Affinity
+  kep_number: "2249"
+  authors: ['@ahg-g']
+  owning_sig: sig-scheduling
+  participating-sigs: [sig-auth]
+  reviewers: ['@alculquicondor', '@Huang-Wei', '@liggitt']
+  approvers: ['@Huang-Wei', '@liggitt']
+  prr-approvers: ['@wojtek-t']
+  creation-date: "2021-01-11"
+  last-updated: ""
+  status: implementable
+  stage: beta
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.21
+      beta: v1.22
+      stable: v1.24
+  feature-gates:
+    - name: PodAffinityNamespaceSelector
+      components:
+        - kube-apiserver
+        - kube-scheduler
+  disable-supported: true
+  metrics:
+    - schedule_attempts_total{result="error|unschedulable"}
+    - plugin_execution_duration_seconds{plugin="InterPodAffinity"}
+- id: ""
+  prnumber: ""
+  name: 2372-node-labels-quota
+  title: Resource Quota based on Node Labels
+  kep_number: "2372"
+  authors: ['@vishh', '@bsalamat']
+  owning_sig: sig-scheduling
+  participating-sigs: [sig-architecture]
+  reviewers: ['@derekwaynecarr', '@davidopp']
+  approvers: [TBD]
+  prr-approvers: []
+  creation-date: "2019-10-11"
+  last-updated: ""
+  status: provisional
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2458-node-resource-score-strategy
+  title: Preferred Fit Strategy
+  kep_number: "2458"
+  authors: ['@ahg-g']
+  owning_sig: sig-scheduling
+  reviewers: ['@alculquicondor', '@Huang-Wei']
+  approvers: ['@Huang-Wei']
+  prr-approvers: ['@wojtek-t']
+  creation-date: "2021-02-08"
+  last-updated: ""
+  status: implementable
+  stage: beta
+  latest-milestone: v1.22
+  milestone:
+      alpha: ""
+      beta: v1.22
+      stable: v1.24
+  feature-gates: []
+  disable-supported: false
+  metrics:
+    - TBD
+- id: ""
+  prnumber: ""
+  name: 268-priority-preemption
+  title: Promote Pod Priority and Preemption to GA
+  kep_number: "268"
+  authors: ['@bsalamat']
+  owning_sig: sig-scheduling
+  participating-sigs: [sig-scheduling]
+  reviewers: ['@k82cn']
+  approvers: ['@liggitt']
+  prr-approvers: []
+  editor: Babak Salamat
+  creation-date: "2019-01-31"
+  last-updated: "2019-01-31"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 382-taint-node-by-condition
+  title: Graduate TaintNodeByCondition to GA
+  kep_number: "382"
+  authors: ['@draveness']
+  owning_sig: sig-scheduling
+  participating-sigs: [sig-node]
+  reviewers: [TBD, '@k82cn']
+  approvers: [TBD, '@k82cn']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-10-12"
+  last-updated: "2019-10-12"
+  status: implemented
+  see-also:
+    - https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/taint-node-by-condition.md
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 548-schedule-daemonset-pods
+  title: Graduate ScheduleDaemonSetPods to GA
+  kep_number: "548"
+  authors: ['@draveness']
+  owning_sig: sig-scheduling
+  participating-sigs: [sig-apps]
+  reviewers: ['@k82cn', '@janetkuo']
+  approvers: ['@k82cn']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-10-11"
+  last-updated: "2019-10-11"
+  status: implemented
+  see-also:
+    - https://docs.google.com/document/d/10Ch3dhD88mnHYTq9q4jtX3e9e6gpndC78g5Ea6q4JY4/edit#heading=h.dtxm02f9bgaw
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 583-coscheduling
+  title: Coscheduling
+  kep_number: "583"
+  authors: ['@k82cn']
+  owning_sig: sig-scheduling
+  reviewers: ['@bsalamat', '@vishh']
+  approvers: ['@bsalamat']
+  prr-approvers: []
+  creation-date: "2018-07-03"
+  last-updated: "2019-01-03"
+  status: provisional
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 624-scheduling-framework
+  title: Scheduling Framework
+  kep_number: "624"
+  authors: ['@bsalamat', '@misterikkit']
+  owning_sig: sig-scheduling
+  participating-sigs: [sig-scheduling]
+  reviewers: ['@huang-wei', '@k82cn', '@ravisantoshgudimetla', '@ahg-g', '@alculquicondor']
+  approvers: ['@ahg-g', '@alculquicondor', '@huang-wei', '@k82cn']
+  prr-approvers: []
+  creation-date: "2018-04-09"
+  last-updated: ""
+  status: implemented
+  see-also:
+    - /keps/sig-scheduling/1451-multi-scheduling-profiles
+  stage: stable
+  latest-milestone: v1.19
+  milestone:
+      alpha: v1.16
+      beta: ""
+      stable: v1.19
+  feature-gates: []
+  disable-supported: false
+  metrics:
+    - framework_extension_point_duration_seconds
+    - plugin_execution_duration_seconds
+- id: ""
+  prnumber: ""
+  name: 785-scheduler-component-config-api
+  title: Scheduler Component Config API
+  kep_number: "785"
+  authors: ['@alculquicondor']
+  owning_sig: sig-scheduling
+  participating-sigs: [sig-architecture]
+  reviewers: ['@Huang-Wei']
+  approvers: ['@ahg-g', '@liggitt']
+  prr-approvers: ['@wojtek-t']
+  creation-date: "2020-05-08"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - /keps/sig-scheduling/1451-multi-scheduling-profiles
+  stage: beta
+  latest-milestone: v1.19
+  milestone:
+      alpha: ""
+      beta: v1.19
+      stable: v1.22
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 895-pod-topology-spread
+  title: Pod Topology Spread
+  kep_number: "895"
+  authors: ['@Huang-Wei']
+  owning_sig: sig-scheduling
+  participating-sigs: [sig-scheduling, sig-api-machinery]
+  reviewers: ['@bsalamat', '@lavalamp', '@krmayankk', '@ahg-g', '@alculquicondor']
+  approvers: ['@ahg-g', '@alculquicondor']
+  prr-approvers: []
+  creation-date: "2019-02-21"
+  last-updated: ""
+  status: implemented
+  see-also:
+    - /keps/sig-scheduling/1258-default-even-pods-spreading
+  stage: stable
+  latest-milestone: v1.19
+  milestone:
+      alpha: v1.16
+      beta: v1.18
+      stable: v1.19
+  feature-gates:
+    - name: EvenPodsSpread
+      components:
+        - kube-scheduler
+        - kube-apiserver
+  disable-supported: true
+  metrics:
+    - plugin_execution_duration_seconds{plugin="PodTopologySpread"}
+- id: ""
+  prnumber: ""
+  name: 902-non-preempting-priorityclass
+  title: Add NonPreempting Option For PriorityClasses
+  kep_number: "902"
+  authors: ['@vllry', '@denkensk']
+  owning_sig: sig-scheduling
+  participating-sigs: [sig-scheduling]
+  reviewers: [k82cn, wgliang, Huang-Wei]
+  approvers: [bsalamat, Huang-Wei]
+  prr-approvers: []
+  creation-date: "2019-03-17"
+  last-updated: ""
+  status: implementable
+  stage: beta
+  latest-milestone: v1.19
+  milestone:
+      alpha: v1.15
+      beta: v1.19
+      stable: ""
+  feature-gates:
+    - name: NonPreemptingPriority
+      components:
+        - kube-apiserver
+        - kube-scheduler
+  disable-supported: true
+  metrics:
+    - pod_preemption_victims
+    - total_preemption_attempts
+    - scheduling_algorithm_preemption_evaluation_seconds
+- id: ""
+  prnumber: ""
+  name: 964-binpacking-priority
+  title: Extending RequestedToCapacityRatio Priority Function to support Resource
+      Bin Packing of Extended Resources - @sudeshsh
+  kep_number: "964"
+  authors: []
+  owning_sig: sig-scheduling
+  participating-sigs: [sig-scheduling]
+  reviewers: ['@k82cn', '@Huang-Wei', '@bsalamat']
+  approvers: ['@k82cn', '@bsalamat']
+  prr-approvers: []
+  creation-date: "2019-03-11"
+  last-updated: "2019-05-01"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 986-resource-quota-scope-selectors
+  title: Resource Quota Scope Selectors
+  kep_number: "986"
+  authors: ['@ravisantoshgudimetla']
+  owning_sig: sig-api-machinery
+  participating-sigs: [sig-scheduling, sig-api-machinery]
+  reviewers: ['@bsalamat', '@k82cn', '@derekwaynecarr', “@sjenning”, '@vikaschoudhary16']
+  approvers: ['@bsalamat', '@derekwaynecarr']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-04-23"
+  last-updated: "2020-04-18"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1753-logs-sanitization
+  title: Kubernetes system components logs sanitization
+  kep_number: "1753"
+  authors: ['@44past4', '@immutableT', '@PurelyApplied']
+  owning_sig: sig-security
+  participating-sigs: [sig-instrumentation]
+  reviewers: ['@ehashman']
+  approvers: ['@dashpole']
+  prr-approvers: ['@wojtek-t']
+  creation-date: "2020-05-07"
+  last-updated: "2020-10-14"
+  status: implementable
+  stage: alpha
+  latest-milestone: "1.19"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1933-secret-logging-static-analysis
+  title: Defend against accidental credential logging via static analysis interation
+      into Prow.
+  kep_number: "1933"
+  authors: ['@PurelyApplied']
+  owning_sig: sig-security
+  participating-sigs: [sig-instrumentation, sig-testing, sig-security]
+  reviewers: ['@BenTheElder', '@dashpole', '@ehashman', '@logicalhan', '@mikejoh']
+  approvers: ['@dashpole', '@ehashman']
+  prr-approvers: ['@deads2k']
+  creation-date: "2020-08-12"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - /keps/sig-instrumentation/1753-logs-sanitization
+    - /keps/sig-instrumentation/1602-structured-logging
+  stage: beta
+  latest-milestone: v1.21
+  milestone:
+      alpha: v1.20
+      beta: v1.21
+      stable: v1.22
+  feature-gates: []
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 121-local-persistent-volumes
+  title: Local Persistent Volumes
+  kep_number: "121"
+  authors: [msau42, vishh, dhirajh, ianchakeres]
+  owning_sig: sig-storage
+  participating-sigs: [sig-storage]
+  reviewers: [saad-ali, jsafrane, gnufied]
+  approvers: [saad-ali]
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-01-24"
+  last-updated: "2020-04-16"
+  status: implemented
+  see-also:
+    - https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/volume-topology-scheduling.md
+  replaces:
+    - https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/local-storage-pv.md
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1412-immutable-secrets-and-configmaps
+  title: Immutable Secrets and ConfigMaps
+  kep_number: "1412"
+  authors: ['@wojtek-t']
+  owning_sig: sig-storage
+  participating-sigs: [sig-apps, sig-node, sig-scalability]
+  reviewers: ['@yujuhong', '@lavalamp', '@msau42']
+  approvers: ['@saad-ali']
+  prr-approvers: ['@johnbelamaric']
+  creation-date: "2019-11-17"
+  last-updated: "2020-12-10"
+  status: implemented
+  stage: stable
+  latest-milestone: v1.21
+  milestone:
+      alpha: v1.18
+      beta: v1.19
+      stable: v1.21
+  feature-gates:
+    - name: ImmutableEphemeralVolumes
+      components:
+        - kube-apiserver
+        - kubelet
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1432-volume-health-monitor
+  title: Volume Health Monitor
+  kep_number: "1432"
+  authors: ['@NickrenREN', '@xing-yang']
+  owning_sig: sig-storage
+  reviewers: ['@msau42', '@jingxu97', '@liggitt', '@gnufied']
+  approvers: ['@msau42', '@saad-ali', '@thockin', '@liggitt']
+  prr-approvers: ['@deads2k']
+  creation-date: "2020-05-12"
+  last-updated: ""
+  status: implementable
+  stage: alpha
+  latest-milestone: v1.21
+  milestone:
+      alpha: v1.21
+      beta: v1.22
+      stable: v1.23
+  feature-gates: []
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1472-storage-capacity-tracking
+  title: Storage Capacity Constraints for Pod Scheduling
+  kep_number: "1472"
+  authors: ['@pohly', '@cofyc']
+  owning_sig: sig-storage
+  participating-sigs: [sig-scheduling]
+  reviewers: ['@saad-ali', '@xing-yang', '@msau42']
+  approvers: ['@saad-ali', '@msau42']
+  prr-approvers: ['@wojtek-t']
+  creation-date: "2019-09-19"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - https://docs.google.com/document/d/1WtX2lRJjZ03RBdzQIZY3IOvmoYiF5JxDX35-SsCIAfg
+  stage: beta
+  latest-milestone: v1.21
+  milestone:
+      alpha: v1.19
+      beta: v1.21
+      stable: v1.23
+  feature-gates:
+    - name: CSIStorageCapacity
+      components:
+        - kube-apiserver
+        - kube-scheduler
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1495-volume-populators
+  title: Volume Populators
+  kep_number: "1495"
+  authors: ['@bswartz']
+  owning_sig: sig-storage
+  participating-sigs: [sig-api-machinery]
+  reviewers: ['@thockin', '@saad-ali', '@smarterclayton', '@j-griffith']
+  approvers: ['@thockin', '@saad-ali']
+  prr-approvers: ['@deads2k']
+  creation-date: "2019-12-03"
+  last-updated: "2021-05-13"
+  status: implementable
+  replaces:
+    - /keps/sig-storage/20200120-generic-data-populators.md
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.18
+      beta: v1.23
+      stable: v1.24
+  feature-gates:
+    - name: AnyVolumeDataSource
+      components:
+        - kube-apiserver
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1682-csi-driver-skip-permission
+  title: Skip Volume Ownership Change
+  kep_number: "1682"
+  authors: ['@huffmanca']
+  owning_sig: sig-storage
+  participating-sigs: [sig-storage]
+  reviewers: ['@gnuified', '@msau42', '@xing-yang']
+  approvers: ['@saad-ali']
+  prr-approvers: []
+  creation-date: "2020-04-27"
+  last-updated: ""
+  status: implementable
+  stage: alpha
+  latest-milestone: v1.19
+  milestone:
+      alpha: v1.19
+      beta: v1.20
+      stable: v1.21
+  feature-gates:
+    - name: CSIVolumeSupportFSGroup
+      components:
+        - kube-apiserver
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1698-generic-ephemeral-volumes
+  title: generic ephemeral inline volumes
+  kep_number: "1698"
+  authors: ['@pohly']
+  owning_sig: sig-storage
+  participating-sigs: [sig-storage]
+  reviewers: ['@jsafrane']
+  approvers: ['@saad-ali']
+  prr-approvers: ['@wojtek-t']
+  creation-date: "2020-04-17"
+  last-updated: ""
+  status: implementable
+  stage: beta
+  latest-milestone: v1.21
+  milestone:
+      alpha: v1.19
+      beta: v1.21
+      stable: v1.23
+  feature-gates:
+    - name: GenericEphemeralVolumes
+      components:
+        - kube-apiserver
+        - kube-controller-manager
+        - kubelet
+  disable-supported: true
+  metrics:
+    - ephemeral_volume_controller_create_total
+    - ephemeral_volume_controller_create_failures_total
+    - workqueue_adds_total (name="ephemeral_volume")
+    - workqueue_depth (name="ephemeral_volume")
+    - workqueue_longest_running_processor_seconds (name="ephemeral_volume")
+    - workqueue_queue_duration_seconds (name="ephemeral_volume")
+    - workqueue_retries_total (name="ephemeral_volume")
+    - workqueue_unfinished_work_seconds (name="ephemeral_volume")
+    - workqueue_work_duration_seconds (name="ephemeral_volume")
+- id: ""
+  prnumber: ""
+  name: 1710-selinux-relabeling
+  title: Skip SELinux relabeling of volumes
+  kep_number: "1710"
+  authors: ['@jsafrane']
+  owning_sig: sig-storage
+  participating-sigs: [sig-node]
+  reviewers: ['@msau42', '@gnufied', '@rhatdan', '@haircommander', '@saschagrunert',
+      '@tallclair']
+  approvers: ['@saad-ali']
+  prr-approvers: []
+  creation-date: "2020-02-18"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - /keps/sig-storage/20200120-skip-permission-change.md
+  stage: alpha
+  latest-milestone: v1.19
+  milestone:
+      alpha: v1.19
+      beta: v1.20
+      stable: v1.22
+  feature-gates:
+    - name: SELinuxRelabelPolicy
+      components:
+        - kube-apiserver
+        - kubelet
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 177-volume-snapshot
+  title: CSI Snapshot
+  kep_number: "177"
+  authors: ['@jingxu97', '@xing-yang', '@yuxiangqian']
+  owning_sig: sig-storage
+  participating-sigs: [sig-storage]
+  reviewers: ['@msau42', '@saad-ali', '@thockin']
+  approvers: ['@msau42', '@saad-ali', '@thockin']
+  prr-approvers: ['@deads2k']
+  creation-date: "2019-07-09"
+  last-updated: ""
+  status: implemented
+  see-also:
+    - keps/sig-storage/1900-volume-snapshot-validation-webhook
+  stage: stable
+  latest-milestone: v1.20
+  milestone:
+      alpha: v1.12
+      beta: v1.17
+      stable: v1.20
+  feature-gates:
+    - name: VolumeSnapshotDataSource
+      components:
+        - kube-apiserver
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1790-recover-resize-failure
+  title: Recover from volume expansion failure
+  kep_number: "1790"
+  authors: ['@gnuified']
+  owning_sig: sig-storage
+  participating-sigs: [sig-api-machinery]
+  reviewers: ['@msau42', '@liggit', '@xing-yang', '@jsafrane']
+  approvers: ['@saad-ali', '@xing-yang']
+  prr-approvers: ['@deads2k']
+  editor: TBD
+  creation-date: "2020-01-27"
+  last-updated: "2020-05-18"
+  status: implementable
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.22
+      beta: ""
+      stable: ""
+  feature-gates:
+    - name: RecoverExpansionFailure
+      components:
+        - kube-apiserver
+        - kube-controller-manager
+        - external-resizer
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1845-prioritization-on-volume-capacity
+  title: Prioritization on Volume Capacity
+  kep_number: "1845"
+  authors: ['@cofyc']
+  owning_sig: sig-storage
+  participating-sigs: [sig-scheduling]
+  reviewers: ['@msau42', '@jsafrane', '@Huang-Wei', '@ahg-g']
+  approvers: ['@msau42', '@jsafrane', '@Huang-Wei', '@ahg-g']
+  prr-approvers: ['@wojtek-t', '@deads2k']
+  creation-date: "2020-06-03"
+  last-updated: ""
+  status: implementable
+  stage: alpha
+  latest-milestone: v1.20
+  milestone:
+      alpha: v1.20
+      beta: v1.21
+      stable: v1.22
+  feature-gates:
+    - name: VolumeCapacityPriority
+      components:
+        - kube-scheduler
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1855-csi-driver-service-account-token
+  title: Service Account Token for CSI Driver
+  kep_number: "1855"
+  authors: ['@zshihang']
+  owning_sig: sig-storage
+  participating-sigs: [sig-auth, sig-storage]
+  reviewers: ['@msau42', '@seh', '@jsafrane', '@mikedanese']
+  approvers: ['@msau42', '@mikedanese']
+  prr-approvers: ['@deads2k']
+  creation-date: "2020-06-09"
+  last-updated: "2021-04-29"
+  status: implementable
+  stage: stable
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.20
+      beta: v1.21
+      stable: v1.22
+  feature-gates:
+    - name: CSIServiceAccountToken
+      components:
+        - kube-apiserver
+        - kubelet
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1900-volume-snapshot-validation-webhook
+  title: CSI Snapshot Webhook
+  kep_number: "1900"
+  authors: ['@andili99', '@yuxiangqian']
+  owning_sig: sig-storage
+  participating-sigs: [sig-storage]
+  reviewers: ['@msau42', '@liggit', '@xing-yang', '@mattcary']
+  approvers: ['@msau42', '@liggit', '@xing-yang', '@mattcary']
+  prr-approvers: []
+  creation-date: "2020-07-22"
+  last-updated: ""
+  status: implemented
+  see-also:
+    - keps/sig-storage/177-volume-snapshot
+  stage: ""
+  latest-milestone: v1.20
+  milestone:
+      alpha: ""
+      beta: v1.19
+      stable: v1.20
+  feature-gates: []
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1979-object-storage-support
+  title: Object Storage Support
+  kep_number: "1979"
+  authors: ['@jeffvance', '@copejon', '@wlan0', '@brahmaroutu']
+  owning_sig: sig-storage
+  participating-sigs: [sig-storage]
+  reviewers: ['@saad-ali', '@alarge', '@erinboyd', '@guymguym', '@rsquared', '@krishchow']
+  approvers: ['@saad-ali', '@xing-yang']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-11-25"
+  last-updated: "2020-09-10"
+  status: provisional
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2261-staging-mount-library
+  title: Move mount library to staging
+  kep_number: "2261"
+  authors: ['@brahmarotu']
+  owning_sig: sig-storage
+  reviewers: ['@msau42', '@thockin']
+  approvers: ['@msau42']
+  prr-approvers: []
+  creation-date: "2020-05-08"
+  last-updated: ""
+  status: implementable
+  stage: stable
+  latest-milestone: v1.20
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: v1.20
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2263-volume-scale-testing
+  title: Volume scale testing
+  kep_number: "2263"
+  authors: ['@msau42']
+  owning_sig: sig-storage
+  participating-sigs: [sig-scalability]
+  reviewers: ['@pohly', '@saad-ali', '@wojtek-t']
+  approvers: ['@saad-ali', '@wojtek-t']
+  prr-approvers: []
+  creation-date: "2019-02-04"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - https://github.com/kubernetes/community/blob/master/sig-scalability/slos/pod_startup_latency.md
+    - https://github.com/kubernetes/perf-tests/blob/master/clusterloader2/docs/design.md
+  stage: stable
+  latest-milestone: v1.15
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2264-csi-release-ci-process
+  title: Kubernetes CSI release and CI process
+  kep_number: "2264"
+  authors: ['@pohly']
+  owning_sig: sig-storage
+  reviewers: ['@msau42', '@saad-ali']
+  approvers: ['@msau42']
+  prr-approvers: []
+  creation-date: "2019-02-04"
+  last-updated: ""
+  status: implemented
+  stage: stable
+  latest-milestone: v1.14
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2317-fsgroup-on-mount
+  title: Provide fsgroup of pod to CSI driver on mount
+  kep_number: "2317"
+  authors: ['@gnufied']
+  owning_sig: sig-storage
+  reviewers: ['@msau42', '@jsafrane']
+  approvers: ['@msau42']
+  prr-approvers: ['@deads2k']
+  creation-date: "2021-01-22"
+  last-updated: ""
+  status: implementable
+  see-also:
+    - https://github.com/kubernetes/enhancements/issues/1682
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.22
+      beta: ""
+      stable: ""
+  feature-gates:
+    - name: MountWithFSGroup
+      components:
+        - kubelet
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2451-service-account-token-volumes
+  title: Service Account Token Volumes
+  kep_number: "2451"
+  authors: ['@smarterclayton', '@liggitt', '@mikedanese', '@zshihang']
+  owning_sig: sig-storage
+  participating-sigs: [sig-auth]
+  reviewers: ['@jsafrane', '@tallclair']
+  approvers: ['@saad-ali']
+  prr-approvers: []
+  editor: '@zshihang'
+  creation-date: "2018-05-15"
+  last-updated: "2020-04-29"
+  status: replaced
+  see-also:
+    - https://github.com/kubernetes/community/blob/e3a6b8172fec9506b15520549e52be683e30cbfb/contributors/design-proposals/storage/svcacct-token-volume-source.md
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2485-read-write-once-pod-pv-access-mode
+  title: ReadWriteOncePod PersistentVolume AccessMode
+  kep_number: "2485"
+  authors: ['@chrishenzie']
+  owning_sig: sig-storage
+  reviewers: [TBD, '@saad-ali', msau42]
+  approvers: [TBD]
+  prr-approvers: [TBD, '@ehashman']
+  creation-date: "2021-02-10"
+  last-updated: ""
+  status: implementable
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.22
+      beta: TBD
+      stable: TBD
+  feature-gates:
+    - name: ReadWriteOncePod
+      components:
+        - kube-apiserver
+        - kube-controller-manager
+        - kube-scheduler
+        - kubelet
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 284-enable-volume-expansion
+  title: Growing Persistent Volume size
+  kep_number: "284"
+  authors: ['@gnuified']
+  owning_sig: sig-storage
+  participating-sigs: [sig-auth]
+  reviewers: ['@msau42', '@liggit', '@thockin']
+  approvers: ['@saad-ali']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2017-08-29"
+  last-updated: "2020-09-30"
+  status: implementable
+  stage: alpha
+  latest-milestone: v1.19
+  milestone:
+      alpha: ""
+      beta: v1.11
+      stable: ""
+  feature-gates:
+    - name: ExpandPersistentVolumes
+      components:
+        - kube-apiserver
+        - kubelet
+        - kube-controller-manager
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 351-raw-block-support
+  title: Raw Block Volumes
+  kep_number: "351"
+  authors: ['@jsafrane']
+  owning_sig: sig-storage
+  participating-sigs: [sig-storage]
+  reviewers: ['@msau42', '@saad-ali']
+  approvers: ['@saad-ali']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-10-08"
+  last-updated: "2020-03-09"
+  status: implemented
+  see-also:
+    - https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/raw-block-pv.md
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 531-online-pv-resizing
+  title: Online Growing Persistent Volume Size
+  kep_number: "531"
+  authors: ['@mlmhl', '@wongma7']
+  owning_sig: sig-storage
+  participating-sigs: [sig-storage]
+  reviewers: ['@gnufied', '@jsafrane']
+  approvers: ['@childsb']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-01-25"
+  last-updated: "2019-02-01"
+  status: implementable
+  see-also:
+    - https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/grow-volume-size.md
+    - https://github.com/kubernetes/community/pull/1535
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 554-maximum-volume-count
+  title: Volume Scheduling Limits
+  kep_number: "554"
+  authors: ['@jsafrane', '@gnufied']
+  owning_sig: sig-storage
+  participating-sigs: [sig-scheduling]
+  reviewers: ['@bsalamat', '@thockin', '@msau42']
+  approvers: ['@bsalamat', '@msau42', '@thockin']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-04-08"
+  last-updated: "2019-04-08"
+  status: implemented
+  see-also:
+    - https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/20190129-csi-migration.md
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 556-csi-volume-resizing
+  title: Support for CSI volume resizing
+  kep_number: "556"
+  authors: ['@gnufied']
+  owning_sig: sig-storage
+  participating-sigs: [sig-storage]
+  reviewers: ['@saad-ali', '@jsafrane']
+  approvers: ['@saad-ali', '@childsb']
+  prr-approvers: []
+  creation-date: "2019-01-29"
+  last-updated: "2019-01-29"
+  status: implementable
+  see-also:
+    - '[Kubernetes Volume expansion](https://github.com/kubernetes/enhancements/issues/284)'
+    - '[Online resizing design](https://github.com/kubernetes/enhancements/pull/737)'
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 557-csi-topology
+  title: CSI Volume Topology
+  kep_number: "557"
+  authors: ['@verult']
+  owning_sig: sig-storage
+  participating-sigs: [sig-storage]
+  reviewers: ['@msau42', '@saad-ali']
+  approvers: ['@msau42', '@saad-ali']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-01-24"
+  last-updated: "2020-04-16"
+  status: implemented
+  see-also:
+    - n/a
+  replaces:
+    - n/a
+  superseded-by:
+    - n/a
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 559-volume-subpath-expansion
+  title: Volume Subpath Env Expansion
+  kep_number: "559"
+  authors: ['@kevtaylor']
+  owning_sig: sig-storage
+  participating-sigs: [sig-storage, sig-architecture]
+  reviewers: ['@msau42', '@thockin', '@liggitt']
+  approvers: ['@liggitt', '@msau42']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2018-10-29"
+  last-updated: "2020-01-03"
+  status: implemented
+  see-also:
+    - n/a
+  replaces:
+    - n/a
+  superseded-by:
+    - n/a
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 565-csi-block-support
+  title: CSI Raw Block Volumes
+  kep_number: "565"
+  authors: ['@bswartz']
+  owning_sig: sig-storage
+  participating-sigs: [sig-storage]
+  reviewers: ['@msau42', '@saad-ali']
+  approvers: ['@saad-ali']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-01-30"
+  last-updated: "2020-03-09"
+  status: implemented
+  see-also:
+    - https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/raw-block-pv.md
+    - https://github.com/kubernetes/enhancements/pull/1288
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 596-csi-inline-volumes
+  title: Ephemeral Inline CSI Volumes
+  kep_number: "596"
+  authors: ['@vladimirvivien', '@pohly']
+  owning_sig: sig-storage
+  participating-sigs: [sig-storage]
+  reviewers: ['@msau42', '@jsafrane', '@liggitt']
+  approvers: ['@thockin', '@saad-ali']
+  prr-approvers: []
+  creation-date: "2019-01-22"
+  last-updated: "2019-08-30"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 603-csi-pod-info
+  title: CSI Pod Info on Mount
+  kep_number: "603"
+  authors: ['@jsafrane']
+  owning_sig: sig-storage
+  participating-sigs: [sig-storage]
+  reviewers: ['@msau42', '@saad-ali']
+  approvers: ['@saad-ali']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-01-29"
+  last-updated: "2020-03-09"
+  status: implemented
+  see-also:
+    - https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/container-storage-interface-pod-information.md
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 625-csi-migration
+  title: In-tree Storage Plugin to CSI Migration
+  kep_number: "625"
+  authors: ['@davidz627', '@jsafrane']
+  owning_sig: sig-storage
+  participating-sigs: [sig-architecture, sig-cluster-lifecycle]
+  reviewers: ['@saadali', '@msau42']
+  approvers: ['@saadali']
+  prr-approvers: ['@wojtek-t']
+  editor: '@davidz627'
+  creation-date: "2019-01-29"
+  last-updated: "2021-02-03"
+  status: implementable
+  see-also:
+    - https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/csi-migration.md
+  stage: beta
+  latest-milestone: v1.21
+  milestone:
+      alpha: v1.14
+      beta: v1.17
+      stable: ""
+  feature-gates:
+    - name: CSIMigration
+      components:
+        - kube-controller-manager
+        - kubelet
+        - kube-scheduler
+    - name: CSIMigration{cloud-provider}
+      components:
+        - kube-controller-manager
+        - kubelet
+        - kube-scheduler
+  disable-supported: true
+  metrics:
+    - csi_sidecar_duration_operation
+    - storage_operation_duration_seconds
+- id: ""
+  prnumber: ""
+  name: 695-skip-permission-change
+  title: Skip Volume Ownership Change
+  kep_number: "695"
+  authors: ['@gnuified']
+  owning_sig: sig-storage
+  participating-sigs: [sig-auth]
+  reviewers: ['@msau42', '@liggit', '@tallclair']
+  approvers: ['@saad-ali']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2020-01-20"
+  last-updated: "2020-01-20"
+  status: implementable
+  see-also:
+    - https://github.com/kubernetes/enhancements/issues/1682
+  stage: alpha
+  latest-milestone: v1.20
+  milestone:
+      alpha: v1.18
+      beta: v1.20
+      stable: v1.21
+  feature-gates:
+    - name: ConfigurableFSGroupPolicy
+      components:
+        - kube-apiserver
+        - kubelet
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 770-csi-skip-attach
+  title: Skip attach for non-attachable CSI volumes
+  kep_number: "770"
+  authors: ['@jsafrane']
+  owning_sig: sig-storage
+  participating-sigs: [sig-storage]
+  reviewers: ['@msau42', '@saad-ali']
+  approvers: ['@saad-ali']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-01-29"
+  last-updated: "2020-03-09"
+  status: implemented
+  see-also:
+    - https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/container-storage-interface-skip-attach.md
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 962-execution-hook
+  title: ExecutionHook
+  kep_number: "962"
+  authors: ['@jingxu97', '@xing-yang']
+  owning_sig: sig-storage
+  participating-sigs: [sig-storage, sig-node, sig-apps, sig-architecture]
+  reviewers: ['@saad-ali', '@thockin', '@liyinan926']
+  approvers: ['@thockin', '@saad-ali', '@liyinan926']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-01-20"
+  last-updated: "2019-04-25"
+  status: implementable
+  see-also:
+    - n/a
+  replaces:
+    - n/a
+  superseded-by:
+    - n/a
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 989-extend-datasource
+  title: Extend usage of Volume DataSource to allow PVCs for Cloning
+  kep_number: "989"
+  authors: ['@j-griffith']
+  owning_sig: sig-storage
+  participating-sigs: [sig-architecture]
+  reviewers: [TBD]
+  approvers: ['@saad-ali', '@thockin']
+  prr-approvers: []
+  editor: '@j-griffith'
+  creation-date: "2018-11-11"
+  last-updated: "2020-03-09"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2290-new-label-for-trusted-PR-identification
+  title: New label for trusted PR identification
+  kep_number: "2290"
+  authors: ['@matthyx']
+  owning_sig: sig-testing
+  participating-sigs: [sig-contributor-experience]
+  reviewers: ['@fejta', '@cjwagner', '@BenTheElder', '@cblecker', '@stevekuznetsov']
+  approvers: [TBD]
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2018-06-25"
+  last-updated: "2019-01-30"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2291-presubmit-config-inside-the-tested-repo
+  title: Presubmit config inside the tested repo
+  kep_number: "2291"
+  authors: ['@alvaroaleman']
+  owning_sig: sig-testing
+  participating-sigs: [sig-testing]
+  reviewers: ['@stevekuznetsov', '@cjwagner']
+  approvers: ['@stevekuznetsov', '@cjwagner']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-06-04"
+  last-updated: "2019-07-24"
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2420-reducing-kubernetes-build-maintenance
+  title: Reducing Kubernetes Build Maintenance
+  kep_number: "2420"
+  authors: [BenTheElder, spiffxp]
+  owning_sig: sig-testing
+  participating-sigs: [sig-release]
+  reviewers: [dims, liggitt]
+  approvers: [spiffxp, justaugustus]
+  prr-approvers: [johnbelamaric, '@johnbelamaric']
+  creation-date: "2021-02-03"
+  last-updated: ""
+  status: implementable
+  stage: beta
+  latest-milestone: v1.21
+  milestone:
+      alpha: v1.21
+      beta: v1.21
+      stable: v1.23
+  feature-gates: []
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2464-kubetest2-ci-migration
+  title: Kubetest2 CI Migration
+  kep_number: "2464"
+  authors: [amwat]
+  owning_sig: sig-testing
+  participating-sigs: [sig-release, sig-scalability]
+  reviewers: [BenTheElder]
+  approvers: [spiffxp, saschagrunert]
+  prr-approvers: [johnbelamaric, '@johnbelamaric']
+  creation-date: "2021-02-08"
+  last-updated: ""
+  status: implementable
+  stage: alpha
+  latest-milestone: v1.21
+  milestone:
+      alpha: v1.21
+      beta: v1.22
+      stable: v1.23
+  feature-gates: []
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2539-continuously-deploy-k8s-prow
+  title: Continuously Deploy K8s Prow
+  kep_number: "2539"
+  authors: ['@chaodaiG']
+  owning_sig: sig-testing
+  participating-sigs: [sig-testing, sig-release]
+  reviewers: ['@spiffxp', '@justaugustus', '@alvaroaleman']
+  approvers: ['@spiffxp', '@justaugustus', '@alvaroaleman']
+  prr-approvers: []
+  creation-date: "2021-02-23"
+  last-updated: ""
+  status: implementable
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 714-break-test-tarball
+  title: Breaking apart the Kubernetes test tarball
+  kep_number: "714"
+  authors: ['@ixdy']
+  owning_sig: sig-testing
+  participating-sigs: [sig-release]
+  reviewers: ['@akutz', '@amwat']
+  approvers: ['@spiffxp', '@tpepper']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-01-18"
+  last-updated: "2019-03-06"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1001-windows-cri-containerd
+  title: Supporting CRI-containerD on Windows
+  kep_number: "1001"
+  authors: ['@patricklang', '@marosset']
+  owning_sig: sig-windows
+  participating-sigs: [sig-windows]
+  reviewers: ['@yujihong', '@derekwaynecarr', '@tallclair']
+  approvers: ['@michmike']
+  prr-approvers: []
+  creation-date: "2019-04-24"
+  last-updated: ""
+  status: implementable
+  stage: stable
+  latest-milestone: v1.20
+  milestone:
+      alpha: v1.18
+      beta: v1.19
+      stable: v1.20
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1043-windows-security-context
+  title: Windows security context API changes
+  kep_number: "1043"
+  authors: ['@ddebroy']
+  owning_sig: sig-windows
+  reviewers: ['@patricklang', '@liggitt']
+  approvers: ['@liggitt']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2019-04-18"
+  last-updated: "2019-04-18"
+  status: implemented
+  see-also:
+    - keps/sig-windows/20181221-windows-group-managed-service-accounts-for-container-identity.md
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1122-windows-csi-support
+  title: Support for CSI Plugins on Windows Nodes
+  kep_number: "1122"
+  authors: ['@ddebroy', '@jingxu97']
+  owning_sig: sig-windows
+  participating-sigs: [sig-windows, sig-storage]
+  reviewers: ['@patricklang', '@michmike', '@jingxu97', '@yujuhong', '@msau42']
+  approvers: ['@patricklang', '@msau42']
+  prr-approvers: ['@deads2k']
+  creation-date: "2019-07-14"
+  last-updated: "2021-05-12"
+  status: implementable
+  stage: stable
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.18
+      beta: v1.19
+      stable: v1.22
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 116-windows-node-support
+  title: Windows node support
+  kep_number: "116"
+  authors: ['@astrieanna', '@benmoss', '@patricklang', '@michmike', '@daschott']
+  owning_sig: sig-windows
+  participating-sigs: [sig-architecture, sig-node]
+  reviewers: [sig-architecture, sig-node, sig-testing, sig-release]
+  approvers: ['@bgrant0607', '@michmike', '@patricklang', '@spiffxp']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2018-11-29"
+  last-updated: "2019-03-06"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1301-windows-runtime-class
+  title: Windows RuntimeClass Support
+  kep_number: "1301"
+  authors: ['@patricklang']
+  owning_sig: sig-windows
+  participating-sigs: [sig-node]
+  reviewers: ['@tallclair', '@derekwaynecarr', '@benmoss', '@ddebroy']
+  approvers: ['@dchen1107']
+  prr-approvers: []
+  editor: '@patricklang'
+  creation-date: "2019-10-08"
+  last-updated: "2019-10-15"
+  status: implementable
+  see-also:
+    - /keps/sig-windows/20190424-windows-cri-containerd.md
+  stage: alpha
+  latest-milestone: "0.0"
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 1981-windows-privileged-container-support
+  title: Windows Privileged Container Support
+  kep_number: "1981"
+  authors: ['@ambguo', '@marosset']
+  owning_sig: sig-windows
+  participating-sigs: [sig-auth, sig-node, sig-storage]
+  reviewers: ['@jsturtevant', '@Random-Liu']
+  approvers: ['@liggitt', '@yujuhong']
+  prr-approvers: ['@deads2k']
+  creation-date: "2020-10-09"
+  last-updated: ""
+  status: implementable
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.22
+      beta: ""
+      stable: ""
+  feature-gates:
+    - name: WindowsHostProcessContainers
+      components:
+        - kube-apiserver
+        - kubelet
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 2258-node-service-log-viewer
+  title: Node service log viewer
+  kep_number: "2258"
+  authors: ['@aravindhp', '@LorbusChris']
+  owning_sig: sig-windows
+  participating-sigs: [sig-node, sig-cli, sig-auth]
+  reviewers: ['@marosset', '@immuzz']
+  approvers: ['@marosset']
+  prr-approvers: ['@johnbelamaric']
+  creation-date: "2021-01-14"
+  last-updated: "2021-05-05"
+  status: implementable
+  stage: alpha
+  latest-milestone: v1.22
+  milestone:
+      alpha: v1.22
+      beta: v1.23
+      stable: v1.24
+  feature-gates:
+    - name: NodeLogs
+      components:
+        - kubelet
+  disable-supported: true
+  metrics: []
+- id: ""
+  prnumber: ""
+  name: 689-windows-gmsa
+  title: Windows Group Managed Service Accounts for Container Identity
+  kep_number: "689"
+  authors: ['@ddebroy', '@jeremywx', '@patricklang']
+  owning_sig: sig-windows
+  participating-sigs: [sig-auth, sig-node, sig-architecture, sig-docs]
+  reviewers: ['@liggitt', '@mikedanese', '@yujuhong', '@patricklang']
+  approvers: ['@liggitt', '@yujuhong', '@patricklang']
+  prr-approvers: []
+  editor: TBD
+  creation-date: "2018-11-29"
+  last-updated: "2020-03-20"
+  status: implemented
+  stage: ""
+  latest-milestone: ""
+  milestone:
+      alpha: ""
+      beta: ""
+      stable: ""
+  feature-gates: []
+  disable-supported: false
+  metrics: []
+

--- a/data/sigs/sigs.yaml
+++ b/data/sigs/sigs.yaml
@@ -1,0 +1,3264 @@
+sigs:
+- dir: sig-api-machinery
+  name: API Machinery
+  mission_statement: >
+    Covers all aspects of API server, API registration and discovery, generic API
+    CRUD semantics, admission control, encoding/decoding, conversion, defaulting,
+    persistence layer (etcd), OpenAPI, CustomResourceDefinition, garbage collection,
+    and client libraries.
+
+  charter_link: charter.md
+  label: api-machinery
+  leadership:
+    chairs:
+    - github: deads2k
+      name: David Eads
+      company: Red Hat
+    - github: fedebongio
+      name: Federico Bongiovanni
+      company: Google
+    tech_leads:
+    - github: deads2k
+      name: David Eads
+      company: Red Hat
+    - github: lavalamp
+      name: Daniel Smith
+      company: Google
+  meetings:
+  - description: Kubebuilder and Controller Runtime Meeting
+    day: Thursday
+    time: "09:00"
+    tz: PT (Pacific Time)
+    frequency: biweekly
+    archive_url: https://docs.google.com/document/d/1Ih-2cgg1bUrLwLVTB9tADlPcVdgnuMNBGbUl4D-0TIk/edit?usp=sharing
+  - description: Regular SIG Meeting
+    day: Wednesday
+    time: "11:00"
+    tz: PT (Pacific Time)
+    frequency: biweekly
+    url: https://zoom.us/my/apimachinery
+    archive_url: https://goo.gl/0lbiM9
+    recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP21oW3hbLyjjj4XhrwKxH2R
+  contact:
+    slack: sig-api-machinery
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-api-machinery
+    teams:
+    - name: sig-api-machinery-api-reviews
+      description: API Changes and Reviews (API Machinery APIs, NOT all APIs)
+    - name: sig-api-machinery-bugs
+      description: Bug Triage and Troubleshooting
+    - name: sig-api-machinery-feature-requests
+      description: Feature Requests
+    - name: sig-api-machinery-misc
+      description: General Discussion
+    - name: sig-api-machinery-pr-reviews
+      description: PR Reviews
+    - name: sig-api-machinery-proposals
+      description: Design Proposals
+    - name: sig-api-machinery-test-failures
+      description: Test Failures and Triage
+    liaison:
+      github: dims
+      name: Davanum Srinivas
+  subprojects:
+  - name: component-base
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/legacyflag/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/component-base/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/component-base/OWNERS
+  - name: control-plane-features
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/kube-storage-version-migrator/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/kubectl-check-ownerreferences/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/garbagecollector/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/namespace/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/resourcequota/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/quota/v1/OWNERS
+  - name: idl-schema-client-pipeline
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-client/gen/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/structured-merge-diff/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/code-generator/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/gengo/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kube-openapi/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/code-generator/OWNERS
+  - name: kubernetes-clients
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-client/c/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-client/csharp/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-client/go-base/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-client/go/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-client/haskell/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-client/java/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-client/javascript/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-client/perl/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-client/python-base/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-client/python/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-client/ruby/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/clientgofix/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/client-go/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/OWNERS
+  - name: server-api-aggregation
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/kube-aggregator/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/kube-aggregator/OWNERS
+  - name: server-binaries
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/cloud-controller-manager/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/controller-manager/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kube-apiserver/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kube-controller-manager/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubeapiserver/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/master/OWNERS
+  - name: server-crd
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/apiextensions-apiserver/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiextensions-apiserver/OWNERS
+  - name: server-frameworks
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/apiserver/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/controller-manager/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/controller-manager/OWNERS
+  - name: server-sdk
+    contact:
+      mailing_list: https://groups.google.com/forum/#!forum/kubebuilder
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/apiserver-builder-alpha/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/apiserver-runtime/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/controller-tools/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/kubebuilder-declarative-pattern/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/kubebuilder-release-tools/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/kubebuilder/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/sample-apiserver/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/sample-controller/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/sample-apiserver/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/sample-controller/master/OWNERS
+  - name: universal-machinery
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/apimachinery/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apimachinery/OWNERS
+  - name: yaml
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/yaml/master/OWNERS
+- dir: sig-apps
+  name: Apps
+  mission_statement: >
+    Covers deploying and operating applications in Kubernetes. We focus on the developer
+    and devops experience of running applications in Kubernetes. We discuss how to
+    define and run apps in Kubernetes, demo relevant tools and projects, and discuss
+    areas of friction that can lead to suggesting improvements or feature requests.
+
+  charter_link: charter.md
+  label: apps
+  leadership:
+    chairs:
+    - github: janetkuo
+      name: Janet Kuo
+      company: Google
+    - github: kow3ns
+      name: Kenneth Owens
+      company: Brex
+    - github: mattfarina
+      name: Matt Farina
+      company: Rancher Labs
+    - github: soltysh
+      name: Maciej Szulik
+      company: Red Hat
+    emeritus_leads:
+    - github: prydonius
+      name: Adnan Abdulhussein
+  meetings:
+  - description: Regular SIG Meeting
+    day: Monday
+    time: "9:00"
+    tz: PT (Pacific Time)
+    frequency: biweekly
+    url: https://zoom.us/j/739385290?pwd=ekVmNGRjT214MGJkY1JUUUpPMVlJUT09
+    archive_url: https://docs.google.com/document/d/1LZLBGW2wRDwAfdBNHJjFfk9CFoyZPcIYGWU7R1PQ3ng/edit#
+    recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP2LMq7vznITnpd2Fk1YIZF3
+  contact:
+    slack: sig-apps
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-apps
+    teams:
+    - name: sig-apps-api-reviews
+      description: API Changes and Reviews
+    - name: sig-apps-bugs
+      description: Bug Triage and Troubleshooting
+    - name: sig-apps-feature-requests
+      description: Feature Requests
+    - name: sig-apps-misc
+      description: General Discussion
+    - name: sig-apps-pr-reviews
+      description: PR Reviews
+    - name: sig-apps-proposals
+      description: Design Proposals
+    - name: sig-apps-test-failures
+      description: Test Failures and Triage
+    liaison:
+      github: mrbobbytables
+      name: Bob Killen
+  subprojects:
+  - name: application
+    description: Application metadata descriptor CRD
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/application/master/OWNERS
+  - name: examples
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/examples/master/OWNERS
+  - name: execution-hook
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/execution-hook/master/OWNERS
+  - name: kompose
+    contact:
+      slack: kompose
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/kompose/master/OWNERS
+  - name: workloads-api
+    description: The core workloads API, which is composed of the CronJob, DaemonSet,
+      Deployment, Job, ReplicaSet, ReplicationController, and StatefulSet kinds
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/apps/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/batch/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/core/v1/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/extensions/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/cronjob/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/daemon/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/deployment/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/disruption/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/history/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/job/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/replicaset/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/replication/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/statefulset/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/apps/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/batch/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/extensions/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/apps/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/batch/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/core/v1/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/extensions/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/e2e/apps/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/integration/daemonset/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/integration/deployment/OWNERS
+- dir: sig-architecture
+  name: Architecture
+  mission_statement: >
+    The Architecture SIG maintains and evolves the design principles of Kubernetes,
+    and provides a consistent body of expertise necessary to ensure architectural
+    consistency over time.
+
+  charter_link: charter.md
+  label: architecture
+  leadership:
+    chairs:
+    - github: derekwaynecarr
+      name: Derek Carr
+      company: Red Hat
+    - github: dims
+      name: Davanum Srinivas
+      company: VMware
+    - github: johnbelamaric
+      name: John Belamaric
+      company: Google
+  meetings:
+  - description: Enhancements Subproject Meeting
+    day: Thursday
+    time: "10:00"
+    tz: PT (Pacific Time)
+    frequency: biweekly
+    url: https://zoom.us/j/95357819945
+    archive_url: https://bit.ly/k8s-enhancements-agenda
+    recordings_url: TBD
+  - description: Production Readiness Office Hours
+    day: Wednesday
+    time: "12:00"
+    tz: PT (Pacific Time)
+    frequency: biweekly
+    url: https://zoom.us/j/482444151
+    archive_url: https://docs.google.com/document/d/10QkXwiZfBL7wBKHHFslooXvGDKHA75jkkgiIXuKFryM/edit?usp=sharing
+    recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP2m6198LaLN6YahX7EEac5g
+  - description: Regular SIG Meeting
+    day: Thursday
+    time: "11:00"
+    tz: PT (Pacific Time)
+    frequency: biweekly
+    url: https://zoom.us/j/845605479
+    archive_url: https://docs.google.com/document/d/1BlmHq5uPyBUDlppYqAAzslVbAO8hilgjqZUTaNXUhKM/edit
+    recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP2m6198LaLN6YahX7EEac5g
+  - description: code organization Office Hours
+    day: Thursday
+    time: "14:00"
+    tz: PT (Pacific Time)
+    frequency: biweekly
+    url: https://zoom.us/j/159990793
+    archive_url: https://docs.google.com/document/d/1HtTI0rJEGP_MSf6eO87aCmx_tzpovPAAg7U2Zxwm8FE/edit#
+    recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP03VEluzh0wpSRPzgve8kI5
+  - description: conformance office Hours
+    day: Tuesday
+    time: "19:00"
+    tz: UTC
+    frequency: biweekly
+    url: https://zoom.us/j/427337923
+    archive_url: https://docs.google.com/document/d/1W31nXh9RYAb_VaYkwuPLd1hFxuRX3iU0DmaQ4lkCsX8/edit#
+    recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP2m6198LaLN6YahX7EEac5g
+  contact:
+    slack: sig-architecture
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-architecture
+    teams:
+    - name: sig-architecture-api-reviews
+      description: API Changes and Reviews
+    - name: sig-architecture-bugs
+      description: Bug Triage and Troubleshooting
+    - name: sig-architecture-feature-requests
+      description: Feature Requests
+    - name: sig-architecture-misc-use-only-as-a-last-resort
+      description: General Discussion
+    - name: sig-architecture-pr-reviews
+      description: PR Reviews
+    - name: sig-architecture-proposals
+      description: Design Proposals
+    - name: sig-architecture-test-failures
+      description: Test Failures and Triage
+    liaison:
+      github: liggitt
+      name: Jordan Liggitt
+  subprojects:
+  - name: architecture-and-api-governance
+    description: '[Described below](#architecture-and-api-governance)'
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/api/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/community/master/contributors/design-proposals/architecture/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/OWNERS
+  - name: code-organization
+    description: '[Described below](#code-organization)'
+    contact:
+      slack: k8s-code-organization
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/depstat/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/component-helpers/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/component-helpers/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/third_party/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/vendor/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/utils/master/OWNERS
+  - name: conformance-definition
+    description: '[Described below](#conformance-definition)'
+    contact:
+      slack: k8s-conformance
+      teams:
+      - name: cncf-conformance-wg
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/conformance/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/conformance/testdata/OWNERS
+  - name: enhancements
+    description: '[Described below](#enhancements)'
+    contact:
+      slack: enhancements
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/enhancements/master/OWNERS
+  - name: production-readiness
+    description: '[Described below](#production-readiness)'
+    contact:
+      slack: prod-readiness
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/community/master/sig-architecture/OWNERS
+- dir: sig-auth
+  name: Auth
+  mission_statement: >
+    Covers improvements to Kubernetes authorization, authentication, and cluster security
+    policy.
+
+
+    "All I want is a secure system where it's easy to do anything I want. Is that
+    so much to ask?" - [xkcd](https://xkcd.com/2044 "xkcd")
+
+  charter_link: charter.md
+  label: auth
+  leadership:
+    chairs:
+    - github: enj
+      name: Mo Khan
+      company: VMware
+    - github: mikedanese
+      name: Mike Danese
+      company: Google
+    - github: ritazh
+      name: Rita Zhang
+      company: Microsoft
+    tech_leads:
+    - github: deads2k
+      name: David Eads
+      company: Red Hat
+    - github: liggitt
+      name: Jordan Liggitt
+      company: Google
+    - github: mikedanese
+      name: Mike Danese
+      company: Google
+    emeritus_leads:
+    - github: ericchiang
+      name: Eric Chiang
+    - github: erictune
+      name: Eric Tune
+    - github: tallclair
+      name: Tim Allclair
+  meetings:
+  - description: Regular SIG Meeting
+    day: Wednesday
+    time: "11:00"
+    tz: PT (Pacific Time)
+    frequency: biweekly
+    url: https://zoom.us/j/264572674
+    archive_url: https://docs.google.com/document/d/1woLGRoONE3EBVx-wTb4pvp4CI7tmLZ6lS26VTbosLKM/edit#
+    recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP0VMOZ-V7-5AchXTHAQFzJw
+  - description: Secrets Store CSI Meeting
+    day: Thursday
+    time: "8:00"
+    tz: PT (Pacific Time)
+    frequency: biweekly
+    url: https://zoom.us/j/91272289538
+    archive_url: https://docs.google.com/document/d/1q74nboAg0GSPcom3kLWCIoWg43Qg3mr306KNL58f2hg/edit#
+    recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP0PCFJrlpV6_nR_j_3RtnwI
+  contact:
+    slack: sig-auth
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-auth
+    teams:
+    - name: sig-auth-api-reviews
+      description: API Changes and Reviews
+    - name: sig-auth-bugs
+      description: Bug Triage and Troubleshooting
+    - name: sig-auth-feature-requests
+      description: Feature Requests
+    - name: sig-auth-misc
+      description: General Discussion
+    - name: sig-auth-pr-reviews
+      description: PR Reviews
+    - name: sig-auth-proposals
+      description: Design Proposals
+    - name: sig-auth-test-failures
+      description: Test Failures and Triage
+    liaison:
+      github: cblecker
+      name: Christoph Blecker
+  subprojects:
+  - name: audit-logging
+    description: |
+      Kubernetes API support for audit logging.
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/apis/audit/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/audit/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/plugin/pkg/audit/OWNERS
+  - name: authenticators
+    description: |
+      Kubernetes API support for authentication.
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/authentication/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubeapiserver/authenticator/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/authentication/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/auth/authenticator/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/authentication/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/authentication/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/kubernetes/typed/authentication/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/listers/authentication/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/plugin/pkg/client/auth/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/tools/auth/OWNERS
+  - name: authorizers
+    description: |
+      Kubernetes API support for authorization.
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/authorization/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/rbac/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubeapiserver/authorizer/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/authorization/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/rbac/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/auth/authorizer/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/authorization/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/rbac/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/authorization/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/kubernetes/typed/authorization/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/kubernetes/typed/rbac/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/listers/authorization/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/listers/rbac/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/kubectl/pkg/cmd/auth/OWNERS
+  - name: certificates
+    description: |
+      Certificates APIs and client infrastructure to support PKI.
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/certificates/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/certificates/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/certificates/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/util/cert/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/client-go/util/certificate/OWNERS
+  - name: encryption-at-rest
+    description: |
+      API storage support for storing data encrypted at rest in etcd.
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/OWNERS
+  - name: hierarchical-namespace-controller
+    description: |
+      Controller to manage hierarchical namespaces
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/hierarchical-namespaces/master/OWNERS
+  - name: multi-tenancy
+    description: |
+      Proposals and prototypes for introducing tenant model to enable multi-tenant cluster
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/OWNERS
+  - name: node-identity-and-isolation
+    description: |
+      Node identity management (co-owned with sig-lifecycle), and authorization restrictions for isolating workloads on separate nodes (co-owned with sig-node).
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/certificates/approver/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/certificate/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/admission/noderestriction/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/auth/authorizer/node/OWNERS
+  - name: policy-management
+    description: |
+      API validation and policies enforced during admission, such as PodSecurityPolicy. Excludes run-time policies like NetworkPolicy and Seccomp.
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/wg-policy-prototypes/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/imagepolicy/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/policy/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/registry/policy/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/security/podsecuritypolicy/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/admission/imagepolicy/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/admission/security/podsecuritypolicy/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/imagepolicy/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/policy/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/pod-security-admission/master/OWNERS
+  - name: secrets-store-csi-driver
+    description: |
+      Integrates secrets stores with Kubernetes via a CSI volume.
+    contact:
+      slack: csi-secrets-store
+      mailing_list: https://groups.google.com/forum/#!forum/kubernetes-secrets-store-csi-driver
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/OWNERS
+  - name: service-accounts
+    description: |
+      Infrastructure implementing Kubernetes service account based workload identity.
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/serviceaccount/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/token/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/serviceaccount/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/plugin/pkg/admission/serviceaccount/OWNERS
+- dir: sig-autoscaling
+  name: Autoscaling
+  mission_statement: >
+    Covers development and maintenance of components for automated scaling in Kubernetes.
+    This includes automated vertical and horizontal pod autoscaling, initial resource
+    estimation, cluster-proportional system component autoscaling, and autoscaling
+    of Kubernetes clusters themselves.
+
+  charter_link: charter.md
+  label: autoscaling
+  leadership:
+    chairs:
+    - github: gjtempleton
+      name: Guy Templeton
+      company: Skyscanner
+    - github: mwielgus
+      name: Marcin Wielgus
+      company: Google
+  meetings:
+  - description: Regular SIG Meeting
+    day: Monday
+    time: "16:00"
+    tz: Poland
+    frequency: weekly
+    url: https://zoom.us/j/944410904
+    archive_url: https://docs.google.com/document/d/1RvhQAEIrVLHbyNnuaT99-6u9ZUMp7BfkPupT2LAZK7w/edit
+  contact:
+    slack: sig-autoscaling
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-autoscaling
+    teams:
+    - name: sig-autoscaling-api-reviews
+      description: API Changes and Reviews
+    - name: sig-autoscaling-bugs
+      description: Bug Triage and Troubleshooting
+    - name: sig-autoscaling-feature-requests
+      description: Feature Requests
+    - name: sig-autoscaling-misc
+      description: General Discussion
+    - name: sig-autoscaling-pr-reviews
+      description: PR Reviews
+    - name: sig-autoscaling-proposals
+      description: Design Proposals
+    - name: sig-autoscaling-test-failures
+      description: Test Failures and Triage
+    liaison:
+      github: derekwaynecarr
+      name: Derek Carr
+  subprojects:
+  - name: addon-resizer
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/autoscaler/master/addon-resizer/OWNERS
+  - name: cluster-autoscaler
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/autoscaler/master/OWNERS
+  - name: horizontal-pod-autoscaler
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/api/master/autoscaling/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/podautoscaler/OWNERS
+  - name: scale-client
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/client-go/master/scale/OWNERS
+  - name: vertical-pod-autoscaler
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/autoscaler/master/OWNERS
+- dir: sig-cli
+  name: CLI
+  mission_statement: >
+    Covers kubectl and related tools. We focus on the development and standardization
+    of the CLI framework and its dependencies, the establishment of conventions for
+    writing CLI commands, POSIX compliance, and improving the command line tools from
+    a developer and devops user experience and usability perspective.
+
+  charter_link: charter.md
+  label: cli
+  leadership:
+    chairs:
+    - github: eddiezane
+      name: Eddie Zaneski
+      company: Amazon
+    - github: seans3
+      name: Sean Sullivan
+      company: Google
+    - github: soltysh
+      name: Maciej Szulik
+      company: Red Hat
+    tech_leads:
+    - github: pwittrock
+      name: Phillip Wittrock
+      company: Apple
+    - github: soltysh
+      name: Maciej Szulik
+      company: Red Hat
+    emeritus_leads:
+    - github: AdoHe
+      name: Tony Ado
+    - github: fabianofranz
+      name: Fabiano Franz
+  meetings:
+  - description: Bug Scrub
+    day: Wednesday
+    time: "09:00"
+    tz: PT (Pacific Time)
+    frequency: monthly
+    url: https://zoom.us/j/288426795?pwd=UDdoYnFyNjBiS1RHcXRxS1BCNy9wUT09
+    archive_url: https://docs.google.com/document/d/1r0YElcXt6G5mOWxwZiXgGu_X6he3F--wKwg-9UBc29I/edit?usp=sharing
+    recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP28HaTzSlFe6RJVxpFmbUvF
+  - description: Regular SIG Meeting
+    day: Wednesday
+    time: "09:00"
+    tz: PT (Pacific Time)
+    frequency: biweekly
+    url: https://zoom.us/j/288426795?pwd=UDdoYnFyNjBiS1RHcXRxS1BCNy9wUT09
+    archive_url: https://docs.google.com/document/d/1r0YElcXt6G5mOWxwZiXgGu_X6he3F--wKwg-9UBc29I/edit?usp=sharing
+    recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP28HaTzSlFe6RJVxpFmbUvF
+  contact:
+    slack: sig-cli
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-cli
+    teams:
+    - name: sig-cli-api-reviews
+      description: API Changes and Reviews
+    - name: sig-cli-bugs
+      description: Bug Triage and Troubleshooting
+    - name: sig-cli-feature-requests
+      description: Feature Requests
+    - name: sig-cli-maintainers
+      description: CLI Maintainers
+    - name: sig-cli-misc
+      description: General Discussion
+    - name: sig-cli-pr-reviews
+      description: PR Reviews
+    - name: sig-cli-proposals
+      description: Design Proposals
+    - name: sig-cli-test-failures
+      description: Test Failures and Triage
+    liaison:
+      github: derekwaynecarr
+      name: Derek Carr
+  subprojects:
+  - name: cli-experimental
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cli-experimental/master/OWNERS
+  - name: cli-sdk
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/cli-runtime/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/cli-runtime/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/sample-cli-plugin/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/sample-cli-plugin/master/OWNERS
+  - name: cli-utils
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cli-utils/master/OWNERS
+  - name: krew
+    description: Plugin manager for kubectl.
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/krew/master/OWNERS
+  - name: krew-index
+    description: Centralized plugin index for krew.
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/krew-index/master/OWNERS
+  - name: kubectl
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/kubectl/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubectl/OWNERS
+  - name: kui
+    description: Hybrid command-line/UI development experience for cloud-native development
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/kui/master/OWNERS
+  - name: kustomize
+    contact:
+      slack: kustomize
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/OWNERS
+- dir: sig-cloud-provider
+  name: Cloud Provider
+  mission_statement: >
+    Ensures that the Kubernetes ecosystem is evolving in a way that is neutral to
+    all (public and private) cloud providers. It will be responsible for establishing
+    standards and requirements that must be met by all providers to ensure optimal
+    integration with Kubernetes.
+
+  charter_link: CHARTER.md
+  label: cloud-provider
+  leadership:
+    chairs:
+    - github: andrewsykim
+      name: Andrew Sy Kim
+      company: VMware
+    - github: cheftako
+      name: Walter Fender
+      company: Google
+    emeritus_leads:
+    - github: hogepodge
+      name: Chris Hoge
+    - github: jagosan
+      name: Jago Macleod
+  meetings:
+  - description: Regular SIG Meeting
+    day: Wednesday
+    time: "13:00"
+    tz: PT (Pacific Time)
+    frequency: biweekly
+    url: https://zoom.us/j/508079177?pwd=ZmEvMksxdTFTc0N1eXFLRm91QUlyUT09
+    archive_url: https://docs.google.com/document/d/1OZE-ub-v6B8y-GuaWejL-vU_f9jsjBbrim4LtTfxssw/edit#heading=h.w7i4ksrweimp
+    recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP3dXLcYbRKCbpPCN-8CDFAB
+  contact:
+    slack: sig-cloud-provider
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-cloud-provider
+    teams:
+    - name: sig-cloud-provider-api-reviews
+      description: API Changes and Reviews
+    - name: sig-cloud-provider-bugs
+      description: Bug Triage and Troubleshooting
+    - name: sig-cloud-provider-feature-requests
+      description: Feature Requests
+    - name: sig-cloud-provider-maintainers
+      description: Cloud Providers Maintainers
+    - name: sig-cloud-provider-pr-reviews
+      description: PR Reviews
+    - name: sig-cloud-provider-proposals
+      description: Design Proposals
+    - name: sig-cloud-provider-test-failures
+      description: Test Failures and Triage
+    - name: sig-cloud-providers-misc
+      description: General Discussion
+    liaison:
+      github: nikhita
+      name: Nikhita Raghunath
+  subprojects:
+  - name: cloud-provider-extraction-migration
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/apiserver-network-proxy/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/community/master/sig-cloud-provider/cloud-provider-extraction-migration/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/legacy-cloud-providers/master/OWNERS
+    meetings:
+    - description: Weekly Sync removing the in-tree cloud providers led by @cheftako
+        and @mcrute
+      day: Thursday
+      time: "13:30"
+      tz: PT (Pacific Time)
+      frequency: weekly
+      url: https://docs.google.com/document/d/1KLsGGzNXQbsPeELCeF_q-f0h0CEGSe20xiwvcR2NlYM/edit
+  - name: kubernetes-cloud-provider
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/cloud-provider-sample/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/cloud-provider/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/cloud-controller-manager/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/cloudprovider/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/cloud/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/cloud-provider/OWNERS
+  - name: provider-alibaba-cloud
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/alibaba-cloud-csi-driver/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/cloud-provider-alibaba-cloud/master/OWNERS
+    meetings:
+    - description: Regular Alibaba Cloud Subproject Meeting
+      day: Tuesday
+      time: "12:00"
+      tz: UTC
+      frequency: 'monthly 2020 start date: Jan. 7th'
+      url: https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit
+      archive_url: https://docs.google.com/document/d/1x7E2Brzx8rAEI4IIsfOZuZUBIf-J4NTIGuDaKb8z_sM/edit
+      recordings_url: https://www.youtube.com/playlist?list=PLWpmsLfcyyD7HAhlLTuwmI9KWuoiaN9nO
+  - name: provider-aws
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/aws-ebs-csi-driver/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/aws-efs-csi-driver/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/aws-encryption-provider/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/aws-fsx-csi-driver/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/aws-iam-authenticator/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/provider-aws-test-infra/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/master/OWNERS
+    meetings:
+    - description: Regular AWS Subproject Meeting
+      day: Friday
+      time: "9:00"
+      tz: PT (Pacific Time)
+      frequency: 'biweekly 2019 start date: Jan. 11th'
+      url: https://zoom.us/my/k8ssigaws
+      archive_url: https://docs.google.com/document/d/1-i0xQidlXnFEP9fXHWkBxqySkXwJnrGJP9OGyP2_P14/edit
+      recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP29DzPOBBaJi-SO3AQ_b4HC
+  - name: provider-azure
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/azurefile-csi-driver/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/blobfuse-csi-driver/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/OWNERS
+    meetings:
+    - description: Azure Subproject Meeting (every four weeks)
+      day: Monday
+      time: "18:00"
+      tz: PT (Pacific Time)
+      frequency: biweekly
+      url: https://zoom.us/j/586836662
+      archive_url: https://docs.google.com/document/d/1SpxvmOgHDhnA72Z0lbhBffrfe9inQxZkU9xqlafOW9k/edit
+      recordings_url: https://www.youtube.com/watch?v=yQLeUKi_dwg&list=PL69nYSiGNLP2JNdHwB8GxRs2mikK7zyc4
+    - description: Azure Subproject Meeting (every four weeks)
+      day: Thursday
+      time: "8:30"
+      tz: PT (Pacific Time)
+      frequency: biweekly
+      url: https://zoom.us/j/586836662
+      archive_url: https://docs.google.com/document/d/1SpxvmOgHDhnA72Z0lbhBffrfe9inQxZkU9xqlafOW9k/edit
+      recordings_url: https://www.youtube.com/watch?v=yQLeUKi_dwg&list=PL69nYSiGNLP2JNdHwB8GxRs2mikK7zyc4
+  - name: provider-baiducloud
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-baiducloud/master/OWNERS
+  - name: provider-gcp
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/gcp-filestore-csi-driver/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/cloud-provider-gcp/master/OWNERS
+    meetings:
+    - description: Regular GCP Subproject Meeting
+      day: Thursday
+      time: "16:00"
+      tz: UTC
+      frequency: biweekly
+      url: https://docs.google.com/document/d/1FQx0BPlkkl1Bn0c9ocVBxYIKojpmrS1CFP5h0DI68AE/edit
+      archive_url: https://docs.google.com/document/d/1mtmwZ4oVSSWhbEw8Lfzvc7ig84qxUpdK6uHyJp8rSGU/edit
+  - name: provider-huaweicloud
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-huaweicloud/master/OWNERS
+  - name: provider-ibmcloud
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-ibmcloud/master/OWNERS
+    meetings:
+    - description: Regular IBM Subproject Meeting
+      day: Wednesday
+      time: "14:00"
+      tz: EST
+      frequency: biweekly
+      url: https://zoom.us/j/9392903494
+      archive_url: https://docs.google.com/document/d/1qd_LTu5GFaxUhSWTHigowHt3XwjJVf1L57kupj8lnwg/edit
+  - name: provider-openstack
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/master/OWNERS
+    meetings:
+    - description: Regular OpenStack Subproject Meeting
+      day: Wednesday
+      time: "08:00"
+      tz: PT (Pacific Time)
+      frequency: biweekly starting Wednesday March 20, 2019
+      url: https://docs.google.com/document/d/1bW3j4hFN4D8rv2LFv-DybB3gcE5ISAaOO_OpvDCgrGg/edit
+      archive_url: https://docs.google.com/document/d/15UwgLbEyZyXXxVtsThcSuPiJru4CuqU9p3ttZSfTaY4/edit
+      recordings_url: https://www.youtube.com/watch?v=iCfUx7ilh0E&list=PL69nYSiGNLP20iTSChQ_i2QQmTBl3M7ax
+  - name: provider-vsphere
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/cloud-provider-vsphere/master/OWNERS
+    meetings:
+    - description: Cloud Provider vSphere monthly syncup
+      day: Wednesday
+      time: "09:00"
+      tz: PT (Pacific Time)
+      frequency: monthly - first Wednesday every month
+      url: https://zoom.us/j/584244729
+      archive_url: https://docs.google.com/document/d/1B0NmmKVh8Ea5hnNsbUsJC7ZyNCsq_6NXl5hRdcHlJgY/edit?usp=sharing
+      recordings_url: https://www.youtube.com/playlist?list=PLutJyDdkKQIpOT4bOfuO3MEMHvU1tRqyR
+- dir: sig-cluster-lifecycle
+  name: Cluster Lifecycle
+  mission_statement: >
+    The Cluster Lifecycle SIG examines how we should change Kubernetes to make it
+    easier to manage and operate with a focus on cluster deployment and upgrades.
+
+  charter_link: charter.md
+  label: cluster-lifecycle
+  leadership:
+    chairs:
+    - github: justinsb
+      name: Justin Santa Barbara
+      company: Google
+    - github: neolit123
+      name: Lubomir Ivanov
+      company: VMware
+    - github: timothysc
+      name: Timothy St. Clair
+      company: VMware
+    tech_leads:
+    - github: fabriziopandini
+      name: Fabrizio Pandini
+      company: VMware
+    emeritus_leads:
+    - github: luxas
+      name: Lucas Käldström
+    - github: roberthbailey
+      name: Robert Bailey
+  meetings:
+  - description: Regular SIG Meeting
+    day: Tuesday
+    time: "08:00"
+    tz: PT (Pacific Time)
+    frequency: biweekly
+    url: https://zoom.us/j/916523531?pwd=eVhPNU5IQWtBYWhmT1N4T0V6bHZFZz09
+    archive_url: https://docs.google.com/document/d/1Gmc7LyCIL_148a9Tft7pdhdee0NBHdOfHS1SAF0duI4/edit
+    recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4
+  contact:
+    slack: sig-cluster-lifecycle
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle
+    teams:
+    - name: sig-cluster-lifecycle
+      description: Notify group
+    liaison:
+      github: dims
+      name: Davanum Srinivas
+  subprojects:
+  - name: bootkube
+    contact:
+      slack: bootkube
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/bootkube/master/OWNERS
+  - name: cluster-addons
+    contact:
+      slack: cluster-addons
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-addons/master/OWNERS
+    meetings:
+    - description: Cluster Addons meeting
+      day: Tuesday
+      time: "09:00"
+      tz: PT (Pacific Time)
+      frequency: biweekly
+      url: https://zoom.us/j/130096731?pwd=U3pzWloxZ0lpbEtadTZGSERRdENrZz09
+      archive_url: https://docs.google.com/document/d/10_tl_SXcFGb-2109QpcFVrdrfnVEuQ05MBrXtasB0vk/edit
+  - name: cluster-api
+    contact:
+      slack: cluster-api
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api/master/OWNERS
+    meetings:
+    - description: Cluster API office hours
+      day: Wednesday
+      time: "10:00"
+      tz: PT (Pacific Time)
+      frequency: weekly
+      url: https://zoom.us/j/861487554?pwd=dTVGVVFCblFJc0VBbkFqQlU0dHpiUT09
+      archive_url: https://docs.google.com/document/d/1LW5SDnJGYNRB_TH9ZXjAn2jFin6fERqpC9a0Em0gwPE/edit
+      recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4
+  - name: cluster-api-provider-aws
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-aws/master/OWNERS
+    meetings:
+    - description: Cluster API Provider AWS office hours
+      day: Monday
+      time: "10:00"
+      tz: PT (Pacific Time)
+      frequency: biweekly
+      url: https://zoom.us/j/423312508?pwd=Tk9OWnZ4WHg2T2xRek9xZXA1eFQ4dz09
+      archive_url: https://docs.google.com/document/d/1iW-kqcX-IhzVGFrRKTSPGBPOc-0aUvygOVoJ5ETfEZU/
+      recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4
+  - name: cluster-api-provider-azure
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/master/OWNERS
+    meetings:
+    - description: Cluster API Provider Azure office hours
+      day: Thursday
+      time: "08:00"
+      tz: PT (Pacific Time)
+      frequency: bi-weekly
+      url: https://zoom.us/j/566930821?pwd=N2JuRWljc3hGS3ZnVlBLTk42TFlzQT09
+      archive_url: http://bit.ly/k8s-capz-agenda
+      recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4
+  - name: cluster-api-provider-digitalocean
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-digitalocean/master/OWNERS
+    meetings:
+    - description: Cluster API Provider DigitalOcean office hours
+      day: Thursday
+      time: "09:00"
+      tz: PT (Pacific Time)
+      frequency: monthly, second Thursday of the month
+      url: https://zoom.us/j/91312171751?pwd=bndnMDdJMkhySDVncjZoR1VhdFBTZz09
+      archive_url: http://bit.ly/k8s-capdo-agenda
+      recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4
+  - name: cluster-api-provider-docker
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-docker/master/OWNERS
+  - name: cluster-api-provider-gcp
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-gcp/master/OWNERS
+  - name: cluster-api-provider-ibmcloud
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-ibmcloud/master/OWNERS
+  - name: cluster-api-provider-kubemark
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-kubemark/master/OWNERS
+  - name: cluster-api-provider-nested
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-nested/master/OWNERS
+    meetings:
+    - description: Cluster API Provider Nested Office Hours
+      day: Tuesday
+      time: "10:00"
+      tz: PT (Pacific Time)
+      frequency: weekly
+      url: https://zoom.us/j/91929881559?pwd=WllxazhTUzBFN1BNWTRadTA3NGtQQT09
+      archive_url: https://docs.google.com/document/d/10aTeq2lhXW_3aFQAd_MdGjY8PtZPslKhZCCcXxFp3_Q/edit
+      recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4
+  - name: cluster-api-provider-openstack
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-openstack/master/OWNERS
+  - name: cluster-api-provider-packet
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-packet/master/OWNERS
+  - name: cluster-api-provider-vsphere
+    contact:
+      slack: cluster-api-vsphere
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-vsphere/master/OWNERS
+    meetings:
+    - description: Cluster API vSphere meeting
+      day: Thursday
+      time: "10:00"
+      tz: PT (Pacific Time)
+      frequency: biweekly starting Thursday June 25th, 2020
+      url: https://zoom.us/j/92253194848?pwd=cVVVNDMxeTl1QVJPUlpvLzNSVU1JZz09
+      archive_url: https://docs.google.com/document/d/1jQrQiOW75uWraPk4b_LWtCTHwT7EZwrWWwMdxeWOEvk/edit?usp=sharing
+      recordings_url: https://www.youtube.com/playlist?list=PLutJyDdkKQIovV-AONxMa2cyv-_5LAYiu
+  - name: etcdadm
+    contact:
+      slack: etcdadm
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/etcdadm/master/OWNERS
+    meetings:
+    - description: etcdadm Office Hours
+      day: Monday
+      time: "09:00"
+      tz: PT (Pacific Time)
+      frequency: biweekly
+      url: https://zoom.us/j/612375927?pwd=MldxRnRSOExCVW1rbjM4ZzBSc3MvUT09
+      archive_url: https://docs.google.com/document/d/1b_J0oBvi9lL0gsPgTOrCw1Zlx3e7BYEuXnB3d2S15pA/edit
+  - name: image-builder
+    contact:
+      slack: image-builder
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/image-builder/master/OWNERS
+    meetings:
+    - description: Image Builder office hours
+      day: Thursday
+      time: "08:00"
+      tz: PT (Pacific Time)
+      frequency: biweekly
+      url: https://zoom.us/j/807524571?pwd=WEFTeDJzeWU3bVFkcWQ0UEdZRkRCdz09
+      archive_url: https://docs.google.com/document/d/1YIOD0Nnid_0h6rKlDxcbfJaoIRNO6mQd9Or5vKRNxaU/edit
+      recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4
+  - name: kops
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/kops/master/OWNERS
+    meetings:
+    - description: kops Office Hours
+      day: Friday
+      time: "09:00"
+      tz: PT (Pacific Time)
+      frequency: biweekly
+      url: https://zoom.us/j/97072789944?pwd=VVlUR3dhN2h5TEFQZHZTVVd4SnJUdz09
+      archive_url: https://docs.google.com/document/d/12QkyL0FkNbWPcLFxxRGSPt_tNPBHbmni3YLY-lHny7E/edit
+  - name: kube-up
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/OWNERS
+  - name: kubeadm
+    contact:
+      slack: kubeadm
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/cluster-bootstrap/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubeadm/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kubeadm/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/system-validators/master/OWNERS
+    meetings:
+    - description: kubeadm Office Hours
+      day: Wednesday
+      time: "09:00"
+      tz: PT (Pacific Time)
+      frequency: biweekly
+      url: https://zoom.us/j/179916854?pwd=dzRhbjFnRGVQRDVUVHY1a29JV2JxUT09
+      archive_url: https://docs.google.com/document/d/1ONcoy8bOw8SWPUwXxnKeRZST3lnUxYpUv4Y6466h9Ek/edit
+      recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4
+  - name: kubespray
+    contact:
+      slack: kubespray
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/kubespray/master/OWNERS
+    meetings:
+    - description: Kubespray Office Hours
+      day: Wednesday
+      time: "08:00"
+      tz: PT (Pacific Time)
+      frequency: biweekly
+      url: https://zoom.us/j/532465189?pwd=THMvL2MzdjZXWG55eHpJMkU2dkI1dz09
+      archive_url: https://docs.google.com/document/d/1oDI1rTwla393k6nEMkqz0RU9rUl3J1hov0kQfNcl-4o/edit
+  - name: minikube
+    contact:
+      slack: minikube
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/minikube/master/OWNERS
+    meetings:
+    - description: minikube office hours
+      day: Monday
+      time: "11:00"
+      tz: PT (Pacific Time)
+      frequency: biweekly
+      url: https://zoom.us/j/97017029363?pwd=U3MvZ3pMMHM5eWorSjgzUnd5OEFtUT09
+      archive_url: https://docs.google.com/document/d/1jhfmL1gsgN39uCEgz5pW9tnIotFgHhxq2yfMK3KYE4w/edit
+- dir: sig-contributor-experience
+  name: Contributor Experience
+  mission_statement: >
+    Developing and sustaining a healthy community of contributors is critical to scaling
+    the project and growing the ecosystem. We need to ensure our contributors are
+    happy and productive, and that there are not bottlenecks hindering the project
+    in, for example: feature velocity, community scaling, pull request latency, and
+    absolute numbers of open pull requests and open issues.
+
+  charter_link: charter.md
+  label: contributor-experience
+  leadership:
+    chairs:
+    - github: alisondy
+      name: Alison Dowdney
+      company: Weaveworks
+    - github: mrbobbytables
+      name: Bob Killen
+      company: Google
+    tech_leads:
+    - github: cblecker
+      name: Christoph Blecker
+      company: Red Hat
+    - github: nikhita
+      name: Nikhita Raghunath
+      company: VMware
+    emeritus_leads:
+    - github: Phillels
+      name: Elsie Phillips
+    - github: castrojo
+      name: Jorge Castro
+    - github: grodrigues3
+      name: Garrett Rodrigues
+    - github: parispittman
+      name: Paris Pittman
+  meetings:
+  - description: Regular SIG Meeting
+    day: Wednesday
+    time: "9:00"
+    tz: PT (Pacific Time)
+    frequency: biweekly
+    url: https://zoom.us/j/397264241?pwd=bHNnZVArNFdPaWVJMmttdko0Sktudz09
+    archive_url: https://docs.google.com/document/d/1CBz8qV_mD6rbDmTsMuosTOQGRXGhN3d8UrcULUI6Vkw/edit
+    recordings_url: https://www.youtube.com/watch?v=EMGUdOKwSns&list=PL69nYSiGNLP2x_48wbOPO0vXQgNTm_xxr
+  contact:
+    slack: sig-contribex
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-contribex
+    teams:
+    - name: sig-contributor-experience
+      description: General Discussion
+    - name: sig-contributor-experience-apac-coordinators
+      description: APAC Coordinator Team
+    - name: sig-contributor-experience-leads
+      description: Chairs and Technical Leads
+    - name: sig-contributor-experience-pr-reviews
+      description: PR Reviews
+    liaison:
+      github: mrbobbytables
+      name: Bob Killen
+  subprojects:
+  - name: community
+    description: Owns and manages overall community repo, including community group
+      documentation and operations.
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/community/master/OWNERS
+  - name: community-management
+    description: Manages operations and policy for upstream community group communication
+      platforms.
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/discuss-theme/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/community/master/communication/OWNERS
+    meetings:
+    - description: APAC Coordinator Meeting
+      day: Thursday
+      time: "5:00"
+      tz: UTC
+      frequency: biweekly
+      url: https://zoom.us/j/144440337?pwd=VEVBejdPYkE2MGdUSDZZZnVlNFdrdz09
+      archive_url: https://docs.google.com/document/d/1qf-02B7EOrItQgwXFxgqZ5qjW0mtfu5qkYIF1Hl4ZLI/
+      recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP2x_48wbOPO0vXQgNTm_xxr
+  - name: contributor-comms
+    description: |
+      Contributor Communications focuses on amplifying the success of Kubernetes contributors through marketing.
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/contributor-tweets/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/community/master/communication/marketing-team/OWNERS
+    meetings:
+    - description: Contributor Comms - Upstream Marketing Team Meeting
+      day: Friday
+      time: "8:00"
+      tz: PT (Pacific Time)
+      frequency: weekly
+      url: https://zoom.us/j/596959769?pwd=TURBNlZPb3BEWVFmbWlCYXlMVVJiUT09
+      archive_url: https://docs.google.com/document/d/1KDoqbw2A6W7rLSbIRuOlqH8gkoOnp2IHHuV9KyJDD2c/edit
+      recordings_url: https://www.youtube.com/watch?v=EMGUdOKwSns&list=PL69nYSiGNLP2x_48wbOPO0vXQgNTm_xxr
+  - name: contributors-documentation
+    description: writes and maintains documentation around contributing to Kubernetes,
+      including the Contributor's Guide, Developer's Guide, and contributor website.
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/community/master/contributors/guide/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/contributor-site/master/OWNERS
+  - name: devstats
+    description: Maintains and updates https://k8s.devstats.cncf.io, including taking
+      requests for new charts.
+    contact:
+      slack: devstats
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/community/master/sig-contributor-experience/devstats/OWNERS
+  - name: events
+    description: Creates and runs contributor-focused events, such as the Contributor
+      Summit.  Event Teams are part of this subproject.
+    contact:
+      slack: events
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/community/master/events/OWNERS
+    meetings:
+    - description: Office Hours European Edition (Open Q&A for end-user kubernetes
+        related questions)
+      day: Wednesday
+      time: "09:00"
+      tz: ET (Eastern Time)
+      frequency: monthly on 3rd Wednesday
+      url: https://hackmd.io/@k8s/office-hours
+    - description: Office Hours Western Edition (Open Q&A for end-user kubernetes
+        related questions)
+      day: Wednesday
+      time: "12:00"
+      tz: ET (Eastern Time)
+      frequency: monthly on 3rd Wednesday
+      archive_url: https://hackmd.io/@k8s/office-hours
+      recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP3azFUvYJjGn45YbF6C-uIg
+  - name: github-management
+    description: Manages and controls Github permissions, repos, and groups, including
+      Org Membership.
+    contact:
+      slack: github-management
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-client/.github/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-csi/.github/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/.github/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/.github/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/community/master/github-management/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes-template-project/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/org/master/OWNERS
+    meetings:
+    - description: GitHub Administration Subproject
+      day: Thursday
+      time: "09:30"
+      tz: PT (Pacific Time)
+      frequency: Monthly on 4th Thursday
+      url: https://zoom.us/j/442435463?pwd=Rk1PWWpSSTJDaWJKdzRYb2EyTlkvZz09
+      archive_url: https://docs.google.com/document/d/1IiVrr1hcFWmbboExk971FsMUGfr2Wp68mdMribCuzLs/edit
+      recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP2x_48wbOPO0vXQgNTm_xxr
+  - name: k8s.io
+    description: Creates and maintains shortcuts and automation apps running in the
+      k8s.io domain.
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/k8s.io/master/OWNERS
+  - name: mentoring
+    description: Oversees and develops programs for helping contributors ascend the
+      contributor ladder, including the New Contributor Workshops, Meet Our Contributors,
+      and other programs.
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/contributor-playground/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/community/master/mentoring/OWNERS
+    meetings:
+    - description: Mentoring Subproject Meeting
+      day: Monday
+      time: "08:00"
+      tz: PT
+      frequency: Biweekly
+      url: https://zoom.us/j/95894431386?pwd=RFdmQzlZeVZDVWJzcFVXZXR5djNwUT09
+      archive_url: https://docs.google.com/document/d/1XiXjDWCc087VKqX2b6LMGRnlaRyLYGh2-eWQQr6dAmc/edit
+      recordings_url: https://www.youtube.com/watch?v=Cqf9dIiS6Ig&list=PL69nYSiGNLP2x_48wbOPO0vXQgNTm_xxr
+  - name: slack-infra
+    description: Creates and maintains tools and automation for Kubernetes Slack.
+    contact:
+      slack: slack-infra
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/slack-infra/main/OWNERS
+- dir: sig-docs
+  name: Docs
+  mission_statement: >
+    Covers documentation, doc processes, and doc publishing for Kubernetes.
+
+  charter_link: charter.md
+  label: docs
+  leadership:
+    chairs:
+    - github: irvifa
+      name: Irvi Aini
+      company: Spotify
+    - github: jimangel
+      name: Jim Angel
+      company: Google
+    - github: kbarnard10
+      name: Kaitlyn Barnard
+      company: Kong
+    tech_leads:
+    - github: kbhawkey
+      name: Karen Bradshaw
+      company: Independent
+    - github: onlydole
+      name: Taylor Dolezal
+      company: Independent
+    - github: sftim
+      name: Tim Bannister
+      company: The Scale Factory
+    emeritus_leads:
+    - github: Bradamant3
+      name: Jennifer Rondeau
+    - github: chenopis
+      name: Andrew Chen
+    - github: jaredbhatti
+      name: Jared Bhatti
+    - github: zacharysarah
+      name: Zach Corleissen
+  meetings:
+  - description: APAC SIG Meeting
+    day: Wednesday
+    time: "01:00"
+    tz: UTC
+    frequency: monthly - Wednesday, after the fourth Tuesday, every month
+    url: https://docs.google.com/document/d/1ddHwLK3kUMX1wVFIwlksjTk0MsqitBnWPe1LRa1Rx5A/edit
+    archive_url: https://docs.google.com/document/d/1ddHwLK3kUMX1wVFIwlksjTk0MsqitBnWPe1LRa1Rx5A/edit
+    recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP3b5hlx0YV7Lo7DtckM84y8
+  - description: Korean Team Meeting
+    day: Thursday
+    time: "13:00"
+    tz: UTC
+    frequency: biweekly
+    url: https://docs.google.com/document/d/1h5sMhBpPB5unJmBAS7KzDiPs-_eFQOu5o4UyHwMtFCA/edit
+    archive_url: https://docs.google.com/document/d/1h5sMhBpPB5unJmBAS7KzDiPs-_eFQOu5o4UyHwMtFCA/edit
+    recordings_url: https://www.youtube.com/playlist?list=PLAOP7m08QDCWZ7RwGca6cU4vzrOMw3ht7
+  - description: Localization Subgroup Meeting
+    day: Monday
+    time: "15:00"
+    tz: UTC
+    frequency: monthly
+    url: https://docs.google.com/document/d/1NwO1AN8Ea2zlK8uAdaDAKf1-LZDAFvSewIfrKqfl5No/
+    archive_url: https://docs.google.com/document/d/1NwO1AN8Ea2zlK8uAdaDAKf1-LZDAFvSewIfrKqfl5No/
+    recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP3b5hlx0YV7Lo7DtckM84y8
+  - description: Regular SIG Meeting
+    day: Tuesday
+    time: "17:30"
+    tz: UTC
+    frequency: weekly - except fourth Tuesday every month
+    url: https://docs.google.com/document/d/1ddHwLK3kUMX1wVFIwlksjTk0MsqitBnWPe1LRa1Rx5A/edit
+    archive_url: https://docs.google.com/document/d/1ddHwLK3kUMX1wVFIwlksjTk0MsqitBnWPe1LRa1Rx5A/edit
+    recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP3b5hlx0YV7Lo7DtckM84y8
+  - description: Spanish Team Meeting
+    day: Tuesday
+    time: "15:30"
+    tz: UTC
+    frequency: weekly
+    url: https://zoom.us/j/95918289494?pwd=Wk9Oa0xZUkFXSDV5OTFoZEZsTURCZz09
+    archive_url: https://docs.google.com/document/d/1jOTK1tqBRwlNQJUB88wfDnGxpdInxMJ7lIFDZy9cMGY
+    recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP3b5hlx0YV7Lo7DtckM84y8
+  contact:
+    slack: sig-docs
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-docs
+    teams:
+    - name: kubernetes-blog
+      description: Kubernetes blog maintainers
+    - name: sig-docs-de-owners
+      description: German language content
+    - name: sig-docs-en-owners
+      description: English content (default)
+    - name: sig-docs-es-owners
+      description: Spanish language content
+    - name: sig-docs-fr-owners
+      description: French language content
+    - name: sig-docs-hi-owners
+      description: Hindi language content
+    - name: sig-docs-id-owners
+      description: Indonesian language content
+    - name: sig-docs-it-owners
+      description: Italian language content
+    - name: sig-docs-ja-owners
+      description: Japanese language content
+    - name: sig-docs-ko-owners
+      description: Korean language content
+    - name: sig-docs-maintainers
+      description: Documentation maintainers
+    - name: sig-docs-pl-owners
+      description: Polish language content
+    - name: sig-docs-pr-reviews
+      description: Documentation PR reviews
+    - name: sig-docs-pt-owners
+      description: Portuguese language content
+    - name: sig-docs-uk-owners
+      description: Ukrainian language content
+    - name: sig-docs-zh-owners
+      description: Chinese language content
+    liaison:
+      github: liggitt
+      name: Jordan Liggitt
+  subprojects:
+  - name: kubernetes-blog
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/website/master/content/en/blog/OWNERS
+  - name: reference-docs
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/reference-docs/master/OWNERS
+  - name: website
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/website/master/OWNERS
+- dir: sig-instrumentation
+  name: Instrumentation
+  mission_statement: >
+    Covers best practices for cluster observability through metrics, logging, and
+    events across all Kubernetes components and development of relevant components
+    such as Heapster and kube-state-metrics. Coordinates metric requirements of different
+    SIGs for other components through finding common APIs.
+
+  charter_link: charter.md
+  label: instrumentation
+  leadership:
+    chairs:
+    - github: ehashman
+      name: Elana Hashman
+      company: Red Hat
+    - github: logicalhan
+      name: Han Kang
+      company: Google
+    tech_leads:
+    - github: brancz
+      name: Frederic Branczyk
+      company: Polar Signals
+    - github: dashpole
+      name: David Ashpole
+      company: Google
+    emeritus_leads:
+    - github: piosz
+      name: Piotr Szczesniak
+  meetings:
+  - description: Regular SIG Meeting
+    day: Thursday
+    time: "9:30"
+    tz: PT (Pacific Time)
+    frequency: biweekly
+    url: https://zoom.us/j/5342565819?pwd=RlVsK21NVnR1dmE3SWZQSXhveHZPdz09
+    archive_url: https://docs.google.com/document/d/1FE4AQ8B49fYbKhfg4Tx0cui1V0eI4o3PxoqQPUwNEiU/edit?usp=sharing
+  - description: Regular Triage Meeting
+    day: Wednesday
+    time: "9:00"
+    tz: PT (Pacific Time)
+    frequency: biweekly
+    url: https://zoom.us/j/5342565819?pwd=RlVsK21NVnR1dmE3SWZQSXhveHZPdz09
+    archive_url: https://docs.google.com/document/d/1FE4AQ8B49fYbKhfg4Tx0cui1V0eI4o3PxoqQPUwNEiU/edit?usp=sharing
+  contact:
+    slack: sig-instrumentation
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-instrumentation
+    teams:
+    - name: sig-instrumentation-api-reviews
+      description: API Changes and Reviews
+    - name: sig-instrumentation-bugs
+      description: Bug Triage and Troubleshooting
+    - name: sig-instrumentation-feature-requests
+      description: Feature Requests
+    - name: sig-instrumentation-misc
+      description: General Discussion
+    - name: sig-instrumentation-pr-reviews
+      description: PR Reviews
+    - name: sig-instrumentation-proposals
+      description: Design Proposals
+    - name: sig-instrumentation-test-failures
+      description: Test Failures and Triage
+    liaison:
+      github: cblecker
+      name: Christoph Blecker
+  subprojects:
+  - name: custom-metrics-apiserver
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/custom-metrics-apiserver/master/OWNERS
+  - name: instrumentation
+    description: Organization of SIG Instrumentation subprojects
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/instrumentation/master/OWNERS
+  - name: instrumentation-addons
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/instrumentation-addons/master/OWNERS
+  - name: instrumentation-tools
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/instrumentation-tools/master/OWNERS
+  - name: klog
+    contact:
+      slack: klog
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/klog/master/OWNERS
+  - name: kube-state-metrics
+    contact:
+      slack: kube-state-metrics
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/kube-state-metrics/master/OWNERS
+  - name: metric-stability-framework
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/component-base/metrics/OWNERS
+  - name: metrics
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/metrics/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/metrics/master/OWNERS
+  - name: metrics-server
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/metrics-server/master/OWNERS
+  - name: prometheus-adapter
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/prometheus-adapter/master/OWNERS
+  - name: structured-logging
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/component-base/logs/OWNERS
+- dir: sig-multicluster
+  name: Multicluster
+  mission_statement: >
+    A Special Interest Group focused on solving common challenges related to the management
+    of multiple Kubernetes clusters, and applications that exist therein. The SIG
+    will be responsible for designing, discussing, implementing and maintaining API’s,
+    tools and documentation related to multi-cluster administration and application
+    management. This includes not only active automated approaches such as Cluster
+    Federation, but also those that employ batch workflow-style continuous deployment
+    systems like Spinnaker and others.  Standalone building blocks for these and other
+    similar systems (for example a cluster registry), and proposed changes to kubernetes
+    core where appropriate will also be in scope.
+
+  charter_link: charter.md
+  label: multicluster
+  leadership:
+    chairs:
+    - github: jeremyot
+      name: Jeremy Olmsted-Thompson
+      company: Google
+    - github: pmorie
+      name: Paul Morie
+      company: Red Hat
+    emeritus_leads:
+    - github: quinton-hoole
+      name: Quinton Hoole
+  meetings:
+  - description: Regular SIG Meeting
+    day: Tuesday
+    time: "9:30"
+    tz: PT (Pacific Time)
+    frequency: weekly
+    url: https://zoom.us/my/k8s.mc
+    archive_url: https://tinyurl.com/sig-multicluster-notes
+    recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP0HqgyqTby6HlDEz7i1mb0-
+  contact:
+    slack: sig-multicluster
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-multicluster
+    teams:
+    - name: sig-multicluster-api-reviews
+      description: API Changes and Reviews
+    - name: sig-multicluster-bugs
+      description: Bug Triage and Troubleshooting
+    - name: sig-multicluster-feature-requests
+      description: Feature Requests
+    - name: sig-multicluster-misc
+      description: General Discussion
+    - name: sig-multicluster-pr-reviews
+      description: PR Reviews
+    - name: sig-multicluster-test-failures
+      description: Test Failures and Triage
+    - name: sig-mutlicluster-proposals
+      description: Design Proposals
+    liaison:
+      github: parispittman
+      name: Paris Pittman
+  subprojects:
+  - name: Kubefed
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/kubefed/master/OWNERS
+  - name: about-api
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/about-api/master/OWNERS
+  - name: kubemci
+    owners:
+    - https://raw.githubusercontent.com/GoogleCloudPlatform/k8s-multicluster-ingress/master/OWNERS
+  - name: mcs-api
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/mcs-api/master/OWNERS
+  - name: work-api
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/work-api/master/OWNERS
+- dir: sig-network
+  name: Network
+  mission_statement: >
+    Covers networking in Kubernetes.
+
+  charter_link: charter.md
+  label: network
+  leadership:
+    chairs:
+    - github: caseydavenport
+      name: Casey Davenport
+      company: Tigera
+    - github: dcbw
+      name: Dan Williams
+      company: Red Hat
+    - github: thockin
+      name: Tim Hockin
+      company: Google
+  meetings:
+  - description: Gateway API Meeting (APAC Friendly)
+    day: Monday
+    time: "15:00"
+    tz: PT (Pacific Time)
+    frequency: biweekly
+    url: https://zoom.us/j/441530404
+    archive_url: https://docs.google.com/document/d/1eg-YjOHaQ7UD28htdNxBR3zufebozXKyI28cl2E11tU/edit
+  - description: Gateway API Meeting (EMEA Friendly)
+    day: Tuesday
+    time: "10:00"
+    tz: PT (Pacific Time)
+    frequency: biweekly
+    url: https://zoom.us/j/441530404
+    archive_url: https://docs.google.com/document/d/1eg-YjOHaQ7UD28htdNxBR3zufebozXKyI28cl2E11tU/edit
+  - description: Network Policy API Meeting
+    day: Monday
+    time: "13:00"
+    tz: PT (Pacific Time)
+    frequency: weekly
+    url: https://zoom.us/j/96264742248
+    archive_url: https://docs.google.com/document/d/1AtWQy2fNa4qXRag9cCp5_HsefD7bxKe3ea2RPn8jnSs
+  - description: SIG Network Ingress NGINX Meeting
+    day: Tuesday
+    time: "9:00"
+    tz: PT (Pacific Time)
+    frequency: biweekly
+    url: https://zoom.us/j/98377891310
+    archive_url: https://docs.google.com/document/d/1DKlpcV6DAW0DsBrzh-OLkZvJQmABCVfRIRWBWjc4zOs/edit
+    recordings_url: https://www.youtube.com/watch?v=VkbEihIb7tA&list=PL69nYSiGNLP2Rqe8T4mDnyHqDZ4VYPY1X
+  - description: SIG Network Kube Proxy Meeting
+    day: Friday
+    time: "8:30"
+    tz: PT (Pacific Time)
+    frequency: weekly
+    url: https://docs.google.com/document/d/1yW3AUp5rYDLYCAtZc6e4zeLbP5HPLXdvuEFeVESOTic/edit
+  - description: SIG Network Meeting
+    day: Thursday
+    time: "14:00"
+    tz: PT (Pacific Time)
+    frequency: biweekly
+    url: https://zoom.us/j/361123509
+    archive_url: https://docs.google.com/document/d/1_w77-zG_Xj0zYvEMfQZTQ-wPP4kXkpGD8smVtW_qqWM/edit
+    recordings_url: https://www.youtube.com/watch?v=phCA5-vWkVM&list=PL69nYSiGNLP2E8vmnqo5MwPOY25sDWIxb
+  contact:
+    slack: sig-network
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-network
+    teams:
+    - name: sig-network-api-reviews
+      description: API Changes and Reviews
+    - name: sig-network-bugs
+      description: Bug Triage and Troubleshooting
+    - name: sig-network-feature-requests
+      description: Feature Requests
+    - name: sig-network-misc
+      description: General Discussion
+    - name: sig-network-pr-reviews
+      description: PR Reviews
+    - name: sig-network-proposals
+      description: Design Proposals
+    - name: sig-network-test-failures
+      description: Test Failures and Triage
+    liaison:
+      github: derekwaynecarr
+      name: Derek Carr
+  subprojects:
+  - name: cluster-proportional-autoscaler
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-proportional-autoscaler/master/OWNERS
+  - name: cluster-proportional-vertical-autoscaler
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-proportional-vertical-autoscaler/master/OWNERS
+  - name: external-dns
+    contact:
+      slack: external-dns
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/external-dns/master/OWNERS
+  - name: gateway-api
+    contact:
+      slack: sig-network-gateway-api
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/endpoint/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/controller/service/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/proxy/OWNERS
+  - name: ingress
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/ingress-controller-conformance/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/ingress-gce/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/OWNERS
+  - name: iptables-wrappers
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/iptables-wrappers/master/OWNERS
+  - name: kpng
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/kpng/master/OWNERS
+  - name: kube-dns
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/dns/master/OWNERS
+  - name: network-policy
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/network-policy-api/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/api/master/networking/OWNERS
+  - name: pod-networking
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/ip-masq-agent/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/network/OWNERS
+- dir: sig-node
+  name: Node
+  mission_statement: >
+    SIG Node is responsible for the components that support the controlled interactions
+    between pods and host resources.
+
+  charter_link: charter.md
+  label: node
+  leadership:
+    chairs:
+    - github: dchen1107
+      name: Dawn Chen
+      company: Google
+    - github: derekwaynecarr
+      name: Derek Carr
+      company: Red Hat
+  meetings:
+  - description: Regular SIG Meeting
+    day: Tuesday
+    time: "10:00"
+    tz: PT (Pacific Time)
+    frequency: weekly
+    url: https://zoom.us/j/4799874685
+    archive_url: https://docs.google.com/document/d/1Ne57gvidMEWXR70OxxnRkYquAoMpt56o75oZtg-OeBg/edit?usp=sharing
+    recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP1wJPj5DYWXjiArF-MJ5fNG
+  - description: Weekly CI/Triage Meeting
+    day: Wednesday
+    time: "10:00"
+    tz: PT (Pacific Time)
+    frequency: weekly
+    url: https://zoom.us/j/4799874685
+    archive_url: https://docs.google.com/document/d/1fb-ugvgdSVIkkuJ388_nhp2pBTy_4HEVg5848Xy7n5U/edit
+  contact:
+    slack: sig-node
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-node
+    teams:
+    - name: sig-node-api-reviews
+      description: API Changes and Reviews
+    - name: sig-node-bugs
+      description: Bug Triage and Troubleshooting
+    - name: sig-node-feature-requests
+      description: Feature Requests
+    - name: sig-node-pr-reviews
+      description: PR Reviews
+    - name: sig-node-proposals
+      description: Design Proposals
+    - name: sig-node-test-failures
+      description: Test Failures and Triage
+    liaison:
+      github: nikhita
+      name: Nikhita Raghunath
+  subprojects:
+  - name: cri-api
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/cri-api/master/OWNERS
+  - name: cri-tools
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cri-tools/master/OWNERS
+  - name: frakti
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/frakti/master/OWNERS
+  - name: kubelet
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kubelet/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/OWNERS
+  - name: node-api
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/api/master/node/OWNERS
+  - name: node-feature-discovery
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery-operator/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/master/OWNERS
+  - name: node-problem-detector
+    contact:
+      slack: node-problem-detector
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/node-problem-detector/master/OWNERS
+  - name: noderesourcetopology-api
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/noderesourcetopology-api/master/OWNERS
+  - name: security-profiles-operator
+    contact:
+      slack: security-profiles-operator
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/security-profiles-operator/master/OWNERS
+- dir: sig-release
+  name: Release
+  mission_statement: >
+    Ensure quality Kubernetes releases
+
+  charter_link: charter.md
+  label: release
+  leadership:
+    chairs:
+    - github: justaugustus
+      name: Stephen Augustus
+      company: Cisco
+    - github: saschagrunert
+      name: Sascha Grunert
+      company: Red Hat
+    tech_leads:
+    - github: hasheddan
+      name: Daniel Mangum
+      company: Upbound
+    - github: jeremyrickard
+      name: Jeremy Rickard
+      company: Apple
+    emeritus_leads:
+    - github: alejandrox1
+      name: Jorge Alarcon Ochoa
+    - github: calebamiles
+      name: Caleb Miles
+    - github: jdumars
+      name: Jaice Singer DuMars
+    - github: tpepper
+      name: Tim Pepper
+  meetings:
+  - description: Regular SIG Meeting
+    day: Tuesday
+    time: "14:30"
+    tz: UTC
+    frequency: biweekly
+    url: https://zoom.us/j/327142148
+    archive_url: https://bit.ly/k8s-sig-release-meeting
+    recordings_url: https://bit.ly/k8s-sig-release-videos
+  contact:
+    slack: sig-release
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-release
+    teams:
+    - name: kubernetes-milestone-maintainers
+      description: Milestone Maintainers
+    - name: release-managers
+      description: Release Managers
+    - name: sig-release
+      description: SIG Release Members
+    - name: sig-release-admins
+      description: Admins for SIG Release repositories
+    liaison:
+      github: dims
+      name: Davanum Srinivas
+  subprojects:
+  - name: Release Engineering
+    description: |
+      The Release Engineering subproject is responsible for the [process/procedures](https://github.com/kubernetes/sig-release/tree/master/release-engineering) and [tools](https://github.com/kubernetes/release) used to create/maintain Kubernetes release artifacts.
+    contact:
+      slack: release-management
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/downloadkubernetes/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/k8s-container-image-promoter/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/mdtoc/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/release-notes/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/release-sdk/main/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/release-utils/main/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/zeitgeist/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/publishing-bot/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/release/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/sig-release/master/release-engineering/OWNERS
+    meetings:
+    - description: Release Engineering
+      day: Tuesday
+      time: "14:30"
+      tz: UTC
+      frequency: biweekly
+      url: https://zoom.us/j/240812475
+      archive_url: https://bit.ly/k8s-releng-meeting
+      recordings_url: https://bit.ly/k8s-sig-release-videos
+  - name: Release Team
+    description: |
+      The Kubernetes Release Team is responsible for the day-to-day work required to successfully create releases of Kubernetes.
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/sig-release/master/release-team/OWNERS
+  - name: SIG Release Process Documentation
+    description: |
+      Documents and processes related to SIG Release
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/sig-release/master/OWNERS
+  - name: hyperkube
+    description: |
+      Best-effort maintaining of hyperkube until 1.18 goes EOL 2021-04-30.
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.18/cluster/images/hyperkube/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/release/master/images/build/debian-hyperkube-base/OWNERS
+  - name: kubernetes/repo-infra
+    description: |
+      Creates and maintains tools and templates for Kubernetes org repositories.
+      Includes bazel tooling for managing dependencies for kubernetes/kubernetes
+      and kubernetes/test-infra.
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/repo-infra/master/OWNERS
+- dir: sig-scalability
+  name: Scalability
+  mission_statement: >
+    SIG Scalability is responsible for defining and driving scalability goals for
+    Kubernetes. We also coordinate and contribute to general system-wide scalability
+    and performance improvements (not falling into the charter of other individual
+    SIGs) by driving large architectural changes and finding bottlenecks, as well
+    as provide guidance and consultations about any scalability and performance related
+    aspects of Kubernetes. <br/> We are actively working on finding and removing various
+    scalability bottlenecks which should lead us towards pushing system's scalability
+    higher. This may include going beyond 5k nodes in the future - although that's
+    not our priority as of now, this is very deeply in our area of interest and we
+    are happy to guide and collaborate on any efforts towards that goal as long as
+    they are not sacrificing on overall Kubernetes architecture (by making it non-maintainable,
+    non-understandable, etc.).
+
+  charter_link: charter.md
+  label: scalability
+  leadership:
+    chairs:
+    - github: mm4tt
+      name: Matt Matejczyk
+      company: Google
+    - github: shyamjvs
+      name: Shyam Jeedigunta
+      company: AWS
+    tech_leads:
+    - github: wojtek-t
+      name: Wojciech Tyczynski
+      company: Google
+  meetings:
+  - description: Regular SIG Meeting
+    day: Thursday
+    time: "10:30"
+    tz: PT (Pacific Time)
+    frequency: bi-weekly ([upcoming meeting dates](#upcoming-meeting-dates))
+    url: https://zoom.us/j/94252896018?pwd=cTlMMlBoTHZqUEdjRm9VY2NWNUg5dz09
+    archive_url: https://docs.google.com/a/bobsplanet.com/document/d/1hEpf25qifVWztaeZPFmjNiJvPo-5JX1z0LSvvVY5G2g/edit?usp=drive_web
+    recordings_url: https://www.youtube.com/watch?v=NDP1uYyom28&list=PL69nYSiGNLP2X-hzNTqyELU6jYS3p10uL
+  contact:
+    slack: sig-scalability
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-scale
+    teams:
+    - name: sig-scalability-api-reviews
+      description: API Changes and Reviews
+    - name: sig-scalability-bugs
+      description: Bug Triage and Troubleshooting
+    - name: sig-scalability-feature-requests
+      description: Feature Requests
+    - name: sig-scalability-misc
+      description: General Discussion
+    - name: sig-scalability-pr-reviews
+      description: PR Reviews
+    - name: sig-scalability-proprosals
+      description: Design Proposals
+    - name: sig-scalability-test-failures
+      description: Test Failures and Triage
+    liaison:
+      github: mrbobbytables
+      name: Bob Killen
+  subprojects:
+  - name: kubernetes-scalability-and-performance-tests-and-validation
+    description: '[Described below](#kubernetes-scalability-and-performance-tests-and-validation)'
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/community/master/sig-scalability/processes/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/e2e/scalability/OWNERS
+  - name: kubernetes-scalability-bottlenecks-detection
+    description: '[Described below](#kubernetes-scalability-bottlenecks-detection)'
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/community/master/sig-scalability/blogs/OWNERS
+  - name: kubernetes-scalability-definition
+    description: '[Described below](#kubernetes-scalability-definition)'
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/community/master/sig-scalability/configs-and-limits/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/community/master/sig-scalability/slos/OWNERS
+  - name: kubernetes-scalability-governance
+    description: '[Described below](#kubernetes-scalability-governance)'
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/community/master/sig-scalability/governance/OWNERS
+  - name: kubernetes-scalability-test-frameworks
+    description: '[Described below](#kubernetes-scalability-test-frameworks)'
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/images/kubemark/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kubemark/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubemark/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/kubemark/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/perf-tests/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/perf-tests/master/clusterloader2/OWNERS
+- dir: sig-scheduling
+  name: Scheduling
+  mission_statement: >
+    SIG Scheduling is responsible for the components that make Pod placement decisions.
+
+  charter_link: charter.md
+  label: scheduling
+  leadership:
+    chairs:
+    - github: Huang-Wei
+      name: Wei Huang
+      company: IBM
+    - github: ahg-g
+      name: Abdullah Gharaibeh
+      company: Google
+    emeritus_leads:
+    - github: bsalamat
+      name: Bobby (Babak) Salamat
+    - github: k82cn
+      name: Klaus Ma
+  meetings:
+  - description: 10AM PT Meeting
+    day: Thursday
+    time: "17:00"
+    tz: UTC
+    frequency: biweekly starting Thursday June 7, 2018
+    url: https://zoom.us/j/841218129
+    archive_url: https://docs.google.com/document/d/13mwye7nvrmV11q9_Eg77z-1w3X7Q1GTbslpml4J7F3A/edit
+    recordings_url: https://www.youtube.com/watch?v=PweKj6SU7UA&list=PL69nYSiGNLP2vwzcCOhxrL3JVBc-eaJWI
+  contact:
+    slack: sig-scheduling
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-scheduling
+    teams:
+    - name: sig-scheduling-api-reviews
+      description: API Changes and Reviews
+    - name: sig-scheduling-bugs
+      description: Bug Triage and Troubleshooting
+    - name: sig-scheduling-feature-requests
+      description: Feature Requests
+    - name: sig-scheduling-misc
+      description: General Discussion
+    - name: sig-scheduling-pr-reviews
+      description: PR Reviews
+    - name: sig-scheduling-proposals
+      description: Design Proposals
+    - name: sig-scheduling-test-failures
+      description: Test Failures and Triage
+    liaison:
+      github: liggitt
+      name: Jordan Liggitt
+  subprojects:
+  - name: cluster-capacity
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/cluster-capacity/master/OWNERS
+  - name: descheduler
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/descheduler/master/OWNERS
+  - name: kube-batch
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/kube-batch/master/OWNERS
+  - name: poseidon
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/poseidon/master/OWNERS
+  - name: scheduler
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/cmd/kube-scheduler/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/scheduler/OWNERS
+  - name: scheduler-plugins
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/scheduler-plugins/master/OWNERS
+- dir: sig-security
+  name: Security
+  mission_statement: >
+    Covers horizontal security initiatives for the Kubernetes project, including regular
+    security audits, the vulnerability management process, cross-cutting security
+    documentation, and security community management.
+
+  charter_link: charter.md
+  label: security
+  leadership:
+    chairs:
+    - github: IanColdwater
+      name: Ian Coldwater
+      company: Twilio
+    - github: tabbysable
+      name: Tabitha Sable
+      company: Datadog
+  meetings:
+  - description: Regular SIG Meeting
+    day: Thursday
+    time: "9:00"
+    tz: PT (Pacific Time)
+    frequency: biweekly
+    url: https://zoom.us/j/9934z1184192?pwd=L25Tc0ZOL3FqU09KNERlTU12dFhTQT09
+    archive_url: https://docs.google.com/document/d/1GgmmNYN88IZ2v2NBiO3gdU8Riomm0upge_XNVxEYXp0/edit?usp=sharing
+    recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP1mXOLAc9ti0oX8s_ookQCi
+  contact:
+    slack: sig-security
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-security
+    teams:
+    - name: sig-security-leads
+      description: SIG Security Leads
+    - name: sig-security-pr-reviews
+      description: SIG Security PR review notifications
+    liaison:
+      github: parispittman
+      name: Paris Pittman
+  subprojects:
+  - name: security-audit
+    description: Third Party Security Audit
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/community/master/sig-security/sig-security-external-audit/OWNERS
+  - name: security-docs
+    description: Security Documents and Documentation
+    contact:
+      slack: sig-security-docs
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/community/master/sig-security/sig-security-docs/OWNERS
+- dir: sig-service-catalog
+  name: Service Catalog
+  mission_statement: >
+    Service Catalog is a Kubernetes extension project that implements the [Open Service
+    Broker API](https://www.openservicebrokerapi.org/) (OSBAPI). It allows application
+    developers the ability to provision and consume cloud services natively from within
+    Kubernetes.
+
+  charter_link: charter.md
+  label: service-catalog
+  leadership:
+    chairs:
+    - github: jberkhahn
+      name: Jonathan Berkhahn
+      company: IBM
+    - github: jhvhs
+      name: Konstantin Semenov
+      company: VMware
+    emeritus_leads:
+    - github: arschles
+      name: Aaron Schlesinger
+    - github: carolynvs
+      name: Carolyn Van Slyck
+    - github: duglin
+      name: Doug Davis
+    - github: jboyd01
+      name: Jay Boyd
+    - github: kibbles-n-bytes
+      name: Michael Kibbe
+    - github: mszostok
+      name: Mateusz Szostok
+    - github: pmorie
+      name: Paul Morie
+    - github: vaikas-google
+      name: Ville Aikas
+  meetings:
+  - description: Regular SIG Meeting
+    day: Monday
+    time: "10:00"
+    tz: PT (Pacific Time)
+    frequency: biweekly
+    url: https://zoom.us/j/7201225346
+    archive_url: https://docs.google.com/document/d/17xlpkoEbPR5M6P5VDzNx17q6-IPFxKyebEekCGYiIKM/edit
+    recordings_url: https://www.youtube.com/watch?v=ukPj1sFFkr0&list=PL69nYSiGNLP2k9ZXx9E1MvRSotFDoHUWs
+  contact:
+    slack: sig-service-catalog
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-service-catalog
+    teams:
+    - name: sig-service-catalog-api-reviews
+      description: API Changes and Reviews
+    - name: sig-service-catalog-bugs
+      description: Bug Triage and Troubleshooting
+    - name: sig-service-catalog-feature-requests
+      description: Feature Requests
+    - name: sig-service-catalog-misc
+      description: General Discussion
+    - name: sig-service-catalog-pr-reviews
+      description: PR Reviews
+    - name: sig-service-catalog-proposals
+      description: Design Proposals
+    - name: sig-service-catalog-test-failures
+      description: Test Failures and Triage
+    liaison:
+      github: cblecker
+      name: Christoph Blecker
+  subprojects:
+  - name: minibroker
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/minibroker/master/OWNERS
+  - name: service-catalog
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/go-open-service-broker-client/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/service-catalog/master/OWNERS
+- dir: sig-storage
+  name: Storage
+  mission_statement: >
+    SIG Storage is responsible for ensuring that different types of file and block
+    storage (whether ephemeral or persistent, local or remote) are available wherever
+    a container is scheduled (including provisioning/creating, attaching, mounting,
+    unmounting, detaching, and deleting of volumes), storage capacity management (container
+    ephemeral storage usage, volume resizing, etc.), influencing scheduling of containers
+    based on storage (data gravity, availability, etc.), and generic operations on
+    storage (snapshoting, etc.).
+
+  charter_link: charter.md
+  label: storage
+  leadership:
+    chairs:
+    - github: saad-ali
+      name: Saad Ali
+      company: Google
+    - github: xing-yang
+      name: Xing Yang
+      company: VMware
+    tech_leads:
+    - github: jsafrane
+      name: Jan Šafránek
+      company: Red Hat
+    - github: msau42
+      name: Michelle Au
+      company: Google
+    emeritus_leads:
+    - github: childsb
+      name: Bradley Childs
+  meetings:
+  - description: Regular SIG Meeting
+    day: Thursday
+    time: "9:00"
+    tz: PT (Pacific Time)
+    frequency: biweekly
+    url: https://zoom.us/j/614261834
+    archive_url: https://docs.google.com/document/d/1-8KEG8AjAgKznS9NFm3qWqkGyCHmvU6HVl0sk5hwoAE/edit?usp=sharing
+    recordings_url: https://www.youtube.com/watch?v=Eh7Qa7KOL8o&list=PL69nYSiGNLP02-BMqJdfFgGxYQ4Nb-2Qq
+  contact:
+    slack: sig-storage
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-storage
+    teams:
+    - name: sig-storage-api-reviews
+      description: API Changes and Reviews
+    - name: sig-storage-bugs
+      description: Bug Triage and Troubleshooting
+    - name: sig-storage-feature-requests
+      description: Feature Requests
+    - name: sig-storage-misc
+      description: General Discussion
+    - name: sig-storage-pr-reviews
+      description: PR Reviews
+    - name: sig-storage-proposals
+      description: Design Proposals
+    - name: sig-storage-test-failures
+      description: Test Failures and Triage
+    liaison:
+      github: parispittman
+      name: Paris Pittman
+  subprojects:
+  - name: external-storage
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/sig-storage-lib-external-provisioner/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/sig-storage-local-static-provisioner/master/OWNERS
+  - name: git-sync
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/git-sync/master/OWNERS
+  - name: gluster-provisioner
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/gluster-block-external-provisioner/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/gluster-file-external-provisioner/master/OWNERS
+  - name: kubernetes-cosi
+    contact:
+      slack: sig-storage-cosi
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/container-object-storage-interface-api/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/container-object-storage-interface-controller/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/container-object-storage-interface-csi-adapter/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/container-object-storage-interface-provisioner-sidecar/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/container-object-storage-interface-spec/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/cosi-driver-minio/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/cosi-driver-sample/master/OWNERS
+  - name: kubernetes-csi
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-csi/cluster-driver-registrar/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-host-path/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-image-populator/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-iscsi/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-csi/csi-driver-smb/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-csi/csi-lib-fc/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-csi/csi-lib-iscsi/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-csi/csi-lib-utils/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-csi/csi-proxy/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-csi/csi-release-tools/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-csi/csi-test/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-csi/docs/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-csi/driver-registrar/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-csi/external-attacher/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-csi/external-health-monitor/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-csi/external-provisioner/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-csi/external-resizer/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-csi/kubernetes-csi.github.io/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-csi/livenessprobe/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-csi/node-driver-registrar/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/csi-api/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/csi-translation-lib/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/csi-api/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/csi-translation-lib/OWNERS
+  - name: mount-utils
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/mount-utils/OWNERS
+  - name: nfs-provisioner
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-sigs/nfs-subdir-external-provisioner/master/OWNERS
+  - name: volume-populators
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-csi/lib-volume-populator/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes-csi/volume-data-source-validator/master/OWNERS
+  - name: volumes
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/volume/OWNERS
+- dir: sig-testing
+  name: Testing
+  mission_statement: >
+    Interested in how we can most effectively test Kubernetes. We're interested specifically
+    in making it easier for the community to run tests and contribute test results,
+    to ensure Kubernetes is stable across a variety of cluster configurations and
+    cloud providers.
+
+  charter_link: charter.md
+  label: testing
+  leadership:
+    chairs:
+    - github: BenTheElder
+      name: Benjamin Elder
+      company: Google
+    - github: spiffxp
+      name: Aaron Crickenberger
+      company: Google
+    - github: stevekuznetsov
+      name: Steve Kuznetsov
+      company: Red Hat
+    emeritus_leads:
+    - github: fejta
+      name: Erick Fejta
+    - github: timothysc
+      name: Timothy St. Clair
+  meetings:
+  - description: SIG Testing Bi-Weekly Meeting
+    day: Tuesday
+    time: "10:00"
+    tz: PT (Pacific Time)
+    frequency: bi-weekly starting Tuesday August 13, 2019
+    url: https://zoom.us/j/135450138?pwd=WGJyaVZzekJCWFBTMGJGTXVjUFJaUT09
+    archive_url: https://bit.ly/k8s-sig-testing-notes
+    recordings_url: https://bit.ly/k8s-sig-testing-videos
+  contact:
+    slack: sig-testing
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-testing
+    teams:
+    - name: sig-testing
+      description: General Discussion
+    - name: sig-testing-pr-reviews
+      description: PR Reviews
+    liaison:
+      github: parispittman
+      name: Paris Pittman
+  subprojects:
+  - name: boskos
+    description: |
+      Boskos is a resource manager service that handles different kinds of resources and transitions between different states. We use it on the Kubernetes project to manage pools of GCP projects for CI/CD.
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/boskos/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/test-infra/master/boskos/OWNERS
+  - name: e2e-framework
+    description: |
+      An experimental e2e testing framework for Kubernetes clusters.
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/e2e-framework/master/OWNERS
+  - name: k8s-gsm-tools
+    description: |
+      Controllers to sync and rotate kubernetes secrets with google cloud secret manager
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/k8s-gsm-tools/master/OWNERS
+  - name: kind
+    description: |
+      Kubernetes IN Docker. Run Kubernetes test clusters on your local machine using Docker containers as nodes.
+    contact:
+      slack: kind
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/kind/master/OWNERS
+  - name: kubetest2
+    description: |
+      Kubetest2 is the framework for launching and running end-to-end tests on kubernetes.
+      It is the next significant iteration of kubetest. We will be deprecating kubetest going forward.
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/kubetest2/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/test-infra/master/kubetest/OWNERS
+  - name: prow
+    description: |
+      Prow is a CI/CD system based on Kubernetes. See prow.k8s.io to see it in action for the Kubernetes project
+    contact:
+      slack: prow
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/test-infra/master/prow/OWNERS
+  - name: sig-testing
+    description: |
+      Home for SIG Testing discussion and documents.
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/sig-testing/master/OWNERS
+  - name: test-infra
+    description: |
+      Miscellaneous tools and configuration to run the testing infrastructure for the Kubernetes project
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/test-infra/master/OWNERS
+  - name: testing-commons
+    description: |
+      **[best-effort]** The testing-commons subproject focuses on matters of code structure, layout, and execution of kubernetes/kubernetes test code. It is currently staffed on a best-effort basis; please bring discussions to the sig-testing slack channel or meeting. For historical context, please see the [former testing-commons meeting agenda](https://docs.google.com/document/d/1TOC8vnmlkWw6HRNHoe5xSv5-qv7LelX6XK3UVCHuwb0/edit) and [archived testing-commons slack channel](https://kubernetes.slack.com/archives/C9NK9KFFW)
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/kubernetes/master/test/OWNERS
+- dir: sig-ui
+  name: UI
+  mission_statement: >
+    Covers all things UI related. Efforts are centered around Kubernetes Dashboard:
+    a general purpose, web-based UI for Kubernetes clusters. It allows users to manage
+    applications running in the cluster and troubleshoot them, as well as manage the
+    cluster itself.
+
+  charter_link: charter.md
+  label: ui
+  leadership:
+    chairs:
+    - github: floreks
+      name: Sebastian Florek
+      company: Loodse
+    - github: jeefy
+      name: Jeffrey Sica
+      company: Red Hat
+    - github: maciaszczykm
+      name: Marcin Maciaszczyk
+      company: Loodse
+    emeritus_leads:
+    - github: danielromlein
+      name: Dan Romlein
+  meetings:
+  - description: Regular SIG Meeting
+    day: Thursday
+    time: "09:00"
+    tz: PT (Pacific Time)
+    frequency: bi-weekly
+    url: https://groups.google.com/forum/#!forum/kubernetes-sig-ui
+    archive_url: https://docs.google.com/document/d/1PwHFvqiShLIq8ZpoXvE3dSUnOv1ts5BTtZ7aATuKd-E/edit?usp=sharing
+    recordings_url: https://www.youtube.com/watch?v=r3pL8i3wPhk&list=PL69nYSiGNLP35H5MZbg9OU6pqpfWgtbLm
+  contact:
+    slack: sig-ui
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-ui
+    liaison:
+      github: nikhita
+      name: Nikhita Raghunath
+  subprojects:
+  - name: dashboard
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/dashboard-metrics-scraper/master/OWNERS
+    - https://raw.githubusercontent.com/kubernetes/dashboard/master/OWNERS
+- dir: sig-usability
+  name: Usability
+  mission_statement: >
+    The scope of SIG usability is the core end-user usability of the Kubernetes project.
+    This covers topics like user experience and accessibility. The goals of the SIG
+    are to ensure that the Kubernetes project is maximally usable by users of a variety
+    of different backgrounds and abilities. Examples of efforts include internationalization
+    and accessibility of documentation.
+
+  charter_link: charter.md
+  label: usability
+  leadership:
+    chairs:
+    - github: hpandeycodeit
+      name: Himanshu Pandey
+      company: VMware
+    - github: morengab
+      name: Gaby Moreno Cesar
+      company: IBM
+    - github: tashimi
+      name: Tasha Drew
+      company: VMware
+    emeritus_leads:
+    - github: Rajakavitha1
+      name: Rajakavitha Kodhandapani
+    - github: vllry
+      name: Vallery Lancey
+  meetings:
+  - description: Regular SIG Meeting
+    day: Tuesday
+    time: "9:00"
+    tz: PT (Pacific Time)
+    frequency: every third week
+    url: https://zoom.us/j/3832562240
+    archive_url: https://docs.google.com/document/d/1gJHgt8RpH4TvqPuC8NtR31-CMqtTYkHy_loxubHq8lg/
+    recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP0eY-U8DVJWHBwKvMDEtOxx
+  contact:
+    slack: sig-usability
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-usability
+    teams:
+    - name: sig-usability-api-reviews
+      description: API Changes and Reviews
+    - name: sig-usability-bugs
+      description: Bug Triage and Troubleshooting
+    - name: sig-usability-feature-requests
+      description: Feature Requests
+    - name: sig-usability-misc
+      description: General Discussion
+    - name: sig-usability-pr-reviews
+      description: PR Reviews
+    - name: sig-usability-proposals
+      description: Design Proposals
+    liaison:
+      github: dims
+      name: Davanum Srinivas
+  subprojects:
+  - name: sig-usability
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/sig-usability/master/OWNERS
+- dir: sig-windows
+  name: Windows
+  mission_statement: >
+    Focuses on supporting Windows Node and scheduling Windows containers on Kubernetes.
+
+  charter_link: charter.md
+  label: windows
+  leadership:
+    chairs:
+    - github: marosset
+      name: Mark Rossetti
+      company: Microsoft
+    tech_leads:
+    - github: ddebroy
+      name: Deep Debroy
+      company: Apple
+    - github: jayunit100
+      name: Jay Vyas
+      company: VMware
+    - github: jsturtevant
+      name: James Sturtevant
+      company: Microsoft
+    emeritus_leads:
+    - github: PatrickLang
+      name: Patrick Lang
+    - github: benmoss
+      name: Ben Moss
+    - github: michmike
+      name: Michael Michael
+  meetings:
+  - description: Backlog Refinement  / Bug Triage Meeting
+    day: Thursday
+    time: "12:30"
+    tz: Eastern Time (ET)
+    frequency: biweekly
+    url: https://zoom.us/j/94389601840?pwd=MCs2SEJQWG0zUWpBS3Nod0ZNMmVXQT09
+  - description: Regular SIG Meeting
+    day: Tuesday
+    time: "12:30"
+    tz: Eastern Time (ET)
+    frequency: weekly
+    url: https://zoom.us/j/96892680257?pwd=TVNyMzB4VVMwRGZnUkgzT1dnb2szZz09
+    archive_url: https://docs.google.com/document/d/1Tjxzjjuy4SQsFSUVXZbvqVb64hjNAG5CQX8bK7Yda9w/edit#heading=h.kbz22d1yc431
+    recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP2OH9InCcNkWNu2bl-gmIU4
+  - description: Weekly CI Meeting
+    day: Tuesday
+    time: "12:15"
+    tz: Eastern Time (ET)
+    frequency: weekly
+    url: https://zoom.us/j/96892680257?pwd=TVNyMzB4VVMwRGZnUkgzT1dnb2szZz09
+    archive_url: https://docs.google.com/document/d/1j2XEKXNyGaSO0XZNkSQUliaT48ZQl6StLhrsVurJoco/edit#
+  contact:
+    slack: sig-windows
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-sig-windows
+    teams:
+    - name: sig-windows-bugs
+      description: Bug Triage and Troubleshooting
+    - name: sig-windows-feature-requests
+      description: Feature Requests
+    - name: sig-windows-misc
+      description: General Discussion
+    liaison:
+      github: liggitt
+      name: Jordan Liggitt
+  subprojects:
+  - name: windows-gmsa
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/windows-gmsa/master/OWNERS
+  - name: windows-samples
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-samples/master/OWNERS
+  - name: windows-testing
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/OWNERS
+  - name: windows-tools
+    owners:
+    - https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/master/OWNERS
+workinggroups:
+- dir: wg-api-expression
+  name: API Expression
+  mission_statement: >
+    Enable API authors to better serve API consumers, by improving and documenting
+    all aspects of Kubernetes API development.
+
+    [See full Mission Statement](https://docs.google.com/document/d/1XYbQXfge2qKM9psksfC5XZnW8hybtLqL1EcJLU4JwKg).
+
+  stakeholder_sigs:
+  - API Machinery
+  - Architecture
+  label: api-expression
+  leadership:
+    chairs:
+    - github: apelisse
+      name: Antoine Pelisse
+      company: Google
+    - github: kwiesmueller
+      name: Kevin Wiesmueller
+      company: //SEIBERT/MEDIA GmbH
+  meetings:
+  - description: Regular WG Meeting
+    day: Tuesday
+    time: "9:30"
+    tz: PT (Pacific Time)
+    frequency: biweekly
+    url: https://zoom.us/j/94238112084
+    archive_url: https://docs.google.com/document/d/1CSpNaicbEqKJoW306qaQEBIkwC1mGIcKl3yiB_C0HZk
+    recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP0CU9g6-yb1NgZXGAhMxfFE&jct=9Leh8O_yrRTB0Kcv3rMKZHncZq8POg
+  contact:
+    slack: wg-api-expression
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-wg-api-expression
+    liaison:
+      github: liggitt
+      name: Jordan Liggitt
+- dir: wg-component-standard
+  name: Component Standard
+  mission_statement: >
+    Develop a standard foundation (philosophy and libraries) for core Kubernetes components
+    to build on top of. Areas to standardize include configuration (flags, ComponentConfig
+    APIs, ...), status endpoints (healthz, configz, ...), integration points (delegated
+    authn/z, ...), and logging. Details are outlined in KEP 0032: https://github.com/kubernetes/enhancements/blob/master/keps/sig-cluster-lifecycle/wgs/0032-create-a-k8s-io-component-repo.md.
+
+  stakeholder_sigs:
+  - API Machinery
+  - Architecture
+  - Cluster Lifecycle
+  label: component-standard
+  leadership:
+    chairs:
+    - github: mtaufen
+      name: Michael Taufen
+      company: Google
+    - github: stealthybox
+      name: Leigh Capili
+      company: Weaveworks
+  meetings:
+  - description: Regular WG Meeting (please join kubernetes-dev@googlegroups.com or
+      kubernetes-wg-component-standard@googlegroups.com to access the notes)
+    day: Tuesday
+    time: "08:30"
+    tz: PT (Pacific Time)
+    frequency: weekly
+    url: https://zoom.us/j/8027741546
+    archive_url: https://docs.google.com/document/d/18TsodX0fqQgViQ7HHUTAhiAwkf6bNhPXH4vNVTI7GwI
+  - description: Weekly Mentorship Office Hours - Come ask questions and get help
+    day: Tuesday
+    time: "10:00"
+    tz: PT (Pacific Time)
+    frequency: weekly
+    url: https://zoom.us/j/8027741546
+    archive_url: https://docs.google.com/document/d/1iVBnMAdiTE1Ej_O4P809MCHGVVUkfYmPx6zlSLG0hOg
+  contact:
+    slack: wg-component-standard
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-wg-component-standard
+    teams:
+    - name: wg-component-standard
+      description: Component Standard Discussion
+    liaison:
+      github: cblecker
+      name: Christoph Blecker
+- dir: wg-data-protection
+  name: Data Protection
+  mission_statement: >
+    A Working Group dedicated to promoting data protection support in Kubernetes,
+    identifying missing functionality and working together to design features to enable
+    data protection support. Involves collaboration with multiple SIGs such as Apps
+    and Storage.
+
+    This [work-in-progress doc](https://docs.google.com/document/d/1yHbW0hxHehQzdaL7AWSl81OW4f2OcBoskXTbezx92-U/edit#)
+    tracks missing building blocks we have identified and what we are working on to
+    fill the gaps.
+
+  charter_link: charter.md
+  stakeholder_sigs:
+  - Apps
+  - Storage
+  label: data-protection
+  leadership:
+    chairs:
+    - github: xing-yang
+      name: Xing Yang
+      company: VMware
+    - github: yuxiangqian
+      name: Xiangqian Yu
+      company: Google
+  meetings:
+  - description: Regular WG Meeting
+    day: Wednesday
+    time: "9:00"
+    tz: PT (Pacific Time)
+    frequency: bi-weekly
+    url: https://zoom.us/j/6933410772
+    archive_url: https://docs.google.com/document/d/15tLCV3csvjHbKb16DVk-mfUmFry_Rlwo-2uG6KNGsfw/edit
+    recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP336DulLgPdlWJ_gzRz1iL5
+  contact:
+    slack: wg-data-protection
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-data-protection
+    liaison:
+      github: parispittman
+      name: Paris Pittman
+- dir: wg-iot-edge
+  name: IoT Edge
+  mission_statement: >
+    A Working Group dedicated to discussing, designing and documenting using Kubernetes
+    for developing and deploying IoT and Edge specific applications
+
+  stakeholder_sigs:
+  - Multicluster
+  - Network
+  label: iot-edge
+  leadership:
+    chairs:
+    - github: cantbewong
+      name: Steve Wong
+      company: VMware
+    - github: cindyxing
+      name: Cindy Xing
+      company: Microsoft
+    - github: dejanb
+      name: Dejan Bosanac
+      company: Red Hat
+    emeritus_leads:
+    - github: ptone
+      name: Preston Holmes
+  meetings:
+  - description: APAC WG Meeting
+    day: Wednesday
+    time: "5:00"
+    tz: UTC
+    frequency: every four weeks
+    url: https://zoom.us/j/91251176046?pwd=cmdqclovM3R3eDB1VlpuL1ZGU1hnZz09
+    archive_url: https://docs.google.com/document/d/1Yuwy9IO4X6XKq2wLW0pVZn5yHQxlyK7wdYBZBXRWiKI/edit?usp=sharing
+  - description: Regular WG Meeting (Pacific Time)
+    day: Wednesday
+    time: "09:00"
+    tz: PT
+    frequency: every four weeks
+    url: https://zoom.us/j/92778512626?pwd=MXhlemwvYnhkQmkxeXllQ0Z5VGs4Zz09
+    archive_url: https://docs.google.com/document/d/1Yuwy9IO4X6XKq2wLW0pVZn5yHQxlyK7wdYBZBXRWiKI/edit?usp=sharing
+  contact:
+    slack: wg-iot-edge
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-wg-iot-edge
+    liaison:
+      github: derekwaynecarr
+      name: Derek Carr
+- dir: wg-k8s-infra
+  name: K8s Infra
+  mission_statement: >
+    A Working Group dedicated to migrating Kubernetes project infrastructure over
+    to the CNCF, and the creation of teams and processes for ongoing maintenance.
+    Involves collaboration with multiple SIGs such as Architecture, Contributor Experience,
+    Release, and Testing, etc.
+
+  charter_link: charter.md
+  stakeholder_sigs:
+  - Architecture
+  - Contributor Experience
+  - Release
+  - Testing
+  label: k8s-infra
+  leadership:
+    chairs:
+    - github: ameukam
+      name: Arnaud Meukam
+      company: Alter Way
+    - github: dims
+      name: Davanum Srinivas
+      company: VMware
+    - github: spiffxp
+      name: Aaron Crickenberger
+      company: Google
+    emeritus_leads:
+    - github: bartsmykla
+      name: Bart Smykla
+  meetings:
+  - description: Regular WG Meeting
+    day: Wednesday
+    time: "20:00"
+    tz: UTC
+    frequency: bi-weekly
+    url: https://zoom.us/j/93109963352?pwd=SHJTcFR2bVg1akYxSDREUWQzaldrQT09
+    archive_url: http://bit.ly/wg-k8s-infra-notes
+    recordings_url: http://bit.ly/wg-k8s-infra-playlist
+  contact:
+    slack: wg-k8s-infra
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-wg-k8s-infra
+    teams:
+    - name: wg-k8s-infra
+      description: active contributors in wg-k8s-infra
+    - name: wg-k8s-infra-leads
+      description: wg-k8s-infra leads
+    liaison:
+      github: nikhita
+      name: Nikhita Raghunath
+- dir: wg-multitenancy
+  name: Multitenancy
+  mission_statement: >
+    Define the models of multitenancy that Kubernetes will support. Discuss and execute
+    upon any remaining work that needs to be done to support these models. Create
+    conformance tests that will prove that these models can be built and used in production
+    environments.
+
+  stakeholder_sigs:
+  - API Machinery
+  - Auth
+  - Network
+  - Node
+  - Scheduling
+  - Storage
+  label: multitenancy
+  leadership:
+    chairs:
+    - github: srampal
+      name: Sanjeev Rampal
+      company: Cisco
+    - github: tashimi
+      name: Tasha Drew
+      company: VMware
+    emeritus_leads:
+    - github: davidopp
+      name: David Oppenheimer
+  meetings:
+  - description: Regular WG Meeting
+    day: Tuesday
+    time: "11:00"
+    tz: PT (Pacific Time)
+    frequency: biweekly
+    url: https://zoom.us/my/k8s.sig.auth
+    archive_url: https://docs.google.com/document/d/1fj3yzmeU2eU8ZNBCUJG97dk_wC7228-e_MmdcmTNrZY/edit?usp=sharing
+    recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP1tBA0W8zEe6UwPsabGQk-j
+  contact:
+    slack: wg-multitenancy
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-wg-multitenancy
+    liaison:
+      github: liggitt
+      name: Jordan Liggitt
+- dir: wg-naming
+  name: Naming
+  stakeholder_sigs:
+  - Architecture
+  - Contributor Experience
+  - Docs
+  label: naming
+  leadership:
+    chairs:
+    - github: celestehorgan
+      name: Celeste Horgan
+      company: CNCF
+    - github: jdumars
+      name: Jaice Singer DuMars
+      company: Apple
+    - github: justaugustus
+      name: Stephen Augustus
+      company: Cisco
+    emeritus_leads:
+    - github: zacharysarah
+      name: Zach Corleissen
+  meetings:
+  - description: Regular WG Meeting
+    day: Monday
+    time: "10:30"
+    tz: PT (Pacific Time)
+    frequency: monthly - second Monday of month
+    url: https://zoom.us/j/91522666403?pwd=WnRSNlNhNXhDWkR2ZU9ydGpsNWxtZz09
+    archive_url: https://bit.ly/k8s-wg-naming-agenda
+    recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP3BrAtDHyr8KTUfhBhCG7CD
+  contact:
+    slack: wg-naming
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-wg-naming
+    liaison:
+      github: mrbobbytables
+      name: Bob Killen
+- dir: wg-policy
+  name: Policy
+  mission_statement: >
+    Provide an overall architecture that describes both the current policy related
+    implementations as well as future policy related proposals in Kubernetes. Through
+    a collaborative method, we want to present both dev and end user a universal view
+    of policy architecture in Kubernetes.
+
+  stakeholder_sigs:
+  - Architecture
+  - Auth
+  - Multicluster
+  - Network
+  - Node
+  - Scheduling
+  - Storage
+  label: policy
+  leadership:
+    chairs:
+    - github: ericavonb
+      name: Erica von Buelow
+      company: Red Hat
+    - github: hannibalhuang
+      name: Howard Huang
+      company: Huawei
+  meetings:
+  - description: Regular WG Meeting
+    day: Wednesday
+    time: "16:00"
+    tz: PT (Pacific Time)
+    frequency: weekly
+    url: https://zoom.us/j/7375677271
+    archive_url: https://docs.google.com/document/d/1ihFfEfgViKlUMbY2NKxaJzBkgHh-Phk5hqKTzK-NEEs/edit?usp=sharing
+  contact:
+    slack: wg-policy
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-wg-policy
+    liaison:
+      github: cblecker
+      name: Christoph Blecker
+- dir: wg-reliability
+  name: Reliability
+  mission_statement: >
+    Allow users to safely use Kubernetes for managing production workloads by ensuring
+    Kubernetes is stable and reliable.
+
+  charter_link: charter.md
+  stakeholder_sigs:
+  - Architecture
+  - Cluster Lifecycle
+  - Release
+  - Scalability
+  - Testing
+  label: reliability
+  leadership:
+    chairs:
+    - github: deads2k
+      name: David Eads
+      company: Red Hat
+    - github: stevekuznetsov
+      name: Steve Kuznetsov
+      company: Red Hat
+    - github: wojtek-t
+      name: Wojciech Tyczynski
+      company: Google
+  meetings:
+  - description: Regular WG Meeting
+    day: Monday
+    time: "11:00"
+    tz: PT (Pacific Time)
+    frequency: biweekly
+    url: https://zoom.us/j/97964505804?pwd=R3hzSnArQWJHYmdWUnpSUDh3aXhFUT09
+    archive_url: https://docs.google.com/document/d/1KF_kof3rBWzis87wMkwXicetREuutxlPI6dFDSqdWbo/edit
+    recordings_url: TODO
+  contact:
+    slack: wg-reliability
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-wg-reliability
+- dir: wg-structured-logging
+  name: Structured Logging
+  mission_statement: >
+    Modernize logging in Kubernetes core components, allowing users to efficiently
+    consume, process, store and analyse information stored in logs.
+
+  stakeholder_sigs:
+  - API Machinery
+  - Architecture
+  - Cloud Provider
+  - Instrumentation
+  - Network
+  - Node
+  - Scheduling
+  - Storage
+  label: structured-logging
+  leadership:
+    chairs:
+    - github: serathius
+      name: Marek Siarkowicz
+      company: Google
+    - github: shubheksha
+      name: Shubheksha Jalan
+      company: Apple
+  meetings:
+  - description: Regular Meeting
+    day: Thursday
+    time: "15:00"
+    tz: UTC
+    frequency: biweekly
+    url: https://zoom.us/j/96716142646?pwd=VmgrN29sbmhDREp3R0NtZlpGSlZ4Zz09
+    archive_url: https://docs.google.com/document/d/1R9bZ34L9vR1ftH0dFeOp-j50lLh5ijKVwwXJ3LDrY4I/edit?usp=sharing
+    recordings_url: https://www.youtube.com/playlist?list=PL69nYSiGNLP2GY3so1z2Cnkvkt5A_x1Aw
+  contact:
+    slack: wg-structured-logging
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-wg-structured-logging
+    liaison:
+      github: dims
+      name: Davanum Srinivas
+usergroups:
+- dir: ug-big-data
+  name: Big Data
+  mission_statement: >
+    Serve as a community resource for advising big data and data science related software
+    projects on techniques and best practices for integrating with Kubernetes. Represents
+    the concerns of users from big data communities to Kubernetes for the purposes
+    of driving new features and other enhancements, based on big data use cases.
+
+  label: big-data
+  leadership:
+    chairs:
+    - github: erikerlandson
+      name: Erik Erlandson
+      company: Red Hat
+    - github: foxish
+      name: Anirudh Ramanathan
+      company: Rockset
+    - github: liyinan926
+      name: Yinan Li
+      company: Google
+  meetings:
+  - description: Regular User Group Meeting
+    day: Wednesday
+    time: "18:00"
+    tz: UTC
+    frequency: biweekly
+    url: https://zoom.us/my/ug.big.data
+    archive_url: https://docs.google.com/document/d/1pnF38NF6N5eM8DlK088XUW85Vms4V2uTsGZvSp8MNIA/edit
+    recordings_url: https://docs.google.com/document/d/1pnF38NF6N5eM8DlK088XUW85Vms4V2uTsGZvSp8MNIA/edit
+  contact:
+    slack: ug-big-data
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-ug-big-data
+    teams:
+    - name: ug-big-data
+      description: General Discussion
+    liaison:
+      github: derekwaynecarr
+      name: Derek Carr
+- dir: ug-vmware-users
+  name: VMware Users
+  mission_statement: >
+    The VMware User Group facilitates communication among Kubernetes users and contributors
+    on topics pertaining to running all conformant forms of Kubernetes on VMware infrastructure.
+
+  label: vmware-users
+  leadership:
+    chairs:
+    - github: cantbewong
+      name: Steve Wong
+      company: VMware
+    - github: mylesagray
+      name: Myles Gray
+      company: VMware
+    tech_leads:
+    - github: brysonshepherd
+      name: Bryson Shepherd
+      company: Walmart
+    - github: phenixblue
+      name: Joe Searcy
+      company: T-Mobile
+  meetings:
+  - description: Regular User Group Meeting
+    day: Thursday
+    time: "11:00"
+    tz: PT (Pacific Time)
+    frequency: monthly
+    url: https://docs.google.com/document/d/1ujpqj4hhcIBrSCK2qn6J1r--3QyD96rfDjXTZQ7n7Mw/edit
+  contact:
+    slack: ug-vmware
+    mailing_list: https://groups.google.com/forum/#!forum/kubernetes-ug-vmware
+    liaison:
+      github: nikhita
+      name: Nikhita Raghunath
+committees:
+- dir: committee-code-of-conduct
+  name: Code of Conduct
+  mission_statement: >
+    The Kubernetes Code of Conduct Committee (CoCC) is the body that is responsible
+    for enforcing and maintaining the Kubernetes Code of Conduct.
+
+  charter_link: charter.md
+  label: code-of-conduct
+  leadership:
+    chairs:
+    - github: AevaOnline
+      name: Aeva Black
+      company: Microsoft
+    - github: celestehorgan
+      name: Celeste Horgan
+      company: CNCF
+    - github: karenhchu
+      name: Karen Chu
+      company: Microsoft
+    - github: tashimi
+      name: Tasha Drew
+      company: VMware
+    - github: tpepper
+      name: Tim Pepper
+      company: VMware
+    emeritus_leads:
+    - github: Bradamant3
+      name: Jennifer Rondeau
+    - github: carolynvs
+      name: Carolyn Van Slyck
+    - github: jdumars
+      name: Jaice Singer DuMars
+    - github: parispittman
+      name: Paris Pittman
+  meetings: []
+  contact:
+    slack: code-of-conduct
+    private_mailing_list: conduct@kubernetes.io
+    teams:
+    - name: code-of-conduct-committee
+      description: General Discussion
+- dir: committee-product-security
+  name: Product Security
+  mission_statement: >
+    The Kubernetes Product Security Committee is the body that is responsible for
+    receiving and responding to reports of security issues in Kubernetes products.
+
+  label: product-security
+  leadership:
+    chairs:
+    - github: cjcullen
+      name: CJ Cullen
+      company: Google
+    - github: joelsmith
+      name: Joel Smith
+      company: Red Hat
+    - github: lukehinds
+      name: Luke Hinds
+      company: Red Hat
+    - github: micahhausler
+      name: Micah Hausler
+      company: Amazon
+    - github: swamymsft
+      name: Swamy Shivaganga Nagaraju
+      company: Microsoft
+    - github: tabbysable
+      name: Tabitha Sable
+      company: Datadog
+    - github: tallclair
+      name: Tim Allclair
+      company: Apple
+  meetings: []
+  contact:
+    private_mailing_list: security@kubernetes.io
+    teams:
+    - name: product-security-committee
+      description: General Discussion
+  subprojects:
+  - name: security
+    description: Policies and documentation for the Product Security Committee
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/security/master/OWNERS
+- dir: committee-steering
+  name: Steering
+  mission_statement: >
+    The Kubernetes Steering Committee is the governing body of the Kubernetes project,
+    providing decision-making and oversight pertaining to the Kubernetes project bylaws,
+    sub-organizations, and financial planning. The Steering Committee also defines
+    the project values and structure.
+
+  charter_link: https://git.k8s.io/steering/charter.md
+  label: steering
+  leadership:
+    chairs:
+    - github: cblecker
+      name: Christoph Blecker
+      company: Red Hat
+    - github: derekwaynecarr
+      name: Derek Carr
+      company: Red Hat
+    - github: dims
+      name: Davanum Srinivas
+      company: VMware
+    - github: liggitt
+      name: Jordan Liggitt
+      company: Google
+    - github: mrbobbytables
+      name: Bob Killen
+      company: Google
+    - github: nikhita
+      name: Nikhita Raghunath
+      company: VMware
+    - github: parispittman
+      name: Paris Pittman
+      company: Apple
+  meetings:
+  - description: Private Steering Committee Meeting
+    day: third Monday
+    time: "9:30"
+    tz: PT (Pacific Time)
+    frequency: monthly
+    url: https://bit.ly/k8s-steering-wd
+    recordings_url: https://www.youtube.com/watch?v=YAzgJRQxsdc&list=PL69nYSiGNLP1yP1B_nd9-drjoxp0Q14qM
+  - description: Public Steering Committee Meeting
+    day: first Monday
+    time: "9:30"
+    tz: PT (Pacific Time)
+    frequency: monthly
+    url: https://bit.ly/k8s-steering-wd
+    recordings_url: https://www.youtube.com/watch?v=YAzgJRQxsdc&list=PL69nYSiGNLP1yP1B_nd9-drjoxp0Q14qM
+  contact:
+    slack: steering-committee
+    mailing_list: https://groups.google.com/a/kubernetes.io/forum/#!forum/steering
+    private_mailing_list: steering-private@kubernetes.io
+    teams:
+    - name: steering-committee
+      description: General Discussion
+  subprojects:
+  - name: funding
+    description: Funding requests for project infrastructure, events, and consulting
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/funding/master/OWNERS
+  - name: steering
+    description: Steering Committee policy and documentation
+    owners:
+    - https://raw.githubusercontent.com/kubernetes/steering/master/OWNERS

--- a/layouts/shortcodes/keps-data.html
+++ b/layouts/shortcodes/keps-data.html
@@ -1,30 +1,63 @@
-
-
-<link href="{{ "css/filter.css" | relURL }}" rel="stylesheet">
-<script src="{{ "js/filter.js" | relURL }}"></script>
-<script
-  src="/js/jquery-3.3.1.min.js"
-  integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
-  crossorigin="anonymous"></script>
-
-<table class="table">
+<script>
+  $(document).ready(function(){
+           $('#keps_search').keyup(function(){
+                search_table($(this).val());
+           });
+           $("select").on('change', function() {
+            search_table($(this).val());
+           })
+           function search_table(value){
+                $('#keps_table tr').each(function(){
+                     var found = 'false';
+                     $(this).each(function(){
+                          if($(this).text().toLowerCase().indexOf(value.toLowerCase()) >= 0)
+                          {
+                               found = 'true';
+                          }
+                     });
+                     if(found == 'true')
+                     {
+                          $(this).show();
+                     }
+                     else
+                     {
+                          $(this).hide();
+                     }
+                });
+           }
+      });
+ </script>
+<div align="center">
+  <input type="text" name="search" id="keps_search" class="form-control" placeholder="Search KEP(s) by keyword" />
+</div>
+<form>
+  <label for="keps">Choose SIG group:</label>
+  <select name="sig group" id="sig_group">
+    {{ range $data_sig := .Site.Data.sigs.sigs.sigs }}
+    <option value="{{$data_sig.dir}}">{{ printf "%s" $data_sig.name }}</option>
+    {{ end }}
+  </select>
+  <br><br>
+  <input type="submit" value="Submit">
+</form>
+<table id="keps_table" class="display" class="table">
   <thead>
-    <tr class="filters">
-      <th><input type="text" placeholder="kep-number" disabled></th>
-      <th><input type="text" placeholder="KEP Name" disabled></th>
-      <th><input type="text" placeholder="SIG" disabled></th>
+    <tr>
+      <th>KEP Number</th>
+      <th>KEP Name</th>
+      <th>SIG-Group</th>
+      <th>Author</th>
     </tr>
   </thead>
   <tbody>
-		{{ range $data := .Site.Data.keps.keps_data.keps }}
-		<tr>
-      <td>{{ printf "%s" $data.kep_number  }}</td>
-      <td>{{ printf "%s" $data.name  }}</td>
-      <td>{{ printf "%s" $data.owning_sig  }}</td>
+    {{ range $data := .Site.Data.keps.keps_data.keps }}
+    <tr>
+      <td>{{ printf "%s" $data.kep_number }}</td>
+      <td>
+        <a href="https://github.com/kubernetes/enhancements/tree/master/keps/{{$data.owning_sig}}/{{$data.name}}">{{ printf "%s" $data.name }}</a></td>
+      <td>{{ printf "%s" $data.owning_sig }}</td>
+      <td>{{ printf "%s" $data.authors }}</td>
     </tr>
     {{ end }}
-
   </tbody>
 </table>
-
-

--- a/layouts/shortcodes/keps-data.html
+++ b/layouts/shortcodes/keps-data.html
@@ -33,12 +33,11 @@
 <form>
   <label for="keps">Choose SIG group:</label>
   <select name="sig group" id="sig_group">
+    <option selected="selected">Select SIG group to filter</option>
     {{ range $data_sig := .Site.Data.sigs.sigs.sigs }}
     <option value="{{$data_sig.dir}}">{{ printf "%s" $data_sig.name }}</option>
     {{ end }}
   </select>
-  <br><br>
-  <input type="submit" value="Submit">
 </form>
 <table id="keps_table" class="display" class="table">
   <thead>

--- a/layouts/shortcodes/keps-data.html
+++ b/layouts/shortcodes/keps-data.html
@@ -4,7 +4,13 @@
                 search_table($(this).val());
            });
            $("select").on('change', function() {
-            search_table($(this).val());
+            if($(this).val() != 'all')
+             {
+                search_table($(this).val());
+             } else {
+                reset_keps_table();
+             }
+
            })
            function search_table(value){
                 $('#keps_table tr').each(function(){
@@ -25,38 +31,45 @@
                      }
                 });
            }
+           function reset_keps_table() {
+              $('#keps_table tr').each(function(f) {
+                  $(this).show();
+              });
+           }
       });
  </script>
-<div align="center">
-  <input type="text" name="search" id="keps_search" class="form-control" placeholder="Search KEP(s) by keyword" />
+<div class="container">
+  <div align="center" class="input-group">
+    <input type="text" name="search" id="keps_search" class="form-control" placeholder="Search KEP(s) by keyword" />
+  </div>
+  <div class="input-group mx-auto" style="width: 400px;">
+    <label for="keps">Choose SIG group:</label>
+    <select class="custom-select" name="sig group" id="sig_group">
+      <option selected value="all">Choose...</option>
+      {{ range $data_sig := .Site.Data.sigs.sigs.sigs }}
+      <option value="{{$data_sig.dir}}">{{ printf "%s" $data_sig.name }}</option>
+      {{ end }}
+    </select>
+  </div>
+  <table id="keps_table" class="table table-bordered table-hover">
+    <thead>
+      <tr>
+        <th scope="col">KEP Number</th>
+        <th scope="col">KEP Name</th>
+        <th scope="col">SIG-Group</th>
+        <th scope="col">Author</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{ range $data := .Site.Data.keps.keps_data.keps }}
+      <tr>
+        <td>{{ printf "%s" $data.kep_number }}</td>
+        <td>
+          <a href="https://github.com/kubernetes/enhancements/tree/master/keps/{{$data.owning_sig}}/{{$data.name}}">{{ printf "%s" $data.name }}</a></td>
+        <td>{{ printf "%s" $data.owning_sig }}</td>
+        <td>{{ printf "%s" $data.authors }}</td>
+      </tr>
+      {{ end }}
+    </tbody>
+  </table>
 </div>
-<form>
-  <label for="keps">Choose SIG group:</label>
-  <select name="sig group" id="sig_group">
-    <option selected="selected">Select SIG group to filter</option>
-    {{ range $data_sig := .Site.Data.sigs.sigs.sigs }}
-    <option value="{{$data_sig.dir}}">{{ printf "%s" $data_sig.name }}</option>
-    {{ end }}
-  </select>
-</form>
-<table id="keps_table" class="display" class="table">
-  <thead>
-    <tr>
-      <th>KEP Number</th>
-      <th>KEP Name</th>
-      <th>SIG-Group</th>
-      <th>Author</th>
-    </tr>
-  </thead>
-  <tbody>
-    {{ range $data := .Site.Data.keps.keps_data.keps }}
-    <tr>
-      <td>{{ printf "%s" $data.kep_number }}</td>
-      <td>
-        <a href="https://github.com/kubernetes/enhancements/tree/master/keps/{{$data.owning_sig}}/{{$data.name}}">{{ printf "%s" $data.name }}</a></td>
-      <td>{{ printf "%s" $data.owning_sig }}</td>
-      <td>{{ printf "%s" $data.authors }}</td>
-    </tr>
-    {{ end }}
-  </tbody>
-</table>

--- a/layouts/shortcodes/keps-data.html
+++ b/layouts/shortcodes/keps-data.html
@@ -61,7 +61,7 @@
     <thead>
       <tr>
         <th scope="col">KEP Number</th>
-        <th scope="col">KEP Name</th>
+        <th scope="col">KEP Title</th>
         <th scope="col">SIG-Group</th>
         <th scope="col">Author</th>
       </tr>
@@ -71,7 +71,7 @@
       <tr>
         <td>{{ printf "%s" $data.kep_number }}</td>
         <td>
-          <a href="https://github.com/kubernetes/enhancements/tree/master/keps/{{$data.owning_sig}}/{{$data.name}}">{{ printf "%s" $data.name }}</a></td>
+          <a href="https://github.com/kubernetes/enhancements/tree/master/keps/{{$data.owning_sig}}/{{$data.name}}">{{ printf "%s" $data.title }}</a></td>
         <td>{{ printf "%s" $data.owning_sig }}</td>
         <td>{{ printf "%s" $data.authors }}</td>
       </tr>

--- a/layouts/shortcodes/keps-data.html
+++ b/layouts/shortcodes/keps-data.html
@@ -39,19 +39,25 @@
       });
  </script>
 <div class="container">
-  <div align="center" class="input-group">
-    <input type="text" name="search" id="keps_search" class="form-control" placeholder="Search KEP(s) by keyword" />
-  </div>
-  <div class="input-group mx-auto" style="width: 400px;">
-    <label for="keps">Choose SIG group:</label>
-    <select class="custom-select" name="sig group" id="sig_group">
-      <option selected value="all">Choose...</option>
-      {{ range $data_sig := .Site.Data.sigs.sigs.sigs }}
-      <option value="{{$data_sig.dir}}">{{ printf "%s" $data_sig.name }}</option>
-      {{ end }}
-    </select>
-  </div>
-  <table id="keps_table" class="table table-bordered table-hover">
+  <dir class="d-flex">
+    <div class="col">
+      <div class="input-group mt-2 col-md-12">
+        <input type="text" name="search" id="keps_search" class="form-control" placeholder="Search KEP(s) by keyword" />
+      </div>
+    </div>
+    <div class="col ml-auto">
+      <div class="input-group mx-auto mt-2 col-md-12" style="width: 400px;">
+        <label for="keps">Choose SIG group:</label>
+        <select class="custom-select" name="sig group" id="sig_group">
+          <option selected value="all">Choose...</option>
+          {{ range $data_sig := .Site.Data.sigs.sigs.sigs }}
+          <option value="{{$data_sig.dir}}">{{ printf "%s" $data_sig.name }}</option>
+          {{ end }}
+        </select>
+      </div>
+    </div>
+  </dir>
+  <table id="keps_table" class="table table-bordered table-hover mt-2 col-md-12">
     <thead>
       <tr>
         <th scope="col">KEP Number</th>

--- a/layouts/shortcodes/keps-data.html
+++ b/layouts/shortcodes/keps-data.html
@@ -1,43 +1,4 @@
-<script>
-  $(document).ready(function(){
-           $('#keps_search').keyup(function(){
-                search_table($(this).val());
-           });
-           $("select").on('change', function() {
-            if($(this).val() != 'all')
-             {
-                search_table($(this).val());
-             } else {
-                reset_keps_table();
-             }
-
-           })
-           function search_table(value){
-                $('#keps_table tr').each(function(){
-                     var found = 'false';
-                     $(this).each(function(){
-                          if($(this).text().toLowerCase().indexOf(value.toLowerCase()) >= 0)
-                          {
-                               found = 'true';
-                          }
-                     });
-                     if(found == 'true')
-                     {
-                          $(this).show();
-                     }
-                     else
-                     {
-                          $(this).hide();
-                     }
-                });
-           }
-           function reset_keps_table() {
-              $('#keps_table tr').each(function(f) {
-                  $(this).show();
-              });
-           }
-      });
- </script>
+<script src="/js/keps/kep_search.js"></script>
 <div class="container">
   <dir class="d-flex">
     <div class="col">

--- a/layouts/shortcodes/keps-data.html
+++ b/layouts/shortcodes/keps-data.html
@@ -1,0 +1,30 @@
+
+
+<link href="{{ "css/filter.css" | relURL }}" rel="stylesheet">
+<script src="{{ "js/filter.js" | relURL }}"></script>
+<script
+  src="/js/jquery-3.3.1.min.js"
+  integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
+  crossorigin="anonymous"></script>
+
+<table class="table">
+  <thead>
+    <tr class="filters">
+      <th><input type="text" placeholder="kep-number" disabled></th>
+      <th><input type="text" placeholder="KEP Name" disabled></th>
+      <th><input type="text" placeholder="SIG" disabled></th>
+    </tr>
+  </thead>
+  <tbody>
+		{{ range $data := .Site.Data.keps.keps_data.keps }}
+		<tr>
+      <td>{{ printf "%s" $data.kep_number  }}</td>
+      <td>{{ printf "%s" $data.name  }}</td>
+      <td>{{ printf "%s" $data.owning_sig  }}</td>
+    </tr>
+    {{ end }}
+
+  </tbody>
+</table>
+
+

--- a/static/js/keps/kep_search.js
+++ b/static/js/keps/kep_search.js
@@ -1,0 +1,35 @@
+  $(document).ready(function() {
+    $('#keps_search').keyup(function() {
+      search_table($(this).val());
+    });
+    $("select").on('change', function() {
+      if ($(this).val() != 'all') {
+        search_table($(this).val());
+      } else {
+        reset_keps_table();
+      }
+
+    })
+
+    function search_table(value) {
+      $('#keps_table').find("tr:gt(0)").each(function() {
+        var found = 'false';
+        $(this).each(function() {
+          if ($(this).text().toLowerCase().indexOf(value.toLowerCase()) >= 0) {
+            found = 'true';
+          }
+        });
+        if (found == 'true') {
+          $(this).show();
+        } else {
+          $(this).hide();
+        }
+      });
+    }
+
+    function reset_keps_table() {
+      $('#keps_table tr').each(function(f) {
+        $(this).show();
+      });
+    }
+  });


### PR DESCRIPTION
This PR is for https://github.com/kubernetes/enhancements/issues/2095 and we want a KEP webpage to find out about specific kep and its metadata easily.

Actual Plan:

1. [TODO] We will have `kep_data.yaml` generated in the repo: https://github.com/kubernetes/enhancements  - somewhere in data folder - This can be done by CI when new KEP is merged in the repo, it will automatically generate the kep_data.yaml file using the query `go run ./cmd/kepctl/main.go query --output yaml > data/kep_data.yaml`
2. `kep_data.yaml` will be used in this repo `website` to put in `/keps` webpage  [Currently I have pushed the dump into data folder but in future we want to take it directly from the `enhancements` repo]
3. `/keps` page will display the content in table and we will have search column [TODO] wise like kep-number, sig-group, kep name, etc. 


