### PR TITLE
Fix typos in tasks docs

### DIFF
--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -280,7 +280,7 @@ kubectl patch deployment valid-deployment  --type json   -p='[{"op": "remove", "
 # Add a new element to a positional array
 kubectl patch sa default --type='json' -p='[{"op": "add", "path": "/secrets/1", "value": {"name": "whatever" } }]'
 
-# Update a deployment's replicas count by patching it's scale subresource
+# Update a deployment's replica count by patching its scale subresource
 kubectl patch deployment nginx-deployment --subresource='scale' --type='merge' -p '{"spec":{"replicas":2}}'
 ```
 

--- a/content/en/docs/tasks/debug/debug-cluster/local-debugging.md
+++ b/content/en/docs/tasks/debug/debug-cluster/local-debugging.md
@@ -24,7 +24,7 @@ This document describes using `telepresence` to develop and debug services runni
 
 ## Connecting your local machine to a remote Kubernetes cluster
  
-After installing `telepresence`, run `telepresence connect` to launch it's Daemon and connect your local workstation to the cluster.
+After installing `telepresence`, run `telepresence connect` to launch its Daemon and connect your local workstation to the cluster.
 
 ```
 $ telepresence connect

--- a/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning.md
+++ b/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning.md
@@ -444,7 +444,7 @@ spec:
     served: true
     # One and only one version must be marked as the storage version.
     storage: true
-    # Each version can define it's own schema when there is no top-level
+    # Each version can define its own schema when there is no top-level
     # schema is defined.
     schema:
       openAPIV3Schema:
@@ -512,7 +512,7 @@ spec:
     served: true
     # One and only one version must be marked as the storage version.
     storage: true
-    # Each version can define it's own schema when there is no top-level
+    # Each version can define its own schema when there is no top-level
     # schema is defined.
     schema:
       openAPIV3Schema:

--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -400,7 +400,7 @@ scaling in that direction.
 ### Stabilization window
 
 The stabilization window is used to restrict the [flapping](#flapping) of
-replicas count when the metrics used for scaling keep fluctuating. The autoscaling algorithm
+replica count when the metrics used for scaling keep fluctuating. The autoscaling algorithm
 uses this window to infer a previous desired state and avoid unwanted changes to workload
 scale.
 


### PR DESCRIPTION
Fix misc typos in `tasks` docs.