### PR TITLE
Improve Katacoda button

### DIFF
--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -1,3 +1,6 @@
+{{ if .HasShortcode "kat-button" }}
+<div id="katacoda-environment" data-katacoda-ondemand="true" data-katacoda-port="30000" data-katacoda-env="minikube" data-katacoda-command="start.sh" data-katacoda-ui="panel"></div>
+{{ end }}
 {{ with .Site.Params.algolia_docsearch }}
 <!-- scripts for algolia docsearch -->
 {{ end }}

--- a/layouts/shortcodes/kat-button
+++ b/layouts/shortcodes/kat-button
@@ -1,3 +1,2 @@
-<div id="my-panel" data-katacoda-ondemand="true" data-katacoda-port="30000" data-katacoda-env="minikube" data-katacoda-command="start.sh" data-katacoda-ui="panel"></div>
-<script src="https://katacoda.com/embed.js"></script>
+<script defer src="https://katacoda.com/embed.js"></script>
 <button class="button" onclick="window.katacoda.init(); ">Launch Terminal</button>


### PR DESCRIPTION
Separate out the HTML `<div>` for Katacoda from the in-page button to trigger it.

- You can now have as many launch buttons as you like
- Script loading is deferred
- The initially-empty `<div>` logically belongs closer to end of the HTML DOM anyway, rather than as a sibling of to the button.

Previews:
- [Hello Minikube](https://deploy-preview-29205--kubernetes-io-main-staging.netlify.app/docs/tutorials/hello-minikube/) vs [original](https://k8s.io/docs/tutorials/hello-minikube/)
- [Set up Ingress on Minikube with the NGINX Ingress Controller](https://deploy-preview-29205--kubernetes-io-main-staging.netlify.app/docs/tasks/access-application-cluster/ingress-minikube/) vs [original](https://k8s.io/docs/tasks/access-application-cluster/ingress-minikube/)

/area web-development