### PR TITLE
Mention the kubectl binary folder as PATH environment variable

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -85,7 +85,7 @@ For example, to download version {{< param "fullversion" >}} on Linux, type:
    chmod +x kubectl
    mkdir -p ~/.local/bin/kubectl
    mv ./kubectl ~/.local/bin/kubectl
-   # and then add ~/.local/bin/kubectl to $PATH
+   # and then add ~/.local/bin to $PATH
    ```
 
    {{< /note >}}

--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -85,7 +85,7 @@ For example, to download version {{< param "fullversion" >}} on Linux, type:
    chmod +x kubectl
    mkdir -p ~/.local/bin/kubectl
    mv ./kubectl ~/.local/bin/kubectl
-   # and then add ~/.local/bin to $PATH
+   # and then append (or prepend) ~/.local/bin to $PATH
    ```
 
    {{< /note >}}

--- a/content/en/docs/tasks/tools/install-kubectl-windows.md
+++ b/content/en/docs/tasks/tools/install-kubectl-windows.md
@@ -59,7 +59,7 @@ The following methods exist for installing kubectl on Windows:
      $($(CertUtil -hashfile .\kubectl.exe SHA256)[1] -replace " ", "") -eq $(type .\kubectl.exe.sha256)
      ```
 
-1. Add the binary's folder to your `PATH`.
+1. Append or prepend the kubectl binary folder to your `PATH` environment variable.
 
 1. Test to ensure the version of `kubectl` is the same as downloaded:
 
@@ -172,7 +172,7 @@ Below are the procedures to set up autocompletion for PowerShell.
      $($(CertUtil -hashfile .\kubectl-convert.exe SHA256)[1] -replace " ", "") -eq $(type .\kubectl-convert.exe.sha256)
      ```
 
-1. Add the binary's folder to your `PATH`.
+1. Append or prepend the kubectl binary folder to your `PATH` environment variable.
 
 1. Verify plugin is successfully installed
 

--- a/content/en/docs/tasks/tools/install-kubectl-windows.md
+++ b/content/en/docs/tasks/tools/install-kubectl-windows.md
@@ -59,7 +59,7 @@ The following methods exist for installing kubectl on Windows:
      $($(CertUtil -hashfile .\kubectl.exe SHA256)[1] -replace " ", "") -eq $(type .\kubectl.exe.sha256)
      ```
 
-1. Add the binary in to your `PATH`.
+1. Add the binary's folder to your `PATH`.
 
 1. Test to ensure the version of `kubectl` is the same as downloaded:
 
@@ -172,7 +172,7 @@ Below are the procedures to set up autocompletion for PowerShell.
      $($(CertUtil -hashfile .\kubectl-convert.exe SHA256)[1] -replace " ", "") -eq $(type .\kubectl-convert.exe.sha256)
      ```
 
-1. Add the binary in to your `PATH`.
+1. Add the binary's folder to your `PATH`.
 
 1. Verify plugin is successfully installed
 


### PR DESCRIPTION
Fixes #31341 

This PR changes/mentions:

* While installing `kubectl` binary  through `curl`, the folder of the binary (`\path_to_kubectl\`) should set as the PATH environment variable for both `Windows` and `Linux`

Files changed:
- https://github.com/kubernetes/website/blob/main/content/en/docs/tasks/tools/install-kubectl-linux.md
- https://github.com/kubernetes/website/blob/main/content/en/docs/tasks/tools/install-kubectl-windows.md