### PR TITLE
Clarify why cordon all but 4 nodes.

### DIFF
--- a/content/en/docs/tutorials/stateful-application/zookeeper.md
+++ b/content/en/docs/tutorials/stateful-application/zookeeper.md
@@ -894,8 +894,7 @@ Use this command to get the nodes in your cluster.
 kubectl get nodes
 ```
 
-Use [`kubectl cordon`](/docs/reference/generated/kubectl/kubectl-commands/#cordon) to
-cordon all but four of the nodes in your cluster.
+This tutorial assumes a cluster with at least four nodes. If the cluster has more than four, use [`kubectl cordon`](/docs/reference/generated/kubectl/kubectl-commands/#cordon) to cordon all but four nodes. Constraining to four nodes will ensure Kubernetes encounters affinity and PodDisruptionBudget constraints when scheduling zookeeper Pods in the following maintenance simulation.
 
 ```shell
 kubectl cordon <node-name>


### PR DESCRIPTION
This change clarifies the reason why all but four nodes should be cordoned before testing in the Surviving Maintenance section.

When following the tutorial, some may be puzzled by the one liner suggesting to cordon all but 4 nodes. 