### PR TITLE
[zh] translation for kubectl install section

### DIFF
--- a/content/zh/docs/tasks/tools/included/kubectl-convert-overview.md
+++ b/content/zh/docs/tasks/tools/included/kubectl-convert-overview.md
@@ -1,0 +1,24 @@
+---
+title: "kubectl-convert 概述"
+description: >-
+  一个 kubectl 插件，允许你将清单从一个 Kubernetes API 版本转换到不同的版本。
+headless: true
+---
+<!--
+---
+title: "kubectl-convert overview"
+description: >-
+  A kubectl plugin that allows you to convert manifests from one version
+  of a Kubernetes API to a different version.
+headless: true
+---
+-->
+
+<!--
+A plugin for Kubernetes command-line tool `kubectl`, which allows you to convert manifests between different API 
+versions. This can be particularly helpful to migrate manifests to a non-deprecated api version with newer Kubernetes release.
+For more info, visit [migrate to non deprecated apis](/docs/reference/using-api/deprecation-guide/#migrate-to-non-deprecated-apis)
+-->
+一个 Kubernetes 命令行工具 `kubectl` 的插件，允许你将清单在不同 API 版本间转换。
+在将清单迁移到具有较新 Kubernetes 版本的未弃用 API 版本时，这个插件特别有用。
+更多信息请访问 [迁移到非弃用 API](/zh/docs/reference/using-api/deprecation-guide/#migrate-to-non-deprecated-apis)

--- a/content/zh/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/zh/docs/tasks/tools/install-kubectl-linux.md
@@ -44,12 +44,10 @@ The following methods exist for installing kubectl on Linux:
 - [Install kubectl binary with curl on Linux](#install-kubectl-binary-with-curl-on-linux)
 - [Install using native package management](#install-using-native-package-management)
 - [Install using other package management](#install-using-other-package-management)
-- [Install on Linux as part of the Google Cloud SDK](#install-on-linux-as-part-of-the-google-cloud-sdk)
 -->
 - [用 curl 在 Linux 系统中安装 kubectl](#install-kubectl-binary-with-curl-on-linux)
 - [用原生包管理工具安装](#install-using-native-package-management)
 - [用其他包管理工具安装](#install-using-other-package-management)
-- [作为谷歌云 SDK 的一部分，在 Linux 中安装](#install-on-linux-as-part-of-the-google-cloud-sdk)
 
 <!-- 
 ### Install kubectl binary with curl on Linux
@@ -145,6 +143,7 @@ The following methods exist for installing kubectl on Linux:
    即使你没有目标系统的 root 权限，仍然可以将 kubectl 安装到目录 `~/.local/bin` 中：
 
    ```bash
+   chmod +x kubectl
    mkdir -p ~/.local/bin/kubectl
    mv ./kubectl ~/.local/bin/kubectl
    # 之后将 ~/.local/bin/kubectl 添加到 $PATH
@@ -261,13 +260,6 @@ kubectl version --client
 {{< /tabs >}}
 
 <!-- 
-### Install on Linux as part of the Google Cloud SDK
--->
-### 作为谷歌云 SDK 的一部分，在 Linux 上安装 {#install-on-linux-as-part-of-the-google-cloud-sdk}
-
-{{< include "included/install-kubectl-gcloud.md" >}}
-
-<!-- 
 ## Verify kubectl configuration
 -->
 ## 验证 kubectl 配置 {#verify-kubectl-configration}
@@ -275,11 +267,11 @@ kubectl version --client
 {{< include "included/verify-kubectl.md" >}}
 
 <!--
-## Optional kubectl configurations
+## Optional kubectl configurations and plugins
 
 ### Enable shell autocompletion
 -->
-## kubectl 的可选配置 {#optional-kubectl-configurations}
+## kubectl 的可选配置和插件 {#optional-kubectl-configurations}
 
 ### 启用 shell 自动补全功能 {#enable-shell-autocompletion}
 
@@ -296,6 +288,91 @@ kubectl 为 Bash 和 Zsh 提供自动补全功能，可以减轻许多输入的�
 {{< tab name="Bash" include="included/optional-kubectl-configs-bash-linux.md" />}}
 {{< tab name="Zsh" include="included/optional-kubectl-configs-zsh.md" />}}
 {{< /tabs >}}
+
+<!--
+### Install `kubectl convert` plugin
+-->
+### 安装 `kubectl convert` 插件
+
+{{< include "included/kubectl-convert-overview.md" >}}
+
+<!--
+1. Download the latest release with the command:
+-->
+1. 用以下命令下载最新发行版：
+
+   ```bash
+   curl -LO https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl-convert
+   ```
+<!--
+1. Validate the binary (optional)
+
+   Download the kubectl-convert checksum file:
+-->
+1. 验证该可执行文件（可选步骤）
+   
+   下载 kubectl-convert 校验和文件：
+   
+   ```bash
+   curl -LO "https://dl.k8s.io/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl-convert.sha256"
+   ```
+
+   <!--
+   Validate the kubectl-convert binary against the checksum file:
+   -->
+   基于校验和，验证 kubectl-convert 的可执行文件：
+
+   ```bash
+   echo "$(<kubectl-convert.sha256) kubectl-convert" | sha256sum --check
+   ```
+
+   <!--
+   If valid, the output is:
+   -->
+   验证通过时，输出为：
+   
+   ```console
+   kubectl-convert: OK
+   ```
+
+   <!--
+   If the check fails, `sha256` exits with nonzero status and prints output similar to:
+   -->
+   验证失败时，`sha256` 将以非零值退出，并打印输出类似于：
+
+   ```bash
+   kubectl-convert: FAILED
+   sha256sum: WARNING: 1 computed checksum did NOT match
+   ```
+   {{< note >}}
+   <!--
+   Download the same version of the binary and checksum.
+   -->
+   下载相同版本的可执行文件和校验和。
+   {{< /note >}}
+
+<!--
+1. Install kubectl-convert
+-->
+1. 安装 kubectl-convert
+
+   ```bash
+   sudo install -o root -g root -m 0755 kubectl-convert /usr/local/bin/kubectl-convert
+   ```
+
+<!--
+1. Verify plugin is successfully installed
+-->
+1. 验证插件是否安装成功
+
+   ```shell
+   kubectl convert --help
+   ```
+
+   <!--
+   If you do not see an error, it means the plugin is successfully installed.
+   -->
+   如果你没有看到任何错误就代表插件安装成功了。
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/zh/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/zh/docs/tasks/tools/install-kubectl-macos.md
@@ -264,11 +264,11 @@ If you are on macOS and using [Macports](https://macports.org/) package manager,
 {{< include "included/verify-kubectl.md" >}}
 
 <!-- 
-## Optional kubectl configurations {#optional-kubectl-configurations}
+## Optional kubectl configurations and plugins {#optional-kubectl-configurations}
 
 ### Enable shell autocompletion {#enable-shell-autocompletion}
 -->
-## 可选的 kubectl 配置 {#optional-kubectl-configurations}
+## 可选的 kubectl 配置和插件 {#optional-kubectl-configurations-and-plugins}
 
 ### 启用 shell 自动补全功能 {#enable-shell-autocompletion}
 
@@ -285,6 +285,120 @@ kubectl 为 Bash 和 Zsh 提供自动补全功能，这可以节省许多输入�
 {{< tab name="Bash" include="included/optional-kubectl-configs-bash-mac.md" />}}
 {{< tab name="Zsh" include="included/optional-kubectl-configs-zsh.md" />}}
 {{< /tabs >}}
+
+<!--
+### Install `kubectl convert` plugin
+-->
+### 安装 `kubectl convert` 插件
+
+{{< include "included/kubectl-convert-overview.md" >}}
+
+<!--
+1. Download the latest release with the command:
+-->
+1. 用以下命令下载最新发行版：
+
+   {{< tabs name="download_convert_binary_macos" >}}
+   {{< tab name="Intel" codelang="bash" >}}
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl-convert"
+   {{< /tab >}}
+   {{< tab name="Apple Silicon" codelang="bash" >}}
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/arm64/kubectl-convert"
+   {{< /tab >}}
+   {{< /tabs >}}
+
+<!--
+1. Validate the binary (optional)
+
+   Download the kubectl-convert checksum file:
+-->
+1. 验证该可执行文件（可选步骤）
+   
+   下载 kubectl-convert 校验和文件：
+
+   {{< tabs name="download_convert_checksum_macos" >}}
+   {{< tab name="Intel" codelang="bash" >}}
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl-convert.sha256"
+   {{< /tab >}}
+   {{< tab name="Apple Silicon" codelang="bash" >}}
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/arm64/kubectl-convert.sha256"
+   {{< /tab >}}
+   {{< /tabs >}}
+
+   <!--
+   Validate the kubectl-convert binary against the checksum file:
+   -->
+   基于校验和，验证 kubectl-convert 的可执行文件：
+
+   ```bash
+   echo "$(<kubectl-convert.sha256)  kubectl-convert" | shasum -a 256 --check
+   ```
+   
+   <!--
+   If valid, the output is:
+   -->
+   验证通过时，输出为：
+
+   ```console
+   kubectl-convert: OK
+   ```
+
+   <!--
+   If the check fails, `shasum` exits with nonzero status and prints output similar to:
+   -->
+   验证失败时，`sha256` 将以非零值退出，并打印输出类似于：
+
+   ```bash
+   kubectl-convert: FAILED
+   shasum: WARNING: 1 computed checksum did NOT match
+   ```
+
+   {{< note >}}
+   <!--
+   Download the same version of the binary and checksum.
+   -->
+   下载相同版本的可执行文件和校验和。
+   {{< /note >}}
+
+<!--
+1. Make kubectl-convert binary executable
+-->
+1. 使 kubectl-convert 二进制文件可执行
+
+   ```bash
+   chmod +x ./kubectl-convert
+   ```
+
+<!--
+1. Move the kubectl-convert binary to a file location on your system `PATH`.
+-->
+1. 将 kubectl-convert 可执行文件移动到系统 `PATH` 环境变量中的一个位置。
+
+   ```bash
+   sudo mv ./kubectl-convert /usr/local/bin/kubectl-convert
+   sudo chown root: /usr/local/bin/kubectl-convert
+   ```
+
+   {{< note >}}
+   <!--
+   Make sure `/usr/local/bin` is in your PATH environment variable.
+   -->
+   确保你的 PATH 环境变量中存在 `/usr/local/bin`
+   {{< /note >}}
+
+<!--
+1. Verify plugin is successfully installed
+-->
+1. 验证插件是否安装成功
+
+   ```shell
+   kubectl convert --help
+   ```
+
+   <!--
+   If you do not see an error, it means the plugin is successfully installed.
+   -->
+   如果你没有看到任何错误就代表插件安装成功了。
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/zh/docs/tasks/tools/install-kubectl-windows.md
+++ b/content/zh/docs/tasks/tools/install-kubectl-windows.md
@@ -42,7 +42,6 @@ The following methods exist for installing kubectl on Windows:
 
 - [用 curl 在 Windows 上安装 kubectl](#install-kubectl-binary-with-curl-on-windows)
 - [在 Windows 上用 Chocolatey 或 Scoop 安装](#install-on-windows-using-chocolatey-or-scoop)
-- [作为谷歌云 SDK 的一部分，在 Windows 上安装](#install-on-windows-as-part-of-the-google-cloud-sdk)
 
 <!-- 
 ### Install kubectl binary with curl on Windows
@@ -211,13 +210,6 @@ Edit the config file with a text editor of your choice, such as Notepad.
 {{< /note >}}
 
 <!-- 
-### Install on Windows as part of the Google Cloud SDK
--->
-### 作为谷歌云 SDK 的一部分，在 Windows 上安装 {#install-on-windows-as-part-of-the-google-cloud-sdk}
-
-{{< include "included/install-kubectl-gcloud.md" >}}
-
-<!-- 
 ## Verify kubectl configuration
 -->
 ## 验证 kubectl 配置 {#verify-kubectl-configration}
@@ -225,11 +217,11 @@ Edit the config file with a text editor of your choice, such as Notepad.
 {{< include "included/verify-kubectl.md" >}}
 
 <!-- 
-## Optional kubectl configurations
+## Optional kubectl configurations and plugins
 
 ### Enable shell autocompletion
 -->
-## kubectl 可选配置 {#optional-kubectl-configurations}
+## kubectl 可选配置和插件 {#optional-kubectl-configurations}
 
 ### 启用 shell 自动补全功能 {#enable-shell-autocompletion}
 
@@ -244,7 +236,76 @@ kubectl 为 Bash 和 Zsh 提供自动补全功能，可以减轻许多输入的�
 
 {{< include "included/optional-kubectl-configs-zsh.md" >}}
 
+<!--
+### Install `kubectl convert` plugin
+-->
+### 安装 `kubectl convert` 插件
+
+{{< include "included/kubectl-convert-overview.md" >}}
+
+<!--
+1. Download the latest release with the command:
+-->
+1. 用以下命令下载最新发行版：
+
+   ```powershell
+   curl -LO https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/windows/amd64/kubectl-convert.exe
+   ```
+
+<!--
+1. Validate the binary (optional)
+
+   Download the kubectl-convert checksum file:
+-->
+1. 验证该可执行文件（可选步骤）
+   
+   下载 kubectl-convert 校验和文件：
+
+   ```powershell
+   curl -LO https://dl.k8s.io/{{< param "fullversion" >}}/bin/windows/amd64/kubectl-convert.exe.sha256
+   ```
+
+   <!--
+   Validate the kubectl-convert binary against the checksum file:
+
+   - Using Command Prompt to manually compare `CertUtil`'s output to the checksum file downloaded:
+   -->
+   基于校验和，验证 kubectl-convert 的可执行文件：
+
+   - 用提示的命令对 `CertUtil` 的输出和下载的校验和文件进行手动比较。
+   
+     ```cmd
+     CertUtil -hashfile kubectl-convert.exe SHA256
+     type kubectl-convert.exe.sha256
+     ```
+
+   <!--
+   - Using PowerShell to automate the verification using the `-eq` operator to get a `True` or `False` result:
+   -->
+   - 使用 PowerShell `-eq` 操作使验证自动化，获得 `True` 或者 `False` 的结果：
+   
+     ```powershell
+     $($(CertUtil -hashfile .\kubectl-convert.exe SHA256)[1] -replace " ", "") -eq $(type .\kubectl-convert.exe.sha256)
+     ```
+
+<!--
+1. Add the binary in to your `PATH`.
+
+1. Verify plugin is successfully installed
+-->
+1. 将可执行文件添加到你的 `PATH` 环境变量。
+
+1. 验证插件是否安装成功
+
+   ```shell
+   kubectl convert --help
+   ```
+
+   <!--
+   If you do not see an error, it means the plugin is successfully installed.
+   -->
+   如果你没有看到任何错误就代表插件安装成功了。
+
 ## {{% heading "whatsnext" %}}
 
 {{< include "included/kubectl-whats-next.md" >}}
-


### PR DESCRIPTION
related: #29329
Translation for the 'kubectl install' section in issue 29329.
Modified:
content/zh/docs/tasks/tools/install-kubectl-linux.md
content/zh/docs/tasks/tools/install-kubectl-macos.md
content/zh/docs/tasks/tools/install-kubectl-windows.md