### PR TITLE
Fix sidebar-tree indentation by updating layout with latest docsy theme

### DIFF
--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -1,5 +1,6 @@
 {{/* We cache this partial for bigger sites and set the active class client side. */}}
-{{ $shouldDelayActive := ge (len .Site.Pages) 2000 }}
+{{ $sidebarCacheLimit := cond (isset .Site.Params.ui "sidebar_cache_limit") .Site.Params.ui.sidebar_cache_limit 2000 }}
+{{ $shouldDelayActive := ge (len .Site.Pages) $sidebarCacheLimit }}
 <div id="td-sidebar-menu" class="td-sidebar__inner{{ if $shouldDelayActive }} d-none{{ end }}">
   {{ if not .Site.Params.ui.sidebar_search_disable }}
   <form class="td-sidebar__search d-flex align-items-center">
@@ -7,57 +8,85 @@
     <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fas fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-docs-nav" aria-expanded="false" aria-label="Toggle section navigation">
     </button>
   </form>
+  {{ else }}
+  <div id="content-mobile">
+  <form class="td-sidebar__search d-flex align-items-center">
+    {{ partial "search-input.html" . }}
+    <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fas fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-docs-nav" aria-expanded="false" aria-label="Toggle section navigation">
+    </button>
+  </form>
+  </div>
+  <div id="content-desktop"></div>
   {{ end }}
-  <nav class="collapse td-sidebar-nav" id="td-section-nav">
+  <nav class="collapse td-sidebar-nav{{ if .Site.Params.ui.sidebar_menu_foldable }} foldable-nav{{ end }}" id="td-section-nav">
     <!-- {{ if  (gt (len .Site.Home.Translations) 0) }}
     <div class="nav-item dropdown d-block d-lg-none">
       {{ partial "navbar-lang-selector.html" . }}
     </div>
     {{ end }} -->
+    <!-- {{ $navRoot := cond (and (ne .Params.toc_root true) (eq .Site.Home.Type "docs")) .Site.Home .FirstSection }} -->
+    {{ $ulNr := 0 }}
+    {{ $ulShow := cond (isset .Site.Params.ui "ul_show") .Site.Params.ui.ul_show 1 }}
+    {{ $sidebarMenuTruncate := cond (isset .Site.Params.ui "sidebar_menu_truncate") .Site.Params.ui.sidebar_menu_truncate 50 }}
     {{ $currentLang := .Site.Language }}
-    {{ template "section-tree-nav-section" (dict "page" . "section" .FirstSection "delayActive" $shouldDelayActive "currentLang" $currentLang)  }}
+    <ul class="td-sidebar-nav__section pr-md-3 ul-{{ $ulNr }}">
+      {{ template "section-tree-nav-section" (dict "page" . "section" $navRoot "shouldDelayActive" $shouldDelayActive "sidebarMenuTruncate" $sidebarMenuTruncate "ulNr" $ulNr "ulShow" (add $ulShow 1) "currentLang" $currentLang)  }}
+    </ul>
   </nav>
 </div>
 {{ define "section-tree-nav-section" }}
-{{ $s := .section }}
-{{ $p := .page }}
-{{ $shouldDelayActive := .delayActive }}
-{{ $active := eq $p.CurrentSection $s }}
-{{ $show := or (eq $s $p.FirstSection) (and (not $p.Site.Params.ui.sidebar_menu_compact) ($p.IsDescendant $s)) }}
-{{ $sid := $s.RelPermalink | anchorize }}
-<ul class="td-sidebar-nav__section pr-md-3">
-  {{ if (ne $s.File.Path "docs/_index.md") }}
-  <li class="td-sidebar-nav__section-title">
-    <a  href="{{ $s.RelPermalink }}" class="align-left pl-0 pr-2{{ if not $show }} collapsed{{ end }}{{ if $active}} active{{ end }} td-sidebar-link td-sidebar-link__section">
-      {{ $s.LinkTitle }}
-    </a>
-  </li>
-  {{ end }}
-  <ul>
-    <li class="collapse {{ if $show }}show{{ end }}" id="{{ $sid }}">
-      {{ $pages := where (union $s.Pages $s.Sections).ByWeight ".Params.toc_hide" "!=" true }}
-      {{ with site.Params.language_alternatives }}
-        {{ range . }}
-          {{ with (where $.section.Translations ".Lang" . ) }}
-            {{ $p := index . 0 }}
-            {{ $pages =  $pages | lang.Merge (union $p.Pages $p.Sections) }}
+  {{ $s := .section }}
+  {{ $p := .page }}
+  {{ $shouldDelayActive := .shouldDelayActive }}
+  {{ $sidebarMenuTruncate := .sidebarMenuTruncate }}
+  {{ $treeRoot := cond (eq .ulNr 0) true false }}
+  {{ $ulNr := .ulNr }}
+  {{ $ulShow := .ulShow }}
+  {{ $active := and (not $shouldDelayActive) (eq $s $p) }}
+  {{ $activePath := and (not $shouldDelayActive) ($p.IsDescendant $s) }}
+  {{ $show := cond (or (lt $ulNr $ulShow) $activePath (and (not $shouldDelayActive) (eq $s.Parent $p.Parent)) (and (not $shouldDelayActive) (eq $s.Parent $p)) (and (not $shouldDelayActive) ($p.IsDescendant $s.Parent))) true false }}
+  {{ $mid := printf "m-%s" ($s.RelPermalink | anchorize) }}
+  {{ $pages_tmp := where (union $s.Pages $s.Sections).ByWeight ".Params.toc_hide" "!=" true }}
+  {{ $pages := $pages_tmp | first $sidebarMenuTruncate }}
+  {{ $withChild := gt (len $pages) 0 }}
+  {{ $manualLink := cond (isset $s.Params "manuallink") $s.Params.manualLink ( cond (isset $s.Params "manuallinkrelref") (relref $s $s.Params.manualLinkRelref) $s.RelPermalink) }}
+  {{ $manualLinkTitle := cond (isset $s.Params "manuallinktitle") $s.Params.manualLinkTitle $s.Title }}
+
+  <li class="td-sidebar-nav__section-title td-sidebar-nav__section{{ if $withChild }} with-child{{ else }} without-child{{ end }}{{ if $activePath }} active-path{{ end }}{{ if (not (or $show $p.Site.Params.ui.sidebar_menu_foldable )) }} collapse{{ end }}" id="{{ $mid }}-li">
+    {{ if (and $p.Site.Params.ui.sidebar_menu_foldable (ge $ulNr 1)) }}
+      <input type="checkbox" id="{{ $mid }}-check"{{ if $activePath}} checked{{ end }}/>
+      <label for="{{ $mid }}-check"><a href="{{ $manualLink }}"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="align-left pl-0 {{ if $active}} active{{ end }} td-sidebar-link{{ if $s.IsPage }} td-sidebar-link__page{{ else }} td-sidebar-link__section{{ end }}{{ if $treeRoot }} tree-root{{ end }}" id="{{ $mid }}">{{ with $s.Params.Icon}}<i class="{{ . }}"></i>{{ end }}<span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ $s.LinkTitle }}</span></a></label>
+    {{ else }}
+      <a href="{{ $manualLink }}"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="align-left pl-0{{ if $active}} active{{ end }} td-sidebar-link{{ if $s.IsPage }} td-sidebar-link__page{{ else }} td-sidebar-link__section{{ end }}{{ if $treeRoot }} tree-root{{ end }}" id="{{ $mid }}">{{ with $s.Params.Icon}}<i class="{{ . }}"></i>{{ end }}<span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ $s.LinkTitle }}</span></a>
+    {{ end }}
+    {{if $withChild }}
+      {{ $ulNr := add $ulNr 1 }}
+      <ul class="ul-{{ $ulNr }}{{ if (gt $ulNr 1)}} foldable{{end}}">
+        {{ $pages := where (union $s.Pages $s.Sections).ByWeight ".Params.toc_hide" "!=" true }}
+        {{ with site.Params.language_alternatives }}
+          {{ range . }}
+            {{ with (where $.section.Translations ".Lang" . ) }}
+              {{ $p := index . 0 }}
+              {{ $pages =  $pages | lang.Merge (union $p.Pages $p.Sections) }}
+            {{ end }}
           {{ end }}
         {{ end }}
-      {{ end }}
-      {{ $pages := $pages | first 50 }}
-      {{ range $pages }}
-        {{ if .IsPage }}
-          {{ $mid := printf "m-%s" (.RelPermalink | anchorize) }}
-          {{ $active := eq . $p }}
-          {{ $isForeignLanguage := (ne (string .Lang) (string $.currentLang)) }}
-          <a class="td-sidebar-link td-sidebar-link__page {{ if and (not $shouldDelayActive) $active }} active{{ end }}" id="{{ $mid }}" {{ if $isForeignLanguage }}target="_blank"{{ end }}  href="{{ .RelPermalink }}">
-            {{ .LinkTitle }}{{ if $isForeignLanguage }} <small>({{ .Lang | upper }})</small>{{ end }}
-          </a>
-        {{ else }}
-          {{ template "section-tree-nav-section" (dict "page" $p "section" . "currentLang" $.currentLang) }}
+        {{ $pages := $pages | first 50 }}
+        {{ range $pages }}
+          {{ if (not (and (eq $s $p.Site.Home) (eq .Params.toc_root true)) ) }}
+            {{ $mid := printf "m-%s" (.RelPermalink | anchorize) }}
+            {{ $active := eq . $p }}
+            {{ $isForeignLanguage := (ne (string .Lang) (string $.currentLang)) }}
+            {{ if (and $isForeignLanguage  ($p.IsDescendant $s)) }}
+              <a class="td-sidebar-link td-sidebar-link__page {{ if and (not $shouldDelayActive) $active }} active{{ end }}" id="{{ $mid }}" {{ if $isForeignLanguage }}target="_blank"{{ end }}  href="{{ .RelPermalink }}">
+                {{ .LinkTitle }}{{ if $isForeignLanguage }} <small>({{ .Lang | upper }})</small>{{ end }}
+              </a>
+            {{ else }}
+              {{ template "section-tree-nav-section" (dict "page" $p "section" . "currentLang" $.currentLang "shouldDelayActive" $shouldDelayActive "sidebarMenuTruncate" $sidebarMenuTruncate "ulNr" $ulNr "ulShow" $ulShow) }}
+            {{ end }}
+          {{ end }}
         {{ end }}
-      {{ end }}
-    </li>
-  </ul>
-</ul>
+      </ul>
+    {{ end }}
+  </li>
 {{ end }}


### PR DESCRIPTION
This PR fixes sidebar tree indentation of the website.

Currently, the sidebar tree does not show indentations due to the latest docsy theme update (#28489 https://github.com/kubernetes/website/tree/main/themes)

With current docsy theme (docsy @ 0f9c38b), the existing layouts/partials/sidebar-tree.html in k/website (https://github.com/kubernetes/website/blob/main/layouts/partials/sidebar-tree.html) seems not work well.

So, this PR merges `layouts/partials/sidebar-tree.html` in k/website with 
`website/themes/layouts/partials/sidebar-tree.html` from docsy @ 0f9c38b (https://github.com/google/docsy/blob/0f9c38b8daae932518bee269de2768395d2a2dc2/layouts/partials/sidebar-tree.html)

The updated sidebar-tree layout will fix sidebar tree indentation of the website.

---

## Current k8s.io snapshot
![image](https://user-images.githubusercontent.com/5966944/122695706-2f85af00-d27c-11eb-9c1c-3ec3c10c4456.png)

---

## Changes with this PR
### English
![image](https://user-images.githubusercontent.com/5966944/122695690-24cb1a00-d27c-11eb-87c7-ec8730e600b8.png)
### l10n (ex: Korean) // shows English doc if the doc is not localized yet
![image](https://user-images.githubusercontent.com/5966944/122695751-50e69b00-d27c-11eb-89b2-6b1cfe7dba6c.png)
