### PR TITLE
[en] Update link to cert-manager website

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
@@ -165,7 +165,7 @@ These are advanced topics for users who need to integrate their organization's c
 ### Set up a signer
 
 The Kubernetes Certificate Authority does not work out of the box.
-You can configure an external signer such as [cert-manager](https://docs.cert-manager.io/en/latest/tasks/issuers/setup-ca.html), or you can use the built-in signer.
+You can configure an external signer such as [cert-manager](https://cert-manager.io/docs/configuration/ca/), or you can use the built-in signer.
 
 The built-in signer is part of [`kube-controller-manager`](/docs/reference/command-line-tools-reference/kube-controller-manager/).
 


### PR DESCRIPTION
The link to the cert-manager docs points to the old cert-manager docs site. We've added a redirect so the old `docs.cert-manager.io` link works, but it'd be best to update the link here too!

Following the example of #28751 which is a similar update to a link, I'll raise the equivalent changes for the Chinese and Korean docs in separate PRs.

/language en