### PR TITLE
Add change-cause annotation to labels/annotations page

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints.md
+++ b/content/en/docs/reference/labels-annotations-taints.md
@@ -63,6 +63,16 @@ The Kubelet populates this label with the hostname. Note that the hostname can b
 This label is also used as part of the topology hierarchy.  See [topology.kubernetes.io/zone](#topologykubernetesiozone) for more information.
 
 
+## kubernetes.io/change-cause {#change-cause}
+
+Example: `kubernetes.io/change-cause=kubectl edit --record deployment foo`
+
+Used on: All Objects
+
+This annotation is a best guess at why something was changed. 
+
+It is populated when adding `--record` to a `kubectl` command that may change an object.
+
 ## controller.kubernetes.io/pod-deletion-cost {#pod-deletion-cost}
 
 Example: `controller.kubernetes.io/pod-deletion-cost=10`


### PR DESCRIPTION
This addresses #29633 by adding the `kubernetes.io/change-cause` annotation to the Annotations/Labels/Taints page. 
