### PR TITLE
Mark dockershim survey closed

### DIFF
--- a/content/en/blog/_posts/2021-11-12-are-you-ready-for-dockershim-removal/index.md
+++ b/content/en/blog/_posts/2021-11-12-are-you-ready-for-dockershim-removal/index.md
@@ -5,17 +5,18 @@ date: 2021-11-12
 slug: are-you-ready-for-dockershim-removal
 ---
 
-{{< note >}}
-This poll will close on January 7, 2022.
-{{</ note >}}
-
 **Author:** Sergey Kanzhelev, Google. With reviews from Davanum Srinivas, Elana Hashman, Noah Kantrowitz, Rey Lejano.
+
+{{% alert color="info" title="Poll closed" %}}
+This poll closed on January 7, 2022.
+{{% /alert %}}
 
 Last year we announced that Dockershim is being deprecated: [Dockershim Deprecation FAQ](/blog/2020/12/02/dockershim-faq/).
 Our current plan is to remove dockershim from the Kubernetes codebase soon.
 We are looking for feedback from you whether you are ready for dockershim
 removal and to ensure that you are ready when the time comes.
-**Please fill out this survey: https://forms.gle/svCJmhvTv78jGdSx8**.
+
+<del>Please fill out this survey: https://forms.gle/svCJmhvTv78jGdSx8</del>
 
 The dockershim component that enables Docker as a Kubernetes container runtime is
 being deprecated in favor of runtimes that directly use the [Container Runtime Interface](/blog/2016/12/container-runtime-interface-cri-in-kubernetes/)
@@ -37,7 +38,7 @@ beta versions, dockershim will be removed in December at the beginning of the
 There is only one month left to give us feedback. We want you to tell us how
 ready you are.
 
-**We are collecting opinions through this survey: [https://forms.gle/svCJmhvTv78jGdSx8](https://forms.gle/svCJmhvTv78jGdSx8)**
+<del>We are collecting opinions through this survey: https://forms.gle/svCJmhvTv78jGdSx8</del>
 To better understand preparedness for the dockershim removal, our survey is
 asking the version of Kubernetes you are currently using, and an estimate of
 when you think you will adopt Kubernetes 1.24. All the aggregated information


### PR DESCRIPTION
Follow-up to https://github.com/kubernetes/website/pull/30972

Change from “This poll will close on January 7, 2022.” to “This poll closed on January 7, 2022.” and strike out the links to it.

/area blog
/hold