### PR TITLE
[zh] Fix link for references

### DIFF
--- a/content/zh/docs/reference/command-line-tools-reference/kube-apiserver.md
+++ b/content/zh/docs/reference/command-line-tools-reference/kube-apiserver.md
@@ -84,7 +84,7 @@ the host's default interface will be used.
 The map from metric-label to value allow-list of this label. The key's format is &lt;MetricName&gt;,&lt;LabelName&gt;. The value's format is &lt;allowed_value&gt;,&lt;allowed_value&gt;...e.g. metric1,label1='v1,v2,v3', metric1,label2='v1,v2,v3' metric2,label1='v1,v2,v3'.
 -->
 允许使用的指标标签到指标值的映射列表。键的格式为 &lt;MetricName&gt;,&lt;LabelName&gt;.
-值的格式为 &lt;allowed_value&gt;,&lt;allowed_value&gt;...。 
+值的格式为 &lt;allowed_value&gt;,&lt;allowed_value&gt;...。
 例如：<code>metric1,label1='v1,v2,v3', metric1,label2='v1,v2,v3' metric2,label1='v1,v2,v3'</code>。
 </p></td>
 </tr>
@@ -97,7 +97,7 @@ The map from metric-label to value allow-list of this label. The key's format is
 <!--
 If true, allow privileged containers. [default=false]
 -->
-如果为 true, 将允许特权容器。[默认值=false]
+如果为 true，将允许特权容器。[默认值=false]
 </td>
 </tr>
 
@@ -131,8 +131,8 @@ of these audiences. If the --service-account-issuer flag is configured
 and this flag is not, this field defaults to a single element list 
 containing the issuer URL.
 -->
-API 的标识符。 
-服务帐户令牌验证者将验证针对 API 使用的令牌是否已绑定到这些受众中的至少一个。 
+API 的标识符。
+服务帐户令牌验证者将验证针对 API 使用的令牌是否已绑定到这些受众中的至少一个。
 如果配置了 <code>--service-account-issuer</code> 标志，但未配置此标志，
 则此字段默认为包含发布者 URL 的单个元素列表。
 </td>
@@ -799,7 +799,7 @@ CORS 允许的来源清单，以逗号分隔。
 <!--
 Indicates the tolerationSeconds of the toleration for notReady:NoExecute that is added by default to every pod that does not already have such a toleration.
 -->
-对污点 NotReady:NoExecute 的容忍时长（以秒计）。 
+对污点 NotReady:NoExecute 的容忍时长（以秒计）。
 默认情况下这一容忍度会被添加到尚未具有此容忍度的每个 pod 中。
 </td>
 </tr>
@@ -833,7 +833,7 @@ that do not have a default watch size set.
 </tr>
 
 <tr>
-<td colspan="2">--delete-collection-workers int&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<!--Default:-->默认值： 1</td>
+<td colspan="2">--delete-collection-workers int&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<!--Default:-->默认值：1</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
@@ -1363,10 +1363,10 @@ Max is .02 (1/50 requests); .001 (1/1000) is a recommended starting point.
 -->
 为防止 HTTP/2 客户端卡在单个 API 服务器上，可启用随机关闭连接（GOAWAY）。
 客户端的其他运行中请求将不会受到影响，并且客户端将重新连接，
-可能会在再次通过负载平衡器后登陆到其他 API 服务器上。 
-此参数设置将发送 GOAWAY 的请求的比例。 
-具有单个 API 服务器或不使用负载平衡器的群集不应启用此功能。 
-最小值为0（关闭），最大值为 .02（1/50 请求）； 建议使用 .001（1/1000）。
+可能会在再次通过负载平衡器后登陆到其他 API 服务器上。
+此参数设置将发送 GOAWAY 的请求的比例。
+具有单个 API 服务器或不使用负载平衡器的集群不应启用此功能。
+最小值为0（关闭），最大值为 .02（1/50 请求）；建议使用 .001（1/1000）。
 </td>
 </tr>
 
@@ -1847,7 +1847,7 @@ open before timing it out. This is the default request timeout for
 requests but may be overridden by flags such as --min-request-timeout 
 for specific types of requests.
 -->
-可选字段，指示处理程序在超时之前必须保持打开请求的持续时间。 
+可选字段，指示处理程序在超时之前必须保持打开请求的持续时间。
 这是请求的默认请求超时，但对于特定类型的请求，可能会被
 <code>--min-request-timeout</code>等标志覆盖。
 </td>
@@ -2004,9 +2004,9 @@ and all are used to determine which issuers are accepted.
 颁发者将在已办法令牌的 "iss" 声明中检查此标识符。
 此值为字符串或 URI。
 如果根据 OpenID Discovery 1.0 规范检查此选项不是有效的 URI，则即使特性门控设置为 true，
-ServiceAccountIssuerDiscovery 功能也将保持禁用状态。 
-强烈建议该值符合 OpenID 规范：https://openid.net/specs/openid-connect-discovery-1_0.html。 
-实践中，这意味着 service-account-issuer 取值必须是 HTTPS URL。 
+ServiceAccountIssuerDiscovery 功能也将保持禁用状态。
+强烈建议该值符合 OpenID 规范： https://openid.net/specs/openid-connect-discovery-1_0.html 。
+实践中，这意味着 service-account-issuer 取值必须是 HTTPS URL。
 还强烈建议此 URL 能够在 {service-account-issuer}/.well-known/openid-configuration
 处提供 OpenID 发现文档。
 当此值被多次指定时，第一次的值用于生成令牌，所有的值用于确定接受哪些发行人。
@@ -2209,7 +2209,7 @@ List of directives for HSTS, comma separated. If this list is empty, then HSTS d
 -->
 为 HSTS 所设置的指令列表，用逗号分隔。
 如果此列表为空，则不会添加 HSTS 指令。
-例如： 'max-age=31536000,includeSubDomains,preload'
+例如：'max-age=31536000,includeSubDomains,preload'
 </p></td>
 </tr>
 
@@ -2280,7 +2280,7 @@ File containing the default x509 private key matching --tls-cert-file.
 </tr>
 
 <tr>
-<td colspan="2">--tls-sni-cert-key string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<!--Default:-->默认值： []</td>
+<td colspan="2">--tls-sni-cert-key string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<!--Default:-->默认值：[]</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">

--- a/content/zh/docs/reference/kubernetes-api/authentication-resources/service-account-v1.md
+++ b/content/zh/docs/reference/kubernetes-api/authentication-resources/service-account-v1.md
@@ -4,7 +4,7 @@ api_metadata:
   import: "k8s.io/api/core/v1"
   kind: "ServiceAccount"
 content_type: "api_reference"
-description: "ServiceAccount 将以下内容绑定在一起：1. 用户可以理解的名称，也可能是外围系统理解的身份标识 2. 可以验证和授权的主体 3. 一组 secret 。"
+description: "ServiceAccount 将以下内容绑定在一起：1. 用户可以理解的名称，也可能是外围系统理解的身份标识 2. 可以验证和授权的主体 3. 一组 secret。"
 title: "ServiceAccount"
 weight: 1
 auto_generated: true
@@ -27,7 +27,7 @@ The file is auto-generated from the Go source code of the component using a gene
 [generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
 to generate the reference documentation, please read
 [Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference content, please follow the 
+To update the reference content, please follow the
 [Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
 guide. You can file document formatting bugs against the
 [reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
@@ -76,20 +76,29 @@ ServiceAccount 将以下内容绑定在一起：
   <!--
   ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
   -->
-  imagePullSecrets 是对同一命名空间中 Secret 的引用列表，用于拉取引用此 ServiceAccount 的 Pod 中的任何镜像。 
-  imagePullSecrets 与 Secrets 不同，因为 Secrets 可以挂载在 Pod 中，但 imagePullSecrets 只能由 kubelet 访问。 
-  更多信息：https://kubernetes.io/zh/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+  imagePullSecrets 是对同一命名空间中 Secret 的引用列表，用于拉取引用此 ServiceAccount 的 Pod 中的任何镜像。
+  imagePullSecrets 与 Secrets 不同，因为 Secrets 可以挂载在 Pod 中，但 imagePullSecrets 只能由 kubelet 访问。
+  更多信息： https://kubernetes.io/zh/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
 
 - **secrets** ([]<a href="{{< ref "../common-definitions/object-reference#ObjectReference" >}}">ObjectReference</a>)
-  
+
   <!--
   *Patch strategy: merge on key `name`*
-  
-  Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount. More info: https://kubernetes.io/docs/concepts/configuration/secret
+
+  Secrets is a list of the secrets in the same namespace that pods running using this ServiceAccount are allowed to use. Pods are only limited to this list if this service account has a "kubernetes.io/enforce-mountable-secrets" annotation set to "true". This field should not be used to find auto-generated service account token secrets for use outside of pods. Instead, tokens can be requested directly using the TokenRequest API, or service account token secrets can be manually created. More info: https://kubernetes.io/docs/concepts/configuration/secret
+  Secrets is a list of the secrets in the same namespace that pods running using this ServiceAccount are allowed to use
+  Pods are only limited to this list if this service account has a "kubernetes.io/enforce-mountabl
+  -secrets" annotation set to "true". This field should not be used to find auto-generated service accoun
+  token secrets for use outside of pods. Instead, tokens can be requested directly using the TokenRequest API, or servic
+  account token secrets can be manually created. More info: https://kubernetes.io/docs/concepts/configuration/secret
   -->
   **补丁策略：基于键 `name` 合并**
-  Secrets 是允许使用此 ServiceAccount 运行的 Pod 使用的 Secret 列表。 
-  更多信息：https://kubernetes.io/zh/docs/concepts/configuration/secret
+
+  Secrets 是允许使用此 ServiceAccount 运行的 pod 使用的同一命名空间中的秘密列表。
+  仅当此服务帐户的 “kubernetes.io/enforce-mountable-secrets” 注释设置为 “true” 时，Pod 才限于此列表。
+  此字段不应用于查找自动生成的服务帐户令牌机密以在 pod 之外使用。
+  相反，可以使用 TokenRequest API 直接请求令牌，或者可以手动创建服务帐户令牌 secret。
+  更多信息： https://kubernetes.io/docs/concepts/configuration/secret
 
 ## ServiceAccountList {#ServiceAccountList}
 
@@ -107,13 +116,13 @@ ServiceAccountList 是 ServiceAccount 对象的列表
 
 
 - **metadata** (<a href="{{< ref "../common-definitions/list-meta#ListMeta" >}}">ListMeta</a>)
-  
+
   <!--
   Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   -->
-  标准列表元数据, 更多信息：https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+  标准列表元数据, 更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 
-<!--  
+<!--
 - **items** ([]<a href="{{< ref "../authentication-resources/service-account-v1#ServiceAccount" >}}">ServiceAccount</a>), required
 -->
 - **items** ([]<a href="{{< ref "../authentication-resources/service-account-v1#ServiceAccount" >}}">ServiceAccount</a>), 必需
@@ -121,7 +130,7 @@ ServiceAccountList 是 ServiceAccount 对象的列表
   <!--
   List of ServiceAccounts. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
   -->
-  ServiceAccount 列表，更多信息：https://kubernetes.io/zh/docs/tasks/configure-pod-container/configure-service-account/
+  ServiceAccount 列表，更多信息： https://kubernetes.io/zh/docs/tasks/configure-pod-container/configure-service-account/
 
 <!--
 ## Operations {#Operations}

--- a/content/zh/docs/reference/kubernetes-api/authentication-resources/token-review-v1.md
+++ b/content/zh/docs/reference/kubernetes-api/authentication-resources/token-review-v1.md
@@ -32,7 +32,7 @@ TokenReview attempts to authenticate a token to a known user. Note: TokenReview 
 -->
 ## TokenReview {#TokenReview}
 
-TokenReview 尝试通过验证令牌来确认已知用户。 
+TokenReview 尝试通过验证令牌来确认已知用户。
 注意：TokenReview 请求可能会被 kube-apiserver 中的 webhook 令牌验证器插件缓存。
 
 <hr>
@@ -48,7 +48,7 @@ TokenReview 尝试通过验证令牌来确认已知用户。
   <!--
   Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   -->
-  标准对象的元数据，更多信息：https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+  标准对象的元数据，更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 
 - **spec** (<a href="{{< ref "../authentication-resources/token-review-v1#TokenReviewSpec" >}}">TokenReviewSpec</a>), required
 
@@ -104,10 +104,10 @@ TokenReviewStatus 是令牌认证请求的结果。
   <!--
   Audiences are audience identifiers chosen by the authenticator that are compatible with both the TokenReview and token. An identifier is any identifier in the intersection of the TokenReviewSpec audiences and the token's audiences. A client of the TokenReview API that sets the spec.audiences field should validate that a compatible audience identifier is returned in the status.audiences field to ensure that the TokenReview server is audience aware. If a TokenReview returns an empty status.audience field where status.authenticated is "true", the token is valid against the audience of the Kubernetes API server.
   -->
-  audiences 是身份验证者选择的与 TokenReview 和令牌兼容的受众标识符。 标识符是 
-  TokenReviewSpec 受众和令牌受众的交集中的任何标识符。 设置 spec.audiences
+  audiences 是身份验证者选择的与 TokenReview 和令牌兼容的受众标识符。标识符是
+  TokenReviewSpec 受众和令牌受众的交集中的任何标识符。设置 spec.audiences
   字段的 TokenReview API 的客户端应验证在 status.audiences 字段中返回了兼容的受众标识符，
-  以确保 TokenReview 服务器能够识别受众。 如果 TokenReview 
+  以确保 TokenReview 服务器能够识别受众。如果 TokenReview
   返回一个空的 status.audience 字段，其中 status.authenticated 为 “true”，
   则该令牌对 Kubernetes API 服务器的受众有效。
 
@@ -148,7 +148,7 @@ TokenReviewStatus 是令牌认证请求的结果。
 
     <!--
     The names of groups this user is a part of.
-    -->  
+    -->
    此用户所属的组的名称。
 
   - **user.uid** (string)
@@ -168,7 +168,7 @@ TokenReviewStatus 是令牌认证请求的结果。
 <!--
 ## Operations {#Operations}
 -->
-## 操作 {#Operations} 
+## 操作 {#Operations}
 
 <hr>
 

--- a/content/zh/docs/reference/kubernetes-api/common-definitions/delete-options.md
+++ b/content/zh/docs/reference/kubernetes-api/common-definitions/delete-options.md
@@ -39,7 +39,7 @@ auto_generated: true
 
   `APIVersion` 定义对象表示的版本化模式。
   服务器应将已识别的模式转换为最新的内部值，并可能拒绝无法识别的值。
-  更多信息：https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+  更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 
 <!--
 - **dryRun** ([]string)
@@ -51,7 +51,7 @@ auto_generated: true
 
   该值如果存在，则表示不应保留修改。
   无效或无法识别的 `dryRun` 指令将导致错误响应并且不会进一步处理请求。有效值为：
-   
+
    - `All`：处理所有试运行阶段（Dry Run Stages）
 
 <!--
@@ -75,7 +75,7 @@ auto_generated: true
 
   `kind` 是一个字符串值，表示此对象代表的 REST 资源。
   服务器可以从客户端提交请求的端点推断出此值。此值无法更新，是驼峰的格式。
-  更多信息：https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds 。
+  更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds 。
 
 <!--
 - **orphanDependents** (boolean)
@@ -105,11 +105,11 @@ auto_generated: true
 
     Specifies the target UID.
 -->
-  
+
 - **preconditions** (Preconditions)
 
   先决条件必须在执行删除之前完成。如果无法满足这些条件，将返回 409（冲突）状态。
-  
+
   <a name="Preconditions"></a>
   *执行操作（更新、删除等）之前必须满足先决条件。*
 
@@ -131,7 +131,7 @@ auto_generated: true
 
   表示是否以及如何执行垃圾收集。可以设置此字段或 `orphanDependents` 字段，但不能同时设置二者。
   默认策略由 `metadata.finalizers` 中现有终结器（Finalizer）集合和特定资源的默认策略决定。
-  可接受的值为： `Orphan` - 令依赖对象成为孤儿对象；`Background` - 允许垃圾收集器在后台删除依赖项；`Foreground` - 一个级联策略，前台删除所有依赖项。
+  可接受的值为：`Orphan` - 令依赖对象成为孤儿对象；`Background` - 允许垃圾收集器在后台删除依赖项；`Foreground` - 一个级联策略，前台删除所有依赖项。
 
 
 

--- a/content/zh/docs/reference/kubernetes-api/common-definitions/list-meta.md
+++ b/content/zh/docs/reference/kubernetes-api/common-definitions/list-meta.md
@@ -71,7 +71,7 @@ ListMeta describes metadata that synthetic resources must have, including lists 
 
   标识该对象的服务器内部版本的字符串，客户端可以用该字段来确定对象何时被更改。
   该值对客户端是不透明的，并且应该原样传回给服务器。该值由系统填充，只读。
-  更多信息：https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency。
+  更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency 。
 
 <!--
   Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.

--- a/content/zh/docs/reference/kubernetes-api/common-definitions/object-meta.md
+++ b/content/zh/docs/reference/kubernetes-api/common-definitions/object-meta.md
@@ -52,7 +52,7 @@ ObjectMeta 是所有持久化资源必须具有的元数据，其中包括用户
   -->
   name 在命名空间内必须是唯一的。创建资源时需要，尽管某些资源可能允许客户端请求自动地生成适当的名称。
   名称主要用于创建幂等性和配置定义。无法更新。
-  更多信息：http://kubernetes.io/docs/user-guide/identifiers#names
+  更多信息： http://kubernetes.io/docs/user-guide/identifiers#names
 
 
 - **generateName** (string)
@@ -72,7 +72,7 @@ ObjectMeta 是所有持久化资源必须具有的元数据，其中包括用户
   如果指定了此字段并且生成的名称存在，则服务器将不会返回 409 ——相反，它将返回 201 Created 或 500，
   原因是 ServerTimeout 指示在分配的时间内找不到唯一名称，客户端应重试（可选，在 Retry-After 标头中指定的时间之后）。
   
-  仅在未指定 name 时应用。更多信息：https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+  仅在未指定 name 时应用。更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
 
 - **namespace** (string)
 
@@ -84,7 +84,7 @@ ObjectMeta 是所有持久化资源必须具有的元数据，其中包括用户
   namespace 定义了一个值空间，其中每个名称必须唯一。空命名空间相当于 “default” 命名空间，但 “default” 是规范表示。
   并非所有对象都需要限定在命名空间中——这些对象的此字段的值将为空。
   
-  必须是 DNS_LABEL。无法更新。更多信息：http://kubernetes.io/docs/user-guide/namespaces
+  必须是 DNS_LABEL。无法更新。更多信息： http://kubernetes.io/docs/user-guide/namespaces
 
 - **labels** (map[string]string)
 
@@ -92,7 +92,7 @@ ObjectMeta 是所有持久化资源必须具有的元数据，其中包括用户
   Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels
   -->
   可用于组织和分类（确定范围和选择）对象的字符串键和值的映射。
-  可以匹配 ReplicationControllers 和 Service 的选择器。更多信息：http://kubernetes.io/docs/user-guide/labels
+  可以匹配 ReplicationControllers 和 Service 的选择器。更多信息： http://kubernetes.io/docs/user-guide/labels
 
 - **annotations** (map[string]string)
 
@@ -100,7 +100,7 @@ ObjectMeta 是所有持久化资源必须具有的元数据，其中包括用户
   Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations
   -->
   annotations 是一个非结构化的键值映射，存储在资源中，可以由外部工具设置以存储和检索任意元数据。
-  它们不可查询，在修改对象时应保留。更多信息：http://kubernetes.io/docs/user-guide/annotations
+  它们不可查询，在修改对象时应保留。更多信息： http://kubernetes.io/docs/user-guide/annotations
 
 
 <!-- ### System {#System} -->
@@ -251,17 +251,17 @@ ObjectMeta 是所有持久化资源必须具有的元数据，其中包括用户
   - **ownerReferences.kind** (string)，<!-- required -->必选
 
     <!-- Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds -->
-    被引用资源的类别。更多信息：https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+    被引用资源的类别。更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 
   - **ownerReferences.name** (string)，<!-- required -->必选
 
     <!-- Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names -->
-    被引用资源的名称。更多信息：http://kubernetes.io/docs/user-guide/identifiers#names
+    被引用资源的名称。更多信息： http://kubernetes.io/docs/user-guide/identifiers#names
 
   - **ownerReferences.uid** (string)，<!-- required -->必选
 
     <!-- UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids -->
-    被引用资源的 uid。更多信息：http://kubernetes.io/docs/user-guide/identifiers#uids
+    被引用资源的 uid。更多信息： http://kubernetes.io/docs/user-guide/identifiers#uids
 
   - **ownerReferences.blockOwnerDeletion** (boolean)
 
@@ -293,7 +293,7 @@ ObjectMeta 是所有持久化资源必须具有的元数据，其中包括用户
   不能保证在单独的操作中按发生前的顺序设置。
   客户端不得设置此值。它以 RFC3339 形式表示，并采用 UTC。
   
-  由系统填充。只读。列表为空。更多信息：https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+  由系统填充。只读。列表为空。更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 
   <a name="Time"></a>
   <!-- 
@@ -331,7 +331,7 @@ ObjectMeta 是所有持久化资源必须具有的元数据，其中包括用户
   此对象可能在此时间戳之后仍然存在，直到管理员或自动化进程可以确定资源已完全终止。
   如果未设置，则未请求优雅删除该对象。
   
-  请求优雅删除时由系统填充。只读。更多信息：https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+  请求优雅删除时由系统填充。只读。更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 
   <a name="Time"></a>
   <!-- 
@@ -360,7 +360,7 @@ ObjectMeta 是所有持久化资源必须具有的元数据，其中包括用户
   它们可能仅对特定资源或一组资源有效。
   
   由系统填充。只读。客户端必须将值视为不透明。
-  更多信息：https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+  更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
 
 - **selfLink** (string)
 
@@ -382,7 +382,7 @@ ObjectMeta 是所有持久化资源必须具有的元数据，其中包括用户
   -->
   UID 是该对象在时间和空间上的唯一值。它通常由服务器在成功创建资源时生成，并且不允许使用 PUT 操作更改。
   
-  由系统填充。只读。更多信息：http://kubernetes.io/docs/user-guide/identifiers#uids
+  由系统填充。只读。更多信息： http://kubernetes.io/docs/user-guide/identifiers#uids
 
 <!-- ### Ignored {#Ignored} -->
 ### 忽略字段 {#Ignored}

--- a/content/zh/docs/reference/kubernetes-api/common-definitions/object-reference.md
+++ b/content/zh/docs/reference/kubernetes-api/common-definitions/object-reference.md
@@ -84,28 +84,28 @@ ObjectReference包含足够的信息，允许你检查或修改引用的对象�
 - **fieldPath** (string)
 
   如果引用的是对象的某个对象是整个对象，则该字符串而不是应包含的 JSON/Go 字段有效访问语句，
-  例如`desiredState.manifest.containers[ 2 ]`。例如，如果对象引用针对的是 Pod 中的一个容器，
-  此字段取值类似于：`spec.containers{name}`（`name`指触发的容器的名称），
-  或者如果没有指定容器名称，`spec.containers[ 2 ]`（此Pod中索引为2的容器）。
+  例如 `desiredState.manifest.containers[ 2 ]`。例如，如果对象引用针对的是 Pod 中的一个容器，
+  此字段取值类似于：`spec.containers{name}`（`name` 指触发的容器的名称），
+  或者如果没有指定容器名称，`spec.containers[ 2 ]`（此 Pod 中索引为 2 的容器）。
   选择这种只是为了有一些定义好的语法来引用对象的部分。
 
 - **kind** (string)
 
-  被引用者的类别（kind）。 更多信息：https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md #types-kinds
+  被引用者的类别（kind）。更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 
 - **name** (string)
 
-  被引用对象的名称。更多信息：https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+  被引用对象的名称。更多信息： https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 
 - **namespace** (string)
 
-  被引用对象的名字空间。更多信息：https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+  被引用对象的名字空间。更多信息： https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
 
 - **resourceVersion** (string)
 
-  被引用对象的特定资源版本（如果有）。更多信息：https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+  被引用对象的特定资源版本（如果有）。更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
 
 - **uid** (string)
 
-  被引用对象的UID。更多信息：https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+  被引用对象的UID。更多信息： https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
 

--- a/content/zh/docs/reference/kubernetes-api/common-definitions/quantity.md
+++ b/content/zh/docs/reference/kubernetes-api/common-definitions/quantity.md
@@ -68,7 +68,7 @@ The serialization format is:
 -->
 ```
 <quantity>        ::= <signedNumber><suffix>
-  (注意 <suffix> 可能为空, 例如 <decimalSI> 的 "" 情形。) </br>
+  (注意 <suffix> 可能为空，例如 <decimalSI> 的 "" 情形。) </br>
 <digit>           ::= 0 | 1 | ... | 9 </br>
 <digits>          ::= <digit> | <digit><digits> </br>
 <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> </br>
@@ -76,7 +76,7 @@ The serialization format is:
 <signedNumber>    ::= <number> | <sign><number> </br>
 <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> </br>
 <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei 
-  (国际单位制度；查阅：http://physics.nist.gov/cuu/Units/binary.html) </br>
+  (国际单位制度；查阅： http://physics.nist.gov/cuu/Units/binary.html)</br>
 <decimalSI>       ::= m | "" | k | M | G | T | P | E 
   (注意，1024 = 1ki 但 1000 = 1k；我没有选择大写。) </br>
 <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber> </br>

--- a/content/zh/docs/reference/kubernetes-api/common-definitions/status.md
+++ b/content/zh/docs/reference/kubernetes-api/common-definitions/status.md
@@ -10,7 +10,7 @@ weight: 12
 auto_generated: true
 ---
 
-<!-- 
+<!--
 api_metadata:
   apiVersion: ""
   import: "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,13 +45,13 @@ guide. You can file document formatting bugs against the
 
 - **apiVersion** (string)
 
-  <!-- 
+  <!--
   APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources 
   -->
 
   APIVersion 定义对象表示的版本化模式。
   服务器应将已识别的模式转换为最新的内部值，并可能拒绝无法识别的值。
-  更多信息：https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+  更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 
 - **code** (int32)
 
@@ -60,7 +60,7 @@ guide. You can file document formatting bugs against the
 
 - **details** (StatusDetails)
 
-  <!--  
+  <!--
   Extended data associated with the reason.  Each reason may define its own extended details. 
   This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.
   -->
@@ -68,7 +68,7 @@ guide. You can file document formatting bugs against the
   此字段是可选的，并且不保证返回的数据符合任何模式，除非由原因类型定义。
 
   <a name="StatusDetails"></a>
-  <!-- 
+  <!--
   *StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. 
   The Reason field of a Status object defines what attributes will be set. 
   Clients must ignore fields that do not match the defined type of each attribute, 
@@ -80,7 +80,7 @@ guide. You can file document formatting bugs against the
 
   - **details.causes** ([]StatusCause)
 
-    <!-- 
+    <!--
     The Causes array includes more details associated with the StatusReason failure. 
     Not all StatusReasons may provide detailed causes. 
     -->
@@ -88,14 +88,14 @@ guide. You can file document formatting bugs against the
     并非所有 StatusReasons 都可以提供详细的原因。
 
     <a name="StatusCause"></a>
-    <!-- 
+    <!--
     *StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.*
     -->
     *StatusCause 提供有关 api.Status 失败的更多信息，包括遇到多个错误的情况。*
 
     - **details.causes.field** (string)
 
-      <!-- 
+      <!--
       The field of the resource that has caused this error, as named by its JSON serialization. 
       May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  
       Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
@@ -104,7 +104,7 @@ guide. You can file document formatting bugs against the
       可能包括嵌套属性的点和后缀表示法。数组是从零开始索引的。
       由于字段有多个错误，字段可能会在一系列原因中出现多次。可选。
 
-      <!-- 
+      <!--
       Examples:
         "name" - the field "name" on the current resource
         "items[0].name" - the field "name" on the first array entry in "items"
@@ -130,14 +130,14 @@ guide. You can file document formatting bugs against the
 
   - **details.kind** (string)
 
-    <!-- 
+    <!--
     The kind attribute of the resource associated with the status StatusReason. 
     On some operations may differ from the requested resource Kind. 
     More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
     -->
     与状态 StatusReason 关联的资源的种类属性。
     在某些操作上可能与请求的资源种类不同。
-    更多信息：https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+    更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 
   - **details.name** (string)
 
@@ -146,7 +146,7 @@ guide. You can file document formatting bugs against the
 
   - **details.retryAfterSeconds** (int32)
 
-    <!-- 
+    <!--
     If specified, the time in seconds before the operation should be retried. 
     Some errors may indicate the client must take an alternate action - 
     for those errors this field may indicate how long to wait before taking the alternate action.
@@ -156,16 +156,16 @@ guide. You can file document formatting bugs against the
 
   - **details.uid** (string)
 
-    <!-- 
+    <!--
     UID of the resource. (when there is a single resource which can be described). 
     More info: http://kubernetes.io/docs/user-guide/identifiers#uids 
     -->
     资源的 UID（当有单个可以描述的资源时）。
-    更多信息：http://kubernetes.io/docs/user-guide/identifiers#uids
+    更多信息： http://kubernetes.io/docs/user-guide/identifiers#uids
 
 - **kind** (string)
 
-  <!-- 
+  <!--
    Kind is a string value representing the REST resource this object represents. 
    Servers may infer this from the endpoint the client submits requests to. 
    Cannot be updated. In CamelCase.
@@ -174,7 +174,7 @@ guide. You can file document formatting bugs against the
   Kind 是一个字符串值，表示此对象表示的 REST 资源。
   服务器可以从客户端提交请求的端点推断出这一点。
   无法更新。驼峰式规则。
-  更多信息：https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+  更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 
 - **message** (string)
 
@@ -185,12 +185,12 @@ guide. You can file document formatting bugs against the
 
   <!-- Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds -->
   标准列表元数据。
-  更多信息：https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+  更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 
 
 - **reason** (string)
 
-  <!-- 
+  <!--
   A machine-readable description of why this operation is in the "Failure" status. 
   If this value is empty there is no information available. 
   A Reason clarifies an HTTP status code but does not override it.
@@ -201,8 +201,8 @@ guide. You can file document formatting bugs against the
 
 - **status** (string)
 
-  <!-- 
+  <!--
   Status of the operation. One of: "Success" or "Failure". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
   -->
-  操作状态。“Success”或“Failure” 之一。 
-  更多信息：https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+  操作状态。“Success”或“Failure” 之一。
+  更多信息： https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status


### PR DESCRIPTION
The link `中文：https://xxx` will not be detect and convert to `<a>`.

The broken version: https://kubernetes.io/zh/docs/reference/kubernetes-api/common-definitions/status/