### PR TITLE
Remove incorrect /dockershim alias

### DIFF
--- a/content/pt-br/blog/_posts/2022-02-17-updated-dockershim-faq.md
+++ b/content/pt-br/blog/_posts/2022-02-17-updated-dockershim-faq.md
@@ -3,7 +3,6 @@ layout: blog
 title: "Atualizado: Perguntas frequentes (FAQ) sobre a remoção do Dockershim"
 date: 2022-02-17
 slug: dockershim-faq
-aliases: [ '/dockershim' ]
 ---
 
 **Esta é uma atualização do artigo original [FAQ sobre a depreciação do Dockershim](/blog/2020/12/02/dockershim-faq/),


### PR DESCRIPTION
Update https://kubernetes.io/dockershim not to use an in-page redirect to https://kubernetes.io/pt-br/blog/2022/02/17/dockershim-faq/

This fixes up a previous, inadvertent mistake where the alias was retained during localization.
Fixes #32589

Fixup for PR #32397 

/area blog
/language pt
/priority important-soon