### PR TITLE
Remove docker mention in bugs guidance

### DIFF
--- a/content/en/docs/tasks/debug-application-cluster/troubleshooting.md
+++ b/content/en/docs/tasks/debug-application-cluster/troubleshooting.md
@@ -101,7 +101,7 @@ If filing a bug, please include detailed information about how to reproduce the
 problem, such as:
 
 * Kubernetes version: `kubectl version`
-* Cloud provider, OS distro, network configuration, and Docker version
+* Cloud provider, OS distro, network configuration, and container runtime version
 * Steps to reproduce the problem
 
 


### PR DESCRIPTION
Related issue #30976

Change advice when creating k/k bugs to tell users to provide the "container runtime version" instead of "Docker version". 

/sig docs
/language en