### PR TITLE
[zh] good first issues in zh/docs/reference/kubernetes-api/common-definitions/

### DIFF
--- a/content/zh/docs/reference/kubernetes-api/common-definitions/delete-options.md
+++ b/content/zh/docs/reference/kubernetes-api/common-definitions/delete-options.md
@@ -4,8 +4,8 @@ api_metadata:
   import: "k8s.io/apimachinery/pkg/apis/meta/v1"
   kind: "DeleteOptions"
 content_type: "api_reference"
-description: "删除 API 对象时可能会提供删除选项。"
-title: "删除选项"
+description: "删除 API 对象时可以提供 DeleteOptions。"
+title: "DeleteOptions"
 weight: 1
 auto_generated: true
 ---
@@ -25,7 +25,7 @@ auto_generated: true
 `import "k8s.io/apimachinery/pkg/apis/meta/v1"`
 
 <!--DeleteOptions may be provided when deleting an API object.-->
-删除 API 对象时可能会提供 DeleteOptions。
+删除 API 对象时可以提供 DeleteOptions。
 
 <hr>
 
@@ -39,7 +39,7 @@ auto_generated: true
 
   `APIVersion` 定义对象表示的版本化模式。
   服务器应将已识别的模式转换为最新的内部值，并可能拒绝无法识别的值。
-  更多信息：https ://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+  更多信息：https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 
 <!--
 - **dryRun** ([]string)
@@ -75,7 +75,7 @@ auto_generated: true
 
   `kind` 是一个字符串值，表示此对象代表的 REST 资源。
   服务器可以从客户端提交请求的端点推断出此值。此值无法更新，是驼峰的格式。
-  更多信息：https ://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds 。
+  更多信息：https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds 。
 
 <!--
 - **orphanDependents** (boolean)
@@ -119,7 +119,7 @@ auto_generated: true
 
   - **preconditions.uid** (string)
 
-    指定目标 UID.
+    指定目标 UID。
 
 <!--
 - **propagationPolicy** (string)

--- a/content/zh/docs/reference/kubernetes-api/common-definitions/label-selector.md
+++ b/content/zh/docs/reference/kubernetes-api/common-definitions/label-selector.md
@@ -5,7 +5,7 @@ api_metadata:
   kind: "LabelSelector"
 content_type: "api_reference"
 description: "标签选择器是对一组资源的标签查询。"
-title: "标签选择器"
+title: "LabelSelector"
 weight: 2
 auto_generated: true
 ---
@@ -23,11 +23,14 @@ weight: 2
 
 `import "k8s.io/apimachinery/pkg/apis/meta/v1"`
 
-<!-- A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.-->
+<!-- 
+A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+-->
 
 标签选择器是对一组资源的标签查询。
 
-`matchLabels` 和 `matchExpressions` 的结果按逻辑与的关系组合。一个 `empty` 标签选择器匹配所有对象。一个 `null` 标签选择器不匹配任何对象。
+`matchLabels` 和 `matchExpressions` 的结果按逻辑与的关系组合。
+一个 `empty` 标签选择器匹配所有对象。一个 `null` 标签选择器不匹配任何对象。
 
 <hr>
 
@@ -42,7 +45,7 @@ weight: 2
 
 - **matchExpressions** ([]LabelSelectorRequirement)
   
-   `matchExpressions` 是 `LabelSelectorRequirement` 的列表，这些需求结果按逻辑与的关系来计算。
+   `matchExpressions` 是标签选择器要求的列表，这些要求的结果按逻辑与的关系来计算。
    
    <a name="LabelSelectorRequirement"></a> 
    *标签选择器要求是包含值、键和关联键和值的运算符的选择器。*
@@ -55,9 +58,9 @@ weight: 2
 
   - **matchExpressions.key** (string)， 必填
 
-    *补丁策略: 按照键 `key` 合并*    
+    *补丁策略：按照键 `key` 合并*    
     
-    `key` 是选择器应用的标签键.
+    `key` 是选择器应用的标签键。
   
    <!-- 
        - **matchExpressions.operator** (string), required
@@ -66,7 +69,7 @@ weight: 2
    
   - **matchExpressions.operator** (string)，必填
  
-    operator 表示键与一组值的关系。有效的运算符包括 `In`、`NotIn`、`Exists` 和 `DoesNotExist`。
+    `operator` 表示键与一组值的关系。有效的运算符包括 `In`、`NotIn`、`Exists` 和 `DoesNotExist`。
     
   <!--
   - **matchExpressions.values** ([]string)
@@ -78,9 +81,9 @@ weight: 2
   
     `values` 是一个字符串值数组。如果运算符为 `In` 或 `NotIn`，则 `values` 数组必须为非空。
     
-     如果运算符是 `Exists` 或 `DoesNotExist`，则 `values` 数组必须为空。
-     
-     该数组在战略性补丁（Strategic Merge Patch）期间被替换。
+    如果运算符是 `Exists` 或 `DoesNotExist`，则 `values` 数组必须为空。
+    
+    该数组在策略性合并补丁（Strategic Merge Patch）期间被替换。
   
 <!--
 - **matchLabels** (map[string]string)


### PR DESCRIPTION
Some `good first issue` about [Kubernetes API docs](https://kubernetes.io/zh/docs/reference/kubernetes-api/common-definitions/delete-options/), mainly for context consistency and link correction.