### PR TITLE
Blog Post for steering-committee-results-2021

### DIFF
--- a/content/en/blog/_posts/steering-committee-results-2021
+++ b/content/en/blog/_posts/steering-committee-results-2021
@@ -1,0 +1,51 @@
+---
+layout: blog
+title: "Announcing the 2021 Steering Committee Election Results"
+date: 2020-11-08
+slug: steering-committee-results-2021
+---
+
+**Author**: Kaslin Fields
+
+The [2021 Steering Committee Election](https://github.com/kubernetes/community/tree/master/events/elections/2021) is now complete. The Kubernetes Steering Committee consists of 7 seats, 4 of which were up for election in 2021. Incoming committee members serve a term of 2 years, and all members are elected by the Kubernetes Community.
+
+This community body is significant since it oversees the governance of the entire Kubernetes project. With that great power comes great responsibility. You can learn more about the steering committee’s role in their [charter](https://github.com/kubernetes/steering/blob/master/charter.md).
+
+## Results
+
+Congratulations to the elected committee members whose two year terms begin immediately (listed in alphabetical order by GitHub handle):
+
+* **Christoph Blecker ([@cblecker](https://github.com/cblecker)),RedHat**
+* **Stephen Augustus ([@justaugusts](https://github.com/justaugustus)), Cisco**
+* **Paris Pittman ([@parispittman](https://github.com/parispittman)), Apple**
+* **Tim Pepper ([@tpepper](https://github.com/tpepper)), VMware**
+
+They join continuing members:
+* **Davanum Srinivas ([@dims](https://github.com/dims)), VMware**
+* **Jordan Liggitt ([@liggitt](https://github.com/liggitt)), Google**
+* **Bob Killen ([@mrbobbytables](https://github.com/mrbobbytables)), Google**
+
+Paris Pittman and Christoph Blecker are returning Steering Committee Members.
+
+## Big Thanks!
+
+Thank you and congratulations on a successful election to this round’s election officers:
+* Alison Dowdney, ([@alisondy](https://github.com/alisondy))
+* Noah Kantrowitz ([@coderanger](https://github.com/coderanger))
+* Josh Berkus ([@jberkus](https://github.com/jberkus))
+
+Thanks to the Emeritus Steering Committee Members. Your prior service is appreciated by the community:
+  * Derek Carr ([@derekwaynecarr](https://github.com/derekwaynecarr))
+  * Nikhita Raghunath ([@nikhita](https://github.com/nikhita))
+
+And thank you to all the candidates who came forward to run for election.
+
+## Get Involved with the Steering Committee
+
+This governing body, like all of Kubernetes, is open to all. You can follow along with Steering Committee [backlog items](https://github.com/kubernetes/steering/projects/1) and weigh in by filing an issue or creating a PR against their [repo](https://github.com/kubernetes/steering). They have an open meeting on [the first Monday at 9:30am PT of every month](https://github.com/kubernetes/steering) and regularly attend Meet Our Contributors. They can also be contacted at their public mailing list steering@kubernetes.io.
+
+You can see what the Steering Committee meetings are all about by watching past meetings on the [YouTube Playlist](https://www.youtube.com/playlist?list=PL69nYSiGNLP1yP1B_nd9-drjoxp0Q14qM).
+
+----
+
+_This post was written by the [Upstream Marketing Working Group](https://github.com/kubernetes/community/tree/master/communication/marketing-team#contributor-marketing). If you want to write stories about the Kubernetes community, learn more about us._


### PR DESCRIPTION
Creating a blog post to communicate the Kubernetes Steering Committee election results for 2021. Based on [last year's blog post](https://kubernetes.io/blog/2020/10/12/steering-committee-results-2020/).
 