### PR TITLE
Explicitly mention the install command requires Kubernetes version

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -33,9 +33,9 @@ The following methods exist for installing kubectl on Linux:
    ```
 
    {{< note >}}
-To download a specific version, replace the `$(curl -L -s https://dl.k8s.io/release/stable.txt)` portion of the command with the specific version.
+To download a specific version, replace the `$(curl -L -s https://dl.k8s.io/release/stable.txt)` portion of the command with the specific Kubernetes version.
 
-For example, to download version {{< param "fullversion" >}} on Linux, type:
+For example, to download kubectl for Kubernetes version {{< param "fullversion" >}} on Linux, type:
 
    ```bash
    curl -LO https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/linux/amd64/kubectl


### PR DESCRIPTION
Installing a custom version of kubectl with curl requires users to provide the Kubernetes version in the curl command. Since this document page is in the context of kubectl, there's a chance users might use the kubectl version. Update the doc to explicitly mention the command requires the Kubernetes version.

