### PR TITLE
[fr] fix typos and trailing spaces

### DIFF
--- a/content/fr/docs/concepts/services-networking/endpoint-slices.md
+++ b/content/fr/docs/concepts/services-networking/endpoint-slices.md
@@ -1,5 +1,5 @@
 ---
-reviewers: 
+reviewers:
 title: EndpointSlices
 feature:
   title: EndpointSlices
@@ -21,14 +21,14 @@ _EndpointSlices_ offrent une méthode simple pour suivre les Endpoints d'un rés
 
 <!-- body -->
 
-## Resource pour EndpointSlice {#endpointslice-resource}
+## Ressource pour EndpointSlice {#endpointslice-resource}
 
-Dans Kubernetes, un EndpointSlice contient des reférences à un ensemble de Endpoints. 
-Le controleur d'EndpointSlice crée automatiquement des EndpointSlices pour un Service quand un {{< glossary_tooltip text="sélecteur" term_id="selector" >}} est spécifié. 
-Ces EnpointSlices vont inclure des références à n'importe quels Pods qui correspondent aux selecteurs de Service. 
+Dans Kubernetes, un EndpointSlice contient des références à un ensemble de Endpoints.
+Le controleur d'EndpointSlice crée automatiquement des EndpointSlices pour un Service quand un {{< glossary_tooltip text="sélecteur" term_id="selector" >}} est spécifié.
+Ces EndpointSlices vont inclure des références à n'importe quels Pods qui correspondent aux selecteurs de Service.
 EndpointSlices groupent ensemble les Endpoints d'un réseau par combinaisons uniques de Services et de Ports.
 
-Par exemple, voici un échantillon d'une resource EndpointSlice pour le Kubernetes Service `exemple`.
+Par exemple, voici un échantillon d'une ressource EndpointSlice pour le Kubernetes Service `exemple`.
 
 ```yaml
 apiVersion: discovery.k8s.io/v1beta1
@@ -53,15 +53,15 @@ endpoints:
       topology.kubernetes.io/zone: us-west2-a
 ```
 
-Les EndpointSlices gérés par le contrôleur d'EndpointSlice n'auront, par défaut, pas plus de 100 Endpoints chacun. 
-En dessous de cette échelle, EndpointSlices devraient mapper 1:1 les Endpoints et les Services et devraientt avoir une performance similaire.
+Les EndpointSlices gérés par le contrôleur d'EndpointSlice n'auront, par défaut, pas plus de 100 Endpoints chacun.
+En dessous de cette échelle, EndpointSlices devraient mapper 1:1 les Endpoints et les Services et devraient avoir une performance similaire.
 
-EndpointSlices peuvent agir en tant que source de vérité pour kube-proxy quand il s'agit du routage d'un trafic interne. 
+EndpointSlices peuvent agir en tant que source de vérité pour kube-proxy quand il s'agit du routage d'un trafic interne.
 Lorsqu'ils sont activés, ils devraient offrir une amélioration de performance pour les services qui ont une grand quantité d'Endpoints.
 
 ### Types d'addresses
 
-Les EndpointSlices supportent 3 types d'addresses:
+Les EndpointSlices supportent 3 types d'addresses :
 
 * IPv4
 * IPv6
@@ -69,14 +69,14 @@ Les EndpointSlices supportent 3 types d'addresses:
 
 ### Topologie
 
-Chaque Endpoint dans un EnpointSlice peut contenir des informations de topologie pertinentes. 
+Chaque Endpoint dans un EndpointSlice peut contenir des informations de topologie pertinentes.
 Ceci est utilisé pour indiquer où se trouve un Endpoint, qui contient les informations sur le Node, zone et région correspondantes. Lorsque les valeurs sont disponibles, les labels de Topologies suivants seront définis par le contrôleur EndpointSlice:
 
 * `kubernetes.io/hostname` - Nom du Node sur lequel l'Endpoint se situe.
 * `topology.kubernetes.io/zone` - Zone dans laquelle l'Endpoint se situe.
 * `topology.kubernetes.io/region` - Région dans laquelle l'Endpoint se situe.
 
-Le contrôleur EndpointSlice surveille les Services et les Pods pour assurer que leurs correspondances avec les EndpointSlices sont à jour. 
+Le contrôleur EndpointSlice surveille les Services et les Pods pour assurer que leurs correspondances avec les EndpointSlices sont à jour.
 Le contrôleur gère les EndpointSlices pour tous les Services qui ont un sélecteur - [référence: {{< glossary_tooltip text="sélecteur" term_id="selector" >}}] - specifié. Celles-ci représenteront les IPs des Pods qui correspondent au sélecteur.
 
 ### Capacité d'EndpointSlices
@@ -85,32 +85,27 @@ Les EndpointSlices sont limités à une capacité de 100 Endpoints chacun, par d
 
 ### Distribution d'EndpointSlices
 
-Chaque EndpointSlice a un ensemble de ports qui s'applique à tous les Endpoints dans la resource. 
-Lorsque les ports nommés sont utilisés pour un Service, les Pods peuvent se retrouver avec différents ports cibles pour le même port nommé, nécessitant différents EndpointSlices. 
+Chaque EndpointSlice a un ensemble de ports qui s'applique à tous les Endpoints dans la ressource.
+Lorsque les ports nommés sont utilisés pour un Service, les Pods peuvent se retrouver avec différents ports cibles pour le même port nommé, nécessitant différents EndpointSlices.
 
 Le contrôleur essaie de remplir les EndpointSlices aussi complètement que possible, mais ne les rééquilibre pas activement. La logique du contrôleur est assez simple:
 
-1. Itérer à travers les EnpointSlices existants, retirer les Endpoints qui ne sont plus voulus et mettre à jour les Endpoints qui ont changé.
+1. Itérer à travers les EndpointSlices existants, retirer les Endpoints qui ne sont plus voulus et mettre à jour les Endpoints qui ont changé.
 2. Itérer à travers les EndpointSlices qui ont été modifiés dans la première étape et les remplir avec n'importe quel Endpoint nécéssaire.
 3. S'il reste encore des Endpoints nouveaux à ajouter, essayez de les mettre dans une slice qui n'a pas été changée et/ou en créer une nouvelle.
 
-Par-dessus tout, la troisième étape priorise la limitation de mises à jour d'EnpointSlice sur une distribution complètement pleine d'EndpointSlices. Par exemple, s'il y avait 10 nouveaux Endpoints à ajouter et 2 EndpointSlices qui peuvent contenir 5 Endpoints en plus chacun; cette approche créera un nouveau EndpointSlice au lieu de remplir les EndpointSlice existants. 
-C'est à dire, une seule création EndpointSlice est préférable à plusieurs mises à jour d'EndpointSlices.
+Par-dessus tout, la troisième étape priorise la limitation de mises à jour d'EndpointSlice sur une distribution complètement pleine d'EndpointSlices. Par exemple, s'il y avait 10 nouveaux Endpoints à ajouter et 2 EndpointSlices qui peuvent contenir 5 Endpoints en plus chacun; cette approche créera un nouveau EndpointSlice au lieu de remplir les EndpointSlice existants. C'est à dire, une seule création EndpointSlice est préférable à plusieurs mises à jour d'EndpointSlices.
 
-Avec kube-proxy exécuté sur chaque Node et surveillant EndpointSlices, chaque changement d'un EndpointSlice devient relativement coûteux puisqu'ils seront transmis à chaque Node du cluster. 
+Avec kube-proxy exécuté sur chaque Node et surveillant EndpointSlices, chaque changement d'un EndpointSlice devient relativement coûteux puisqu'ils seront transmis à chaque Node du cluster.
 Cette approche vise à limiter le nombre de modifications qui doivent être envoyées à chaque Node, même si ça peut causer plusieurs EndpointSlices non remplis.
 
 En pratique, cette distribution bien peu idéale devrait être rare. La plupart des changements traités par le contrôleur EndpointSlice seront suffisamment petits pour tenir dans un EndpointSlice existant, et sinon, un nouveau EndpointSlice aurait probablement été bientôt nécessaire de toute façon. Les mises à jour continues des déploiements fournissent également une compaction naturelle des EndpointSlices avec tous leurs pods et les Endpoints correspondants qui se feront remplacer.
 
 ## Motivation
 
-L'API des Endpoints fournit une méthode simple et facile à suivre pour les Endpoints dans Kubernetes. 
-Malheureusement, comme les clusters Kubernetes et Services sont devenus plus grands, les limitations de cette API sont devenues plus visibles. 
-Plus particulièrement, celles-ci comprennent des limitations liées au dimensionnement vers un plus grand nombre d'Endpoints d'un réseau.
+L'API des Endpoints fournit une méthode simple et facile à suivre pour les Endpoints dans Kubernetes. Malheureusement, comme les clusters Kubernetes et Services sont devenus plus grands, les limitations de cette API sont devenues plus visibles. Plus particulièrement, celles-ci comprennent des limitations liées au dimensionnement vers un plus grand nombre d'Endpoints d'un réseau.
 
-Puisque tous les Endpoints d'un réseau pour un Service ont été stockés dans une seule ressource Endpoints, ces ressources pourraient devenir assez lourdes. 
-Cela affecte les performances des composants Kubernetes (notamment le plan de contrôle) et cause une grande quantité de trafic réseau et de traitements lorsque les Endpoints changent. 
-Les EndpointSlices aident à atténuer ces problèmes ainsi qu'à fournir une plate-forme extensible pour des fonctionnalités supplémentaires telles que le routage topologique. 
+Puisque tous les Endpoints d'un réseau pour un Service ont été stockés dans une seule ressource Endpoints, ces ressources pourraient devenir assez lourdes. Cela affecte les performances des composants Kubernetes (notamment le plan de contrôle) et cause une grande quantité de trafic réseau et de traitements lorsque les Endpoints changent. Les EndpointSlices aident à atténuer ces problèmes ainsi qu'à fournir une plate-forme extensible pour des fonctionnalités supplémentaires telles que le routage topologique.
 
 
 


### PR DESCRIPTION
Fix various typos and unnecessary trailing spaces for EndpointSlice FR page.