### PR TITLE
replace dnsutils example image

### DIFF
--- a/content/en/examples/admin/dns/dnsutils.yaml
+++ b/content/en/examples/admin/dns/dnsutils.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
   - name: dnsutils
-    image: gcr.io/kubernetes-e2e-test-images/dnsutils:1.3
+    image: k8s.gcr.io/e2e-test-images/jessie-dnsutils:1.3
     command:
       - sleep
       - "3600"

--- a/content/id/examples/admin/dns/dnsutils.yaml
+++ b/content/id/examples/admin/dns/dnsutils.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
   - name: dnsutils
-    image: gcr.io/kubernetes-e2e-test-images/dnsutils:1.3
+    image: k8s.gcr.io/e2e-test-images/jessie-dnsutils:1.3
     command:
       - sleep
       - "3600"

--- a/content/zh/examples/admin/dns/dnsutils.yaml
+++ b/content/zh/examples/admin/dns/dnsutils.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
   - name: dnsutils
-    image: gcr.io/kubernetes-e2e-test-images/dnsutils:1.3
+    image: k8s.gcr.io/e2e-test-images/jessie-dnsutils:1.3
     command:
       - sleep
       - "3600"


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1522

The gcr.io/kubernetes-e2e-test-images repo is deprecated and will
eventually go away. Use an equivalent image from the project-owned
k8s.gcr.io repo

There is a blog post that also references the old repo, but we are
leaving that untouched as historical reference. The images it lists
are appropriate for the version of kubernetes that was available at
the time. To update the list would be to re-engineer the effort for
the latest version of kubernetes, which seems slightly out of scope
here. (ref: https://github.com/kubernetes/website/blob/main/content/en/blog/_posts/2020-01-15-Kubernetes-on-MIPS.md)