### PR TITLE
[ja] Fix a non-existent link

### DIFF
--- a/content/ja/docs/tasks/debug-application-cluster/debug-pod-replication-controller.md
+++ b/content/ja/docs/tasks/debug-application-cluster/debug-pod-replication-controller.md
@@ -47,7 +47,7 @@ Podをスケジュールできない理由に関するスケジューラーか�
 クラスター内のCPUまたはメモリーの供給を使い果たした可能性があります。
 この場合、いくつかのことを試すことができます。
 
-* クラスターに[ノードを追加します](/docs/tasks/administer-cluster/cluster-management/#resizing-a-cluster)。
+* クラスターにノードを追加します。
 
 * [不要なPodを終了](/docs/concepts/workloads/pods/#pod-termination)して、
   `Pending`状態のPodのための空きリソースを作ります。


### PR DESCRIPTION
## Description
This page was linking to a non-existent URL.

## Reference
en: https://github.com/kubernetes/website/blob/main/content/en/docs/tasks/debug-application-cluster/debug-pod-replication-controller.md#insufficient-resources
zh: https://github.com/kubernetes/website/blob/main/content/zh/docs/tasks/debug-application-cluster/debug-pod-replication-controller.md#%E8%B5%84%E6%BA%90%E4%B8%8D%E8%B6%B3