### PR TITLE
Removed 'dockershim' section from link  https://kubernetes.io/docs/co…

### DIFF
--- a/content/en/docs/concepts/containers/runtime-class.md
+++ b/content/en/docs/concepts/containers/runtime-class.md
@@ -107,11 +107,6 @@ to the behavior when the RuntimeClass feature is disabled.
 
 For more details on setting up CRI runtimes, see [CRI installation](/docs/setup/production-environment/container-runtimes/).
 
-#### dockershim
-
-RuntimeClasses with dockershim must set the runtime handler to `docker`. Dockershim does not support
-custom configurable runtime handlers.
-
 #### {{< glossary_tooltip term_id="containerd" >}}
 
 Runtime handlers are configured through containerd's configuration at


### PR DESCRIPTION
Ref: #30773

Removed dockershim section at https://kubernetes.io/docs/concepts/containers/runtime-class/#cri-configuration, so that the users should not use the deprecated functionality !