### PR TITLE
Add seccomp tutorial to index

### DIFF
--- a/content/en/docs/tutorials/_index.md
+++ b/content/en/docs/tutorials/_index.md
@@ -51,6 +51,8 @@ Before walking through each tutorial, you may want to bookmark the
 
 * [AppArmor](/docs/tutorials/clusters/apparmor/)
 
+* [seccomp](/docs/tutorials/clusters/seccomp/)
+
 ## Services
 
 * [Using Source IP](/docs/tutorials/services/source-ip/)


### PR DESCRIPTION
This adds the seccomp tutorial page to the index side by side to AppArmor.
