### PR TITLE
releng: update patch release dates for 1.19

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -76,11 +76,14 @@ schedules:
       targetDate: 2020-12-18
       note: "Tagging Issue https://groups.google.com/g/kubernetes-dev/c/dNH2yknlCBA"
 - release: 1.19
-  next: 1.19.15
-  cherryPickDeadline: 2021-09-10
-  targetDate: 2021-09-15
+  next: 1.19.16
+  cherryPickDeadline: 2021-10-22
+  targetDate: 2021-10-27
   endOfLifeDate: 2021-10-28
   previousPatches:
+    - release: 1.19.15
+      cherryPickDeadline: 2021-09-10
+      targetDate: 2021-09-15
     - release: 1.19.14
       cherryPickDeadline: 2021-08-07
       targetDate: 2021-08-11


### PR DESCRIPTION
Follow up of https://github.com/kubernetes/website/pull/29937 / https://github.com/kubernetes/website/pull/29939

add missing data for 1.19 patch release

/assign @puerco @saschagrunert @Verolop @xmudrii 
cc @kubernetes/release-managers 
