### PR TITLE
Explain build image versioning for local preview container image

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,6 +7,7 @@ timeout: 1200s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
+    # It's fine to bump the tag to a recent version, as needed
   - name: "gcr.io/k8s-testimages/gcb-docker-gcloud:v20190906-745fed4"
     entrypoint: make
     env:


### PR DESCRIPTION
Add a comment to help folks know that it's OK to bump the build image version as needed.

This build image is what we used for making the Hugo container image that contributors can then use for local site previews
(Netlify _doesn't_ use that image for building the live site).