### PR TITLE
[zh] fix mismatched namespace in content/zh/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace.md

### DIFF
--- a/content/zh/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace.md
+++ b/content/zh/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace.md
@@ -245,7 +245,7 @@ kubectl delete namespace default-cpu-example
 删除你的命名空间：
 
 ```shell
-kubectl delete namespace constraints-cpu-example
+kubectl delete namespace default-cpu-example
 ```
 
 ## {{% heading "whatsnext" %}}


### PR DESCRIPTION
close https://github.com/kubernetes/website/issues/33612

The name of the deleted namespace does not match the name of the namespace that created

<img width="582" alt="Screen Shot 2022-05-11 at 23 09 20" src="https://user-images.githubusercontent.com/26692080/167884591-0754b231-8dd1-4dc3-bd0b-01f074d10869.png">

