### PR TITLE
Cleaning up OWNERS_ALIASES file

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,11 +1,9 @@
 aliases:
   sig-docs-blog-owners: # Approvers for blog content
-    - castrojo
     - kbarnard10
     - onlydole
     - mrbobbytables
   sig-docs-blog-reviewers: # Reviewers for blog content
-    - castrojo
     - kbarnard10
     - mrbobbytables
     - onlydole
@@ -31,9 +29,7 @@ aliases:
     - reylejano
     - savitharaghunathan
     - sftim
-    - steveperry-53
     - tengqm
-    - zparnold
   sig-docs-en-reviews: # PR reviews for English content
     - bradtopol
     - celestehorgan
@@ -44,9 +40,7 @@ aliases:
     - onlydole
     - rajeshdeshpande02
     - sftim
-    - steveperry-53
     - tengqm
-    - zparnold
   sig-docs-es-owners: # Admins for Spanish content
     - raelga
     - electrocucaracha
@@ -235,10 +229,12 @@ aliases:
     - parispittman
   # authoritative source: https://git.k8s.io/sig-release/OWNERS_ALIASES
   sig-release-leads:
+    - cpanato # SIG Technical Lead
     - hasheddan # SIG Technical Lead
     - jeremyrickard # SIG Technical Lead
     - justaugustus # SIG Chair
     - LappleApple # SIG Program Manager
+    - puerco # SIG Technical Lead
     - saschagrunert # SIG Chair
   release-engineering-approvers:
     - cpanato # Release Manager
@@ -250,6 +246,7 @@ aliases:
   release-engineering-reviewers:
     - ameukam # Release Manager Associate
     - jimangel # Release Manager Associate
+    - markyjackson-taulia # Release Manager Associate
     - mkorbi # Release Manager Associate
     - palnabarun # Release Manager Associate
     - onlydole # Release Manager Associate


### PR DESCRIPTION
It's been awhile since we've cleaned up our [OWNERS_ALIASES](https://github.com/kubernetes/website/blob/main/OWNERS_ALIASES) file. I made the following adjustments:

## Removed
- @steveperry-53, the person, the myth, the legend (and sorely missed), should not be a reviewer as they are already emeritus.
- @castrojo was removed from blog owner / approver due to their new role. 👋 Hope things are well!
- @zparnold, I'm not sure about this one, but I DM'd them on slack to see if this makes sense.

## Updated
- Updated the SIG Release aliases based off of https://github.com/kubernetes/sig-release/blob/master/OWNERS_ALIASES

## Open Questions / Next Steps
- ~~@sftim, you're currently not in the blog approver group, do you have any desire to be?~~
- Bring up at weekly meeting: interests for growing reviewer pool (for blog and docs)

If anyone thinks I've made an error in my edits or desire to remain in your role, leave a comment!

As always, you can reference this PR if you wish to have your role reinstated. I'll hold this PR for any discussion for a max of 30 days.

/cc @sig-docs-en-owners
/hold