### PR TITLE
Volume Populators: fix feature gate name

### DIFF
--- a/content/en/blog/_posts/2022-05-16-volume-populators-beta.md
+++ b/content/en/blog/_posts/2022-05-16-volume-populators-beta.md
@@ -8,7 +8,7 @@ slug: volume-populators-beta
 **Author:**
 Ben Swartzlander (NetApp)
 
-The volume populators feature is now two releases old and entering beta! The `AnyVolumeDataSouce` feature
+The volume populators feature is now two releases old and entering beta! The `AnyVolumeDataSource` feature
 gate defaults to enabled in Kubernetes v1.24, which means that users can specify any custom resource
 as the data source of a PVC.
 


### PR DESCRIPTION
This MR fixes the typo in recent blog post about [Volume Populators](https://kubernetes.io/blog/2022/05/16/volume-populators-beta/).
