### PR TITLE
[zh]Add synonym for namespace

### DIFF
--- a/content/zh/docs/concepts/overview/working-with-objects/namespaces.md
+++ b/content/zh/docs/concepts/overview/working-with-objects/namespaces.md
@@ -21,6 +21,7 @@ These virtual clusters are called namespaces.
 -->
 Kubernetes 支持多个虚拟集群，它们底层依赖于同一个物理集群。
 这些虚拟集群被称为名字空间。
+在一些文档里名字空间也称为命名空间。
 
 <!-- body -->
 

--- a/content/zh/docs/reference/glossary/namespace.md
+++ b/content/zh/docs/reference/glossary/namespace.md
@@ -39,3 +39,4 @@ Namespaces are used to organize objects in a cluster and provide a way to divide
 -->
 
 名字空间用来组织集群中对象，并为集群资源划分提供了一种方法。同一名字空间内的资源名称必须唯一，但跨名字空间时不作要求。
+在一些文档里名字空间也称为命名空间。


### PR DESCRIPTION
Some places translates 'namespace' to ‘命名空间’(e.g.), others '名字空间‘ (e.g.). This happens even in the same page! This is confusing for new learners. Add explicit clarification that these two names are synonyms.
related: #28459