### PR TITLE
[1.22] kubectl command headers docs

### DIFF
--- a/content/en/docs/reference/kubectl/kubectl.md
+++ b/content/en/docs/reference/kubectl/kubectl.md
@@ -328,7 +328,31 @@ kubectl [flags]
 </tbody>
 </table>
 
+## {{% heading "envvars" %}}
 
+<table style="width: 100%; table-layout: fixed;">
+<colgroup>
+<col span="1" style="width: 10px;" />
+<col span="1" />
+</colgroup>
+<tbody>
+
+<tr>
+<td colspan="2">KUBECONFIG</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">Path to the kubectl configuration ("kubeconfig") file. Default: "$HOME/.kube/config"</td>
+</tr>
+
+<tr>
+<td colspan="2">KUBECTL_COMMAND_HEADERS</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;">When set to false, turns off extra HTTP headers detailing invoked kubectl command (Kubernetes version v1.22 or later)</td>
+</tr>
+
+</tbody>
+</table>
 
 ## {{% heading "seealso" %}}
 

--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -60,6 +60,9 @@ other = "Older versions"
 [end_of_life]
 other = "End of Life:"
 
+[envvars_heading]
+other = "Environment variables"
+
 [error_404_were_you_looking_for]
 other = "Were you looking for:"
 


### PR DESCRIPTION
* This 1.22 docs PR adds a section on `kubectl` environment variables.
* Adds instructions for how to turn of `kubectl` HTTP command headers using the `KUBECTL_COMMAND_HEADERS` environment variable.

k/e
* https://github.com/kubernetes/enhancements/issues/859

k/k
* https://github.com/kubernetes/kubernetes/pull/103238

