### PR TITLE
Updated dockershim removal banner wording

### DIFF
--- a/data/announcements/scheduled.yaml
+++ b/data/announcements/scheduled.yaml
@@ -36,7 +36,7 @@ announcements:
   style: "background: #326ce5"
   title: "Dockershim removed from Kubernetes"
   message: |
-    As of Kubernetes 1.24, Dockershim is longer included in Kubernetes.
+    As of Kubernetes 1.24, Dockershim is no longer included in Kubernetes.
     Read the [Dockershim Removal FAQ](/dockershim) to see what this means to you.
 
 - name: Kubecon 2020 NA

--- a/data/announcements/scheduled.yaml
+++ b/data/announcements/scheduled.yaml
@@ -34,9 +34,9 @@ announcements:
   startTime: 2022-04-07T00:00:00 # Added in PR: https://github.com/kubernetes/website/pull/32805
   endTime: 2022-05-10T00:00:00 # Expires 2022-05-10, but will change text slightly on release date
   style: "background: #326ce5"
-  title: "Dockershim removal set for Kubernetes 1.24"
+  title: "Dockershim removed from Kubernetes"
   message: |
-    As of Kubernetes 1.24, Dockershim will no longer be included in Kubernetes.
+    As of Kubernetes 1.24, Dockershim is longer included in Kubernetes.
     Read the [Dockershim Removal FAQ](/dockershim) to see what this means to you.
 
 - name: Kubecon 2020 NA


### PR DESCRIPTION
I updated the wording on the dockershim removal banner to go into effect on Kubernetes 1.24 release day.

(This replaces [PR #33123](https://github.com/kubernetes/website/pull/33123))
