### PR TITLE
Add formatting to the example block for the Endpoints doc

### DIFF
--- a/content/en/docs/reference/kubernetes-api/service-resources/endpoints-v1.md
+++ b/content/en/docs/reference/kubernetes-api/service-resources/endpoints-v1.md
@@ -29,6 +29,7 @@ guide. You can file document formatting bugs against the
 ## Endpoints {#Endpoints}
 
 Endpoints is a collection of endpoints that implement the actual service. Example:
+```
   Name: "mysvc",
   Subsets: [
     {
@@ -40,7 +41,7 @@ Endpoints is a collection of endpoints that implement the actual service. Exampl
       Ports: [{"name": "a", "port": 93}, {"name": "b", "port": 76}]
     },
  ]
-
+```
 <hr>
 
 - **apiVersion**: v1


### PR DESCRIPTION
Wrap the example section with in the code  block tags so that it appears with proper formatting on the website. This is for the `en` web site. This resolves issue #30878 

