### PR TITLE
Add supported version to fish completion

### DIFF
--- a/content/en/docs/tasks/tools/included/optional-kubectl-configs-fish.md
+++ b/content/en/docs/tasks/tools/included/optional-kubectl-configs-fish.md
@@ -13,3 +13,5 @@ kubectl completion fish | source
 ```
 
 After reloading your shell, kubectl autocompletion should be working.
+
+Note: this requires kubectl 1.23 or later.


### PR DESCRIPTION
I added the supported kubectl version to the fish completion page. Spent some time trying to figure out why it wouldn't work when I copied it directly from the documentation. Turns out Docker Desktop had installed an older version of kubectl. Trying to save others some time.

Reference: https://github.com/kubernetes/kubectl/issues/1189