### PR TITLE
Update configmap docs with subpath limitation

### DIFF
--- a/content/en/docs/concepts/configuration/configmap.md
+++ b/content/en/docs/concepts/configuration/configmap.md
@@ -239,6 +239,10 @@ propagation delay, where the cache propagation delay depends on the chosen cache
 
 ConfigMaps consumed as environment variables are not updated automatically and require a pod restart. 
 
+{{< note >}}
+A container using a ConfigMap as a [subPath](/docs/concepts/storage/volumes#using-subpath) volume will not receive ConfigMap updates.
+{{< /note >}}
+
 ## Immutable ConfigMaps {#configmap-immutable}
 
 {{< feature-state for_k8s_version="v1.21" state="stable" >}}

--- a/content/en/docs/concepts/configuration/configmap.md
+++ b/content/en/docs/concepts/configuration/configmap.md
@@ -240,7 +240,7 @@ propagation delay, where the cache propagation delay depends on the chosen cache
 ConfigMaps consumed as environment variables are not updated automatically and require a pod restart. 
 
 {{< note >}}
-A container using a ConfigMap as a [subPath](/docs/concepts/storage/volumes#using-subpath) volume will not receive ConfigMap updates.
+A container using a ConfigMap as a [subPath](/docs/concepts/storage/volumes#using-subpath) volume mount will not receive ConfigMap updates.
 {{< /note >}}
 
 ## Immutable ConfigMaps {#configmap-immutable}


### PR DESCRIPTION
This note should be added to avoid confusion just as [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/#mounted-secrets-are-updated-automatically)