### PR TITLE
Updated overview section of ConfigMaps

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -8,8 +8,10 @@ card:
 ---
 
 <!-- overview -->
+Many applications rely on configuration which is used during either application initialization or runtime.
+Most of the times there is a requirement to adjust values assigned to configuration parameters.
+ConfigMaps is the kubernetes way to inject application pods with configuration data. 
 ConfigMaps allow you to decouple configuration artifacts from image content to keep containerized applications portable. This page provides a series of usage examples demonstrating how to create ConfigMaps and configure Pods using data stored in ConfigMaps.
-
 
 
 ## {{% heading "prerequisites" %}}


### PR DESCRIPTION
Fix for #30729. Updated content of the overview section of https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/. New content will help the new K8S users to understand concept of ConfigMaps quickly.