### PR TITLE
Update Steering membership following 2021 election

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -223,12 +223,12 @@ aliases:
   # authoritative source: git.k8s.io/community/OWNERS_ALIASES
   committee-steering: # provide PR approvals for announcements
     - cblecker
-    - derekwaynecarr
     - dims
+    - justaugustus
     - liggitt
     - mrbobbytables
-    - nikhita
     - parispittman
+    - tpepper
   # authoritative source: https://git.k8s.io/sig-release/OWNERS_ALIASES
   sig-release-leads:
     - cpanato # SIG Technical Lead

--- a/content/en/blog/_posts/2021-11-08-steering-committee-results-2021.md
+++ b/content/en/blog/_posts/2021-11-08-steering-committee-results-2021.md
@@ -16,25 +16,28 @@ This community body is significant since it oversees the governance of the entir
 Congratulations to the elected committee members whose two year terms begin immediately (listed in alphabetical order by GitHub handle):
 
 * **Christoph Blecker ([@cblecker](https://github.com/cblecker)), Red Hat**
-* **Stephen Augustus ([@justaugusts](https://github.com/justaugustus)), Cisco**
+* **Stephen Augustus ([@justaugustus](https://github.com/justaugustus)), Cisco**
 * **Paris Pittman ([@parispittman](https://github.com/parispittman)), Apple**
 * **Tim Pepper ([@tpepper](https://github.com/tpepper)), VMware**
 
 They join continuing members:
+
 * **Davanum Srinivas ([@dims](https://github.com/dims)), VMware**
 * **Jordan Liggitt ([@liggitt](https://github.com/liggitt)), Google**
 * **Bob Killen ([@mrbobbytables](https://github.com/mrbobbytables)), Google**
 
 Paris Pittman and Christoph Blecker are returning Steering Committee Members.
 
-## Big Thanks!
+## Big Thanks
 
 Thank you and congratulations on a successful election to this round’s election officers:
+
 * Alison Dowdney, ([@alisondy](https://github.com/alisondy))
 * Noah Kantrowitz ([@coderanger](https://github.com/coderanger))
 * Josh Berkus ([@jberkus](https://github.com/jberkus))
 
 Thanks to the Emeritus Steering Committee Members. Your prior service is appreciated by the community:
+
 * Derek Carr ([@derekwaynecarr](https://github.com/derekwaynecarr))
 * Nikhita Raghunath ([@nikhita](https://github.com/nikhita))
 
@@ -46,6 +49,6 @@ This governing body, like all of Kubernetes, is open to all. You can follow alon
 
 You can see what the Steering Committee meetings are all about by watching past meetings on the [YouTube Playlist](https://www.youtube.com/playlist?list=PL69nYSiGNLP1yP1B_nd9-drjoxp0Q14qM).
 
-----
+---
 
 _This post was written by the [Upstream Marketing Working Group](https://github.com/kubernetes/community/tree/master/communication/marketing-team#contributor-marketing). If you want to write stories about the Kubernetes community, learn more about us._


### PR DESCRIPTION
Part of https://github.com/kubernetes/steering/issues/219.

Emeritus:
- @nikhita 
- @derekwaynecarr 

Returning:
- @parispittman 
- @cblecker 

New:
- @justaugustus 
- @tpepper 

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @parispittman @nikhita @mrbobbytables 
cc: @kubernetes/steering-committee 