### PR TITLE
Download Kubernetes link goes to right page #31794

### DIFF
--- a/content/en/docs/home/_index.md
+++ b/content/en/docs/home/_index.md
@@ -60,7 +60,7 @@ cards:
   title: K8s Release Notes
   description: If you are installing Kubernetes or upgrading to the newest version, refer to the current release notes.
   button: "Download Kubernetes"
-  button_path: "/docs/setup/release/notes"
+  button_path: "/releases/download.md"
 - name: about
   title: About the documentation
   description: This website contains documentation for the current and previous 4 versions of Kubernetes.

--- a/content/en/docs/home/_index.md
+++ b/content/en/docs/home/_index.md
@@ -60,7 +60,7 @@ cards:
   title: K8s Release Notes
   description: If you are installing Kubernetes or upgrading to the newest version, refer to the current release notes.
   button: "Download Kubernetes"
-  button_path: "/releases/download.md"
+  button_path: "/releases/download/"
 - name: about
   title: About the documentation
   description: This website contains documentation for the current and previous 4 versions of Kubernetes.


### PR DESCRIPTION
- 1. Why are we solving this issue?
https://kubernetes.io/docs/home/ has a link (styled as a button) titled “Download Kubernetes”. At the moment that link goes to https://kubernetes.io/releases/notes/ which isn't quite right.
- 2. To address this issue, are there any code changes? If there are code changes, what needs to be done in the code and what places can the assignee treat as reference points?
[content/en/docs/home/_index.md](https://github.com/kubernetes/website/compare/main...shaggyyy2002:nitin?expand=1#diff-9cee966b161af433cb46ed88b566eb5d94787325a8e92bb0e20de8824efb3ab9) changed the link to  directory of the download page.
- 3. How can the assignee reach out to you for help?
Gmail - nitinagouda@acpce.ac.in 
