### PR TITLE
[zh] Fix blog articles using wrong custom URIs

### DIFF
--- a/content/zh/blog/_posts/2015-03-00-Kubernetes-Gathering-Videos.md
+++ b/content/zh/blog/_posts/2015-03-00-Kubernetes-Gathering-Videos.md
@@ -11,7 +11,7 @@ slug: kubernetes-gathering-videos
 title: " Kubernetes Gathering Videos "
 date: 2015-03-23
 slug: kubernetes-gathering-videos
-url: /blog/2015/03/Kubernetes-Gathering-Videos
+url: /zh/blog/2015/03/Kubernetes-Gathering-Videos
 ---
 -->
 

--- a/content/zh/blog/_posts/2015-03-00-Weekly-Kubernetes-Community-Hangout.md
+++ b/content/zh/blog/_posts/2015-03-00-Weekly-Kubernetes-Community-Hangout.md
@@ -9,7 +9,7 @@ slug: weekly-kubernetes-community-hangout
 title: " Weekly Kubernetes Community Hangout Notes - March 27 2015 "
 date: 2015-03-28
 slug: weekly-kubernetes-community-hangout
-url: /blog/2015/03/Weekly-Kubernetes-Community-Hangout
+url: /zh/blog/2015/03/Weekly-Kubernetes-Community-Hangout
 ---
 -->
 

--- a/content/zh/blog/_posts/2015-03-00-Welcome-To-Kubernetes-Blog.md
+++ b/content/zh/blog/_posts/2015-03-00-Welcome-To-Kubernetes-Blog.md
@@ -9,7 +9,7 @@ slug: welcome-to-kubernetes-blog
 title: Welcome to the Kubernetes Blog!
 date: 2015-03-20
 slug: welcome-to-kubernetes-blog
-url: /blog/2015/03/Welcome-To-Kubernetes-Blog
+url: /zh/blog/2015/03/Welcome-To-Kubernetes-Blog
 ---
 -->
 

--- a/content/zh/blog/_posts/2015-04-00-Borg-Predecessor-To-Kubernetes.md
+++ b/content/zh/blog/_posts/2015-04-00-Borg-Predecessor-To-Kubernetes.md
@@ -9,7 +9,7 @@ url: /zh/blog/2015/04/Borg-Predecessor-To-Kubernetes
 title: " Borg: The Predecessor to Kubernetes "
 date: 2015-04-23
 slug: borg-predecessor-to-kubernetes
-url: /blog/2015/04/Borg-Predecessor-To-Kubernetes
+url: /zh/blog/2015/04/Borg-Predecessor-To-Kubernetes
 ---
 -->
 <!--

--- a/content/zh/blog/_posts/2015-04-00-Weekly-Kubernetes-Community-Hangout.md
+++ b/content/zh/blog/_posts/2015-04-00-Weekly-Kubernetes-Community-Hangout.md
@@ -2,14 +2,14 @@
 title: " 每周 Kubernetes 社区例会笔记 - 2015年4月3日 "
 date: 2015-04-04
 slug: weekly-kubernetes-community-hangout
-url: /blog/2015/04/Weekly-Kubernetes-Community-Hangout
+url: /zh/blog/2015/04/Weekly-Kubernetes-Community-Hangout
 ---
 <!--
 ---
 title: " Weekly Kubernetes Community Hangout Notes - April 3 2015 "
 date: 2015-04-04
 slug: weekly-kubernetes-community-hangout
-url: /blog/2015/04/Weekly-Kubernetes-Community-Hangout
+url: /zh/blog/2015/04/Weekly-Kubernetes-Community-Hangout
 ---
 -->
 <!--

--- a/content/zh/blog/_posts/2015-04-00-Weekly-Kubernetes-Community-Hangout_17.md
+++ b/content/zh/blog/_posts/2015-04-00-Weekly-Kubernetes-Community-Hangout_17.md
@@ -9,7 +9,7 @@ slug: weekly-kubernetes-community-hangout_17
 title: " Weekly Kubernetes Community Hangout Notes - April 17 2015 "
 date: 2015-04-17
 slug: weekly-kubernetes-community-hangout_17
-url: /blog/2015/04/Weekly-Kubernetes-Community-Hangout_17
+url: /zh/blog/2015/04/Weekly-Kubernetes-Community-Hangout_17
 ---
 -->
 

--- a/content/zh/blog/_posts/2015-04-00-Weekly-Kubernetes-Community-Hangout_29.md
+++ b/content/zh/blog/_posts/2015-04-00-Weekly-Kubernetes-Community-Hangout_29.md
@@ -9,7 +9,7 @@ slug: weekly-kubernetes-community-hangout_29
 title: " Weekly Kubernetes Community Hangout Notes - April 24 2015 "
 date: 2015-04-30
 slug: weekly-kubernetes-community-hangout_29
-url: /blog/2015/04/Weekly-Kubernetes-Community-Hangout_29
+url: /zh/blog/2015/04/Weekly-Kubernetes-Community-Hangout_29
 ---
 
 -->

--- a/content/zh/blog/_posts/2015-05-00-Appc-Support-For-Kubernetes-Through-Rkt.md
+++ b/content/zh/blog/_posts/2015-05-00-Appc-Support-For-Kubernetes-Through-Rkt.md
@@ -3,14 +3,14 @@
 title: " AppC Support for Kubernetes through RKT "
 date: 2015-05-04
 slug: appc-support-for-kubernetes-through-rkt
-url: /blog/2015/05/Appc-Support-For-Kubernetes-Through-Rkt
+url: /zh/blog/2015/05/Appc-Support-For-Kubernetes-Through-Rkt
 ---
 -->
 ---
 title: " 通过 RKT 对 Kubernetes 的 AppC 支持 "
 date: 2015-05-04
 slug: appc-support-for-kubernetes-through-rkt
-url: /blog/2015/05/Appc-Support-For-Kubernetes-Through-Rkt
+url: /zh/blog/2015/05/Appc-Support-For-Kubernetes-Through-Rkt
 ---
 <!--
 We very recently accepted a pull request to the Kubernetes project to add appc support for the Kubernetes community. &nbsp;Appc is a new open container specification that was initiated by CoreOS, and is supported through CoreOS rkt container runtime.

--- a/content/zh/blog/_posts/2015-05-00-Kubernetes-On-Openstack.md
+++ b/content/zh/blog/_posts/2015-05-00-Kubernetes-On-Openstack.md
@@ -9,7 +9,7 @@ slug: kubernetes-on-openstack
 title: " Kubernetes on OpenStack "
 date: 2015-05-19
 slug: kubernetes-on-openstack
-url: /blog/2015/05/Kubernetes-On-Openstack
+url: /zh/blog/2015/05/Kubernetes-On-Openstack
 ---
 -->
 

--- a/content/zh/blog/_posts/2015-05-00-Weekly-Kubernetes-Community-Hangout.md
+++ b/content/zh/blog/_posts/2015-05-00-Weekly-Kubernetes-Community-Hangout.md
@@ -9,7 +9,7 @@ slug: weekly-kubernetes-community-hangout
 title: " Weekly Kubernetes Community Hangout Notes - May 1 2015 "
 date: 2015-05-11
 slug: weekly-kubernetes-community-hangout
-url: /blog/2015/05/Weekly-Kubernetes-Community-Hangout
+url: /zh/blog/2015/05/Weekly-Kubernetes-Community-Hangout
 ---
 -->
 

--- a/content/zh/blog/_posts/2015-06-00-Slides-Cluster-Management-With.md
+++ b/content/zh/blog/_posts/2015-06-00-Slides-Cluster-Management-With.md
@@ -9,7 +9,7 @@ slug: slides-cluster-management-with
 title: " Slides: Cluster Management with Kubernetes, talk given at the University of Edinburgh "
 date: 2015-06-26
 slug: slides-cluster-management-with
-url: /blog/2015/06/Slides-Cluster-Management-With
+url: /zh/blog/2015/06/Slides-Cluster-Management-With
 ---
 -->
 

--- a/content/zh/blog/_posts/2015-07-00-Announcing-First-Kubernetes-Enterprise.md
+++ b/content/zh/blog/_posts/2015-07-00-Announcing-First-Kubernetes-Enterprise.md
@@ -7,7 +7,7 @@ slug: announcing-first-kubernetes-enterprise
 title: " Announcing the First Kubernetes Enterprise Training Course "
 date: 2015-07-08
 slug: announcing-first-kubernetes-enterprise
-url: /blog/2015/07/Announcing-First-Kubernetes-Enterprise
+url: /zh/blog/2015/07/Announcing-First-Kubernetes-Enterprise
 --- -->
 
 <!-- At Google we rely on Linux application containers to run our core infrastructure. Everything from Search to Gmail runs in containers. &nbsp;In fact, we like containers so much that even our Google Compute Engine VMs run in containers! &nbsp;Because containers are critical to our business, we have been working with the community on many of the basic container technologies (from cgroups to Docker’s LibContainer) and even decided to build the next generation of Google’s container scheduling technology, Kubernetes, in the open. -->

--- a/content/zh/blog/_posts/2015-08-00-Weekly-Kubernetes-Community-Hangout.md
+++ b/content/zh/blog/_posts/2015-08-00-Weekly-Kubernetes-Community-Hangout.md
@@ -3,7 +3,7 @@
 title: " Weekly Kubernetes Community Hangout Notes - July 31 2015 "
 date: 2015-08-04
 slug: weekly-kubernetes-community-hangout
-url: /blog/2015/08/Weekly-Kubernetes-Community-Hangout
+url: /zh/blog/2015/08/Weekly-Kubernetes-Community-Hangout
 ---
 -->
 
@@ -11,7 +11,7 @@ url: /blog/2015/08/Weekly-Kubernetes-Community-Hangout
 title: " Kubernetes社区每周环聊笔记-2015年7月31日 "
 date: 2015-08-04
 slug: weekly-kubernetes-community-hangout
-url: /blog/2015/08/Weekly-Kubernetes-Community-Hangout
+url: /zh/blog/2015/08/Weekly-Kubernetes-Community-Hangout
 ---
 
 <!--

--- a/content/zh/blog/_posts/2015-11-00-Kubernetes-1-1-Performance-Upgrades-Improved-Tooling-And-A-Growing-Community.md
+++ b/content/zh/blog/_posts/2015-11-00-Kubernetes-1-1-Performance-Upgrades-Improved-Tooling-And-A-Growing-Community.md
@@ -2,14 +2,14 @@
 title: " Kubernetes 1.1 性能升级，工具改进和社区不断壮大  "
 date: 2015-11-09
 slug: kubernetes-1-1-performance-upgrades-improved-tooling-and-a-growing-community
-url: /blog/2015/11/Kubernetes-1-1-Performance-Upgrades-Improved-Tooling-And-A-Growing-Community
+url: /zh/blog/2015/11/Kubernetes-1-1-Performance-Upgrades-Improved-Tooling-And-A-Growing-Community
 ---
 <!--
 ---
 title: " Kubernetes 1.1 Performance upgrades, improved tooling and a growing community  "
 date: 2015-11-09
 slug: kubernetes-1-1-performance-upgrades-improved-tooling-and-a-growing-community
-url: /blog/2015/11/Kubernetes-1-1-Performance-Upgrades-Improved-Tooling-And-A-Growing-Community
+url: /zh/blog/2015/11/Kubernetes-1-1-Performance-Upgrades-Improved-Tooling-And-A-Growing-Community
 ---
 -->
 <!--

--- a/content/zh/blog/_posts/2015-12-00-Managing-Kubernetes-Pods-Services-And-Replication-Controllers-With-Puppet.md
+++ b/content/zh/blog/_posts/2015-12-00-Managing-Kubernetes-Pods-Services-And-Replication-Controllers-With-Puppet.md
@@ -9,7 +9,7 @@ slug: managing-kubernetes-pods-services-and-replication-controllers-with-puppet
 title: " Managing Kubernetes Pods, Services and Replication Controllers with Puppet "
 date: 2015-12-17
 slug: managing-kubernetes-pods-services-and-replication-controllers-with-puppet
-url: /blog/2015/12/Managing-Kubernetes-Pods-Services-And-Replication-Controllers-With-Puppet
+url: /zh/blog/2015/12/Managing-Kubernetes-Pods-Services-And-Replication-Controllers-With-Puppet
 ---
 -->
 

--- a/content/zh/blog/_posts/2016-01-00-Kubernetes-Community-Meeting-Notes.md
+++ b/content/zh/blog/_posts/2016-01-00-Kubernetes-Community-Meeting-Notes.md
@@ -2,14 +2,14 @@
 title: " Kubernetes 社区会议记录 - 20160114 "
 date: 2016-01-28
 slug: kubernetes-community-meeting-notes
-url: /blog/2016/01/Kubernetes-Community-Meeting-Notes
+url: /zh/blog/2016/01/Kubernetes-Community-Meeting-Notes
 ---
 <!--
 ---
 title: " Kubernetes Community Meeting Notes - 20160114 "
 date: 2016-01-28
 slug: kubernetes-community-meeting-notes
-url: /blog/2016/01/Kubernetes-Community-Meeting-Notes
+url: /zh/blog/2016/01/Kubernetes-Community-Meeting-Notes
 ---
 -->
 <!--

--- a/content/zh/blog/_posts/2016-01-00-Simple-Leader-Election-With-Kubernetes.md
+++ b/content/zh/blog/_posts/2016-01-00-Simple-Leader-Election-With-Kubernetes.md
@@ -11,7 +11,7 @@ slug: simple-leader-election-with-kubernetes
 title: "Kubernetes 和 Docker 简单的 leader election"
 date: 2016-01-11
 slug: simple-leader-election-with-kubernetes
-url: /blog/2016/01/Simple-Leader-Election-With-Kubernetes
+url: /zh/blog/2016/01/Simple-Leader-Election-With-Kubernetes
 
 <!--
 Kubernetes simplifies the deployment and operational management of services running on clusters. However, it also simplifies the development of these services. In this post we'll see how you can use Kubernetes to easily perform leader election in your distributed application. Distributed applications usually replicate the tasks of a service for reliability and scalability, but often it is necessary to designate one of the replicas as the leader who is responsible for coordination among all of the replicas.

--- a/content/zh/blog/_posts/2016-01-00-Why-Kubernetes-Doesnt-Use-Libnetwork.md
+++ b/content/zh/blog/_posts/2016-01-00-Why-Kubernetes-Doesnt-Use-Libnetwork.md
@@ -8,7 +8,7 @@ slug: why-kubernetes-doesnt-use-libnetwork
 title: " Why Kubernetes doesn’t use libnetwork "
 date: 2016-01-14
 slug: why-kubernetes-doesnt-use-libnetwork
-url: /blog/2016/01/Why-Kubernetes-Doesnt-Use-Libnetwork
+url: /zh/blog/2016/01/Why-Kubernetes-Doesnt-Use-Libnetwork
 --- -->
 
 <!-- Kubernetes has had a very basic form of network plugins since before version 1.0 was released — around the same time as Docker's [libnetwork](https://github.com/docker/libnetwork) and Container Network Model ([CNM](https://github.com/docker/libnetwork/blob/master/docs/design.md)) was introduced. Unlike libnetwork, the Kubernetes plugin system still retains its "alpha" designation. Now that Docker's network plugin support is released and supported, an obvious question we get is why Kubernetes has not adopted it yet. After all, vendors will almost certainly be writing plugins for Docker — we would all be better off using the same drivers, right?   -->

--- a/content/zh/blog/_posts/2016-02-00-Kubecon-Eu-2016-Kubernetes-Community-In.md
+++ b/content/zh/blog/_posts/2016-02-00-Kubecon-Eu-2016-Kubernetes-Community-In.md
@@ -9,7 +9,7 @@ slug: kubecon-eu-2016-kubernetes-community-in
 title: " KubeCon EU 2016: Kubernetes Community in London "
 date: 2016-02-24
 slug: kubecon-eu-2016-kubernetes-community-in
-url: /blog/2016/02/Kubecon-Eu-2016-Kubernetes-Community-In
+url: /zh/blog/2016/02/Kubecon-Eu-2016-Kubernetes-Community-In
 ---
 -->
 

--- a/content/zh/blog/_posts/2016-02-00-Kubernetes-Community-Meeting-Notes.md
+++ b/content/zh/blog/_posts/2016-02-00-Kubernetes-Community-Meeting-Notes.md
@@ -8,7 +8,7 @@ slug: kubernetes-community-meeting-notes
 title: " Kubernetes community meeting notes - 20160204 "
 date: 2016-02-09
 slug: kubernetes-community-meeting-notes
-url: /blog/2016/02/Kubernetes-Community-Meeting-Notes
+url: /zh/blog/2016/02/Kubernetes-Community-Meeting-Notes
 ---
 -->
 <!--

--- a/content/zh/blog/_posts/2016-02-00-State-Of-Container-World-January-2016.md
+++ b/content/zh/blog/_posts/2016-02-00-State-Of-Container-World-January-2016.md
@@ -2,14 +2,14 @@
 title: " 容器世界现状，2016年1月 "
 date: 2016-02-01
 slug: state-of-container-world-january-2016
-url: /blog/2016/02/State-Of-Container-World-January-2016
+url: /zh/blog/2016/02/State-Of-Container-World-January-2016
 ---
 <!--
 ---
 title: " State of the Container World, January 2016 "
 date: 2016-02-01
 slug: state-of-container-world-january-2016
-url: /blog/2016/02/State-Of-Container-World-January-2016
+url: /zh/blog/2016/02/State-Of-Container-World-January-2016
 ---
 -->
 <!--

--- a/content/zh/blog/_posts/2016-02-00-kubernetes-community-meeting-notes_23.md
+++ b/content/zh/blog/_posts/2016-02-00-kubernetes-community-meeting-notes_23.md
@@ -2,7 +2,7 @@
 title: "Kubernetes 社区会议记录 - 20160218"
 date: 2016-02-23
 slug: kubernetes-community-meeting-notes_23
-url: /blog/2016/02/kubernetes-community-meeting-notes_23
+url: /zh/blog/2016/02/kubernetes-community-meeting-notes_23
 ---
 
 <!--
@@ -10,8 +10,8 @@ url: /blog/2016/02/kubernetes-community-meeting-notes_23
 title: " Kubernetes Community Meeting Notes - 20160218 "
 date: 2016-02-23
 slug: kubernetes-community-meeting-notes_23
-url: /blog/2016/02/kubernetes-community-meeting-notes_23
-url: /blog/2016/02/kubernetes-community-meeting-notes_23
+url: /zh/blog/2016/02/kubernetes-community-meeting-notes_23
+url: /zh/blog/2016/02/kubernetes-community-meeting-notes_23
 ---
 -->
 

--- a/content/zh/blog/_posts/2016-04-00-Adding-Support-For-Kubernetes-In-Rancher.md
+++ b/content/zh/blog/_posts/2016-04-00-Adding-Support-For-Kubernetes-In-Rancher.md
@@ -2,14 +2,14 @@
 title: " 在 Rancher 中添加对 Kuernetes 的支持 "
 date: 2016-04-08
 slug: adding-support-for-kubernetes-in-rancher
-url: /blog/2016/04/Adding-Support-For-Kubernetes-In-Rancher
+url: /zh/blog/2016/04/Adding-Support-For-Kubernetes-In-Rancher
 ---
 <!--
 ---
 title: " Adding Support for Kubernetes in Rancher "
 date: 2016-04-08
 slug: adding-support-for-kubernetes-in-rancher
-url: /blog/2016/04/Adding-Support-For-Kubernetes-In-Rancher
+url: /zh/blog/2016/04/Adding-Support-For-Kubernetes-In-Rancher
 ---
 -->
 <!--

--- a/content/zh/blog/_posts/2016-04-00-Kubernetes-Network-Policy-APIs.md
+++ b/content/zh/blog/_posts/2016-04-00-Kubernetes-Network-Policy-APIs.md
@@ -9,7 +9,7 @@ url: /zh/blog/2016/04/Kubernetes-Network-Policy-APIs
 title: " SIG-Networking: Kubernetes Network Policy APIs Coming in 1.3 "
 date: 2016-04-18
 slug: kubernetes-network-policy-apis
-url: /blog/2016/04/Kubernetes-Network-Policy-APIs
+url: /zh/blog/2016/04/Kubernetes-Network-Policy-APIs
 ---
 -->
 <!--

--- a/content/zh/blog/_posts/2016-04-00-Sig-Clusterops-Promote-Operability-And-Interoperability-Of-K8S-Clusters.md
+++ b/content/zh/blog/_posts/2016-04-00-Sig-Clusterops-Promote-Operability-And-Interoperability-Of-K8S-Clusters.md
@@ -2,14 +2,14 @@
 title: " SIG-ClusterOps: 提升 Kubernetes 集群的可操作性和互操作性 "
 date: 2016-04-19
 slug: sig-clusterops-promote-operability-and-interoperability-of-k8s-clusters
-url: /blog/2016/04/Sig-Clusterops-Promote-Operability-And-Interoperability-Of-K8S-Clusters
+url: /zh/blog/2016/04/Sig-Clusterops-Promote-Operability-And-Interoperability-Of-K8S-Clusters
 ---
 <!--
 ---
 title: " SIG-ClusterOps: Promote operability and interoperability of Kubernetes clusters "
 date: 2016-04-19
 slug: sig-clusterops-promote-operability-and-interoperability-of-k8s-clusters
-url: /blog/2016/04/Sig-Clusterops-Promote-Operability-And-Interoperability-Of-K8S-Clusters
+url: /zh/blog/2016/04/Sig-Clusterops-Promote-Operability-And-Interoperability-Of-K8S-Clusters
 ---
 -->
 <!--

--- a/content/zh/blog/_posts/2016-05-00-Coreosfest2016-Kubernetes-Community.md
+++ b/content/zh/blog/_posts/2016-05-00-Coreosfest2016-Kubernetes-Community.md
@@ -2,14 +2,14 @@
 title: " CoreOS Fest 2016: CoreOS 和 Kubernetes 在柏林（和旧金山）社区见面会 "
 date: 2016-05-03
 slug: coreosfest2016-kubernetes-community
-url: /blog/2016/05/Coreosfest2016-Kubernetes-Community
+url: /zh/blog/2016/05/Coreosfest2016-Kubernetes-Community
 ---
 <!--
 ---
 title: " CoreOS Fest 2016: CoreOS and Kubernetes Community meet in Berlin (& San Francisco) "
 date: 2016-05-03
 slug: coreosfest2016-kubernetes-community
-url: /blog/2016/05/Coreosfest2016-Kubernetes-Community
+url: /zh/blog/2016/05/Coreosfest2016-Kubernetes-Community
 ---
 -->
 <!--

--- a/content/zh/blog/_posts/2016-07-00-Bringing-End-To-End-Kubernetes-Testing-To-Azure-2.md
+++ b/content/zh/blog/_posts/2016-07-00-Bringing-End-To-End-Kubernetes-Testing-To-Azure-2.md
@@ -2,14 +2,14 @@
 题目: " 将端到端的 Kubernetes 测试引入 Azure （第二部分） "
 日期: 2016-07-18
 slug: bringing-end-to-end-kubernetes-testing-to-azure-2
-url: /blog/2016/07/Bringing-End-To-End-Kubernetes-Testing-To-Azure-2
+url: /zh/blog/2016/07/Bringing-End-To-End-Kubernetes-Testing-To-Azure-2
 ---
 <!--
 ---
 title: " Bringing End-to-End Kubernetes Testing to Azure (Part 2) "
 date: 2016-07-18
 slug: bringing-end-to-end-kubernetes-testing-to-azure-2
-url: /blog/2016/07/Bringing-End-To-End-Kubernetes-Testing-To-Azure-2
+url: /zh/blog/2016/07/Bringing-End-To-End-Kubernetes-Testing-To-Azure-2
 ---
 -->
 

--- a/content/zh/blog/_posts/2016-07-00-Citrix-Netscaler-And-Kubernetes.md
+++ b/content/zh/blog/_posts/2016-07-00-Citrix-Netscaler-And-Kubernetes.md
@@ -9,7 +9,7 @@ slug: citrix-netscaler-and-kubernetes
 title: " Citrix + Kubernetes = A Home Run "
 date: 2016-07-14
 slug: citrix-netscaler-and-kubernetes
-url: /blog/2016/07/Citrix-Netscaler-And-Kubernetes
+url: /zh/blog/2016/07/Citrix-Netscaler-And-Kubernetes
 ---
 -->
 

--- a/content/zh/blog/_posts/2016-07-00-Dashboard-Web-Interface-For-Kubernetes.md
+++ b/content/zh/blog/_posts/2016-07-00-Dashboard-Web-Interface-For-Kubernetes.md
@@ -9,7 +9,7 @@ slug: dashboard-web-interface-for-kubernetes
 title: " Dashboard - Full Featured Web Interface for Kubernetes "
 date: 2016-07-15
 slug: dashboard-web-interface-for-kubernetes
-url: /blog/2016/07/Dashboard-Web-Interface-For-Kubernetes
+url: /zh/blog/2016/07/Dashboard-Web-Interface-For-Kubernetes
 ---
 -->
 

--- a/content/zh/blog/_posts/2016-07-00-Oh-The-Places-You-Will-Go.md
+++ b/content/zh/blog/_posts/2016-07-00-Oh-The-Places-You-Will-Go.md
@@ -9,7 +9,7 @@ slug: oh-the-places-you-will-go
 title: " Happy Birthday Kubernetes. Oh, the places you’ll go! "
 date: 2016-07-21
 slug: oh-the-places-you-will-go
-url: /blog/2016/07/Oh-The-Places-You-Will-Go
+url: /zh/blog/2016/07/Oh-The-Places-You-Will-Go
 ---
 -->
 

--- a/content/zh/blog/_posts/2016-07-00-stateful-applications-in-containers-kubernetes.md
+++ b/content/zh/blog/_posts/2016-07-00-stateful-applications-in-containers-kubernetes.md
@@ -2,14 +2,14 @@
 title: "容器中运行有状态的应用！？ Kubernetes 1.3 说 “是！” "
 date: 2016-07-13
 slug: stateful-applications-in-containers-kubernetes
-url: /blog/2016/07/stateful-applications-in-containers-kubernetes
+url: /zh/blog/2016/07/stateful-applications-in-containers-kubernetes
 ---
 <!--
 ---
 title: " Stateful Applications in Containers!? Kubernetes 1.3 Says “Yes!” "
 date: 2016-07-13
 slug: stateful-applications-in-containers-kubernetes
-url: /blog/2016/07/stateful-applications-in-containers-kubernetes
+url: /zh/blog/2016/07/stateful-applications-in-containers-kubernetes
 ---
 -->
 

--- a/content/zh/blog/_posts/2016-08-00-Stateful-Applications-Using-Kubernetes-Datera.md
+++ b/content/zh/blog/_posts/2016-08-00-Stateful-Applications-Using-Kubernetes-Datera.md
@@ -9,7 +9,7 @@ url: /zh/blog/2016/08/Stateful-Applications-Using-Kubernetes-Datera
 title: " Scaling Stateful Applications using Kubernetes Pet Sets and FlexVolumes with Datera Elastic Data Fabric "
 date: 2016-08-29
 slug: stateful-applications-using-kubernetes-datera
-url: /blog/2016/08/Stateful-Applications-Using-Kubernetes-Datera
+url: /zh/blog/2016/08/Stateful-Applications-Using-Kubernetes-Datera
 ---
 --->
 

--- a/content/zh/blog/_posts/2017-10-00-Five-Days-Of-Kubernetes-18.md
+++ b/content/zh/blog/_posts/2017-10-00-Five-Days-Of-Kubernetes-18.md
@@ -9,7 +9,7 @@ slug: five-days-of-kubernetes-18
 title: " Five Days of Kubernetes 1.8 "
 date: 2017-10-24
 slug: five-days-of-kubernetes-18
-url: /blog/2017/10/Five-Days-Of-Kubernetes-18
+url: /zh/blog/2017/10/Five-Days-Of-Kubernetes-18
 ---
 -->
 

--- a/content/zh/blog/_posts/2017-10-00-Kubernetes-Community-Steering-Committee-Election-Results.md
+++ b/content/zh/blog/_posts/2017-10-00-Kubernetes-Community-Steering-Committee-Election-Results.md
@@ -2,14 +2,14 @@
 title: " Kubernetes 社区指导委员会选举结果 "
 date: 2017-10-05
 slug: kubernetes-community-steering-committee-election-results
-url: /blog/2017/10/Kubernetes-Community-Steering-Committee-Election-Results
+url: /zh/blog/2017/10/Kubernetes-Community-Steering-Committee-Election-Results
 ---
 <!--
 ---
 title: " Kubernetes Community Steering Committee Election Results "
 date: 2017-10-05
 slug: kubernetes-community-steering-committee-election-results
-url: /blog/2017/10/Kubernetes-Community-Steering-Committee-Election-Results
+url: /zh/blog/2017/10/Kubernetes-Community-Steering-Committee-Election-Results
 ---
 -->
 <!--

--- a/content/zh/blog/_posts/2017-11-00-Autoscaling-In-Kubernetes.md
+++ b/content/zh/blog/_posts/2017-11-00-Autoscaling-In-Kubernetes.md
@@ -9,7 +9,7 @@ slug: autoscaling-in-kubernetes
 title: " Autoscaling in Kubernetes "
 date: 2017-11-17
 slug: autoscaling-in-kubernetes
-url: /blog/2017/11/Autoscaling-In-Kubernetes
+url: /zh/blog/2017/11/Autoscaling-In-Kubernetes
 ---
 -->
 

--- a/content/zh/blog/_posts/2018-01-00-Kubernetes-V19-Beta-Windows-Support.md
+++ b/content/zh/blog/_posts/2018-01-00-Kubernetes-V19-Beta-Windows-Support.md
@@ -2,14 +2,14 @@
 title: Kubernetes 1.9 对 Windows Server 容器提供 Beta 版本支持
 date: 2018-01-09
 slug: kubernetes-v19-beta-windows-support
-url: /blog/2018/01/Kubernetes-V19-Beta-Windows-Support
+url: /zh/blog/2018/01/Kubernetes-V19-Beta-Windows-Support
 ---
 <!--
 ---
 title: Kubernetes v1.9 releases beta support for Windows Server Containers
 date: 2018-01-09
 slug: kubernetes-v19-beta-windows-support
-url: /blog/2018/01/Kubernetes-V19-Beta-Windows-Support
+url: /zh/blog/2018/01/Kubernetes-V19-Beta-Windows-Support
 ---
 --->
 

--- a/content/zh/blog/_posts/2018-03-00-Principles-Of-Container-App-Design.md
+++ b/content/zh/blog/_posts/2018-03-00-Principles-Of-Container-App-Design.md
@@ -9,7 +9,7 @@ url: /zh/blog/2018/03/Principles-Of-Container-App-Design
 title: "Principles of Container-based Application Design"
 date: 2018-03-15
 slug: principles-of-container-app-design
-url: /blog/2018/03/Principles-Of-Container-App-Design
+url: /zh/blog/2018/03/Principles-Of-Container-App-Design
 ---
 -->
 


### PR DESCRIPTION
Some blog articles with custom URIs have been localized into Chinese without removing the custom URI from the front matter. The right thing to have done initially would be to _omit_ the `url:` field from front matter when localizing.

Update these articles to use appropriate URIs.

/area blog