### PR TITLE
Update TLS doc to use example signer for arbitrary https server

### DIFF
--- a/content/en/examples/tls/server-signing-config.json
+++ b/content/en/examples/tls/server-signing-config.json
@@ -1,0 +1,15 @@
+{
+    "signing": {
+        "default": {
+            "usages": [
+                "digital signature",
+                "key encipherment",
+                "server auth"
+            ],
+            "expiry": "876000h",
+            "ca_constraint": {
+                "is_ca": false
+            }
+        }
+    }
+}


### PR DESCRIPTION
The current doc encourages use of the kubelet-serving signer for arbitrary https serving certificates, which is incorrect.

This updates the doc to use an example signer, and demonstrates how all actors against the CSR API work:
* requester submitting CSR
* approver
* signer
* requester retrieving and using the CSR

/sig auth
/cc @deads2k @nckturner 

preview at https://deploy-preview-31591--kubernetes-io-main-staging.netlify.app/docs/tasks/tls/managing-tls-in-a-cluster/