### PR TITLE
releng: Bump oct patch release one week later

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -1,8 +1,8 @@
 schedules:
 - release: 1.22
   next: 1.22.3
-  cherryPickDeadline: 2021-10-15
-  targetDate: 2021-10-20
+  cherryPickDeadline: 2021-10-22
+  targetDate: 2021-10-27
   endOfLifeDate: 2022-10-28
   previousPatches:
     - release: 1.22.2
@@ -13,8 +13,8 @@ schedules:
       targetDate: 2021-08-19
 - release: 1.21
   next: 1.21.6
-  cherryPickDeadline: 2021-10-15
-  targetDate: 2021-10-20
+  cherryPickDeadline: 2021-10-22
+  targetDate: 2021-10-27
   endOfLifeDate: 2022-06-28
   previousPatches:
     - release: 1.21.5
@@ -35,8 +35,8 @@ schedules:
       note: Regression https://groups.google.com/g/kubernetes-dev/c/KuF8s2zueFs
 - release: 1.20
   next: 1.20.12
-  cherryPickDeadline: 2021-10-15
-  targetDate: 2021-10-20
+  cherryPickDeadline: 2021-10-22
+  targetDate: 2021-10-27
   endOfLifeDate: 2022-02-28
   previousPatches:
     - release: 1.20.11


### PR DESCRIPTION
As the cherry-pick deadline for October '21 lands right during KubeCon
week, SIG Release decided to move the patch releases one week later.

This PR modifies the dates in the schedule data file.

/assign @justaugustus @jeremyrickard @jimangel 
/cc @kubernetes/release-engineering 

/priority critical-urgent

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>
