### PR TITLE
Update API Reference multi-pages for v1.24

### DIFF
--- a/content/en/docs/reference/kubernetes-api/service-resources/ingress-v1.md
+++ b/content/en/docs/reference/kubernetes-api/service-resources/ingress-v1.md
@@ -109,16 +109,14 @@ IngressSpec describes the Ingress the user wishes to exist.
 
       - **rules.http.paths.pathType** (string), required
 
-        PathType determines the interpretation of the Path matching. PathType can be one of the following enum values: 
-          - `"Exact"` Matches the URL path exactly.
-          - `"Prefix"` Matches based on a URL path prefix split by '/'. Matching is
+        PathType determines the interpretation of the Path matching. PathType can be one of the following values: * Exact: Matches the URL path exactly. * Prefix: Matches based on a URL path prefix split by '/'. Matching is
           done on a path element by element basis. A path element refers is the
           list of labels in the path split by the '/' separator. A request is a
           match for path p if every p is an element-wise prefix of p of the
           request path. Note that if the last element of the path is a substring
           of the last element in request path, it is not a match (e.g. /foo/bar
           matches /foo/bar/baz, but does not match /foo/barbaz).
-          - `"ImplementationSpecific"` Interpretation of the Path matching is up to
+        * ImplementationSpecific: Interpretation of the Path matching is up to
           the IngressClass. Implementations can treat this as a separate PathType
           or treat it identically to Prefix or Exact path types.
         Implementations are required to support all path types.


### PR DESCRIPTION
Update of API Reference multi-pages (https://kubernetes.io/docs/reference/kubernetes-api/) for v1.24
