### PR TITLE
kubeadm: remove ClusterStatus references

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
@@ -41,8 +41,6 @@ For control-plane nodes additional steps are performed:
 
 1. Adding new local etcd member.
 
-1. Adding this node to the ClusterStatus of the kubeadm cluster.
-
 ### Using join phases with kubeadm {#join-phases}
 
 Kubeadm allows you join a node to the cluster in phases using `kubeadm join phase`.

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-reset.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-reset.md
@@ -16,8 +16,7 @@ Performs a best effort revert of changes made by `kubeadm init` or `kubeadm join
 
 `kubeadm reset` is responsible for cleaning up a node local file system from files that were created using
 the `kubeadm init` or `kubeadm join` commands. For control-plane nodes `reset` also removes the local stacked
-etcd member of this node from the etcd cluster and also removes this node's information from the kubeadm
-`ClusterStatus` object. `ClusterStatus` is a kubeadm managed Kubernetes API object that holds a list of kube-apiserver endpoints.
+etcd member of this node from the etcd cluster.
 
 `kubeadm reset phase` can be used to execute the separate phases of the above workflow.
 To skip a list of phases you can use the `--skip-phases` flag, which works in a similar way to


### PR DESCRIPTION
The `ClusterStatus` object was removed in 1.22, so I think the wording it no longer accurate for the current version.

xref [#101915](https://github.com/kubernetes/kubernetes/pull/101915)

