### PR TITLE
fixed the spacing for IANA standard service name link.

### DIFF
--- a/content/en/docs/reference/kubernetes-api/service-resources/service-v1.md
+++ b/content/en/docs/reference/kubernetes-api/service-resources/service-v1.md
@@ -100,7 +100,7 @@ ServiceSpec describes the attributes that a user creates on a service.
 
   - **ports.appProtocol** (string)
 
-    The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names ). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+    The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml ). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.
 
 - **type** (string)
 


### PR DESCRIPTION
There was a spacing issue with the IANA standard service name link, which is now fixed and tested. In addition, I also notice, this `service-v1.md` is not written in a proper format. If you reviewers and maintainers are happy. I can propose a better way to write this file and create a separate PR as a newly proposed solution.

Issue details can be found [here](https://github.com/kubernetes/website/issues/29986)

Signed-off-by: Mohit Sharma <imoisharma@icloud.com>