### PR TITLE
Improvement: Runtime Class

### DIFF
--- a/content/en/docs/concepts/containers/runtime-class.md
+++ b/content/en/docs/concepts/containers/runtime-class.md
@@ -118,7 +118,7 @@ Runtime handlers are configured through containerd's configuration at
 `/etc/containerd/config.toml`. Valid handlers are configured under the runtimes section:
 
 ```
-[plugins.cri.containerd.runtimes.${HANDLER_NAME}]
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.${HANDLER_NAME}]
 ```
 
 See containerd's config documentation for more details:


### PR DESCRIPTION

This PR correct the Runtime handlers configuration in [containerd](https://kubernetes.io/docs/concepts/containers/runtime-class/#hahahugoshortcode-s3-hbhb)

As mentioned in  [CRI Plugin Config Guide](https://github.com/containerd/cri/blob/master/docs/config.md)

```
    # 'plugins."io.containerd.grpc.v1.cri".containerd.runtimes' is a map from CRI RuntimeHandler strings, which specify types
    # of runtime configurations, to the matching configurations.
    # In this example, 'runc' is the RuntimeHandler string to match.
    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]```
