### PR TITLE
[WIP] Tweak scroll behavior for narrow viewports

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -26,6 +26,20 @@ $announcement-size-adjustment: 8px;
   }
 }
 
+/* Fix misplaced scrolling to targets with narrow
+   viewports
+*/
+@media only screen and (max-width: 768px) {
+  body {
+    scroll-padding: 16rem 0 0 0;
+  }
+
+  .td-main {
+    padding-top: 4rem;
+  }
+}
+
+
 section {
   .main-section {
     @media only screen and (min-width: 1024px) {

--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -29,17 +29,14 @@ $announcement-size-adjustment: 8px;
 /* Fix misplaced scrolling to targets with narrow
    viewports
 */
-@media only screen and (max-width: 768px) {
-  body {
-    scroll-padding: 16rem 0 0 0;
+html {
+  @media only screen and (max-width: 768px) {
+    scroll-padding-top: 5rem;
   }
-
-  .td-main {
-    padding-top: 4rem;
+  @media only screen and (max-width: 1024px) {
+    scroll-padding-top: 4rem;
   }
 }
-
-
 section {
   .main-section {
     @media only screen and (min-width: 1024px) {


### PR DESCRIPTION
This change means that when the viewport is narrow, scrolling to (or navigating to) a fragment doesn't put the top of the actual target fragment behind the top nav.

Compare https://kubernetes.io/docs/concepts/storage/persistent-volumes/#resizing-an-in-use-persistentvolumeclaim to its [preview](https://deploy-preview-29910--kubernetes-io-main-staging.netlify.app/docs/concepts/storage/persistent-volumes/#resizing-an-in-use-persistentvolumeclaim), and then try both with a narrow viewport.

Want to try on your mobile device?

<img src="http://api.qrserver.com/v1/create-qr-code/?color=000000&amp;bgcolor=FFFFFF&amp;data=https%3A%2F%2Fk8s.io%2Fdocs%2Fconcepts%2Fstorage%2Fpersistent-volumes%2F%23resizing-an-in-use-persistentvolumeclaim&amp;qzone=1&amp;margin=0&amp;size=200x200&amp;ecc=M" alt="Before (QR code)" /> <img src="https://user-images.githubusercontent.com/22591623/135768020-09559199-3dfc-4002-97d7-cf17a40f4ff4.png" alt="" /> <img src="http://api.qrserver.com/v1/create-qr-code/?color=000000&amp;bgcolor=FFFFFF&amp;data=https%3A%2F%2Fdeploy-preview-29910--kubernetes-io-main-staging.netlify.app%2Fdocs%2Fconcepts%2Fstorage%2Fpersistent-volumes%2F%23resizing-an-in-use-persistentvolumeclaim&amp;qzone=1&amp;margin=0&amp;size=200x200&amp;ecc=M" alt="After (QR code)" />
(before and after)

/area web-development

Fixes #29909