### PR TITLE
Add v1.23 release to release list

### DIFF
--- a/content/en/releases/patch-releases.md
+++ b/content/en/releases/patch-releases.md
@@ -85,6 +85,14 @@ releases may also occur in between these.
 
 ## Detailed Release History for Active Branches
 
+### 1.23
+
+**1.23** enters maintenance mode on **2022-12-28**.
+
+End of Life for **1.23** is **2023-02-28**.
+
+_Patch release schedule is not yet decided._
+
 ### 1.22
 
 **1.22** enters maintenance mode on **2022-08-28**

--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -1,4 +1,7 @@
 schedules:
+- release: 1.23
+  next: 1.23.1
+  endOfLifeDate: 2023-02-28
 - release: 1.22
   next: 1.22.5
   cherryPickDeadline: 2021-12-10


### PR DESCRIPTION
https://kubernetes.io/releases/ and https://kubernetes.io/releases/patch-releases/ don't list Kubernetes v1.23 at all; I think the should, albeit that the patch releases page would say that there aren't any patch releases yet.

We can also say when v1.23 goes out of support.

[[preview](https://deploy-preview-30800--kubernetes-io-main-staging.netlify.app/releases)]

/sig release
/milestone 1.23