### PR TITLE
Document the Pod security webhook

### DIFF
--- a/content/en/docs/concepts/security/pod-security-admission.md
+++ b/content/en/docs/concepts/security/pod-security-admission.md
@@ -41,6 +41,9 @@ Setting pod security controls by namespace is an alpha feature. You must enable 
 --feature-gates="...,PodSecurity=true"
 ```
 
+Alternatively, see [Pod Security Webhook](#pod-security-webhook) for instructions on running Pod
+Security as a Validating Admission Webhook.
+
 ## Pod Security levels
 
 Pod Security admission places requirements on a Pod's [Security
@@ -135,6 +138,35 @@ current policy level:
   - `container.apparmor.security.beta.kubernetes.io/*`
 - Valid updates to `.spec.activeDeadlineSeconds`
 - Valid updates to `.spec.tolerations`
+
+## Pod Security Webhook
+
+As an alternative to the built-in admission controller, Pod Security can also be run as a [dynamic
+admission webhook](/docs/reference/access-authn-authz/extensible-admission-controllers/). Running as
+a webhook is useful for enabling Pod Security on older clusters or clusters where the built-in
+controller cannot be enabled, but the webhook is not as performant as the built-in admission
+controller.
+
+### Webhook Installation
+
+The manifests for a recommended installation can be found at https://git.k8s.io/pod-security-admission/webhook.
+
+In order to set up the webhook, a serving certificate & private key pair must be generated. This can
+be done manually, or managed automatically by an operator like https://cert-manager.io/. To
+streamline the process of manual certificate generation, the webhook includes a
+[make](https://www.gnu.org/software/make/) target to generate a self-signed certificate-key pair.
+Running the make rule requires `make` and `openssl` to be installed.
+
+Here is a sample set of commands to install the latest version of the webhook:
+
+```shell
+# Fetch the latest verison of the webhook manifests.
+# Alternatively, replace "master" with the desired version, such as "kubernetes-1.22.3"
+git clone -b master https://github.com/kubernetes/pod-security-admission.git
+cd pod-security-admission/webhook
+make certs          # Generate the self-signed certificate-key pair.
+kubectl apply -k .  # Install the webhook in the "pod-security-webhook" namespace.
+```
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/tasks/configure-pod-container/enforce-standards-admission-controller.md
+++ b/content/en/docs/tasks/configure-pod-container/enforce-standards-admission-controller.md
@@ -13,9 +13,9 @@ You can configure this admission controller to set cluster-wide defaults and [ex
 
 ## {{% heading "prerequisites" %}}
 
-{{% version-check %}}
-
-- Enable the `PodSecurity` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features).
+The Pod Security admission controller must be enabled on the cluster. See [Pod Security
+Admission](/docs/concepts/security/pod-security-admission/) for instructions on enabling the
+admission controller.
 
 ## Configure the Admission Controller
 

--- a/content/en/docs/tasks/configure-pod-container/enforce-standards-namespace-labels.md
+++ b/content/en/docs/tasks/configure-pod-container/enforce-standards-namespace-labels.md
@@ -11,9 +11,9 @@ Namespaces can be labeled to enforce the [Pod Security Standards](/docs/concepts
 
 ## {{% heading "prerequisites" %}}
 
-{{% version-check %}}
-
-- Enable the `PodSecurity` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features).
+The Pod Security admission controller must be enabled on the cluster. See [Pod Security
+Admission](/docs/concepts/security/pod-security-admission/) for instructions on enabling the
+admission controller.
 
 ## Requiring the `baseline` Pod Security Standard with namespace labels
 

--- a/content/en/docs/tasks/configure-pod-container/migrate-from-psp.md
+++ b/content/en/docs/tasks/configure-pod-container/migrate-from-psp.md
@@ -15,9 +15,9 @@ admission controller. This can be done effectively using a combination of dry-ru
 
 ## {{% heading "prerequisites" %}}
 
-{{% version-check %}}
-
-- Enable the `PodSecurity` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features).
+The Pod Security admission controller must be enabled on the cluster. See [Pod Security
+Admission](/docs/concepts/security/pod-security-admission/) for instructions on enabling the
+admission controller.
 
 <!-- body -->
 


### PR DESCRIPTION
Document the Pod Security webhook as an alternative to the built-in admission controller. Also update the prerequisites on related pages to refer to the Pod Security Admission concept page to indirectly include the webhook as an option.

fixes https://github.com/kubernetes/website/issues/30133

/sig auth

/assign @liggitt
/cc @sejr 