### PR TITLE
Updated configure-liveness-readiness-startup-probes.md

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -59,7 +59,7 @@ and restarts it.
 When the container starts, it executes this command:
 
 ```shell
-/bin/sh -c "touch /tmp/healthy; sleep 30; rm -rf /tmp/healthy; sleep 600"
+/bin/sh -c "touch /tmp/healthy; sleep 30; rm -f /tmp/healthy; sleep 600"
 ```
 
 For the first 30 seconds of the container's life, there is a `/tmp/healthy` file.

--- a/content/en/examples/pods/probe/exec-liveness.yaml
+++ b/content/en/examples/pods/probe/exec-liveness.yaml
@@ -11,7 +11,7 @@ spec:
     args:
     - /bin/sh
     - -c
-    - touch /tmp/healthy; sleep 30; rm -rf /tmp/healthy; sleep 600
+    - touch /tmp/healthy; sleep 30; rm -f /tmp/healthy; sleep 600
     livenessProbe:
       exec:
         command:


### PR DESCRIPTION
We don't need to pass **-r** flag with rm command to delete a file. We use **-r** flag to delete a directory recursively.

Though it is harmless to use `rm -rf `to delete a file but it doesn't make sense to use -r explicitly.  
