### PR TITLE
Fix typos,config paths in kubelet-in-userns.md. Add link to port forwarder implementation

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubelet-in-userns.md
+++ b/content/en/docs/tasks/administer-cluster/kubelet-in-userns.md
@@ -152,8 +152,7 @@ containerd or CRI-O and ensure that it is running within the user namespace befo
 
 Running CRI plugin of containerd in a user namespace is supported since containerd 1.4.
 
-Running containerd within a user namespace requires the following configurations
-in `/etc/containerd/config.toml`.
+Running containerd within a user namespace requires the following configurations.
 
 ```toml
 version = 2
@@ -176,6 +175,9 @@ version = 2
   SystemdCgroup = false
 ```
 
+The default path of the configuration file is `/etc/containerd/config.toml`.
+The path can be specified with `containerd -c /path/to/containerd/config.toml`.
+
 {{% /tab %}}
 {{% tab name="CRI-O" %}}
 
@@ -183,7 +185,7 @@ Running CRI-O in a user namespace is supported since CRI-O 1.22.
 
 CRI-O requires an environment variable `_CRIO_ROOTLESS=1` to be set.
 
-The following configurations (in `/etc/crio/crio.conf`) are also recommended:
+The following configurations are also recommended:
 
 ```toml
 [crio]
@@ -197,6 +199,8 @@ The following configurations (in `/etc/crio/crio.conf`) are also recommended:
   cgroup_manager = "cgroupfs"
 ```
 
+The default path of the configuration file is `/etc/crio/crio.conf`.
+The path can be specified with `crio --config /path/to/crio/crio.conf`.
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/docs/tasks/administer-cluster/kubelet-in-userns.md
+++ b/content/en/docs/tasks/administer-cluster/kubelet-in-userns.md
@@ -141,6 +141,7 @@ the host with an external port forwarder, such as RootlessKit, slirp4netns, or
 You can use the port forwarder from K3s.
 See [Running K3s in Rootless Mode](https://rancher.com/docs/k3s/latest/en/advanced/#known-issues-with-rootless-mode)
 for more details.
+The implementation can be found in [the `pkg/rootlessports` package](https://github.com/k3s-io/k3s/blob/v1.22.3+k3s1/pkg/rootlessports/controller.go) of k3s.
 
 ### Configuring CRI
 

--- a/content/en/docs/tasks/administer-cluster/kubelet-in-userns.md
+++ b/content/en/docs/tasks/administer-cluster/kubelet-in-userns.md
@@ -14,7 +14,7 @@ without root privileges, by using a {{< glossary_tooltip text="user namespace" t
 This technique is also known as _rootless mode_.
 
 {{< note >}}
-This document describes how to run Kubernetes Node components (and hence pods) a non-root user.
+This document describes how to run Kubernetes Node components (and hence pods) as a non-root user.
 
 If you are just looking for how to run a pod as a non-root user, see [SecurityContext](/docs/tasks/configure-pod-container/security-context/).
 {{< /note >}}
@@ -153,7 +153,7 @@ containerd or CRI-O and ensure that it is running within the user namespace befo
 Running CRI plugin of containerd in a user namespace is supported since containerd 1.4.
 
 Running containerd within a user namespace requires the following configurations
-in `/etc/containerd/containerd-config.toml`.
+in `/etc/containerd/config.toml`.
 
 ```toml
 version = 2


### PR DESCRIPTION
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

# Commit 1: `kubelet-in-userns.md: fix typoes`

(EOM)
- - -

# Commit 2: `kubelet-in-userns.md: fix unexpected config paths`

Referring to `/etc/containerd/config.toml` makes sense only when the user has read/write permissions to `/etc/containerd/config.toml` in the current mount namespace, which is not always assumed in the context of this documentation.

The same applies to `/etc/crio/crio.conf`, too.

Partially revert PR #30020 

- - -

# Commit 3: `kubelet-in-userns.md: add back the link to example port forwarder implementation`

Add back the link to `k3s/pkg/rootlessports/controller.go` removed in PR #30020 .

As stated in `{{ <note> }}`, the corresponding section is written for developers of Kubernetes distros, not for end users.
So we should retain the implementation details here.

Partially revert PR #30020 .
