### PR TITLE
id: Fix default disk type for Azure

### DIFF
--- a/content/id/docs/concepts/storage/storage-classes.md
+++ b/content/id/docs/concepts/storage/storage-classes.md
@@ -595,11 +595,11 @@ metadata:
 provisioner: kubernetes.io/azure-disk
 parameters:
   storageaccounttype: Standard_LRS
-  kind: Shared
+  kind: managed
 ```
 
 * `storageaccounttype`: Akun penyimpanan Azure yang ada pada tingkatan Sku. Nilai _default_-nya adalah kosong.
-* `kind`: Nilai yang mungkin adalah `shared` (default), `dedicated`, dan `managed`.
+* `kind`: Nilai yang mungkin adalah `shared`, `dedicated`, dan `managed` (default).
   Ketika `kind` yang digunakan adalah `shared`, semua disk yang tidak di-_manage_ akan
   dibuat pada beberapa akun penyimpanan yang ada pada grup sumber daya yang sama dengan klaster.
   Ketika `kind` yang digunakan adalah `dedicated`, sebuah akun penyimpanan


### PR DESCRIPTION
/kind bug

Since Kubernetes v1.12 the default disk kind is `managed` (not `shared`).
Ref https://github.com/kubernetes/kubernetes/pull/67483

/assign @andyzhangx 