### PR TITLE
Corrected the "all Kubernetes bug reports" link in Kubernetes Security and Disclosure Information.

### DIFF
--- a/content/en/docs/reference/issues-security/security.md
+++ b/content/en/docs/reference/issues-security/security.md
@@ -27,7 +27,7 @@ We're extremely grateful for security researchers and users that report vulnerab
 
 To make a report, submit your vulnerability to the [Kubernetes bug bounty program](https://hackerone.com/kubernetes). This allows triage and handling of the vulnerability with standardized response times.
 
-You can also email the private [security@kubernetes.io](mailto:security@kubernetes.io) list with the security details and the details expected for [all Kubernetes bug reports](https://git.k8s.io/kubernetes/.github/ISSUE_TEMPLATE/bug-report.md).
+You can also email the private [security@kubernetes.io](mailto:security@kubernetes.io) list with the security details and the details expected for [all Kubernetes bug reports](https://github.com/kubernetes/kubernetes/blob/master/.github/ISSUE_TEMPLATE/bug-report.yaml).
 
 You may encrypt your email to this list using the GPG keys of the [Security Response Committee members](https://git.k8s.io/security/README.md#product-security-committee-psc). Encryption using GPG is NOT required to make a disclosure.
 


### PR DESCRIPTION
This PR fixes the link of `all Kubernetes bug reports` under the  [Report a Vulnerability](https://kubernetes.io/docs/reference/issues-security/security/#report-a-vulnerability)  in the Kubernetes Security and Disclosure Information docs.

Fixes: #30308