### PR TITLE
Add a manual anchor to an interesting spot in the NetworkPolicy docs

### DIFF
--- a/content/en/docs/concepts/services-networking/network-policies.md
+++ b/content/en/docs/concepts/services-networking/network-policies.md
@@ -154,6 +154,7 @@ contains two elements in the `from` array, and allows connections from Pods in t
 
 When in doubt, use `kubectl describe` to see how Kubernetes has interpreted the policy.
 
+<a name="behavior-of-ipblock-selectors"></a>
 __ipBlock__: This selects particular IP CIDR ranges to allow as ingress sources or egress destinations. These should be cluster-external IPs, since Pod IPs are ephemeral and unpredictable.
 
 Cluster ingress and egress mechanisms often require rewriting the source or destination IP


### PR DESCRIPTION
I have had to point people to this spot numerous times, and always have to say "go to https://kubernetes.io/docs/concepts/services-networking/network-policies/#behavior-of-to-and-from-selectors and then scroll down to the 'ipBlock' section". So this just adds a direct anchor.