### PR TITLE
Notify deletion of Kubelet Bootstrap Token

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/kubelet-integration.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/kubelet-integration.md
@@ -151,8 +151,10 @@ systemctl daemon-reload && systemctl restart kubelet
 After the kubelet loads the new configuration, kubeadm writes the
 `/etc/kubernetes/bootstrap-kubelet.conf` KubeConfig file, which contains a CA certificate and Bootstrap
 Token. These are used by the kubelet to perform the TLS Bootstrap and obtain a unique
-credential, which is stored in `/etc/kubernetes/kubelet.conf`. When this file is written, the kubelet
-has finished performing the TLS Bootstrap.
+credential, which is stored in `/etc/kubernetes/kubelet.conf`.
+
+When the `/etc/kubernetes/kubelet.conf` file is written, the kubelet has finished performing the TLS Bootstrap.
+Kubeadm deletes the `/etc/kubernetes/bootstrap-kubelet.conf` file after completing the TLS Bootstrap.
 
 ##  The kubelet drop-in file for systemd
 


### PR DESCRIPTION
**Description:**
Kubeadm deletes the file `/etc/kubernetes/bootstrap-kubelet.conf` as per https://github.com/kubernetes/kubernetes/pull/80676.

When checking out the Kubelet init arg `--bootstrap-kubeconfig` the highlighted file no longer exists in the file system which can cause some users confusion. Had to find the aforementioned PR to figure out it has been deleted.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
