### PR TITLE
Update kubeadm-upgrade.md

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -81,7 +81,8 @@ Pick a control plane node that you wish to upgrade first. It must have the `/etc
     -
     # since apt-get version 1.1 you can also use the following method
     apt-get update && \
-    apt-get install -y --allow-change-held-packages kubeadm={{< skew currentVersion >}}.x-00
+    apt-get install -y --allow-change-held-packages kubeadm={{< skew currentVersion >}}.x-00 && \
+    apt-mark hold kubeadm
 {{% /tab %}}
 {{% tab name="CentOS, RHEL or Fedora" %}}
     # replace x in {{< skew currentVersion >}}.x-0 with the latest patch version
@@ -178,7 +179,8 @@ Also calling `kubeadm upgrade plan` and upgrading the CNI provider plugin is no 
     -
     # since apt-get version 1.1 you can also use the following method
     apt-get update && \
-    apt-get install -y --allow-change-held-packages kubelet={{< skew currentVersion >}}.x-00 kubectl={{< skew currentVersion >}}.x-00
+    apt-get install -y --allow-change-held-packages kubelet={{< skew currentVersion >}}.x-00 kubectl={{< skew currentVersion >}}.x-00 && \
+    apt-mark hold kubelet kubectl
 {{% /tab %}}
 {{% tab name="CentOS, RHEL or Fedora" %}}
     # replace x in {{< skew currentVersion >}}.x-0 with the latest patch version

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -78,11 +78,6 @@ Pick a control plane node that you wish to upgrade first. It must have the `/etc
     apt-mark unhold kubeadm && \
     apt-get update && apt-get install -y kubeadm={{< skew currentVersion >}}.x-00 && \
     apt-mark hold kubeadm
-    -
-    # since apt-get version 1.1 you can also use the following method
-    apt-get update && \
-    apt-get install -y --allow-change-held-packages kubeadm={{< skew currentVersion >}}.x-00 && \
-    apt-mark hold kubeadm
 {{% /tab %}}
 {{% tab name="CentOS, RHEL or Fedora" %}}
     # replace x in {{< skew currentVersion >}}.x-0 with the latest patch version
@@ -176,11 +171,6 @@ Also calling `kubeadm upgrade plan` and upgrading the CNI provider plugin is no 
     apt-mark unhold kubelet kubectl && \
     apt-get update && apt-get install -y kubelet={{< skew currentVersion >}}.x-00 kubectl={{< skew currentVersion >}}.x-00 && \
     apt-mark hold kubelet kubectl
-    -
-    # since apt-get version 1.1 you can also use the following method
-    apt-get update && \
-    apt-get install -y --allow-change-held-packages kubelet={{< skew currentVersion >}}.x-00 kubectl={{< skew currentVersion >}}.x-00 && \
-    apt-mark hold kubelet kubectl
 {{% /tab %}}
 {{% tab name="CentOS, RHEL or Fedora" %}}
     # replace x in {{< skew currentVersion >}}.x-0 with the latest patch version
@@ -220,11 +210,6 @@ without compromising the minimum required capacity for running your workloads.
     apt-mark unhold kubeadm && \
     apt-get update && apt-get install -y kubeadm={{< skew currentVersion >}}.x-00 && \
     apt-mark hold kubeadm
-    -
-    # since apt-get version 1.1 you can also use the following method
-    apt-get update && \
-    apt-get install -y --allow-change-held-packages kubeadm={{< skew currentVersion >}}.x-00 && \
-    apt-mark hold kubeadm
 {{% /tab %}}
 {{% tab name="CentOS, RHEL or Fedora" %}}
     # replace x in {{< skew currentVersion >}}.x-0 with the latest patch version
@@ -258,11 +243,6 @@ without compromising the minimum required capacity for running your workloads.
     # replace x in {{< skew currentVersion >}}.x-00 with the latest patch version
     apt-mark unhold kubelet kubectl && \
     apt-get update && apt-get install -y kubelet={{< skew currentVersion >}}.x-00 kubectl={{< skew currentVersion >}}.x-00 && \
-    apt-mark hold kubelet kubectl
-    -
-    # since apt-get version 1.1 you can also use the following method
-    apt-get update && \
-    apt-get install -y --allow-change-held-packages kubelet={{< skew currentVersion >}}.x-00 kubectl={{< skew currentVersion >}}.x-00 && \
     apt-mark hold kubelet kubectl
 {{% /tab %}}
 {{% tab name="CentOS, RHEL or Fedora" %}}

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -223,7 +223,8 @@ without compromising the minimum required capacity for running your workloads.
     -
     # since apt-get version 1.1 you can also use the following method
     apt-get update && \
-    apt-get install -y --allow-change-held-packages kubeadm={{< skew currentVersion >}}.x-00
+    apt-get install -y --allow-change-held-packages kubeadm={{< skew currentVersion >}}.x-00 && \
+    apt-mark hold kubeadm
 {{% /tab %}}
 {{% tab name="CentOS, RHEL or Fedora" %}}
     # replace x in {{< skew currentVersion >}}.x-0 with the latest patch version
@@ -261,7 +262,8 @@ without compromising the minimum required capacity for running your workloads.
     -
     # since apt-get version 1.1 you can also use the following method
     apt-get update && \
-    apt-get install -y --allow-change-held-packages kubelet={{< skew currentVersion >}}.x-00 kubectl={{< skew currentVersion >}}.x-00
+    apt-get install -y --allow-change-held-packages kubelet={{< skew currentVersion >}}.x-00 kubectl={{< skew currentVersion >}}.x-00 && \
+    apt-mark hold kubelet kubectl
 {{% /tab %}}
 {{% tab name="CentOS, RHEL or Fedora" %}}
     # replace x in {{< skew currentVersion >}}.x-0 with the latest patch version


### PR DESCRIPTION
`apt-mark hold` is still required when `apt-get` is used with `--allow-change-held-packages`.

`--allow-change-held-packages` unholds the package but it doesn't pin the new version.

After feedback in the PR it was decided to remove these examples completely.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
