### PR TITLE
doc: add note about endpoint.name==service.name

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -203,6 +203,8 @@ subsets:
 The name of the Endpoints object must be a valid
 [DNS subdomain name](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names).
 
+{{< note >}} The name of the Endpoint must be the same as the name of the Service. {{< /note >}}
+
 {{< note >}}
 The endpoint IPs _must not_ be: loopback (127.0.0.0/8 for IPv4, ::1/128 for IPv6), or
 link-local (169.254.0.0/16 and 224.0.0.0/24 for IPv4, fe80::/64 for IPv6).

--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -205,8 +205,8 @@ The name of the Endpoints object must be a valid
 [DNS subdomain name](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names).
 
 When you create an [Endpoints](docs/reference/kubernetes-api/service-resources/endpoints-v1/)
-object for a Service, you set the name of the new Endpoints object to be the same as the
-name of the Service.
+object for a Service, you set the name of the new object to be the same as that
+of the Service.
 
 {{< note >}}
 The endpoint IPs _must not_ be: loopback (127.0.0.0/8 for IPv4, ::1/128 for IPv6), or

--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -203,7 +203,9 @@ subsets:
 The name of the Endpoints object must be a valid
 [DNS subdomain name](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names).
 
-{{< note >}} The name of the Endpoint must be the same as the name of the Service. {{< /note >}}
+When you create an [Endpoints](docs/reference/kubernetes-api/service-resources/endpoints-v1/)
+object for a Service, you set the name of the new Endpoints to be the same as the
+name of the Service.
 
 {{< note >}}
 The endpoint IPs _must not_ be: loopback (127.0.0.0/8 for IPv4, ::1/128 for IPv6), or

--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -192,6 +192,7 @@ where it's running, by adding an Endpoints object manually:
 apiVersion: v1
 kind: Endpoints
 metadata:
+  # the name here should match the name of the Service
   name: my-service
 subsets:
   - addresses:

--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -205,7 +205,7 @@ The name of the Endpoints object must be a valid
 [DNS subdomain name](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names).
 
 When you create an [Endpoints](docs/reference/kubernetes-api/service-resources/endpoints-v1/)
-object for a Service, you set the name of the new Endpoints to be the same as the
+object for a Service, you set the name of the new Endpoints object to be the same as the
 name of the Service.
 
 {{< note >}}


### PR DESCRIPTION
#### Description

- For Services without selectors, there is no mention of the requirement that the name of the associated Endpoint object must be the same as the Service name. 
- Thus, I have added that note.
