### PR TITLE
[zh] sync v1.24 kubeadm-14a

### DIFF
--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_apiserver-etcd-client.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_apiserver-etcd-client.md
@@ -1,3 +1,18 @@
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference conent, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
+
+<!-- 
+Renew the certificate the apiserver uses to access etcd 
+-->
+续订 apiserver 用于访问 etcd 的证书
 
 <!-- 
 ### Synopsis
@@ -49,8 +64,10 @@ kubeadm certs renew apiserver-etcd-client [flags]
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!-- The path where to save and store the certificates.  -->
-存储证书的路径。
+<!-- 
+<p>The path where to save and store the certificates.</p>
+-->
+<p>存储证书的路径。</p>
 </td>
 </tr>
 
@@ -59,28 +76,10 @@ kubeadm certs renew apiserver-etcd-client [flags]
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!-- Path to a kubeadm configuration file.  -->
-kubeadm 配置文件的路径。
-</td>
-</tr>
-
-<tr>
-<td colspan="2">--csr-dir string</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!-- The path to output the CSRs and private keys to -->
-输出 CSR 和私钥的路径
-</td>
-</tr>
-
-<tr>
-<td colspan="2">--csr-only</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!-- Create CSRs instead of generating certificates -->
-创建 CSR 而不是生成证书
+<!-- 
+<p>Path to a kubeadm configuration file.</p>  
+-->
+<p>kubeadm 配置文件的路径。</p>
 </td>
 </tr>
 
@@ -89,8 +88,10 @@ kubeadm 配置文件的路径。
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!-- help for apiserver-etcd-client -->
-apiserver-etcd-client 操作的帮助命令
+<!-- 
+<p>help for apiserver-etcd-client</p>
+-->
+<p>apiserver-etcd-client 操作的帮助命令</p>
 </td>
 </tr>
 
@@ -105,20 +106,10 @@ apiserver-etcd-client 操作的帮助命令
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file.
+<p>The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file.</p>
 -->
-与集群通信时使用的 kubeconfig 文件。
-如果未设置该参数，则可以在一组标准位置中搜索现有的 kubeconfig 文件。
-</td>
-</tr>
-
-<tr>
-<td colspan="2">--use-api</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!-- Use the Kubernetes certificate API to renew certificates -->
-使用 Kubernetes 证书 API 续订证书
+<p>与集群通信时使用的 kubeconfig 文件。
+如果未设置该参数，则可以在一组标准位置中搜索现有的 kubeconfig 文件。</p>
 </td>
 </tr>
 
@@ -144,8 +135,10 @@ The kubeconfig file to use when talking to the cluster. If the flag is not set, 
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!-- [EXPERIMENTAL] The path to the 'real' host root filesystem.  -->
-[实验] 到 '真实' 主机根文件系统的路径。
+<!-- 
+<p>[EXPERIMENTAL] The path to the 'real' host root filesystem.</p>
+-->
+<p>[实验] 到 '真实' 主机根文件系统的路径。</p>
 </td>
 </tr>
 

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_scheduler.conf.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_scheduler.conf.md
@@ -1,3 +1,18 @@
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference conent, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
+
+<!-- 
+Renew the certificate embedded in the kubeconfig file for the scheduler manager to use 
+-->
+续订 kubeconfig 文件中嵌入的证书，以供调度管理器使用
 
 <!--
 ### Synopsis
@@ -52,9 +67,9 @@ kubeadm certs renew scheduler.conf [flags]
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-The path where to save the certificates.
+<p>The path where to save the certificates.</p>
 -->
-保存证书的路径。
+<p>保存证书的路径。</p>
 </td>
 </tr>
 
@@ -64,33 +79,9 @@ The path where to save the certificates.
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-Path to a kubeadm configuration file.
+<p>Path to a kubeadm configuration file.</p>
 -->
-kubeadm 配置文件的路径。
-</td>
-</tr>
-
-<tr>
-<td colspan="2">--csr-dir string</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-The path to output the CSRs and private keys to
--->
-CSR 和私钥的输出路径
-</td>
-</tr>
-
-<tr>
-<td colspan="2">--csr-only</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-Create CSRs instead of generating certificates
--->
-创建 CSR 而不是生成证书
+<p>kubeadm 配置文件的路径。</p>
 </td>
 </tr>
 
@@ -100,9 +91,9 @@ Create CSRs instead of generating certificates
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-help for scheduler.conf
+<p>help for scheduler.conf</p>
 -->
-scheduler.conf 操作的帮助命令
+<p>scheduler.conf 操作的帮助命令</p>
 </td>
 </tr>
 
@@ -117,22 +108,10 @@ scheduler.conf 操作的帮助命令
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file.
+<p>The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file.</p>
 -->
-与集群通信时使用的 kubeconfig 文件。
-如果未设置该参数，则可以在一组标准位置中搜索现有的 kubeconfig 文件。
-</td>
-</tr>
-
-<tr>
-<td colspan="2">--use-api</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
-<!--
-Use the Kubernetes certificate API to renew certificates
--->
-使用 Kubernetes 证书 API 续订证书
+<p>与集群通信时使用的 kubeconfig 文件。
+如果未设置该参数，则可以在一组标准位置中搜索现有的 kubeconfig 文件。</p>
 </td>
 </tr>
 
@@ -157,9 +136,9 @@ Use the Kubernetes certificate API to renew certificates
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-[EXPERIMENTAL] The path to the 'real' host root filesystem.
+<p>[EXPERIMENTAL] The path to the 'real' host root filesystem.</p>
 -->
-[实验] 到 '真实' 主机根文件系统的路径。
+<p>[实验] 到 '真实' 主机根文件系统的路径。</p>
 </td>
 </tr>
 

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_all.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_all.md
@@ -1,3 +1,18 @@
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference conent, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
+
+<!-- 
+Generate all certificates 
+-->
+生成所有证书
 
 <!--
 ### Synopsis
@@ -8,7 +23,6 @@
 <!--
 Generate all certificates
 -->
-
 生成所有证书
 
 ```
@@ -34,21 +48,21 @@ kubeadm init phase certs all [flags]
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-The IP address the API Server will advertise it's listening on. If not set the default network interface will be used.
+<p>The IP address the API Server will advertise it's listening on. If not set the default network interface will be used.</p>
 -->
-API 服务器所公布的其正在监听的 IP 地址。如果未设置，将使用默认网络接口。
+<p>API 服务器所公布的其正在监听的 IP 地址。如果未设置，将使用默认网络接口。</p>
 </td>
 </tr>
 
 <tr>
-<td colspan="2">--apiserver-cert-extra-sans stringSlice</td>
+<td colspan="2">--apiserver-cert-extra-sans strings</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-Optional extra Subject Alternative Names (SANs) to use for the API Server serving certificate. Can be both IP addresses and DNS names.
+<p>Optional extra Subject Alternative Names (SANs) to use for the API Server serving certificate. Can be both IP addresses and DNS names.</p>
 -->
-用于 API 服务器服务证书的可选额外替代名称（SAN）。可以同时使用 IP 地址和 DNS 名称。
+<p>用于 API 服务器服务证书的可选额外替代名称（SAN）。可以同时使用 IP 地址和 DNS 名称。</p>
 </td>
 </tr>
 
@@ -63,9 +77,9 @@ Optional extra Subject Alternative Names (SANs) to use for the API Server servin
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-The path where to save and store the certificates.
+<p>The path where to save and store the certificates.</p>
 -->
-证书的存储路径。
+<p>证书的存储路径。</p>
 </td>
 </tr>
 
@@ -75,9 +89,9 @@ The path where to save and store the certificates.
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-Path to a kubeadm configuration file.
+<p>Path to a kubeadm configuration file.</p>
 -->
-kubeadm 配置文件的路径。
+<p>kubeadm 配置文件的路径。</p>
 </td>
 </tr>
 
@@ -87,9 +101,9 @@ kubeadm 配置文件的路径。
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-Specify a stable IP address or DNS name for the control plane.
+<p>Specify a stable IP address or DNS name for the control plane.</p>
 -->
-为控制平面指定一个稳定的 IP 地址或 DNS 名称。
+<p>为控制平面指定一个稳定的 IP 地址或 DNS 名称。</p>
 </td>
 </tr>
 
@@ -99,9 +113,9 @@ Specify a stable IP address or DNS name for the control plane.
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-help for all
+<p>help for all</p>
 -->
-all 操作的帮助命令 
+<p>all 操作的帮助命令</p>
 </td>
 </tr>
 
@@ -116,9 +130,9 @@ all 操作的帮助命令
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-Choose a specific Kubernetes version for the control plane.
+<p>Choose a specific Kubernetes version for the control plane.</p>
 -->
-为控制平面选择特定的 Kubernetes 版本。
+<p>为控制平面选择特定的 Kubernetes 版本。</p>
 </td>
 </tr>
 
@@ -133,9 +147,9 @@ Choose a specific Kubernetes version for the control plane.
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-Use alternative range of IP address for service VIPs.
+<p>Use alternative range of IP address for service VIPs.</p>
 -->
-VIP 服务使用其它的 IP 地址范围。
+<p>VIP 服务使用其它的 IP 地址范围。</p>
 </td>
 </tr>
 
@@ -150,9 +164,9 @@ VIP 服务使用其它的 IP 地址范围。
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-Use alternative domain for services, e.g. "myorg.internal".
+<p>Use alternative domain for services, e.g. "myorg.internal".</p>
 -->
-服务使用其它的域名，例如："myorg.internal"。
+<p>服务使用其它的域名，例如："myorg.internal"。</p>
 </td>
 </tr>
 
@@ -178,9 +192,9 @@ Use alternative domain for services, e.g. "myorg.internal".
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-[EXPERIMENTAL] The path to the 'real' host root filesystem.
+<p>[EXPERIMENTAL] The path to the 'real' host root filesystem.</p>
 -->
-[实验] 到 '真实' 主机根文件系统的路径。
+<p>[实验] 到 '真实' 主机根文件系统的路径。</p>
 </td>
 </tr>
 

--- a/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_kubeconfig_scheduler.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_kubeconfig_scheduler.md
@@ -1,3 +1,18 @@
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference conent, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
+
+<!-- 
+Generate a kubeconfig file for the scheduler to use 
+-->
+生成调度器使用的 kubeconfig 文件
 
 <!--
 ### Synopsis
@@ -34,9 +49,9 @@ kubeadm init phase kubeconfig scheduler [flags]
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-The IP address the API Server will advertise it's listening on. If not set the default network interface will be used.
+<p>The IP address the API Server will advertise it's listening on. If not set the default network interface will be used.</p>
 -->
-API 服务器所公布的其正在监听的 IP 地址。如果未设置，则使用默认的网络接口。
+<p>API 服务器所公布的其正在监听的 IP 地址。如果未设置，则使用默认的网络接口。</p>
 </td>
 </tr>
 
@@ -51,9 +66,9 @@ API 服务器所公布的其正在监听的 IP 地址。如果未设置，则使
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-Port for the API Server to bind to.
+<p>Port for the API Server to bind to.</p>
 -->
-要绑定到 API 服务器的端口。
+<p>要绑定到 API 服务器的端口。</p>
 </td>
 </tr>
 
@@ -68,9 +83,9 @@ Port for the API Server to bind to.
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-The path where to save and store the certificates.
+<p>The path where to save and store the certificates.</p>
 -->
-保存和存储证书的路径。
+<p>保存和存储证书的路径。</p>
 </td>
 </tr>
 
@@ -80,9 +95,9 @@ The path where to save and store the certificates.
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-Path to kubeadm configuration file.
+<p>Path to kubeadm configuration file.</p>
 -->
-kubeadm 配置文件的路径。
+<p>kubeadm 配置文件的路径。</p>
 </td>
 </tr>
 
@@ -92,9 +107,9 @@ kubeadm 配置文件的路径。
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-Specify a stable IP address or DNS name for the control plane.
+<p>Specify a stable IP address or DNS name for the control plane.</p>
 -->
-为控制平面指定一个稳定的 IP 地址或 DNS 名称。
+<p>为控制平面指定一个稳定的 IP 地址或 DNS 名称。</p>
 </td>
 </tr>
 
@@ -104,9 +119,9 @@ Specify a stable IP address or DNS name for the control plane.
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-help for scheduler
+<p>help for scheduler</p>
 -->
-scheduler 操作的帮助命令
+<p>scheduler 操作的帮助命令</p>
 </td>
 </tr>
 
@@ -121,9 +136,9 @@ scheduler 操作的帮助命令
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-The path where to save the kubeconfig file.
+<p>The path where to save the kubeconfig file.</p>
 -->
-kubeconfig 文件的保存路径。
+<p>kubeconfig 文件的保存路径。</p>
 </td>
 </tr>
 
@@ -138,9 +153,9 @@ kubeconfig 文件的保存路径。
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-Choose a specific Kubernetes version for the control plane.
+<p>Choose a specific Kubernetes version for the control plane.</p>
 -->
-为控制平面指定特定的 Kubernetes 版本。
+<p>为控制平面指定特定的 Kubernetes 版本。</p>
 </td>
 </tr>
 
@@ -166,9 +181,9 @@ Choose a specific Kubernetes version for the control plane.
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-[EXPERIMENTAL] The path to the 'real' host root filesystem.
+<p>[EXPERIMENTAL] The path to the 'real' host root filesystem.</p>
 -->
-[实验] 到 '真实' 主机根文件系统的路径。
+<p>[实验] 到 '真实' 主机根文件系统的路径。</p>
 </td>
 </tr>
 


### PR DESCRIPTION
related issues: #33479 
```
18	19	content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_apiserver-etcd-client.md
18	19	content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_certs_renew_scheduler.conf.md
24	11	content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_certs_all.md
22	9	content/en/docs/reference/setup-tools/kubeadm/generated/kubeadm_init_phase_kubeconfig_scheduler.md
```
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
