### PR TITLE
[zh] resync windows pages: intro.md and windows-resource-management.md

### DIFF
--- a/content/zh/docs/concepts/configuration/windows-resource-management.md
+++ b/content/zh/docs/concepts/configuration/windows-resource-management.md
@@ -46,90 +46,89 @@ Linux cgroup API 可用于收集 CPU、I/O 和内存使用统计数据。
 容器不能使用来自主机的标识，因为安全帐户管理器（Security Account Manager，SAM）是独立的。
 
 <!--
-## Memory reservations {#resource-management-memory}
+## Memory management {#resource-management-memory}
 
 Windows does not have an out-of-memory process killer as Linux does. Windows always
 treats all user-mode memory allocations as virtual, and pagefiles are mandatory.
 
-Windows nodes do not overcommit memory for processes running in containers. The
+Windows nodes do not overcommit memory for processes. The
 net effect is that Windows won't reach out of memory conditions the same way Linux
 does, and processes page to disk instead of being subject to out of memory (OOM)
 termination. If memory is over-provisioned and all physical memory is exhausted,
 then paging can slow down performance.
 -->
-## 内存预留 {#resource-management-memory}
+## 内存管理 {#resource-management-memory}
 
 Windows 不像 Linux 一样提供杀手（killer）机制，杀死内存不足的进程。
 Windows 始终将所有用户态内存分配视为虚拟内存，并强制使用页面文件（pagefile）。
 
-Windows 节点不会为容器中运行的进程过量使用内存。
+Windows 节点不会为进程过量使用内存。
 最终结果是 Windows 不会像 Linux 那样达到内存不足的情况，Windows 将进程页面放到磁盘，
 不会因为内存不足（OOM）而终止进程。
 如果内存配置过量且所有物理内存都已耗尽，则换页性能就会降低。
-
 <!--
-You can place bounds on memory use for workloads using the kubelet
-parameters `--kubelet-reserve` and/or `--system-reserve`; these account
-for memory usage on the node (outside of containers), and reduce
-[NodeAllocatable](/docs/tasks/administer-cluster/reserve-compute-resources/#node-allocatable).
-As you deploy workloads, set resource limits on containers. This also subtracts from `NodeAllocatable` and prevents the scheduler from adding more pods once a node is full.
--->
-你可以使用 kubelet 的 `--kubelet-reserve` 和/或 `--system-reserve`
-参数设定工作负载的内存使用边界；这些参数负责表示节点上（容器外）的内存用量，并会减少
-[节点可分配（NodeAllocatable）](/zh/docs/tasks/administer-cluster/reserve-compute-resources/#node-allocatable)内存量。
-在你部署工作负载时，会对容器设置资源限制值。
-这个限制值也会从 `NodeAllocatable` 中减去，并防止调度器在节点已满时增加更多 Pod。
+## CPU management {#resource-management-cpu}
 
-<!--
-When you set memory resource limits for Windows containers, you should either set a limit and leave the memory request unspecified, or set the request equal to the limit.
+Windows can limit the amount of CPU time allocated for different processes but cannot
+guarantee a minimum amount of CPU time.
 
-On Windows, good practice to avoid over-provisioning is to configure the kubelet
-with a system reserved memory of at least 2GiB to account for Windows, Kubernetes
-and container runtime overheads.
--->
-{{< note >}} 
-当你为 Windows 容器设置内存资源限制时，你应设置一个内存限制但不指定内存请求，
-或将请求值设为等于限制值。
-{{< /note >}}
-
-在 Windows 上，避免过量配置的良好做法是为 kubelet 配置至少 2GiB 的系统预留内存，
-以满足 Windows、Kubernetes 和容器运行时开销。
-
-<!--
-## CPU reservations {#resource-management-cpu}
-
-To account for CPU use by the operating system, the container runtime, and by
-Kubernetes host processes such as the kubelet, you can (and should) reserve a
-percentage of total CPU. You should determine this CPU reservation taking account of to the number of CPU cores available on the node. To decide on the CPU percentage to reserve, identify the maximum pod density for each node and monitor the CPU usage of the system services running there, then choose a value that meets your workload needs.
--->
-## CPU 预留 {#resource-management-cpu}
-
-为了满足操作系统、容器运行时和 kubelet 等 Kubernetes 主机进程的 CPU 使用量，
-你可以（且应该）从 CPU 总量中预留一定百分比。
-你应该根据节点上可用的 CPU 核数来确定这个 CPU 预留量。
-要决定预留的 CPU 百分比，需确定每个节点的最大 Pod 密度，
-并监控节点上运行的系统服务的 CPU 使用量，然后选择一个满足工作负载需求的值。
-
-<!--
-You can place bounds on CPU usage for workloads using the
-kubelet parameters `--kubelet-reserve` and/or `--system-reserve` to
-account for CPU usage on the node (outside of containers).
-This reduces `NodeAllocatable`.
-The cluster-wide scheduler then takes this reservation into account when determining pod placement.
-
-On Windows, the kubelet supports a command-line flag to set the priority of the
-kubelet process: `--windows-priorityclass`. This flag allows the kubelet process to get more CPU time slices when compared to other processes running on the Windows host.
+On Windows, the kubelet supports a command-line flag to set the
+[scheduling priority](https://docs.microsoft.com/windows/win32/procthread/scheduling-priorities) of the
+kubelet process: `--windows-priorityclass`. This flag allows the kubelet process to get
+more CPU time slices when compared to other processes running on the Windows host.
 More information on the allowable values and their meaning is available at
 [Windows Priority Classes](https://docs.microsoft.com/en-us/windows/win32/procthread/scheduling-priorities#priority-class).
 To ensure that running Pods do not starve the kubelet of CPU cycles, set this flag to `ABOVE_NORMAL_PRIORITY_CLASS` or above.
 -->
-你可以使用 kubelet 的 `--kubelet-reserve` 和/或 `--system-reserve`
-参数设定工作负载的 CPU 使用边界，以统计节点上（容器外）的 CPU 使用量。
-这会减少 `NodeAllocatable`。
-然后集群范围的调度器在决定放置 Pod 时会考虑这个预留量。
+## CPU 管理 {#resource-management-cpu}
 
-在 Windows 上，kubelet 支持使用命令行标志来设置 kubelet 进程的优先级：`--windows-priorityclass`。
+Windows 可以限制为不同进程分配的 CPU 时间长度，但无法保证最小的 CPU 时间长度。
+
+在 Windows 上，kubelet 支持使用命令行标志来设置 kubelet 进程的[调度优先级](https://docs.microsoft.com/zh-cn/windows/win32/procthread/scheduling-priorities)：
+`--windows-priorityclass`。
 与 Windows 主机上运行的其他进程相比，此标志允许 kubelet 进程获取更多的 CPU 时间片。
 有关允许值及其含义的更多信息，请访问 [Windows 优先级类](https://docs.microsoft.com/zh-cn/windows/win32/procthread/scheduling-priorities#priority-class)。
 为了确保运行的 Pod 不会耗尽 kubelet 的 CPU 时钟周期，
 要将此标志设置为 `ABOVE_NORMAL_PRIORITY_CLASS` 或更高。
+
+<!--
+## Resource reservation {#resource-reservation}
+
+To account for memory and CPU used by the operating system, the container runtime, and by
+Kubernetes host processes such as the kubelet, you can (and should) reserve
+memory and CPU resources with the  `--kube-reserved` and/or `--system-reserved` kubelet flags.
+On Windows these values are only used to calculate the node's
+[allocatable](/docs/tasks/administer-cluster/reserve-compute-resources/#node-allocatable) resources.
+-->
+## 资源预留 {#resource-reservation}
+
+为了满足操作系统、容器运行时和 kubelet 等 Kubernetes 主机进程使用的内存和 CPU，
+你可以（且应该）用 `--kube-reserved` 和/或 `--system-reserved` kubelet 标志来预留内存和 CPU 资源。
+在 Windows 上，这些值仅用于计算节点的[可分配](/zh/docs/tasks/administer-cluster/reserve-compute-resources/#node-allocatable)资源。
+
+<!--
+As you deploy workloads, set resource memory and CPU limits on containers.
+This also subtracts from `NodeAllocatable` and helps the cluster-wide scheduler in determining which pods to place on which nodes.
+
+Scheduling pods without limits may over-provision the Windows nodes and in extreme
+cases can cause the nodes to become unhealthy.
+-->
+{{< caution >}}
+在你部署工作负载时，需对容器设置内存和 CPU 资源的限制。
+这也会从 `NodeAllocatable` 中减去，帮助集群范围的调度器决定哪些 Pod 放到哪些节点上。
+
+若调度 Pod 时未设置限制值，可能对 Windows 节点过量配置资源。
+在极端情况下，这会让节点变得不健康。
+{{< /caution >}}
+
+<!--
+On Windows, a good practice is to reserve at least 2GiB of memory.
+
+To determine how much CPU to reserve,
+identify the maximum pod density for each node and monitor the CPU usage of
+the system services running there, then choose a value that meets your workload needs.
+-->
+在 Windows 上，一种好的做法是预留至少 2GiB 的内存。
+
+要决定预留多少 CPU，需明确每个节点的最大 Pod 密度，
+并监控节点上运行的系统服务的 CPU 使用率，然后选择一个满足工作负载需求的值。

--- a/content/zh/docs/concepts/windows/intro.md
+++ b/content/zh/docs/concepts/windows/intro.md
@@ -81,7 +81,8 @@ Some node features are only available if you use a specific
 including:
 
 * HugePages: not supported for Windows containers
-* Privileged containers: not supported for Windows containers
+* Privileged containers: not supported for Windows containers.
+  [HostProcess Containers](/docs/tasks/configure-pod-container/create-hostprocess-pod/) offer similar functionality.
 * TerminationGracePeriod: requires containerD
 -->
 ## 兼容性与局限性 {#limitations}
@@ -89,9 +90,10 @@ including:
 某些节点层面的功能特性仅在使用特定[容器运行时](#container-runtime)时才可用；
 另外一些特性则在 Windows 节点上不可用，包括：
 
-* 巨页（HugePages）：Windows 容器当前不支持
-* 特权容器：Windows 容器当前不支持
-* TerminationGracePeriod：需要 containerD
+* 巨页（HugePages）：Windows 容器当前不支持。
+* 特权容器：Windows 容器当前不支持。
+  [HostProcess 容器](/zh/docs/tasks/configure-pod-container/create-hostprocess-pod/)提供类似功能。
+* TerminationGracePeriod：需要 containerD。
 
 <!--
 Not all features of shared namespaces are supported. See [API compatibility](#api)
@@ -133,7 +135,7 @@ Kubernetes 关键组件在 Windows 上的工作方式与在 Linux 上相同。
   Pod capabilities, properties and events are supported with Windows containers:
   * Single or multiple containers per Pod with process isolation and volume sharing
   * Pod `status` fields
-  * Readiness and Liveness probes
+  * Readiness, liveness, and startup probes
   * postStart & preStop container lifecycle hooks
   * ConfigMap, Secrets: as environment variables or volumes
   * `emptyDir` volumes
@@ -163,7 +165,7 @@ Kubernetes 关键组件在 Windows 上的工作方式与在 Linux 上相同。
   
   * 每个 Pod 有一个或多个容器，具有进程隔离和卷共享能力
   * Pod `status` 字段
-  * Readiness 和 Liveness 探针
+  * 就绪、存活和启动探针
   * postStart 和 preStop 容器生命周期回调
   * ConfigMap 和 Secret：作为环境变量或卷
   * `emptyDir` 卷
@@ -270,10 +272,11 @@ Some kubelet command line options behave differently on Windows, as described be
   [NodeAllocatable](/docs/tasks/administer-cluster/reserve-compute-resources/#node-allocatable)
 * Eviction by using `--enforce-node-allocable` is not implemented
 * Eviction by using `--eviction-hard` and `--eviction-soft` are not implemented
-* A kubelet running on a Windows node does not have memory
-  restrictions. `--kubelet-reserve` and `--system-reserve` do not set limits on
-  kubelet or processes running on the host. This means kubelet or a process on the host
-  could cause memory resource starvation outside the node-allocatable and scheduler.
+* When running on a Windows node the kubelet does not have memory or CPU
+  restrictions. `--kube-reserved` and `--system-reserved` only subtract from `NodeAllocatable`
+  and do not guarantee resource provided for workloads.
+  See [Resource Management for Windows nodes](/docs/concepts/configuration/windows-resource-management/#resource-reservation)
+  for more information.
 * The `MemoryPressure` Condition is not implemented
 * The kubelet does not take OOM eviction actions
 -->
@@ -283,10 +286,9 @@ Some kubelet command line options behave differently on Windows, as described be
   [NodeAllocatable](/zh/docs/tasks/administer-cluster/reserve-compute-resources/#node-allocatable)。
 * 未实现使用 `--enforce-node-allocable` 驱逐。
 * 未实现使用 `--eviction-hard` 和 `--eviction-soft` 驱逐。
-* 在 Windows 节点上运行的 kubelet 没有内存限制。
-  `--kubelet-reserve` 和 `--system-reserve` 没有对主机上运行的 kubelet 或进程设置限制。
-  这意味着 kubelet 或主机上的进程使用的内存可能会超过节点可分配内存和调度器设定的内存，
-  从而造成内存资源不足。
+* 在 Windows 节点上运行时，kubelet 没有内存或 CPU 限制。
+  `--kube-reserved` 和 `--system-reserved` 仅从 `NodeAllocatable` 中减去，并且不保证为工作负载提供的资源。
+  有关更多信息，请参考 [Windows 节点的资源管理](/zh/docs/concepts/configuration/windows-resource-management/#resource-reservation)。
 * 未实现 `MemoryPressure` 条件。
 * kubelet 不会执行 OOM 驱逐操作。
 
@@ -488,15 +490,17 @@ Pod 的所有 [`securityContext`](/docs/reference/kubernetes-api/workload-resour
 字段都无法在 Windows 上生效。
 
 <!--
-### Node problem detector
+## Node problem detector
 
 The node problem detector (see
 [Monitor Node Health](/docs/tasks/debug/debug-cluster/monitor-node-health/))
-is not compatible with Windows.
+has preliminary support for Windows.
+For more information, visit the project's [GitHub page](https://github.com/kubernetes/node-problem-detector#windows).
 -->
-### 节点问题检测器 {#node-problem-detector}
+## 节点问题检测器 {#node-problem-detector}
 
-节点问题检测器（参考[节点健康监测](/zh/docs/tasks/debug/debug-cluster/monitor-node-health/)）与 Windows 不兼容。
+节点问题检测器（参考[节点健康监测](/zh/docs/tasks/debug/debug-cluster/monitor-node-health/)）初步支持 Windows。
+有关更多信息，请访问该项目的 [GitHub 页面](https://github.com/kubernetes/node-problem-detector#windows)。
 
 <!--
 ### Pause container
@@ -562,7 +566,7 @@ The following container runtimes work with Windows:
 {{% thirdparty-content %}}
 
 <!--
-#### cri-containerd
+#### ContainerD
 
 {{< feature-state for_k8s_version="v1.20" state="stable" >}}
 
@@ -571,7 +575,7 @@ as the container runtime for Kubernetes nodes that run Windows.
 
 Learn how to [install ContainerD on a Windows node](/docs/setup/production-environment/container-runtimes/#install-containerd).
 -->
-#### cri-containerd {#cri-containerd}
+#### ContainerD {#containerd}
 
 {{< feature-state for_k8s_version="v1.20" state="stable" >}}
 
@@ -666,7 +670,7 @@ If you have what looks like a bug, or you would like to
 make a feature request, please follow the [SIG Windows contributing guide](https://github.com/kubernetes/community/blob/master/sig-windows/CONTRIBUTING.md#reporting-issues-and-feature-requests) to create a new issue.
 You should first search the list of issues in case it was
 reported previously and comment with your experience on the issue and add additional
-logs. SIG-Windows Slack is also a great avenue to get some initial support and
+logs. SIG Windows channel on the Kubernetes Slack is also a great avenue to get some initial support and
 troubleshooting ideas prior to creating a ticket.
 -->
 ### 报告问题和功能请求 {#report-issue-and-feature-request}
@@ -674,9 +678,10 @@ troubleshooting ideas prior to creating a ticket.
 如果你发现疑似 bug，或者你想提出功能请求，请按照
 [SIG Windows 贡献指南](https://github.com/kubernetes/community/blob/master/sig-windows/CONTRIBUTING.md#reporting-issues-and-feature-requests)
 新建一个 Issue。
-您应该先搜索 issue 列表，以防之前报告过这个问题，凭你对该问题的经验添加评论，
+你应该先搜索 issue 列表，以防之前报告过这个问题，凭你对该问题的经验添加评论，
 并随附日志信息。
-SIG Windows Slack 也是一个很好的途径，让你在创建工单之前获得一些初始支持和故障排查的思路。
+Kubernetes Slack 上的 SIG Windows 频道也是一个很好的途径，
+可以在创建工单之前获得一些初始支持和故障排查思路。
 
 ## {{% heading "whatsnext" %}}
 


### PR DESCRIPTION
By following instructions from @tengqm, resync the Chinese pages after #34083 is merged. Related issue is #34033.

The path is:
```
content/en/docs/concepts/configuration/windows-resource-management.md
content/en/docs/concepts/windows/intro.md
```