### PR TITLE
Reword preStop hook usage regarding container's Terminated state

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -136,7 +136,7 @@ completion or failed for some reason. When you use `kubectl` to query a Pod with
 a container that is `Terminated`, you see a reason, an exit code, and the start and
 finish time for that container's period of execution.
 
-If a container has a `preStop` hook configured, that runs before the container enters
+If a container has a `preStop` hook configured, this hook runs before the container enters
 the `Terminated` state.
 
 ## Container restart policy {#restart-policy}


### PR DESCRIPTION
### Reword preStop hook usage regarding container's Terminated state

#### From

```
If a container has a `preStop` hook configured, that runs before the container enters
```

#### To

```
If a container has a `preStop` hook configured, this hook runs before the container enters
```

#### Reason

It is unclear to what `that runs before the container enters` refers to when reading the sentence:

```
Reword preStop hook usage regarding container's Terminated state
```

make it explicit that it is about the hook.