### PR TITLE
[zh] synchronize translate kubelet-integration.md

### DIFF
--- a/content/zh/docs/setup/production-environment/tools/kubeadm/kubelet-integration.md
+++ b/content/zh/docs/setup/production-environment/tools/kubeadm/kubelet-integration.md
@@ -257,34 +257,41 @@ When you run `kubeadm join`, kubeadm uses the Bootstrap Token credential to perf
 a TLS bootstrap, which fetches the credential needed to download the
 `kubelet-config-1.X` ConfigMap and writes it to `/var/lib/kubelet/config.yaml`. The dynamic
 environment file is generated in exactly the same way as `kubeadm init`.
-
-Next, `kubeadm` runs the following two commands to load the new configuration into the kubelet:
-
-```bash
-systemctl daemon-reload && systemctl restart kubelet
-```
-
-After the kubelet loads the new configuration, kubeadm writes the
-`/etc/kubernetes/bootstrap-kubelet.conf` KubeConfig file, which contains a CA certificate and Bootstrap
-Token. These are used by the kubelet to perform the TLS Bootstrap and obtain a unique
-credential, which is stored in `/etc/kubernetes/kubelet.conf`. When this file is written, the kubelet
-has finished performing the TLS Bootstrap.
 -->
+
 ### 当使用 `kubeadm join`时的工作流程
 
 当运行 `kubeadm join` 时，kubeadm 使用 Bootstrap Token 证书执行 TLS 引导，该引导会获取一份证书，该证书需要下载 `kubelet-config-1.X` ConfigMap 并把它写入 `/var/lib/kubelet/config.yaml` 中。
 动态环境文件的生成方式恰好与 `kubeadm init` 相同。
 
-接下来，kubeadm 运行以下两个命令将新配置加载到 kubelet 中：
+<!--
+Next, `kubeadm` runs the following two commands to load the new configuration into the kubelet:
+-->
+接下来，`kubeadm` 运行以下两个命令将新配置加载到 kubelet 中：
 
 ```bash
 systemctl daemon-reload && systemctl restart kubelet
 ```
 
+<!--
+After the kubelet loads the new configuration, kubeadm writes the
+`/etc/kubernetes/bootstrap-kubelet.conf` KubeConfig file, which contains a CA certificate and Bootstrap
+Token. These are used by the kubelet to perform the TLS Bootstrap and obtain a unique
+credential, which is stored in `/etc/kubernetes/kubelet.conf`.
+-->
+
 在 kubelet 加载新配置后，kubeadm 将写入 `/etc/kubernetes/bootstrap-kubelet.conf` KubeConfig 文件中，
 该文件包含 CA 证书和引导程序令牌。
 kubelet 使用这些证书执行 TLS 引导程序并获取唯一的凭据，该凭据被存储在 `/etc/kubernetes/kubelet.conf` 中。
-当此文件被写入后，kubelet 就完成了执行 TLS 引导程序。
+
+<!--
+When the `/etc/kubernetes/kubelet.conf` file is written, the kubelet has finished performing the TLS Bootstrap.
+Kubeadm deletes the `/etc/kubernetes/bootstrap-kubelet.conf` file after completing the TLS Bootstrap.
+-->
+
+当 `/etc/kubernetes/kubelet.conf` 文件被写入后，kubelet 就完成了 TLS 引导程序。
+Kubeadm 在完成 TLS 引导程序后将删除 `/etc/kubernetes/bootstrap-kubelet.conf` 文件。
+
 
 <!--
 ##  The kubelet drop-in file for systemd

--- a/content/zh/docs/setup/production-environment/tools/kubeadm/kubelet-integration.md
+++ b/content/zh/docs/setup/production-environment/tools/kubeadm/kubelet-integration.md
@@ -261,8 +261,9 @@ environment file is generated in exactly the same way as `kubeadm init`.
 
 ### 当使用 `kubeadm join`时的工作流程
 
-当运行 `kubeadm join` 时，kubeadm 使用 Bootstrap Token 证书执行 TLS 引导，该引导会获取一份证书，该证书需要下载 `kubelet-config-1.X` ConfigMap 并把它写入 `/var/lib/kubelet/config.yaml` 中。
-动态环境文件的生成方式恰好与 `kubeadm init` 相同。
+当运行 `kubeadm join` 时，kubeadm 使用 Bootstrap Token 证书执行 TLS 引导，该引导会获取一份证书，
+该证书需要下载 `kubelet-config-1.X` ConfigMap 并把它写入 `/var/lib/kubelet/config.yaml` 中。
+动态环境文件的生成方式恰好与 `kubeadm init` 完全相同。
 
 <!--
 Next, `kubeadm` runs the following two commands to load the new configuration into the kubelet:
@@ -289,8 +290,8 @@ When the `/etc/kubernetes/kubelet.conf` file is written, the kubelet has finishe
 Kubeadm deletes the `/etc/kubernetes/bootstrap-kubelet.conf` file after completing the TLS Bootstrap.
 -->
 
-当 `/etc/kubernetes/kubelet.conf` 文件被写入后，kubelet 就完成了 TLS 引导程序。
-Kubeadm 在完成 TLS 引导程序后将删除 `/etc/kubernetes/bootstrap-kubelet.conf` 文件。
+当 `/etc/kubernetes/kubelet.conf` 文件被写入后，kubelet 就完成了 TLS 引导过程。
+Kubeadm 在完成 TLS 引导过程后将删除 `/etc/kubernetes/bootstrap-kubelet.conf` 文件。
 
 
 <!--


### PR DESCRIPTION
/language zh

---

So far, all the files in the `content/zh/docs/setup/production-environment/tools` directory have been traced to the latest English version.
In addition, the file `content/zh/docs/setup/production-environment/tools/kubeadm/high-availability.md` is updated first in the Chinese version and is not within the scope of this tracking.

---

至此，`content/zh/docs/setup/production-environment/tools`目录下的所有文件均已追踪到最新的英文版本。
另外，文件`content/zh/docs/setup/production-environment/tools/kubeadm/high-availability.md`是中文版优先更新的，不在本次追踪范围内。

---

Related PR: #31095 #31094 #31092 #31084 #31082 
