### PR TITLE
Added Documents for kubernetes.io/enforce-mountable-secrets.

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints.md
+++ b/content/en/docs/reference/labels-annotations-taints.md
@@ -80,6 +80,14 @@ Used on: All Objects
 
 This annotation is used for describing specific behaviour of given object.
 
+## kubernetes.io/enforce-mountable-secrets {#enforce-mountable-secrets}
+
+Example: `kubernetes.io/enforce-mountable-secrets: "true"`
+
+Used on: ServiceAccount
+
+The value for this annotation must be **true** to take effect. This annotation indicates that a ServiceAccount should enforce mountable secrets. This field should not be used to find auto-generated service account token secrets for use outside of pods.
+
 ## controller.kubernetes.io/pod-deletion-cost {#pod-deletion-cost}
 
 Example: `controller.kubernetes.io/pod-deletion-cost=10`

--- a/content/en/docs/reference/labels-annotations-taints.md
+++ b/content/en/docs/reference/labels-annotations-taints.md
@@ -86,7 +86,7 @@ Example: `kubernetes.io/enforce-mountable-secrets: "true"`
 
 Used on: ServiceAccount
 
-The value for this annotation must be **true** to take effect. This annotation indicates that a ServiceAccount should enforce mountable secrets. This field should not be used to find auto-generated service account token secrets for use outside of pods.
+The value for this annotation must be **true** to take effect. This annotation indicates that pods running as this service account may only reference Secret API objects specified in the service account's `secrets` field.
 
 ## controller.kubernetes.io/pod-deletion-cost {#pod-deletion-cost}
 


### PR DESCRIPTION
Added the document for kubernetes.io/enforce-mountable-secrets annotation in [Well-Known Labels, Annotations and Taints](https://kubernetes.io/docs/reference/labels-annotations-taints/).

Fixes: #31853
