### PR TITLE
Added Note for Deprecation of Flexvolume

### DIFF
--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -1381,6 +1381,10 @@ plugin path on each node and in some cases the control plane nodes as well.
 Pods interact with FlexVolume drivers through the `flexvolume` in-tree volume plugin.
 For more details, see the [FlexVolume](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-storage/flexvolume.md) examples.
 
+{{< note >}}
+FlexVolume is deprecated starting v1.23. Out-of-tree CSI driver is the recommended way to write volume driver in Kubernetes. Maintainers of FlexVolume driver should implement a CSI Driver and move users of FlexVolume to CSI. Users of FlexVolume should move their workloads to CSI Driver.
+{{< /note >}}
+
 ## Mount propagation
 
 Mount propagation allows for sharing volumes mounted by a container to


### PR DESCRIPTION
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
Issue #30180

Description : marked flexVolume deprecated for v1.23

Changed to branch dev-1.23 for pr https://github.com/kubernetes/website/pull/30216