### PR TITLE
Added a note for CRD improvement in Docs

### DIFF
--- a/content/en/docs/concepts/storage/volume-snapshot-classes.md
+++ b/content/en/docs/concepts/storage/volume-snapshot-classes.md
@@ -39,6 +39,10 @@ request a particular class. Administrators set the name and other parameters
 of a class when first creating VolumeSnapshotClass objects, and the objects cannot
 be updated once they are created.
 
+{{< note >}}
+Installation of the CRDs is the responsibility of the Kubernetes distribution. Without the required CRDs present, the creation of a VolumeSnapshotClass fails.  
+{{< /note >}}
+
 ```yaml
 apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass


### PR DESCRIPTION
For Applying [VolumeSnapshotClass yaml](https://kubernetes.io/docs/concepts/storage/volume-snapshot-classes/#the-volumesnapshotclass-resource) we must have apply respective CRD's for the same.This statement is not been explicitly define,So i have added a note for the same.