### PR TITLE
fix error display string

### DIFF
--- a/layouts/shortcodes/feature-state.html
+++ b/layouts/shortcodes/feature-state.html
@@ -3,7 +3,7 @@
 {{ $for_k8s_version := .Get "for_k8s_version" | default (.Page.Param "version")}}
 {{ $is_valid := strings.Contains $valid_states $state }}
 {{ if not $is_valid }}
-{{ errorf "%q is not a valid feature-state, use one of %q" $valid_states }}
+{{ errorf "%q is not a valid feature-state, use one of %q" $state $valid_states }}
 {{ else }}
 <div style="margin-top: 10px; margin-bottom: 10px;">
 <b>FEATURE STATE:</b> <code>Kubernetes {{ $for_k8s_version }} [{{ $state }}]</code>


### PR DESCRIPTION
Currently error looks like this:

> `1:17:45 PM: ERROR 2022/02/18 21:17:45 "alpha, beta, deprecated, stable" is not a valid feature-state, use one of %!q(MISSING)`