### PR TITLE
fix small grammatical error in operator.md

### DIFF
--- a/content/pt-br/docs/concepts/extend-kubernetes/operator.md
+++ b/content/pt-br/docs/concepts/extend-kubernetes/operator.md
@@ -52,7 +52,7 @@ Algumas das coisas que um operador pode ser usado para automatizar incluem:
   como esquemas de base de dados ou definições de configuração extra
 * publicar um *Service* para aplicações que não suportam a APIs do Kubernetes
   para as descobrir
-* simular una falha em todo ou parte do cluster de forma a testar a resiliência
+* simular uma falha em todo ou parte do cluster de forma a testar a resiliência
 * escolher um lider para uma aplicação distribuída sem um processo
   de eleição de membro interno
 


### PR DESCRIPTION
fixes a small grammatical error in operator.md

"una falha..." -> "uma falha..."
