### PR TITLE
Add sftim as a blog editor

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,6 +2,7 @@ aliases:
   sig-docs-blog-owners: # Approvers for blog content
     - onlydole
     - mrbobbytables
+    - sftim
   sig-docs-blog-reviewers: # Reviewers for blog content
     - mrbobbytables
     - onlydole


### PR DESCRIPTION
I've been taking part in the blog team as a review for a while, and I'm also a tech lead for SIG Docs.

I suggest I also step forward as a blog editor.

/cc @onlydole
/cc @mrbobbytables

I'll update https://github.com/kubernetes/community/tree/master/sig-docs/blog-subproject if accepted.