### PR TITLE
mention the correct feature gate name for RBD CSI migration.

### DIFF
--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -858,7 +858,7 @@ operations from the existing in-tree plugin to the `rbd.csi.ceph.com` {{<
 glossary_tooltip text="CSI" term_id="csi" >}} driver. In order to use this
 feature, the
 [Ceph CSI driver](https://github.com/ceph/ceph-csi)
-must be installed on the cluster and the `CSIMigration` and `CSIMigrationRBD`
+must be installed on the cluster and the `CSIMigration` and `csiMigrationRBD`
 [feature gates](/docs/reference/command-line-tools-reference/feature-gates/)
 must be enabled.
 

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -88,7 +88,7 @@ different Kubernetes components.
 | `CSIMigrationOpenStack` | `true` | Beta | 1.18 | |
 | `CSIMigrationvSphere` | `false` | Beta | 1.19 | |
 | `CSIMigrationPortworx` | `false` | Alpha | 1.23 | |
-| `CSIMigrationRBD` | `false` | Alpha | 1.23 | |
+| `csiMigrationRBD` | `false` | Alpha | 1.23 | |
 | `CSIStorageCapacity` | `false` | Alpha | 1.19 | 1.20 |
 | `CSIStorageCapacity` | `true` | Beta | 1.21 | |
 | `CSIVolumeHealth` | `false` | Alpha | 1.21 | |
@@ -653,9 +653,9 @@ Each feature gate is designed for enabling/disabling a specific feature:
   operations from the GCE-PD in-tree plugin to PD CSI plugin. Supports falling
   back to in-tree GCE plugin if a node does not have PD CSI plugin installed and
   configured. Requires CSIMigration feature flag enabled.
-- `CSIMigrationRBD`: Enables shims and translation logic to route volume
+- `csiMigrationRBD`: Enables shims and translation logic to route volume
   operations from the RBD in-tree plugin to Ceph RBD CSI plugin. Requires
-  CSIMigration and CSIMigrationRBD feature flags enabled and Ceph CSI plugin
+  CSIMigration and csiMigrationRBD feature flags enabled and Ceph CSI plugin
   installed and configured in the cluster. This flag has been deprecated in
   favor of the
   `InTreePluginRBDUnregister` feature flag which prevents the registration of


### PR DESCRIPTION
The feature gate string (CSIMigrationRBD) was not matching with the
implementation (csiMigrationRBD) and this commit make it in parity

Ref# https://github.com/kubernetes/kubernetes/pull/107571

Master branch has this corrected to CSIMigrationRBD ( kubernetes/kubernetes#107554 ) and master documentation matches.
Release 1.23 has it in current form ie csiMigrationRBD and this PR correct the same.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

