### PR TITLE
Add note about deprecated seccomp annotation

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints.md
+++ b/content/en/docs/reference/labels-annotations-taints.md
@@ -426,3 +426,9 @@ or updating objects that contain Pod templates, such as Deployments, Jobs, State
 
 See [Enforcing Pod Security at the Namespace Level](/docs/concepts/security/pod-security-admission)
 for more information.
+
+## seccomp.security.alpha.kubernetes.io/pod and container.seccomp.security.alpha.kubernetes.io/[NAME] (deprecated)
+
+The seccomp annotations have been deprecated since Kubernetes v1.19 and will
+become non-functional in v1.25. Please use the `seccompProfile` of the
+`SecurityContext` instead.

--- a/content/en/docs/tutorials/clusters/seccomp.md
+++ b/content/en/docs/tutorials/clusters/seccomp.md
@@ -170,11 +170,19 @@ Download the correct manifest for your Kubernetes version:
 {{< tab name="v1.19 or Later (GA)" >}}
 {{< codenew file="pods/security/seccomp/ga/audit-pod.yaml" >}}
 {{< /tab >}}}
-{{{< tab name="Pre-v1.19 (alpha)" >}}
+{{{< tab name="Pre-v1.19 (deprecated)" >}}
 {{< codenew file="pods/security/seccomp/alpha/audit-pod.yaml" >}}
 {{< /tab >}}
 {{< /tabs >}}
 <br>
+
+{{< note >}}
+The functional support for the already deprecated seccomp annotations
+`seccomp.security.alpha.kubernetes.io/pod` (for the whole pod) and
+`container.seccomp.security.alpha.kubernetes.io/[name]` (for a single container)
+is going to be removed with the release of Kubernetes v1.25. Please always use
+the native API fields in favor of the annotations.
+{{< /note >}}
 
 Create the Pod in the cluster:
 
@@ -270,7 +278,7 @@ Download the correct manifest for your Kubernetes version:
 {{< tab name="v1.19 or Later (GA)" >}}
 {{< codenew file="pods/security/seccomp/ga/violation-pod.yaml" >}}
 {{< /tab >}}}
-{{{< tab name="Pre-v1.19 (alpha)" >}}
+{{{< tab name="Pre-v1.19 (deprecated)" >}}
 {{< codenew file="pods/security/seccomp/alpha/violation-pod.yaml" >}}
 {{< /tab >}}
 {{< /tabs >}}
@@ -321,7 +329,7 @@ Download the correct manifest for your Kubernetes version:
 {{< tab name="v1.19 or Later (GA)" >}}
 {{< codenew file="pods/security/seccomp/ga/fine-pod.yaml" >}}
 {{< /tab >}}}
-{{{< tab name="Pre-v1.19 (alpha)" >}}
+{{{< tab name="Pre-v1.19 (deprecated)" >}}
 {{< codenew file="pods/security/seccomp/alpha/fine-pod.yaml" >}}
 {{< /tab >}}
 {{< /tabs >}}
@@ -403,7 +411,7 @@ Download the correct manifest for your Kubernetes version:
 {{< tab name="v1.19 or Later (GA)" >}}
 {{< codenew file="pods/security/seccomp/ga/default-pod.yaml" >}}
 {{< /tab >}}}
-{{{< tab name="Pre-v1.19 (alpha)" >}}
+{{{< tab name="Pre-v1.19 (deprecated)" >}}
 {{< codenew file="pods/security/seccomp/alpha/default-pod.yaml" >}}
 {{< /tab >}}
 {{< /tabs >}}


### PR DESCRIPTION
We now add a note to clarify that the annotations are deprecated and
will become non-functional in v1.25.

Refers to kubernetes/enhancements#135 (comment)