### PR TITLE
Removing cni-ipvlan-vpc-k8s

### DIFF
--- a/content/en/docs/concepts/cluster-administration/networking.md
+++ b/content/en/docs/concepts/cluster-administration/networking.md
@@ -83,22 +83,6 @@ addressing, and it can be used in combination with other CNI plugins.
 
 CNI-Genie also supports [assigning multiple IP addresses to a pod](https://github.com/Huawei-PaaS/CNI-Genie/blob/master/docs/multiple-ips/README.md#feature-2-extension-cni-genie-multiple-ip-addresses-per-pod), each from a different CNI plugin.
 
-### cni-ipvlan-vpc-k8s
-[cni-ipvlan-vpc-k8s](https://github.com/lyft/cni-ipvlan-vpc-k8s) contains a set
-of CNI and IPAM plugins to provide a simple, host-local, low latency, high
-throughput, and compliant networking stack for Kubernetes within Amazon Virtual
-Private Cloud (VPC) environments by making use of Amazon Elastic Network
-Interfaces (ENI) and binding AWS-managed IPs into Pods using the Linux kernel's
-IPvlan driver in L2 mode.
-
-The plugins are designed to be straightforward to configure and deploy within a
-VPC. Kubelets boot and then self-configure and scale their IP usage as needed
-without requiring the often recommended complexities of administering overlay
-networks, BGP, disabling source/destination checks, or adjusting VPC route
-tables to provide per-instance subnets to each host (which is limited to 50-100
-entries per VPC). In short, cni-ipvlan-vpc-k8s significantly reduces the
-network complexity required to deploy Kubernetes at scale within AWS.
-
 ### Coil
 
 [Coil](https://github.com/cybozu-go/coil) is a CNI plugin designed for ease of integration, providing flexible egress networking.


### PR DESCRIPTION
This only works within AWS.  It is not necessary for k8s to run/function properly (in project).

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
