### PR TITLE
[ko] Update links in `dev-1.23-ko.3`

### DIFF
--- a/content/ko/docs/concepts/services-networking/service-topology.md
+++ b/content/ko/docs/concepts/services-networking/service-topology.md
@@ -16,7 +16,7 @@ weight: 10
 
 이 기능, 특히 알파 `topologyKeys` API는 쿠버네티스 v1.21부터
 더 이상 사용되지 않는다.
-쿠버네티스 v1.21에 도입된 [토폴로지 인지 힌트](/docs/concepts/services-networking/topology-aware-hints/)는
+쿠버네티스 v1.21에 도입된 [토폴로지 인지 힌트](/ko/docs/concepts/services-networking/topology-aware-hints/)는
 유사한 기능을 제공한다.
 
 {{</ note >}}

--- a/content/ko/docs/concepts/services-networking/service-traffic-policy.md
+++ b/content/ko/docs/concepts/services-networking/service-traffic-policy.md
@@ -68,6 +68,6 @@ kube-proxy는 `spec.internalTrafficPolicy` 의 설정에 따라서 라우팅되�
 
 ## {{% heading "whatsnext" %}}
 
-* [토폴로지 인식 힌트](/docs/concepts/services-networking/topology-aware-hints/)에 대해서 읽기
+* [토폴로지 인지 힌트](/ko/docs/concepts/services-networking/topology-aware-hints/)에 대해서 읽기
 * [서비스 외부 트래픽 정책](/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip)에 대해서 읽기
 * [서비스와 애플리케이션 연결하기](/ko/docs/concepts/services-networking/connect-applications-service/) 읽기

--- a/content/ko/docs/concepts/storage/volumes.md
+++ b/content/ko/docs/concepts/storage/volumes.md
@@ -881,6 +881,8 @@ RBD CSI 드라이버로의 마이그레이션을 시도하기 전에
   `adminSecretName` 값이 `adminId` 파라미터 값의 
   base64 값으로 패치되어야 하며, 아니면 이 단계를 건너뛸 수 있다.
 
+{{< /note >}}
+
 ### secret
 
 `secret` 볼륨은 암호와 같은 민감한 정보를 파드에 전달하는데
@@ -1196,10 +1198,10 @@ CSI 호환 볼륨 드라이버가 쿠버네티스 클러스터에 배포되면
 `csi` 볼륨은 세 가지 방법으로 파드에서 사용할 수 있다.
 
 * [퍼시스턴트볼륨클레임](#persistentvolumeclaim)에 대한 참조를 통해서
-* [일반 임시 볼륨](/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volume)과 함께
+* [일반 임시 볼륨](/ko/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes)과 함께
 (알파 기능)
 * 드라이버가 지원하는 경우
-[CSI 임시 볼륨](/docs/concepts/storage/ephemeral-volumes/#csi-ephemeral-volume)과 함께 (베타 기능)
+[CSI 임시 볼륨](/ko/docs/concepts/storage/ephemeral-volumes/#csi-ephemeral-volumes)과 함께 (베타 기능)
 
 스토리지 관리자가 다음 필드를 사용해서 CSI 퍼시스턴트 볼륨을
 구성할 수 있다.
@@ -1262,11 +1264,11 @@ CSI 설정 변경 없이 평소와 같이
 
 {{< feature-state for_k8s_version="v1.16" state="beta" >}}
 
-파드 명세 내에서 CSI 볼륨을 직접 구성할 수
-있다. 이 방식으로 지정된 볼륨은 임시 볼륨이며
-파드가 다시 시작할 때 지속되지 않는다. 자세한 내용은 [임시
-볼륨](/docs/concepts/storage/ephemeral-volumes/#csi-ephemeral-volumes)을
-참고한다.
+파드 명세 내에서 CSI 볼륨을 직접 구성할 수 있다. 
+이 방식으로 지정된 볼륨은 임시 볼륨이며 
+파드가 다시 시작할 때 지속되지 않는다. 
+자세한 내용은 
+[임시 볼륨](/ko/docs/concepts/storage/ephemeral-volumes/#csi-ephemeral-volumes)을 참고한다.
 
 CSI 드라이버의 개발 방법에 대한 더 자세한 정보는
 [쿠버네티스-csi 문서](https://kubernetes-csi.github.io/docs/)를 참조한다.

--- a/content/ko/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/ko/docs/reference/command-line-tools-reference/feature-gates.md
@@ -809,7 +809,7 @@ kubelet과 같은 컴포넌트의 기능 게이트를 설정하려면,
 - `GenericEphemeralVolume`: 일반 볼륨의 모든 기능을 지원하는 임시, 인라인
   볼륨을 활성화한다(타사 스토리지 공급 업체, 스토리지 용량 추적, 스냅샷으로부터 복원
   등에서 제공할 수 있음).
-  [임시 볼륨](/docs/concepts/storage/ephemeral-volumes/)을 참고한다.
+  [임시 볼륨](/ko/docs/concepts/storage/ephemeral-volumes/)을 참고한다.
 - `GracefulNodeShutdown` : kubelet에서 정상 종료를 지원한다.
   시스템 종료 중에 kubelet은 종료 이벤트를 감지하고 노드에서 실행 중인
   파드를 정상적으로 종료하려고 시도한다. 자세한 내용은
@@ -1064,7 +1064,7 @@ kubelet과 같은 컴포넌트의 기능 게이트를 설정하려면,
   서비스 어카운트 토큰을 파드에 주입할 수 있다.
 - `TopologyAwareHints`: 엔드포인트슬라이스(EndpointSlices)에서 토폴로지 힌트 기반
   토폴로지-어웨어 라우팅을 활성화한다. 자세한 내용은
-  [토폴로지 어웨어 힌트](/docs/concepts/services-networking/topology-aware-hints/)
+  [토폴로지 인지 힌트](/ko/docs/concepts/services-networking/topology-aware-hints/)
   를 참고한다.
 - `TopologyManager`: 쿠버네티스의 다른 컴포넌트에 대한 세분화된 하드웨어 리소스
   할당을 조정하는 메커니즘을 활성화한다.

--- a/content/ko/docs/tutorials/_index.md
+++ b/content/ko/docs/tutorials/_index.md
@@ -53,8 +53,8 @@ content_type: concept
 
 ## 보안
 
-* [파드 보안 표준을 클러스터 수준으로 적용하기](/docs/tutorials/security/cluster-level-pss/)
-* [파드 보안 표준을 네임스페이스 수준으로 적용하기](/docs/tutorials/security/ns-level-pss/)
+* [파드 보안 표준을 클러스터 수준으로 적용하기](/ko/docs/tutorials/security/cluster-level-pss/)
+* [파드 보안 표준을 네임스페이스 수준으로 적용하기](/ko/docs/tutorials/security/ns-level-pss/)
 * [AppArmor](/ko/docs/tutorials/security/apparmor/)
 * [seccomp](/docs/tutorials/security/seccomp/)
 ## {{% heading "whatsnext" %}}

--- a/content/ko/docs/tutorials/security/cluster-level-pss.md
+++ b/content/ko/docs/tutorials/security/cluster-level-pss.md
@@ -229,7 +229,7 @@ weight: 10
         # default false
         selinuxRelabel: false
         # optional: set propagation mode (None, HostToContainer or Bidirectional)
-        # see https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation
+        # see https://kubernetes.io/ko/docs/concepts/storage/volumes/#마운트-전파-propagation
         # default None
         propagation: None
     EOF


### PR DESCRIPTION
- This PR is similar with #33566.
- Update links in `dev-1.23-ko.3`
- Fix wrong Note box scoping in Korean "Volumes" page
  (closes #32808)