### PR TITLE
Fix the cascading deletion page

### DIFF
--- a/content/en/docs/tasks/administer-cluster/use-cascading-deletion.md
+++ b/content/en/docs/tasks/administer-cluster/use-cascading-deletion.md
@@ -5,7 +5,8 @@ content_type: task
 
 <!--overview-->
 
-This page shows you how to specify the type of [cascading deletion](/docs/concepts/workloads/controllers/garbage-collection/#cascading-deletion)
+This page shows you how to specify the type of
+[cascading deletion](/docs/concepts/architecture/garbage-collection/#cascading-deletion)
 to use in your cluster during {{<glossary_tooltip text="garbage collection" term_id="garbage-collection">}}.
 
 ## {{% heading "prerequisites" %}}
@@ -26,7 +27,7 @@ kubectl get pods -l app=nginx --output=yaml
 
 The output has an `ownerReferences` field similar to this:
 
-```
+```yaml
 apiVersion: v1
     ...
     ownerReferences:
@@ -41,7 +42,7 @@ apiVersion: v1
 
 ## Use foreground cascading deletion {#use-foreground-cascading-deletion}
 
-By default, Kubernetes uses [background cascading deletion](/docs/concepts/workloads/controllers/garbage-collection/#background-deletion)
+By default, Kubernetes uses [background cascading deletion](/docs/concepts/architecture/garbage-collection/#background-deletion)
 to delete dependents of an object. You can switch to foreground cascading deletion
 using either `kubectl` or the Kubernetes API, depending on the Kubernetes
 version your cluster runs. {{<version-check>}}
@@ -64,9 +65,9 @@ kubectl delete deployment nginx-deployment --cascade=foreground
 
 1. Start a local proxy session:
 
-    ```shell
-    kubectl proxy --port=8080
-    ```
+   ```shell
+   kubectl proxy --port=8080
+   ```
 
 1. Use `curl` to trigger deletion:
 
@@ -80,19 +81,19 @@ kubectl delete deployment nginx-deployment --cascade=foreground
    like this:
 
    ```
-    "kind": "Deployment",
-    "apiVersion": "apps/v1",
-    "metadata": {
-        "name": "nginx-deployment",
-        "namespace": "default",
-        "uid": "d1ce1b02-cae8-4288-8a53-30e84d8fa505",
-        "resourceVersion": "1363097",
-        "creationTimestamp": "2021-07-08T20:24:37Z",
-        "deletionTimestamp": "2021-07-08T20:27:39Z",
-        "finalizers": [
-          "foregroundDeletion"
-        ]
-        ...
+   "kind": "Deployment",
+   "apiVersion": "apps/v1",
+   "metadata": {
+       "name": "nginx-deployment",
+       "namespace": "default",
+       "uid": "d1ce1b02-cae8-4288-8a53-30e84d8fa505",
+       "resourceVersion": "1363097",
+       "creationTimestamp": "2021-07-08T20:24:37Z",
+       "deletionTimestamp": "2021-07-08T20:27:39Z",
+       "finalizers": [
+         "foregroundDeletion"
+       ]
+       ...
    ```
 
 {{% /tab %}}
@@ -104,9 +105,9 @@ For details, read the [documentation for your Kubernetes version](/docs/home/sup
 
 1. Start a local proxy session:
 
-    ```shell
-    kubectl proxy --port=8080
-    ```
+   ```shell
+   kubectl proxy --port=8080
+   ```
 
 1. Use `curl` to trigger deletion:
 
@@ -120,19 +121,19 @@ For details, read the [documentation for your Kubernetes version](/docs/home/sup
    like this:
 
    ```
-    "kind": "Deployment",
-    "apiVersion": "apps/v1",
-    "metadata": {
-        "name": "nginx-deployment",
-        "namespace": "default",
-        "uid": "d1ce1b02-cae8-4288-8a53-30e84d8fa505",
-        "resourceVersion": "1363097",
-        "creationTimestamp": "2021-07-08T20:24:37Z",
-        "deletionTimestamp": "2021-07-08T20:27:39Z",
-        "finalizers": [
-          "foregroundDeletion"
-        ]
-        ...
+   "kind": "Deployment",
+   "apiVersion": "apps/v1",
+   "metadata": {
+       "name": "nginx-deployment",
+       "namespace": "default",
+       "uid": "d1ce1b02-cae8-4288-8a53-30e84d8fa505",
+       "resourceVersion": "1363097",
+       "creationTimestamp": "2021-07-08T20:24:37Z",
+       "deletionTimestamp": "2021-07-08T20:27:39Z",
+       "finalizers": [
+         "foregroundDeletion"
+       ]
+       ...
    ```
 {{% /tab %}}
 {{</tabs>}}
@@ -165,32 +166,32 @@ kubectl delete deployment nginx-deployment --cascade=background
 
 1. Start a local proxy session:
 
-    ```shell
-    kubectl proxy --port=8080
-    ```
+   ```shell
+   kubectl proxy --port=8080
+   ```
 
 1. Use `curl` to trigger deletion:
 
-    ```shell
-    curl -X DELETE localhost:8080/apis/apps/v1/namespaces/default/deployments/nginx-deployment \
-        -d '{"kind":"DeleteOptions","apiVersion":"v1","propagationPolicy":"Background"}' \
-        -H "Content-Type: application/json"
-    ```
+   ```shell
+   curl -X DELETE localhost:8080/apis/apps/v1/namespaces/default/deployments/nginx-deployment \
+       -d '{"kind":"DeleteOptions","apiVersion":"v1","propagationPolicy":"Background"}' \
+       -H "Content-Type: application/json"
+   ```
 
-    The output is similar to this:
+   The output is similar to this:
 
-    ```
-    "kind": "Status",
-    "apiVersion": "v1",
-    ...
-    "status": "Success",
-    "details": {
-        "name": "nginx-deployment",
-        "group": "apps",
-        "kind": "deployments",
-        "uid": "cc9eefb9-2d49-4445-b1c1-d261c9396456"
-    }
-    ```
+   ```
+   "kind": "Status",
+   "apiVersion": "v1",
+   ...
+   "status": "Success",
+   "details": {
+       "name": "nginx-deployment",
+       "group": "apps",
+       "kind": "deployments",
+       "uid": "cc9eefb9-2d49-4445-b1c1-d261c9396456"
+   }
+   ```
 {{% /tab %}}
 {{% tab name="Versions prior to Kubernetes 1.20.x" %}}
 Kubernetes uses background cascading deletion by default, and does so
@@ -211,32 +212,32 @@ kubectl delete deployment nginx-deployment --cascade=true
 
 1. Start a local proxy session:
 
-    ```shell
-    kubectl proxy --port=8080
-    ```
+   ```shell
+   kubectl proxy --port=8080
+   ```
 
 1. Use `curl` to trigger deletion:
 
-    ```shell
-    curl -X DELETE localhost:8080/apis/apps/v1/namespaces/default/deployments/nginx-deployment \
-        -d '{"kind":"DeleteOptions","apiVersion":"v1","propagationPolicy":"Background"}' \
-        -H "Content-Type: application/json"
-    ```
+   ```shell
+   curl -X DELETE localhost:8080/apis/apps/v1/namespaces/default/deployments/nginx-deployment \
+       -d '{"kind":"DeleteOptions","apiVersion":"v1","propagationPolicy":"Background"}' \
+       -H "Content-Type: application/json"
+   ```
 
-    The output is similar to this:
+   The output is similar to this:
 
-    ```
-    "kind": "Status",
-    "apiVersion": "v1",
-    ...
-    "status": "Success",
-    "details": {
-        "name": "nginx-deployment",
-        "group": "apps",
-        "kind": "deployments",
-        "uid": "cc9eefb9-2d49-4445-b1c1-d261c9396456"
-    }
-    ```
+   ```
+   "kind": "Status",
+   "apiVersion": "v1",
+   ...
+   "status": "Success",
+   "details": {
+       "name": "nginx-deployment",
+       "group": "apps",
+       "kind": "deployments",
+       "uid": "cc9eefb9-2d49-4445-b1c1-d261c9396456"
+   }
+   ```
 {{% /tab %}}
 {{</tabs>}}
 
@@ -264,33 +265,33 @@ kubectl delete deployment nginx-deployment --cascade=orphan
 
 1. Start a local proxy session:
 
-    ```shell
-    kubectl proxy --port=8080
-    ```
+   ```shell
+   kubectl proxy --port=8080
+   ```
 
 1. Use `curl` to trigger deletion:
 
-    ```shell
-    curl -X DELETE localhost:8080/apis/apps/v1/namespaces/default/deployments/nginx-deployment \
-        -d '{"kind":"DeleteOptions","apiVersion":"v1","propagationPolicy":"Orphan"}' \
-        -H "Content-Type: application/json"
-    ```
+   ```shell
+   curl -X DELETE localhost:8080/apis/apps/v1/namespaces/default/deployments/nginx-deployment \
+       -d '{"kind":"DeleteOptions","apiVersion":"v1","propagationPolicy":"Orphan"}' \
+       -H "Content-Type: application/json"
+   ```
 
-    The output contains `orphan` in the `finalizers` field, similar to this:
+   The output contains `orphan` in the `finalizers` field, similar to this:
 
-    ```
-    "kind": "Deployment",
-    "apiVersion": "apps/v1",
-    "namespace": "default",
-    "uid": "6f577034-42a0-479d-be21-78018c466f1f",
-    "creationTimestamp": "2021-07-09T16:46:37Z",
-    "deletionTimestamp": "2021-07-09T16:47:08Z",
-    "deletionGracePeriodSeconds": 0,
-    "finalizers": [
-      "orphan"
-    ],
-    ...
-    ```
+   ```
+   "kind": "Deployment",
+   "apiVersion": "apps/v1",
+   "namespace": "default",
+   "uid": "6f577034-42a0-479d-be21-78018c466f1f",
+   "creationTimestamp": "2021-07-09T16:46:37Z",
+   "deletionTimestamp": "2021-07-09T16:47:08Z",
+   "deletionGracePeriodSeconds": 0,
+   "finalizers": [
+     "orphan"
+   ],
+   ...
+   ```
 
 {{% /tab %}}
 {{% tab name="Versions prior to Kubernetes 1.20.x" %}}
@@ -309,33 +310,33 @@ kubectl delete deployment nginx-deployment --cascade=orphan
 
 1. Start a local proxy session:
 
-    ```shell
-    kubectl proxy --port=8080
-    ```
+   ```shell
+   kubectl proxy --port=8080
+   ```
 
 1. Use `curl` to trigger deletion:
 
-    ```shell
-    curl -X DELETE localhost:8080/apis/apps/v1/namespaces/default/deployments/nginx-deployment \
-        -d '{"kind":"DeleteOptions","apiVersion":"v1","propagationPolicy":"Orphan"}' \
-        -H "Content-Type: application/json"
-    ```
+   ```shell
+   curl -X DELETE localhost:8080/apis/apps/v1/namespaces/default/deployments/nginx-deployment \
+       -d '{"kind":"DeleteOptions","apiVersion":"v1","propagationPolicy":"Orphan"}' \
+       -H "Content-Type: application/json"
+   ```
 
-    The output contains `orphan` in the `finalizers` field, similar to this:
+   The output contains `orphan` in the `finalizers` field, similar to this:
 
-    ```
-    "kind": "Deployment",
-    "apiVersion": "apps/v1",
-    "namespace": "default",
-    "uid": "6f577034-42a0-479d-be21-78018c466f1f",
-    "creationTimestamp": "2021-07-09T16:46:37Z",
-    "deletionTimestamp": "2021-07-09T16:47:08Z",
-    "deletionGracePeriodSeconds": 0,
-    "finalizers": [
-      "orphan"
-    ],
-    ...
-    ```
+   ```
+   "kind": "Deployment",
+   "apiVersion": "apps/v1",
+   "namespace": "default",
+   "uid": "6f577034-42a0-479d-be21-78018c466f1f",
+   "creationTimestamp": "2021-07-09T16:46:37Z",
+   "deletionTimestamp": "2021-07-09T16:47:08Z",
+   "deletionGracePeriodSeconds": 0,
+   "finalizers": [
+     "orphan"
+   ],
+   ...
+   ```
 {{% /tab %}}
 {{</tabs>}}
 
@@ -349,4 +350,4 @@ kubectl get pods -l app=nginx
 
 * Learn about [owners and dependents](/docs/concepts/overview/working-with-objects/owners-dependents/) in Kubernetes.
 * Learn about Kubernetes [finalizers](/docs/concepts/overview/working-with-objects/finalizers/).
-* Learn about [garbage collection](/docs/concepts/workloads/controllers/garbage-collection/).
+* Learn about [garbage collection](/docs/concepts/architecture/garbage-collection/).


### PR DESCRIPTION
This PR fixes two problems in the cascading deletion page:

- The indentation of list items should be 2 spaces for unordered lists,
  or 3 spaces for ordered lists. We should avoid using 4 spaces as
  indentation because 4-spaces indentation has special meaning in
  markdown.
- The garbage-collection page was moved to a new place. With redirect
  records for English site, there seems no obvious problems. However,
  for localization teams, such redirection records don't exist. It is
  super easy to create a dangling link in localized pages.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
