### PR TITLE
sha256sum requires 2nd space for the file type

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -52,7 +52,7 @@ For example, to download version {{< param "fullversion" >}} on Linux, type:
    Validate the kubectl binary against the checksum file:
 
    ```bash
-   echo "$(<kubectl.sha256) kubectl" | sha256sum --check
+   echo "$(<kubectl.sha256)  kubectl" | sha256sum --check
    ```
 
    If valid, the output is:


### PR DESCRIPTION
Hi folks, I’m at https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/ step 2. Validate the binary (optional) and it’s not working on some hosts. 

```
$ version=v1.19.15
$ curl --silent -LO "https://dl.k8s.io/${version}/bin/linux/amd64/kubectl
$ curl --silent -LO "https://dl.k8s.io/${version}/bin/linux/amd64/kubectl.sha256"
$ echo "$(<kubectl.sha256) kubectl" | sha256sum --check
sha256sum: standard input: no properly formatted SHA256 checksum lines found
$
```

But the  sha256's themselves are fine:

```
$ cat kubectl.sha256
6f2ac7db8cfd59f660abc9891c1bb7da2dabd1cf5e114d836f2ffd39ee677d04
$ sha256sum kubectl
6f2ac7db8cfd59f660abc9891c1bb7da2dabd1cf5e114d836f2ffd39ee677d04  kubectl
$
```

The manual page for [sha256sum](https://man.archlinux.org/man/sha256sum.1.en) says  need to be a second space  character in the output, which is not included in the instructions.

> The sums are computed as described in FIPS-180-2. When checking, the input should be a former output of this program. The default mode is to print a line with: checksum, a space, a character indicating input mode ('*' for binary, ' ' for text or where binary is insignificant), and name for each FILE.
> 
> Note: There is no difference between binary mode and text mode on GNU systems.

Therefore, using two spaces works:

```
# Fails
$ echo "$(<kubectl.sha256) kubectl" | sha256sum --check
sha256sum: standard input: no properly formatted SHA256 checksum lines found

# Works!
$ echo "$(<kubectl.sha256)  kubectl" | sha256sum --check
kubectl: OK
```


<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
