### PR TITLE
Update TTL mechanism in Job to stable feature state

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -308,7 +308,7 @@ cleaned up by CronJobs based on the specified capacity-based cleanup policy.
 
 ### TTL mechanism for finished Jobs
 
-{{< feature-state for_k8s_version="v1.21" state="beta" >}}
+{{< feature-state for_k8s_version="v1.23" state="stable" >}}
 
 Another way to clean up finished Jobs (either `Complete` or `Failed`)
 automatically is to use a TTL mechanism provided by a


### PR DESCRIPTION
This PR updates feature state for [TTL mechanism](https://kubernetes.io/docs/concepts/workloads/controllers/job/#ttl-mechanism-for-finished-jobs) in Job with stable.
[According to here](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/), TTL mechanism (enabled by `TTLAfterFinished` feature gate) has been GA from k8s v1.23, so we can update "beta" to "stable".