### PR TITLE
Add a ports and protocols reference page

### DIFF
--- a/content/en/docs/reference/_index.md
+++ b/content/en/docs/reference/_index.md
@@ -64,6 +64,8 @@ client libraries:
   * [Scheduler Policies](/docs/reference/scheduling/policies)
   * [Scheduler Profiles](/docs/reference/scheduling/config#profiles)
 
+* List of [ports and protocols](/docs/reference/ports-and-protocols/) that
+  should be open on control plane and worker nodes
 ## Config APIs
 
 This section hosts the documentation for "unpublished" APIs which are used to

--- a/content/en/docs/reference/ports-and-protocols.md
+++ b/content/en/docs/reference/ports-and-protocols.md
@@ -1,0 +1,40 @@
+---
+title: Ports and Protocols
+content_type: reference
+weight: 50
+---
+
+When running Kubernetes in an environment with strict network boundaries, such 
+as on-premises datacenter with physical network firewalls or Virtual 
+Networks in Public Cloud, it is useful to be aware of the ports and protocols 
+used by Kubernetes components
+
+## Control plane
+
+| Protocol | Direction | Port Range | Purpose                 | Used By                   |
+|----------|-----------|------------|-------------------------|---------------------------|
+| TCP      | Inbound   | 6443       | Kubernetes API server   | All                       |
+| TCP      | Inbound   | 2379-2380  | etcd server client API  | kube-apiserver, etcd      |
+| TCP      | Inbound   | 10250      | Kubelet API             | Self, Control plane       |
+| TCP      | Inbound   | 10259      | kube-scheduler          | Self                      |
+| TCP      | Inbound   | 10257      | kube-controller-manager | Self                      |
+
+Although etcd ports are included in control plane section, you can also host your own
+etcd cluster externally or on custom ports. 
+
+## Worker node(s) {#node}
+
+| Protocol | Direction | Port Range  | Purpose               | Used By                 |
+|----------|-----------|-------------|-----------------------|-------------------------|
+| TCP      | Inbound   | 10250       | Kubelet API           | Self, Control plane     |
+| TCP      | Inbound   | 30000-32767 | NodePort Services†    | All                     |
+
+† Default port range for [NodePort Services](/docs/concepts/services-networking/service/).
+
+All default port numbers can be overridden. When custom ports are used those 
+ports need to be open instead of defaults mentioned here. 
+
+One common example is API server port that is sometimes switched
+to 443. Alternatively, the default port is kept as is and API server is put 
+behind a load balancer that listens on 443 and routes the requests to API server
+on the default port.

--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -67,31 +67,9 @@ sudo sysctl --system
 For more details please see the [Network Plugin Requirements](/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/#network-plugin-requirements) page.
 
 ## Check required ports
-
-### Control-plane node(s)
-
-| Protocol | Direction | Port Range | Purpose                 | Used By                   |
-|----------|-----------|------------|-------------------------|---------------------------|
-| TCP      | Inbound   | 6443\*      | Kubernetes API server   | All                       |
-| TCP      | Inbound   | 2379-2380  | etcd server client API  | kube-apiserver, etcd      |
-| TCP      | Inbound   | 10250      | kubelet API             | Self, Control plane       |
-| TCP      | Inbound   | 10251      | kube-scheduler          | Self                      |
-| TCP      | Inbound   | 10252      | kube-controller-manager | Self                      |
-
-### Worker node(s)
-
-| Protocol | Direction | Port Range  | Purpose               | Used By                 |
-|----------|-----------|-------------|-----------------------|-------------------------|
-| TCP      | Inbound   | 10250       | kubelet API           | Self, Control plane     |
-| TCP      | Inbound   | 30000-32767 | NodePort Services†    | All                     |
-
-† Default port range for [NodePort Services](/docs/concepts/services-networking/service/).
-
-Any port numbers marked with * are overridable, so you will need to ensure any
-custom ports you provide are also open.
-
-Although etcd ports are included in control-plane nodes, you can also host your own
-etcd cluster externally or on custom ports.
+These
+[required ports](/docs/reference/ports-and-protocols/)
+need to be open in order for Kubernetes components to communicate with each other.
 
 The pod network plugin you use (see below) may also require certain ports to be
 open. Since this differs with each pod network plugin, please see the


### PR DESCRIPTION
- Refactored ports and protocols info under cluster-adminstration
- Updated the ports for kube-scheduler and kube-controller based on
  current state

Fixes #29698 

/sig security node architecture