### PR TITLE
[ingresscontroller] Add Easegress IngressController

### DIFF
--- a/content/en/docs/concepts/services-networking/ingress-controllers.md
+++ b/content/en/docs/concepts/services-networking/ingress-controllers.md
@@ -32,6 +32,7 @@ Kubernetes as a project supports and maintains [AWS](https://github.com/kubernet
   Citrix Application Delivery Controller.
 * [Contour](https://projectcontour.io/) is an [Envoy](https://www.envoyproxy.io/) based ingress controller.
 * [EnRoute](https://getenroute.io/) is an [Envoy](https://www.envoyproxy.io) based API gateway that can run as an ingress controller.
+* [Easegress IngressController](https://github.com/megaease/easegress/blob/main/doc/ingresscontroller.md) is an [Easegress](https://megaease.com/easegress/) based API gateway that can run as an ingress controller.
 * F5 BIG-IP [Container Ingress Services for Kubernetes](https://clouddocs.f5.com/containers/latest/userguide/kubernetes/)
   lets you use an Ingress to configure F5 BIG-IP virtual servers.
 * [Gloo](https://gloo.solo.io) is an open-source ingress controller based on [Envoy](https://www.envoyproxy.io),

--- a/content/zh/docs/concepts/services-networking/ingress-controllers.md
+++ b/content/zh/docs/concepts/services-networking/ingress-controllers.md
@@ -69,6 +69,7 @@ Kubernetes 作为一个项目，目前支持和维护
   的 Ingress 控制器。
 * [EnRoute](https://getenroute.io/) 是一个基于 [Envoy](https://www.envoyproxy.io) API 网关，
   可以作为 Ingress 控制器来执行。
+* [Easegress IngressController](https://github.com/megaease/easegress/blob/main/doc/ingresscontroller.md) 是一个基于 [Easegress](https://megaease.com/easegress/) API 网关，可以作为 Ingress 控制器来执行。
 <!--
 * F5 BIG-IP [Container Ingress Services for Kubernetes](https://clouddocs.f5.com/containers/latest/userguide/kubernetes/)
   lets you use an Ingress to configure F5 BIG-IP virtual servers.


### PR DESCRIPTION
Hi, This PR is aiming to introduce `Easegress` as a Kubernetes Ingress Controller into this Kubernetes website. 
1. We had implemented this feature in our open-source API gateway [Easegress](https://github.com/megaease/easegress)
2. The IngressController configuration and demoing doc is [here](https://github.com/megaease/easegress/blob/main/doc/ingresscontroller.md)

Thanks.
