### PR TITLE
update dev-1.24 config.toml for release 1.24

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -186,30 +186,30 @@ docsbranch = "main"
 url = "https://kubernetes.io"
 
 [[params.versions]]
-fullversion = "v1.23.2"
+fullversion = "v1.23.6"
 version = "v1.23"
-githubbranch = "v1.23.2"
+githubbranch = "v1.23.6"
 docsbranch = "release-1.23"
 url = "https://v1-23.docs.kubernetes.io"
 
 [[params.versions]]
-fullversion = "v1.22.6"
+fullversion = "v1.22.9"
 version = "v1.22"
-githubbranch = "v1.22.6"
+githubbranch = "v1.22.9"
 docsbranch = "release-1.22"
 url = "https://v1-22.docs.kubernetes.io"
 
 [[params.versions]]
-fullversion = "v1.21.9"
+fullversion = "v1.21.12"
 version = "v1.21"
-githubbranch = "v1.21.9"
+githubbranch = "v1.21.12"
 docsbranch = "release-1.21"
 url = "https://v1-21.docs.kubernetes.io"
 
 [[params.versions]]
-fullversion = "v1.20.13"
+fullversion = "v1.20.15"
 version = "v1.20"
-githubbranch = "v1.20.13"
+githubbranch = "v1.20.15"
 docsbranch = "release-1.20"
 url = "https://v1-20.docs.kubernetes.io"
 


### PR DESCRIPTION
Updated config.toml for release v1.24

Versions were updated based on [latest patch releases](https://github.com/kubernetes/website/blob/main/content/en/releases/patch-releases.md)

No hold needed, this is targeting dev-1.24