### PR TITLE
storage: Minor fixes to Windows projected volumes

### DIFF
--- a/content/en/docs/concepts/storage/projected-volumes.md
+++ b/content/en/docs/concepts/storage/projected-volumes.md
@@ -71,7 +71,7 @@ volume mount will not receive updates for those volume sources.
 
 ## SecurityContext interactions
 
-The [proposal for file permission handling in projected service account volume](https://github.com/kubernetes/enhancements/pull/1598)
+The [proposal for file permission handling in projected service account volume](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/2451-service-account-token-volumes#token-volume-projection)
 enhancement introduced the projected files having the the correct owner
 permissions set.
 
@@ -100,6 +100,8 @@ into their own volume mount outside of `C:\`.
 By default, the projected files will have the following ownership as shown for
 an example projected volume file:
 ```powershell
+PS C:\> Get-Acl C:\var\run\secrets\kubernetes.io\serviceaccount\..2021_08_31_22_22_18.318230061\ca.crt | Format-List
+
 Path   : Microsoft.PowerShell.Core\FileSystem::C:\var\run\secrets\kubernetes.io\serviceaccount\..2021_08_31_22_22_18.318230061\ca.crt
 Owner  : BUILTIN\Administrators
 Group  : NT AUTHORITY\SYSTEM

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -811,7 +811,7 @@ For more details, see the [Portworx volume](https://github.com/kubernetes/exampl
 ### projected
 
 A projected volume maps several existing volume sources into the same
-directory. For more details, see [projected volumes](/docs/concepts/storage/projected-volumes/)
+directory. For more details, see [projected volumes](/docs/concepts/storage/projected-volumes/).
 
 ### quobyte (deprecated) {#quobyte}
 


### PR DESCRIPTION
Follow up to https://github.com/kubernetes/website/pull/30366:
- Add missing period
- Link to projected volume permission KEP instead of PR
- Add missing PowerShell command