### PR TITLE
Add kubectl folder to the PATH

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -85,7 +85,7 @@ For example, to download version {{< param "fullversion" >}} on Linux, type:
    chmod +x kubectl
    mkdir -p ~/.local/bin/kubectl
    mv ./kubectl ~/.local/bin/kubectl
-   # and then append (or prepend) ~/.local/bin to $PATH
+   # and then append (or prepend) ~/.local/bin/kubectl to $PATH
    ```
 
    {{< /note >}}


### PR DESCRIPTION
The folder `kubectl` was removed in PR #31355.
Adding it back so that `kubectl` binary inside the `kubectl` folder is accessible.