### PR TITLE
Revise page “Contributing to the Upstream Kubernetes Code”

### DIFF
--- a/content/en/docs/contribute/generate-ref-docs/contribute-upstream.md
+++ b/content/en/docs/contribute/generate-ref-docs/contribute-upstream.md
@@ -27,6 +27,8 @@ API or the `kube-*` components from the upstream code, see the following instruc
   - [Golang](https://golang.org/doc/install) version 1.13+
   - [Docker](https://docs.docker.com/engine/installation/)
   - [etcd](https://github.com/coreos/etcd/)
+  - [make](https://www.gnu.org/software/make/)
+  - [gcc compiler/linker](https://gcc.gnu.org/)
 
 - Your `GOPATH` environment variable must be set, and the location of `etcd`
   must be in your `PATH` environment variable.
@@ -142,8 +144,9 @@ Run `git status` to see what was generated.
 On branch master
 ...
     modified:   api/openapi-spec/swagger.json
+    modified:   api/openapi-spec/v3/apis__apps__v1_openapi.json
+    modified:   pkg/generated/openapi/zz_generated.openapi.go
     modified:   staging/src/k8s.io/api/apps/v1/generated.proto
-    modified:   staging/src/k8s.io/api/apps/v1/types.go
     modified:   staging/src/k8s.io/api/apps/v1/types_swagger_doc_generated.go
 ```
 


### PR DESCRIPTION
Following #32718, this PR corrects the guide on how to contribute to upstream code. 