### PR TITLE
kubeadm: update legacy kubelet config map information and document feature gates

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -129,6 +129,62 @@ the [kubeadm config migrate](/docs/reference/setup-tools/kubeadm/kubeadm-config/
 For more information on the fields and usage of the configuration you can navigate to our
 [API reference page](/docs/reference/config-api/kubeadm-config.v1beta3/).
 
+### Using kubeadm init with feature gates {#feature-gates}
+
+Kubeadm supports a set of feature gates that are unique to kubeadm and can only be applied
+during cluster creation with `kubeadm init`. These features can control the behavior
+of the cluster. Feature gates are removed after a feature graduates to GA.
+
+To pass a feature gate you can either use the `--feature-gates` flag for
+`kubeadm init`, or you can add items into the `featureGates` field when you pass
+a [configuration file](/docs/reference/config-api/kubeadm-config.v1beta3/#kubeadm-k8s-io-v1beta3-ClusterConfiguration)
+using `--config`.
+
+Passing [feature gates for core Kubernetes components](/docs/reference/command-line-tools-reference/feature-gates)
+directly to kubeadm is not supported. Instead, it is possible to pass them by
+[Customizing components with the kubeadm API](/docs/setup/production-environment/tools/kubeadm/control-plane-flags/).
+
+List of feature gates:
+
+{{< table caption="kubeadm feature gates" >}}
+Feature | Default | Alpha | Beta
+:-------|:--------|:------|:-----
+`PublicKeysECDSA` | `false` | 1.19 | -
+`RootlessControlPlane` | `false` | 1.22 | -
+`UnversionedKubeletConfigMap` | `true` | 1.22 | 1.23
+{{< /table >}}
+
+{{< note >}}
+Once a feature gate goes GA it is removed from this list as its value becomes locked to `true` by default.
+{{< /note >}}
+
+Feature gate descriptions:
+
+`PublicKeysECDSA`
+: Can be used to create a cluster that uses ECDSA certificates instead of the default RSA algorithm.
+Renewal of existing ECDSA certificates is also supported using `kubeadm certs renew`, but you cannot
+switch between the RSA and ECDSA algorithms on the fly or during upgrades.
+
+`RootlessControlPlane`
+: Setting this flag configures the kubeadm deployed control plane component static Pod containers
+for `kube-apiserver`, `kube-controller-manager`, `kube-scheduler` and `etcd` to run as non-root users.
+If the flag is not set, those components run as root. You can change the value of this feature gate before
+you upgrade to a newer version of Kubernetes.
+
+`UnversionedKubeletConfigMap`
+: This flag controls the name of the {{< glossary_tooltip text="ConfigMap" term_id="configmap" >}} where kubeadm stores
+kubelet configuration data. With this flag not specified or set to `true`, the ConfigMap is named `kubelet-config`.
+If you set this flag to `false`, the name of the ConfigMap includes the major and minor version for Kubernetes
+(for example: `kubelet-config-{{< skew currentVersion >}}`). Kubeadm ensures that RBAC rules for reading and writing
+that ConfigMap are appropriate for the value you set. When kubeadm writes this ConfigMap (during `kubeadm init`
+or `kubeadm upgrade apply`), kubeadm respects the value of `UnversionedKubeletConfigMap`. When reading that ConfigMap
+(during `kubeadm join`, `kubeadm reset`, `kubeadm upgrade ...`), kubeadm attempts to use unversioned ConfigMap name first;
+if that does not succeed, kubeadm falls back to using the legacy (versioned) name for that ConfigMap.
+
+{{< note >}}
+Setting `UnversionedKubeletConfigMap` to `false` is supported but **deprecated**.
+{{< /note >}}
+
 ### Adding kube-proxy parameters {#kube-proxy}
 
 For information about kube-proxy parameters in the kubeadm configuration see:

--- a/content/en/docs/setup/production-environment/tools/kubeadm/kubelet-integration.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/kubelet-integration.md
@@ -103,10 +103,9 @@ for more information on the individual fields.
 ### Workflow when using `kubeadm init`
 
 When you call `kubeadm init`, the kubelet configuration is marshalled to disk
-at `/var/lib/kubelet/config.yaml`, and also uploaded to a ConfigMap in the cluster. The ConfigMap
-is named `kubelet-config-1.X`, where `X` is the minor version of the Kubernetes version you are
-initializing. A kubelet configuration file is also written to `/etc/kubernetes/kubelet.conf` with the
-baseline cluster-wide configuration for all kubelets in the cluster. This configuration file
+at `/var/lib/kubelet/config.yaml`, and also uploaded to a `kubelet-config` ConfigMap in the `kube-system`
+namespace of the cluster. A kubelet configuration file is also written to `/etc/kubernetes/kubelet.conf`
+with the baseline cluster-wide configuration for all kubelets in the cluster. This configuration file
 points to the client certificates that allow the kubelet to communicate with the API server. This
 addresses the need to
 [propagate cluster-level configuration to each kubelet](#propagating-cluster-level-configuration-to-each-kubelet).
@@ -137,7 +136,7 @@ If the reload and restart are successful, the normal `kubeadm init` workflow con
 
 When you run `kubeadm join`, kubeadm uses the Bootstrap Token credential to perform
 a TLS bootstrap, which fetches the credential needed to download the
-`kubelet-config-1.X` ConfigMap and writes it to `/var/lib/kubelet/config.yaml`. The dynamic
+`kubelet-config` ConfigMap and writes it to `/var/lib/kubelet/config.yaml`. The dynamic
 environment file is generated in exactly the same way as `kubeadm init`.
 
 Next, `kubeadm` runs the following two commands to load the new configuration into the kubelet:

--- a/content/en/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver.md
@@ -96,9 +96,7 @@ nodes before deleting the old nodes.
 
 ### Modify the kubelet ConfigMap
 
-- Find the kubelet ConfigMap name using `kubectl get cm -n kube-system | grep kubelet-config`.
-- Call `kubectl edit cm kubelet-config-x.yy -n kube-system` (replace `x.yy` with
-the Kubernetes version).
+- Call `kubectl edit cm kubelet-config -n kube-system`.
 - Either modify the existing `cgroupDriver` value or add a new field that looks like this:
 
   ```yaml


### PR DESCRIPTION
has two separate commits.
- first removes some instances of the legacy naming (kubelet-config-x.yy), controller by the UnversionedKubeletConfigMap feature which becomes beta in 1.24 and is enabled by default.
- second documents the current state of feature gates

fixes https://github.com/kubernetes/website/issues/28788
xref https://github.com/kubernetes/kubeadm/issues/1582
