### PR TITLE
Specify the type of configuration file in the kube-proxy and kube-scheduler --config flag help doc

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/kube-proxy.md
+++ b/content/en/docs/reference/command-line-tools-reference/kube-proxy.md
@@ -116,7 +116,7 @@ kube-proxy [flags]
 <td colspan="2">--config string</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>The path to the configuration file.</p></td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>The path to the kube-proxy configuration file.</p></td>
 </tr>
 
 <tr>

--- a/content/en/docs/reference/command-line-tools-reference/kube-scheduler.md
+++ b/content/en/docs/reference/command-line-tools-reference/kube-scheduler.md
@@ -166,7 +166,7 @@ kube-scheduler [flags]
 <td colspan="2">--config string</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>The path to the configuration file. The following flags can overwrite fields in this file:<br/>--algorithm-provider<br/>--policy-config-file<br/>--policy-configmap<br/>--policy-configmap-namespace</p></td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>The path to the kube-scheduler configuration file. The following flags can overwrite fields in this file:<br/>--algorithm-provider<br/>--policy-config-file<br/>--policy-configmap<br/>--policy-configmap-namespace</p></td>
 </tr>
 
 <tr>


### PR DESCRIPTION
Specify the type of configuration file in the help doc for `--config` flag to avoid confusion between the various Kubernetes configurations files.
It is easier to figure out which file it is when dealing with individual tools, but it might be confusing when reading about them in the larger K8s context, in which case it helps to explicitly mention the type of the configuration file.