### PR TITLE
dns-pod-service.md: Fix unqualified host search ex

### DIFF
--- a/content/en/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/en/docs/concepts/services-networking/dns-pod-service.md
@@ -39,7 +39,7 @@ namespace.
 
 DNS queries may be expanded using the pod's `/etc/resolv.conf`. Kubelet 
 sets this file for each pod. For example, a query for just `data` may be 
-expanded to `data.test.cluster.local`. The values of the `search` option 
+expanded to `data.test.svc.cluster.local`. The values of the `search` option 
 are used to expand queries. To learn more about DNS queries, see 
 [the `resolv.conf` manual page.](https://www.man7.org/linux/man-pages/man5/resolv.conf.5.html) 
 


### PR DESCRIPTION
Unless I am mistaken, according to the provided search config, the query for `data` is missing the `svc` component in the full search.
