### PR TITLE
Highlight discussion issue for dockershim deprecation

### DIFF
--- a/content/en/blog/_posts/2017-11-00-Containerd-Container-Runtime-Options-Kubernetes.md
+++ b/content/en/blog/_posts/2017-11-00-Containerd-Container-Runtime-Options-Kubernetes.md
@@ -4,7 +4,12 @@ date: 2017-11-02
 slug: containerd-container-runtime-options-kubernetes
 url: /blog/2017/11/Containerd-Container-Runtime-Options-Kubernetes
 ---
- **_Editor's note: Today's post is by Lantao Liu, Software Engineer at Google, and Mike Brown, Open Source Developer Advocate at IBM._**  
+
+**Authors:** Lantao Liu (Google), and Mike Brown (IBM)
+
+_Update: Kubernetes support for Docker via `dockershim` is now deprecated.
+For more information, read the [deprecation notice](/blog/2020/12/08/kubernetes-1-20-release-announcement/#dockershim-deprecation).
+You can also discuss the deprecation via a dedicated [GitHub issue](https://github.com/kubernetes/kubernetes/issues/106917)._
 
 A _container runtime_ is software that executes containers and manages container images on a node. Today, the most widely known container runtime is [Docker](https://www.docker.com/), but there are other container runtimes in the ecosystem, such as [rkt](https://coreos.com/rkt/), [containerd](https://containerd.io/), and [lxd](https://linuxcontainers.org/lxd/). Docker is by far the most common container runtime used in production Kubernetes environments, but Docker’s smaller offspring, containerd, may prove to be a better option. This post describes using containerd with Kubernetes.  
 

--- a/content/en/blog/_posts/2020-12-02-dont-panic-kubernetes-and-docker.md
+++ b/content/en/blog/_posts/2020-12-02-dont-panic-kubernetes-and-docker.md
@@ -7,6 +7,10 @@ slug: dont-panic-kubernetes-and-docker
 
 **Authors:** Jorge Castro, Duffie Cooley, Kat Cosgrove, Justin Garrison, Noah Kantrowitz, Bob Killen, Rey Lejano, Dan “POP” Papandrea, Jeffrey Sica, Davanum “Dims” Srinivas
 
+_Update: Kubernetes support for Docker via `dockershim` is now deprecated.
+For more information, read the [deprecation notice](/blog/2020/12/08/kubernetes-1-20-release-announcement/#dockershim-deprecation).
+You can also discuss the deprecation via a dedicated [GitHub issue](https://github.com/kubernetes/kubernetes/issues/106917)._
+
 Kubernetes is [deprecating
 Docker](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md#deprecation)
 as a container runtime after v1.20.

--- a/content/en/blog/_posts/2021-11-12-are-you-ready-for-dockershim-removal/index.md
+++ b/content/en/blog/_posts/2021-11-12-are-you-ready-for-dockershim-removal/index.md
@@ -5,13 +5,20 @@ date: 2021-11-12
 slug: are-you-ready-for-dockershim-removal
 ---
 
-**Author:** Sergey Kanzhelev, Google. With reviews from Davanum Srinivas, Elana Hashman, Noah Kantrowitz, Rey Lejano.
+**Authors:** Sergey Kanzhelev, Google. With reviews from Davanum Srinivas, Elana Hashman, Noah Kantrowitz, Rey Lejano.
 
 {{% alert color="info" title="Poll closed" %}}
 This poll closed on January 7, 2022.
 {{% /alert %}}
 
-Last year we announced that Dockershim is being deprecated: [Dockershim Deprecation FAQ](/blog/2020/12/02/dockershim-faq/).
+Last year we [announced](/blog/2020/12/08/kubernetes-1-20-release-announcement/#dockershim-deprecation)
+that Kubernetes' dockershim component (which provides a built-in integration for
+Docker Engine) is deprecated.
+
+_Update: There's a [Dockershim Deprecation FAQ](/blog/2020/12/02/dockershim-faq/)
+with more information, and you can also discuss the deprecation via a dedicated
+[GitHub issue](https://github.com/kubernetes/kubernetes/issues/106917)._
+
 Our current plan is to remove dockershim from the Kubernetes codebase soon.
 We are looking for feedback from you whether you are ready for dockershim
 removal and to ensure that you are ready when the time comes.

--- a/content/en/blog/_posts/2022-02-17-updated-dockershim-faq.md
+++ b/content/en/blog/_posts/2022-02-17-updated-dockershim-faq.md
@@ -1,6 +1,7 @@
 ---
 layout: blog
 title: "Updated: Dockershim Removal FAQ"
+linkTitle: "Dockershim Removal FAQ"
 date: 2022-02-17
 slug: dockershim-faq
 aliases: [ '/dockershim' ]
@@ -184,7 +185,7 @@ options are available as you migrate things over.
 [documentation]: https://github.com/containerd/cri/blob/master/docs/registry.md
 
 For instructions on how to use containerd and CRI-O with Kubernetes, see the
-Kubernetes documentation on [Container Runtimes]
+Kubernetes documentation on [Container Runtimes].
 
 [Container Runtimes]: /docs/setup/production-environment/container-runtimes/
 
@@ -192,7 +193,10 @@ Kubernetes documentation on [Container Runtimes]
 
 If you use a vendor-supported Kubernetes distribution, you can ask them about
 upgrade plans for their products. For end-user questions, please post them
-to our end user community forum: https://discuss.kubernetes.io/. 
+to our end user community forum: https://discuss.kubernetes.io/.
+
+You can discuss the decision to remove dockershim via a dedicated
+[GitHub issue](https://github.com/kubernetes/kubernetes/issues/106917).
 
 You can also check out the excellent blog post
 [Wait, Docker is deprecated in Kubernetes now?][dep] a more in-depth technical

--- a/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/_index.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/_index.md
@@ -1,7 +1,8 @@
 ---
 title: "Migrating from dockershim"
 weight: 10
-content_type: task 
+content_type: task
+no_list: true
 ---
 
 <!-- overview -->
@@ -14,9 +15,30 @@ in Kubernetes 1.20, there were questions on how this will affect various workloa
 installations. Our [Dockershim Removal FAQ](/blog/2022/02/17/dockershim-faq/) is there to help you
 to understand the problem better.
 
-It is recommended to migrate from dockershim to alternative container runtimes.
-Check out [container runtimes](/docs/setup/production-environment/container-runtimes/)
-section to know your options. Make sure to
-[report issues](https://github.com/kubernetes/kubernetes/issues) you encountered
-with the migration. So the issue can be fixed in a timely manner and your cluster would be
-ready for dockershim removal.
+<!-- body -->
+
+If you use Docker via dockershim as your container runtime, the Kubernetes project
+recommends that you migrate to an alternative container runtime.
+If you're not sure whether you are using Docker,
+[find out what container runtime is used on a node](/docs/tasks/administer-cluster/migrating-from-dockershim/find-out-runtime-you-use/).
+
+Your cluster might have more than one kind of node, although this is not a common
+configuration.
+
+These tasks will help you to migrate:
+
+* [Check whether Dockershim deprecation affects you](/docs/tasks/administer-cluster/migrating-from-dockershim/check-if-dockershim-deprecation-affects-you/)
+* [Migrating from dockershim](/docs/tasks/administer-cluster/migrating-from-dockershim/)
+* [Migrating telemetry and security agents from dockershim](/docs/tasks/administer-cluster/migrating-from-dockershim/migrating-telemetry-and-security-agents/)
+
+
+## {{% heading "whatsnext" %}}
+
+* Check out [container runtimes](/docs/setup/production-environment/container-runtimes/)
+  to understand your options for a container runtime.
+* There is a
+  [GitHub issue](https://github.com/kubernetes/kubernetes/issues/106917)
+  to track discussion about the deprecation and removal of dockershim.
+* If you found a defect or other technical concern relating to migrating away from dockershim,
+  you can [report an issue](https://github.com/kubernetes/kubernetes/issues/new/choose)
+  to the Kubernetes project.

--- a/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/check-if-dockershim-deprecation-affects-you.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/check-if-dockershim-deprecation-affects-you.md
@@ -10,7 +10,9 @@ weight: 20
 
 The `dockershim` component of Kubernetes allows to use Docker as a Kubernetes's
 {{< glossary_tooltip text="container runtime" term_id="container-runtime" >}}.
-Kubernetes' built-in `dockershim` component was deprecated in release v1.20.
+Kubernetes' built-in `dockershim` component was
+[deprecated](/blog/2020/12/08/kubernetes-1-20-release-announcement/#dockershim-deprecation)
+in release v1.20.
 
 This page explains how your cluster could be using Docker as a container runtime,
 provides details on the role that `dockershim` plays when in use, and shows steps
@@ -88,3 +90,8 @@ You can still pull images or build them using `docker build` command. But images
 built or pulled by Docker would not be visible to container runtime and
 Kubernetes. They needed to be pushed to some registry to allow them to be used
 by Kubernetes.
+
+## {{% heading "whatsnext" %}}
+
+- Read [Migrating from dockershim](/docs/tasks/administer-cluster/migrating-from-dockershim/) to understand your next steps
+- Read the [dockershim deprecation FAQ](/blog/2020/12/02/dockershim-faq/) article for more information.

--- a/static/_redirects
+++ b/static/_redirects
@@ -487,7 +487,6 @@
 /editdocs/     /docs/contribute/     301
 /docs/home/editdocs/  /docs/contribute/ 301
 
-
 /docs/admin/accessing-the-api/     /docs/concepts/overview/kubernetes-api/ 301
 /docs/admin/admission-controllers/     /docs/reference/access-authn-authz/admission-controllers/ 301
 /docs/admin/authentication/     /docs/reference/access-authn-authz/authentication/ 301
@@ -501,8 +500,13 @@
 /docs/admin/authorization/webhook/     /docs/reference/access-authn-authz/webhook/ 301
 /docs/admin/authorization/     /docs/reference/access-authn-authz/authorization/ 301
 /docs/admin/high-availability/building/     /docs/setup/production-environment/tools/kubeadm/high-availability/   301
+
 /code-of-conduct/     /community/code-of-conduct/   301
 /values/     /community/values/   302
+
+/dockershim /blog/2022/02/17/dockershim-faq/ 302
+/dockershim/ /blog/2022/02/17/dockershim-faq/ 302
+
 
 /docs/setup/release/notes/     /releases/notes/   302
 /docs/setup/release/                 /releases/   301


### PR DESCRIPTION
- Link to k/kubernetes issue 106917
  (various places)
- Related rewording to make that extra link work in context

and also:
- Replace alias for dockershim FAQ with a Netlify redirect

Previews:
- [`/blog/2017/11/containerd-container-runtime-options-kubernetes/`](https://deploy-preview-30840--kubernetes-io-main-staging.netlify.app/blog/2017/11/containerd-container-runtime-options-kubernetes/)
- [`/blog/2020/12/02/dont-panic-kubernetes-and-docker/`](https://deploy-preview-30840--kubernetes-io-main-staging.netlify.app/blog/2020/12/02/dont-panic-kubernetes-and-docker/)
- [`/blog/2021/11/12/are-you-ready-for-dockershim-removal/`](https://deploy-preview-30840--kubernetes-io-main-staging.netlify.app/blog/2021/11/12/are-you-ready-for-dockershim-removal/)
- [`/dockershim`](https://deploy-preview-30840--kubernetes-io-main-staging.netlify.app/dockershim)
- [`/docs/tasks/administer-cluster/migrating-from-dockershim/`](https://deploy-preview-30840--kubernetes-io-main-staging.netlify.app/docs/tasks/administer-cluster/migrating-from-dockershim/)


Fixes #30839