### PR TITLE
[zh] Fix some typos

### DIFF
--- a/content/zh/docs/concepts/scheduling-eviction/node-pressure-eviction.md
+++ b/content/zh/docs/concepts/scheduling-eviction/node-pressure-eviction.md
@@ -430,7 +430,7 @@ As a result, kubelet ranks and evicts pods in the following order:
 
 1. 首先考虑资源使用量超过其请求的 `BestEffort` 或 `Burstable` Pod。
    这些 Pod 会根据它们的优先级以及它们的资源使用级别超过其请求的程度被逐出。
-1. 资源使用量少于请求量的 `Guaranted` Pod 和 `Burstable` Pod 根据其优先级被最后驱逐。
+1. 资源使用量少于请求量的 `Guaranteed` Pod 和 `Burstable` Pod 根据其优先级被最后驱逐。
 
 {{<note>}}
 <!-- 
@@ -456,7 +456,7 @@ then the kubelet must choose to evict one of these pods to preserve node stabili
 and to limit the impact of resource starvation on other pods. In this case, it
 will choose to evict pods of lowest Priority first.
 -->
-仅当 `Guaranted` Pod 中所有容器都被指定了请求和限制并且二者相等时，才保证 Pod 不被驱逐。
+仅当 `Guaranteed` Pod 中所有容器都被指定了请求和限制并且二者相等时，才保证 Pod 不被驱逐。
 这些 Pod 永远不会因为另一个 Pod 的资源消耗而被驱逐。
 如果系统守护进程（例如 `kubelet`、`docker` 和 `journald`）
 消耗的资源比通过 `system-reserved` 或 `kube-reserved` 分配保留的资源多，

--- a/content/zh/docs/setup/release/notes.md
+++ b/content/zh/docs/setup/release/notes.md
@@ -1161,7 +1161,7 @@ filename | sha512 hash
 ### Bug or Regression
 
 - Add missing --kube-api-content-type in kubemark hollow template ([#98911](https://github.com/kubernetes/kubernetes/pull/98911), [@Jeffwan](https://github.com/Jeffwan)) [SIG Scalability and Testing]
-- Avoid duplicate error messages when runing kubectl edit quota ([#98201](https://github.com/kubernetes/kubernetes/pull/98201), [@pacoxu](https://github.com/pacoxu)) [SIG API Machinery and Apps]
+- Avoid duplicate error messages when running kubectl edit quota ([#98201](https://github.com/kubernetes/kubernetes/pull/98201), [@pacoxu](https://github.com/pacoxu)) [SIG API Machinery and Apps]
 - Cleanup subnet in frontend IP configs to prevent huge subnet request bodies in some scenarios. ([#98133](https://github.com/kubernetes/kubernetes/pull/98133), [@nilo19](https://github.com/nilo19)) [SIG Cloud Provider]
 - Fix errors when accessing Windows container stats for Dockershim ([#98510](https://github.com/kubernetes/kubernetes/pull/98510), [@jsturtevant](https://github.com/jsturtevant)) [SIG Node and Windows]
 - Fixes spurious errors about IPv6 in kube-proxy logs on nodes with IPv6 disabled. ([#99127](https://github.com/kubernetes/kubernetes/pull/99127), [@danwinship](https://github.com/danwinship)) [SIG Network and Node]

--- a/content/zh/docs/tasks/access-application-cluster/web-ui-dashboard.md
+++ b/content/zh/docs/tasks/access-application-cluster/web-ui-dashboard.md
@@ -172,7 +172,7 @@ The deploy wizard expects that you provide the following information:
  -->
 - **容器镜像**（必填）：公共镜像仓库上的 Docker
   [容器镜像](/zh/docs/concepts/containers/images/) 或者私有镜像仓库
-  （通常是 Google Container Registery 或者 Docker Hub）的 URL。容器镜像参数说明必须以冒号结尾。
+  （通常是 Google Container Registry 或者 Docker Hub）的 URL。容器镜像参数说明必须以冒号结尾。
 
 <!--
 - **Number of pods** (mandatory): The target number of Pods you want your application to be deployed in. The value must be a positive integer.


### PR DESCRIPTION
Fix some typos:
1. `Guaranted` -> `Guaranteed`
1. `runing` -> `running`
1. `Registery` -> `Registry`