### PR TITLE
Fix blog article title for storage-capacity-ga announcement

### DIFF
--- a/content/en/blog/_posts/2022-05-06-storage-capacity-GA/index.md
+++ b/content/en/blog/_posts/2022-05-06-storage-capacity-GA/index.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-title: "Storage Capacity Tracking reaches GA in Kubernetes 1.24"
+title: "Kubernetes 1.24: Storage Capacity Tracking Now Generally Available"
 date: 2022-05-06
 slug: storage-capacity-ga
 ---


### PR DESCRIPTION
Use the same article naming as the rest of the release comms series. Fixup for #32659 
