### PR TITLE
Sync SIG Release leads OWNERS alias with auth source

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -235,10 +235,12 @@ aliases:
     - parispittman
   # authoritative source: https://git.k8s.io/sig-release/OWNERS_ALIASES
   sig-release-leads:
+    - cpanato # SIG Technical Lead
     - hasheddan # SIG Technical Lead
     - jeremyrickard # SIG Technical Lead
     - justaugustus # SIG Chair
     - LappleApple # SIG Program Manager
+    - puerco # SIG Technical Lead
     - saschagrunert # SIG Chair
   release-engineering-approvers:
     - cpanato # Release Manager


### PR DESCRIPTION
This commit syncs the `sig-release-leads` OWNERS alias with the
authoritative source in https://git.k8s.io/sig-release/OWNERS_ALIASES

Specifically, it adds @cpanato and @puerco (SIG Release Tech Leads) to the leads alias.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>
