### PR TITLE
update link to metrics-server design doc

### DIFF
--- a/content/en/docs/tasks/debug/debug-cluster/resource-metrics-pipeline.md
+++ b/content/en/docs/tasks/debug/debug-cluster/resource-metrics-pipeline.md
@@ -237,7 +237,7 @@ To learn more about the metrics-server, see the
 
 You can also check out the following:
 
-* [metrics-server design](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/instrumentation/metrics-server.md)
+* [metrics-server design](https://github.com/kubernetes/design-proposals-archive/blob/main/instrumentation/metrics-server.md)
 * [metrics-server FAQ](https://github.com/kubernetes-sigs/metrics-server/blob/master/FAQ.md)
 * [metrics-server known issues](https://github.com/kubernetes-sigs/metrics-server/blob/master/KNOWN_ISSUES.md)
 * [metrics-server releases](https://github.com/kubernetes-sigs/metrics-server/releases)


### PR DESCRIPTION
Update to follow link to new archive location of metrics-server design doc.

