### PR TITLE
Update config.toml for dev-1.22 branch.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -142,8 +142,8 @@ latest = "v1.22"
 
 fullversion = "v1.22.0"
 version = "v1.22"
-githubbranch = "master"
-docsbranch = "master"
+githubbranch = "main"
+docsbranch = "main"
 deprecated = false
 currentUrl = "https://kubernetes.io/docs/home/"
 nextUrl = "https://kubernetes-io-vnext-staging.netlify.com/"
@@ -181,29 +181,36 @@ js = [
 fullversion = "v1.22.0"
 version = "v1.22"
 githubbranch = "v1.22.0"
-docsbranch = "master"
+docsbranch = "main"
 url = "https://kubernetes.io"
 
 [[params.versions]]
-fullversion = "v1.21.1"
+fullversion = "v1.21.4"
 version = "v1.21"
-githubbranch = "v1.21.1"
+githubbranch = "v1.21.4"
 docsbranch = "release-1.21"
 url = "https://v1-21.docs.kubernetes.io"
 
 [[params.versions]]
-fullversion = "v1.20.7"
+fullversion = "v1.20.10"
 version = "v1.20"
-githubbranch = "v1.20.7"
+githubbranch = "v1.20.10"
 docsbranch = "release-1.20"
 url = "https://v1-20.docs.kubernetes.io"
 
 [[params.versions]]
-fullversion = "v1.19.11"
+fullversion = "v1.19.14"
 version = "v1.19"
-githubbranch = "v1.19.11"
+githubbranch = "v1.19.14"
 docsbranch = "release-1.19"
 url = "https://v1-19.docs.kubernetes.io"
+
+[[params.versions]]
+fullversion = "v1.18.20"
+version = "v1.18"
+githubbranch = "v1.18.20"
+docsbranch = "release-1.18"
+url = "https://v1-18.docs.kubernetes.io"
 
 # User interface configuration
 [params.ui]


### PR DESCRIPTION
This will bump the versions of the `config.toml` according to the latest release patches for each individual version.
It also replaces the `master` branch with `main` 

/assign @jimangel @irvifa @sftim 

~p.s.: There is no `release-1.21` branch yet, this will be created on release day manually.~
release-1.21 was created!