### PR TITLE
Add note on owner references back to garbage collection page

### DIFF
--- a/content/en/docs/concepts/architecture/garbage-collection.md
+++ b/content/en/docs/concepts/architecture/garbage-collection.md
@@ -37,6 +37,24 @@ to the labels, each `EndpointSlice` that is managed on behalf of a Service has
 an owner reference. Owner references help different parts of Kubernetes avoid
 interfering with objects they don’t control.
 
+{{< note >}}
+Cross-namespace owner references are disallowed by design.
+Namespaced dependents can specify cluster-scoped or namespaced owners.
+A namespaced owner **must** exist in the same namespace as the dependent.
+If it does not, the owner reference is treated as absent, and the dependent
+is subject to deletion once all owners are verified absent.
+
+Cluster-scoped dependents can only specify cluster-scoped owners.
+In v1.20+, if a cluster-scoped dependent specifies a namespaced kind as an owner,
+it is treated as having an unresolvable owner reference, and is not able to be garbage collected.
+
+In v1.20+, if the garbage collector detects an invalid cross-namespace `ownerReference`,
+or a cluster-scoped dependent with an `ownerReference` referencing a namespaced kind, a warning Event 
+with a reason of `OwnerRefInvalidNamespace` and an `involvedObject` of the invalid dependent is reported.
+You can check for that kind of Event by running
+`kubectl get events -A --field-selector=reason=OwnerRefInvalidNamespace`.
+{{< /note >}}
+
 ## Cascading deletion {#cascading-deletion}
 
 Kubernetes checks for and deletes objects that no longer have owner

--- a/content/en/docs/concepts/overview/working-with-objects/owners-dependents.md
+++ b/content/en/docs/concepts/overview/working-with-objects/owners-dependents.md
@@ -42,6 +42,24 @@ A Kubernetes admission controller controls user access to change this field for
 dependent resources, based on the delete permissions of the owner. This control
 prevents unauthorized users from delaying owner object deletion.
 
+{{< note >}}
+Cross-namespace owner references are disallowed by design.
+Namespaced dependents can specify cluster-scoped or namespaced owners.
+A namespaced owner **must** exist in the same namespace as the dependent.
+If it does not, the owner reference is treated as absent, and the dependent
+is subject to deletion once all owners are verified absent.
+
+Cluster-scoped dependents can only specify cluster-scoped owners.
+In v1.20+, if a cluster-scoped dependent specifies a namespaced kind as an owner,
+it is treated as having an unresolvable owner reference, and is not able to be garbage collected.
+
+In v1.20+, if the garbage collector detects an invalid cross-namespace `ownerReference`,
+or a cluster-scoped dependent with an `ownerReference` referencing a namespaced kind, a warning Event 
+with a reason of `OwnerRefInvalidNamespace` and an `involvedObject` of the invalid dependent is reported.
+You can check for that kind of Event by running
+`kubectl get events -A --field-selector=reason=OwnerRefInvalidNamespace`.
+{{< /note >}}
+
 ## Ownership and finalizers
 
 When you tell Kubernetes to delete a resource, the API server allows the


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/website/issues/29480

Adds note on owner references back to garbage collection page that was removed in https://github.com/kubernetes/website/pull/28870

/kind cleanup
/kind documentation
/language en
/sig api-machinery
/sig docs
/priority important-soon
/cc @liggitt 
/assign @jimangel @sftim 