### PR TITLE
Fixing improper sentence in HPA documentation

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -198,9 +198,8 @@ The detailed documentation of `kubectl autoscale` can be found [here](/docs/refe
 
 ## Autoscaling during rolling update
 
-Currently in Kubernetes, it is possible to perform a rolling update by using the deployment object, which manages the underlying replica sets for you.
-Horizontal Pod Autoscaler only supports the latter approach: the Horizontal Pod Autoscaler is bound to the deployment object,
-it sets the size for the deployment object, and the deployment is responsible for setting sizes of underlying replica sets.
+Currently in Kubernetes, a rolling update is performed using a deployment object, which manages the underlying replica sets for you.
+A Horizontal Pod Autoscaler is bound to a single deployment object - it sets the size for the deployment object, and the deployment is responsible for setting sizes of underlying replica sets.
 
 Horizontal Pod Autoscaler does not work with rolling update using direct manipulation of replication controllers,
 i.e. you cannot bind a Horizontal Pod Autoscaler to a replication controller and do rolling update.


### PR DESCRIPTION
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

It looks like this sentence used to describe two methods for performing a rolling restart:

```
Currently in Kubernetes, it is possible to perform a rolling update by managing replication controllers 
directly, or by using the deployment object, which manages the underlying replica sets for you.
Horizontal Pod Autoscaler only supports the latter approach: the Horizontal Pod Autoscaler is bound
to the deployment object,
```

But when that sentence was updated to remove one of the options, the word `latter` remained in place which is no longer correct:
```
Currently in Kubernetes, it is possible to perform a rolling update by using the deployment object, 
which manages the underlying replica sets for you. Horizontal Pod Autoscaler only supports the latter 
approach: the Horizontal Pod Autoscaler is bound to the deployment object, 
```

I've reworded this sentence to remove the improper use of `latter`, let me know what you think. 