### PR TITLE
Improvement: Remove Heapster content from HPA.

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -70,12 +70,7 @@ The HorizontalPodAutoscaler normally fetches metrics from a series of aggregated
 `custom.metrics.k8s.io`, and `external.metrics.k8s.io`).  The `metrics.k8s.io` API is usually provided by
 metrics-server, which needs to be launched separately. See
 [metrics-server](/docs/tasks/debug-application-cluster/resource-metrics-pipeline/#metrics-server)
-for instructions. The HorizontalPodAutoscaler can also fetch metrics directly from Heapster.
-
-{{< note >}}
-{{< feature-state state="deprecated" for_k8s_version="v1.11" >}}
-Fetching metrics from Heapster is deprecated as of Kubernetes 1.11.
-{{< /note >}}
+for instructions.
 
 See [Support for metrics APIs](#support-for-metrics-apis) for more details.
 
@@ -343,8 +338,6 @@ APIs, cluster administrators must ensure that:
      If you would like to write your own, check out the [boilerplate](https://github.com/kubernetes-sigs/custom-metrics-apiserver) to get started.
 
    * For external metrics, this is the `external.metrics.k8s.io` API.  It may be provided by the custom metrics adapters provided above.
-
-* The `--horizontal-pod-autoscaler-use-rest-clients` is `true` or unset.  Setting this to false switches to Heapster-based autoscaling, which is deprecated.
 
 For more information on these different metrics paths and how they differ please see the relevant design proposals for
 [the HPA V2](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/autoscaling/hpa-v2.md),

--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -68,9 +68,7 @@ or the custom metrics API (for all other metrics).
 
 The HorizontalPodAutoscaler normally fetches metrics from a series of aggregated APIs (`metrics.k8s.io`,
 `custom.metrics.k8s.io`, and `external.metrics.k8s.io`).  The `metrics.k8s.io` API is usually provided by
-metrics-server, which needs to be launched separately. See
-[metrics-server](/docs/tasks/debug-application-cluster/resource-metrics-pipeline/#metrics-server)
-for instructions.
+metrics-server, which needs to be launched separately. For more information about resource metrics, see [Metrics Server](/docs/tasks/debug-application-cluster/resource-metrics-pipeline/#metrics-server).
 
 See [Support for metrics APIs](#support-for-metrics-apis) for more details.
 


### PR DESCRIPTION

Removed the heapster content from the  [HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

Fixes: #29544