### PR TITLE
Add info about finding the runtime endpoint

### DIFF
--- a/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/find-out-runtime-you-use.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/find-out-runtime-you-use.md
@@ -32,16 +32,22 @@ kubectl get nodes -o wide
 The output is similar to the following. The column `CONTAINER-RUNTIME` outputs
 the runtime and its version.
 
+For Docker Engine, the output is similar to this:
+
 ```none
-# For dockershim
 NAME         STATUS   VERSION    CONTAINER-RUNTIME
 node-1       Ready    v1.16.15   docker://19.3.1
 node-2       Ready    v1.16.15   docker://19.3.1
 node-3       Ready    v1.16.15   docker://19.3.1
 ```
+If your runtime shows as Docker Engine, you still might not be affected by the
+removal of dockershim in Kubernetes 1.24. [Check the runtime
+endpoint](#which-endpoint) to see if you use dockershim. If you don't use
+dockershim, you aren't affected. 
+
+For containerd, the output is similar to this:
 
 ```none
-# For containerd
 NAME         STATUS   VERSION   CONTAINER-RUNTIME
 node-1       Ready    v1.19.6   containerd://1.4.1
 node-2       Ready    v1.19.6   containerd://1.4.1
@@ -49,4 +55,44 @@ node-3       Ready    v1.19.6   containerd://1.4.1
 ```
 
 Find out more information about container runtimes
-on [Container Runtimes](/docs/setup/production-environment/container-runtimes/) page.
+on [Container Runtimes](/docs/setup/production-environment/container-runtimes/)
+page.
+
+## Find out what container runtime endpoint you use {#which-endpoint}
+
+The container runtime talks to the kubelet over a Unix socket using the [CRI
+protocol](/docs/concepts/architecture/cri/), which is based on the gRPC
+framework. The kubelet acts as a client, and the runtime acts as the server.
+In some cases, you might find it useful to know which socket your nodes use. For
+example, with the removal of dockershim in Kubernetes 1.24 and later, you might
+want to know whether you use Docker Engine with dockershim.
+
+{{<note>}}
+If you currently use Docker Engine in your nodes with `cri-dockerd`, you aren't
+affected by the dockershim removal.
+{{</note>}}
+
+You can check which socket you use by checking the kubelet configuration on your
+nodes.
+
+1.  Read the starting commands for the kubelet process:
+
+    ```
+    tr \\0 ' ' < /proc/"$(pgrep kubelet)"/cmdline
+    ```
+    If you don't have `tr` or `pgrep`, check the command line for the kubelet
+    process manually.
+
+1.  In the output, look for the `--container-runtime` flag and the
+    `--container-runtime-endpoint` flag.
+
+    *   If your nodes use Kubernetes v1.23 and earlier and these flags aren't
+        present or if the `--container-runtime` flag is not `remote`,
+        you use the dockershim socket with Docker Engine.
+    *   If the `--container-runtime-endpoint` flag is present, check the socket
+        name to find out which runtime you use. For example,
+        `unix:///run/containerd/containerd.sock` is the containerd endpoint.
+
+If you use Docker Engine with the dockershim, [migrate to a different runtime](/docs/tasks/administer-cluster/migrating-from-dockershim/change-runtime-containerd/),
+or, if you want to continue using Docker Engine in v1.24 and later, migrate to a
+CRI-compatible adapter like [`cri-dockerd`](https://github.com/Mirantis/cri-dockerd).


### PR DESCRIPTION
Fixes #30974

Add a section to "Find out what container runtime is used on a node" to find the runtime endpoint, with a clarification that Docker users who use cri-dockerd already wouldn't be affected by the dockershim removal. 

/sig docs
/language en
/cc @sftim @afbjorklund 