### PR TITLE
[hi] Use localized text for Hindi language configuration

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -427,8 +427,8 @@ language_alternatives = ["en"]
 
 [languages.hi]
 title = "Kubernetes"
-description = "Production-Grade Container Orchestration"
-languageName = "Hindi"
+description = "प्रोडक्शन-ग्रेड कंटेनर ऑर्केस्ट्रेशन"
+languageName = "हिन्दी"
 weight = 11
 contentDir = "content/hi"
 languagedirection = "ltr"


### PR DESCRIPTION
```diff
- description = "Production-Grade Container Orchestration"
+ description = "प्रोडक्शन-ग्रेड कंटेनर ऑर्केस्ट्रेशन"
```
and
```diff
- languageName = "Hindi"
+ languageName = "हिन्दी"
```
/language hi
