### PR TITLE
Mark storage capacity as GA + related updates

### DIFF
--- a/content/en/docs/concepts/storage/storage-capacity.md
+++ b/content/en/docs/concepts/storage/storage-capacity.md
@@ -16,37 +16,41 @@ Storage capacity is limited and may vary depending on the node on
 which a pod runs: network-attached storage might not be accessible by
 all nodes, or storage is local to a node to begin with.
 
-{{< feature-state for_k8s_version="v1.21" state="beta" >}}
+{{< feature-state for_k8s_version="v1.24" state="stable" >}}
 
 This page describes how Kubernetes keeps track of storage capacity and
-how the scheduler uses that information to schedule Pods onto nodes
+how the scheduler uses that information to [schedule Pods](/docs/concepts/scheduling-eviction/) onto nodes
 that have access to enough storage capacity for the remaining missing
 volumes. Without storage capacity tracking, the scheduler may choose a
 node that doesn't have enough capacity to provision a volume and
 multiple scheduling retries will be needed.
 
-Tracking storage capacity is supported for {{< glossary_tooltip
-text="Container Storage Interface" term_id="csi" >}} (CSI) drivers and
-[needs to be enabled](#enabling-storage-capacity-tracking) when installing a CSI driver.
+## {{% heading "prerequisites" %}}
+
+Kubernetes v{{< skew currentVersion >}} includes cluster-level API support for
+storage capacity tracking. To use this you must also be using a CSI driver that
+supports capacity tracking. Consult the documentation for the CSI drivers that
+you use to find out whether this support is available and, if so, how to use
+it. If you are not running Kubernetes v{{< skew currentVersion >}}, check the
+documentation for that version of Kubernetes.
 
 <!-- body -->
 
 ## API
 
 There are two API extensions for this feature:
-- CSIStorageCapacity objects:
+- [CSIStorageCapacity](/docs/reference/kubernetes-api/config-and-storage-resources/csi-storage-capacity-v1/) objects:
   these get produced by a CSI driver in the namespace
   where the driver is installed. Each object contains capacity
   information for one storage class and defines which nodes have
   access to that storage.
-- [The `CSIDriverSpec.StorageCapacity` field](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#csidriverspec-v1-storage-k8s-io):
+- [The `CSIDriverSpec.StorageCapacity` field](/docs/reference/kubernetes-api/config-and-storage-resources/csi-driver-v1/#CSIDriverSpec):
   when set to `true`, the Kubernetes scheduler will consider storage
   capacity for volumes that use the CSI driver.
 
 ## Scheduling
 
 Storage capacity information is used by the Kubernetes scheduler if:
-- the `CSIStorageCapacity` feature gate is true,
 - a Pod uses a volume that has not been created yet,
 - that volume uses a {{< glossary_tooltip text="StorageClass" term_id="storage-class" >}} which references a CSI driver and
   uses `WaitForFirstConsumer` [volume binding
@@ -97,20 +101,9 @@ multiple volumes: one volume might have been created already in a
 topology segment which then does not have enough capacity left for
 another volume. Manual intervention is necessary to recover from this,
 for example by increasing capacity or deleting the volume that was
-already created. [Further
-work](https://github.com/kubernetes/enhancements/pull/1703) is needed
-to handle this automatically.
-
-## Enabling storage capacity tracking
-
-Storage capacity tracking is a beta feature and enabled by default in
-a Kubernetes cluster since Kubernetes 1.21. In addition to having the
-feature enabled in the cluster, a CSI driver also has to support
-it. Please refer to the driver's documentation for details.
+already created.
 
 ## {{% heading "whatsnext" %}}
 
  - For more information on the design, see the
 [Storage Capacity Constraints for Pod Scheduling KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/1472-storage-capacity-tracking/README.md).
-- For more information on further development of this feature, see the [enhancement tracking issue #1472](https://github.com/kubernetes/enhancements/issues/1472).
-- Learn about [Kubernetes Scheduler](/docs/concepts/scheduling-eviction/kube-scheduler/)

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -90,8 +90,6 @@ different Kubernetes components.
 | `CSIMigrationvSphere` | `false` | Beta | 1.19 | |
 | `CSIMigrationPortworx` | `false` | Alpha | 1.23 | |
 | `csiMigrationRBD` | `false` | Alpha | 1.23 | |
-| `CSIStorageCapacity` | `false` | Alpha | 1.19 | 1.20 |
-| `CSIStorageCapacity` | `true` | Beta | 1.21 | |
 | `CSIVolumeHealth` | `false` | Alpha | 1.21 | |
 | `CSRDuration` | `true` | Beta | 1.22 | |
 | `ControllerManagerLeaderMigration` | `false` | Alpha | 1.21 | 1.21 |
@@ -276,6 +274,9 @@ different Kubernetes components.
 | `CSIServiceAccountToken` | `false` | Alpha | 1.20 | 1.20 |
 | `CSIServiceAccountToken` | `true` | Beta | 1.21 | 1.21 |
 | `CSIServiceAccountToken` | `true` | GA | 1.22 | |
+| `CSIStorageCapacity` | `false` | Alpha | 1.19 | 1.20 |
+| `CSIStorageCapacity` | `true` | Beta | 1.21 | 1.23 |
+| `CSIStorageCapacity` | `true` | GA | 1.24 | |
 | `CSIVolumeFSGroupPolicy` | `false` | Alpha | 1.19 | 1.19 |
 | `CSIVolumeFSGroupPolicy` | `true` | Beta | 1.20 | 1.22 |
 | `CSIVolumeFSGroupPolicy` | `true` | GA | 1.23 | |


### PR DESCRIPTION
The feature is meant to graduate to GA in 1.24.

/hold

https://github.com/kubernetes/kubernetes/pull/108445 needs to be merged first.
