### PR TITLE
PodResources: Introducing isExclusive field in ContainerResources

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
+++ b/content/en/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
@@ -219,6 +219,7 @@ message ContainerResources {
     string name = 1;
     repeated ContainerDevices devices = 2;
     repeated int64 cpu_ids = 3;
+    bool is_exclusive = 4;
 }
 
 // Topology describes hardware topology of the resource


### PR DESCRIPTION
A pod with same non-integral CPU request and limit belongs to Guaranteed
QoS class but obtains CPUs from the shared pool. Currently, in podresource API
there is no way to distinguish such pods from the pods which have been exclusively
allocated CPUs.

One of the primary goals of recent enhancements of PodResource API is to allow it to
enable node monitoring agents to know the allocatable compute resources on a node,
in order to calculate the node compute resource utilization. However, not being
able to determine if a pod has been exclusively allocated CPUs or CPUs belong to
the shared pool means that the goal cannot be realized.

We need to enhance the podresource API to give it the ability to determine if a pod
belongs to the shared pool or exclusive pool to be able to do proper accounting in
the node monitoring agents.

Implementation PR: https://github.com/kubernetes/kubernetes/pull/102989
