### PR TITLE
install-kubeadm: use nc instead of telnet

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -69,7 +69,7 @@ For more details please see the [Network Plugin Requirements](/docs/concepts/ext
 ## Check required ports
 These
 [required ports](/docs/reference/ports-and-protocols/)
-need to be open in order for Kubernetes components to communicate with each other. You can use NetCat to check if a port is open. For example:
+need to be open in order for Kubernetes components to communicate with each other. You can use tools like netcat to check if a port is open. For example:
 
 ```shell
 nc 127.0.0.1 6443

--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -69,10 +69,10 @@ For more details please see the [Network Plugin Requirements](/docs/concepts/ext
 ## Check required ports
 These
 [required ports](/docs/reference/ports-and-protocols/)
-need to be open in order for Kubernetes components to communicate with each other. You can use telnet to check if a port is open. For example:
+need to be open in order for Kubernetes components to communicate with each other. You can use NetCat to check if a port is open. For example:
 
 ```shell
-telnet 127.0.0.1 6443
+nc 127.0.0.1 6443
 ```
 
 The pod network plugin you use (see below) may also require certain ports to be


### PR DESCRIPTION
Telnet is a command that really should not be used any more, as there is too great a chance it could be misused. Some operating systems have fully removed the tool.  NetCat, nc, is a better and newer tool for testing single open ports.

<!-- 🛈

While telnet has been used for a long time, and most are aware of it, there are newer and better commands which are also less likely to be used for insecure connections. I would suggest using nc instead of telent. 

-->
