### PR TITLE
Mark blogs older than a year as outdated

### DIFF
--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -202,10 +202,10 @@ other = "Objectives"
 [options_heading]
 other = "Options"
 
-[outdated_blog_over_one_year_old]
+[outdated_blog__message]
 other = "The Kubernetes project considers this article to be outdated because it is more than one year old. Check that the information in the page has not become incorrect since its publication."
 
-[outdated_blog_title]
+[outdated_blog__title]
 other = "Outdated article"
 
 [post_create_issue]

--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -202,6 +202,14 @@ other = "Objectives"
 [options_heading]
 other = "Options"
 
+[outdated_page_message]
+other = "Kubernetes authors consider this page to be outdated because REASON. We suggest that you use more recent resources."
+[outdated_page_reason]
+other = "it is more than a year old"
+
+[outdated_page_title]
+other = "Outdated page"
+
 [post_create_issue]
 other = "Create an issue"
 

--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -208,7 +208,7 @@ other = "Kubernetes authors consider this page to be outdated because REASON. We
 other = "it is more than a year old"
 
 [outdated_page_title]
-other = "Outdated page"
+other = "Outdated article"
 
 [post_create_issue]
 other = "Create an issue"

--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -202,12 +202,10 @@ other = "Objectives"
 [options_heading]
 other = "Options"
 
-[outdated_page_message]
-other = "Kubernetes authors consider this page to be outdated because REASON. We suggest that you use more recent resources."
-[outdated_page_reason]
-other = "it is more than a year old"
+[outdated_blog_over_one_year_old]
+other = "The Kubernetes project considers this article to be outdated because it is more than one year old. Check that the information in the page has not become incorrect since its publication."
 
-[outdated_page_title]
+[outdated_blog_title]
 other = "Outdated article"
 
 [post_create_issue]

--- a/layouts/partials/deprecation-warning.html
+++ b/layouts/partials/deprecation-warning.html
@@ -15,7 +15,7 @@
 <section id="deprecation-warning" class="blog-outdated-warning">
   <div class="content deprecation-warning pageinfo">
     <h3>{{ $title }}</h3>
-    <p> {{ $msg }}</p>
+    <p>{{ $msg }}</p>
   </div>
 </section>
 {{ end }}

--- a/layouts/partials/deprecation-warning.html
+++ b/layouts/partials/deprecation-warning.html
@@ -10,10 +10,8 @@
   </div>
 </section>
 {{ else if and (eq .Section "blog") .Date (.Date.Before (now.AddDate -1 0 0)) -}}
-{{ $title := .Param "outdated_page.title" | default (T "outdated_page_title") -}}
-{{ $msg := .Param "outdated_page.message" | default (T "outdated_page_message") -}}
-{{ $reason := .Param "outdated_page.reason" | default (T "outdated_page_reason") -}}
-{{ $msg = replaceRE "REASON" $reason $msg -}}
+{{ $title := .Param "outdated_blog.title" | default (T "outdated_blog_title") -}}
+{{ $msg := .Param "outdated_blog.message" | default (T "outdated_blog_over_one_year_old")  -}}
 <section id="deprecation-warning" class="blog-outdated-warning">
   <div class="content deprecation-warning pageinfo">
     <h3>{{ $title }}</h3>

--- a/layouts/partials/deprecation-warning.html
+++ b/layouts/partials/deprecation-warning.html
@@ -14,7 +14,7 @@
 {{ $msg := .Param "outdated_page.message" | default (T "outdated_page_message") -}}
 {{ $reason := .Param "outdated_page.reason" | default (T "outdated_page_reason") -}}
 {{ $msg = replaceRE "REASON" $reason $msg -}}
-<section id="deprecation-warning">
+<section id="deprecation-warning" class="blog-outdated-warning">
   <div class="content deprecation-warning pageinfo">
     <h3>{{ $title }}</h3>
     <p> {{ $msg }}</p>

--- a/layouts/partials/deprecation-warning.html
+++ b/layouts/partials/deprecation-warning.html
@@ -10,12 +10,10 @@
   </div>
 </section>
 {{ else if and (eq .Section "blog") .Date (.Date.Before (now.AddDate -1 0 0)) -}}
-{{ $title := .Param "outdated_blog.title" | default (T "outdated_blog_title") -}}
-{{ $msg := .Param "outdated_blog.message" | default (T "outdated_blog_over_one_year_old")  -}}
-<section id="deprecation-warning" class="blog-outdated-warning">
+<section id="deprecation-warning" class="outdated-blog">
   <div class="content deprecation-warning pageinfo">
-    <h3>{{ $title }}</h3>
-    <p>{{ $msg }}</p>
+    <h3>{{ T "outdated_blog__title" }}</h3>
+    <p>{{ T "outdated_blog__message" }}</p>
   </div>
 </section>
 {{ end }}

--- a/layouts/partials/deprecation-warning.html
+++ b/layouts/partials/deprecation-warning.html
@@ -9,4 +9,15 @@
     </p>
   </div>
 </section>
+{{ else if and (eq .Section "blog") .Date (.Date.Before (now.AddDate -1 0 0)) -}}
+{{ $title := .Param "outdated_page.title" | default (T "outdated_page_title") -}}
+{{ $msg := .Param "outdated_page.message" | default (T "outdated_page_message") -}}
+{{ $reason := .Param "outdated_page.reason" | default (T "outdated_page_reason") -}}
+{{ $msg = replaceRE "REASON" $reason $msg -}}
+<section id="deprecation-warning">
+  <div class="content deprecation-warning pageinfo">
+    <h3>{{ $title }}</h3>
+    <p> {{ $msg }}</p>
+  </div>
+</section>
 {{ end }}


### PR DESCRIPTION
- Fixes #31043
- Works across languages.
- In addition to fixing #31043, this **supports marking a page as outdated for a reason other than its publication date**. For example, we could explicitly mark a page as outdated because it mentions the deprecated Dockershim. Currently, the partial code probes a page's params for this extra info. We could just as well pull it from i18n data -- or maybe that isn't worth the trouble since each language will have it's own version of blogs posts when they are translated. Anyhow, this extra feature is up for discussion. I can pull it out or change it.

**Preview**, for example, see:

- https://deploy-preview-31594--kubernetes-io-main-staging.netlify.app/blog/2018/12/12/kubernetes-federation-evolution has a banner
- https://deploy-preview-31594--kubernetes-io-main-staging.netlify.app/blog/2021/12/22/kubernetes-in-kubernetes-and-pxe-bootable-server-farm has no banner.

**Screenshot**:

![image](https://user-images.githubusercontent.com/4140793/152034651-f71f7478-2d42-4098-b910-145b1a727ef8.png)

/cc @nate-double-u 