### PR TITLE
Fix typo in podsecurity config example

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/enforce-standards-admission-controller.md
+++ b/content/en/docs/tasks/configure-pod-container/enforce-standards-admission-controller.md
@@ -48,7 +48,7 @@ plugins:
       # Array of authenticated usernames to exempt.
       usernames: []
       # Array of runtime class names to exempt.
-      runtimeClassNames: []
+      runtimeClasses: []
       # Array of namespaces to exempt.
       namespaces: []
 ```


### PR DESCRIPTION
/sig auth
/cc @tallclair 