### PR TITLE
[en] Update Bash alias auto-completion

### DIFF
--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -30,7 +30,7 @@ You can also use a shorthand alias for `kubectl` that also works with completion
 
 ```bash
 alias k=kubectl
-complete -F __start_kubectl k
+complete -o default -F __start_kubectl k
 ```
 
 ### ZSH

--- a/content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-linux.md
+++ b/content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-linux.md
@@ -43,7 +43,7 @@ If you have an alias for kubectl, you can extend shell completion to work with t
 
 ```bash
 echo 'alias k=kubectl' >>~/.bashrc
-echo 'complete -F __start_kubectl k' >>~/.bashrc
+echo 'complete -o default -F __start_kubectl k' >>~/.bashrc
 ```
 
 {{< note >}}

--- a/content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-mac.md
+++ b/content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-mac.md
@@ -77,7 +77,7 @@ You now have to ensure that the kubectl completion script gets sourced in all yo
 
     ```bash
     echo 'alias k=kubectl' >>~/.bash_profile
-    echo 'complete -F __start_kubectl k' >>~/.bash_profile
+    echo 'complete -o default -F __start_kubectl k' >>~/.bash_profile
     ```
 
 - If you installed kubectl with Homebrew (as explained [here](/docs/tasks/tools/install-kubectl-macos/#install-with-homebrew-on-macos)), then the kubectl completion script should already be in `/usr/local/etc/bash_completion.d/kubectl`. In that case, you don't need to do anything.


### PR DESCRIPTION
### Problem
Related to this *kubectl* issue: [1181](https://github.com/kubernetes/kubectl/issues/1181).

Current Bash alias documentation leads to an inoperative path completion (especially when using the Kustomize flag `-k`).

The faulted command is the one describing the shell completion extension for an alias: `complete -F __start_kubectl k`

It missed the `-o default` argument to enable the the default completion settings which let doing file completion:
`complete -o default -F __start_kubectl k`.

### Correction
Applied this command to update the various templates affected:
```bash
grep -rl "complete -F __start_kubectl k" content/en/ | xargs sed -i 's/complete -F __start_kubectl k/complete -o default -F __start_kubectl k/g'
```