### PR TITLE
ja: Make docs/reference/_index.md follow v1.19 of the original text

### DIFF
--- a/content/ja/docs/reference/_index.md
+++ b/content/ja/docs/reference/_index.md
@@ -16,8 +16,8 @@ content_type: concept
 
 ## APIリファレンス
 
-* [Kubernetes API概要](/docs/reference/using-api/) - Kubernetes APIの概要です。
-* [Kubernetes APIリファレンス {{< latest-version >}}](/docs/reference/generated/kubernetes-api/{{< latest-version >}}/)
+* [KubernetesのAPIリファレンス {{< param "version" >}}](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/)
+* [Kubernetes APIを使う](/docs/reference/using-api/) - Kubernetes APIの概要です。
 
 ## APIクライアントライブラリー
 
@@ -42,10 +42,8 @@ content_type: concept
 * [kube-proxy](/docs/reference/command-line-tools-reference/kube-proxy/) - 単純なTCP/UDPストリームのフォワーディングや、一連のバックエンド間でTCP/UDPのラウンドロビンでのフォワーディングを実行できます。
 * [kube-scheduler](/docs/reference/command-line-tools-reference/kube-scheduler/) - 可用性、パフォーマンス、およびキャパシティを管理するスケジューラーです。
   * [kube-schedulerポリシー](/docs/reference/scheduling/policies)
-  * [kube-schedulerプロファイル](/docs/reference/scheduling/profiles)
+  * [kube-schedulerプロファイル](/docs/reference/scheduling/config#profiles)
 
 ## 設計のドキュメント
 
 Kubernetesの機能に関する設計ドキュメントのアーカイブです。[Kubernetesアーキテクチャ](https://git.k8s.io/community/contributors/design-proposals/architecture/architecture.md) と[Kubernetesデザイン概要](https://git.k8s.io/community/contributors/design-proposals)から読み始めると良いでしょう。
-
-


### PR DESCRIPTION
fix #28269

update `content/ja/docs/reference/_index.md`.

File to update
https://github.com/kubernetes/website/tree/dev-1.19-ja.2/content/ja/docs/reference/_index.md

Original
https://github.com/kubernetes/website/tree/release-1.19/content/en/docs/reference/_index.md

diff between translated and v1.19
https://gist.github.com/772916d5b97d7e37a59794a74227eaed


<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “master”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
