### PR TITLE
Added note for when baseurl fails in kubeadm install

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -217,6 +217,11 @@ sudo systemctl enable --now kubelet
 
   - You can leave SELinux enabled if you know how to configure it but it may require settings that are not supported by kubeadm.
 
+  - If the `baseurl` fails because your Red Hat-based distribution cannot interpret `basearch`, replace `\$basearch` with your computer's architecture.
+  Type `uname -m` to see that value.
+  Supported architectures include x86_64, aarch64, armhfp, ppc64le, and s390x.
+  So, for x86_64, the `baseurl` would be: `https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64`.
+
 {{% /tab %}}
 {{% tab name="Without a package manager" %}}
 Install CNI plugins (required for most pod network):

--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -219,8 +219,7 @@ sudo systemctl enable --now kubelet
 
   - If the `baseurl` fails because your Red Hat-based distribution cannot interpret `basearch`, replace `\$basearch` with your computer's architecture.
   Type `uname -m` to see that value.
-  Supported architectures include x86_64, aarch64, armhfp, ppc64le, and s390x.
-  So, for x86_64, the `baseurl` would be: `https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64`.
+  For example, the `baseurl` URL for `x86_64` could be: `https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64`.
 
 {{% /tab %}}
 {{% tab name="Without a package manager" %}}


### PR DESCRIPTION
With the Red Hat-based procedure for [Installing kubeadm, kubelet and kubectl](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#installing-kubeadm-kubelet-and-kubectl), there may be times that a person's Red Hat-based distro does not properly interpret $basearch, so it fails to install the kubernetes package.
I added a bullet to the Notes section to describe how to get around that.

This addresses [Issue #31038](https://github.com/kubernetes/website/issues/31038)
