### PR TITLE
Updated circtl version to v1.22.0 from v1.17.0 in install kubeadm doc #30349

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -243,7 +243,7 @@ sudo mkdir -p $DOWNLOAD_DIR
 Install crictl (required for kubeadm / Kubelet Container Runtime Interface (CRI))
 
 ```bash
-CRICTL_VERSION="v1.17.0"
+CRICTL_VERSION="v1.22.0"
 ARCH="amd64"
 curl -L "https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-${ARCH}.tar.gz" | sudo tar -C $DOWNLOAD_DIR -xz
 ```


### PR DESCRIPTION
Fixes #30349 
It changes the version of the crictl in "install kubeadm" doc when installing without package managers to v1.22.0 from v1.17.0.
File changed:  [Installing kubeadm Without a  package manager](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#installing-kubeadm-kubelet-and-kubectl)
