### PR TITLE
Update documentation of `--watch-cache-sizes`

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/kube-apiserver.md
+++ b/content/en/docs/reference/command-line-tools-reference/kube-apiserver.md
@@ -1107,7 +1107,7 @@ kube-apiserver [flags]
 <td colspan="2">--watch-cache-sizes strings</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Watch cache size settings for some resources (pods, nodes, etc.), comma separated. The individual setting format: resource[.group]#size, where resource is lowercase plural (no version), group is omitted for resources of apiVersion v1 (the legacy core API) and included for others, and size is a number. It takes effect when watch-cache is enabled. Some resources (replicationcontrollers, endpoints, nodes, pods, services, apiservices.apiregistration.k8s.io) have system defaults set by heuristics, others default to default-watch-cache-size</p></td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Watch cache size settings for some resources (pods, nodes, etc.), comma separated. The individual setting format: resource[.group]#size, where resource is lowercase plural (no version), group is omitted for resources of apiVersion v1 (the legacy core API) and included for others, and size is a number. This option is only meaningful for resources built into the apiserver, not ones defined by CRDs or aggregated from external servers, and is only consulted if the watch-cache is enabled. The only meaningful size setting to supply here is zero, which means to disable watch caching for the associated resource; all non-zero values are equivalent and mean to not disable watch caching for that resource.</p></td>
 </tr>
 
 </tbody>


### PR DESCRIPTION
This PR updates the documentation of the `--watch-cache-sizes` command-line option of `kube-apiserver` in two ways.

1. This PR adds mention of something that has always been true: that this option is only meaningful for resources built into the apiserver.
2. This PR updates the description to track the fact (not very new now :-) that all non-zero sizes are equivalent and mean only to not disable watch caching.

/sig api-machinery
/cc @wojtek-t 
