### PR TITLE
Update line breaks of comments

### DIFF
--- a/content/ja/docs/reference/kubectl/cheatsheet.md
+++ b/content/ja/docs/reference/kubectl/cheatsheet.md
@@ -293,8 +293,8 @@ kubectl logs -f my-pod                              # Podのログをストリ�
 kubectl logs -f my-pod -c my-container              # 複数のコンテナがあるPodで、特定のコンテナのログをストリームで確認します(標準出力)
 kubectl logs -f -l name=myLabel --all-containers    # name-myLabelラベルを持つすべてのコンテナのログをストリームで確認します(標準出力)
 kubectl run -i --tty busybox --image=busybox -- sh  # Podをインタラクティブシェルとして実行します
-kubectl run nginx --image=nginx -n 
-mynamespace                                         # 特定の名前空間でnginx Podを実行します
+kubectl run nginx --image=nginx -n                  # 特定の名前空間でnginx Podを実行します 
+mynamespace
 kubectl run nginx --image=nginx                     # nginx Podを実行し、マニフェストファイルをpod.yamlという名前で書き込みます
 --dry-run=client -o yaml > pod.yaml
 kubectl attach my-pod -i                            # 実行中のコンテナに接続します


### PR DESCRIPTION
下のコマンドに書き方を合わせて、2行コマンドがある場合、1行目の横にコメントが書かれているようにしました。

```
kubectl run nginx --image=nginx -n                  # 特定の名前空間でnginx Podを実行します 
mynamespace                                         
kubectl run nginx --image=nginx                     # nginx Podを実行し、マニフェストファイルをpod.yamlという名前で書き込みます
--dry-run=client -o yaml > pod.yaml
```

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
