### PR TITLE
[zh] Translate section of `Define a gRPC liveness probe` into Simplified Chinese

### DIFF
--- a/content/zh/examples/pods/probe/grpc-liveness.yaml
+++ b/content/zh/examples/pods/probe/grpc-liveness.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: etcd-with-grpc
+spec:
+  containers:
+  - name: etcd
+    image: k8s.gcr.io/etcd:3.5.1-0
+    command: [ "/usr/local/bin/etcd", "--data-dir",  "/var/lib/etcd", "--listen-client-urls", "http://0.0.0.0:2379", "--advertise-client-urls", "http://127.0.0.1:2379", "--log-level", "debug"]
+    ports:
+    - containerPort: 2379
+    livenessProbe:
+      grpc:
+        port: 2379
+      initialDelaySeconds: 10


### PR DESCRIPTION
* Synchronize the section of `Define a gRPC liveness probe`  to file content/zh/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md.
* Translate section of  `Define a gRPC liveness probe`  into Simplified Chinese on file content/zh/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md.
* Copy content/en/examples/pods/probe/grpc-liveness.yaml as content/zh/examples/pods/probe/grpc-liveness.yaml.

/assign @chenrui333
