### PR TITLE
Note that subPathExpr uses round brackets.

### DIFF
--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -1133,6 +1133,7 @@ spec:
     volumeMounts:
     - name: workdir1
       mountPath: /logs
+      # The variable expansion uses round brackets (not curly brackets).
       subPathExpr: $(POD_NAME)
   restartPolicy: Never
   volumes:


### PR DESCRIPTION
I was silly and spent far too long using `${ENV_VAR}` whereas the correct syntax is `$(ENV_VAR)`, and wasn't able to understand what I was doing wrong. The syntax/issue makes sense once you know it, but is very hard to spot as a typo (imo/ime).

Adding the extra detail felt like it may be helpful for anyone else who may be confused in the same way.

Absolutely no stress if you think this is unnecessary, or that there is a better way to document it - just thought it might be helpful for others :-)