### PR TITLE
[en] gc: Re-title section for garbage collection of containers

### DIFF
--- a/content/en/docs/concepts/architecture/garbage-collection.md
+++ b/content/en/docs/concepts/architecture/garbage-collection.md
@@ -137,7 +137,7 @@ collection, which deletes images in order based on the last time they were used,
 starting with the oldest first. The kubelet deletes images
 until disk usage reaches the `LowThresholdPercent` value.
 
-### Container image garbage collection {#container-image-garbage-collection}
+### Container garbage collection {#container-garbage-collection}
 
 The kubelet garbage collects unused containers based on the following variables,
 which you can define: 


### PR DESCRIPTION
Small nit: Re-title section to make it clear that it is gc of containers
by the Kubelet and not container images (which is covered in another
section)

/sig api-machinery
/area en
