### PR TITLE
Avoid recommending a local container image build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ container-push: container-image ## Push container image for the preview of the w
 container-build: module-check
 	$(CONTAINER_RUN) --read-only --mount type=tmpfs,destination=/tmp,tmpfs-mode=01777 $(CONTAINER_IMAGE) sh -c "npm ci && hugo --minify --environment development"
 
-container-serve: module-check ## Boot the development server using container. Run `make container-image` before this.
+container-serve: module-check ## Boot the development server using container.
 	$(CONTAINER_RUN) --cap-drop=ALL --cap-add=AUDIT_WRITE --read-only --mount type=tmpfs,destination=/tmp,tmpfs-mode=01777 -p 1313:1313 $(CONTAINER_IMAGE) hugo server --buildFuture --environment development --bind 0.0.0.0 --destination /tmp/hugo --cleanDestinationDir
 
 test-examples:

--- a/README.md
+++ b/README.md
@@ -36,10 +36,9 @@ git submodule update --init --recursive --depth 1
 
 ## Running the website using a container
 
-To build the site in a container, run the following to build the container image and run it:
+To build the site in a container, run the following:
 
 ```bash
-make container-image
 make container-serve
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ git submodule update --init --recursive --depth 1
 To build the site in a container, run the following:
 
 ```bash
+# You can set $CONTAINER_ENGINE to the name of any Docker-like container tool
 make container-serve
 ```
 

--- a/content/en/docs/contribute/new-content/open-a-pr.md
+++ b/content/en/docs/contribute/new-content/open-a-pr.md
@@ -291,34 +291,24 @@ You can either build the website's container image or run Hugo locally. Building
 The commands below use Docker as default container engine. Set the `CONTAINER_ENGINE` environment variable to override this behaviour.
 {{< /note >}}
 
-1.  Build the image locally:
+1. Build the container image locally  
+   _You only need this step if you are testing a change to the Hugo tool itself_
+   ```bash
+   # Run this in a terminal (if required)
+   make container-image
+   ```
 
-      ```bash
-      # Use docker (default)
-      make container-image
+1. Start Hugo in a container:
 
-      ### OR ###
+   ```bash
+   # Run this in a terminal
+   make container-serve
+   ```
 
-      # Use podman
-      CONTAINER_ENGINE=podman make container-image
-      ```
-
-2. After building the `kubernetes-hugo` image locally, build and serve the site:
-
-      ```bash
-      # Use docker (default)
-      make container-serve
-
-      ### OR ###
-
-      # Use podman
-      CONTAINER_ENGINE=podman make container-serve
-      ```
-
-3.  In a web browser, navigate to `https://localhost:1313`. Hugo watches the
+1.  In a web browser, navigate to `https://localhost:1313`. Hugo watches the
     changes and rebuilds the site as needed.
 
-4.  To stop the local Hugo instance, go back to the terminal and type `Ctrl+C`,
+1.  To stop the local Hugo instance, go back to the terminal and type `Ctrl+C`,
     or close the terminal window.
 
 {{% /tab %}}


### PR DESCRIPTION
Most of the time, you can pull the image from the internet (since https://github.com/kubernetes/website/issues/33395 was fixed).

Update the advice to developers accordingly. 
- [preview](https://deploy-preview-34112--kubernetes-io-main-staging.netlify.app/docs/contribute/new-content/open-a-pr/)
- [preview](https://github.com/kubernetes/website/blob/a531bcc933fe50fbf1d91f71eedfd9f19d98a01c/README.md#readme)