### PR TITLE
Remove incorrect /dockershim alias

### DIFF
--- a/content/zh/blog/_posts/2022-02-17-updated-dockershim-faq.md
+++ b/content/zh/blog/_posts/2022-02-17-updated-dockershim-faq.md
@@ -3,7 +3,6 @@ layout: blog
 title: "更新：弃用 Dockershim 的常见问题"
 date: 2022-02-17
 slug: dockershim-faq
-aliases: [ '/dockershim' ]
 ---
 <!-- 
 layout: blog


### PR DESCRIPTION
Update https://kubernetes.io/dockershim not to use an in-page redirect to https://kubernetes.io/zh/blog/2022/02/17/dockershim-faq/

This fixes up a previous, inadvertent mistake where the alias was retained during localization.

Fixup for PR #32342 

/area blog
/language zh
/priority important-soon