### PR TITLE
Include link to Pod Security Admission in the PodSecurityPolicy deprecation notice

### DIFF
--- a/content/en/docs/concepts/policy/pod-security-policy.md
+++ b/content/en/docs/concepts/policy/pod-security-policy.md
@@ -12,7 +12,7 @@ weight: 30
 {{< feature-state for_k8s_version="v1.21" state="deprecated" >}}
 
 PodSecurityPolicy is deprecated as of Kubernetes v1.21, and will be removed in v1.25. It has been replaced by
-[Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/). For more information on the deprecation,
+[Pod Security Admission](/docs/concepts/security/pod-security-admission/). For more information on the deprecation,
 see [PodSecurityPolicy Deprecation: Past, Present, and Future](/blog/2021/04/06/podsecuritypolicy-deprecation-past-present-and-future/).
 
 Pod Security Policies enable fine-grained authorization of pod creation and

--- a/content/en/docs/concepts/policy/pod-security-policy.md
+++ b/content/en/docs/concepts/policy/pod-security-policy.md
@@ -11,7 +11,8 @@ weight: 30
 
 {{< feature-state for_k8s_version="v1.21" state="deprecated" >}}
 
-PodSecurityPolicy is deprecated as of Kubernetes v1.21, and will be removed in v1.25. For more information on the deprecation,
+PodSecurityPolicy is deprecated as of Kubernetes v1.21, and will be removed in v1.25. It has been replaced by
+[Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/). For more information on the deprecation,
 see [PodSecurityPolicy Deprecation: Past, Present, and Future](/blog/2021/04/06/podsecuritypolicy-deprecation-past-present-and-future/).
 
 Pod Security Policies enable fine-grained authorization of pod creation and


### PR DESCRIPTION
Add a link to the [Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/) feature, which replaces [PodSecurityPolicy](https://kubernetes.io/docs/concepts/policy/pod-security-policy/). Currently users who read the docs on [PodSecurityPolicy](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) may not realize what the replacement is (at least, that was the case for me). The linked [blog post](https://kubernetes.io/blog/2021/04/06/podsecuritypolicy-deprecation-past-present-and-future/) talks about the KEP that created Pod Security Admission, but with no direct link.