### PR TITLE
Recommend runtimeclasses for scheduling

### DIFF
--- a/content/en/docs/setup/production-environment/windows/user-guide-windows-containers.md
+++ b/content/en/docs/setup/production-environment/windows/user-guide-windows-containers.md
@@ -218,7 +218,10 @@ Here are values used today for each Windows Server version.
 ### Simplifying with RuntimeClass
 
 [RuntimeClass] can be used to simplify the process of using taints and tolerations. 
-A cluster administrator can create a `RuntimeClass` object which is used to encapsulate these taints and tolerations.
+A cluster administrator can create a `RuntimeClass` object which is used to encapsulate these taints and tolerations. 
+Please note that this is the recommended way to schedule pods onto Windows nodes instead of using nodeSelector and
+tolerations as they can be added to pod spec by any user. In future, we will enforce runtimeclasses to be used. Pods
+having just nodeSelector and tolerations are going to be rejected during apiserver admission.
 
 
 1. Save this file to `runtimeClasses.yml`. It includes the appropriate `nodeSelector` 

--- a/content/en/docs/setup/production-environment/windows/user-guide-windows-containers.md
+++ b/content/en/docs/setup/production-environment/windows/user-guide-windows-containers.md
@@ -134,8 +134,7 @@ nodeSelector and tolerations on the pod spec. Using the runtimeclasses is recomm
 [RuntimeClass] can be used to simplify the process of using taints and tolerations. 
 A cluster administrator can create a `RuntimeClass` object which is used to encapsulate these taints and tolerations. 
 Please note that this is the recommended way to schedule pods onto Windows nodes instead of using nodeSelector and
-tolerations as they can be added to pod spec by any user. In future, we will enforce runtimeclasses to be used. Pods
-having just nodeSelector and tolerations are going to be rejected during apiserver admission time.
+tolerations as they can be added to pod spec by any user.
 
 
 1. Save this file to `runtimeClasses.yml`. It includes the appropriate `nodeSelector` 


### PR DESCRIPTION
In future, we will enforce runtimeclasses to be used. Pods having just nodeSelector 
and tolerations are going to be rejected during apiserver admission. This commit
ensures we recommend using runtimeclasses in the current release so that the
transition will be smooth for end-users when we make it mandatory in future releases

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
