### PR TITLE
Fix minor typo in certificates.md

### DIFF
--- a/content/en/docs/setup/best-practices/certificates.md
+++ b/content/en/docs/setup/best-practices/certificates.md
@@ -23,7 +23,7 @@ Kubernetes requires PKI for the following operations:
 
 * Client certificates for the kubelet to authenticate to the API server
 * Kubelet [server certificates](/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/#client-and-serving-certificates)
-  for the the API server to talk to the kubelets
+  for the API server to talk to the kubelets
 * Server certificate for the API server endpoint
 * Client certificates for administrators of the cluster to authenticate to the API server
 * Client certificates for the API server to talk to the kubelets


### PR DESCRIPTION
Remove double "the" from certificates.md