### PR TITLE
Use cat instead of shell built-in to read checksum

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -52,7 +52,7 @@ For example, to download version {{< param "fullversion" >}} on Linux, type:
    Validate the kubectl binary against the checksum file:
 
    ```bash
-   echo "$(<kubectl.sha256)  kubectl" | sha256sum --check
+   echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
    ```
 
    If valid, the output is:
@@ -212,7 +212,7 @@ Below are the procedures to set up autocompletion for Bash, Fish, and Zsh.
    Validate the kubectl-convert binary against the checksum file:
 
    ```bash
-   echo "$(<kubectl-convert.sha256) kubectl-convert" | sha256sum --check
+   echo "$(cat kubectl-convert.sha256) kubectl-convert" | sha256sum --check
    ```
 
    If valid, the output is:

--- a/content/en/docs/tasks/tools/install-kubectl-macos.md
+++ b/content/en/docs/tasks/tools/install-kubectl-macos.md
@@ -69,7 +69,7 @@ The following methods exist for installing kubectl on macOS:
    Validate the kubectl binary against the checksum file:
 
    ```bash
-   echo "$(<kubectl.sha256)  kubectl" | shasum -a 256 --check
+   echo "$(cat kubectl.sha256)  kubectl" | shasum -a 256 --check
    ```
 
    If valid, the output is:
@@ -205,7 +205,7 @@ Below are the procedures to set up autocompletion for Bash, Fish, and Zsh.
    Validate the kubectl-convert binary against the checksum file:
 
    ```bash
-   echo "$(<kubectl-convert.sha256)  kubectl-convert" | shasum -a 256 --check
+   echo "$(cat kubectl-convert.sha256)  kubectl-convert" | shasum -a 256 --check
    ```
 
    If valid, the output is:


### PR DESCRIPTION
This PR replaces the shell built-in `$(<file)` with `$(cat file)`.

Using cat allows to run this command in `sh` and any other shell which [does not have support for `$(<`](https://github.com/koalaman/shellcheck/wiki/SC3034)

I ran into this problem when trying to use this command in a Dockerfile.
