### PR TITLE
Remove annotation for Experimental Windows Hyper-v

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints.md
+++ b/content/en/docs/reference/labels-annotations-taints.md
@@ -200,6 +200,19 @@ Used on: Service
 
 The kube-proxy has this label for custom proxy, which delegates service control to custom proxy.
 
+## experimental.windows.kubernetes.io/isolation-type (deprecated)
+
+Example: `experimental.windows.kubernetes.io/isolation-type: "hyperv"`
+
+Used on: Pod
+
+The annotation is used to run Windows containers with Hyper-V isolation. To use Hyper-V isolation feature and create a Hyper-V isolated container, the kubelet should be started with feature gates HyperVContainer=true and the Pod should include the annotation experimental.windows.kubernetes.io/isolation-type=hyperv.
+
+{{< note >}}
+You can only set this annotation on Pods that have a single container.
+Starting in v1.20, this annotation is deprecated as experimental hyper-v support was removed in 1.21.
+{{< /note >}}
+
 ## ingressclass.kubernetes.io/is-default-class
 
 Example: `ingressclass.kubernetes.io/is-default-class: "true"`

--- a/content/en/docs/reference/labels-annotations-taints.md
+++ b/content/en/docs/reference/labels-annotations-taints.md
@@ -200,7 +200,7 @@ Used on: Service
 
 The kube-proxy has this label for custom proxy, which delegates service control to custom proxy.
 
-## experimental.windows.kubernetes.io/isolation-type (deprecated)
+## experimental.windows.kubernetes.io/isolation-type (deprecated) {#experimental-windows-kubernetes-io-isolation-type}
 
 Example: `experimental.windows.kubernetes.io/isolation-type: "hyperv"`
 
@@ -210,7 +210,7 @@ The annotation is used to run Windows containers with Hyper-V isolation. To use 
 
 {{< note >}}
 You can only set this annotation on Pods that have a single container.
-Starting in v1.20, this annotation is deprecated as experimental hyper-v support was removed in 1.21.
+Starting from v1.20, this annotation is deprecated. Experimental Hyper-V support was removed in 1.21.
 {{< /note >}}
 
 ## ingressclass.kubernetes.io/is-default-class

--- a/content/en/docs/reference/labels-annotations-taints.md
+++ b/content/en/docs/reference/labels-annotations-taints.md
@@ -200,18 +200,6 @@ Used on: Service
 
 The kube-proxy has this label for custom proxy, which delegates service control to custom proxy.
 
-## experimental.windows.kubernetes.io/isolation-type
-
-Example: `experimental.windows.kubernetes.io/isolation-type: "hyperv"`
-
-Used on: Pod
-
-The annotation is used to run Windows containers with Hyper-V isolation. To use Hyper-V isolation feature and create a Hyper-V isolated container, the kubelet should be started with feature gates HyperVContainer=true and the Pod should include the annotation experimental.windows.kubernetes.io/isolation-type=hyperv.
-
-{{< note >}}
-You can only set this annotation on Pods that have a single container.
-{{< /note >}}
-
 ## ingressclass.kubernetes.io/is-default-class
 
 Example: `ingressclass.kubernetes.io/is-default-class: "true"`


### PR DESCRIPTION
This feature was marked for depreciation in 1.20 and removed in 1.21: https://github.com/kubernetes/kubernetes/pull/95505.

/sig windows
/kind cleanup

/cc @marosset 


<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
