### PR TITLE
Fix: typo in cloud-controller.md

### DIFF
--- a/content/en/docs/concepts/architecture/cloud-controller.md
+++ b/content/en/docs/concepts/architecture/cloud-controller.md
@@ -78,7 +78,7 @@ when you declare a Service resource that requires them.
 
 ## Authorization
 
-This section breaks down the access that the cloud controller managers requires
+This section breaks down the access that the cloud controller manager requires
 on various API objects, in order to perform its operations.
 
 ### Node controller {#authorization-node-controller}


### PR DESCRIPTION
From docs: "The cloud-controller-manager is a Kubernetes control plane component". That is, a singular manager. This PR fixes typo in docs where it was later referenced to as "cloud controller managers".