### PR TITLE
kubeadm/TS guide: fix a misleading step about cert rotation

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
@@ -224,9 +224,17 @@ the `ca.key` you must sign the embedded certificates in the `kubelet.conf` exter
 1. Copy this resulted `kubelet.conf` to `/etc/kubernetes/kubelet.conf` on the failed node.
 1. Restart the kubelet (`systemctl restart kubelet`) on the failed node and wait for
 `/var/lib/kubelet/pki/kubelet-client-current.pem` to be recreated.
-1. Run `kubeadm init phase kubelet-finalize all` on the failed node. This will make the new
-`kubelet.conf` file use `/var/lib/kubelet/pki/kubelet-client-current.pem` and will restart the kubelet.
+1. Manually edit the `kubelet.conf` to point to the rotated kubelet client certificates, by replacing
+`client-certificate-data` and `client-key-data` with:
+
+    ```yaml
+    client-certificate: /var/lib/kubelet/pki/kubelet-client-current.pem
+    client-key: /var/lib/kubelet/pki/kubelet-client-current.pem
+    ```
+
+1. Restart the kubelet.
 1. Make sure the node becomes `Ready`.
+
 ## Default NIC When using flannel as the pod network in Vagrant
 
 The following error might indicate that something was wrong in the pod network:


### PR DESCRIPTION
The "kubelet-finalize" step does not work on worker nodes,
because commonly they do not have the cluster CA key and all
"init" phases have a pre-step to check for the existence of
the CA key, designating the cluster as one that uses external CA
or not.

Changing this behavior is complicated in kubeadm, thus manually
instruct the user how to do edit the file and to restart the kubelet.

This is already what we do in:
https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-certs/#check-certificate-expiration

xref https://kubernetes.slack.com/archives/C2P1JHS2E/p1634632991154100

preview:
https://deploy-preview-30146--kubernetes-io-main-staging.netlify.app/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm/#kubelet-client-cert
