### PR TITLE
align second yaml snippet to the first one

### DIFF
--- a/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
+++ b/content/en/docs/tasks/access-application-cluster/ingress-minikube.md
@@ -240,13 +240,13 @@ The following manifest defines an Ingress that sends traffic to your Service via
    following lines at the end:
 
     ```yaml
-          - path: /v2
-            pathType: Prefix
-            backend:
-              service:
-                name: web2
-                port:
-                  number: 8080
+              - path: /v2
+                pathType: Prefix
+                backend:
+                  service:
+                    name: web2
+                    port:
+                      number: 8080
     ```
 
 1. Apply the changes:


### PR DESCRIPTION
This snippet had less indentation then the previous.

Now the second path is aligned to the second path

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
