### PR TITLE
Fixup incorrect systemctl command

### DIFF
--- a/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/migrate-dockershim-dockerd.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/migrate-dockershim-dockerd.md
@@ -93,7 +93,7 @@ in the control plane. To modify this socket for each affected node:
 ## Restart the kubelet
 
 ```shell
-systemctl start kubelet
+systemctl restart kubelet
 ```
 
 ## Verify that the node is healthy


### PR DESCRIPTION
The subcommand for restart is `restart`; update accordingly.