### PR TITLE
Mention Detector for Docker Socket in dockershim removal FAQ

### DIFF
--- a/content/en/blog/_posts/2022-02-17-updated-dockershim-faq.md
+++ b/content/en/blog/_posts/2022-02-17-updated-dockershim-faq.md
@@ -202,7 +202,10 @@ discussion of the changes.
 
 ### Is there any tooling that can help me find dockershim in use
 
-Yes! The [Detector for Docker Socket (DDS)][dds] is a kubectl plugin to detect if active Kubernetes workloads are mounting the docker socket (docker.sock) volume. Find more details and usage patterns in the [DDS project's README][dds].
+Yes! The [Detector for Docker Socket (DDS)][dds] is a kubectl plugin that you can
+install and then use to check your cluster. DDS can detect if active Kubernetes workloads
+are mounting the Docker Engine socket (`docker.sock`) as a volume.
+Find more details and usage patterns in the DDS project's [README][dds].
 
 [dds]: https://github.com/aws-containers/kubectl-detector-for-docker-socket
 


### PR DESCRIPTION
Adding the new Detector for Docker Socket plugin to the FAQ.

The tool will help folks find Dockershim usage in files on disk as well as running clusters.

It was developed and released through AWS' open source release process and we're recommending to customers use this tool.
