### PR TITLE
[ko] Translate docs/contribute/analytics.md

### DIFF
--- a/content/ko/docs/contribute/analytics.md
+++ b/content/ko/docs/contribute/analytics.md
@@ -1,0 +1,25 @@
+---
+title: 사이트 분석 보기
+content_type: concept
+weight: 100
+card:
+  name: contribute
+  weight: 100
+---
+
+<!-- overview -->
+
+이 페이지는 kubernetes.io 사이트 분석을 제공하는 대시보드에 대한 정보를 담고 있다.
+
+
+<!-- body -->
+
+[대시보드 보기](https://datastudio.google.com/reporting/fede2672-b2fd-402a-91d2-7473bdb10f04).
+
+이 대시보드는 Google Data Studio를 사용하여 구축되었으며 kubernetes.io에서 Google Analytics를 사용하여 수집한 정보를 보여준다.
+
+### 대시보드 사용
+
+기본적으로 대시보드는 지난 30일 동안 수집된 모든 데이터의 분석을 제공한다. 날짜 선택을 통해 특정 날짜 범위의 데이터를 볼 수 있다. 그 외 필터링 옵션을 사용하면, 사용자의 위치, 사이트에 접속하는데 사용된 장치, 번역된 문서 언어 등을 기준으로 데이터를 확인할 수 있다.
+
+ 이 대시보드에 문제가 있거나 개선을 요청하려면, [이슈를 오픈](https://github.com/kubernetes/website/issues/new/choose) 한다.


### PR DESCRIPTION
- Related issue: #28513 

**NOTE**
원문의 title이 `Viewing Site Analytics`이긴 하지만, `사이트 분석 보기`로 번역했을 때는 어떤 사이트의 분석인지 의미를 확인하기 어려울 것 같아, `kubernetes.io 사이트`로 풀어서 번역하였습니다. 

> [원문 링크](https://github.com/kubernetes/website/blob/dev-1.21-ko.5/content/en/docs/contribute/analytics.md)

/language ko
