### PR TITLE
Update kubeadm CRI detection docs in light of dockershim deprecation

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -93,30 +93,30 @@ to interface with your chosen container runtime.
 
 If you don't specify a runtime, kubeadm automatically tries to detect an installed
 container runtime by scanning through a list of well known Unix domain sockets.
-The following table lists container runtimes and their associated socket paths:
+The following table lists container runtimes that kubeadm looks for, and their associated socket paths:
 
 {{< table caption = "Container runtimes and their socket paths" >}}
-| Runtime    | Path to Unix domain socket        |
-|------------|-----------------------------------|
-| Docker     | `/var/run/dockershim.sock`        |
-| containerd | `/run/containerd/containerd.sock` |
-| CRI-O      | `/var/run/crio/crio.sock`         |
+| Runtime        | Path to Unix domain socket        |
+|----------------|-----------------------------------|
+| Docker Engine  | `/var/run/dockershim.sock`        |
+| containerd     | `/run/containerd/containerd.sock` |
+| CRI-O          | `/var/run/crio/crio.sock`         |
 {{< /table >}}
 
 <br />
-If both Docker and containerd are detected, Docker takes precedence. This is
+If both Docker Engine and containerd are detected, kubeadm will give precedence to Docker Engine. This is
 needed because Docker 18.09 ships with containerd and both are detectable even if you only
 installed Docker.
-If any other two or more runtimes are detected, kubeadm exits with an error.
+**If any other two or more runtimes are detected, kubeadm exits with an error.**
 
-The kubelet integrates with Docker through the built-in `dockershim` CRI implementation.
+The kubelet can integrate with Docker Engine using the deprecated `dockershim` adapter (the dockershim is part of the kubelet itself).
 
 See [container runtimes](/docs/setup/production-environment/container-runtimes/)
 for more information.
 {{% /tab %}}
 {{% tab name="other operating systems" %}}
 By default, kubeadm uses {{< glossary_tooltip term_id="docker" >}} as the container runtime.
-The kubelet integrates with Docker through the built-in `dockershim` CRI implementation.
+The kubelet can integrate with Docker Engine using the deprecated `dockershim` adapter (the dockershim is part of the kubelet itself).
 
 See [container runtimes](/docs/setup/production-environment/container-runtimes/)
 for more information.


### PR DESCRIPTION
Fixes issue #26780

Preview: https://deploy-preview-32761--kubernetes-io-main-staging.netlify.app/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#installing-runtime

This change is for v1.23; I expect that v1.24 changes will overwrite this.

/sig cluster-lifecycle node
/language en
/priority important-longterm