### PR TITLE
Add MongoDB deployment and service.

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
+++ b/content/en/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
@@ -31,7 +31,7 @@ for database debugging.
 1. Create a Deployment that runs MongoDB:
 
     ```shell
-    kubectl apply -f https://k8s.io/examples/application/guestbook/mongo-deployment.yaml
+    kubectl apply -f https://k8s.io/examples/application/mongodb/mongo-deployment.yaml
     ```
 
     The output of a successful command verifies that the deployment was created:
@@ -84,7 +84,7 @@ for database debugging.
 2. Create a Service to expose MongoDB on the network:
 
     ```shell
-    kubectl apply -f https://k8s.io/examples/application/guestbook/mongo-service.yaml
+    kubectl apply -f https://k8s.io/examples/application/mongodb/mongo-service.yaml
     ```
 
     The output of a successful command verifies that the Service was created:

--- a/content/en/examples/application/mongodb/mongo-deployment.yaml
+++ b/content/en/examples/application/mongodb/mongo-deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mongo
+  labels:
+    app.kubernetes.io/name: mongo
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mongo
+      app.kubernetes.io/component: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mongo
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+      - name: mongo
+        image: mongo:4.2
+        args:
+          - --bind_ip
+          - 0.0.0.0
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 27017

--- a/content/en/examples/application/mongodb/mongo-service.yaml
+++ b/content/en/examples/application/mongodb/mongo-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongo
+  labels:
+    app.kubernetes.io/name: mongo
+    app.kubernetes.io/component: backend
+spec:
+  ports:
+  - port: 27017
+    targetPort: 27017
+  selector:
+    app.kubernetes.io/name: mongo
+    app.kubernetes.io/component: backend


### PR DESCRIPTION

Add MongoDB deployment and service in `/examples/application/mongodb` and change their links in `Use Port Forwarding to Access Applications in a Cluster` task.

Fix: #28500