### PR TITLE
Add Out-of-band release 1.23.3 to schedule files

### DIFF
--- a/content/en/releases/patch-releases.md
+++ b/content/en/releases/patch-releases.md
@@ -92,7 +92,7 @@ End of Life for **1.23** is **2023-02-28**.
 
 | Patch Release | Cherry Pick Deadline | Target Date | Note |
 |---------------|----------------------|-------------|------|
-| 1.23.2        | 2022-01-14           | 2022-01-19  | [Out-of-Band Release](https://groups.google.com/u/2/a/kubernetes.io/g/dev/c/Xl1sm-CItaY) |
+| 1.23.3        | 2022-01-24           | 2022-01-25  | [Out-of-Band Release](https://groups.google.com/u/2/a/kubernetes.io/g/dev/c/Xl1sm-CItaY) |
 | 1.23.2        | 2022-01-14           | 2022-01-19  |      |
 | 1.23.1        | 2021-12-14           | 2021-12-16  |      |
 

--- a/content/en/releases/patch-releases.md
+++ b/content/en/releases/patch-releases.md
@@ -92,6 +92,7 @@ End of Life for **1.23** is **2023-02-28**.
 
 | Patch Release | Cherry Pick Deadline | Target Date | Note |
 |---------------|----------------------|-------------|------|
+| 1.23.2        | 2022-01-14           | 2022-01-19  | [Out-of-Band Release](https://groups.google.com/u/2/a/kubernetes.io/g/dev/c/Xl1sm-CItaY) |
 | 1.23.2        | 2022-01-14           | 2022-01-19  |      |
 | 1.23.1        | 2021-12-14           | 2021-12-16  |      |
 

--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -1,11 +1,14 @@
 schedules:
 - release: 1.23
   releaseDate: 2021-12-07
-  next: 1.23.2
-  cherryPickDeadline: 2022-01-14
-  targetDate: 2022-01-19
+  next: 1.23.3
+  cherryPickDeadline: 2022-01-24
+  targetDate: 2022-01-25
   endOfLifeDate: 2023-02-28
   previousPatches:
+    - release: 1.23.2
+      cherryPickDeadline: 2022-01-14
+      targetDate: 2022-01-19
     - release: 1.23.1
       cherryPickDeadline: 2021-12-14
       targetDate: 2021-12-16


### PR DESCRIPTION
This PR adds the emergency 1.23.3 release to the release schedule files.

/cc @jimangel @justaugustus @saschagrunert @jeremyrickard 

/sig release 
/priority critical-urgent
