### PR TITLE
Fix hyperlink to CNCF on https://k8s.io/docs/home/

### DIFF
--- a/static/css/gridpage.css
+++ b/static/css/gridpage.css
@@ -21,6 +21,11 @@
     padding: 0 30px 0 0;
     margin-bottom: 50px;
     min-height: 152px;
+  
+}
+.launch-card h2::before {
+    margin-top: 1rem !important;
+    height: 0 !important;
 }
 
 .gridPage p {

--- a/static/css/gridpage.css
+++ b/static/css/gridpage.css
@@ -24,8 +24,8 @@
   
 }
 .launch-card h2::before {
-    margin-top: 1rem !important;
-    height: 0 !important;
+    margin-top: 1rem ;
+    height: 0 ;
 }
 
 .gridPage p {

--- a/static/css/gridpage.css
+++ b/static/css/gridpage.css
@@ -23,6 +23,10 @@
     min-height: 152px;
   
 }
+/* 
+ * Remove the height of the H2 element pseudo-class and set the appropriate spacing 
+ * to avoid mistakenly overriding the styles of other elements 
+ */
 .launch-card h2::before {
     margin-top: 1rem ;
     height: 0 ;


### PR DESCRIPTION
Fixed the problem that the CNCF hyperlink of the HOME page was covered by other elements, resulting in unclickable

#33034 