### PR TITLE
updated the missing kubectl pod command

### DIFF
--- a/content/en/docs/tutorials/hello-minikube.md
+++ b/content/en/docs/tutorials/hello-minikube.md
@@ -113,7 +113,7 @@ Pod runs a Container based on the provided Docker image.
 3. View the Pod:
 
     ```shell
-    kubectl get pods
+    kubectl get pods or kubectl get po -A
     ```
 
     The output is similar to:


### PR DESCRIPTION
sometimes the conventional kubectl get pods command is not accessible for the windows and linux-ubuntu wsl2 terminal .
it was fixed using " kubectl get po -A "

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
