### PR TITLE
Changing note about limits without requests

### DIFF
--- a/content/en/docs/concepts/configuration/manage-resources-containers.md
+++ b/content/en/docs/concepts/configuration/manage-resources-containers.md
@@ -49,7 +49,7 @@ runtimes can have different ways to implement the same restrictions.
 {{< note >}}
 If a container specifies its own memory limit, but does not specify a memory request, Kubernetes
 automatically assigns a memory request that matches the limit. Similarly, if a container specifies its own
-CPU limit, but does not specify a CPU request, Kubernetes automatically assigns a CPU request that matches
+CPU limit (or any other resource limit), but does not specify a CPU request, Kubernetes automatically assigns a CPU request that matches
 the limit.
 {{< /note >}}
 

--- a/content/en/docs/concepts/configuration/manage-resources-containers.md
+++ b/content/en/docs/concepts/configuration/manage-resources-containers.md
@@ -47,10 +47,9 @@ or by enforcement (the system prevents the container from ever exceeding the lim
 runtimes can have different ways to implement the same restrictions.
 
 {{< note >}}
-If a container specifies its own memory limit, but does not specify a memory request, Kubernetes
-automatically assigns a memory request that matches the limit. Similarly, if a container specifies its own
-CPU limit (or any other resource limit), but does not specify a CPU request, Kubernetes automatically assigns a CPU request that matches
-the limit.
+If you specify a limit for a resource, but do not specify any request, and no admission-time
+mechanism has applied a default request for that resource, then Kubernetes copies the limit
+you specified and uses it as the requested value for the resource.
 {{< /note >}}
 
 ## Resource types


### PR DESCRIPTION
this is true for all limits (not only CPU and memory but also ephemeral storage)

Implementation is here (as looping on all the limits): 
https://github.com/kubernetes/kubernetes/blob/4d08582d1fa21e1f5887e73380001ac827371553/pkg/apis/core/v1/defaults.go#L159


Maybe another phrasing is better, but currently I (and probably) didn't understand that it applies to all resources (such as GPU, ephemeral-storage etc)