### PR TITLE
Add example for Prefix on ingress.md

### DIFF
--- a/content/en/docs/concepts/services-networking/ingress.md
+++ b/content/en/docs/concepts/services-networking/ingress.md
@@ -169,26 +169,27 @@ supported path types:
 
 ### Examples
 
-| Kind   | Path(s)                         | Request path(s)               | Matches?                           |
-|--------|---------------------------------|-------------------------------|------------------------------------|
-| Prefix | `/`                             | (all paths)                   | Yes                                |
-| Exact  | `/foo`                          | `/foo`                        | Yes                                |
-| Exact  | `/foo`                          | `/bar`                        | No                                 |
-| Exact  | `/foo`                          | `/foo/`                       | No                                 |
-| Exact  | `/foo/`                         | `/foo`                        | No                                 |
-| Prefix | `/foo`                          | `/foo`, `/foo/`               | Yes                                |
-| Prefix | `/foo/`                         | `/foo`, `/foo/`               | Yes                                |
-| Prefix | `/aaa/bb`                       | `/aaa/bbb`                    | No                                 |
-| Prefix | `/aaa/bbb`                      | `/aaa/bbb`                    | Yes                                |
-| Prefix | `/aaa/bbb/`                     | `/aaa/bbb`                    | Yes, ignores trailing slash        |
-| Prefix | `/aaa/bbb`                      | `/aaa/bbb/`                   | Yes,  matches trailing slash       |
-| Prefix | `/aaa/bbb`                      | `/aaa/bbb/ccc`                | Yes, matches subpath               |
-| Prefix | `/aaa/bbb`                      | `/aaa/bbbxyz`                 | No, does not match string prefix   |
-| Prefix | `/`, `/aaa`                     | `/aaa/ccc`                    | Yes, matches `/aaa` prefix         |
-| Prefix | `/`, `/aaa`, `/aaa/bbb`         | `/aaa/bbb`                    | Yes, matches `/aaa/bbb` prefix     |
-| Prefix | `/`, `/aaa`, `/aaa/bbb`         | `/ccc`                        | Yes, matches `/` prefix            |
-| Prefix | `/aaa`                          | `/ccc`                        | No, uses default backend           |
-| Mixed  | `/foo` (Prefix), `/foo` (Exact) | `/foo`                        | Yes, prefers Exact                 |
+| Kind   | Path(s)                         | Request path(s)               | Matches?                            |
+|--------|---------------------------------|-------------------------------|-------------------------------------|
+| Prefix | `/`                             | (all paths)                   | Yes                                 |
+| Exact  | `/foo`                          | `/foo`                        | Yes                                 |
+| Exact  | `/foo`                          | `/bar`                        | No                                  |
+| Exact  | `/foo`                          | `/foo/`                       | No                                  |
+| Exact  | `/foo/`                         | `/foo`                        | No                                  |
+| Prefix | `/foo`                          | `/foo`, `/foo/`               | Yes                                 |
+| Prefix | `/foo/`                         | `/foo`, `/foo/`               | Yes                                 |
+| Prefix | `/aaa/bb`                       | `/aaa/bbb`                    | No                                  |
+| Prefix | `/aaa/bbb`                      | `/aaa/bbb`                    | Yes                                 |
+| Prefix | `/aaa/bbb/`                     | `/aaa/bbb`                    | Yes, ignores trailing slash         |
+| Prefix | `/aaa/bbb`                      | `/aaa/bbb/`                   | Yes,  matches trailing slash        |
+| Prefix | `/aaa/bbb`                      | `/aaa/bbb/ccc`                | Yes, matches subpath                |
+| Prefix | `/aaa/bbb`                      | `/aaa/bbb/ccc/ddd`            | No, /aaa/bbb is not a prefix of /ddd|
+| Prefix | `/aaa/bbb`                      | `/aaa/bbbxyz`                 | No, does not match string prefix    |
+| Prefix | `/`, `/aaa`                     | `/aaa/ccc`                    | Yes, matches `/aaa` prefix          |
+| Prefix | `/`, `/aaa`, `/aaa/bbb`         | `/aaa/bbb`                    | Yes, matches `/aaa/bbb` prefix      |
+| Prefix | `/`, `/aaa`, `/aaa/bbb`         | `/ccc`                        | Yes, matches `/` prefix             |
+| Prefix | `/aaa`                          | `/ccc`                        | No, uses default backend            |
+| Mixed  | `/foo` (Prefix), `/foo` (Exact) | `/foo`                        | Yes, prefers Exact                  |
 
 #### Multiple matches
 In some cases, multiple paths within an Ingress will match a request. In those


### PR DESCRIPTION
From my experience the example that was added is not matched.
If I understand correctly the path is checked on elements separated by a '/'. If the specified path prefixes the element that is checked it is a match. If there are multiple elements following the specified path prefix this will not result in a match.
 I found the documentation unclear on this. Adding this example might help.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
