### PR TITLE
Update broken links in debug/debug-application/debug-service.md

### DIFF
--- a/content/en/docs/tasks/debug/debug-application/debug-service.md
+++ b/content/en/docs/tasks/debug/debug-application/debug-service.md
@@ -728,13 +728,13 @@ Service is not working.  Please let us know what is going on, so we can help
 investigate!
 
 Contact us on
-[Slack](/docs/tasks/debug/overview/#slack) or
+[Slack](https://slack.k8s.io/) or
 [Forum](https://discuss.kubernetes.io) or
 [GitHub](https://github.com/kubernetes/kubernetes).
 
 ## {{% heading "whatsnext" %}}
 
-Visit the [troubleshooting overview document](/docs/tasks/debug/overview/)
+Visit the [troubleshooting overview document](/docs/tasks/debug/)
 for more information.
 
 


### PR DESCRIPTION
This PR is supposed to fix the broken links in the path `content/en/docs/tasks/debug/debug-application/debug-service.md`

Fixes: https://github.com/kubernetes/website/issues/34174

