### PR TITLE
Clarify glossary entry for PodDisruptionBudget

### DIFF
--- a/content/en/docs/reference/glossary/pod-disruption-budget.md
+++ b/content/en/docs/reference/glossary/pod-disruption-budget.md
@@ -22,5 +22,5 @@ tags:
 
 <!--more--> 
 
-PDBs cannot prevent an involuntary disruption, but 
- will count against the budget.
+Involuntary disruptions cannot be prevented by PDBs; however they 
+do count against the budget.


### PR DESCRIPTION
٩꒰｡•‿•｡꒱۶ Hello friends!

The last line of this definition is a bit ambiguous so I edited it to more explicitly say that involuntary disruptions count against the Pod Disruption Budget.   
