### PR TITLE
Document where to find container images for Kubernetes components

### DIFF
--- a/content/en/docs/setup/_index.md
+++ b/content/en/docs/setup/_index.md
@@ -27,6 +27,13 @@ control, available resources, and expertise required to operate and manage a clu
 You can [download Kubernetes](/releases/download/) to deploy a Kubernetes cluster
 on a local machine, into the cloud, or for your own datacenter.
 
+Several [Kubernetes components](/docs/concepts/overview/components/) such as `kube-apiserver` or `kube-proxy` can also be
+deployed as [container images](/releases/download/#container-images) within the cluster.
+
+It is **recommended** to run Kubernetes components as container images wherever
+that is possible, and to have Kubernetes manage those components.
+Components that run containers - notably, the kubelet - can't be included in this category.
+
 If you don't want to manage a Kubernetes cluster yourself, you could pick a managed service, including
 [certified platforms](/docs/setup/production-environment/turnkey-solutions/).
 There are also other standardized and custom solutions across a wide range of cloud and


### PR DESCRIPTION
Hi,

Description: Guide users where to find/download Kubernetes component container images. This will help users locate/download Kubernetes container images i.e Api Server, Kube-proxy. Also useful for users trying to deploy to air-gapped systems.

Closes: #31293 

Reference Page: https://kubernetes.io/docs/setup/

Question: Currently we are moving to [registry.k8s.io](https://registry.k8s.io/) however this returns a 404 is it okay to keep it for now or should I change it to [k8s.gcr.io](https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/GLOBAL)

![image](https://user-images.githubusercontent.com/8469842/169889278-922fd0f8-09ce-40c7-ae1a-1c01bbf005b7.png)

Signed-off-by: afro-coder <leon9923@gmail.com>

Regards,
Leon.