### PR TITLE
[ko] Update outdated files in `dev-1.24-ko.1` (M139-M162)

### DIFF
--- a/content/ko/examples/admin/logging/two-files-counter-pod-agent-sidecar.yaml
+++ b/content/ko/examples/admin/logging/two-files-counter-pod-agent-sidecar.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: count
-    image: busybox
+    image: busybox:1.28
     args:
     - /bin/sh
     - -c

--- a/content/ko/examples/admin/logging/two-files-counter-pod-streaming-sidecar.yaml
+++ b/content/ko/examples/admin/logging/two-files-counter-pod-streaming-sidecar.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: count
-    image: busybox
+    image: busybox:1.28
     args:
     - /bin/sh
     - -c
@@ -22,14 +22,14 @@ spec:
     - name: varlog
       mountPath: /var/log
   - name: count-log-1
-    image: busybox
-    args: [/bin/sh, -c, 'tail -n+1 -f /var/log/1.log']
+    image: busybox:1.28
+    args: [/bin/sh, -c, 'tail -n+1 -F /var/log/1.log']
     volumeMounts:
     - name: varlog
       mountPath: /var/log
   - name: count-log-2
-    image: busybox
-    args: [/bin/sh, -c, 'tail -n+1 -f /var/log/2.log']
+    image: busybox:1.28
+    args: [/bin/sh, -c, 'tail -n+1 -F /var/log/2.log']
     volumeMounts:
     - name: varlog
       mountPath: /var/log

--- a/content/ko/examples/admin/logging/two-files-counter-pod.yaml
+++ b/content/ko/examples/admin/logging/two-files-counter-pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: count
-    image: busybox
+    image: busybox:1.28
     args:
     - /bin/sh
     - -c

--- a/content/ko/examples/admin/resource/limit-range-pod-1.yaml
+++ b/content/ko/examples/admin/resource/limit-range-pod-1.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: busybox-cnt01
-    image: busybox
+    image: busybox:1.28
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo hello from cnt01; sleep 10;done"]
     resources:
@@ -16,7 +16,7 @@ spec:
         memory: "200Mi"
         cpu: "500m"
   - name: busybox-cnt02
-    image: busybox
+    image: busybox:1.28
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo hello from cnt02; sleep 10;done"]
     resources:
@@ -24,7 +24,7 @@ spec:
         memory: "100Mi"
         cpu: "100m"
   - name: busybox-cnt03
-    image: busybox
+    image: busybox:1.28
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo hello from cnt03; sleep 10;done"]
     resources:
@@ -32,6 +32,6 @@ spec:
         memory: "200Mi"
         cpu: "500m"
   - name: busybox-cnt04
-    image: busybox
+    image: busybox:1.28
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo hello from cnt04; sleep 10;done"]

--- a/content/ko/examples/admin/resource/limit-range-pod-2.yaml
+++ b/content/ko/examples/admin/resource/limit-range-pod-2.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: busybox-cnt01
-    image: busybox
+    image: busybox:1.28
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo hello from cnt01; sleep 10;done"]
     resources:
@@ -16,7 +16,7 @@ spec:
         memory: "200Mi"
         cpu: "500m"
   - name: busybox-cnt02
-    image: busybox
+    image: busybox:1.28
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo hello from cnt02; sleep 10;done"]
     resources:
@@ -24,7 +24,7 @@ spec:
         memory: "100Mi"
         cpu: "100m"
   - name: busybox-cnt03
-    image: busybox
+    image: busybox:1.28
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo hello from cnt03; sleep 10;done"]
     resources:
@@ -32,6 +32,6 @@ spec:
         memory: "200Mi"
         cpu: "500m"
   - name: busybox-cnt04
-    image: busybox
+    image: busybox:1.28
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo hello from cnt04; sleep 10;done"]

--- a/content/ko/examples/admin/resource/limit-range-pod-3.yaml
+++ b/content/ko/examples/admin/resource/limit-range-pod-3.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: busybox-cnt01
-    image: busybox
+    image: busybox:1.28
     resources:
       limits:
         memory: "300Mi"

--- a/content/ko/examples/application/job/cronjob.yaml
+++ b/content/ko/examples/application/job/cronjob.yaml
@@ -10,7 +10,7 @@ spec:
         spec:
           containers:
           - name: hello
-            image: busybox
+            image: busybox:1.28
             imagePullPolicy: IfNotPresent
             command:
             - /bin/sh

--- a/content/ko/examples/application/job/job-tmpl.yaml
+++ b/content/ko/examples/application/job/job-tmpl.yaml
@@ -13,6 +13,6 @@ spec:
     spec:
       containers:
       - name: c
-        image: busybox
+        image: busybox:1.28
         command: ["sh", "-c", "echo Processing item $ITEM && sleep 5"]
       restartPolicy: Never

--- a/content/ko/examples/application/mysql/mysql-configmap.yaml
+++ b/content/ko/examples/application/mysql/mysql-configmap.yaml
@@ -9,8 +9,10 @@ data:
     # Primary에만 이 구성을 적용한다.
     [mysqld]
     log-bin
+    datadir=/var/lib/mysql/mysql
   replica.cnf: |
     # 레플리카에만 이 구성을 적용한다.
     [mysqld]
     super-read-only
+    datadir=/var/lib/mysql/mysql
 

--- a/content/ko/examples/application/mysql/mysql-services.yaml
+++ b/content/ko/examples/application/mysql/mysql-services.yaml
@@ -27,4 +27,3 @@ spec:
     port: 3306
   selector:
     app: mysql
-

--- a/content/ko/examples/controllers/daemonset.yaml
+++ b/content/ko/examples/controllers/daemonset.yaml
@@ -15,8 +15,11 @@ spec:
         name: fluentd-elasticsearch
     spec:
       tolerations:
-      # this toleration is to have the daemonset runnable on master nodes
-      # remove it if your masters can't run pods
+      # 이 톨러레이션(toleration)은 데몬셋이 컨트롤 플레인 노드에서 실행될 수 있도록 만든다.
+      # 컨트롤 플레인 노드가 이 파드를 실행해서는 안 되는 경우, 이 톨러레이션을 제거한다.
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule

--- a/content/ko/examples/controllers/fluentd-daemonset-update.yaml
+++ b/content/ko/examples/controllers/fluentd-daemonset-update.yaml
@@ -19,9 +19,13 @@ spec:
         name: fluentd-elasticsearch
     spec:
       tolerations:
-      # 이 톨러레이션(toleration)은 마스터 노드에서 실행 가능한 데몬셋이
-      # 마스터에서 파드를 실행할 수 없는 경우 이를 제거하는 것이다
+      # 이 톨러레이션(toleration)은 데몬셋이 컨트롤 플레인 노드에서 실행될 수 있도록 만든다.
+      # 컨트롤 플레인 노드가 이 파드를 실행해서는 안 되는 경우, 이 톨러레이션을 제거한다.
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
       - key: node-role.kubernetes.io/master
+        operator: Exists
         effect: NoSchedule
       containers:
       - name: fluentd-elasticsearch

--- a/content/ko/examples/controllers/fluentd-daemonset.yaml
+++ b/content/ko/examples/controllers/fluentd-daemonset.yaml
@@ -19,9 +19,13 @@ spec:
         name: fluentd-elasticsearch
     spec:
       tolerations:
-      # 이 톨러레이션(toleration)은 마스터 노드에서 실행 가능한 데몬셋이
-      # 마스터에서 파드를 실행할 수 없는 경우 이를 제거하는 것이다
+      # 이 톨러레이션(toleration)은 데몬셋이 컨트롤 플레인 노드에서 실행될 수 있도록 만든다.
+      # 컨트롤 플레인 노드가 이 파드를 실행해서는 안 되는 경우, 이 톨러레이션을 제거한다.
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
       - key: node-role.kubernetes.io/master
+        operator: Exists
         effect: NoSchedule
       containers:
       - name: fluentd-elasticsearch

--- a/content/ko/examples/debug/counter-pod.yaml
+++ b/content/ko/examples/debug/counter-pod.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   containers:
   - name: count
-    image: busybox
+    image: busybox:1.28
     args: [/bin/sh, -c,
             'i=0; while true; do echo "$i: $(date)"; i=$((i+1)); sleep 1; done']

--- a/content/ko/examples/pods/init-containers.yaml
+++ b/content/ko/examples/pods/init-containers.yaml
@@ -14,7 +14,7 @@ spec:
   # 이 컨테이너들은 파드 초기화 중에 실행된다.
   initContainers:
   - name: install
-    image: busybox
+    image: busybox:1.28
     command:
     - wget
     - "-O"

--- a/content/ko/examples/pods/inject/dependent-envars.yaml
+++ b/content/ko/examples/pods/inject/dependent-envars.yaml
@@ -10,7 +10,7 @@ spec:
       command:
         - sh
         - -c
-      image: busybox
+      image: busybox:1.28
       env:
         - name: SERVICE_PORT
           value: "80"

--- a/content/ko/examples/pods/pod-with-node-affinity.yaml
+++ b/content/ko/examples/pods/pod-with-node-affinity.yaml
@@ -8,11 +8,10 @@ spec:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
         - matchExpressions:
-          - key: kubernetes.io/e2e-az-name
+          - key: kubernetes.io/os
             operator: In
             values:
-            - e2e-az1
-            - e2e-az2
+            - linux
       preferredDuringSchedulingIgnoredDuringExecution:
       - weight: 1
         preference:

--- a/content/ko/examples/pods/resource/memory-request-limit-3.yaml
+++ b/content/ko/examples/pods/resource/memory-request-limit-3.yaml
@@ -8,9 +8,9 @@ spec:
   - name: memory-demo-3-ctr
     image: polinux/stress
     resources:
-      limits:
-        memory: "1000Gi"
       requests:
+        memory: "1000Gi"
+      limits:
         memory: "1000Gi"
     command: ["stress"]
     args: ["--vm", "1", "--vm-bytes", "150M", "--vm-hang", "1"]

--- a/content/ko/examples/pods/resource/memory-request-limit.yaml
+++ b/content/ko/examples/pods/resource/memory-request-limit.yaml
@@ -8,9 +8,9 @@ spec:
   - name: memory-demo-ctr
     image: polinux/stress
     resources:
-      limits:
-        memory: "200Mi"
       requests:
         memory: "100Mi"
+      limits:
+        memory: "200Mi"
     command: ["stress"]
     args: ["--vm", "1", "--vm-bytes", "150M", "--vm-hang", "1"]

--- a/content/ko/examples/pods/security/hello-apparmor.yaml
+++ b/content/ko/examples/pods/security/hello-apparmor.yaml
@@ -9,5 +9,5 @@ metadata:
 spec:
   containers:
   - name: hello
-    image: busybox
+    image: busybox:1.28
     command: [ "sh", "-c", "echo 'Hello AppArmor!' && sleep 1h" ]

--- a/content/ko/examples/policy/restricted-psp.yaml
+++ b/content/ko/examples/policy/restricted-psp.yaml
@@ -3,6 +3,7 @@ kind: PodSecurityPolicy
 metadata:
   name: restricted
   annotations:
+    # docker/default 는 seccomp를 위한 프로파일을 나타내지만, 특별히 도커 런타임에 묶여 있는 것은 아니다.
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
     apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
     apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'

--- a/content/ko/examples/service/networking/hostaliases-pod.yaml
+++ b/content/ko/examples/service/networking/hostaliases-pod.yaml
@@ -15,7 +15,7 @@ spec:
     - "bar.remote"
   containers:
   - name: cat-hosts
-    image: busybox
+    image: busybox:1.28
     command:
     - cat
     args:

--- a/content/ko/releases/_index.md
+++ b/content/ko/releases/_index.md
@@ -7,7 +7,7 @@ type: docs
 
 <!-- overview -->
 
-쿠버네티스 프로젝트는 가장 최신의 3개 마이너(minor) 릴리스({{< skew latestVersion >}}, {{< skew prevMinorVersion >}}, {{< skew oldestMinorVersion >}})에 대해서 릴리스 브랜치를 관리한다. 쿠버네티스 1.19 및 이후 신규 버전은 약 1년간 패치 지원을 받을 수 있다. 쿠버네티스 1.18 및 이전 버전은 약 9개월간의 패치 지원을 받을 수 있다.
+쿠버네티스 프로젝트는 가장 최신의 3개 마이너(minor) 릴리스({{< skew latestVersion >}}, {{< skew prevMinorVersion >}}, {{< skew oldestMinorVersion >}})에 대해서 릴리스 브랜치를 관리한다. 쿠버네티스 1.19 및 이후 신규 버전은 [약 1년간 패치 지원](/releases/patch-releases/#support-period)을 받을 수 있다. 쿠버네티스 1.18 및 이전 버전은 약 9개월간의 패치 지원을 받을 수 있다.
 
 쿠버네티스 버전은 **x.y.z** 의 형태로 표현되는데,
 **x** 는 메이저(major) 버전, **y** 는 마이너(minor), **z** 는 패치(patch) 버전을 의미하며, 이는 [시맨틱 버전](https://semver.org/)의 용어를 따른 것이다.


### PR DESCRIPTION
한 PR에 너무 많은 변경사항을 포함시키면 리뷰하기 어려울 수 있어서, 적절히 분할하여 올립니다. 😊

- Related issue: #33472 (**dev-1.24-ko.1**)

> ### 24 files to be modified
> * [ ]  M139.  `content/en/examples/admin/logging/two-files-counter-pod-agent-sidecar.yaml`  | 1(+XS) 1(-)
> * [ ]  M140.  `content/en/examples/admin/logging/two-files-counter-pod-streaming-sidecar.yaml`  | 5(+XS) 5(-)
> * [ ]  M141.  `content/en/examples/admin/logging/two-files-counter-pod.yaml`  | 1(+XS) 1(-)
> * [ ]  M142.  `content/en/examples/admin/resource/limit-range-pod-1.yaml`  | 4(+XS) 4(-)
> * [ ]  M143.  `content/en/examples/admin/resource/limit-range-pod-2.yaml`  | 4(+XS) 4(-)
> * [ ]  M144.  `content/en/examples/admin/resource/limit-range-pod-3.yaml`  | 1(+XS) 1(-)
> * [ ]  M145.  `content/en/examples/application/job/cronjob.yaml`  | 1(+XS) 1(-)
> * [ ]  M146.  `content/en/examples/application/job/job-tmpl.yaml`  | 1(+XS) 1(-)
> * [ ]  M147.  `content/en/examples/application/mysql/mysql-configmap.yaml`  | 2(+XS) 0(-)
> * [ ]  M148.  `content/en/examples/application/mysql/mysql-services.yaml`  | 1(+XS) 0(-)
> * [ ]  M149.  `content/en/examples/controllers/daemonset.yaml`  | 5(+XS) 2(-)
> * [ ]  M150.  `content/en/examples/controllers/fluentd-daemonset-update.yaml`  | 6(+XS) 2(-)
> * [ ]  M151.  `content/en/examples/controllers/fluentd-daemonset.yaml`  | 6(+XS) 2(-)
> * [ ]  M152.  `content/en/examples/debug/counter-pod.yaml`  | 1(+XS) 1(-)
> * [ ]  M153.  `content/en/examples/pods/init-containers.yaml`  | 1(+XS) 1(-)
> * [ ]  M154.  `content/en/examples/pods/inject/dependent-envars.yaml`  | 1(+XS) 1(-)
> * [ ]  M155.  `content/en/examples/pods/pod-with-node-affinity.yaml`  | 2(+XS) 3(-)
> * [ ]  M156.  `content/en/examples/pods/resource/memory-request-limit-3.yaml`  | 2(+XS) 2(-)
> * [ ]  M157.  `content/en/examples/pods/resource/memory-request-limit.yaml`  | 2(+XS) 2(-)
> * [ ]  M158.  `content/en/examples/pods/security/hello-apparmor.yaml`  | 1(+XS) 1(-)
> * [ ]  M159.  `content/en/examples/policy/restricted-psp.yaml`  | 1(+XS) 0(-)
> * [ ]  M160.  `content/en/examples/service/networking/hostaliases-pod.yaml`  | 1(+XS) 1(-)
> * [ ]  M161.  `content/en/includes/default-storage-class-prereqs.md`  | 2(+XS) 2(-)
> * [ ]  M162.  `content/en/releases/_index.md`  | 2(+XS) 2(-)

[참고]
변경 사항 중에서 링크 업데이트를 반영하지 않은 부분이 있는데,
이는
- #33781 에서 처리될 예정이거나,
- #33472 의 R1-R9 를 처리하는 PR에서 
  링크도 함께 업데이트 하거나,
- #33472 가 마무리될 쯤에 
  `dev-1.24-ko.1` 의 링크들을 다시 한 번 점검하고 업데이트 하는 것이 좋을 것 같습니다.

/language ko