### PR TITLE
fix perl command in job example

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -297,7 +297,7 @@ spec:
       containers:
       - name: pi
         image: perl
-        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(800)"]
       restartPolicy: Never
 ```
 
@@ -343,7 +343,7 @@ spec:
       containers:
       - name: pi
         image: perl
-        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(800)"]
       restartPolicy: Never
 ```
 

--- a/content/en/docs/tasks/configure-pod-container/translate-compose-kubernetes.md
+++ b/content/en/docs/tasks/configure-pod-container/translate-compose-kubernetes.md
@@ -469,7 +469,7 @@ version: '2'
 services:
   pival:
     image: perl
-    command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+    command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(800)"]
     restart: "on-failure"
 ```
 

--- a/content/en/examples/controllers/job.yaml
+++ b/content/en/examples/controllers/job.yaml
@@ -8,7 +8,7 @@ spec:
       containers:
       - name: pi
         image: perl
-        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(800)"]
       restartPolicy: Never
   backoffLimit: 4
 


### PR DESCRIPTION
<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

fix: #34073

Maybe the latest version of perl deletes something, if the calculation is less, it will not report an error.
According to my test, in perl 5.34, the original command is available. In perl 5.36, unable to calculate two thousand decimal places.


