### PR TITLE
fix busybox image to version 1.28

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/pod-overhead.md
+++ b/content/en/docs/concepts/scheduling-eviction/pod-overhead.md
@@ -72,7 +72,7 @@ spec:
   runtimeClassName: kata-fc
   containers:
   - name: busybox-ctr
-    image: busybox
+    image: busybox:1.28
     stdin: true
     tty: true
     resources:

--- a/content/en/docs/concepts/storage/ephemeral-volumes.md
+++ b/content/en/docs/concepts/storage/ephemeral-volumes.md
@@ -107,7 +107,7 @@ metadata:
 spec:
   containers:
     - name: my-frontend
-      image: busybox
+      image: busybox:1.28
       volumeMounts:
       - mountPath: "/data"
         name: my-csi-inline-vol
@@ -158,7 +158,7 @@ metadata:
 spec:
   containers:
     - name: my-frontend
-      image: busybox
+      image: busybox:1.28
       volumeMounts:
       - mountPath: "/scratch"
         name: scratch-volume

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -251,7 +251,7 @@ metadata:
 spec:
   containers:
     - name: test
-      image: busybox
+      image: busybox:1.28
       volumeMounts:
         - name: config-vol
           mountPath: /etc/config
@@ -1128,7 +1128,7 @@ spec:
         fieldRef:
           apiVersion: v1
           fieldPath: metadata.name
-    image: busybox
+    image: busybox:1.28
     command: [ "sh", "-c", "while [ true ]; do echo 'Hello'; sleep 10; done | tee -a /logs/hello.txt" ]
     volumeMounts:
     - name: workdir1

--- a/content/en/docs/concepts/workloads/pods/_index.md
+++ b/content/en/docs/concepts/workloads/pods/_index.md
@@ -180,7 +180,7 @@ spec:
     spec:
       containers:
       - name: hello
-        image: busybox
+        image: busybox:1.28
         command: ['sh', '-c', 'echo "Hello, Kubernetes!" && sleep 3600']
       restartPolicy: OnFailure
     # The pod template ends here

--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -96,10 +96,10 @@ kubectl apply -f https://git.io/vPieo          # create resource(s) from url
 kubectl create deployment nginx --image=nginx  # start a single instance of nginx
 
 # create a Job which prints "Hello World"
-kubectl create job hello --image=busybox -- echo "Hello World" 
+kubectl create job hello --image=busybox:1.28 -- echo "Hello World" 
 
 # create a CronJob that prints "Hello World" every minute
-kubectl create cronjob hello --image=busybox   --schedule="*/1 * * * *" -- echo "Hello World"    
+kubectl create cronjob hello --image=busybox:1.28   --schedule="*/1 * * * *" -- echo "Hello World"    
 
 kubectl explain pods                           # get the documentation for pod manifests
 
@@ -112,7 +112,7 @@ metadata:
 spec:
   containers:
   - name: busybox
-    image: busybox
+    image: busybox:1.28
     args:
     - sleep
     - "1000000"
@@ -124,7 +124,7 @@ metadata:
 spec:
   containers:
   - name: busybox
-    image: busybox
+    image: busybox:1.28
     args:
     - sleep
     - "1000"
@@ -314,7 +314,7 @@ kubectl logs my-pod -c my-container --previous      # dump pod container logs (s
 kubectl logs -f my-pod                              # stream pod logs (stdout)
 kubectl logs -f my-pod -c my-container              # stream pod container logs (stdout, multi-container case)
 kubectl logs -f -l name=myLabel --all-containers    # stream all pods logs with label name=myLabel (stdout)
-kubectl run -i --tty busybox --image=busybox -- sh  # Run pod as interactive shell
+kubectl run -i --tty busybox --image=busybox:1.28 -- sh  # Run pod as interactive shell
 kubectl run nginx --image=nginx -n mynamespace      # Start a single instance of nginx pod in the namespace of mynamespace
 kubectl run nginx --image=nginx                     # Run pod nginx and write its spec into a file called pod.yaml
 --dry-run=client -o yaml > pod.yaml

--- a/content/en/docs/tasks/administer-cluster/declare-network-policy.md
+++ b/content/en/docs/tasks/administer-cluster/declare-network-policy.md
@@ -68,7 +68,7 @@ pod/nginx-701339712-e0qfq   1/1           Running       0          35s
 You should be able to access the new `nginx` service from other Pods. To access the `nginx` Service from another Pod in the `default` namespace, start a busybox container:
 
 ```console
-kubectl run busybox --rm -ti --image=busybox -- /bin/sh
+kubectl run busybox --rm -ti --image=busybox:1.28 -- /bin/sh
 ```
 
 In your shell, run the following command:
@@ -111,7 +111,7 @@ networkpolicy.networking.k8s.io/access-nginx created
 When you attempt to access the `nginx` Service from a Pod without the correct labels, the request times out:
 
 ```console
-kubectl run busybox --rm -ti --image=busybox -- /bin/sh
+kubectl run busybox --rm -ti --image=busybox:1.28 -- /bin/sh
 ```
 
 In your shell, run the command:
@@ -130,7 +130,7 @@ wget: download timed out
 You can create a Pod with the correct labels to see that the request is allowed:
 
 ```console
-kubectl run busybox --rm -ti --labels="access=true" --image=busybox -- /bin/sh
+kubectl run busybox --rm -ti --labels="access=true" --image=busybox:1.28 -- /bin/sh
 ```
 
 In your shell, run the command:

--- a/content/en/docs/tasks/debug-application-cluster/debug-running-pod.md
+++ b/content/en/docs/tasks/debug-application-cluster/debug-running-pod.md
@@ -110,7 +110,7 @@ specify the `-i`/`--interactive` argument, `kubectl` will automatically attach
 to the console of the Ephemeral Container.
 
 ```shell
-kubectl debug -it ephemeral-demo --image=busybox --target=ephemeral-demo
+kubectl debug -it ephemeral-demo --image=busybox:1.28 --target=ephemeral-demo
 ```
 
 ```
@@ -182,7 +182,7 @@ but you need debugging utilities not included in `busybox`. You can simulate
 this scenario using `kubectl run`:
 
 ```shell
-kubectl run myapp --image=busybox --restart=Never -- sleep 1d
+kubectl run myapp --image=busybox:1.28 --restart=Never -- sleep 1d
 ```
 
 Run this command to create a copy of `myapp` named `myapp-debug` that adds a
@@ -225,7 +225,7 @@ To simulate a crashing application, use `kubectl run` to create a container
 that immediately exits:
 
 ```
-kubectl run --image=busybox myapp -- false
+kubectl run --image=busybox:1.28 myapp -- false
 ```
 
 You can see using `kubectl describe pod myapp` that this container is crashing:
@@ -283,7 +283,7 @@ additional utilities.
 As an example, create a Pod using `kubectl run`:
 
 ```
-kubectl run myapp --image=busybox --restart=Never -- sleep 1d
+kubectl run myapp --image=busybox:1.28 --restart=Never -- sleep 1d
 ```
 
 Now use `kubectl debug` to make a copy and change its container image

--- a/content/en/docs/tasks/job/parallel-processing-expansion.md
+++ b/content/en/docs/tasks/job/parallel-processing-expansion.md
@@ -201,7 +201,7 @@ spec:
     spec:
       containers:
       - name: c
-        image: busybox
+        image: busybox:1.28
         command: ["sh", "-c", "echo Processing URL {{ url }} && sleep 5"]
       restartPolicy: Never
 {% endfor %}

--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -152,7 +152,7 @@ runs in an infinite loop, sending queries to the php-apache service.
 ```shell
 # Run this in a separate terminal
 # so that the load generation continues and you can carry on with the rest of the steps
-kubectl run -i --tty load-generator --rm --image=busybox --restart=Never -- /bin/sh -c "while sleep 0.01; do wget -q -O- http://php-apache; done"
+kubectl run -i --tty load-generator --rm --image=busybox:1.28 --restart=Never -- /bin/sh -c "while sleep 0.01; do wget -q -O- http://php-apache; done"
 ```
 
 Now run:

--- a/content/en/docs/tutorials/security/apparmor.md
+++ b/content/en/docs/tutorials/security/apparmor.md
@@ -264,7 +264,7 @@ metadata:
 spec:
   containers:
   - name: hello
-    image: busybox
+    image: busybox:1.28
     command: [ "sh", "-c", "echo 'Hello AppArmor!' && sleep 1h" ]
 EOF
 pod/hello-apparmor-2 created

--- a/content/en/docs/tutorials/services/source-ip.md
+++ b/content/en/docs/tutorials/services/source-ip.md
@@ -119,7 +119,7 @@ clusterip    ClusterIP   10.0.170.92   <none>        80/TCP    51s
 And hitting the `ClusterIP` from a pod in the same cluster:
 
 ```shell
-kubectl run busybox -it --image=busybox --restart=Never --rm
+kubectl run busybox -it --image=busybox:1.28 --restart=Never --rm
 ```
 The output is similar to this:
 ```

--- a/content/en/examples/admin/logging/two-files-counter-pod-agent-sidecar.yaml
+++ b/content/en/examples/admin/logging/two-files-counter-pod-agent-sidecar.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: count
-    image: busybox
+    image: busybox:1.28
     args:
     - /bin/sh
     - -c

--- a/content/en/examples/admin/logging/two-files-counter-pod-streaming-sidecar.yaml
+++ b/content/en/examples/admin/logging/two-files-counter-pod-streaming-sidecar.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: count
-    image: busybox
+    image: busybox:1.28
     args:
     - /bin/sh
     - -c
@@ -22,13 +22,13 @@ spec:
     - name: varlog
       mountPath: /var/log
   - name: count-log-1
-    image: busybox
+    image: busybox:1.28
     args: [/bin/sh, -c, 'tail -n+1 -f /var/log/1.log']
     volumeMounts:
     - name: varlog
       mountPath: /var/log
   - name: count-log-2
-    image: busybox
+    image: busybox:1.28
     args: [/bin/sh, -c, 'tail -n+1 -f /var/log/2.log']
     volumeMounts:
     - name: varlog

--- a/content/en/examples/admin/logging/two-files-counter-pod.yaml
+++ b/content/en/examples/admin/logging/two-files-counter-pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: count
-    image: busybox
+    image: busybox:1.28
     args:
     - /bin/sh
     - -c

--- a/content/en/examples/admin/resource/limit-range-pod-1.yaml
+++ b/content/en/examples/admin/resource/limit-range-pod-1.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: busybox-cnt01
-    image: busybox
+    image: busybox:1.28
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo hello from cnt01; sleep 10;done"]
     resources:
@@ -16,7 +16,7 @@ spec:
         memory: "200Mi"
         cpu: "500m"
   - name: busybox-cnt02
-    image: busybox
+    image: busybox:1.28
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo hello from cnt02; sleep 10;done"]
     resources:
@@ -24,7 +24,7 @@ spec:
         memory: "100Mi"
         cpu: "100m"
   - name: busybox-cnt03
-    image: busybox
+    image: busybox:1.28
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo hello from cnt03; sleep 10;done"]
     resources:
@@ -32,6 +32,6 @@ spec:
         memory: "200Mi"
         cpu: "500m"
   - name: busybox-cnt04
-    image: busybox
+    image: busybox:1.28
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo hello from cnt04; sleep 10;done"]

--- a/content/en/examples/admin/resource/limit-range-pod-2.yaml
+++ b/content/en/examples/admin/resource/limit-range-pod-2.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: busybox-cnt01
-    image: busybox
+    image: busybox:1.28
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo hello from cnt01; sleep 10;done"]
     resources:
@@ -16,7 +16,7 @@ spec:
         memory: "200Mi"
         cpu: "500m"
   - name: busybox-cnt02
-    image: busybox
+    image: busybox:1.28
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo hello from cnt02; sleep 10;done"]
     resources:
@@ -24,7 +24,7 @@ spec:
         memory: "100Mi"
         cpu: "100m"
   - name: busybox-cnt03
-    image: busybox
+    image: busybox:1.28
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo hello from cnt03; sleep 10;done"]
     resources:
@@ -32,6 +32,6 @@ spec:
         memory: "200Mi"
         cpu: "500m"
   - name: busybox-cnt04
-    image: busybox
+    image: busybox:1.28
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo hello from cnt04; sleep 10;done"]

--- a/content/en/examples/admin/resource/limit-range-pod-3.yaml
+++ b/content/en/examples/admin/resource/limit-range-pod-3.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: busybox-cnt01
-    image: busybox
+    image: busybox:1.28
     resources:
       limits:
         memory: "300Mi"

--- a/content/en/examples/application/job/cronjob.yaml
+++ b/content/en/examples/application/job/cronjob.yaml
@@ -10,7 +10,7 @@ spec:
         spec:
           containers:
           - name: hello
-            image: busybox
+            image: busybox:1.28
             imagePullPolicy: IfNotPresent
             command:
             - /bin/sh

--- a/content/en/examples/application/job/job-tmpl.yaml
+++ b/content/en/examples/application/job/job-tmpl.yaml
@@ -13,6 +13,6 @@ spec:
     spec:
       containers:
       - name: c
-        image: busybox
+        image: busybox:1.28
         command: ["sh", "-c", "echo Processing item $ITEM && sleep 5"]
       restartPolicy: Never

--- a/content/en/examples/debug/counter-pod.yaml
+++ b/content/en/examples/debug/counter-pod.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   containers:
   - name: count
-    image: busybox
+    image: busybox:1.28
     args: [/bin/sh, -c,
             'i=0; while true; do echo "$i: $(date)"; i=$((i+1)); sleep 1; done']

--- a/content/en/examples/pods/init-containers.yaml
+++ b/content/en/examples/pods/init-containers.yaml
@@ -14,7 +14,7 @@ spec:
   # These containers are run during pod initialization
   initContainers:
   - name: install
-    image: busybox
+    image: busybox:1.28
     command:
     - wget
     - "-O"

--- a/content/en/examples/pods/inject/dependent-envars.yaml
+++ b/content/en/examples/pods/inject/dependent-envars.yaml
@@ -10,7 +10,7 @@ spec:
       command:
         - sh
         - -c
-      image: busybox
+      image: busybox:1.28
       env:
         - name: SERVICE_PORT
           value: "80"

--- a/content/en/examples/pods/security/hello-apparmor.yaml
+++ b/content/en/examples/pods/security/hello-apparmor.yaml
@@ -9,5 +9,5 @@ metadata:
 spec:
   containers:
   - name: hello
-    image: busybox
+    image: busybox:1.28
     command: [ "sh", "-c", "echo 'Hello AppArmor!' && sleep 1h" ]

--- a/content/en/examples/pods/security/security-context.yaml
+++ b/content/en/examples/pods/security/security-context.yaml
@@ -12,7 +12,7 @@ spec:
     emptyDir: {}
   containers:
   - name: sec-ctx-demo
-    image: busybox
+    image: busybox:1.28
     command: [ "sh", "-c", "sleep 1h" ]
     volumeMounts:
     - name: sec-ctx-vol

--- a/content/en/examples/pods/share-process-namespace.yaml
+++ b/content/en/examples/pods/share-process-namespace.yaml
@@ -8,7 +8,7 @@ spec:
   - name: nginx
     image: nginx
   - name: shell
-    image: busybox
+    image: busybox:1.28
     securityContext:
       capabilities:
         add:

--- a/content/en/examples/pods/storage/projected-secret-downwardapi-configmap.yaml
+++ b/content/en/examples/pods/storage/projected-secret-downwardapi-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: container-test
-    image: busybox
+    image: busybox:1.28
     volumeMounts:
     - name: all-in-one
       mountPath: "/projected-volume"

--- a/content/en/examples/pods/storage/projected-secrets-nondefault-permission-mode.yaml
+++ b/content/en/examples/pods/storage/projected-secrets-nondefault-permission-mode.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: container-test
-    image: busybox
+    image: busybox:1.28
     volumeMounts:
     - name: all-in-one
       mountPath: "/projected-volume"

--- a/content/en/examples/pods/storage/projected-service-account-token.yaml
+++ b/content/en/examples/pods/storage/projected-service-account-token.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: container-test
-    image: busybox
+    image: busybox:1.28
     volumeMounts:
     - name: token-vol
       mountPath: "/service-account"

--- a/content/en/examples/pods/storage/projected.yaml
+++ b/content/en/examples/pods/storage/projected.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: test-projected-volume
-    image: busybox
+    image: busybox:1.28
     args:
     - sleep
     - "86400"

--- a/content/en/examples/service/networking/hostaliases-pod.yaml
+++ b/content/en/examples/service/networking/hostaliases-pod.yaml
@@ -15,7 +15,7 @@ spec:
     - "bar.remote"
   containers:
   - name: cat-hosts
-    image: busybox
+    image: busybox:1.28
     command:
     - cat
     args:


### PR DESCRIPTION
The current busybox image has issues with `nslookup`.

This confuses users again and again.

This PR fixes the image to `busybox:1.28`.

Closes #31930

    Related issues:
    
     https://github.com/docker-library/busybox/issues/48
     https://github.com/kubernetes/kubernetes/issues/66924
