### PR TITLE
Catch APF description up with recent developments

### DIFF
--- a/content/en/examples/priority-and-fairness/health-for-strangers.yaml
+++ b/content/en/examples/priority-and-fairness/health-for-strangers.yaml
@@ -1,4 +1,4 @@
-apiVersion: flowcontrol.apiserver.k8s.io/v1beta1
+apiVersion: flowcontrol.apiserver.k8s.io/v1beta2
 kind: FlowSchema
 metadata:
   name: health-for-strangers


### PR DESCRIPTION
Fix some rot in the description of API Priority and Fairness.

Primarily the change, in release 1.22, of how configuration objects
are maintained.

Also describe the new priority level.

Also catch up with the introduction of v1beta2.

Also move the sections on defaults and health check configuration to
follow the introduction of configuration objects.

/cc @tkashem 
/cc @wojtek-t 
/cc @deads2k 
/cc @lavalamp 