### PR TITLE
kubeadm: use git.k8s.io to link to kubeadm repo

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/high-availability.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/high-availability.md
@@ -77,7 +77,7 @@ option. Your cluster requirements may need a different configuration.
     - Make sure the address of the load balancer always matches
       the address of kubeadm's `ControlPlaneEndpoint`.
 
-    - Read the [Options for Software Load Balancing](https://github.com/kubernetes/kubeadm/blob/master/docs/ha-considerations.md#options-for-software-load-balancing)
+    - Read the [Options for Software Load Balancing](https://git.k8s.io/kubeadm/docs/ha-considerations.md#options-for-software-load-balancing)
       guide for more details.
 
 1.  Add the first control plane nodes to the load balancer and test the


### PR DESCRIPTION
With the kubeadm repository changing branch from
master -> main, use the "branchless" URL:
  git.k8s.io/kubeadm
when linking to the HA guide.

xref https://github.com/kubernetes/kubeadm/issues/2589
