### PR TITLE
Redirect pointers to kubeadm config

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init-phase.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init-phase.md
@@ -143,8 +143,8 @@ install them selectively.
 {{< tab name="kube-proxy" include="generated/kubeadm_init_phase_addon_kube-proxy.md" />}}
 {{< /tabs >}}
 
-For more details on each field in the `v1beta2` configuration you can navigate to our
-[API reference pages.] (https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2)
+For more details on each field in the `v1beta3` configuration you can navigate to our
+[API reference pages](/docs/reference/config-api/kubeadm-config.v1beta3/)
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
@@ -282,8 +282,8 @@ The default configuration can be printed out using the
 If your configuration is not using the latest version it is **recommended** that you migrate using
 the [kubeadm config migrate](/docs/reference/setup-tools/kubeadm/kubeadm-config/) command.
 
-For more information on the fields and usage of the configuration you can navigate to our API reference
-page and pick a version from [the list](https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm#pkg-subdirectories).
+For more information on the fields and usage of the configuration you can
+refer to the [configuration API reference](/docs/reference/config-api/kubeadm-config.v1beta3/)
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/setup/production-environment/tools/kubeadm/control-plane-flags.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/control-plane-flags.md
@@ -24,13 +24,11 @@ The `extraArgs` field consist of `key: value` pairs. To override a flag for a co
 3.  Run `kubeadm init` with `--config <YOUR CONFIG YAML>`.
 
 For more details on each field in the configuration you can navigate to our
-[API reference pages](https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2#ClusterConfiguration).
+[API reference pages](/docs/reference/config-api/kubeadm-config.v1beta3/).
 
 {{< note >}}
 You can generate a `ClusterConfiguration` object with default values by running `kubeadm config print init-defaults` and saving the output to a file of your choice.
 {{< /note >}}
-
-
 
 <!-- body -->
 
@@ -40,9 +38,9 @@ For details, see the [reference documentation for kube-apiserver](/docs/referenc
 
 Example usage:
 ```yaml
-apiVersion: kubeadm.k8s.io/v1beta2
+apiVersion: kubeadm.k8s.io/v1beta3
 kind: ClusterConfiguration
-kubernetesVersion: v1.16.0
+kubernetesVersion: v1.20.0
 apiServer:
   extraArgs:
     advertise-address: 192.168.0.103
@@ -57,9 +55,9 @@ For details, see the [reference documentation for kube-controller-manager](/docs
 
 Example usage:
 ```yaml
-apiVersion: kubeadm.k8s.io/v1beta2
+apiVersion: kubeadm.k8s.io/v1beta3
 kind: ClusterConfiguration
-kubernetesVersion: v1.16.0
+kubernetesVersion: v1.20.0
 controllerManager:
   extraArgs:
     cluster-signing-key-file: /home/johndoe/keys/ca.key
@@ -73,9 +71,9 @@ For details, see the [reference documentation for kube-scheduler](/docs/referenc
 
 Example usage:
 ```yaml
-apiVersion: kubeadm.k8s.io/v1beta2
+apiVersion: kubeadm.k8s.io/v1beta3
 kind: ClusterConfiguration
-kubernetesVersion: v1.16.0
+kubernetesVersion: v1.20.0
 scheduler:
   extraArgs:
     config: /etc/kubernetes/scheduler-config.yaml

--- a/content/en/docs/setup/production-environment/tools/kubeadm/high-availability.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/high-availability.md
@@ -115,7 +115,7 @@ option. Your cluster requirements may need a different configuration.
 
     {{< note >}}
     The `kubeadm init` flags `--config` and `--certificate-key` cannot be mixed, therefore if you want
-    to use the [kubeadm configuration](https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2)
+    to use the [kubeadm configuration](/docs/reference/config-api/kubeadm-config.v1beta3/)
     you must add the `certificateKey` field in the appropriate config locations
     (under `InitConfiguration` and `JoinConfiguration: controlPlane`).
     {{< /note >}}
@@ -230,7 +230,7 @@ in the kubeadm config file.
 
 1.  Create a file called `kubeadm-config.yaml` with the following contents:
 
-        apiVersion: kubeadm.k8s.io/v1beta2
+        apiVersion: kubeadm.k8s.io/v1beta3
         kind: ClusterConfiguration
         kubernetesVersion: stable
         controlPlaneEndpoint: "LOAD_BALANCER_DNS:LOAD_BALANCER_PORT"

--- a/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
@@ -258,7 +258,12 @@ Error from server: Get https://10.19.0.41:10250/containerLogs/default/mysql-ddc6
   curl http://169.254.169.254/metadata/v1/interfaces/public/0/anchor_ipv4/address
   ```
 
-  The workaround is to tell `kubelet` which IP to use using `--node-ip`. When using DigitalOcean, it can be the public one (assigned to `eth0`) or the private one (assigned to `eth1`) should you want to use the optional private network. The [`KubeletExtraArgs` section of the kubeadm `NodeRegistrationOptions` structure](https://github.com/kubernetes/kubernetes/blob/release-1.13/cmd/kubeadm/app/apis/kubeadm/v1beta1/types.go) can be used for this.
+  The workaround is to tell `kubelet` which IP to use using `--node-ip`.
+  When using DigitalOcean, it can be the public one (assigned to `eth0`) or the private one
+  (assigned to `eth1`) should you want to use the optional private network.
+  The `kubeletExtraArgs` section of the kubeadm
+  [`NodeRegistrationOptions` structure](/docs/reference/config-api/kubeadm-config.v1beta3/#kubeadm-k8s-io-v1beta3-NodeRegistrationOptions)
+  can be used for this.
 
   Then restart `kubelet`:
 
@@ -357,7 +362,9 @@ The tracking issue for this problem is [here](https://github.com/kubernetes/kube
 
 ## The NodeRegistration.Taints field is omitted when marshalling kubeadm configuration
 
-*Note: This [issue](https://github.com/kubernetes/kubeadm/issues/1358) only applies to tools that marshal kubeadm types (e.g. to a YAML configuration file). It will be fixed in kubeadm API v1beta2.*
+Note: This [issue](https://github.com/kubernetes/kubeadm/issues/1358) only applies to tools
+that marshal kubeadm types (e.g. to a YAML configuration file). It was fixed in kubeadm
+configuration API v1beta2.
 
 By default, kubeadm applies the `node-role.kubernetes.io/master:NoSchedule` taint to control-plane nodes.
 If you prefer kubeadm to not taint the control-plane node, and set `InitConfiguration.NodeRegistration.Taints` to an empty slice,
@@ -381,19 +388,19 @@ Kubernetes components like the kubelet and kube-controller-manager use the defau
 for the feature to work.
 
 To workaround this issue you can configure the flex-volume directory using the kubeadm
-[configuration file](https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2).
+[configuration file](/docs/reference/config-api/kubeadm-config.v1beta3/).
 
 On the primary control-plane Node (created using `kubeadm init`) pass the following
 file using `--config`:
 
 ```yaml
-apiVersion: kubeadm.k8s.io/v1beta2
+apiVersion: kubeadm.k8s.io/v1beta3
 kind: InitConfiguration
 nodeRegistration:
   kubeletExtraArgs:
     volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
 ---
-apiVersion: kubeadm.k8s.io/v1beta2
+apiVersion: kubeadm.k8s.io/v1beta3
 kind: ClusterConfiguration
 controllerManager:
   extraArgs:
@@ -403,7 +410,7 @@ controllerManager:
 On joining Nodes:
 
 ```yaml
-apiVersion: kubeadm.k8s.io/v1beta2
+apiVersion: kubeadm.k8s.io/v1beta3
 kind: JoinConfiguration
 nodeRegistration:
   kubeletExtraArgs:

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
@@ -161,10 +161,11 @@ The built-in signer is part of [`kube-controller-manager`](/docs/reference/comma
 
 To activate the built-in signer, you must pass the `--cluster-signing-cert-file` and `--cluster-signing-key-file` flags.
 
-If you're creating a new cluster, you can use a kubeadm [configuration file](https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2):
+If you're creating a new cluster, you can use a kubeadm
+[configuration file](/docs/reference/config-api/kubeadm-config.v1beta3/):
 
 ```yaml
-apiVersion: kubeadm.k8s.io/v1beta2
+apiVersion: kubeadm.k8s.io/v1beta3
 kind: ClusterConfiguration
 controllerManager:
   extraArgs:


### PR DESCRIPTION
This PR redirects pointers of kubeadm config to the generated reference rather than the godoc site. Where appropriate, references to v1beta2 are replaced by v1beta3.

This one follows the #28775 PR.
