### PR TITLE
Fix a zh_CN translation error in authentication.md

### DIFF
--- a/content/zh/docs/reference/access-authn-authz/authentication.md
+++ b/content/zh/docs/reference/access-authn-authz/authentication.md
@@ -764,9 +764,8 @@ users:
 <!--
 Once your `id_token` expires, `kubectl` will attempt to refresh your `id_token` using your `refresh_token` and `client_secret` storing the new values for the `refresh_token` and `id_token` in your `.kube/config`.
 -->
-当你的 `id_token` 过期时，`kubectl` 会尝试使用你的 `refresh_token` 来刷新你的
-`id_token`，并且在 `client_secret` 中存放 `refresh_token` 的新值，同时把
-`id_token` 的新值写入到 `.kube/config` 文件中。
+当你的 `id_token` 过期时，`kubectl` 会尝试使用你的 `refresh_token` 和 `client_secret` 来刷新你的
+`id_token`，并把 `refresh_token` 和 `id_token` 的新值写入到 `.kube/config` 文件中。
 
 <!--
 ##### Option 2 - Use the `--token` Option


### PR DESCRIPTION
Fix a translation error in the `OpenID Connect Tokens - Using kubectl - Option 1 - OIDC Authenticatorg` part in zh/docs/reference/access-authn-authz/authentication.md. 

修复zh/docs/reference/access-authn-authz/authentication.md文件中的`OpenID Connect Tokens - Using kubectl - Option 1 - OIDC Authenticatorg`小节的一处翻译错误。

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
