### PR TITLE
Use previous release examples in codenew shortcode

### DIFF
--- a/layouts/shortcodes/codenew.html
+++ b/layouts/shortcodes/codenew.html
@@ -4,7 +4,7 @@
 {{ $fileDir := path.Split $file }}
 {{ $bundlePath := path.Join .Page.File.Dir $fileDir.Dir }}
 {{ $filename := printf "/content/%s/examples/%s" .Page.Lang $file | safeURL }}
-{{ $ghlink := printf "https://%s/main%s" site.Params.githubwebsiteraw $filename | safeURL }}
+{{ $ghlink := printf "https://%s/%s%s" site.Params.githubwebsiteraw (default "main" site.Params.docsbranch) $filename | safeURL }}
 {{/* First assume this is a bundle and the file is inside it. */}}
 {{ $resource := $p.Resources.GetMatch (printf "%s*" $file ) }}
 {{ with $resource }}


### PR DESCRIPTION
Fix a minor bug in the `{{< codenew >}}` shortcode.
When serving a previous release, link to the example for that specific release (and not to the example for the current release).

For example, https://v1-22.docs.kubernetes.io/docs/concepts/workloads/controllers/replicaset/ serves the example from the _main_ branch; this PR would fix that (once backported).