### PR TITLE
[ja] Remove ^H character

### DIFF
--- a/content/ja/docs/tasks/network/validate-dual-stack.md
+++ b/content/ja/docs/tasks/network/validate-dual-stack.md
@@ -135,7 +135,7 @@ status:
   loadBalancer: {}
 ```
 
-`.spec.ipFamilies`内の配列の1番目の要素に`IPv6`を明示的に指定した、次のようなServiceを作成してみます。Kubernetesは`service-cluster-ip-range`で設定したIPv6の範囲からcluster IPを割り当てて、`.spec.ipFamilyPolicy`を`SingleStack`に設定します。
+`.spec.ipFamilies`内の配列の1番目の要素に`IPv6`を明示的に指定した、次のようなServiceを作成してみます。Kubernetesは`service-cluster-ip-range`で設定したIPv6の範囲からcluster IPを割り当てて、`.spec.ipFamilyPolicy`を`SingleStack`に設定します。
 
 {{< codenew file="service/networking/dual-stack-ipfamilies-ipv6.yaml" >}}
 
@@ -173,7 +173,7 @@ status:
   loadBalancer: {}
 ```
 
-`.spec.ipFamiliePolicy`に`PreferDualStack`を明示的に指定した、次のようなServiceを作成してみます。Kubernetesは(クラスターでデュアルスタックを有効化しているため)IPv4およびIPv6のアドレスの両方を割り当て、`.spec.ClusterIPs`のリストから、`.spec.ipFamilies`配列の最初の要素のアドレスファミリーに基づいた`.spec.ClusterIP`を設定します。
+`.spec.ipFamiliePolicy`に`PreferDualStack`を明示的に指定した、次のようなServiceを作成してみます。Kubernetesは(クラスターでデュアルスタックを有効化しているため)IPv4およびIPv6のアドレスの両方を割り当て、`.spec.ClusterIPs`のリストから、`.spec.ipFamilies`配列の最初の要素のアドレスファミリーに基づいた`.spec.ClusterIP`を設定します。
 
 {{< codenew file="service/networking/dual-stack-preferred-svc.yaml" >}}
 

--- a/content/ja/docs/tutorials/clusters/apparmor.md
+++ b/content/ja/docs/tutorials/clusters/apparmor.md
@@ -35,7 +35,7 @@ AppArmorを利用すれば、コンテナに許可することを制限したり
    gke-test-default-pool-239f5d02-xwux: v1.4.0
    ```
 
-2. AppArmorカーネルモジュールが有効であること。LinuxカーネルがAppArmorプロファイルを強制するためには、AppArmorカーネルモジュールのインストールと有効化が必須です。UbuntuやSUSEなどのディストリビューションではデフォルトで有効化されますが、他の多くのディストリビューションでのサポートはオプションです。モジュールが有効になっているかチェックするには、次のように`/sys/module/apparmor/parameters/enabled`ファイルを確認します。
+2. AppArmorカーネルモジュールが有効であること。LinuxカーネルがAppArmorプロファイルを強制するためには、AppArmorカーネルモジュールのインストールと有効化が必須です。UbuntuやSUSEなどのディストリビューションではデフォルトで有効化されますが、他の多くのディストリビューションでのサポートはオプションです。モジュールが有効になっているかチェックするには、次のように`/sys/module/apparmor/parameters/enabled`ファイルを確認します。
 
    ```shell
    cat /sys/module/apparmor/parameters/enabled


### PR DESCRIPTION
Signed-off-by: Guangwen Feng <fenggw-fnst@cn.fujitsu.com>

The ^H character (ASCII code 08 Backspace) will break the format of the content in some environments, so drop it.