### PR TITLE
Correct separator in generated ConfigMap.

### DIFF
--- a/content/en/docs/tasks/manage-kubernetes-objects/kustomization.md
+++ b/content/en/docs/tasks/manage-kubernetes-objects/kustomization.md
@@ -113,10 +113,10 @@ The generated ConfigMap is:
 ```yaml
 apiVersion: v1
 data:
-    FOO=Bar
+  FOO: Bar
 kind: ConfigMap
 metadata:
-  name: example-configmap-1-8mbdf7882g
+  name: example-configmap-1-42cfbf598f
 ```
 
 {{< note >}}


### PR DESCRIPTION
The document doesn't show the actual separator used by the generated ConfigMap . The input file uses "=" to separate key from value. The generated ConfigMap uses the YAML ": " separator. The rendered output is not a valid ConfigMap and doesn't match the output of kustomize.