### PR TITLE
updating json-schema address: fixing broken link 

### DIFF
--- a/content/en/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1.md
+++ b/content/en/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1.md
@@ -283,7 +283,7 @@ CustomResourceDefinitionSpec describes how a user wants their resource to appear
 
 ## JSONSchemaProps {#JSONSchemaProps}
 
-JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-schema.org/).
+JSONSchemaProps is a JSON-Schema following Specification Draft 4. See https://json-schema.org/ for details.
 
 <hr>
 


### PR DESCRIPTION
Updating json-schema website link address in CustomResourceDefinition here : https://kubernetes.io/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1/#JSONSchemaProps

> Previous link was sending user to "[http://json-schema.org/)](http://json-schema.org/)"
> changed it to correct address.: "http://json-schema.org/"
