### PR TITLE
Fixing Skew in localization doc

### DIFF
--- a/content/en/docs/contribute/localization.md
+++ b/content/en/docs/contribute/localization.md
@@ -346,7 +346,7 @@ Teams must merge localized content into the same branch from which the content w
 
 For example:
 - a localization branch sourced from `main` must be merged into `main`.
-- a localization branch sourced from `release-{{ skew "prevMinorVersion" }}` must be merged into `release-{{ skew "prevMinorVersion" }}`.
+- a localization branch sourced from `release-{{% skew "prevMinorVersion" %}}` must be merged into `release-{{% skew "prevMinorVersion" %}}`.
 
 {{< note >}}
 If your localization branch was created from `main` branch but it is not merged into `main` before new release branch `{{< release-branch >}}` created, merge it into both `main` and new release branch `{{< release-branch >}}`. To merge your localization branch into new release branch `{{< release-branch >}}`, you need to switch upstream branch of your localization branch to `{{< release-branch >}}`.
@@ -361,5 +361,3 @@ For more information about working from forks or directly from the repository, s
 ## Upstream contributions
 
 SIG Docs welcomes upstream contributions and corrections to the English source.
-
-


### PR DESCRIPTION
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

Fixes: #30140 

**In PR:** Resolved the bug by fixing the skew in the localization doc under the branching strategy section of [Localizing Kubernetes Documentation](https://kubernetes.io/docs/contribute/localization/#branching-strategy). 

**Changes:** `release-{{ skew "prevMinorVersion" }}`  -> `release-{{% skew "prevMinorVersion" %}}`

**Page Updated:** https://kubernetes.io/docs/contribute/localization/#branching-strategy






