### PR TITLE
Adjust indents to fix page style

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -45,40 +45,40 @@ This page shows you how to set up a simple Ingress which routes requests to Serv
 1. Verify that the NGINX Ingress controller is running
 
 
-  {{< tabs name="tab_with_md" >}}
-  {{% tab name="minikube v1.19 or later" %}}
-```shell
-kubectl get pods -n ingress-nginx
-```
-  {{< note >}}This can take up to a minute.{{< /note >}}
+    {{< tabs name="tab_with_md" >}}
+    {{% tab name="minikube v1.19 or later" %}}
+    ```shell
+    kubectl get pods -n ingress-nginx
+    ```
+    {{< note >}}This can take up to a minute.{{< /note >}}
 
-Output:
+    Output:
 
-```
-NAME                                        READY   STATUS      RESTARTS    AGE
-ingress-nginx-admission-create-g9g49        0/1     Completed   0          11m
-ingress-nginx-admission-patch-rqp78         0/1     Completed   1          11m
-ingress-nginx-controller-59b45fb494-26npt   1/1     Running     0          11m
-```
+    ```
+    NAME                                        READY   STATUS      RESTARTS    AGE
+    ingress-nginx-admission-create-g9g49        0/1     Completed   0          11m
+    ingress-nginx-admission-patch-rqp78         0/1     Completed   1          11m
+    ingress-nginx-controller-59b45fb494-26npt   1/1     Running     0          11m
+    ```
     {{% /tab %}}
 
-  {{% tab name="minikube v1.18.1 or earlier" %}}
-```shell
-kubectl get pods -n kube-system
-```
-{{< note >}}This can take up to a minute.{{< /note >}}
+    {{% tab name="minikube v1.18.1 or earlier" %}}
+    ```shell
+    kubectl get pods -n kube-system
+    ```
+    {{< note >}}This can take up to a minute.{{< /note >}}
 
-Output:
+    Output:
 
-```
-NAME                                        READY     STATUS    RESTARTS   AGE
-default-http-backend-59868b7dd6-xb8tq       1/1       Running   0          1m
-kube-addon-manager-minikube                 1/1       Running   0          3m
-kube-dns-6dcb57bcc8-n4xd4                   3/3       Running   0          2m
-kubernetes-dashboard-5498ccf677-b8p5h       1/1       Running   0          2m
-nginx-ingress-controller-5984b97644-rnkrg   1/1       Running   0          1m
-storage-provisioner                         1/1       Running   0          2m
-```
+    ```
+    NAME                                        READY     STATUS    RESTARTS   AGE
+    default-http-backend-59868b7dd6-xb8tq       1/1       Running   0          1m
+    kube-addon-manager-minikube                 1/1       Running   0          3m
+    kube-dns-6dcb57bcc8-n4xd4                   3/3       Running   0          2m
+    kubernetes-dashboard-5498ccf677-b8p5h       1/1       Running   0          2m
+    nginx-ingress-controller-5984b97644-rnkrg   1/1       Running   0          1m
+    storage-provisioner                         1/1       Running   0          2m
+    ```
     {{% /tab %}}
       {{< /tabs >}}
   


### PR DESCRIPTION
The style of [this page](https://kubernetes.io/docs/tasks/access-application-cluster/ingress-minikube/#enable-the-ingress-controller
) is currently broken. 

I have adjusted the indents to fix the style  and nest the docs into the numbered list.


## before

![image](https://user-images.githubusercontent.com/12762000/138570458-ec687127-47ea-49f5-9d0c-5ed3fe838a1c.png)

## after

![image](https://user-images.githubusercontent.com/12762000/138570499-7710ff66-cb1f-48c2-befa-32b170dea1ea.png)


