### PR TITLE
调度框架 #32036 changes done

### DIFF
--- a/content/zh/docs/concepts/scheduling-eviction/scheduling-framework.md
+++ b/content/zh/docs/concepts/scheduling-eviction/scheduling-framework.md
@@ -306,7 +306,7 @@ _Permit_ 插件在每个 Pod 调度周期的最后调用，用于防止或延迟
     If any Permit plugin denies a Pod, it is returned to the scheduling queue.
     This will trigger [Unreserve](#unreserve) plugins.
 -->
-1.  **拒绝** \
+2.  **拒绝** \
     如果任何 Permit 插件拒绝 Pod，则该 Pod 将被返回到调度队列。
     这将触发[Unreserve](#unreserve) 插件。
 
@@ -318,7 +318,7 @@ _Permit_ 插件在每个 Pod 调度周期的最后调用，用于防止或延迟
     and the Pod is returned to the scheduling queue, triggering [Unreserve](#unreserve)
     plugins.
 -->
-1.  **等待**（带有超时） \
+1.  **等待**（带有超时) \
     如果一个 Permit 插件返回 “等待” 结果，则 Pod 将保持在一个内部的 “等待中”
     的 Pod 列表，同时该 Pod 的绑定周期启动时即直接阻塞直到得到
     [批准](#frameworkhandle)。如果超时发生，**等待** 变成 **拒绝**，并且 Pod


### PR DESCRIPTION
I have solved the mentioned issue which is opened on 调度框架 #32036

https://kubernetes.io/zh/docs/concepts/scheduling-eviction/scheduling-framework/#:~:text=%E8%BF%9B%E8%A1%8C%E7%BB%91%E5%AE%9A%E3%80%82-,%E6%8B%92%E7%BB%9D,-%E5%A6%82%E6%9E%9C%E4%BB%BB%E4%BD%95%20Permit
"1. 拒绝" should be changed to "2. 拒绝"

https://kubernetes.io/zh/docs/concepts/scheduling-eviction/scheduling-framework/#:~:text=Unreserve%20%E6%8F%92%E4%BB%B6%E3%80%82-,%E7%AD%89%E5%BE%85%EF%BC%88%E5%B8%A6%E6%9C%89%E8%B6%85%E6%97%B6%EF%BC%89,-%E5%A6%82%E6%9E%9C%E4%B8%80%E4%B8%AA%20Permit
"1. 等待（带有超时）" should be changed to "1. 等待（带有超时"