### PR TITLE
Create an entry that describes the Kui tool within docs

### DIFF
--- a/content/en/docs/reference/tools/_index.md
+++ b/content/en/docs/reference/tools/_index.md
@@ -49,3 +49,17 @@ Use Kompose to:
 * Translate a Docker Compose file into Kubernetes objects
 * Go from local Docker development to managing your application via Kubernetes
 * Convert v1 or v2 Docker Compose `yaml` files or [Distributed Application Bundles](https://docs.docker.com/compose/bundles/)
+
+## Kui
+
+[`Kui`](https://github.com/kubernetes-sigs/kui) is a tool for enhancing CLIs with Graphics.
+
+Kui takes the normal `kubectl` command line requests and responds with graphics. Instead 
+of ASCII tables `Sortable tables` are presented as the output.
+
+Use Kui to:
+
+* Click the long auto-generated resource names instead of copying and pasting it
+* Process `kubectl` commands 2-3 faster than `kubectl` itself
+* See waterfall diagrams of your jobs by executing `k get jobs`
+* Browse through resources in a tabbed UI with help of a click

--- a/content/en/docs/reference/tools/_index.md
+++ b/content/en/docs/reference/tools/_index.md
@@ -52,14 +52,16 @@ Use Kompose to:
 
 ## Kui
 
-[`Kui`](https://github.com/kubernetes-sigs/kui) is a tool for enhancing CLIs with Graphics.
+[`Kui`](https://github.com/kubernetes-sigs/kui) is a GUI tool that takes your normal
+`kubectl` command line requests and responds with graphics.
 
 Kui takes the normal `kubectl` command line requests and responds with graphics. Instead 
-of ASCII tables `Sortable tables` are presented as the output.
+of ASCII tables, Kui provides a GUI rendering with tables that you can sort.
 
-Use Kui to:
+Kui lets you:
 
-* Click the long auto-generated resource names instead of copying and pasting it
-* Process `kubectl` commands 2-3 faster than `kubectl` itself
-* See waterfall diagrams of your jobs by executing `k get jobs`
-* Browse through resources in a tabbed UI with help of a click
+* Directly click on long, auto-generated resource names instead of copying and pasting
+* Type in `kubectl` commands and see them execute, even sometimes faster than `kubectl` itself
+* Query a {{< glossary_tooltip text="Job" term_id="job">}} and see its execution rendered
+  as a waterfall diagram
+* Click through resources in your cluster using a tabbed UI 


### PR DESCRIPTION
Fixes #30584

It adds a new entry mentioning the `Kui` tool and its uses in the `Other Tools` section of the docs.
Files changed: https://kubernetes.io/docs/reference/tools/

Signed 
Vitthal Kaul : vitthalsai2001@gmail.com