### PR TITLE
Remove stale information about pod restart reasons.

### DIFF
--- a/content/en/docs/concepts/workloads/pods/init-containers.md
+++ b/content/en/docs/concepts/workloads/pods/init-containers.md
@@ -325,9 +325,7 @@ reasons:
   to garbage collection.
 
 The Pod will not be restarted when the init container image is changed, or the
-init container completion record has been lost due to garbage collection. This
-applies for Kubernetes v1.20 and later. If you are using an earlier version of
-Kubernetes, consult the documentation for the version you are using.
+init container completion record has been lost due to garbage collection.
 
 ## {{% heading "whatsnext" %}}
 


### PR DESCRIPTION
K8s versions older than 1.20 are not supported, making the info stale.