### PR TITLE
 rename fejta-bot to k8s-ci-robot on pr-wranglers page DE

### DIFF
--- a/content/de/docs/contribute/participate/pr-wranglers.md
+++ b/content/de/docs/contribute/participate/pr-wranglers.md
@@ -76,6 +76,6 @@ Um eine Pull-Anfrage zu schließen, hinterlasse einen `/close`-Kommentar zu dem 
 
 {{< note >}}
 
-Der [`fejta-bot`](https://github.com/fejta-bot) Bot markiert Themen nach 90 Tagen Inaktivität als veraltet. Nach weiteren 30 Tagen markiert er Issues als faul und schließt sie.  PR-Beauftragte sollten Themen nach 14-30 Tagen Inaktivität schließen.
+Der [`k8s-ci-robot`](https://github.com/k8s-ci-robot) Bot markiert Themen nach 90 Tagen Inaktivität als veraltet. Nach weiteren 30 Tagen markiert er Issues als faul und schließt sie.  PR-Beauftragte sollten Themen nach 14-30 Tagen Inaktivität schließen.
 
 {{< /note >}}


### PR DESCRIPTION
## Description 

The **Note** on the [PR Wranglers - When to Close PRs](https://kubernetes.io/docs/contribute/participate/pr-wranglers/#when-to-close-pull-requests) page mentions that `fejta-bot` adds the `lifecycle/stale` label to PRs, but as I understand it, that functionality was moved to `k8s-ci-robot`a while back

based on PRs with said label, this appears to be the case. 


<img width="507" alt="Screen Shot 2022-05-31 at 10 25 32 AM" src="https://user-images.githubusercontent.com/5605413/171235883-41afe931-23bd-4402-b6fd-c595fe92eea7.png">


Breaking https://github.com/kubernetes/website/pull/34077 (English) into multiple PRs 
