### PR TITLE
Add dockershim removal banner

### DIFF
--- a/data/announcements/scheduled.yaml
+++ b/data/announcements/scheduled.yaml
@@ -31,8 +31,8 @@
 announcements:
 
 - name: Dockershim removal
-  startTime: 2022-04-13T00:00:00 # Added in PR: 
-  endTime: 2022-05-13T00:00:00 # Expires 2022-05-19
+  startTime: 2022-04-13T00:00:00 # Added in PR: https://github.com/kubernetes/website/pull/32805
+  endTime: 2022-05-19T00:00:00 # Expires 2022-05-19
   style: "background: #3d4cb7"
   title: "Dockershim removal set for Kubernetes 1.24"
   message: |

--- a/data/announcements/scheduled.yaml
+++ b/data/announcements/scheduled.yaml
@@ -30,11 +30,11 @@
 # leave the "announcements" key in place
 announcements:
 
-- name: Dockershim removal coming in Kubernetes 1.24
+- name: Dockershim removal
   startTime: 2022-04-13T00:00:00 # Added in PR: 
   endTime: 2022-05-13T00:00:00 # Expires 2022-05-19
   style: "background: #3d4cb7"
-  title: "Dockershim removal: Read the FAQ"
+  title: "Dockershim removal set for Kubernetes 1.24"
   message: |
     As of Kubernetes 1.24, Dockershim will no longer be included in Kubernetes.
     Read the [Dockershim Removal FAQ](https://kubernetes.io/blog/2022/02/17/dockershim-faq/) to see what this means to you.

--- a/data/announcements/scheduled.yaml
+++ b/data/announcements/scheduled.yaml
@@ -32,12 +32,12 @@ announcements:
 
 - name: Dockershim removal
   startTime: 2022-04-07T00:00:00 # Added in PR: https://github.com/kubernetes/website/pull/32805
-  endTime: 2022-05-19T00:00:00 # Expires 2022-05-19
-  style: "background: #3d4cb7"
+  endTime: 2022-05-10T00:00:00 # Expires 2022-05-10, but will change text slightly on release date
+  style: "background: #326ce5"
   title: "Dockershim removal set for Kubernetes 1.24"
   message: |
     As of Kubernetes 1.24, Dockershim will no longer be included in Kubernetes.
-    Read the [Dockershim Removal FAQ](/blog/2022/02/17/dockershim-faq/) to see what this means to you.
+    Read the [Dockershim Removal FAQ](/dockershim) to see what this means to you.
 
 - name: Kubecon 2020 NA
   startTime: 2020-10-26T00:00:00 # Added in https://github.com/kubernetes/website/pull/24714

--- a/data/announcements/scheduled.yaml
+++ b/data/announcements/scheduled.yaml
@@ -30,6 +30,15 @@
 # leave the "announcements" key in place
 announcements:
 
+- name: Dockershim removal coming in Kubernetes 1.24
+  startTime: 2022-04-13T00:00:00 # Added in PR: 
+  endTime: 2022-05-13T00:00:00 # Expires 2022-05-19
+  style: "background: #3d4cb7"
+  title: "Dockershim removal: Read the FAQ"
+  message: |
+    As of Kubernetes 1.24, Dockershim will no longer be included in Kubernetes.
+    Read the [Dockershim Removal FAQ](https://kubernetes.io/blog/2022/02/17/dockershim-faq/) to see what this means to you.
+
 - name: Kubecon 2020 NA
   startTime: 2020-10-26T00:00:00 # Added in https://github.com/kubernetes/website/pull/24714
   endTime: 2020-11-23T00:00:00 # Removed in https://github.com/kubernetes/website/pull/25173

--- a/data/announcements/scheduled.yaml
+++ b/data/announcements/scheduled.yaml
@@ -31,13 +31,13 @@
 announcements:
 
 - name: Dockershim removal
-  startTime: 2022-04-13T00:00:00 # Added in PR: https://github.com/kubernetes/website/pull/32805
+  startTime: 2022-04-07T00:00:00 # Added in PR: https://github.com/kubernetes/website/pull/32805
   endTime: 2022-05-19T00:00:00 # Expires 2022-05-19
   style: "background: #3d4cb7"
   title: "Dockershim removal set for Kubernetes 1.24"
   message: |
     As of Kubernetes 1.24, Dockershim will no longer be included in Kubernetes.
-    Read the [Dockershim Removal FAQ](https://kubernetes.io/blog/2022/02/17/dockershim-faq/) to see what this means to you.
+    Read the [Dockershim Removal FAQ](/blog/2022/02/17/dockershim-faq/) to see what this means to you.
 
 - name: Kubecon 2020 NA
   startTime: 2020-10-26T00:00:00 # Added in https://github.com/kubernetes/website/pull/24714


### PR DESCRIPTION
Adding an announcement banner to highlight the removal of Dockershim from Kubernetes 1.24 release.
See [Issue #30827](https://github.com/kubernetes/website/issues/30837).

I set the banner to start one week before the scheduled 1.24 release and to run for one month after that. I'm looking for feedback on what an appropriate time frame might be.

Here's the netlify example:

![DockershimBanner](https://user-images.githubusercontent.com/11200463/162433077-e4169be4-c670-42e8-b1ca-6254dcd053ff.png)

