### PR TITLE
ServiceAccountTokenVolumeProjection: api-audiences flag can be omitted

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-service-account.md
@@ -292,7 +292,7 @@ command line arguments to `kube-apiserver`:
 * `--service-account-issuer`
 * `--service-account-key-file`
 * `--service-account-signing-key-file`
-* `--api-audiences`
+* `--api-audiences` (can be omitted)
 
 {{< /note >}}
 


### PR DESCRIPTION
As a follow up to the discussion in https://github.com/kubernetes/website/issues/30317

This PR adds short notice that `--api-audiences` is not required to enable `ServiceAccountTokenVolumeProjection` feature. It defaults to `--service-account-issuerd` value if configured, so it can be omitted.

```
      --api-audiences strings                             Identifiers of the API. The service account token authenticator will validate that tokens used against the API are bound to at least one of these audiences. If the --service-account-issuer flag is configured and this flag is not, this field defaults to a single element list containing the issuer URL.
```

preview: https://deploy-preview-30387--kubernetes-io-main-staging.netlify.app/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection