### PR TITLE
set hpa examples to current networking api version

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -321,7 +321,7 @@ object:
   metric:
     name: requests-per-second
   describedObject:
-    apiVersion: networking.k8s.io/v1beta1
+    apiVersion: networking.k8s.io/v1
     kind: Ingress
     name: main-route
   target:
@@ -367,7 +367,7 @@ spec:
       metric:
         name: requests-per-second
       describedObject:
-        apiVersion: networking.k8s.io/v1beta1
+        apiVersion: networking.k8s.io/v1
         kind: Ingress
         name: main-route
       target:
@@ -390,7 +390,7 @@ status:
       metric:
         name: requests-per-second
       describedObject:
-        apiVersion: networking.k8s.io/v1beta1
+        apiVersion: networking.k8s.io/v1
         kind: Ingress
         name: main-route
       current:


### PR DESCRIPTION
Update hpa examples to match current api version.
Why? The examples can't be used on newer kubernetes version.
