### PR TITLE
Add docker deprecation notice

### DIFF
--- a/content/en/docs/reference/glossary/container-runtime.md
+++ b/content/en/docs/reference/glossary/container-runtime.md
@@ -19,3 +19,8 @@ Kubernetes supports several container runtimes: {{< glossary_tooltip term_id="do
 {{< glossary_tooltip term_id="containerd" >}}, {{< glossary_tooltip term_id="cri-o" >}},
 and any implementation of the [Kubernetes CRI (Container Runtime
 Interface)](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/container-runtime-interface.md).
+
+Note that {{< glossary_tooltip term_id="docker">}} support is deprecated since `v1.20`
+and is planned to be removed in `v1.22`. For more information and and a list of
+alternatives, refer to [this FAQ blog
+post](https://kubernetes.io/blog/2020/12/02/dockershim-faq/).

--- a/content/en/docs/reference/glossary/container-runtime.md
+++ b/content/en/docs/reference/glossary/container-runtime.md
@@ -21,6 +21,6 @@ and any implementation of the [Kubernetes CRI (Container Runtime
 Interface)](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/container-runtime-interface.md).
 
 Note that {{< glossary_tooltip term_id="docker">}} support is deprecated since `v1.20`
-and is planned to be removed in `v1.22`. For more information and and a list of
+and is planned to be removed in `v1.22`. For more information and a list of
 alternatives, refer to [this FAQ blog
 post](https://kubernetes.io/blog/2020/12/02/dockershim-faq/).


### PR DESCRIPTION
New folks may still turn to docker as a container runtime if they have just started
using k8s which is not a good idea if they're planning for the long run. Therefore,
adding a deprecation notice would serve everyone well.
