### PR TITLE
Fixed typo in cpu-constraint-namespace.md & memory-default-namespace.md

### DIFF
--- a/content/en/docs/tasks/administer-cluster/manage-resources/cpu-constraint-namespace.md
+++ b/content/en/docs/tasks/administer-cluster/manage-resources/cpu-constraint-namespace.md
@@ -170,7 +170,7 @@ kubectl apply -f https://k8s.io/examples/admin/resource/cpu-constraints-pod-3.ya
 ```
 
 The output shows that the Pod does not get created, because it defines an unacceptable container.
-That container is not acceptable because it specifies a CPU limit that is lower than the
+That container is not acceptable because it specifies a CPU request that is lower than the
 enforced minimum:
 
 ```

--- a/content/en/docs/tasks/administer-cluster/manage-resources/memory-default-namespace.md
+++ b/content/en/docs/tasks/administer-cluster/manage-resources/memory-default-namespace.md
@@ -177,7 +177,7 @@ Here are two of the restrictions that a resource quota imposes on a namespace:
 * For every Pod that runs in the namespace, the Pod and each of its containers must have a memory limit.
   (If you specify a memory limit for every container in a Pod, Kubernetes can infer the Pod-level memory
   limit by adding up the limits for its containers).
-* CPU limits apply a resource reservation on the node where the Pod in question is scheduled.
+* Memory limits apply a resource reservation on the node where the Pod in question is scheduled.
   The total amount of memory reserved for all Pods in the namespace must not exceed a specified limit.
 * The total amount of memory actually used by all Pods in the namespace must also not exceed a specified limit.
 


### PR DESCRIPTION
It Fixes typo error in cpu-constraint-namespace.md and memory-default-namespace.md

ref : #31856


 
