### PR TITLE
Add jmyung to sig-docs-ko-reviews

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -133,6 +133,7 @@ aliases:
     - gochist
     - ianychoi
     - jihoon-seo
+    - jmyung
     - pjhwa
     - seokho-son
     - yoonian


### PR DESCRIPTION
I'd like to apply for sig-docs-ko-reviews role.
I've met the requirements for reviewer:

18 PRs merged: https://github.com/kubernetes/website/pulls?q=is%3Apr+is%3Amerged+author%3Ajmyung
35 PRs reviewed: https://github.com/kubernetes/website/pulls?q=type%3Apr+reviewed-by%3Ajmyung
Member of Kubernetes for 3+ months
Thanks!

/assign @jmyung 
(According to the steps in https://kubernetes.io/docs/contribute/participate/roles-and-responsibilities/#becoming-a-reviewer)