### PR TITLE
Drop feature state for kubeadm / kubelet

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/kubelet-integration.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/kubelet-integration.md
@@ -8,8 +8,6 @@ weight: 80
 
 <!-- overview -->
 
-{{< feature-state for_k8s_version="v1.11" state="stable" >}}
-
 The lifecycle of the kubeadm CLI tool is decoupled from the
 [kubelet](/docs/reference/command-line-tools-reference/kubelet), which is a daemon that runs
 on each node within the Kubernetes cluster. The kubeadm CLI tool is executed by the user when Kubernetes is


### PR DESCRIPTION
Remove a feature-state shortcode from https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/kubelet-integration/

It won't be clear to readers what feature is being covered here. The advice in this page is version-specific (especially given the removal of the dockershim); removing this shortcode takes away a detail that might mislead people into thinking the page has not changed recently.

/sig cluster-lifecycle
/sig node