### PR TITLE
Update links to Dockershim Removal FAQ

### DIFF
--- a/content/en/blog/_posts/2020-12-02-dont-panic-kubernetes-and-docker.md
+++ b/content/en/blog/_posts/2020-12-02-dont-panic-kubernetes-and-docker.md
@@ -101,4 +101,4 @@ questions regardless of experience level or complexity! Our goal is to make sure
 everyone is educated as much as possible on the upcoming changes. We hope
 this has answered most of your questions and soothed some anxieties! ❤️
 
-Looking for more answers? Check out our accompanying [Dockershim Deprecation FAQ](/blog/2020/12/02/dockershim-faq/).
+Looking for more answers? Check out our accompanying [Dockershim Removal FAQ](/blog/2022/02/17/dockershim-faq/) _(updated February 2022)_.

--- a/content/en/docs/reference/node/topics-on-dockershim-and-cri-compatible-runtimes.md
+++ b/content/en/docs/reference/node/topics-on-dockershim-and-cri-compatible-runtimes.md
@@ -12,7 +12,7 @@ with that removal.
 
 ## Kubernetes project
 
-* Kubernetes blog: [Dockershim Deprecation FAQ](/blog/2020/12/02/dockershim-faq/) (originally published 2020/12/02)
+* Kubernetes blog: [Dockershim Removal FAQ](/blog/2022/02/17/dockershim-faq/) (originally published 2022/02/17)
 
 * Kubernetes blog: [Kubernetes is Moving on From Dockershim: Commitments and Next Steps](/blog/2022/01/07/kubernetes-is-moving-on-from-dockershim/) (published 2022/01/07)
 

--- a/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/_index.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/_index.md
@@ -11,7 +11,8 @@ dockershim to other container runtimes.
 
 Since the announcement of [dockershim deprecation](/blog/2020/12/08/kubernetes-1-20-release-announcement/#dockershim-deprecation)
 in Kubernetes 1.20, there were questions on how this will affect various workloads and Kubernetes
-installations. You can find this blog post useful to understand the problem better: [Dockershim Deprecation FAQ](/blog/2020/12/02/dockershim-faq/)
+installations. Our [Dockershim Removal FAQ](/blog/2022/02/17/dockershim-faq/) is there to help you
+to understand the problem better.
 
 It is recommended to migrate from dockershim to alternative container runtimes.
 Check out [container runtimes](/docs/setup/production-environment/container-runtimes/)


### PR DESCRIPTION
- Identify selected links to the Dockershim Deprecation FAQ
- Replace them with links to the updated FAQ

/kind cleanup

Follows on from https://github.com/kubernetes/website/pull/31765