### PR TITLE
Update `api-reference` shortcode

### DIFF
--- a/layouts/shortcodes/api-reference.html
+++ b/layouts/shortcodes/api-reference.html
@@ -4,4 +4,4 @@
 {{ $textArg := .Get "text" }}
 {{ $page := site.GetPage "page" (printf "%s/%s" $base $pageArg) }}
 {{ $metadata := $page.Params.api_metadata }}
-<a href="{{ $page.URL }}{{if $anchorArg}}#{{ $anchorArg }}{{end}}">{{if $textArg}}{{ $textArg }}{{else if $anchorArg}}{{ $anchorArg }}{{else}}{{ $metadata.kind }}{{end}}</a>
+<a href="{{ $page.RelPermalink }}{{if $anchorArg}}#{{ $anchorArg }}{{end}}">{{if $textArg}}{{ $textArg }}{{else if $anchorArg}}{{ $anchorArg }}{{else}}{{ $metadata.kind }}{{end}}</a>


### PR DESCRIPTION
Closes #33001

From https://github.com/kubernetes/website/issues/33001#issuecomment-1103389479:

After doing some testing, it seems that the `$page.URL` field is accessible with Hugo 0.87.0, but not with Hugo 0.96.0 (and maybe with some other versions too).
(I tried to find Hugo changelog that says `URL` field of [`Page` object](https://gohugo.io/variables/page/) is deprecated in what Hugo version, but I could not find.)

Suggested solution:
Instead of `URL` field, if we use [`RelPermalink` field](https://gohugo.io/variables/page/#:~:text=.RelPermalink,link%20for%20this%20page.), I checked locally that it seems working.

[`layouts/shortcodes/api-reference.html`]
```diff
-<a href="{{ $page.URL }}{{if $anchorArg}}#{{ $anchorArg }}{{end}}">{{if $textArg}}{{ $textArg }}{{else if $anchorArg}}{{ $anchorArg }}{{else}}{{ $metadata.kind }}{{end}}</a>
+<a href="{{ $page.RelPermalink }}{{if $anchorArg}}#{{ $anchorArg }}{{end}}">{{if $textArg}}{{ $textArg }}{{else if $anchorArg}}{{ $anchorArg }}{{else}}{{ $metadata.kind }}{{end}}</a>
```

How I checked:
In `CronJob` page (http://localhost:1313/docs/concepts/workloads/controllers/cron-jobs/#what-s-next),
the link `CronJob` goes to http://localhost:1313/docs/reference/kubernetes-api/workload-resources/cron-job-v1/ ,
for these cases:
- (As-is) `$page.URL`, with Hugo 0.87.0
- (To-be) `$page.RelPermalink`, with Hugo 0.87.0
- (To-be) `$page.RelPermalink`, with Hugo 0.96.0

/area web-development
/cc @sftim @tengqm (from #33048)