### PR TITLE
Configure multiple schedulers: switch to the secure ports

### DIFF
--- a/content/en/examples/admin/sched/my-scheduler.yaml
+++ b/content/en/examples/admin/sched/my-scheduler.yaml
@@ -30,7 +30,6 @@ roleRef:
   name: system:volume-scheduler
   apiGroup: rbac.authorization.k8s.io
 ---
-
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -44,7 +43,6 @@ data:
       - schedulerName: my-scheduler
     leaderElection:
       leaderElect: false
-
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -76,13 +74,15 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 10251
+            port: 10259
+            scheme: HTTPS
           initialDelaySeconds: 15
         name: kube-second-scheduler
         readinessProbe:
           httpGet:
             path: /healthz
-            port: 10251
+            port: 10259
+            scheme: HTTPS
         resources:
           requests:
             cpu: '0.1'


### PR DESCRIPTION
Starting v1.23 the kube-scheduler no longer provides insecure serving. Please see https://github.com/kubernetes/kubernetes/pull/102857 for more details.

Configuring the probes to check the healthz endpoint on port 10251 with http protocol will crash loop back the container.

Also, aligning some of the changes performed in https://github.com/kubernetes/website/pull/30107 for other language variants.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
