### PR TITLE
add dns troubleshooting steps for coredns permissions

### DIFF
--- a/content/en/docs/tasks/administer-cluster/dns-debugging-resolution.md
+++ b/content/en/docs/tasks/administer-cluster/dns-debugging-resolution.md
@@ -258,18 +258,18 @@ CoreDNS must be able to list {{< glossary_tooltip text="service"
 term_id="service" >}} and {{< glossary_tooltip text="endpoint"
 term_id="endpoint" >}} related resources to properly resolve service names.
 
-Sample Error Message:
+Sample error message:
 ```
 2022-03-18T07:12:15.699431183Z [INFO] 10.96.144.227:52299 - 3686 "A IN serverproxy.contoso.net.cluster.local. udp 52 false 512" SERVFAIL qr,aa,rd 145 0.000091221s
 ```
 
 First, get the current ClusterRole of `system:coredns`:
 
-```
+```shell
 kubectl describe clusterrole system:coredns -n kube-system
 ```
 
-Expected Output:
+Expected output:
 ```
 PolicyRule:
   Resources                        Non-Resource URLs  Resource Names  Verbs
@@ -284,11 +284,11 @@ PolicyRule:
 
 If any permissions are missing, edit the ClusterRole to add them:
 
-```
+```shell
 kubectl edit clusterrole system:coredns -n kube-system
 ```
 
-Example Insertion of EndpointSlices Permissions:
+Example insertion of EndpointSlices permissions:
 ```
 ...
 - apiGroups:

--- a/content/en/docs/tasks/administer-cluster/dns-debugging-resolution.md
+++ b/content/en/docs/tasks/administer-cluster/dns-debugging-resolution.md
@@ -252,6 +252,54 @@ linux/amd64, go1.10.3, 2e322f6
 2018/09/07 15:29:04 [INFO] Reloading complete
 172.17.0.18:41675 - [07/Sep/2018:15:29:11 +0000] 59925 "A IN kubernetes.default.svc.cluster.local. udp 54 false 512" NOERROR qr,aa,rd,ra 106 0.000066649s
 ```
+### Does CoreDNS have sufficient permissions?
+
+CoreDNS must be able to list {{< glossary_tooltip text="service"
+term_id="service" >}} and {{< glossary_tooltip text="endpoint"
+term_id="endpoint" >}} related resources to properly resolve service names.
+
+Sample Error Message:
+```
+2022-03-18T07:12:15.699431183Z [INFO] 10.96.144.227:52299 - 3686 "A IN serverproxy.contoso.net.cluster.local. udp 52 false 512" SERVFAIL qr,aa,rd 145 0.000091221s
+```
+
+First, get the current ClusterRole of `system:coredns`:
+
+```
+kubectl describe clusterrole system:coredns -n kube-system
+```
+
+Expected Output:
+```
+PolicyRule:
+  Resources                        Non-Resource URLs  Resource Names  Verbs
+  ---------                        -----------------  --------------  -----
+  nodes                            []                 []              [get]
+  endpoints                        []                 []              [list watch]
+  namespaces                       []                 []              [list watch]
+  pods                             []                 []              [list watch]
+  services                         []                 []              [list watch]
+  endpointslices.discovery.k8s.io  []                 []              [list watch]
+```
+
+If any permissions are missing, edit the ClusterRole to add them:
+
+```
+kubectl edit clusterrole system:coredns -n kube-system
+```
+
+Example Insertion of EndpointSlices Permissions:
+```
+...
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+...
+```
 
 ### Are you in the right namespace for the service?
 


### PR DESCRIPTION
update DNS debugging resolution task.

DNS resolutions may fail when CoreDNS does not have, for example, permission to list EndpointSlices.

This PR adds a troubleshooting step to check the permissions. 
