### PR TITLE
Improve release data shortcode

### DIFF
--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -217,6 +217,11 @@ other = ")"
 [release_date_before]
 other = "(released: "
 
+# See https://gohugo.io/functions/format/#gos-layout-string
+# Use a suitable format for your locale
+[release_date_format]
+other = "2006-01-02"
+
 [seealso_heading]
 other = "See Also"
 

--- a/layouts/shortcodes/release-data.html
+++ b/layouts/shortcodes/release-data.html
@@ -7,20 +7,20 @@
 {{ if not $data.previousPatches }}
 <!-- initial minor release -->
 <div>
-    <b class="release-inline-heading">{{ T "latest_release" }}</b><span class="release-inline-value">{{ printf "%s.0" $dataVersion }}{{ if isset $data "releaseDate" }} {{ T "release_date_before" }}{{ printf "%s" $data.releaseDate }}{{ T "release_date_after" }}{{- end -}}</span>
+    <b class="release-inline-heading">{{ T "latest_release" }}</b><span class="release-inline-value">{{ printf "%s.0" $dataVersion }}{{ if isset $data "releaseDate" }} {{ T "release_date_before" }}<time datetime="{{ time.Format "2006-01-02" $data.releaseDate }}">{{ time.Format ( T "release_date_format") $data.releaseDate }}</time>{{ T "release_date_after" }}{{- end -}}</span>
 </div>
 <div>
-   <b class="release-inline-heading">{{ T "end_of_life" }}</b><span class="release-eoldate release-inline-value">{{ printf "%s" $data.endOfLifeDate }}</span>
+   <b class="release-inline-heading">{{ T "end_of_life" }}</b><span class="release-eoldate release-inline-value"><time datetime="{{ time.Format "2006-01-02" $data.endOfLifeDate }}">{{ time.Format ( T "release_date_format") $data.endOfLifeDate }}</time></span>
 </div>
 <div>
     <b class="release-inline-heading">{{ T "previous_patches" }}</b> <span class="notapplicable release-inline-value">{{ T "not_applicable" }}</span>
 </div>
 {{- else -}}
 <div>
-    <b class="release-inline-heading">{{ T "latest_release" }}</b><span class="release-inline-value">{{ index $data.previousPatches 0 "release" }} {{ T "release_date_before" }}{{ printf "%s" ( index $data.previousPatches 0 "targetDate" ) }}{{ T "release_date_after" }}</span>
+    <b class="release-inline-heading">{{ T "latest_release" }}</b><span class="release-inline-value">{{ index $data.previousPatches 0 "release" }} {{ T "release_date_before" }}<time datetime="{{ time.Format "2006-01-02" ( index $data.previousPatches 0 "targetDate" ) }}">{{ time.Format ( T "release_date_format") ( index $data.previousPatches 0 "targetDate" ) }}</time>{{ T "release_date_after" }}</span>
 </div>
 <div>
-    <b class="release-inline-heading">{{ T "end_of_life" }}</b><span class="release-eoldate release-inline-value">{{ printf "%s" $data.endOfLifeDate }}</span>
+    <b class="release-inline-heading">{{ T "end_of_life" }}</b><span class="release-eoldate release-inline-value"><time datetime="{{ time.Format "2006-01-02" $data.endOfLifeDate }}">{{ time.Format ( T "release_date_format") $data.endOfLifeDate }}</time></span>
 </div>
 <div>
 <b>{{ T "previous_patches" }}</b>

--- a/layouts/shortcodes/release-data.html
+++ b/layouts/shortcodes/release-data.html
@@ -5,20 +5,19 @@
 
 <div class="release-details">
 {{ if not $data.previousPatches }}
+<!-- initial minor release -->
 <div>
-<b class="release-inline-heading">{{ T "latest_release" }}</b><span class="release-version release-inline-value">{{ printf "%s.0" $dataVersion }}</span>
+    <b class="release-inline-heading">{{ T "latest_release" }}</b><span class="release-inline-value">{{ printf "%s.0" $dataVersion }}{{ if isset $data "releaseDate" }} {{ T "release_date_before" }}{{ printf "%s" $data.releaseDate }}{{ T "release_date_after" }}{{- end -}}</span>
 </div>
 <div>
-  <b class="release-inline-heading">{{ T "end_of_life" }}</b><span class="release-eoldate release-inline-value">{{ printf "%s" $data.endOfLifeDate }}</span>
+   <b class="release-inline-heading">{{ T "end_of_life" }}</b><span class="release-eoldate release-inline-value">{{ printf "%s" $data.endOfLifeDate }}</span>
 </div>
 <div>
     <b class="release-inline-heading">{{ T "previous_patches" }}</b> <span class="notapplicable release-inline-value">{{ T "not_applicable" }}</span>
 </div>
-{{ end }}
-
-{{ if $data.previousPatches }}
+{{- else -}}
 <div>
-    <b class="release-inline-heading">{{ T "latest_release" }}</b><span class="release-inline-value">{{ index $data.previousPatches 0 "release" }} {{ T "release_date_before" }}{{ index $data.previousPatches 0 "targetDate" }}{{ T "release_date_after" }}</span>
+    <b class="release-inline-heading">{{ T "latest_release" }}</b><span class="release-inline-value">{{ index $data.previousPatches 0 "release" }} {{ T "release_date_before" }}{{ printf "%s" ( index $data.previousPatches 0 "targetDate" ) }}{{ T "release_date_after" }}</span>
 </div>
 <div>
     <b class="release-inline-heading">{{ T "end_of_life" }}</b><span class="release-eoldate release-inline-value">{{ printf "%s" $data.endOfLifeDate }}</span>
@@ -30,10 +29,10 @@
         {{ if $key }}{{ T "inline_list_separator" }}{{ end }}
         <a href="https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-{{ $dataVersion }}.md#v{{ replace .release `.` `` }}">{{ printf "%s" .release }}</a>
     {{- end -}}
-{{- end -}}
     </span>
 </div>
 
+{{- end -}}
 <!-- not yet localized, mark as English -->
 <p lang="en">
 Complete {{ $dataVersion }} <a href="/releases/patch-releases/#{{ replace $dataVersion `.` `-` }}">Schedule</a>


### PR DESCRIPTION
- Fix HTML for release-data shortcode
  - Add support for a `releaseDate` field for minor versions, allowing us to publish a release date even when no patch releases are out
- Implement localizable date formats for release data.
  A localization can now customize `release_date_format` to set the Golang date format string appropriate for their locale.

[[preview](https://deploy-preview-30924--kubernetes-io-main-staging.netlify.app/releases/)]

/area web-development
/sig release