### PR TITLE
Adding third party shortcode to the Telepresence content

### DIFF
--- a/content/en/docs/tasks/debug-application-cluster/local-debugging.md
+++ b/content/en/docs/tasks/debug-application-cluster/local-debugging.md
@@ -4,7 +4,9 @@ content_type: task
 ---
 
 <!-- overview -->
- 
+
+{{% thirdparty-content %}}
+
 Kubernetes applications usually consist of multiple, separate services, each running in its own container. Developing and debugging these services on a remote Kubernetes cluster can be cumbersome, requiring you to [get a shell on a running container](/docs/tasks/debug-application-cluster/get-shell-running-container/) in order to run debugging tools.
  
 `telepresence` is a tool to ease the process of developing and debugging services locally while proxying the service to a remote Kubernetes cluster. Using `telepresence` allows you to use custom tools, such as a debugger and IDE, for a local service and provides the service full access to ConfigMap, secrets, and the services running on the remote cluster.


### PR DESCRIPTION
This pull request addresses [issue #31032](https://github.com/kubernetes/website/issues/31032) by adding the `{{% thirdparty-content %}}` shortcode to the [Developing and Debugging services locally documentation](https://kubernetes.io/docs/tasks/debug-application-cluster/local-debugging/) as suggested by @reylejano. 

Please review. 😃 
