### PR TITLE
Diagram-Guide: corrected Figure 10 caption

### DIFF
--- a/content/en/docs/contribute/style/diagram-guide.md
+++ b/content/en/docs/contribute/style/diagram-guide.md
@@ -629,7 +629,7 @@ Here is the `{{</* figure */>}}` shortcode for this diagram:
 {{</* figure src="/images/docs/components-of-kubernetes.svg" alt="Kubernetes pod running inside a cluster" class="diagram-large" caption="Figure 10. Kubernetes Architecture." link="https://kubernetes.io/docs/concepts/overview/components/" */>}}
 ```
 
-{{< figure src="/images/docs/components-of-kubernetes.svg" alt="Kubernetes pod running inside a cluster" class="diagram-large" caption="Figure 9. Kubernetes Architecture." link="https://kubernetes.io/docs/concepts/overview/components/" >}}
+{{< figure src="/images/docs/components-of-kubernetes.svg" alt="Kubernetes pod running inside a cluster" class="diagram-large" caption="Figure 10. Kubernetes Architecture." link="https://kubernetes.io/docs/concepts/overview/components/" >}}
 
 
 ## Tips


### PR DESCRIPTION
Typo fix for Figure 10 in How to use captions section

