### PR TITLE
docs: added internal load balancer service annotations for Oracle Cloud (OCI)

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -860,6 +860,17 @@ metadata:
 ```
 
 {{% /tab %}}
+{{% tab name="OCI" %}}
+
+```yaml
+[...]
+metadata:
+    name: my-service
+    annotations:
+        service.beta.kubernetes.io/oci-load-balancer-internal: true
+[...]
+```
+{{% /tab %}}
 {{< /tabs >}}
 
 #### TLS support on AWS {#ssl-support-on-aws}


### PR DESCRIPTION
Added tab and sample code describing how to use annotations to create an internal load balancer instance in Oracle Cloud Infrastructure (OCI). 

Reviewed-by: Avi Miller <avi.miller@oracle.com>
Signed-off-by: Ali Mukadam <ali.mukadam@oracle.com>