### PR TITLE
Move to Minikube 1.20 image of Katacoda for Hello Minikube Tutorial

### DIFF
--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -1,5 +1,5 @@
 {{ if .HasShortcode "kat-button" }}
-<div id="katacoda-environment" data-katacoda-ondemand="true" data-katacoda-port="30000" data-katacoda-env="minikube" data-katacoda-command="start.sh" data-katacoda-ui="panel"></div>
+<div id="katacoda-environment" data-katacoda-ondemand="true" data-katacoda-port="30000" data-katacoda-env="minikube:1.20" data-katacoda-command="start.sh" data-katacoda-ui="panel"></div>
 {{ end }}
 {{ with .Site.Params.algolia_docsearch }}
 <!-- scripts for algolia docsearch -->


### PR DESCRIPTION
Fixes #29204 

Upgrades the tutorial to use Minikube 1.20 which is the latest version available on Katacoda. 