### PR TITLE
Fix Minor Typo on API Concepts Page

### DIFF
--- a/content/en/docs/reference/using-api/api-concepts.md
+++ b/content/en/docs/reference/using-api/api-concepts.md
@@ -15,7 +15,7 @@ primary resources via the standard HTTP verbs (POST, PUT, PATCH, DELETE,
 GET).
 
 For some resources, the API includes additional subresources that allow
-fine grained authorization (such as separate viewing details for a Pod from
+fine grained authorization (such as separate views for Pod details and
 retrieving its logs), and can accept and serve those resources in different
 representations for convenience or efficiency.
 

--- a/content/en/docs/reference/using-api/api-concepts.md
+++ b/content/en/docs/reference/using-api/api-concepts.md
@@ -15,7 +15,7 @@ primary resources via the standard HTTP verbs (POST, PUT, PATCH, DELETE,
 GET).
 
 For some resources, the API includes additional subresources that allow
-fine grained authorization (such as a separating viewing details for a Pod from
+fine grained authorization (such as separating viewing details for a Pod from
 retrieving its logs), and can accept and serve those resources in different
 representations for convenience or efficiency.
 

--- a/content/en/docs/reference/using-api/api-concepts.md
+++ b/content/en/docs/reference/using-api/api-concepts.md
@@ -15,7 +15,7 @@ primary resources via the standard HTTP verbs (POST, PUT, PATCH, DELETE,
 GET).
 
 For some resources, the API includes additional subresources that allow
-fine grained authorization (such as separating viewing details for a Pod from
+fine grained authorization (such as separate viewing details for a Pod from
 retrieving its logs), and can accept and serve those resources in different
 representations for convenience or efficiency.
 

--- a/content/en/docs/reference/using-api/api-concepts.md
+++ b/content/en/docs/reference/using-api/api-concepts.md
@@ -16,7 +16,7 @@ GET).
 
 For some resources, the API includes additional subresources that allow
 fine grained authorization (such as separate views for Pod details and
-retrieving its logs), and can accept and serve those resources in different
+log retrievals), and can accept and serve those resources in different
 representations for convenience or efficiency.
 
 Kubernetes supports efficient change notifications on resources via *watches*.


### PR DESCRIPTION
I found a minor typo while reading the API concepts document on kubernetes.io and wanted to address it via this Pull Request.