### PR TITLE
Add glossary_tooltip for StatefulSet in Recommended labels

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/common-labels.md
+++ b/content/en/docs/concepts/overview/working-with-objects/common-labels.md
@@ -42,7 +42,7 @@ on every resource object.
 | `app.kubernetes.io/managed-by`      | The tool being used to manage the operation of an application | `helm` | string |
 | `app.kubernetes.io/created-by`      | The controller/user who created this resource | `controller-manager` | string |
 
-To illustrate these labels in action, consider the following StatefulSet object:
+To illustrate these labels in action, consider the following {{< glossary_tooltip text="StatefulSet" term_id="statefulset" >}} object:
 
 ```yaml
 apiVersion: apps/v1

--- a/content/en/docs/concepts/overview/working-with-objects/common-labels.md
+++ b/content/en/docs/concepts/overview/working-with-objects/common-labels.md
@@ -45,6 +45,7 @@ on every resource object.
 To illustrate these labels in action, consider the following {{< glossary_tooltip text="StatefulSet" term_id="statefulset" >}} object:
 
 ```yaml
+# This is an excerpt
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:


### PR DESCRIPTION
Resolves #31191 

This PR adds:
- glossary_tooltip to explain StatefulSet as it has not been introduced at this point (recommended_labels) yet.
- comment in example manifest to specify that it's an excerpt and hence incomplete.
