### PR TITLE
Mention that privileged containers run unconfined

### DIFF
--- a/content/en/docs/tutorials/clusters/seccomp.md
+++ b/content/en/docs/tutorials/clusters/seccomp.md
@@ -46,6 +46,12 @@ make sure that your cluster is [configured
 correctly](https://kind.sigs.k8s.io/docs/user/quick-start/#setting-kubernetes-version)
 for the version you are using.
 
+{{< note >}}
+It is not possible to apply a seccomp profile to a container running with
+`privileged: true` set in the container's `securityContext`. Privileged containers always
+run as `Unconfined`.
+{{< /note >}}
+
 <!-- steps -->
 
 ## Enable the use of `RuntimeDefault` as the default seccomp profile for all workloads


### PR DESCRIPTION
This is a note which helps users to understand the interaction between
privileged containers and seccomp profiles.

Refers to https://github.com/kubernetes/website/pull/28951#discussion_r692251747