### PR TITLE
[ja] Improve Japanese expression in Secret

### DIFF
--- a/content/ja/docs/concepts/configuration/secret.md
+++ b/content/ja/docs/concepts/configuration/secret.md
@@ -194,7 +194,7 @@ Basic認証Secret型は、ユーザーの便宜のためにのみ提供されて
 
 ### SSH authentication secrets
 
-組み込みのタイプ`kubernetes.io/ssh-auth`は、SSH認証で使用されるデータを保存するために提供されています。このSecret型を使用する場合、使用するSSH認証として`data`（または`stringData`）フィールドに`ssh-privatekey`キーと値のペアを指定する必要があります。 
+組み込みのタイプ`kubernetes.io/ssh-auth`は、SSH認証で使用されるデータを保存するために提供されています。このSecret型を使用する場合、使用するSSH認証として`data`（または`stringData`）フィールドに`ssh-privatekey`キーと値のペアを指定する必要があります。
 
 次のYAMLはSSH authentication Secretの設定例です：
 
@@ -284,7 +284,7 @@ Bootstrap type Secretには、`data`で指定された次のキーがありま�
 - `usage-bootstrap-<usage>`：Bootstrap tokenの追加の使用法を示すブールフラグ。
 - `auth-extra-groups`：`system：bootstrappers`グループに加えて認証されるグループ名のコンマ区切りのリスト。
 
-上記のYAMLは、値がすべてbase64でエンコードされた文字列であるため、混乱しているように見える場合があります。実際、次のYAMLを使用して同一のSecretを作成できます。
+上記のYAMLは、値がすべてbase64でエンコードされた文字列であるため、分かりづらく見えるかもしれません。実際、次のYAMLを使用して同一のSecretを作成できます。
 
 ```yaml
 apiVersion: v1

--- a/content/ja/docs/concepts/configuration/secret.md
+++ b/content/ja/docs/concepts/configuration/secret.md
@@ -284,7 +284,7 @@ Bootstrap type Secretには、`data`で指定された次のキーがありま�
 - `usage-bootstrap-<usage>`：Bootstrap tokenの追加の使用法を示すブールフラグ。
 - `auth-extra-groups`：`system：bootstrappers`グループに加えて認証されるグループ名のコンマ区切りのリスト。
 
-上記のYAMLは、値がすべてbase64でエンコードされた文字列であるため、分かりづらく見えるかもしれません。実際、次のYAMLを使用して同一のSecretを作成できます。
+上記のYAMLは、値がすべてbase64でエンコードされた文字列であるため、分かりづらく見えるかもしれません。実際には、次のYAMLを使用して同一のSecretを作成できます。
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
# Why

- To help Japanese readers understand the documentation more easily and precisely.

# What

> The above YAML may look confusing because the values are all in base64 encoded strings. (https://kubernetes.io/docs/concepts/configuration/secret/#bootstrap-token-secrets)

- Before: 上記のYAMLは、値がすべてbase64でエンコードされた文字列であるため、**混乱しているように見える場合があります**。
- After: 上記のYAMLは、値がすべてbase64でエンコードされた文字列であるため、**分かりづらく見えるかもしれません**。

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
