### PR TITLE
ja: Fixed outdated Japanese content to mention latest KubeCon 2022 conference

### DIFF
--- a/content/ja/_index.html
+++ b/content/ja/_index.html
@@ -41,12 +41,12 @@ Kubernetesはオープンソースなので、オンプレミスやパブリッ�
         <button id="desktopShowVideoButton" onclick="kub.showVideo()">ビデオを見る</button>
         <br>
         <br>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/?utm_source=kubernetes.io&utm_medium=nav&utm_campaign=kccncna20" button id="desktopKCButton">2020年11月17日-20日のKubeCon NAバーチャルに参加する</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/?utm_source=kubernetes.io&utm_medium=nav&utm_campaign=kccncna22" button id="desktopKCButton">2022年10月24日から28日までミシガン州のKubeConデトロイトに参加する</a>
         <br>
         <br>
         <br>
         <br>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/?utm_source=kubernetes.io&utm_medium=nav&utm_campaign=kccnceu21" button id="desktopKCButton">2021年5月4日-7日のKubeCon EUバーチャルに参加する</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/?utm_source=kubernetes.io&utm_medium=nav&utm_campaign=kccnceu22" button id="desktopKCButton">スペインのKubeConバレンシアに参加+バーチャル、2022年5月16〜20日</a>
 </div>
 <div id="videoPlayer">
     <iframe data-url="https://www.youtube.com/embed/H06qrNmGqyE?autoplay=1" frameborder="0" allowfullscreen></iframe>

--- a/content/ja/_index.html
+++ b/content/ja/_index.html
@@ -41,12 +41,12 @@ Kubernetesはオープンソースなので、オンプレミスやパブリッ�
         <button id="desktopShowVideoButton" onclick="kub.showVideo()">ビデオを見る</button>
         <br>
         <br>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/?utm_source=kubernetes.io&utm_medium=nav&utm_campaign=kccncna22" button id="desktopKCButton">2022年10月24日から28日までミシガン州のKubeConデトロイトに参加する</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/?utm_source=kubernetes.io&utm_medium=nav&utm_campaign=kccnceu22" button id="desktopKCButton">2022年5月16日〜20日のKubeCon EUバーチャルに参加する</a>
         <br>
         <br>
         <br>
         <br>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/?utm_source=kubernetes.io&utm_medium=nav&utm_campaign=kccnceu22" button id="desktopKCButton">スペインのKubeConバレンシアに参加+バーチャル、2022年5月16〜20日</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/?utm_source=kubernetes.io&utm_medium=nav&utm_campaign=kccncna22" button id="desktopKCButton">2022年10月24日-28日のKubeCon NAバーチャルに参加する</a>
 </div>
 <div id="videoPlayer">
     <iframe data-url="https://www.youtube.com/embed/H06qrNmGqyE?autoplay=1" frameborder="0" allowfullscreen></iframe>


### PR DESCRIPTION
Updated the _index.html file `content/it/_index.html to` include the
latest links for the Cloud Native Computing Foundation’s flagship conference.
KubeCon + CloudNativeCon

These KubeCon conferences are already over but we still have :

- 2020年11月17日-20日のKubeCon NAバーチャルに参加する
- 2021年5月4日-7日のKubeCon EUバーチャルに参加する

These have been updated to :

- 2021年5月4日-7日のKubeCon EUバーチャルに参加する
- スペインのKubeConバレンシアに参加+バーチャル、2022年5月16〜20日

Issue : #31400