### PR TITLE
Add Bengali owners and reviewers to main branch OWNERS ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -8,6 +8,10 @@ aliases:
     - onlydole
     - sftim
     - nate-double-u
+  sig-docs-bn-owners: # Admins for Bengali content
+    - mitul3737
+  sig-docs-bn-reviews: # PR reviews for Bengali content
+    - mitul3737
   sig-docs-de-owners: # Admins for German content
     - bene2k1
     - mkorbi


### PR DESCRIPTION
This PR updates the k/website OWNERS_ALIASES file with the Bengali localization team owners and reviewers

These changes are made in the `dev-1.23-bn.1` branch, I'm not sure if they are appropriate to `main` until the `bn` localization is live