### PR TITLE
Sticky table of contents

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -305,6 +305,12 @@ footer {
   padding-top: 1.5rem !important;
   top: 5rem !important;
 
+  @supports (position: sticky) {
+    position: sticky !important;
+    height: calc(100vh - 10rem);
+    overflow-y: auto;
+  }
+
   #TableOfContents {
     padding-top: 1rem;
   }


### PR DESCRIPTION
Sticky table of contents can improve the reading experience,  especially for long pages like [this](https://kubernetes.io/docs/contribute/localization/)