### PR TITLE
[zh] Fix scheduling-eviction index

### DIFF
--- a/content/zh/docs/concepts/scheduling-eviction/_index.md
+++ b/content/zh/docs/concepts/scheduling-eviction/_index.md
@@ -6,10 +6,10 @@ description: >
   在Kubernetes中，调度 (scheduling) 指的是确保 Pods 匹配到合适的节点，
   以便 kubelet 能够运行它们。抢占 (Preemption) 指的是终止低优先级的 Pods 以便高优先级的 Pods 可以
   调度运行的过程。驱逐 (Eviction) 是在资源匮乏的节点上，主动让一个或多个 Pods 失效的过程。
+no_list: true
 ---
 
 <!--
----
 title: "Scheduling, Preemption and Eviction"
 weight: 90
 content_type: concept
@@ -20,7 +20,6 @@ description: >
   Nodes. Eviction is the process of proactively terminating one or more Pods on
   resource-starved Nodes.
 no_list: true
----
 -->
 
 <!--


### PR DESCRIPTION
The `no_list: true` directive is important. We should not remove it when
translating an index page.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
