### PR TITLE
[uk] Fix `Kubernetes` typo

### DIFF
--- a/content/uk/docs/concepts/overview/what-is-kubernetes.md
+++ b/content/uk/docs/concepts/overview/what-is-kubernetes.md
@@ -93,7 +93,7 @@ Containers have become popular because they provide extra benefits, such as:
 <!--
 ## Why you need Kubernetes and what can it do
 -->
-## Чому вам потрібен Kebernetes і що він може робити
+## Чому вам потрібен Kubernetes і що він може робити
 
 <!--
 Containers are a good way to bundle and run your applications. In a production environment, you need to manage the containers that run the applications and ensure that there is no downtime. For example, if a container goes down, another container needs to start. Wouldn't it be easier if this behavior was handled by a system?


### PR DESCRIPTION
Fix `Kebernetes` to `Kubernetes`