### PR TITLE
Update website owners aliases

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -148,8 +148,11 @@ aliases:
     - divya-mohan0209
     - jimangel
     - kbhawkey
+    - natalisucks
     - onlydole
+    - reylejano
     - sftim
+    - tengqm
   sig-docs-zh-owners: # Admins for Chinese content
     # chenopis
     - chenrui333
@@ -242,7 +245,6 @@ aliases:
   # authoritative source: https://git.k8s.io/sig-release/OWNERS_ALIASES
   sig-release-leads:
     - cpanato # SIG Technical Lead
-    - hasheddan # SIG Technical Lead
     - jeremyrickard # SIG Technical Lead
     - justaugustus # SIG Chair
     - LappleApple # SIG Program Manager


### PR DESCRIPTION
This PR updates the k/website OWNERS_ALIASES with the following:
- add @natalisucks @tengqm @reylejano to `sig-docs-leads`
  - see [SIG Docs leadership in the readme](https://github.com/kubernetes/community/blob/master/sig-docs/README.md#leadership)
- remove Daniel (hasheddan) from `sig-release-leads` to align with https://git.k8s.io/sig-release/OWNERS_ALIASES

/assign @divya-mohan0209 @natalisucks
/cc @tengqm @kubernetes/sig-release-leads 
