### PR TITLE
fix typo kubee-system to kube-system

### DIFF
--- a/content/zh/docs/setup/production-environment/tools/kubeadm/kubelet-integration.md
+++ b/content/zh/docs/setup/production-environment/tools/kubeadm/kubelet-integration.md
@@ -223,7 +223,7 @@ If the reload and restart are successful, the normal `kubeadm init` workflow con
 ### 当使用 `kubeadm init`时的工作流程
 
 当调用 `kubeadm init` 时，kubelet 的配置会被写入磁盘 `/var/lib/kubelet/config.yaml`，
-并上传到集群 `kubee-system` 命名空间的 `kubelet-config` ConfigMap。
+并上传到集群 `kube-system` 命名空间的 `kubelet-config` ConfigMap。
 kubelet 配置信息也被写入 `/etc/kubernetes/kubelet.conf`，其中包含集群内所有 kubelet 的基线配置。
 此配置文件指向允许 kubelet 与 API 服务器通信的客户端证书。
 这解决了[将集群级配置传播到每个 kubelet](#propagating-cluster-level-configuration-to-each-kubelet) 的需求。


### PR DESCRIPTION
Signed-off-by: Abirdcfly <fp544037857@gmail.com>
fix https://github.com/kubernetes/website/issues/33845
just fix typo 

```bash
❯ grep -rn kubee-system *
content/zh/docs/setup/production-environment/tools/kubeadm/kubelet-integration.md:226:并上传到集群 `kubee-system` 命名空间的 `kubelet-config` ConfigMap。

```
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
