### PR TITLE
Add immediate pod deletion to cheat sheet 

### DIFF
--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -289,10 +289,11 @@ kubectl scale --replicas=5 rc/foo rc/bar rc/baz                   # Scale multip
 ## Deleting resources
 
 ```bash
-kubectl delete -f ./pod.json                                              # Delete a pod using the type and name specified in pod.json
-kubectl delete pod,service baz foo                                        # Delete pods and services with same names "baz" and "foo"
-kubectl delete pods,services -l name=myLabel                              # Delete pods and services with label name=myLabel
-kubectl -n my-ns delete pod,svc --all                                      # Delete all pods and services in namespace my-ns,
+kubectl delete -f ./pod.json                                      # Delete a pod using the type and name specified in pod.json
+kubectl delete pod unwanted --now                                 # Delete a pod with no grace period
+kubectl delete pod,service baz foo                                # Delete pods and services with same names "baz" and "foo"
+kubectl delete pods,services -l name=myLabel                      # Delete pods and services with label name=myLabel
+kubectl -n my-ns delete pod,svc --all                             # Delete all pods and services in namespace my-ns,
 # Delete all pods matching the awk pattern1 or pattern2
 kubectl get pods  -n mynamespace --no-headers=true | awk '/pattern1|pattern2/{print $1}' | xargs  kubectl delete -n mynamespace pod
 ```


### PR DESCRIPTION
`kubectl delete pod unwanted --now` [[preview](https://deploy-preview-30110--kubernetes-io-main-staging.netlify.app/cheatsheet/#deleting-resources)]

From the build-in `kubectl` help:
```
      --now=false: If true, resources are signaled for immediate shutdown (same
as --grace-period=1).
```


/kind feature
/sig cli