### PR TITLE
Cheatsheet syntax to retrieve Secret values with dashes (-) in their key names

### DIFF
--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -177,6 +177,9 @@ kubectl get pods --selector=app=cassandra -o \
 kubectl get configmap myconfig \
   -o jsonpath='{.data.ca\.crt}'
 
+# Retrieve a value with dashes instead of underscores.
+kubectl get secret mysecret --template='{{index .data "key-name-with-dashes"}}'
+
 # Get all worker nodes (use a selector to exclude results that have a label
 # named 'node-role.kubernetes.io/master')
 kubectl get node --selector='!node-role.kubernetes.io/master'

--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -178,7 +178,7 @@ kubectl get configmap myconfig \
   -o jsonpath='{.data.ca\.crt}'
 
 # Retrieve a value with dashes instead of underscores.
-kubectl get secret mysecret --template='{{index .data "key-name-with-dashes"}}'
+kubectl get secret my-secret --template='{{index .data "key-name-with-dashes"}}'
 
 # Get all worker nodes (use a selector to exclude results that have a label
 # named 'node-role.kubernetes.io/master')

--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -177,7 +177,7 @@ kubectl get pods --selector=app=cassandra -o \
 kubectl get configmap myconfig \
   -o jsonpath='{.data.ca\.crt}'
 
-# Retrieve a value with dashes instead of underscores.
+# Retrieve a base64 encoded value with dashes instead of underscores.
 kubectl get secret my-secret --template='{{index .data "key-name-with-dashes"}}'
 
 # Get all worker nodes (use a selector to exclude results that have a label


### PR DESCRIPTION
This template syntax was not obvious to me until someone pointed it out on stackexchange, it should be in the cheatsheet for future users. Because trying to retrieve a value with dashes in its key-name using the normal template syntax will result in an error.

I placed the example under the other example that also deals with "non-standard" characters in key names like period.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
