### PR TITLE
Update Kubernetes API index page

### DIFF
--- a/content/en/docs/reference/kubernetes-api/_index.md
+++ b/content/en/docs/reference/kubernetes-api/_index.md
@@ -5,4 +5,4 @@ weight: 30
 
 <!-- overview -->
 
-{{< glossary_definition prepend="Kubernetes' API is" term_id="kubernetes-api" length="all" >}}
+{{< glossary_definition prepend="Kubernetes API is" term_id="kubernetes-api" length="all" >}}


### PR DESCRIPTION
Correction of a small typo in the Kubernetes API index page 

![image](https://user-images.githubusercontent.com/23166349/141091660-57cc9940-fd35-45ef-91bc-ba5ab40a88dd.png)
