### PR TITLE
Update install-kubectl-linux.md

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -84,8 +84,8 @@ For example, to download version {{< param "fullversion" >}} on Linux, type:
    ```bash
    chmod +x kubectl
    mkdir -p ~/.local/bin/kubectl
-   mv ./kubectl ~/.local/bin/kubectl
-   # and then append (or prepend) ~/.local/bin to $PATH
+   mv ./kubectl ~/.local/bin/kubectl/
+   # and then append (or prepend) ~/.local/bin/kubectl to $PATH
    ```
 
    {{< /note >}}


### PR DESCRIPTION
adding kubectl  to  PATH  ,  since kubectl  is copied to  ~/.local/bin/kubectl  directory PATH  should be set to ~/.local/bin/kubectl

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
