### PR TITLE
update some typo produced by scripts/verify-spelling.sh

### DIFF
--- a/content/en/docs/tasks/manage-kubernetes-objects/kustomization.md
+++ b/content/en/docs/tasks/manage-kubernetes-objects/kustomization.md
@@ -299,7 +299,7 @@ metadata:
 type: Opaque
 ```
 
-Like ConfigMaps, generated Secrets can be used in Deployments by refering to the name of the secretGenerator:
+Like ConfigMaps, generated Secrets can be used in Deployments by referring to the name of the secretGenerator:
 
 ```shell
 # Create a password.txt file

--- a/scripts/.spelling_failures
+++ b/scripts/.spelling_failures
@@ -1,0 +1,10 @@
+content/en/blog/_posts/2016-05-00-Coreosfest2016-Kubernetes-Community.md
+content/en/blog/_posts/2016-10-00-Dynamic-Provisioning-And-Storage-In-Kubernetes.md
+content/en/blog/_posts/2017-02-00-Postgresql-Clusters-Kubernetes-Statefulsets.md
+content/en/blog/_posts/2018-06-28-Airflow-Kubernetes-Operator.md
+content/en/blog/_posts/2018-10-02-network-bootable-farm-with-ltsp.md
+content/en/blog/_posts/2019-03-19-kubeedge-k8s-based-edge-intro.md
+content/en/blog/_posts/2020-05-06-third-party-dual-sourced-content.md
+content/en/blog/_posts/2020-05-21-wsl2-dockerdesktop-k8s.md
+content/en/blog/_posts/2020-07-27-kubernetes-1-17-release-interview.md
+

--- a/scripts/verify-spelling.sh
+++ b/scripts/verify-spelling.sh
@@ -63,6 +63,9 @@ cd "${ROOT}"
 RES=0
 echo "Checking spelling..."
 ERROR_LOG="${TMP_DIR}/errors.log"
+
+# NOTE we usually don't correct old blog articles, so we ignore them in
+# this file.
 skipping_file="${KUBE_ROOT}/scripts/.spelling_failures"
 failing_packages=$(sed "s| | -e |g" "${skipping_file}")
 git ls-files | grep content/${LANGUAGE} | grep -v -e "${failing_packages}" | xargs misspell > "${ERROR_LOG}"

--- a/scripts/verify-spelling.sh
+++ b/scripts/verify-spelling.sh
@@ -15,14 +15,14 @@
 # limitations under the License.
 ##########
 # This script verifies mispellings in location. Today it only supports
-# verifying English locale but can be modified in a future to support 
+# verifying English locale but can be modified in a future to support
 # also other locales.
 # You need to run this script inside the root directory of "website" git repo.
-# 
+#
 # Syntax: verify-spelling.sh LOCALE
 # Example: verify-spelling.sh en
 # If no locale is passed, it will assume "en"
-# 
+#
 # Requirements:
 # - go v1.14 or superior version
 
@@ -33,6 +33,9 @@ set -o nounset
 set -o pipefail
 
 TOOL_VERSION="v0.3.4"
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+export KUBE_ROOT
 
 LANGUAGE="${1:-en}"
 # cd to the root path
@@ -60,7 +63,9 @@ cd "${ROOT}"
 RES=0
 echo "Checking spelling..."
 ERROR_LOG="${TMP_DIR}/errors.log"
-git ls-files | grep content/${LANGUAGE} | xargs misspell > "${ERROR_LOG}"
+skipping_file="${KUBE_ROOT}/scripts/.spelling_failures"
+failing_packages=$(sed "s| | -e |g" "${skipping_file}")
+git ls-files | grep content/${LANGUAGE} | grep -v -e "${failing_packages}" | xargs misspell > "${ERROR_LOG}"
 if [[ -s "${ERROR_LOG}" ]]; then
   sed 's/^/error: /' "${ERROR_LOG}" # add 'error' to each line to highlight in e2e status
   echo "Found spelling errors!"

--- a/scripts/verify-spelling.sh
+++ b/scripts/verify-spelling.sh
@@ -16,7 +16,7 @@
 ##########
 # This script verifies mispellings in location. Today it only supports
 # verifying English locale but can be modified in a future to support
-# also other locales.
+# other locales also
 # You need to run this script inside the root directory of "website" git repo.
 #
 # Syntax: verify-spelling.sh LOCALE
@@ -35,7 +35,6 @@ set -o pipefail
 TOOL_VERSION="v0.3.4"
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
-export KUBE_ROOT
 
 LANGUAGE="${1:-en}"
 # cd to the root path


### PR DESCRIPTION
ref: https://github.com/kubernetes/website/pull/26228
1. Update some typo produced by scripts/verify-spelling.sh. 
2. Supporting ignore files when run `bash scripts/verify-spelling.sh`
BTW, I suggest checking the spelling in the prow job when a pr is opened, which is useful.