### PR TITLE
Add jihoon-seo to sig-docs-ko-reviews

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -132,10 +132,11 @@ aliases:
     - ClaudiaJKang
     - gochist
     - ianychoi
-    - seokho-son
-    - ysyukr
+    - jihoon-seo
     - pjhwa
+    - seokho-son
     - yoonian
+    - ysyukr
   sig-docs-leads: # Website chairs and tech leads
     - irvifa
     - jimangel


### PR DESCRIPTION
I'd like to apply for sig-docs-ko-reviews role.
I've met the [requirements for reviewer](https://github.com/kubernetes/community/blob/master/community-membership.md#reviewer):

* 20+ PRs merged: https://github.com/kubernetes/website/pulls?q=is%3Apr+is%3Amerged+author%3Ajihoon-seo
* 5+ PRs reviewed: https://github.com/kubernetes/website/pulls?q=type%3Apr+reviewed-by%3Ajihoon-seo
* Member of Kubernetes for 3+ months

Thanks!

/assign @seokho-son 
(According to the steps in https://kubernetes.io/docs/contribute/participate/roles-and-responsibilities/#becoming-a-reviewer)
