### PR TITLE
Modify release schedules to add cherry-pick deadlines for July '21

### DIFF
--- a/content/en/releases/patch-releases.md
+++ b/content/en/releases/patch-releases.md
@@ -76,12 +76,11 @@ Timelines may vary with the severity of bug fixes, but for easier planning we
 will target the following monthly release points. Unplanned, critical
 releases may also occur in between these.
 
-| Monthly Patch Release | Target date |
-| --------------------- | ----------- |
-| June 2021             | 2021-06-16  |
-| July 2021             | 2021-07-14  |
-| August 2021           | 2021-08-11  |
-| September 2021        | 2021-09-15  |
+| Monthly Patch Release | Cherry Pick Deadline | Target date |
+| --------------------- | -------------------- | ----------- |
+| July 2021             | 2021-07-10           | 2021-07-14  |
+| August 2021           | 2021-08-07           | 2021-08-11  |
+| September 2021        | 2021-09-11           | 2021-09-15  |
 
 ## Detailed Release History for Active Branches
 
@@ -93,6 +92,7 @@ End of Life for **1.21** is **2022-06-28**
 
 | PATCH RELEASE | CHERRY PICK DEADLINE | TARGET DATE | NOTE                                                                   |
 | ------------- | -------------------- | ----------- | ---------------------------------------------------------------------- |
+| 1.21.3        | 2021-07-10           | 2021-07-14  |                                                                        |
 | 1.21.2        | 2021-06-12           | 2021-06-16  |                                                                        |
 | 1.21.1        | 2021-05-07           | 2021-05-12  | [Regression](https://groups.google.com/g/kubernetes-dev/c/KuF8s2zueFs) |
 
@@ -104,6 +104,7 @@ End of Life for **1.20** is **2022-02-28**
 
 | PATCH RELEASE | CHERRY PICK DEADLINE | TARGET DATE | NOTE                                                                                |
 | ------------- | -------------------- | ----------- | ----------------------------------------------------------------------------------- |
+| 1.20.9        | 2021-07-10           | 2021-07-14  |                                                                                     |
 | 1.20.8        | 2021-06-12           | 2021-06-16  |                                                                                     |
 | 1.20.7        | 2021-05-07           | 2021-05-12  | [Regression](https://groups.google.com/g/kubernetes-dev/c/KuF8s2zueFs)              |
 | 1.20.6        | 2021-04-09           | 2021-04-14  |                                                                                     |
@@ -121,6 +122,7 @@ End of Life for **1.19** is **2021-10-28**
 
 | PATCH RELEASE | CHERRY PICK DEADLINE | TARGET DATE | NOTE                                                                      |
 | ------------- | -------------------- | ----------- | ------------------------------------------------------------------------- |
+| 1.19.13       | 2021-07-10           | 2021-07-14  |                                                                           |
 | 1.19.12       | 2021-06-12           | 2021-06-16  |                                                                           |
 | 1.19.11       | 2021-05-07           | 2021-05-12  | [Regression](https://groups.google.com/g/kubernetes-dev/c/KuF8s2zueFs)    |
 | 1.19.10       | 2021-04-09           | 2021-04-14  |                                                                           |

--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -1,20 +1,26 @@
 schedules:
 - release: 1.21
-  next: 1.21.2
-  cherryPickDeadline: 2021-06-12
-  targetDate: 2021-06-16
+  next: 1.21.3
+  cherryPickDeadline: 2021-07-10
+  targetDate: 2021-07-14
   endOfLifeDate: 2022-04-30
   previousPatches:
+    - release: 1.21.2
+      cherryPickDeadline: 2021-06-12
+      targetDate: 2021-06-16
     - release: 1.21.1
       cherryPickDeadline: 2021-05-07
       targetDate: 2021-05-12
       note: Regression https://groups.google.com/g/kubernetes-dev/c/KuF8s2zueFs
 - release: 1.20
-  next: 1.20.8
-  cherryPickDeadline: 2021-06-12
-  targetDate: 2021-06-16
+  next: 1.20.9
+  cherryPickDeadline: 2021-07-10
+  targetDate: 2021-07-14
   endOfLifeDate: 2021-12-30
   previousPatches:
+    - release: 1.20.8
+      cherryPickDeadline: 2021-06-12
+      targetDate: 2021-06-16
     - release: 1.20.7
       cherryPickDeadline: 2021-05-07
       targetDate: 2021-05-12
@@ -40,11 +46,14 @@ schedules:
       targetDate: 2020-12-18
       note: "Tagging Issue https://groups.google.com/g/kubernetes-dev/c/dNH2yknlCBA"
 - release: 1.19
-  next: 1.19.12
-  cherryPickDeadline: 2021-06-12
-  targetDate: 2021-06-16
+  next: 1.19.13
+  cherryPickDeadline: 2021-07-10
+  targetDate: 2021-07-14
   endOfLifeDate: 2021-09-30
   previousPatches:
+    - release: 1.19.12
+      cherryPickDeadline: 2021-06-12
+      targetDate: 2021-06-16
     - release: 1.19.11
       cherryPickDeadline: 2021-05-07
       targetDate: 2021-05-12


### PR DESCRIPTION
This PR updates the patch releases page markdown and the automatic schedule to add the cherry-pick deadlines for July '21 and also to add the upcoming releases in the machine-readable yaml schedule.

I made a slight modification to the table in the general calendar to add the CP dates there too to make it easier to see them at a glance.