### PR TITLE
Link to release note in older version is broken

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -29,7 +29,7 @@ The upgrade workflow at high level is the following:
 
 ## {{% heading "prerequisites" %}}
 
-- Make sure you read the [release notes]({{< latest-release-notes >}}) carefully.
+- Make sure you read the [release notes](https://git.k8s.io/kubernetes/CHANGELOG) carefully.
 - The cluster should use a static control plane and etcd pods or external etcd.
 - Make sure to back up any important components, such as app-level state stored in a database.
   `kubeadm upgrade` does not touch your workloads, only components internal to Kubernetes, but backups are always a best practice.

--- a/content/zh/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/zh/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -58,7 +58,7 @@ The upgrade workflow at high level is the following:
 ## {{% heading "prerequisites" %}}
 
 <!--
-- Make sure you read the [release notes]({{< latest-release-notes >}}) carefully.
+- Make sure you read the [release notes](https://git.k8s.io/kubernetes/CHANGELOG) carefully.
 - The cluster should use a static control plane and etcd pods or external etcd.
 - Make sure to back up any important components, such as app-level state stored in a database.
   `kubeadm upgrade` does not touch your workloads, only components internal to Kubernetes, but backups are always a best practice.


### PR DESCRIPTION
<!-- 🛈

 Hello!

The link to release note in older version is broken. In [v1.23](https://v1-23.docs.kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/#before-you-begin) and the previous document, the "release notes" is linked to the current one (v1.24).

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
