### PR TITLE
Recolor warning about old blog articles

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -402,6 +402,11 @@ body {
     color: #000;
 }
 
+.deprecation-warning.outdated-blog, .pageinfo.deprecation-warning.outdated-blog {
+    background-color: $blue;
+    color: $white;
+}
+
 body.td-home .deprecation-warning, body.td-blog .deprecation-warning, body.td-documentation .deprecation-warning {
     border-radius: 3px;
 }

--- a/layouts/partials/deprecation-warning.html
+++ b/layouts/partials/deprecation-warning.html
@@ -10,8 +10,8 @@
   </div>
 </section>
 {{ else if and (eq .Section "blog") .Date (.Date.Before (now.AddDate -1 0 0)) -}}
-<section id="deprecation-warning" class="outdated-blog">
-  <div class="content deprecation-warning pageinfo">
+<section id="deprecation-warning">
+  <div class="content deprecation-warning pageinfo outdated-blog">
     <h3>{{ T "outdated_blog__title" }}</h3>
     <p>{{ T "outdated_blog__message" }}</p>
   </div>


### PR DESCRIPTION
Use white on blue for the message about old blog articles. This color combination is on-brand and stands out, whilst looking less alarming than the black on yellow for old documentation versions.

Current (before) example: https://blog.k8s.io/2019/12/09/kubernetes-1-17-release-announcement/
Proposed (after) example: https://deploy-preview-31623--kubernetes-io-main-staging.netlify.app/blog/2019/12/09/kubernetes-1-17-release-announcement/