### PR TITLE
adjust format in geference/glossary-1

### DIFF
--- a/content/zh/docs/reference/glossary/network-policy.md
+++ b/content/zh/docs/reference/glossary/network-policy.md
@@ -41,4 +41,7 @@ tags:
 Network Policies help you declaratively configure which Pods are allowed to connect to each other, which namespaces are allowed to communicate, and more specifically which port numbers to enforce each policy on. `NetworkPolicy` resources use labels to select Pods and define rules which specify what traffic is allowed to the selected Pods. Network Policies are implemented by a supported network plugin provided by a network provider. Be aware that creating a network resource without a controller to implement it will have no effect.
 -->
 
-网络策略帮助您声明式地配置允许哪些 Pod 之间接、哪些命名空间之间允许进行通信，并具体配置了哪些端口号来执行各个策略。`NetworkPolicy` 资源使用标签来选择 Pod，并定义了所选 Pod 可以接受什么样的流量。网络策略由网络提供商提供的并被 Kubernetes 支持的网络插件实现。请注意，当没有控制器实现网络资源时，创建网络资源将不会生效。
+网络策略帮助你声明式地配置允许哪些 Pod 之间、哪些命名空间之间允许进行通信，
+并具体配置了哪些端口号来执行各个策略。`NetworkPolicy` 资源使用标签来选择 Pod，
+并定义了所选 Pod 可以接受什么样的流量。网络策略由网络提供商提供的并被 Kubernetes 支持的网络插件实现。
+请注意，当没有控制器实现网络资源时，创建网络资源将不会生效。

--- a/content/zh/docs/reference/glossary/pod.md
+++ b/content/zh/docs/reference/glossary/pod.md
@@ -4,7 +4,7 @@ id: pod
 date: 2018-04-12
 full_link: /docs/concepts/workloads/pods/pod-overview/
 short_description: >
-  Pod 表示您的集群上一组正在运行的容器。
+  Pod 表示你的集群上一组正在运行的容器。
 
 aka: 
 tags:

--- a/content/zh/docs/reference/glossary/volume-plugin.md
+++ b/content/zh/docs/reference/glossary/volume-plugin.md
@@ -40,7 +40,7 @@ tags:
 A Volume Plugin lets you attach and mount storage volumes for use by a {{< glossary_tooltip text="Pod" term_id="pod" >}}. Volume plugins can be _in tree_ or _out of tree_. _In tree_ plugins are part of the Kubernetes code repository and follow its release cycle. _Out of tree_ plugins are developed independently.
 -->
 
-卷插件让您能给 {{< glossary_tooltip text="Pod" term_id="pod" >}} 附加和挂载存储卷。
+卷插件让你能给 {{< glossary_tooltip text="Pod" term_id="pod" >}} 附加和挂载存储卷。
 卷插件既可以是 _in tree_ 也可以是 _out of tree_ 。_in tree_ 插件是 Kubernetes 代码库的一部分，
 并遵循其发布周期。而 _Out of tree_ 插件则是独立开发的。
 


### PR DESCRIPTION
```
% ./scripts/lsync.sh content/zh/docs/reference/glossary/network-policy.md
diff --git a/content/en/docs/reference/glossary/network-policy.md b/content/en/docs/reference/glossary/network-policy.md
old mode 100755
new mode 100644
% ./scripts/lsync.sh content/zh/docs/reference/glossary/pod.md
diff --git a/content/en/docs/reference/glossary/pod.md b/content/en/docs/reference/glossary/pod.md
old mode 100755
new mode 100644
% ./scripts/lsync.sh content/zh/docs/reference/glossary/volume-plugin.md
diff --git a/content/en/docs/reference/glossary/volume-plugin.md b/content/en/docs/reference/glossary/volume-plugin.md
old mode 100755
new mode 100644

```