### PR TITLE
Update cron-jobs.md

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/en/docs/concepts/workloads/controllers/cron-jobs.md
@@ -10,7 +10,7 @@ weight: 80
 
 <!-- overview -->
 
-{{< feature-state for_k8s_version="v1.21" state="stable" >}}
+{{< feature-state for_k8s_version="v1.22" state="stable" >}}
 
 A _CronJob_ creates {{< glossary_tooltip term_id="job" text="Jobs" >}} on a repeating schedule.
 


### PR DESCRIPTION
I did not find the CRON_TZ field in the source code of the k8s version before 1.22, but this document notes that it was written for the 1.21 version of k8s

