### PR TITLE
Fix golang client-go/tools/cache package name

### DIFF
--- a/content/en/docs/reference/using-api/api-concepts.md
+++ b/content/en/docs/reference/using-api/api-concepts.md
@@ -183,7 +183,7 @@ and starting the **watch** from the `resourceVersion` that was returned.
 
 For subscribing to collections, Kubernetes client libraries typically offer some form
 of standard tool for this **list**-then-**watch** logic. (In the Go client library,
-this is called a `Reflector` and is located in the `k8s.io/client-go/cache` package.)
+this is called a `Reflector` and is located in the `k8s.io/client-go/tools/cache` package.)
 
 ### Watch bookmarks
 


### PR DESCRIPTION
Documentation shows incorrect package name, it should refer to [`client-go/ools/cache`](https://pkg.go.dev/k8s.io/client-go/tools/cache).

This is me re-opening #31480.  That one ran into CLA robot trouble and was shut down; I was advised to resubmit using the same username that signed the CLA.

This *is* me, ariels@treeverse.io and @arielshaqed so I am not sure what to do.  However the CNCF/Linux CLA bot people said some things had gone wrong, so perhaps resubmitting will help.  I hope.