### PR TITLE
[WIP] Create new Updating Existing Content doc

### DIFF
--- a/content/en/docs/contribute/existing-content/_index.md
+++ b/content/en/docs/contribute/existing-content/_index.md
@@ -1,0 +1,19 @@
+---
+title: Updating existing content
+content_type: concept
+main_menu: true
+weight: 25
+---
+
+Making corrections to existing documentation to fix such things as broken links or outdated content is one of the best ways to begin contributing.
+
+More information to come...
+
+## Ongoing documentation maintenance
+
+## Ongoing blog maintenance
+
+SIG-Docs approvers for English content can approve edits after the fact such as: broken links, copy edits, etc. However, approval and editorial review for new blog posts is limited to the Blog Team.
+
+We typically do not make edits to blog posts more than 1 years old.
+


### PR DESCRIPTION
It was noted that a small section of the [Submitting blog posts and case studies](https://kubernetes.io/docs/contribute/new-content/blogs-case-studies/) doc described how to update existing blogs. Per [this comment](https://github.com/kubernetes/community/pull/6312#discussion_r780676908), I'm creating a new page to contain guidelines for updating existing documentation and blog content. This is currently a work in progress.
