### PR TITLE
fix example command downgrade ssa to csa

### DIFF
--- a/content/en/docs/reference/using-api/server-side-apply.md
+++ b/content/en/docs/reference/using-api/server-side-apply.md
@@ -459,7 +459,7 @@ non-default field manager, as seen in the following example. The default field
 manager for kubectl server-side apply is `kubectl`.
 
 ```shell
-kubectl apply --server-side --field-manager=my-manager [--dry-run=server]
+kubectl apply --server-side --field-manager=kubectl [--dry-run=server]
 ```
 
 ## API Endpoint

--- a/content/en/docs/reference/using-api/server-side-apply.md
+++ b/content/en/docs/reference/using-api/server-side-apply.md
@@ -459,7 +459,7 @@ non-default field manager, as seen in the following example. The default field
 manager for kubectl server-side apply is `kubectl`.
 
 ```shell
-kubectl apply --server-side --field-manager=kubectl [--dry-run=server]
+kubectl apply --field-manager=my-manager [--dry-run=server]
 ```
 
 ## API Endpoint


### PR DESCRIPTION
The command to downgrade from server side apply to client side apply is exactly the same as supplying a non-default field manager. I suppose it was copy/pasted and the `field-manager` option was not altered. If I read correctly, the field manager should be set (back) to `kubectl` to downgrade.

(replaces #28681 because that was signed with a noreply email, sorry)