### PR TITLE
deprecation: Update quobyte storage class

### DIFF
--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -601,6 +601,12 @@ parameters:
 
 ### Quobyte
 
+{{< feature-state for_k8s_version="v1.22" state="deprecated" >}}
+
+The Quobyte in-tree storage plugin is deprecated, an 
+[example](https://github.com/quobyte/quobyte-csi/blob/master/example/StorageClass.yaml)
+`StorageClass` for the out-of-tree Quobyte plugin can be found at the Quobyte CSI repository.
+
 ```yaml
 apiVersion: storage.k8s.io/v1
 kind: StorageClass


### PR DESCRIPTION
This change adds a deprecation notice for the in-tree quobyte storage class and offers a link to the out-of-tree example.

/assign @xing-yang @sftim