### PR TITLE
[ja] Fix `Kubernetes` typo

### DIFF
--- a/content/ja/docs/reference/glossary/cloud-controller-manager.md
+++ b/content/ja/docs/reference/glossary/cloud-controller-manager.md
@@ -4,7 +4,7 @@ id: cloud-controller-manager
 date: 2018-04-12
 full_link: /ja/docs/concepts/architecture/cloud-controller/
 short_description: >
-  サードパーティクラウドプロバイダーにKubernetewを結合するコントロールプレーンコンポーネント
+  サードパーティクラウドプロバイダーにKubernetesを結合するコントロールプレーンコンポーネント
 aka: 
 tags:
 - core-object


### PR DESCRIPTION
Fix `Kubernetew` to `Kubernetes`