### PR TITLE
Create dockershim shortcode

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -8,6 +8,8 @@ weight: 20
 ---
 <!-- overview -->
 
+{{% dockershim-removal %}}
+
 You need to install a
 {{< glossary_tooltip text="container runtime" term_id="container-runtime" >}}
 into each node in the cluster so that Pods can run there. This page outlines

--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -36,6 +36,9 @@ other = " documentation is no longer actively maintained. The version you are cu
 [deprecation_file_warning]
 other = "Deprecated"
 
+[dockershim_message]
+other = """The dockershim code required to run Docker Engine has been removed from the Kubernetes project as of release 1.24. Read the <a href="/dockershim">Dockershim Removal FAQ</a> for further details."""
+
 [docs_label_browse]
 other = "Browse Docs"
 

--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -37,7 +37,7 @@ other = " documentation is no longer actively maintained. The version you are cu
 other = "Deprecated"
 
 [dockershim_message]
-other = """The dockershim code required to run Docker Engine has been removed from the Kubernetes project as of release 1.24. Read the <a href="/dockershim">Dockershim Removal FAQ</a> for further details."""
+other = """Dockershim has been removed from the Kubernetes project as of release 1.24. Read the <a href="/dockershim">Dockershim Removal FAQ</a> for further details."""
 
 [docs_label_browse]
 other = "Browse Docs"

--- a/layouts/shortcodes/dockershim-removal.html
+++ b/layouts/shortcodes/dockershim-removal.html
@@ -1,0 +1,3 @@
+<div class="alert alert-secondary callout note" role="alert">
+  <strong>{{ T "note" | safeHTML }}</strong> {{ T "dockershim_message" | safeHTML }}
+</div>


### PR DESCRIPTION
Creating a shortcode to put on pages that mention "Docker Engine" to alert people of the Dockershim removal and point them to the "Dockershim Removal FAQ", per [Issue #32805](https://github.com/kubernetes/website/pull/32805).

I've not done one of these before, so I assume that I'll have to work with it for a bit to get it right before this PR is ready for review.