### PR TITLE
[WIP] Finding a way to integrate downloadkubernetes.com as hugo shortcode

### DIFF
--- a/content/en/releases/download.md
+++ b/content/en/releases/download.md
@@ -4,11 +4,9 @@ type: docs
 ---
 ## Core Kubernetes components
 
-Find links to download Kubernetes components (and their checksums) in the [CHANGELOG](https://github.com/kubernetes/kubernetes/tree/master/CHANGELOG) files.
+Find links to download Kubernetes components (and their checksums) in the [CHANGELOG](https://github.com/kubernetes/kubernetes/tree/master/CHANGELOG) files. Alternately, use the helpful links below.
 
-Alternately, use [downloadkubernetes.com](https://www.downloadkubernetes.com/) to filter by version and architecture.
-
-## kubectl
+## Kubectl (latest)
 
 <!-- overview -->
 The Kubernetes command-line tool, [kubectl](/docs/reference/kubectl/kubectl/), allows
@@ -24,3 +22,53 @@ Find your preferred operating system below.
 - [Install kubectl on Linux](/docs/tasks/tools/install-kubectl-linux)
 - [Install kubectl on macOS](/docs/tasks/tools/install-kubectl-macos)
 - [Install kubectl on Windows](/docs/tasks/tools/install-kubectl-windows)
+
+<!-- TODO: update down to the minor patch in the header and add checksum -->
+| Architecture | {{< skew latestVersion >}} | {{< skew prevMinorVersion >}} | {{< skew oldestMinorVersion >}} |
+|----------|----------|----------|----------|
+| amd64   | download  | download    | download   |
+| arm  | download  | download  | download  |
+| arm64 | download  | download  | download  |
+| Windows  | download  | download  | download  |
+| s390x | download  | download  | download  |
+
+
+<!--
+{{< download-kubernetes test >}}
+{{< download-kubernetes kubectl >}}
+ -->
+
+Alternately, use [downloadkubernetes.com](https://www.downloadkubernetes.com/) to filter by version and architecture.
+
+## Linux
+
+| Binary | {{< skew latestVersion >}} | {{< skew prevMinorVersion >}} | {{< skew oldestMinorVersion >}} |
+|----------|----------|----------|----------|
+| apiextensions-apiserver   | download  | download    | download   |
+| kube-aggregator  | download  | download  | download  |
+| kube-apiserver | download  | download  | download  |
+| kube-controller-manager  | download  | download  | download  |
+| kube-proxy | download  | download  | download  |
+| kube-scheduler  | download  | download    | download   |
+| kubeadm  | download  | download  | download  |
+| download | download  | download  | download  |
+| download-convert  | download  | download  | download  |
+| kubelet | download  | download  | download  |
+| mounter | download  | download  | download  |
+
+
+## Windows
+
+| Binary | {{< skew latestVersion >}} | {{< skew prevMinorVersion >}} | {{< skew oldestMinorVersion >}} |
+|----------|----------|----------|----------|
+| apiextensions-apiserver   | download  | download    | download   |
+| kube-aggregator  | download  | download  | download  |
+| kube-apiserver | download  | download  | download  |
+| kube-controller-manager  | download  | download  | download  |
+| kube-proxy | download  | download  | download  |
+| kube-scheduler  | download  | download    | download   |
+| kubeadm  | download  | download  | download  |
+| download | download  | download  | download  |
+| download-convert  | download  | download  | download  |
+| kubelet | download  | download  | download  |
+| mounter | download  | download  | download  |

--- a/layouts/shortcodes/download-kubernetes.html
+++ b/layouts/shortcodes/download-kubernetes.html
@@ -1,0 +1,114 @@
+
+<!-- capture component from first argument in "download-kubernetes" -->
+{{- $component := .Get 0 -}}
+
+<!-- strip "v" from latest verison 
+{{- $latestVersion := site.Params.latest -}}
+{{- $latestVersion := (replace $latestVersion "v" "") -}}
+
+splits a string x.Xy into substrings separated by a "." delimiter  
+{{- $versionArray := split $latestVersion "." -}}
+
+ capture minorVersion ("Xy") in a variable
+{{- $minorVersion := int (index $versionArray 1) -}}
+
+increment latest 1 minor number for "nextMinorVerison" 
+{{- $nextMinorVersion := add $minorVersion 1 -}}
+
+subtract latest 1 minor number for "prevMinorVerison" 
+{{- $prevMinorVersion := sub $minorVersion 1 -}}
+
+ subtract latest 2 minor numbers for "oldestMinorVerison" 
+{{- $oldestMinorVersion := sub $minorVersion 2 -}}
+
+
+
+{{- $latestVersion := site.Params.latest }}
+{{- $latestReleaseNotes := print "https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-" (replace $latestVersion "v" "") ".md" }}
+{{- $latestReleaseNotes }}
+
+ output nextMinorVersion based on captured arg -->
+
+{{- if eq $component "kubectl" -}}
+
+<h2>{{ $component }}</h2>
+
+<!-- for all the release data (as a map) -->
+{{ range $data := .Site.Data.releases.schedule.schedules }}
+
+<!-- give me the version from the release key in X.Y format -->
+{{- $dataVersion := printf "%.2f" $data.release  -}}
+
+<!-- if there's no previous patch releases, it must be ".0" 
+    NOTE: There's probably a better way to fix this...
+-->
+{{ if not $data.previousPatches }}
+
+<!-- give me the version in X.Y.0 format -->
+<b>{{ T "latest_release" }}</b> {{ printf "%s.0" $dataVersion }}
+{{ end }}
+
+
+<!-- bold translated text to head the section -->
+<b>{{ T "previous_patches" }}</b>
+
+    <!-- give me the previous patches keys/values (all as a map) -->
+    {{ range $previousPatchesList := $data.previousPatches }}
+
+        <!-- split into keys / values -->
+        {{range $previous_patches_key, $previous_patches_value := $previousPatchesList }}
+            <!-- dump all the "release" keys  -->
+            {{ if eq $previous_patches_key "release" }}<a href="https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-{{ $dataVersion }}.md#v{{ replace $previous_patches_value `.` `` }}">{{ printf "%s" $previous_patches_value }}{{ T "inline_list_separator" }} </a>
+            {{ end }}
+        {{ end }}
+    {{ end }}
+{{ end }}
+
+
+{{- end -}}
+
+<!--
+example shortcode use:
+- download-kubernetes kubectl
+- skew latestVersion
+- skew prevMinorVersion
+- skew oldestMinorVersion
+- skew latestVersionAddMinor -1 "-"
+-->
+
+
+
+{{ range $data := .Site.Data.releases.schedule.schedules }}
+{{- $dataVersion := printf "%.2f" $data.release  -}}
+<h2>{{ $dataVersion }}</h2>
+
+<br>
+
+{{ if not $data.previousPatches }}
+<b>{{ T "latest_release" }}</b> {{ printf "%s.0" $dataVersion }}
+<br>
+<b>{{ T "end_of_life" }}</b> {{ printf "%s" $data.endOfLifeDate }}
+<br>
+<b>{{ T "previous_patches" }}</b> n/a
+{{ end }}
+
+{{ if $data.previousPatches }}
+<b>{{ T "latest_release" }}</b> {{ index $data.previousPatches 0 "release" }} (released: {{ index $data.previousPatches 0 "targetDate" }})
+<br>
+<b>{{ T "end_of_life" }}</b> {{ printf "%s" $data.endOfLifeDate }}
+<br>
+<b>{{ T "previous_patches" }}</b>
+    {{ range $previousPatchesList := $data.previousPatches }}
+        {{range $previous_patches_key, $previous_patches_value := $previousPatchesList }}
+            {{ if eq $previous_patches_key "release" }}<a href="https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-{{ $dataVersion }}.md#v{{ replace $previous_patches_value `.` `` }}">{{ printf "%s" $previous_patches_value }}{{ T "inline_list_separator" }} </a>
+            {{ end }}
+        {{ end }}
+    {{ end }}
+{{ end }}
+
+
+<br>
+Complete {{ $dataVersion }} <a href="/releases/patch-releases/#{{ replace $dataVersion `.` `-` }}">Schedule</a> and <a href="https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-{{ $dataVersion }}.md">Changelog</a>
+
+
+{{ end }}


### PR DESCRIPTION
This is an early preview, I didn't want to get too far into this before getting feedback. There's 1,000 different ways to generate this page but I want to do what makes the most sense.

Feedback welcome, specifically on the content presentation via the most impactful way to display rows & columns. "Live" filtering is complex without nasty JS code, but we can rearrange / format almost anything on the page.

Right now, I'm thinking we cover the most popular URLs on the page and provide links or additional help at the bottom about finding the more obscure components.

I also tried using tabs, so each version was it's own tab but the markdown tables lost their format. This is fixable with CSS work but I didn't have the spare cycles to make it work. Happy to collaborate with someone on this branch!

Direct preview: https://deploy-preview-29448--kubernetes-io-main-staging.netlify.app/releases/download/

/hold
/sig docs
/assign @saschagrunert @puerco 
/cc @kubernetes/release-engineering 