### PR TITLE
Remove unessesary indentation on code

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -168,7 +168,7 @@ Also calling `kubeadm upgrade plan` and upgrading the CNI provider plugin is no 
 
 -  Upgrade the kubelet and kubectl:
 
-{{< tabs name="k8s_kubelet_and_kubectl" >}}
+{{< tabs name="k8s_install_kubelet" >}}
 {{% tab name="Ubuntu, Debian or HypriotOS" %}}
     # replace x in {{< skew latestVersion >}}.x-00 with the latest patch version
     apt-mark unhold kubelet kubectl && \

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -89,6 +89,7 @@ Pick a control plane node that you wish to upgrade first. It must have the `/etc
 {{% /tab %}}
 {{< /tabs >}}
 
+
 -  Verify that the download works and has the expected version:
 
     ```shell
@@ -185,6 +186,7 @@ Also calling `kubeadm upgrade plan` and upgrading the CNI provider plugin is no 
 {{% /tab %}}
 {{< /tabs >}}
 
+
 -  Restart the kubelet:
 
     ```shell
@@ -264,6 +266,7 @@ without compromising the minimum required capacity for running your workloads.
     yum install -y kubelet-{{< skew latestVersion >}}.x-0 kubectl-{{< skew latestVersion >}}.x-0 --disableexcludes=kubernetes
 {{% /tab %}}
 {{< /tabs >}}
+
 
 -  Restart the kubelet:
 

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -166,11 +166,10 @@ Also calling `kubeadm upgrade plan` and upgrading the CNI provider plugin is no 
 
 ### Upgrade kubelet and kubectl
 
--  Upgrade the kubelet and kubectl
+-  Upgrade the kubelet and kubectl:
 
-{{< tabs name="k8s_install_kubelet" >}}
-{{< tab name="Ubuntu, Debian or HypriotOS" >}}
-    <pre>
+{{< tabs name="k8s_kubelet_and_kubectl" >}}
+{{% tab name="Ubuntu, Debian or HypriotOS" %}}
     # replace x in {{< skew latestVersion >}}.x-00 with the latest patch version
     apt-mark unhold kubelet kubectl && \
     apt-get update && apt-get install -y kubelet={{< skew latestVersion >}}.x-00 kubectl={{< skew latestVersion >}}.x-00 && \
@@ -179,14 +178,11 @@ Also calling `kubeadm upgrade plan` and upgrading the CNI provider plugin is no 
     # since apt-get version 1.1 you can also use the following method
     apt-get update && \
     apt-get install -y --allow-change-held-packages kubelet={{< skew latestVersion >}}.x-00 kubectl={{< skew latestVersion >}}.x-00
-    </pre>
-{{< /tab >}}
-{{< tab name="CentOS, RHEL or Fedora" >}}
-    <pre>
+{{% /tab %}}
+{{% tab name="CentOS, RHEL or Fedora" %}}
     # replace x in {{< skew latestVersion >}}.x-0 with the latest patch version
     yum install -y kubelet-{{< skew latestVersion >}}.x-0 kubectl-{{< skew latestVersion >}}.x-0 --disableexcludes=kubernetes
-    </pre>
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 -  Restart the kubelet:

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -88,6 +88,7 @@ Pick a control plane node that you wish to upgrade first. It must have the `/etc
     yum install -y kubeadm-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
 {{% /tab %}}
 {{< /tabs >}}
+<br />
 
 -  Verify that the download works and has the expected version:
 
@@ -184,6 +185,7 @@ Also calling `kubeadm upgrade plan` and upgrading the CNI provider plugin is no 
     yum install -y kubelet-{{< skew currentVersion >}}.x-0 kubectl-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
 {{% /tab %}}
 {{< /tabs >}}
+<br />
 
 -  Restart the kubelet:
 
@@ -264,6 +266,7 @@ without compromising the minimum required capacity for running your workloads.
     yum install -y kubelet-{{< skew currentVersion >}}.x-0 kubectl-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
 {{% /tab %}}
 {{< /tabs >}}
+<br />
 
 -  Restart the kubelet:
 

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -89,7 +89,6 @@ Pick a control plane node that you wish to upgrade first. It must have the `/etc
 {{% /tab %}}
 {{< /tabs >}}
 
-
 -  Verify that the download works and has the expected version:
 
     ```shell
@@ -186,7 +185,6 @@ Also calling `kubeadm upgrade plan` and upgrading the CNI provider plugin is no 
 {{% /tab %}}
 {{< /tabs >}}
 
-
 -  Restart the kubelet:
 
     ```shell
@@ -266,7 +264,6 @@ without compromising the minimum required capacity for running your workloads.
     yum install -y kubelet-{{< skew latestVersion >}}.x-0 kubectl-{{< skew latestVersion >}}.x-0 --disableexcludes=kubernetes
 {{% /tab %}}
 {{< /tabs >}}
-
 
 -  Restart the kubelet:
 


### PR DESCRIPTION
**Description:**

The indentation on the code is quite annoying when copying it. I haven't touched the content itself. I only changed the indentation. The `:` I added to `Upgrade the kubelet and kubectl` is to make it equal to the exactly same section further below.

[Link to issue in the docs](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/#upgrade-kubelet-and-kubectl)

Before:
![image](https://user-images.githubusercontent.com/16527874/133936011-20d57288-ae63-4359-b179-670777ff87b8.png)

After:
![image](https://user-images.githubusercontent.com/16527874/133936076-e4f6c346-a790-4276-8973-d968e916e365.png)

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
