### PR TITLE
static-pods: use /etc/kubernetes/manifests

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/static-pod.md
+++ b/content/en/docs/tasks/configure-pod-container/static-pod.md
@@ -90,7 +90,7 @@ For example, this is how to start a simple web server as a static Pod:
     EOF
     ```
 
-3. Restart the kubelet is usualy not necessary, since the kubelet scans the directory and creates and evicts pods accordingly.
+3. Restarting the kubelet is usually not necessary because the kubelet scans the directory and creates and evicts pods accordingly.
 
 ### Web-hosted static pod manifest {#pods-created-via-http}
 


### PR DESCRIPTION
The old docs used `/etc/kubelet.d/`. This MR uses the well-known path `/etc/kubernetes/manifests`

relates: #32835

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
