### PR TITLE
replaced link from api-beta2 to api-beta3

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -127,7 +127,7 @@ If your configuration is not using the latest version it is **recommended** that
 the [kubeadm config migrate](/docs/reference/setup-tools/kubeadm/kubeadm-config/) command.
 
 For more information on the fields and usage of the configuration you can navigate to our
-[API reference page](/docs/reference/config-api/kubeadm-config.v1beta2/).
+[API reference page](/docs/reference/config-api/kubeadm-config.v1beta3/).
 
 ### Adding kube-proxy parameters {#kube-proxy}
 


### PR DESCRIPTION

This pull request solves issue #30040 
This changes the API reference link from [API-beta2](https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta2/) to [API-beta3](https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta3/), on page https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file

> For more information on the fields and usage of the configuration you can navigate to our ***API reference page***.