### PR TITLE
No need for special handling for zsh aliases

### DIFF
--- a/content/en/docs/tasks/tools/included/optional-kubectl-configs-zsh.md
+++ b/content/en/docs/tasks/tools/included/optional-kubectl-configs-zsh.md
@@ -12,16 +12,11 @@ To do so in all your shell sessions, add the following to your `~/.zshrc` file:
 source <(kubectl completion zsh)
 ```
 
-If you have an alias for kubectl, you can extend shell completion to work with that alias:
-
-```zsh
-echo 'alias k=kubectl' >>~/.zshrc
-echo 'compdef __start_kubectl k' >>~/.zshrc
-```
+If you have an alias for kubectl, kubectl autocompletion will automatically work with it.
 
 After reloading your shell, kubectl autocompletion should be working.
 
-If you get an error like `complete:13: command not found: compdef`, then add the following to the beginning of your `~/.zshrc` file:
+If you get an error like `2: command not found: compdef`, then add the following to the beginning of your `~/.zshrc` file:
 
 ```zsh
 autoload -Uz compinit


### PR DESCRIPTION
Zsh completion is native since v1.22. Native zsh completion automatically deals with aliases without needing any extra configuration from the user.

Ref: https://github.com/kubernetes/kubernetes/pull/96087

/cc @eddiezane @brianpursley 