### PR TITLE
Remove unnecessary text

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -74,7 +74,7 @@ need to be open in order for Kubernetes components to communicate with each othe
 nc 127.0.0.1 6443
 ```
 
-The pod network plugin you use (see below) may also require certain ports to be
+The pod network plugin you use may also require certain ports to be
 open. Since this differs with each pod network plugin, please see the
 documentation for the plugins about what port(s) those need.
 


### PR DESCRIPTION
This PR omits unnecessary text on the Kubeadm installation page.

Fixes #33468 
