### PR TITLE
[ko] add sudo to Red Hat-based distributions

### DIFF
--- a/content/ko/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/ko/docs/tasks/tools/install-kubectl-linux.md
@@ -130,7 +130,7 @@ card:
 {{% /tab %}}
 
 {{< tab name="레드햇 기반의 배포판" codelang="bash" >}}
-sudo cat <<EOF > /etc/yum.repos.d/kubernetes.repo
+cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
 baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64

--- a/content/ko/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/ko/docs/tasks/tools/install-kubectl-linux.md
@@ -130,7 +130,7 @@ card:
 {{% /tab %}}
 
 {{< tab name="레드햇 기반의 배포판" codelang="bash" >}}
-cat <<EOF > /etc/yum.repos.d/kubernetes.repo
+sudo cat <<EOF > /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
 baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
@@ -139,7 +139,7 @@ gpgcheck=1
 repo_gpgcheck=1
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOF
-yum install -y kubectl
+sudo yum install -y kubectl
 {{< /tab >}}
 {{< /tabs >}}
 


### PR DESCRIPTION

The commands needs to be run using sudo.
Debian-based distributions already include sudo in the documentation, but Red Hat-Based distributions, so I added it.
