### PR TITLE
[ja] Fix: link to ja/docs/concepts/extend-kubernetes/operator/ in ja/docs/concepts/extend-kubernetes/

### DIFF
--- a/content/ja/docs/concepts/extend-kubernetes/_index.md
+++ b/content/ja/docs/concepts/extend-kubernetes/_index.md
@@ -161,4 +161,4 @@ Kubernetesはいくつかのビルトイン認証方式と、それらが要件�
   * [ネットワークプラグイン](/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/)
   * [デバイスプラグイン](/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)
 * [kubectlプラグイン](/docs/tasks/extend-kubectl/kubectl-plugins/)について学ぶ
-* [オペレーターパターン](/docs/concepts/extend-kubernetes/operator/)について学ぶ
+* [オペレーターパターン](/ja/docs/concepts/extend-kubernetes/operator/)について学ぶ

--- a/content/ja/docs/concepts/extend-kubernetes/_index.md
+++ b/content/ja/docs/concepts/extend-kubernetes/_index.md
@@ -30,7 +30,7 @@ Kubernetesは柔軟な設定が可能で、高い拡張性を持っています�
 
 ホスティングされたKubernetesサービスやマネージドなKubernetesでは、フラグと設定ファイルが常に変更できるとは限りません。変更可能な場合でも、通常はクラスターの管理者のみが変更できます。また、それらは将来のKubernetesバージョンで変更される可能性があり、設定変更にはプロセスの再起動が必要になるかもしれません。これらの理由により、この方法は他の選択肢が無いときにのみ利用するべきです。
 
-[ResourceQuota](/docs/concepts/policy/resource-quotas/)、[PodSecurityPolicy](/docs/concepts/policy/pod-security-policy/)、[NetworkPolicy](/docs/concepts/services-networking/network-policies/)、そしてロールベースアクセス制御([RBAC](/docs/reference/access-authn-authz/rbac/))といった *ビルトインポリシーAPI* は、ビルトインのKubernetes APIです。APIは通常、ホスティングされたKubernetesサービスやマネージドなKubernetesで利用されます。これらは宣言的で、Podのような他のKubernetesリソースと同じ慣例に従っています。そのため、新しいクラスターの設定は繰り返し再利用することができ、アプリケーションと同じように管理することが可能です。さらに、安定版(stable)を利用している場合、他のKubernetes APIのような[定義済みのサポートポリシー](/docs/reference/deprecation-policy/)を利用することができます。これらの理由により、この方法は、適切な用途の場合、 *設定ファイル* や *フラグ* よりも好まれます。
+[ResourceQuota](/ja/docs/concepts/policy/resource-quotas/)、[PodSecurityPolicy](/docs/concepts/policy/pod-security-policy/)、[NetworkPolicy](/ja/docs/concepts/services-networking/network-policies/)、そしてロールベースアクセス制御([RBAC](/ja/docs/reference/access-authn-authz/rbac/))といった *ビルトインポリシーAPI* は、ビルトインのKubernetes APIです。APIは通常、ホスティングされたKubernetesサービスやマネージドなKubernetesで利用されます。これらは宣言的で、Podのような他のKubernetesリソースと同じ慣例に従っています。そのため、新しいクラスターの設定は繰り返し再利用することができ、アプリケーションと同じように管理することが可能です。さらに、安定版(stable)を利用している場合、他のKubernetes APIのような[定義済みのサポートポリシー](/docs/reference/deprecation-policy/)を利用することができます。これらの理由により、この方法は、適切な用途の場合、 *設定ファイル* や *フラグ* よりも好まれます。
 
 ## 拡張
 
@@ -115,7 +115,7 @@ Kubdernetesはいくつかのビルトイン認証方式をサポートしてい
 
 [認証](/ja/docs/reference/access-authn-authz/authentication/)は、全てのリクエストのヘッダーまたは証明書情報を、リクエストを投げたクライアントのユーザー名にマッピングします。
 
-Kubernetesはいくつかのビルトイン認証方式と、それらが要件に合わない場合、[認証Webhook](/docs/reference/access-authn-authz/authentication/#webhook-token-authentication)を提供します。
+Kubernetesはいくつかのビルトイン認証方式と、それらが要件に合わない場合、[認証Webhook](ja/docs/reference/access-authn-authz/authentication/#webhook-token-authentication)を提供します。
 
 ### 認可
 

--- a/content/ja/docs/concepts/extend-kubernetes/_index.md
+++ b/content/ja/docs/concepts/extend-kubernetes/_index.md
@@ -115,7 +115,7 @@ Kubdernetesはいくつかのビルトイン認証方式をサポートしてい
 
 [認証](/ja/docs/reference/access-authn-authz/authentication/)は、全てのリクエストのヘッダーまたは証明書情報を、リクエストを投げたクライアントのユーザー名にマッピングします。
 
-Kubernetesはいくつかのビルトイン認証方式と、それらが要件に合わない場合、[認証Webhook](ja/docs/reference/access-authn-authz/authentication/#webhook-token-authentication)を提供します。
+Kubernetesはいくつかのビルトイン認証方式と、それらが要件に合わない場合、[認証Webhook](/ja/docs/reference/access-authn-authz/authentication/#webhook-token-authentication)を提供します。
 
 ### 認可
 


### PR DESCRIPTION
Fix the link to `ja/docs/concepts/extend-kubernetes/operator/`