### PR TITLE
Add glossary entry for cadvisor

### DIFF
--- a/content/en/docs/concepts/architecture/garbage-collection.md
+++ b/content/en/docs/concepts/architecture/garbage-collection.md
@@ -124,7 +124,8 @@ resource type.
 ### Container image lifecycle
 
 Kubernetes manages the lifecycle of all images through its *image manager*,
-which is part of the kubelet, with the cooperation of cadvisor. The kubelet
+which is part of the kubelet, with the cooperation of 
+{{< glossary_tooltip text="cadvisor" term_id="cadvisor" >}}. The kubelet
 considers the following disk usage limits when making garbage collection
 decisions:
 

--- a/content/en/docs/reference/glossary/cadvisor.md
+++ b/content/en/docs/reference/glossary/cadvisor.md
@@ -1,0 +1,16 @@
+---
+title: cAdvisor
+id: cadvisor
+date: 2021-12-09
+full_link: https://github.com/google/cadvisor/
+short_description: >
+  Tool that provides understanding of the resource usage and perfomance characteristics for containers 
+aka:
+tags:
+- tool
+---
+cAdvisor (Container Advisor) provides container users an understanding of the resource usage and performance characteristics of their running {{< glossary_tooltip text="containers" term_id="container" >}}.
+
+<!--more-->
+
+It is a running daemon that collects, aggregates, processes, and exports information about running containers. Specifically, for each container it keeps resource isolation parameters, historical resource usage, histograms of complete historical resource usage and network statistics. This data is exported by container and machine-wide.


### PR DESCRIPTION
This PR introduces a new glossary entry for [cadvisor](https://github.com/google/cadvisor#readme). The glossary entry is used to explain this tool on the k8s.io/docs/concepts/architecture/garbage-collection/ page.

Resolves #30814 