### PR TITLE
WIP: Replace taint master with control-plane

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -681,7 +681,7 @@ Each feature gate is designed for enabling/disabling a specific feature:
   This API augments the [resource allocation reporting](/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#monitoring-device-plugin-resources)
   with informations about the allocatable resources, enabling clients to properly track the free compute resources on a node.
 - `LegacyNodeRoleBehavior`: When disabled, legacy behavior in service load balancers and
-  node disruption will ignore the `node-role.kubernetes.io/master` label in favor of the
+  node disruption will ignore the `node-role.kubernetes.io/control-plane` label in favor of the
   feature-specific labels provided by `NodeDisruptionExclusion` and `ServiceNodeExclusion`.
 - `LocalStorageCapacityIsolation`: Enable the consumption of
   [local ephemeral storage](/docs/concepts/configuration/manage-resources-containers/)

--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -173,8 +173,8 @@ kubectl get configmap myconfig \
   -o jsonpath='{.data.ca\.crt}'
 
 # Get all worker nodes (use a selector to exclude results that have a label
-# named 'node-role.kubernetes.io/master')
-kubectl get node --selector='!node-role.kubernetes.io/master'
+# named 'node-role.kubernetes.io/control-plane')
+kubectl get node --selector='!node-role.kubernetes.io/control-plane'
 
 # Get all running pods in the namespace
 kubectl get pods --field-selector=status.phase=Running

--- a/content/en/docs/reference/setup-tools/kubeadm/implementation-details.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/implementation-details.md
@@ -354,8 +354,8 @@ Please note that:
 
 As soon as the control plane is available, kubeadm executes following actions:
 
-- Labels the node as control-plane with `node-role.kubernetes.io/master=""`
-- Taints the node with `node-role.kubernetes.io/master:NoSchedule`
+- Labels the node as control-plane with `node-role.kubernetes.io/control-plane=""`
+- Taints the node with `node-role.kubernetes.io/control-plane:NoSchedule`
 
 Please note that:
 

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init-phase.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init-phase.md
@@ -105,7 +105,7 @@ By default the certs and encryption key expire after two hours.
 
 ## kubeadm init phase mark-control-plane {#cmd-phase-mark-control-plane}
 
-Use the following phase to label and taint the node with the `node-role.kubernetes.io/master=""` key-value pair.
+Use the following phase to label and taint the node with the `node-role.kubernetes.io/control-plane=""` key-value pair.
 
 {{< tabs name="tab-mark-control-plane" >}}
 {{< tab name="mark-control-plane" include="generated/kubeadm_init_phase_mark-control-plane.md" />}}

--- a/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
@@ -271,18 +271,18 @@ reasons. If you want to be able to schedule Pods on the control-plane node, for 
 single-machine Kubernetes cluster for development, run:
 
 ```bash
-kubectl taint nodes --all node-role.kubernetes.io/master-
+kubectl taint nodes --all node-role.kubernetes.io/control-plane-
 ```
 
 With output looking something like:
 
 ```
 node "test-01" untainted
-taint "node-role.kubernetes.io/master:" not found
-taint "node-role.kubernetes.io/master:" not found
+taint "node-role.kubernetes.io/control-plane:" not found
+taint "node-role.kubernetes.io/control-plane:" not found
 ```
 
-This will remove the `node-role.kubernetes.io/master` taint from any nodes that
+This will remove the `node-role.kubernetes.io/control-plane` taint from any nodes that
 have it, including the control-plane node, meaning that the scheduler will then be able
 to schedule Pods everywhere.
 

--- a/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
@@ -343,7 +343,7 @@ A known solution is to patch the kube-proxy DaemonSet to allow scheduling it on 
 nodes regardless of their conditions, keeping it off of other nodes until their initial guarding
 conditions abate:
 ```
-kubectl -n kube-system patch ds kube-proxy -p='{ "spec": { "template": { "spec": { "tolerations": [ { "key": "CriticalAddonsOnly", "operator": "Exists" }, { "effect": "NoSchedule", "key": "node-role.kubernetes.io/master" } ] } } } }'
+kubectl -n kube-system patch ds kube-proxy -p='{ "spec": { "template": { "spec": { "tolerations": [ { "key": "CriticalAddonsOnly", "operator": "Exists" }, { "effect": "NoSchedule", "key": "node-role.kubernetes.io/control-plane" } ] } } } }'
 ```
 
 The tracking issue for this problem is [here](https://github.com/kubernetes/kubeadm/issues/1027).
@@ -352,17 +352,17 @@ The tracking issue for this problem is [here](https://github.com/kubernetes/kube
 
 *Note: This [issue](https://github.com/kubernetes/kubeadm/issues/1358) only applies to tools that marshal kubeadm types (e.g. to a YAML configuration file). It will be fixed in kubeadm API v1beta2.*
 
-By default, kubeadm applies the `node-role.kubernetes.io/master:NoSchedule` taint to control-plane nodes.
+By default, kubeadm applies the `node-role.kubernetes.io/control-plane:NoSchedule` taint to control-plane nodes.
 If you prefer kubeadm to not taint the control-plane node, and set `InitConfiguration.NodeRegistration.Taints` to an empty slice,
 the field will be omitted when marshalling. When the field is omitted, kubeadm applies the default taint.
 
 There are at least two workarounds:
 
-1. Use the `node-role.kubernetes.io/master:PreferNoSchedule` taint instead of an empty slice. [Pods will get scheduled on masters](/docs/concepts/scheduling-eviction/taint-and-toleration/), unless other nodes have capacity.
+1. Use the `node-role.kubernetes.io/control-plane:PreferNoSchedule` taint instead of an empty slice. [Pods will get scheduled on masters](/docs/concepts/scheduling-eviction/taint-and-toleration/), unless other nodes have capacity.
 
 2. Remove the taint after kubeadm init exits:
 ```bash
-kubectl taint nodes NODE_NAME node-role.kubernetes.io/master:NoSchedule-
+kubectl taint nodes NODE_NAME node-role.kubernetes.io/control-plane:NoSchedule-
 ```
 
 ## `/usr` is mounted read-only on nodes {#usr-mounted-read-only}

--- a/content/en/examples/admin/cloud/ccm-example.yaml
+++ b/content/en/examples/admin/cloud/ccm-example.yaml
@@ -1,5 +1,5 @@
 # This is an example of how to setup cloud-controller-manager as a Daemonset in your cluster.
-# It assumes that your masters can run pods and has the role node-role.kubernetes.io/master
+# It assumes that your control-planes can run pods and has the role node-role.kubernetes.io/control-plane
 # Note that this Daemonset will not work straight out of the box for your cloud, this is
 # meant to be a guideline.
 
@@ -59,11 +59,11 @@ spec:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         value: "true"
         effect: NoSchedule
-      # this is to have the daemonset runnable on master nodes
+      # this is to have the daemonset runnable on control-plane nodes
       # the taint may vary depending on your cluster setup
-      - key: node-role.kubernetes.io/master
+      - key: node-role.kubernetes.io/control-plane
         effect: NoSchedule
-      # this is to restrict CCM to only run on master nodes
+      # this is to restrict CCM to only run on control-plane nodes
       # the node selector may vary depending on your cluster setup
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""

--- a/content/en/examples/controllers/daemonset.yaml
+++ b/content/en/examples/controllers/daemonset.yaml
@@ -15,9 +15,9 @@ spec:
         name: fluentd-elasticsearch
     spec:
       tolerations:
-      # this toleration is to have the daemonset runnable on master nodes
-      # remove it if your masters can't run pods
-      - key: node-role.kubernetes.io/master
+      # this toleration is to have the daemonset runnable on control-plane nodes
+      # remove it if your control-planes can't run pods
+      - key: node-role.kubernetes.io/control-plane
         effect: NoSchedule
       containers:
       - name: fluentd-elasticsearch

--- a/content/en/examples/controllers/fluentd-daemonset-update.yaml
+++ b/content/en/examples/controllers/fluentd-daemonset-update.yaml
@@ -19,9 +19,9 @@ spec:
         name: fluentd-elasticsearch
     spec:
       tolerations:
-      # this toleration is to have the daemonset runnable on master nodes
-      # remove it if your masters can't run pods
-      - key: node-role.kubernetes.io/master
+      # this toleration is to have the daemonset runnable on control-plane nodes
+      # remove it if your control-planes can't run pods
+      - key: node-role.kubernetes.io/control-plane
         effect: NoSchedule
       containers:
       - name: fluentd-elasticsearch

--- a/content/en/examples/controllers/fluentd-daemonset.yaml
+++ b/content/en/examples/controllers/fluentd-daemonset.yaml
@@ -19,9 +19,9 @@ spec:
         name: fluentd-elasticsearch
     spec:
       tolerations:
-      # this toleration is to have the daemonset runnable on master nodes
-      # remove it if your masters can't run pods
-      - key: node-role.kubernetes.io/master
+      # this toleration is to have the daemonset runnable on control-plane nodes
+      # remove it if your control-planes can't run pods
+      - key: node-role.kubernetes.io/control-plane
         effect: NoSchedule
       containers:
       - name: fluentd-elasticsearch


### PR DESCRIPTION
Since kubeadm v1.20, a label "node-role.kubernetes.io/control-plane" has been introduced as [1].
In addition, the label "node-role.kubernetes.io/master" has been deprecated.
This updates the related pages for newer versions.

https://github.com/kubernetes/kubernetes/blob/b28bf04cd054a285e553b146c6cdd934afefeef0/CHANGELOG/CHANGELOG-1.20.md#urgent-upgrade-notes
