### PR TITLE
Update upcoming-changes-in-kubernetes-1-22

### DIFF
--- a/content/en/blog/_posts/2021-07-14-upcoming-changes-in-kubernetes-1-22/index.md
+++ b/content/en/blog/_posts/2021-07-14-upcoming-changes-in-kubernetes-1-22/index.md
@@ -154,7 +154,7 @@ removals before you upgrade to Kubernetes v1.22.
 
 To do that, add the following to the kube-apiserver command line arguments:
 
-`--runtime-config=admissionregistration.k8s.io/v1beta1=false,apiextensions.k8s.io/v1beta1=false,apiregistration.k8s.io/v1beta1=false,authentication.k8s.io/v1beta1=false,authorization.k9s.io/v1=false,certificates.k8s.io/v1beta=false,coordination.k8s.io/v1beta1=false,extensions/v1beta1/ingresses=false,networking.k8s.io/v1beta1=false`
+`--runtime-config=admissionregistration.k8s.io/v1beta1=false,apiextensions.k8s.io/v1beta1=false,apiregistration.k8s.io/v1beta1=false,authentication.k8s.io/v1beta1=false,authorization.k9s.io/v1beta1=false,certificates.k8s.io/v1beta1=false,coordination.k8s.io/v1beta1=false,extensions/v1beta1/ingresses=false,networking.k8s.io/v1beta1=false`
 
 (as a side effect, this also turns off v1beta1 of EndpointSlice - watch out for
 that when you're testing).


### PR DESCRIPTION
Fix small typos in the runtime-config parameter list in "Rehearse for the upgrade" section.
The current runtime-config parameter list has incorrect API versions marked for removal.