### PR TITLE
Fix text around liveness probe probe-level grace period behavior

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -506,7 +506,7 @@ those existing Pods.
 
 When you (or the control plane, or some other component) create replacement
 Pods, and the feature gate `ProbeTerminationGracePeriod` is disabled, then the
-API server ignores the Pod-level `terminationGracePeriodSeconds` field, even if
+API server ignores the Probe-level `terminationGracePeriodSeconds` field, even if
 a Pod or pod template specifies it.
 {{< /note >}}
 


### PR DESCRIPTION
Updating the probe level termination grace period notes added as part of https://github.com/kubernetes/website/pull/28930

From the [KEP-2238](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2238-liveness-probe-grace-period#beta-122) page, it was probably intended to say `API server ignores the Probe-level terminationGracePeriodSeconds field` in the docs, but instead said `API server ignores the Pod-level terminationGracePeriodSeconds field` which seems incorrect. 

> Ensure that when feature gate is off in API server, probe-level TerminationGracePeriodSeconds is blanked out.
