### PR TITLE
Update `cascade` default value to background

### DIFF
--- a/content/en/blog/_posts/2021-05-14-using-finalizers-to-control-deletion.md
+++ b/content/en/blog/_posts/2021-05-14-using-finalizers-to-control-deletion.md
@@ -190,7 +190,7 @@ kubectl get configmap
 No resources found in default namespace.
 ```
 
-To sum things up, when there's an override owner reference from a child to a parent, deleting the parent deletes the children automatically. This is called `cascade`. The default for cascade is `true`, however, you can use the --cascade=orphan option for `kubectl delete` to delete an object and orphan its children. 
+To sum things up, when there's an override owner reference from a child to a parent, deleting the parent deletes the children automatically. This is called `cascade`. The default for cascade is `background`, however, you can use the --cascade=orphan option for `kubectl delete` to delete an object and orphan its children. 
 
 In the following example, there is a parent and a child. Notice the owner references are still included. If I delete the parent using --cascade=orphan, the parent is deleted but the child still exists:
 

--- a/content/en/blog/_posts/2021-05-14-using-finalizers-to-control-deletion.md
+++ b/content/en/blog/_posts/2021-05-14-using-finalizers-to-control-deletion.md
@@ -190,7 +190,8 @@ kubectl get configmap
 No resources found in default namespace.
 ```
 
-To sum things up, when there's an override owner reference from a child to a parent, deleting the parent deletes the children automatically. This is called `cascade`. The default for cascade is `background`, however, you can use the --cascade=orphan option for `kubectl delete` to delete an object and orphan its children. 
+To sum things up, when there's an override owner reference from a child to a parent, deleting the parent deletes the children automatically. This is called `cascade`. The default for cascade is `true`, however, you can use the --cascade=orphan option for `kubectl delete` to delete an object and orphan its children.  *Update: starting with kubectl v1.20, the default for cascade is `background`.*
+
 
 In the following example, there is a parent and a child. Notice the owner references are still included. If I delete the parent using --cascade=orphan, the parent is deleted but the child still exists:
 


### PR DESCRIPTION
The default value of `cascade` was changed to `background`, but there was a document that has not been modified yet, so I modified it.

Documents related to cascade
- https://kubernetes.io/docs/tasks/administer-cluster/use-cascading-deletion/#use-foreground-cascading-deletion
- https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#delete
