### PR TITLE
Document Service Traffic Policies

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -393,6 +393,15 @@ Valid values are `Cluster` and `Local`. Set the field to `Cluster` to route exte
 and `Local` to only route to ready node-local endpoints. If the traffic policy is `Local` and there are are no node-local
 endpoints, traffic is dropped by kube-proxy.
 
+{{< note >}}
+{{< feature-state for_k8s_version="v1.22" state="alpha" >}}
+If the feature gate ProxyTerminatingEndpoints is enabled from kube-proxy, it will route traffic to terminating endpoints
+if and only if the external traffic policy is `Local` and there are only terminating endpoints on the node. This capability
+was added to allow external load balancers to gracefully drain connections from node ports even when the health check node
+port starts to fail. Otherwise, traffic can be lost between the time a node is still in the node pool of a load balancer
+and traffic is being dropped during the termination period of a pod.
+{{< /note >}}
+
 ### Internal Traffic Policy
 
 {{< feature-state for_k8s_version="v1.22" state="beta" >}}

--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -384,6 +384,24 @@ The IP address that you choose must be a valid IPv4 or IPv6 address from within 
 If you try to create a Service with an invalid clusterIP address value, the API
 server will return a 422 HTTP status code to indicate that there's a problem.
 
+## Traffic Policies
+
+### External Traffic Policy
+
+You can set the `spec.externalTrafficPolicy` field to control how traffic from external sources is routed.
+Valid values are `Cluster` and `Local`. Set the field to `Cluster` to route external traffic to all ready endpoints
+and `Local` to only route to ready node-local endpoints. If the traffic policy is `Local` and there are are no node-local
+endpoints, traffic is dropped by kube-proxy.
+
+### Internal Traffic Policy
+
+{{< feature-state for_k8s_version="v1.22" state="beta" >}}
+
+You can set the `spec.internalTrafficPolicy` field to control how traffic from internal sources is routed.
+Valid values are `Cluster` and `Local`. Set the field to `Cluster` to route internal traffic to all ready endpoints
+and `Local` to only route to ready node-local endpoints. If the traffic policy is `Local` and there are are no node-local
+endpoints, traffic is dropped by kube-proxy.
+
 ## Discovering services
 
 Kubernetes supports 2 primary modes of finding a Service - environment


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim kim.andrewsy@gmail.com

Documents traffic policies that can be set for Services. This PR adds documentation for both internalTrafficPolicy and externalTrafficPolicy. externalTrafficPolicy has always existed and is not new, but I realized the services document didn't have any explicit mention of it so I added it here. internalTrafficPolicy is a new feature we promoted to beta in v1.22. This PR also documents the new ProxyTerminatingEndpoints feature (alpha) and it's relation to externalTrafficPolicy.

Related KEPS:
kubernetes/enhancements#2086
kubernetes/enhancements#1669

Original PR was https://github.com/kubernetes/website/pull/28981