### PR TITLE
Fix link for debian-base.

### DIFF
--- a/content/en/docs/tutorials/stateful-application/cassandra.md
+++ b/content/en/docs/tutorials/stateful-application/cassandra.md
@@ -266,7 +266,7 @@ to also be deleted. Never assume you'll be able to access data if its volume cla
 
 The Pods in this tutorial use the [`gcr.io/google-samples/cassandra:v13`](https://github.com/kubernetes/examples/blob/master/cassandra/image/Dockerfile)
 image from Google's [container registry](https://cloud.google.com/container-registry/docs/).
-The Docker image above is based on [debian-base](https://github.com/kubernetes/kubernetes/tree/master/build/debian-base)
+The Docker image above is based on [debian-base](https://github.com/kubernetes/release/tree/master/images/build/debian-base)
 and includes OpenJDK 8.
 
 This image includes a standard Cassandra installation from the Apache Debian repo.


### PR DESCRIPTION

Update the Link for debian-base under [Cassandra container environment variables](https://kubernetes.io/docs/tutorials/stateful-application/cassandra/#cassandra-container-environment-variables) in  [Deploying Cassandra with a StatefulSet](https://kubernetes.io/docs/tutorials/stateful-application/cassandra/) docs.

As per this [pr](https://github.com/kubernetes/release/pull/1450), debian-base image is Migrated from kubernetes/kubernetes to kubernetes/release.