### PR TITLE
Revise task for practising NGINX Ingress controller

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -2,6 +2,7 @@
 title: Set up Ingress on Minikube with the NGINX Ingress Controller
 content_type: task
 weight: 100
+min-kubernetes-server-version: 1.19
 ---
 
 <!-- overview -->
@@ -17,22 +18,20 @@ This page shows you how to set up a simple Ingress which routes requests to Serv
 
 
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+If you are using an older Kubernetes version, switch to the documentation
+for that version.
 
 
+### Create a Minikube cluster
+
+Using Katacoda
+: {{< kat-button >}}
+
+Locally
+: If you already [installed Minikube](/docs/tasks/tools/#minikube)
+  locally, run `minikube start` to create a cluster.
 
 <!-- steps -->
-
-## Create a Minikube cluster
-
-1. Click **Launch Terminal**
-
-    {{< kat-button >}}
-
-1. (Optional) If you installed Minikube locally, run the following command:
-
-    ```shell
-    minikube start
-    ```
 
 ## Enable the Ingress controller
 
@@ -45,14 +44,14 @@ This page shows you how to set up a simple Ingress which routes requests to Serv
 1. Verify that the NGINX Ingress controller is running
 
 
-  {{< tabs name="tab_with_md" >}}
-  {{% tab name="minikube v1.19 or later" %}}
+   {{< tabs name="tab_with_md" >}}
+   {{% tab name="minikube v1.19 or later" %}}
 ```shell
 kubectl get pods -n ingress-nginx
 ```
-  {{< note >}}This can take up to a minute.{{< /note >}}
+   {{< note >}}It can take up to a minute before you see these pods running OK.{{< /note >}}
 
-Output:
+   The output is similar to:
 
 ```
 NAME                                        READY   STATUS      RESTARTS    AGE
@@ -60,15 +59,14 @@ ingress-nginx-admission-create-g9g49        0/1     Completed   0          11m
 ingress-nginx-admission-patch-rqp78         0/1     Completed   1          11m
 ingress-nginx-controller-59b45fb494-26npt   1/1     Running     0          11m
 ```
-    {{% /tab %}}
-
-  {{% tab name="minikube v1.18.1 or earlier" %}}
+   {{% /tab %}}
+   {{% tab name="minikube v1.18.1 or earlier" %}}
 ```shell
 kubectl get pods -n kube-system
 ```
-{{< note >}}This can take up to a minute.{{< /note >}}
+   {{< note >}}It can take up to a minute before you see these pods running OK.{{< /note >}}
 
-Output:
+   The output is similar to:
 
 ```
 NAME                                        READY     STATUS    RESTARTS   AGE
@@ -79,133 +77,121 @@ kubernetes-dashboard-5498ccf677-b8p5h       1/1       Running   0          2m
 nginx-ingress-controller-5984b97644-rnkrg   1/1       Running   0          1m
 storage-provisioner                         1/1       Running   0          2m
 ```
-    {{% /tab %}}
-      {{< /tabs >}}
-  
 
-
-    ```shell
-    kubectl get pods -n ingress-nginx
-    ```
-
-    {{< note >}}This can take up to a minute.{{< /note >}}
-
-    Output:
-
-    ```shell
-    NAME                                        READY   STATUS      RESTARTS   AGE
-    ingress-nginx-admission-create-2tgrf        0/1     Completed   0          3m28s
-    ingress-nginx-admission-patch-68b98         0/1     Completed   0          3m28s
-    ingress-nginx-controller-59b45fb494-lzmw2   1/1     Running     0          3m28s
-    ```
-
+  Make sure that you see a Pod with a name that starts with `nginx-ingress-controller-`.
+   {{% /tab %}}
+   {{< /tabs >}}
 
 ## Deploy a hello, world app
 
 1. Create a Deployment using the following command:
 
-    ```shell
-    kubectl create deployment web --image=gcr.io/google-samples/hello-app:1.0
-    ```
+   ```shell
+   kubectl create deployment web --image=gcr.io/google-samples/hello-app:1.0
+   ```
 
-    Output:
+   The output should be:
 
-    ```shell
-    deployment.apps/web created
-    ```
+   ```
+   deployment.apps/web created
+   ```
 
 1. Expose the Deployment:
 
-    ```shell
-    kubectl expose deployment web --type=NodePort --port=8080
-    ```
+   ```shell
+   kubectl expose deployment web --type=NodePort --port=8080
+   ```
 
-    Output:
+   The output should be:
 
-    ```shell
-    service/web exposed
-    ```
+   ```
+   service/web exposed
+   ```
 
 1. Verify the Service is created and is available on a node port:
 
     ```shell
-    kubectl get service web
-    ```
+   kubectl get service web
+   ```
 
-    Output:
+   The output is similar to:
 
-    ```shell
-    NAME      TYPE       CLUSTER-IP       EXTERNAL-IP   PORT(S)          AGE
-    web       NodePort   10.104.133.249   <none>        8080:31637/TCP   12m
-    ```
+   ```
+   NAME      TYPE       CLUSTER-IP       EXTERNAL-IP   PORT(S)          AGE
+   web       NodePort   10.104.133.249   <none>        8080:31637/TCP   12m
+   ```
 
-1. Visit the service via NodePort:
+1. Visit the Service via NodePort:
 
-    ```shell
-    minikube service web --url
-    ```
+   ```shell
+   minikube service web --url
+   ```
 
-    Output:
+   The output is similar to:
 
-    ```shell
-    http://172.17.0.15:31637
-    ```
+   ```
+   http://172.17.0.15:31637
+   ```
 
-    {{< note >}}Katacoda environment only: at the top of the terminal panel, click the plus sign, and then click **Select port to view on Host 1**. Enter the NodePort, in this case `31637`, and then click **Display Port**.{{< /note >}}
+   {{< note >}}Katacoda environment only: at the top of the terminal panel, click the plus sign, and then click **Select port to view on Host 1**. Enter the NodePort, in this case `31637`, and then click **Display Port**.{{< /note >}}
 
-    Output:
+   The output is similar to:
 
-    ```shell
-    Hello, world!
-    Version: 1.0.0
-    Hostname: web-55b8c6998d-8k564
-    ```
+   ```
+   Hello, world!
+   Version: 1.0.0
+   Hostname: web-55b8c6998d-8k564
+   ```
 
-    You can now access the sample app via the Minikube IP address and NodePort. The next step lets you access
-    the app using the Ingress resource.
+   You can now access the sample app via the Minikube IP address and NodePort. The next step lets you access
+   the app using the Ingress resource.
 
-## Create an Ingress resource
+## Create an Ingress
 
-The following file is an Ingress resource that sends traffic to your Service via hello-world.info.
+The following manifest defines an Ingress that sends traffic to your Service via hello-world.info.
 
 1. Create `example-ingress.yaml` from the following file:
 
-  {{< codenew file="service/networking/example-ingress.yaml" >}}
+   {{< codenew file="service/networking/example-ingress.yaml" >}}
 
-1. Create the Ingress resource by running the following command:
+1. Create the Ingress object by running the following command:
 
-    ```shell
-    kubectl apply -f https://k8s.io/examples/service/networking/example-ingress.yaml
-    ```
+   ```shell
+   kubectl apply -f https://k8s.io/examples/service/networking/example-ingress.yaml
+   ```
 
-    Output:
+   The output should be:
 
-    ```shell
-    ingress.networking.k8s.io/example-ingress created
-    ```
+   ```
+   ingress.networking.k8s.io/example-ingress created
+   ```
 
 1. Verify the IP address is set:
 
-    ```shell
-    kubectl get ingress
-    ```
+   ```shell
+   kubectl get ingress
+   ```
 
-    {{< note >}}This can take a couple of minutes.{{< /note >}}
+   {{< note >}}This can take a couple of minutes.{{< /note >}}
 
-    ```shell
-    NAME              CLASS    HOSTS              ADDRESS        PORTS   AGE
-    example-ingress   <none>   hello-world.info   172.17.0.15    80      38s
-    ```
+   You should see an IPv4 address in the ADDRESS column; for example:
 
-1. Add the following line to the bottom of the `/etc/hosts` file.
+   ```
+   NAME              CLASS    HOSTS              ADDRESS        PORTS   AGE
+   example-ingress   <none>   hello-world.info   172.17.0.15    80      38s
+   ```
 
-    {{< note >}}If you are running Minikube locally, use `minikube ip` to get the external IP. The IP address displayed within the ingress list will be the internal IP.{{< /note >}}
+1. Add the following line to the bottom of the `/etc/hosts` file on
+   your computer (you will need adminstrator access):
 
     ```
     172.17.0.15 hello-world.info
     ```
 
-    This sends requests from hello-world.info to Minikube.
+   {{< note >}}If you are running Minikube locally, use `minikube ip` to get the external IP. The IP address displayed within the ingress list will be the internal IP.{{< /note >}}
+
+    After you make this change, your web browser sends requests for
+    hello-world.info URLs to Minikube.
 
 1. Verify that the Ingress controller is directing traffic:
 
@@ -213,9 +199,9 @@ The following file is an Ingress resource that sends traffic to your Service via
     curl hello-world.info
     ```
 
-    Output:
+    You should see:
 
-    ```shell
+    ```
     Hello, world!
     Version: 1.0.0
     Hostname: web-55b8c6998d-8k564
@@ -223,34 +209,35 @@ The following file is an Ingress resource that sends traffic to your Service via
 
     {{< note >}}If you are running Minikube locally, you can visit hello-world.info from your browser.{{< /note >}}
 
-## Create Second Deployment
+## Create a second Deployment
 
-1. Create a v2 Deployment using the following command:
+1. Create another Deployment using the following command:
 
-    ```shell
-    kubectl create deployment web2 --image=gcr.io/google-samples/hello-app:2.0
-    ```
-    Output:
+   ```shell
+   kubectl create deployment web2 --image=gcr.io/google-samples/hello-app:2.0
+   ```
+   The output should be:
 
-    ```shell
-    deployment.apps/web2 created
-    ```
+   ```
+   deployment.apps/web2 created
+   ```
 
-1. Expose the Deployment:
+1. Expose the second Deployment:
 
-    ```shell
-    kubectl expose deployment web2 --port=8080 --type=NodePort
-    ```
+   ```shell
+   kubectl expose deployment web2 --port=8080 --type=NodePort
+   ```
 
-    Output:
+   The output should be:
 
-    ```shell
-    service/web2 exposed
-    ```
+   ```
+   service/web2 exposed
+   ```
 
-## Edit Ingress
+## Edit the existing Ingress {#edit-ingress}
 
-1. Edit the existing `example-ingress.yaml` and add the following lines:
+1. Edit the existing `example-ingress.yaml` manifest, and add the
+   following lines at the end:
 
     ```yaml
           - path: /v2
@@ -264,47 +251,47 @@ The following file is an Ingress resource that sends traffic to your Service via
 
 1. Apply the changes:
 
-    ```shell
-    kubectl apply -f example-ingress.yaml
-    ```
+   ```shell
+   kubectl apply -f example-ingress.yaml
+   ```
 
-    Output:
+   You should see:
 
-    ```shell
-    ingress.networking/example-ingress configured
-    ```
+   ```
+   ingress.networking/example-ingress configured
+   ```
 
-## Test Your Ingress
+## Test your Ingress
 
 1. Access the 1st version of the Hello World app.
 
-    ```shell
-    curl hello-world.info
-    ```
+   ```shell
+   curl hello-world.info
+   ```
 
-    Output:
+   The output is similar to:
 
-    ```shell
-    Hello, world!
-    Version: 1.0.0
-    Hostname: web-55b8c6998d-8k564
-    ```
+   ```
+   Hello, world!
+   Version: 1.0.0
+   Hostname: web-55b8c6998d-8k564
+   ```
 
 1. Access the 2nd version of the Hello World app.
 
-    ```shell
-    curl hello-world.info/v2
-    ```
+   ```shell
+   curl hello-world.info/v2
+   ```
 
-    Output:
+   The output is similar to:
 
-    ```shell
-    Hello, world!
-    Version: 2.0.0
-    Hostname: web2-75cd47646f-t8cjk
-    ```
+   ```
+   Hello, world!
+   Version: 2.0.0
+   Hostname: web2-75cd47646f-t8cjk
+   ```
 
-    {{< note >}}If you are running Minikube locally, you can visit hello-world.info and hello-world.info/v2 from your browser.{{< /note >}}
+   {{< note >}}If you are running Minikube locally, you can visit hello-world.info and hello-world.info/v2 from your browser.{{< /note >}}
 
 
 
@@ -314,6 +301,4 @@ The following file is an Ingress resource that sends traffic to your Service via
 * Read more about [Ingress](/docs/concepts/services-networking/ingress/)
 * Read more about [Ingress Controllers](/docs/concepts/services-networking/ingress-controllers/)
 * Read more about [Services](/docs/concepts/services-networking/service/)
-
-
 


### PR DESCRIPTION
Improve [Set up Ingress on Minikube with the NGINX Ingress Controller](https://kubernetes.io/docs/tasks/access-application-cluster/ingress-minikube/) [[preview](https://deploy-preview-29206--kubernetes-io-main-staging.netlify.app/docs/tasks/access-application-cluster/ingress-minikube/)]

- style tweaks
- fix sample output being marked as Bourne-style shell code
- mention that you need Kubernetes v1.19 minimum

This change does _not_ fix issue #29204, about Minikube deploying a too-old version of Kubernetes. That can come separately.