### PR TITLE
Fix article “Faster than a speeding latte”

### DIFF
--- a/content/en/blog/_posts/2015-04-00-Faster-Than-Speeding-Latte.md
+++ b/content/en/blog/_posts/2015-04-00-Faster-Than-Speeding-Latte.md
@@ -1,8 +1,11 @@
 ---
-title: " Faster than a speeding Latte "
+title: "Faster than a speeding Latte"
 date: 2015-04-06
 slug: faster-than-speeding-latte
 url: /blog/2015/04/Faster-Than-Speeding-Latte
+evergreen: true
 ---
+
 Check out Brendan Burns racing Kubernetes.
-[![Check out Brendan Burns racing Kubernetes](https://img.youtube.com/vi/7vZ9dRKRMyc/0.jpg)](https://www.youtube.com/watch?v=?7vZ9dRKRMyc)
+
+{{< youtube id="7vZ9dRKRMyc" title="Latte vs. Kubernetes setup - which is faster?">}}


### PR DESCRIPTION
Fixup for https://kubernetes.io/blog/2015/04/faster-than-speeding-latte/

/kind cleanup
/language en