### PR TITLE
Fix broken link in blog post

### DIFF
--- a/content/en/blog/_posts/2022-04-28-Increasing-the-security-bar-in-Ingress-NGINX/index.md
+++ b/content/en/blog/_posts/2022-04-28-Increasing-the-security-bar-in-Ingress-NGINX/index.md
@@ -144,7 +144,7 @@ as we may have a different controller as soon as it "knows" what to provide to t
 (we need some help here!!)
 
 Some other projects in Kubernetes already take this approach
-(like [KPNG](​​https://github.com/kubernetes-sigs/kpng), the proposed replacement for `kube-proxy`),
+(like [KPNG](https://github.com/kubernetes-sigs/kpng), the proposed replacement for `kube-proxy`),
 and we plan to align with them and get the same experience for Ingress-NGINX.
 
 ## Further reading


### PR DESCRIPTION
A couple of miscreant [left-to-right mark](https://en.wikipedia.org/wiki/Left-to-right_mark) characters led to this URL:

https://kubernetes.io/blog/2022/04/28/ingress-nginx-1-2-0/%E2%80%8B%E2%80%8Bhttps://github.com/kubernetes-sigs/kpng

This commit should fix that, though it may look like nothing changed in the GitHub preview as the bad characters are non-printing.