### PR TITLE
remove 'Tools Included' from sidebar of translated page

### DIFF
--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -69,7 +69,7 @@
           {{ range . }}
             {{ with (where $.section.Translations ".Lang" . ) -}}
               {{ $p := index . 0 -}}
-              {{ $pages =  $pages | lang.Merge (union $p.Pages $p.Sections) -}}
+              {{ $pages = where ( $pages | lang.Merge (union $p.Pages $p.Sections)) ".Params.toc_hide" "!=" true -}}
             {{ end -}}
           {{ end -}}
         {{ end -}}


### PR DESCRIPTION
Closes #29771 