### PR TITLE
Update manage-resources-containers.md

### DIFF
--- a/content/en/docs/concepts/configuration/manage-resources-containers.md
+++ b/content/en/docs/concepts/configuration/manage-resources-containers.md
@@ -116,11 +116,11 @@ CPU is always requested as an absolute quantity, never as a relative quantity;
 
 Limits and requests for `memory` are measured in bytes. You can express memory as
 a plain integer or as a fixed-point number using one of these suffixes:
-E, P, T, G, M, k. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi,
+E, P, T, G, M, k, m (millis). You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi,
 Mi, Ki. For example, the following represent roughly the same value:
 
 ```shell
-128974848, 129e6, 129M, 123Mi
+128974848, 129e6, 129M,  128974848000m, 123Mi
 ```
 
 Here's an example.


### PR DESCRIPTION
Although it's not recommended, we also support 'm' as an unit for memory which means milli-bytes.

https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go#L46

This is confusing because this behaviour is not mentioned in any document. We need to document it unless we block using this unit.

https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory