### PR TITLE
Update EPS docs to indicate behavior is unique to 1.21

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -188,7 +188,7 @@ selectors and uses DNS names instead. For more information, see the
 [ExternalName](#externalname) section later in this document.
 
 ### Over Capacity Endpoints
-If an Endpoints resource has more than 1000 endpoints then a Kubernetes v1.21 (or later)
+If an Endpoints resource has more than 1000 endpoints then a Kubernetes v1.21
 cluster annotates that Endpoints with `endpoints.kubernetes.io/over-capacity: warning`.
 This annotation indicates that the affected Endpoints object is over capacity.
 


### PR DESCRIPTION
The behavior of the annotation changes in 1.22. Update docs to indicate only in 1.21 clusters will annotations have the value of `warning`.

For reference, the 1.22 docs will be updated as part of https://github.com/kubernetes/website/pull/28745.

/cc @sftim @robscott