### PR TITLE
De-emphasize deprecated scheduling policies for v1.23 and later

### DIFF
--- a/content/en/docs/reference/scheduling/policies.md
+++ b/content/en/docs/reference/scheduling/policies.md
@@ -1,7 +1,8 @@
 ---
 title: Scheduling Policies
 content_type: concept
-weight: 10
+sitemap:
+  priority: 0.2 # Scheduling priorities are deprecated
 ---
 
 <!-- overview -->


### PR DESCRIPTION
Scheduling priorities are deprecated, so:
- move the page later in the parent topic
- hint that it's not a priority in the sitemap for the live docs

Follow -up to https://github.com/kubernetes/website/pull/30404


/milestone 1.23
/kind cleanup