### PR TITLE
Added CSS to improve user experience with docs and reduce wasted space

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -378,6 +378,12 @@ body.td-home .deprecation-warning, body.td-blog .deprecation-warning, body.td-do
     border-radius: 3px;
 }
 
+
+.td-documentation .td-content > .highlight {
+  max-width: initial;
+  width: 100%;
+}
+
 body.td-home #deprecation-warning {
     max-width: 1000px;
     margin-top: 2.5rem;


### PR DESCRIPTION
Hi,

First-time contributor here, feel free to correct me.

Description: Fixes #30097 
This change will improve the width used by the text/code blocks in the existing docs
https://kubernetes.io/docs/reference/kubectl/cheatsheet/

Before
![image](https://user-images.githubusercontent.com/8469842/137912774-5c3646d8-45b8-40ec-b407-97b0e54dd838.png)

After
![image](https://user-images.githubusercontent.com/8469842/137912830-487cd7f1-710b-4872-acd3-52394a462a84.png)

Regards,
Leon.
