### PR TITLE
Add Sysbox as an option to run kubernetes inside unprivileged containers or pods.

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubelet-in-userns.md
+++ b/content/en/docs/tasks/administer-cluster/kubelet-in-userns.md
@@ -49,6 +49,24 @@ Rootless Podman is not supported.
 
 <!-- Supporting rootless podman is discussed in https://github.com/kubernetes/minikube/issues/8719 -->
 
+## Running Kubernetes inside Unprivileged Containers
+
+{{% thirdparty-content %}}
+
+### sysbox
+
+[Sysbox](https://github.com/nestybox/sysbox) is an open-source container runtime
+(similar to "runc") that supports running system-level workloads such as Docker
+and Kubernetes inside unprivileged containers isolated with the Linux user
+namespace.
+
+See [Sysbox Quick Start Guide: Kubernetes-in-Docker](https://github.com/nestybox/sysbox/blob/master/docs/quickstart/kind.md) for more info.
+
+Sysbox supports running Kubernetes inside unprivileged containers without
+requiring Cgroup v2 and without the `KubeletInUserNamespace` feature gate. It
+does this by exposing specially crafted `/proc` and `/sys` filesystems inside
+the container plus several other advanced OS virtualization techniques.
+
 ## Running Rootless Kubernetes directly on a host
 
 {{% thirdparty-content %}}
@@ -235,7 +253,7 @@ This feature gate also allows kube-proxy to ignore an error during setting `RLIM
 The `KubeletInUserNamespace` feature gate was introduced in Kubernetes v1.22 with "alpha" status.
 
 Running kubelet in a user namespace without using this feature gate is also possible
-by mounting a specially crafted proc filesystem, but not officially supported.
+by mounting a specially crafted proc filesystem (as done by [Sysbox](https://github.com/nestybox/sysbox)), but not officially supported.
 
 ### Configuring kube-proxy
 
@@ -272,4 +290,3 @@ on the rootlesscontaine.rs website.
 - [Usernetes](https://github.com/rootless-containers/usernetes)
 - [Running K3s with rootless mode](https://rancher.com/docs/k3s/latest/en/advanced/#running-k3s-with-rootless-mode-experimental)
 - [KEP-2033: Kubelet-in-UserNS (aka Rootless mode)](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2033-kubelet-in-userns-aka-rootless)
-


### PR DESCRIPTION
Sysbox is an open-source container runtime (similar to "runc") that supports running VM-workloads such as Docker and Kubernetes inside unprivileged containers or pods.

Sysbox containers always use the Linux user-namespace for isolation, plus specially crafted proc and sys filesystems, some syscall interception, filesystem ID-mapping, and more.

It's possible to run Kubernetes, K3s, K0s, inside containers or pods deployed with Sysbox. This commit aims to make the Kubernetes community aware of this option.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>