### PR TITLE
#33866: Modified Title of Certificates

### DIFF
--- a/content/en/docs/tasks/administer-cluster/certificates.md
+++ b/content/en/docs/tasks/administer-cluster/certificates.md
@@ -1,5 +1,5 @@
 ---
-title: Certificates
+title: Generating Certificates Manually
 content_type: task
 weight: 20
 ---


### PR DESCRIPTION
Issue: https://github.com/kubernetes/website/issues/33866#issue-1243899398

- Problem:
Within the [Administer A Cluster](https://kubernetes.io/docs/tasks/administer-cluster/) tasks section, the page titles describe different tasks that a cluster operator might want to perform.

However, [Certificates](https://kubernetes.io/docs/tasks/administer-cluster/certificates/) has a title that describes a concept. As a result, this page stands out from the others when you look at the list.

Solution:
The title of the 'Certificates' has been modified to 'Generating Certificates Manually'. The context inside the Certificates aims on teaching the concept , So in order to make the title look more familiar, It's changed.