### PR TITLE
Use consistent terminology for the Kubernetes general CA

### DIFF
--- a/content/en/docs/tasks/extend-kubernetes/configure-aggregation-layer.md
+++ b/content/en/docs/tasks/extend-kubernetes/configure-aggregation-layer.md
@@ -17,7 +17,7 @@ Configuring the [aggregation layer](/docs/concepts/extend-kubernetes/api-extensi
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
 
 {{< note >}}
-There are a few setup requirements for getting the aggregation layer working in your environment to support mutual TLS auth between the proxy and extension apiservers. Kubernetes and the kube-apiserver have multiple CAs, so make sure that the proxy is signed by the aggregation layer CA and not by something else, like the master CA.
+There are a few setup requirements for getting the aggregation layer working in your environment to support mutual TLS auth between the proxy and extension apiservers. Kubernetes and the kube-apiserver have multiple CAs, so make sure that the proxy is signed by the aggregation layer CA and not by something else, like the Kubernetes general CA.
 {{< /note >}}
 
 {{< caution >}}


### PR DESCRIPTION
https://kubernetes.io/docs/setup/best-practices/certificates/ calls this the "Kubernetes general CA". Make the two documents consistent in their terminology.
