### PR TITLE
[ja] fix translation cordon/uncordon

### DIFF
--- a/content/ja/docs/reference/kubectl/cheatsheet.md
+++ b/content/ja/docs/reference/kubectl/cheatsheet.md
@@ -309,7 +309,7 @@ kubectl top pod POD_NAME --containers               # 特定のPodとそのコ�
 ```bash
 kubectl cordon my-node                                                # my-nodeをスケジューリング不能に設定します
 kubectl drain my-node                                                 # メンテナンスの準備としてmy-nodeで動作中のPodを空にします
-kubectl uncordon my-node                                              # my-nodeにスケジューリングされるように設定します
+kubectl uncordon my-node                                              # my-nodeをスケジューリング可能に設定します
 kubectl top node my-node                                              # 特定のノードのメトリクスを表示します
 kubectl cluster-info                                                  # Kubernetesクラスターのマスターとサービスのアドレスを表示します
 kubectl cluster-info dump                                             # 現在のクラスター状態を標準出力にダンプします

--- a/content/ja/docs/reference/kubectl/cheatsheet.md
+++ b/content/ja/docs/reference/kubectl/cheatsheet.md
@@ -307,7 +307,7 @@ kubectl top pod POD_NAME --containers               # 特定のPodとそのコ�
 ## ノードおよびクラスターとの対話処理
 
 ```bash
-kubectl cordon my-node                                                # my-nodeにスケジューリングされないように設定します
+kubectl cordon my-node                                                # my-nodeをスケジューリング不能に設定します
 kubectl drain my-node                                                 # メンテナンスの準備としてmy-nodeで動作中のPodを空にします
 kubectl uncordon my-node                                              # my-nodeにスケジューリングされるように設定します
 kubectl top node my-node                                              # 特定のノードのメトリクスを表示します

--- a/content/ja/docs/reference/kubectl/cheatsheet.md
+++ b/content/ja/docs/reference/kubectl/cheatsheet.md
@@ -307,9 +307,9 @@ kubectl top pod POD_NAME --containers               # 特定のPodとそのコ�
 ## ノードおよびクラスターとの対話処理
 
 ```bash
-kubectl cordon my-node                                                # my-nodeをスケーリングされないように設定します
+kubectl cordon my-node                                                # my-nodeにスケジューリングされないように設定します
 kubectl drain my-node                                                 # メンテナンスの準備としてmy-nodeで動作中のPodを空にします
-kubectl uncordon my-node                                              # my-nodeをスケーリングされるように設定します
+kubectl uncordon my-node                                              # my-nodeにスケジューリングされるように設定します
 kubectl top node my-node                                              # 特定のノードのメトリクスを表示します
 kubectl cluster-info                                                  # Kubernetesクラスターのマスターとサービスのアドレスを表示します
 kubectl cluster-info dump                                             # 現在のクラスター状態を標準出力にダンプします


### PR DESCRIPTION
Fix translation of `cordon`/`uncordon`.

- `スケーリング` means `Scaling`
  -  [Google Translate](https://translate.google.com/?sl=auto&tl=en&text=%E3%82%B9%E3%82%B1%E3%83%BC%E3%83%AA%E3%83%B3%E3%82%B0&op=translate)
- `スケジューリング` means `Scheduling`
  - [Google Translate](https://translate.google.com/?sl=auto&tl=en&text=%E3%82%B9%E3%82%B1%E3%82%B8%E3%83%A5%E3%83%BC%E3%83%AA%E3%83%B3%E3%82%B0&op=translate)
