### PR TITLE
fix the constraint template for gatekeeper.

### DIFF
--- a/content/en/blog/_posts/2019-08-06-OPA-Gatekeeper-Policy-and-Governance-for-Kubernetes.md
+++ b/content/en/blog/_posts/2019-08-06-OPA-Gatekeeper-Policy-and-Governance-for-Kubernetes.md
@@ -81,7 +81,7 @@ spec:
       rego: |
         package k8srequiredlabels
 
-        deny[{"msg": msg, "details": {"missing_labels": missing}}] {
+        violation[{"msg": msg, "details": {"missing_labels": missing}}] {
           provided := {label | input.review.object.metadata.labels[label]}
           required := {label | label := input.parameters.labels[_]}
           missing := required - provided


### PR DESCRIPTION
Signed-off-by: Mohit Sharma <imoisharma@icloud.com>

On Reading the [OPA Gatekeeper: Policy and Governance for Kubernetes](https://kubernetes.io/blog/2019/08/06/opa-gatekeeper-policy-and-governance-for-kubernetes/) blog. One user finds it out it'd have the wrong syntax under the constraint template.  

Related Links: 
- Issues details can be found [here](https://github.com/kubernetes/website/issues/29597)
- How to write Contraint Template for OPA can be found [here](https://open-policy-agent.github.io/gatekeeper/website/docs/howto/#constraint-templates)

If have any concerns, feel free to comment down below. Thanks

Best Regards
Mohit Sharma
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->