### PR TITLE
Callout that impersonation needs (ClusterRole)Binding

### DIFF
--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -856,6 +856,10 @@ rules:
   resourceNames: ["06f6ce97-e2c5-4ab8-7ba5-7654dd08d52b"]
 ```
 
+{{< note >}}
+Note that impersonation is not namespace scoped - i.e. it requires a `ClusterRole` and `ClusterRoleBinding`, and does not function with `Role` and `RoleBinding`.
+{{< /note >}}
+
 ## client-go credential plugins
 
 {{< feature-state for_k8s_version="v1.22" state="stable" >}}


### PR DESCRIPTION
I learned through trial and error that impersonation does not work with `Role` and `RoleBinding` - this was not obvious. It would be good if the docs call this out.