### PR TITLE
[ko] Update outdated files in dev-1.22-ko.3 (M28-M38)

### DIFF
--- a/content/ko/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/ko/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -2,6 +2,7 @@
 title: NGINX 인그레스(Ingress) 컨트롤러로 Minikube에서 인그레스 설정하기
 content_type: task
 weight: 100
+min-kubernetes-server-version: 1.19
 ---
 
 <!-- overview -->
@@ -17,22 +18,20 @@ API 객체이다. [인그레스 컨트롤러](/ko/docs/concepts/services-network
 
 
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+만약 이보다 더 이전 버전의 쿠버네티스를 사용하고 있다면, 
+해당 쿠버네티스 버전의 문서를 참고한다.
 
 
+### Minikube 클러스터 생성하기
+
+Katacoda 활용하기
+: {{< kat-button >}}
+
+로컬에서 생성하기
+: 이미 로컬에 [Minikube를 설치](/ko/docs/tasks/tools/#minikube)했다면,
+  `minikube start`를 실행하여 클러스터를 생성한다.
 
 <!-- steps -->
-
-## Minikube 클러스터 생성하기
-
-1. **터미널 실행**을 클릭한다.
-
-    {{< kat-button >}}
-
-1. (선택 사항) Minikube를 로컬로 설치한 경우 다음 명령을 실행한다.
-
-    ```shell
-    minikube start
-    ```
 
 ## 인그레스 컨트롤러 활성화
 
@@ -45,14 +44,14 @@ API 객체이다. [인그레스 컨트롤러](/ko/docs/concepts/services-network
 1. NGINX 인그레스 컨트롤러가 실행 중인지 확인한다.
 
 
-  {{< tabs name="tab_with_md" >}}
-  {{% tab name="minikube v1.19 or later" %}}
+   {{< tabs name="tab_with_md" >}}
+   {{% tab name="minikube v1.19 or later" %}}
 ```shell
 kubectl get pods -n ingress-nginx
 ```
-  {{< note >}}이 작업은 1분 정도 소요될 수 있다.{{< /note >}}
+   {{< note >}}파드가 정상적으로 실행되기까지 1분 정도 소요될 수 있다.{{< /note >}}
 
-Output:
+   결과는 다음과 같다.
 
 ```
 NAME                                        READY   STATUS      RESTARTS    AGE
@@ -60,15 +59,14 @@ ingress-nginx-admission-create-g9g49        0/1     Completed   0          11m
 ingress-nginx-admission-patch-rqp78         0/1     Completed   1          11m
 ingress-nginx-controller-59b45fb494-26npt   1/1     Running     0          11m
 ```
-    {{% /tab %}}
-
-  {{% tab name="minikube v1.18.1 or earlier" %}}
+   {{% /tab %}}
+   {{% tab name="minikube v1.18.1 or earlier" %}}
 ```shell
 kubectl get pods -n kube-system
 ```
-{{< note >}}이 작업은 1분 정도 소요될 수 있다.{{< /note >}}
+   {{< note >}}파드가 정상적으로 실행되기까지 1분 정도 소요될 수 있다.{{< /note >}}
 
-Output:
+   결과는 다음과 같다.
 
 ```
 NAME                                        READY     STATUS    RESTARTS   AGE
@@ -79,133 +77,121 @@ kubernetes-dashboard-5498ccf677-b8p5h       1/1       Running   0          2m
 nginx-ingress-controller-5984b97644-rnkrg   1/1       Running   0          1m
 storage-provisioner                         1/1       Running   0          2m
 ```
-    {{% /tab %}}
-      {{< /tabs >}}
-  
 
-
-    ```shell
-    kubectl get pods -n ingress-nginx
-    ```
-
-    {{< note >}}이 작업은 1분 정도 소요될 수 있다.{{< /note >}}
-
-    Output:
-
-    ```shell
-    NAME                                        READY   STATUS      RESTARTS   AGE
-    ingress-nginx-admission-create-2tgrf        0/1     Completed   0          3m28s
-    ingress-nginx-admission-patch-68b98         0/1     Completed   0          3m28s
-    ingress-nginx-controller-59b45fb494-lzmw2   1/1     Running     0          3m28s
-    ```
-
+  `nginx-ingress-controller-`로 시작하는 파드가 있는지 확인한다.
+   {{% /tab %}}
+   {{< /tabs >}}
 
 ## hello, world 앱 배포하기
 
 1. 다음 명령을 사용하여 디플로이먼트(Deployment)를 생성한다.
 
-    ```shell
-    kubectl create deployment web --image=gcr.io/google-samples/hello-app:1.0
-    ```
+   ```shell
+   kubectl create deployment web --image=gcr.io/google-samples/hello-app:1.0
+   ```
 
-    Output:
+   결과는 다음과 같다.
 
-    ```shell
-    deployment.apps/web created
-    ```
+   ```
+   deployment.apps/web created
+   ```
 
 1. 디플로이먼트를 노출시킨다.
 
-    ```shell
-    kubectl expose deployment web --type=NodePort --port=8080
-    ```
+   ```shell
+   kubectl expose deployment web --type=NodePort --port=8080
+   ```
 
-    Output:
+   결과는 다음과 같다.
 
-    ```shell
-    service/web exposed
-    ```
+   ```
+   service/web exposed
+   ```
 
 1. 서비스(Service)가 생성되고 노드 포트에서 사용할 수 있는지 확인한다.
 
-    ```shell
-    kubectl get service web
-    ```
+   ```shell
+   kubectl get service web
+   ```
 
-    Output:
+   결과는 다음과 같다.
 
-    ```shell
-    NAME      TYPE       CLUSTER-IP       EXTERNAL-IP   PORT(S)          AGE
-    web       NodePort   10.104.133.249   <none>        8080:31637/TCP   12m
-    ```
+   ```
+   NAME      TYPE       CLUSTER-IP       EXTERNAL-IP   PORT(S)          AGE
+   web       NodePort   10.104.133.249   <none>        8080:31637/TCP   12m
+   ```
 
 1. 노드포트(NodePort)를 통해 서비스에 접속한다.
 
-    ```shell
-    minikube service web --url
-    ```
+   ```shell
+   minikube service web --url
+   ```
 
-    Output:
+   결과는 다음과 같다.
 
-    ```shell
-    http://172.17.0.15:31637
-    ```
+   ```
+   http://172.17.0.15:31637
+   ```
 
-    {{< note >}}Katacoda 환경만 해당: 터미널 패널 상단에서 더하기 기호를 클릭한 다음 **Select port to view on Host 1**을 클릭한다. 노드포트(이 경우 '31637')를 입력한 다음 **Display Port**를 클릭한다.{{< /note >}}
+   {{< note >}}Katacoda 환경만 해당: 터미널 패널 상단에서 더하기 기호를 클릭한 다음 **Select port to view on Host 1**을 클릭한다. 노드포트(이 경우 '31637')를 입력한 다음 **Display Port**를 클릭한다.{{< /note >}}
 
-    Output:
+   결과는 다음과 같다.
 
-    ```shell
-    Hello, world!
-    Version: 1.0.0
-    Hostname: web-55b8c6998d-8k564
-    ```
+   ```
+   Hello, world!
+   Version: 1.0.0
+   Hostname: web-55b8c6998d-8k564
+   ```
 
-    이제 Minikube IP 주소와 노드포트를 통해 샘플 앱에 액세스할 수 있다. 다음 단계에서는 
-    인그레스 리소스를 사용하여 앱에 액세스할 수 있다.
+   이제 Minikube IP 주소와 노드포트를 통해 샘플 앱에 액세스할 수 있다. 다음 단계에서는 
+   인그레스 리소스를 사용하여 앱에 액세스할 수 있다.
 
-## 인그레스 리소스 생성하기
+## 인그레스 생성하기
 
-다음 파일은 hello-world.info를 통해 서비스로 트래픽을 보내는 인그레스 리소스다.
+다음 매니페스트는 hello-world.info를 통해 서비스로 트래픽을 보내는 인그레스를 정의한다.
 
 1. 다음 파일을 통해 `example-ingress.yaml`을 만든다.
 
   {{< codenew file="service/networking/example-ingress.yaml" >}}
 
-1. 다음 명령어를 실행하여 인그레스 리소스를 생성한다.
+1. 다음 명령어를 실행하여 인그레스 오브젝트를 생성한다.
 
-    ```shell
-    kubectl apply -f https://k8s.io/examples/service/networking/example-ingress.yaml
-    ```
+   ```shell
+   kubectl apply -f https://k8s.io/examples/service/networking/example-ingress.yaml
+   ```
 
-    Output:
+   결과는 다음과 같다.
 
-    ```shell
-    ingress.networking.k8s.io/example-ingress created
-    ```
+   ```
+   ingress.networking.k8s.io/example-ingress created
+   ```
 
 1. IP 주소가 설정되었는지 확인한다.
 
-    ```shell
-    kubectl get ingress
-    ```
+   ```shell
+   kubectl get ingress
+   ```
 
-    {{< note >}}이 작업은 몇 분 정도 소요될 수 있다.{{< /note >}}
+   {{< note >}}이 작업은 몇 분 정도 소요될 수 있다.{{< /note >}}
 
-    ```shell
-    NAME              CLASS    HOSTS              ADDRESS        PORTS   AGE
-    example-ingress   <none>   hello-world.info   172.17.0.15    80      38s
-    ```
+다음 예시와 같이, ADDRESS 열에서 IPv4 주소를 확인할 수 있다.
 
-1. `/etc/hosts` 파일의 맨 아래에 다음 행을 추가한다.
+   ```
+   NAME              CLASS    HOSTS              ADDRESS        PORTS   AGE
+   example-ingress   <none>   hello-world.info   172.17.0.15    80      38s
+   ```
 
-    {{< note >}}Minikube를 로컬에서 실행하는 경우 'minikube ip'를 사용하여 외부 IP를 가져온다. 인그레스 목록에 표시되는 IP 주소는 내부 IP가 된다.{{< /note >}}
+1. 호스트 컴퓨터의 `/etc/hosts` 파일 맨 아래에 
+   다음 행을 추가한다 (관리자 권한 필요).
 
     ```
     172.17.0.15 hello-world.info
     ```
 
-    이것은 hello-world.info에서 Minikube로 요청을 보낸다.
+   {{< note >}}Minikube를 로컬에서 실행하는 경우 'minikube ip'를 사용하여 외부 IP를 가져온다. 인그레스 목록에 표시되는 IP 주소는 내부 IP가 된다.{{< /note >}}
+
+    이렇게 하면, 웹 브라우저가 
+    hello-world.info URL에 대한 요청을 Minikube로 전송한다.
 
 1. 인그레스 컨트롤러가 트래픽을 전달하는지 확인한다.
 
@@ -213,9 +199,9 @@ storage-provisioner                         1/1       Running   0          2m
     curl hello-world.info
     ```
 
-    Output:
+    결과는 다음과 같다.
 
-    ```shell
+    ```
     Hello, world!
     Version: 1.0.0
     Hostname: web-55b8c6998d-8k564
@@ -225,32 +211,33 @@ storage-provisioner                         1/1       Running   0          2m
 
 ## 두 번째 디플로이먼트 생성하기
 
-1. 다음 명령을 사용하여 v2 디플로이먼트를 생성한다.
+1. 다음 명령을 사용하여 두 번째 디플로이먼트를 생성한다.
 
-    ```shell
-    kubectl create deployment web2 --image=gcr.io/google-samples/hello-app:2.0
-    ```
-    Output:
+   ```shell
+   kubectl create deployment web2 --image=gcr.io/google-samples/hello-app:2.0
+   ```
+   결과는 다음과 같다.
 
-    ```shell
-    deployment.apps/web2 created
-    ```
+   ```
+   deployment.apps/web2 created
+   ```
 
-1. 디플로이먼트를 노출시킨다.
+1. 두 번째 디플로이먼트를 노출시킨다.
 
-    ```shell
-    kubectl expose deployment web2 --port=8080 --type=NodePort
-    ```
+   ```shell
+   kubectl expose deployment web2 --port=8080 --type=NodePort
+   ```
 
-    Output:
+   결과는 다음과 같다.
 
-    ```shell
-    service/web2 exposed
-    ```
+   ```
+   service/web2 exposed
+   ```
 
-## 인그레스 수정하기
+## 기존 인그레스 수정하기 {#edit-ingress}
 
-1. 기존 `example-ingress.yaml`을 편집하여 다음 줄을 추가한다.
+1. 기존 `example-ingress.yaml` 매니페스트를 편집하고, 
+하단에 다음 줄을 추가한다.
 
     ```yaml
           - path: /v2
@@ -264,47 +251,47 @@ storage-provisioner                         1/1       Running   0          2m
 
 1. 변경 사항을 적용한다.
 
-    ```shell
-    kubectl apply -f example-ingress.yaml
-    ```
+   ```shell
+   kubectl apply -f example-ingress.yaml
+   ```
 
-    Output:
+   결과는 다음과 같다.
 
-    ```shell
-    ingress.networking/example-ingress configured
-    ```
+   ```
+   ingress.networking/example-ingress configured
+   ```
 
 ## 인그레스 테스트하기
 
 1. Hello World 앱의 첫 번째 버전에 액세스한다.
 
-    ```shell
-    curl hello-world.info
-    ```
+   ```shell
+   curl hello-world.info
+   ```
 
-    Output:
+   결과는 다음과 같다.
 
-    ```shell
-    Hello, world!
-    Version: 1.0.0
-    Hostname: web-55b8c6998d-8k564
-    ```
+   ```
+   Hello, world!
+   Version: 1.0.0
+   Hostname: web-55b8c6998d-8k564
+   ```
 
 1. Hello World 앱의 두 번째 버전에 액세스한다.
 
-    ```shell
-    curl hello-world.info/v2
-    ```
+   ```shell
+   curl hello-world.info/v2
+   ```
 
-    Output:
+   결과는 다음과 같다.
 
-    ```shell
-    Hello, world!
-    Version: 2.0.0
-    Hostname: web2-75cd47646f-t8cjk
-    ```
+   ```
+   Hello, world!
+   Version: 2.0.0
+   Hostname: web2-75cd47646f-t8cjk
+   ```
 
-    {{< note >}}Minikube를 로컬에서 실행하는 경우 브라우저에서 hello-world.info 및 hello-world.info/v2에 접속할 수 있다.{{< /note >}}
+   {{< note >}}Minikube를 로컬에서 실행하는 경우 브라우저에서 hello-world.info 및 hello-world.info/v2에 접속할 수 있다.{{< /note >}}
 
 
 
@@ -314,6 +301,4 @@ storage-provisioner                         1/1       Running   0          2m
 * [인그레스](/ko/docs/concepts/services-networking/ingress/)에 대해 더 보기.
 * [인그레스 컨트롤러](/ko/docs/concepts/services-networking/ingress-controllers/)에 대해 더 보기.
 * [서비스](/ko/docs/concepts/services-networking/service/)에 대해 더 보기.
-
-
 

--- a/content/ko/docs/tasks/access-application-cluster/web-ui-dashboard.md
+++ b/content/ko/docs/tasks/access-application-cluster/web-ui-dashboard.md
@@ -35,7 +35,7 @@ card:
 대시보드 UI는 기본으로 배포되지 않는다. 배포하려면 다음 커맨드를 실행한다.
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.3.1/aio/deploy/recommended.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.4.0/aio/deploy/recommended.yaml
 ```
 
 ## 대시보드 UI 접근

--- a/content/ko/docs/tasks/administer-cluster/change-pv-reclaim-policy.md
+++ b/content/ko/docs/tasks/administer-cluster/change-pv-reclaim-policy.md
@@ -88,8 +88,8 @@ kubectl patch pv <your-pv-name> -p "{\"spec\":{\"persistentVolumeReclaimPolicy\"
 * [퍼시스턴트볼륨](/ko/docs/concepts/storage/persistent-volumes/)에 대해 더 배워 보기.
 * [퍼시스턴트볼륨클레임](/ko/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims)에 대해 더 배워 보기.
 
-### Reference
+### 레퍼런스 {#reference}
 
-* [퍼시스턴트볼륨](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#persistentvolume-v1-core)
-* [퍼시스턴트볼륨클레임](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#persistentvolumeclaim-v1-core)
-* [PersistentVolumeSpec](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#persistentvolumeclaim-v1-core)의 `persistentVolumeReclaimPolicy` 필드에 대해 보기.
+* {{< api-reference page="config-and-storage-resources/persistent-volume-v1" >}}
+  * Pay attention to the 퍼시스턴트볼륨의 `.spec.persistentVolumeReclaimPolicy` [필드](docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1/#PersistentVolumeSpec)에 주의한다.
+* {{< api-reference page="config-and-storage-resources/persistent-volume-claim-v1" >}}

--- a/content/ko/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/ko/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -82,8 +82,8 @@ service/php-apache created
 다음 명령어는 첫 번째 단계에서 만든 php-apache 디플로이먼트 파드의 개수를
 1부터 10 사이로 유지하는 Horizontal Pod Autoscaler를 생성한다.
 간단히 얘기하면, HPA는 (디플로이먼트를 통한) 평균 CPU 사용량을 50%로 유지하기 위하여 레플리카의 개수를 늘리고 줄인다.
-(kubectl run으로 각 파드는 200 밀리코어까지 요청할 수 있고,
-따라서 여기서 말하는 평균 CPU 사용은 100 밀리코어를 말한다).
+kubectl run으로 각 파드는 200 밀리코어를 요청하므로,
+여기서 말하는 평균 CPU 사용은 100 밀리코어를 말한다.
 이에 대한 자세한 알고리즘은 [여기](/ko/docs/tasks/run-application/horizontal-pod-autoscale/#알고리즘-세부-정보)를 참고하기 바란다.
 
 ```shell

--- a/content/ko/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/ko/docs/tasks/tools/install-kubectl-linux.md
@@ -12,8 +12,8 @@ card:
 
 ## {{% heading "prerequisites" %}}
 
-클러스터의 마이너(minor) 버전 차이 내에 있는 kubectl 버전을 사용해야 한다. 예를 들어, v{{< skew latestVersion >}} 클라이언트는 v{{< skew prevMinorVersion >}}, v{{< skew latestVersion >}}, v{{< skew nextMinorVersion >}}의 컨트롤 플레인과 연동될 수 있다.
-최신 버전의 kubectl을 사용하면 예기치 않은 문제를 피할 수 있다.
+클러스터의 마이너(minor) 버전 차이 내에 있는 kubectl 버전을 사용해야 한다. 예를 들어, v{{< skew currentVersion >}} 클라이언트는 v{{< skew currentVersionAddMinor -1 >}}, v{{< skew currentVersion >}}, v{{< skew currentVersionAddMinor 1 >}}의 컨트롤 플레인과 연동될 수 있다.
+호환되는 최신 버전의 kubectl을 사용하면 예기치 않은 문제를 피할 수 있다.
 
 ## 리눅스에 kubectl 설치
 

--- a/content/ko/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/ko/docs/tasks/tools/install-kubectl-macos.md
@@ -12,8 +12,8 @@ card:
 
 ## {{% heading "prerequisites" %}}
 
-클러스터의 마이너(minor) 버전 차이 내에 있는 kubectl 버전을 사용해야 한다. 예를 들어, v{{< skew latestVersion >}} 클라이언트는 v{{< skew prevMinorVersion >}}, v{{< skew latestVersion >}}, v{{< skew nextMinorVersion >}}의 컨트롤 플레인과 연동될 수 있다.
-최신 버전의 kubectl을 사용하면 예기치 않은 문제를 피할 수 있다.
+클러스터의 마이너(minor) 버전 차이 내에 있는 kubectl 버전을 사용해야 한다. 예를 들어, v{{< skew currentVersion >}} 클라이언트는 v{{< skew currentVersionAddMinor -1 >}}, v{{< skew currentVersion >}}, v{{< skew currentVersionAddMinor 1 >}}의 컨트롤 플레인과 연동될 수 있다.
+호환되는 최신 버전의 kubectl을 사용하면 예기치 않은 문제를 피할 수 있다.
 
 ## macOS에 kubectl 설치
 

--- a/content/ko/docs/tasks/tools/install-kubectl-windows.md
+++ b/content/ko/docs/tasks/tools/install-kubectl-windows.md
@@ -12,8 +12,8 @@ card:
 
 ## {{% heading "prerequisites" %}}
 
-클러스터의 마이너(minor) 버전 차이 내에 있는 kubectl 버전을 사용해야 한다. 예를 들어, v{{< skew latestVersion >}} 클라이언트는 v{{< skew prevMinorVersion >}}, v{{< skew latestVersion >}}, v{{< skew nextMinorVersion >}}의 컨트롤 플레인과 연동될 수 있다.
-최신 버전의 kubectl을 사용하면 예기치 않은 문제를 피할 수 있다.
+클러스터의 마이너(minor) 버전 차이 내에 있는 kubectl 버전을 사용해야 한다. 예를 들어, v{{< skew currentVersion >}} 클라이언트는 v{{< skew currentVersionAddMinor -1 >}}, v{{< skew currentVersion >}}, v{{< skew currentVersionAddMinor 1 >}}의 컨트롤 플레인과 연동될 수 있다.
+호환되는 최신 버전의 kubectl을 사용하면 예기치 않은 문제를 피할 수 있다.
 
 ## 윈도우에 kubectl 설치
 

--- a/content/ko/docs/tutorials/stateful-application/zookeeper.md
+++ b/content/ko/docs/tutorials/stateful-application/zookeeper.md
@@ -40,7 +40,6 @@ weight: 40
 튜토리얼을 시작하기 전에 수동으로 3개의 20 GiB 볼륨을
 프로비저닝해야 한다.
 
-
 ## {{% heading "objectives" %}}
 
 이 튜토리얼을 마치면 다음에 대해 알게 된다.
@@ -49,7 +48,6 @@ weight: 40
 - 어떻게 앙상블을 일관되게 설정하는가.
 - 어떻게 ZooKeeper 서버 디플로이먼트를 앙상블 안에서 퍼뜨리는가.
 - 어떻게 PodDisruptionBudget을 이용하여 계획된 점검 기간 동안 서비스 가용성을 보장하는가.
-
 
 <!-- lessoncontent -->
 
@@ -262,13 +260,15 @@ server.3=zk-2.zk-hs.default.svc.cluster.local:2888:3888
 
 ### 앙상블 무결성 테스트
 
-가장 기본적인 테스트는 한 ZooKeeper 서버에 데이터를 쓰고 다른 ZooKeeper 서버에서 데이터를 읽는 것이다.
+가장 기본적인 테스트는 한 ZooKeeper 서버에 데이터를 쓰고 
+다른 ZooKeeper 서버에서 데이터를 읽는 것이다.
 
 아래 명령어는 앙상블 내에 `zk-0` 파드에서 `/hello` 경로로 `world`를 쓰는 스크립트인 `zkCli.sh`를 실행한다.
 
 ```shell
-kubectl exec zk-0 zkCli.sh create /hello world
+kubectl exec zk-0 -- zkCli.sh create /hello world
 ```
+
 ```
 WATCHER::
 
@@ -279,7 +279,7 @@ Created /hello
 `zk-1` 파드에서 데이터를 읽기 위해 다음 명령어를 이용하자.
 
 ```shell
-kubectl exec zk-1 zkCli.sh get /hello
+kubectl exec zk-1 -- zkCli.sh get /hello
 ```
 
 `zk-0`에서 생성한 그 데이터는 앙상블 내에 모든 서버에서
@@ -409,7 +409,6 @@ numChildren = 0
 
 `zk` 스테이트풀셋의 `spec`에 `volumeClaimTemplates` 필드는 각 파드에 프로비전될 퍼시스턴트볼륨을 지정한다.
 
-
 ```yaml
 volumeClaimTemplates:
   - metadata:
@@ -442,7 +441,6 @@ datadir-zk-2   Bound     pvc-bee0817e-bcb1-11e6-994f-42010a800002   20Gi       R
 ```
 
 `스테이트풀셋`의 컨테이너 `template`의 `volumeMounts` 부분이 ZooKeeper 서버의 데이터 디렉터리에 퍼시스턴트볼륨 마운트하는 내용이다.
-
 
 ```shell
 volumeMounts:
@@ -591,6 +589,7 @@ kubectl exec zk-0 -- ps -elf
 
 `securityContext` 오브젝트의 `runAsUser` 필드 값이 1000 이므로
 루트 사용자로 실행하는 대신 ZooKeeper 프로세스는 ZooKeeper 사용자로 실행된다.
+
 ```
 F S UID        PID  PPID  C PRI  NI ADDR SZ WCHAN  STIME TTY          TIME CMD
 4 S zookeep+     1     0  0  80   0 -  1127 -      20:46 ?        00:00:00 sh -c zkGenConfig.sh && zkServer.sh start-foreground
@@ -695,6 +694,7 @@ kubectl exec zk-0 -- ps -ef
 
 컨테이너의 엔트리 포인트로 PID 1 인 명령이 사용되었으며
 ZooKeeper 프로세스는 엔트리 포인트의 자식 프로세스로 PID 27 이다.
+
 ```
 UID        PID  PPID  C STIME TTY          TIME CMD
 zookeep+     1     0  0 15:03 ?        00:00:00 sh -c zkGenConfig.sh && zkServer.sh start-foreground
@@ -1033,7 +1033,6 @@ kubectl 을 종료하기 위해 `CTRL-C`를 이용하자.
 
 `zk-0`에서 온전성 테스트 때에 입력한 값을 가져오는 `zkCli.sh`를 이용하자.
 
-
 ```shell
 kubectl exec zk-0 zkCli.sh get /hello
 ```
@@ -1132,9 +1131,7 @@ drain으로 노드를 통제하고 유지보수를 위해 노드를 오프라인
 서비스는 혼란 예산을 표기한 서비스는 그 예산이 존중은 존중될 것이다.
 파드가 즉각적으로 재스케줄 할 수 있도록 항상 중요 서비스를 위한 추가 용량을 할당해야 한다.
 
-
 ## {{% heading "cleanup" %}}
-
 
 - `kubectl uncordon`은 클러스터 내에 모든 노드를 통제 해제한다.
 - 반드시 이 튜토리얼에서 사용한 퍼시스턴트 볼륨을 위한 퍼시스턴트 스토리지 미디어를 삭제하자.

--- a/content/ko/releases/notes.md
+++ b/content/ko/releases/notes.md
@@ -8,6 +8,6 @@ sitemap:
   priority: 0.5
 ---
 
-릴리스 노트는 사용자의 쿠버네티스 버전에 해당하는 [변경로그(Changelog)](https://github.com/kubernetes/kubernetes/tree/master/CHANGELOG)를 통해서 확인할 수 있다. {{< skew latestVersion >}} 의 변경로그는 [깃허브](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-{{< skew latestVersion >}}.md)에 있다.
+릴리스 노트는 사용자의 쿠버네티스 버전에 해당하는 [변경로그(Changelog)](https://github.com/kubernetes/kubernetes/tree/master/CHANGELOG)를 통해서 확인할 수 있다. {{< skew currentVersionAddMinor 0 >}} 의 변경로그는 [깃허브](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-{{< skew currentVersionAddMinor 0 >}}.md)에 있다.
 
-대안으로, 릴리스 노트는 [relnotes.k8s.io](https://relnotes.k8s.io)에서 온라인으로 검색 및 필터링이 가능하다. {{< skew latestVersion >}}로 필터링된 릴리스 노트는 [relnotes.k8s.io](https://relnotes.k8s.io/?releaseVersions={{< skew latestVersion >}}.0)에서 확인한다.
+대안으로, 릴리스 노트는 [relnotes.k8s.io](https://relnotes.k8s.io)에서 온라인으로 검색 및 필터링이 가능하다. {{< skew currentVersionAddMinor 0 >}}로 필터링된 릴리스 노트는 [relnotes.k8s.io](https://relnotes.k8s.io/?releaseVersions={{< skew currentVersionAddMinor 0 >}}.0)에서 확인한다.

--- a/content/ko/training/_index.html
+++ b/content/ko/training/_index.html
@@ -14,6 +14,9 @@ class: training
         <h2>클라우드 네이티브 커리어를 구축하세요</h2>
         <p>쿠버네티스는 클라우드 네이티브 무브먼트의 핵심입니다. 리눅스 재단이 제공하는 교육과 인증 프로그램을 통해 커리어에 투자하고, 쿠버네티스를 배우며, 클라우드 네이티브 프로젝트를 성공적으로 수행하세요.</p>
       </div>
+      <div class="logo-certification cta-image" id="logo-kcnf">
+        <img src="/images/training/kubernetes-kcnf-white.svg" />
+      </div>
       <div class="logo-certification cta-image" id="logo-cka">
         <img src="/images/training/kubernetes-cka-white.svg"/>
       </div>
@@ -81,6 +84,15 @@ class: training
   <div class="main-section padded">
     <h2>쿠버네티스 공인 자격 획득하기</h2>
     <div class="col-container">
+      <div class="col-nav">
+        <h5>
+          <b>쿠버네티스 및 클라우드 네이티브 전문가(Kubernetes and Cloud Native Associate, KCNA)</b>
+        </h5>
+        <p>쿠버네티스 및 클라우드 네이티브 전문가 시험은 사용자의 쿠버네티스와 더 넓은 클라우드 네이티브 생태계에 대한 핵심 지식과 기술을 보여줍니다.</p>
+        <p>인증된 KCNA는 전체적인 클라우드 네이티브 생태계, 특히 쿠버네티스에 대한 개념적 지식을 확인시켜 줄 것입니다.</p>
+        <br>
+        <a href="https://training.linuxfoundation.org/certification/kubernetes-cloud-native-associate/" target="_blank" class="button">Go to Certification</a>
+      </div>
       <div class="col-nav">
           <h5>
             <b>공인 쿠버네티스 애플리케이션 개발자(Certified Kubernetes Application Developer, CKAD)</b>


### PR DESCRIPTION
- Related issue: #30414

> 28. [ ]  **M28.**  `content/en/docs/tasks/access-application-cluster/ingress-minikube.md`  | **134(+L) 149(-)**
> 29. [ ]  M29.  `content/en/docs/tasks/access-application-cluster/web-ui-dashboard.md`  | 1(+XS) 1(-)
> 30. [ ]  M30.  `content/en/docs/tasks/administer-cluster/change-pv-reclaim-policy.md`  | 4(+XS) 4(-)
> 31. [ ]  M31.  `content/en/docs/tasks/configure-pod-container/configure-gmsa.md`  | 1(+XS) 1(-)
> 32. [ ]  M32.  `content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md`  | 2(+XS) 2(-)
> 33. [ ]  M33.  `content/en/docs/tasks/tools/install-kubectl-linux.md`  | 4(+XS) 4(-)
> 34. [ ]  M34.  `content/en/docs/tasks/tools/install-kubectl-macos.md`  | 2(+XS) 2(-)
> 35. [ ]  M35.  `content/en/docs/tasks/tools/install-kubectl-windows.md`  | 2(+XS) 2(-)
> 36. [ ]  M36.  `content/en/docs/tutorials/stateful-application/zookeeper.md`  | 2(+XS) 2(-)
> 37. [ ]  M37.  `content/en/releases/notes.md`  | 2(+XS) 2(-)
> 38. [ ]  M38.  `content/en/training/_index.html`  | 12(+S) 0(-)

/language ko
