### PR TITLE
Clarify that burstable pods also have their limit enforced by CFS quota

### DIFF
--- a/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
+++ b/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
@@ -63,7 +63,8 @@ duration as `--node-status-update-frequency`.
 The `none` policy explicitly enables the existing default CPU
 affinity scheme, providing no affinity beyond what the OS scheduler does
 automatically.  Limits on CPU usage for
-[Guaranteed pods](/docs/tasks/configure-pod-container/quality-service-pod/)
+[Guaranteed pods](/docs/tasks/configure-pod-container/quality-service-pod/) and
+[Burstable pods](/docs/tasks/configure-pod-container/quality-service-pod/)
 are enforced using CFS quota.
 
 ### Static policy

--- a/content/zh/docs/tasks/administer-cluster/cpu-management-policies.md
+++ b/content/zh/docs/tasks/administer-cluster/cpu-management-policies.md
@@ -94,7 +94,8 @@ CPU 管理器定期通过 CRI 写入资源更新，以保证内存中 CPU 分配
 The `none` policy explicitly enables the existing default CPU
 affinity scheme, providing no affinity beyond what the OS scheduler does
 automatically.  Limits on CPU usage for
-[Guaranteed pods](/docs/tasks/configure-pod-container/quality-service-pod/)
+[Guaranteed pods](/docs/tasks/configure-pod-container/quality-service-pod/) and
+[Burstable pods](/docs/tasks/configure-pod-container/quality-service-pod/)
 are enforced using CFS quota.
 -->
 ### none 策略

--- a/content/zh/docs/tasks/administer-cluster/cpu-management-policies.md
+++ b/content/zh/docs/tasks/administer-cluster/cpu-management-policies.md
@@ -94,8 +94,7 @@ CPU 管理器定期通过 CRI 写入资源更新，以保证内存中 CPU 分配
 The `none` policy explicitly enables the existing default CPU
 affinity scheme, providing no affinity beyond what the OS scheduler does
 automatically.  Limits on CPU usage for
-[Guaranteed pods](/docs/tasks/configure-pod-container/quality-service-pod/) and
-[Burstable pods](/docs/tasks/configure-pod-container/quality-service-pod/)
+[Guaranteed pods](/docs/tasks/configure-pod-container/quality-service-pod/)
 are enforced using CFS quota.
 -->
 ### none 策略


### PR DESCRIPTION
Adding a clarification that Burstable pods also have their limits enforced via CFS Quota.
This was verified in the Kubernetes slack [here](https://kubernetes.slack.com/archives/C0BP8PW9G/p1626436421142300).
