### PR TITLE
[zh] Fix tiny translation mistakes in RBAC

### DIFF
--- a/content/zh/docs/reference/access-authn-authz/rbac.md
+++ b/content/zh/docs/reference/access-authn-authz/rbac.md
@@ -244,7 +244,7 @@ metadata:
 subjects:
 # 你可以指定不止一个“subject（主体）”
 - kind: User
-  name: jane # "name" 是不区分大小写的
+  name: jane # "name" 是区分大小写的
   apiGroup: rbac.authorization.k8s.io
 roleRef:
   # "roleRef" 指定与某 Role 或 ClusterRole 的绑定关系
@@ -268,7 +268,7 @@ RoleBinding 所在名字空间的资源。这种引用使得你可以跨整个�
 之后在多个名字空间中复用。
 
 例如，尽管下面的 RoleBinding 引用的是一个 ClusterRole，"dave"（这里的主体，
-不区分大小写）只能访问 "development" 名字空间中的 Secrets 对象，因为 RoleBinding
+区分大小写）只能访问 "development" 名字空间中的 Secrets 对象，因为 RoleBinding
 所在的名字空间（由其 metadata 决定）是 "development"。
 
 ```yaml
@@ -283,7 +283,7 @@ metadata:
   namespace: development
 subjects:
 - kind: User
-  name: dave # 'name' 是不区分大小写的
+  name: dave # 'name' 是区分大小写的
   apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
@@ -312,7 +312,7 @@ metadata:
   name: read-secrets-global
 subjects:
 - kind: Group
-  name: manager # 'name' 是不区分大小写的
+  name: manager # 'name' 是区分大小写的
   apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
Signed-off-by: rudeigerc <rudeigerc@gmail.com>

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

Fix tiny translation mistakes in `content/zh/docs/reference/access-authn-authz/rbac.md`.

Origin: "name" is case sensitive

Wrong: "name" 是不区分大小写的
Corrected: "name" 是区分大小写的

/language zh