### PR TITLE
Selector expect map not string

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -397,7 +397,9 @@ section to your HorizontalPodAutoscaler manifest to specify that you need one wo
   external:
     metric:
       name: queue_messages_ready
-      selector: "queue=worker_tasks"
+      selector:
+        matchLabels:
+          queue: "worker_tasks"
     target:
       type: AverageValue
       averageValue: 30


### PR DESCRIPTION
If we using string then k8s api is throwing validation error

`(HorizontalPodAutoscaler.spec.metrics[0].object.metric.selector): invalid type for io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector: got "string", expected "map"; if you choose to ignore these errors, turn validation off with --validate=false`

