### PR TITLE
add k8s.gcr.io/pause:3.5 to windows pause image list

### DIFF
--- a/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
+++ b/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
@@ -102,6 +102,8 @@ limitation and compatibility rules will change.
 
 Microsoft maintains a Windows pause infrastructure container at
 `mcr.microsoft.com/oss/kubernetes/pause:3.4.1`.
+Kubernetes maintains a multi-architecture image `k8s.gcr.io/pause:3.5` that
+supports Linux as well as Windows.
 
 #### Compute
 


### PR DESCRIPTION
part of #26335

Just add k8s.gcr.io/pause:3.5 to windows pause image list.

I think we should remove `mcr.microsoft.com/oss/kubernetes/pause:3.4.1` if `k8s.gcr.io/pause:3.5` is perfered. 