### PR TITLE
Removing /docs/setup/production-environment/windows/ 

### DIFF
--- a/content/en/docs/setup/production-environment/windows/_index.md
+++ b/content/en/docs/setup/production-environment/windows/_index.md
@@ -1,4 +1,0 @@
----
-title: "Windows in Kubernetes"
-weight: 50
----

--- a/static/_redirects
+++ b/static/_redirects
@@ -566,6 +566,7 @@
 /docs/setup/production-environment/windows/user-guide-windows-nodes/     /docs/tasks/administer-cluster/kubeadm/adding-windows-nodes/   301
 /docs/setup/windows/user-guide-windows-containers/     /docs/setup/production-environment/windows/user-guide-windows-containers/   301
 /docs/setup/production-environment/windows/intro-windows-in-kubernetes/     /docs/concepts/windows/intro/   301
+/docs/setup/production-environment/windows/     /docs/concepts/windows/   301
 /docs/setup/multiple-zones/     /docs/setup/best-practices/multiple-zones/   301
 /docs/setup/cluster-large/     /docs/setup/best-practices/cluster-large/   301
 /docs/setup/node-conformance/     /docs/setup/best-practices/node-conformance/   301


### PR DESCRIPTION
since all content has been moved to other sections

Signed-off-by: Mark Rossetti <marosset@microsoft.com>

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
Part of https://github.com/kubernetes/website/issues/31428

https://github.com/kubernetes/website/pull/33582 moved all of the content under /docs/setup/production-environment/windows/ to various other sections but forgot to remove the index file