### PR TITLE
Fix kubectl-convert plugin typo on "Install kubectl on macOS"

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/en/docs/tasks/tools/install-kubectl-macos.md
@@ -185,7 +185,7 @@ Below are the procedures to set up autocompletion for Bash and Zsh.
 
 1. Validate the binary (optional)
 
-   Download the kubectl checksum file:
+   Download the kubectl-convert checksum file:
 
    {{< tabs name="download_convert_checksum_macos" >}}
    {{< tab name="Intel" codelang="bash" >}}


### PR DESCRIPTION
Compared with the other distro guide about installation kubectl([linux](https://github.com/kubernetes/website/blob/main/content/en/docs/tasks/tools/install-kubectl-linux.md#install-kubectl-convert-plugin), [windows](https://github.com/kubernetes/website/blob/main/content/en/docs/tasks/tools/install-kubectl-windows.md#install-kubectl-convert-plugin)), the macOS installation guide has a typo about validation of kubectl-convert. 
This commits fixes the typo on "Install kubectl on macOS" documentation.
