### PR TITLE
kubelet-in-userns.md: update for minikube

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubelet-in-userns.md
+++ b/content/en/docs/tasks/administer-cluster/kubelet-in-userns.md
@@ -34,14 +34,21 @@ If you are just looking for how to run a pod as a non-root user, see [SecurityCo
 
 ## Running Kubernetes inside Rootless Docker/Podman
 
-[kind](https://kind.sigs.k8s.io/) supports running Kubernetes inside a Rootless Docker or Rootless Podman.
+### kind
+
+[kind](https://kind.sigs.k8s.io/) supports running Kubernetes inside Rootless Docker or Rootless Podman.
 
 See [Running kind with Rootless Docker](https://kind.sigs.k8s.io/docs/user/rootless/).
 
-<!--
-[minikube](https://minikube.sigs.k8s.io/docs/) also plans to support Rootless Docker/Podman drivers.
-See [minikube issue #10836](https://github.com/kubernetes/minikube/issues/10836) to track the progress.
--->
+### minikube
+
+[minikube](https://minikube.sigs.k8s.io/) also supports running Kubernetes inside Rootless Docker.
+
+See the page about the [docker](https://minikube.sigs.k8s.io/docs/drivers/docker/) driver in the Minikube documentation.
+
+Rootless Podman is not supported.
+
+<!-- Supporting rootless podman is discussed in https://github.com/kubernetes/minikube/issues/8719 -->
 
 ## Running Rootless Kubernetes directly on a host
 


### PR DESCRIPTION
minikube now supports Rootless Docker driver.

minikube internally sets the KubeletInUserNamespace feature gate automatically for supporting Rootless Docker driver.

https://minikube.sigs.k8s.io/docs/drivers/docker/


<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
