### PR TITLE
Update content/en/docs/reference/labels-annotations-taints/audit-annotations.md

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/audit-annotations.md
+++ b/content/en/docs/reference/labels-annotations-taints/audit-annotations.md
@@ -68,7 +68,7 @@ See [Auditing](/docs/tasks/debug-application-cluster/audit/) for more informatio
 
 ## authorization.k8s.io/reason
 
-Example: `authorization.k8s.io/decision: "Human-readable reason for the decision"`
+Example: `authorization.k8s.io/reason: "Human-readable reason for the decision"`
 
 This annotation gives reason for the [decision](#authorization-k8s-io-decision) in Kubernetes audit logs.
 


### PR DESCRIPTION
Fix the spelling error: `authorization.k8s.io/decision` -> `authorization.k8s.io/reason`.