### PR TITLE
[it] Fix `Kubernetes` typo

### DIFF
--- a/content/it/training/_index.html
+++ b/content/it/training/_index.html
@@ -95,7 +95,7 @@ class: training
           <h5>
             <b>Certified Kubernetes Administrator (CKA)</b>
           </h5>
-          <p>Il programma "Certified Kubernetes Administrator" assicura che la persona ha le capacità, conoscenze, e competenze per operare come amministratore di Kubernets.</p>
+          <p>Il programma "Certified Kubernetes Administrator" assicura che la persona ha le capacità, conoscenze, e competenze per operare come amministratore di Kubernetes.</p>
           <br>
           <a href=https://training.linuxfoundation.org/certification/certified-kubernetes-administrator-cka/" target="_blank" class="button">Vai alla certificazione</a>
         </center>


### PR DESCRIPTION
Fix `Kubernets` to `Kubernetes`