### PR TITLE
[pt-br] Update link to updated Check if Dockershim Deprecation Affects You page

### DIFF
--- a/content/pt-br/blog/_posts/2022-02-17-updated-dockershim-faq.md
+++ b/content/pt-br/blog/_posts/2022-02-17-updated-dockershim-faq.md
@@ -15,7 +15,7 @@ como parte do lançamento do Kubernetes v1.20. Para obter mais detalhes sobre
 o que isso significa, confira a postagem do blog
 [Não entre em pânico: Kubernetes e Docker](/pt-br/blog/2020/12/02/dont-panic-kubernetes-and-docker/).
 
-Além disso, você pode ler [verifique se a remoção do dockershim afeta você](/docs/tasks/administer-cluster/migrating-from-dockershim/check-if-dockershim-deprecation-affects-you/)
+Além disso, você pode ler [verifique se a remoção do dockershim afeta você](/docs/tasks/administer-cluster/migrating-from-dockershim/check-if-dockershim-removal-affects-you/)
 para determinar qual impacto a remoção do _dockershim_ teria para você
 ou para sua organização.
 


### PR DESCRIPTION
This PR updates the pt-br blog that links to the English site of Check if Dockershim Deprecation Affects You page which is proposed to be renamed in PR https://github.com/kubernetes/website/pull/32780  to Check if Dockershim Removal Affects You 

Hold until PR https://github.com/kubernetes/website/pull/32780 is merged and v1.24 is released (when the `dev-1.24` branch is merged into `main`)
/hold

The link in the preview will not work until PR https://github.com/kubernetes/website/pull/32780 is merged and v1.24 is released