### PR TITLE
Fix zsh completion setup

### DIFF
--- a/content/en/docs/tasks/tools/included/optional-kubectl-configs-zsh.md
+++ b/content/en/docs/tasks/tools/included/optional-kubectl-configs-zsh.md
@@ -16,7 +16,7 @@ If you have an alias for kubectl, you can extend shell completion to work with t
 
 ```zsh
 echo 'alias k=kubectl' >>~/.zshrc
-echo 'complete -F __start_kubectl k' >>~/.zshrc
+echo 'compdef __start_kubectl k' >>~/.zshrc
 ```
 
 After reloading your shell, kubectl autocompletion should be working.

--- a/content/es/docs/tasks/tools/install-kubectl.md
+++ b/content/es/docs/tasks/tools/install-kubectl.md
@@ -493,7 +493,7 @@ Si tienes alias para kubectl, puedes extender el completado de intérprete de co
 
 ```zsh
 echo 'alias k=kubectl' >>~/.zshrc
-echo 'complete -F __start_kubectl k' >>~/.zshrc
+echo 'compdef __start_kubectl k' >>~/.zshrc
 ```
 
 Tras recargar tu intérprete de comandos, el auto-completado de kubectl debería funcionar.

--- a/content/fr/docs/tasks/tools/install-kubectl.md
+++ b/content/fr/docs/tasks/tools/install-kubectl.md
@@ -457,7 +457,7 @@ Si vous avez un alias pour kubectl, vous pouvez étendre la completion de votre 
 
 ```shell
 echo 'alias k=kubectl' >>~/.zshrc
-echo 'complete -F __start_kubectl k' >>~/.zshrc
+echo 'compdef __start_kubectl k' >>~/.zshrc
 ```
 
 Après avoir rechargé votre shell, l'auto-complétion de kubectl devrait fonctionner.

--- a/content/id/docs/tasks/tools/install-kubectl.md
+++ b/content/id/docs/tasks/tools/install-kubectl.md
@@ -472,7 +472,7 @@ Jika kamu menggunakan alias untuk `kubectl`, kamu masih dapat menggunakan fitur 
 
 ```shell
 echo 'alias k=kubectl' >>~/.zshrc
-echo 'complete -F __start_kubectl k' >>~/.zshrc
+echo 'compdef __start_kubectl k' >>~/.zshrc
 ```
 
 Setelah memuat ulang terminal, penyelesaian otomatis dari `kubectl` seharusnya sudah dapat bekerja.

--- a/content/ja/docs/tasks/tools/install-kubectl.md
+++ b/content/ja/docs/tasks/tools/install-kubectl.md
@@ -484,7 +484,7 @@ kubectlにエイリアスを張っている場合は、以下のようにシェ�
 
 ```zsh
 echo 'alias k=kubectl' >>~/.zshrc
-echo 'complete -F __start_kubectl k' >>~/.zshrc
+echo 'compdef __start_kubectl k' >>~/.zshrc
 ```
 
 シェルをリロードしたあとに、kubectlの自動補完が機能するはずです。

--- a/content/ko/docs/tasks/tools/included/optional-kubectl-configs-zsh.md
+++ b/content/ko/docs/tasks/tools/included/optional-kubectl-configs-zsh.md
@@ -16,7 +16,7 @@ kubectl에 대한 앨리어스가 있는 경우, 해당 앨리어스로 작업�
 
 ```zsh
 echo 'alias k=kubectl' >>~/.zshrc
-echo 'complete -F __start_kubectl k' >>~/.zshrc
+echo 'compdef __start_kubectl k' >>~/.zshrc
 ```
 
 셸을 다시 로드하면, kubectl 자동 완성 기능이 작동할 것이다.

--- a/content/ru/docs/tasks/tools/install-kubectl.md
+++ b/content/ru/docs/tasks/tools/install-kubectl.md
@@ -461,7 +461,7 @@ source <(kubectl completion zsh)
 
 ```shell
 echo 'alias k=kubectl' >>~/.zshrc
-echo 'complete -F __start_kubectl k' >>~/.zshrc
+echo 'compdef __start_kubectl k' >>~/.zshrc
 ```
 
 После перезагрузки командной оболочки должны появляться дополнения ввода kubectl.

--- a/content/vi/docs/tasks/tools/install-kubectl.md
+++ b/content/vi/docs/tasks/tools/install-kubectl.md
@@ -450,7 +450,7 @@ Nếu bạn có alias cho kubectl, bạn có thể mở rộng shell completion 
 
 ```shell
 echo 'alias k=kubectl' >>~/.zshrc
-echo 'complete -F __start_kubectl k' >>~/.zshrc
+echo 'compdef __start_kubectl k' >>~/.zshrc
 ```
     
 Sau khi tải lại shell, kubectl autocompletion sẽ hoạt động.

--- a/content/zh/docs/tasks/tools/included/optional-kubectl-configs-zsh.md
+++ b/content/zh/docs/tasks/tools/included/optional-kubectl-configs-zsh.md
@@ -32,7 +32,7 @@ If you have an alias for kubectl, you can extend shell completion to work with t
 
 ```zsh
 echo 'alias k=kubectl' >>~/.zshrc
-echo 'complete -F __start_kubectl k' >>~/.zshrc
+echo 'compdef __start_kubectl k' >>~/.zshrc
 ```
 
 <!-- 


### PR DESCRIPTION
Changed the `zsh` completion documentation to use `compdef` instead of `complete`.