### PR TITLE
CSI migration portworx in alpha state

### DIFF
--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -1050,6 +1050,16 @@ but new volumes created by the vSphere CSI driver will not be honoring these par
 
 To turn off the `vsphereVolume` plugin from being loaded by the controller manager and the kubelet, you need to set `InTreePluginvSphereUnregister` feature flag to `true`. You must install a `csi.vsphere.vmware.com` {{< glossary_tooltip text="CSI" term_id="csi" >}} driver on all worker nodes.
 
+#### Portworx CSI migration
+{{< feature-state for_k8s_version="v1.23" state="alpha" >}}
+
+The `CSIMigration` feature for Portworx has been added but disabled by default in Kubernetes 1.23 since it's in alpha state.
+It redirects all plugin operations from the existing in-tree plugin to the
+`pxd.portworx.com` Container Storage Interface (CSI) Driver.
+[Portworx CSI Driver](https://docs.portworx.com/portworx-install-with-kubernetes/storage-operations/csi/)
+must be installed on the cluster.
+To enable the feature, set `CSIMigrationPortworx=true` in kube-controller-manager and kubelet.
+
 ## Using subPath {#using-subpath}
 
 Sometimes, it is useful to share one volume for multiple uses in a single pod.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -84,6 +84,7 @@ different Kubernetes components.
 | `CSIMigrationOpenStack` | `false` | Alpha | 1.14 | 1.17 |
 | `CSIMigrationOpenStack` | `true` | Beta | 1.18 | |
 | `CSIMigrationvSphere` | `false` | Beta | 1.19 | |
+| `CSIMigrationPortworx` | `false` | Alpha | 1.23 | |
 | `CSIMigrationRBD` | `false` | Alpha | 1.23 | |
 | `CSIStorageCapacity` | `false` | Alpha | 1.19 | 1.20 |
 | `CSIStorageCapacity` | `true` | Beta | 1.21 | |
@@ -664,6 +665,9 @@ Each feature gate is designed for enabling/disabling a specific feature:
   CSIMigrationvSphere feature flags enabled and vSphere CSI plugin installed and
   configured on all nodes in the cluster. This flag has been deprecated in favor
   of the `InTreePluginvSphereUnregister` feature flag which prevents the registration of in-tree vsphere plugin.
+- `CSIMigrationPortworx`: Enables shims and translation logic to route volume operations
+  from the Portworx in-tree plugin to Portworx CSI plugin.
+  Requires Portworx CSI driver to be installed and configured in the cluster, and feature gate set `CSIMigrationPortworx=true` in kube-controller-manager and kubelet configs.
 - `CSINodeInfo`: Enable all logic related to the CSINodeInfo API object in csi.storage.k8s.io.
 - `CSIPersistentVolume`: Enable discovering and mounting volumes provisioned through a
   [CSI (Container Storage Interface)](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/container-storage-interface.md)


### PR DESCRIPTION
<!-- 🛈

Document that Portworx CSI migration is added and disabled by default in Kubernetes 1.23 and that the corresponding CSI driver must be installed.

PR: https://github.com/kubernetes/kubernetes/pull/103447
KEP: https://github.com/kubernetes/enhancements/issues/2589
-->
