### PR TITLE
[de] fix malformed link on front page

### DIFF
--- a/content/de/_index.html
+++ b/content/de/_index.html
@@ -9,7 +9,7 @@ cid: home
 {{% blocks/feature image="flower" %}}
 ### [Kubernetes (K8s)]({{< relref "/docs/concepts/overview/what-is-kubernetes" >}}) ist ein Open-Source-System zur Automatisierung der Bereitstellung, Skalierung und Verwaltung von containerisierten Anwendungen.
 
-Es gruppiert Container, aus denen sich eine Anwendung zusammensetzt, in logische Einheiten, um die Verwaltung und Erkennung zu erleichtern. Kubernetes baut auf [15 Jahre Erfahrung in Bewältigung von Produktions-Workloads bei Google] (http://queue.acm.org/detail.cfm?id=2898444), kombiniert mit Best-of-Breed-Ideen und Praktiken aus der Community.
+Es gruppiert Container, aus denen sich eine Anwendung zusammensetzt, in logische Einheiten, um die Verwaltung und Erkennung zu erleichtern. Kubernetes baut auf [15 Jahre Erfahrung in Bewältigung von Produktions-Workloads bei Google](http://queue.acm.org/detail.cfm?id=2898444), kombiniert mit Best-of-Breed-Ideen und Praktiken aus der Community.
 {{% /blocks/feature %}}
 
 {{% blocks/feature image="scalable" %}}


### PR DESCRIPTION
Currently, there is a broken link on the front page. A spare whitespace between link text and url causes the URL to be printed after what should be the link text. This PR removes the whitespace and thus fixes the link.
