### PR TITLE
Update network plugins page for cni spec v1.0.0

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins.md
+++ b/content/en/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins.md
@@ -14,8 +14,11 @@ weight: 10
 Kubernetes {{< skew currentVersion >}} supports [Container Network Interface](https://github.com/containernetworking/cni)
 (CNI) plugins for cluster networking. You must use a CNI plugin that is compatible with your cluster and that suits your needs. Different plugins are available (both open- and closed- source) in the wider Kubernetes ecosystem.
 
-You must use a CNI plugin that is compatible with the
-[v0.4.0](https://github.com/containernetworking/cni/blob/spec-v0.4.0/SPEC.md) release of the CNI specification.
+You must use a CNI plugin that is compatible with the 
+[v0.4.0](https://github.com/containernetworking/cni/blob/spec-v0.4.0/SPEC.md) or later
+releases of the CNI specification. The Kubernetes project recommends using a plugin that is
+compatible with the [v1.0.0](https://github.com/containernetworking/cni/blob/spec-v1.0.0/SPEC.md)
+CNI specification (plugins can be compatible with multiple spec versions).
 
 <!-- body -->
 


### PR DESCRIPTION
This PR updates the network plugins page for CNI spec v1.0.0 as of Kubernetes v1.24

CNI spec bump from 0.4.0 to 1.0.0 in https://github.com/containernetworking/cni/pull/854
Kubernetes tracking issue: kubernetes/kubernetes#109686