### PR TITLE
Revert changes from PR 32941 that merged before 1.24 release

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -14,7 +14,6 @@ card:
 This page shows how to install the `kubeadm` toolbox.
 For information on how to create a cluster with kubeadm once you have performed this installation process, see the [Using kubeadm to Create a Cluster](/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/) page.
 
-{{% dockershim-removal %}}
 
 ## {{% heading "prerequisites" %}}
 

--- a/content/en/docs/setup/production-environment/tools/kubeadm/kubelet-integration.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/kubelet-integration.md
@@ -10,8 +10,6 @@ weight: 80
 
 {{< feature-state for_k8s_version="v1.11" state="stable" >}}
 
-{{% dockershim-removal %}}
-
 The lifecycle of the kubeadm CLI tool is decoupled from the
 [kubelet](/docs/reference/command-line-tools-reference/kubelet), which is a daemon that runs
 on each node within the Kubernetes cluster. The kubeadm CLI tool is executed by the user when Kubernetes is

--- a/content/en/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes.md
@@ -16,7 +16,6 @@ weight: 30
 
 You can use Kubernetes to run a mixture of Linux and Windows nodes, so you can mix Pods that run on Linux on with Pods that run on Windows. This page shows how to register Windows nodes to your cluster.
 
-{{% dockershim-removal %}}
 
 ## {{% heading "prerequisites" %}}
  {{< version-check >}}

--- a/content/en/docs/tasks/network/customize-hosts-file-for-pods.md
+++ b/content/en/docs/tasks/network/customize-hosts-file-for-pods.md
@@ -11,9 +11,6 @@ min-kubernetes-server-version: 1.7
 
 <!-- overview -->
 
-{{% dockershim-removal %}}
-
-
 Adding entries to a Pod's `/etc/hosts` file provides Pod-level override of hostname resolution when DNS and other options are not applicable. You can add these custom entries with the HostAliases field in PodSpec.
 
 Modification not using HostAliases is not suggested because the file is managed by the kubelet and can be overwritten on during Pod creation/restart.


### PR DESCRIPTION
Reverts changes that added the dockershim shortcode to pages and merged before the v1.24 release
Reverts most of https://github.com/kubernetes/website/pull/32941
cc @chrisnegus @sftim 