### PR TITLE
[ko] Update outdated files in dev-1.21-ko.7 (p2)

### DIFF
--- a/content/ko/docs/setup/production-environment/tools/kubeadm/control-plane-flags.md
+++ b/content/ko/docs/setup/production-environment/tools/kubeadm/control-plane-flags.md
@@ -23,7 +23,7 @@ kubeadm의 `ClusterConfiguration` 오브젝트는 API 서버, 컨트롤러매니
 3.  `kubeadm init`에 `--config <CONFIG YAML 파일>` 파라미터를 추가해서 실행한다.
 
 각 필드의 구성에서 자세한 정보를 보려면,
-[API 참고 문서](https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2#ClusterConfiguration)에서 확인해 볼 수 있다.
+[API 참고 문서](/docs/reference/config-api/kubeadm-config.v1beta2/)에서 확인해 볼 수 있다.
 
 {{< note >}}
 `kubeadm config print init-defaults`를 실행하고 원하는 파일에 출력을 저장하여 기본값인 `ClusterConfiguration` 오브젝트를 생성할 수 있다.

--- a/content/ko/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
+++ b/content/ko/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
@@ -102,6 +102,8 @@ weight: 65
 
 Microsoft는 `mcr.microsoft.com/oss/kubernetes/pause:3.4.1`에서
 윈도우 퍼즈 인프라 컨테이너를 유지한다.
+이외에도 `k8s.gcr.io/pause:3.5`를 통해 쿠버네티스에서 관리하는 다중 아키텍처 이미지를
+사용할 수도 있는데, 이 이미지는 리눅스와 윈도우를 모두 지원한다.
 
 #### 컴퓨트
 

--- a/content/ko/docs/tasks/administer-cluster/highly-available-control-plane.md
+++ b/content/ko/docs/tasks/administer-cluster/highly-available-control-plane.md
@@ -10,7 +10,7 @@ content_type: task
 
 {{< feature-state for_k8s_version="v1.5" state="alpha" >}}
 
-구글 컴퓨트 엔진(Google Compute Engine, 이하 GCE)의 `kube-up`이나 `kube-down` 스크립트에 쿠버네티스 컨트롤 플레인 노드를 복제할 수 있다.
+구글 컴퓨트 엔진(Google Compute Engine, 이하 GCE)의 `kube-up`이나 `kube-down` 스크립트에 쿠버네티스 컨트롤 플레인 노드를 복제할 수 있다. 하지만 이러한 스크립트들은 프로덕션 용도로 사용하기에 적합하지 않으며, 프로젝트의 CI에서만 주로 사용된다.
 이 문서는 kube-up/down 스크립트를 사용하여 고가용(HA) 컨트롤 플레인을 관리하는 방법과 GCE와 함께 사용하기 위해 HA 컨트롤 플레인을 구현하는 방법에 관해 설명한다.
 
 

--- a/content/ko/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
+++ b/content/ko/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
@@ -161,7 +161,7 @@ HA 클러스터를 실행 중인 경우, 모든 컨트롤 플레인 노드에서
 
 빌트인 서명자를 활성화하려면, `--cluster-signing-cert-file` 와 `--cluster-signing-key-file` 플래그를 전달해야 한다.
 
-새 클러스터를 생성하는 경우, kubeadm [구성 파일](https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2)을 사용할 수 있다.
+새 클러스터를 생성하는 경우, kubeadm [구성 파일](/docs/reference/config-api/kubeadm-config.v1beta2/)을 사용할 수 있다.
 
 ```yaml
 apiVersion: kubeadm.k8s.io/v1beta2

--- a/content/ko/docs/tasks/tools/included/kubectl-convert-overview.md
+++ b/content/ko/docs/tasks/tools/included/kubectl-convert-overview.md
@@ -1,0 +1,11 @@
+---
+title: "kubectl-convert 개요"
+description: >-
+  특정 버전의 쿠버네티스 API로 작성된 매니페스트를 다른 버전으로 변환하는
+  kubectl 플러그인.
+headless: true
+---
+
+이것은 쿠버네티스 커맨드 라인 도구인 `kubectl`의 플러그인으로서, 특정 버전의 쿠버네티스 API로 작성된 매니페스트를 다른 버전으로
+변환할 수 있도록 한다. 이것은 매니페스트를 최신 쿠버네티스 릴리스의 사용 중단되지 않은 API로 마이그레이션하는 데 특히 유용하다.
+더 많은 정보는 다음의 [사용 중단되지 않은 API로 마이그레이션](/docs/reference/using-api/deprecation-guide/#migrate-to-non-deprecated-apis)을 참고한다.

--- a/content/ko/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/ko/docs/tasks/tools/install-kubectl-linux.md
@@ -82,6 +82,7 @@ card:
    대상 시스템에 root 접근 권한을 가지고 있지 않더라도, `~/.local/bin` 디렉터리에 kubectl을 설치할 수 있다.
 
    ```bash
+   chmod +x kubectl
    mkdir -p ~/.local/bin/kubectl
    mv ./kubectl ~/.local/bin/kubectl
    # 그리고 ~/.local/bin/kubectl을 $PATH에 추가
@@ -171,7 +172,7 @@ kubectl version --client
 
 {{< include "included/verify-kubectl.md" >}}
 
-## 선택적 kubectl 구성
+## 선택적 kubectl 구성 및 플러그인
 
 ### 셸 자동 완성 활성화
 
@@ -183,6 +184,61 @@ kubectl은 Bash 및 Zsh에 대한 자동 완성 지원을 제공하므로 입력
 {{< tab name="Bash" include="included/optional-kubectl-configs-bash-linux.md" />}}
 {{< tab name="Zsh" include="included/optional-kubectl-configs-zsh.md" />}}
 {{< /tabs >}}
+
+### `kubectl convert` 플러그인 설치
+
+{{< include "included/kubectl-convert-overview.md" >}}
+
+1. 다음 명령으로 최신 릴리스를 다운로드한다.
+
+   ```bash
+   curl -LO https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl-convert
+   ```
+
+1. 바이너리를 검증한다. (선택 사항)
+
+   kubectl-convert 체크섬(checksum) 파일을 다운로드한다.
+
+   ```bash
+   curl -LO "https://dl.k8s.io/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl-convert.sha256"
+   ```
+
+   kubectl-convert 바이너리를 체크섬 파일을 통해 검증한다.
+
+   ```bash
+   echo "$(<kubectl-convert.sha256) kubectl-convert" | sha256sum --check
+   ```
+
+   검증이 성공한다면, 출력은 다음과 같다.
+
+   ```console
+   kubectl-convert: OK
+   ```
+
+   검증이 실패한다면, `sha256`이 0이 아닌 상태로 종료되며 다음과 유사한 결과를 출력한다.
+
+   ```bash
+   kubectl-convert: FAILED
+   sha256sum: WARNING: 1 computed checksum did NOT match
+   ```
+
+   {{< note >}}
+   동일한 버전의 바이너리와 체크섬을 다운로드한다.
+   {{< /note >}}
+
+1. kubectl-convert 설치
+
+   ```bash
+   sudo install -o root -g root -m 0755 kubectl-convert /usr/local/bin/kubectl-convert
+   ```
+
+1. 플러그인이 정상적으로 설치되었는지 확인한다.
+
+   ```shell
+   kubectl convert --help
+   ```
+
+   에러가 출력되지 않는다면, 플러그인이 정상적으로 설치된 것이다.
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/ko/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/ko/docs/tasks/tools/install-kubectl-macos.md
@@ -155,7 +155,7 @@ macOS에서 [Macports](https://macports.org/) 패키지 관리자를 사용하�
 
 {{< include "included/verify-kubectl.md" >}}
 
-## 선택적 kubectl 구성
+## 선택적 kubectl 구성 및 플러그인
 
 ### 셸 자동 완성 활성화
 
@@ -167,6 +167,82 @@ kubectl은 Bash 및 Zsh에 대한 자동 완성 지원을 제공하므로 입력
 {{< tab name="Bash" include="included/optional-kubectl-configs-bash-mac.md" />}}
 {{< tab name="Zsh" include="included/optional-kubectl-configs-zsh.md" />}}
 {{< /tabs >}}
+
+### `kubectl convert` 플러그인 설치
+
+{{< include "included/kubectl-convert-overview.md" >}}
+
+1. 다음 명령으로 최신 릴리스를 다운로드한다.
+
+   {{< tabs name="download_convert_binary_macos" >}}
+   {{< tab name="Intel" codelang="bash" >}}
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl-convert"
+   {{< /tab >}}
+   {{< tab name="Apple Silicon" codelang="bash" >}}
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/arm64/kubectl-convert"
+   {{< /tab >}}
+   {{< /tabs >}}
+
+1. 바이너리를 검증한다. (선택 사항)
+
+   kubectl-convert 체크섬(checksum) 파일을 다운로드한다.
+
+   {{< tabs name="download_convert_checksum_macos" >}}
+   {{< tab name="Intel" codelang="bash" >}}
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl-convert.sha256"
+   {{< /tab >}}
+   {{< tab name="Apple Silicon" codelang="bash" >}}
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/arm64/kubectl-convert.sha256"
+   {{< /tab >}}
+   {{< /tabs >}}
+
+   kubectl-convert 바이너리를 체크섬 파일을 통해 검증한다.
+
+   ```bash
+   echo "$(<kubectl-convert.sha256)  kubectl-convert" | shasum -a 256 --check
+   ```
+
+   검증이 성공한다면, 출력은 다음과 같다.
+
+   ```console
+   kubectl-convert: OK
+   ```
+
+   검증이 실패한다면, `shasum`이 0이 아닌 상태로 종료되며 다음과 유사한 결과를 출력한다.
+
+   ```bash
+   kubectl-convert: FAILED
+   shasum: WARNING: 1 computed checksum did NOT match
+   ```
+
+   {{< note >}}
+   동일한 버전의 바이너리와 체크섬을 다운로드한다.
+   {{< /note >}}
+
+1. kubectl-convert 바이너리를 실행 가능하게 한다.
+
+   ```bash
+   chmod +x ./kubectl-convert
+   ```
+
+1. kubectl-convert 바이너리를 시스템 `PATH` 의 파일 위치로 옮긴다.
+
+   ```bash
+   sudo mv ./kubectl /usr/local/bin/kubectl-convert
+   sudo chown root: /usr/local/bin/kubectl-convert
+   ```
+
+   {{< note >}}
+   `PATH` 환경 변수 안에 `/usr/local/bin` 이 있는지 확인한다.
+   {{< /note >}}
+
+1. 플러그인이 정상적으로 설치되었는지 확인한다.
+
+   ```shell
+   kubectl convert --help
+   ```
+
+   에러가 출력되지 않는다면, 플러그인이 정상적으로 설치된 것이다.
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/ko/docs/tasks/tools/install-kubectl-windows.md
+++ b/content/ko/docs/tasks/tools/install-kubectl-windows.md
@@ -130,7 +130,7 @@ card:
 
 {{< include "included/verify-kubectl.md" >}}
 
-## 선택적 kubectl 구성
+## 선택적 kubectl 구성 및 플러그인
 
 ### 셸 자동 완성 활성화
 
@@ -139,6 +139,49 @@ kubectl은 Bash 및 Zsh에 대한 자동 완성 지원을 제공하므로 입력
 다음은 Zsh에 대한 자동 완성을 설정하는 절차이다.
 
 {{< include "included/optional-kubectl-configs-zsh.md" >}}
+
+### `kubectl convert` 플러그인 설치
+
+{{< include "included/kubectl-convert-overview.md" >}}
+
+1. 다음 명령으로 최신 릴리스를 다운로드한다.
+
+   ```powershell
+   curl -LO https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/windows/amd64/kubectl-convert.exe
+   ```
+
+1. 바이너리를 검증한다. (선택 사항)
+
+   kubectl-convert 체크섬(checksum) 파일을 다운로드한다.
+
+   ```powershell
+   curl -LO https://dl.k8s.io/{{< param "fullversion" >}}/bin/windows/amd64/kubectl-convert.exe.sha256
+   ```
+
+   kubectl-convert 바이너리를 체크섬 파일을 통해 검증한다.
+
+   - 수동으로 `CertUtil` 의 출력과 다운로드한 체크섬 파일을 비교하기 위해서 커맨드 프롬프트를 사용한다.
+
+     ```cmd
+     CertUtil -hashfile kubectl-convert.exe SHA256
+     type kubectl-convert.exe.sha256
+     ```
+
+   - `-eq` 연산자를 통해 `True` 또는 `False` 결과를 얻는 자동 검증을 위해서 PowerShell을 사용한다.
+
+     ```powershell
+     $($(CertUtil -hashfile .\kubectl-convert.exe SHA256)[1] -replace " ", "") -eq $(type .\kubectl-convert.exe.sha256)
+     ```
+
+1. 바이너리를 `PATH` 가 설정된 디렉터리에 추가한다.
+
+1. 플러그인이 정상적으로 설치되었는지 확인한다.
+
+   ```shell
+   kubectl convert --help
+   ```
+
+   에러가 출력되지 않는다면, 플러그인이 정상적으로 설치된 것이다.
 
 ## {{% heading "whatsnext" %}}
 


### PR DESCRIPTION
Related: #28963

This commit fixes M13~M19 on 28963.

1. [X] M13.  `content/en/docs/setup/production-environment/tools/kubeadm/control-plane-flags.md`  | 1(+XS) 1(-)
1. [X] M14.  `content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md`  | 2(+XS) 0(-)
1. [X] M15.  `content/en/docs/tasks/administer-cluster/highly-available-control-plane.md`  | 1(+XS) 1(-)
1. [X] M16.  `content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md`  | 1(+XS) 1(-)
1. [X] M17.  `content/en/docs/tasks/tools/install-kubectl-linux.md`  | 57(+M) 1(-)
1. [X] M18.  `content/en/docs/tasks/tools/install-kubectl-macos.md`  | 77(+M) 1(-)
1. [X] M19.  `content/en/docs/tasks/tools/install-kubectl-windows.md`  | 44(+M) 1(-)