### PR TITLE
Fix to reveal more info when '[+]' is clicked

### DIFF
--- a/content/en/docs/reference/glossary/pod-disruption-budget.md
+++ b/content/en/docs/reference/glossary/pod-disruption-budget.md
@@ -15,4 +15,12 @@ tags:
  - operation
 ---
 
- A [Pod Disruption Budget](/docs/concepts/workloads/pods/disruptions/) allows an application owner to create an object for a replicated application, that ensures a certain number or percentage of Pods with an assigned label will not be voluntarily evicted at any point in time. PDBs cannot prevent an involuntary disruption, but will count against the budget.
+ A [Pod Disruption Budget](/docs/concepts/workloads/pods/disruptions/) allows an 
+ application owner to create an object for a replicated application, that ensures 
+ a certain number or percentage of Pods with an assigned label will not be voluntarily
+ evicted at any point in time.
+
+<!--more--> 
+
+PDBs cannot prevent an involuntary disruption, but 
+ will count against the budget.


### PR DESCRIPTION
ᕕ(ᐛ)ᕗ Hello friends!

Currently in the glossary, in the 'Pod Disruption Budget' definition, when the '[+]' is clicked the definition simply repeats itself.  

 This should fix that to instead display more information when the '[+]' is clicked.  
