### PR TITLE
Add apiserver default flag value & word plural

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/kube-apiserver.md
+++ b/content/en/docs/reference/command-line-tools-reference/kube-apiserver.md
@@ -1030,7 +1030,7 @@ kube-apiserver [flags]
 <td colspan="2">--service-cluster-ip-range string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10.0.0.0</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>A CIDR notation IP range from which to assign service cluster IPs. This must not overlap with any IP ranges assigned to nodes or pods. Max of two dual-stack CIDRs is allowed.</p></td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>A CIDR notation IP range from which to assign service cluster IPs. This must not overlap with any IP ranges assigned to nodes or pods. Max of two dual-stack CIDRs are allowed.</p></td>
 </tr>
 
 <tr>

--- a/content/en/docs/reference/command-line-tools-reference/kube-apiserver.md
+++ b/content/en/docs/reference/command-line-tools-reference/kube-apiserver.md
@@ -1027,7 +1027,7 @@ kube-apiserver [flags]
 </tr>
 
 <tr>
-<td colspan="2">--service-cluster-ip-range string</td>
+<td colspan="2">--service-cluster-ip-range string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: 10.0.0.0</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;"><p>A CIDR notation IP range from which to assign service cluster IPs. This must not overlap with any IP ranges assigned to nodes or pods. Max of two dual-stack CIDRs is allowed.</p></td>


### PR DESCRIPTION
In Line: `https://github.com/kubernetes/kubernetes/blob/master/pkg/kubeapiserver/options/options.go#L29`
1. The default `service-cluster-ip-range` is `10.0.0.0`, better to display here to indicate default value;
2. The max of two dual-stack CIDRs `are` allowed.
