### PR TITLE
Allow marking blog posts as evergreen and exempt from outdated warning

### DIFF
--- a/content/en/blog/_posts/2019-12-09-kubernetes-1.17-release-announcement.md
+++ b/content/en/blog/_posts/2019-12-09-kubernetes-1.17-release-announcement.md
@@ -3,6 +3,7 @@ layout: blog
 title: "Kubernetes 1.17: Stability"
 date: 2019-12-09T13:00:00-08:00
 slug: kubernetes-1-17-release-announcement
+evergreen: true
 ---
 
 **Authors:** [Kubernetes 1.17 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.17/release_team.md)

--- a/content/en/blog/_posts/2020-03-25-kubernetes-1.18-release-announcement.md
+++ b/content/en/blog/_posts/2020-03-25-kubernetes-1.18-release-announcement.md
@@ -3,6 +3,7 @@ layout: blog
 title: 'Kubernetes 1.18: Fit & Finish'
 date: 2020-03-25
 slug: kubernetes-1-18-release-announcement
+evergreen: true
 ---
 
 **Authors:** [Kubernetes 1.18 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.18/release_team.md)

--- a/content/en/blog/_posts/2020-08-26-kubernetes-release-1.19.md
+++ b/content/en/blog/_posts/2020-08-26-kubernetes-release-1.19.md
@@ -3,6 +3,7 @@ layout: blog
 title: 'Kubernetes  1.19: Accentuate the Paw-sitive'
 date: 2020-08-26
 slug: kubernetes-release-1.19-accentuate-the-paw-sitive
+evergreen: true
 ---
 
 **Authors:** [Kubernetes 1.19 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.19/release_team.md)

--- a/content/en/blog/_posts/2020-09-03-warnings/index.md
+++ b/content/en/blog/_posts/2020-09-03-warnings/index.md
@@ -3,9 +3,10 @@ layout: blog
 title: "Warning: Helpful Warnings Ahead"
 date: 2020-09-03
 slug: warnings
+evergreen: true
 ---
 
-**Author**: Jordan Liggitt (Google)
+**Author**: [Jordan Liggitt](https://github.com/liggitt) (Google)
 
 As Kubernetes maintainers, we're always looking for ways to improve usability while preserving compatibility.
 As we develop features, triage bugs, and answer support questions, we accumulate information that would be helpful for Kubernetes users to know.
@@ -327,7 +328,3 @@ A couple areas we're looking at next are warning about [known problematic values
 we cannot reject outright for compatibility reasons, and warning about use of deprecated fields or field values
 (like selectors using beta os/arch node labels, [deprecated in v1.14](/docs/reference/labels-annotations-taints/#beta-kubernetes-io-arch-deprecated)).
 I'm excited to see progress in this area, continuing to make it easier to use Kubernetes.
-
----
-
-_[Jordan Liggitt](https://twitter.com/liggitt) is a software engineer at Google, and helps lead Kubernetes authentication, authorization, and API efforts._

--- a/content/en/blog/_posts/2020-12-08-kubernetes-release-1.20.md
+++ b/content/en/blog/_posts/2020-12-08-kubernetes-release-1.20.md
@@ -3,6 +3,7 @@ layout: blog
 title: 'Kubernetes 1.20: The Raddest Release'
 date: 2020-12-08
 slug: kubernetes-1-20-release-announcement
+evergreen: true
 ---
 
 **Authors:** [Kubernetes 1.20 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.20/release_team.md)

--- a/content/en/blog/_posts/2021-04-08-kubernetes-release-1.21.md
+++ b/content/en/blog/_posts/2021-04-08-kubernetes-release-1.21.md
@@ -3,6 +3,7 @@ layout: blog
 title: 'Kubernetes 1.21: Power to the Community'
 date: 2021-04-08
 slug: kubernetes-1-21-release-announcement
+evergreen: true
 ---
 
 **Authors:** [Kubernetes 1.21 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.21/release-team.md)

--- a/content/en/blog/_posts/2021-08-04-kubernetes-release-1.22.md
+++ b/content/en/blog/_posts/2021-08-04-kubernetes-release-1.22.md
@@ -3,6 +3,7 @@ layout: blog
 title: 'Kubernetes 1.22: Reaching New Peaks'
 date: 2021-08-04
 slug: kubernetes-1-22-release-announcement
+evergreen: true
 ---
 
 **Authors:** [Kubernetes 1.22 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.22/release-team.md)

--- a/content/en/blog/_posts/2021-12-07-kubernetes-release-1.23.md
+++ b/content/en/blog/_posts/2021-12-07-kubernetes-release-1.23.md
@@ -3,6 +3,7 @@ layout: blog
 title: 'Kubernetes 1.23: The Next Frontier'
 date: 2021-12-07
 slug: kubernetes-1-23-release-announcement
+evergreen: true
 ---
 
 **Authors:** [Kubernetes 1.23 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.23/release-team.md)

--- a/content/en/docs/contribute/new-content/blogs-case-studies.md
+++ b/content/en/docs/contribute/new-content/blogs-case-studies.md
@@ -83,6 +83,15 @@ To submit a blog post follow these directions:
       - _initial commit_
       - _draft post_
   - The blog team will then review your PR and give you comments on things you might need to fix. After that the bot will merge your PR and your blog post will be published. 
+  - If the content of the blog post contains only content that is not expected to require updates to stay accurate for the reader, it can be marked as evergreen and exempted from the automatic warning about outdated content added to blog posts older than one year.
+    - To mark a blog post as evergreen, add this to the front matter:
+      
+      ```yaml
+      evergreen: true
+      ```
+    - Examples of content that should not be marked evergreen:
+      - **Tutorials** that only apply to specific releases or versions and not all future versions
+      - References to pre-GA APIs or features
 
 
 ## Submit a case study

--- a/layouts/partials/deprecation-warning.html
+++ b/layouts/partials/deprecation-warning.html
@@ -9,7 +9,7 @@
     </p>
   </div>
 </section>
-{{ else if and (eq .Section "blog") .Date (.Date.Before (now.AddDate -1 0 0)) -}}
+{{ else if and (eq .Section "blog") (not .Params.evergreen) .Date (.Date.Before (now.AddDate -1 0 0)) -}}
 <section id="deprecation-warning">
   <div class="content deprecation-warning pageinfo outdated-blog">
     <h3>{{ T "outdated_blog__title" }}</h3>


### PR DESCRIPTION
fixes https://github.com/kubernetes/website/issues/31778

The [guide to contributing blog posts](https://kubernetes.io/docs/contribute/new-content/blogs-case-studies/#guidelines-and-expectations) says:

> - Blog posts should aim to be future proof
>   - Given the development velocity of the project, we want evergreen content that won't require updates to stay accurate for the reader. 

Blog posts that follow that guide should be able to skip the "outdated" content warning placed on posts older than a year

Before:
https://kubernetes.io/blog/2020/08/26/kubernetes-release-1.19-accentuate-the-paw-sitive/

After:
https://deploy-preview-31934--kubernetes-io-main-staging.netlify.app/blog/2020/08/26/kubernetes-release-1.19-accentuate-the-paw-sitive/