### PR TITLE
Remove deprecated `--record` flag from example

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/kubernetes-objects.md
+++ b/content/en/docs/concepts/overview/working-with-objects/kubernetes-objects.md
@@ -63,7 +63,7 @@ One way to create a Deployment using a `.yaml` file like the one above is to use
 in the `kubectl` command-line interface, passing the `.yaml` file as an argument. Here's an example:
 
 ```shell
-kubectl apply -f https://k8s.io/examples/application/deployment.yaml --record
+kubectl apply -f https://k8s.io/examples/application/deployment.yaml
 ```
 
 The output is similar to this:


### PR DESCRIPTION
Trying to use this flag `--record` in the example leads to the warning:
```
Flag --record has been deprecated, --record will be removed in the future
```
It should be removed from the docs if it will no longer be supported.