### PR TITLE
Fix link to hpa API reference

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -575,4 +575,4 @@ For more information on HorizontalPodAutoscaler:
 * Read documentation for [`kubectl autoscale`](/docs/reference/generated/kubectl/kubectl-commands/#autoscale).
 * If you would like to write your own custom metrics adapter, check out the
   [boilerplate](https://github.com/kubernetes-sigs/custom-metrics-apiserver) to get started.
-* Read the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler/) for HorizontalPodAutoscaler.
+* Read the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2beta2/) for HorizontalPodAutoscaler.


### PR DESCRIPTION
The current link is broken. This PR points it to the current reference documentation for the hpa.