### PR TITLE
Promote IPv4/IPv6 dual-stack support to Stable in 1.23

### DIFF
--- a/content/en/docs/concepts/cluster-administration/networking.md
+++ b/content/en/docs/concepts/cluster-administration/networking.md
@@ -64,7 +64,7 @@ This means that containers within a `Pod` can all reach each other's ports on
 usage, but this is no different from processes in a VM.  This is called the
 "IP-per-pod" model.
 
-How this is implemented is a detail of the particular container runtime in use.
+How this is implemented is a detail of the particular container runtime in use. Likewise, the networking option you choose may support [dual-stack IPv4/IPv6 networking](/docs/concepts/services-networking/dual-stack/); implementations vary.
 
 It is possible to request ports on the `Node` itself which forward to your `Pod`
 (called host ports), but this is a very niche operation. How that forwarding is

--- a/content/en/docs/concepts/services-networking/dual-stack.md
+++ b/content/en/docs/concepts/services-networking/dual-stack.md
@@ -16,7 +16,7 @@ weight: 70
 
 <!-- overview -->
 
-{{< feature-state for_k8s_version="v1.21" state="beta" >}}
+{{< feature-state for_k8s_version="v1.23" state="stable" >}}
 
 IPv4/IPv6 dual-stack networking enables the allocation of both IPv4 and IPv6 addresses to {{< glossary_tooltip text="Pods" term_id="pod" >}} and {{< glossary_tooltip text="Services" term_id="service" >}}.
 
@@ -47,8 +47,6 @@ The following prerequisites are needed in order to utilize IPv4/IPv6 dual-stack 
 
 ## Configure IPv4/IPv6 dual-stack
 
-To use IPv4/IPv6 dual-stack, ensure the `IPv6DualStack` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) is enabled for the relevant components of your cluster. (Starting in 1.21, IPv4/IPv6 dual-stack defaults to enabled.)
-
 To configure IPv4/IPv6 dual-stack, set dual-stack cluster network assignments:
 
    * kube-apiserver:
@@ -65,9 +63,6 @@ An example of an IPv4 CIDR: `10.244.0.0/16` (though you would supply your own ad
 
 An example of an IPv6 CIDR: `fdXY:IJKL:MNOP:15::/64` (this shows the format but is not a valid address - see [RFC 4193](https://tools.ietf.org/html/rfc4193))
 
-Starting in 1.21, IPv4/IPv6 dual-stack defaults to enabled.
-You can disable it when necessary by specifying `--feature-gates="IPv6DualStack=false"`
-on the kube-apiserver, kube-controller-manager, kubelet, and kube-proxy command line.
 {{< /note >}}
 
 ## Services
@@ -81,7 +76,7 @@ set the `.spec.ipFamilyPolicy` field to one of the following values:
 
 * `SingleStack`: Single-stack service. The control plane allocates a cluster IP for the Service, using the first configured service cluster IP range.
 * `PreferDualStack`:
-  * Allocates IPv4 and IPv6 cluster IPs for the Service. (If the cluster has `--feature-gates="IPv6DualStack=false"`, this setting follows the same behavior as `SingleStack`.)
+  * Allocates IPv4 and IPv6 cluster IPs for the Service.
 * `RequireDualStack`: Allocates Service `.spec.ClusterIPs` from both IPv4 and IPv6 address ranges.
   * Selects the `.spec.ClusterIP` from the list of `.spec.ClusterIPs` based on the address family of the first element in the `.spec.ipFamilies` array.
 
@@ -124,7 +119,7 @@ These examples demonstrate the behavior of various dual-stack Service configurat
 
 #### Dual-stack defaults on existing Services
 
-These examples demonstrate the default behavior when dual-stack is newly enabled on a cluster where Services already exist. (Upgrading an existing cluster to 1.21 will enable dual-stack unless `--feature-gates="IPv6DualStack=false"` is set.)
+These examples demonstrate the default behavior when dual-stack is newly enabled on a cluster where Services already exist. (Upgrading an existing cluster to 1.21 or beyond will enable dual-stack.)
 
 1. When dual-stack is enabled on a cluster, existing Services (whether `IPv4` or `IPv6`) are configured by the control plane to set `.spec.ipFamilyPolicy` to `SingleStack` and set `.spec.ipFamilies` to the address family of the existing Service. The existing Service cluster IP will be stored in `.spec.ClusterIPs`.
 

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -127,8 +127,6 @@ different Kubernetes components.
 | `InTreePluginGCEUnregister` | `false` | Alpha | 1.21 | |
 | `InTreePluginOpenStackUnregister` | `false` | Alpha | 1.21 | |
 | `InTreePluginvSphereUnregister` | `false` | Alpha | 1.21 | |
-| `IPv6DualStack` | `false` | Alpha | 1.15 | 1.20 |
-| `IPv6DualStack` | `true` | Beta | 1.21 | |
 | `JobMutableNodeSchedulingDirectives` | `true` | Beta | 1.23 | |
 | `JobTrackingWithFinalizers` | `false` | Alpha | 1.22 | 1.22 |
 | `JobTrackingWithFinalizers` | `true` | Beta | 1.23 | |
@@ -331,6 +329,9 @@ different Kubernetes components.
 | `IngressClassNamespacedParams` | `true` | GA | 1.23 | - |
 | `Initializers` | `false` | Alpha | 1.7 | 1.13 |
 | `Initializers` | - | Deprecated | 1.14 | - |
+| `IPv6DualStack` | `false` | Alpha | 1.15 | 1.20 |
+| `IPv6DualStack` | `true` | Beta | 1.21 | 1.22 |
+| `IPv6DualStack` | `true` | GA | 1.23 | - |
 | `KubeletConfigFile` | `false` | Alpha | 1.8 | 1.9 |
 | `KubeletConfigFile` | - | Deprecated | 1.10 | - |
 | `KubeletPluginsWatcher` | `false` | Alpha | 1.11 | 1.11 |

--- a/content/en/docs/setup/production-environment/tools/kubeadm/dual-stack-support.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/dual-stack-support.md
@@ -7,9 +7,9 @@ min-kubernetes-server-version: 1.21
 
 <!-- overview -->
 
-{{< feature-state for_k8s_version="v1.21" state="beta" >}}
+{{< feature-state for_k8s_version="v1.23" state="stable" >}}
 
-Your Kubernetes cluster can run in [dual-stack](/docs/concepts/services-networking/dual-stack/) networking mode, which means that cluster networking lets you use either address family. In a dual-stack cluster, the control plane can assign both an IPv4 address and an IPv6 address to a single {{< glossary_tooltip text="Pod" term_id="pod" >}} or a {{< glossary_tooltip text="Service" term_id="service" >}}.
+Your Kubernetes cluster includes [dual-stack](/docs/concepts/services-networking/dual-stack/) networking, which means that cluster networking lets you use either address family. In a cluster, the control plane can assign both an IPv4 address and an IPv6 address to a single {{< glossary_tooltip text="Pod" term_id="pod" >}} or a {{< glossary_tooltip text="Service" term_id="service" >}}.
 
 <!-- body -->
 
@@ -28,10 +28,8 @@ The size of the IP address allocations should be suitable for the number of Pods
 Services that you are planning to run.
 
 {{< note >}}
-If you are upgrading an existing cluster then, by default, the `kubeadm upgrade` command
-changes the [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
-`IPv6DualStack` to `true` if that is not already enabled.
-However, `kubeadm` does not support making modifications to the pod IP address range
+If you are upgrading an existing cluster with the `kubeadm upgrade` command,
+`kubeadm` does not support making modifications to the pod IP address range
 (“cluster CIDR”) nor to the cluster's Service address range (“Service CIDR”).
 {{< /note >}}
 
@@ -51,8 +49,6 @@ To make things clearer, here is an example kubeadm [configuration file](https://
 ---
 apiVersion: kubeadm.k8s.io/v1beta3
 kind: ClusterConfiguration
-featureGates:
-  IPv6DualStack: true
 networking:
   podSubnet: 10.244.0.0/16,2001:db8:42:0::/56
   serviceSubnet: 10.96.0.0/16,2001:db8:42:1::/112
@@ -132,23 +128,15 @@ kubeadm join --config=kubeadm-config.yaml
 ### Create a single-stack cluster
 
 {{< note >}}
-Enabling the dual-stack feature doesn't mean that you need to use dual-stack addressing.
+Dual-stack support doesn't mean that you need to use dual-stack addressing.
 You can deploy a single-stack cluster that has the dual-stack networking feature enabled.
 {{< /note >}}
-
-In 1.21 the `IPv6DualStack` feature is Beta and the feature gate is defaulted to `true`. To disable the feature you must configure the feature gate to `false`. Note that once the feature is GA, the feature gate will be removed.
-
-```shell
-kubeadm init --feature-gates IPv6DualStack=false
-```
 
 To make things more clear, here is an example kubeadm [configuration file](https://pkg.go.dev/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3) `kubeadm-config.yaml` for the single-stack control plane node.
 
 ```yaml
 apiVersion: kubeadm.k8s.io/v1beta3
 kind: ClusterConfiguration
-featureGates:
-  IPv6DualStack: false
 networking:
   podSubnet: 10.244.0.0/16
   serviceSubnet: 10.96.0.0/16

--- a/content/en/docs/tasks/network/validate-dual-stack.md
+++ b/content/en/docs/tasks/network/validate-dual-stack.md
@@ -3,7 +3,7 @@ reviewers:
 - lachie83
 - khenidak
 - bridgetkromhout
-min-kubernetes-server-version: v1.20
+min-kubernetes-server-version: v1.23
 title: Validate IPv4/IPv6 dual-stack
 content_type: task
 ---
@@ -21,6 +21,9 @@ This document shares how to validate IPv4/IPv6 dual-stack enabled Kubernetes clu
 
 {{< version-check >}}
 
+{{< note >}}
+While you can validate with an earlier version, the feature is only GA and officially supported since v1.23.
+{{< /note >}}
 
 
 <!-- steps -->


### PR DESCRIPTION
We anticipate moving dual-stack to stable and removing the feature gate in 1.23.

Enhancements issue: https://github.com/kubernetes/enhancements/issues/563
Kubernetes PR: https://github.com/kubernetes/kubernetes/pull/104691

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>
