### PR TITLE
Restrict width of blog figures for wide viewports

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -635,6 +635,13 @@ body.td-documentation {
   }
 }
 
+// Match Docsy-imposed max width on text body
+@media (min-width: 1200px) {
+  body.td-blog main .td-content > figure {
+    max-width: 80%;
+  }
+}
+
 .td-content {
   table code {
     background-color: inherit !important;


### PR DESCRIPTION
Docsy uses Bootstrap to restrict the width of text paragraphs when the viewport is very wide. Also apply that to `<figure>` elements within blog articles.

Previews:
- [before](https://deploy-preview-29634--kubernetes-io-main-staging.netlify.app/blog/2021/09/29/how-to-handle-data-duplication-in-data-heavy-kubernetes-environments/)
- [after](https://deploy-preview-29846--kubernetes-io-main-staging.netlify.app/blog/2021/09/29/how-to-handle-data-duplication-in-data-heavy-kubernetes-environments/)

Helps with the rendering of blog article [How to Handle Data Duplication in Data-Heavy Kubernetes Environments](https://blog.k8s.io/2021/09/29/how-to-handle-data-duplication-in-data-heavy-kubernetes-environments/) (scheduled by https://github.com/kubernetes/website/pull/29634).

/area web-development