### PR TITLE
Update cronjob.yaml

### DIFF
--- a/content/en/examples/application/job/cronjob.yaml
+++ b/content/en/examples/application/job/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1
+apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: hello


### PR DESCRIPTION
**Description:**

`apiVersion: batch/v1 ` cause a failure while creating object using this manifest, however it works fine with apiVersion: `batch/v1beta1`

Even the imperative kubectl command line generates the updated apiVersion. 

```
 $ kubectl create cronjob my-cron --image=anraj/my-cron --schedule "*/1 * * * *" --dry-run=client -o yaml
apiVersion: batch/v1beta1
kind: CronJob
metadata:
  creationTimestamp: null
  name: my-cron
spec:
  jobTemplate:
    metadata:
      creationTimestamp: null
      name: my-cron
    spec:
      template:
        metadata:
          creationTimestamp: null
        spec:
          containers:
          - image: anraj/my-cron
            name: my-cron
            resources: {}
          restartPolicy: OnFailure
  schedule: '*/1 * * * *'
status: {}
```
