### PR TITLE
Improve code style advice for kubelet component name

### DIFF
--- a/content/en/docs/contribute/style/style-guide.md
+++ b/content/en/docs/contribute/style/style-guide.md
@@ -149,12 +149,12 @@ Run the process as a DaemonSet in the `kube-system` namespace. | Run the process
 
 ### Use code style for Kubernetes command tool and component names
 
-{{< table caption = "Do and Don't - Use code style for Kubernetes command tool and component names" >}}
+{{< table caption = "Do and Don't - Use code style for Kubernetes command tools but not for component names" >}}
 Do | Don't
 :--| :-----
-The `kubelet` preserves node stability. | The kubelet preserves node stability.
 The `kubectl` handles locating and authenticating to the API server. | The kubectl handles locating and authenticating to the apiserver.
-Run the process with the certificate, `kube-apiserver --client-ca-file=FILENAME`. | Run the process with the certificate, kube-apiserver --client-ca-file=FILENAME. |
+Run the process with the certificate, `kube-apiserver --client-ca-file=FILENAME`. | Run the process with the certificate, kube-apiserver --client-ca-file=FILENAME.
+The kubelet preserves node stability. | The `kubelet` preserves node stability.
 {{< /table >}}
 
 ### Starting a sentence with a component tool or component name

--- a/content/en/docs/contribute/style/style-guide.md
+++ b/content/en/docs/contribute/style/style-guide.md
@@ -152,7 +152,7 @@ Run the process as a DaemonSet in the `kube-system` namespace. | Run the process
 {{< table caption = "Do and Don't - Use code style for Kubernetes command tool and component names" >}}
 Do | Don't
 :--| :-----
-The kubelet preserves node stability. | The `kubelet` preserves node stability.
+The `kubelet` preserves node stability. | The kubelet preserves node stability.
 The `kubectl` handles locating and authenticating to the API server. | The kubectl handles locating and authenticating to the apiserver.
 Run the process with the certificate, `kube-apiserver --client-ca-file=FILENAME`. | Run the process with the certificate, kube-apiserver --client-ca-file=FILENAME. |
 {{< /table >}}


### PR DESCRIPTION
The style code example for the kubelet component and/or the advice is not clear. This change tries to fix that.