### PR TITLE
Fixed broken link in service-v1

### DIFF
--- a/content/en/docs/reference/kubernetes-api/service-resources/service-v1.md
+++ b/content/en/docs/reference/kubernetes-api/service-resources/service-v1.md
@@ -100,7 +100,7 @@ ServiceSpec describes the attributes that a user creates on a service.
 
   - **ports.appProtocol** (string)
 
-    The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and https://www.iana.org/assignments/service-names ). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+    The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and [IANA Service Name and Transport Protocol Port Number Registry](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml)). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.
 
 - **type** (string)
 

--- a/content/en/docs/reference/kubernetes-api/service-resources/service-v1.md
+++ b/content/en/docs/reference/kubernetes-api/service-resources/service-v1.md
@@ -100,7 +100,7 @@ ServiceSpec describes the attributes that a user creates on a service.
 
   - **ports.appProtocol** (string)
 
-    The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+    The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.
 
 - **type** (string)
 

--- a/content/en/docs/reference/kubernetes-api/service-resources/service-v1.md
+++ b/content/en/docs/reference/kubernetes-api/service-resources/service-v1.md
@@ -100,7 +100,7 @@ ServiceSpec describes the attributes that a user creates on a service.
 
   - **ports.appProtocol** (string)
 
-    The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+    The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and https://www.iana.org/assignments/service-names ). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.
 
 - **type** (string)
 


### PR DESCRIPTION
Fixed broken link in service-v1. The link for IANA standard service names under ServiceSpec > ports ([]ServicePort) > ports.appProtocol (string) has an extra character ) which results in a 404, and the link use http:// instead of https://. Updated and fixed the broken link. This PR fixes #29550 

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
