### PR TITLE
Update: Developing and debugging services locally

### DIFF
--- a/content/en/docs/tasks/debug-application-cluster/local-debugging.md
+++ b/content/en/docs/tasks/debug-application-cluster/local-debugging.md
@@ -4,58 +4,56 @@ content_type: task
 ---
 
 <!-- overview -->
-
-Kubernetes applications usually consist of multiple, separate services, each running in its own container. Developing and debugging these services on a remote Kubernetes cluster can be cumbersome, requiring you to [get a shell on a running container](/docs/tasks/debug-application-cluster/get-shell-running-container/) and running your tools inside the remote shell.
-
-`telepresence` is a tool to ease the process of developing and debugging services locally, while proxying the service to a remote Kubernetes cluster. Using `telepresence` allows you to use custom tools, such as a debugger and IDE, for a local service and provides the service full access to ConfigMap, secrets, and the services running on the remote cluster.
-
+ 
+Kubernetes applications usually consist of multiple, separate services, each running in its own container. Developing and debugging these services on a remote Kubernetes cluster can be cumbersome, requiring you to [get a shell on a running container](/docs/tasks/debug-application-cluster/get-shell-running-container/) in order to run debugging tools.
+ 
+`telepresence` is a tool to ease the process of developing and debugging services locally while proxying the service to a remote Kubernetes cluster. Using `telepresence` allows you to use custom tools, such as a debugger and IDE, for a local service and provides the service full access to ConfigMap, secrets, and the services running on the remote cluster.
+ 
 This document describes using `telepresence` to develop and debug services running on a remote cluster locally.
-
-
-
 
 ## {{% heading "prerequisites" %}}
 
-
 * Kubernetes cluster is installed
 * `kubectl` is configured to communicate with the cluster
-* [Telepresence](https://www.telepresence.io/reference/install) is installed
-
+* [Telepresence](https://www.telepresence.io/docs/latest/install/) is installed
 
 
 <!-- steps -->
 
-## Getting a shell on a remote cluster
+## Connecting your local machine to a remote Kubernetes cluster
+ 
+After installing `telepresence`, run `telepresence connect` to launch it's Daemon and connect your local workstation to the cluster.
 
-Open a terminal and run `telepresence` with no arguments to get a `telepresence` shell. This shell runs locally, giving you full access to your local filesystem.
+```
+$ telepresence connect
+ 
+Launching Telepresence Daemon
+...
+Connected to context default (https://<cluster public IP>)
+```
 
-The `telepresence` shell can be used in a variety of ways. For example, write a shell script on your laptop, and run it directly from the shell in real time. You can do this on a remote shell as well, but you might not be able to use your preferred code editor, and the script is deleted when the container is terminated.
-
-Enter `exit` to quit and close the shell.
-
+You can curl services using the Kubernetes syntax e.g. `curl -ik https://kubernetes.default`
+ 
 ## Developing or debugging an existing service
 
 When developing an application on Kubernetes, you typically program or debug a single service. The service might require access to other services for testing and debugging. One option is to use the continuous deployment pipeline, but even the fastest deployment pipeline introduces a delay in the program or debug cycle.
+ 
+Use the `telepresence intercept $SERVICE_NAME --port $LOCAL_PORT:REMOTE_PORT` command to create an "intercept" for rerouting remote service traffic.
+ 
+Where:
 
-Use the `--swap-deployment` option to swap an existing deployment with the Telepresence proxy. Swapping allows you to run a service locally and connect to the remote Kubernetes cluster. The services in the remote cluster can now access the locally running instance.
+-   `$SERVICE_NAME`  is the name of your local service
+-   `$LOCAL_PORT` is the port that your service is running on your local workstation
+-   And `$REMOTE_PORT` is the port your service listens to in the cluster
 
-To run telepresence with `--swap-deployment`, enter:
+Running this command tells Telepresence to send remote traffic to your local service instead of the service in the remote Kubernetes cluster. Make edits to your service source code locally, save, and see the corresponding changes when accessing your remote application take effect immediately. You can also run your local service using a debugger or any other local development tool.
 
-`telepresence --swap-deployment $DEPLOYMENT_NAME`
+## How does Telepresence work?
 
-where $DEPLOYMENT_NAME is the name of your existing deployment.
-
-Running this command spawns a shell. In the shell, start your service. You can then make edits to the source code locally, save, and see the changes take effect immediately. You can also run your service in a debugger, or any other local development tool.
-
-
+Telepresence installs a traffic-agent sidecar next to your existing application's container running in the remote cluster. It then captures all traffic requests going into the Pod, and instead of forwarding this to the application in the remote cluster, it routes all traffic (when you create a [global intercept](https://www.getambassador.io/docs/telepresence/latest/concepts/intercepts/#global-intercept)) or a subset of the traffic (when you create a [personal intercept](https://www.getambassador.io/docs/telepresence/latest/concepts/intercepts/#personal-intercept)) to your local development environment.
 
 ## {{% heading "whatsnext" %}}
-
-
+ 
 If you're interested in a hands-on tutorial, check out [this tutorial](https://cloud.google.com/community/tutorials/developing-services-with-k8s) that walks through locally developing the Guestbook application on Google Kubernetes Engine.
-
-Telepresence has [numerous proxying options](https://www.telepresence.io/reference/methods), depending on your situation.
-
+ 
 For further reading, visit the [Telepresence website](https://www.telepresence.io).
-
-


### PR DESCRIPTION
The [Developing and debugging services locally](https://kubernetes.io/docs/tasks/debug-application-cluster/local-debugging/) tutorial contains commands that were used in Telepresence 1 instead of the current default version (Telepresence 2). This means that any reader who follows the instructions in this tutorial will not achieve its intended goal.

This pull request adds the current commands and modifies its description. Please review!