### PR TITLE
Fix link to HorizontalPodAutoscaler API reference

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -575,4 +575,4 @@ For more information on HorizontalPodAutoscaler:
 * Read documentation for [`kubectl autoscale`](/docs/reference/generated/kubectl/kubectl-commands/#autoscale).
 * If you would like to write your own custom metrics adapter, check out the
   [boilerplate](https://github.com/kubernetes-sigs/custom-metrics-apiserver) to get started.
-* Read the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler/) for HorizontalPodAutoscaler.
+* Read the [API reference](/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2/) for HorizontalPodAutoscaler.


### PR DESCRIPTION
The existing URL broke with the switch to the stable v2 API for HorizontalPodAutoscaler. Fix that.

Rework of PR #30805