### PR TITLE
Revise seccomp tutorial

### DIFF
--- a/content/en/docs/tutorials/clusters/seccomp.md
+++ b/content/en/docs/tutorials/clusters/seccomp.md
@@ -17,7 +17,7 @@ Seccomp stands for secure computing mode and has been a feature of the Linux
 kernel since version 2.6.12. It can be used to sandbox the privileges of a
 process, restricting the calls it is able to make from userspace into the
 kernel. Kubernetes lets you automatically apply seccomp profiles loaded onto a
-Node to your Pods and containers.
+{{< glossary_tooltip text="node" term_id="node" >}} to your Pods and containers.
 
 Identifying the privileges required for your workloads can be difficult. In this
 tutorial, you will go through how to load seccomp profiles into a local

--- a/content/en/docs/tutorials/clusters/seccomp.md
+++ b/content/en/docs/tutorials/clusters/seccomp.md
@@ -57,7 +57,7 @@ run as `Unconfined`.
 <!-- steps -->
 
 
-## Create Seccomp Profiles
+## Download example seccomp profiles {#download-profiles}
 
 The contents of these profiles will be explored later on, but for now go ahead
 and download them into a directory named `profiles/` so that they can be loaded
@@ -91,7 +91,7 @@ audit.json  fine-grained.json  violation.json
 ```
 
 
-## Create a Local Kubernetes Cluster with kind
+## Create a local Kubernetes cluster with kind
 
 
 For simplicity, [kind](https://kind.sigs.k8s.io/) can be used to create a single
@@ -309,7 +309,7 @@ kubectl delete service audit-pod --wait
 kubectl delete pod audit-pod --wait --now
 ```
 
-## Create Pod with seccomp Profile that Causes Violation
+## Create Pod with seccomp profile that causes violation
 
 For demonstration, apply a profile to the Pod that does not allow for any
 syscalls.
@@ -349,7 +349,7 @@ kubectl delete service violation-pod --wait
 kubectl delete pod violation-pod --wait --now
 ```
 
-## Create Pod with seccomp Profile that Only Allows Necessary Syscalls
+## Create Pod with seccomp profile that only allows necessary syscalls
 
 If you take a look at the `fine-pod.json`, you will notice some of the syscalls
 seen in the first example where the profile set `"defaultAction":
@@ -428,7 +428,7 @@ kubectl delete service fine-pod --wait
 kubectl delete pod fine-pod --wait --now
 ```
 
-## Create Pod that uses the Container Runtime Default seccomp Profile
+## Create Pod that uses the container runtime default seccomp profile
 
 Most container runtimes provide a sane set of default syscalls that are allowed
 or not. You can adopt these defaults for your workload by setting the seccomp

--- a/content/en/docs/tutorials/clusters/seccomp.md
+++ b/content/en/docs/tutorials/clusters/seccomp.md
@@ -344,7 +344,7 @@ only the privileges they need.
 
 Clean up that Pod and Service before moving to the next section:
 
-```
+```shell
 kubectl delete service violation-pod --wait
 kubectl delete pod violation-pod --wait --now
 ```
@@ -431,13 +431,39 @@ kubectl delete pod fine-pod --wait --now
 ## Create Pod that uses the Container Runtime Default seccomp Profile
 
 Most container runtimes provide a sane set of default syscalls that are allowed
-or not. The defaults can easily be applied in Kubernetes by using the
-`runtime/default` annotation or setting the seccomp type in the security context
-of a pod or container to `RuntimeDefault`.
+or not. You can adopt these defaults for your workload by setting the seccomp
+type in the security context of a pod or container to `RuntimeDefault`.
+
+{{< note >}}
+If you have the `SeccompDefault` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) enabled, then Pods use the `RuntimeDefault` seccomp profile whenever
+no other seccomp profile is specified. Otherwise, the default is `Unconfined`.
+{{< /note >}}
+
+Here's a manifest for a Pod that requests the `RuntimeDefault` seccomp profile
+for all its containers:
 
 {{< codenew file="pods/security/seccomp/ga/default-pod.yaml" >}}
 
-The default seccomp profile should provide adequate access for most workloads.
+Create that Pod:
+```shell
+kubectl apply -f https://k8s.io/examples/pods/security/seccomp/ga/default-pod.yaml
+```
+
+```shell
+kubectl get pod default-pod
+```
+
+The Pod should be showing as having started successfully:
+```
+NAME        READY   STATUS    RESTARTS   AGE
+default-pod 1/1     Running   0          20s
+```
+
+Finally, now that you saw that work OK, clean up:
+
+```shell
+kubectl delete pod default-pod --wait --now
+```
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/examples/pods/security/seccomp/ga/default-pod.yaml
+++ b/content/en/examples/pods/security/seccomp/ga/default-pod.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: audit-pod
+  name: default-pod
   labels:
-    app: audit-pod
+    app: default-pod
 spec:
   securityContext:
     seccompProfile:
@@ -12,6 +12,6 @@ spec:
   - name: test-container
     image: hashicorp/http-echo:0.2.3
     args:
-    - "-text=just made some syscalls!"
+    - "-text=just made some more syscalls!"
     securityContext:
       allowPrivilegeEscalation: false


### PR DESCRIPTION
Revise https://kubernetes.io/docs/tutorials/clusters/seccomp/ (for v1.23) [[preview](https://deploy-preview-30109--kubernetes-io-main-staging.netlify.app/docs/tutorials/clusters/seccomp/)]

- drop documentation for v1.18 and earlier as these won't be supported any more
- `kubectl` has a built-in HTTP client; use that rather than `curl` first
- reorder the advice so that we mention installing `kind` before configuring it with the `SeccompDefault` feature gate
- fix the name of the `RuntimeDefault` example Pod
- other tidying

/milestone 1.23
/sig node
/sig security
/kind cleanup
/language en