### PR TITLE
kubeadm: fix wrong config example for customization with patches

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/control-plane-flags.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/control-plane-flags.md
@@ -144,9 +144,8 @@ You can pass this file to `kubeadm init` with `--config <YOUR CONFIG YAML>`:
 ```yaml
 apiVersion: kubeadm.k8s.io/v1beta3
 kind: InitConfiguration
-nodeRegistration:
-  patches:
-    directory: /home/user/somedir
+patches:
+  directory: /home/user/somedir
 ```
 
 {{< note >}}
@@ -159,9 +158,8 @@ You can pass this file to `kubeadm join` with `--config <YOUR CONFIG YAML>`:
 ```yaml
 apiVersion: kubeadm.k8s.io/v1beta3
 kind: JoinConfiguration
-nodeRegistration:
-  patches:
-    directory: /home/user/somedir
+patches:
+  directory: /home/user/somedir
 ```
 
 The directory must contain files named `target[suffix][+patchtype].extension`.


### PR DESCRIPTION
The patches sub-structure is top level and not under nodeRegistration.

fixes https://github.com/kubernetes/website/issues/30834

/sig cluster-lifecycle
/kind bug