### PR TITLE
Update "multiple schedulers" example

### DIFF
--- a/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
+++ b/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
@@ -73,7 +73,7 @@ config. Save it as `my-scheduler.yaml`:
 
 In the above manifest, we have used a [Scheduler Configuration](/docs/reference/scheduling/config/)
 to customize the behavior of your scheduler implementation. This configuration has been passed to
-the `kube-scheduler` during initialization via its `--config` command line argument.
+the `kube-scheduler` during its initialization via `--config` command line argument.
 
 In the aforementioned Scheduler Configuration, your scheduler implementation has been represented via
 a [KubeSchedulerProfile](/docs/reference/config-api/kube-scheduler-config.v1beta2/#kubescheduler-config-k8s-io-v1beta2-KubeSchedulerProfile).
@@ -177,8 +177,8 @@ scheduler in that pod spec. Let's look at three examples.
   {{< codenew file="admin/sched/pod3.yaml" >}}
 
   In this case, we specify that this pod should be scheduled using the scheduler that we
-  deployed - `my-scheduler`. Note that the value of `spec.schedulerName` should match the name supplied to the scheduler
-  command as an argument in the deployment config for the scheduler.
+  deployed - `my-scheduler`. Note that the value of `spec.schedulerName` should match the name supplied for the scheduler
+  in the `schedulerName` field of the mapping `KubeSchedulerProfile` of the scheduler.
 
   Save this file as `pod3.yaml` and submit it to the Kubernetes cluster.
 

--- a/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
+++ b/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
@@ -182,7 +182,7 @@ scheduler in that pod spec. Let's look at three examples.
 
   In this case, we specify that this pod should be scheduled using the scheduler that we
   deployed - `my-scheduler`. Note that the value of `spec.schedulerName` should match the name supplied for the scheduler
-  in the `schedulerName` field of the mapping `KubeSchedulerProfile` of the scheduler.
+  in the `schedulerName` field of the mapping `KubeSchedulerProfile`.
 
   Save this file as `pod3.yaml` and submit it to the Kubernetes cluster.
 

--- a/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
+++ b/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
@@ -119,11 +119,11 @@ pod in this list.
 
 To run multiple-scheduler with leader election enabled, you must do the following:
 
-First, update the following fields in your YAML file:
+First, update the following fields in the Scheduler Configuration of your YAML file:
 
-* `--leader-elect=true`
-* `--lock-object-namespace=<lock-object-namespace>`
-* `--lock-object-name=<lock-object-name>`
+* `leaderElection.leaderElect` to `true`
+* `leaderElection.resourceNamespace` to `<lock-object-namespace>`
+* `leaderElection.resourceName` to `<lock-object-name>`
 
 {{< note >}}
 The control plane creates the lock objects for you, but the namespace must already exist.

--- a/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
+++ b/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
@@ -119,7 +119,11 @@ pod in this list.
 
 To run multiple-scheduler with leader election enabled, you must do the following:
 
-First, update the following fields in the Scheduler Configuration of your YAML file:
+First, update the scheduler configuration (earlier you applied a
+`my-scheduler.yaml` file that included a ConfigMap named `my-scheduler-config`; the
+scheduler configuration is in YAML format, within the `data` field of that ConfigMap).
+
+The fields to change in the inner KubeSchedulerConfiguration are:
 
 * `leaderElection.leaderElect` to `true`
 * `leaderElection.resourceNamespace` to `<lock-object-namespace>`

--- a/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
+++ b/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
@@ -71,7 +71,7 @@ config. Save it as `my-scheduler.yaml`:
 
 {{< codenew file="admin/sched/my-scheduler.yaml" >}}
 
-In the above manifest, we have used a [Scheduler Configuration](/docs/reference/scheduling/config/)
+In the above manifest, you use a [Scheduler Configuration](/docs/reference/scheduling/config/)
 to customize the behavior of your scheduler implementation. This configuration has been passed to
 the `kube-scheduler` during its initialization via `--config` command line argument. The configuration
 file has been embedded within the ConfigMap `my-scheduler-config` which has been injected to the scheduler

--- a/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
+++ b/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
@@ -73,9 +73,7 @@ config. Save it as `my-scheduler.yaml`:
 
 In the above manifest, you use a [Scheduler Configuration](/docs/reference/scheduling/config/)
 to customize the behavior of your scheduler implementation. This configuration has been passed to
-the `kube-scheduler` during its initialization via `--config` command line argument. The configuration
-file has been embedded within the ConfigMap `my-scheduler-config` which has been injected to the scheduler
-Deployment via a volume.
+the `kube-scheduler` during initialization with the `--config` option. The `my-scheduler-config` ConfigMap stores the configuration file. The Pod of the`my-scheduler` Deployment mounts the `my-scheduler-config` ConfigMap as a volume.
 
 In the aforementioned Scheduler Configuration, your scheduler implementation has been represented via
 a [KubeSchedulerProfile](/docs/reference/config-api/kube-scheduler-config.v1beta2/#kubescheduler-config-k8s-io-v1beta2-KubeSchedulerProfile).

--- a/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
+++ b/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
@@ -75,13 +75,15 @@ In the above manifest, you use a [Scheduler Configuration](/docs/reference/sched
 to customize the behavior of your scheduler implementation. This configuration has been passed to
 the `kube-scheduler` during initialization with the `--config` option. The `my-scheduler-config` ConfigMap stores the configuration file. The Pod of the`my-scheduler` Deployment mounts the `my-scheduler-config` ConfigMap as a volume.
 
-In the aforementioned Scheduler Configuration, your scheduler implementation has been represented via
+In the aforementioned Scheduler Configuration, your scheduler implementation is represented via
 a [KubeSchedulerProfile](/docs/reference/config-api/kube-scheduler-config.v1beta2/#kubescheduler-config-k8s-io-v1beta2-KubeSchedulerProfile).
-An important thing to note here is that the name of the scheduler specified via `schedulerName` field of the defined `KubeSchedulerProfile`,
-should be unique among all schedulers running in the cluster. This is the name that is matched against the value of the optional `spec.schedulerName` on pods, to determine whether
-this scheduler is responsible for scheduling a particular pod.
+{{< note >}}
+To determine if a scheduler is responsible for scheduling a specific Pod, the `spec.schedulerName` field in a 
+PodTemplate or Pod manifest must match the `schedulerName` field of the `KubeSchedulerProfile`.
+All schedulers running in the cluster must have unique names.
+{{< /note >}}
 
-Also, note that we created a dedicated service account `my-scheduler` and bound the cluster role
+Also, note that you create a dedicated service account `my-scheduler` and bind the ClusterRole
 `system:kube-scheduler` to it so that it can acquire the same privileges as `kube-scheduler`.
 
 Please see the

--- a/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
+++ b/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
@@ -73,12 +73,14 @@ config. Save it as `my-scheduler.yaml`:
 
 In the above manifest, we have used a [Scheduler Configuration](/docs/reference/scheduling/config/)
 to customize the behavior of your scheduler implementation. This configuration has been passed to
-the `kube-scheduler` during its initialization via `--config` command line argument.
+the `kube-scheduler` during its initialization via `--config` command line argument. The configuration
+file has been embedded within the ConfigMap `my-scheduler-config` which has been injected to the scheduler
+Deployment via a volume.
 
 In the aforementioned Scheduler Configuration, your scheduler implementation has been represented via
 a [KubeSchedulerProfile](/docs/reference/config-api/kube-scheduler-config.v1beta2/#kubescheduler-config-k8s-io-v1beta2-KubeSchedulerProfile).
 An important thing to note here is that the name of the scheduler specified via `schedulerName` field of the defined `KubeSchedulerProfile`,
-should be unique. This is the name that is matched against the value of the optional `spec.schedulerName` on pods, to determine whether
+should be unique among all schedulers running in the cluster. This is the name that is matched against the value of the optional `spec.schedulerName` on pods, to determine whether
 this scheduler is responsible for scheduling a particular pod.
 
 Also, note that we created a dedicated service account `my-scheduler` and bound the cluster role

--- a/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
+++ b/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
@@ -71,15 +71,24 @@ config. Save it as `my-scheduler.yaml`:
 
 {{< codenew file="admin/sched/my-scheduler.yaml" >}}
 
-An important thing to note here is that the name of the scheduler specified as an
-argument to the scheduler command in the container spec should be unique. This is the name that is matched against the value of the optional `spec.schedulerName` on pods, to determine whether this scheduler is responsible for scheduling a particular pod.
+In the above manifest, we have used a [Scheduler Configuration](/docs/reference/scheduling/config/)
+to customize the behavior of your scheduler implementation. This configuration has been passed to
+the `kube-scheduler` during initialization via its `--config` command line argument.
+
+In the aforementioned Scheduler Configuration, your scheduler implementation has been represented via
+a [KubeSchedulerProfile](/docs/reference/config-api/kube-scheduler-config.v1beta2/#kubescheduler-config-k8s-io-v1beta2-KubeSchedulerProfile).
+An important thing to note here is that the name of the scheduler specified via `schedulerName` field of the defined `KubeSchedulerProfile`,
+should be unique. This is the name that is matched against the value of the optional `spec.schedulerName` on pods, to determine whether
+this scheduler is responsible for scheduling a particular pod.
 
 Note also that we created a dedicated service account `my-scheduler` and bind the cluster role
 `system:kube-scheduler` to it so that it can acquire the same privileges as `kube-scheduler`.
 
 Please see the
 [kube-scheduler documentation](/docs/reference/command-line-tools-reference/kube-scheduler/) for
-detailed description of other command line arguments.
+detailed description of other command line arguments and
+[Scheduler Configuration reference](https://kubernetes.io/docs/reference/config-api/kube-scheduler-config.v1beta2/) for
+detailed description of other customizable `kube-scheduler` configurations.
 
 ## Run the second scheduler in the cluster
 

--- a/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
+++ b/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
@@ -121,11 +121,7 @@ pod in this list.
 
 To run multiple-scheduler with leader election enabled, you must do the following:
 
-First, update the scheduler configuration (earlier you applied a
-`my-scheduler.yaml` file that included a ConfigMap named `my-scheduler-config`; the
-scheduler configuration is in YAML format, within the `data` field of that ConfigMap).
-
-The fields to change in the inner KubeSchedulerConfiguration are:
+Update the following fields for the KubeSchedulerConfiguration in the `my-scheduler-config` ConfigMap in your YAML file:
 
 * `leaderElection.leaderElect` to `true`
 * `leaderElection.resourceNamespace` to `<lock-object-namespace>`

--- a/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
+++ b/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
@@ -81,7 +81,7 @@ An important thing to note here is that the name of the scheduler specified via 
 should be unique. This is the name that is matched against the value of the optional `spec.schedulerName` on pods, to determine whether
 this scheduler is responsible for scheduling a particular pod.
 
-Note also that we created a dedicated service account `my-scheduler` and bind the cluster role
+Also, note that we created a dedicated service account `my-scheduler` and bound the cluster role
 `system:kube-scheduler` to it so that it can acquire the same privileges as `kube-scheduler`.
 
 Please see the

--- a/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
+++ b/content/en/docs/tasks/extend-kubernetes/configure-multiple-schedulers.md
@@ -71,7 +71,7 @@ config. Save it as `my-scheduler.yaml`:
 
 {{< codenew file="admin/sched/my-scheduler.yaml" >}}
 
-In the above manifest, you use a [Scheduler Configuration](/docs/reference/scheduling/config/)
+In the above manifest, you use a [KubeSchedulerConfiguration](/docs/reference/scheduling/config/)
 to customize the behavior of your scheduler implementation. This configuration has been passed to
 the `kube-scheduler` during initialization with the `--config` option. The `my-scheduler-config` ConfigMap stores the configuration file. The Pod of the`my-scheduler` Deployment mounts the `my-scheduler-config` ConfigMap as a volume.
 

--- a/content/en/examples/admin/sched/my-scheduler.yaml
+++ b/content/en/examples/admin/sched/my-scheduler.yaml
@@ -32,6 +32,10 @@ roleRef:
 ---
 
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-scheduler-config
+  namespace: kube-system
 data:
   my-scheduler-config.yaml: |
     apiVersion: kubescheduler.config.k8s.io/v1beta2
@@ -40,10 +44,6 @@ data:
       - schedulerName: my-scheduler
     leaderElection:
       leaderElect: false
-kind: ConfigMap
-metadata:
-  name: my-scheduler-config
-  namespace: kube-system
 
 ---
 apiVersion: apps/v1

--- a/content/en/examples/admin/sched/my-scheduler.yaml
+++ b/content/en/examples/admin/sched/my-scheduler.yaml
@@ -96,6 +96,4 @@ spec:
       volumes:
         - name: config-volume
           configMap:
-            # Provide the name of the ConfigMap containing the files you want
-            # to add to the container
             name: my-scheduler-config

--- a/content/en/examples/admin/sched/my-scheduler.yaml
+++ b/content/en/examples/admin/sched/my-scheduler.yaml
@@ -30,6 +30,22 @@ roleRef:
   name: system:volume-scheduler
   apiGroup: rbac.authorization.k8s.io
 ---
+
+apiVersion: v1
+data:
+  my-scheduler-config.yaml: |
+    apiVersion: kubescheduler.config.k8s.io/v1beta2
+    kind: KubeSchedulerConfiguration
+    profiles:
+      - schedulerName: my-scheduler
+    leaderElection:
+      leaderElect: false
+kind: ConfigMap
+metadata:
+  name: my-scheduler-config
+  namespace: kube-system
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -55,9 +71,8 @@ spec:
       containers:
       - command:
         - /usr/local/bin/kube-scheduler
-        - --address=0.0.0.0
-        - --leader-elect=false
-        - --scheduler-name=my-scheduler
+        - --bind-address=0.0.0.0
+        - --config=/etc/kubernetes/my-scheduler/my-scheduler-config.yaml
         image: gcr.io/my-gcp-project/my-kube-scheduler:1.0
         livenessProbe:
           httpGet:
@@ -74,7 +89,14 @@ spec:
             cpu: '0.1'
         securityContext:
           privileged: false
-        volumeMounts: []
+        volumeMounts:
+          - name: config-volume
+            mountPath: /etc/kubernetes/my-scheduler
       hostNetwork: false
       hostPID: false
-      volumes: []
+      volumes:
+        - name: config-volume
+          configMap:
+            # Provide the name of the ConfigMap containing the files you want
+            # to add to the container
+            name: my-scheduler-config

--- a/content/en/examples/admin/sched/my-scheduler.yaml
+++ b/content/en/examples/admin/sched/my-scheduler.yaml
@@ -71,7 +71,6 @@ spec:
       containers:
       - command:
         - /usr/local/bin/kube-scheduler
-        - --bind-address=0.0.0.0
         - --config=/etc/kubernetes/my-scheduler/my-scheduler-config.yaml
         image: gcr.io/my-gcp-project/my-kube-scheduler:1.0
         livenessProbe:


### PR DESCRIPTION
**Description:**
Update multiple scheduler deployment example to align with changes introduced via `v1.22`. Addresses https://github.com/kubernetes/website/issues/29342.

**Test Environment:**
```
Client Version: version.Info{Major:"1", Minor:"21", GitVersion:"v1.21.1", GitCommit:"5e58841cce77d4bc13713ad2b91fa0d961e69192", GitTreeState:"clean", BuildDate:"2021-05-12T14:18:45Z", GoVersion:"go1.16.4", Compiler:"gc", Platform:"darwin/arm64"}
Server Version: version.Info{Major:"1", Minor:"22", GitVersion:"v1.22.1", GitCommit:"632ed300f2c34f6d6d15ca4cef3d3c7073412212", GitTreeState:"clean", BuildDate:"2021-08-20T00:45:19Z", GoVersion:"go1.16.7", Compiler:"gc", Platform:"linux/amd64"}
```
Furthermore, used the default `kube-scheduler` image `k8s.gcr.io/kube-scheduler:v1.22.0` for testing.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->