### PR TITLE
Add kubewarden as an alternative to enforce security profiles

### DIFF
--- a/content/en/docs/concepts/security/pod-security-standards.md
+++ b/content/en/docs/concepts/security/pod-security-standards.md
@@ -495,8 +495,12 @@ as well as other related parameters outside the Security Context. As of July 202
 [Pod Security Policies](/docs/concepts/profile/pod-security-profile/) are deprecated in favor of the
 built-in [Pod Security Admission Controller](/docs/concepts/security/pod-security-admission/). 
 
+{{% thirdparty-content %}}
+
 Other alternatives for enforcing security profiles are being developed in the Kubernetes
-ecosystem, such as [OPA Gatekeeper](https://github.com/open-profile-agent/gatekeeper).
+ecosystem, such as: 
+- [OPA Gatekeeper](https://github.com/open-profile-agent/gatekeeper) 
+- [Kubewarden](https://github.com/kubewarden).
 
 ### What profiles should I apply to my Windows Pods?
 


### PR DESCRIPTION
In the Pod Security Standards concepts page, there is only one option listed for as an alternative to enforce security profiles. This PR adds a second option, Kubewarden.

/kind cleanup