### PR TITLE
Bump Ruby version for Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,9 +7,9 @@ functions = "functions"
 command = "git submodule update --init --recursive --depth 1 && make non-production-build"
 
 [build.environment]
-HUGO_VERSION = "0.82.0"
 NODE_VERSION = "10.20.0"
-RUBY_VERSION = "2.7.1"
+HUGO_VERSION = "0.82.0"
+RUBY_VERSION = "3.0.1"
 
 [context.production.environment]
 HUGO_BASEURL = "https://kubernetes.io/"


### PR DESCRIPTION
Rather than specifying an old Ruby version, ~don't set any version. The site can build without Ruby~ pick something recent.

If we don't specify any version, Netlify tries to install an even _older_ Ruby.