### PR TITLE
Clarify that HPA controller searches for labels 

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -56,8 +56,9 @@ Kubernetes implements horizontal pod autoscaling as a control loop that runs int
 (and the default interval is 15 seconds).
 
 Once during each period, the controller manager queries the resource utilization against the
-metrics specified in each HorizontalPodAutoscaler definition.  The controller manager
-obtains the metrics from either the resource metrics API (for per-pod resource metrics),
+metrics specified in each HorizontalPodAutoscaler definition.  The controller manager 
+finds the target resource defined by the `scaleTargetRef`,
+then selects the pods based on the target resource's `.spec.selector` labels, and obtains the metrics from either the resource metrics API (for per-pod resource metrics),
 or the custom metrics API (for all other metrics).
 
 * For per-pod resource metrics (like CPU), the controller fetches the metrics


### PR DESCRIPTION
closes #31451 - [link](https://github.com/kubernetes/website/issues/31451)

Added the clarification that the HPA controller looks for labels of the target object and not the target object resource.

I thought about adding a new section that explains how the HPA controller finds the right pods but this short fix seems better.

Verified using:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: cpu-stress-no-stress
  namespace: default
  labels:
    app: cpu-stress
    stress: cpu
spec:
  replicas: 1
  selector:
    matchLabels:
      app: cpu-stress
      stress: cpu
  template:
    metadata:
      labels:
        app: cpu-stress
        stress: cpu
    spec:
      containers:
      - name: nothing
        image: nginx
      - name: cpu-demo1
        image: nginx
        resources:
          requests:
            cpu: "250m"
          limits:
            cpu: "500m"
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: cpu-stress
  namespace: default
  labels:
    app: cpu-stress
    stress: cpu
spec:
  replicas: 1
  selector:
    matchLabels:
      app: cpu-stress
      stress: cpu
  template:
    metadata:
      labels:
        app: cpu-stress
        stress: cpu
    spec:
      containers:
      - name: nothing
        image: nginx
        resources:
          requests:
            cpu: "250m"
          limits:
            cpu: "500m"
      - name: cpu-demo1
        image: polinux/stress
        command: ["stress"]
        args: ["--cpu", "2"]
        resources:
          requests:
            cpu: "250m"
          limits:
            cpu: "500m"
---
apiVersion: autoscaling/v1
kind: HorizontalPodAutoscaler
metadata:
  name: cpu-stress-hpa
  namespace: default
spec:
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: cpu-stress
  minReplicas: 1
  maxReplicas: 5
  targetCPUUtilizationPercentage: 50
```