### PR TITLE
Wrong policy key in Auditing page #31640

### DIFF
--- a/content/en/examples/audit/audit-policy.yaml
+++ b/content/en/examples/audit/audit-policy.yaml
@@ -27,7 +27,7 @@ rules:
   # Don't log watch requests by the "system:kube-proxy" on endpoints or services
   - level: None
     users: ["system:kube-proxy"]
-    verbs: ["watch"]
+    verb: ["watch"]
     resources:
     - group: "" # core API group
       resources: ["endpoints", "services"]


### PR DESCRIPTION
Updated the key in audit page , bcz of it kube-api contianer was failing to get created and showing-
Error: loading audit policy file: failed decoding: yaml: line 6: did not find expected key: from file /etc/kubernetes/prod-audit.yaml