### PR TITLE
[de] Fix Markdown format

### DIFF
--- a/content/de/docs/concepts/workloads/pods/_index.md
+++ b/content/de/docs/concepts/workloads/pods/_index.md
@@ -248,7 +248,7 @@ einige Einschränkungen:
   Eintrag zur Liste `metadata.finalizers` hinzugefügt werden.
 - Pod-Updates dürfen keine Felder ändern, die Ausnahmen sind 
   `spec.containers[*].image`,
- `spec.initContainers[*].image`,` spec.activeDeadlineSeconds` oder
+ `spec.initContainers[*].image`, `spec.activeDeadlineSeconds` oder
  `spec.tolerations`. Für `spec.tolerations` kannnst du nur neue Einträge 
   hinzufügen.
 - Für `spec.activeDeadlineSeconds` sind nur zwei Änderungen erlaubt:

--- a/content/de/docs/reference/kubectl/cheatsheet.md
+++ b/content/de/docs/reference/kubectl/cheatsheet.md
@@ -322,7 +322,7 @@ Ausgabeformat | Beschreibung
 
 ### Kubectl Ausgabe Ausführlichkeit und Debugging
 
-Die Ausführlichkeit von Kubectl wird mit den Flags `-v` oder `--v ` gesteuert, gefolgt von einer Ganzzahl, die die Protokollebene darstellt. Allgemeine Protokollierungskonventionen für Kubernetes und die zugehörigen Protokollebenen werden [hier](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md) beschrieben.
+Die Ausführlichkeit von Kubectl wird mit den Flags `-v` oder `--v` gesteuert, gefolgt von einer Ganzzahl, die die Protokollebene darstellt. Allgemeine Protokollierungskonventionen für Kubernetes und die zugehörigen Protokollebenen werden [hier](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md) beschrieben.
 
 Ausführlichkeit | Beschreibung
 --------------| -----------


### PR DESCRIPTION
### Main Change
- Change `` The` code `format `` to `` The `code` format ``

### Related PR
- #32897