### PR TITLE
update release-1.21 config.toml for release 1.24

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -138,9 +138,9 @@ time_format_default = "January 02, 2006 at 3:04 PM PST"
 description = "Production-Grade Container Orchestration"
 showedit = true
 
-latest = "v1.23"
+latest = "v1.24"
 
-fullversion = "v1.21.7"
+fullversion = "v1.21.12"
 version = "v1.21"
 githubbranch = "release-1.21"
 docsbranch = "release-1.21"
@@ -178,39 +178,39 @@ js = [
 ]
 
 [[params.versions]]
-fullversion = "v1.23.0"
-version = "v1.23"
-githubbranch = "v1.23.0"
+fullversion = "v1.24.0"
+version = "v1.24"
+githubbranch = "v1.24.0"
 docsbranch = "main"
 url = "https://kubernetes.io"
 
 [[params.versions]]
-fullversion = "v1.22.4"
+fullversion = "v1.23.6"
+version = "v1.23"
+githubbranch = "v1.23.6"
+docsbranch = "release-1.23"
+url = "https://v1-23.docs.kubernetes.io"
+
+[[params.versions]]
+fullversion = "v1.22.9"
 version = "v1.22"
-githubbranch = "v1.22.4"
+githubbranch = "v1.22.9"
 docsbranch = "release-1.22"
 url = "https://v1-22.docs.kubernetes.io"
 
 [[params.versions]]
-fullversion = "v1.21.7"
+fullversion = "v1.21.12"
 version = "v1.21"
-githubbranch = "v1.21.7"
+githubbranch = "v1.21.12"
 docsbranch = "release-1.21"
 url = "https://v1-21.docs.kubernetes.io"
 
 [[params.versions]]
-fullversion = "v1.20.13"
+fullversion = "v1.20.15"
 version = "v1.20"
-githubbranch = "v1.20.13"
+githubbranch = "v1.20.15"
 docsbranch = "release-1.20"
 url = "https://v1-20.docs.kubernetes.io"
-
-[[params.versions]]
-fullversion = "v1.19.16"
-version = "v1.19"
-githubbranch = "v1.19.16"
-docsbranch = "release-1.19"
-url = "https://v1-19.docs.kubernetes.io"
 
 # User interface configuration
 [params.ui]


### PR DESCRIPTION
Updated config.toml for release v1.24

Versions were updated based on [latest patch releases](https://github.com/kubernetes/website/blob/main/content/en/releases/patch-releases.md)

/hold until 1.24 release day

/cc @reylejano @sftim @divya-mohan0209 @jimangel @PI-Victor @jlbutler