### PR TITLE
[zh] rename fejta-bot to k8s-ci-robot on pr-wranglers page

### DIFF
--- a/content/zh/docs/contribute/participate/pr-wranglers.md
+++ b/content/zh/docs/contribute/participate/pr-wranglers.md
@@ -179,10 +179,10 @@ To close a pull request, leave a `/close` comment on the PR.
 要关闭 PR，请在 PR 上输入 `/close` 评论。
 
 <!--
-The [`fejta-bot`](https://github.com/fejta-bot) bot marks issues as stale after 90 days of inactivity. After 30 more days it marks issues as rotten and closes them.  PR wranglers should close issues after 14-30 days of inactivity.
+The [`k8s-ci-robot`](https://github.com/k8s-ci-robot) bot marks issues as stale after 90 days of inactivity. After 30 more days it marks issues as rotten and closes them.  PR wranglers should close issues after 14-30 days of inactivity.
 -->
 {{< note >}}
-一个名为 [`fejta-bot`](https://github.com/fejta-bot) 的自动服务会在 Issue 停滞 90
+一个名为 [`k8s-ci-robot`](https://github.com/k8s-ci-robot) 的自动服务会在 Issue 停滞 90
 天后自动将其标记为过期；然后再等 30 天，如果仍然无人过问，则将其关闭。
 PR 管理者应该在 issues 处于无人过问状态 14-30 天后关闭它们。
 {{< /note >}}


### PR DESCRIPTION
  ## Description 
  
  The **Note** on the [PR Wranglers - When to Close PRs](https://kubernetes.io/docs/contribute/participate/pr-wranglers/#when-to-close-pull-requests) page mentions that `fejta-bot` adds the `lifecycle/stale` label to PRs, but as I understand it, that functionality was moved to `k8s-ci-robot`a while back
  
  based on PRs with said label, this appears to be the case. 
  
  
  <img width="507" alt="Screen Shot 2022-05-31 at 10 25 32 AM" src="https://user-images.githubusercontent.com/5605413/171235883-41afe931-23bd-4402-b6fd-c595fe92eea7.png">
  
Breaking into Multiple PRs
https://github.com/kubernetes/website/pull/34077 - en
https://github.com/kubernetes/website/pull/34084 - de
https://github.com/kubernetes/website/pull/34085 - ko
this pr - zh
https://github.com/kubernetes/website/pull/34087 - ru
