### PR TITLE
Added missing ServiceAccount, ClusterRole and ClusterRoleBinding to DNS Horizontal Autoscaler.

### DIFF
--- a/content/en/examples/admin/dns/dns-horizontal-autoscaler.yaml
+++ b/content/en/examples/admin/dns/dns-horizontal-autoscaler.yaml
@@ -1,33 +1,94 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: kube-dns-autoscaler
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:kube-dns-autoscaler
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list", "watch"]
+  - apiGroups: [""]
+    resources: ["replicationcontrollers/scale"]
+    verbs: ["get", "update"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/scale", "replicasets/scale"]
+    verbs: ["get", "update"]
+# Remove the configmaps rule once below issue is fixed:
+# kubernetes-incubator/cluster-proportional-autoscaler#16
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:kube-dns-autoscaler
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+subjects:
+  - kind: ServiceAccount
+    name: kube-dns-autoscaler
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: system:kube-dns-autoscaler
+  apiGroup: rbac.authorization.k8s.io
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: dns-autoscaler
+  name: kube-dns-autoscaler
   namespace: kube-system
   labels:
-    k8s-app: dns-autoscaler
+    k8s-app: kube-dns-autoscaler
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
 spec:
   selector:
     matchLabels:
-      k8s-app: dns-autoscaler
+      k8s-app: kube-dns-autoscaler
   template:
     metadata:
       labels:
-        k8s-app: dns-autoscaler
+        k8s-app: kube-dns-autoscaler
     spec:
+      priorityClassName: system-cluster-critical
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+        supplementalGroups: [ 65534 ]
+        fsGroup: 65534
+      nodeSelector:
+        kubernetes.io/os: linux
       containers:
       - name: autoscaler
-        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.6.0
+        image: k8s.gcr.io/cpa/cluster-proportional-autoscaler:1.8.4
         resources:
-          requests:
-            cpu: 20m
-            memory: 10Mi
+            requests:
+                cpu: "20m"
+                memory: "10Mi"
         command:
-        - /cluster-proportional-autoscaler
-        - --namespace=kube-system
-        - --configmap=dns-autoscaler
-        - --target=<SCALE_TARGET>
-        # When cluster is using large nodes(with more cores), "coresPerReplica" should dominate.
-        # If using small nodes, "nodesPerReplica" should dominate.
-        - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"min":1}}
-        - --logtostderr=true
-        - --v=2
+          - /cluster-proportional-autoscaler
+          - --namespace=kube-system
+          - --configmap=kube-dns-autoscaler
+          # Should keep target in sync with cluster/addons/dns/kube-dns.yaml.base
+          - --target=<SCALE_TARGET>
+          # When cluster is using large nodes(with more cores), "coresPerReplica" should dominate.
+          # If using small nodes, "nodesPerReplica" should dominate.
+          - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true,"includeUnschedulableNodes":true}}
+          - --logtostderr=true
+          - --v=2
+      tolerations:
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"
+      serviceAccountName: kube-dns-autoscaler


### PR DESCRIPTION
Added missing ServiceAccount, ClusterRole, and ClusterRoleBinding.
Without these components, the deployment fails. It confuses new users as the document is not complete.
By updating this example code snippet, users can directly use the YAML to deploy DNS Horizontal Autoscaler.

- https://github.com/kubernetes/website/issues/15280
- https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
