### PR TITLE
[zh] Translate common-definitions/local-object-reference page into Chinese

### DIFF
--- a/content/zh/docs/reference/kubernetes-api/common-definitions/local-object-reference.md
+++ b/content/zh/docs/reference/kubernetes-api/common-definitions/local-object-reference.md
@@ -38,7 +38,7 @@ LocalObjectReference 包含足够的信息，可以让你在同一命名空间�
 -->
 - **name** (string)
 
-  引用者的名称。
+  被引用者的名称。
   更多信息: https://kubernetes.io/zh/docs/concepts/overview/working-with-objects/names/#names。
 
 

--- a/content/zh/docs/reference/kubernetes-api/common-definitions/local-object-reference.md
+++ b/content/zh/docs/reference/kubernetes-api/common-definitions/local-object-reference.md
@@ -39,7 +39,7 @@ LocalObjectReference 包含足够的信息，可以让你在同一命名空间�
 - **name** (string)
 
   引用者的名称。
-  更多信息: https://kubernetes.io/zh/docs/concepts/overview/working-with-objects/names/#names 。
+  更多信息: https://kubernetes.io/zh/docs/concepts/overview/working-with-objects/names/#names。
 
 
 

--- a/content/zh/docs/reference/kubernetes-api/common-definitions/local-object-reference.md
+++ b/content/zh/docs/reference/kubernetes-api/common-definitions/local-object-reference.md
@@ -1,0 +1,46 @@
+---
+api_metadata:
+  apiVersion: ""
+  import: "k8s.io/api/core/v1"
+  kind: "LocalObjectReference"
+content_type: "api_reference"
+description: "LocalObjectReference 包含足够的信息，可以让你在同一命名空间内找到引用的对象。"
+title: "LocalObjectReference"
+weight: 4
+auto_generated: true
+---
+
+<!--
+api_metadata:
+  apiVersion: ""
+  import: "k8s.io/api/core/v1"
+  kind: "LocalObjectReference"
+content_type: "api_reference"
+description: "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace."
+title: "LocalObjectReference"
+weight: 4
+auto_generated: true
+-->
+
+`import "k8s.io/api/core/v1"`
+
+<!--
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+-->
+LocalObjectReference 包含足够的信息，可以让你在同一命名空间（namespace）内找到引用的对象。
+
+<hr>
+
+<!--
+- **name** (string)
+
+  Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+-->
+- **name** (string)
+
+  引用者的名称。
+  更多信息: https://kubernetes.io/zh/docs/concepts/overview/working-with-objects/names/#names 。
+
+
+
+


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/website/issues/32248

Do not have chinese docs: https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/local-object-reference/ 

so need to translate common-definitions/local-object-reference page into Chinese