### PR TITLE
Revert an incorrect fix

### DIFF
--- a/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
+++ b/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
@@ -327,7 +327,7 @@ ETCDCTL_API=3 etcdctl --endpoints 10.2.0.9:2379 snapshot restore snapshotdb
 ```
 Another example for restoring using etcdutl options:
 ```shell
-ETCDCTL_API=3 etcdctl --data-dir <data-dir-location> snapshot restore snapshotdb
+ETCDCTL_API=3 etcdutl --data-dir <data-dir-location> snapshot restore snapshotdb
 ```
 
 For more information and examples on restoring a cluster from a snapshot file, see


### PR DESCRIPTION
corrections for  etctutl command name that was incorrectly “fixed” #30215
