### PR TITLE
[de] Fix `Kubernetes` typo

### DIFF
--- a/content/de/docs/concepts/extend-kubernetes/_index.md
+++ b/content/de/docs/concepts/extend-kubernetes/_index.md
@@ -1,4 +1,4 @@
 ---
-title: "Kubernets erweitern"
+title: "Kubernetes erweitern"
 weight: 110
 ---

--- a/content/de/docs/contribute/_index.md
+++ b/content/de/docs/contribute/_index.md
@@ -1,6 +1,6 @@
 ---
 content_type: concept
-title: Zur Kubernets-Dokumentation beitragen
+title: Zur Kubernetes-Dokumentation beitragen
 linktitle: Mitmachen
 main_menu: true
 weight: 80

--- a/content/de/docs/tutorials/kubernetes-basics/_index.html
+++ b/content/de/docs/tutorials/kubernetes-basics/_index.html
@@ -46,7 +46,7 @@ card:
     </div>
 
     <div id="basics-modules" class="content__modules">
-      <h2>Kubernets Grundlagen Module</h2>
+      <h2>Kubernetes Grundlagen Module</h2>
       <div class="row">
         <div class="col-md-12">
           <div class="row">


### PR DESCRIPTION
- Change `Kubernets` to `Kubernetes`