### PR TITLE
release-managers: add adolfo/carlos as tech leads

### DIFF
--- a/content/en/releases/release-managers.md
+++ b/content/en/releases/release-managers.md
@@ -192,6 +192,8 @@ GitHub team: [@kubernetes/sig-release-leads](https://github.com/orgs/kubernetes/
 
 ### Technical Leads
 
+- Adolfo García Veytia ([@puerco](https://github.com/puerco))
+- Carlos Panato ([@cpanato](https://github.com/cpanato))
 - Daniel Mangum ([@hasheddan](https://github.com/hasheddan))
 - Jeremy Rickard ([@jeremyrickard](https://github.com/jeremyrickard))
 


### PR DESCRIPTION
As part of the onboard described in this issue: https://github.com/kubernetes/sig-release/issues/1590

/assign @justaugustus @saschagrunert @hasheddan 
