### PR TITLE
Get HPA in autoscaling/v2beta2 API version

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -189,7 +189,7 @@ by making use of the `autoscaling/v2beta2` API version.
 First, get the YAML of your HorizontalPodAutoscaler in the `autoscaling/v2beta2` form:
 
 ```shell
-kubectl get hpa php-apache -o yaml > /tmp/hpa-v2.yaml
+kubectl get hpa.v2beta2.autoscaling php-apache -o yaml > /tmp/hpa-v2.yaml
 ```
 
 Open the `/tmp/hpa-v2.yaml` file in an editor, and you should see YAML which looks like this:


### PR DESCRIPTION
To get HorizontalPodAutoscaler in `autoscaling/v2beta2` API version:
```shell
kubectl get hpa.v2beta2.autoscaling php-apache -o yaml > /tmp/hpa-v2.yaml
```
