### PR TITLE
Incorrect or out of date script localization in init 容器 concept 

### DIFF
--- a/content/zh/docs/concepts/workloads/pods/init-containers.md
+++ b/content/zh/docs/concepts/workloads/pods/init-containers.md
@@ -183,7 +183,7 @@ Here are some ideas for how to use init containers:
 * 等待一个 Service 完成创建，通过类似如下 shell 命令：
 
   ```shell
-  for i in {1..100}; do sleep 1; if dig myservice; then exit 0; fi; exit 1
+  for i in {1..100}; do sleep 1; if dig myservice; then exit 0; fi; done; exit 1
   ```
 
 * 注册这个 Pod 到远程服务器，通过在命令中调用 API，类似如下：


### PR DESCRIPTION
There was a bug:
https://kubernetes.io/zh/docs/concepts/workloads/pods/init-containers/#:~:text=if%20dig%20myservice%3B-,then%20exit%200%3B%20fi%3B,-exit%201
"then exit 0; fi; exit 1" should be changed to "then exit 0; fi; done; exit 1".
I have corrected it and changed it accordingly.