### PR TITLE
Fix typo `a extension` and its related `en` doc sync

### DIFF
--- a/content/zh/docs/tasks/extend-kubernetes/configure-aggregation-layer.md
+++ b/content/zh/docs/tasks/extend-kubernetes/configure-aggregation-layer.md
@@ -27,7 +27,7 @@ Kubernetes API 的一部分。
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
 
 <!--
-There are a few setup requirements for getting the aggregation layer working in your environment to support mutual TLS auth between the proxy and extension apiservers. Kubernetes and the kube-apiserver have multiple CAs, so make sure that the proxy is signed by the aggregation layer CA and not by something else, like the master CA.
+There are a few setup requirements for getting the aggregation layer working in your environment to support mutual TLS auth between the proxy and extension apiservers. Kubernetes and the kube-apiserver have multiple CAs, so make sure that the proxy is signed by the aggregation layer CA and not by something else, like the Kubernetes general CA.
 -->
 {{< note >}}
 要使聚合层在你的环境中正常工作以支持代理服务器和扩展 apiserver 之间的相互 TLS 身份验证，
@@ -550,10 +550,10 @@ APIService 对象的名称必须是合法的
 <!--
 #### Contacting the extension apiserver
 
-Once the Kubernetes apiserver has determined a request should be sent to a extension apiserver,
+Once the Kubernetes apiserver has determined a request should be sent to an extension apiserver,
 it needs to know how to contact it.
 
-The `service` stanza is a reference to the service for a extension apiserver.
+The `service` stanza is a reference to the service for an extension apiserver.
 The service namespace and name are required. The port is optional and defaults to 443.
 The path is optional and defaults to "/".
 


### PR DESCRIPTION
After review feedback(https://github.com/kubernetes/website/pull/29450), a new PR to fixed typo `a extension` to `an extension`, to better the documents.
