### PR TITLE
[en] Fix link to param "version"

### DIFF
--- a/content/en/docs/reference/_index.md
+++ b/content/en/docs/reference/_index.md
@@ -19,7 +19,7 @@ This section of the Kubernetes documentation contains references.
 ## API Reference
 
 * [Kubernetes API Overview](/docs/reference/using-api/api-overview/) - Overview of the API for Kubernetes.
-* [Kubernetes API Reference {{< param "version" >}}](/docs/reference/generated/kubernetes-api/{{{< param "version" >}}/)
+* [Kubernetes API Reference {{< param "version" >}}](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/)
 
 ## API Client Libraries
 


### PR DESCRIPTION
Link to doc: https://v1-17.docs.kubernetes.io/docs/reference/#api-reference

The link to "Kubernetes API Reference v1.17" is broken due to a malformed URL in cc9b8e77db392fc177d50af494be8b5c1dfe72e3. This PR fixes the issue.