### PR TITLE
Update persistent-volumes.md

### DIFF
--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -131,7 +131,9 @@ The `Retain` reclaim policy allows for manual reclamation of the resource. When 
 
 1. Delete the PersistentVolume. The associated storage asset in external infrastructure (such as an AWS EBS, GCE PD, Azure Disk, or Cinder volume) still exists after the PV is deleted.
 1. Manually clean up the data on the associated storage asset accordingly.
-1. Manually delete the associated storage asset, or if you want to reuse the same storage asset, create a new PersistentVolume with the storage asset definition.
+1. Manually delete the associated storage asset.
+
+If you want to reuse the same storage asset, create a new PersistentVolume with the same storage asset definition.
 
 #### Delete
 


### PR DESCRIPTION
Makes option 3 for "reclaiming" a released PV a bit clearer. Used to be:

> Manually delete the associated storage asset, or if you want to reuse the same storage asset, create a new PersistentVolume with the same storage asset definition.

But the 2nd part applies more to reclamation option 1 and is kind of contradictory with option 3 (which isn't really "reclaiming" anything AFAICT). So just  move to it's own stand alone sentence.
