### PR TITLE
Remove trailing whitespaces from cli commands

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/en/docs/tasks/tools/install-kubectl-macos.md
@@ -114,7 +114,7 @@ The following methods exist for installing kubectl on macOS:
    Or use this for detailed view of version:
 
    ```cmd
-   kubectl version --client --output=yaml    
+   kubectl version --client --output=yaml
    ```
 
 ### Install with Homebrew on macOS
@@ -124,7 +124,7 @@ If you are on macOS and using [Homebrew](https://brew.sh/) package manager, you 
 1. Run the installation command:
 
    ```bash
-   brew install kubectl 
+   brew install kubectl
    ```
 
    or


### PR DESCRIPTION
I was going through the website and found (unnecessary) trailing whitespaces on two cli commands which I've removed in this PR.