### PR TITLE
Add dockershim shortcode to appropriate pages

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -15,7 +15,6 @@ You need to install a
 into each node in the cluster so that Pods can run there. This page outlines
 what is involved and describes related tasks for setting up nodes.
 
-
 Kubernetes {{< skew currentVersion >}} requires that you use a runtime that
 conforms with the
 {{< glossary_tooltip term_id="cri" text="Container Runtime Interface">}} (CRI).

--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -14,7 +14,7 @@ card:
 This page shows how to install the `kubeadm` toolbox.
 For information on how to create a cluster with kubeadm once you have performed this installation process, see the [Using kubeadm to Create a Cluster](/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/) page.
 
-
+{{% dockershim-removal %}}
 
 ## {{% heading "prerequisites" %}}
 

--- a/content/en/docs/setup/production-environment/tools/kubeadm/kubelet-integration.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/kubelet-integration.md
@@ -10,6 +10,8 @@ weight: 80
 
 {{< feature-state for_k8s_version="v1.11" state="stable" >}}
 
+{{% dockershim-removal %}}
+
 The lifecycle of the kubeadm CLI tool is decoupled from the
 [kubelet](/docs/reference/command-line-tools-reference/kubelet), which is a daemon that runs
 on each node within the Kubernetes cluster. The kubeadm CLI tool is executed by the user when Kubernetes is

--- a/content/en/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes.md
@@ -16,8 +16,7 @@ weight: 30
 
 You can use Kubernetes to run a mixture of Linux and Windows nodes, so you can mix Pods that run on Linux on with Pods that run on Windows. This page shows how to register Windows nodes to your cluster.
 
-
-
+{{% dockershim-removal %}}
 
 ## {{% heading "prerequisites" %}}
  {{< version-check >}}

--- a/content/en/docs/tasks/network/customize-hosts-file-for-pods.md
+++ b/content/en/docs/tasks/network/customize-hosts-file-for-pods.md
@@ -11,6 +11,9 @@ min-kubernetes-server-version: 1.7
 
 <!-- overview -->
 
+{{% dockershim-removal %}}
+
+
 Adding entries to a Pod's `/etc/hosts` file provides Pod-level override of hostname resolution when DNS and other options are not applicable. You can add these custom entries with the HostAliases field in PodSpec.
 
 Modification not using HostAliases is not suggested because the file is managed by the kubelet and can be overwritten on during Pod creation/restart.


### PR DESCRIPTION
This is a follow-up to [PR #32826](https://github.com/kubernetes/website/pull/32826), which created a shortcode note describing the dockershim removal. This PR will actually add that shortcode to appropriate pages. The note will be placed at the top of each page and read as follows:

`Dockershim has been removed from the Kubernetes project as of release 1.24. Read the <a href="/dockershim">Dockershim Removal FAQ</a> for further details.`

The recommendation is to keep these short codes in place until at least until release 1.25.