### PR TITLE
fix whitespace error in HPA walkthrough

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -382,9 +382,9 @@ status:
   - type: Resource
     resource:
       name: cpu
-    current:
-      averageUtilization: 0
-      averageValue: 0
+      current:
+        averageUtilization: 0
+        averageValue: 0
   - type: Object
     object:
       metric:

--- a/content/id/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/id/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -326,9 +326,9 @@ status:
   - type: Resource
     resource:
       name: cpu
-    current:
-      averageUtilization: 0
-      averageValue: 0
+      current:
+        averageUtilization: 0
+        averageValue: 0
   - type: Object
     object:
       metric:

--- a/content/ja/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/ja/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -292,9 +292,9 @@ status:
   - type: Resource
     resource:
       name: cpu
-    current:
-      averageUtilization: 0
-      averageValue: 0
+      current:
+        averageUtilization: 0
+        averageValue: 0
   - type: Object
     object:
       metric:

--- a/content/ko/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/ko/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -332,9 +332,9 @@ status:
   - type: Resource
     resource:
       name: cpu
-    current:
-      averageUtilization: 0
-      averageValue: 0
+      current:
+        averageUtilization: 0
+        averageValue: 0
   - type: Object
     object:
       metric:

--- a/content/zh/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/zh/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -492,9 +492,9 @@ status:
   - type: Resource
     resource:
       name: cpu
-    current:
-      averageUtilization: 0
-      averageValue: 0
+      current:
+        averageUtilization: 0
+        averageValue: 0
   - type: Object
     object:
       metric:


### PR DESCRIPTION
Fixing placement of `currentMetrics.resource.current` in the following example from HPA walkthrough guide:

```
status:
  observedGeneration: 1
  lastScaleTime: <some-time>
  currentReplicas: 1
  desiredReplicas: 1
  currentMetrics:
  - type: Resource
    resource:
      name: cpu
    current:
      averageUtilization: 0
      averageValue: 0
```

The problem is that `current` section should be placed under `resource`. Fixing this will align the example with the other example in the guide, observed behaviour and [API docs which places both `name` and `current` sections under `resource`](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2/):

- currentMetrics.resource.current (MetricValueStatus), required
- currentMetrics.resource.name (string), required
