### PR TITLE
Fix gradient background rendering for announcements

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -585,7 +585,7 @@ body.td-documentation {
 #announcement, #fp-announcement {
   > * {
     color: inherit;
-    background: inherit;
+    background: transparent;
   }
 
   a {


### PR DESCRIPTION
When an announcement uses a gradient background, the inherited background looks wrong. Instead, make the child element's background transparent.

/area web-development