### PR TITLE
Change 'container' to 'Pod' in Jobs documentation

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -250,7 +250,7 @@ back-off count is reset when a Job's Pod is deleted or successful without any
 other Pods for the Job failing around that time.
 
 {{< note >}}
-If your job has `restartPolicy = "OnFailure"`, keep in mind that your container running the Job
+If your job has `restartPolicy = "OnFailure"`, keep in mind that your Pod running the Job
 will be terminated once the job backoff limit has been reached. This can make debugging the Job's executable more difficult. We suggest setting
 `restartPolicy = "Never"` when debugging the Job or using a logging system to ensure output
 from failed Jobs is not lost inadvertently.


### PR DESCRIPTION
In [Pod backoff failure policy](https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy) on the Job page, I guess it should say:

> If your job has `restartPolicy = "OnFailure"`, keep in mind that your **Pod** running the Job will be terminated once the job backoff limit has been reached.

Using "container" makes less sense, as the container is anyway restarted, and when the backoff limit is reached, the entire Pod is deleted. There are more details in this [issue comment](https://github.com/kubernetes/kubernetes/issues/74848#issuecomment-971487582).