### PR TITLE
Remove bootstrap token being in beta state in kubelet-tls-bootstrappi…

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping.md
+++ b/content/en/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping.md
@@ -126,7 +126,6 @@ of provisioning.
 2. [Token authentication file](#token-authentication-file)
 
 Bootstrap tokens are a simpler and more easily managed method to authenticate kubelets, and do not require any additional flags when starting kube-apiserver.
-Using bootstrap tokens is currently __beta__ as of Kubernetes version 1.12.
 
 Whichever method you choose, the requirement is that the kubelet be able to authenticate as a user with the rights to:
 


### PR DESCRIPTION
Bootstrap Token have been stable since v1.18 release - https://kubernetes.io/docs/reference/access-authn-authz/bootstrap-tokens/