### PR TITLE
Update Portuguese content to mention KubeCon 2022 conference

### DIFF
--- a/content/pt-br/_index.html
+++ b/content/pt-br/_index.html
@@ -42,12 +42,12 @@ O Kubernetes é Open Source, o que te oferece a liberdade de utilizá-lo em seu 
         <button id="desktopShowVideoButton" onclick="kub.showVideo()">Assista Video</button>
         <br>
         <br>
-        <a href="https://events.linuxfoundation.org/events/kubecon-cloudnativecon-europe-2019" button id="desktopKCButton">KubeCon em Barcelona on Maio 20-23, 2019</a>
+        <a href="https://events.linuxfoundation.org/events/kubecon-cloudnativecon-europe-2019" button id="desktopKCButton">KubeCon na Europa de 16 a 20 de maio de 2022</a>
         <br>
         <br>
         <br>
         <br>
-        <a href="https://www.lfasiallc.com/events/kubecon-cloudnativecon-china-2019" button id="desktopKCButton">KubeCon em Shanghai em Junho, 24-26 de 2019</a>
+        <a href="https://www.lfasiallc.com/events/kubecon-cloudnativecon-china-2019" button id="desktopKCButton">KubeCon na América do Norte de 24 a 28 de outubro de 2022</a>
 </div>
 <div id="videoPlayer">
     <iframe data-url="https://www.youtube.com/embed/H06qrNmGqyE?autoplay=1" frameborder="0" allowfullscreen></iframe>


### PR DESCRIPTION
Updated the _index.html file content/pt-br/_index.html to include the
latest links for the Cloud Native Computing Foundation’s  conference.
KubeCon + CloudNativeCon

Although  KubeCon conferences are over but they still have :

- KubeCon em Barcelona on Maio 20-23, 2019
- KubeCon em Shanghai em Junho, 24-26 de 2019

These have been updated to :

- KubeCon na Europa de 16 a 20 de maio de 2022
- KubeCon na América do Norte de 24 a 28 de outubro de 2022



Issue Fix : Update Portuguese content to mention KubeCon 2022 conference https://github.com/kubernetes/website/issues/31618