### PR TITLE
fixed some translations error for zh docs #31888

### DIFF
--- a/content/zh/docs/concepts/cluster-administration/system-metrics.md
+++ b/content/zh/docs/concepts/cluster-administration/system-metrics.md
@@ -128,7 +128,7 @@ For example:
 <!--
 * After deprecation
 -->
-* 被启用之后：
+* 被弃用之后：
 
   ```
   # HELP some_counter (Deprecated since 1.15.0) this counts things

--- a/content/zh/docs/reference/access-authn-authz/_index.md
+++ b/content/zh/docs/reference/access-authn-authz/_index.md
@@ -1,5 +1,5 @@
 ---
-title: 访问 API
+title: API 访问控制
 weight: 15
 no_list: true
 ---


### PR DESCRIPTION
This was a Bug Report. The problem was:
- content/zh/docs/concepts/cluster-administration/system-metrics.md
   line 131 , '启用' should be '弃用'

- content/zh/docs/reference/access-authn-authz/_index.md
   Title '访问 API' should be ‘API 访问控制'
I have corrected the documentation error. Please review
