### PR TITLE
Fix inconsistent writing of "control plane"

### DIFF
--- a/content/en/docs/reference/glossary/kube-controller-manager.md
+++ b/content/en/docs/reference/glossary/kube-controller-manager.md
@@ -11,7 +11,7 @@ tags:
 - architecture
 - fundamental
 ---
- Control Plane component that runs {{< glossary_tooltip text="controller" term_id="controller" >}} processes.
+ Control plane component that runs {{< glossary_tooltip text="controller" term_id="controller" >}} processes.
 
 <!--more-->
 


### PR DESCRIPTION
The term "control plane" is written as title case (e.g. Control Plane) only in this document. When it is referenced, it creates inconsistency in other documents. This commit will fix it by lower-casing the second word.
