### PR TITLE
Fix the broken link for "webhook.go"

### DIFF
--- a/content/en/docs/reference/access-authn-authz/webhook.md
+++ b/content/en/docs/reference/access-authn-authz/webhook.md
@@ -172,5 +172,5 @@ Access to other non-resource paths can be disallowed without restricting access
 to the REST api.
 
 For further documentation refer to the authorization.v1beta1 API objects and
-[webhook.go](https://github.com/kubernetes/kubernetes/blob/{{< param "githubbranch" >}}/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go).
+[webhook.go](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go).
 


### PR DESCRIPTION


Fix the broken link for **`webhook.go`**  in [Webhook Mode](https://kubernetes.io/docs/reference/access-authn-authz/webhook/)

Fixes: #29294