### PR TITLE
Line separation is needed in reference/kubectl/overview

### DIFF
--- a/content/en/docs/reference/kubectl/overview.md
+++ b/content/en/docs/reference/kubectl/overview.md
@@ -91,6 +91,7 @@ If:
 * the `KUBERNETES_SERVICE_HOST` environment variable is set, and
 * the `KUBERNETES_SERVICE_PORT` environment variable is set, and
 * you don't explicitly specify a namespace on the kubectl command line
+
 then kubectl assumes it is running in your cluster. The kubectl tool looks up the
 namespace of that ServiceAccount (this is the same as the namespace of the Pod)
 and acts against that namespace. This is different from what happens outside of a


### PR DESCRIPTION
This fix improves the content formatting by separating bullet point list from a block of remarks that are related to ALL the points in the list.