### PR TITLE
Improvement: Updated FEATURE STATE of NamespaceDefaultLabelName.

### DIFF
--- a/content/en/docs/concepts/services-networking/network-policies.md
+++ b/content/en/docs/concepts/services-networking/network-policies.md
@@ -281,7 +281,7 @@ the policy will be applied only for the single `port` field.
 
 ## Targeting a Namespace by its name
 
-{{< feature-state state="beta" for_k8s_version="1.21" >}}
+{{< feature-state for_k8s_version="1.22" state="stable" >}}
 
 The Kubernetes control plane sets an immutable label `kubernetes.io/metadata.name` on all
 namespaces, provided that the `NamespaceDefaultLabelName`


### PR DESCRIPTION
This PR fixed the `FEATURE STATE` of **NamespaceDefaultLabelName** in [Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/).

Fixes: #32121