### PR TITLE
Update link to new Helm Chart repo

### DIFF
--- a/content/en/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
+++ b/content/en/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
@@ -16,7 +16,7 @@ This tutorial shows you how to deploy a WordPress site and a MySQL database usin
 A [PersistentVolume](/docs/concepts/storage/persistent-volumes/) (PV) is a piece of storage in the cluster that has been manually provisioned by an administrator, or dynamically provisioned by Kubernetes using a [StorageClass](/docs/concepts/storage/storage-classes).  A [PersistentVolumeClaim](/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims) (PVC) is a request for storage by a user that can be fulfilled by a PV. PersistentVolumes and PersistentVolumeClaims are independent from Pod lifecycles and preserve data through restarting, rescheduling, and even deleting Pods.
 
 {{< warning >}}
-This deployment is not suitable for production use cases, as it uses single instance WordPress and MySQL Pods. Consider using [WordPress Helm Chart](https://github.com/kubernetes/charts/tree/master/stable/wordpress) to deploy WordPress in production.
+This deployment is not suitable for production use cases, as it uses single instance WordPress and MySQL Pods. Consider using [WordPress Helm Chart](https://github.com/bitnami/charts/) to deploy WordPress in production.
 {{< /warning >}}
 
 {{< note >}}


### PR DESCRIPTION
The repository of the current link indicates that it is currently deprecated and has a link to the new repository where the project is maintained.