### PR TITLE
[ja]fix typo in k8s.io/ja/docs/reference/access-authn-authz/rbac/ #31220

### DIFF
--- a/content/ja/docs/reference/access-authn-authz/rbac.md
+++ b/content/ja/docs/reference/access-authn-authz/rbac.md
@@ -29,7 +29,7 @@ RBAC APIは4種類のKubernetesオブジェクト(_Role_、 _ClusterRole_、  _R
 
 ### RoleとClusterRole
 
-RBACの _Role_ または _ClusterRole_ には、一連の権限を表すルールが含まれて言います。
+RBACの _Role_ または _ClusterRole_ には、一連の権限を表すルールが含まれています。
 権限は完全な追加方式です(「deny」のルールはありません)。
 
 Roleは常に特定の{{< glossary_tooltip text="namespace" term_id="namespace" >}}で権限を設定します。


### PR DESCRIPTION
- fix typo
  - related to [Improvement for k8s.io/ja/docs/reference/access-authn-authz/rbac/ #31220](https://github.com/kubernetes/website/issues/31220)