### PR TITLE
use for_k8s_version not for_kubernetes_version

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/daemonset.md
+++ b/content/en/docs/concepts/workloads/controllers/daemonset.md
@@ -107,7 +107,7 @@ If you do not specify either, then the DaemonSet controller will create Pods on 
 
 ### Scheduled by default scheduler
 
-{{< feature-state for_kubernetes_version="1.17" state="stable" >}}
+{{< feature-state for_k8s_version="1.17" state="stable" >}}
 
 A DaemonSet ensures that all eligible nodes run a copy of a Pod. Normally, the
 node that a Pod runs on is selected by the Kubernetes scheduler. However,


### PR DESCRIPTION
This PR use `for_k8s_version` property on _feature-state_ short code, not `for_kubernetes_version`.
_feature-state_ short code has property `for_k8s_version`, not `for_kubernetes_version`.

Currently, [the page](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#scheduled-by-default-scheduler) says "FEATURE STATE: Kubernetes v1.23 [stable]", but this feature(Scheduled by default scheduler) is stable from 1.17 on markdown file.

Maybe version is set to latest(v1.23) if `for_kubernetes_version` is used? :thinking: 

