### PR TITLE
The `schedule: "*/1 * * * *"` is the same as "* * * * *"

### DIFF
--- a/content/en/examples/application/job/cronjob.yaml
+++ b/content/en/examples/application/job/cronjob.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: hello
 spec:
-  schedule: "*/1 * * * *"
+  schedule: "* * * * *"
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
The `spec.schedule` field in the CronJob eexample uses `*/1`, which is the same as `*`.  This PR should reduce confusion over the crontab format. 