### PR TITLE
Add references to pod security levels and admission controller

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/enforce-standards-namespace-labels.md
+++ b/content/en/docs/tasks/configure-pod-container/enforce-standards-namespace-labels.md
@@ -7,7 +7,11 @@ content_type: task
 min-kubernetes-server-version: v1.22
 ---
 
-Namespaces can be labeled to enforce the [Pod Security Standards](/docs/concepts/security/pod-security-standards).
+Namespaces can be labeled to enforce the [Pod Security Standards](/docs/concepts/security/pod-security-standards). The three policies
+[privileged](/docs/concepts/security/pod-security-standards/#privileged), [baseline](/docs/concepts/security/pod-security-standards/#baseline)
+and [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted) broadly cover the security spectrum
+and are implemented by the [Pod Security](/docs/concepts/security/pod-security-admission/) {{< glossary_tooltip
+text="admission controller" term_id="admission-controller" >}}.
 
 ## {{% heading "prerequisites" %}}
 


### PR DESCRIPTION
As per the issue, add reference to and links for the 3 different pod security policies and notes the admission controller is what implemented these.

Closes #33027 
