### PR TITLE
Migrate crictl to docker-cli mapping to references

### DIFF
--- a/content/en/docs/reference/tools/_index.md
+++ b/content/en/docs/reference/tools/_index.md
@@ -12,16 +12,17 @@ Kubernetes contains several tools to help you work with the Kubernetes system.
 
 <!-- body -->
 
-## Minikube
+## crictl
 
-[`minikube`](https://minikube.sigs.k8s.io/docs/) is a tool that
-runs a single-node Kubernetes cluster locally on your workstation for
-development and testing purposes.
+[`crictl`](https://github.com/kubernetes-sigs/cri-tools) is a command-line
+interface for inspecting and debugging {{<glossary_tooltip term_id="cri" text="CRI">}}-compatible
+container runtimes.
 
 ## Dashboard
 
 [`Dashboard`](/docs/tasks/access-application-cluster/web-ui-dashboard/), the web-based user interface of Kubernetes, allows you to deploy containerized applications
-to a Kubernetes cluster, troubleshoot them, and manage the cluster and its resources itself.
+to a Kubernetes cluster, troubleshoot them, and manage the cluster and its
+resources itself.
 
 ## Helm
 {{% thirdparty-content single="true" %}}
@@ -65,3 +66,9 @@ Kui lets you:
 * Query a {{< glossary_tooltip text="Job" term_id="job">}} and see its execution rendered
   as a waterfall diagram
 * Click through resources in your cluster using a tabbed UI 
+
+## Minikube
+
+[`minikube`](https://minikube.sigs.k8s.io/docs/) is a tool that
+runs a single-node Kubernetes cluster locally on your workstation for
+development and testing purposes.

--- a/content/en/docs/reference/tools/map-crictl-dockercli.md
+++ b/content/en/docs/reference/tools/map-crictl-dockercli.md
@@ -1,0 +1,76 @@
+---
+title: Mapping from dockercli to crictl
+content_type: reference
+---
+
+{{% thirdparty-content %}}
+
+{{<note>}}
+This page is deprecated and will be removed in Kubernetes 1.27.
+{{</note>}}
+
+`crictl` is a command-line interface for {{<glossary_tooltip term_id="cri" text="CRI">}}-compatible container runtimes.
+You can use it to inspect and debug container runtimes and applications on a
+Kubernetes node. `crictl` and its source are hosted in the
+[cri-tools](https://github.com/kubernetes-sigs/cri-tools) repository.
+
+This page provides a reference for mapping common commands for the `docker`
+command-line tool into the equivalent commands for `crictl`.
+
+## Mapping from docker CLI to crictl
+
+The exact versions for the mapping table are for `docker` CLI v1.40 and `crictl`
+v1.19.0. This list is not exhaustive. For example, it doesn't include
+experimental `docker` CLI commands.
+
+{{< note >}}
+The output format of `crictl` is similar to `docker` CLI, despite some missing
+columns for some CLI. Make sure to check output for the specific command if your
+command output is being parsed programmatically.
+{{< /note >}}
+
+### Retrieve debugging information
+
+{{< table caption="mapping from docker cli to crictl - retrieve debugging information" >}}
+docker cli | crictl | Description | Unsupported Features
+-- | -- | -- | --
+`attach` | `attach` | Attach to a running container | `--detach-keys`, `--sig-proxy`
+`exec` | `exec` | Run a command in a running container | `--privileged`, `--user`, `--detach-keys`
+`images` | `images` | List images |  
+`info` | `info` | Display system-wide information |  
+`inspect` | `inspect`, `inspecti` | Return low-level information on a container, image or task |  
+`logs` | `logs` | Fetch the logs of a container | `--details`
+`ps` | `ps` | List containers |  
+`stats` | `stats` | Display a live stream of container(s) resource usage statistics | Column: NET/BLOCK I/O, PIDs
+`version` | `version` | Show the runtime (Docker, ContainerD, or others) version information |  
+{{< /table >}}
+
+### Perform Changes
+
+{{< table caption="mapping from docker cli to crictl - perform changes" >}}
+docker cli | crictl | Description | Unsupported Features
+-- | -- | -- | --
+`create` | `create` | Create a new container |  
+`kill` | `stop` (timeout = 0) | Kill one or more running container | `--signal`
+`pull` | `pull` | Pull an image or a repository from a registry | `--all-tags`, `--disable-content-trust`
+`rm` | `rm` | Remove one or more containers |  
+`rmi` | `rmi` | Remove one or more images |  
+`run` | `run` | Run a command in a new container |  
+`start` | `start` | Start one or more stopped containers | `--detach-keys`
+`stop` | `stop` | Stop one or more running containers |  
+`update` | `update` | Update configuration of one or more containers | `--restart`, `--blkio-weight` and some other resource limit not supported by CRI.
+{{< /table >}}
+
+### Supported only in crictl
+
+{{< table caption="mapping from docker cli to crictl - supported only in crictl" >}}
+crictl | Description
+-- | --
+`imagefsinfo` | Return image filesystem info
+`inspectp` | Display the status of one or more pods
+`port-forward` | Forward local port to a pod
+`pods` | List pods
+`runp` | Run a new pod
+`rmp` | Remove one or more pods
+`stopp` | Stop one or more running pods
+{{< /table >}}

--- a/content/en/docs/tasks/debug-application-cluster/crictl.md
+++ b/content/en/docs/tasks/debug-application-cluster/crictl.md
@@ -17,14 +17,10 @@ You can use it to inspect and debug container runtimes and applications on a
 Kubernetes node. `crictl` and its source are hosted in the
 [cri-tools](https://github.com/kubernetes-sigs/cri-tools) repository.
 
-
-
 ## {{% heading "prerequisites" %}}
 
 
 `crictl` requires a Linux operating system with a CRI runtime.
-
-
 
 <!-- steps -->
 
@@ -41,26 +37,36 @@ of Kubernetes. Extract it and move it to a location on your system path, such as
 The `crictl` command has several subcommands and runtime flags. Use
 `crictl help` or `crictl <subcommand> help` for more details.
 
-`crictl` connects to `unix:///var/run/dockershim.sock` by default. For other
-runtimes, you can set the endpoint in multiple different ways:
+You can set the endpoint for `crictl` by doing one of the following:
 
-- By setting flags `--runtime-endpoint` and `--image-endpoint`
-- By setting environment variables `CONTAINER_RUNTIME_ENDPOINT` and `IMAGE_SERVICE_ENDPOINT`
-- By setting the endpoint in the config file `--config=/etc/crictl.yaml`
+* Set the `--runtime-endpoint` and `--image-endpoint` flags.
+* Set the `CONTAINER_RUNTIME_ENDPOINT` and `IMAGE_SERVICE_ENDPOINT` environment
+  variables.
+* Set the endpoint in the configuration file `/etc/crictl.yaml`. To specify a
+  different file, use the `--config=PATH_TO_FILE` flag when you run `crictl`.
+
+{{<note>}}
+If you don't set an endpoint, `crictl` attempts to connect to a list of known
+endpoints, which might result in an impact to performance.
+{{</note>}}
 
 You can also specify timeout values when connecting to the server and enable or
 disable debugging, by specifying `timeout` or `debug` values in the configuration
 file or using the `--timeout` and `--debug` command-line flags.
 
-To view or edit the current configuration, view or edit the contents of `/etc/crictl.yaml`.
+To view or edit the current configuration, view or edit the contents of
+`/etc/crictl.yaml`. For example, the configuration when using the `containerd`
+container runtime would be similar to this:
 
-```shell
-cat /etc/crictl.yaml
-runtime-endpoint: unix:///var/run/dockershim.sock
-image-endpoint: unix:///var/run/dockershim.sock
+```
+runtime-endpoint: unix:///var/run/containerd/containerd.sock
+image-endpoint: unix:///var/run/containerd/containerd.sock
 timeout: 10
 debug: true
 ```
+
+To learn more about `crictl`, refer to the [`crictl`
+documentation](https://github.com/kubernetes-sigs/cri-tools/blob/master/docs/crictl.md).
 
 ## Example crictl commands
 
@@ -348,64 +354,9 @@ CONTAINER ID        IMAGE               CREATED              STATE              
 3e025dd50a72d       busybox             About a minute ago   Running             busybox             0
 ```
 
+## {{% heading "whatsnext" %}}
 
-
+* [Learn more about `crictl`](https://github.com/kubernetes-sigs/cri-tools).
+* [Map `docker` CLI commands to `crictl`](/reference/tools/map-crictl-dockercli/).
 
 <!-- discussion -->
-
-See [kubernetes-sigs/cri-tools](https://github.com/kubernetes-sigs/cri-tools)
-for more information.
-
-## Mapping from docker cli to crictl
-
-The exact versions for below mapping table are for docker cli v1.40 and crictl v1.19.0. Please note that the list is not exhaustive. For example, it doesn't include experimental commands of docker cli.
-
-{{< note >}}
-The output format of CRICTL is similar to Docker CLI, despite some missing columns for some CLI. Make sure to check output for the specific command if your script output parsing.
-{{< /note >}}
-
-### Retrieve Debugging Information
-
-{{< table caption="mapping from docker cli to crictl - retrieve debugging information" >}}
-docker cli | crictl | Description | Unsupported Features
--- | -- | -- | --
-`attach` | `attach` | Attach to a running container | `--detach-keys`, `--sig-proxy`
-`exec` | `exec` | Run a command in a running container | `--privileged`, `--user`, `--detach-keys`
-`images` | `images` | List images |  
-`info` | `info` | Display system-wide information |  
-`inspect` | `inspect`, `inspecti` | Return low-level information on a container, image or task |  
-`logs` | `logs` | Fetch the logs of a container | `--details`
-`ps` | `ps` | List containers |  
-`stats` | `stats` | Display a live stream of container(s) resource usage statistics | Column: NET/BLOCK I/O, PIDs
-`version` | `version` | Show the runtime (Docker, ContainerD, or others) version information |  
-{{< /table >}}
-
-### Perform Changes
-
-{{< table caption="mapping from docker cli to crictl - perform changes" >}}
-docker cli | crictl | Description | Unsupported Features
--- | -- | -- | --
-`create` | `create` | Create a new container |  
-`kill` | `stop` (timeout = 0) | Kill one or more running container | `--signal`
-`pull` | `pull` | Pull an image or a repository from a registry | `--all-tags`, `--disable-content-trust`
-`rm` | `rm` | Remove one or more containers |  
-`rmi` | `rmi` | Remove one or more images |  
-`run` | `run` | Run a command in a new container |  
-`start` | `start` | Start one or more stopped containers | `--detach-keys`
-`stop` | `stop` | Stop one or more running containers |  
-`update` | `update` | Update configuration of one or more containers | `--restart`, `--blkio-weight` and some other resource limit not supported by CRI.
-{{< /table >}}
-
-### Supported only in crictl
-
-{{< table caption="mapping from docker cli to crictl - supported only in crictl" >}}
-crictl | Description
--- | --
-`imagefsinfo` | Return image filesystem info
-`inspectp` | Display the status of one or more pods
-`port-forward` | Forward local port to a pod
-`pods` | List pods
-`runp` | Run a new pod
-`rmp` | Remove one or more pods
-`stopp` | Stop one or more running pods
-{{< /table >}}


### PR DESCRIPTION
Issue: #30976 

This PR migrates a portion of `crictl.md` that maps `docker-cli` commands to equivalent `crictl` commands to the References > Other Tools section and insta-deprecates the page. 

Also updates the `crictl.md` docs to mention default isn't `dockershim.sock` and to mention that default endpoints are deprecated. 

/sig docs
/sig node
/language en
/cc @sftim @SergeyKanzhelev 