### PR TITLE
[en] Update docs/doc-contributor-tools/linkchecker

### DIFF
--- a/content/en/docs/doc-contributor-tools/linkchecker/README.md
+++ b/content/en/docs/doc-contributor-tools/linkchecker/README.md
@@ -46,7 +46,7 @@ To run the link checker:
 2. Run the following command:
 
   ```
-  make docker-internal-linkcheck
+  make container-internal-linkcheck
   ```
 
 ## Understanding the output


### PR DESCRIPTION
When I execute the command `make docker-internal-linkcheck`, the output:
``` 
$make docker-internal-linkcheck
-e **** The use of docker-internal-linkcheck is deprecated. Use container-internal-linkcheck instead. ****
/Library/Developer/CommandLineTools/usr/bin/make container-internal-linkcheck
```
I think the document need to be updated