### PR TITLE
[zh] Fix links for docs

### DIFF
--- a/content/zh/docs/concepts/security/overview.md
+++ b/content/zh/docs/concepts/security/overview.md
@@ -5,6 +5,15 @@ description: >
 content_type: concept
 weight: 1
 ---
+<!--
+reviewers:
+- zparnold
+title: Overview of Cloud Native Security
+description: >
+  A model for thinking about Kubernetes security in the context of Cloud Native security.
+content_type: concept
+weight: 1
+-->
 
 <!-- overview -->
 <!--
@@ -27,7 +36,7 @@ This container security model provides suggestions, not proven information secur
 You can think about security in layers. The 4C's of Cloud Native security are Cloud,
 Clusters, Containers, and Code.
 -->
-## 云原生安全的 4 个 C
+## 云原生安全的 4 个 C    {#the-4c-s-of-cloud-native-security}
 
 你可以分层去考虑安全性，云原生安全的 4 个 C 分别是云（Cloud）、集群（Cluster）、容器（Container）和代码（Code）。
 
@@ -53,7 +62,10 @@ security at the Code level.
 云原生安全模型的每一层都是基于下一个最外层，代码层受益于强大的基础安全层（云、集群、容器）。
 你无法通过在代码层解决安全问题来为基础层中糟糕的安全标准提供保护。
 
-## 云
+<!--
+## Cloud
+-->
+## 云    {#cloud}
 
 <!--
 In many ways, the Cloud (or co-located servers, or the corporate datacenter) is the
@@ -75,7 +87,7 @@ If you are running a Kubernetes cluster on your own hardware or a different clou
 consult your documentation for security best practices.
 Here are links to some of the popular cloud providers' security documentation:
 -->
-### 云提供商安全性
+### 云提供商安全性    {#cloud-provider-security}
 
 如果你是在你自己的硬件或者其他不同的云提供商上运行 Kubernetes 集群，
 请查阅相关文档来获取最好的安全实践。
@@ -137,7 +149,7 @@ There are two areas of concern for securing Kubernetes:
 * Securing the cluster components that are configurable
 * Securing the applications which run in the cluster
 -->
-## 集群
+## 集群    {#cluster}
 
 保护 Kubernetes 有两个方面需要注意：
 
@@ -205,7 +217,7 @@ Image Signing and Enforcement | Sign container images to maintain a system of tr
 Disallow privileged users | When constructing containers, consult your documentation for how to create users inside of the containers that have the least level of operating system privilege necessary in order to carry out the goal of the container.
 Use container runtime with stronger isolation | Select [container runtime classes](/docs/concepts/containers/runtime-class/) that provide stronger isolation
 -->
-## 容器
+## 容器    {#container}
 
 容器安全性不在本指南的探讨范围内。下面是一些探索此主题的建议和连接：
 
@@ -222,7 +234,7 @@ Application code is one of the primary attack surfaces over which you have the m
 While securing application code is outside of the Kubernetes security topic, here
 are recommendations to protect application code:
 -->
-## 代码
+## 代码    {#code}
 
 应用程序代码是你最能够控制的主要攻击面之一，虽然保护应用程序代码不在 Kubernetes 安全主题范围内，但以下是保护应用程序代码的建议：
 
@@ -241,7 +253,7 @@ Dynamic probing attacks | There are a few automated tools that you can run again
 
 {{< /table >}}
 -->
-### 代码安全性
+### 代码安全性    {#code-security}
 
 {{< table caption="代码安全" >}}
 
@@ -250,7 +262,7 @@ Dynamic probing attacks | There are a few automated tools that you can run again
 仅通过 TLS 访问 | 如果你的代码需要通过 TCP 通信，请提前与客户端执行 TLS 握手。除少数情况外，请加密传输中的所有内容。更进一步，加密服务之间的网络流量是一个好主意。这可以通过被称为双向 TLS 或 [mTLS](https://en.wikipedia.org/wiki/Mutual_authentication) 的过程来完成，该过程对两个证书持有服务之间的通信执行双向验证。 |
 限制通信端口范围 | 此建议可能有点不言自明，但是在任何可能的情况下，你都只应公开服务上对于通信或度量收集绝对必要的端口。|
 第三方依赖性安全 | 最好定期扫描应用程序的第三方库以了解已知的安全漏洞。每种编程语言都有一个自动执行此检查的工具。 |
-静态代码分析 | 大多数语言都提供给了一种方法，来分析代码段中是否存在潜在的不安全的编码实践。只要有可能，你都应该使用自动工具执行检查，该工具可以扫描代码库以查找常见的安全错误，一些工具可以在以下连接中找到：https://owasp.org/www-community/Source_Code_Analysis_Tools |
+静态代码分析 | 大多数语言都提供给了一种方法，来分析代码段中是否存在潜在的不安全的编码实践。只要有可能，你都应该使用自动工具执行检查，该工具可以扫描代码库以查找常见的安全错误，一些工具可以在以下连接中找到： https://owasp.org/www-community/Source_Code_Analysis_Tools |
 动态探测攻击 | 你可以对服务运行一些自动化工具，来尝试一些众所周知的服务攻击。这些攻击包括 SQL 注入、CSRF 和 XSS。[OWASP Zed Attack](https://owasp.org/www-project-zap/) 代理工具是最受欢迎的动态分析工具之一。 |
 
 {{< /table >}}

--- a/content/zh/docs/doc-contributor-tools/linkchecker/README.md
+++ b/content/zh/docs/doc-contributor-tools/linkchecker/README.md
@@ -1,24 +1,26 @@
-<!-- 
+<!--
 # Internal link checking tool
  -->
 # 内置链接检查工具
 
-<!-- 
+<!--
 You can use [htmltest](https://github.com/wjdp/htmltest) to check for broken links in [`/content/en/`](https://git.k8s.io/website/content/en/). This is useful when refactoring sections of content, moving pages around, or renaming files or page headers.
  -->
-你可以使用 [htmltest](https://github.com/wjdp/htmltest) 来检查 [`/content/en/`](https://git.k8s.io/website/content/en/) 下面的失效链接。这在重构章节内容、移动页面或者重命名文件或页眉时非常有用。
+你可以使用 [htmltest](https://github.com/wjdp/htmltest) 来检查
+[`/content/en/`](https://git.k8s.io/website/content/en/) 下面的失效链接。
+这在重构章节内容、移动页面或者重命名文件或页眉时非常有用。
 
-<!-- 
+<!--
 ## How the tool works
  -->
 ## 工作原理
 
-<!-- 
+<!--
 `htmltest` scans links in the generated HTML files of the kubernetes website repository. It runs using a `make` command which does the following:
  -->
 `htmltest` 会扫描 kubernetes website 仓库构建生成的 HTML 文件。通过执行 `make` 命令进行了下列操作：
 
-<!-- 
+<!--
 - Builds the site and generates output HTML in the `/public` directory of your local `kubernetes/website` repository
 - Pulls the `wdjp/htmltest` Docker image
 - Mounts your local `kubernetes/website` repository to the Docker image
@@ -29,21 +31,22 @@ You can use [htmltest](https://github.com/wjdp/htmltest) to check for broken lin
 - 挂载本地 `kubernetes/website` 仓库到 Docker 容器中
 - 扫描 `/public` 目录下生成的文件并将遇到的失效链接通过命令行打印出来
 
-<!-- 
+<!--
 ## What it does and doesn't check
  -->
 ## 哪些链接不会检查
 
-<!-- 
+<!--
 The link checker scans generated HTML files, not raw Markdown. The htmltest tool depends on a configuration file, [`.htmltest.yml`](https://git.k8s.io/website/.htmltest.yml), to determine which content to examine.
 
 The link checker scans the following:
  -->
-该链接检查器扫描生成的 HTML 文件，而非原始的 Markdown. 该 htmltest 工具依赖于一个配置文件，[`.htmltest.yml`](https://git.k8s.io/website/.htmltest.yml)，来决定检查哪些内容。
+该链接检查器扫描生成的 HTML 文件，而非原始的 Markdown. 该 htmltest 工具依赖于配置文件
+[`.htmltest.yml`](https://git.k8s.io/website/.htmltest.yml)，来决定检查哪些内容。
 
 该链接检查器扫描以下内容：
 
-<!-- 
+<!--
 - All content generated from Markdown in [`/content/en/docs`](https://git.k8s.io/website/content/en/docs/) directory, excluding:
   - Generated API references, for example https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/
 - All internal links, excluding:
@@ -56,12 +59,12 @@ The link checker scans the following:
   - 空白锚点 (`<a href="#">` 或 `[title](#)`) 以及空白目标地址  (`<a href="">` 或 `[title]()`)
   - 指向图片或其他媒体文件的内部链接
 
-<!-- 
+<!--
 The link checker does not scan the following:
  -->
 该链接检查器不会扫描以下内容：
 
-<!-- 
+<!--
 - Links included in the top and side nav bars, footer links, or links in a page's `<head>` section, such as links to CSS stylesheets, scripts, and meta information
 - Top level pages and their children, for example: `/training`, `/community`, `/case-studies/adidas`
 - Blog posts
@@ -69,34 +72,34 @@ The link checker does not scan the following:
 - Localizations
  -->
 - 包含在顶部和侧边导航栏的链接，以及页脚链接或者页面的 `<head>` 部分中的链接，例如 CSS 样式表、脚本以及元信息的链接。
-- 顶级页面及其子页面，例如： `/training`, `/community`, `/case-studies/adidas`
+- 顶级页面及其子页面，例如：`/training`、`/community`、`/case-studies/adidas`
 - 博客文章
-- API 参考文档，例如：https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/
+- API 参考文档，例如： https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/
 - 本地化内容
 
-<!-- 
+<!--
 ## Prerequisites and installation
  -->
 ## 先决条件以及安装说明
 
-<!-- 
+<!--
 You must install
  -->
 必须安装：
 * [Docker](https://docs.docker.com/get-docker/)
 * [make](https://www.gnu.org/software/make/)
- 
-<!-- 
+
+<!--
 ## Running the link checker
  -->
 ## 运行链接检查器
 
-<!-- 
+<!--
 To run the link checker:
  -->
 运行链接检查器需要：
 
-<!-- 
+<!--
 1. Navigate to the root directory of your local `kubernetes/website` repository.
 
 2. Run the following command:
@@ -109,12 +112,12 @@ To run the link checker:
   make container-internal-linkcheck
   ```
 
-<!-- 
+<!--
 ## Understanding the output
  -->
 ## 理解输出的内容
 
-<!-- 
+<!--
 If the link checker finds broken links, the output is similar to the following:
  -->
 如果链接检查器发现了失效链接，则输出内容类似如下：
@@ -125,7 +128,7 @@ tasks/access-kubernetes-api/custom-resources/index.html
   hash does not exist --- tasks/access-kubernetes-api/custom-resources/index.html --> #preserving-unknown-fields
 ```
 
-<!-- 
+<!--
 This is one set of broken links. The log adds an output for each page with broken links.
 
 In this output, the file with broken links is `tasks/access-kubernetes-api/custom-resources.md`.
@@ -138,15 +141,15 @@ One way to fix this is to:
  -->
 这是一系列失效链接。该日志附带了每个页面下的失效链接。
 
-在这部分输出中，包含失效链接的文件是 `tasks/access-kubernetes-api/custom-resources.md`.
+在这部分输出中，包含失效链接的文件是 `tasks/access-kubernetes-api/custom-resources.md`。
 
-该工具给出了一个理由：`hash does not exist`. 在大部分情况下，你可以忽略这个。
+该工具给出了一个理由：`hash does not exist`，在大部分情况下，你可以忽略这个。
 
-目标链接是 `#preserving-unknown-fields`.
+目标链接是 `#preserving-unknown-fields`。
 
 修复这个问题的一种方式是：
 
-<!-- 
+<!--
 1. Navigate to the Markdown file with a broken link.
 2. Using a text editor, do a full-text search (usually Ctrl+F or Command+F) for the broken link's URL, `#preserving-unknown-fields`.
 3. Fix the link. For a broken page hash (or _anchor_) link, check whether the topic was renamed or removed.
@@ -155,7 +158,7 @@ One way to fix this is to:
 2. 使用文本编辑器全文搜索失效链接的 URL（通常使用 Ctrl+F 或 Command+F）`#preserving-unknown-fields`.
 3. 修复该链接。对于一个失效的锚点（或者 _anchor_ ）链接，检查该主题是否已更名或者移除。
 
-<!-- 
+<!--
 Run htmltest to verify that broken links are fixed.
  -->
 运行 htmltest 来验证失效链接是否已修复。

--- a/content/zh/docs/tasks/configure-pod-container/translate-compose-kubernetes.md
+++ b/content/zh/docs/tasks/configure-pod-container/translate-compose-kubernetes.md
@@ -438,7 +438,7 @@ If you are manually pushing the Openshift artifacts using ``oc create -f``, you 
 -->
 {{< note >}}
 如果使用 ``oc create -f`` 手动推送 Openshift 工件，则需要确保在构建配置工件之前推送
-imagestream 工件，以解决 Openshift 的这个问题：https://github.com/openshift/origin/issues/4518 。
+imagestream 工件，以解决 Openshift 的这个问题： https://github.com/openshift/origin/issues/4518 。
 {{< /note >}}
 
 <!--


### PR DESCRIPTION
The link `中文：https://xxx` will not be detect and convert to `<a>`.

The broken version: https://kubernetes.io/zh/docs/concepts/security/overview/#%E4%BB%A3%E7%A0%81%E5%AE%89%E5%85%A8%E6%80%A7

## Related PR
For better review result, I've split into 4 PRs.
- (this) #33987
- #33988
- #33989
- #33990