### PR TITLE
Hugo improvements

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -216,6 +216,8 @@ url = "https://v1-18.docs.kubernetes.io"
 [params.ui]
 # Enable to show the side bar menu in its compact state.
 sidebar_menu_compact = false
+# https://github.com/gohugoio/hugo/issues/8918#issuecomment-903314696
+sidebar_cache_limit = 1
 #  Set to true to disable breadcrumb navigation.
 breadcrumb_disable = false
 #  Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,7 +8,7 @@ command = "git submodule update --init --recursive --depth 1 && make non-product
 
 [build.environment]
 NODE_VERSION = "10.20.0"
-HUGO_VERSION = "0.82.0"
+HUGO_VERSION = "0.87.0"
 RUBY_VERSION = "3.0.1"
 
 [context.production.environment]


### PR DESCRIPTION
This PR was created to address the performance of Hugo. I would love to have a few folks check full functionality.

By setting `params.ui.sidebar_cache_limit` to 1, the build time went from **1m30s** to **15s** locally and **5m45s** to **45s** in Netlify!!! ([details](https://github.com/gohugoio/hugo/issues/8918#issuecomment-903314696))

While I was making tweaks, I wanted to remove the `WARNING: calling IsSet with unsupported type "invalid" (<nil>) will always return false.` Fixed via docsy, so I upgraded the module in the second commit following my [old instructions](https://github.com/kubernetes/website/pull/23434).

Lastly, I tested this on the latest build of Hugo and updated `netlify.toml` to match.

Potentially fixes: https://github.com/kubernetes/website/issues/29429

Site preview: https://deploy-preview-29504--kubernetes-io-main-staging.netlify.app