### PR TITLE
[zh] adjust format in docs/reference/glossary-2

### DIFF
--- a/content/zh/docs/reference/glossary/etcd.md
+++ b/content/zh/docs/reference/glossary/etcd.md
@@ -40,7 +40,7 @@ If your Kubernetes cluster uses etcd as its backing store, make sure you have a
 [back up](/docs/tasks/administer-cluster/configure-upgrade-etcd/#backing-up-an-etcd-cluster) plan
 for those data.
 -->	
-您的 Kubernetes 集群的 etcd 数据库通常需要有个备份计划。
+你的 Kubernetes 集群的 etcd 数据库通常需要有个备份计划。
 <!--
 You can find in-depth information about etcd in the official [documentation](https://etcd.io/docs/).
 -->

--- a/content/zh/docs/reference/glossary/kops.md
+++ b/content/zh/docs/reference/glossary/kops.md
@@ -56,7 +56,7 @@ Support for using kops with GCE and VMware vSphere are in alpha.
   * The ability to directly provision, or to generate Terraform manifests
 -->
 
-`kops` 为您的集群提供了：
+`kops` 为你的集群提供了：
 
   * 全自动化安装
   * 基于 DNS 的集群标识
@@ -69,4 +69,5 @@ Support for using kops with GCE and VMware vSphere are in alpha.
 You can also build your own cluster using {{< glossary_tooltip term_id="kubeadm" >}} as a building block. `kops` builds on the kubeadm work.
 -->
 
-您也可以将自己的集群作为一个构造块，使用 {{< glossary_tooltip term_id="kubeadm" >}} 构造集群。`kops` 是建立在 kubeadm 之上的。
+你也可以将自己的集群作为一个构造块，使用 {{< glossary_tooltip term_id="kubeadm" >}} 构造集群。
+`kops` 是建立在 kubeadm 之上的。

--- a/content/zh/docs/reference/glossary/logging.md
+++ b/content/zh/docs/reference/glossary/logging.md
@@ -36,4 +36,4 @@ tags:
 Application and systems logs can help you understand what is happening inside your cluster. The logs are particularly useful for debugging problems and monitoring cluster activity. 
 -->
 
-应用程序和系统日志可以帮助您了解集群内部发生的情况。日志对于调试问题和监视集群活动非常有用。
+应用程序和系统日志可以帮助你了解集群内部发生的情况。日志对于调试问题和监视集群活动非常有用。


### PR DESCRIPTION
```
website-1 % ./scripts/lsync.sh content/zh/docs/reference/glossary/logging.md
content/zh/docs/reference/glossary/logging.md is still in sync


 website-1 % ./scripts/lsync.sh content/zh/docs/reference/glossary/kops.md
diff --git a/content/en/docs/reference/glossary/kops.md b/content/en/docs/reference/glossary/kops.md
old mode 100755
new mode 100644


website-1 % ./scripts/lsync.sh content/zh/docs/reference/glossary/etcd.md
diff --git a/content/en/docs/reference/glossary/etcd.md b/content/en/docs/reference/glossary/etcd.md
old mode 100755
new mode 100644
```