### PR TITLE
[fr] Fix `Kubernetes` typo

### DIFF
--- a/content/fr/includes/partner-script.js
+++ b/content/fr/includes/partner-script.js
@@ -509,7 +509,7 @@
 			name: 'Nirmata',
 			logo: 'nirmata',
 			link: 'https://www.nirmata.com/',
-			blurb: 'Nirmata - Nirmata Managed Kubernets'
+			blurb: 'Nirmata - Nirmata Managed Kubernetes'
 				},
 		{
 			type: 2,


### PR DESCRIPTION
Fix `Kubernets` to `Kubernetes`