### PR TITLE
Docs - Fixed double quotes issue with feature-gates

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -29,7 +29,7 @@ To set feature gates for a component, such as kubelet, use the `--feature-gates`
 flag assigned to a list of feature pairs:
 
 ```shell
---feature-gates="...,GracefulNodeShutdown=true"
+--feature-gates=...,GracefulNodeShutdown=true
 ```
 
 The following tables are a summary of the feature gates that you can set on


### PR DESCRIPTION
Double quotes was giving error as below, may be need to update the code to accept the double quotes.

```bash
Error: invalid argument "\"GracefulNodeShutdown=true\"" for "--feature-gates" flag: invalid value of "GracefulNodeShutdown=true", err: strconv.ParseBool: parsing "true\"": invalid syntax
```
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
