### PR TITLE
Website etcd restore example: use local loopback IP to reduce confusion

### DIFF
--- a/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
+++ b/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
@@ -323,7 +323,7 @@ either be a snapshot file from a previous backup operation, or from a remaining
 Here is an example:
 
 ```shell
-ETCDCTL_API=3 etcdctl --endpoints 10.2.0.9:2379 snapshot restore snapshotdb
+ETCDCTL_API=3 etcdctl --endpoints 127.0.0.1:2379 snapshot restore snapshotdb
 ```
 
 For more information and examples on restoring a cluster from a snapshot file, see

--- a/content/zh/docs/tasks/administer-cluster/configure-upgrade-etcd.md
+++ b/content/zh/docs/tasks/administer-cluster/configure-upgrade-etcd.md
@@ -642,7 +642,7 @@ etcd 支持从 [major.minor](http://semver.org/) 或其他不同 patch 版本的
 例如：
 
 ```shell
-ETCDCTL_API=3 etcdctl --endpoints 10.2.0.9:2379 snapshot restore snapshotdb
+ETCDCTL_API=3 etcdctl --endpoints 127.0.0.1:2379 snapshot restore snapshotdb
 ```
 
 有关从快照文件还原集群的详细信息和示例，请参阅 


### PR DESCRIPTION
The example restore endpoint for etcdctl is the arbitrary IP `10.2.0.9:2379` which is unnecessary and may be unhelpful for operators.

A different option to use for the IP in the example may be the localhost loopback address `127.0.0.1:2379`

This will likely be more useful in the majority of cases and may reduce the cognitive load of operators attempting to restore a cluster at a stressful time when they need to do so. 