### PR TITLE
Fix heading for v1.24 release announcement

### DIFF
--- a/content/en/blog/_posts/2022-05-03-kubernetes-release-1.24.md
+++ b/content/en/blog/_posts/2022-05-03-kubernetes-release-1.24.md
@@ -5,8 +5,6 @@ date: 2022-05-03
 slug: kubernetes-1-24-release-announcement
 ---
 
-# Kubernetes 1.24
-
 **Authors**: [Kubernetes 1.24 Release Team](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.24/release-team.md)
 
 We are excited to announce the release of Kubernetes 1.24, the first release of 2022!


### PR DESCRIPTION
Blog articles don't need to start with a first-level heading; the theme handles that automatically.

- [Before](https://kubernetes.io/blog/2022/05/03/kubernetes-1-24-release-announcement/)
- [After](https://deploy-preview-33442--kubernetes-io-main-staging.netlify.app/blog/2022/05/03/kubernetes-1-24-release-announcement/)

/sig release