### PR TITLE
docs: update scale-intro.html (pt-br)

### DIFF
--- a/content/pt-br/docs/tutorials/kubernetes-basics/scale/scale-intro.html
+++ b/content/pt-br/docs/tutorials/kubernetes-basics/scale/scale-intro.html
@@ -102,7 +102,7 @@ weight: 10
 
         <div class="row">
             <div class="col-md-8">
-                <p>No momento em que tiver múltiplas instâncias de uma aplicação em execução, será capaz de fazer atualizações graduais sem indisponibilidade. Nós cobriremos isso no próximo módulo. Agora, vamos ao terminal online e escalar nossa aplicação.</p>
+                <p>No momento em que múltiplas instâncias de uma aplicação estiverem em execução será possível realizar atualizações graduais no cluster sem que ocorra indisponibilidade. Nós cobriremos isso no próximo módulo. Agora, vamos ao terminal online e escalar nossa aplicação.</p>
             </div>
         </div>
         <br>


### PR DESCRIPTION
The doc version for brazilian portuguese scale-intro page seems to be generated by an AI powered engine, which is not quite right and/or specific as the original one.

This PR changes a few words and a bit of the structure of the phrase in the pt-br doc, using de original (en) version as source of information.
