### PR TITLE
Add details about enabling individual API resources using --runtime-config

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -1118,3 +1118,8 @@ Each feature gate is designed for enabling/disabling a specific feature:
 
 * The [deprecation policy](/docs/reference/using-api/deprecation-policy/) for Kubernetes explains
   the project's approach to removing features and components.
+* Since Kubernetes 1.24, new beta APIs are not enabled by default.  When enabling a beta
+  feature, you will also need to enable any associated API resources.
+  For example, to enable a particular resource like
+  `storage.k8s.io/v1beta1/csistoragecapacities`, set `--runtime-config=storage.k8s.io/v1beta1/csistoragecapacities`.
+  See [API Versioning](/docs/reference/using-api/#api-versioning) for more details on the command line flags.

--- a/content/en/docs/reference/using-api/_index.md
+++ b/content/en/docs/reference/using-api/_index.md
@@ -108,7 +108,7 @@ part is omitted, it is treated as if `=true` is specified. For example:
 
  - to disable `batch/v1`, set `--runtime-config=batch/v1=false`
  - to enable `batch/v2alpha1`, set `--runtime-config=batch/v2alpha1`
- - to enable a particular resource like `storage.k8s.io/v1beta1/csistoragecapacities`, set `--runtime-config=storage.k8s.io/v1beta1/csistoragecapacities`
+ - to enable a specific version of an API, such as `storage.k8s.io/v1beta1/csistoragecapacities`, set `--runtime-config=storage.k8s.io/v1beta1/csistoragecapacities`
 
 {{< note >}}
 When you enable or disable groups or resources, you need to restart the API

--- a/content/en/docs/reference/using-api/_index.md
+++ b/content/en/docs/reference/using-api/_index.md
@@ -108,6 +108,7 @@ part is omitted, it is treated as if `=true` is specified. For example:
 
  - to disable `batch/v1`, set `--runtime-config=batch/v1=false`
  - to enable `batch/v2alpha1`, set `--runtime-config=batch/v2alpha1`
+ - to enable a particular resource like `storage.k8s.io/v1beta1/csistoragecapacities`, set `--runtime-config=storage.k8s.io/v1beta1/csistoragecapacities`
 
 {{< note >}}
 When you enable or disable groups or resources, you need to restart the API


### PR DESCRIPTION
This is in support of beta APIs off by default KEP.  When beta APIs are off by default, we must describe how to turn particular ones on.  

xref https://github.com/kubernetes/enhancements/issues/3136

