### PR TITLE
Fix formatting in create-cluster-kubeadm.md

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
@@ -9,6 +9,7 @@ weight: 30
 <!-- overview -->
 
 <img src="https://raw.githubusercontent.com/kubernetes/kubeadm/master/logos/stacked/color/kubeadm-stacked-color.png" align="right" width="150px">
+
 Using `kubeadm`, you can create a minimum viable Kubernetes cluster that conforms to best practices.
 In fact, you can use `kubeadm` to set up a cluster that will pass the
 [Kubernetes Conformance tests](https://kubernetes.io/blog/2017/10/software-conformance-certification).


### PR DESCRIPTION
The first paragraph of create-cluster-kubeadm.md had broken formatting. This adds a newline to fix it.