### PR TITLE
Update capitalization for mount options based on correct PV types

### DIFF
--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -535,19 +535,19 @@ Not all Persistent Volume types support mount options.
 
 The following volume types support mount options:
 
-* AWSElasticBlockStore
-* AzureDisk
-* AzureFile
-* CephFS
-* Cinder (OpenStack block storage)
-* GCEPersistentDisk
-* Glusterfs
-* NFS
-* Quobyte Volumes
-* RBD (Ceph Block Device)
-* StorageOS
-* VsphereVolume
-* iSCSI
+* `awsElasticBlockStore`
+* `azureDisk`
+* `azureFile`
+* `cephfs`
+* `cinder` (**deprecated** in v1.18)
+* `gcePersistentDisk`
+* `glusterfs`
+* `iscsi`
+* `nfs`
+* `quobyte` (**deprecated** in v1.22)
+* `rbd`
+* `storageos` (**deprecated** in v1.22)
+* `vsphereVolume`
 
 Mount options are not validated. If a mount option is invalid, the mount fails.
 


### PR DESCRIPTION
Refers https://github.com/kubernetes/website/issues/31540

### What is changing?
- As mentioned in the [bug report](https://github.com/kubernetes/website/issues/31540)  , the capitialization for the list of volume types in which `mountOptions` are available was incorrect. This causes the reader some additional cognitive load to match it to the correct PV type.
- This PR corrects the list to mention the exact volume type.