### PR TITLE
Added ingressClassName: nginx to Ingress example

### DIFF
--- a/content/en/docs/concepts/services-networking/ingress.md
+++ b/content/en/docs/concepts/services-networking/ingress.md
@@ -88,6 +88,15 @@ has all the information needed to configure a load balancer or proxy server. Mos
 contains a list of rules matched against all incoming requests. Ingress resource only supports rules
 for directing HTTP(S) traffic.
 
+If the `ingressClassName` is omitted, a [default Ingress class](#default-ingress-class) 
+should be defined.
+
+There are some ingress controllers, that work without the definition of a 
+default `IngressClass`. For example, the Ingress-NGINX controller can be 
+configured with a [flag](https://kubernetes.github.io/ingress-nginx/#what-is-the-flag-watch-ingress-without-class) 
+`--watch-ingress-without-class`. It is [recommended](https://kubernetes.github.io/ingress-nginx/#i-have-only-one-instance-of-the-ingresss-nginx-controller-in-my-cluster-what-should-i-do)  though, to specify the 
+default `IngressClass` as shown [below](#default-ingress-class).
+
 ### Ingress rules
 
 Each HTTP rule contains the following information:
@@ -265,6 +274,14 @@ the admission controller prevents creating new Ingress objects that don't have
 an `ingressClassName` specified. You can resolve this by ensuring that at most 1
 IngressClass is marked as default in your cluster.
 {{< /caution >}}
+
+There are some ingress controllers, that work without the definition of a
+default `IngressClass`. For example, the Ingress-NGINX controller can be
+configured with a [flag](https://kubernetes.github.io/ingress-nginx/#what-is-the-flag-watch-ingress-without-class)
+`--watch-ingress-without-class`. It is [recommended](https://kubernetes.github.io/ingress-nginx/#i-have-only-one-instance-of-the-ingresss-nginx-controller-in-my-cluster-what-should-i-do)  though, to specify the
+default `IngressClass`:
+
+{{< codenew file="service/networking/default-ingressclass.yaml" >}}
 
 ## Types of Ingress
 

--- a/content/en/examples/service/networking/default-ingressclass.yaml
+++ b/content/en/examples/service/networking/default-ingressclass.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+  name: nginx-example
+  annotations:
+    ingressclass.kubernetes.io/is-default-class: "true"
+spec:
+  controller: k8s.io/ingress-nginx

--- a/content/en/examples/service/networking/minimal-ingress.yaml
+++ b/content/en/examples/service/networking/minimal-ingress.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
+  ingressClassName: nginx-example
   rules:
   - http:
       paths:


### PR DESCRIPTION
When reading through the documentation in the Ingress section (https://kubernetes.io/docs/concepts/services-networking/ingress/#the-ingress-resource), that example only works if a default IngressClass has been declared. To make it more straightforward for non-expert users, I believe it is better to provide a working example.

Therefore, I added `ingressClassName: nginx` to the Ingress example, mentioned the necessity of it, and referenced the section describing that further.
 
The nginx ingress controller documentation states, that for >= 1.19, the annotation will not work anymore (https://kubernetes.github.io/ingress-nginx/user-guide/basic-usage/). Therefore I believe that we should backport it to the corresponding versions of the documentation, if possible.

I believe there might be users still using versions older than 1.19. We could possibly also provide an example with the previously used annotation in those docs.
