### PR TITLE
Update powershell script

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -152,7 +152,7 @@ installing the `containerd.io` package can be found at
 {{% /tab %}}
 {{% tab name="Windows (PowerShell)" %}}
 
-Start a Powershell session, set `$Version` to the desired version (ex: `$Version=1.4.3`), 
+Start a Powershell session, set `$Version` to the desired version (ex: `$Version="1.4.3"`), 
 and then run the following commands:
 
 1. Download containerd:


### PR DESCRIPTION
Setting powershell variables container only numbers does not work with multiple periods (at least on Powershell 5.1). Using quotes is necessary.

The proposed update changes the 'set $version variable' instruction to use double quotes for the version.  Without this, the variable is not set due to multiple periods in the value.
