### PR TITLE
Correcting the docs for label kubernetes.io/metadata.name

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints.md
+++ b/content/en/docs/reference/labels-annotations-taints.md
@@ -36,9 +36,9 @@ Example: `kubernetes.io/metadata.name=mynamespace`
 
 Used on: Namespaces
 
-The [`Control Plane`](https://kubernetes.io/docs/concepts/overview/components/)
-sets this label on all namespaces. It is **mandatory** to `set a label`
-on all the namespaces. The label value is set to the name of the namespace.
+The Kubernetes {{< glossary_tooltip text="control plane" term_id="control-plane" >}}
+sets this label on all namespaces. The label value is set
+to the name of the namespace. You can't change this label's value. 
 
 This is useful if you want to target a specific namespace with a label
 {{< glossary_tooltip text="selector" term_id="selector" >}}.

--- a/content/en/docs/reference/labels-annotations-taints.md
+++ b/content/en/docs/reference/labels-annotations-taints.md
@@ -36,7 +36,7 @@ Example: `kubernetes.io/metadata.name=mynamespace`
 
 Used on: Namespaces
 
-The Kubernetes {{< glossary_tooltip text="control plane" term_id="control-plane" >}}
+The Kubernetes API server (part of the {{< glossary_tooltip text="control plane" term_id="control-plane" >}}) 
 sets this label on all namespaces. The label value is set
 to the name of the namespace. You can't change this label's value. 
 

--- a/content/en/docs/reference/labels-annotations-taints.md
+++ b/content/en/docs/reference/labels-annotations-taints.md
@@ -36,10 +36,9 @@ Example: `kubernetes.io/metadata.name=mynamespace`
 
 Used on: Namespaces
 
-When the `NamespaceDefaultLabelName`
-[feature gate](/docs/reference/command-line-tools-reference/feature-gates/) is enabled,
-the Kubernetes API server sets this label on all namespaces. The label value is set to
-the name of the namespace.
+The [`Control Plane`](https://kubernetes.io/docs/concepts/overview/components/)
+sets this label on all namespaces. It is **mandatory** to `set a label`
+on all the namespaces. The label value is set to the name of the namespace.
 
 This is useful if you want to target a specific namespace with a label
 {{< glossary_tooltip text="selector" term_id="selector" >}}.


### PR DESCRIPTION
Fixes #30614 

The section is reworded in a manner that it  now indicates that the `Control Plane` sets the label on the namespaces.

Files Changed: https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-metadata-name