### PR TITLE
Revise older blog articles and mark some evergreen

### DIFF
--- a/content/en/blog/_posts/2015-03-00-Welcome-To-Kubernetes-Blog.md
+++ b/content/en/blog/_posts/2015-03-00-Welcome-To-Kubernetes-Blog.md
@@ -1,9 +1,12 @@
 ---
-title: Welcome to the Kubernetes Blog! 
+title: Welcome to the Kubernetes Blog!
 date: 2015-03-20
 slug: welcome-to-kubernetes-blog
 url: /blog/2015/03/Welcome-To-Kubernetes-Blog
 ---
+
+**Author:** Kit Merker (Google)
+
 Welcome to the new Kubernetes Blog. Follow this blog to learn about the Kubernetes Open Source project. We plan to post release notes, how-to articles, events, and maybe even some off topic fun here from time to time.
 
 
@@ -25,6 +28,3 @@ To start things off, here's a roundup of recent Kubernetes posts from other site
 
 
 Happy cloud computing!
-
-
- - Kit Merker - Product Manager, Google Cloud Platform

--- a/content/en/blog/_posts/2015-03-00-Welcome-To-Kubernetes-Blog.md
+++ b/content/en/blog/_posts/2015-03-00-Welcome-To-Kubernetes-Blog.md
@@ -3,6 +3,7 @@ title: Welcome to the Kubernetes Blog!
 date: 2015-03-20
 slug: welcome-to-kubernetes-blog
 url: /blog/2015/03/Welcome-To-Kubernetes-Blog
+evergreen: true
 ---
 
 **Author:** Kit Merker (Google)

--- a/content/en/blog/_posts/2015-05-00-Kubernetes-Release-0160.md
+++ b/content/en/blog/_posts/2015-05-00-Kubernetes-Release-0160.md
@@ -3,6 +3,7 @@ title: "Kubernetes Release: 0.16.0"
 date: 2015-05-11
 slug: kubernetes-release-0160
 url: /blog/2015/05/Kubernetes-Release-0160
+evergreen: true
 ---
 Release Notes:
 

--- a/content/en/blog/_posts/2015-05-00-Kubernetes-Release-0160.md
+++ b/content/en/blog/_posts/2015-05-00-Kubernetes-Release-0160.md
@@ -1,5 +1,5 @@
 ---
-title: " Kubernetes Release: 0.16.0 "
+title: "Kubernetes Release: 0.16.0"
 date: 2015-05-11
 slug: kubernetes-release-0160
 url: /blog/2015/05/Kubernetes-Release-0160

--- a/content/en/blog/_posts/2015-05-00-Kubernetes-Release-0170.md
+++ b/content/en/blog/_posts/2015-05-00-Kubernetes-Release-0170.md
@@ -1,5 +1,5 @@
 ---
-title: " Kubernetes Release: 0.17.0 "
+title: "Kubernetes Release: 0.17.0"
 date: 2015-05-15
 slug: kubernetes-release-0170
 url: /blog/2015/05/Kubernetes-Release-0170

--- a/content/en/blog/_posts/2015-05-00-Kubernetes-Release-0170.md
+++ b/content/en/blog/_posts/2015-05-00-Kubernetes-Release-0170.md
@@ -3,6 +3,7 @@ title: "Kubernetes Release: 0.17.0"
 date: 2015-05-15
 slug: kubernetes-release-0170
 url: /blog/2015/05/Kubernetes-Release-0170
+evergreen: true
 ---
 Release Notes:  
 

--- a/content/en/blog/_posts/2015-07-00-Announcing-First-Kubernetes-Enterprise.md
+++ b/content/en/blog/_posts/2015-07-00-Announcing-First-Kubernetes-Enterprise.md
@@ -1,9 +1,10 @@
 ---
-title: " Announcing the First Kubernetes Enterprise Training Course "
+title: "Announcing the First Kubernetes Enterprise Training Course"
 date: 2015-07-08
 slug: announcing-first-kubernetes-enterprise
 url: /blog/2015/07/Announcing-First-Kubernetes-Enterprise
 ---
+
 At Google we rely on Linux application containers to run our core infrastructure. Everything from Search to Gmail runs in containers. &nbsp;In fact, we like containers so much that even our Google Compute Engine VMs run in containers! &nbsp;Because containers are critical to our business, we have been working with the community on many of the basic container technologies (from cgroups to Docker’s LibContainer) and even decided to build the next generation of Google’s container scheduling technology, Kubernetes, in the open.
 
 

--- a/content/en/blog/_posts/2015-11-00-Kubernetes-1-1-Performance-Upgrades-Improved-Tooling-And-A-Growing-Community.md
+++ b/content/en/blog/_posts/2015-11-00-Kubernetes-1-1-Performance-Upgrades-Improved-Tooling-And-A-Growing-Community.md
@@ -3,6 +3,7 @@ title: "Kubernetes 1.1 Performance upgrades, improved tooling and a growing comm
 date: 2015-11-09
 slug: kubernetes-1-1-performance-upgrades-improved-tooling-and-a-growing-community
 url: /blog/2015/11/Kubernetes-1-1-Performance-Upgrades-Improved-Tooling-And-A-Growing-Community
+evergreen: true
 ---
 
 **Author:** David Aronchick (Google)

--- a/content/en/blog/_posts/2015-11-00-Kubernetes-1-1-Performance-Upgrades-Improved-Tooling-And-A-Growing-Community.md
+++ b/content/en/blog/_posts/2015-11-00-Kubernetes-1-1-Performance-Upgrades-Improved-Tooling-And-A-Growing-Community.md
@@ -1,9 +1,12 @@
 ---
-title: " Kubernetes 1.1 Performance upgrades, improved tooling and a growing community  "
+title: "Kubernetes 1.1 Performance upgrades, improved tooling and a growing community"
 date: 2015-11-09
 slug: kubernetes-1-1-performance-upgrades-improved-tooling-and-a-growing-community
 url: /blog/2015/11/Kubernetes-1-1-Performance-Upgrades-Improved-Tooling-And-A-Growing-Community
 ---
+
+**Author:** David Aronchick (Google)
+
 Since the Kubernetes 1.0 release in July, we’ve seen tremendous adoption by companies building distributed systems to manage their container clusters. We’re also been humbled by the rapid growth of the community who help make Kubernetes better everyday. We have seen commercial offerings such as Tectonic by CoreOS and RedHat Atomic Host emerge to deliver deployment and support of Kubernetes. And a growing ecosystem has added Kubernetes support including tool vendors such as Sysdig and Project Calico.  
 
 With the help of hundreds of contributors, we’re proud to announce the availability of Kubernetes 1.1, which offers major performance upgrades, improved tooling, and new features that make applications even easier to build and deploy.  
@@ -50,4 +53,3 @@ As we mentioned above, we would love your help:
 
 But, most of all, just let us know how you are transforming your business using Kubernetes, and how we can help you do it even faster. Thank you for your support!  
 
-&nbsp;- David Aronchick, Senior Product Manager for Kubernetes and Google Container Engine

--- a/content/en/blog/_posts/2016-02-00-Kubecon-Eu-2016-Kubernetes-Community-In.md
+++ b/content/en/blog/_posts/2016-02-00-Kubecon-Eu-2016-Kubernetes-Community-In.md
@@ -3,6 +3,7 @@ title: "KubeCon EU 2016: Kubernetes Community in London"
 date: 2016-02-24
 slug: kubecon-eu-2016-kubernetes-community-in
 url: /blog/2016/02/Kubecon-Eu-2016-Kubernetes-Community-In
+evergreen: true
 ---
 
 **Author:** Sarah Novotny (Google)

--- a/content/en/blog/_posts/2016-02-00-Kubecon-Eu-2016-Kubernetes-Community-In.md
+++ b/content/en/blog/_posts/2016-02-00-Kubecon-Eu-2016-Kubernetes-Community-In.md
@@ -1,37 +1,40 @@
 ---
-title: " KubeCon EU 2016: Kubernetes Community in London "
+title: "KubeCon EU 2016: Kubernetes Community in London"
 date: 2016-02-24
 slug: kubecon-eu-2016-kubernetes-community-in
 url: /blog/2016/02/Kubecon-Eu-2016-Kubernetes-Community-In
 ---
 
-KubeCon EU 2016 is the inaugural [European Kubernetes](http://kubernetes.io/) community conference that follows on the American launch in November 2015. KubeCon is fully dedicated to education and community engagement for[Kubernetes](http://kubernetes.io/) enthusiasts, production users and the surrounding ecosystem.
+**Author:** Sarah Novotny (Google)
+
+KubeCon EU 2016 is the inaugural European Kubernetes community conference that follows on the American launch in November 2015. KubeCon is fully dedicated to education and community engagement for [Kubernetes](/) enthusiasts, production users and the surrounding ecosystem.
 
 Come join us in London and hang out with hundreds from the Kubernetes community and experience a wide variety of deep technical expert talks and use cases.
 
 Don’t miss these great speaker sessions at the conference:
 
-* “Kubernetes Hardware Hacks: Exploring the Kubernetes API Through Knobs, Faders, and Sliders” by Ian Lewis and Brian Dorsey, Developer Advocate, Google -* [http://sched.co/6Bl3](http://sched.co/6Bl3)  
+* “Kubernetes Hardware Hacks: Exploring the Kubernetes API Through Knobs, Faders, and Sliders” by Ian Lewis and Brian Dorsey, Developer Advocate, Google [https://sched.co/6Bl3](http://sched.co/6Bl3)
 
-* “rktnetes: what's new with container runtimes and Kubernetes” by Jonathan Boulle, Developer and Team Lead at CoreOS -* [http://sched.co/6BY7](http://sched.co/6BY7)
+* “rktnetes: what's new with container runtimes and Kubernetes” by Jonathan Boulle, Developer and Team Lead at CoreOS [https://sched.co/6BY7](http://sched.co/6BY7)
 
-* “Kubernetes Documentation: Contributing, fixing issues, collecting bounties” by John Mulhausen, Lead Technical Writer, Google -* [http://sched.co/6BUP](http://sched.co/6BUP)&nbsp;
-* “[What is OpenStack's role in a Kubernetes world?](https://kubeconeurope2016.sched.org/event/6BYC/what-is-openstacks-role-in-a-kubernetes-world?iframe=yes&w=i:0;&sidebar=yes&bg=no#?iframe=yes&w=i:100;&sidebar=yes&bg=no)” By Thierry Carrez, Director of Engineering, OpenStack Foundation -* http://sched.co/6BYC
-* “A Practical Guide to Container Scheduling” by Mandy Waite, Developer Advocate, Google -* [http://sched.co/6BZa](http://sched.co/6BZa)  
+* “Kubernetes Documentation: Contributing, fixing issues, collecting bounties” by John Mulhausen, Lead Technical Writer, Google [https://sched.co/6BUP](http://sched.co/6BUP)&nbsp;
 
-* “[Kubernetes in Production in The New York Times newsroom](https://kubeconeurope2016.sched.org/event/67f2/kubernetes-in-production-in-the-new-york-times-newsroom?iframe=yes&w=i:0;&sidebar=yes&bg=no#?iframe=yes&w=i:100;&sidebar=yes&bg=no)” Eric Lewis, Web Developer, New York Times -* [http://sched.co/67f2](http://sched.co/67f2)
-* “[Creating an Advanced Load Balancing Solution for Kubernetes with NGINX](https://kubeconeurope2016.sched.org/event/6Bc9/creating-an-advanced-load-balancing-solution-for-kubernetes-with-nginx?iframe=yes&w=i:0;&sidebar=yes&bg=no#?iframe=yes&w=i:100;&sidebar=yes&bg=no)” by Andrew Hutchings, Technical Product Manager, NGINX -* http://sched.co/6Bc9
-* And many more http://kubeconeurope2016.sched.org/
+* “[What is OpenStack's role in a Kubernetes world?](https://kubeconeurope2016.sched.org/event/6BYC/what-is-openstacks-role-in-a-kubernetes-world?iframe=yes&w=i:0;&sidebar=yes&bg=no#?iframe=yes&w=i:100;&sidebar=yes&bg=no)” By Thierry Carrez, Director of Engineering, OpenStack Foundation [https://sched.co/6BYC](http://sched.co/6BYC)
+
+* “A Practical Guide to Container Scheduling” by Mandy Waite, Developer Advocate, Google [https://sched.co/6BZa](http://sched.co/6BZa)
+
+* “[Kubernetes in Production in The New York Times newsroom](https://kubeconeurope2016.sched.org/event/67f2/kubernetes-in-production-in-the-new-york-times-newsroom?iframe=yes&w=i:0;&sidebar=yes&bg=no#?iframe=yes&w=i:100;&sidebar=yes&bg=no)” Eric Lewis, Web Developer, New York Times [https://sched.co/67f2](http://sched.co/67f2)
+
+* “[Creating an Advanced Load Balancing Solution for Kubernetes with NGINX](https://kubeconeurope2016.sched.org/event/6Bc9/creating-an-advanced-load-balancing-solution-for-kubernetes-with-nginx?iframe=yes&w=i:0;&sidebar=yes&bg=no#?iframe=yes&w=i:100;&sidebar=yes&bg=no)” by Andrew Hutchings, Technical Product Manager, NGINX [https://sched.co/6Bc9](https://sched.co/6Bc9)
+
+…and many more https://kubeconeurope2016.sched.org/
 
 
-Get your KubeCon EU [tickets here](https://ti.to/kubecon/kubecon-eu-2016).
+~Get your KubeCon EU [tickets here](https://ti.to/kubecon/kubecon-eu-2016)~.
 
 Venue Location: CodeNode * 10 South Pl, London, United Kingdom  
 Accommodations: [hotels](https://skillsmatter.com/contact-us#hotels)   
 Website: [kubecon.io](https://www.kubecon.io/)   
 Twitter: [@KubeConio](https://twitter.com/kubeconio) #KubeCon
+
 Google is a proud Diamond sponsor of KubeCon EU 2016. Come to London next month, March 10th & 11th, and visit booth #13 to learn all about Kubernetes, Google Container Engine (GKE) and Google Cloud Platform!  
-
-_KubeCon is organized by KubeAcademy, LLC, a community-driven group of developers focused on the education of developers and the promotion of Kubernetes._  
-
--* Sarah Novotny, Kubernetes Community Manager, Google  

--- a/content/en/blog/_posts/2016-03-00-Kubernetes-1-2-Even-More-Performance-Upgrades-Plus-Easier-Application-Deployment-And-Management-.md
+++ b/content/en/blog/_posts/2016-03-00-Kubernetes-1-2-Even-More-Performance-Upgrades-Plus-Easier-Application-Deployment-And-Management-.md
@@ -1,17 +1,19 @@
 ---
-title: " Kubernetes 1.2: Even more performance upgrades, plus easier application deployment and management  "
+title: "Kubernetes 1.2: Even more performance upgrades, plus easier application deployment and management"
 date: 2016-03-17
 slug: kubernetes-1.2-even-more-performance-upgrades-plus-easier-application-deployment-and-management
 url: /blog/2016/03/Kubernetes-1-2-Even-More-Performance-Upgrades-Plus-Easier-Application-Deployment-And-Management
 ---
-Today we released Kubernetes 1.2. This release represents significant improvements for large organizations building distributed systems. Now with over 680 unique contributors to the project, this release represents our largest yet.  
+**Author:** David Aronchick (Google)
+
+Today the Kubernetes project released Kubernetes 1.2. This release represents significant improvements for large organizations building distributed systems. Now with over 680 unique contributors to the project, this release represents our largest yet.  
 
 From the beginning, our mission has been to make building distributed systems easy and accessible for all. With the Kubernetes 1.2 release we’ve made strides towards our goal by increasing scale, decreasing latency and overall simplifying the way applications are deployed and managed. Now, developers at organizations of all sizes can build production scale apps more easily than ever before.&nbsp;
 
-### What’s new:&nbsp;
+## What’s new
 
 - **Significant scale improvements**. Increased cluster scale by 400% to 1,000 nodes and 30,000 containers per cluster.
-- **Simplified application deployment and management**.&nbsp;
+- **Simplified application deployment and management**.
 
   - Dynamic Configuration (via the ConfigMap API) enables applications to pull their configuration when they run rather than packaging it in at build time.&nbsp;
   - Turnkey Deployments (via the Beta Deployment API) let you declare your application and Kubernetes will do the rest. It handles versioning, multiple simultaneous rollouts, aggregating status across all pods, maintaining application availability and rollback.&nbsp;
@@ -28,15 +30,15 @@ From the beginning, our mission has been to make building distributed systems ea
 
 - **And many more**. For a complete list of updates, see the [release notes on github](https://github.com/kubernetes/kubernetes/releases/tag/v1.2.0).&nbsp;
 
-#### Community&nbsp;
+## Community
 
-All these improvements would not be possible without our enthusiastic and global community. The momentum is astounding. We’re seeing over 400 pull requests per week, a 50% increase since the previous 1.1 release. There are meetups and conferences discussing Kubernetes nearly every day, on top of the 85 Kubernetes related [meetup groups](http://www.meetup.com/topics/kubernetes/) around the world. We’ve also seen significant participation in the community in the form of Special Interest Groups, with 18 active SIGs that cover topics from AWS and OpenStack to big data and scalability, to get involved [join or start a new SIG](https://github.com/kubernetes/kubernetes/wiki/Special-Interest-Groups-(SIGs)). Lastly, we’re proud that Kubernetes is the first project to be accepted to the Cloud Native Computing Foundation (CNCF), read more about the announcement [here](https://cncf.io/news/announcement/2016/03/cloud-native-computing-foundation-accepts-kubernetes-first-hosted-projec-0).&nbsp;
+All these improvements would not be possible without our enthusiastic and global community. The momentum is astounding. We’re seeing over 400 pull requests per week, a 50% increase since the previous 1.1 release. There are meetups and conferences discussing Kubernetes nearly every day, on top of the 85 Kubernetes related [meetup groups](http://www.meetup.com/topics/kubernetes/) around the world. We’ve also seen significant participation in the community in the form of Special Interest Groups, with 18 active SIGs that cover topics from AWS and OpenStack to big data and scalability, to get involved [join or start a new SIG](https://github.com/kubernetes/kubernetes/wiki/Special-Interest-Groups-(SIGs)). Lastly, we’re proud that Kubernetes is the first project to be accepted to the Cloud Native Computing Foundation (CNCF), read more about the announcement [here](https://cncf.io/news/announcement/2016/03/cloud-native-computing-foundation-accepts-kubernetes-first-hosted-projec-0).
 
 
 
-#### Documentation&nbsp;
+## Documentation
 
-With Kubernetes 1.2 comes a relaunch of our website at [kubernetes.io](http://kubernetes.io/). We’ve slimmed down the docs contribution process so that all you have to do is fork/clone and send a PR. And the site works the same whether you’re staging it on your laptop, on github.io, or viewing it in production. It’s a pure GitHub Pages project; no scripts, no plugins.&nbsp;
+With Kubernetes 1.2 comes a relaunch of our website at [kubernetes.io](http://kubernetes.io/). We’ve slimmed down the docs contribution process so that all you have to do is fork/clone and send a PR. And the site works the same whether you’re staging it on your laptop, on github.io, or viewing it in production. It’s a pure GitHub Pages project; no scripts, no plugins.
 
 
 
@@ -48,7 +50,7 @@ To entice you even further to contribute, we’re also announcing our new bounty
 
 
 
-#### Roadmap&nbsp;
+## Roadmap
 
 All of our work is done in the open, to learn the latest about the project j[oin the weekly community meeting](https://groups.google.com/forum/#!forum/kubernetes-community-video-chat) or [watch a recorded hangout](https://www.youtube.com/playlist?list=PL69nYSiGNLP1pkHsbPjzAewvMgGUpkCnJ). In keeping with our major release schedule of every three to four months, here are just a few items that are in development for [next release and beyond](https://github.com/kubernetes/kubernetes/wiki/Release-1.3):&nbsp;
 
@@ -64,7 +66,7 @@ Kubernetes 1.2 is available for download at [get.k8s.io](http://get.k8s.io/) and
 
 
 
-#### Connect&nbsp;
+## Connect
 
 We’d love to hear from you and see you participate in this growing community:&nbsp;
 
@@ -73,8 +75,7 @@ We’d love to hear from you and see you participate in this growing community:&
 - &nbsp;Connect with the community on [Slack](http://slack.kubernetes.io/)&nbsp;
 - Follow us on Twitter [@Kubernetesio](https://twitter.com/kubernetesio) for latest updates&nbsp;
 
-Thank you for your support!&nbsp;
+Thank you for your support!
 
 
 
-&nbsp;-&nbsp;_David Aronchick, Senior Product Manager for Kubernetes, Google_

--- a/content/en/blog/_posts/2016-03-00-Kubernetes-1-2-Even-More-Performance-Upgrades-Plus-Easier-Application-Deployment-And-Management-.md
+++ b/content/en/blog/_posts/2016-03-00-Kubernetes-1-2-Even-More-Performance-Upgrades-Plus-Easier-Application-Deployment-And-Management-.md
@@ -3,6 +3,7 @@ title: "Kubernetes 1.2: Even more performance upgrades, plus easier application 
 date: 2016-03-17
 slug: kubernetes-1.2-even-more-performance-upgrades-plus-easier-application-deployment-and-management
 url: /blog/2016/03/Kubernetes-1-2-Even-More-Performance-Upgrades-Plus-Easier-Application-Deployment-And-Management
+evergreen: true
 ---
 **Author:** David Aronchick (Google)
 

--- a/content/en/blog/_posts/2016-07-00-Kubernetes-1-3-Bridging-Cloud-Native-And-Enterprise-Workloads.md
+++ b/content/en/blog/_posts/2016-07-00-Kubernetes-1-3-Bridging-Cloud-Native-And-Enterprise-Workloads.md
@@ -1,9 +1,12 @@
 ---
-title: " Kubernetes 1.3: Bridging Cloud Native and Enterprise Workloads "
+title: "Kubernetes 1.3: Bridging Cloud Native and Enterprise Workloads"
 date: 2016-07-06
 slug: kubernetes-1.3-bridging-cloud-native-and-enterprise-workloads
 url: /blog/2016/07/Kubernetes-1-3-Bridging-Cloud-Native-And-Enterprise-Workloads
 ---
+
+**Author:** Aparna Sinha, Google
+
 Nearly two years ago, when we officially kicked off the Kubernetes project, we wanted to simplify distributed systems management and provide the core technology required to everyone. The community’s response to this effort has blown us away. Today, thousands of customers, partners and developers are running clusters in production using Kubernetes and have joined the cloud native revolution.&nbsp;  
 
 Thanks to the help of over 800 contributors, we are pleased to announce today the availability of Kubernetes 1.3, our most robust and feature-rich release to date.  
@@ -14,7 +17,7 @@ Product highlights in Kubernetes 1.3 include the ability to bridge services acro
 
 
 
-**What’s new:**
+## What’s new
 
 - **Increased scale and automation** - Customers want to scale their services up and down automatically in response to application demand. In 1.3 we have made it easier to autoscale clusters up and down while doubling the maximum number of nodes per cluster. Customers no longer need to think about cluster size, and can allow the underlying cluster to respond to demand.
 
@@ -31,13 +34,13 @@ Product highlights in Kubernetes 1.3 include the ability to bridge services acro
 - **Updated Kubernetes dashboard UI** - Customers can now use the Kubernetes open source dashboard for the majority of interactions with their clusters, rather than having to use the CLI. The updated UI lets users control, edit and create all workload resources (including Deployments and PetSets).
 - And many more. For a complete list of updates, see the [_release notes on GitHub_](https://github.com/kubernetes/kubernetes/releases/tag/v1.3.0).
 
-**Community**
+## Community
 
 We could not have achieved this milestone without the tireless effort of countless people that are part of the Kubernetes community. We have [19 different Special Interest Groups](https://github.com/kubernetes/community/blob/master/README.md#special-interest-groups-sig), and over 100 meetups around the world. Kubernetes is a community project, built in the open, and it truly would not be possible without the over 233 person-years of effort the community has put in to date. Woot!
 
 
 
-**Availability**
+## Availability
 
 Kubernetes 1.3 is available for download at [get.k8s.io](http://get.k8s.io/)&nbsp;and via the open source repository hosted on [GitHub](http://github.com/kubernetes/kubernetes). To get started with Kubernetes try our [Hello World app](/docs/hellonode/).
 
@@ -47,7 +50,7 @@ To learn the latest about the project, we encourage everyone to [join the weekly
 
 
 
-**Connect**
+## Connect
 
 We’d love to hear from you and see you participate in this growing community:
 
@@ -58,8 +61,4 @@ We’d love to hear from you and see you participate in this growing community:
 
 
 
-Thank you for your support!&nbsp;
-
-
-
--- Aparna Sinha, Product Manager, Google
+Thank you for your support!

--- a/content/en/blog/_posts/2016-07-00-Kubernetes-1-3-Bridging-Cloud-Native-And-Enterprise-Workloads.md
+++ b/content/en/blog/_posts/2016-07-00-Kubernetes-1-3-Bridging-Cloud-Native-And-Enterprise-Workloads.md
@@ -3,6 +3,7 @@ title: "Kubernetes 1.3: Bridging Cloud Native and Enterprise Workloads"
 date: 2016-07-06
 slug: kubernetes-1.3-bridging-cloud-native-and-enterprise-workloads
 url: /blog/2016/07/Kubernetes-1-3-Bridging-Cloud-Native-And-Enterprise-Workloads
+evergreen: true
 ---
 
 **Author:** Aparna Sinha, Google

--- a/content/en/blog/_posts/2017-09-00-Kubernetes-18-Security-Workloads-And.md
+++ b/content/en/blog/_posts/2017-09-00-Kubernetes-18-Security-Workloads-And.md
@@ -3,6 +3,7 @@ title: " Kubernetes 1.8: Security, Workloads and Feature Depth "
 date: 2017-09-29
 slug: kubernetes-18-security-workloads-and
 url: /blog/2017/09/Kubernetes-18-Security-Workloads-And
+evergreen: true
 ---
 
 **Authors:** Kubernetes v1.8 release team

--- a/content/en/blog/_posts/2017-09-00-Kubernetes-18-Security-Workloads-And.md
+++ b/content/en/blog/_posts/2017-09-00-Kubernetes-18-Security-Workloads-And.md
@@ -4,7 +4,8 @@ date: 2017-09-29
 slug: kubernetes-18-security-workloads-and
 url: /blog/2017/09/Kubernetes-18-Security-Workloads-And
 ---
-_Editor's note: today's post is by Aparna Sinha, Group Product Manager, Kubernetes, Google; Ihor Dvoretskyi, Developer Advocate, CNCF; Jaice Singer DuMars, Kubernetes Ambassador, Microsoft; and Caleb Miles, Technical Program Manager, CoreOS on the latest release of Kubernetes 1.8._  
+
+**Authors:** Kubernetes v1.8 release team
 
 
 We’re pleased to announce the delivery of Kubernetes 1.8, our third release this year. Kubernetes 1.8 represents a snapshot of many exciting enhancements and refinements underway. In addition to functional improvements, we’re increasing project-wide focus on maturing [process](https://github.com/kubernetes/sig-release), formalizing [architecture](https://github.com/kubernetes/community/tree/master/sig-architecture), and strengthening Kubernetes’ [governance model](https://github.com/kubernetes/community/tree/master/community/elections/2017). The evolution of mature processes clearly signals that sustainability is a driving concern, and helps to ensure that Kubernetes is a viable and thriving project far into the future.  
@@ -50,7 +51,7 @@ The [Release team](https://github.com/kubernetes/features/blob/master/release-1.
 As the Kubernetes community has grown, our release process has become an amazing demonstration of collaboration in open source software development. Kubernetes continues to gain new users at a rapid clip. This growth creates a positive feedback cycle where more contributors commit code creating a more vibrant ecosystem.  
 
 
-## User Highlights
+## User highlights
 
 According to [Redmonk](http://redmonk.com/fryan/2017/09/10/cloud-native-technologies-in-the-fortune-100/), 54 percent of Fortune 100 companies are running Kubernetes in some form with adoption coming from every sector across the world. Recent user stories from the community include:   
 
@@ -91,3 +92,6 @@ The simplest way to get involved with Kubernetes is by joining one of the many [
 - Follow us on Twitter [@Kubernetesio](https://twitter.com/kubernetesio) for latest updates
 - Chat with the community on [Slack](http://slack.k8s.io/).
 - [Share your Kubernetes story.](https://docs.google.com/a/linuxfoundation.org/forms/d/e/1FAIpQLScuI7Ye3VQHQTwBASrgkjQDSS5TP0g3AXfFhwSM9YpHgxRKFA/viewform)
+
+
+_Editor's note: this announcement was authored by Aparna Sinha (Google), Ihor Dvoretskyi (CNCF), Jaice Singer DuMars (Microsoft), and Caleb Miles (CoreOS)._

--- a/content/en/blog/_posts/2017-12-00-Kubernetes-19-Workloads-Expanded-Ecosystem.md
+++ b/content/en/blog/_posts/2017-12-00-Kubernetes-19-Workloads-Expanded-Ecosystem.md
@@ -3,6 +3,7 @@ title: "Kubernetes 1.9: Apps Workloads GA and Expanded Ecosystem"
 date: 2017-12-15
 slug: kubernetes-19-workloads-expanded-ecosystem
 url: /blog/2017/12/Kubernetes-19-Workloads-Expanded-Ecosystem
+evergreen: true
 ---
 
 **Authors:** Kubernetes v1.9 release team

--- a/content/en/blog/_posts/2017-12-00-Kubernetes-19-Workloads-Expanded-Ecosystem.md
+++ b/content/en/blog/_posts/2017-12-00-Kubernetes-19-Workloads-Expanded-Ecosystem.md
@@ -1,9 +1,12 @@
 ---
-title: " Kubernetes 1.9: Apps Workloads GA and Expanded Ecosystem "
+title: "Kubernetes 1.9: Apps Workloads GA and Expanded Ecosystem"
 date: 2017-12-15
 slug: kubernetes-19-workloads-expanded-ecosystem
 url: /blog/2017/12/Kubernetes-19-Workloads-Expanded-Ecosystem
 ---
+
+**Authors:** Kubernetes v1.9 release team
+
 We’re pleased to announce the delivery of Kubernetes 1.9, our fourth and final release this year.  
 
 Today’s release continues the evolution of an increasingly rich feature set, more robust stability, and even greater community contributions. As the fourth release of the year, it gives us an opportunity to look back at the progress made in key areas. Particularly notable is the advancement of the Apps Workloads API to stable. This removes any reservations potential adopters might have had about the functional stability required to run mission-critical workloads. Another big milestone is the beta release of Windows support, which opens the door for many Windows-specific applications and workloads to run in Kubernetes, significantly expanding the implementation scenarios and enterprise readiness of Kubernetes.  
@@ -87,7 +90,7 @@ For recorded sessions from the largest Kubernetes gathering, [KubeCon + CloudNat
 
 ## Webinar
 
-Join members of the Kubernetes 1.9 release team on **January 9th from 10am-11am PT** to learn about the major features in this release as they demo some of the highlights in the areas of Windows and Docker support, storage, admission control, and the workloads API.&nbsp;[Register here](https://zoom.us/webinar/register/WN_oVjQMwyzQFOmWsfVzDsa2A).  
+Join members of the Kubernetes 1.9 release team on **January 9th from 10am-11am PT** to learn about the major features in this release as they demo some of the highlights in the areas of Windows and Docker support, storage, admission control, and the workloads API.&nbsp;[~Register here~](https://zoom.us/webinar/register/WN_oVjQMwyzQFOmWsfVzDsa2A).  
 
 
 ## Get involved:

--- a/content/en/blog/_posts/2018-03-26-kubernetes-1-10-stabilizing-storage-security-networking.md
+++ b/content/en/blog/_posts/2018-03-26-kubernetes-1-10-stabilizing-storage-security-networking.md
@@ -1,13 +1,8 @@
 ---
-title: 'Kubernetes 1.10: Stabilizing Storage, Security, and Networking '
-author: kbarnard
-tags:
+title: 'Kubernetes 1.10: Stabilizing Storage, Security, and Networking'
 date: 2018-03-26
 modified_time: '2018-03-27T11:01:39.569-07:00'
-blogger_id: tag:blogger.com,1999:blog-112706738355446097.post-6519705795358457586
-blogger_orig_url: https://kubernetes.io/blog/2018/03/26/kubernetes-1.10-stabilizing-storage-security-networking/
 slug: kubernetes-1.10-stabilizing-storage-security-networking
-date: 2018-03-26
 ---
 
 ***Editor's note: today's post is by the [1.10 Release

--- a/content/en/blog/_posts/2018-03-26-kubernetes-1-10-stabilizing-storage-security-networking.md
+++ b/content/en/blog/_posts/2018-03-26-kubernetes-1-10-stabilizing-storage-security-networking.md
@@ -3,6 +3,7 @@ title: 'Kubernetes 1.10: Stabilizing Storage, Security, and Networking'
 date: 2018-03-26
 modified_time: '2018-03-27T11:01:39.569-07:00'
 slug: kubernetes-1.10-stabilizing-storage-security-networking
+evergreen: true
 ---
 
 ***Editor's note: today's post is by the [1.10 Release

--- a/content/en/blog/_posts/2018-06-26-kubernetes-1-11-release-announcement.md
+++ b/content/en/blog/_posts/2018-06-26-kubernetes-1-11-release-announcement.md
@@ -3,6 +3,7 @@ layout: blog
 title: 'Kubernetes 1.11: In-Cluster Load Balancing and CoreDNS Plugin Graduate to General Availability'
 date:  2018-06-27
 slug: kubernetes-1.11-release-announcement
+evergreen: true
 ---
 
 **Author**: Kubernetes 1.11 [Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.11/release_team.md)

--- a/content/en/blog/_posts/2018-09-27-kubernetes-1-12-release-announcement.md
+++ b/content/en/blog/_posts/2018-09-27-kubernetes-1-12-release-announcement.md
@@ -2,6 +2,7 @@
 layout: blog
 title:  'Kubernetes 1.12: Kubelet TLS Bootstrap and Azure Virtual Machine Scale Sets (VMSS) Move to General Availability'
 date:   2018-09-27
+evergreen: true
 ---
 
 **Author**: The 1.12 [Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.12/release_team.md)

--- a/content/en/blog/_posts/2018-10-16-kubernetes-2018-north-american-contributor-summit.md
+++ b/content/en/blog/_posts/2018-10-16-kubernetes-2018-north-american-contributor-summit.md
@@ -2,6 +2,7 @@
 layout: blog
 title: "Kubernetes 2018 North American Contributor Summit"
 date: 2018-10-16
+evergreen: true
 ---
 
 **Authors:**

--- a/content/en/blog/_posts/2018-10-16-kubernetes-2018-north-american-contributor-summit.md
+++ b/content/en/blog/_posts/2018-10-16-kubernetes-2018-north-american-contributor-summit.md
@@ -1,13 +1,11 @@
 ---
-layout: "Blog"
+layout: blog
 title: "Kubernetes 2018 North American Contributor Summit"
-date: 2018-10-16    
+date: 2018-10-16
 ---
 
 **Authors:**
-[Bob Killen][bob] (University of Michigan)
-[Sahdev Zala][sahdev] (IBM),
-[Ihor Dvoretskyi][ihor] (CNCF) 
+[Bob Killen][bob] (University of Michigan), [Sahdev Zala][sahdev] (IBM), [Ihor Dvoretskyi][ihor] (CNCF)
 
 
 The 2018 North American Kubernetes Contributor Summit to be hosted right before
@@ -22,32 +20,34 @@ Unlike previous Contributor Summits, the event now spans two-days with a more
 relaxed ‘hallway’ track and general Contributor get-together to be hosted from
 5-8pm on Sunday December 9th at the [Garage Lounge and Gaming Hall][garage], just
 a short walk away from the Convention Center. There, contributors can enjoy
-billiards, bowling, trivia and more; accompanied by a variety of food and drink. 
+billiards, bowling, trivia and more; accompanied by a variety of food and drink.
 
 Things pick up the following day, Monday the 10th with three separate tracks: 
 
-### New Contributor Workshop:
+### New contributor workshop
 A half day workshop aimed at getting new and first time contributors onboarded
 and comfortable with working within the Kubernetes Community. Staying for the
 duration is required; this is not a workshop you can drop into. 
 
-### Current Contributor Track:
+### Current contributor track
 Reserved for those that are actively engaged with the development of the
 project; the Current Contributor Track includes Talks, Workshops, Birds of a
 Feather, Unconferences, Steering Committee Sessions, and more! Keep an eye on
 the [schedule in GitHub][schedule] as content is frequently being updated.
 
-### Docs Sprint:
-SIG-Docs will have a curated list of issues and challenges to be tackled closer
+### Docs sprint
+
+SIG Docs will have a curated list of issues and challenges to be tackled closer
 to the event date.
 
-## To Register:
+## How To Register {#to-register}
+
 To register for the Contributor Summit, see the [Registration section of the
 Event Details in GitHub][register]. Please note that registrations are being
 reviewed. If you select the “Current Contributor Track” and are not an active
 contributor, you will be asked to attend the New Contributor Workshop, or asked
 to be put on a waitlist. With thousands of contributors and only 300 spots, we
-need to make sure the right folks are in the room. 
+need to make sure the right folks are in the room.
 
 If you have any questions or concerns, please don’t hesitate to reach out to
 the Contributor Summit Events Team at community@kubernetes.io.

--- a/content/en/blog/_posts/2018-12-03-kubernetes-1-13-release-announcement.md
+++ b/content/en/blog/_posts/2018-12-03-kubernetes-1-13-release-announcement.md
@@ -3,6 +3,7 @@ layout: blog
 title: 'Kubernetes 1.13: Simplified Cluster Management with Kubeadm, Container Storage Interface (CSI), and CoreDNS as Default DNS are Now Generally Available'
 date: 2018-12-03
 slug: kubernetes-1-13-release-announcement
+evergreen: true
 ---
 
 **Author**: The 1.13 [Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.13/release_team.md)

--- a/content/en/blog/_posts/2018-12-04-kubeadm-ga-release.md
+++ b/content/en/blog/_posts/2018-12-04-kubeadm-ga-release.md
@@ -2,6 +2,7 @@
 layout: blog
 title: Production-Ready Kubernetes Cluster Creation with kubeadm
 date: 2018-12-04
+evergreen: true
 ---
 
 **Authors**: Lucas Käldström (CNCF Ambassador) and Luc Perkins (CNCF Developer Advocate)

--- a/content/en/blog/_posts/2019-03-20-A-Look-Back-And-Whats-In-Store-For-Kubernetes-Contributor-Summits.md
+++ b/content/en/blog/_posts/2019-03-20-A-Look-Back-And-Whats-In-Store-For-Kubernetes-Contributor-Summits.md
@@ -2,6 +2,7 @@
 title: A Look Back and What's in Store for Kubernetes Contributor Summits
 date: 2019-03-20
 layout: blog
+evergreen: true
 ---
 
 **Authors:**

--- a/content/en/blog/_posts/2019-03-20-A-Look-Back-And-Whats-In-Store-For-Kubernetes-Contributor-Summits.md
+++ b/content/en/blog/_posts/2019-03-20-A-Look-Back-And-Whats-In-Store-For-Kubernetes-Contributor-Summits.md
@@ -1,12 +1,11 @@
 ---
 title: A Look Back and What's in Store for Kubernetes Contributor Summits
 date: 2019-03-20
+layout: blog
 ---
 
 **Authors:**
 Paris Pittman (Google), Jonas Rosland (VMware)
-
-**tl;dr** - [click here] for Barcelona Contributor Summit information.
 
 {{<figure width="600" src="/images/blog/2019-03-14-A-Look-Back-And-Whats-In-Store-For-Kubernetes-Contributor-Summits/celebrationsig.jpg" caption="Seattle Contributor Summit">}}
 
@@ -28,13 +27,14 @@ We build the contributor summits around you:
 
 These personas combined with ample feedback from previous events, produce the   altogether experience that welcomed over 600 contributors in Copenhagen (May), Shanghai(November), and Seattle(December) in 2018. Seattle's event drew over 300+ contributors, equal to Shanghai and Copenhagen combined, for the 6th contributor event in Kubernetes history. In true Kubernetes fashion, we expect another record breaking year of attendance. We've pre-ordered 900+ [contributor patches], a tradition, and we are   looking forward to giving them to you!
 
-With that said...  
+With that said…
+
 **Save the Dates:**  
 Barcelona: May 19th (evening) and 20th (all day)  
 Shanghai: June 24th (all day)  
 San Diego: November 18th, 19th, and activities in KubeCon/CloudNativeCon week
 
-In an effort of continual improvement, here's what to expect from us this year:  
+In an effort of continual improvement, here's what to expect from us this year:
 
 * Large new contributor workshops and contributor socials at all three events expected to break previous attendance records
 * A multiple track event in San Diego for all contributor types including workshops, birds of a feather, lightning talks and more
@@ -42,7 +42,8 @@ In an effort of continual improvement, here's what to expect from us this year:
 * [An event website]!
 * Follow along with updates: kubernetes-dev@googlegroups.com is our main communication hub as always; however, we will also blog here, our [Thursday Kubernetes Community Meeting], [twitter], SIG meetings, event site, discuss.kubernetes.io, and #contributor-summit on Slack.
 * Opportunities to get involved: We still have 2019 roles available!
-Reach out to Contributor Experience via community@kubernetes.io, stop by a Wednesday SIG update meeting, or catch us on Slack (#sig-contribex).  
+Reach out to Contributor Experience via community@kubernetes.io, stop by a Wednesday SIG update meeting, or catch us on Slack (#sig-contribex).
+
 
 {{<figure width="600" src="/images/blog/2019-03-14-A-Look-Back-And-Whats-In-Store-For-Kubernetes-Contributor-Summits/unconference.jpg" caption="Unconference voting">}}
 
@@ -51,11 +52,11 @@ Reach out to Contributor Experience via community@kubernetes.io, stop by a Wedne
 Our 2018 crew 🥁  
 Jorge Castro, Paris Pittman, Bob Killen, Jeff Sica, Megan Lehn, Guinevere Saenger, Josh Berkus, Noah Abrahams, Yang Li, Xiangpeng Zhao, Puja Abbassi, Lindsey Tulloch, Zach Corleissen, Tim Pepper, Ihor Dvoretskyi, Nancy Mohamed, Chris Short, Mario Loria, Jason DeTiberus, Sahdev Zala, Mithra Raja
 
-And an introduction to our 2019 crew (a thanks in advance ;) )...  
-Jonas Rosland, Josh Berkus, Paris Pittman, Jorge Castro, Bob Killen, Deb Giles, Guinevere Saenger, Noah Abrahams, Yang Li, Xiangpeng Zhao, Puja Abbassi, Rui Chen, Tim Pepper, Ihor Dvoretskyi, Dawn Foster  
+And an introduction to our 2019 crew (a thanks in advance ;) )…  
+Jonas Rosland, Josh Berkus, Paris Pittman, Jorge Castro, Bob Killen, Deb Giles, Guinevere Saenger, Noah Abrahams, Yang Li, Xiangpeng Zhao, Puja Abbassi, Rui Chen, Tim Pepper, Ihor Dvoretskyi, Dawn Foster
 
 
-## Relive Seattle Contributor Summit 
+## Relive Seattle Contributor Summit
 
 📈 80% growth rate since the Austin 2017 December event
 
@@ -81,15 +82,11 @@ Jonas Rosland, Josh Berkus, Paris Pittman, Jorge Castro, Bob Killen, Deb Giles, 
 
 📸 Pictures (special thanks to [rdodev])
 
-Garage Pic
-Reg Desk
-
 {{<figure width="600" src="/images/blog/2019-03-14-A-Look-Back-And-Whats-In-Store-For-Kubernetes-Contributor-Summits/grouppicseatle.JPG" caption="Some of the group in Seattle">}}
 
 “I love Contrib Summit! The intros and deep dives during KubeCon were a great extension of Contrib Summit. Y'all did an excellent job in the morning to level set expectations and prime everyone.” -- julianv    
 “great work! really useful and fun!” - coffeepac
 
-[click here]: https://events.linuxfoundation.org/events/contributor-summit-europe-2019/
 [Contributor Experience]: https://github.com/kubernetes/community/tree/master/sig-contributor-experience
 [Subproject OWNERs]: https://github.com/kubernetes/community/blob/master/community-membership.md
 [Chair or Tech Lead]: https://github.com/kubernetes/community/blob/master/committee-steering/governance/sig-governance.md

--- a/content/en/blog/_posts/2019-03-25-1-14-release-announcement.md
+++ b/content/en/blog/_posts/2019-03-25-1-14-release-announcement.md
@@ -2,6 +2,7 @@
 title: 'Kubernetes 1.14: Production-level support for Windows Nodes, Kubectl Updates, Persistent Local Volumes GA'
 date: 2019-03-25
 slug: kubernetes-1-14-release-announcement
+evergreen: true
 ---
 
 **Authors:** The 1.14 [Release Team](https://bit.ly/k8s114-team)

--- a/content/en/blog/_posts/2019-05-02-kubecon-diversity-lunch-and-hack.md
+++ b/content/en/blog/_posts/2019-05-02-kubecon-diversity-lunch-and-hack.md
@@ -36,4 +36,4 @@ To make this all possible, we need you. Yes, you, to register. As much as we lov
 
 We look forward to seeing you!
 
-_Special thanks to [Leah Petersen](https://www.linkedin.com/in/leahstunts/), [Sarah Conway](https://www.linkedin.com/in/sarah-conway-6166151/) and [Paris Pittman](https://www.linkedin.com/in/parispittman/) for their help in editing this post._ 
+_Special thanks to [Leah Petersen](https://www.linkedin.com/in/leahstunts/), [Sarah Conway](https://www.linkedin.com/in/sarah-conway-6166151/) and [Paris Pittman](https://www.linkedin.com/in/parispittman/) for their help in editing this post._

--- a/content/en/blog/_posts/2019-05-02-kubecon-diversity-lunch-and-hack.md
+++ b/content/en/blog/_posts/2019-05-02-kubecon-diversity-lunch-and-hack.md
@@ -2,6 +2,7 @@
 title: "Join us for the 2019 KubeCon Diversity Lunch & Hack"
 date: 2019-05-02
 slug: kubecon-diversity-lunch-and-hack
+evergreen: false
 ---
 
 **Authors:** Kiran Oliver, Podcast Producer, The New Stack

--- a/content/en/blog/_posts/2019-06-19-kubernetes-1-15-release-announcement.md
+++ b/content/en/blog/_posts/2019-06-19-kubernetes-1-15-release-announcement.md
@@ -3,6 +3,7 @@ layout: blog
 title: "Kubernetes 1.15: Extensibility and Continuous Improvement"
 date: 2019-06-19
 slug: kubernetes-1-15-release-announcement
+evergreen: true
 ---
 **Authors:** The 1.15 [Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.15/release_team.md)
 

--- a/content/en/blog/_posts/2019-09-24-san-diego-contributor-summit.md
+++ b/content/en/blog/_posts/2019-09-24-san-diego-contributor-summit.md
@@ -3,6 +3,7 @@ layout: blog
 title: "Contributor Summit San Diego Registration Open!"
 date: 2019-09-24
 slug: san-diego-contributor-summit
+evergreen: true
 ---
 
 **Authors:** Paris Pittman (Google), Jeffrey Sica (Red Hat), Jonas Rosland (VMware)

--- a/content/en/blog/_posts/2019-09-24-san-diego-contributor-summit.md
+++ b/content/en/blog/_posts/2019-09-24-san-diego-contributor-summit.md
@@ -5,17 +5,15 @@ date: 2019-09-24
 slug: san-diego-contributor-summit
 ---
 
-**Authors: Paris Pittman (Google), Jeffrey Sica (Red Hat), Jonas Rosland (VMware)**
-
-
+**Authors:** Paris Pittman (Google), Jeffrey Sica (Red Hat), Jonas Rosland (VMware)
 
 [Contributor Summit San Diego 2019 Event Page]  
-Registration is now open and in record time, we’ve hit capacity for the
-*new contributor workshop* session of the event! Waitlist is now available.
+In record time, we’ve hit capacity for the *new contributor workshop* session of
+the event!
 
 **Sunday, November 17**  
 Evening Contributor Celebration:  
-[QuartYard]*  
+[QuartYard]†  
 Address: 1301 Market Street, San Diego, CA 92101  
 Time: 6:00PM - 9:00PM  
 
@@ -68,7 +66,7 @@ Check out past blogs on [persona building around our events] and the [Barcelona 
 
 ![Group Picture in 2018](/images/blog/2019-09-24-san-diego-contributor-summit/IMG_2588.JPG)
 
-*=QuartYard has a huge stage! Want to perform something in front of your contributor peers? Reach out to us! community@kubernetes.io
+†=QuartYard has a huge stage! Want to perform something in front of your contributor peers? Reach out to us! community@kubernetes.io
 
 
 

--- a/content/en/blog/_posts/2019-10-10-contributor-summit-san-diego-schedule.md
+++ b/content/en/blog/_posts/2019-10-10-contributor-summit-san-diego-schedule.md
@@ -5,13 +5,7 @@ date: 2019-10-10
 slug: contributor-summit-san-diego-schedule
 ---
 
-
-Authors: Josh Berkus (Red Hat), Paris Pittman (Google), Jonas Rosland (VMware)
-
-tl;dr A week ago we announced that [registration is open][reg] for the contributor
-summit , and we're now live with [the full Contributor Summit schedule!][schedule]
-Grab your spot while tickets are still available. There is currently a waitlist
-for new contributor workshop.  ([Register here!][reg])
+**Authors:** Josh Berkus (Red Hat), Paris Pittman (Google), Jonas Rosland (VMware)
 
 There are many great sessions planned for the Contributor Summit, spread across
 five rooms of current contributor content in addition to the new contributor
@@ -32,7 +26,7 @@ While the schedule contains difficult decisions in every timeslot, we've picked
 a few below to give you a taste of what you'll hear, see, and participate in, at
 the summit:
 
-* **[Vision]**: SIG-Architecture will be sharing their vision of where we're going
+* **[Vision]**: SIG Architecture will be sharing their vision of where we're going
   with Kubernetes development for the next year and beyond.
 * **[Security]**: Tim Allclair and CJ Cullen will present on the current state of
   Kubernetes security. In another security talk, Vallery Lancey will lead a
@@ -47,7 +41,7 @@ the summit:
   one, or at least pass one.
 * **[End Users]**: Several end users from the CNCF partner ecosystem, invited by
   Cheryl Hung, will hold a Q&A with contributors to strengthen our feedback loop.
-* **[Docs]**: As always, SIG-Docs will run a three-hour contributing-to-documentation
+* **[Docs]**: As always, SIG Docs will run a three-hour contributing-to-documentation
   workshop.
 
 We're also giving out awards to contributors who distinguished themselves in 2019,

--- a/content/en/blog/_posts/2020-02-18-Contributor-Summit-Amsterdam-Schedule-Announced.md
+++ b/content/en/blog/_posts/2020-02-18-Contributor-Summit-Amsterdam-Schedule-Announced.md
@@ -5,11 +5,28 @@ date: 2020-02-18
 slug: Contributor-Summit-Amsterdam-Schedule-Announced
 ---
 
-**Authors:** Jeffrey Sica (Red Hat), Amanda Katona (VMware) 
+**Authors:** Jeffrey Sica (Red Hat), Amanda Katona (VMware)
 
-tl;dr [Registration is open](https://events.linuxfoundation.org/kubernetes-contributor-summit-europe/) and the [schedule is live](https://kcseu2020.sched.com/) so register now and we’ll see you in Amsterdam!
+![Contributor Summit](/images/blog/2020-02-18-Contributor-Summit-Amsterdam-Schedule-Announced/contribsummit.jpg)
 
-## Kubernetes Contributor Summit 
+Hello everyone and Happy 2020! It’s hard to believe that KubeCon EU 2020 is less than six weeks away, and with that another contributor summit! This year we have the pleasure of being in Amsterdam in early spring, so be sure to pack some warmer clothing. This summit looks to be exciting with a lot of fantastic community-driven content. We received **26** submissions from the CFP. From that, the events team selected **12** sessions. Each of the sessions falls into one of four categories:
+
+*   Community
+*   Contributor Improvement
+*   Sustainability
+*   In-depth Technical
+
+On top of the presentations, there will be a dedicated Docs Sprint as well as the New Contributor Workshop 101 and 201 Sessions. All told, we will have five separate rooms of content throughout the day on Monday. Please **[see the full schedule](https://kcseu2020.sched.com/)** to see what sessions you’d be interested in. We hope between the content provided and the inevitable hallway track, everyone has a fun and enriching experience. 
+
+Speaking of fun, the social Sunday night should be a blast! We’re hosting this summit’s social close to the conference center, at [ZuidPool](https://www.zuid-pool.nl/en/). There will be games, bingo, and unconference sign-up throughout the evening. It should be a relaxed way to kick off the week. 
+
+[~Registration is open~](https://events.linuxfoundation.org/kubernetes-contributor-summit-europe/)! Space is limited so it’s always a good idea to register early.
+
+If you have any questions, reach out to the [Amsterdam Team](https://github.com/kubernetes/community/tree/master/events/2020/03-contributor-summit#team) on Slack in the [#contributor-summit](https://kubernetes.slack.com/archives/C7J893413) channel.
+
+Hope to see you there!
+
+## Kubernetes Contributor Summit schedule
 
 **Sunday, March 29, 2020**
 
@@ -25,21 +42,3 @@ tl;dr [Registration is open](https://events.linuxfoundation.org/kubernetes-contr
 - Address: [Europaplein 24, 1078 GZ Amsterdam, Netherlands](https://www.google.com/search?q=kubecon+amsterdam+2020&oq=kubecon+amste&aqs=chrome.0.35i39j69i57j0l4j69i61l2.3957j1j4&sourceid=chrome&ie=UTF-8&ibp=htl;events&rciv=evn&sa=X&ved=2ahUKEwiZoLvQ0dvnAhVST6wKHScBBZ8Q5bwDMAB6BAgSEAE#)
 - Time:  09:00 - 17:00 (Breakfast at 08:00)
 
-![Contributor Summit](/images/blog/2020-02-18-Contributor-Summit-Amsterdam-Schedule-Announced/contribsummit.jpg)
-
-Hello everyone and Happy 2020! It’s hard to believe that KubeCon EU 2020 is less than six weeks away, and with that another contributor summit! This year we have the pleasure of being in Amsterdam in early spring, so be sure to pack some warmer clothing. This summit looks to be exciting with a lot of fantastic community-driven content. We received **26** submissions from the CFP. From that, the events team selected **12** sessions. Each of the sessions falls into one of four categories:
-
-*   Community
-*   Contributor Improvement
-*   Sustainability
-*   In-depth Technical 
-
-On top of the presentations, there will be a dedicated Docs Sprint as well as the New Contributor Workshop 101 and 201 Sessions. All told, we will have five separate rooms of content throughout the day on Monday. Please **[see the full schedule](https://kcseu2020.sched.com/)** to see what sessions you’d be interested in. We hope between the content provided and the inevitable hallway track, everyone has a fun and enriching experience. 
-
-Speaking of fun, the social Sunday night should be a blast! We’re hosting this summit’s social close to the conference center, at [ZuidPool](https://www.zuid-pool.nl/en/). There will be games, bingo, and unconference sign-up throughout the evening. It should be a relaxed way to kick off the week. 
-
-[Registration is open](https://events.linuxfoundation.org/kubernetes-contributor-summit-europe/)! Space is limited so it’s always a good idea to register early. 
-
-If you have any questions, reach out to the [Amsterdam Team](https://github.com/kubernetes/community/tree/master/events/2020/03-contributor-summit#team) on Slack in the [#contributor-summit](https://kubernetes.slack.com/archives/C7J893413) channel.
-
-Hope to see you there!

--- a/content/en/blog/_posts/2020-03-04-Contributor-Summit-Delayed.md
+++ b/content/en/blog/_posts/2020-03-04-Contributor-Summit-Delayed.md
@@ -3,6 +3,7 @@ layout: blog
 title: Contributor Summit Amsterdam Postponed
 date: 2020-03-04
 slug: Contributor-Summit-Delayed
+evergreen: true
 ---
 
 **Authors:** Dawn Foster (VMware), Jorge Castro (VMware)

--- a/content/en/blog/_posts/2020-03-04-Contributor-Summit-Delayed.md
+++ b/content/en/blog/_posts/2020-03-04-Contributor-Summit-Delayed.md
@@ -5,11 +5,11 @@ date: 2020-03-04
 slug: Contributor-Summit-Delayed
 ---
 
-**Authors:** Dawn Foster (VMware), Jorge Castro (VMware) 
+**Authors:** Dawn Foster (VMware), Jorge Castro (VMware)
 
 The CNCF has announced that [KubeCon + CloudNativeCon EU has been delayed](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/attend/novel-coronavirus-update/) until July/August of 2020. As a result the Contributor Summit planning team is weighing options for how to proceed. Here’s the current plan:
 
 - There will be an in-person Contributor Summit as planned when KubeCon + CloudNativeCon is rescheduled.
-- We are looking at options for having additional virtual contributor activities in the meantime. 
+- We are looking at options for having additional virtual contributor activities in the meantime.
 
 We will communicate via this blog and the usual communications channels on the final plan. Please bear with us as we adapt when we get more information. Thank you for being patient as the team pivots to bring you a great Contributor Summit!


### PR DESCRIPTION
After this change:

- all release announcement articles are evergreen (no “outdated content” banner)
  - uh, except v1.0 which isn't yet imported into the blog
- the formatting of older articles and author attributions is closer to how we do it today
- some now-inaccurate TL;DR: sections are gone from the relevant articles