### PR TITLE
Remove stale note about EvenPodsSpread

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-topology-spread-constraints.md
+++ b/content/en/docs/concepts/workloads/pods/pod-topology-spread-constraints.md
@@ -12,14 +12,6 @@ obsolete -->
 
 You can use _topology spread constraints_ to control how {{< glossary_tooltip text="Pods" term_id="Pod" >}} are spread across your cluster among failure-domains such as regions, zones, nodes, and other user-defined topology domains. This can help to achieve high availability as well as efficient resource utilization.
 
-{{< note >}}
-In versions of Kubernetes before v1.18, you must enable the `EvenPodsSpread`
-[feature gate](/docs/reference/command-line-tools-reference/feature-gates/) on
-the [API server](/docs/concepts/overview/components/#kube-apiserver) and the
-[scheduler](/docs/reference/command-line-tools-reference/kube-scheduler/) in order to use Pod
-topology spread constraints.
-{{< /note >}}
-
 <!-- body -->
 
 ## Prerequisites


### PR DESCRIPTION
EvenPodsSpread is GA and enabled by default since 1.19 and 1.18 & previous versions are not supported.