### PR TITLE
[zh] Fix Markdown format

### DIFF
--- a/content/zh/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/zh/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -310,7 +310,7 @@ For example, consider the following Pod spec:
 
 例如，考虑下面的 Pod 规约：
 
-{{<codenew file="pods/pod-with-affinity-anti-affinity.yaml">}}
+{{< codenew file="pods/pod-with-affinity-anti-affinity.yaml" >}}
 
 <!--
 If there are two possible nodes that match the

--- a/content/zh/docs/reference/access-authn-authz/rbac.md
+++ b/content/zh/docs/reference/access-authn-authz/rbac.md
@@ -50,7 +50,7 @@ kube-apiserver --authorization-mode=Example,RBAC --<其他选项> --<其他选�
 The RBAC API declares four kinds of Kubernetes object: _Role_, _ClusterRole_,
 _RoleBinding_ and _ClusterRoleBinding_. You can
 [describe objects](/docs/concepts/overview/working-with-objects/kubernetes-objects/#understanding-kubernetes-objects),
-or amend them, using tools such as `kubectl,` just like any other Kubernetes object.
+or amend them, using tools such as `kubectl`, just like any other Kubernetes object.
 
 -->
 ## API 对象  {#api-overview}

--- a/content/zh/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/zh/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -358,7 +358,7 @@ kubelet 可以配置为使用该协议来执行应用活跃性检查。
 
 下面是一个示例清单：
 
-{{< codenew file="pods/probe/grpc-liveness.yaml">}}
+{{< codenew file="pods/probe/grpc-liveness.yaml" >}}
 
 <!--
 To use a gRPC probe, `port` must be configured. If the health endpoint is configured

--- a/content/zh/docs/tasks/run-application/run-replicated-stateful-application.md
+++ b/content/zh/docs/tasks/run-application/run-replicated-stateful-application.md
@@ -530,7 +530,7 @@ kubectl get pod mysql-2
 <!--
 Look for `1/2` in the `READY` column: 
 -->
-在 `READY` 列中查找 ` 1/2` ：
+在 `READY` 列中查找 `1/2`：
 
 ```
 NAME      READY     STATUS    RESTARTS   AGE


### PR DESCRIPTION
- Change `` `hello,` world `` to `` `hello`, world ``
- Use correct `codenew` statement

Ref: #32897