### PR TITLE
Clarify that RBAC auto-reconciliation can only add permissions/subjects, not remove

### DIFF
--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -582,6 +582,7 @@ Modifications to these resources can result in non-functional clusters.
 
 At each start-up, the API server updates default cluster roles with any missing permissions,
 and updates default cluster role bindings with any missing subjects.
+It does not remove any extra permissions or subjects, it only adds back missing ones.
 This allows the cluster to repair accidental modifications, and helps to keep roles and role bindings
 up-to-date as permissions and subjects change in new Kubernetes releases.
 
@@ -602,7 +603,7 @@ kubectl get clusterroles system:discovery -o yaml
 ```
 
 {{< note >}}
-If you edit that ClusterRole, your changes will be overwritten on API server restart
+If you edit that ClusterRole, your changes may be overwritten on API server restart
 via [auto-reconciliation](#auto-reconciliation). To avoid that overwriting,
 either do not manually edit the role, or disable auto-reconciliation.
 {{< /note >}}


### PR DESCRIPTION
I (and a colleague) found this section a little misleading because we read it to mean that ALL modifications will get undone/overwritten by the auto-reconciliation hook. However, only deletions of default permissions/subjects will get undone/overwritten by auto-reconciliation. Additions to the default permissions/subjects, i.e. `extra` permissions/subjects will be left alone. 

Specific example: I have some old clusters I have upgraded from 1.13 to 1.22. In 1.14, the system:unauthenticated subject was removed from the system:discovery ClusterRoleBinding. So as of 1.14 the system:unauthenticated subject is considered an extra subject and is left alone by auto-reconciliation. This surprised me since from reading this section I thought that auto-reconciliation should remove the extra subject. But auto-reconciliation can only add missing subjects, it does/can not remove extra subjects, and it is my responsibility to remove the extra subject: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.14.md#no-really-you-must-read-this-before-you-upgrade

REF:
RemoveExtraPermissions and RemoveExtraSubjects are left as `false` for ClusterRoles/ClusterRoleBindings/Role/RoleBindings auto-reconciliation

RemoveExtraPermissions
https://github.com/kubernetes/kubernetes/blob/edac6fce2ad4a1366a73afc8ac9ca50b2fbf7fc7/staging/src/k8s.io/component-helpers/auth/rbac/reconciliation/reconcile_role.go#L67

RemoveExtraSubjects
https://github.com/kubernetes/kubernetes/blob/edac6fce2ad4a1366a73afc8ac9ca50b2fbf7fc7/staging/src/k8s.io/component-helpers/auth/rbac/reconciliation/reconcile_rolebindings.go#L58

ClusterRoles
https://github.com/kubernetes/kubernetes/blob/edac6fce2ad4a1366a73afc8ac9ca50b2fbf7fc7/pkg/registry/rbac/rest/storage_rbac.go#L210

ClusterRoleBindings
https://github.com/kubernetes/kubernetes/blob/edac6fce2ad4a1366a73afc8ac9ca50b2fbf7fc7/pkg/registry/rbac/rest/storage_rbac.go#L240

Roles
https://github.com/kubernetes/kubernetes/blob/edac6fce2ad4a1366a73afc8ac9ca50b2fbf7fc7/pkg/registry/rbac/rest/storage_rbac.go#L273

RoleBindings
https://github.com/kubernetes/kubernetes/blob/edac6fce2ad4a1366a73afc8ac9ca50b2fbf7fc7/pkg/registry/rbac/rest/storage_rbac.go#L305
