### PR TITLE
[zh]adjust format content/zh/docs/reference/kubectl/

### DIFF
--- a/content/zh/docs/reference/kubectl/conventions.md
+++ b/content/zh/docs/reference/kubectl/conventions.md
@@ -94,4 +94,4 @@ You can use the `--dry-run=client` flag to preview the object that would be sent
 <!--
 * You can use `kubectl apply` to create or update resources. For more information about using kubectl apply to update resources, see [Kubectl Book](https://kubectl.docs.kubernetes.io).
 -->
-* 您可以使用 `kubectl apply` 命令创建或更新资源。有关使用 kubectl apply 更新资源的详细信息，请参阅 [Kubectl 文档](https://kubectl.docs.kubernetes.io)。
+* 你可以使用 `kubectl apply` 命令创建或更新资源。有关使用 kubectl apply 更新资源的详细信息，请参阅 [Kubectl 文档](https://kubectl.docs.kubernetes.io)。

--- a/content/zh/docs/reference/kubectl/docker-cli-to-kubectl.md
+++ b/content/zh/docs/reference/kubectl/docker-cli-to-kubectl.md
@@ -19,7 +19,9 @@ reviewers:
 <!--
 You can use the Kubernetes command line tool `kubectl` to interact with the API Server. Using kubectl is straightforward if you are familiar with the Docker command line tool. However, there are a few differences between the docker commands and the kubectl commands. The following sections show a Docker sub-command and describe the equivalent `kubectl` command.
 -->
-您可以使用 Kubernetes 命令行工具 `kubectl` 与 API 服务器进行交互。如果您熟悉 Docker 命令行工具，则使用 kubectl 非常简单。但是，Docker 命令和 kubectl 命令之间有一些区别。以下显示了 Docker 子命令，并描述了等效的 `kubectl` 命令。
+你可以使用 Kubernetes 命令行工具 `kubectl` 与 API 服务器进行交互。如果你熟悉 Docker 命令行工具，
+则使用 kubectl 非常简单。但是，Docker 命令和 kubectl 命令之间有一些区别。以下显示了 Docker 子命令，
+并描述了等效的 `kubectl` 命令。
 
 
 <!-- body -->
@@ -74,7 +76,7 @@ deployment.apps/nginx-app env updated
 <!--
 `kubectl` commands print the type and name of the resource created or mutated, which can then be used in subsequent commands. You can expose a new Service after a Deployment is created.
 -->
-`kubectl` 命令打印创建或突变资源的类型和名称，然后可以在后续命令中使用。部署后，您可以公开新服务。
+`kubectl` 命令打印创建或突变资源的类型和名称，然后可以在后续命令中使用。部署后，你可以公开新服务。
 {{< /note >}}
 
 <!--
@@ -94,12 +96,16 @@ service "nginx-http" exposed
 <!--
 By using kubectl, you can create a [Deployment](/docs/concepts/workloads/controllers/deployment/) to ensure that N pods are running nginx, where N is the number of replicas stated in the spec and defaults to 1. You can also create a [service](/docs/concepts/services-networking/service/) with a selector that matches the pod labels. For more information, see [Use a Service to Access an Application in a Cluster](/docs/tasks/access-application-cluster/service-access-application-cluster).
 -->
-在 kubectl 命令中，我们创建了一个 [Deployment](/zh/docs/concepts/workloads/controllers/deployment/)，这将保证有 N 个运行 nginx 的 pod(N 代表 spec 中声明的 replica 数，默认为 1)。我们还创建了一个 [service](/zh/docs/concepts/services-networking/service/)，其选择器与容器标签匹配。查看[使用服务访问群集中的应用程序](/zh/docs/tasks/access-application-cluster/service-access-application-cluster) 获取更多信息。
+在 kubectl 命令中，我们创建了一个 [Deployment](/zh/docs/concepts/workloads/controllers/deployment/)，
+这将保证有 N 个运行 nginx 的 Pod(N 代表 spec 中声明的 replica 数，默认为 1)。
+我们还创建了一个 [service](/zh/docs/concepts/services-networking/service/)，其选择器与容器标签匹配。
+查看[使用服务访问群集中的应用程序](/zh/docs/tasks/access-application-cluster/service-access-application-cluster) 获取更多信息。
 
 <!--
 By default images run in the background, similar to `docker run -d ...`. To run things in the foreground, use [`kubectl run`](/docs/reference/generated/kubectl/kubectl-commands/#run) to create pod:
 -->
-默认情况下镜像会在后台运行，与 `docker run -d ...` 类似，如果您想在前台运行，使用 [`kubectl run`](/docs/reference/generated/kubectl/kubectl-commands/#run) 在前台运行 Pod:
+默认情况下镜像会在后台运行，与 `docker run -d ...` 类似，如果你想在前台运行，
+使用 [`kubectl run`](/docs/reference/generated/kubectl/kubectl-commands/#run) 在前台运行 Pod:
 
 ```shell
 kubectl run [-i] [--tty] --attach <name> --image=<image>
@@ -109,14 +115,16 @@ kubectl run [-i] [--tty] --attach <name> --image=<image>
 Unlike `docker run ...`, if you specify `--attach`, then you attach `stdin`, `stdout` and `stderr`. You cannot control which streams are attached (`docker -a ...`).
 To detach from the container, you can type the escape sequence Ctrl+P followed by Ctrl+Q.
 -->
-与 `docker run ...` 不同的是，如果指定了 `--attach` ，我们将连接到 `stdin`，`stdout` 和 `stderr`，而不能控制具体连接到哪个输出流（`docker -a ...`）。要从容器中退出，可以输入 Ctrl + P，然后按 Ctrl + Q。
+与 `docker run ...` 不同的是，如果指定了 `--attach` ，我们将连接到 `stdin`，`stdout` 和 `stderr`，
+而不能控制具体连接到哪个输出流（`docker -a ...`）。要从容器中退出，可以输入 Ctrl + P，然后按 Ctrl + Q。
 
 <!--
 Because the kubectl run command starts a Deployment for the container, the Deployment restarts if you terminate the attached process by using Ctrl+C, unlike `docker run -it`.
 To destroy the Deployment and its pods you need to run `kubectl delete deployment <name>`.
 -->
-因为我们使用 Deployment 启动了容器，如果您终止连接到的进程（例如 `ctrl-c`），容器将会重启，这跟 `docker run -it` 不同。
-如果想销毁该 Deployment（和它的 pod），您需要运行 `kubectl delete deployment <name>`。
+因为我们使用 Deployment 启动了容器，如果你终止连接到的进程（例如 `ctrl-c`），容器将会重启，
+这跟 `docker run -it` 不同。 如果想销毁该 Deployment（和它的 Pod），
+你需要运行 `kubectl delete deployment <name>`。
 
 ## docker ps
 
@@ -158,7 +166,8 @@ ubuntu                      0/1       Completed   0          20s
 <!--
 To attach a process that is already running in a container, see [kubectl attach](/docs/reference/generated/kubectl/kubectl-commands/#attach).
 -->
-如何连接到已经运行在容器中的进程？查看 [kubectl attach](/docs/reference/generated/kubectl/kubectl-commands/#attach)。
+如何连接到已经运行在容器中的进程？
+查看 [kubectl attach](/docs/reference/generated/kubectl/kubectl-commands/#attach)。
 
 <!--
 docker:
@@ -308,7 +317,10 @@ kubectl logs -f nginx-app-zibvs
 <!--
 There is a slight difference between pods and containers; by default pods do not terminate if their processes exit. Instead the pods restart the process. This is similar to the docker run option `--restart=always` with one major difference. In docker, the output for each invocation of the process is concatenated, but for Kubernetes, each invocation is separate. To see the output from a previous run in Kubernetes, do this:
 -->
-现在是时候提一下 pod 和容器之间的细微差别了；默认情况下如果 pod 中的进程退出 pod 也不会终止，相反它将会重启该进程。这类似于 docker run 时的 `--restart=always` 选项， 这是主要差别。在 docker 中，进程的每个调用的输出都是被连接起来的，但是对于 kubernetes，每个调用都是分开的。要查看以前在 kubernetes 中执行的输出，请执行以下操作：
+现在是时候提一下 Pod 和容器之间的细微差别了；默认情况下如果 Pod 中的进程退出 Pod 也不会终止，
+相反它将会重启该进程。这类似于 docker run 时的 `--restart=always` 选项， 这是主要差别。
+在 docker 中，进程的每个调用的输出都是被连接起来的，但是对于 kubernetes，每个调用都是分开的。
+要查看以前在 kubernetes 中执行的输出，请执行以下操作：
 
 ```shell
 kubectl logs --previous nginx-app-zibvs
@@ -393,7 +405,8 @@ kubectl get po -l app=nginx-app
 <!--
 When you use kubectl, you don't delete the pod directly.You have to first delete the Deployment that owns the pod. If you delete the pod directly, the Deployment recreates the pod.
 -->
-请注意，我们不直接删除 pod。使用 kubectl 命令，我们要删除拥有该 pod 的 Deployment。如果我们直接删除 pod，Deployment 将会重新创建该 pod。
+请注意，我们不直接删除 Pod。使用 kubectl 命令，我们要删除拥有该 Pod 的 Deployment。
+如果我们直接删除 Pod，Deployment 将会重新创建该 Pod。
 {{< /note >}}
 
 ## docker login
@@ -401,7 +414,8 @@ When you use kubectl, you don't delete the pod directly.You have to first delete
 <!--
 There is no direct analog of `docker login` in kubectl. If you are interested in using Kubernetes with a private registry, see [Using a Private Registry](/docs/concepts/containers/images/#using-a-private-registry).
 -->
-在 kubectl 中没有对 `docker login` 的直接模拟。如果您有兴趣在私有镜像仓库中使用 Kubernetes，请参阅[使用私有镜像仓库](/zh/docs/concepts/containers/images/#using-a-private-registry)。
+在 kubectl 中没有对 `docker login` 的直接模拟。如果你有兴趣在私有镜像仓库中使用 Kubernetes，
+请参阅[使用私有镜像仓库](/zh/docs/concepts/containers/images/#using-a-private-registry)。
 
 ## docker version
 

--- a/content/zh/docs/reference/kubectl/kubectl.md
+++ b/content/zh/docs/reference/kubectl/kubectl.md
@@ -220,7 +220,7 @@ kubectl [flags]
       <!--
       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       -->
-      设置为 true，则表示不会检查服务器证书的有效性。这样会导致您的 HTTPS 连接不安全。
+      设置为 true，则表示不会检查服务器证书的有效性。这样会导致你的 HTTPS 连接不安全。
       </td>
     </tr>
     <tr>

--- a/content/zh/docs/reference/using-api/client-libraries.md
+++ b/content/zh/docs/reference/using-api/client-libraries.md
@@ -27,8 +27,8 @@ you do not need to implement the API calls and request/response types yourself.
 You can use a client library for the programming language you are using.
 -->
 在使用 [Kubernetes REST API](/zh/docs/reference/using-api/) 编写应用程序时，
-您并不需要自己实现 API 调用和 “请求/响应” 类型。
-您可以根据自己的编程语言需要选择使用合适的客户端库。
+你并不需要自己实现 API 调用和 “请求/响应” 类型。
+你可以根据自己的编程语言需要选择使用合适的客户端库。
 
 <!--
 Client libraries often handle common tasks such as authentication for you.
@@ -37,7 +37,7 @@ authenticate if the API client is running inside the Kubernetes cluster, or can
 understand the [kubeconfig file](/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)
 format to read the credentials and the API Server address.
 -->
-客户端库通常为您处理诸如身份验证之类的常见任务。
+客户端库通常为你处理诸如身份验证之类的常见任务。
 如果 API 客户端在 Kubernetes 集群中运行，大多数客户端库可以发现并使用 Kubernetes 服务帐户进行身份验证，
 或者能够理解 [kubeconfig 文件](/zh/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)
 格式来读取凭据和 API 服务器地址。


### PR DESCRIPTION
[zh]adjust format content/zh/docs/reference/kubectl/

```
% ./scripts/lsync.sh content/zh/docs/reference/kubectl/conventions.md
content/zh/docs/reference/kubectl/conventions.md is still in sync


 % ./scripts/lsync.sh content/zh/docs/reference/kubectl/docker-cli-to-kubectl.md
content/zh/docs/reference/kubectl/docker-cli-to-kubectl.md is still in sync


\% ./scripts/lsync.sh content/zh/docs/reference/kubectl/kubectl.md
content/zh/docs/reference/kubectl/kubectl.md is still in sync


% ./scripts/lsync.sh content/zh/docs/reference/using-api/client-libraries.md
content/zh/docs/reference/using-api/client-libraries.md is still in sync
```