### PR TITLE
Placeholder for 'kubectl events' docs

### DIFF
--- a/static/docs/reference/generated/kubectl/kubectl-commands.html
+++ b/static/docs/reference/generated/kubectl/kubectl-commands.html
@@ -7710,6 +7710,11 @@ applications.</p>
 <h3 id="usage">Usage</h3>
 <p><code>$ kubectl alpha</code></p>
 <hr>
+<h1 id="alpha events">alpha</h1>
+<p>Print events.</p>
+<h3 id="usage">Usage</h3>
+<p>Coming soon!</p>
+<hr>
 <h1 id="api-resources">api-resources</h1>
 <blockquote class="code-block example">
 <p> Print the supported API resources</p>


### PR DESCRIPTION
Docs for https://github.com/kubernetes/enhancements/issues/1440
PR is at https://github.com/kubernetes/kubernetes/pull/99557

I understand the docs will be generated following [this process](https://kubernetes.io/docs/contribute/generate-ref-docs/kubectl/)

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
