### PR TITLE
refresh mounted secrets/configmaps by updating pod annotation

### DIFF
--- a/content/en/docs/concepts/configuration/configmap.md
+++ b/content/en/docs/concepts/configuration/configmap.md
@@ -235,7 +235,8 @@ all requests directly to the API server.
 As a result, the total delay from the moment when the ConfigMap is updated to the moment
 when new keys are projected to the Pod can be as long as the kubelet sync period + cache
 propagation delay, where the cache propagation delay depends on the chosen cache type
-(it equals to watch propagation delay, ttl of cache, or zero correspondingly).
+(it equals to watch propagation delay, ttl of cache, or zero correspondingly). You can
+trigger an immediate refresh by updating one of the Pod's annotations.
 
 ConfigMaps consumed as environment variables are not updated automatically and require a pod restart. 
 

--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -392,6 +392,7 @@ when new keys are projected to the Pod can be as long as the kubelet sync period
 propagation delay, where the cache propagation delay depends on the chosen cache type
 (following the same order listed in the previous paragraph, these are:
 watch propagation delay, the configured cache TTL, or zero for direct polling).
+You can trigger an immediate refresh by updating one of the Pod's annotations.
 
 ### Using Secrets as environment variables
 


### PR DESCRIPTION
Updated `concepts/configuration/configmap.md` and `concepts/configuration/secret.md`, to include the "tip" in the [tasks/configure-pod-container/configure-pod-configmap.md](https://github.com/kubernetes/website/blob/b91979ef89d09c7eba1f87449d00856cb49f1bf6/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md?plain=1#L641-L642)

I tested the tip, "changing annotations", it does work as advertised.