### PR TITLE
Remove deprecated `extensions` API group in document

### DIFF
--- a/content/en/docs/reference/access-authn-authz/abac.md
+++ b/content/en/docs/reference/access-authn-authz/abac.md
@@ -33,13 +33,13 @@ properties:
       - `group`, type string; if you specify `group`, it must match one of the groups of the authenticated user. `system:authenticated` matches all authenticated requests. `system:unauthenticated` matches all unauthenticated requests.
     - Resource-matching properties:
       - `apiGroup`, type string; an API group.
-        - Ex: `extensions`
+        - Ex: `apps`, `networking.k8s.io`
         - Wildcard: `*` matches all API groups.
       - `namespace`, type string; a namespace.
         - Ex: `kube-system`
         - Wildcard: `*` matches all resource requests.
       - `resource`, type string; a resource type
-        - Ex: `pods`
+        - Ex: `pods`, `deployments`
         - Wildcard: `*` matches all resource requests.
     - Non-resource-matching properties:
       - `nonResourcePath`, type string; non-resource request paths.

--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -384,11 +384,11 @@ rules:
 ```
 
 Allow reading/writing Deployments (at the HTTP level: objects with `"deployments"`
-in the resource part of their URL) in both the `"extensions"` and `"apps"` API groups:
+in the resource part of their URL) in the `"apps"` API groups:
 
 ```yaml
 rules:
-- apiGroups: ["extensions", "apps"]
+- apiGroups: ["apps"]
   #
   # at the HTTP level, the name of the resource for accessing Deployment
   # objects is "deployments"
@@ -397,7 +397,7 @@ rules:
 ```
 
 Allow reading Pods in the core API group, as well as reading or writing Job
-resources in the `"batch"` or `"extensions"` API groups:
+resources in the `"batch"` API group:
 
 ```yaml
 rules:
@@ -407,7 +407,7 @@ rules:
   # objects is "pods"
   resources: ["pods"]
   verbs: ["get", "list", "watch"]
-- apiGroups: ["batch", "extensions"]
+- apiGroups: ["batch"]
   #
   # at the HTTP level, the name of the resource for accessing Job
   # objects is "jobs"


### PR DESCRIPTION
The `extensions` API group is deprecated.

### Changes in ABAC page
- Use `networking.k8s.io` instead of `extensions` in `apiGroups` field.
    - Ref: kubernetes/kubernetes#74057
- Add more examples.

### Changes in RBAC page
- Remove deprecated `extensions` API group for Jobs
    - Ref: kubernetes/kubernetes#36355
- Remove deprecated `extensions` API group for Deployments
    - Ref: kubernetes/kubernetes#70672