### PR TITLE
Remove `LappleApple` from SIG Release `OWNERS_ALIASES`

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -250,7 +250,6 @@ aliases:
     - cpanato # SIG Technical Lead
     - jeremyrickard # SIG Technical Lead
     - justaugustus # SIG Chair
-    - LappleApple # SIG Program Manager
     - puerco # SIG Technical Lead
     - saschagrunert # SIG Chair
   release-engineering-approvers:


### PR DESCRIPTION

#### What type of PR is this:


/kind cleanup

#### What this PR does / why we need it:
Lauri has stepped back from SIG Release some time ago. This cleanup should reflect the current state of the SIG. :sob: 

cc @kubernetes/sig-release-leads 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #
or
None
-->
Refers to https://github.com/kubernetes/community/pull/6675, https://github.com/kubernetes/org/pull/3450
#### Special notes for your reviewer:
None