### PR TITLE
Grammatical Mistake in kubernetes.io/community/

### DIFF
--- a/content/en/community/_index.html
+++ b/content/en/community/_index.html
@@ -13,7 +13,7 @@ cid: community
 <div class="intro">
 <br class="mobile">
 <p>The Kubernetes community -- users, contributors, and the culture we've built together -- is one of the biggest reasons for the meteoric rise of this open source project. Our culture and values continue to grow and change as the project itself grows and changes. We all work together toward constant improvement of the project and the ways we work on it.
-<br><br>We are the people who file issues and pull requests, attend SIG meetings, Kubernetes meetups, and KubeCon, advocate for it's adoption and innovation, run <code>kubectl get pods</code>, and contribute in a thousand other vital ways. Read on to learn how you can get involved and become part of this amazing community.</p>
+<br><br>We are the people who file issues and pull requests, attend SIG meetings, Kubernetes meetups, and KubeCon, advocate for its adoption and innovation, run <code>kubectl get pods</code>, and contribute in a thousand other vital ways. Read on to learn how you can get involved and become part of this amazing community.</p>
 <br class="mobile">
 </div>
 


### PR DESCRIPTION
**Problem:**
In the statement `advocate for it's adoption and innovation` , we are talking about the adoption of Kubernetes. Hence, possessive pronoun, "its" should be used.

Ref. issue #28960 
