### PR TITLE
[hi] Enable Hindi localization

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -30,8 +30,7 @@ pygmentsStyle = "emacs"
 enableGitInfo = true
 
 # Norwegian ("no") is sometimes but not currently used for testing.
-# Hindi is disabled because it's currently in development.
-disableLanguages = ["hi", "no"]
+disableLanguages = ["no"]
 
 [caches]
  [caches.assets]


### PR DESCRIPTION
Enable the Hindi localization. This change marks Hindi as enabled in order to enable effective Netlify previewing for work on the Hindi localization.

/language hi