### PR TITLE
Update token authentication file (#29139)

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping.md
+++ b/content/en/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping.md
@@ -167,7 +167,7 @@ If you want to use bootstrap tokens, you must enable it on kube-apiserver with t
 
 #### Token authentication file
 
-kube-apiserver has an ability to accept tokens as authentication.
+kube-apiserver has the ability to accept tokens as authentication.
 These tokens are arbitrary but should represent at least 128 bits of entropy derived
 from a secure random number generator (such as `/dev/urandom` on most modern Linux
 systems). There are multiple ways you can generate a token. For example:


### PR DESCRIPTION
Fixed issue #29139.

https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/#token-authentication-file says:

    kube-apiserver has AN ability to accept tokens as authentication.

A better wording:

    kube-apiserver has THE ability to accept tokens as authentication.
