### PR TITLE
Make kubectl executable in non-root install docs

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -82,6 +82,7 @@ For example, to download version {{< param "fullversion" >}} on Linux, type:
    If you do not have root access on the target system, you can still install kubectl to the `~/.local/bin` directory:
 
    ```bash
+   chmod +x kubectl
    mkdir -p ~/.local/bin/kubectl
    mv ./kubectl ~/.local/bin/kubectl
    # and then add ~/.local/bin/kubectl to $PATH


### PR DESCRIPTION
Following the "if you do not have root access" installation docs for kubectl results in a "permission denied" error, so this small change adds the appropriate chmod command to minimise confusion.