### PR TITLE
Fix kind delete cluster commands

### DIFF
--- a/content/en/docs/tutorials/security/cluster-level-pss.md
+++ b/content/en/docs/tutorials/security/cluster-level-pss.md
@@ -304,8 +304,8 @@ following:
 
 ## Clean up
 
-Run `kind delete cluster -name psa-with-cluster-pss` and
-`kind delete cluster -name psa-wo-cluster-pss` to delete the clusters you
+Run `kind delete cluster --name psa-with-cluster-pss` and
+`kind delete cluster --name psa-wo-cluster-pss` to delete the clusters you
 created.
 
 ## {{% heading "whatsnext" %}}


### PR DESCRIPTION
The name flag requires two leading dashes, not one.
