### PR TITLE
added line separation in kubectl page

### DIFF
--- a/content/en/docs/reference/kubectl/overview.md
+++ b/content/en/docs/reference/kubectl/overview.md
@@ -545,3 +545,4 @@ Current user: plugins-user
 * Start using the [kubectl](/docs/reference/generated/kubectl/kubectl-commands/) commands.
 
 * To find out more about plugins, take a look at the [example cli plugin](https://github.com/kubernetes/sample-cli-plugin).
+

--- a/content/en/docs/reference/kubectl/overview.md
+++ b/content/en/docs/reference/kubectl/overview.md
@@ -91,6 +91,7 @@ If:
 * the `KUBERNETES_SERVICE_HOST` environment variable is set, and
 * the `KUBERNETES_SERVICE_PORT` environment variable is set, and
 * you don't explicitly specify a namespace on the kubectl command line
+
 then kubectl assumes it is running in your cluster. The kubectl tool looks up the
 namespace of that ServiceAccount (this is the same as the namespace of the Pod)
 and acts against that namespace. This is different from what happens outside of a
@@ -545,4 +546,4 @@ Current user: plugins-user
 
 * To find out more about plugins, take a look at the [example cli plugin](https://github.com/kubernetes/sample-cli-plugin).
 
-
+ 

--- a/content/en/docs/reference/kubectl/overview.md
+++ b/content/en/docs/reference/kubectl/overview.md
@@ -545,5 +545,3 @@ Current user: plugins-user
 * Start using the [kubectl](/docs/reference/generated/kubectl/kubectl-commands/) commands.
 
 * To find out more about plugins, take a look at the [example cli plugin](https://github.com/kubernetes/sample-cli-plugin).
-
- 


### PR DESCRIPTION
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
Fixes #30357 

Added line separation in [Kubectl doc](https://kubernetes.io/docs/reference/kubectl/overview/#in-cluster-authentication-and-namespace-overrides) ie [reference/kubectl/overview](https://kubernetes.io/docs/reference/kubectl/overview/#in-cluster-authentication-and-namespace-overrides).

