### PR TITLE
[ko] fix typo in get-shell-running-container page

### DIFF
--- a/content/ko/docs/tasks/debug-application-cluster/get-shell-running-container.md
+++ b/content/ko/docs/tasks/debug-application-cluster/get-shell-running-container.md
@@ -154,5 +154,4 @@ kubectl exec -i -t my-pod --container main-app -- /bin/bash
 ## {{% heading "whatsnext" %}}
 
 
-* [kubectl
-* exec](/docs/reference/generated/kubectl/kubectl-commands/#exec)를참고한다.
+* [kubectl exec](/docs/reference/generated/kubectl/kubectl-commands/#exec)를 참고한다.


### PR DESCRIPTION
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

It fixes typo error in get-shell-running-container.md