### PR TITLE
Follow up to dockershim migration message after release of v1.24

### DIFF
--- a/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/_index.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/_index.md
@@ -14,7 +14,9 @@ in Kubernetes 1.20, there were questions on how this will affect various workloa
 installations. Our [Dockershim Removal FAQ](/blog/2022/02/17/dockershim-faq/) is there to help you
 to understand the problem better.
 
-It is recommended to migrate from dockershim to alternative container runtimes.
+Dockershim was removed from Kubernetes with the release of v1.24.
+If you use Docker via dockershim as your container runtime, and wish to upgrade to v1.24,
+it is recommended that you either migrate to another runtime or find an alternative means to obtain Docker Engine support.
 Check out [container runtimes](/docs/setup/production-environment/container-runtimes/)
 section to know your options. Make sure to
 [report issues](https://github.com/kubernetes/kubernetes/issues) you encountered


### PR DESCRIPTION
This a follow-up PR to #33016 based on the [PR comment](https://github.com/kubernetes/website/pull/33016#issuecomment-1101807930).

This PR:
- Rewords the [dockershim  migration](https://kubernetes.io/docs/tasks/administer-cluster/migrating-from-dockershim/) message to be viewed accordingly following the release of v1.24