### PR TITLE
add note to tell user how to run the ingress on a Mac

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -190,6 +190,8 @@ The following manifest defines an Ingress that sends traffic to your Service via
 
    {{< note >}}If you are running Minikube locally, use `minikube ip` to get the external IP. The IP address displayed within the ingress list will be the internal IP.{{< /note >}}
 
+   {{< note >}}If you are running Minikube locally on Mac, use `127.0.0.1` and run `minikube tunnel`.{{< /note >}}
+
     After you make this change, your web browser sends requests for
     hello-world.info URLs to Minikube.
 


### PR DESCRIPTION
Minikube's Mac and Linux behavior of ingress are a bit different in that Mac exposes the ingress to localhost and requires a tunnel.

My notes on the issue:
https://stackoverflow.com/questions/70961901/ingress-with-minikube-working-differently-on-mac-vs-ubuntu-when-to-set-etc-host
