### PR TITLE
Correct FQDN for DockerHub.

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
+++ b/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
@@ -102,7 +102,7 @@ kubectl create secret docker-registry regcred --docker-server=<your-registry-ser
 where:
 
 * `<your-registry-server>` is your Private Docker Registry FQDN.
-  Use `https://index.docker.io/v2/` for DockerHub.
+  Use `https://index.docker.io/v1/` for DockerHub.
 * `<your-name>` is your Docker username.
 * `<your-pword>` is your Docker password.
 * `<your-email>` is your Docker email.


### PR DESCRIPTION

Minor improvement: FQDN Value of --docker-server is `https://index.docker.io/v1/` instead of `https://index.docker.io/v2/` in [Pull an Image from a Private Registry](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-secret-by-providing-credentials-on-the-command-line) task.