### PR TITLE
Service Traffic Policy: Fix constraints section

### DIFF
--- a/content/en/docs/concepts/services-networking/service-traffic-policy.md
+++ b/content/en/docs/concepts/services-networking/service-traffic-policy.md
@@ -60,12 +60,6 @@ considered.
 When the [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
 `ServiceInternalTrafficPolicy` is enabled, `spec.internalTrafficPolicy` defaults to "Cluster".
 
-## Constraints
-
-* Service Internal Traffic Policy is not used when `externalTrafficPolicy` is set
-  to `Local` on a Service. It is possible to use both features in the same cluster
-  on different Services, just not on the same Service.
-
 ## {{% heading "whatsnext" %}}
 
 * Read about [Topology Aware Hints](/docs/concepts/services-networking/topology-aware-hints)


### PR DESCRIPTION
The constraints section incorrectly points out that
ITP and ETP are not co-habitable. This PR fixes this.

/cc @danwinship PTAL
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
