### PR TITLE
Mark “Remembering Dan Kohn” article evergreen

### DIFF
--- a/content/en/blog/_posts/2020-11-02-remembering-dan-kohn.md
+++ b/content/en/blog/_posts/2020-11-02-remembering-dan-kohn.md
@@ -3,6 +3,7 @@ layout: blog
 title: "Remembering Dan Kohn"
 date: 2020-11-02
 slug: remembering-dan-kohn
+evergreen: true
 ---
 
 **Author**: The Kubernetes Steering Committee


### PR DESCRIPTION
This change updates https://kubernetes.io/blog/2020/11/02/remembering-dan-kohn/ to remove a banner that (currently) reads:
> This article is more than one year old. Older articles may contain outdated content. Check that the information in the page has not become incorrect since its publication.
