### PR TITLE
fix(blog): RWX access mode is about nodes, not pods

### DIFF
--- a/content/en/blog/_posts/2021-09-13-read-write-once-pod-access-mode-alpha.md
+++ b/content/en/blog/_posts/2021-09-13-read-write-once-pod-access-mode-alpha.md
@@ -28,7 +28,7 @@ metadata:
   name: shared-cache
 spec:
   accessModes:
-  - ReadWriteMany # Allow many pods to access shared-cache simultaneously.
+  - ReadWriteMany # Allow many nodes to access shared-cache simultaneously.
   resources:
     requests:
       storage: 1Gi


### PR DESCRIPTION
Hi,

Just a very minor typo in 2021-09-13-read-write-once-pod-access-mode-alpha.md blog post.

RWX access mode is about nodes, not pods. As stated later in the article ```The ReadWriteOnce access mode restricts volume access to a single node```

Regards,
