### PR TITLE
Update docs for primary branch rename: PodSecurityPolicy

### DIFF
--- a/content/en/docs/concepts/security/pod-security-standards.md
+++ b/content/en/docs/concepts/security/pod-security-standards.md
@@ -283,9 +283,9 @@ of individual policies are not defined here.
 
 [**PodSecurityPolicy**](/docs/concepts/policy/pod-security-policy/)
 
-- [Privileged](https://raw.githubusercontent.com/kubernetes/website/master/content/en/examples/policy/privileged-psp.yaml)
-- [Baseline](https://raw.githubusercontent.com/kubernetes/website/master/content/en/examples/policy/baseline-psp.yaml)
-- [Restricted](https://raw.githubusercontent.com/kubernetes/website/master/content/en/examples/policy/restricted-psp.yaml)
+- {{< example file="policy/privileged-psp.yaml" >}}Privileged{{< /example >}}
+- {{< example file="policy/baseline-psp.yaml" >}}Baseline{{< /example >}}
+- {{< example file="policy/restricted-psp.yaml" >}}Restricted{{< /example >}}
 
 ## FAQ
 

--- a/layouts/shortcodes/example.html
+++ b/layouts/shortcodes/example.html
@@ -1,0 +1,14 @@
+{{ $file := .Get "file" }}
+{{ $codelang := .Get "language" | default (path.Ext $file | strings.TrimPrefix ".") }}
+{{ $fileDir := path.Split $file }}
+{{ $bundlePath := path.Join .Page.File.Dir $fileDir.Dir }}
+{{ $filename := printf "/content/%s/examples/%s" .Page.Lang $file | safeURL }}
+{{ $ghlink := printf "https://%s/%s%s" site.Params.githubwebsiteraw (default "main" (site.Params.github_branch)) $filename | safeURL }}
+
+<a href="{{ $ghlink }}" download="{{ $file }}">
+{{- if gt (len .Inner) 0 -}}
+  {{- .Inner -}}
+{{- else -}}
+  {{- $file -}}
+{{- end -}}
+</a>


### PR DESCRIPTION
- Add shortcode for hyperlinking to examples
- Use it for https://k8s.io/docs/concepts/security/pod-security-standards/

Part of the fixes for #28462