### PR TITLE
Update the Seccomp link.

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/security-context.md
+++ b/content/en/docs/tasks/configure-pod-container/security-context.md
@@ -24,7 +24,7 @@ a Pod or Container. Security context settings include, but are not limited to:
 
 * [AppArmor](/docs/tutorials/clusters/apparmor/): Use program profiles to restrict the capabilities of individual programs.
 
-* [Seccomp](https://en.wikipedia.org/wiki/Seccomp): Filter a process's system calls.
+* [Seccomp](/docs/tutorials/clusters/seccomp/): Filter a process's system calls.
 
 * AllowPrivilegeEscalation: Controls whether a process can gain more privileges than its parent process. This bool directly controls whether the [`no_new_privs`](https://www.kernel.org/doc/Documentation/prctl/no_new_privs.txt) flag gets set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged OR 2) has `CAP_SYS_ADMIN`.
 


### PR DESCRIPTION

Update the Seccomp Link in Configure a Security Context for a Pod or Container(https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)

Fixes: #28677