### PR TITLE
Fix nit in ingress.md

### DIFF
--- a/content/en/docs/concepts/services-networking/ingress.md
+++ b/content/en/docs/concepts/services-networking/ingress.md
@@ -316,7 +316,7 @@ spec:
   parameters:
     # The parameters for this IngressClass are specified in an
     # IngressParameter (API group k8s.example.com) named "external-config",
-    # that's in the "external-configuration" configuration namespace.
+    # that's in the "external-configuration" namespace.
     scope: Namespace
     apiGroup: k8s.example.com
     kind: IngressParameter


### PR DESCRIPTION
This PR removes redundant word in content/en/docs/concepts/services-networking/ingress.md.
