### PR TITLE
Fix wording of basic auth secret doc to keep it consistent with validation

### DIFF
--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -244,7 +244,7 @@ on the fly:
 
 The `kubernetes.io/basic-auth` type is provided for storing credentials needed
 for basic authentication. When using this Secret type, the `data` field of the
-Secret must contain the following two keys:
+Secret must contain one of the following two keys:
 
 - `username`: the user name for authentication;
 - `password`: the password or token for authentication.


### PR DESCRIPTION
As described in https://github.com/kubernetes/kubernetes/pull/103707, there is an inconsistency with the API docs and the actual validation. The comment described in https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/validation/validation.go#L5487 also mentions that only of them is required, and the validation only fails if both do not exist. With this change, we will now mention that only one of the fields are required.
