### PR TITLE
sample outputs created  working with Kubernetes v1.24 without docker

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -81,13 +81,13 @@ kubectl describe pod liveness-exec
 The output indicates that no liveness probes have failed yet:
 
 ```
-FirstSeen    LastSeen    Count   From            SubobjectPath           Type        Reason      Message
---------- --------    -----   ----            -------------           --------    ------      -------
-24s       24s     1   {default-scheduler }                    Normal      Scheduled   Successfully assigned liveness-exec to worker0
-23s       23s     1   {kubelet worker0}   spec.containers{liveness}   Normal      Pulling     pulling image "k8s.gcr.io/busybox"
-23s       23s     1   {kubelet worker0}   spec.containers{liveness}   Normal      Pulled      Successfully pulled image "k8s.gcr.io/busybox"
-23s       23s     1   {kubelet worker0}   spec.containers{liveness}   Normal      Created     Created container with docker id 86849c15382e; Security:[seccomp=unconfined]
-23s       23s     1   {kubelet worker0}   spec.containers{liveness}   Normal      Started     Started container with docker id 86849c15382e
+Type    Reason     Age   From               Message
+  ----    ------     ----  ----               -------
+  Normal  Scheduled  11s   default-scheduler  Successfully assigned default/liveness-exec to node01
+  Normal  Pulling    9s    kubelet, node01    Pulling image "k8s.gcr.io/busybox"
+  Normal  Pulled     7s    kubelet, node01    Successfully pulled image "k8s.gcr.io/busybox"
+  Normal  Created    7s    kubelet, node01    Created container liveness
+  Normal  Started    7s    kubelet, node01    Started container liveness
 ```
 
 After 35 seconds, view the Pod events again:
@@ -100,14 +100,15 @@ At the bottom of the output, there are messages indicating that the liveness
 probes have failed, and the containers have been killed and recreated.
 
 ```
-FirstSeen LastSeen    Count   From            SubobjectPath           Type        Reason      Message
---------- --------    -----   ----            -------------           --------    ------      -------
-37s       37s     1   {default-scheduler }                    Normal      Scheduled   Successfully assigned liveness-exec to worker0
-36s       36s     1   {kubelet worker0}   spec.containers{liveness}   Normal      Pulling     pulling image "k8s.gcr.io/busybox"
-36s       36s     1   {kubelet worker0}   spec.containers{liveness}   Normal      Pulled      Successfully pulled image "k8s.gcr.io/busybox"
-36s       36s     1   {kubelet worker0}   spec.containers{liveness}   Normal      Created     Created container with docker id 86849c15382e; Security:[seccomp=unconfined]
-36s       36s     1   {kubelet worker0}   spec.containers{liveness}   Normal      Started     Started container with docker id 86849c15382e
-2s        2s      1   {kubelet worker0}   spec.containers{liveness}   Warning     Unhealthy   Liveness probe failed: cat: can't open '/tmp/healthy': No such file or directory
+  Type     Reason     Age                From               Message
+  ----     ------     ----               ----               -------
+  Normal   Scheduled  57s                default-scheduler  Successfully assigned default/liveness-exec to node01
+  Normal   Pulling    55s                kubelet, node01    Pulling image "k8s.gcr.io/busybox"
+  Normal   Pulled     53s                kubelet, node01    Successfully pulled image "k8s.gcr.io/busybox"
+  Normal   Created    53s                kubelet, node01    Created container liveness
+  Normal   Started    53s                kubelet, node01    Started container liveness
+  Warning  Unhealthy  10s (x3 over 20s)  kubelet, node01    Liveness probe failed: cat: can't open '/tmp/healthy': No such file or directory
+  Normal   Killing    10s                kubelet, node01    Container liveness failed liveness probe, will be restarted
 ```
 
 Wait another 30 seconds, and verify that the container has been restarted:
@@ -405,7 +406,7 @@ If you have pods that are impacted from the default 1 second timeout,
 you should update their probe timeout so that you're ready for the
 eventual removal of that feature gate.
 
-With the fix of the defect, for exec probes, on Kubernetes `1.20+` with the `dockershim` container runtime,
+With the fix of the defect, for exec probes, on Kubernetes `1.20+` with the `docker` container runtime,
 the process inside the container may keep running even after probe returned failure because of the timeout.
 {{< /note >}}
 {{< caution >}}

--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -406,7 +406,11 @@ If you have pods that are impacted from the default 1 second timeout,
 you should update their probe timeout so that you're ready for the
 eventual removal of that feature gate.
 
+<<<<<<< HEAD
 With the fix of the defect, for exec probes, on Kubernetes `1.20+` with the `docker` container runtime,
+=======
+With the fix of the defect, for exec probes, on Kubernetes `1.20+` with the `containerd` container runtime,
+>>>>>>> 4d5c692cd (sample outputs created without docker working with kubernetes v1.24)
 the process inside the container may keep running even after probe returned failure because of the timeout.
 {{< /note >}}
 {{< caution >}}

--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -406,11 +406,7 @@ If you have pods that are impacted from the default 1 second timeout,
 you should update their probe timeout so that you're ready for the
 eventual removal of that feature gate.
 
-<<<<<<< HEAD
-With the fix of the defect, for exec probes, on Kubernetes `1.20+` with the `docker` container runtime,
-=======
-With the fix of the defect, for exec probes, on Kubernetes `1.20+` with the `containerd` container runtime,
->>>>>>> 4d5c692cd (sample outputs created without docker working with kubernetes v1.24)
+With the fix of the defect, for exec probes, on Kubernetes `1.20+` with the `dockershim` container runtime,
 the process inside the container may keep running even after probe returned failure because of the timeout.
 {{< /note >}}
 {{< caution >}}


### PR DESCRIPTION
This PR resolves issue  #31423 
Sample Images produced using Kubernetes configured via Katakoda. 

Ps: This is my first PR, reviews requested. 
@celestehorgan @sftim  