### PR TITLE
Add help docs for module-check and module-init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,10 @@ CCEND=\033[0m
 help: ## Show this help.
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
-module-check:
+module-check: ## Check if all of the required submodules are correctly initialized.
 	@git submodule status --recursive | awk '/^[+-]/ {err = 1; printf "\033[31mWARNING\033[0m Submodule not initialized: \033[34m%s\033[0m\n",$$2} END { if (err != 0) print "You need to run \033[32mmake module-init\033[0m to initialize missing modules first"; exit err }' 1>&2
 
-module-init:
+module-init: ## Initialize required submodules.
 	@echo "Initializing submodules..." 1>&2
 	@git submodule update --init --recursive --depth 1
 


### PR DESCRIPTION
Now command `make` will show help docs for `module-check` and `module-init` targets also.