### PR TITLE
Remove google_news template from layout

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -31,7 +31,6 @@
 {{ partialCached "favicons.html" . }}
 <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
 {{- template "_internal/opengraph.html" . -}}
-{{- template "_internal/google_news.html" . -}}
 {{- template "_internal/schema.html" . -}}
 {{- template "_internal/twitter_cards.html" . -}}
 {{- if hugo.IsProduction -}}


### PR DESCRIPTION
It cause local Hugo build warning

```
WARN 2022/05/31 22:40:00 The google_news internal template will be removed in a future release.
Please remove calls to this template.
See https://github.com/gohugoio/hugo/issues/9172 for additional information.
```

It's recommended to remove the deprecated `news_keywords` metadata.
- https://github.com/gohugoio/hugo/issues/9172