### PR TITLE
[WIP] Updated dockershim removal banner for release 1.24

### DIFF
--- a/data/announcements/scheduled.yaml
+++ b/data/announcements/scheduled.yaml
@@ -34,7 +34,7 @@ announcements:
   startTime: 2022-04-07T00:00:00 # Added in PR: https://github.com/kubernetes/website/pull/32805
   endTime: 2022-05-10T00:00:00 # Expires 2022-05-10, but will change text slightly on release date
   style: "background: #326ce5"
-  title: "Dockershim removed from Kubernetes 1.24"
+  title: "Dockershim removed from Kubernetes"
   message: |
     As of Kubernetes 1.24, Dockershim is no longer included in Kubernetes.
     Read the [Dockershim Removal FAQ](/dockershim) to see what this means to you.

--- a/data/announcements/scheduled.yaml
+++ b/data/announcements/scheduled.yaml
@@ -34,9 +34,9 @@ announcements:
   startTime: 2022-04-07T00:00:00 # Added in PR: https://github.com/kubernetes/website/pull/32805
   endTime: 2022-05-10T00:00:00 # Expires 2022-05-10, but will change text slightly on release date
   style: "background: #326ce5"
-  title: "Dockershim removal set for Kubernetes 1.24"
+  title: "Dockershim removed from Kubernetes 1.24"
   message: |
-    As of Kubernetes 1.24, Dockershim will no longer be included in Kubernetes.
+    As of Kubernetes 1.24, Dockershim is no longer included in Kubernetes.
     Read the [Dockershim Removal FAQ](/dockershim) to see what this means to you.
 
 - name: Kubecon 2020 NA


### PR DESCRIPTION
I updated the wording on the dockershim removal banner to go into effect on Kubernetes 1.24 release day.

I marked it as WIP so people can review the wording and let me know if this should go into the dev-1.24 branch or just go into main after the release goes live.
