### PR TITLE
Use Docsy alert classes

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -313,33 +313,40 @@ main {
 
 // blockquotes and callouts
 
-.td-content, body {
-  blockquote.callout {
+body {
+  .alert {
+    // Override Docsy styles
     padding: 0.4rem 0.4rem 0.4rem 1rem;
-    border: 1px solid #eee;
-    border-left-width: 0.5em;
+    border-top: 1px solid #eee;
+    border-bottom: 1px solid #eee;
+    border-right: 1px solid #eee;
+    border-radius: 0.25em;
+    border-left-width: 0.5em; // fallback in case calc() is missing
     background: #fff;
     color: #000;
     margin-top: 0.5em;
     margin-bottom: 0.5em;
   }
-  blockquote.callout {
-    border-radius: calc(1em/3);
+  // Set minimum width and radius for alert color
+  .alert {
+      border-left-width: calc(max(0.5em, 4px));
+      border-top-left-radius: calc(max(0.5em, 4px));
+      border-bottom-left-radius: calc(max(0.5em, 4px));
   }
-  .callout.caution {
+  .alert.callout.caution {
     border-left-color: #f0ad4e;
   }
-
-  .callout.note {
+  .alert.callout.note {
     border-left-color: #428bca;
   }
-
-  .callout.warning {
+  .alert.callout.warning {
     border-left-color: #d9534f;
   }
+  .alert.third-party-content {
+    border-left-color: #444;
+  }
 
-
-  h1:first-of-type + blockquote.callout {
+  h1:first-of-type + .alert.callout {
     margin-top: 1.5em;
   }
 }
@@ -367,7 +374,7 @@ main {
   background: #f8f9cb;
 }
 
-.deprecation-warning {
+.deprecation-warning, .pageinfo.deprecation-warning {
     padding: 20px;
     margin: 20px 0;
     background-color: #faf5b6;

--- a/layouts/partials/deprecation-warning.html
+++ b/layouts/partials/deprecation-warning.html
@@ -1,6 +1,6 @@
 {{ if (.Site.Param "deprecated") }}
 <section id="deprecation-warning">
-  <div class="content deprecation-warning">
+  <div class="content deprecation-warning pageinfo">
     <h3>
       {{ T "deprecation_title" }} {{ .Param "version" }}
     </h3>

--- a/layouts/shortcodes/caution.html
+++ b/layouts/shortcodes/caution.html
@@ -1,3 +1,3 @@
-<blockquote class="caution callout">
-  <div><strong>{{ T "caution" }}</strong> {{ trim .Inner " \n" | markdownify }}</div>
-</blockquote>
+<div class="alert alert-warning caution callout" role="alert">
+  <strong>{{ T "caution" }}</strong> {{ trim .Inner " \n" | markdownify }}
+</div>

--- a/layouts/shortcodes/note.html
+++ b/layouts/shortcodes/note.html
@@ -1,3 +1,3 @@
-<blockquote class="note callout">
-  <div><strong>{{ T "note" }}</strong> {{ trim .Inner " \n" | markdownify }}</div>
-</blockquote>
+<div class="alert alert-info note callout" role="alert">
+  <strong>{{ T "note" }}</strong> {{ trim .Inner " \n" | markdownify }}
+</div>

--- a/layouts/shortcodes/warning.html
+++ b/layouts/shortcodes/warning.html
@@ -1,3 +1,4 @@
-<blockquote class="warning callout">
-  <div><strong>{{ T "warning" }}</strong> {{ trim .Inner " \n" | markdownify }}</div>
-</blockquote>
+<div class="alert alert-danger warning callout" role="alert">
+  <strong>{{ T "warning" }}</strong> {{ trim .Inner " \n" | markdownify }}
+</div>
+


### PR DESCRIPTION
Update the Kubernetes overrides from the Docsy theme to diverge less, specifically in the areas of callouts (alerts) and pageinfo blocks.


The existing [shortcodes](https://kubernetes.io/docs/contribute/style/style-guide/#shortcodes) for note, caution and warning still work with this update. After this change, they share consistent styling with how we render [Docsy alerts](https://www.docsy.dev/docs/adding-content/shortcodes/#alert).

For a before-and-after view, compare https://kubernetes.io/docs/reference/tools/#helm to the [preview](https://deploy-preview-30068--kubernetes-io-main-staging.netlify.app/docs/reference/tools/#helm).

/kind cleanup
/area web-development