### PR TITLE
Correct some misrepresentations on Chinese pages

### DIFF
--- a/content/zh/docs/tutorials/security/ns-level-pss.md
+++ b/content/zh/docs/tutorials/security/ns-level-pss.md
@@ -61,7 +61,7 @@ Install the following on your workstation:
    kind create cluster --name psa-ns-level --image kindest/node:v1.23.0
    ```
    <!-- The output is similar to this: -->
-   输入类似于：
+   输出类似于：
    ```
    Creating cluster "psa-ns-level" ...
     ✓ Ensuring node image (kindest/node:v1.23.0) 🖼 
@@ -84,7 +84,7 @@ Install the following on your workstation:
    kubectl cluster-info --context kind-psa-ns-level
    ```
     <!-- The output is similar to this: -->
-   输入类似于：
+   输出类似于：
    ```
    Kubernetes control plane is running at https://127.0.0.1:50996
    CoreDNS is running at https://127.0.0.1:50996/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
@@ -194,7 +194,7 @@ namespace/example created
     kubectl apply -n default -f /tmp/pss/nginx-pod.yaml
     ```
    <!-- Output is similar to this: -->
-   输入类似于：
+   输出类似于：
    ```
    pod/nginx created
    ```


### PR DESCRIPTION
Correct some misrepresentations on Chinese pages

# 原始文件内容
原始文档上写的是：输入类似于 （Enter something like），但是者实际上是一个输出内容。
此错误在这个页面上不止一处，已经全部订正

```bash
输入类似于 -> 输出类似于
input -> output
```

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
