### PR TITLE
kubeadm-config.md: update the page to reflect current state

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-config.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-config.md
@@ -12,20 +12,27 @@ During `kubeadm init`, kubeadm uploads the `ClusterConfiguration` object to your
 in a ConfigMap called `kubeadm-config` in the `kube-system` namespace. This configuration is then read during
 `kubeadm join`, `kubeadm reset` and `kubeadm upgrade`.
 
-You can use `kubeadm config print` to print the default configuration and `kubeadm config migrate` to
-convert your old configuration files to a newer version. `kubeadm config images list` and
-`kubeadm config images pull` can be used to list and pull the images that kubeadm requires.
+You can use `kubeadm config print` to print the default static configuration that kubeadm
+uses for `kubeadm init` and `kubeadm join`.
 
-For more information navigate to
+{{< note >}}
+The output of the command is meant to serve as an example. You must manually edit the output
+of this command to adapt to your setup. Remove the fields that you are not certain about and kubeadm
+will try to default them on runtime by examining the host.
+{{< /note >}}
+
+For more information on `init` and `join` navigate to
 [Using kubeadm init with a configuration file](/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file)
 or [Using kubeadm join with a configuration file](/docs/reference/setup-tools/kubeadm/kubeadm-join/#config-file).
 
-You can also configure several kubelet-configuration options with `kubeadm init`. These options will be the same on any node in your cluster.
-See [Configuring each kubelet in your cluster using kubeadm](/docs/setup/production-environment/tools/kubeadm/kubelet-integration/) for details.
+For more information on using the kubeadm configuration API navigate to
+[Customizing components with the kubeadm API](/docs/setup/production-environment/tools/kubeadm/control-plane-flags).
 
-In Kubernetes v1.13.0 and later to list/pull kube-dns images instead of the CoreDNS image
-the `--config` method described [here](/docs/reference/setup-tools/kubeadm/kubeadm-init-phase/#cmd-phase-addon)
-has to be used.
+You can use `kubeadm config migrate` to convert your old configuration files that contain a deprecated
+API version to a newer, supported API version.
+
+`kubeadm config images list` and `kubeadm config images pull` can be used to list and pull the images
+that kubeadm requires.
 
 <!-- body -->
 ## kubeadm config print {#cmd-config-print}


### PR DESCRIPTION
We have seen a number of questions around the usage of "config print".
Clarify the usage of this command. Add a note that the output should
not be taken literally and that it requires edits from the user to adapt
to their specific host.

Link to the "customizing components" page instead of the "kubelet
integration" page. The former already links to the later.

Remove note about kube-dns which hasn't been supported for a while.


NOTE: this is targeting "main" correctly / not an 1.23 item