### PR TITLE
Fixed the link for Exemptions.

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/enforce-standards-admission-controller.md
+++ b/content/en/docs/tasks/configure-pod-container/enforce-standards-admission-controller.md
@@ -9,7 +9,7 @@ min-kubernetes-server-version: v1.22
 
 As of v1.22, Kubernetes provides a built-in [admission controller](/docs/reference/access-authn-authz/admission-controllers/#podsecurity)
 to enforce the [Pod Security Standards](/docs/concepts/security/pod-security-standards).
-You can configure this admission controller to set cluster-wide defaults and [exemptions](#exemptions).
+You can configure this admission controller to set cluster-wide defaults and [exemptions](/docs/concepts/security/pod-security-admission/#exemptions).
 
 ## {{% heading "prerequisites" %}}
 


### PR DESCRIPTION
This PR has fixed the link for Exemptions in [Enforce Pod Security Standards by Configuring the Built-in Admission Controller](https://kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-admission-controller/).

Fixes: #29702