### PR TITLE
Change back feature state to alpha for HonorPVReclaimPolicy

### DIFF
--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -176,7 +176,7 @@ spec:
 However, the particular path specified in the custom recycler Pod template in the `volumes` part is replaced with the particular path of the volume that is being recycled.
 
 ### PersistentVolume deletion protection finalizer
-{{< feature-state for_k8s_version="v1.24" state="beta" >}}
+{{< feature-state for_k8s_version="v1.23" state="alpha" >}}
 
 Finalizers can be added on a PersistentVolume to ensure that PersistentVolumes
 having `Delete` reclaim policy are deleted only after the backing storage are deleted.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -115,8 +115,7 @@ different Kubernetes components.
 | `GracefulNodeShutdownBasedOnPodPriority` | `false` | Alpha | 1.23 | |
 | `GRPCContainerProbe` | `false` | Alpha | 1.23 | 1.23 |
 | `GRPCContainerProbe` | `true` | Beta | 1.24 | |
-| `HonorPVReclaimPolicy` | `false` | Alpha | 1.23 | 1.23 |
-| `HonorPVReclaimPolicy` | `true` | Beta | 1.24 | |
+| `HonorPVReclaimPolicy` | `false` | Alpha | 1.23 |  |
 | `HPAContainerMetrics` | `false` | Alpha | 1.20 | |
 | `HPAScaleToZero` | `false` | Alpha | 1.16 | |
 | `IdentifyPodOS` | `false` | Alpha | 1.23 | 1.23 |


### PR DESCRIPTION
`HonorPVReclaimPolicy` will be moved back to `alpha` in 1.24. This PR updates the doc to indicate that.

Signed-off-by: Deepak Kinni <dkinni@vmware.com>

