### PR TITLE
[zh] sync auth docs

### DIFF
--- a/content/zh/docs/reference/access-authn-authz/abac.md
+++ b/content/zh/docs/reference/access-authn-authz/abac.md
@@ -38,7 +38,7 @@ Attribute-based access control (ABAC) defines an access control paradigm whereby
 To enable `ABAC` mode, specify `--authorization-policy-file=SOME_FILENAME` and `--authorization-mode=ABAC` on startup.
 
 The file format is [one JSON object per line](http://jsonlines.org/).  There
-should be no enclosing list or map, just one map per line.
+should be no enclosing list or map, only one map per line.
 
 Each line is a "policy object", where each such object is a map with the following
 properties:
@@ -73,7 +73,7 @@ properties:
 
 基于 `ABAC` 模式，可以这样指定策略文件 `--authorization-policy-file=SOME_FILENAME`。
 
-此文件格式是 [JSON Lines](https://jsonlines.org/)，不应存在封闭的列表或映射，每行一个映射。
+此文件格式是 [JSON Lines](https://jsonlines.org/)，不应存在外层的列表或映射，每行应只有一个映射。
 
 每一行都是一个策略对象，策略对象是具有以下属性的映射：
 
@@ -258,7 +258,7 @@ Kubectl 使用 api-server 的 `/api` 和 `/apis` 端点来发现服务资源类�
     ```
 
 <!--
-[Complete file example](http://releases.k8s.io/{{< param "githubbranch" >}}/pkg/auth/authorizer/abac/example_policy_file.jsonl)
+[Complete file example](http://releases.k8s.io/{{< param "fullversion" >}}/pkg/auth/authorizer/abac/example_policy_file.jsonl)
 
 ## A quick note on service accounts
 
@@ -270,7 +270,7 @@ system:serviceaccount:<namespace>:<serviceaccountname>
 
 -->
 
-[完整文件示例](https://releases.k8s.io/{{< param "githubbranch" >}}/pkg/auth/authorizer/abac/example_policy_file.jsonl)
+[完整文件示例](https://releases.k8s.io/{{< param "fullversion" >}}/pkg/auth/authorizer/abac/example_policy_file.jsonl)
 
 ## 服务帐户的快速说明
 

--- a/content/zh/docs/reference/access-authn-authz/admission-controllers.md
+++ b/content/zh/docs/reference/access-authn-authz/admission-controllers.md
@@ -1171,7 +1171,29 @@ PodNodeSelector 允许 Pod 强制在特定标签的节点上运行。
 另请参阅 PodTolerationRestriction 准入插件，该插件可防止 Pod 在特定污点的节点上运行。
 {{< /note >}}
 
+### PodSecurity {#podsecurity}
+
+{{< feature-state for_k8s_version="v1.22" state="alpha" >}}
+
+<!--
+This is the replacement for the deprecated [PodSecurityPolicy](#podsecuritypolicy) admission controller
+defined in the next section. This admission controller acts on creation and modification of the pod and
+determines if it should be admitted based on the requested security context and the 
+[Pod Security Standards](/docs/concepts/security/pod-security-standards/).
+
+See the [Pod Security Admission documentation](/docs/concepts/security/pod-security-admission/)
+for more information.
+-->
+这是下节已被废弃的 [PodSecurityPolicy](#podsecuritypolicy) 准入控制器的替代品。
+此准入控制器负责在创建和修改 Pod 时根据请求的安全上下文和
+[Pod 安全标准](/zh/docs/concepts/security/pod-security-standards/)
+来确定是否可以执行请求。
+
+更多信息请参阅 [Pod 安全性准入控制器](/zh/docs/concepts/security/pod-security-admission/)。
+
 ### PodSecurityPolicy {#podsecuritypolicy}
+
+{{< feature-state for_k8s_version="v1.21" state="deprecated" >}}
 
 <!--
 This admission controller acts on creation and modification of the pod and determines if it should be admitted

--- a/content/zh/examples/access/endpoints-aggregated.yaml
+++ b/content/zh/examples/access/endpoints-aggregated.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    kubernetes.io/description: |-
+      Add endpoints write permissions to the edit and admin roles. This was
+      removed by default in 1.22 because of CVE-2021-25740. See
+      https://issue.k8s.io/103675. This can allow writers to direct LoadBalancer
+      or Ingress implementations to expose backend IPs that would not otherwise
+      be accessible, and can circumvent network policies or security controls
+      intended to prevent/isolate access to those backends.
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: custom:aggregate-to-edit:endpoints # you can change this if you wish
+rules:
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["create", "delete", "deletecollection", "patch", "update"]


### PR DESCRIPTION
related: #29327

Sync Chinese for following:
```
1	1	content/zh/docs/reference/access-authn-authz/abac.md
11	2	content/zh/docs/reference/access-authn-authz/authorization.md
4	9	content/zh/docs/reference/access-authn-authz/service-accounts-admin.md (already synced. No change in this PR)
14	0	content/zh/docs/reference/access-authn-authz/admission-controllers.md
26	3	content/zh/docs/reference/access-authn-authz/rbac.md
```