### PR TITLE
Fix footer rendering

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -215,6 +215,10 @@ body.td-404 main .error-details {
   }
 }
 
+body > footer {
+  width: 100vw;
+}
+
 /* FOOTER */
 footer {
   background-color: #303030;
@@ -222,8 +226,14 @@ footer {
   padding: 1rem !important;
   min-height: initial !important;
 
-  .footer__links {
-    width: 100%;
+  > div, > p {
+    max-width: 95%;
+    @media only screen and (min-width: 768px) {
+      max-width: calc(min(80rem,90vw)); // avoid spreading too wide
+    }
+  }
+
+  > .footer__links {
     margin: auto;
     padding-bottom: 1rem;
 
@@ -233,6 +243,8 @@ footer {
     }
 
     @media only screen and (min-width: 768px) {
+      max-width: calc(min(60rem,90vw)); // avoid spreading too wide
+
       nav {
         display: flex;
         flex-direction: row;

--- a/static/css/newcommunity.css
+++ b/static/css/newcommunity.css
@@ -85,7 +85,7 @@ body {
   font-weight: 300;
   /* letter-spacing:0.03em; */
   /* font-size:15px; */
-  margin: 0 auto;
+  margin: 0;
 
 }
 
@@ -636,11 +636,9 @@ h2:after {
 
   body {
     overflow-x: hidden;
-    line-height: 1.5em;
     margin-top: 1%;
     letter-spacing: 0.03em;
     /* font-size: 13px; */
-    margin: 0 auto;
 
   }
 


### PR DESCRIPTION
The [community page](https://kubernetes.io/community/) had the wrong rendering for the page footer [[preview](https://deploy-preview-31277--kubernetes-io-main-staging.netlify.app/community/)].
Ensure that the footer is as wide as the viewport.

Also, improve how the text in the footer is laid out when the viewport is quite wide.

/area web-development