### PR TITLE
Add Java Operator SDK to operator frameworks

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/operator.md
+++ b/content/en/docs/concepts/extend-kubernetes/operator.md
@@ -111,6 +111,7 @@ Operator.
 {{% thirdparty-content %}}
 
 * [Charmed Operator Framework](https://juju.is/)
+* [Java Operator SDK](https://github.com/java-operator-sdk/java-operator-sdk)
 * [Kopf](https://github.com/nolar/kopf) (Kubernetes Operator Pythonic Framework)
 * [kubebuilder](https://book.kubebuilder.io/)
 * [KubeOps](https://buehler.github.io/dotnet-operator-sdk/) (.NET operator SDK)


### PR DESCRIPTION
Java Operator SDK allows to implement Kubernetes Operators in Java. Already used for various services in production, a running project for more then two and half years. This PR adds it to the list of tools that helps implementing Kubernetes operators.
