### PR TITLE
Two small blog fixups

### DIFF
--- a/content/en/blog/_posts/2021-12-09-pod-security-admission-beta.md
+++ b/content/en/blog/_posts/2021-12-09-pod-security-admission-beta.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-title: 'Pod Security Graduates to Beta'
+title: 'Kubernetes 1.23: Pod Security Graduates to Beta'
 date: 2021-12-09
 slug: pod-security-admission-beta
 ---

--- a/content/en/blog/_posts/2021-12-15-prevent-persistentvolume-leaks-when-deleting-out-of-order.md
+++ b/content/en/blog/_posts/2021-12-15-prevent-persistentvolume-leaks-when-deleting-out-of-order.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-title: "Kubernetes 1.23 Prevent PersistentVolume leaks when deleting out of order"
+title: "Kubernetes 1.23: Prevent PersistentVolume leaks when deleting out of order"
 date: 2021-12-15T10:00:00-08:00
 slug: kubernetes-1-23-prevent-persistentvolume-leaks-when-deleting-out-of-order
 ---


### PR DESCRIPTION
- Retitle (published) Pod Security blog article
  - Prefix title with “Kubernetes 1.23: ”
- Fixup Prevent PersistentVolume leaks blog article
  - Add `:` into title
  - Fix path in repository

/kind cleanup
/area blog