### PR TITLE
 rename fejta-bot to k8s-ci-robot on pr-wranglers page ko

### DIFF
--- a/content/ko/docs/contribute/participate/pr-wranglers.md
+++ b/content/ko/docs/contribute/participate/pr-wranglers.md
@@ -85,6 +85,6 @@ PR 랭글러는 일주일 간 매일 다음의 일을 해야 한다.
 
 {{< note >}}
 
-[`fejta-bot`](https://github.com/fejta-bot)이라는 봇은 90일 동안 활동이 없으면 이슈를 오래된 것(stale)으로 표시한다. 30일이 더 지나면 rotten으로 표시하고 종료한다. PR 랭글러는 14-30일 동안 활동이 없으면 이슈를 닫아야 한다.
+[`k8s-triage-robot`](https://github.com/k8s-triage-robot)이라는 봇은 90일 동안 활동이 없으면 이슈를 오래된 것(stale)으로 표시한다. 30일이 더 지나면 rotten으로 표시하고 종료한다. PR 랭글러는 14-30일 동안 활동이 없으면 이슈를 닫아야 한다.
 
 {{< /note >}}


### PR DESCRIPTION
## Description 

The **Note** on the [PR Wranglers - When to Close PRs](https://kubernetes.io/docs/contribute/participate/pr-wranglers/#when-to-close-pull-requests) page mentions that `fejta-bot` adds the `lifecycle/stale` label to PRs, but as I understand it, that functionality was moved to `k8s-ci-robot`a while back

based on PRs with said label, this appears to be the case. 


<img width="507" alt="Screen Shot 2022-05-31 at 10 25 32 AM" src="https://user-images.githubusercontent.com/5605413/171235883-41afe931-23bd-4402-b6fd-c595fe92eea7.png">


https://github.com/kubernetes/website/pull/34077 - en
https://github.com/kubernetes/website/pull/34084 - de
this PR - ko
https://github.com/kubernetes/website/pull/34086 - zh
https://github.com/kubernetes/website/pull/34087 - ru
