### PR TITLE
Removing myself from sig-docs-en-owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -25,7 +25,6 @@ aliases:
     - jlbutler
     - kbhawkey
     - natalisucks
-    - nate-double-u # RT 1.24 Docs Lead
     - onlydole
     - pi-victor
     - reylejano


### PR DESCRIPTION
v1.24 has been completed. Thanks everyone for all your help and support.

This PR removes `nate-double-u` from `sig-docs-en-owners`