### PR TITLE
[zh] fix the beta summary indentation in using-api

### DIFF
--- a/content/zh/docs/reference/using-api/_index.md
+++ b/content/zh/docs/reference/using-api/_index.md
@@ -111,7 +111,7 @@ Here's a summary of each level:
     特性默认开启。
   - 尽管一些特性会发生细节上的变化，但它们将会被长期支持。
 
-<!--
+  <!--
   - The schema and/or semantics of objects may change in incompatible ways in
     a subsequent beta or stable release. When this happens, migration
     instructions are provided. Schema changes may require deleting, editing, and
@@ -120,7 +120,7 @@ Here's a summary of each level:
   - The software is not recommended for production uses. Subsequent releases
     may introduce incompatible changes. If you have multiple clusters which
     can be upgraded independently, you may be able to relax this restriction.
--->
+  -->
   - 在随后的 Beta 版或稳定版中，对象的模式和（或）语义可能以不兼容的方式改变。
     当这种情况发生时，将提供迁移说明。
      模式更改可能需要删除、编辑和重建 API 对象。
@@ -130,10 +130,10 @@ Here's a summary of each level:
     后续发布版本可能会有不兼容的变动。
     如果你有多个集群可以独立升级，可以放宽这一限制。
 
-<!--
+  <!--
   Please try beta features and provide feedback. After the features exit beta, it
   may not be practical to make more changes.
--->
+  -->
   {{< note >}}
   请试用测试版特性时并提供反馈。特性完成 Beta 阶段测试后，
   就可能不会有太多的变更了。


### PR DESCRIPTION
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
https://kubernetes.io/zh/docs/reference/using-api/#api-%E7%89%88%E6%9C%AC%E6%8E%A7%E5%88%B6 has wrong indentation of beta summary:
![image](https://user-images.githubusercontent.com/419660/125263184-66a82700-e335-11eb-8945-b3d5824ffa20.png)