### PR TITLE
Correct default values of memory and cpu.

### DIFF
--- a/content/en/docs/tutorials/stateful-application/cassandra.md
+++ b/content/en/docs/tutorials/stateful-application/cassandra.md
@@ -50,7 +50,7 @@ To complete this tutorial, you should already have a basic familiarity with
 ### Additional Minikube setup instructions
 
 {{< caution >}}
-[Minikube](https://minikube.sigs.k8s.io/docs/) defaults to 1024MiB of memory and 1 CPU.
+[Minikube](https://minikube.sigs.k8s.io/docs/) defaults to 2048MB of memory and 2 CPU.
 Running Minikube with the default resource configuration results in insufficient resource
 errors during this tutorial. To avoid these errors, start Minikube with the following settings:
 


### PR DESCRIPTION

Correct the default value of `memory` and `cpu` for minikube in [Additional Minikube setup instructions](https://kubernetes.io/docs/tutorials/stateful-application/cassandra/#additional-minikube-setup-instructions) under [Deploying Cassandra with a StatefulSet](https://kubernetes.io/docs/tutorials/stateful-application/cassandra/) tutorial.

Source: minikube [code](https://github.com/kubernetes/minikube/blob/232080ae0cbcf9cb9a388eb76cc11cf6884e19c0/pkg/minikube/constants/constants.go#L102)  and minikube [documentation](https://minikube.sigs.k8s.io/docs/start/#what-youll-need)
