### PR TITLE
Update init containers concept to link to new API reference

### DIFF
--- a/content/en/docs/concepts/workloads/pods/init-containers.md
+++ b/content/en/docs/concepts/workloads/pods/init-containers.md
@@ -32,9 +32,11 @@ If a Pod's init container fails, the kubelet repeatedly restarts that init conta
 However, if the Pod has a `restartPolicy` of Never, and an init container fails during startup of that Pod, Kubernetes treats the overall Pod as failed.
 
 To specify an init container for a Pod, add the `initContainers` field into
-the Pod specification, as an array of objects of type
-[Container](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#container-v1-core),
-alongside the app `containers` array.
+the [Pod specification](/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec),
+as an array of `container` items (similar to the app `containers` field and its contents).
+See [Container](/docs/reference/kubernetes-api/workload-resources/pod-v1/#Container) in the
+API reference for more details.
+
 The status of the init containers is returned in `.status.initContainerStatuses`
 field as an array of the container statuses (similar to the `.status.containerStatuses`
 field).


### PR DESCRIPTION
Change how https://kubernetes.io/docs/concepts/workloads/pods/init-containers/ links to the Pod spec and to the definition of container items within a Pod spec: use the new [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/) for Pod instead of the legacy single-page reference.

/kind cleanup