### PR TITLE
Customize sidebar tree style

### DIFF
--- a/assets/scss/_sidebar-tree.scss
+++ b/assets/scss/_sidebar-tree.scss
@@ -1,0 +1,167 @@
+//
+// Left side navigation
+//
+.td-sidebar-nav {
+    padding-right: 0.5rem;
+    margin-right: -15px;
+    margin-left: -15px;
+
+    @include media-breakpoint-up(md) {
+        @supports (position: sticky) {
+            max-height: calc(100vh - 10rem);
+            overflow-y: auto;
+        }
+    }
+
+
+    @include media-breakpoint-up(md) {
+        display: block !important;
+    }
+
+
+    &__section {
+	white-space: nowrap;  /* website customization */
+        li {
+            list-style: none;
+        }
+
+        ul {
+            padding: 0 6px;   /* website customization */
+            margin: 0;
+        }
+
+        @include media-breakpoint-up(md) {
+            & .ul-1 ul {
+                padding-left: 1.5em;
+            }
+        }
+
+
+        padding-left: 0;
+    }
+
+    &__section-title {
+        display: block;
+        font-weight: $font-weight-medium;
+	white-space: nowrap;    /* website customization */
+
+        .active {
+            font-weight: $font-weight-bold;
+	    color: $blue;       /* website customization */
+        }
+
+        a {
+            color: $gray-900;
+        }
+    }
+
+    .td-sidebar-link {
+        display: block;
+        padding-bottom: 0.375rem;
+
+        &__page {
+            color: $gray-700;
+            // font-weight: $font-weight-light;    /* website customization */
+	    font-size: 90%;         /* website customization */
+	    white-space: nowrap;    /* website customization */
+        }
+    }
+
+    a {
+        &:hover {
+            color: $blue;
+            text-decoration: none;
+        }
+
+        &.active {
+            font-weight: $font-weight-bold;
+        }
+    }
+
+    .dropdown {
+        a {
+            color: $gray-700;
+        }
+
+        .nav-link {
+             padding: 0 0 1rem;
+        }
+    }
+
+    & > .td-sidebar-nav__section {
+        padding-top: .5rem;
+        padding-left: 1.5rem;
+    }
+
+    li i { // Layout of icons
+        padding-right: 0.5em;
+        &:before{
+            display: inline-block;
+            text-align: center;
+            min-width: 1em;
+        }
+    }
+
+    .td-sidebar-link.tree-root{
+        font-weight: $font-weight-bold;
+        color: $td-sidebar-tree-root-color;
+        border-bottom: 1px $td-sidebar-tree-root-color solid;
+        margin-bottom: 1rem;
+    }
+}
+
+.td-sidebar {
+    @include media-breakpoint-up(md) {
+        padding-top: 4rem;
+        background-color: $td-sidebar-bg-color;
+        padding-right: 1rem;
+        border-right: 1px solid $td-sidebar-border-color;
+    }
+
+
+    padding-bottom: 1rem;
+
+    &__toggle {
+        line-height: 1;
+        color: $gray-900;
+        margin: 1rem;
+    }
+
+    &__search {
+        padding: 1rem 15px;
+        margin-right: -15px;
+        margin-left: -15px;
+    }
+
+    &__inner {
+        order: 0;
+
+        @include media-breakpoint-up(md) {
+            @supports (position: sticky) {
+                position: sticky;
+                top: 4rem;
+                z-index: 10;
+                height: calc(100vh - 6rem);
+            }
+        }
+
+
+        @include media-breakpoint-up(xl) {
+            flex: 0 1 320px;
+        }
+
+
+        .td-search-box {
+            width: 100%;
+        }
+    }
+
+    #content-desktop {display: block;}
+    #content-mobile {display: none;}
+
+    @include media-breakpoint-down(md) {
+
+    #content-desktop {display: none;}
+    #content-mobile {display: block;}
+    }
+}


### PR DESCRIPTION
This PR tweaks the sidebar navigator:

- slightly decrease font size by 10% for page links
- indent each level of list by 6px
- disallow title wrapping
- allow the list to be scrolled horizontally

This file is copied from Docsy source with customization lines highlighted with "/* website customization */".
