### PR TITLE
Added the note for --service-account-issuer flag.

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-service-account.md
@@ -294,6 +294,8 @@ command line arguments to `kube-apiserver`:
 * `--service-account-signing-key-file`
 * `--api-audiences` (can be omitted)
 
+To enable non-disruptive change of issuer we can specify `--service-account-issuer` flag multiple times to `kube-apiserver` for k8s v1.22 and later versions.
+
 {{< /note >}}
 
 The kubelet can also project a service account token into a Pod. You can

--- a/content/en/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-service-account.md
@@ -297,10 +297,10 @@ command line arguments to `kube-apiserver`:
      File containing PEM-encoded x509 RSA or ECDSA private or public keys, used to verify ServiceAccount tokens. The specified file can contain multiple keys, and the flag can be specified multiple times with different files. If specified multiple times, tokens signed by any of the specified keys are considered valid by the Kubernetes API server.
 * `--service-account-signing-key-file`
 
-     Path to the file that contains the current private key of the service account token issuer. The issuer will sign issued ID tokens with this private key.
+     Path to the file that contains the current private key of the service account token issuer. The issuer signs issued ID tokens with this private key.
 * `--api-audiences` (can be omitted)
 
-     The service account token authenticator will validate that tokens used against the API are bound to at least one of these audiences. If `api-audiences` is specified multiple times, tokens for any of the specified audiences are considered valid by the Kubernetes API server. If the `--service-account-issuer` flag is configured and this flag is not, this field defaults to a single element list containing the issuer URL.
+     The service account token authenticator validates that tokens used against the API are bound to at least one of these audiences. If `api-audiences` is specified multiple times, tokens for any of the specified audiences are considered valid by the Kubernetes API server. If the `--service-account-issuer` flag is configured and this flag is not, this field defaults to a single element list containing the issuer URL.
 
 {{< /note >}}
 

--- a/content/en/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-service-account.md
@@ -290,14 +290,17 @@ To enable and use token request projection, you must specify each of the followi
 command line arguments to `kube-apiserver`:
 
 * `--service-account-issuer`
+
+     It can be used as the Identifier of the service account token issuer. You can specify the `--service-account-issuer` argument multiple times, this can be useful to enable a non-disruptive change of the issuer. When this flag is specified multiple times, the first is used to generate tokens and all are used to determine which issuers are accepted. You must be running running Kubernetes v1.22 or later to be able to specify `--service-account-issuer` multiple times.
 * `--service-account-key-file`
+
+     File containing PEM-encoded x509 RSA or ECDSA private or public keys, used to verify ServiceAccount tokens. The specified file can contain multiple keys, and the flag can be specified multiple times with different files. If specified multiple times, tokens signed by any of the specified keys are considered valid by the Kubernetes API server.
 * `--service-account-signing-key-file`
+
+     Path to the file that contains the current private key of the service account token issuer. The issuer will sign issued ID tokens with this private key.
 * `--api-audiences` (can be omitted)
 
-You can specify the `--service-account-issuer` argument multiple times. This can be useful to
-enable a non-disruptive change of the key for an issuer.
-You must be running running Kubernetes v1.22 or later to be able to specify
-`--service-account-issuer` multiple times.
+     The service account token authenticator will validate that tokens used against the API are bound to at least one of these audiences. If `api-audiences` is specified multiple times, tokens for any of the specified audiences are considered valid by the Kubernetes API server. If the `--service-account-issuer` flag is configured and this flag is not, this field defaults to a single element list containing the issuer URL.
 
 {{< /note >}}
 

--- a/content/en/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-service-account.md
@@ -294,7 +294,10 @@ command line arguments to `kube-apiserver`:
 * `--service-account-signing-key-file`
 * `--api-audiences` (can be omitted)
 
-To enable non-disruptive change of issuer we can specify `--service-account-issuer` flag multiple times to `kube-apiserver` for k8s v1.22 and later versions.
+You can specify the `--service-account-issuer` argument multiple times. This can be useful to
+enable a non-disruptive change of the key for an issuer.
+You must be running running Kubernetes v1.22 or later to be able to specify
+`--service-account-issuer` multiple times.
 
 {{< /note >}}
 


### PR DESCRIPTION

This PR adds more information for  --service-account-issuer flag under [Service Account Token Volume Projection](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection) in [Configure Service Accounts for Pods](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) task.

Fixes: #31235