### PR TITLE
Fix directory to make and put kubectl in

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -83,7 +83,7 @@ For example, to download version {{< param "fullversion" >}} on Linux, type:
 
    ```bash
    chmod +x kubectl
-   mkdir -p ~/.local/bin/kubectl
+   mkdir -p ~/.local/bin
    mv ./kubectl ~/.local/bin/kubectl
    # and then append (or prepend) ~/.local/bin to $PATH
    ```


### PR DESCRIPTION
proposed change in Install kubestl section 
when installing kubectl   in ~/.local/bin/  there is no need for creataion of kubectl folder under ~/.local/bin
