### PR TITLE
Fix Typo: group instead of groups

### DIFF
--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -637,7 +637,7 @@ either do not manually edit the role, or disable auto-reconciliation.
 </tr>
 <tr>
 <td><b>system:public-info-viewer</b></td>
-<td><b>system:authenticated</b> and <b>system:unauthenticated</b> groups</td>
+<td><b>system:authenticated</b> and <b>system:unauthenticated</b> group</td>
 <td>Allows read-only access to non-sensitive information about the cluster. Introduced in Kubernetes v1.14.</td>
 </tr>
 </tbody>


### PR DESCRIPTION

Fix typo in [API discovery roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#discovery-roles). Both system: authenticated and system: unauthenticated have kind as a group instead of groups. as shown below:

```
subjects:
- apiGroup: rbac.authorization.k8s.io
  kind: Group
  name: system:authenticated
- apiGroup: rbac.authorization.k8s.io
  kind: Group
  name: system:unauthenticated
```
