### PR TITLE
feat: Dockerfile for arm64 architecture

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,37 @@
+# This is a modified version of the original Dockerfile in this repository,
+# edited to install Hugo Extended from a tarball in a way that works with arm64
+# architectures.
+
+FROM golang:1.16-alpine
+
+RUN apk add --no-cache \
+    curl \
+    gcc \
+    g++ \
+    git \
+    musl-dev \
+    openssh-client \
+    rsync \
+    build-base \
+    libc6-compat \
+    npm && \
+    npm install -D autoprefixer postcss-cli
+
+ARG HUGO_VERSION
+
+RUN mkdir $HOME/src && \
+    cd $HOME/src && \
+    curl -L https://github.com/gohugoio/hugo/archive/refs/tags/v${HUGO_VERSION}.tar.gz | tar -xz && \
+    cd "hugo-${HUGO_VERSION}" && \
+    go install --tags extended && \
+    cp /go/bin/hugo /usr/local/bin/hugo && \
+    mkdir -p /usr/local/src && \
+    cd /usr/local/src && \
+    addgroup -Sg 1000 hugo && \
+    adduser -Sg hugo -u 1000 -h /src hugo
+
+WORKDIR /src
+
+USER hugo:hugo
+
+EXPOSE 1313

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,13 @@ container-image: ## Build a container image for the preview of the website
 		--tag $(CONTAINER_IMAGE) \
 		--build-arg HUGO_VERSION=$(HUGO_VERSION)
 
+container-image-arm64: ## Build a container image for the preview of the website that works with arm64
+	$(CONTAINER_ENGINE) build . \
+		--file Dockerfile.arm64 \
+		--network=host \
+		--tag $(CONTAINER_IMAGE) \
+		--build-arg HUGO_VERSION=$(HUGO_VERSION)
+
 container-build: module-check
 	$(CONTAINER_RUN) --read-only --mount type=tmpfs,destination=/tmp,tmpfs-mode=01777 $(CONTAINER_IMAGE) sh -c "npm ci && hugo --minify --environment development"
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ make container-serve
 
 If you see errors, it probably means that the hugo container did not have enough computing resources available. To solve it, increase the amount of allowed CPU and memory usage for Docker on your machine ([MacOSX](https://docs.docker.com/docker-for-mac/#resources) and [Windows](https://docs.docker.com/docker-for-windows/#resources)).
 
+If you use a computer with arm64 architecture instead of amd64, use the target `make container-image-arm64` instead to build the container image.
+
 Open up your browser to <http://localhost:1313> to view the website. As you make changes to the source files, Hugo updates the website and forces a browser refresh.
 
 ## Running the website locally using Hugo


### PR DESCRIPTION
## Changes
- Create a new Dockerfile that works for Apple Silicon processors.
- Create a new target in the Makefile that allows building this new Dockerfile.
- Update documentation to tell how to use the new Makefile target.

May fix https://github.com/kubernetes/website/issues/32099