### PR TITLE
Add hpa v2beta1 and v2beta2 to deprecation guide

### DIFF
--- a/content/en/docs/reference/using-api/deprecation-guide.md
+++ b/content/en/docs/reference/using-api/deprecation-guide.md
@@ -20,6 +20,16 @@ deprecated API versions to newer and more stable API versions.
 
 ## Removed APIs by release
 
+### v1.26
+
+The **v1.26** release will stop serving the following deprecated API versions:
+
+#### HorizontalPodAutoscaler {#horizontalpodautoscaler-v126}
+
+The **autoscaling/v2beta2** API version of HorizontalPodAutoscaler will no longer be served in v1.26.
+
+* Migrate manifests and API clients to use the **autoscaling/v2** API version, available since v1.23.
+* All existing persisted objects are accessible via the new API
 
 ### v1.25
 
@@ -59,6 +69,13 @@ The **events.k8s.io/v1beta1** API version of Event will no longer be served in v
     * use `series.count` instead of the deprecated `count` field (which is renamed to `deprecatedCount` and not permitted in new **events.k8s.io/v1** Events)
     * use `reportingController` instead of the deprecated `source.component` field (which is renamed to `deprecatedSource.component` and not permitted in new **events.k8s.io/v1** Events)
     * use `reportingInstance` instead of the deprecated `source.host` field (which is renamed to `deprecatedSource.host` and not permitted in new **events.k8s.io/v1** Events)
+
+#### HorizontalPodAutoscaler {#horizontalpodautoscaler-v125}
+
+The **autoscaling/v2beta1** API version of HorizontalPodAutoscaler will no longer be served in v1.25.
+
+* Migrate manifests and API clients to use the **autoscaling/v2** API version, available since v1.23.
+* All existing persisted objects are accessible via the new API
 
 #### PodDisruptionBudget {#poddisruptionbudget-v125}
 


### PR DESCRIPTION
This PR adds: 
  - HorizontalPodAutoscaler autoscaling/v2beta2 API removal for Kubernetes v1.26.
autoscaling/v2beta2 API is deprecated in v1.23 as autoscaling/v2 reaches stable in v1.23
  - HorizontalPodAutoscaler autoscaling/v2beta1 API removal for Kubernetes v1.25.
autoscaling/v2beta1 API is deprecated as of [May 2018 in this PR](https://github.com/kubernetes/kubernetes/pull/64097) and autoscaling/v2 is stable in v1.23

According to the HPA v2 to Stable KEP working document and the Kubernetes Deprecation Policy, autoscaling/v2beta2 must be supported for 9 months or 3 releases (which ever is longer) after the announced deprecation.

autoscaling/v2beta2 must be served in v1.23, v1.24, v1.25 and can be removed in v1.26

Follow-up to https://github.com/kubernetes/website/pull/30720

/cc @kubernetes/sig-autoscaling-pr-reviews @jlbutler @sftim
/assign @josephburnett @gjtempleton
/hold until lgtm from SIG Autoscaling