### PR TITLE
Extend debugging endpoint description

### DIFF
--- a/content/en/docs/tasks/debug-application-cluster/debug-service.md
+++ b/content/en/docs/tasks/debug-application-cluster/debug-service.md
@@ -461,6 +461,9 @@ other error, such as the Service selecting for `app=hostnames`, but the
 Deployment specifying `run=hostnames`, as in versions previous to 1.18, where
 the `kubectl run` command could have been also used to create a Deployment.
 
+Another reason for the `ENDPOINTS` column being `<none>` might be different 
+port names provided in service and deployment.
+
 ## Are the Pods working?
 
 At this point, you know that your Service exists and has selected your Pods.


### PR DESCRIPTION
This change in debugging endpoints description provides information for a specific situation. When ENDPOINTS is <none>, there may be another reason behind that (different port names when using port naming).

This port naming thing is already mentioned in "Is the Service defined correctly?" as:

> If you meant to use a named port, do your Pods expose a port with the same name?

However, this is another section. As a person, who was debugging an issue with an empty endpoint, I was going through "Does the Service have any Endpoints?" only and could not answer there. This change will make it easier to find a solution for this quite often problem.