### PR TITLE
fix namespace typo

### DIFF
--- a/content/zh/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace.md
+++ b/content/zh/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace.md
@@ -245,7 +245,7 @@ kubectl delete namespace default-cpu-example
 删除你的命名空间：
 
 ```shell
-kubectl delete namespace constraints-cpu-example
+kubectl delete namespace default-cpu-example
 ```
 
 ## {{% heading "whatsnext" %}}


### PR DESCRIPTION
create default-cpu-example namespace, but delete constraints-cpu-example namespace.