### PR TITLE
Update patch schedule and add 1.22 to the party

### DIFF
--- a/content/en/releases/patch-releases.md
+++ b/content/en/releases/patch-releases.md
@@ -80,11 +80,21 @@ releases may also occur in between these.
 | --------------------- | -------------------- | ----------- |
 | August 2021           | 2021-08-07           | 2021-08-11  |
 | September 2021        | 2021-09-10           | 2021-09-15  |
-| October 2021          | 2021-10-08           | 2021-10-13  |
+| October 2021          | 2021-10-15           | 2021-10-20  |
 | November 2021         | 2021-11-12           | 2021-11-17  |
 | December 2021         | 2021-12-10           | 2021-12-15  |
 
 ## Detailed Release History for Active Branches
+
+### 1.22
+
+**1.22** enters maintenance mode on **2022-08-28**
+
+End of Life for **1.22** is **2022-10-28**
+
+| PATCH RELEASE | CHERRY PICK DEADLINE | TARGET DATE | NOTE |
+|---------------|----------------------|-------------|------|
+| 1.22.1        | 2021-08-16           | 2021-08-19  |      |
 
 ### 1.21
 

--- a/content/en/releases/patch-releases.md
+++ b/content/en/releases/patch-releases.md
@@ -79,8 +79,10 @@ releases may also occur in between these.
 | Monthly Patch Release | Cherry Pick Deadline | Target date |
 | --------------------- | -------------------- | ----------- |
 | August 2021           | 2021-08-07           | 2021-08-11  |
-| September 2021        | 2021-09-11           | 2021-09-15  |
-| October 2021          | 2021-10-09           | 2021-10-13  |
+| September 2021        | 2021-09-10           | 2021-09-15  |
+| October 2021          | 2021-10-08           | 2021-10-13  |
+| November 2021         | 2021-11-12           | 2021-11-17  |
+| December 2021         | 2021-12-10           | 2021-12-15  |
 
 ## Detailed Release History for Active Branches
 

--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -1,4 +1,10 @@
 schedules:
+- release: 1.22
+  next: 1.22.1
+  cherryPickDeadline: 2021-08-16
+  targetDate: 2021-08-19
+  endOfLifeDate: 2022-10-28
+  previousPatches:
 - release: 1.21
   next: 1.21.4
   cherryPickDeadline: 2021-08-07


### PR DESCRIPTION
- update the cherry pick deadline to one day before for the upcoming months, it was set to a Saturday, moving to Friday
- Add 1.22 to the patch schedule

Need to define the `maintenance mode` and `End of life` for 1.22

/hold

/assign @saschagrunert @puerco @jeremyrickard @justaugustus 
cc @kubernetes/release-engineering 
