### PR TITLE
Revise concept & reference docs for Services, Ingress & networking

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -866,6 +866,9 @@ either:
   * For IPv4 endpoints, the DNS system creates A records.
   * For IPv6 endpoints, the DNS system creates AAAA records.
 
+When you define a headless Service without a selector, the `port` must
+match the `targetPort`.
+
 ## Discovering services
 
 For clients running inside your cluster, Kubernetes supports two primary modes of


### PR DESCRIPTION
Overall PR (changes have been split out).

Individual PRs:

- #37385
- #36668
- #36669
- #36670
- #36671
- #36672
- #36673
- #36675
- #37386 
- #37442
- #38054
- #38055
- #38551
- #38561
- #38562
- #38563
- #39499
- #40227
- #40671
- #41195
---

The effect of **this** PR, overall:

- Revise [Services](https://k8s.io/docs/concepts/services-networking/service/) documentation [[preview](https://deploy-preview-30817--kubernetes-io-main-staging.netlify.app/docs/concepts/services-networking/service/)]
  - migrate reference details out of Concepts section
  - drop some vendor-specific details that don't fit well with our content guide
  - write “primary” in place of “master”
  - general tidying
- Move [Connecting Applications with Services](https://k8s.io/docs/concepts/services-networking/connect-applications-service/) (to tutorials section)
- favor EndpointSlices over Endpoints
- Reorganize the [Services, Load Balancing, and Networking section](https://k8s.io/docs/concepts/services-networking/)
  - and add page descriptions [[preview](https://deploy-preview-30817--kubernetes-io-main-staging.netlify.app/docs/concepts/services-networking/)]
- Remove enabling Service Topology
- Update https://k8s.io/docs/concepts/policy/ to link to the NetworkPolicy docs

/language en
/label refactor
/sig network

Helps with https://github.com/kubernetes/website/issues/14770