### PR TITLE
Update pod security docs for dockershim removal

### DIFF
--- a/content/en/docs/concepts/security/pod-security-policy.md
+++ b/content/en/docs/concepts/security/pod-security-policy.md
@@ -658,8 +658,7 @@ added. Capabilities listed in `RequiredDropCapabilities` must not be included in
 
 **DefaultAddCapabilities** - The capabilities which are added to containers by
 default, in addition to the runtime defaults. See the
-[Docker documentation](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities)
-for the default list of capabilities when using the Docker runtime.
+the documentation for your container runtime for information on working with Linux capabilities.
 
 ### SELinux
 

--- a/content/en/examples/policy/restricted-psp.yaml
+++ b/content/en/examples/policy/restricted-psp.yaml
@@ -3,6 +3,7 @@ kind: PodSecurityPolicy
 metadata:
   name: restricted
   annotations:
+    # docker/default identifies an seccomp profile, but it is not particularly tied to the Docker runtime
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
     apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
     apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'

--- a/content/en/examples/policy/restricted-psp.yaml
+++ b/content/en/examples/policy/restricted-psp.yaml
@@ -3,7 +3,7 @@ kind: PodSecurityPolicy
 metadata:
   name: restricted
   annotations:
-    # docker/default identifies an seccomp profile, but it is not particularly tied to the Docker runtime
+    # docker/default identifies a profile for seccomp, but it is not particularly tied to the Docker runtime
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
     apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
     apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'


### PR DESCRIPTION
This PR addresses [Issue 30950](https://github.com/kubernetes/website/issues/30950) and [Issue 30949](https://github.com/kubernetes/website/issues/30949)

Changes are made to  [pod-security-policy page](https://kubernetes.io/docs/concepts/security/pod-security-policy/) and the related [restricted-psp.yaml](https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/policy/restricted-psp.yaml) file to clarify references to Docker in those files.
