### PR TITLE
Add kube-rs to operator.md's third-party content

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/operator.md
+++ b/content/en/docs/concepts/extend-kubernetes/operator.md
@@ -112,6 +112,7 @@ Operator.
 
 * [Charmed Operator Framework](https://juju.is/)
 * [Kopf](https://github.com/nolar/kopf) (Kubernetes Operator Pythonic Framework)
+* [kube-rs](https://kube.rs/) (Rust)
 * [kubebuilder](https://book.kubebuilder.io/)
 * [KubeOps](https://buehler.github.io/dotnet-operator-sdk/) (.NET operator SDK)
 * [KUDO](https://kudo.dev/) (Kubernetes Universal Declarative Operator)


### PR DESCRIPTION
We have a [controller guide featured](https://kube.rs/controllers/intro/) on the linked webpage for this so hopefully this is appropriate.