### PR TITLE
[PT-BR] Update CronJob documentation page

### DIFF
--- a/content/pt-br/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/pt-br/docs/concepts/workloads/controllers/cron-jobs.md
@@ -1,54 +1,113 @@
 ---
 reviewers:
-  - erictune
-  - soltysh
-  - janetkuo
+- erictune
+- soltysh
+- janetkuo
 title: CronJob
 content_type: concept
 weight: 80
 ---
 
-<!-- overview -->
+<!-- visão geral -->
 
-{{< feature-state for_k8s_version="v1.8" state="beta" >}}
+{{< feature-state for_k8s_version="v1.21" state="stable" >}}
 
-Um _Cron Job_ cria [Jobs](/docs/concepts/workloads/controllers/jobs-run-to-completion/) em um cronograma baseado em tempo.
+Um _CronJob_ cria {{< glossary_tooltip term_id="job" text="Jobs" >}} em um cronograma recorrente.
 
-Um objeto CronJob é como um arquivo _crontab_ (tabela cron). Executa um job periodicamente em um determinado horário, escrito no formato [Cron](https://en.wikipedia.org/wiki/Cron).
+Um objeto CronJob é como uma linha em um arquivo _crontab_ (tabela cron). Executa uma tarefa periodicamente em um determinado cronograma, escrito no formato [Cron](https://en.wikipedia.org/wiki/Cron).
 
-{{< note >}}
-Todos os **CronJob** `schedule (horários):` são indicados em UTC.
-{{< /note >}}
+{{< caution >}}
 
-Ao criar o manifesto para um recurso CronJob, verifique se o nome que você fornece é um [nome de subdomínio DNS](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names) válido.
-O nome não deve ter mais que 52 caracteres. Isso ocorre porque o controlador do CronJob anexará automaticamente 11 caracteres ao nome da tarefa fornecido e há uma restrição de que o comprimento máximo de um nome da tarefa não pode ultrapassar 63 caracteres.
+Todos os horários da propriedade `schedule:` do  *CronJob* são baseadas no fuso horário do {{< glossary_tooltip term_id="kube-controller-manager" >}}.
 
-Para obter instruções sobre como criar e trabalhar com tarefas cron, e para obter um exemplo de arquivo de especificação para uma tarefa cron, consulte [Executando tarefas automatizadas com tarefas cron](/docs/tasks/job/automated-tasks-with-cron-jobs).
+Se a camada de gerenciamento do cluster executa o kube-controller-manager em Pods ou contêineres avulsos, o fuso horário configurado para o contêiner executando o kube-controller-manager determina o fuso horário que o controlador dos objetos CronJob utiliza.
 
+{{< /caution >}}
 
+Ao criar o manifesto para um objeto CronJob, verifique se o nome que você forneceu é um [nome de subdomínio DNS](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names) válido.
+O nome não pode ter mais que 52 caracteres. Esta limitação existe porque o controlador do CronJob adicionará automaticamente 11 caracteres ao final do nome de tarefa escolhido, e o comprimento máximo de um nome de tarefa não pode ultrapassar 63 caracteres.
 
 <!-- body -->
 
-## Limitações do Cron Job
+## CronJob
 
-Um trabalho cron cria um objeto de trabalho _about_ uma vez por tempo de execução de seu planejamento, Dizemos "about" porque há certas circunstâncias em que duas tarefas podem ser criadas ou nenhum trabalho pode ser criado. Tentamos torná-los únicos, mas não os impedimos completamente. Portanto, os trabalhos devem ser _idempotente_.
+CronJobs são úteis para criar tarefas periódicas e recorrentes, como a execução de _backups_ ou o envio de mensagens de e-mail. CronJobs também permitem o agendamento de tarefas individuais para um horário específico, como por exemplo uma tarefa que executa quando a chance do cluster estar ocioso é maior.
 
-Se `startingDeadlineSeconds` estiver definido como um valor grande ou não definido (o padrão) e se `concurrencyPolicy` estiver definido como `Allow(Permitir)` os trabalhos sempre serão executados pelo menos uma vez.
+### Exemplo
 
-Para cada CronJob, o CronJob {{< glossary_tooltip term_id="controller" >}} verifica quantas agendas faltou na duração, desde o último horário agendado até agora. Se houver mais de 100 agendamentos perdidos, ele não iniciará o trabalho e registrará o erro
+Este manifesto de CronJob de exemplo imprime o horário atual e uma mensagem dizendo olá a cada minuto:
+
+{{< codenew file="application/job/cronjob.yaml" >}}
+
+(O artigo [Running Automated Tasks with a CronJob](/docs/tasks/job/automated-tasks-with-cron-jobs/) demonstra este exemplo com maiores detalhes).
+
+### Sintaxe do cronograma cron
+
+```
+# ┌───────────── minuto (0 - 59)
+# │ ┌───────────── hora (0 - 23)
+# │ │ ┌───────────── dia do mês (1 - 31)
+# │ │ │ ┌───────────── mês (1 - 12)
+# │ │ │ │ ┌───────────── dia da semana (0 - 6) (domingo a sábado;
+# │ │ │ │ │                                 7 também representa domingo em alguns sistemas operacionais)
+# │ │ │ │ │
+# │ │ │ │ │
+# * * * * *
+```
+
+| Expressão 								| Descrição																								  	| Equivalente a |
+| ------------- 						| ------------- 																							|-------------  |
+| @yearly (ou @annually)		| Executa uma vez por ano, à meia-noite de 1º de janeiro 			| 0 0 1 1 * 		|
+| @monthly 									| Executa uma vez por mês, à meia-noite do primeiro dia do mês| 0 0 1 * * 		|
+| @weekly 									| Executa uma vez por semana, à meia-noite de domingo					| 0 0 * * 0 		|
+| @daily (ou @midnight)			| Executa uma vez por dia, à meia-noite												| 0 0 * * * 		|
+| @hourly 									| Executa uma vez por hora, no minuto zero         			  		| 0 * * * * 		|
+
+Por exemplo, a linha abaixo determina que a tarefa deve iniciar toda sexta-feira à meia-noite, bem como em todo dia 13 do mês à meia-noite:
+
+`0 0 13 * 5`
+
+É também possível gerar expressões de cronograma para CronJobs utilizando ferramentas da _web_ como o [crontab.guru](https://crontab.guru/).
+
+## Limitações do CronJob
+
+Um CronJob cria uma tarefa _aproximadamente_ uma vez por tempo de execução de seu cronograma. Dizemos "aproximadamente" porque existem circunstâncias em que duas tarefas podem ser criadas, e outras circunstâncias em que nenhuma tarefa será criada. Tentamos tornar estas situações raras, mas não preveni-las completamente. Portanto, as tarefas devem ser _idempotentes_.
+
+Se o valor da propriedade `startingDeadlineSeconds` (limite de tempo de inicialização, em segundos) estiver definido como um valor grande, ou não definido (o padrão), e se a propriedade `concurrencyPolicy` (política de concorrência) estiver definido como `Allow` (permitir), as tarefas sempre serão executadas pelo menos uma vez.
+
+{{< caution >}}
+
+Se a propriedade `startingDeadlineSeconds` estiver definida com um valor menor que 10 segundos, a tarefa cron poderá não ser agendada. Isso ocorre porque o cronograma de execução do {{< glossary_tooltip term_id="controller" text="controlador" >}} do CronJob verifica tarefas a cada 10 segundos.
+
+{{< /caution >}}
+
+Para cada CronJob, o {{< glossary_tooltip term_id="controller" text="controlador" >}} do CronJob verifica quantos agendamentos foram perdidos no tempo entre o último horário agendado e o horário atual. Se houver mais de 100 agendamentos perdidos no período, o controlador não iniciará o trabalho e gerará a seguinte mensagem de erro:
 
 ```
 Cannot determine if job needs to be started. Too many missed start time (> 100). Set or decrease .spec.startingDeadlineSeconds or check clock skew.
 ```
 
-É importante observar que, se o campo `startingDeadlineSeconds` estiver definido (não `nil`), o controlador contará quantas tarefas perdidas ocorreram a partir do valor de `startingDeadlineSeconds` até agora, e não do último horário programado até agora. Por exemplo, se `startingDeadlineSeconds` for `200`, o controlador contará quantas tarefas perdidas ocorreram nos últimos 200 segundos.
+É importante observar que, se o campo `startingDeadlineSeconds` estiver definido (não `nil`), o controlador contará quantas tarefas perdidas ocorreram a partir do valor de `startingDeadlineSeconds` até agora, e não do último horário agendado até agora. Por exemplo, se `startingDeadlineSeconds` for `200`, o controlador contará quantas tarefas perdidas ocorreram nos últimos 200 segundos.
 
-Um CronJob é contado como perdido se não tiver sido criado no horário agendado. Por exemplo, se `concurrencyPolicy` estiver definido como `Forbid` e um CronJob tiver sido tentado ser agendado quando havia um agendamento anterior ainda em execução, será contabilizado como perdido.
+Um CronJob é considerado perdido se não for criado no horário agendado. Por exemplo, se `concurrencyPolicy` estiver definido como `Forbid` (proibir) e uma tentativa de agendamento de um novo CronJob ocorreu quando havia um agendamento anterior ainda em execução, o novo agendamento será contabilizado como perdido.
 
-Por exemplo, suponha que um CronJob esteja definido para agendar um novo trabalho a cada minuto, começando em `08:30:00`, e seu campo `startingDeadlineSeconds` não esteja defindo. Se o controlador CronJob estiver baixo de `08:29:00` para `10:21:00`, o trabalho não será iniciado, pois o número de trabalhos perdidos que perderam o cronograma é maior que 100.
+Por exemplo, suponha que um CronJob esteja definido para agendar uma nova tarefa a cada minuto, começando às `08:30:00`, e seu campo `startingDeadlineSeconds` não esteja definido. Se o controlador do CronJob estiver inativo das `08:29:00` até as `10:21:00`, a tarefa não será iniciada, pois o número de tarefas que perderam seus horários agendados é maior que 100.
 
-Para ilustrar ainda mais esse conceito, suponha que um CronJob esteja definido para agendar um novo trabalho a cada minuto, começando em `08:30:00`, e seu `startingDeadlineSeconds` está definido em 200 segundos. Se o controlador CronJob estiver inativo no mesmo período do exemplo anterior (`08:29:00` a `10:21:00`), o trabalho ainda será iniciado às 10:22:00. Isso acontece pois o controlador agora verifica quantos agendamentos perdidos ocorreram nos últimos 200 segundos (ou seja, 3 agendamentos perdidos), em vez do último horário agendado até agora.
+Para ilustrar melhor este conceito, suponha que um CronJob esteja definido para agendar uma nova tarefa a cada minuto, começando às `08:30:00`, e seu `startingDeadlineSeconds` esteja definido em 200 segundos. Se o controlador do CronJob estiver inativo no mesmo período do exemplo anterior (das `08:29:00` às `10:21:00`), a tarefa ainda será iniciada às 10:22:00. Isso acontece pois o controlador agora verifica quantos agendamentos perdidos ocorreram nos últimos 200 segundos (ou seja, 3 agendamentos perdidos), ao invés de verificar o período entre o último horário agendado e o horário atual.
 
-O CronJob é responsável apenas pela criação de trabalhos que correspondem à sua programação, e o trabalho, por sua vez, é responsável pelo gerenciamento dos Pods que ele representa.
+O CronJob é responsável apenas pela criação das tarefas que correspondem à sua programação, e a tarefa, por sua vez, é responsável pelo gerenciamento dos Pods que ele representa.
+
+## Versão do controlador
+
+A partir da versão 1.21 do Kubernetes, a segunda versão do controlador do CronJob é a implementação ativada por padrão. Para desativar o controlador do CronJob padrão e utilizar a versão original do controlador do CronJob, é necessário adicionar o _flag_ de [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) `CronJobControllerV2` à chamada do {{< glossary_tooltip term_id="kube-controller-manager" >}} com o valor `false` (falso). Por exemplo:
+```
+--feature-gates="CronJobControllerV2=false"
+```
 
 
+## {{% heading "whatsnext" %}}
+
+A página [Cron expression format](https://en.wikipedia.org/wiki/Cron) documenta o formato dos campos de agendamento do CronJob.
+
+Para instruções sobre criação e utilização de tarefas cron, e para um exemplo de manifesto de CronJob, veja
+[Running automated tasks with cron jobs](/docs/tasks/job/automated-tasks-with-cron-jobs).

--- a/content/pt-br/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/pt-br/docs/concepts/workloads/controllers/cron-jobs.md
@@ -1,8 +1,4 @@
 ---
-reviewers:
-- erictune
-- soltysh
-- janetkuo
 title: CronJob
 content_type: concept
 weight: 80
@@ -25,17 +21,17 @@ Se a camada de gerenciamento do cluster executa o kube-controller-manager em Pod
 {{< /caution >}}
 
 Ao criar o manifesto para um objeto CronJob, verifique se o nome que você forneceu é um [nome de subdomínio DNS](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names) válido.
-O nome não pode ter mais que 52 caracteres. Esta limitação existe porque o controlador do CronJob adicionará automaticamente 11 caracteres ao final do nome de tarefa escolhido, e o comprimento máximo de um nome de tarefa não pode ultrapassar 63 caracteres.
+O nome não pode ter mais que 52 caracteres. Esta limitação existe porque o controlador do CronJob adicionará automaticamente 11 caracteres ao final do nome escolhido para a tarefa, e o tamanho máximo de um nome de tarefa não pode ultrapassar 63 caracteres.
 
 <!-- body -->
 
 ## CronJob
 
-CronJobs são úteis para criar tarefas periódicas e recorrentes, como a execução de _backups_ ou o envio de mensagens de e-mail. CronJobs também permitem o agendamento de tarefas individuais para um horário específico, como por exemplo uma tarefa que executa quando a chance do cluster estar ocioso é maior.
+CronJobs são úteis para criar tarefas periódicas e recorrentes, como a execução de _backups_ ou o envio de mensagens de e-mail. CronJobs também permitem o agendamento de tarefas individuais para um horário específico, como por exemplo uma tarefa que é executada em um período maior de ociosidade do cluster.
 
 ### Exemplo
 
-Este manifesto de CronJob de exemplo imprime o horário atual e uma mensagem dizendo olá a cada minuto:
+Este manifesto de CronJob de exemplo imprime a data e horário atuais, seguidos da mensagem "Hello from the Kubernetes cluster", uma vez por minuto:
 
 {{< codenew file="application/job/cronjob.yaml" >}}
 
@@ -71,7 +67,7 @@ Por exemplo, a linha abaixo determina que a tarefa deve iniciar toda sexta-feira
 
 ## Limitações do CronJob
 
-Um CronJob cria uma tarefa _aproximadamente_ uma vez por tempo de execução de seu cronograma. Dizemos "aproximadamente" porque existem circunstâncias em que duas tarefas podem ser criadas, e outras circunstâncias em que nenhuma tarefa será criada. Tentamos tornar estas situações raras, mas não preveni-las completamente. Portanto, as tarefas devem ser _idempotentes_.
+Um CronJob cria uma tarefa _aproximadamente_ uma vez por tempo de execução de seu cronograma. Dizemos "aproximadamente" porque existem circunstâncias em que duas tarefas podem ser criadas, e outras circunstâncias em que nenhuma tarefa será criada. Tentamos tornar estas situações raras, mas não é possível preveni-las completamente. Portanto, as tarefas devem ser _idempotentes_.
 
 Se o valor da propriedade `startingDeadlineSeconds` (limite de tempo de inicialização, em segundos) estiver definido como um valor grande, ou não definido (o padrão), e se a propriedade `concurrencyPolicy` (política de concorrência) estiver definido como `Allow` (permitir), as tarefas sempre serão executadas pelo menos uma vez.
 

--- a/content/pt-br/docs/reference/glossary/job.md
+++ b/content/pt-br/docs/reference/glossary/job.md
@@ -1,0 +1,19 @@
+---
+title: Job
+id: job
+date: 2021-07-14
+full_link: /docs/concepts/workloads/controllers/job
+short_description: >
+  Uma tarefa finita ou em lotes que executa até finalizar.
+
+aka:
+tags:
+- fundamental
+- core-object
+- workload
+---
+Uma tarefa finita ou em lotes que executa até finalizar.
+
+<!--more-->
+
+Cria um ou mais objetos do tipo {{< glossary_tooltip term_id="pod" >}} e garante que um número determinado destes finaliza sua execução com sucesso. Conforme os Pods finalizam com sucesso, o Job observa as execuções bem-sucedidas.

--- a/content/pt-br/examples/application/job/cronjob.yaml
+++ b/content/pt-br/examples/application/job/cronjob.yaml
@@ -1,0 +1,19 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: hello
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: hello
+            image: busybox
+            imagePullPolicy: IfNotPresent
+            command:
+            - /bin/sh
+            - -c
+            - date; echo Olá do cluster do Kubernetes
+          restartPolicy: OnFailure

--- a/content/pt-br/examples/application/job/cronjob.yaml
+++ b/content/pt-br/examples/application/job/cronjob.yaml
@@ -15,5 +15,5 @@ spec:
             command:
             - /bin/sh
             - -c
-            - date; echo Olá do cluster do Kubernetes
+            - date; echo Hello from the Kubernetes cluster
           restartPolicy: OnFailure


### PR DESCRIPTION
## Changes
• Updated CronJob documentation page to reflect the latest English version in the Brazilian Portuguese translation.