### PR TITLE
Update memory-default-namespace.md

### DIFF
--- a/content/en/docs/tasks/administer-cluster/manage-resources/memory-default-namespace.md
+++ b/content/en/docs/tasks/administer-cluster/manage-resources/memory-default-namespace.md
@@ -16,7 +16,7 @@ A Kubernetes cluster can be divided into namespaces. Once you have a namespace t
 has a default memory
 [limit](/docs/concepts/configuration/manage-resources-containers/#requests-and-limits),
 and you then try to create a Pod with a container that does not specify its own memory
-limit its own memory limit, then the
+limit, then the
 {{< glossary_tooltip text="control plane" term_id="control-plane" >}} assigns the default
 memory limit to that container.
 


### PR DESCRIPTION
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
In the section Configure Default Memory Requests and Limits for a Namespace, the below paragraph has `its own memory limit` mentioned twice:
```
A Kubernetes cluster can be divided into namespaces. Once you have a namespace that has a default memory [limit](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits), and you then try to create a Pod with a container that does not specify its own memory limit `its own memory limit`, then the [control plane](https://kubernetes.io/docs/reference/glossary/?all=true#term-control-plane) assigns the default memory limit to that container.
```
