### PR TITLE
[ko] Update outdated files in dev-1.22-ko.1 (D1-D2)

### DIFF
--- a/content/ko/docs/concepts/cluster-administration/kubelet-garbage-collection.md
+++ b/content/ko/docs/concepts/cluster-administration/kubelet-garbage-collection.md
@@ -6,6 +6,18 @@ weight: 70
 
 <!-- overview -->
 
+
+{{< note >}}
+이 한글 문서는 더 이상 관리되지 않습니다.
+
+이 문서의 기반이 된 영어 원문은 삭제되었으며,
+[Garbage Collection](/docs/concepts/architecture/garbage-collection/)에 병합되었습니다.
+
+[Garbage Collection](/docs/concepts/architecture/garbage-collection/)의 한글화가 완료되면,
+이 문서는 삭제될 수 있습니다.
+{{< /note >}}
+
+
 가비지 수집은 사용되지 않는 
 [이미지](/ko/docs/concepts/containers/#컨테이너-이미지)들과 
 [컨테이너](/ko/docs/concepts/containers/)들을 정리하는 kubelet의 유용한 기능이다. Kubelet은 

--- a/content/ko/docs/concepts/workloads/controllers/garbage-collection.md
+++ b/content/ko/docs/concepts/workloads/controllers/garbage-collection.md
@@ -6,6 +6,18 @@ weight: 60
 
 <!-- overview -->
 
+
+{{< note >}}
+이 한글 문서는 더 이상 관리되지 않습니다.
+
+이 문서의 기반이 된 영어 원문은 삭제되었으며,
+[Garbage Collection](/docs/concepts/architecture/garbage-collection/)에 병합되었습니다.
+
+[Garbage Collection](/docs/concepts/architecture/garbage-collection/)의 한글화가 완료되면,
+이 문서는 삭제될 수 있습니다.
+{{< /note >}}
+
+
 쿠버네티스의 가비지 수집기는 한때 소유자가 있었지만, 더 이상
 소유자가 없는 오브젝트들을 삭제하는 역할을 한다.
 


### PR DESCRIPTION
Partially fix: #29257

1. [x] D1.  `content/en/docs/concepts/cluster-administration/kubelet-garbage-collection.md`
1. [x] D2.  `content/en/docs/concepts/workloads/controllers/garbage-collection.md`

#### 처리 방법 참고
두 영문 문서는 main branch에서 삭제되었고, 다른 문서(https://kubernetes.io/docs/concepts/architecture/garbage-collection/)에 병합되었습니다. ([관련PR](https://github.com/kubernetes/website/pull/28870/files))

관련 한글 문서는 삭제하는 형태로 갱신해왔으나, 해당 문서를 단순 삭제하면 향후 
https://kubernetes.io/docs/concepts/architecture/garbage-collection/ 번역 시, 기 번역된 자료를 활용하기가 어려움으로

이 문서들을 삭제하지 않고, 다음과 같은 노트를 추가하는 방식으로 처리해 보았습니다.

```
{{< note >}}
한글 문서 관련 알림: 이 문서의 기반이 된 영어 원문은 삭제되었으며,
[Garbage Collection](/docs/concepts/architecture/garbage-collection/)에 병합되었습니다.
[Garbage Collection](/docs/concepts/architecture/garbage-collection/)의 한글화가 완료되면,
이 문서는 삭제될 수 있습니다.
{{< /note >}}
```
