### PR TITLE
kubeadm upgrade to the latest patch release, not the latest stable

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -45,7 +45,7 @@ The upgrade workflow at high level is the following:
 
 ## Determine which version to upgrade to
 
-Find the latest stable {{< skew currentVersion >}} version using the OS package manager:
+Find the latest patch release for Kubernetes {{< skew currentVersion >}} using the OS package manager:
 
 {{< tabs name="k8s_install_versions" >}}
 {{% tab name="Ubuntu, Debian or HypriotOS" %}}


### PR DESCRIPTION
to fix a review comment in [29746](https://github.com/kubernetes/website/pull/29746/files#r711796974):
kubeadm upgrade to the latest patch release, not the latest stable
