### PR TITLE
Update quality-service-pod.md

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/quality-service-pod.md
+++ b/content/en/docs/tasks/configure-pod-container/quality-service-pod.md
@@ -107,7 +107,7 @@ kubectl delete pod qos-demo --namespace=qos-example
 A Pod is given a QoS class of Burstable if:
 
 * The Pod does not meet the criteria for QoS class Guaranteed.
-* At least one Container in the Pod has a memory or CPU request.
+* At least one Container in the Pod has a memory or CPU request or limit.
 
 Here is the configuration file for a Pod that has one Container. The Container has a memory limit of 200 MiB
 and a memory request of 100 MiB.


### PR DESCRIPTION
Update `Burstable` conditions with limit.

From the code, the `Burstable` QoS is: At least one Container in the Pod has a memory or CPU request or limit.
https://github.com/kubernetes/kubernetes/blob/8e0ac5b6a1105e0e9d124f240da2b7acb33e6963/pkg/apis/core/v1/helper/qos/qos.go#L39-L102