### PR TITLE
[zh] Fix rendering of 'label-selector' page

### DIFF
--- a/content/zh/docs/reference/kubernetes-api/common-definitions/label-selector.md
+++ b/content/zh/docs/reference/kubernetes-api/common-definitions/label-selector.md
@@ -1,14 +1,3 @@
-<!--
-api_metadata:
-  apiVersion: ""
-  import: "k8s.io/apimachinery/pkg/apis/meta/v1"
-  kind: "LabelSelector"
-content_type: "api_reference"
-description: "A label selector is a label query over a set of resources."
-title: "LabelSelector"
-weight: 2
--->
-
 ---
 api_metadata:
   apiVersion: ""
@@ -20,6 +9,17 @@ title: "标签选择器"
 weight: 2
 auto_generated: true
 ---
+
+<!--
+api_metadata:
+  apiVersion: ""
+  import: "k8s.io/apimachinery/pkg/apis/meta/v1"
+  kind: "LabelSelector"
+content_type: "api_reference"
+description: "A label selector is a label query over a set of resources."
+title: "LabelSelector"
+weight: 2
+-->
 
 `import "k8s.io/apimachinery/pkg/apis/meta/v1"`
 


### PR DESCRIPTION
Closes #32436

[As-is]
Wrong rendering in ['label-selector' page](https://kubernetes.io/zh/docs/reference/kubernetes-api/common-definitions/label-selector/)
![image](https://user-images.githubusercontent.com/46767780/159648287-585bf718-3908-4766-b88f-7e86c9413581.png)

cf. en version page: https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/label-selector/
![image](https://user-images.githubusercontent.com/46767780/159648454-0ecb0fe4-8c62-4bdf-9631-467cbca07f47.png)

---

Preview: https://deploy-preview-32437--kubernetes-io-main-staging.netlify.app/zh/docs/reference/kubernetes-api/common-definitions/label-selector/
![image](https://user-images.githubusercontent.com/46767780/159656070-5dbb6c64-8182-47fd-995a-5f6d2721306b.png)