### PR TITLE
[zh] Add translation for the missing sentence

### DIFF
--- a/content/zh/docs/reference/using-api/server-side-apply.md
+++ b/content/zh/docs/reference/using-api/server-side-apply.md
@@ -840,7 +840,7 @@ with an empty entry. Two examples are:
 可以从对象中剥离所有 managedField，
 实现方法是通过使用 `MergePatch`、 `StrategicMergePatch`、
 `JSONPatch`、 `Update`、以及所有的非应用方式的操作来覆盖它。
-这可以通过用空条目覆盖 managedFields 字段的方式实现。
+这可以通过用空条目覆盖 managedFields 字段的方式实现。以下是两个示例：
 
 ```console
 PATCH /api/v1/namespaces/default/configmaps/example-cm


### PR DESCRIPTION
Signed-off-by: Guangwen Feng <fenggw-fnst@cn.fujitsu.com>

Add translation for the missing sentence: "Two examples are:"

FYI: I have run lsync.sh on the newest 'main' branch, it shows:
```
$ ./scripts/lsync.sh content/zh/docs/reference/using-api/server-side-apply.md
diff --git a/content/en/docs/reference/using-api/server-side-apply.md b/content/en/docs/reference/using-api/server-side-apply.md
index 60acb02f7..6b932278d 100644
--- a/content/en/docs/reference/using-api/server-side-apply.md
+++ b/content/en/docs/reference/using-api/server-side-apply.md
@@ -508,11 +508,3 @@ sub-resources that don't receive the resource object type. If you are
 using Server Side Apply with such a sub-resource, the changed fields
 won't be tracked.
 {{< /caution >}}
-
-## Disabling the feature
-
-Server Side Apply is a beta feature, so it is enabled by default. To turn this
-[feature gate](/docs/reference/command-line-tools-reference/feature-gates) off,
-you need to include the `--feature-gates ServerSideApply=false` flag when
-starting `kube-apiserver`. If you have multiple `kube-apiserver` replicas, all
-should have the same flag setting.
```
But this has already been updated by https://github.com/kubernetes/website/pull/30236.