### PR TITLE
Action on Docker mentions in Concepts > Cluster Administration

### DIFF
--- a/content/en/docs/concepts/cluster-administration/system-logs.md
+++ b/content/en/docs/concepts/cluster-administration/system-logs.md
@@ -182,7 +182,8 @@ There are two types of system components: those that run in a container and thos
 that do not run in a container. For example:
 
 * The Kubernetes scheduler and kube-proxy run in a container.
-* The kubelet and container runtime, for example Docker, do not run in containers.
+* The kubelet and {{<glossary_tooltip term_id="container-runtime" text="container runtime">}}
+  do not run in containers.
 
 On machines with systemd, the kubelet and container runtime write to journald.
 Otherwise, they write to `.log` files in the `/var/log` directory.

--- a/content/en/docs/reference/glossary/container-runtime.md
+++ b/content/en/docs/reference/glossary/container-runtime.md
@@ -17,5 +17,5 @@ tags:
 
 Kubernetes supports container runtimes such as
 {{< glossary_tooltip term_id="containerd" >}}, {{< glossary_tooltip term_id="cri-o" >}},
-and any implementation of the [Kubernetes CRI (Container Runtime
+and any other implementation of the [Kubernetes CRI (Container Runtime
 Interface)](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/container-runtime-interface.md).

--- a/content/en/docs/reference/glossary/container-runtime.md
+++ b/content/en/docs/reference/glossary/container-runtime.md
@@ -15,7 +15,7 @@ tags:
 
 <!--more-->
 
-Kubernetes supports several container runtimes: {{< glossary_tooltip term_id="docker">}},
+Kubernetes supports container runtimes such as
 {{< glossary_tooltip term_id="containerd" >}}, {{< glossary_tooltip term_id="cri-o" >}},
 and any implementation of the [Kubernetes CRI (Container Runtime
 Interface)](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/container-runtime-interface.md).


### PR DESCRIPTION
Part of #30897

* Remove Docker from container runtime glossary tooltip
* Remove "for example, Docker" in system-logs.md and added glossary tooltip for runtimes

## Pending (can be another PR)

* What to do about container engine descriptions in logging.md in this section? 

/sig docs
/sig node
/language en 
/cc @sftim 
