### PR TITLE
Updating runAsNonRoot support for Windows

### DIFF
--- a/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
+++ b/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
@@ -526,13 +526,13 @@ work between Windows and Linux:
 * `securityContext.readOnlyRootFilesystem` -
    not possible on Windows; write access is required for registry & system
    processes to run inside the container
-* `EcurityContext.runAsGroup` -
+* `securityContext.runAsGroup` -
    not possible on Windows as there is no GID support
-* `ecurityContext.runAsNonRoot` -
-   Windows does not have a root user. The closest equivalent is `ContainerAdministrator`
-   which is an identity that doesn't exist on the node.
+* `securityContext.runAsNonRoot` -
+   this setting will prevent containers from running as `ContainerAdministrator`
+   which is the closest equivalent to a root user on Windows.
 * `securityContext.runAsUser` -
-   use [`runAsUsername`](/docs/tasks/configure-pod-container/configure-runasusername)
+   use [`runAsUserName`](/docs/tasks/configure-pod-container/configure-runasusername)
    instead
 * `securityContext.seLinuxOptions` -
    not possible on Windows as SELinux is Linux-specific


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

In v1.20 support for `runAsNonRoot` on Windows was added to the kubelet.
This PR updates documentation to reflect those changes.

I am also fixing a few minor typos.

/sig windows