### PR TITLE
Added command to view CSR to Certificates page

### DIFF
--- a/content/en/docs/tasks/administer-cluster/certificates.md
+++ b/content/en/docs/tasks/administer-cluster/certificates.md
@@ -116,6 +116,9 @@ manually through `easyrsa`, `openssl` or `cfssl`.
         openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key \
         -CAcreateserial -out server.crt -days 10000 \
         -extensions v3_ext -extfile csr.conf
+1.  View the certificate signing request:
+
+        openssl req  -noout -text -in ./server.csr
 1.  View the certificate:
 
         openssl x509  -noout -text -in ./server.crt


### PR DESCRIPTION
As requested in [Issue 28487](https://github.com/kubernetes/website/issues/28487), the PR adds an openssl command for viewing the CSR file created on the [Certificates](https://kubernetes.io/docs/tasks/administer-cluster/certificates/) page.