### PR TITLE
chore: add space between words

### DIFF
--- a/content/en/docs/reference/access-authn-authz/node.md
+++ b/content/en/docs/reference/access-authn-authz/node.md
@@ -34,8 +34,8 @@ Write operations:
 
 Auth-related operations:
 
-* read/write access to the certification signing requests API for TLS bootstrapping
-* the ability to create tokenreviews and subject access reviews for delegated authentication/authorization checks
+* read/write access to the [`CertificateSigningRequest`](/docs/reference/access-authn-authz/certificate-signing-requests/) API for TLS bootstrapping
+* the ability to create tokenreviews and subjectaccessreviews for delegated authentication/authorization checks
 
 In future releases, the node authorizer may add or remove permissions to ensure kubelets
 have the minimal set of permissions required to operate correctly.

--- a/content/en/docs/reference/access-authn-authz/node.md
+++ b/content/en/docs/reference/access-authn-authz/node.md
@@ -34,8 +34,8 @@ Write operations:
 
 Auth-related operations:
 
-* read/write access to the certificationsigningrequests API for TLS bootstrapping
-* the ability to create tokenreviews and subjectaccessreviews for delegated authentication/authorization checks
+* read/write access to the certification signing requests API for TLS bootstrapping
+* the ability to create tokenreviews and subject access reviews for delegated authentication/authorization checks
 
 In future releases, the node authorizer may add or remove permissions to ensure kubelets
 have the minimal set of permissions required to operate correctly.


### PR DESCRIPTION
I was just reading docs and notice small typo where a space between words was missed. 