### PR TITLE
Add hpa v2beta2 to deprecation guide for v1.23

### DIFF
--- a/content/en/docs/reference/using-api/deprecation-guide.md
+++ b/content/en/docs/reference/using-api/deprecation-guide.md
@@ -21,6 +21,16 @@ deprecated API versions to newer and more stable API versions.
 ## Removed APIs by release
 
 
+### v1.27
+
+The **v1.27** release will stop serving the following deprecated API versions:
+
+#### HorizontalPodAutoscaler {#horizontalpodautoscaler-v127}
+
+The **autoscaling/v2beta2** API version of HorizontalPodAutoscaler will no longer be served in v1.27.
+
+* Migrate manifests and API clients to use the **autoscaling/v2** API version, available since v1.23.
+
 ### v1.25
 
 The **v1.25** release will stop serving the following deprecated API versions:
@@ -83,6 +93,16 @@ RuntimeClass in the **node.k8s.io/v1beta1** API version will no longer be served
 * Migrate manifests and API clients to use the **node.k8s.io/v1** API version, available since v1.20.
 * All existing persisted objects are accessible via the new API
 * No notable changes
+
+### v1.24
+
+The **v1.24** release will stop serving the following deprecated API versions:
+
+#### HorizontalPodAutoscaler {#horizontalpodautoscaler-v124}
+
+The **autoscaling/v2beta1** API version of HorizontalPodAutoscaler will no longer be served in v1.24.
+
+* Migrate manifests and API clients to use the **autoscaling/v2** API version, available since v1.23.
 
 ### v1.22
 


### PR DESCRIPTION
This PR adds HorizontalPodAutoscaler `autoscaling/v2beta2` API removal for Kubernetes v1.27.
`autoscaling/v2beta2` API is deprecated in v1.23 as `autoscaling/v2` reaches stable in v1.23

According to the [HPA v2 to Stable KEP working document](https://docs.google.com/document/d/1QGT9Waxc500ICGX_TGIoxfOWKmWbXYC6TWxfdUC2Njg/edit?usp=sharing) and the [Kubernetes Deprecation Policy](https://kubernetes.io/docs/reference/using-api/deprecation-policy/), `autoscaling/v2beta2` must be supported for 9 months or 3 releases (which ever is longer) after the announced deprecation.

`autoscaling/v2beta2` must be served in v1.24, v1.25, v1.26 and can be removed in v1.27

/cc @kubernetes/sig-autoscaling-pr-reviews @jlbutler @sftim 
/assign @josephburnett @gjtempleton
/hold until lgtm from SIG Autoscaling