### PR TITLE
Mark when JavaScript is available

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -72,6 +72,8 @@ var kub = (function () {
         headlineWrapper = $('#headlineWrapper');
         HEADER_HEIGHT = header.outerHeight();
 
+        document.documentElement.classList.remove('no-js');
+
         resetTheView();
 
         window.addEventListener('resize', resetTheView);


### PR DESCRIPTION
There is already a `no-js` class set on the `<html>` element; this change removes it when JavaScript is running OK.

This might be useful for custom styling, or for using a pure-CSS fallback for some scripted behavior.

/area web-development