### PR TITLE
Fix layout issue in docs pages, like jobs

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -39,9 +39,6 @@ section {
 }
 
 body {
-  display: grid;
-  grid-column-template: auto;
-
   header + .td-outer {
     min-height: 50vh;
     height: auto;


### PR DESCRIPTION
This fixes an issue where the [docs page for Jobs resource](https://kubernetes.io/docs/concepts/workloads/controllers/job/), among other pages, is not rendering correctly. A few screens worth of horizontal scrolling applies because the `display` property of `body` has been changed globally. See #30470 for more details.

This is a 4k screenshot zoomed out to 25%, showing the buggy behaviour:
![image](https://user-images.githubusercontent.com/20756439/141794786-641df9da-370b-4858-a252-0dad63cec9c7.png)


Note that I'm not particularly in context with #30082 (where these 2 lines were introduced), perhaps someone could verify that everything from that PR still works as expected?

Find that the page is now correctly working in the [preview](https://deploy-preview-30490--kubernetes-io-main-staging.netlify.app/docs/concepts/workloads/controllers/job/).

- Fixes #30463
- Fixes #30467
- Fixes #30470
- Fixes #30487
- Fixes #30488
- Fixes #30489
- Fixes #30491
- Fixes #30492
- Fixes #30493