### PR TITLE
modify kubeadm config example about joining a node to dual-stack cluster

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/dual-stack-support.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/dual-stack-support.md
@@ -93,6 +93,10 @@ kind: JoinConfiguration
 discovery:
   bootstrapToken:
     apiServerEndpoint: 10.100.0.1:6443
+    token: "clvldh.vjjwg16ucnhp94qr"
+    caCertHashes:
+    - "sha256:a4863cde706cfc580a439f842cc65d5ef112b7b2be31628513a9881cf0d9fe0e"
+    # change auth info above to match the actual token and CA certificate hash for your cluster
 nodeRegistration:
   kubeletExtraArgs:
     node-ip: 10.100.0.3,fd00:1:2:3::3
@@ -109,6 +113,10 @@ controlPlane:
 discovery:
   bootstrapToken:
     apiServerEndpoint: 10.100.0.1:6443
+    token: "clvldh.vjjwg16ucnhp94qr"
+    caCertHashes:
+    - "sha256:a4863cde706cfc580a439f842cc65d5ef112b7b2be31628513a9881cf0d9fe0e"
+    # change auth info above to match the actual token and CA certificate hash for your cluster
 nodeRegistration:
   kubeletExtraArgs:
     node-ip: 10.100.0.4,fd00:1:2:3::4
@@ -118,7 +126,7 @@ nodeRegistration:
 `advertiseAddress` in JoinConfiguration.controlPlane specifies the IP address that the API Server will advertise it is listening on. The value of `advertiseAddress` equals the `--apiserver-advertise-address` flag of `kubeadm join`.
 
 ```shell
-kubeadm join --config=kubeadm-config.yaml ...
+kubeadm join --config=kubeadm-config.yaml
 ```
 
 ### Create a single-stack cluster


### PR DESCRIPTION
With the example posted on the [documentation website](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/dual-stack-support/), some errors occurred when I join a node to dual-stack cluster.
But I made it with the config below after consulting the [code](https://github.com/kubernetes/kubeadm/blob/ebd1ae0b04a22e94bc73d07f10a5c2416ac7afe0/kinder/pkg/kubeadm/config.go#L192-L196) of kubeadm.

```diff
apiVersion: kubeadm.k8s.io/v1beta3
kind: JoinConfiguration
discovery:
  bootstrapToken:
    apiServerEndpoint: 10.211.55.11:6443
+   token: "i5pvuz.c320kr5wsh8lt582"
+   unsafeSkipCAVerification: true
nodeRegistration:
  kubeletExtraArgs:
    node-ip: 10.211.55.12,fdb2:2c26:f4e4:0:21c:42ff:fe92:3fcb
```

So, should we update the documentation, or just the example didn't get across to me?

