### PR TITLE
Add recommendation for Deployment when HPA is enabled

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/deployment.md
+++ b/content/en/docs/concepts/workloads/controllers/deployment.md
@@ -1070,6 +1070,18 @@ allowed, which is the default if not specified.
 
 `.spec.replicas` is an optional field that specifies the number of desired Pods. It defaults to 1.
 
+Should you manually scale a Deployment, example via `kubectl scale deployment
+deployment --replicas=X`, and then you update that Deployment based on a manifest
+(for example: by running `kubectl apply -f deployment.yaml`),
+then applying that manifest overwrites the manual scaling that you previously did.
+
+If a [HorizontalPodAutoscaler](/docs/tasks/run-application/horizontal-pod-autoscale/) (or any
+similar API for horizontal scaling) is managing scaling for a Deployment, don't set `.spec.replicas`.
+
+Instead, allow the Kubernetes
+{{< glossary_tooltip text="control plane" term_id="control-plane" >}} to manage the
+`.spec.replicas` field automatically.
+
 ### Selector
 
 `.spec.selector` is a required field that specifies a [label selector](/docs/concepts/overview/working-with-objects/labels/)

--- a/content/en/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/en/docs/concepts/workloads/controllers/statefulset.md
@@ -295,6 +295,22 @@ a Pod is considered ready, see [Container Probes](/docs/concepts/workloads/pods/
 
 Please note that this field only works if you enable the `StatefulSetMinReadySeconds` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/).
 
+### Replicas
+
+`.spec.replicas` is an optional field that specifies the number of desired Pods. It defaults to 1.
+
+Should you manually scale a deployment, example via `kubectl scale
+statefulset statefulset --replicas=X`, and then you update that StatefulSet
+based on a manifest (for example: by running `kubectl apply -f
+statefulset.yaml`), then applying that manifest overwrites the manual scaling
+that you previously did.
+
+If a [HorizontalPodAutoscaler](/docs/tasks/run-application/horizontal-pod-autoscale/)
+(or any similar API for horizontal scaling) is managing scaling for a
+Statefulset, don't set `.spec.replicas`. Instead, allow the Kubernetes
+{{<glossary_tooltip text="control plane" term_id="control-plane" >}} to manage
+the `.spec.replicas` field automatically.
+
 ## {{% heading "whatsnext" %}}
 
 


### PR DESCRIPTION
* Advertise that we need to remove `spec.replicas` when a Horizontal Pod
  Autoscaler is active to prevent unnecessary changes in Pod counts during
  Deployment object changes
* Make note that a Deployment that has this value set behave awkwardly if a
  Deployment is scaled manually outside of the Deployment object

Signed-off-by: John T Skarbek <jtslear@gmail.com>

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

This should be able to address and potentially close issue: https://github.com/kubernetes/kubernetes/issues/25238
