### PR TITLE
Fix grpc field name inconsistency with API naming rules

### DIFF
--- a/content/en/examples/pods/probe/grpc-liveness.yaml
+++ b/content/en/examples/pods/probe/grpc-liveness.yaml
@@ -10,6 +10,6 @@ spec:
     ports:
     - containerPort: 2379
     livenessProbe:
-      gRPC:
+      grpc:
         port: 2379
       initialDelaySeconds: 10


### PR DESCRIPTION
/sig node
/priority critical-urgent
/kind bug

Related to https://github.com/kubernetes/kubernetes/issues/106772
See discussion in  https://kubernetes.slack.com/archives/CJUQN3E4T/p1638309300059900

This PR depends on other PRs: https://github.com/kubernetes/kubernetes/pull/106774 and corresponding cherry-pick to 1.23 branch (to be updated), setting hold on it:
/hold 