### PR TITLE
[zh] fixed the non-consistent translation of sidebar

### DIFF
--- a/content/zh/docs/concepts/workloads/pods/_index.md
+++ b/content/zh/docs/concepts/workloads/pods/_index.md
@@ -187,7 +187,7 @@ that updates those files from a remote source, as in the following diagram:
 -->
 
 例如，你可能有一个容器，为共享卷中的文件提供 Web 服务器支持，以及一个单独的
-“sidecar（挂斗）”容器负责从远端更新这些文件，如下图所示：
+“sidecar（边车）”容器负责从远端更新这些文件，如下图所示：
 
 {{< figure src="/images/docs/pod.svg" alt="example pod diagram" width="50%" >}}
 


### PR DESCRIPTION
fix the non-consistent translation of 'sidecar'
according to [中文本地化样式指南](https://github.com/kubernetes/website/blob/main/content/zh/docs/contribute/localization_zh.md) sidecar should be "边车" not "挂斗".