### PR TITLE
Change language so that docker is an example

### DIFF
--- a/content/en/docs/tasks/debug-application-cluster/debug-pod-replication-controller.md
+++ b/content/en/docs/tasks/debug-application-cluster/debug-pod-replication-controller.md
@@ -86,8 +86,8 @@ worker node, but it can't run on that machine. Again, the information from
 
 * Make sure that you have the name of the image correct.
 * Have you pushed the image to the repository?
-* Run a manual `docker pull <image>` on your machine to see if the image can be
-  pulled.
+* Try to manually pull the image to see if it can be pulled. For example, if you
+  use Docker on your PC, run `docker pull <image>`.
 
 ### My pod is crashing or otherwise unhealthy
 


### PR DESCRIPTION
Related to #30976

Mirrors the wording in #31679 to remove docker pull as the *de facto* command and instead make it an example of a manual image pull.

/sig docs
/language en