### PR TITLE
Update URL for Metacontroller

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/operator.md
+++ b/content/en/docs/concepts/extend-kubernetes/operator.md
@@ -116,7 +116,7 @@ Operator.
 * [Charmed Operator Framework](https://juju.is/)
 * [kubebuilder](https://book.kubebuilder.io/)
 * [KUDO](https://kudo.dev/) (Kubernetes Universal Declarative Operator)
-* [Metacontroller](https://metacontroller.app/) along with WebHooks that
+* [Metacontroller](https://metacontroller.github.io/metacontroller/intro.html) along with WebHooks that
   you implement yourself
 * [Operator Framework](https://operatorframework.io)
 * [shell-operator](https://github.com/flant/shell-operator)


### PR DESCRIPTION
The Metacontroller project has moved from Google control to community support. This PR is to update the URL as the existing one no longer works. Ref: https://github.com/metacontroller/metacontroller#a-new-home