### PR TITLE
Revise header file generation

### DIFF
--- a/layouts/index.headers
+++ b/layouts/index.headers
@@ -1,38 +1,43 @@
-{{- if eq (getenv "HUGO_ENV") "production" }}
+#
+# See https://docs.netlify.com/routing/headers/#syntax-for-the-headers-file
+#
+# Headers set for all pages
+/*
+  Link: </images/favicon.png>; rel=icon
+{{/* Don't have indexing for previews etc */}}
+{{- if ne (getenv "HUGO_ENV") "production" -}}
+  X-Robots-Tag: noindex
+{{- end }}
 {{- $cssFilesFromConfig := site.Params.pushAssets.css -}}
 {{- $jsFilesFromConfig := site.Params.pushAssets.js -}}
-{{- $pages := site.RegularPages -}}
-  Link: </images/favicon.png>; rel=preload; as=image
   {{- range $cssFilesFromConfig -}}
-  {{- $cssUrl := printf "/css/%s.css" . }}
+  {{- $cssUrl := printf "/css/%s.css" . -}}
   Link: <{{ $cssUrl }}>; rel=preload; as=style
   {{- end -}}
   {{- range $jsFilesFromConfig -}}
-  {{- $jsUrl := printf "/js/%s.js" . }}
+  {{- $jsUrl := printf "/js/%s.js" . -}}
   Link: <{{ $jsUrl }}>; rel=preload; as=script
   {{- end -}}
+# Headers for specific pages
+{{- $pages := site.RegularPages -}}
 {{- range $pages }}
 {{- if or (.Params.deprecated) (eq .Params.class "gridPage") (.Params.case_study_styles) (.Params.css) (.Params.js) }}
-{{ .URL }}
-  {{- if eq .Params.class "gridPage" }}
+{{ .RelPermalink }}
+  {{- if eq .Params.class "gridPage" -}}
   Link: </css/gridpage.css>; rel=preload; as=style
   {{- end -}}
-  {{- if .Params.case_study_styles }}
+  {{- if .Params.case_study_styles -}}
   Link: </css/case_study_styles.css>; rel=preload; as=style
   {{- end -}}
   {{- with .Params.css -}}
-  {{- range (split . ",") }}
+  {{- range (split . ",") -}}
   Link: <{{ trim . " " }}>; rel=preload; as=style
   {{- end -}}
   {{- end -}}
   {{- with .Params.js -}}
-  {{- range (split . ",") }}
+  {{- range (split . ",") -}}
   Link: <{{ trim . " " }}>; rel=preload; as=script
   {{- end -}}
   {{- end -}}
-{{- end }}
 {{- end -}}
-{{- else }}
-/*
-  X-Robots-Tag: noindex
-{{- end }}
+{{- end -}}


### PR DESCRIPTION
Hugo generates a headers file that Netlify then uses to serve headers for the site.

A key change is to fix the logic to make sure previews are served with an HTTP header to prevent robot indexing.
The build script `check-headers-file.sh` verifies that that header is NOT present for production deploys.

If we accept this change, I also recommend backporting it.

Fixes #27338 (I hope)