### PR TITLE
Remove docker samples from debug-application-introspection

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/service-access-application-cluster.md
+++ b/content/en/docs/tasks/access-application-cluster/service-access-application-cluster.md
@@ -4,149 +4,400 @@ content_type: tutorial
 weight: 60
 ---
 
-<!-- overview -->
+This page shows you how to use Kubernetes
+[Services](https://kubernetes.io/docs/concepts/services-networking/service/) to
+access the applications in your cluster.
 
-This page shows how to create a Kubernetes Service object that external
-clients can use to access an application running in a cluster. The Service
-provides load balancing for an application that has two running instances.
+After creating and deploying an application, you might want to expose it on a
+network. Kubernetes gives every Pod an IP address within the cluster, so that
+Pods can reach other Pods in the cluster without additional configuration.
+However, when Pods are terminated and restarted, they're given new IP addresses.
+A Service logically groups Pods together and uses a unique IP address (a
+clusterIP) to allow communications to reach the Pods.
 
+## Objectives
 
+In this tutorial, you'll do the following:
 
+* Create a Deployment.
+* Expose the Deployment to the cluster using a Service.
+* Access the Service from inside your cluster.
+* Secure the Service.
+* Expose the Service to the internet.
 
 ## {{% heading "prerequisites" %}}
 
+* Ensure that you're familiar with [Pod
+  networking](https://kubernetes.io/docs/concepts/workloads/pods/#pod-networking)
+  and Services.
+* Become familiar with [The Kubernetes network model](https://kubernetes.io/docs/concepts/cluster-administration/networking/#the-kubernetes-network-model).
 
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
 
+## Create a Deployment {#creating-a-deployment}
 
+1. Save the following manifest as `my-nginx-deployment.yaml`:
 
+   {{< codenew file="service/networking/run-my-nginx.yaml" >}}
 
-## {{% heading "objectives" %}}
+1. Apply the manifest:
 
-
-* Run two instances of a Hello World application.
-* Create a Service object that exposes a node port.
-* Use the Service object to access the running application.
-
-
-
-
-<!-- lessoncontent -->
-
-## Creating a service for an application running in two pods
-
-Here is the configuration file for the application Deployment:
-
-{{< codenew file="service/access/hello-application.yaml" >}}
-
-1. Run a Hello World application in your cluster:
-   Create the application Deployment using the file above:
    ```shell
-   kubectl apply -f https://k8s.io/examples/service/access/hello-application.yaml
+   kubectl apply -f ./my-nginx-deployment.yaml
    ```
-   The preceding command creates a
-   {{< glossary_tooltip text="Deployment" term_id="deployment" >}}
-   and an associated
-   {{< glossary_tooltip term_id="replica-set" text="ReplicaSet" >}}.
-   The ReplicaSet has two
-   {{< glossary_tooltip text="Pods" term_id="pod" >}}
-   each of which runs the Hello World application.
+1. Check which nodes the Pods are on:
 
-
-1. Display information about the Deployment:
    ```shell
-   kubectl get deployments hello-world
-   kubectl describe deployments hello-world
+   kubectl get pods -l run=my-nginx -o wide
    ```
 
-1. Display information about your ReplicaSet objects:
+   The output is similar to this: 
+
+   ```
+   NAME                        READY     STATUS    RESTARTS   AGE       IP            NODE
+   my-nginx-3800858182-jr4a2   1/1       Running   0          13s       10.244.3.4    kubernetes-minion-905m
+   my-nginx-3800858182-kna2y   1/1       Running   0          13s       10.244.2.5    kubernetes-minion-ljyd
+   ```
+1. Get the IP address of the Pods:
+
    ```shell
-   kubectl get replicasets
-   kubectl describe replicasets
+   kubectl get pods -l run=my-nginx -o yaml | grep podIP
    ```
 
-1. Create a Service object that exposes the deployment:
-   ```shell
-   kubectl expose deployment hello-world --type=NodePort --name=example-service
-   ```
-
-1. Display information about the Service:
-   ```shell
-   kubectl describe services example-service
-   ```
    The output is similar to this:
-   ```shell
-   Name:                   example-service
-   Namespace:              default
-   Labels:                 run=load-balancer-example
-   Annotations:            <none>
-   Selector:               run=load-balancer-example
-   Type:                   NodePort
-   IP:                     10.32.0.16
-   Port:                   <unset> 8080/TCP
-   TargetPort:             8080/TCP
-   NodePort:               <unset> 31496/TCP
-   Endpoints:              10.200.1.4:8080,10.200.2.5:8080
-   Session Affinity:       None
-   Events:                 <none>
-   ```
-   Make a note of the NodePort value for the service. For example,
-   in the preceding output, the NodePort value is 31496.
 
-1. List the pods that are running the Hello World application:
-   ```shell
-   kubectl get pods --selector="run=load-balancer-example" --output=wide
    ```
+   podIP: 10.12.0.9
+   podIP: 10.12.1.6
+   ```
+
+You can get a session into any node in your cluster and `curl` either Pod IP
+address. The containers don't use port 80 on the node. There are no NAT rules to
+route traffic to the Pods. You could run multiple nginx deployments on the same
+node, using the same `containerPort`, and use the IP addresses to access them
+from other Pods or nodes in your cluster.
+
+## Create a Service {#creating-a-service}
+
+You can use a Service to prevent issues with Pod communication after restarts or
+evictions. In this example, you create a Service for the nginx Deployment that
+targets TCP port 80 on each Pod and exposes it on a Service port. 
+
+1. Save the following manifest as `my-nginx-service.yaml`:
+
+   {{< codenew file="service/networking/nginx-svc.yaml" >}}
+
+1. Apply the manifest:
+
+   ```shell
+   kubectl apply -f ./my-nginx-service.yaml
+   ```
+
+   This is equivalent to running the following command:
+
+   ```shell
+   kubectl expose deployment/my-nginx
+   ```
+
+1. Check the Service: 
+
+   ```shell
+   kubectl get svc my-nginx
+   ```
+
    The output is similar to this:
-   ```shell
-   NAME                           READY   STATUS    ...  IP           NODE
-   hello-world-2895499144-bsbk5   1/1     Running   ...  10.200.1.4   worker1
-   hello-world-2895499144-m1pwt   1/1     Running   ...  10.200.2.5   worker2
-   ```
-1. Get the public IP address of one of your nodes that is running
-   a Hello World pod. How you get this address depends on how you set
-   up your cluster. For example, if you are using Minikube, you can
-   see the node address by running `kubectl cluster-info`. If you are
-   using Google Compute Engine instances, you can use the
-   `gcloud compute instances list` command to see the public addresses of your
-   nodes.
 
-1. On your chosen node, create a firewall rule that allows TCP traffic
-   on your node port. For example, if your Service has a NodePort value of
-   31568, create a firewall rule that allows TCP traffic on port 31568. Different
-   cloud providers offer different ways of configuring firewall rules.
-
-1. Use the node address and node port to access the Hello World application:
-   ```shell
-   curl http://<public-node-ip>:<node-port>
    ```
-   where `<public-node-ip>` is the public IP address of your node,
-   and `<node-port>` is the NodePort value for your service. The
-   response to a successful request is a hello message:
-   ```shell
-   Hello Kubernetes!
+   NAME       TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)   AGE
+   my-nginx   ClusterIP   10.0.162.149   <none>        80/TCP    21s
    ```
 
-## Using a service configuration file
+1. Get the Pod `endpoints` associated with the Service:
 
-As an alternative to using `kubectl expose`, you can use a
-[service configuration file](/docs/concepts/services-networking/service/)
-to create a Service.
+   ```shell
+   kubectl get ep my-nginx
+   ```
 
+   The output is similar to this:
 
+   ```
+   NAME       ENDPOINTS                     AGE
+   my-nginx   10.244.2.5:80,10.244.3.4:80   1m
+   ```
+   
+   Each Pod in your deployment has an endpoint that the Service uses to reach
+   it. When new Pods are selected by the Service selector, those endpoints are
+   added to the corresponding [Endpoint API resource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#endpoints-v1-core) for the Service, and the old
+   endpoints are removed.
 
+You can now reach the Service by opening a session from any node in your cluster
+and using `curl` to reach the `<CLUSTER-IP>:<PORT>`. In this example, that's
+`10.0.162.149:80`. For more information about the service IP address, see
+[Virtual IPs and service
+proxies](/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies).
 
-## {{% heading "cleanup" %}}
+## Access the Service {#accessing-the-service}
 
+You can use the following methods to access the Service: 
 
-To delete the Service, enter this command:
+* Environment variables
+* DNS
 
-    kubectl delete services example-service
+For more information on these methods, see [Discovering
+services](https://kubernetes.io/docs/concepts/services-networking/service/#discovering-services).
 
-To delete the Deployment, the ReplicaSet, and the Pods that are running
-the Hello World application, enter this command:
+### Use environment variables {#environment-variables}
 
-    kubectl delete deployment hello-world
+When a Pod is scheduled on a node, the kubelet adds environment variables
+corresponding to each *existing* Service. If you create the Service after
+creating the Pod, the environment variables for that Service won't exist until
+you restart the Pod. 
+
+1. List your running Pods:
+
+   ```shell
+   kubectl get pods -l run=my-nginx
+   ```
+
+   The output is similar to this: 
+
+   ```
+   NAME                        READY     STATUS    RESTARTS   AGE       IP            NODE
+   my-nginx-3800858182-jr4a2   1/1       Running   0          13s       10.244.3.4    kubernetes-minion-905m
+   my-nginx-3800858182-kna2y   1/1       Running   0          13s       10.244.2.5    kubernetes-minion-ljyd
+   ```
+
+1. Get the environment variables for Services in one of the Pods:
+
+   ```shell
+   kubectl exec my-nginx-3800858182-jr4a2 -- printenv | grep SERVICE
+   ```
+
+   The output is similar to this:
+
+   ```
+   KUBERNETES_SERVICE_HOST=10.0.0.1
+   KUBERNETES_SERVICE_PORT=443
+   KUBERNETES_SERVICE_PORT_HTTPS=443   
+   ```
+   In this output, the `my-nginx` Service has no variables present. 
+
+1. Restart the Pods by scaling the Deployment down to 0 and back up:
+
+   ```shell
+   kubectl scale deployment my-nginx --replicas=0
+   kubectl scale deployment my-nginx --replicas=2
+   kubectl get pods -l run=my-nginx -o wide
+   ```
+
+   The output is similar to this:
+
+   ```
+   NAME                        READY     STATUS    RESTARTS   AGE     IP            NODE
+   my-nginx-3800858182-e9ihh   1/1       Running   0          5s      10.244.2.7    kubernetes-minion-ljyd
+   my-nginx-3800858182-j4rm4   1/1       Running   0          5s      10.244.3.8    kubernetes-minion-905m
+   ```
+   In this output, the Pod names and IP addresses are different because they
+   were restarted.
+   
+1. Get the environment variables for a Pod:
+
+   ```shell
+   kubectl exec my-nginx-3800858182-e9ihh -- printenv | grep SERVICE
+   ```
+
+   The output is similar to this: 
+
+   ```
+   KUBERNETES_SERVICE_PORT=443
+   MY_NGINX_SERVICE_HOST=10.0.162.149
+   KUBERNETES_SERVICE_HOST=10.0.0.1
+   MY_NGINX_SERVICE_PORT=80
+   KUBERNETES_SERVICE_PORT_HTTPS=443
+   ```
+
+### Use DNS to access the Service {#use-dns}
+
+{{<note>}}
+To use DNS, your cluster must have a DNS server that assigns DNS names to
+Service IP addresses. Kubernetes offers the [CoreDNS cluster
+add-on](https://kubernetes.io/docs/tasks/administer-cluster/coredns/#installing-coredns)
+(`kube-dns`) to accomplish this. This example uses `kube-dns`.
+{{</note>}}
+
+1. Check that `kube-dns` is running:
+
+   ```shell
+   kubectl get svc kube-dns -n kube-system
+   ```
+
+   The output is similar to this:
+
+   ```
+   NAME       TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)         AGE
+   kube-dns   ClusterIP   10.0.0.10    <none>        53/UDP,53/TCP   8m
+   ```
+
+1. Run a `curl` application to interact with `kube-dns`:
+
+   ```shell
+   kubectl run curl --image=radial/busyboxplus:curl -i --tty
+   ```
+
+1. Press Enter when prompted. You should now have a session ready for commands.
+
+1. Look up the DNS name assigned to the `my-nginx` Service:
+
+   ```shell
+   nslookup my-nginx
+   ```
+
+   The output is similar to this:
+
+   ```
+   Server:    10.0.0.10
+   Address 1: 10.0.0.10
+
+   Name:      my-nginx
+   Address 1: 10.0.162.149 
+   ```
+
+1. Type `exit` to end the session.
+
+## Secure the Service {#secure-service}
+
+Before exposing your nginx Service to the internet, you should secure the
+channel. You'll need the following:
+
+* Self-signed HTTPS certificates
+* An nginx server to use the certificates
+* A Secret to allow Pods to access the certificates
+
+You can create the certificates using `make` or do it manually:
+
+{{< tabs name="secure-service" >}}
+   {{% tab name="`make`" %}}
+      1. To use `make` to create certificates, run the following:
+
+         ```shell
+         make keys KEY=/tmp/nginx.key CERT=/tmp/nginx.crt
+         ```
+      1. Create a Secret that contains the certificates:
+
+         ```shell
+         kubectl create secret tls nginxsecret --key /tmp/nginx.key --cert /tmp/nginx.crt
+         ```
+      1. Check that the Secret was created:
+
+         ```shell
+         kubectl get secrets
+         ```
+
+         The output is similar to this:
+
+         ```
+         NAME                  TYPE                                  DATA      AGE
+         default-token-il9rc   kubernetes.io/service-account-token   1         1d
+         nginxsecret           kubernetes.io/tls                     2         1m
+         ```
+   {{% /tab %}}
+   {{< tab name="Manually create credentials" >}}
+      If you have issues running `make`, you can create the certificates and Secret
+      manually.
+
+      1. Generate a key pair:
+         
+         ```shell
+         openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /d/tmp/nginx.key -out /d/tmp/nginx.crt -subj "/CN=my-nginx/O=my-nginx"
+         ```
+      1. Base64 encode the keys: 
+
+         ```shell
+         cat /d/tmp/nginx.crt | base64
+         cat /d/tmp/nginx.key | base64
+         ```
+      1. Create a `Secret` manifest:
+
+         ```yaml
+         apiVersion: v1
+         kind: Secret
+         metadata:
+            name: nginxsecret
+            namespace: default
+         type: kubernetes.io/tls
+         data:
+            tls.crt: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURIekNDQWdlZ0F3SUJBZ0lKQUp5M3lQK0pzMlpJTUEwR0NTcUdTSWIzRFFFQkJRVUFNQ1l4RVRBUEJnTlYKQkFNVENHNW5hVzU0YzNaak1SRXdEd1lEVlFRS0V3aHVaMmx1ZUhOMll6QWVGdzB4TnpFd01qWXdOekEzTVRKYQpGdzB4T0RFd01qWXdOekEzTVRKYU1DWXhFVEFQQmdOVkJBTVRDRzVuYVc1NGMzWmpNUkV3RHdZRFZRUUtFd2h1CloybHVlSE4yWXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBSjFxSU1SOVdWM0IKMlZIQlRMRmtobDRONXljMEJxYUhIQktMSnJMcy8vdzZhU3hRS29GbHlJSU94NGUrMlN5ajBFcndCLzlYTnBwbQppeW1CL3JkRldkOXg5UWhBQUxCZkVaTmNiV3NsTVFVcnhBZW50VWt1dk1vLzgvMHRpbGhjc3paenJEYVJ4NEo5Ci82UVRtVVI3a0ZTWUpOWTVQZkR3cGc3dlVvaDZmZ1Voam92VG42eHNVR0M2QURVODBpNXFlZWhNeVI1N2lmU2YKNHZpaXdIY3hnL3lZR1JBRS9mRTRqakxCdmdONjc2SU90S01rZXV3R0ljNDFhd05tNnNTSzRqYUNGeGpYSnZaZQp2by9kTlEybHhHWCtKT2l3SEhXbXNhdGp4WTRaNVk3R1ZoK0QrWnYvcW1mMFgvbVY0Rmo1NzV3ajFMWVBocWtsCmdhSXZYRyt4U1FVQ0F3RUFBYU5RTUU0d0hRWURWUjBPQkJZRUZPNG9OWkI3YXc1OUlsYkROMzhIYkduYnhFVjcKTUI4R0ExVWRJd1FZTUJhQUZPNG9OWkI3YXc1OUlsYkROMzhIYkduYnhFVjdNQXdHQTFVZEV3UUZNQU1CQWY4dwpEUVlKS29aSWh2Y05BUUVGQlFBRGdnRUJBRVhTMW9FU0lFaXdyMDhWcVA0K2NwTHI3TW5FMTducDBvMm14alFvCjRGb0RvRjdRZnZqeE04Tzd2TjB0clcxb2pGSW0vWDE4ZnZaL3k4ZzVaWG40Vm8zc3hKVmRBcStNZC9jTStzUGEKNmJjTkNUekZqeFpUV0UrKzE5NS9zb2dmOUZ3VDVDK3U2Q3B5N0M3MTZvUXRUakViV05VdEt4cXI0Nk1OZWNCMApwRFhWZmdWQTRadkR4NFo3S2RiZDY5eXM3OVFHYmg5ZW1PZ05NZFlsSUswSGt0ejF5WU4vbVpmK3FqTkJqbWZjCkNnMnlwbGQ0Wi8rUUNQZjl3SkoybFIrY2FnT0R4elBWcGxNSEcybzgvTHFDdnh6elZPUDUxeXdLZEtxaUMwSVEKQ0I5T2wwWW5scE9UNEh1b2hSUzBPOStlMm9KdFZsNUIyczRpbDlhZ3RTVXFxUlU9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+            tls.key: "LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQ2RhaURFZlZsZHdkbFIKd1V5eFpJWmVEZWNuTkFhbWh4d1NpeWF5N1AvOE9ta3NVQ3FCWmNpQ0RzZUh2dGtzbzlCSzhBZi9WemFhWm9zcApnZjYzUlZuZmNmVUlRQUN3WHhHVFhHMXJKVEVGSzhRSHA3VkpMcnpLUC9QOUxZcFlYTE0yYzZ3MmtjZUNmZitrCkU1bEVlNUJVbUNUV09UM3c4S1lPNzFLSWVuNEZJWTZMMDUrc2JGQmd1Z0ExUE5JdWFubm9UTWtlZTRuMG4rTDQKb3NCM01ZUDhtQmtRQlAzeE9JNHl3YjREZXUraURyU2pKSHJzQmlIT05Xc0RadXJFaXVJMmdoY1kxeWIyWHI2UAozVFVOcGNSbC9pVG9zQngxcHJHclk4V09HZVdPeGxZZmcvbWIvNnBuOUYvNWxlQlkrZStjSTlTMkQ0YXBKWUdpCkwxeHZzVWtGQWdNQkFBRUNnZ0VBZFhCK0xkbk8ySElOTGo5bWRsb25IUGlHWWVzZ294RGQwci9hQ1Zkank4dlEKTjIwL3FQWkUxek1yall6Ry9kVGhTMmMwc0QxaTBXSjdwR1lGb0xtdXlWTjltY0FXUTM5SjM0VHZaU2FFSWZWNgo5TE1jUHhNTmFsNjRLMFRVbUFQZytGam9QSFlhUUxLOERLOUtnNXNrSE5pOWNzMlY5ckd6VWlVZWtBL0RBUlBTClI3L2ZjUFBacDRuRWVBZmI3WTk1R1llb1p5V21SU3VKdlNyblBESGtUdW1vVlVWdkxMRHRzaG9reUxiTWVtN3oKMmJzVmpwSW1GTHJqbGtmQXlpNHg0WjJrV3YyMFRrdWtsZU1jaVlMbjk4QWxiRi9DSmRLM3QraTRoMTVlR2ZQegpoTnh3bk9QdlVTaDR2Q0o3c2Q5TmtEUGJvS2JneVVHOXBYamZhRGR2UVFLQmdRRFFLM01nUkhkQ1pKNVFqZWFKClFGdXF4cHdnNzhZTjQyL1NwenlUYmtGcVFoQWtyczJxWGx1MDZBRzhrZzIzQkswaHkzaE9zSGgxcXRVK3NHZVAKOWRERHBsUWV0ODZsY2FlR3hoc0V0L1R6cEdtNGFKSm5oNzVVaTVGZk9QTDhPTm1FZ3MxMVRhUldhNzZxelRyMgphRlpjQ2pWV1g0YnRSTHVwSkgrMjZnY0FhUUtCZ1FEQmxVSUUzTnNVOFBBZEYvL25sQVB5VWs1T3lDdWc3dmVyClUycXlrdXFzYnBkSi9hODViT1JhM05IVmpVM25uRGpHVHBWaE9JeXg5TEFrc2RwZEFjVmxvcG9HODhXYk9lMTAKMUdqbnkySmdDK3JVWUZiRGtpUGx1K09IYnRnOXFYcGJMSHBzUVpsMGhucDBYSFNYVm9CMUliQndnMGEyOFVadApCbFBtWmc2d1BRS0JnRHVIUVV2SDZHYTNDVUsxNFdmOFhIcFFnMU16M2VvWTBPQm5iSDRvZUZKZmcraEppSXlnCm9RN3hqWldVR3BIc3AyblRtcHErQWlSNzdyRVhsdlhtOElVU2FsbkNiRGlKY01Pc29RdFBZNS9NczJMRm5LQTQKaENmL0pWb2FtZm1nZEN0ZGtFMXNINE9MR2lJVHdEbTRpb0dWZGIwMllnbzFyb2htNUpLMUI3MkpBb0dBUW01UQpHNDhXOTVhL0w1eSt5dCsyZ3YvUHM2VnBvMjZlTzRNQ3lJazJVem9ZWE9IYnNkODJkaC8xT2sybGdHZlI2K3VuCnc1YytZUXRSTHlhQmd3MUtpbGhFZDBKTWU3cGpUSVpnQWJ0LzVPbnlDak9OVXN2aDJjS2lrQ1Z2dTZsZlBjNkQKckliT2ZIaHhxV0RZK2Q1TGN1YSt2NzJ0RkxhenJsSlBsRzlOZHhrQ2dZRUF5elIzT3UyMDNRVVV6bUlCRkwzZAp4Wm5XZ0JLSEo3TnNxcGFWb2RjL0d5aGVycjFDZzE2MmJaSjJDV2RsZkI0VEdtUjZZdmxTZEFOOFRwUWhFbUtKCnFBLzVzdHdxNWd0WGVLOVJmMWxXK29xNThRNTBxMmk1NVdUTThoSDZhTjlaMTltZ0FGdE5VdGNqQUx2dFYxdEYKWSs4WFJkSHJaRnBIWll2NWkwVW1VbGc9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K"
+         ```
+         Replace the `tls.crt` and `tls.key` fields with the base64 encoded output from the previous step.
+         
+      1. Apply the manifest:
+      
+         ```shell
+         kubectl apply -f nginxsecret.yaml
+         ```
+      1. Check that the Secret was created:
+
+         ```shell
+         kubectl get secrets
+         ```
+
+         The output is similar to this:
+
+         ```
+         NAME                  TYPE                                  DATA      AGE
+         default-token-il9rc   kubernetes.io/service-account-token   1         1d
+         nginxsecret           kubernetes.io/tls                     2         1m
+         ```
+   {{< /tab >}}
+{{< /tabs >}}
+
+After creating the Secret, create a ConfigMap:
+
+```shell
+kubectl create configmap nginxconfigmap --from-file=default.conf
+```
+
+Modify the nginx Deployment and Service to use the certificates and Secret you
+created:
+
+1. Save the following manifest as `nginx-secure.yaml`:
+
+   {{< codenew file="service/networking/nginx-secure-app.yaml" >}}
+
+   In this manifest:
+
+   * The Deployment and Service specifications are modified in one file.
+   * The nginx server serves HTTP traffic on port 80 and HTTPS traffic on port 443.
+     The Service exposes both ports.
+   * Each container has access to the keys through `volumeMounts`. This happens
+     before the server is started.
+
+1. Apply the updated manifest:
+
+   ```shell
+   kubectl apply -f ./nginx-secure-app.yaml
+   ```
+
+1. Get the new Pod IP addresses:
+
+   ```shell
+   kubectl get pods -o yaml | grep -i podIp
+   ```
+
+1. Establish a session in a node and try to reach the Pod:
+
+   ```shell
+   curl -k https://10.244.3.5
+   ```
+   The `-k` parameter tells `curl` to ignore CName mismatches when making
+   connections over HTTPS. 
+
+   The output is similar to this: 
+
+   ```
+   <h1>Welcome to nginx!</h1>
+   ```
 
 
 

--- a/content/en/docs/tasks/debug-application-cluster/debug-application-introspection.md
+++ b/content/en/docs/tasks/debug-application-cluster/debug-application-introspection.md
@@ -40,70 +40,77 @@ kubectl get pods
 ```
 
 ```none
-NAME                                READY     STATUS    RESTARTS   AGE
-nginx-deployment-1006230814-6winp   1/1       Running   0          11s
-nginx-deployment-1006230814-fmgu3   1/1       Running   0          11s
+NAME                                READY   STATUS    RESTARTS   AGE
+nginx-deployment-67d4bdd6f5-cx2nz   1/1     Running   0          13s
+nginx-deployment-67d4bdd6f5-w6kd7   1/1     Running   0          13s
 ```
 
 We can retrieve a lot more information about each of these pods using `kubectl describe pod`. For example:
 
 ```shell
-kubectl describe pod nginx-deployment-1006230814-6winp
+kubectl describe pod nginx-deployment-67d4bdd6f5-w6kd7
 ```
 
 ```none
-Name:		nginx-deployment-1006230814-6winp
-Namespace:	default
-Node:		kubernetes-node-wul5/10.240.0.9
-Start Time:	Thu, 24 Mar 2016 01:39:49 +0000
-Labels:		app=nginx,pod-template-hash=1006230814
-Annotations:    kubernetes.io/created-by={"kind":"SerializedReference","apiVersion":"v1","reference":{"kind":"ReplicaSet","namespace":"default","name":"nginx-deployment-1956810328","uid":"14e607e7-8ba1-11e7-b5cb-fa16" ...
-Status:		Running
-IP:		10.244.0.6
-Controllers:	ReplicaSet/nginx-deployment-1006230814
+Name:         nginx-deployment-67d4bdd6f5-w6kd7
+Namespace:    default
+Priority:     0
+Node:         kube-worker-1/192.168.0.113
+Start Time:   Thu, 17 Feb 2022 16:51:01 -0500
+Labels:       app=nginx
+              pod-template-hash=67d4bdd6f5
+Annotations:  <none>
+Status:       Running
+IP:           10.88.0.3
+IPs:
+  IP:           10.88.0.3
+  IP:           2001:4860:4860::3
+Controlled By:  ReplicaSet/nginx-deployment-67d4bdd6f5
 Containers:
   nginx:
-    Container ID:	docker://90315cc9f513c724e9957a4788d3e625a078de84750f244a40f97ae355eb1149
-    Image:		nginx
-    Image ID:		docker://6f62f48c4e55d700cf3eb1b5e33fa051802986b77b874cc351cce539e5163707
-    Port:		80/TCP
-    QoS Tier:
-      cpu:	Guaranteed
-      memory:	Guaranteed
+    Container ID:   containerd://5403af59a2b46ee5a23fb0ae4b1e077f7ca5c5fb7af16e1ab21c00e0e616462a
+    Image:          nginx
+    Image ID:       docker.io/library/nginx@sha256:2834dc507516af02784808c5f48b7cbe38b8ed5d0f4837f16e78d00deb7e7767
+    Port:           80/TCP
+    Host Port:      0/TCP
+    State:          Running
+      Started:      Thu, 17 Feb 2022 16:51:05 -0500
+    Ready:          True
+    Restart Count:  0
     Limits:
-      cpu:	500m
-      memory:	128Mi
+      cpu:     500m
+      memory:  128Mi
     Requests:
-      memory:		128Mi
-      cpu:		500m
-    State:		Running
-      Started:		Thu, 24 Mar 2016 01:39:51 +0000
-    Ready:		True
-    Restart Count:	0
-    Environment:        <none>
+      cpu:        500m
+      memory:     128Mi
+    Environment:  <none>
     Mounts:
-      /var/run/secrets/kubernetes.io/serviceaccount from default-token-5kdvl (ro)
+      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-bgsgp (ro)
 Conditions:
-  Type          Status
-  Initialized   True
-  Ready         True
-  PodScheduled  True
+  Type              Status
+  Initialized       True 
+  Ready             True 
+  ContainersReady   True 
+  PodScheduled      True 
 Volumes:
-  default-token-4bcbi:
-    Type:	Secret (a volume populated by a Secret)
-    SecretName:	default-token-4bcbi
-    Optional:   false
-QoS Class:      Guaranteed
-Node-Selectors: <none>
-Tolerations:    <none>
+  kube-api-access-bgsgp:
+    Type:                    Projected (a volume that contains injected data from multiple sources)
+    TokenExpirationSeconds:  3607
+    ConfigMapName:           kube-root-ca.crt
+    ConfigMapOptional:       <nil>
+    DownwardAPI:             true
+QoS Class:                   Guaranteed
+Node-Selectors:              <none>
+Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
+                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
 Events:
-  FirstSeen	LastSeen	Count	From					SubobjectPath		Type		Reason		Message
-  ---------	--------	-----	----					-------------		--------	------		-------
-  54s		54s		1	{default-scheduler }						Normal		Scheduled	Successfully assigned nginx-deployment-1006230814-6winp to kubernetes-node-wul5
-  54s		54s		1	{kubelet kubernetes-node-wul5}	spec.containers{nginx}	Normal		Pulling		pulling image "nginx"
-  53s		53s		1	{kubelet kubernetes-node-wul5}	spec.containers{nginx}	Normal		Pulled		Successfully pulled image "nginx"
-  53s		53s		1	{kubelet kubernetes-node-wul5}	spec.containers{nginx}	Normal		Created		Created container with docker id 90315cc9f513
-  53s		53s		1	{kubelet kubernetes-node-wul5}	spec.containers{nginx}	Normal		Started		Started container with docker id 90315cc9f513
+  Type    Reason     Age   From               Message
+  ----    ------     ----  ----               -------
+  Normal  Scheduled  34s   default-scheduler  Successfully assigned default/nginx-deployment-67d4bdd6f5-w6kd7 to kube-worker-1
+  Normal  Pulling    31s   kubelet            Pulling image "nginx"
+  Normal  Pulled     30s   kubelet            Successfully pulled image "nginx" in 1.146417389s
+  Normal  Created    30s   kubelet            Created container nginx
+  Normal  Started    30s   kubelet            Started container nginx
 ```
 
 Here you can see configuration information about the container(s) and Pod (labels, resource requirements, etc.), as well as status information about the container(s) and Pod (state, readiness, restart count, events, etc.).
@@ -203,18 +210,22 @@ kubectl get pod nginx-deployment-1006230814-6winp -o yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    kubernetes.io/created-by: |
-      {"kind":"SerializedReference","apiVersion":"v1","reference":{"kind":"ReplicaSet","namespace":"default","name":"nginx-deployment-1006230814","uid":"4c84c175-f161-11e5-9a78-42010af00005","apiVersion":"extensions","resourceVersion":"133434"}}
-  creationTimestamp: 2016-03-24T01:39:50Z
-  generateName: nginx-deployment-1006230814-
+  creationTimestamp: "2022-02-17T21:51:01Z"
+  generateName: nginx-deployment-67d4bdd6f5-
   labels:
     app: nginx
-    pod-template-hash: "1006230814"
-  name: nginx-deployment-1006230814-6winp
+    pod-template-hash: 67d4bdd6f5
+  name: nginx-deployment-67d4bdd6f5-w6kd7
   namespace: default
-  resourceVersion: "133447"
-  uid: 4c879808-f161-11e5-9a78-42010af00005
+  ownerReferences:
+  - apiVersion: apps/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: ReplicaSet
+    name: nginx-deployment-67d4bdd6f5
+    uid: 7d41dfd4-84c0-4be4-88ab-cedbe626ad82
+  resourceVersion: "1364"
+  uid: a6501da1-0447-4262-98eb-c03d4002222e
 spec:
   containers:
   - image: nginx
@@ -231,42 +242,88 @@ spec:
         cpu: 500m
         memory: 128Mi
     terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
     volumeMounts:
     - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-      name: default-token-4bcbi
+      name: kube-api-access-bgsgp
       readOnly: true
   dnsPolicy: ClusterFirst
-  nodeName: kubernetes-node-wul5
+  enableServiceLinks: true
+  nodeName: kube-worker-1
+  preemptionPolicy: PreemptLowerPriority
+  priority: 0
   restartPolicy: Always
+  schedulerName: default-scheduler
   securityContext: {}
   serviceAccount: default
   serviceAccountName: default
   terminationGracePeriodSeconds: 30
+  tolerations:
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
+    tolerationSeconds: 300
+  - effect: NoExecute
+    key: node.kubernetes.io/unreachable
+    operator: Exists
+    tolerationSeconds: 300
   volumes:
-  - name: default-token-4bcbi
-    secret:
-      secretName: default-token-4bcbi
+  - name: kube-api-access-bgsgp
+    projected:
+      defaultMode: 420
+      sources:
+      - serviceAccountToken:
+          expirationSeconds: 3607
+          path: token
+      - configMap:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          name: kube-root-ca.crt
+      - downwardAPI:
+          items:
+          - fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+            path: namespace
 status:
   conditions:
   - lastProbeTime: null
-    lastTransitionTime: 2016-03-24T01:39:51Z
+    lastTransitionTime: "2022-02-17T21:51:01Z"
+    status: "True"
+    type: Initialized
+  - lastProbeTime: null
+    lastTransitionTime: "2022-02-17T21:51:06Z"
     status: "True"
     type: Ready
+  - lastProbeTime: null
+    lastTransitionTime: "2022-02-17T21:51:06Z"
+    status: "True"
+    type: ContainersReady
+  - lastProbeTime: null
+    lastTransitionTime: "2022-02-17T21:51:01Z"
+    status: "True"
+    type: PodScheduled
   containerStatuses:
-  - containerID: docker://90315cc9f513c724e9957a4788d3e625a078de84750f244a40f97ae355eb1149
-    image: nginx
-    imageID: docker://6f62f48c4e55d700cf3eb1b5e33fa051802986b77b874cc351cce539e5163707
+  - containerID: containerd://5403af59a2b46ee5a23fb0ae4b1e077f7ca5c5fb7af16e1ab21c00e0e616462a
+    image: docker.io/library/nginx:latest
+    imageID: docker.io/library/nginx@sha256:2834dc507516af02784808c5f48b7cbe38b8ed5d0f4837f16e78d00deb7e7767
     lastState: {}
     name: nginx
     ready: true
     restartCount: 0
+    started: true
     state:
       running:
-        startedAt: 2016-03-24T01:39:51Z
-  hostIP: 10.240.0.9
+        startedAt: "2022-02-17T21:51:05Z"
+  hostIP: 192.168.0.113
   phase: Running
-  podIP: 10.244.0.6
-  startTime: 2016-03-24T01:39:49Z
+  podIP: 10.88.0.3
+  podIPs:
+  - ip: 10.88.0.3
+  - ip: 2001:4860:4860::3
+  qosClass: Guaranteed
+  startTime: "2022-02-17T21:51:01Z"
 ```
 
 ## Example: debugging a down/unreachable node
@@ -279,114 +336,175 @@ kubectl get nodes
 
 ```none
 NAME                     STATUS       ROLES     AGE     VERSION
-kubernetes-node-861h     NotReady     <none>    1h      v1.13.0
-kubernetes-node-bols     Ready        <none>    1h      v1.13.0
-kubernetes-node-st6x     Ready        <none>    1h      v1.13.0
-kubernetes-node-unaj     Ready        <none>    1h      v1.13.0
+kube-worker-1            NotReady     <none>    1h      v1.23.3
+kubernetes-node-bols     Ready        <none>    1h      v1.23.3
+kubernetes-node-st6x     Ready        <none>    1h      v1.23.3
+kubernetes-node-unaj     Ready        <none>    1h      v1.23.3
 ```
 
 ```shell
-kubectl describe node kubernetes-node-861h
+kubectl describe node kube-worker-1
 ```
 
 ```none
-Name:			kubernetes-node-861h
-Role
-Labels:		 kubernetes.io/arch=amd64
-           kubernetes.io/os=linux
-           kubernetes.io/hostname=kubernetes-node-861h
-Annotations:        node.alpha.kubernetes.io/ttl=0
-                    volumes.kubernetes.io/controller-managed-attach-detach=true
-Taints:             <none>
-CreationTimestamp:	Mon, 04 Sep 2017 17:13:23 +0800
-Phase:
+Name:               kube-worker-1
+Roles:              <none>
+Labels:             beta.kubernetes.io/arch=amd64
+                    beta.kubernetes.io/os=linux
+                    kubernetes.io/arch=amd64
+                    kubernetes.io/hostname=kube-worker-1
+                    kubernetes.io/os=linux
+Annotations:        kubeadm.alpha.kubernetes.io/cri-socket: /run/containerd/containerd.sock
+                    node.alpha.kubernetes.io/ttl: 0
+                    volumes.kubernetes.io/controller-managed-attach-detach: true
+CreationTimestamp:  Thu, 17 Feb 2022 16:46:30 -0500
+Taints:             node.kubernetes.io/unreachable:NoExecute
+                    node.kubernetes.io/unreachable:NoSchedule
+Unschedulable:      false
+Lease:
+  HolderIdentity:  kube-worker-1
+  AcquireTime:     <unset>
+  RenewTime:       Thu, 17 Feb 2022 17:13:09 -0500
 Conditions:
-  Type		Status		LastHeartbeatTime			LastTransitionTime			Reason					Message
-  ----    ------    -----------------     ------------------      ------          -------
-  OutOfDisk             Unknown         Fri, 08 Sep 2017 16:04:28 +0800         Fri, 08 Sep 2017 16:20:58 +0800         NodeStatusUnknown       Kubelet stopped posting node status.
-  MemoryPressure        Unknown         Fri, 08 Sep 2017 16:04:28 +0800         Fri, 08 Sep 2017 16:20:58 +0800         NodeStatusUnknown       Kubelet stopped posting node status.
-  DiskPressure          Unknown         Fri, 08 Sep 2017 16:04:28 +0800         Fri, 08 Sep 2017 16:20:58 +0800         NodeStatusUnknown       Kubelet stopped posting node status.
-  Ready                 Unknown         Fri, 08 Sep 2017 16:04:28 +0800         Fri, 08 Sep 2017 16:20:58 +0800         NodeStatusUnknown       Kubelet stopped posting node status.
-Addresses:	10.240.115.55,104.197.0.26
+  Type                 Status    LastHeartbeatTime                 LastTransitionTime                Reason              Message
+  ----                 ------    -----------------                 ------------------                ------              -------
+  NetworkUnavailable   False     Thu, 17 Feb 2022 17:09:13 -0500   Thu, 17 Feb 2022 17:09:13 -0500   WeaveIsUp           Weave pod has set this
+  MemoryPressure       Unknown   Thu, 17 Feb 2022 17:12:40 -0500   Thu, 17 Feb 2022 17:13:52 -0500   NodeStatusUnknown   Kubelet stopped posting node status.
+  DiskPressure         Unknown   Thu, 17 Feb 2022 17:12:40 -0500   Thu, 17 Feb 2022 17:13:52 -0500   NodeStatusUnknown   Kubelet stopped posting node status.
+  PIDPressure          Unknown   Thu, 17 Feb 2022 17:12:40 -0500   Thu, 17 Feb 2022 17:13:52 -0500   NodeStatusUnknown   Kubelet stopped posting node status.
+  Ready                Unknown   Thu, 17 Feb 2022 17:12:40 -0500   Thu, 17 Feb 2022 17:13:52 -0500   NodeStatusUnknown   Kubelet stopped posting node status.
+Addresses:
+  InternalIP:  192.168.0.113
+  Hostname:    kube-worker-1
 Capacity:
- cpu:           2
- hugePages:     0
- memory:        4046788Ki
- pods:          110
+  cpu:                2
+  ephemeral-storage:  15372232Ki
+  hugepages-2Mi:      0
+  memory:             2025188Ki
+  pods:               110
 Allocatable:
- cpu:           1500m
- hugePages:     0
- memory:        1479263Ki
- pods:          110
+  cpu:                2
+  ephemeral-storage:  14167048988
+  hugepages-2Mi:      0
+  memory:             1922788Ki
+  pods:               110
 System Info:
- Machine ID:                    8e025a21a4254e11b028584d9d8b12c4
- System UUID:                   349075D1-D169-4F25-9F2A-E886850C47E3
- Boot ID:                       5cd18b37-c5bd-4658-94e0-e436d3f110e0
- Kernel Version:                4.4.0-31-generic
- OS Image:                      Debian GNU/Linux 8 (jessie)
- Operating System:              linux
- Architecture:                  amd64
- Container Runtime Version:     docker://1.12.5
- Kubelet Version:               v1.6.9+a3d1dfa6f4335
- Kube-Proxy Version:            v1.6.9+a3d1dfa6f4335
-ExternalID:                     15233045891481496305
-Non-terminated Pods:            (9 in total)
-  Namespace                     Name                                            CPU Requests    CPU Limits      Memory Requests Memory Limits
-  ---------                     ----                                            ------------    ----------      --------------- -------------
-......
+  Machine ID:                 9384e2927f544209b5d7b67474bbf92b
+  System UUID:                aa829ca9-73d7-064d-9019-df07404ad448
+  Boot ID:                    5a295a03-aaca-4340-af20-1327fa5dab5c
+  Kernel Version:             5.13.0-28-generic
+  OS Image:                   Ubuntu 21.10
+  Operating System:           linux
+  Architecture:               amd64
+  Container Runtime Version:  containerd://1.5.9
+  Kubelet Version:            v1.23.3
+  Kube-Proxy Version:         v1.23.3
+Non-terminated Pods:          (4 in total)
+  Namespace                   Name                                 CPU Requests  CPU Limits  Memory Requests  Memory Limits  Age
+  ---------                   ----                                 ------------  ----------  ---------------  -------------  ---
+  default                     nginx-deployment-67d4bdd6f5-cx2nz    500m (25%)    500m (25%)  128Mi (6%)       128Mi (6%)     23m
+  default                     nginx-deployment-67d4bdd6f5-w6kd7    500m (25%)    500m (25%)  128Mi (6%)       128Mi (6%)     23m
+  kube-system                 kube-proxy-dnxbz                     0 (0%)        0 (0%)      0 (0%)           0 (0%)         28m
+  kube-system                 weave-net-gjxxp                      100m (5%)     0 (0%)      200Mi (10%)      0 (0%)         28m
 Allocated resources:
   (Total limits may be over 100 percent, i.e., overcommitted.)
-  CPU Requests  CPU Limits      Memory Requests         Memory Limits
-  ------------  ----------      ---------------         -------------
-  900m (60%)    2200m (146%)    1009286400 (66%)        5681286400 (375%)
-Events:         <none>
+  Resource           Requests     Limits
+  --------           --------     ------
+  cpu                1100m (55%)  1 (50%)
+  memory             456Mi (24%)  256Mi (13%)
+  ephemeral-storage  0 (0%)       0 (0%)
+  hugepages-2Mi      0 (0%)       0 (0%)
+Events:
+...
 ```
 
 ```shell
-kubectl get node kubernetes-node-861h -o yaml
+kubectl get node kube-worker-1 -o yaml
 ```
 
 ```yaml
 apiVersion: v1
 kind: Node
 metadata:
-  creationTimestamp: 2015-07-10T21:32:29Z
+  annotations:
+    kubeadm.alpha.kubernetes.io/cri-socket: /run/containerd/containerd.sock
+    node.alpha.kubernetes.io/ttl: "0"
+    volumes.kubernetes.io/controller-managed-attach-detach: "true"
+  creationTimestamp: "2022-02-17T21:46:30Z"
   labels:
-    kubernetes.io/hostname: kubernetes-node-861h
-  name: kubernetes-node-861h
-  resourceVersion: "757"
-  uid: 2a69374e-274b-11e5-a234-42010af0d969
-spec:
-  externalID: "15233045891481496305"
-  podCIDR: 10.244.0.0/24
-  providerID: gce://striped-torus-760/us-central1-b/kubernetes-node-861h
+    beta.kubernetes.io/arch: amd64
+    beta.kubernetes.io/os: linux
+    kubernetes.io/arch: amd64
+    kubernetes.io/hostname: kube-worker-1
+    kubernetes.io/os: linux
+  name: kube-worker-1
+  resourceVersion: "4026"
+  uid: 98efe7cb-2978-4a0b-842a-1a7bf12c05f8
+spec: {}
 status:
   addresses:
-  - address: 10.240.115.55
+  - address: 192.168.0.113
     type: InternalIP
-  - address: 104.197.0.26
-    type: ExternalIP
+  - address: kube-worker-1
+    type: Hostname
+  allocatable:
+    cpu: "2"
+    ephemeral-storage: "14167048988"
+    hugepages-2Mi: "0"
+    memory: 1922788Ki
+    pods: "110"
   capacity:
-    cpu: "1"
-    memory: 3800808Ki
-    pods: "100"
+    cpu: "2"
+    ephemeral-storage: 15372232Ki
+    hugepages-2Mi: "0"
+    memory: 2025188Ki
+    pods: "110"
   conditions:
-  - lastHeartbeatTime: 2015-07-10T21:34:32Z
-    lastTransitionTime: 2015-07-10T21:35:15Z
-    reason: Kubelet stopped posting node status.
-    status: Unknown
+  - lastHeartbeatTime: "2022-02-17T22:20:32Z"
+    lastTransitionTime: "2022-02-17T22:20:32Z"
+    message: Weave pod has set this
+    reason: WeaveIsUp
+    status: "False"
+    type: NetworkUnavailable
+  - lastHeartbeatTime: "2022-02-17T22:20:15Z"
+    lastTransitionTime: "2022-02-17T22:13:25Z"
+    message: kubelet has sufficient memory available
+    reason: KubeletHasSufficientMemory
+    status: "False"
+    type: MemoryPressure
+  - lastHeartbeatTime: "2022-02-17T22:20:15Z"
+    lastTransitionTime: "2022-02-17T22:13:25Z"
+    message: kubelet has no disk pressure
+    reason: KubeletHasNoDiskPressure
+    status: "False"
+    type: DiskPressure
+  - lastHeartbeatTime: "2022-02-17T22:20:15Z"
+    lastTransitionTime: "2022-02-17T22:13:25Z"
+    message: kubelet has sufficient PID available
+    reason: KubeletHasSufficientPID
+    status: "False"
+    type: PIDPressure
+  - lastHeartbeatTime: "2022-02-17T22:20:15Z"
+    lastTransitionTime: "2022-02-17T22:15:15Z"
+    message: kubelet is posting ready status. AppArmor enabled
+    reason: KubeletReady
+    status: "True"
     type: Ready
+  daemonEndpoints:
+    kubeletEndpoint:
+      Port: 10250
   nodeInfo:
-    bootID: 4e316776-b40d-4f78-a4ea-ab0d73390897
-    containerRuntimeVersion: docker://Unknown
-    kernelVersion: 3.16.0-0.bpo.4-amd64
-    kubeProxyVersion: v0.21.1-185-gffc5a86098dc01
-    kubeletVersion: v0.21.1-185-gffc5a86098dc01
-    machineID: ""
-    osImage: Debian GNU/Linux 7 (wheezy)
-    systemUUID: ABE5F6B4-D44B-108B-C46A-24CCE16C8B6E
+    architecture: amd64
+    bootID: 22333234-7a6b-44d4-9ce1-67e31dc7e369
+    containerRuntimeVersion: containerd://1.5.9
+    kernelVersion: 5.13.0-28-generic
+    kubeProxyVersion: v1.23.3
+    kubeletVersion: v1.23.3
+    machineID: 9384e2927f544209b5d7b67474bbf92b
+    operatingSystem: linux
+    osImage: Ubuntu 21.10
+    systemUUID: aa829ca9-73d7-064d-9019-df07404ad448
 ```
-
 
 
 ## {{% heading "whatsnext" %}}


### PR DESCRIPTION
Related issue #30976

The output samples in this page used docker as the runtime. I've switched to samples taken from a cluster running containerd. 

/sig docs
/language en