### PR TITLE
Manage TLS Certificates in a Cluster: Fix typo in template for glossary reference

### DIFF
--- a/content/en/docs/tasks/tls/managing-tls-in-a-cluster.md
+++ b/content/en/docs/tasks/tls/managing-tls-in-a-cluster.md
@@ -308,7 +308,7 @@ kubectl create secret tls server --cert server.crt --key server-key.pem
 secret/server created
 ```
 
-Finally, you can populate `ca.pem` into a {< glossary_tooltip text="ConfigMap" term_id="configmap" >}}
+Finally, you can populate `ca.pem` into a {{< glossary_tooltip text="ConfigMap" term_id="configmap" >}}
 and use it as the trust root to verify the serving certificate:
 
 ```shell


### PR DESCRIPTION
Link to glossary term "ConfigMap" didn't render correctly due to
a missing "{" at the beginning of template. This PR fixes it.