### PR TITLE
docs: Add "KubeOps" operator SDK to third-party list

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/operator.md
+++ b/content/en/docs/concepts/extend-kubernetes/operator.md
@@ -119,6 +119,7 @@ Operator.
   you implement yourself
 * [Operator Framework](https://operatorframework.io)
 * [shell-operator](https://github.com/flant/shell-operator)
+* [KubeOps](https://buehler.github.io/dotnet-operator-sdk/)
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/concepts/extend-kubernetes/operator.md
+++ b/content/en/docs/concepts/extend-kubernetes/operator.md
@@ -119,7 +119,7 @@ Operator.
   you implement yourself
 * [Operator Framework](https://operatorframework.io)
 * [shell-operator](https://github.com/flant/shell-operator)
-* [KubeOps](https://buehler.github.io/dotnet-operator-sdk/)
+* [KubeOps](https://buehler.github.io/dotnet-operator-sdk/) (dotnet operator SDK)
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/concepts/extend-kubernetes/operator.md
+++ b/content/en/docs/concepts/extend-kubernetes/operator.md
@@ -114,12 +114,12 @@ Operator.
 
 * [Charmed Operator Framework](https://juju.is/)
 * [kubebuilder](https://book.kubebuilder.io/)
+* [KubeOps](https://buehler.github.io/dotnet-operator-sdk/) (dotnet operator SDK)
 * [KUDO](https://kudo.dev/) (Kubernetes Universal Declarative Operator)
 * [Metacontroller](https://metacontroller.github.io/metacontroller/intro.html) along with WebHooks that
   you implement yourself
 * [Operator Framework](https://operatorframework.io)
 * [shell-operator](https://github.com/flant/shell-operator)
-* [KubeOps](https://buehler.github.io/dotnet-operator-sdk/) (dotnet operator SDK)
 
 ## {{% heading "whatsnext" %}}
 


### PR DESCRIPTION
Adding dotnet operator SDK/framework to third-party list of operator SDKs.
