### PR TITLE
kubeadm: use k8s-staging-ci-images instead of kubernetes-ci-images

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -142,7 +142,7 @@ For information about passing flags to control plane components see:
 
 By default, kubeadm pulls images from `k8s.gcr.io`. If the
 requested Kubernetes version is a CI label (such as `ci/latest`)
-`gcr.io/kubernetes-ci-images` is used.
+`gcr.io/k8s-staging-ci-images` is used.
 
 You can override this behavior by using [kubeadm with a configuration file](#config-file).
 Allowed customization are:

--- a/content/fr/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/fr/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -131,7 +131,7 @@ Pour de l'information sur comment passer des options aux composants du control p
 
 ### Utiliser des images personnalisées {#custom-images}
 
-Par défaut, kubeadm télécharge les images depuis `k8s.gcr.io`, à moins que la version demandée de Kubernetes soit une version Intégration Continue (CI). Dans ce cas, `gcr.io/kubernetes-ci-images` est utilisé.
+Par défaut, kubeadm télécharge les images depuis `k8s.gcr.io`, à moins que la version demandée de Kubernetes soit une version Intégration Continue (CI). Dans ce cas, `gcr.io/k8s-staging-ci-images` est utilisé.
 
 Vous pouvez outrepasser ce comportement en utilisant [kubeadm avec un fichier de configuration](#config-file).
 Les personnalisations permises sont :

--- a/content/zh/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -293,10 +293,10 @@ For information about passing flags to control plane components see:
 <!--
 By default, kubeadm pulls images from `k8s.gcr.io`. If the
 requested Kubernetes version is a CI label (such as `ci/latest`)
-`gcr.io/kubernetes-ci-images` is used.
+`gcr.io/k8s-staging-ci-images` is used.
 -->
 默认情况下, kubeadm 会从 `k8s.gcr.io` 仓库拉取镜像。如果请求的 Kubernetes 版本是 CI 标签
-（例如 `ci/latest`），则使用 `gcr.io/kubernetes-ci-images`。
+（例如 `ci/latest`），则使用 `gcr.io/k8s-staging-ci-images`。
 
 <!--
 You can override this behavior by using [kubeadm with a configuration file](#config-file).


### PR DESCRIPTION
Related:
- This is part of: https://github.com/kubernetes/k8s.io/issues/2318
- Similar PR: https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/pull/300
- The change this is documenting, which landed 2021-01-14: https://github.com/kubernetes/kubernetes/pull/97087

This replacement is technically capable of being backported to the v1.21
and v1.22 docs based on when the change it's documenting landed, but I
don't feel strongly that it needs to. The old default repo has still been
populated with ci builds through v1.22. This only truly matters for v1.23,
as that's when we stopped landing builds in the (incorrect as of v1.21)
old default.