### PR TITLE
Remove incorrect /dockershim alias from zh translations of dockershim FAQ

### DIFF
--- a/content/zh/blog/_posts/2020-12-02-dockershim-faq.md
+++ b/content/zh/blog/_posts/2020-12-02-dockershim-faq.md
@@ -3,14 +3,12 @@ layout: blog
 title: "弃用 Dockershim 的常见问题"
 date: 2020-12-02
 slug: dockershim-faq
-aliases: [ '/dockershim' ]
 ---
 <!-- 
 layout: blog
 title: "Dockershim Deprecation FAQ"
 date: 2020-12-02
 slug: dockershim-faq
-aliases: [ '/dockershim' ]
 -->
 
 <!--

--- a/content/zh/blog/_posts/2022-02-17-updated-dockershim-faq.md
+++ b/content/zh/blog/_posts/2022-02-17-updated-dockershim-faq.md
@@ -9,7 +9,6 @@ layout: blog
 title: "Updated: Dockershim Removal FAQ"
 date: 2022-02-17
 slug: dockershim-faq
-aliases: [ '/dockershim' ]
 -->
 
 <!--


### PR DESCRIPTION
Remove incorrect /dockershim alias in both Dockershim FAQ pages within the zh translation subset which causes kubernetes.io/dockershim to redirect to said pages.
Same fix as was needed for Portuguese version at #32590

Fixes #33232