### PR TITLE
correcting redis address in stateless-application guestbook document

### DIFF
--- a/content/en/docs/tutorials/stateless-application/guestbook.md
+++ b/content/en/docs/tutorials/stateless-application/guestbook.md
@@ -19,7 +19,7 @@ ready)_, multi-tier web application using Kubernetes and
 [Docker](https://www.docker.com/). This example consists of the following
 components:
 
-* A single-instance [Redis](https://www.redis.com/) to store guestbook entries
+* A single-instance [Redis](https://www.redis.io/) to store guestbook entries
 * Multiple web frontend instances
 
 ## {{% heading "objectives" %}}


### PR DESCRIPTION
Updating the Redis link in  Deploying PHP Guestbook application with Redis: [https://kubernetes.io/docs/tutorials/stateless-application/guestbook/](https://kubernetes.io/docs/tutorials/stateless-application/guestbook/)

This link is directed to [redis.com](redis.com) , the update will direct it to [redis.io](redis.io)