### PR TITLE
kubeadm-upgrade: adjust note about node drain

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -37,8 +37,11 @@ The upgrade workflow at high level is the following:
 
 ### Additional information
 
-- [Draining nodes](/docs/tasks/administer-cluster/safely-drain-node/) before kubelet MINOR version
-  upgrades is required. In the case of control plane nodes, they could be running CoreDNS Pods or other critical workloads.
+- The instructions below outline when to drain each node during the upgrade process.
+If you are performing a **minor** version upgrade for any kubelet, you **must**
+first drain the node (or nodes) that you are upgrading. In the case of control plane nodes,
+they could be running CoreDNS Pods or other critical workloads. For more information see
+[Draining nodes](/docs/tasks/administer-cluster/safely-drain-node/).
 - All containers are restarted after upgrade, because the container spec hash value is changed.
 
 <!-- steps -->


### PR DESCRIPTION
The current entry under additional information about drain can
be confusing and users might jump into draining the nodes before
the upgrade steps (as a pre-req), following the
instructions in the external link. This is not accurate.

Adjust the entry text to explain that drain is a step as part of
the upgrade process and this additional information entry just
mentions why it is needed.

fixes https://github.com/kubernetes/website/issues/31300
