### PR TITLE
Reorder storage concepts

### DIFF
--- a/content/en/docs/concepts/storage/ephemeral-volumes.md
+++ b/content/en/docs/concepts/storage/ephemeral-volumes.md
@@ -7,7 +7,7 @@ reviewers:
 - pohly
 title: Ephemeral Volumes
 content_type: concept
-weight: 50
+weight: 30
 ---
 
 <!-- overview -->

--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -10,14 +10,13 @@ feature:
   title: Storage orchestration
   description: >
     Automatically mount the storage system of your choice, whether from local storage, a public cloud provider such as <a href="https://cloud.google.com/storage/">GCP</a> or <a href="https://aws.amazon.com/products/storage/">AWS</a>, or a network storage system such as NFS, iSCSI, Gluster, Ceph, Cinder, or Flocker.
-
 content_type: concept
 weight: 20
 ---
 
 <!-- overview -->
 
-This document describes the current state of _persistent volumes_ in Kubernetes. Familiarity with [volumes](/docs/concepts/storage/volumes/) is suggested.
+This document describes _persistent volumes_ in Kubernetes. Familiarity with [volumes](/docs/concepts/storage/volumes/) is suggested.
 
 <!-- body -->
 

--- a/content/en/docs/concepts/storage/projected-volumes.md
+++ b/content/en/docs/concepts/storage/projected-volumes.md
@@ -6,6 +6,7 @@ reviewers:
 - zshihang
 title: Projected Volumes
 content_type: concept
+weight: 21 # just after persistent volumes
 ---
 
 <!-- overview -->

--- a/content/en/docs/concepts/storage/projected-volumes.md
+++ b/content/en/docs/concepts/storage/projected-volumes.md
@@ -1,6 +1,5 @@
 ---
 reviewers:
-- sftim
 - marosset
 - jsturtevant
 - zshihang
@@ -11,7 +10,7 @@ weight: 21 # just after persistent volumes
 
 <!-- overview -->
 
-This document describes the current state of _projected volumes_ in Kubernetes. Familiarity with [volumes](/docs/concepts/storage/volumes/) is suggested.
+This document describes _projected volumes_ in Kubernetes. Familiarity with [volumes](/docs/concepts/storage/volumes/) is suggested.
 
 <!-- body -->
 

--- a/content/en/docs/concepts/storage/storage-capacity.md
+++ b/content/en/docs/concepts/storage/storage-capacity.md
@@ -7,7 +7,7 @@ reviewers:
 - pohly
 title: Storage Capacity
 content_type: concept
-weight: 45
+weight: 70
 ---
 
 <!-- overview -->

--- a/content/en/docs/concepts/storage/storage-capacity.md
+++ b/content/en/docs/concepts/storage/storage-capacity.md
@@ -16,7 +16,6 @@ Storage capacity is limited and may vary depending on the node on
 which a pod runs: network-attached storage might not be accessible by
 all nodes, or storage is local to a node to begin with.
 
-{{< feature-state for_k8s_version="v1.19" state="alpha" >}}
 {{< feature-state for_k8s_version="v1.21" state="beta" >}}
 
 This page describes how Kubernetes keeps track of storage capacity and

--- a/content/en/docs/concepts/storage/volume-pvc-datasource.md
+++ b/content/en/docs/concepts/storage/volume-pvc-datasource.md
@@ -6,7 +6,7 @@ reviewers:
 - msau42
 title: CSI Volume Cloning
 content_type: concept
-weight: 30
+weight: 60
 ---
 
 <!-- overview -->

--- a/content/en/docs/concepts/storage/volume-snapshot-classes.md
+++ b/content/en/docs/concepts/storage/volume-snapshot-classes.md
@@ -8,7 +8,7 @@ reviewers:
 - yuxiangqian
 title: Volume Snapshot Classes
 content_type: concept
-weight: 30
+weight: 41 # just after volume snapshots
 ---
 
 <!-- overview -->

--- a/content/en/docs/concepts/storage/volume-snapshots.md
+++ b/content/en/docs/concepts/storage/volume-snapshots.md
@@ -8,7 +8,7 @@ reviewers:
 - yuxiangqian
 title: Volume Snapshots
 content_type: concept
-weight: 20
+weight: 40
 ---
 
 <!-- overview -->


### PR DESCRIPTION
Introduce concepts in an order that should suit people new to Kubernetes, so that you don't encounter details like volume cloning
until you've seen more of the basic volume types (persistent, ephemeral, projected).

[Before](https://k8s.io/docs/concepts/storage/) vs [after](https://deploy-preview-30517--kubernetes-io-main-staging.netlify.app/docs/concepts/storage/).

The order I ended up with is:
- **Volumes**
- **Persistent Volumes**
- **Projected Volumes**
- **Ephemeral Volumes**
- **Storage Classes**
- **Dynamic Volume Provisioning**
- **Volume Snapshots**
- **Volume Snapshot Classes**
- **CSI Volume Cloning**
- **Storage Capacity**
- **Node-specific Volume Limits**
- **Volume Health Monitoring**

/sig storage
(to check if this makes sense)