### PR TITLE
Update memory-default-namespace.md

### DIFF
--- a/content/en/docs/tasks/administer-cluster/manage-resources/memory-default-namespace.md
+++ b/content/en/docs/tasks/administer-cluster/manage-resources/memory-default-namespace.md
@@ -13,7 +13,7 @@ This page shows how to configure default memory requests and limits for a
 {{< glossary_tooltip text="namespace" term_id="namespace" >}}.
 
 A Kubernetes cluster can be divided into namespaces. Once you have a namespace that
-that has a default memory
+has a default memory
 [limit](/docs/concepts/configuration/manage-resources-containers/#requests-and-limits),
 and you then try to create a Pod with a container that does not specify its own memory
 limit its own memory limit, then the


### PR DESCRIPTION
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/

In the section **Configure Default Memory Requests and Limits for a Namespace**, the below paragraph has `that` mentioned twice:
```
A Kubernetes cluster can be divided into namespaces. Once you have a namespace that `that` has a default memory [limit](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits), and you then try to create a Pod with a container that does not specify its own memory limit its own memory limit, then the [control plane](https://kubernetes.io/docs/reference/glossary/?all=true#term-control-plane) assigns the default memory limit to that container.
```
https://github.com/kubernetes/website/commit/a191d716276b9fb951b1f99e2380c4c626396edd
