### PR TITLE
Added CNCF Project List Link and enhancing the documentation

### DIFF
--- a/content/en/docs/contribute/_index.md
+++ b/content/en/docs/contribute/_index.md
@@ -12,6 +12,11 @@ card:
 ---
 
 <!-- overview -->
+Kubernetes which is an open-source system for automating deployment, scaling, and management of containerized applications
+was accepted to CNCF(Cloud Native Computing Foundation) on March 16, 2016 and is at the Graduated project maturity level.
+For more information about CNCF Projects,Refer the below link: 
+ 
+https://contribute.cncf.io/contributors/projects/#kubernetes
 
 *Kubernetes welcomes improvements from all contributors, new and experienced!*
 

--- a/content/en/docs/tasks/administer-cluster/certificates.md
+++ b/content/en/docs/tasks/administer-cluster/certificates.md
@@ -1,5 +1,5 @@
 ---
-title: Certificates
+title: Generating Certificates Manually
 content_type: task
 weight: 20
 ---


### PR DESCRIPTION
Problem:
This is a Feature Request

What would you like to be added
Update https://kubernetes.io/docs/contribute/ so that early in the page there is a link to
https://contribute.cncf.io/contributors/projects/#kubernetes

You should decide on some suitable text for the hyperlink. Read https://contribute.cncf.io/contributors/ to get ideas about what to write, if you're not sure.

ℹ️ Don't remove any of the existing links; this is an addition.

Solution:
I've kept the description short for the newbie to come and interact with the CNCF project site, thus adding features.
