### PR TITLE
Revise third-party content warning

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -343,6 +343,26 @@ main {
   }
 }
 
+// Highlight disclaimer when targeted as a fragment
+
+#third-party-content-disclaimer {
+  color: #000;
+  background: #f8f9fa;
+  transition: all 0.5s ease;
+}
+
+@keyframes disclaimer-highlight {
+  from { background: #f8f922; color: #000; }
+  50% { background: #f8f944; color: #000; }
+  to { background: #f8f9cb; color: #000; }
+}
+
+#third-party-content-disclaimer:target {
+  color: #000;
+  animation: disclaimer-highlight 1.25s ease;
+  background: #f8f9cb;
+}
+
 .deprecation-warning {
     padding: 20px;
     margin: 20px 0;

--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -338,10 +338,14 @@ main {
     border-left-color: #d9534f;
   }
 
+
   h1:first-of-type + blockquote.callout {
     margin-top: 1.5em;
   }
 }
+
+// Special color for third party content disclaimers
+.alert.third-party-content { border-left-color: #222 };
 
 // Highlight disclaimer when targeted as a fragment
 

--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -217,7 +217,17 @@ other = "Subscribe"
 other = "Synopsis"
 
 [thirdparty_message]
-other = """This section links to third party projects that provide functionality required by Kubernetes. The Kubernetes project authors aren't responsible for these projects. This page follows <a href="https://github.com/cncf/foundation/blob/master/website-guidelines.md" target="_blank">CNCF website guidelines</a> by listing projects alphabetically. To add a project to this list, read the <a href="/docs/contribute/style/content-guide/#third-party-content">content guide</a> before submitting a change."""
+other = """This section links to third party projects that provide functionality required by Kubernetes. The Kubernetes project authors aren't responsible for these projects, which are listed alphabetically. To add a project to this list, read the <a href="/docs/contribute/style/content-guide/#third-party-content">content guide</a> before submitting a change. <a href="#third-party-content-disclaimer">More information.</a>"""
+
+[thirdparty_message_edit_disclaimer]
+other="""Third party content advice"""
+
+
+[thirdparty_message_single_item]
+other = """&#128711; This item links to a third party project or product that is not part of Kubernetes itself. <a class="alert-more-info" href="#third-party-content-disclaimer">More information</a>"""
+
+[thirdparty_message_disclaimer]
+other = """<p>Items on this page refer to third party products or projects that provide functionality required by Kubernetes. The Kubernetes project authors aren't responsible for those third-party products or projects. See the <a href="https://github.com/cncf/foundation/blob/master/website-guidelines.md" target="_blank">CNCF website guidelines</a> for more details.</p><p>You should read the <a href="/docs/contribute/style/content-guide/#third-party-content">content guide</a> before proposing a change that adds an extra third-party link.</p>"""
 
 [ui_search_placeholder]
 other = "Search"

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -22,6 +22,11 @@
               {{ partial "deprecation-warning.html" . }}
             {{ end }}
               {{ block "main" . }}{{ end }}
+              {{- if .HasShortcode "thirdparty-content" -}}
+                {{ block "thirdparty-disclaimer" . }}
+                  {{ partial "docs/thirdparty-disclaimer.html" . }}
+                {{- end -}}
+              {{- end -}}
             {{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) }}
               {{ partial "feedback.html" .Site.Params.ui.feedback }}
             {{ end }}

--- a/layouts/partials/docs/thirdparty-disclaimer.html
+++ b/layouts/partials/docs/thirdparty-disclaimer.html
@@ -1,0 +1,3 @@
+<div class="pageinfo pageinfo-secondary" id="third-party-content-disclaimer">
+{{ T "thirdparty_message_disclaimer" | safeHTML }}
+</div>

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -24,6 +24,10 @@
 
     {{ if not (.Param "auto_generated") }}
     <a href="{{ $editURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
+    {{- if .HasShortcode "thirdparty-content" -}}
+    <a href="#third-party-content-disclaimer" class="third-party-disclaimer-link"><i class="fa fa-icon-circle fa-fw"></i> {{ T "thirdparty_message_edit_disclaimer" | safeHTML }}</a>
+    {{- end }}
+
     <a href="{{ $newPageURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_create_child_page" }}</a>
     {{ end }}
 

--- a/layouts/shortcodes/thirdparty-content.html
+++ b/layouts/shortcodes/thirdparty-content.html
@@ -1,4 +1,9 @@
-<blockquote class="callout caution" role="alert">
-  <strong>{{ T "caution" | safeHTML }}</strong>
+{{- $single := .Get "single" | default "false" -}}
+<div class="alert alert-secondary callout third-party-content" role="alert">
+{{- if not (eq $single "true" ) -}}
+  <strong>{{ T "note" | safeHTML }}</strong>
   {{ T "thirdparty_message" | safeHTML }}
-</blockquote>
+{{- else -}}
+  {{ T "thirdparty_message_single_item" | safeHTML }}
+{{- end -}}
+</div>


### PR DESCRIPTION
Revise third party content notices.

- [Example](https://deploy-preview-29877--kubernetes-io-main-staging.netlify.app/docs/setup/production-environment/container-runtimes/#container-runtimes).
- [Current rendering](https://k8s.io/docs/setup/production-environment/container-runtimes/#container-runtimes).

1. Add a page info block at the foot of the page about third party content, whenever the shortcode is used.
2. Add a link to that page info block just under the “edit this page” link
3. Highlight the page info block when linked to
4. Add a second mode to the third-party content shortcode, that you can use when mixing an out-of-project item into a list of in-project items.


Prompted by https://github.com/kubernetes/website/pull/27428#discussion_r720094963