### PR TITLE
Soften / shrink older article warning

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -401,8 +401,8 @@ body {
 }
 
 .deprecation-warning, .pageinfo.deprecation-warning {
-    padding: 20px;
-    margin: 20px 0;
+    padding: clamp(10px, 2vmin, 20px);
+    margin: clamp(10px, 1vh, 20px) 0;
     background-color: #faf5b6;
     color: #000;
 }
@@ -416,6 +416,9 @@ body.td-home .deprecation-warning, body.td-blog .deprecation-warning, body.td-do
     border-radius: 3px;
 }
 
+.deprecation-warning p:only-child {
+  margin-bottom: 0;
+}
 
 .td-documentation .td-content > .highlight {
   max-width: initial;

--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -206,10 +206,7 @@ other = "Objectives"
 other = "Options"
 
 [outdated_blog__message]
-other = "The Kubernetes project considers this article to be outdated because it is more than one year old. Check that the information in the page has not become incorrect since its publication."
-
-[outdated_blog__title]
-other = "Outdated article"
+other = "This article is more than one year old. Older articles may contain outdated content. Check that the information in the page has not become incorrect since its publication."
 
 [post_create_issue]
 other = "Create an issue"

--- a/layouts/partials/deprecation-warning.html
+++ b/layouts/partials/deprecation-warning.html
@@ -12,7 +12,6 @@
 {{ else if and (eq .Section "blog") .Date (.Date.Before (now.AddDate -1 0 0)) -}}
 <section id="deprecation-warning">
   <div class="content deprecation-warning pageinfo outdated-blog">
-    <h3>{{ T "outdated_blog__title" }}</h3>
     <p>{{ T "outdated_blog__message" }}</p>
   </div>
 </section>


### PR DESCRIPTION
xref https://github.com/kubernetes/website/issues/31778

The current language sounds like the page was specifically judged to be outdated, instead of a general warning.

I also dropped the title and padding to shrink the space taken by the warning. It currently takes about 1/3 of the screen on mobile devices.

[Before](https://kubernetes.io/blog/2020/09/03/warnings/) / [After](https://deploy-preview-31932--kubernetes-io-main-staging.netlify.app//blog/2020/09/03/warnings/):

<img width="200" src="https://user-images.githubusercontent.com/980082/155867331-0b2978a2-03dc-43f5-9fb7-739127f689fa.png"> <img width="200" src="https://user-images.githubusercontent.com/980082/155867804-79aa5055-ebed-472d-b0fc-be4e9e5c414b.png">
