### PR TITLE
updating cilium network policy docs

### DIFF
--- a/content/en/docs/tasks/administer-cluster/network-policy-provider/cilium-network-policy.md
+++ b/content/en/docs/tasks/administer-cluster/network-policy-provider/cilium-network-policy.md
@@ -24,7 +24,7 @@ For background on Cilium, read the [Introduction to Cilium](https://docs.cilium.
 ## Deploying Cilium on Minikube for Basic Testing
 
 To get familiar with Cilium easily you can follow the
-[Cilium Kubernetes Getting Started Guide](https://docs.cilium.io/en/stable/gettingstarted/minikube/)
+[Cilium Kubernetes Getting Started Guide](https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/)
 to perform a basic DaemonSet installation of Cilium in minikube.
 
 To start minikube, minimal version required is >= v1.3.1, run the with the


### PR DESCRIPTION
The Document : https://kubernetes.io/docs/tasks/administer-cluster/network-policy-provider/cilium-network-policy/
has error link for installing cilium on minikube. 
fixed it to stable version: https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/

However, the details are for cilium v1.8 and can be updated. 
/kind bug