### PR TITLE
Update audit.md

### DIFF
--- a/content/en/docs/tasks/debug-application-cluster/audit.md
+++ b/content/en/docs/tasks/debug-application-cluster/audit.md
@@ -157,9 +157,8 @@ volumeMounts:
   - mountPath: /etc/kubernetes/audit-policy.yaml
     name: audit
     readOnly: true
-  - mountPath: /var/log/audit.log
+  - mountPath: /var/log
     name: audit-log
-    readOnly: false
 ```
 and finally configure the `hostPath`:
 
@@ -170,10 +169,11 @@ and finally configure the `hostPath`:
     path: /etc/kubernetes/audit-policy.yaml
     type: File
 
+# Should mount directory instead of file. Log rotation will fail if single file mounted
 - name: audit-log
   hostPath:
-    path: /var/log/audit.log
-    type: FileOrCreate
+    path: /var/log
+    type: DirectoryOrCreate
 
 ```
 

--- a/content/zh/docs/tasks/debug-application-cluster/audit.md
+++ b/content/zh/docs/tasks/debug-application-cluster/audit.md
@@ -277,9 +277,8 @@ volumeMounts:
   - mountPath: /etc/kubernetes/audit-policy.yaml
     name: audit
     readOnly: true
-  - mountPath: /var/log/audit.log
+  - mountPath: /var/log
     name: audit-log
-    readOnly: false
 ```
 
 <!-- 
@@ -295,8 +294,8 @@ and finally configure the `hostPath`:
 
 - name: audit-log
   hostPath:
-    path: /var/log/audit.log
-    type: FileOrCreate
+    path: /var/log
+    type: DirectoryOrCreate
 ```
 
 <!--


### PR DESCRIPTION
if use  FileOrCreate, will occur "Device or resource busy" error when log rotate.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
