### PR TITLE
Make FEATURE STATE localizable

### DIFF
--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -69,6 +69,9 @@ other = "Were you looking for:"
 [examples_heading]
 other = "Examples"
 
+[feature_state]
+other = "FEATURE STATE:"
+
 [feedback_heading]
 other = "Feedback"
 

--- a/layouts/shortcodes/feature-state.html
+++ b/layouts/shortcodes/feature-state.html
@@ -6,6 +6,6 @@
 {{ errorf "%q is not a valid feature-state, use one of %q" $state $valid_states }}
 {{ else }}
 <div style="margin-top: 10px; margin-bottom: 10px;">
-<b>FEATURE STATE:</b> <code>Kubernetes {{ $for_k8s_version }} [{{ $state }}]</code>
+  <b>{{ T "feature_state" }}</b> <code>Kubernetes {{ $for_k8s_version }} [{{ $state }}]</code>
 </div>
 {{ end }}


### PR DESCRIPTION
Add i18n string for FEATURE STATE, for ease of localization.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
