### PR TITLE
Fix approval rules for GitHub workflows

### DIFF
--- a/.github/workflows/OWNERS
+++ b/.github/workflows/OWNERS
@@ -3,6 +3,9 @@
 # When modifying this file, consider the security implications of
 # allowing listed reviewers / approvals to modify or remove any
 # configured GitHub Actions.
+#
+options:
+  no_parent_owners: true
 
 reviewers:
 - sig-docs-leads


### PR DESCRIPTION
Only SIG Docs leads (chairs + tech leads) should be able to approve changes to workflows.

Tweak rules so Prow knows this.