### PR TITLE
Fix incorrect markup for navbar

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -10,7 +10,7 @@
 			{{ with site.GetPage "section" . }}
 			<li class="nav-item mr-2 mb-lg-0">
 				{{ $active := eq .Section $.Section }}
-				<a class="nav-link{{if $active }} active{{end}}" href="{{ .RelPermalink }}" >{{ .Title }}</span></a>
+				<a class="nav-link{{if $active }} active{{end}}" href="{{ .RelPermalink }}" >{{ .Title }}</a>
 			</li>
 			{{ end }}
 			{{ end }}


### PR DESCRIPTION
Remove a vestigial `</span>` from the navbar partial.

/area web-development