### PR TITLE
Suggested improvement for audit log set up

### DIFF
--- a/content/en/docs/tasks/debug-application-cluster/audit.md
+++ b/content/en/docs/tasks/debug-application-cluster/audit.md
@@ -147,7 +147,10 @@ If your cluster's control plane runs the kube-apiserver as a Pod, remember to mo
 to the location of the policy file and log file, so that audit records are persisted. For example:
 ```shell
     --audit-policy-file=/etc/kubernetes/audit-policy.yaml \
-    --audit-log-path=/var/log/audit.log
+    --audit-log-path=/var/log/kube-api/audit.log
+    --audt-log-maxage=5
+    --audit-log-maxbackup=2
+    --audit-log-maxsize=10
 ```
 then mount the volumes:
 
@@ -157,7 +160,7 @@ volumeMounts:
   - mountPath: /etc/kubernetes/audit-policy.yaml
     name: audit
     readOnly: true
-  - mountPath: /var/log/audit.log
+  - mountPath: /var/log/kube-api
     name: audit-log
     readOnly: false
 ```
@@ -172,8 +175,8 @@ and finally configure the `hostPath`:
 
 - name: audit-log
   hostPath:
-    path: /var/log/audit.log
-    type: FileOrCreate
+    path: /var/log/kube-api
+    type: DirectoryOrCreate 
 
 ```
 


### PR DESCRIPTION
Hello,

I want to suggest a small improvement, I was setting up the Kubernetes audit according to the documentation and faced an issue. It was related to the Kubernetes API not being able to rename the file

`Error in audit plugin 'log' affecting 1 audit events: can't rename log file: rename /var/log/audit.log /var/log/audit-2021-11-03T06-52-01.404.log: device or resource busy`

It turns to be caused by mounting the file only and not a directory. 
My suggestion is to add the options to enable rotation and to set up the volumeMounts and volumes properly to help future users not deal with it.
The other approach, we can take is to add a note saying that if the user wants to rotate a different set-up is needed, I am just not sure if it will be convoluted.