### PR TITLE
fix content error in  Kubernetes signers#kubernetes.io/kubelet-serving

### DIFF
--- a/content/zh/docs/reference/access-authn-authz/certificate-signing-requests.md
+++ b/content/zh/docs/reference/access-authn-authz/certificate-signing-requests.md
@@ -276,7 +276,7 @@ Kubernetes提供了内置的签名者，每个签名者都有一个众所周知�
    1. 许可的 x509 扩展：允许 key usage、DNSName/IPAddress subjectAltName 等扩展，
       禁止  EmailAddress、URI subjectAltName 等扩展，并丢弃其他扩展。
       至少有一个 DNS 或 IP 的 SubjectAltName 存在。
-   1. 许可的密钥用途：必须是 `["key encipherment", "digital signature", "client auth"]`
+   1. 许可的密钥用途：必须是 `["key encipherment", "digital signature", "server auth"]`
    1. 过期日期/证书生命期：通过 kube-controller-manager 中签名者的实现所对应的标志
       `--cluster-signing-duration` 来设置。
    1. 允许/不允许 CA 位：不允许。


### PR DESCRIPTION
fix content error in  Kubernetes signers#kubernetes.io/kubelet-serving

Chinese version:
https://kubernetes.io/zh/docs/reference/access-authn-authz/certificate-signing-requests/
![image](https://user-images.githubusercontent.com/38010908/131835865-85e597d4-3144-423c-b717-d3a123dc5774.png)

English version:
https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/
![image](https://user-images.githubusercontent.com/38010908/131835927-fcb92854-dfa3-4481-b54c-436b6e823d27.png)


