### PR TITLE
Add secure example for getting secret values

### DIFF
--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
@@ -130,6 +130,12 @@ The output is similar to:
 Now you can decode the `password` data:
 
 ```shell
+# This is an example for documentation purposes.
+# If you did things this way, the data 'MWYyZDFlMmU2N2Rm' could be stored in
+# your shell history.
+# Someone with access to you computer could find that remembered command
+# and base-64 decode the secret, perhaps without your knowledge.
+# It's usually better to combine the steps, as shown later in the page.
 echo 'MWYyZDFlMmU2N2Rm' | base64 --decode
 ```
 
@@ -138,6 +144,15 @@ The output is similar to:
 ```
 1f2d1e2e67df
 ```
+
+In order to avoid storing a secret encoded value in your shell history, you can
+run the following command:
+
+```shell
+kubectl get secret db-user-pass -o jsonpath='{.data.password}' | base64 --decode
+```
+
+The output shall be similar as above.
 
 ## Clean Up
 


### PR DESCRIPTION
The current example showing how to decode a secret
does it in several steps which is fine but if some level
of security is required will leak the encoded secret
value in the shell history thus making it retrievable.

This patch adds an example on how to retrieve that
value without exposing it.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
