### PR TITLE
[en] Updated the page to be more docker specific

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/assign-memory-resource.md
+++ b/content/en/docs/tasks/configure-pod-container/assign-memory-resource.md
@@ -174,7 +174,7 @@ The output shows that the Container was killed because it is out of memory (OOM)
 ```shell
 lastState:
    terminated:
-     containerID: docker://65183c1877aaec2e8427bc95609cc52677a454b56fcb24340dbd22917c23b10f
+     containerID: 65183c1877aaec2e8427bc95609cc52677a454b56fcb24340dbd22917c23b10f
      exitCode: 137
      finishedAt: 2017-06-20T20:52:19Z
      reason: OOMKilled

--- a/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
+++ b/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
@@ -68,7 +68,8 @@ If you use a Docker credentials store, you won't see that `auth` entry but a `cr
 A Kubernetes cluster uses the Secret of `kubernetes.io/dockerconfigjson` type to authenticate with
 a container registry to pull a private image.
 
-If you are using the Docker Hub regsitry and already ran `docker login`, you can copy that credential into Kubernetes:
+If you are using the Docker Hub registry and already ran `docker login`, you can copy
+that credential into Kubernetes:
 
 ```shell
 kubectl create secret generic regcred \

--- a/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
+++ b/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
@@ -7,8 +7,9 @@ weight: 100
 <!-- overview -->
 
 This page shows how to create a Pod that uses a
-{{< glossary_tooltip text="Secret" term_id="secret" >}} to pull an image from a
-private container image registry or repository.
+{{< glossary_tooltip text="Secret" term_id="secret" >}} to pull an image 
+from a private container image registry or repository. There are many private 
+registries in use. This task uses Docker Hub as an example of the steps needed.
 
 {{% thirdparty-content single="true" %}}
 
@@ -18,6 +19,8 @@ private container image registry or repository.
 
 * To do this exercise, you need the `docker` command line tool, and a
   [Docker ID](https://docs.docker.com/docker-id/) for which you know the password.
+* If you are using a different private container registry, you need the command 
+  line tool for that registry and any login information for the registry. 
 
 <!-- steps -->
 
@@ -59,12 +62,12 @@ The output contains a section similar to this:
 If you use a Docker credentials store, you won't see that `auth` entry but a `credsStore` entry with the name of the store as value.
 {{< /note >}}
 
-## Create a Secret based on existing Docker credentials {#registry-secret-existing-credentials}
+## Create a Secret based on existing credentials {#registry-secret-existing-credentials}
 
 A Kubernetes cluster uses the Secret of `kubernetes.io/dockerconfigjson` type to authenticate with
 a container registry to pull a private image.
 
-If you already ran `docker login`, you can copy that credential into Kubernetes:
+If you are using the Docker Hub regsitry and already ran `docker login`, you can copy that credential into Kubernetes:
 
 ```shell
 kubectl create secret generic regcred \
@@ -213,4 +216,3 @@ kubectl get pod private-reg
 * Learn more about [adding image pull secrets to a service account](/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account).
 * See [kubectl create secret docker-registry](/docs/reference/generated/kubectl/kubectl-commands/#-em-secret-docker-registry-em-).
 * See the `imagePullSecrets` field within the [container definitions](/docs/reference/kubernetes-api/workload-resources/pod-v1/#containers) of a Pod
-

--- a/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
+++ b/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
@@ -68,7 +68,7 @@ If you use a Docker credentials store, you won't see that `auth` entry but a `cr
 A Kubernetes cluster uses the Secret of `kubernetes.io/dockerconfigjson` type to authenticate with
 a container registry to pull a private image.
 
-If you are using the Docker Hub registry and already ran `docker login`, you can copy
+If you already ran `docker login`, you can copy
 that credential into Kubernetes:
 
 ```shell

--- a/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
+++ b/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
@@ -82,7 +82,7 @@ secret) then you can customise the Secret before storing it.
 Be sure to:
 
 - set the name of the data item to `.dockerconfigjson`
-- base64 encode the docker file and paste that string, unbroken
+- base64 encode the Docker configuration file and then paste that string, unbroken
   as the value for field `data[".dockerconfigjson"]`
 - set `type` to `kubernetes.io/dockerconfigjson`
 

--- a/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
+++ b/content/en/docs/tasks/configure-pod-container/pull-image-private-registry.md
@@ -9,7 +9,8 @@ weight: 100
 This page shows how to create a Pod that uses a
 {{< glossary_tooltip text="Secret" term_id="secret" >}} to pull an image 
 from a private container image registry or repository. There are many private 
-registries in use. This task uses Docker Hub as an example of the steps needed.
+registries in use. This task uses [Docker Hub](https://www.docker.com/products/docker-hub)
+as an example registry.
 
 {{% thirdparty-content single="true" %}}
 


### PR DESCRIPTION
An update of this page with Docker-specific details. 

The page talks about using secrets in general, making it more docker specific will express to the reader that there are other registries and that we are using docker in this task.

Issue #31409 