### PR TITLE
Fixed Portuguese componenets link (#29522)

### DIFF
--- a/content/pt-br/docs/concepts/overview/what-is-kubernetes.md
+++ b/content/pt-br/docs/concepts/overview/what-is-kubernetes.md
@@ -90,5 +90,5 @@ Kubernetes:
 
 ## {{% heading "whatsnext" %}}
 
-*   Dê uma olhada em [Componentes do Kubernetes](/docs/concepts/overview/components/).
+*   Dê uma olhada em [Componentes do Kubernetes](/pt-br/docs/concepts/overview/components/).
 *   Pronto para [Iniciar](/docs/setup/)?


### PR DESCRIPTION
Fixed "What's next" links in portuguese section which was forwarding to the english page
