### PR TITLE
Partly remove support for seccomp annotations

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -630,7 +630,8 @@ The value of the annotation is the name of the PodSecurityPolicy that was used f
 
 ### seccomp.security.alpha.kubernetes.io/pod (deprecated) {#seccomp-security-alpha-kubernetes-io-pod}
 
-This annotation has been deprecated since Kubernetes v1.19 and will become non-functional in v1.25.
+This annotation has been deprecated since Kubernetes v1.19 and will become non-functional in a future release.
+please use the corresponding pod or container `securityContext.seccompProfile` field instead.
 To specify security settings for a Pod, include the `securityContext` field in the Pod specification.
 The [`securityContext`](/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context) field within a Pod's `.spec` defines pod-level security attributes.
 When you [specify the security context for a Pod](/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod),
@@ -638,7 +639,8 @@ the settings you specify apply to all containers in that Pod.
 
 ### container.seccomp.security.alpha.kubernetes.io/[NAME] (deprecated) {#container-seccomp-security-alpha-kubernetes-io}
 
-This annotation has been deprecated since Kubernetes v1.19 and will become non-functional in v1.25.
+This annotation has been deprecated since Kubernetes v1.19 and will become non-functional in a future release.
+please use the corresponding pod or container `securityContext.seccompProfile` field instead.
 The tutorial [Restrict a Container's Syscalls with seccomp](/docs/tutorials/security/seccomp/) takes
 you through the steps you follow to apply a seccomp profile to a Pod or to one of
 its containers. That tutorial covers the supported mechanism for configuring seccomp in Kubernetes,

--- a/content/en/docs/tutorials/security/seccomp.md
+++ b/content/en/docs/tutorials/security/seccomp.md
@@ -281,8 +281,14 @@ Here's a manifest for that Pod:
 The functional support for the already deprecated seccomp annotations
 `seccomp.security.alpha.kubernetes.io/pod` (for the whole pod) and
 `container.seccomp.security.alpha.kubernetes.io/[name]` (for a single container)
-is going to be removed with the release of Kubernetes v1.25. Please always use
+is going to be removed with a future release of Kubernetes. Please always use
 the native API fields in favor of the annotations.
+
+Since Kubernetes v1.25, kubelets no longer support the annotations, use of the
+annotations in static pods is no longer supported, and the seccomp annotations
+are no longer auto-populated when pods with seccomp fields are created.
+Auto-population of the seccomp fields from the annotations is planned to be
+removed in a future release.
 {{< /note >}}
 
 Create the Pod in the cluster:


### PR DESCRIPTION
From the release notes of https://github.com/kubernetes/kubernetes/pull/109819, we have to update according to the following situation:

```
Action required: support for the alpha seccomp annotations
`seccomp.security.alpha.kubernetes.io/pod` and
`container.seccomp.security.alpha.kubernetes.io`, deprecated since
v1.19, has been partially removed. Kubelets no longer support the
annotations, use of the annotations in static pods is no longer
supported, and the seccomp annotations are no longer auto-populated when
pods with seccomp fields are created. Auto-population of the seccomp
fields from the annotations is planned to be removed in 1.27. Pods
should use the corresponding pod or container
`securityContext.seccompProfile` field instead.
```

Refers to https://github.com/kubernetes/enhancements/issues/135