### PR TITLE
[zh] add sudo to Red Hat-based distributions

### DIFF
--- a/content/zh/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/zh/docs/tasks/tools/install-kubectl-linux.md
@@ -208,7 +208,7 @@ The following methods exist for installing kubectl on Linux:
 {{< /tab >}}
 
 {{< tab name="基于 Red Hat 的发行版" codelang="bash" >}}
-cat <<EOF > /etc/yum.repos.d/kubernetes.repo
+sudo cat <<EOF > /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
 baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
@@ -217,7 +217,7 @@ gpgcheck=1
 repo_gpgcheck=1
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOF
-yum install -y kubectl
+sudo yum install -y kubectl
 {{< /tab >}}
 {{< /tabs >}}
 

--- a/content/zh/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/zh/docs/tasks/tools/install-kubectl-linux.md
@@ -208,7 +208,7 @@ The following methods exist for installing kubectl on Linux:
 {{< /tab >}}
 
 {{< tab name="基于 Red Hat 的发行版" codelang="bash" >}}
-sudo cat <<EOF > /etc/yum.repos.d/kubernetes.repo
+cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
 baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64


### PR DESCRIPTION

The commands needs to be run using sudo.
Debian-based distributions already include sudo in the documentation, but Red Hat-Based distributions, so I added it.
