### PR TITLE
Redirect common Go package URLs to pkg.go.dev

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -546,3 +546,8 @@
 /id/docs/concepts/configuration/pod-overhead/     /id/docs/concepts/scheduling-eviction/pod-overhead/   301
 
 /pt/*         /pt-br/:splat  302!
+
+# Redirect common Go packages redirected from k8s.io/* to show Go package documentation.
+/api/* https://pkg.go.dev/k8s.io/api/:splat 302!
+/apimachinery/* https://pkg.go.dev/k8s.io/api/:splat 302!
+/client-go/* https://pkg.go.dev/k8s.io/client-go/:splat 302!


### PR DESCRIPTION
This is a second attempt at the change in https://github.com/kubernetes/k8s.io/pull/3130

Today, a valid Go import path like k8s.io/api/core/v1 redirects to https://kubernetes.io/api/core/v1 when viewed in a browser, which is an unhelpful 404. 😢

With this change, I'd like to propose that that import path should redirect to the much more helpful Go package documentation at https://pkg.go.dev/k8s.io/api/core/v1

This change currently only applies to:

- `k8s.io/api/...`
- `k8s.io/apimachinery/...`
- `k8s.io/client-go/...`

If this is helpful we can look into applying this across more repos.

Because the Go import redirect triggered by `?go-get=1` is processed in the k8s.io redirect in https://github.com/kubernetes/k8s.io, this behavior should be unaffected by this change.

cc @sftim 