### PR TITLE
Changing "VMs" to "machines" in this sentence

### DIFF
--- a/content/en/docs/concepts/overview/components.md
+++ b/content/en/docs/concepts/overview/components.md
@@ -30,7 +30,7 @@ Control plane components can be run on any machine in the cluster. However,
 for simplicity, set up scripts typically start all control plane components on
 the same machine, and do not run user containers on this machine. See
 [Creating Highly Available clusters with kubeadm](/docs/setup/production-environment/tools/kubeadm/high-availability/)
-for an example control plane setup that runs across multiple VMs.
+for an example control plane setup that runs across multiple machines.
 
 ### kube-apiserver
 


### PR DESCRIPTION
The rest of this paragraph talks about nodes being "machines," whereas this sentence is more specific, referring to virtual machines ("VMs"). The article this sentence points to also uses "machines" and isn't specific to VMs.
