### PR TITLE
[es] add sudo to Red Hat-based distributions

### DIFF
--- a/content/es/docs/tasks/tools/install-kubectl.md
+++ b/content/es/docs/tasks/tools/install-kubectl.md
@@ -68,7 +68,7 @@ sudo apt-get update
 sudo apt-get install -y kubectl
 {{< /tab >}}
 
-{{< tab name="CentOS, RHEL or Fedora" codelang="bash" >}}cat <<EOF > /etc/yum.repos.d/kubernetes.repo
+{{< tab name="CentOS, RHEL or Fedora" codelang="bash" >}}cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
 baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
@@ -77,7 +77,7 @@ gpgcheck=1
 repo_gpgcheck=1
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOF
-yum install -y kubectl
+sudo yum install -y kubectl
 {{< /tab >}}
 {{< /tabs >}}
 


### PR DESCRIPTION

The commands needs to be run using sudo.
Debian-based distributions already include sudo in the documentation, but Red Hat-Based distributions, so I added it.
