### PR TITLE
Clarifying gcr vs mcr pause image usage for Windows

### DIFF
--- a/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
+++ b/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
@@ -102,8 +102,7 @@ limitation and compatibility rules will change.
 Kubernetes maintains a multi-architecture image `k8s.gcr.io/pause:3.5` that
 supports Linux as well as Windows.
 
-Microsoft maintains a Windows pause infrastructure container at
-`mcr.microsoft.com/oss/kubernetes/pause:3.5`.
+Microsoft maintains a Windows pause infrastructure container with Linux and Windows amd64 images at `mcr.microsoft.com/oss/kubernetes/pause:3.5`.
 This image is built from the same source as the Kubernetes maintained image but all of the Windows binaries are (authenticode signed)[https://docs.microsoft.com/en-us/windows-hardware/drivers/install/authenticode] by Microsoft.
 
 #### Compute
@@ -1065,9 +1064,8 @@ contributors. Follow the instructions in the SIG-Windows
     Register kubelet.exe:
 
     ```powershell
-    # Microsoft releases the pause infrastructure container at mcr.microsoft.com/oss/kubernetes/pause:3.4.1
     nssm install kubelet C:\k\kubelet.exe
-    nssm set kubelet AppParameters --hostname-override=<hostname> --v=6 --pod-infra-container-image=mcr.microsoft.com/oss/kubernetes/pause:3.4.1 --resolv-conf="" --allow-privileged=true --enable-debugging-handlers --cluster-dns=<DNS-service-IP> --cluster-domain=cluster.local --kubeconfig=c:\k\config --hairpin-mode=promiscuous-bridge --image-pull-progress-deadline=20m --cgroups-per-qos=false  --log-dir=<log directory> --logtostderr=false --enforce-node-allocatable="" --network-plugin=cni --cni-bin-dir=c:\k\cni --cni-conf-dir=c:\k\cni\config
+    nssm set kubelet AppParameters --hostname-override=<hostname> --v=6 --pod-infra-container-image=k8s.gcr.io/pause:3.5 --resolv-conf="" --allow-privileged=true --enable-debugging-handlers --cluster-dns=<DNS-service-IP> --cluster-domain=cluster.local --kubeconfig=c:\k\config --hairpin-mode=promiscuous-bridge --image-pull-progress-deadline=20m --cgroups-per-qos=false  --log-dir=<log directory> --logtostderr=false --enforce-node-allocatable="" --network-plugin=cni --cni-bin-dir=c:\k\cni --cni-conf-dir=c:\k\cni\config
     nssm set kubelet AppDirectory C:\k
     nssm start kubelet
     ```
@@ -1237,7 +1235,7 @@ contributors. Follow the instructions in the SIG-Windows
 * `kubectl port-forward` fails with "unable to do port forwarding: wincat not found"
 
   This was implemented in Kubernetes 1.15 by including wincat.exe in the
-  pause infrastructure container `mcr.microsoft.com/oss/kubernetes/pause:3.4.1`.
+  pause infrastructure container `k8s.gcr.io/pause:3.5`.
   Be sure to use these versions or newer ones.  If you would like to build your
   own pause infrastructure container be sure to include
   [wincat](https://github.com/kubernetes-sigs/sig-windows-tools/tree/master/cmd/wincat).
@@ -1262,10 +1260,9 @@ contributors. Follow the instructions in the SIG-Windows
   to accommodate worker containers crashing or restarting without losing any of
   the networking configuration.
 
-  The "pause" (infrastructure) image is hosted on Microsoft Container Registry
-  (MCR). You can access it using `mcr.microsoft.com/oss/kubernetes/pause:3.4.1`.
+  The "pause" (infrastructure) image can be found at `k8s.gcr.io/pause:3.5`
   For more details, see the
-  [DOCKERFILE](https://github.com/kubernetes-sigs/windows-testing/blob/master/images/pause/Dockerfile).
+  [DOCKERFILE](https://github.com/kubernetes/kubernetes/blob/master/build/pause/Dockerfile_windows).
 
 ### Further investigation
 

--- a/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
+++ b/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
@@ -99,10 +99,12 @@ limitation and compatibility rules will change.
 
 #### Pause Image
 
-Microsoft maintains a Windows pause infrastructure container at
-`mcr.microsoft.com/oss/kubernetes/pause:3.4.1`.
 Kubernetes maintains a multi-architecture image `k8s.gcr.io/pause:3.5` that
 supports Linux as well as Windows.
+
+Microsoft maintains a Windows pause infrastructure container at
+`mcr.microsoft.com/oss/kubernetes/pause:3.5`.
+This image is built from the same source as the Kubernetes maintained image but all of the Windows binaries are (authenticode signed)[https://docs.microsoft.com/en-us/windows-hardware/drivers/install/authenticode] by Microsoft.
 
 #### Compute
 

--- a/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
+++ b/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
@@ -1236,10 +1236,10 @@ contributors. Follow the instructions in the SIG-Windows
 
 * `kubectl port-forward` fails with "unable to do port forwarding: wincat not found"
 
-  Port forwarding support for Windows was added in Kubernetes 1.15 by including wincat.exe in the
-  [pause infrastructure container](#Pause-Image).
-  Be sure to use these versions or newer ones.  If you would like to build your
-  own pause infrastructure container be sure to include
+  Port forwarding support for Windows was requires wincat.exe to be available in the
+  [pause infrastructure container](#pause-image).
+  Ensure you are using a supported image that is compatable with your Windows OS version.
+  If you would like to build your own pause infrastructure container be sure to include
   [wincat](https://github.com/kubernetes/kubernetes/tree/master/build/pause/windows/wincat).
 
 * My Kubernetes installation is failing because my Windows Server node is

--- a/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
+++ b/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
@@ -1263,8 +1263,6 @@ contributors. Follow the instructions in the SIG-Windows
 
   The latest version of the pause image can be found above [here](#Pause-Image).
 
-  Source / Build files for the pause image can be founud at https://github.com/kubernetes/kubernetes/blob/master/build/pause/.
-
 ### Further investigation
 
 If these steps don't resolve your problem, you can get help running Windows
@@ -1332,4 +1330,3 @@ guide is available
 [here](/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes/). We are
 also making investments in cluster API to ensure Windows nodes are properly
 provisioned.
-

--- a/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
+++ b/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
@@ -1330,3 +1330,4 @@ guide is available
 [here](/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes/). We are
 also making investments in cluster API to ensure Windows nodes are properly
 provisioned.
+

--- a/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
+++ b/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
@@ -99,7 +99,8 @@ limitation and compatibility rules will change.
 
 #### Pause Image
 
-Kubernetes maintains a multi-architecture image that includes support for Windows at `k8s.gcr.io/pause:3.5`.
+Kubernetes maintains a multi-architecture image that includes support for Windows.
+For Kubernetes v1.22 the recommended pause image is `k8s.gcr.io/pause:3.5`.
 The [source code](https://github.com/kubernetes/kubernetes/tree/master/build/pause)
 is available on GitHub.
 

--- a/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
+++ b/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
@@ -100,7 +100,8 @@ limitation and compatibility rules will change.
 #### Pause Image
 
 Kubernetes maintains a multi-architecture image that includes support for Windows at `k8s.gcr.io/pause:3.5`.
-Source for the pause image can be found  [here](https://github.com/kubernetes/kubernetes/tree/master/build/pause).
+The [source code](https://github.com/kubernetes/kubernetes/tree/master/build/pause)
+is available on GitHub.
 
 Microsoft maintains a multi-architecture image with Linux and Windows amd64 support at `mcr.microsoft.com/oss/kubernetes/pause:3.5`.
 This image is built from the same source as the Kubernetes maintained image but all of the Windows binaries are [authenticode signed](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/authenticode) by Microsoft.
@@ -1330,4 +1331,3 @@ guide is available
 [here](/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes/). We are
 also making investments in cluster API to ensure Windows nodes are properly
 provisioned.
-

--- a/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
+++ b/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
@@ -106,7 +106,7 @@ is available on GitHub.
 
 Microsoft maintains a multi-architecture image with Linux and Windows amd64 support at `mcr.microsoft.com/oss/kubernetes/pause:3.5`.
 This image is built from the same source as the Kubernetes maintained image but all of the Windows binaries are [authenticode signed](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/authenticode) by Microsoft.
-For this reason the Microsoft maintained image is recommended for production environments.
+The Microsoft maintained image is recommended for production environments when signed binaries are required.
 
 #### Compute
 

--- a/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
+++ b/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
@@ -1262,7 +1262,8 @@ contributors. Follow the instructions in the SIG-Windows
   to accommodate worker containers crashing or restarting without losing any of
   the networking configuration.
 
-  Refer to the [pause image section](#Pause-Image) to find the latest version of the pause image.
+  Refer to the [pause image](#pause-image) section to find the recommended version
+  of the pause image.
 
 ### Further investigation
 

--- a/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
+++ b/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
@@ -1239,7 +1239,7 @@ contributors. Follow the instructions in the SIG-Windows
   [pause infrastructure container](#Pause-Image).
   Be sure to use these versions or newer ones.  If you would like to build your
   own pause infrastructure container be sure to include
-  [wincat](https://github.com/kubernetes-sigs/sig-windows-tools/tree/master/cmd/wincat).
+  [wincat](https://github.com/kubernetes/kubernetes/tree/master/build/pause/windows/wincat).
 
 * My Kubernetes installation is failing because my Windows Server node is
   behind a proxy

--- a/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
+++ b/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
@@ -1237,7 +1237,7 @@ contributors. Follow the instructions in the SIG-Windows
 
 * `kubectl port-forward` fails with "unable to do port forwarding: wincat not found"
 
-  Port forwarding support for Windows was requires wincat.exe to be available in the
+  Port forwarding support for Windows requires wincat.exe to be available in the
   [pause infrastructure container](#pause-image).
   Ensure you are using a supported image that is compatable with your Windows OS version.
   If you would like to build your own pause infrastructure container be sure to include

--- a/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
+++ b/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
@@ -1261,7 +1261,7 @@ contributors. Follow the instructions in the SIG-Windows
   to accommodate worker containers crashing or restarting without losing any of
   the networking configuration.
 
-  The latest version of the pause image can be found above [here](#Pause-Image).
+  Refer to the [pause image section](#Pause-Image) to find the latest version of the pause image.
 
 ### Further investigation
 

--- a/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
+++ b/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
@@ -99,11 +99,12 @@ limitation and compatibility rules will change.
 
 #### Pause Image
 
-Kubernetes maintains a multi-architecture image `k8s.gcr.io/pause:3.5` that
-supports Linux as well as Windows.
+Kubernetes maintains a multi-architecture image that includes support for Windows at `k8s.gcr.io/pause:3.5`.
+Source for the pause image can be found  [here](https://github.com/kubernetes/kubernetes/tree/master/build/pause).
 
-Microsoft maintains a Windows pause infrastructure container with Linux and Windows amd64 images at `mcr.microsoft.com/oss/kubernetes/pause:3.5`.
-This image is built from the same source as the Kubernetes maintained image but all of the Windows binaries are (authenticode signed)[https://docs.microsoft.com/en-us/windows-hardware/drivers/install/authenticode] by Microsoft.
+Microsoft maintains a multi-architecture image with Linux and Windows amd64 support at `mcr.microsoft.com/oss/kubernetes/pause:3.5`.
+This image is built from the same source as the Kubernetes maintained image but all of the Windows binaries are [authenticode signed](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/authenticode) by Microsoft.
+For this reason the Microsoft maintained image is recommended for production environments.
 
 #### Compute
 
@@ -1234,8 +1235,8 @@ contributors. Follow the instructions in the SIG-Windows
 
 * `kubectl port-forward` fails with "unable to do port forwarding: wincat not found"
 
-  This was implemented in Kubernetes 1.15 by including wincat.exe in the
-  pause infrastructure container `k8s.gcr.io/pause:3.5`.
+  Port forwarding support for Windows was added in Kubernetes 1.15 by including wincat.exe in the
+  [pause infrastructure container](#Pause-Image).
   Be sure to use these versions or newer ones.  If you would like to build your
   own pause infrastructure container be sure to include
   [wincat](https://github.com/kubernetes-sigs/sig-windows-tools/tree/master/cmd/wincat).
@@ -1260,9 +1261,9 @@ contributors. Follow the instructions in the SIG-Windows
   to accommodate worker containers crashing or restarting without losing any of
   the networking configuration.
 
-  The "pause" (infrastructure) image can be found at `k8s.gcr.io/pause:3.5`
-  For more details, see the
-  [DOCKERFILE](https://github.com/kubernetes/kubernetes/blob/master/build/pause/Dockerfile_windows).
+  The latest version of the pause image can be found above [here](#Pause-Image).
+
+  Source / Build files for the pause image can be founud at https://github.com/kubernetes/kubernetes/blob/master/build/pause/.
 
 ### Further investigation
 


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

Clarifying differences between gcr and mcr Windows pause images.

Fixes #29056

/sig windows
