### PR TITLE
Update blog post to include the fix version and fix the link to the PR

### DIFF
--- a/content/en/blog/_posts/2019-03-29-kube-proxy-subtleties-debugging-an-intermittent-connection-resets.md
+++ b/content/en/blog/_posts/2019-03-29-kube-proxy-subtleties-debugging-an-intermittent-connection-resets.md
@@ -144,10 +144,9 @@ ways to address it.
 - Specifically add an iptables rule to drop the packets that are marked as
   *INVALID*, so it won’t reach to client pod and cause harm.
 
-The fix is drafted (https://github.com/kubernetes/kubernetes/pull/74840), but
-unfortunately it didn’t catch the v1.14 release window. However, for the users
-that are affected by this bug, there is a way to mitigate the problem by applying
-the following rule in your cluster.
+The [fix](https://github.com/kubernetes/kubernetes/pull/74840) is available in v1.15+.
+However, for the users that are affected by this bug, there is a way to mitigate the
+problem by applying the following rule in your cluster.
 
 ```yaml
 apiVersion: extensions/v1beta1


### PR DESCRIPTION
Signed-off-by: Charles Pretzer <charles@charlespretzer.com>

The blog post rendered the link as `https://github.com/kubernetes/kubernetes/pull/74840),` which resulted in a 404 error when clicking through to the link.

This PR updates the doc to use markdown syntax for the link and changes the language to describe that the fix is in k8s v1.15+

