### PR TITLE
Find out what container runtime is used and mention private registries

### DIFF
--- a/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/check-if-dockershim-deprecation-affects-you.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/check-if-dockershim-deprecation-affects-you.md
@@ -1,6 +1,6 @@
 ---
 title: Check whether Dockershim deprecation affects you
-content_type: task 
+content_type: task
 reviewers:
 - SergeyKanzhelev
 weight: 20
@@ -26,16 +26,21 @@ When alternative container runtime is used, executing Docker commands may either
 not work or yield unexpected output. This is how you can find whether you have a
 dependency on Docker:
 
-1. Make sure no privileged Pods execute Docker commands.
-2. Check that scripts and apps running on nodes outside of Kubernetes
+1. Make sure no privileged Pods execute Docker commands (like `docker ps`),
+   restart the Docker service (commands such as `systemctl restart docker.service`),
+   or modify Docker-specific files such as `/etc/docker/daemon.json`.
+1. Check for any private registries or image mirror settings in the Docker
+   configuration file (like `/etc/docker/daemon.json`). Those typically need to
+   be reconfigured for another container runtime.
+1. Check that scripts and apps running on nodes outside of your Kubernetes
    infrastructure do not execute Docker commands. It might be:
    - SSH to nodes to troubleshoot;
    - Node startup scripts;
    - Monitoring and security agents installed on nodes directly.
-3. Third-party tools that perform above mentioned privileged operations. See
+1. Third-party tools that perform above mentioned privileged operations. See
    [Migrating telemetry and security agents from dockershim](/docs/tasks/administer-cluster/migrating-from-dockershim/migrating-telemetry-and-security-agents)
    for more information.
-4. Make sure there is no indirect dependencies on dockershim behavior.
+1. Make sure there is no indirect dependencies on dockershim behavior.
    This is an edge case and unlikely to affect your application. Some tooling may be configured
    to react to Docker-specific behaviors, for example, raise alert on specific metrics or search for
    a specific log message as part of troubleshooting instructions.

--- a/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/find-out-runtime-you-use.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/find-out-runtime-you-use.md
@@ -1,0 +1,52 @@
+---
+title: Find Out What Container Runtime is Used on a Node
+content_type: task
+reviewers:
+- SergeyKanzhelev
+weight: 10
+---
+
+<!-- overview -->
+
+This page outlines steps to find out what [container runtime](/docs/setup/production-environment/container-runtimes/)
+the nodes in your cluster use.
+
+Depending on the way you run your cluster, the container runtime for the nodes may
+have been pre-configured or you need to configure it. If you're using a managed
+Kubernetes service, there might be vendor-specific ways to check what container runtime is
+configured for the nodes. The method described on this page should work whenever
+the execution of `kubectl` is allowed.
+
+## {{% heading "prerequisites" %}}
+
+Install and configure `kubectl`. See [Install Tools](/docs/tasks/tools/#kubectl) section for details.
+
+## Find out the container runtime used on a Node
+
+Use `kubectl` to fetch and show node information:
+
+```shell
+kubectl get nodes -o wide
+```
+
+The output is similar to the following. The column `CONTAINER-RUNTIME` outputs
+the runtime and its version.
+
+```none
+# For dockershim
+NAME         STATUS   VERSION    CONTAINER-RUNTIME
+node-1       Ready    v1.16.15   docker://19.3.1
+node-2       Ready    v1.16.15   docker://19.3.1
+node-3       Ready    v1.16.15   docker://19.3.1
+```
+
+```none
+# For containerd
+NAME         STATUS   VERSION   CONTAINER-RUNTIME
+node-1       Ready    v1.19.6   containerd://1.4.1
+node-2       Ready    v1.19.6   containerd://1.4.1
+node-3       Ready    v1.19.6   containerd://1.4.1
+```
+
+Find out more information about container runtimes
+on [Container Runtimes](/docs/setup/production-environment/container-runtimes/) page.


### PR DESCRIPTION
A small update to the dockershim deprecation page.

First, added an instruction to find out the container runtime. Second, mention the private registries.