### PR TITLE
Changed the explicit mention of Docker due to deprecation in Tasks > …

### DIFF
--- a/content/en/docs/tasks/network/customize-hosts-file-for-pods.md
+++ b/content/en/docs/tasks/network/customize-hosts-file-for-pods.md
@@ -118,9 +118,9 @@ with the additional entries specified at the bottom.
 ## Why does the kubelet manage the hosts file? {#why-does-kubelet-manage-the-hosts-file}
 
 The kubelet [manages](https://github.com/kubernetes/kubernetes/issues/14633) the
-`hosts` file for each container of the Pod to prevent Docker from
-[modifying](https://github.com/moby/moby/issues/17190) the file after the
-containers have already been started.
+`hosts` file for each container of the Pod to prevent the container runtime from
+modifying the file after the containers have already been started.
+For e.g. earlier Docker used to [modify](https://github.com/moby/moby/issues/17190) the `hosts` file after the containers start.
 
 {{< caution >}}
 Avoid making manual changes to the hosts file inside a container.

--- a/content/en/docs/tasks/network/customize-hosts-file-for-pods.md
+++ b/content/en/docs/tasks/network/customize-hosts-file-for-pods.md
@@ -120,7 +120,12 @@ with the additional entries specified at the bottom.
 The kubelet manages the
 `hosts` file for each container of the Pod to prevent the container runtime from
 modifying the file after the containers have already been started.
-For e.g. earlier Docker used to [modify](https://github.com/moby/moby/issues/17190) the `hosts` file after the containers start.
+Historically, Kubernetes always used Docker Engine as its container runtime, and Docker Engine would
+then modify the `/etc/hosts` file after each container had started.
+
+Current Kubernetes can use a variety of container runtimes; even so, the kubelet manages the
+hosts file within each container so that the outcome is as intended regardless of which
+container runtime you use.
 
 {{< caution >}}
 Avoid making manual changes to the hosts file inside a container.

--- a/content/en/docs/tasks/network/customize-hosts-file-for-pods.md
+++ b/content/en/docs/tasks/network/customize-hosts-file-for-pods.md
@@ -117,7 +117,7 @@ with the additional entries specified at the bottom.
 
 ## Why does the kubelet manage the hosts file? {#why-does-kubelet-manage-the-hosts-file}
 
-The kubelet [manages](https://github.com/kubernetes/kubernetes/issues/14633) the
+The kubelet manages the
 `hosts` file for each container of the Pod to prevent the container runtime from
 modifying the file after the containers have already been started.
 For e.g. earlier Docker used to [modify](https://github.com/moby/moby/issues/17190) the `hosts` file after the containers start.


### PR DESCRIPTION
In https://k8s.io/docs/tasks/network/customize-hosts-file-for-pods, Docker was mentioned at the end due to its involvement in deleting the Pod hosts file. Due to the dockershim removal and stopping Docker support by the k8s community, the file has been edited accordingly.

Resolves issue #30977 
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
