### PR TITLE
Retitle “Kubernetes API Aggregation Layer” concept

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation.md
+++ b/content/en/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation.md
@@ -1,5 +1,5 @@
 ---
-title: Extending the Kubernetes API with the aggregation layer
+title: Kubernetes API Aggregation Layer
 reviewers:
 - lavalamp
 - cheftako


### PR DESCRIPTION
_[preview](https://deploy-preview-29229--kubernetes-io-main-staging.netlify.app/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/) vs [original](https://k8s.io/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/)_

The old title “Extending the Kubernetes API with the aggregation layer” sounds more like a task page than a concept, so I reworded.

/wg api-expression