### PR TITLE
fix node-eviction-rate zh translation

### DIFF
--- a/content/zh/docs/reference/command-line-tools-reference/kube-controller-manager.md
+++ b/content/zh/docs/reference/command-line-tools-reference/kube-controller-manager.md
@@ -1555,8 +1555,8 @@ Mask size for IPv6 node cidr in dual-stack cluster. Default is 64.
 <!--
 Number of nodes per second on which pods are deleted in case of node failure when a zone is healthy (see --unhealthy-zone-threshold for definition of healthy/unhealthy). Zone refers to entire cluster in non-multizone clusters.
 -->
-当某区域变得不健康，节点失效时，每秒钟可以从此标志所设定的节点
-个数上删除 Pods。请参阅 <code>--unhealthy-zone-threshold</code> 
+当某区域健康时，在节点故障的情况下每秒删除 Pods 的节点数。
+请参阅 <code>--unhealthy-zone-threshold</code>
 以了解“健康”的判定标准。这里的区域（zone）在集群并不跨多个区域时
 指的是整个集群。
 </td>


### PR DESCRIPTION
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
fix https://github.com/kubernetes/website/issues/33540

For kube-controller-manager node-eviction-rate, the Chinese document of "when a zone is healthy" is completely the opposite meaning.

This is PR is trying to fix it .