### PR TITLE
Change allowed values in PSS Seccomp section

### DIFF
--- a/content/en/docs/concepts/security/pod-security-standards.md
+++ b/content/en/docs/concepts/security/pod-security-standards.md
@@ -264,7 +264,7 @@ well as lower-trust users.The following listed controls should be enforced/disal
 				spec.containers[*].securityContext.seccompProfile<br>
 				spec.initContainers[*].securityContext.seccompProfile<br>
 				<br><b>Allowed Values:</b><br>
-				'runtime/default'<br>
+				'RuntimeDefault'<br>
 				undefined / nil<br>
 			</td>
 		</tr>


### PR DESCRIPTION
According to the document, it seems `runtime/default` is for annotation and `RuntimeDefault` is correct for `securityContext`. Or, is `runtime/default` still valid for `securityContext` as well?
https://kubernetes.io/docs/tutorials/clusters/seccomp/#create-pod-that-uses-the-container-runtime-default-seccomp-profile
