### PR TITLE
TLS documentation could be more clear regarding certificate approval

### DIFF
--- a/content/en/docs/tasks/tls/managing-tls-in-a-cluster.md
+++ b/content/en/docs/tasks/tls/managing-tls-in-a-cluster.md
@@ -164,11 +164,11 @@ Events: <none>
 
 Approving the certificate signing request is either done by an automated
 approval process or on a one off basis by a cluster administrator. More
-information on what this involves is [covered below](approving-certificate-signing-requests).
+information on what this involves is [covered below](#approving-certificate-signing-requests).
 
 ## Download the Certificate and Use It
 
-Once the CSR is signed and [approved](approving-certificate-signing-requests) you should see the following:
+Once the CSR is signed and [approved](#approving-certificate-signing-requests) you should see the following:
 
 ```shell
 kubectl get csr

--- a/content/en/docs/tasks/tls/managing-tls-in-a-cluster.md
+++ b/content/en/docs/tasks/tls/managing-tls-in-a-cluster.md
@@ -164,11 +164,11 @@ Events: <none>
 
 Approving the certificate signing request is either done by an automated
 approval process or on a one off basis by a cluster administrator. More
-information on what this involves is covered below.
+information on what this involves is [covered below](approving-certificate-signing-requests).
 
 ## Download the Certificate and Use It
 
-Once the CSR is signed and approved you should see the following:
+Once the CSR is signed and [approved](approving-certificate-signing-requests) you should see the following:
 
 ```shell
 kubectl get csr


### PR DESCRIPTION
Based on the current flow of the document, the certificate signing request will be in a `Pending` state at the time a reader sees the command to download the issued certificate.

To address this, it would be better to reorder the sections to discuss certificate approval first, or to provide links to the aforementioned approval section

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
