### PR TITLE
Add proxy-url example to kubectl documentation

### DIFF
--- a/content/en/docs/concepts/configuration/organize-cluster-access-kubeconfig.md
+++ b/content/en/docs/concepts/configuration/organize-cluster-access-kubeconfig.md
@@ -156,7 +156,7 @@ You can configure `kubectl` to use proxy by setting `proxy-url` in the kubeconfi
 apiVersion: v1
 kind: Config
 
-proxy-url: https://proxy.host/3128
+proxy-url: https://proxy.host:3128
 
 clusters:
 - cluster:

--- a/content/en/docs/concepts/configuration/organize-cluster-access-kubeconfig.md
+++ b/content/en/docs/concepts/configuration/organize-cluster-access-kubeconfig.md
@@ -148,7 +148,28 @@ File references on the command line are relative to the current working director
 In `$HOME/.kube/config`, relative paths are stored relatively, and absolute paths
 are stored absolutely.
 
+## Proxy
 
+You can configure `kubectl` to use proxy by setting `proxy-url` in the kubeconfig file, like:
+
+```yaml
+apiVersion: v1
+kind: Config
+
+proxy-url: https://proxy.host/3128
+
+clusters:
+- cluster:
+  name: development
+
+users:
+- name: developer
+
+contexts:
+- context:
+  name: development
+
+```
 
 
 ## {{% heading "whatsnext" %}}


### PR DESCRIPTION
I was pointed to https://github.com/kubernetes/client-go/issues/351#issuecomment-626752837 but wasn't able to find any mention of `proxy-url` in docs.