### PR TITLE
Add multi-container info on pod failure docs

### DIFF
--- a/content/en/docs/tasks/debug-application-cluster/determine-reason-pod-failure.md
+++ b/content/en/docs/tasks/debug-application-cluster/determine-reason-pod-failure.md
@@ -75,6 +75,11 @@ only the termination message:
 
         kubectl get pod termination-demo -o go-template="{{range .status.containerStatuses}}{{.lastState.terminated.message}}{{end}}"
 
+1. If you are running a multi-container pod, you can use a Go template to include the container's name. By doing so, you can discover which of the containers is failing (please note that the `multi-container-pod` creation is not covered in this exercise):
+
+        kubectl get pod multi-container-pod -o go-template='{{range .status.containerStatuses}}{{printf "%s:\n%s\n\n" .name .lastState.terminated.message}}{{end}}'
+
+
 ## Customizing the termination message
 
 Kubernetes retrieves termination messages from the termination message file

--- a/content/en/docs/tasks/debug-application-cluster/determine-reason-pod-failure.md
+++ b/content/en/docs/tasks/debug-application-cluster/determine-reason-pod-failure.md
@@ -75,7 +75,7 @@ only the termination message:
 
         kubectl get pod termination-demo -o go-template="{{range .status.containerStatuses}}{{.lastState.terminated.message}}{{end}}"
 
-1. If you are running a multi-container pod, you can use a Go template to include the container's name. By doing so, you can discover which of the containers is failing (please note that the `multi-container-pod` creation is not covered in this exercise):
+ If you are running a multi-container pod, you can use a Go template to include the container's name. By doing so, you can discover which of the containers is failing (please note that the `multi-container-pod` creation is not covered in this exercise):
 
         kubectl get pod multi-container-pod -o go-template='{{range .status.containerStatuses}}{{printf "%s:\n%s\n\n" .name .lastState.terminated.message}}{{end}}'
 

--- a/content/en/docs/tasks/debug-application-cluster/determine-reason-pod-failure.md
+++ b/content/en/docs/tasks/debug-application-cluster/determine-reason-pod-failure.md
@@ -77,8 +77,9 @@ only the termination message:
 
 If you are running a multi-container pod, you can use a Go template to include the container's name. By doing so, you can discover which of the containers is failing:
 
-        kubectl get pod multi-container-pod -o go-template='{{range .status.containerStatuses}}{{printf "%s:\n%s\n\n" .name .lastState.terminated.message}}{{end}}'
-
+```shell
+kubectl get pod multi-container-pod -o go-template='{{range .status.containerStatuses}}{{printf "%s:\n%s\n\n" .name .lastState.terminated.message}}{{end}}'
+```
 
 ## Customizing the termination message
 

--- a/content/en/docs/tasks/debug-application-cluster/determine-reason-pod-failure.md
+++ b/content/en/docs/tasks/debug-application-cluster/determine-reason-pod-failure.md
@@ -75,7 +75,7 @@ only the termination message:
 
         kubectl get pod termination-demo -o go-template="{{range .status.containerStatuses}}{{.lastState.terminated.message}}{{end}}"
 
- If you are running a multi-container pod, you can use a Go template to include the container's name. By doing so, you can discover which of the containers is failing (please note that the `multi-container-pod` creation is not covered in this exercise):
+ If you are running a multi-container pod, you can use a Go template to include the container's name. By doing so, you can discover which of the containers is failing:
 
         kubectl get pod multi-container-pod -o go-template='{{range .status.containerStatuses}}{{printf "%s:\n%s\n\n" .name .lastState.terminated.message}}{{end}}'
 

--- a/content/en/docs/tasks/debug-application-cluster/determine-reason-pod-failure.md
+++ b/content/en/docs/tasks/debug-application-cluster/determine-reason-pod-failure.md
@@ -75,7 +75,7 @@ only the termination message:
 
         kubectl get pod termination-demo -o go-template="{{range .status.containerStatuses}}{{.lastState.terminated.message}}{{end}}"
 
- If you are running a multi-container pod, you can use a Go template to include the container's name. By doing so, you can discover which of the containers is failing:
+If you are running a multi-container pod, you can use a Go template to include the container's name. By doing so, you can discover which of the containers is failing:
 
         kubectl get pod multi-container-pod -o go-template='{{range .status.containerStatuses}}{{printf "%s:\n%s\n\n" .name .lastState.terminated.message}}{{end}}'
 


### PR DESCRIPTION
Update the [docs about pod failure reason](https://k8s.io/docs/tasks/debug-application-cluster/determine-reason-pod-failure), adding how to get which container is failing, if the pod is a multi-container pod.

Previously, the docs were only covering single-container pods. This will hopefully help people trying figure out which container is failing, if they have a multi-container pod.

Fixes #31543