### PR TITLE
storage class parameters value should be string

### DIFF
--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -434,7 +434,7 @@ provisioner: example.com/external-nfs
 parameters:
   server: nfs-server.example.com
   path: /share
-  readOnly: false
+  readOnly: "false"
 ```
 
 * `server`: Server is the hostname or IP address of the NFS server.
@@ -797,7 +797,7 @@ parameters:
   storagePool: sp1
   storageMode: ThinProvisioned
   secretRef: sio-secret
-  readOnly: false
+  readOnly: "false"
   fsType: xfs
 ```
 


### PR DESCRIPTION
failed to create with the example
```
[root@daocloud ~]# kubectl create -f sc.yaml
Error from server (BadRequest): error when creating "sc.json": StorageClass in version "v1" cannot be handled as a StorageClass: json: cannot unmarshal bool into Go struct field StorageClass.parameters of type string
[root@daocloud ~]# cat sc.json
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: example-nfs
provisioner: example.com/external-nfs
parameters:
  server: nfs-server.example.com
  path: /share
  readOnly: false
```

Work
```
[root@daocloud ~]# kubectl create -f sc.yaml
storageclass.storage.k8s.io/example-nfs created
[root@daocloud ~]# cat sc.yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: example-nfs
provisioner: example.com/external-nfs
parameters:
  server: nfs-server.example.com
  path: /share
  readOnly: "false"
[root@daocloud ~]#
```