### PR TITLE
Remove capture shortcode

### DIFF
--- a/layouts/shortcodes/capture.html
+++ b/layouts/shortcodes/capture.html
@@ -1,8 +1,0 @@
-{{ $_hugo_config := `{ "version": 1 }`}}
-{{- $id := .Get 0 -}}
-{{- if not $id -}}
-{{- errorf "missing id in capture" -}}
-{{- end -}}
-{{- $capture_id := printf "capture %s" $id -}}
-{{- .Page.Scratch.Set $capture_id .Inner -}}
-{{ warnf "Invalid shortcode: %s, in %q" $capture_id (relLangURL .Page.Path) }}


### PR DESCRIPTION
The capture shortcode is no longer used: the switch was made on 2020-06-15, in PR #20874, when we adopted the [Docsy](https://www.docsy.dev/) theme for Hugo.

Remove it. After this change, it won't be possible to use this legacy shortcode (builds would fail).

Example of the old shortcode:
```markdown
{{% capture overview %}}
Text here
{{% /capture %}}
```

/kind cleanup