### PR TITLE
Removes a space that breaks a markdown link

### DIFF
--- a/content/en/docs/concepts/storage/projected-volumes.md
+++ b/content/en/docs/concepts/storage/projected-volumes.md
@@ -54,8 +54,7 @@ into a Pod at a specified path. For example:
 
 The example Pod has a projected volume containing the injected service account
 token. Containers in this Pod can use that token to access the Kubernetes API
-server, authenticating with the identity of [the pod's ServiceAccount]
-(/docs/tasks/configure-pod-container/configure-service-account/).
+server, authenticating with the identity of [the pod's ServiceAccount](/docs/tasks/configure-pod-container/configure-service-account/).
 The `audience` field contains the intended audience of the
 token. A recipient of the token must identify itself with an identifier specified
 in the audience of the token, and otherwise should reject the token. This field


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@twitter.com>

A small patch that fixes a markdown link.

## Before

![Screen Shot 2022-03-29 at 12 57 21 PM](https://user-images.githubusercontent.com/98927/160696468-8eda18da-a458-4b58-a882-6bfa65ef4332.png)

## After

![Screen Shot 2022-03-29 at 1 29 27 PM](https://user-images.githubusercontent.com/98927/160701407-8006184a-f554-4bc1-9e99-8dd20efd398c.png)

