### PR TITLE
docs: add link to a new kubelet csr approver

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
@@ -284,7 +284,6 @@ the node identity with an out of band mechanism.
 
 Third party custom controllers can be used:
 - [kubelet-csr-approver](https://github.com/postfinance/kubelet-csr-approver)
-- [kubelet-rubber-stamp](https://github.com/kontena/kubelet-rubber-stamp)
 
 Such a controller is not a secure mechanism unless it not only verifies the CommonName
 in the CSR but also verifies the requested IPs and domain names. This would prevent

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
@@ -283,6 +283,7 @@ the node identity with an out of band mechanism.
 {{% thirdparty-content %}}
 
 Third party custom controllers can be used:
+- [kubelet-csr-approver](https://github.com/postfinance/kubelet-csr-approver)
 - [kubelet-rubber-stamp](https://github.com/kontena/kubelet-rubber-stamp)
 
 Such a controller is not a secure mechanism unless it not only verifies the CommonName


### PR DESCRIPTION
I have recently written a `kubelet-serving` CSR approver, which is compatible with K8s 1.21, 1.22, and which implements a series of security check before signing CSR.

I think it could probably help other K8s users to know its existence, therefore my pull request!

additionally, the other CSR approver (`kubelet-rubber-stamp`) listed before my change, is not compatible with K8s 1.22, and doesn't implement proper validation of the CSRs (it will basically approve every CSR a node creates), and isn't maintained anymore. if you think it makes sense, I could make another commit to remove it from the list
