### PR TITLE
Add ipv4 forwarding instruction to kubeadm installation requirements

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -46,6 +46,41 @@ check the documentation for that version.
 
 
 <!-- body -->
+## Install and configure prerequisites
+
+The following steps apply common settings for Kubernetes nodes on Linux. 
+
+You can skip a particular setting if you're certain you don't need it.
+
+For more information, see [Network Plugin Requirements](/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/#network-plugin-requirements) or the documentation for your specific container runtime.
+
+### Forwarding IPv4 and letting iptables see bridged traffic
+
+Verify that the `br_netfilter` module is loaded by running `lsmod | grep br_netfilter`. 
+
+To load it explicitly, run `sudo modprobe br_netfilter`.
+
+In order for a Linux node's iptables to correctly view bridged traffic, verify that `net.bridge.bridge-nf-call-iptables` is set to 1 in your `sysctl` config. For example:
+
+```bash
+cat <<EOF | sudo tee /etc/modules-load.d/k8s.conf
+overlay
+br_netfilter
+EOF
+
+sudo modprobe overlay
+sudo modprobe br_netfilter
+
+# sysctl params required by setup, params persist across reboots
+cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+net.bridge.bridge-nf-call-iptables  = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+net.ipv4.ip_forward                 = 1
+EOF
+
+# Apply sysctl params without reboot
+sudo sysctl --system
+```
 
 ## Cgroup drivers
 
@@ -139,38 +174,18 @@ This section outlines the necessary steps to use containerd as CRI runtime.
 
 Use the following commands to install Containerd on your system:
 
-1. Install and configure prerequisites:
 
-   (these instructions apply to Linux nodes only)
 
-   ```shell
-   cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
-   overlay
-   br_netfilter
-   EOF
+Follow the instructions for [getting started with containerd](https://github.com/containerd/containerd/blob/main/docs/getting-started.md). Return to this step once you've created a valid configuration file, `config.toml`. 
 
-   sudo modprobe overlay
-   sudo modprobe br_netfilter
-
-   # Setup required sysctl params, these persist across reboots.
-   cat <<EOF | sudo tee /etc/sysctl.d/99-kubernetes-cri.conf
-   net.bridge.bridge-nf-call-iptables  = 1
-   net.ipv4.ip_forward                 = 1
-   net.bridge.bridge-nf-call-ip6tables = 1
-   EOF
-
-   # Apply sysctl params without reboot
-   sudo sysctl --system
-   ```
-
-1. Install containerd:
-
-   Visit
-   [Getting started with containerd](https://github.com/containerd/containerd/blob/main/docs/getting-started.md)
-   and follow the instructions there, up to the point where you have a valid
-   configuration file, config.toml.
-   On Linux, you can find this file under the path `/etc/containerd/config.toml`.
-   On Windows, you can find this file under the path `C:\Program Files\containerd\config.toml`.
+{{< tabs name="Finding your config.toml file" >}}
+{{% tab name="Linux" %}}
+You can find this file under the path `/etc/containerd/config.toml`.
+{{% /tab %}}
+{{< tab name="Windows" >}}
+You can find this file under the path `C:\Program Files\containerd\config.toml`.
+{{< /tab >}}
+{{< /tabs >}}
 
 On Linux the default CRI socket for containerd is `/run/containerd/containerd.sock`.
 On Windows the default CRI endpoint is `npipe://./pipe/containerd-containerd`.

--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -45,26 +45,6 @@ may [fail](https://github.com/kubernetes/kubeadm/issues/31).
 If you have more than one network adapter, and your Kubernetes components are not reachable on the default
 route, we recommend you add IP route(s) so Kubernetes cluster addresses go via the appropriate adapter.
 
-## Letting iptables see bridged traffic
-
-Make sure that the `br_netfilter` module is loaded. This can be done by running `lsmod | grep br_netfilter`. To load it explicitly call `sudo modprobe br_netfilter`.
-
-As a requirement for your Linux Node's iptables to correctly see bridged traffic, you should ensure `net.bridge.bridge-nf-call-iptables` is set to 1 in your `sysctl` config, e.g.
-
-```bash
-cat <<EOF | sudo tee /etc/modules-load.d/k8s.conf
-br_netfilter
-EOF
-
-cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
-net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-EOF
-sudo sysctl --system
-```
-
-For more details please see the [Network Plugin Requirements](/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/#network-plugin-requirements) page.
-
 ## Check required ports
 These
 [required ports](/docs/reference/ports-and-protocols/)


### PR DESCRIPTION
Currently the `kubeadm` steps walk you through prereqs to install a cluster but walking through these steps on Centos Stream 8 i foudn that my pre-flight checks for `kubeadm init` failed with the following error:

```
[root@cp1 ~]# kubeadm init --config kubeadm-config.yml                                                                                                        
[init] Using Kubernetes version: v1.23.5                                                                                                                      
[preflight] Running pre-flight checks                                                                                                                         
error execution phase preflight: [preflight] Some fatal errors occurred:                                                                                      
        [ERROR FileContent--proc-sys-net-ipv4-ip_forward]: /proc/sys/net/ipv4/ip_forward contents are not set to 1                                            
[preflight] If you know what you are doing, you can make a check non-fatal with `--ignore-preflight-errors=...`                                               
To see the stack trace of this error execute with --v=5 or higher                                                                                             
```

This error can be resolved by adding an additional step for users to ensure they have already enabled ipv4 forwarding on their hosts, and provide them a simple command to do so.