### PR TITLE
[zh]fix display issue of Control Plane in glossary

### DIFF
--- a/content/zh/docs/reference/glossary/control-plane.md
+++ b/content/zh/docs/reference/glossary/control-plane.md
@@ -29,6 +29,8 @@ tags:
 控制平面（Control Plane）是指容器编排层，它暴露 API 和接口来定义、
 部署容器和管理容器的生命周期。
 
+<!--more-->
+
 <!--
  This layer is composed by many different components, such as (but not restricted to):
 


### PR DESCRIPTION
I found a tiny issue when I add glossary of container-runtime-interface, details as below:
<img width="1104" alt="截屏2022-02-23 16 44 39" src="https://user-images.githubusercontent.com/23924124/155286208-ac3554b7-c4da-4ae0-bfd5-95c057bcded5.png">

this page displays not only content but also comments which is only revealed when clicked the "+" button.

so the html tag `<!--more-->` not just comment but a dividing line.