### PR TITLE
Update the "hello minikube" tutorial to match updated output from minikube

### DIFF
--- a/content/en/docs/tutorials/hello-minikube.md
+++ b/content/en/docs/tutorials/hello-minikube.md
@@ -224,7 +224,7 @@ The minikube tool includes a set of built-in {{< glossary_tooltip text="addons" 
     The output is similar to:
 
     ```
-    metrics-server was successfully enabled
+    The 'metrics-server' addon is enabled
     ```
 
 3. View the Pod and Service you created:


### PR DESCRIPTION
The output from the `minikube addons enable` command in the documentation did not match the output from the current version of minikube (which is also in katakoda). This might be confusing for new users.