### PR TITLE
Update l10n guide to use both native and English names in config.toml

### DIFF
--- a/content/en/docs/contribute/localization.md
+++ b/content/en/docs/contribute/localization.md
@@ -131,7 +131,7 @@ contentDir = "content/de"
 weight = 8
 ```
 
-Assign "language name in native alphabets (language name in English alphabets)" to `languageName`, for example, `languageName = "한국어 (Korean)"`. Also, assign "language name in Latin script" to `languageNameLatinScript`, for example, `languageNameLatinScript ="Korean"`.
+The value for `languageName` will be listed in language selection bar. Assign "language name in native script (language name in latin script)" to `languageName`, for example, `languageName = "한국어 (Korean)"`. `languageNameLatinScript` can be used to access the language name in latin script and use it in the theme. Assign "language name in latin script" to `languageNameLatinScript`, for example, `languageNameLatinScript ="Korean"`. 
 
 When assigning a `weight` parameter for your block, find the language block with the highest weight and add 1 to that value.
 

--- a/content/en/docs/contribute/localization.md
+++ b/content/en/docs/contribute/localization.md
@@ -125,10 +125,13 @@ Add a configuration block for the new language to `config.toml`, under the exist
 [languages.de]
 title = "Kubernetes"
 description = "Produktionsreife Container-Verwaltung"
-languageName = "Deutsch"
+languageName = "Deutsch (German)"
+languageNameLatinScript = "German"
 contentDir = "content/de"
-weight = 3
+weight = 8
 ```
+
+Assign "language name in native alphabets (language name in English alphabets)" to `languageName`, for example, `languageName = "한국어 (Korean)"`. Also, assign "language name in Latin script" to `languageNameLatinScript`, for example, `languageNameLatinScript ="Korean"`.
 
 When assigning a `weight` parameter for your block, find the language block with the highest weight and add 1 to that value.
 


### PR DESCRIPTION
This PR is to update localization.md to guide  to use both native and English names in `config.toml` to resolve #31657.

Some languages (Chinese, Korean and Japanese) are using both their own alphabets and Latin script in languageName (ex: `languageName = "한국어 Korean"`), but the others are using own native script only.

This inconsistency issue was discussed in Kube SIG Docs localization meeting Monday 2/7, 2022. And we decided a new recommended best practice using both native script and Latin (ex: "한국어 Korean") as it help folks who can't read native alphabets to know which language it is.

- I'd like to suggest a format for consistency: `"language name in native script (language name in Latin script)"` to `languageName`
  - languageName = "中文 (Chinese)"
  - languageName = "한국어 (Korean)"
  - languageName ="Français (French)"
  - languageName = "हिन्दी (Hindi)"
- Also, add description and example for `languageNameLatinScript`

