### PR TITLE
Modified title of "Certificates" task

### DIFF
--- a/content/en/docs/tasks/administer-cluster/certificates.md
+++ b/content/en/docs/tasks/administer-cluster/certificates.md
@@ -1,5 +1,5 @@
 ---
-title: Certificates
+title: Generate Certificates Manually
 content_type: task
 weight: 20
 ---


### PR DESCRIPTION
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

Issue- #33866 

Problem:
Within the [Administer A Cluster](https://kubernetes.io/docs/tasks/administer-cluster/) tasks section, the page titles describe different tasks that a cluster operator might want to perform.

However, [Certificates](https://kubernetes.io/docs/tasks/administer-cluster/certificates/) has a title that describes a concept. As a result, this page stands out from the others when you look at the list.

Solution:
Added a new Title to the task "Generate Certificates Manually" as this task generates certs manually using different tools. 

Page Updated:
https://kubernetes.io/docs/tasks/administer-cluster/certificates/