### PR TITLE
Update link text to configure-pod-configmap.md

### DIFF
--- a/content/en/docs/concepts/services-networking/network-policies.md
+++ b/content/en/docs/concepts/services-networking/network-policies.md
@@ -54,7 +54,7 @@ POSTing this to the API server for your cluster will have no effect unless your 
 __Mandatory Fields__: As with all other Kubernetes config, a NetworkPolicy
 needs `apiVersion`, `kind`, and `metadata` fields.  For general information
 about working with config files, see
-[Configure Containers Using a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/),
+[Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/),
 and [Object Management](/docs/concepts/overview/working-with-objects/object-management).
 
 __spec__: NetworkPolicy [spec](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status) has all the information needed to define a particular network policy in the given namespace.

--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -10,7 +10,7 @@ card:
 <!-- overview -->
 Many applications rely on configuration which is used during either application initialization or runtime.
 Most of the times there is a requirement to adjust values assigned to configuration parameters.
-ConfigMaps is the kubernetes way to inject application pods with configuration data. 
+ConfigMaps is the kubernetes way to inject application pods with configuration data.
 ConfigMaps allow you to decouple configuration artifacts from image content to keep containerized applications portable. This page provides a series of usage examples demonstrating how to create ConfigMaps and configure Pods using data stored in ConfigMaps.
 
 
@@ -461,35 +461,35 @@ configmap/special-config-2-c92b5mmcf2 created
 
 ### Define a container environment variable with data from a single ConfigMap
 
-1.  Define an environment variable as a key-value pair in a ConfigMap:
+1. Define an environment variable as a key-value pair in a ConfigMap:
 
-    ```shell
-    kubectl create configmap special-config --from-literal=special.how=very
-    ```
+   ```shell
+   kubectl create configmap special-config --from-literal=special.how=very
+   ```
 
-2.  Assign the `special.how` value defined in the ConfigMap to the `SPECIAL_LEVEL_KEY` environment variable in the Pod specification.
+2. Assign the `special.how` value defined in the ConfigMap to the `SPECIAL_LEVEL_KEY` environment variable in the Pod specification.
 
    {{< codenew file="pods/pod-single-configmap-env-variable.yaml" >}}
 
    Create the Pod:
 
- ```shell
- kubectl create -f https://kubernetes.io/examples/pods/pod-single-configmap-env-variable.yaml
- ```
+   ```shell
+   kubectl create -f https://kubernetes.io/examples/pods/pod-single-configmap-env-variable.yaml
+   ```
 
    Now, the Pod's output includes environment variable `SPECIAL_LEVEL_KEY=very`.
 
 ### Define container environment variables with data from multiple ConfigMaps
 
- * As with the previous example, create the ConfigMaps first.
+* As with the previous example, create the ConfigMaps first.
 
-   {{< codenew file="configmap/configmaps.yaml" >}}
+  {{< codenew file="configmap/configmaps.yaml" >}}
 
-   Create the ConfigMap:
+  Create the ConfigMap:
 
- ```shell
- kubectl create -f https://kubernetes.io/examples/configmap/configmaps.yaml
- ```
+  ```shell
+  kubectl create -f https://kubernetes.io/examples/configmap/configmaps.yaml
+  ```
 
 * Define the environment variables in the Pod specification.
 
@@ -497,9 +497,9 @@ configmap/special-config-2-c92b5mmcf2 created
 
   Create the Pod:
 
- ```shell
- kubectl create -f https://kubernetes.io/examples/pods/pod-multiple-configmap-env-variable.yaml
- ```
+  ```shell
+  kubectl create -f https://kubernetes.io/examples/pods/pod-multiple-configmap-env-variable.yaml
+  ```
 
   Now, the Pod's output includes environment variables `SPECIAL_LEVEL_KEY=very` and `LOG_LEVEL=INFO`.
 
@@ -515,21 +515,21 @@ This functionality is available in Kubernetes v1.6 and later.
 
   Create the ConfigMap:
 
- ```shell
- kubectl create -f https://kubernetes.io/examples/configmap/configmap-multikeys.yaml
- ```
+  ```shell
+  kubectl create -f https://kubernetes.io/examples/configmap/configmap-multikeys.yaml
+  ```
 
 * Use `envFrom` to define all of the ConfigMap's data as container environment variables. The key from the ConfigMap becomes the environment variable name in the Pod.
 
- {{< codenew file="pods/pod-configmap-envFrom.yaml" >}}
+  {{< codenew file="pods/pod-configmap-envFrom.yaml" >}}
 
- Create the Pod:
+  Create the Pod:
 
- ```shell
- kubectl create -f https://kubernetes.io/examples/pods/pod-configmap-envFrom.yaml
- ```
+  ```shell
+  kubectl create -f https://kubernetes.io/examples/pods/pod-configmap-envFrom.yaml
+  ```
 
- Now, the Pod's output includes environment variables `SPECIAL_LEVEL=very` and `SPECIAL_TYPE=charm`.
+  Now, the Pod's output includes environment variables `SPECIAL_LEVEL=very` and `SPECIAL_TYPE=charm`.
 
 
 ## Use ConfigMap-defined environment variables in Pod commands
@@ -680,15 +680,15 @@ data:
 
 - If you use `envFrom` to define environment variables from ConfigMaps, keys that are considered invalid will be skipped. The pod will be allowed to start, but the invalid names will be recorded in the event log (`InvalidVariableNames`). The log message lists each skipped key. For example:
 
-   ```shell
-   kubectl get events
-   ```
+  ```shell
+  kubectl get events
+  ```
 
-   The output is similar to this:
-   ```
-   LASTSEEN FIRSTSEEN COUNT NAME          KIND  SUBOBJECT  TYPE      REASON                            SOURCE                MESSAGE
-   0s       0s        1     dapi-test-pod Pod              Warning   InvalidEnvironmentVariableNames   {kubelet, 127.0.0.1}  Keys [1badkey, 2alsobad] from the EnvFrom configMap default/myconfig were skipped since they are considered invalid environment variable names.
-   ```
+  The output is similar to this:
+  ```
+  LASTSEEN FIRSTSEEN COUNT NAME          KIND  SUBOBJECT  TYPE      REASON                            SOURCE                MESSAGE
+  0s       0s        1     dapi-test-pod Pod              Warning   InvalidEnvironmentVariableNames   {kubelet, 127.0.0.1}  Keys [1badkey, 2alsobad] from the EnvFrom configMap default/myconfig were skipped since they are considered invalid environment variable names.
+  ```
 
 - ConfigMaps reside in a specific {{< glossary_tooltip term_id="namespace" >}}. A ConfigMap can only be referenced by pods residing in the same namespace.
 
@@ -699,4 +699,3 @@ data:
 ## {{% heading "whatsnext" %}}
 
 * Follow a real world example of [Configuring Redis using a ConfigMap](/docs/tutorials/configuration/configure-redis-using-configmap/).
-

--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -8,7 +8,7 @@ content_type: tutorial
 
 <!-- overview -->
 
-This page provides a real world example of how to configure Redis using a ConfigMap and builds upon the [Configure Containers Using a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/) task. 
+This page provides a real world example of how to configure Redis using a ConfigMap and builds upon the [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/) task. 
 
 
 
@@ -27,7 +27,7 @@ This page provides a real world example of how to configure Redis using a Config
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
 
 * The example shown on this page works with `kubectl` 1.14 and above.
-* Understand [Configure Containers Using a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/).
+* Understand [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/).
 
 
 


### PR DESCRIPTION
When syncing #33967 (zh), I found that the link text `Configure Containers Using a ConfigMap` is inconsist with the article title `Configure a Pod to Use a ConfigMap`.

The two document was merged into one in 5 years ago, I think using the same title is better.
- #6648

This PR also fix some formatting issues.