### PR TITLE
[ko] fix broken links in install kubectl windows page

### DIFF
--- a/content/ko/docs/tasks/tools/install-kubectl-windows.md
+++ b/content/ko/docs/tasks/tools/install-kubectl-windows.md
@@ -30,7 +30,7 @@ card:
    또는 `curl` 을 설치한 경우, 다음 명령을 사용한다.
 
    ```powershell
-   curl -LO https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/windows/amd64/kubectl.exe
+   curl -LO "https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/windows/amd64/kubectl.exe"
    ```
 
    {{< note >}}
@@ -42,7 +42,7 @@ card:
    kubectl 체크섬 파일을 다운로드한다.
 
    ```powershell
-   curl -LO https://dl.k8s.io/{{< param "fullversion" >}}/bin/windows/amd64/kubectl.exe.sha256
+   curl -LO "https://dl.k8s.io/{{< param "fullversion" >}}/bin/windows/amd64/kubectl.exe.sha256"
    ```
 
    kubectl 바이너리를 체크섬 파일을 통해 검증한다.
@@ -147,7 +147,7 @@ kubectl은 Bash 및 Zsh에 대한 자동 완성 지원을 제공하므로 입력
 1. 다음 명령으로 최신 릴리스를 다운로드한다.
 
    ```powershell
-   curl -LO https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/windows/amd64/kubectl-convert.exe
+   curl -LO "https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/windows/amd64/kubectl-convert.exe"
    ```
 
 1. 바이너리를 검증한다. (선택 사항)
@@ -155,7 +155,7 @@ kubectl은 Bash 및 Zsh에 대한 자동 완성 지원을 제공하므로 입력
    kubectl-convert 체크섬(checksum) 파일을 다운로드한다.
 
    ```powershell
-   curl -LO https://dl.k8s.io/{{< param "fullversion" >}}/bin/windows/amd64/kubectl-convert.exe.sha256
+   curl -LO "https://dl.k8s.io/{{< param "fullversion" >}}/bin/windows/amd64/kubectl-convert.exe.sha256"
    ```
 
    kubectl-convert 바이너리를 체크섬 파일을 통해 검증한다.


### PR DESCRIPTION
It seems the same issue #29570 exist in this localization as well. 
/language ko
