### PR TITLE
fixed order for resources: requests and limits

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/assign-memory-resource.md
+++ b/content/en/docs/tasks/configure-pod-container/assign-memory-resource.md
@@ -99,10 +99,10 @@ and a memory limit of 200 MiB.
 ```yaml
 ...
 resources:
-  limits:
-    memory: 200Mi
   requests:
     memory: 100Mi
+  limits:
+    memory: 200Mi
 ...
 ```
 

--- a/content/en/examples/pods/resource/memory-request-limit-3.yaml
+++ b/content/en/examples/pods/resource/memory-request-limit-3.yaml
@@ -8,9 +8,9 @@ spec:
   - name: memory-demo-3-ctr
     image: polinux/stress
     resources:
-      limits:
-        memory: "1000Gi"
       requests:
+        memory: "1000Gi"
+      limits:
         memory: "1000Gi"
     command: ["stress"]
     args: ["--vm", "1", "--vm-bytes", "150M", "--vm-hang", "1"]

--- a/content/en/examples/pods/resource/memory-request-limit.yaml
+++ b/content/en/examples/pods/resource/memory-request-limit.yaml
@@ -8,9 +8,9 @@ spec:
   - name: memory-demo-ctr
     image: polinux/stress
     resources:
-      limits:
-        memory: "200Mi"
       requests:
         memory: "100Mi"
+      limits:
+        memory: "200Mi"
     command: ["stress"]
     args: ["--vm", "1", "--vm-bytes", "150M", "--vm-hang", "1"]


### PR DESCRIPTION
Hi,

I was following this how-to and fall into this little (very little) annoyance.

Sometimes the yaml was ordered in "limits, requests" and in another block it is order reversed in "requests, limits".

This commit makes it uniform (for this page only). I have choosen for the order "request, limits", because that make the most sense to me and because the main page about resources uses this order aswell.
https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#example-1

