### PR TITLE
rename fejta-bot to k8s-ci-robot on pr-wranglers page

### DIFF
--- a/content/en/docs/contribute/participate/pr-wranglers.md
+++ b/content/en/docs/contribute/participate/pr-wranglers.md
@@ -84,7 +84,7 @@ To close a pull request, leave a `/close` comment on the PR.
 
 {{< note >}}
 
-The [`fejta-bot`](https://github.com/fejta-bot) bot marks issues as stale after 90 days of inactivity. After 30 more days it marks issues as rotten and closes them.  PR wranglers should close issues after 14-30 days of inactivity.
+The [`k8s-triage-robot`](https://github.com/k8s-triage-robot) bot marks issues as stale after 90 days of inactivity. After 30 more days it marks issues as rotten and closes them.  PR wranglers should close issues after 14-30 days of inactivity.
 
 {{< /note >}}
 


### PR DESCRIPTION
## Description 

The **Note** on the [PR Wranglers - When to Close PRs](https://kubernetes.io/docs/contribute/participate/pr-wranglers/#when-to-close-pull-requests) page mentions that `fejta-bot` adds the `lifecycle/stale` label to PRs, but as I understand it, that functionality was moved to `k8s-ci-robot`a while back

based on PRs with said label, this appears to be the case. 


<img width="507" alt="Screen Shot 2022-05-31 at 10 25 32 AM" src="https://user-images.githubusercontent.com/5605413/171235883-41afe931-23bd-4402-b6fd-c595fe92eea7.png">

Breaking into Multiple PRs
This PR - en
https://github.com/kubernetes/website/pull/34084 - de
https://github.com/kubernetes/website/pull/34085 - ko
https://github.com/kubernetes/website/pull/34086 - zh
https://github.com/kubernetes/website/pull/34087 - ru
