### PR TITLE
Fix the missing termination character with HTML5 named character reference

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive.html
+++ b/content/en/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive.html
@@ -26,7 +26,7 @@ weight: 20
         <div class="row">
             <div class="col-md-12">
             	<a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/" role="button">Home<span class=""></span></a>
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/" role="button">Continue to Module 2 &gt<span class=""></span></a>
+                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/" role="button">Continue to Module 2 &gt;<span class=""></span></a>
             </div>
         </div>
 

--- a/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive.html
+++ b/content/en/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive.html
@@ -37,9 +37,9 @@ weight: 20
         </div>
         <div class="row">
             <div class="col-md-12">
-            	<a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro/" role="button"> &lt Return to Module 1<span class=""></span></a>
+            	<a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro/" role="button"> &lt; Return to Module 1<span class=""></span></a>
             	<a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/" role="button">Home<span class=""></span></a>
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/explore/explore-intro/" role="button">Continue to Module 3 &gt<span class=""></span></a>
+                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/explore/explore-intro/" role="button">Continue to Module 3 &gt;<span class=""></span></a>
             </div>
         </div>
 

--- a/content/en/docs/tutorials/kubernetes-basics/explore/explore-interactive.html
+++ b/content/en/docs/tutorials/kubernetes-basics/explore/explore-interactive.html
@@ -29,9 +29,9 @@ weight: 20
         </div>
         <div class="row">
             <div class="col-md-12">
-            	<a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/" role="button">&lt Return to Module 2<span class="btn"></span></a>
+            	<a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/" role="button">&lt; Return to Module 2<span class="btn"></span></a>
             	<a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/" role="button">Home<span class=""></span></a>
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/expose/expose-intro/" role="button">Continue to Module 4 &gt<span class="btn"></span></a>
+                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/expose/expose-intro/" role="button">Continue to Module 4 &gt;<span class="btn"></span></a>
             </div>
         </div>
 

--- a/content/en/docs/tutorials/kubernetes-basics/expose/expose-interactive.html
+++ b/content/en/docs/tutorials/kubernetes-basics/expose/expose-interactive.html
@@ -26,9 +26,9 @@ weight: 20
         </div>
         <div class="row">
             <div class="col-md-12">
-            	<a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/explore/explore-intro/" role="button">&lt Return to Module 3<span class=""></span></a>
+            	<a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/explore/explore-intro/" role="button">&lt; Return to Module 3<span class=""></span></a>
             	<a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/" role="button">Home<span class=""></span></a>
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/scale/scale-intro/" role="button">Continue to Module 5 &gt<span class=""></span></a>
+                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/scale/scale-intro/" role="button">Continue to Module 5 &gt;<span class=""></span></a>
             </div>
         </div>
 

--- a/content/en/docs/tutorials/kubernetes-basics/scale/scale-interactive.html
+++ b/content/en/docs/tutorials/kubernetes-basics/scale/scale-interactive.html
@@ -26,9 +26,9 @@ weight: 20
         </div>
         <div class="row">
             <div class="col-md-12">
-            	<a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/expose/expose-interactive/" role="button">&lt Return to Module 4<span class=""></span></a>
+            	<a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/expose/expose-interactive/" role="button">&lt; Return to Module 4<span class=""></span></a>
             	<a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/" role="button">Home<span class=""></span></a>
-                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/update/update-intro/" role="button">Continue to Module 6 &gt<span class=""></span></a>
+                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/update/update-intro/" role="button">Continue to Module 6 &gt;<span class=""></span></a>
             </div>
         </div>
 

--- a/content/en/docs/tutorials/kubernetes-basics/update/update-interactive.html
+++ b/content/en/docs/tutorials/kubernetes-basics/update/update-interactive.html
@@ -26,7 +26,7 @@ weight: 20
         </div>
         <div class="row">
             <div class="col-md-12">
-               <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/scale/scale-interactive/" role="button">&lt Return to Module 5<span class=""></span></a>
+               <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/scale/scale-interactive/" role="button">&lt; Return to Module 5<span class=""></span></a>
                <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/" role="button">Return to Kubernetes Basics<span class=""></span></a>
             </div>
         </div>


### PR DESCRIPTION
The HTML5 named character reference such as `&gt`, `&lt` should be terminated
with semicolon character. This commit fixes the missing termination character
with the kubernetes-basics tutorials.

This could also be verified with [W3C markup validation](https://validator.w3.org/#validate-by-input).
![Screen Shot 2021-08-01 at 12 21 43 AM](https://user-images.githubusercontent.com/17492826/127744545-c0a1c73b-28ff-44b1-84e8-257273596c01.png)

More detailed information can be found at [here](https://html.spec.whatwg.org/multipage/named-characters.html).

This bug was found by @yoonian.

/cc @yoonian 