### PR TITLE
create-cluster-kubeadm: fix typo in "master" label

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
@@ -290,7 +290,7 @@ reasons. If you want to be able to schedule Pods on the control plane nodes,
 for example for a single machine Kubernetes cluster, run:
 
 ```bash
-kubectl taint nodes --all node-role.kubernetes.io/control-plane- node-role.kubernetes.io/control-master-
+kubectl taint nodes --all node-role.kubernetes.io/control-plane- node-role.kubernetes.io/master-
 ```
 
 The output will look something like:


### PR DESCRIPTION
A prior change to modify the command for control plane
untaint introduced a typo "control-master-". Fix it,
as it should be "master-".

https://github.com/kubernetes/website/pull/31391/commits/806518df130f7fa1daa0a82dd51499daa94e9591#diff-3f8a89709e5cc8ce9dd6404c2b29d0aef5ab2a9797ddbd2889299661f6f635a0R293

/cc @sftim 
