### PR TITLE
Recommend using TTL field in job

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -344,11 +344,20 @@ up by the TTL controller after it finishes.
 
 {{< note >}}
 It is recommended to set `ttlSecondsAfterFinished` field because unmanaged jobs
-(jobs not created via high level controllers like cronjobs) have a default deletion
-policy of `orphanDependents` causing pods created by this job to be left around.
-Even though podgc collector eventually deletes these lingering pods, sometimes these
+(Jobs that you created directly, and not indirectly through other workload APIs
+such as CronJob) have a default deletion
+policy of `orphanDependents` causing Pods created by an unmanaged Job to be left around
+after that Job is fully deleted.
+Even though the {{< glossary_tooltip text="control plane" term_id="control-plane" >}} eventually
+[garbage collects](/docs/concepts/workloads/pods/pod-lifecycle/#pod-garbage-collection)
+the Pods from a deleted Job after they either fail or complete, sometimes those
 lingering pods may cause cluster performance degradation or in worst case cause the
-cluster to go down.
+cluster to go offline due to this degradation.
+
+You can use [LimitRanges](/docs/concepts/policy/limit-range/) and
+[ResourceQuotas](/docs/concepts/policy/resource-quotas/) to place a
+cap on the amount of resources that a particular namespace can
+consume.
 {{< /note >}}
 
 

--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -342,6 +342,16 @@ If the field is set to `0`, the Job will be eligible to be automatically deleted
 immediately after it finishes. If the field is unset, this Job won't be cleaned
 up by the TTL controller after it finishes.
 
+{{< note >}}
+It is recommended to set `ttlSecondsAfterFinished` field because unmanaged jobs
+(jobs not created via high level controllers like cronjobs) have a default deletion
+policy of `orphanDependents` causing pods created by this job to be left around.
+Even though podgc collector eventually deletes these lingering pods, sometimes these
+lingering pods may cause cluster performance degradation or in worst case cause the
+cluster to go down.
+{{< /note >}}
+
+
 ## Job patterns
 
 The Job object can be used to support reliable parallel execution of Pods.  The Job object is not


### PR DESCRIPTION
Recommend using ttlSecondsAfterFinished in the job spec so that the pod deletion can be guaranteed when jobs get deleted.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

cc @liggitt  @soltysh 