### PR TITLE
runtime-class.md: update containerd/cri link

### DIFF
--- a/content/en/docs/concepts/containers/runtime-class.md
+++ b/content/en/docs/concepts/containers/runtime-class.md
@@ -126,8 +126,7 @@ Runtime handlers are configured through containerd's configuration at
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.${HANDLER_NAME}]
 ```
 
-See containerd's config documentation for more details:
-https://github.com/containerd/cri/blob/master/docs/config.md
+See the containerd [CRI Plugin Config Guide](https://github.com/containerd/containerd/blob/main/docs/cri/config.md) for more details.
 
 #### {{< glossary_tooltip term_id="cri-o" >}}
 


### PR DESCRIPTION
The `containerd/cri` repo was merged into the `containerd/containerd` repo.
The `containerd/cri` repo is now archived: https://github.com/containerd/cri

