### PR TITLE
fix(kubectl bash alias auto-completion): make complete command use default completion

### DIFF
--- a/content/de/docs/reference/kubectl/cheatsheet.md
+++ b/content/de/docs/reference/kubectl/cheatsheet.md
@@ -31,7 +31,7 @@ Sie können auch ein Abkürzungsalias für `kubectl` verwenden, welches auch mit
 
 ```bash
 alias k=kubectl
-complete -F __start_kubectl k
+complete -o default -F __start_kubectl k
 ```
 
 ### ZSH

--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -30,7 +30,7 @@ You can also use a shorthand alias for `kubectl` that also works with completion
 
 ```bash
 alias k=kubectl
-complete -F __start_kubectl k
+complete -o default -F __start_kubectl k
 ```
 
 ### ZSH

--- a/content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-linux.md
+++ b/content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-linux.md
@@ -43,7 +43,7 @@ If you have an alias for kubectl, you can extend shell completion to work with t
 
 ```bash
 echo 'alias k=kubectl' >>~/.bashrc
-echo 'complete -F __start_kubectl k' >>~/.bashrc
+echo 'complete -o default -F __start_kubectl k' >>~/.bashrc
 ```
 
 {{< note >}}

--- a/content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-mac.md
+++ b/content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-mac.md
@@ -77,7 +77,7 @@ You now have to ensure that the kubectl completion script gets sourced in all yo
 
     ```bash
     echo 'alias k=kubectl' >>~/.bash_profile
-    echo 'complete -F __start_kubectl k' >>~/.bash_profile
+    echo 'complete -o default -F __start_kubectl k' >>~/.bash_profile
     ```
 
 - If you installed kubectl with Homebrew (as explained [here](/docs/tasks/tools/install-kubectl-macos/#install-with-homebrew-on-macos)), then the kubectl completion script should already be in `/usr/local/etc/bash_completion.d/kubectl`. In that case, you don't need to do anything.

--- a/content/es/docs/tasks/tools/included/optional-kubectl-configs-bash-linux.md
+++ b/content/es/docs/tasks/tools/included/optional-kubectl-configs-bash-linux.md
@@ -44,7 +44,7 @@ Si tiene un alias para kubectl, puede extender el completado del shell para trab
 
 ```bash
 echo 'alias k=kubectl' >>~/.bashrc
-echo 'complete -F __start_kubectl k' >>~/.bashrc
+echo 'complete -o default -F __start_kubectl k' >>~/.bashrc
 ```
 
 {{< note >}}

--- a/content/es/docs/tasks/tools/included/optional-kubectl-configs-bash-mac.md
+++ b/content/es/docs/tasks/tools/included/optional-kubectl-configs-bash-mac.md
@@ -76,7 +76,7 @@ Ahora debe asegurarse de que el script de completado de kubectl se obtenga en to
 
     ```bash
     echo 'alias k=kubectl' >>~/.bash_profile
-    echo 'complete -F __start_kubectl k' >>~/.bash_profile
+    echo 'complete -o default -F __start_kubectl k' >>~/.bash_profile
     ```
 
 - Si instaló kubectl con Homebrew (como se explica [aquí](/docs/tasks/tools/install-kubectl-macos/#install-with-homebrew-on-macos)), entonces el script de completado de kubectl ya debería estar en `/usr/local/etc/bash_completion.d/kubectl`. En ese caso, no necesita hacer nada.

--- a/content/fr/docs/reference/kubectl/cheatsheet.md
+++ b/content/fr/docs/reference/kubectl/cheatsheet.md
@@ -36,7 +36,7 @@ Vous pouvez de plus déclarer un alias pour `kubectl` qui fonctionne aussi avec 
 
 ```bash
 alias k=kubectl
-complete -F __start_kubectl k
+complete -o default -F __start_kubectl k
 ```
 
 ### ZSH

--- a/content/fr/docs/tasks/tools/install-kubectl.md
+++ b/content/fr/docs/tasks/tools/install-kubectl.md
@@ -363,7 +363,7 @@ Vous devez maintenant vérifier que le script de completion de kubectl est bien 
 
     ```shell
     echo 'alias k=kubectl' >>~/.bashrc
-    echo 'complete -F __start_kubectl k' >>~/.bashrc
+    echo 'complete -o default -F __start_kubectl k' >>~/.bashrc
     ```
 
 {{< note >}}
@@ -431,7 +431,7 @@ Si vous n'avez pas installé via Homebrew, vous devez maintenant vous assurer qu
 
     ```shell
     echo 'alias k=kubectl' >>~/.bashrc
-    echo 'complete -F __start_kubectl k' >>~/.bashrc
+    echo 'complete -o default -F __start_kubectl k' >>~/.bashrc
     ```
     
 Si vous avez installé kubectl avec Homebrew (comme expliqué [ici](#installer-avec-homebrew-sur-macos)), alors le script de complétion a été automatiquement installé dans `/usr/local/etc/bash_completion.d/kubectl`. Dans ce cas, vous n'avez rien à faire.

--- a/content/id/docs/reference/kubectl/cheatsheet.md
+++ b/content/id/docs/reference/kubectl/cheatsheet.md
@@ -31,7 +31,7 @@ Kamu juga dapat menggunakan alias singkatan untuk `kubectl` yang juga bisa berfu
 
 ```bash
 alias k=kubectl
-complete -F __start_kubectl k
+complete -o default -F __start_kubectl k
 ```
 
 ### ZSH

--- a/content/id/docs/tasks/tools/install-kubectl.md
+++ b/content/id/docs/tasks/tools/install-kubectl.md
@@ -359,7 +359,7 @@ Jika kamu menggunakan alias untuk `kubectl`, kamu masih dapat menggunakan fitur 
 
     ```shell
     echo 'alias k=kubectl' >>~/.bashrc
-    echo 'complete -F __start_kubectl k' >>~/.bashrc
+    echo 'complete -o default -F __start_kubectl k' >>~/.bashrc
     ```
 
 {{< note >}}
@@ -447,7 +447,7 @@ Sekarang kamu harus memastikan bahwa skrip penyelesaian untuk `kubectl` sudah di
 
     ```shell
     echo 'alias k=kubectl' >>~/.bashrc
-    echo 'complete -F __start_kubectl k' >>~/.bashrc
+    echo 'complete -o default -F __start_kubectl k' >>~/.bashrc
     ```
 - Jika kamu menginstal `kubectl` dengan Homebrew (seperti yang sudah dijelaskan [di atas](#install-with-homebrew-on-macos)), maka skrip penyelesaian untuk `kubectl` sudah berada di `/usr/local/etc/bash_completion.d/kubectl`. Kamu tidak perlu melakukan apa-apa lagi.
 

--- a/content/ja/docs/reference/kubectl/cheatsheet.md
+++ b/content/ja/docs/reference/kubectl/cheatsheet.md
@@ -25,7 +25,7 @@ echo "source <(kubectl completion bash)" >> ~/.bashrc # bashシェルでのコ�
 
 ```bash
 alias k=kubectl
-complete -F __start_kubectl k
+complete -o default -F __start_kubectl k
 ```
 
 ### ZSH

--- a/content/ja/docs/tasks/tools/install-kubectl.md
+++ b/content/ja/docs/tasks/tools/install-kubectl.md
@@ -369,7 +369,7 @@ source /usr/share/bash-completion/bash_completion
 
 ```bash
 echo 'alias k=kubectl' >>~/.bashrc
-echo 'complete -F __start_kubectl k' >>~/.bashrc
+echo 'complete -o default -F __start_kubectl k' >>~/.bashrc
 ```
 
 {{< note >}}
@@ -458,7 +458,7 @@ export BASH_COMPLETION_COMPAT_DIR="/usr/local/etc/bash_completion.d"
 
    ```bash
    echo 'alias k=kubectl' >>~/.bash_profile
-   echo 'complete -F __start_kubectl k' >>~/.bash_profile
+   echo 'complete -o default -F __start_kubectl k' >>~/.bash_profile
    ```
 
 - kubectlをHomwbrewでインストールした場合([前述](#homebrewを使用してmacosへインストールする)のとおり)、kubectlの補完スクリプトはすでに`/usr/local/etc/bash_completion.d/kubectl`に格納されているでしょう。この場合、なにも操作する必要はありません。

--- a/content/ko/docs/reference/kubectl/cheatsheet.md
+++ b/content/ko/docs/reference/kubectl/cheatsheet.md
@@ -29,7 +29,7 @@ echo "source <(kubectl completion bash)" >> ~/.bashrc # 자동 완성을 bash �
 
 ```bash
 alias k=kubectl
-complete -F __start_kubectl k
+complete -o default -F __start_kubectl k
 ```
 
 ### ZSH

--- a/content/ko/docs/tasks/tools/included/optional-kubectl-configs-bash-linux.md
+++ b/content/ko/docs/tasks/tools/included/optional-kubectl-configs-bash-linux.md
@@ -44,7 +44,7 @@ kubectl에 대한 앨리어스(alias)가 있는 경우, 해당 앨리어스로 �
 
 ```bash
 echo 'alias k=kubectl' >>~/.bashrc
-echo 'complete -F __start_kubectl k' >>~/.bashrc
+echo 'complete -o default -F __start_kubectl k' >>~/.bashrc
 ```
 
 {{< note >}}

--- a/content/ko/docs/tasks/tools/included/optional-kubectl-configs-bash-mac.md
+++ b/content/ko/docs/tasks/tools/included/optional-kubectl-configs-bash-mac.md
@@ -77,7 +77,7 @@ export BASH_COMPLETION_COMPAT_DIR="/usr/local/etc/bash_completion.d"
 
     ```bash
     echo 'alias k=kubectl' >>~/.bash_profile
-    echo 'complete -F __start_kubectl k' >>~/.bash_profile
+    echo 'complete -o default -F __start_kubectl k' >>~/.bash_profile
     ```
 
 - Homebrew로 kubectl을 설치한 경우([여기](/ko/docs/tasks/tools/install-kubectl-macos/#install-with-homebrew-on-macos)의 설명을 참고), kubectl 자동 완성 스크립트가 이미 `/usr/local/etc/bash_completion.d/kubectl` 에 있을 것이다. 이 경우, 아무 것도 할 필요가 없다.

--- a/content/pt-br/docs/reference/kubectl/cheatsheet.md
+++ b/content/pt-br/docs/reference/kubectl/cheatsheet.md
@@ -35,7 +35,7 @@ Você também pode usar uma abreviação para o atalho para `kubectl` que també
 
 ```bash
 alias k=kubectl
-complete -F __start_kubectl k
+complete -o default -F __start_kubectl k
 ```
 
 ### ZSH

--- a/content/ru/docs/reference/kubectl/cheatsheet.md
+++ b/content/ru/docs/reference/kubectl/cheatsheet.md
@@ -35,7 +35,7 @@ echo "source <(kubectl completion bash)" >> ~/.bashrc # добавление а�
 
 ```bash
 alias k=kubectl
-complete -F __start_kubectl k
+complete -o default -F __start_kubectl k
 ```
 
 ### ZSH

--- a/content/ru/docs/tasks/tools/install-kubectl.md
+++ b/content/ru/docs/tasks/tools/install-kubectl.md
@@ -368,7 +368,7 @@ source /usr/share/bash-completion/bash_completion
 
     ```shell
     echo 'alias k=kubectl' >>~/.bashrc
-    echo 'complete -F __start_kubectl k' >>~/.bashrc
+    echo 'complete -o default -F __start_kubectl k' >>~/.bashrc
     ```
 
 {{< note >}}
@@ -435,7 +435,7 @@ export BASH_COMPLETION_COMPAT_DIR="/usr/local/etc/bash_completion.d"
 
     ```shell
     echo 'alias k=kubectl' >>~/.bashrc
-    echo 'complete -F __start_kubectl k' >>~/.bashrc
+    echo 'complete -o default -F __start_kubectl k' >>~/.bashrc
     ```
 
 Если вы установили kubectl с помощью Homebrew (как описано [выше](#install-with-homebrew-on-macos)), то скрипт дополнения ввода kubectl уже должен быть находится в `/usr/local/etc/bash_completion.d/kubectl`. В этом случае вам не нужно ничего делать.

--- a/content/vi/docs/reference/kubectl/cheatsheet.md
+++ b/content/vi/docs/reference/kubectl/cheatsheet.md
@@ -33,7 +33,7 @@ Bạn có thể dùng một alias cho `kubectl` cũng hoạt động với compl
 
 ```bash
 alias k=kubectl
-complete -F __start_kubectl k
+complete -o default -F __start_kubectl k
 ```
 
 ### ZSH

--- a/content/vi/docs/tasks/tools/install-kubectl.md
+++ b/content/vi/docs/tasks/tools/install-kubectl.md
@@ -356,7 +356,7 @@ Bây giờ bạn cần đảm bảo rằng kubectl completion script được so
 
     ```shell
     echo 'alias k=kubectl' >>~/.bashrc
-    echo 'complete -F __start_kubectl k' >>~/.bashrc
+    echo 'complete -o default -F __start_kubectl k' >>~/.bashrc
     ```
 
 {{< note >}}
@@ -424,7 +424,7 @@ Bây giờ bạn phải đảm bảo rằng kubectl completion script đã đư�
 
     ```shell
     echo 'alias k=kubectl' >>~/.bashrc
-    echo 'complete -F __start_kubectl k' >>~/.bashrc
+    echo 'complete -o default -F __start_kubectl k' >>~/.bashrc
     ```
     
 - Nếu bạn đã cài kubectl với Homebrew (như đã giới thiệu [bên trên](#install-with-homebrew-on-macos))) thì kubectl completion script sẽ có trong `/usr/local/etc/bash_completion.d/kubectl`. Trong trường hợp này thì bạn không cần làm gì cả.

--- a/content/zh/docs/reference/kubectl/cheatsheet.md
+++ b/content/zh/docs/reference/kubectl/cheatsheet.md
@@ -54,7 +54,7 @@ echo "source <(kubectl completion bash)" >> ~/.bashrc # 在您的 bash shell 中
 
 ```bash
 alias k=kubectl
-complete -F __start_kubectl k
+complete -o default -F __start_kubectl k
 ```
 
 ### ZSH

--- a/content/zh/docs/tasks/tools/included/optional-kubectl-configs-bash-linux.md
+++ b/content/zh/docs/tasks/tools/included/optional-kubectl-configs-bash-linux.md
@@ -86,7 +86,7 @@ If you have an alias for kubectl, you can extend shell completion to work with t
 
 ```bash
 echo 'alias k=kubectl' >>~/.bashrc
-echo 'complete -F __start_kubectl k' >>~/.bashrc
+echo 'complete -o default -F __start_kubectl k' >>~/.bashrc
 ```
 
 {{< note >}}

--- a/content/zh/docs/tasks/tools/included/optional-kubectl-configs-bash-mac.md
+++ b/content/zh/docs/tasks/tools/included/optional-kubectl-configs-bash-mac.md
@@ -148,7 +148,7 @@ You now have to ensure that the kubectl completion script gets sourced in all yo
 
     ```bash
     echo 'alias k=kubectl' >>~/.bash_profile
-    echo 'complete -F __start_kubectl k' >>~/.bash_profile
+    echo 'complete -o default -F __start_kubectl k' >>~/.bash_profile
     ```
 
 <!-- 


### PR DESCRIPTION
### Problem
Related to this *kubectl* issue: [1181](https://github.com/kubernetes/kubectl/issues/1181).

Current Bash alias documentation leads to an inoperative path completion (especially when using the Kustomize flag `-k`).

The faulted command is the one describing the shell completion extension for an alias: `complete -F __start_kubectl k`

It missed the `-o default` argument to enable the the default completion settings which let doing file completion:
`complete -o default -F __start_kubectl k`.

### Correction
Applied this command to fix the various templates affected:
```bash
grep -rl "complete -F __start_kubectl k" content/ | xargs sed -i 's/complete -F __start_kubectl k/complete -o default -F __start_kubectl k/g'
```
