### PR TITLE
Ensure “Download Kubernetes” link goes to right page #31794

### DIFF
--- a/content/en/docs/home/_index.md
+++ b/content/en/docs/home/_index.md
@@ -60,7 +60,7 @@ cards:
   title: K8s Release Notes
   description: If you are installing Kubernetes or upgrading to the newest version, refer to the current release notes.
   button: "Download Kubernetes"
-  button_path: "/docs/setup/release/notes"
+  button_path: "/releases/download"
 - name: about
   title: About the documentation
   description: This website contains documentation for the current and previous 4 versions of Kubernetes.


### PR DESCRIPTION
https://kubernetes.io/docs/home/ has a link (styled as a button) titled “Download Kubernetes”. At the moment that link goes to https://kubernetes.io/releases/notes/ which isn't quite right. 
Now link has been updated to  https://kubernetes.io/releases/download/