### PR TITLE
Link to new API reference page for APIService

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation.md
+++ b/content/en/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation.md
@@ -34,7 +34,7 @@ If your extension API server cannot achieve that latency requirement, consider m
 
 * To get the aggregator working in your environment, [configure the aggregation layer](/docs/tasks/extend-kubernetes/configure-aggregation-layer/).
 * Then, [setup an extension api-server](/docs/tasks/extend-kubernetes/setup-extension-api-server/) to work with the aggregation layer.
-* Also, learn how to [extend the Kubernetes API using Custom Resource Definitions](/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/).
-* Read the specification for [APIService](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#apiservice-v1-apiregistration-k8s-io)
+* Read about [APIService](/docs/reference/kubernetes-api/cluster-resources/api-service-v1/) in the API reference
 
+Alternatively: learn how to [extend the Kubernetes API using Custom Resource Definitions](/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/).
 


### PR DESCRIPTION
In [Extending the Kubernetes API with the aggregation layer](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/) I'd prefer to link to https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/api-service-v1/ rather than to the legacy single-page API reference (which doesn't have any navigation sidebar, search, etc).

This PR does that. [[preview](https://deploy-preview-29228--kubernetes-io-main-staging.netlify.app/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/#what-s-next)]