### PR TITLE
Corrected alpha release for APIPriorityAndFairness FeatureGate

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -53,7 +53,7 @@ different Kubernetes components.
 |---------|---------|-------|-------|-------|
 | `APIListChunking` | `false` | Alpha | 1.8 | 1.8 |
 | `APIListChunking` | `true` | Beta | 1.9 | |
-| `APIPriorityAndFairness` | `false` | Alpha | 1.17 | 1.19 |
+| `APIPriorityAndFairness` | `false` | Alpha | 1.18 | 1.19 |
 | `APIPriorityAndFairness` | `true` | Beta | 1.20 | |
 | `APIResponseCompression` | `false` | Alpha | 1.7 | 1.15 |
 | `APIResponseCompression` | `true` | Beta | 1.16 | |


### PR DESCRIPTION
The `APIPriorityAndFairness` FeatureGate was introduced in release 1.15, before the feature was fully implemented.   The feature reached Alpha in release 1.18.  This PR fixes the doc to cite 1.18 as the first release at the Alpha level.

This partially addresses https://github.com/kubernetes/kubernetes/issues/107238 and the need for this change was mentioned in https://github.com/kubernetes/kubernetes/pull/107316#pullrequestreview-844155533 .