### PR TITLE
clarify Kubernetes.io word list

### DIFF
--- a/content/en/docs/contribute/style/style-guide.md
+++ b/content/en/docs/contribute/style/style-guide.md
@@ -244,7 +244,7 @@ kind: Pod
 
 ## Kubernetes.io word list
 
-A list of Kubernetes-specific terms and words to be used consistently across the site.
+A list of Kubernetes-specific terms and words to be used consistently in text across the site.
 
 {{< table caption = "Kubernetes.io word list" >}}
 Term | Usage


### PR DESCRIPTION
#31904

Clarify wording in direction to always capitalize Kubernetes so that it excludes the logo.
