### PR TITLE
Fix wording for "concepts/overview/working-with-objects/kubernetes-ob…

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/kubernetes-objects.md
+++ b/content/en/docs/concepts/overview/working-with-objects/kubernetes-objects.md
@@ -83,8 +83,8 @@ In the `.yaml` file for the Kubernetes object you want to create, you'll need to
 
 The precise format of the object `spec` is different for every Kubernetes object, and contains nested fields specific to that object. The [Kubernetes API Reference](https://kubernetes.io/docs/reference/kubernetes-api/) can help you find the spec format for all of the objects you can create using Kubernetes.
 
-For example, the reference for Pod details the [`spec` field](/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec)
-for a Pod in the API, and the reference for Deployment details the [`spec` field](/docs/reference/kubernetes-api/workload-resources/deployment-v1/#DeploymentSpec) for Deployments.
+For example, see the reference for Pod details, [`spec` field](/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec)
+for a Pod in the API, and the reference for Deployment details, [`spec` field](/docs/reference/kubernetes-api/workload-resources/deployment-v1/#DeploymentSpec) for Deployments.
 In those API reference pages you'll see mention of PodSpec and DeploymentSpec. These names are implementation details of the Golang code that Kubernetes uses to implement its API.
 
 

--- a/content/zh/docs/concepts/overview/working-with-objects/kubernetes-objects.md
+++ b/content/zh/docs/concepts/overview/working-with-objects/kubernetes-objects.md
@@ -174,8 +174,8 @@ In the `.yaml` file for the Kubernetes object you want to create, you'll need to
 <!--
 The precise format of the object `spec` is different for every Kubernetes object, and contains nested fields specific to that object. The [Kubernetes API Reference](https://kubernetes.io/docs/reference/kubernetes-api/) can help you find the spec format for all of the objects you can create using Kubernetes.
 
-For example, the reference for Pod details the [`spec` field](/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec)
-for a Pod in the API, and the reference for Deployment details the [`spec` field](/docs/reference/kubernetes-api/workload-resources/deployment-v1/#DeploymentSpec) for Deployments.
+For example, see the reference for Pod details, [`spec` field](/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec)
+for a Pod in the API, and the reference for Deployment details, [`spec` field](/docs/reference/kubernetes-api/workload-resources/deployment-v1/#DeploymentSpec) for Deployments.
 In those API reference pages you'll see mention of PodSpec and DeploymentSpec. These names are implementation details of the Golang code that Kubernetes uses to implement its API.
 -->
 对象 `spec` 的精确格式对每个 Kubernetes 对象来说是不同的，包含了特定于该对象的嵌套字段。


### PR DESCRIPTION
### Fix wording for "concepts/overview/working-with-objects/kubernetes-objects/#required-fields"

Reworded references to Pod details (`spec` field) so it makes better sense when read.