### PR TITLE
fix glossary 

### DIFF
--- a/content/en/docs/tasks/debug-application-cluster/debug-application.md
+++ b/content/en/docs/tasks/debug-application-cluster/debug-application.md
@@ -57,7 +57,7 @@ If a Pod is stuck in the `Waiting` state, then it has been scheduled to a worker
 Again, the information from `kubectl describe ...` should be informative.  The most common cause of `Waiting` pods is a failure to pull the image.  There are three things to check:
 
 * Make sure that you have the name of the image correct.
-* Have you pushed the image to the repository?
+* Have you pushed the image to the registry?
 * Run a manual `docker pull <image>` on your machine to see if the image can be pulled.
 
 #### My pod is crashing or otherwise unhealthy


### PR DESCRIPTION

Reference: 
https://docs.docker.com/engine/reference/commandline/push/

> Use docker image push to share your images to the Docker Hub **registry** or to a self-hosted one.

Comment:
https://github.com/kubernetes/website/pull/31089#discussion_r777190920

> "Repository" is a collection of container images or other artifacts in the registry that have the same name but different tags.