### PR TITLE
improve example for kubelet config file

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubelet-config-file.md
+++ b/content/en/docs/tasks/administer-cluster/kubelet-config-file.md
@@ -30,11 +30,15 @@ Here is an example of what this file might look like:
 ```
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+address: "192.168.0.8",
+port: 20250,
+serializeImagePulls: false,
 evictionHard:
     memory.available:  "200Mi"
 ```
 
-In the example, the Kubelet is configured to evict Pods when available memory drops below 200Mi.
+In the example, the Kubelet is configured to serve on IP address 192.168.0.8 and port 20250, pull images in parallel,
+and evict Pods when available memory drops below 200Mi.
 All other Kubelet configuration values are left at their built-in defaults, unless overridden
 by flags. Command line flags which target the same value as a config file will override that value.
 


### PR DESCRIPTION
Current kubelet config file example shows a complex data type. It's much better to also show some simple common parameter types so that beginners can refer to the example for common usage directly.