### PR TITLE
Add k8s.dev url to Community page

### DIFF
--- a/content/en/community/_index.html
+++ b/content/en/community/_index.html
@@ -19,6 +19,7 @@ cid: community
 
 <div class="community__navbar">
 
+<a href="https://www.kubernetes.dev/">Contributor Community</a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 <a href="#values">Community Values</a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 <a href="#conduct">Code of conduct </a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 <a href="#videos">Videos</a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;


### PR DESCRIPTION
Description: Add k8s.dev url to Community page
kubernetes/contributor-site#202 calls for making the contributor site more findable.

