### PR TITLE
Link to PSP migration guide from PSP to PSS reference

### DIFF
--- a/content/en/docs/reference/access-authn-authz/psp-to-pod-security-standards.md
+++ b/content/en/docs/reference/access-authn-authz/psp-to-pod-security-standards.md
@@ -20,6 +20,9 @@ Anything outside the allowed values for those profiles would fall under the
 [Privileged](/docs/concepts/security/pod-security-standards/#priveleged) profile. "No opinion"
 means all values are allowed under all Pod Security Standards.
 
+For a step-by-step migration guide, see
+[Migrate from PodSecurityPolicy to the Built-In PodSecurity Admission Controller](/docs/tasks/configure-pod-container/migrate-from-psp/).
+
 <!-- body -->
 
 ## PodSecurityPolicy Spec


### PR DESCRIPTION
Link back to PSP migration guide from the PSP to Pod Security Standards reference page.
