### PR TITLE
Update Managing Resources to mention the measure of CPU time

### DIFF
--- a/content/en/docs/concepts/configuration/manage-resources-containers.md
+++ b/content/en/docs/concepts/configuration/manage-resources-containers.md
@@ -181,8 +181,9 @@ When using Docker:
   flag in the `docker run` command.
 
 - The `spec.containers[].resources.limits.cpu` is converted to its millicore value and
-  multiplied by 100. The resulting value is the total amount of CPU time that a container can use
-  every 100ms. A container cannot use more than its share of CPU time during this interval.
+  multiplied by 100. The resulting value is the total amount of CPU time in microseconds
+  that a container can use every 100ms. A container cannot use more than its share of
+  CPU time during this interval.
 
   {{< note >}}
   The default quota period is 100ms. The minimum resolution of CPU quota is 1ms.


### PR DESCRIPTION
Fixes #18476

Was:

> CPU time that a container

Changed to:

> CPU time in microseconds that a container

Why? It is not immediately clear why we need to divide the value by 100, but if we include microseconds everything sets into place.

If you take millicores (that's 1/1,000 of a core, from [milli- prefix](https://en.wikipedia.org/wiki/Milli-)) and multiply them by 100 (gives 1/100,000 of a core) and then multiply this by 10 to get from 100ms to 1s, you get something else but millicores. Now consider that 1/1,000,000 of a second is [exactly 1 microsecond](https://en.wikipedia.org/wiki/Microsecond).

The reasoning for this division is simple: we use CPU shares to limit the amount of available CPU time, which is set in microseconds. See [these sections on configuring CPU limits in Docker](https://docs.docker.com/config/containers/resource_constraints/#configure-the-realtime-scheduler), and here's a piece of relevant Linux kernel documentation [in regard default time unit](https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html#conventions). Otherwise put, converting time unit into microseconds is the way to do it.

Here's a primer:
- Consider a container has 100 millicores dedicated to it.
- 100 * 100 = 10000 microseconds
- Accounting period is 100ms
- 100ms is 100000 microseconds
- Therefore with 100 millicores a container could use 10000/100000 of every 100ms, or 1/10. 
- This is exactly what one expects because 100 millicores is 1/10 of a core.