### PR TITLE
Direct support query submitters to Server Fault

### DIFF
--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -11,7 +11,7 @@ STOP -- PLEASE READ!
 
 GitHub is not the right place for support requests.
 
-If you're looking for help, check [Stack Overflow](https://stackoverflow.com/questions/tagged/kubernetes)
+If you're looking for help, check [Server Fault](https://serverfault.com/questions/tagged/kubernetes).
 
 You can also post your question on the [Kubernetes Slack](http://slack.k8s.io/) or the [Discuss Kubernetes](https://discuss.kubernetes.io/) forum.
 


### PR DESCRIPTION
When people are about to ask a support question, signpost them using the right URL for Server Fault queries tagged Kubernetes, not the wrong URL for Stack Overflow (which is more about workload / app development help).

/language en