### PR TITLE
Updates in pod-topology-spread-constraints.md

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-topology-spread-constraints.md
+++ b/content/en/docs/concepts/workloads/pods/pod-topology-spread-constraints.md
@@ -349,12 +349,14 @@ Also, the legacy `SelectorSpread` plugin, which provides an equivalent behavior,
 is disabled.
 
 {{< note >}}
+The `PodTopologySpread` plugin does not score the nodes that don't have
+the topology keys specified in the spreading constraints. This might result
+in a different default behavior compared to the legacy `SelectorSpread` plugin when
+using the default topology constraints.
+
 If your nodes are not expected to have **both** `kubernetes.io/hostname` and
 `topology.kubernetes.io/zone` labels set, define your own constraints
 instead of using the Kubernetes defaults.
-
-The `PodTopologySpread` plugin does not score the nodes that don't have
-the topology keys specified in the spreading constraints.
 {{< /note >}}
 
 If you don't want to use the default Pod spreading constraints for your cluster,


### PR DESCRIPTION
Updated notes regarding the default behavior of the `Pod Topology Spread Constraints`.

When upgrading from K8s 1.19 to 1.20 the `DefaultPodTopologySpread` feature gate is enabled, resulting in a change of default scheduler plugins.
The `SelectorSpread` used in 1.19 is indifferent which labels exists on node/workers, but `PodTopologySpread` in 1.20 default requires `kubernetes.io/hostname` and `topology.kubernetes.io/zone`.
The `topology.kubernetes.io/zone` label is common in public cloud, but not for some on-prem setups which can result in unexpected skew in pod placements after a K8s lift.

Also updated indentation on an example section to remove graphical glitches in the documentation.
