### PR TITLE
Cleanup admission-controllers page

### DIFF
--- a/content/en/docs/reference/access-authn-authz/admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/admission-controllers.md
@@ -94,7 +94,7 @@ kube-apiserver -h | grep enable-admission-plugins
 In the current version, the default ones are:
 
 ```shell
-CertificateApproval, CertificateSigning, CertificateSubjectRestriction, DefaultIngressClass, DefaultStorageClass, DefaultTolerationSeconds, LimitRanger, MutatingAdmissionWebhook, NamespaceLifecycle, PersistentVolumeClaimResize, Priority, ResourceQuota, RuntimeClass, ServiceAccount, StorageObjectInUseProtection, TaintNodesByCondition, ValidatingAdmissionWebhook
+CertificateApproval, CertificateSigning, CertificateSubjectRestriction, DefaultIngressClass, DefaultStorageClass, DefaultTolerationSeconds, LimitRanger, MutatingAdmissionWebhook, NamespaceLifecycle, PersistentVolumeClaimResize, PodSecurity, Priority, ResourceQuota, RuntimeClass, ServiceAccount, StorageObjectInUseProtection, TaintNodesByCondition, ValidatingAdmissionWebhook
 ```
 
 ## What does each admission controller do?
@@ -232,12 +232,10 @@ of it.
 This admission controller mitigates the problem where the API server gets flooded by
 event requests. The cluster admin can specify event rate limits by:
 
- * Enabling the `EventRateLimit` admission controller;
- * Referencing an `EventRateLimit` configuration file from the file provided to the API
-   server's command line flag `--admission-control-config-file`:
+* Enabling the `EventRateLimit` admission controller;
+* Referencing an `EventRateLimit` configuration file from the file provided to the API
+  server's command line flag `--admission-control-config-file`:
 
-{{< tabs name="eventratelimit_example" >}}
-{{% tab name="apiserver.config.k8s.io/v1" %}}
 ```yaml
 apiVersion: apiserver.config.k8s.io/v1
 kind: AdmissionConfiguration
@@ -246,19 +244,6 @@ plugins:
   path: eventconfig.yaml
 ...
 ```
-{{% /tab %}}
-{{% tab name="apiserver.k8s.io/v1alpha1" %}}
-```yaml
-# Deprecated in v1.17 in favor of apiserver.config.k8s.io/v1
-apiVersion: apiserver.k8s.io/v1alpha1
-kind: AdmissionConfiguration
-plugins:
-- name: EventRateLimit
-  path: eventconfig.yaml
-...
-```
-{{% /tab %}}
-{{< /tabs >}}
 
 There are four types of limits that can be specified in the configuration:
 
@@ -283,7 +268,7 @@ limits:
   burst: 50
 ```
 
-See the [EventRateLimit proposal](https://git.k8s.io/community/contributors/design-proposals/api-machinery/admission_control_event_rate_limit.md)
+See the [EventRateLimit Config API (v1alpha1)](/docs/reference/config-api/apiserver-eventratelimit.v1alpha1/)
 for more details.
 
 ### ExtendedResourceToleration {#extendedresourcetoleration}
@@ -319,8 +304,6 @@ imagePolicy:
 
 Reference the ImagePolicyWebhook configuration file from the file provided to the API server's command line flag `--admission-control-config-file`:
 
-{{< tabs name="imagepolicywebhook_example1" >}}
-{{% tab name="apiserver.config.k8s.io/v1" %}}
 ```yaml
 apiVersion: apiserver.config.k8s.io/v1
 kind: AdmissionConfiguration
@@ -329,24 +312,9 @@ plugins:
   path: imagepolicyconfig.yaml
 ...
 ```
-{{% /tab %}}
-{{% tab name="apiserver.k8s.io/v1alpha1" %}}
-```yaml
-# Deprecated in v1.17 in favor of apiserver.config.k8s.io/v1
-apiVersion: apiserver.k8s.io/v1alpha1
-kind: AdmissionConfiguration
-plugins:
-- name: ImagePolicyWebhook
-  path: imagepolicyconfig.yaml
-...
-```
-{{% /tab %}}
-{{< /tabs >}}
 
 Alternatively, you can embed the configuration directly in the file:
 
-{{< tabs name="imagepolicywebhook_example2" >}}
-{{% tab name="apiserver.config.k8s.io/v1" %}}
 ```yaml
 apiVersion: apiserver.config.k8s.io/v1
 kind: AdmissionConfiguration
@@ -360,31 +328,14 @@ plugins:
       retryBackoff: 500
       defaultAllow: true
 ```
-{{% /tab %}}
-{{% tab name="apiserver.k8s.io/v1alpha1" %}}
-```yaml
-# Deprecated in v1.17 in favor of apiserver.config.k8s.io/v1
-apiVersion: apiserver.k8s.io/v1alpha1
-kind: AdmissionConfiguration
-plugins:
-- name: ImagePolicyWebhook
-  configuration:
-    imagePolicy:
-      kubeConfigFile: <path-to-kubeconfig-file>
-      allowTTL: 50
-      denyTTL: 50
-      retryBackoff: 500
-      defaultAllow: true
-```
-{{% /tab %}}
-{{< /tabs >}}
 
 The ImagePolicyWebhook config file must reference a
 [kubeconfig](/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)
 formatted file which sets up the connection to the backend.
 It is required that the backend communicate over TLS.
 
-The kubeconfig file's cluster field must point to the remote service, and the user field must contain the returned authorizer.
+The kubeconfig file's `cluster` field must point to the remote service, and the `user` field
+must contain the returned authorizer.
 
 ```yaml
 # clusters refers to the remote service.
@@ -407,9 +358,17 @@ For additional HTTP configuration, refer to the
 
 #### Request Payloads
 
-When faced with an admission decision, the API Server POSTs a JSON serialized `imagepolicy.k8s.io/v1alpha1` `ImageReview` object describing the action. This object contains fields describing the containers being admitted, as well as any pod annotations that match `*.image-policy.k8s.io/*`.
+When faced with an admission decision, the API Server POSTs a JSON serialized
+`imagepolicy.k8s.io/v1alpha1` `ImageReview` object describing the action.
+This object contains fields describing the containers being admitted, as well as
+any pod annotations that match `*.image-policy.k8s.io/*`.
 
-Note that webhook API objects are subject to the same versioning compatibility rules as other Kubernetes API objects. Implementers should be aware of looser compatibility promises for alpha objects and check the "apiVersion" field of the request to ensure correct deserialization. Additionally, the API Server must enable the imagepolicy.k8s.io/v1alpha1 API extensions group (`--runtime-config=imagepolicy.k8s.io/v1alpha1=true`).
+Note that webhook API objects are subject to the same versioning compatibility rules
+as other Kubernetes API objects. Implementers should be aware of looser compatibility
+promises for alpha objects and check the "apiVersion" field of the request to
+ensure correct deserialization.
+Additionally, the API Server must enable the `imagepolicy.k8s.io/v1alpha1` API extensions
+group (`--runtime-config=imagepolicy.k8s.io/v1alpha1=true`).
 
 An example request body:
 
@@ -434,7 +393,9 @@ An example request body:
 }
 ```
 
-The remote service is expected to fill the `ImageReviewStatus` field of the request and respond to either allow or disallow access. The response body's "spec" field is ignored and may be omitted. A permissive response would return:
+The remote service is expected to fill the `ImageReviewStatus` field of the request and
+respond to either allow or disallow access. The response body's `spec` field is ignored and
+may be omitted. A permissive response would return:
 
 ```json
 {
@@ -459,11 +420,15 @@ To disallow access, the service would return:
 }
 ```
 
-For further documentation refer to the `imagepolicy.v1alpha1` API objects and `plugin/pkg/admission/imagepolicy/admission.go`.
+For further documentation refer to the `imagepolicy.v1alpha1` API objects and
+`plugin/pkg/admission/imagepolicy/admission.go`.
 
 #### Extending with Annotations
 
-All annotations on a Pod that match `*.image-policy.k8s.io/*` are sent to the webhook. Sending annotations allows users who are aware of the image policy backend to send extra information to it, and for different backends implementations to accept different information.
+All annotations on a Pod that match `*.image-policy.k8s.io/*` are sent to the webhook.
+Sending annotations allows users who are aware of the image policy backend to
+send extra information to it, and for different backends implementations to
+accept different information.
 
 Examples of information you might put here are:
 
@@ -471,7 +436,7 @@ Examples of information you might put here are:
  * a ticket number from a ticket system that documents the break-glass request
  * provide a hint to the policy server as to the imageID of the image being provided, to save it a lookup
 
-In any case, the annotations are provided by the user and are not validated by Kubernetes in any way. In the future, if an annotation is determined to be widely useful, it may be promoted to a named field of `ImageReviewSpec`.
+In any case, the annotations are provided by the user and are not validated by Kubernetes in any way.
 
 ### LimitPodHardAntiAffinityTopology {#limitpodhardantiaffinitytopology}
 
@@ -480,14 +445,16 @@ This admission controller denies any pod that defines `AntiAffinity` topology ke
 
 ### LimitRanger {#limitranger}
 
-This admission controller will observe the incoming request and ensure that it does not violate any of the constraints
-enumerated in the `LimitRange` object in a `Namespace`.  If you are using `LimitRange` objects in
-your Kubernetes deployment, you MUST use this admission controller to enforce those constraints. LimitRanger can also
-be used to apply default resource requests to Pods that don't specify any; currently, the default LimitRanger
-applies a 0.1 CPU requirement to all Pods in the `default` namespace.
+This admission controller will observe the incoming request and ensure that it does not violate
+any of the constraints enumerated in the `LimitRange` object in a `Namespace`.  If you are using
+`LimitRange` objects in your Kubernetes deployment, you MUST use this admission controller to
+enforce those constraints. LimitRanger can also be used to apply default resource requests to Pods
+that don't specify any; currently, the default LimitRanger applies a 0.1 CPU requirement to all
+Pods in the `default` namespace.
 
-See the [limitRange design doc](https://git.k8s.io/community/contributors/design-proposals/resource-management/admission_control_limit_range.md)
-and the [example of Limit Range](/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/) for more details.
+See the [LimitRange API reference](/docs/reference/kubernetes-api/policy-resources/limit-range-v1/)
+and the [example of LimitRange](/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/)
+for more details.
 
 ### MutatingAdmissionWebhook {#mutatingadmissionwebhook}
 
@@ -507,16 +474,16 @@ versions >= 1.9).
 
 #### Use caution when authoring and installing mutating webhooks
 
- * Users may be confused when the objects they try to create are different from
-   what they get back.
- * Built in control loops may break when the objects they try to create are
-   different when read back.
-   * Setting originally unset fields is less likely to cause problems than
-     overwriting fields set in the original request. Avoid doing the latter.
- * Future changes to control loops for built-in resources or third-party resources
-   may break webhooks that work well today. Even when the webhook installation API
-   is finalized, not all possible webhook behaviors will be guaranteed to be supported
-   indefinitely.
+* Users may be confused when the objects they try to create are different from
+  what they get back.
+* Built in control loops may break when the objects they try to create are
+  different when read back.
+  * Setting originally unset fields is less likely to cause problems than
+    overwriting fields set in the original request. Avoid doing the latter.
+* Future changes to control loops for built-in resources or third-party resources
+  may break webhooks that work well today. Even when the webhook installation API
+  is finalized, not all possible webhook behaviors will be guaranteed to be supported
+  indefinitely.
 
 ### NamespaceAutoProvision {#namespaceautoprovision}
 
@@ -533,26 +500,28 @@ If the namespace referenced from a request doesn't exist, the request is rejecte
 
 ### NamespaceLifecycle {#namespacelifecycle}
 
-This admission controller enforces that a `Namespace` that is undergoing termination cannot have new objects created in it,
-and ensures that requests in a non-existent `Namespace` are rejected. This admission controller also prevents deletion of
-three system reserved namespaces `default`, `kube-system`, `kube-public`.
+This admission controller enforces that a `Namespace` that is undergoing termination cannot have
+new objects created in it, and ensures that requests in a non-existent `Namespace` are rejected.
+This admission controller also prevents deletion of three system reserved namespaces `default`,
+`kube-system`, `kube-public`.
 
-A `Namespace` deletion kicks off a sequence of operations that remove all objects (pods, services, etc.) in that
-namespace.  In order to enforce integrity of that process, we strongly recommend running this admission controller.
+A `Namespace` deletion kicks off a sequence of operations that remove all objects (pods, services,
+etc.) in that namespace.  In order to enforce integrity of that process, we strongly recommend
+running this admission controller.
 
 ### NodeRestriction {#noderestriction}
 
 This admission controller limits the `Node` and `Pod` objects a kubelet can modify. In order to be limited by this admission controller,
 kubelets must use credentials in the `system:nodes` group, with a username in the form `system:node:<nodeName>`.
 Such kubelets will only be allowed to modify their own `Node` API object, and only modify `Pod` API objects that are bound to their node.
-In Kubernetes 1.11+, kubelets are not allowed to update or remove taints from their `Node` API object.
+kubelets are not allowed to update or remove taints from their `Node` API object.
 
-In Kubernetes 1.13+, the `NodeRestriction` admission plugin prevents kubelets from deleting their `Node` API object,
+The `NodeRestriction` admission plugin prevents kubelets from deleting their `Node` API object,
 and enforces kubelet modification of labels under the `kubernetes.io/` or `k8s.io/` prefixes as follows:
 
 * **Prevents** kubelets from adding/removing/updating labels with a `node-restriction.kubernetes.io/` prefix.
-This label prefix is reserved for administrators to label their `Node` objects for workload isolation purposes,
-and kubelets will not be allowed to modify labels with that prefix.
+  This label prefix is reserved for administrators to label their `Node` objects for workload isolation purposes,
+  and kubelets will not be allowed to modify labels with that prefix.
 * **Allows** kubelets to add/remove/update these labels and label prefixes:
   * `kubernetes.io/hostname`
   * `kubernetes.io/arch`
@@ -566,9 +535,11 @@ and kubelets will not be allowed to modify labels with that prefix.
   * `kubelet.kubernetes.io/`-prefixed labels
   * `node.kubernetes.io/`-prefixed labels
 
-Use of any other labels under the `kubernetes.io` or `k8s.io` prefixes by kubelets is reserved, and may be disallowed or allowed by the `NodeRestriction` admission plugin in the future.
+Use of any other labels under the `kubernetes.io` or `k8s.io` prefixes by kubelets is reserved,
+and may be disallowed or allowed by the `NodeRestriction` admission plugin in the future.
 
-Future versions may add additional restrictions to ensure kubelets have the minimal set of permissions required to operate correctly.
+Future versions may add additional restrictions to ensure kubelets have the minimal set of
+permissions required to operate correctly.
 
 ### OwnerReferencesPermissionEnforcement {#ownerreferencespermissionenforcement}
 
@@ -582,7 +553,8 @@ subresource of the referenced *owner* can change it.
 
 {{< feature-state for_k8s_version="v1.24" state="stable" >}}
 
-This admission controller implements additional validations for checking incoming `PersistentVolumeClaim` resize requests.
+This admission controller implements additional validations for checking incoming
+`PersistentVolumeClaim` resize requests.
 
 Enabling the `PersistentVolumeClaimResize` admission controller is recommended.
 This admission controller prevents resizing of all claims by default unless a claim's `StorageClass`
@@ -624,7 +596,8 @@ Starting from 1.11, this admission controller is disabled by default.
 
 {{< feature-state for_k8s_version="v1.5" state="alpha" >}}
 
-This admission controller defaults and limits what node selectors may be used within a namespace by reading a namespace annotation and a global configuration.
+This admission controller defaults and limits what node selectors may be used within a namespace
+by reading a namespace annotation and a global configuration.
 
 #### Configuration File Format
 
@@ -639,10 +612,9 @@ podNodeSelectorPluginConfig:
  namespace2: name-of-node-selector
 ```
 
-Reference the `PodNodeSelector` configuration file from the file provided to the API server's command line flag `--admission-control-config-file`:
+Reference the `PodNodeSelector` configuration file from the file provided to the API server's
+command line flag `--admission-control-config-file`:
 
-{{< tabs name="podnodeselector_example1" >}}
-{{% tab name="apiserver.config.k8s.io/v1" %}}
 ```yaml
 apiVersion: apiserver.config.k8s.io/v1
 kind: AdmissionConfiguration
@@ -651,23 +623,11 @@ plugins:
   path: podnodeselector.yaml
 ...
 ```
-{{% /tab %}}
-{{% tab name="apiserver.k8s.io/v1alpha1" %}}
-```yaml
-# Deprecated in v1.17 in favor of apiserver.config.k8s.io/v1
-apiVersion: apiserver.k8s.io/v1alpha1
-kind: AdmissionConfiguration
-plugins:
-- name: PodNodeSelector
-  path: podnodeselector.yaml
-...
-```
-{{% /tab %}}
-{{< /tabs >}}
 
 #### Configuration Annotation Format
 
-`PodNodeSelector` uses the annotation key `scheduler.alpha.kubernetes.io/node-selector` to assign node selectors to namespaces.
+`PodNodeSelector` uses the annotation key `scheduler.alpha.kubernetes.io/node-selector` to assign
+node selectors to namespaces.
 
 ```yaml
 apiVersion: v1
@@ -682,12 +642,15 @@ metadata:
 
 This admission controller has the following behavior:
 
-1. If the `Namespace` has an annotation with a key `scheduler.alpha.kubernetes.io/node-selector`, use its value as the
-node selector.
-2. If the namespace lacks such an annotation, use the `clusterDefaultNodeSelector` defined in the `PodNodeSelector`
-plugin configuration file as the node selector.
-3. Evaluate the pod's node selector against the namespace node selector for conflicts. Conflicts result in rejection.
-4. Evaluate the pod's node selector against the namespace-specific allowed selector defined the plugin configuration file.
+1. If the `Namespace` has an annotation with a key `scheduler.alpha.kubernetes.io/node-selector`,
+   use its value as the node selector.
+2. If the namespace lacks such an annotation, use the `clusterDefaultNodeSelector` defined in the
+   `PodNodeSelector` plugin configuration file as the node selector.
+3. Evaluate the pod's node selector against the namespace node selector for conflicts. Conflicts
+   result in rejection.
+4. Evaluate the pod's node selector against the namespace-specific allowed selector defined the
+   plugin configuration file.
+
 Conflicts result in rejection.
 
 {{< note >}}
@@ -721,7 +684,8 @@ for more information.
 
 {{< feature-state for_k8s_version="v1.7" state="alpha" >}}
 
-The PodTolerationRestriction admission controller verifies any conflict between tolerations of a pod and the tolerations of its namespace.
+The PodTolerationRestriction admission controller verifies any conflict between tolerations of a
+pod and the tolerations of its namespace.
 It rejects the pod request if there is a conflict.
 It then merges the tolerations annotated on the namespace into the tolerations of the pod.
 The resulting tolerations are checked against a list of allowed tolerations annotated to the namespace.
@@ -748,16 +712,18 @@ metadata:
 
 ### Priority {#priority}
 
-The priority admission controller uses the `priorityClassName` field and populates the integer value of the priority.
+The priority admission controller uses the `priorityClassName` field and populates the integer
+value of the priority.
 If the priority class is not found, the Pod is rejected.
 
 ### ResourceQuota {#resourcequota}
 
-This admission controller will observe the incoming request and ensure that it does not violate any of the constraints
-enumerated in the `ResourceQuota` object in a `Namespace`.  If you are using `ResourceQuota`
-objects in your Kubernetes deployment, you MUST use this admission controller to enforce quota constraints.
+This admission controller will observe the incoming request and ensure that it does not violate
+any of the constraints enumerated in the `ResourceQuota` object in a `Namespace`.  If you are
+using `ResourceQuota` objects in your Kubernetes deployment, you MUST use this admission
+controller to enforce quota constraints.
 
-See the [resourceQuota design doc](https://git.k8s.io/community/contributors/design-proposals/resource-management/admission_control_resource_quota.md)
+See the [ResourceQuota API reference](/docs/reference/kubernetes-api/policy-resources/resource-quota-v1/)
 and the [example of Resource Quota](/docs/concepts/policy/resource-quotas/) for more details.
 
 ### RuntimeClass {#runtimeclass}
@@ -793,7 +759,8 @@ pod privileges.
 
 This admission controller implements automation for
 [serviceAccounts](/docs/tasks/configure-pod-container/configure-service-account/).
-We strongly recommend using this admission controller if you intend to make use of Kubernetes `ServiceAccount` objects.
+We strongly recommend using this admission controller if you intend to make use of Kubernetes
+`ServiceAccount` objects.
 
 ### StorageObjectInUseProtection
 
@@ -809,7 +776,10 @@ for more detailed information.
 
 {{< feature-state for_k8s_version="v1.17" state="stable" >}}
 
-This admission controller {{< glossary_tooltip text="taints" term_id="taint" >}} newly created Nodes as `NotReady` and `NoSchedule`. That tainting avoids a race condition that could cause Pods to be scheduled on new Nodes before their taints were updated to accurately reflect their reported conditions.
+This admission controller {{< glossary_tooltip text="taints" term_id="taint" >}} newly created
+Nodes as `NotReady` and `NoSchedule`. That tainting avoids a race condition that could cause Pods
+to be scheduled on new Nodes before their taints were updated to accurately reflect their reported
+conditions.
 
 ### ValidatingAdmissionWebhook {#validatingadmissionwebhook}
 

--- a/content/en/docs/reference/config-api/apiserver-eventratelimit.v1alpha1.md
+++ b/content/en/docs/reference/config-api/apiserver-eventratelimit.v1alpha1.md
@@ -1,0 +1,121 @@
+---
+title: Event Rate Limit Configuration (v1alpha1)
+content_type: tool-reference
+package: evenratelimit.admission.k8s.io/v1alpha1
+auto_generated: true
+---
+
+
+## Resource Types 
+
+
+- [Configuration](#evenratelimit-admission-k8s-io-v1alpha1-Configuration)
+  
+    
+
+## `Configuration`     {#evenratelimit-admission-k8s-io-v1alpha1-Configuration}
+    
+
+
+<p>Configuration provides configuration for the EventRateLimit admission
+controller.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>evenratelimit.admission.k8s.io/v1alpha1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>Configuration</code></td></tr>
+    
+  
+<tr><td><code>limits</code> <B>[Required]</B><br/>
+<a href="#evenratelimit-admission-k8s-io-v1alpha1-Limit"><code>[]Limit</code></a>
+</td>
+<td>
+   <p>limits are the limits to place on event queries received.
+Limits can be placed on events received server-wide, per namespace,
+per user, and per source+object.
+At least one limit is required.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `Limit`     {#evenratelimit-admission-k8s-io-v1alpha1-Limit}
+    
+
+**Appears in:**
+
+- [Configuration](#evenratelimit-admission-k8s-io-v1alpha1-Configuration)
+
+
+<p>Limit is the configuration for a particular limit type</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>type</code> <B>[Required]</B><br/>
+<a href="#evenratelimit-admission-k8s-io-v1alpha1-LimitType"><code>LimitType</code></a>
+</td>
+<td>
+   <p>type is the type of limit to which this configuration applies</p>
+</td>
+</tr>
+<tr><td><code>qps</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>qps is the number of event queries per second that are allowed for this
+type of limit. The qps and burst fields are used together to determine if
+a particular event query is accepted. The qps determines how many queries
+are accepted once the burst amount of queries has been exhausted.</p>
+</td>
+</tr>
+<tr><td><code>burst</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>burst is the burst number of event queries that are allowed for this type
+of limit. The qps and burst fields are used together to determine if a
+particular event query is accepted. The burst determines the maximum size
+of the allowance granted for a particular bucket. For example, if the burst
+is 10 and the qps is 3, then the admission control will accept 10 queries
+before blocking any queries. Every second, 3 more queries will be allowed.
+If some of that allowance is not used, then it will roll over to the next
+second, until the maximum allowance of 10 is reached.</p>
+</td>
+</tr>
+<tr><td><code>cacheSize</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>cacheSize is the size of the LRU cache for this type of limit. If a bucket
+is evicted from the cache, then the allowance for that bucket is reset. If
+more queries are later received for an evicted bucket, then that bucket
+will re-enter the cache with a clean slate, giving that bucket a full
+allowance of burst queries.</p>
+<p>The default cache size is 4096.</p>
+<p>If limitType is 'server', then cacheSize is ignored.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `LimitType`     {#evenratelimit-admission-k8s-io-v1alpha1-LimitType}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [Limit](#evenratelimit-admission-k8s-io-v1alpha1-Limit)
+
+
+<p>LimitType is the type of the limit (e.g., per-namespace)</p>
+
+
+
+  


### PR DESCRIPTION
This PR fixes several things in the admission-controllers page:

- The `PodSecurity` plugin is enabled by default, but it was not listed so;
- The `apiserver.config.k8s.io/v1alpha1` has been deprecated since v1.17, we are still documenting it side by side with the `apiserver.config.k8s.io/v1` API group;
- The `eventratelimit.admission.k8s.io/v1alpha1` API could use a better reference rather than the design doc; **The imagepolicy.v1alpha1 API is not documented anywhere, I'll add it later on.**
- There are statements about future, which should be removed;
- We are supposed refer to the `LimitRage` API reference rather than pointing users to the design docs;
- We are supposed refer to the `ResourceQuota` API reference rather than pointing users to the design docs;
- There are long lines in the page source which could have been wrapped properly.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
