### PR TITLE
kubeadm: fix wrong path in the etcd HA guide (step 7)

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm.md
@@ -267,8 +267,8 @@ on Kubernetes dual-stack support see [Dual-stack support with kubeadm](/docs/set
 
     ```sh
     root@HOST0 $ kubeadm init phase etcd local --config=/tmp/${HOST0}/kubeadmcfg.yaml
-    root@HOST1 $ kubeadm init phase etcd local --config=/tmp/${HOST1}/kubeadmcfg.yaml
-    root@HOST2 $ kubeadm init phase etcd local --config=/tmp/${HOST2}/kubeadmcfg.yaml
+    root@HOST1 $ kubeadm init phase etcd local --config=$HOME/kubeadmcfg.yaml
+    root@HOST2 $ kubeadm init phase etcd local --config=$HOME/kubeadmcfg.yaml
     ```
 
 1. Optional: Check the cluster health


### PR DESCRIPTION
The guide generates some files on one of three ETCD
hosts. It then copies files from host 1 to 2 and 3.
Due to that some file paths differ.

Update step 7 to reflect that and to match step 6.

fixes https://github.com/kubernetes/website/issues/31692
