### PR TITLE
Show why list permission should never be given if 'GET' isn't

### DIFF
--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -929,6 +929,64 @@ To bootstrap initial roles and role bindings:
 * Use a credential with the "system:masters" group, which is bound to the "cluster-admin" super-user role by the default bindings.
 * If your API server runs with the insecure port enabled (`--insecure-port`), you can also make API calls via that port, which does not enforce authentication or authorization.
 
+## Preventing excess access via the list permission
+Since the list response contains all items, not just their name, the `list` permission should never be given to a role that doesn't already have the `get` permission.
+
+### Example misuse
+
+```bash
+# Create example A, which can only list secrets in the default namespace
+# It does not have the GET permission
+kubectl create serviceaccount only-list-secrets-sa
+kubectl create role only-list-secrets-role --verb=list --resource=secrets
+kubectl create rolebinding only-list-secrets-default-ns --role=only-list-secrets-role --serviceaccount=default:only-list-secrets-sa
+
+# Now to impersonate that service account
+kubectl proxy &
+
+# Create a secret to get
+kubectl create secret generic abc
+
+# Prove we cannot get that secret
+curl http://127.0.0.1:8001/api/v1/namespaces/default/secrets/abc -H "Authorization: Bearer $(kubectl -n default get secrets -ojson | jq '.items[]| select(.metadata.annotations."kubernetes.io/service-account.name"=="only-list-secrets-sa")| .data.token' | tr -d '"' | base64 -d)"
+{
+  "kind": "Status",
+  "apiVersion": "v1",
+  "metadata": {
+
+  },
+  "status": "Failure",
+  "message": "secrets \"abc\" is forbidden: User \"system:serviceaccount:default:only-list-secrets-sa\" cannot get resource \"secrets\" in API group \"\" in the namespace \"default\"",
+  "reason": "Forbidden",
+  "details": {
+    "name": "abc",
+    "kind": "secrets"
+  },
+  "code": 403
+}
+
+# Now to get all secrets in the default namespace, despite not having "get" permission
+curl http://127.0.0.1:8001/api/v1/namespaces/default/secrets?limit=500 -H "Authorization: Bearer $(kubectl -n default get secrets -ojson | jq '.items[]| select(.metadata.annotations."kubernetes.io/service-account.name"=="only-list-secrets-sa")| .data.token' | tr -d '"' | base64 -d)"
+{
+  "kind": "SecretList",
+  "apiVersion": "v1",
+  "metadata": {
+    "selfLink": "/api/v1/namespaces/default/secrets",
+    "resourceVersion": "17718246"
+  },
+  "items": [
+  REDACTED : REDACTED
+  ]
+}
+
+# Cleanup
+kubectl delete serviceaccount only-list-secrets-sa
+kubectl delete role only-list-secrets-role --verb=list --resource=secrets
+kubectl delete rolebinding only-list-secrets-default-ns --role=only-list-secrets-role --serviceaccount=default:only-list-secrets-sa
+kubectl delete secret abc
+
+```
+
 ## Command-line utilities
 
 ### `kubectl create role`

--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -984,6 +984,8 @@ kubectl delete serviceaccount only-list-secrets-sa
 kubectl delete role only-list-secrets-role --verb=list --resource=secrets
 kubectl delete rolebinding only-list-secrets-default-ns --role=only-list-secrets-role --serviceaccount=default:only-list-secrets-sa
 kubectl delete secret abc
+# Kill backgrounded kubectl proxy
+kill "%$(jobs | grep "kubectl proxy" | cut -d [ -f 2| cut -d ] -f 1)"
 
 ```
 


### PR DESCRIPTION
Currently it's possible to give the LIST permission, without granting GET. Due to this some Kubernetes administrators may be under the impression that those items cannot be obtained by users or service accounts with only the LIST permission. 

This is incorrect, and I'd like to add this example to show why this shouldn't be done.

I'm happy to move this elsewhere in the documentation!