### PR TITLE
Fix obsolete link to Sig docs agenda doc

### DIFF
--- a/content/en/docs/contribute/style/style-guide.md
+++ b/content/en/docs/contribute/style/style-guide.md
@@ -14,7 +14,7 @@ For additional information on creating new content for the Kubernetes
 documentation, read the [Documentation Content Guide](/docs/contribute/style/content-guide/).
 
 Changes to the style guide are made by SIG Docs as a group. To propose a change
-or addition, [add it to the agenda](https://docs.google.com/document/d/1ddHwLK3kUMX1wVFIwlksjTk0MsqitBnWPe1LRa1Rx5A/edit) for an upcoming SIG Docs meeting, and attend the meeting to participate in the
+or addition, [add it to the agenda](https://bit.ly/sig-docs-agenda) for an upcoming SIG Docs meeting, and attend the meeting to participate in the
 discussion.
 
 <!-- body -->


### PR DESCRIPTION
The link to the agenda doc of Sig Docs in `Kubernetes documentatin style guide` on [Line 17](https://github.com/kubernetes/website/blob/main/content/en/docs/contribute/style/style-guide.md?plain=1#L17) was linked to the older doc which is archived now. Fixed it with new one.