### PR TITLE
Fix to reveal more info when '[+]' is clicked

### DIFF
--- a/content/en/docs/reference/glossary/pod-disruption.md
+++ b/content/en/docs/reference/glossary/pod-disruption.md
@@ -14,6 +14,11 @@ tags:
  - operation
 ---
 
-[Pod disruption](/docs/concepts/workloads/pods/disruptions/) is the process by which Pods on Nodes are terminated either voluntarily or involuntarily. 
+[Pod disruption](/docs/concepts/workloads/pods/disruptions/) is the process by which 
+Pods on Nodes are terminated either voluntarily or involuntarily. 
 
-Voluntary disruptions are started intentionally by application owners or cluster administrators. Involuntary disruptions are unintentional and can be triggered by unavoidable issues like Nodes running out of resources, or by accidental deletions. 
+<!--more--> 
+
+Voluntary disruptions are started intentionally by application owners or cluster 
+administrators. Involuntary disruptions are unintentional and can be triggered by 
+unavoidable issues like Nodes running out of resources, or by accidental deletions. 


### PR DESCRIPTION
(´ ▽｀).。ｏ♡ Hello friends!

Currently in the glossary, in the 'Pod Disruption' definition, when the '[+]' is clicked the definition simply repeats itself.  

 This should fix that to instead display more information when the '[+]' is clicked.  