### PR TITLE
Update controlling-access.md as --insecure-port flag deprecated

### DIFF
--- a/content/en/docs/concepts/security/controlling-access.md
+++ b/content/en/docs/concepts/security/controlling-access.md
@@ -142,11 +142,7 @@ By default, the Kubernetes API server serves HTTP on 2 ports:
       - is intended for testing and bootstrap, and for other components of the master node
         (scheduler, controller-manager) to talk to the API
       - no TLS
-<<<<<<< HEAD
-      - default is port 8080 (no longer support `--insecure-port` flag to change port)
-=======
       - default is port 8080
->>>>>>> f1689e206b4618d46ddd9766e962647265ed8713
       - default IP is localhost, change with `--insecure-bind-address` flag.
       - request **bypasses** authentication and authorization modules.
       - request handled by admission control module(s).

--- a/content/en/docs/concepts/security/controlling-access.md
+++ b/content/en/docs/concepts/security/controlling-access.md
@@ -142,7 +142,7 @@ By default, the Kubernetes API server serves HTTP on 2 ports:
       - is intended for testing and bootstrap, and for other components of the master node
         (scheduler, controller-manager) to talk to the API
       - no TLS
-      - default is port 8080, change with `--insecure-port` flag.
+      - default is port 8080 (no longer support `--insecure-port` flag to change port)
       - default IP is localhost, change with `--insecure-bind-address` flag.
       - request **bypasses** authentication and authorization modules.
       - request handled by admission control module(s).


### PR DESCRIPTION
This change intends to remove deprecated --insecure-port flag. This PR fixes issue #29300 
