### PR TITLE
Update activeDeadlineSeconds with Pod page

### DIFF
--- a/content/en/docs/concepts/workloads/pods/init-containers.md
+++ b/content/en/docs/concepts/workloads/pods/init-containers.md
@@ -278,9 +278,11 @@ Init containers have all of the fields of an app container. However, Kubernetes
 prohibits `readinessProbe` from being used because init containers cannot
 define readiness distinct from completion. This is enforced during validation.
 
-Use `activeDeadlineSeconds` on the Pod and `livenessProbe` on the container to
-prevent init containers from failing forever. The active deadline includes init
-containers.
+Use `activeDeadlineSeconds` on the Pod to prevent init containers from failing forever.
+The active deadline includes init containers.
+However it is recommended to use `activeDeadlineSeconds` if user deploy their application
+as a Job, because `activeDeadlineSeconds` has an effect even after initContainer finished.
+The Pod which is already running correctly would be killed by `activeDeadlineSeconds` if you set.
 
 The name of each app and init container in a Pod must be unique; a
 validation error is thrown for any container sharing a name with another.


### PR DESCRIPTION
Refs: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#detailed-behavior

Use activeDeadlineSeconds on the Pod and livenessProbe on the container to prevent init containers from failing forever. The active deadline includes init containers.

The above statement is not clear.

user must not follow it unless they deploy their application as a Job, because 'activeDeadlineSeconds' has an effect even after initContainer finished. The Pod which is already running correctly would be killed by 'activeDeadlineSeconds' if you set.