### PR TITLE
[zh] adjust format in docs/reference/glossary

### DIFF
--- a/content/zh/docs/reference/glossary/aggregation-layer.md
+++ b/content/zh/docs/reference/glossary/aggregation-layer.md
@@ -4,7 +4,7 @@ id: aggregation-layer
 date: 2018-10-08
 full_link: /zh/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/
 short_description: >
-  聚合层允许您在自己的集群上安装额外的 Kubernetes 风格的 API。
+  聚合层允许你在自己的集群上安装额外的 Kubernetes 风格的 API。
 
 aka: 
 tags:
@@ -36,7 +36,7 @@ tags:
  The aggregation layer lets you install additional Kubernetes-style APIs in your cluster.
 -->
 
-聚合层允许您在自己的集群上安装额外的 Kubernetes 风格的 API。
+聚合层允许你在自己的集群上安装额外的 Kubernetes 风格的 API。
 
 <!--more-->
  
@@ -45,4 +45,5 @@ tags:
 When you've configured the {{< glossary_tooltip text="Kubernetes API Server" term_id="kube-apiserver" >}} to [support additional APIs](/docs/tasks/extend-kubernetes/configure-aggregation-layer/), you can add `APIService` objects to "claim" a URL path in the Kubernetes API.
 -->
 
-当您配置了 {{< glossary_tooltip text="Kubernetes API Server" term_id="kube-apiserver" >}} 来 [支持额外的 API](/zh/docs/tasks/extend-kubernetes/configure-aggregation-layer/)，您就可以在 Kubernetes API 中增加 `APIService` 对象来  "申领（Claim）" 一个 URL 路径。 
+当你配置了 {{< glossary_tooltip text="Kubernetes API Server" term_id="kube-apiserver" >}} 来 [支持额外的 API](/zh/docs/tasks/extend-kubernetes/configure-aggregation-layer/)，
+你就可以在 Kubernetes API 中增加 `APIService` 对象来  "申领（Claim）" 一个 URL 路径。 

--- a/content/zh/docs/reference/glossary/app-container.md
+++ b/content/zh/docs/reference/glossary/app-container.md
@@ -42,6 +42,6 @@ once the application container has started.
 If a pod doesn't have any init containers configured, all the containers in that pod are app containers.
 -->
 
-初始化容器使您可以分离对于{{< glossary_tooltip text="工作负载" term_id="workload" >}}
+初始化容器使你可以分离对于{{< glossary_tooltip text="工作负载" term_id="workload" >}}
 整体而言很重要的初始化细节，并且一旦应用容器启动，它不需要继续运行。
 如果 pod 没有配置任何初始化容器，则该 pod 中的所有容器都是应用程序容器。

--- a/content/zh/docs/reference/glossary/configmap.md
+++ b/content/zh/docs/reference/glossary/configmap.md
@@ -41,4 +41,4 @@ environment variables, command-line arguments, or as configuration files in a
 A ConfigMap allows you to decouple environment-specific configuration from your {{< glossary_tooltip text="container images" term_id="image" >}}, so that your applications are easily portable.
 -->
 
-ConfigMap 将您的环境配置信息和 {{< glossary_tooltip text="容器镜像" term_id="image" >}} 解耦，便于应用配置的修改。
+ConfigMap 将你的环境配置信息和 {{< glossary_tooltip text="容器镜像" term_id="image" >}} 解耦，便于应用配置的修改。

--- a/content/zh/docs/reference/glossary/customresourcedefinition.md
+++ b/content/zh/docs/reference/glossary/customresourcedefinition.md
@@ -4,7 +4,7 @@ id: CustomResourceDefinition
 date: 2018-04-12
 full_link: /zh/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/
 short_description: >
-  通过定制化的代码给您的 Kubernetes API 服务器增加资源对象，而无需编译完整的定制 API 服务器。
+  通过定制化的代码给你的 Kubernetes API 服务器增加资源对象，而无需编译完整的定制 API 服务器。
 
 aka: 
 tags:
@@ -33,7 +33,7 @@ tags:
  Custom code that defines a resource to add to your Kubernetes API server without building a complete custom server.
 -->
 
- 通过定制化的代码给您的 Kubernetes API 服务器增加资源对象，而无需编译完整的定制 API 服务器。
+ 通过定制化的代码给你的 Kubernetes API 服务器增加资源对象，而无需编译完整的定制 API 服务器。
 
 <!--more--> 
 
@@ -41,5 +41,6 @@ tags:
 Custom Resource Definitions let you extend the Kubernetes API for your environment if the publicly supported API resources can't meet your needs. 
 -->
 
-当 Kubernetes 公开支持的 API 资源不能满足您的需要时，定制资源对象（Custom Resource Definitions）让您可以在您的环境上扩展 Kubernetes API。
+当 Kubernetes 公开支持的 API 资源不能满足你的需要时，
+定制资源对象（Custom Resource Definitions）让你可以在你的环境上扩展 Kubernetes API。
 

--- a/content/zh/docs/reference/glossary/disruption.md
+++ b/content/zh/docs/reference/glossary/disruption.md
@@ -41,7 +41,7 @@ Kubernetes terms that an _involuntary disruption_.
 
 See [Disruptions](/docs/concepts/workloads/pods/disruptions/) for more information.
  -->
-如果您作为一个集群操作人员，销毁了一个从属于某个应用的 Pod, Kubernetes 视之为 _自愿干扰（Voluntary Disruption）_。如果由于节点故障
-或者影响更大区域故障的断电导致 Pod 离线，kubernetes 视之为 _非愿干扰（Involuntary Disruption）_。
+如果你作为一个集群操作人员，销毁了一个从属于某个应用的 Pod, Kubernetes 视之为**自愿干扰（Voluntary Disruption）**。
+如果由于节点故障 或者影响更大区域故障的断电导致 Pod 离线，kubernetes 视之为**非愿干扰（Involuntary Disruption）**。
 
 更多信息请查阅[Disruptions](/zh/docs/concepts/workloads/pods/disruptions/)

--- a/content/zh/docs/reference/glossary/ephemeral-container.md
+++ b/content/zh/docs/reference/glossary/ephemeral-container.md
@@ -4,12 +4,12 @@ id: ephemeral-container
 date: 2019-08-26
 full_link: /zh/docs/concepts/workloads/pods/ephemeral-containers/
 short_description: >
-  您可以在 Pod 中临时运行的一种容器类型
+  你可以在 Pod 中临时运行的一种容器类型
 aka:
 tags:
 - fundamental
 ---
-  您可以在 {{< glossary_tooltip term_id="pod" >}} 中临时运行的一种 {{< glossary_tooltip term_id="container" >}} 类型。
+  你可以在 {{< glossary_tooltip term_id="pod" >}} 中临时运行的一种 {{< glossary_tooltip term_id="container" >}} 类型。
 
 <!--
 ---


### PR DESCRIPTION
```
% ./scripts/lsync.sh content/zh/docs/reference/glossary/customresourcedefinition.md
diff --git a/content/en/docs/reference/glossary/customresourcedefinition.md b/content/en/docs/reference/glossary/customresourcedefinition.md
old mode 100755
new mode 100644

% ./scripts/lsync.sh content/zh/docs/reference/glossary/disruption.md
content/zh/docs/reference/glossary/disruption.md is still in sync

 % ./scripts/lsync.sh content/zh/docs/reference/glossary/ephemeral-container.md
content/zh/docs/reference/glossary/ephemeral-container.md is still in sync

 % ./scripts/lsync.sh content/zh/docs/reference/glossary/aggregation-layer.md
content/zh/docs/reference/glossary/aggregation-layer.md is still in sync

% ./scripts/lsync.sh content/zh/docs/reference/glossary/app-container.md
content/zh/docs/reference/glossary/app-container.md is still in sync

% ./scripts/lsync.sh content/zh/docs/reference/glossary/configmap.md
diff --git a/content/en/docs/reference/glossary/configmap.md b/content/en/docs/reference/glossary/configmap.md
old mode 100755
new mode 100644

```