### PR TITLE
Clarifications for dual-stack going GA in 1.23.

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/dual-stack-support.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/dual-stack-support.md
@@ -71,7 +71,7 @@ Run kubeadm to initiate the dual-stack control plane node:
 kubeadm init --config=kubeadm-config.yaml
 ```
 
-Currently, the kube-controller-manager flags `--node-cidr-mask-size-ipv4|--node-cidr-mask-size-ipv6` are being left with default values. See [enable IPv4/IPv6 dual stack](/docs/concepts/services-networking/dual-stack#enable-ipv4ipv6-dual-stack).
+The kube-controller-manager flags `--node-cidr-mask-size-ipv4|--node-cidr-mask-size-ipv6` are set with default values. See [configure IPv4/IPv6 dual stack](/docs/concepts/services-networking/dual-stack#configure-ipv4-ipv6-dual-stack).
 
 {{< note >}}
 The `--apiserver-advertise-address` flag does not support dual-stack.

--- a/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
+++ b/content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md
@@ -340,9 +340,7 @@ Kubernetes on Windows does not support single-stack "IPv6-only" networking. Howe
 dual-stack IPv4/IPv6 networking for pods and nodes with single-family services
 is supported.
 
-You can enable IPv4/IPv6 dual-stack networking for `l2bridge` networks using the
-`IPv6DualStack` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/).
-See [enable IPv4/IPv6 dual stack](/docs/concepts/services-networking/dual-stack#enable-ipv4ipv6-dual-stack) for more details.
+You can use IPv4/IPv6 dual-stack networking with `l2bridge` networks. See [configure IPv4/IPv6 dual stack](/docs/concepts/services-networking/dual-stack#configure-ipv4-ipv6-dual-stack) for more details.
 
 {{< note >}}
 Overlay (VXLAN) networks on Windows do not support dual-stack networking.


### PR DESCRIPTION
As requested by @sftim in https://github.com/kubernetes/website/pull/29386#pullrequestreview-811843907, slight adjustments for dual-stack docs as of 1.23. /cc @khenidak @marosset @jsturtevant for accuracy check/edits

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>

