### PR TITLE
Update incorrect GH profile link

### DIFF
--- a/content/en/blog/_posts/2020-10-12-steering-committee-results.md
+++ b/content/en/blog/_posts/2020-10-12-steering-committee-results.md
@@ -29,7 +29,7 @@ They join continuing members Christoph Blecker ([@cblecker](https://github.com/c
   * Josh Berkus ([@jberkus](https://github.com/jberkus)), Red Hat
 * Thanks to the Emeritus Steering Committee Members. Your prior service is appreciated by the community:
   * Aaron Crickenberger ([@spiffxp](https://github.com/spiffxp)), Google
-  * and Lachlan Evenson([@lachie8e)](https://github.com/lachie8e)), Microsoft
+  * and Lachlan Evenson([@lachie83)](https://github.com/lachie83)), Microsoft
 * And thank you to all the candidates who came forward to run for election. As [Jorge Castro put it](https://twitter.com/castrojo/status/1315718627639820288?s=20): we are spoiled with capable, kind, and selfless volunteers who put the needs of the project first.
 
 ## Get Involved with the Steering Committee


### PR DESCRIPTION
This fixes an incorrect GH profile link.

Signed-off-by: Lachlan Evenson <lachlan.evenson@microsoft.com>

cc @tallclair 