### PR TITLE
[zh] Resync links to moved pages

### DIFF
--- a/content/zh/docs/concepts/architecture/control-plane-node-communication.md
+++ b/content/zh/docs/concepts/architecture/control-plane-node-communication.md
@@ -24,7 +24,7 @@ This document catalogs the communication paths between the control plane (apiser
 <!-- body -->
 <!--
 ## Node to Control Plane
-Kubernetes has a "hub-and-spoke" API pattern. All API usage from nodes (or the pods they run) terminate at the apiserver. None of the other control plane components are designed to expose remote services. The apiserver is configured to listen for remote connections on a secure HTTPS port (typically 443) with one or more forms of client [authentication](/docs/reference/access-authn-authz/authentication/) enabled.
+Kubernetes has a "hub-and-spoke" API pattern. All API usage from nodes (or the pods they run) terminates at the apiserver. None of the other control plane components are designed to expose remote services. The apiserver is configured to listen for remote connections on a secure HTTPS port (typically 443) with one or more forms of client [authentication](/docs/reference/access-authn-authz/authentication/) enabled.
 One or more forms of [authorization](/docs/reference/access-authn-authz/authorization/) should be enabled, especially if [anonymous requests](/docs/reference/access-authn-authz/authentication/#anonymous-requests) or [service account tokens](/docs/reference/access-authn-authz/authentication/#service-account-tokens) are allowed.
 -->
 ## 节点到控制面
@@ -39,11 +39,11 @@ API 服务器被配置为在一个安全的 HTTPS 端口（通常为 443）上�
 或[服务账号令牌](/zh/docs/reference/access-authn-authz/authentication/#service-account-tokens)的时候。
 
 <!--
-Nodes should be provisioned with the public root certificate for the cluster such that they can connect securely to the apiserver along with valid client credentials. A good approach is that the client credentials provided to the kubelet are in the form of a client certificate. See [kubelet TLS bootstrapping](/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/) for automated provisioning of kubelet client certificates.
+Nodes should be provisioned with the public root certificate for the cluster such that they can connect securely to the apiserver along with valid client credentials. A good approach is that the client credentials provided to the kubelet are in the form of a client certificate. See [kubelet TLS bootstrapping](/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/) for automated provisioning of kubelet client certificates.
 -->
 应该使用集群的公共根证书开通节点，这样它们就能够基于有效的客户端凭据安全地连接 API 服务器。
 一种好的方法是以客户端证书的形式将客户端凭据提供给 kubelet。
-请查看 [kubelet TLS 启动引导](/zh/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/)
+请查看 [kubelet TLS 启动引导](/zh/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/)
 以了解如何自动提供 kubelet 客户端证书。
 
 <!--
@@ -102,10 +102,10 @@ These connections terminate at the kubelet's HTTPS endpoint. By default, the api
 <!--
 To verify this connection, use the `--kubelet-certificate-authority` flag to provide the apiserver with a root certificate bundle to use to verify the kubelet's serving certificate.
 
-If that is not possible, use [SSH tunneling](/docs/concepts/architecture/master-node-communication/#ssh-tunnels) between the apiserver and kubelet if required to avoid connecting over an
+If that is not possible, use [SSH tunneling](#ssh-tunnels) between the apiserver and kubelet if required to avoid connecting over an
 untrusted or public network.
 
-Finally, [Kubelet authentication and/or authorization](/docs/reference/command-line-tools-reference/kubelet-authentication-authorization/) should be enabled to secure the kubelet API.
+Finally, [Kubelet authentication and/or authorization](/docs/reference/access-authn-authz/kubelet-authn-authz/) should be enabled to secure the kubelet API.
 -->
 为了对这个连接进行认证，使用 `--kubelet-certificate-authority` 标志给 API
 服务器提供一个根证书包，用于 kubelet 的服务证书。
@@ -114,13 +114,13 @@ Finally, [Kubelet authentication and/or authorization](/docs/reference/command-l
 kubelet 之间使用 [SSH 隧道](#ssh-tunnels)。
 
 最后，应该启用
-[kubelet 用户认证和/或鉴权](/zh/docs/reference/command-line-tools-reference/kubelet-authentication-authorization/)
+[kubelet 用户认证和/或鉴权](/zh/docs/reference/access-authn-authz/kubelet-authn-authz/)
 来保护 kubelet API。
 
 <!--
 ### apiserver to nodes, pods, and services
 
-The connections from the apiserver to a node, pod, or service default to plain HTTP connections and are therefore neither authenticated nor encrypted. They can be run over a secure HTTPS connection by prefixing `https:` to the node, pod, or service name in the API URL, but they will not validate the certificate provided by the HTTPS endpoint nor provide client credentials so while the connection will be encrypted, it will not provide any guarantees of integrity. These connections **are not currently safe** to run over untrusted and/or public networks.
+The connections from the apiserver to a node, pod, or service default to plain HTTP connections and are therefore neither authenticated nor encrypted. They can be run over a secure HTTPS connection by prefixing `https:` to the node, pod, or service name in the API URL, but they will not validate the certificate provided by the HTTPS endpoint nor provide client credentials. So while the connection will be encrypted, it will not provide any guarantees of integrity. These connections **are not currently safe** to run over untrusted or public networks.
 -->
 ### API 服务器到节点、Pod 和服务
 
@@ -136,7 +136,7 @@ The connections from the apiserver to a node, pod, or service default to plain H
 Kubernetes supports SSH tunnels to protect the control plane to nodes communication paths. In this configuration, the apiserver initiates an SSH tunnel to each node in the cluster (connecting to the ssh server listening on port 22) and passes all traffic destined for a kubelet, node, pod, or service through the tunnel.
 This tunnel ensures that the traffic is not exposed outside of the network in which the nodes are running.
 
-SSH tunnels are currently deprecated so you shouldn't opt to use them unless you know what you are doing. The Konnectivity service is a replacement for this communication channel.
+SSH tunnels are currently deprecated, so you shouldn't opt to use them unless you know what you are doing. The Konnectivity service is a replacement for this communication channel.
 -->
 ### SSH 隧道 {#ssh-tunnels}
 

--- a/content/zh/docs/concepts/cluster-administration/_index.md
+++ b/content/zh/docs/concepts/cluster-administration/_index.md
@@ -123,14 +123,14 @@ Before choosing a guide, here are some considerations:
 ### Securing the kubelet
 
 * [Master-Node communication](/docs/concepts/architecture/master-node-communication/)
-* [TLS bootstrapping](/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/)
+* [TLS bootstrapping](/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/)
 * [Kubelet authentication/authorization](/docs/admin/kubelet-authentication-authorization/)
 -->
 ### 保护 kubelet   {#securing-the-kubelet}
 
 * [主控节点通信](/zh/docs/concepts/architecture/control-plane-node-communication/)
-* [TLS 引导](/zh/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/)
-* [Kubelet 认证/授权](/zh/docs/reference/command-line-tools-reference/kubelet-authentication-authorization/)
+* [TLS 引导](/zh/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/)
+* [Kubelet 认证/授权](/zh/docs/reference/access-authn-authz/kubelet-authn-authz/)
 
 <!--
 ## Optional Cluster Services

--- a/content/zh/docs/reference/access-authn-authz/bootstrap-tokens.md
+++ b/content/zh/docs/reference/access-authn-authz/bootstrap-tokens.md
@@ -21,14 +21,14 @@ creating new clusters or joining new nodes to an existing cluster.  It was built
 to support [kubeadm](/docs/reference/setup-tools/kubeadm/), but can be used in other contexts
 for users that wish to start clusters without `kubeadm`. It is also built to
 work, via RBAC policy, with the
-[Kubelet TLS Bootstrapping](/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/) system.
+[Kubelet TLS Bootstrapping](/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/) system.
 -->
 启动引导令牌是一种简单的持有者令牌（Bearer Token），这种令牌是在新建集群
 或者在现有集群中添加新节点时使用的。
 它被设计成能够支持 [`kubeadm`](/zh/docs/reference/setup-tools/kubeadm/)，
 但是也可以被用在其他的案例中以便用户在不使用 `kubeadm` 的情况下启动集群。
 它也被设计成可以通过 RBAC 策略，结合
-[Kubelet TLS 启动引导](/zh/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/)
+[Kubelet TLS 启动引导](/zh/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/)
 系统进行工作。
 
 <!-- body -->
@@ -108,12 +108,16 @@ controller on the controller manager.
 
 过期的令牌可以通过启用控制器管理器中的 `tokencleaner` 控制器来删除。
 
+```
+--controllers=*,tokencleaner
+```
+
 <!--
 ## Bootstrap Token Secret Format
 
 Each valid token is backed by a secret in the `kube-system` namespace.  You can
 find the full design doc
-[here](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/cluster-lifecycle/bootstrap-discovery.md).
+[here](https://github.com/kubernetes/design-proposals-archive/blob/main/cluster-lifecycle/bootstrap-discovery.md).
 
 Here is what the secret looks like.
 -->
@@ -121,7 +125,7 @@ Here is what the secret looks like.
 
 每个合法的令牌背后对应着 `kube-system` 名字空间中的某个 Secret 对象。
 你可以从
-[这里](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/cluster-lifecycle/bootstrap-discovery.md)
+[这里](https://github.com/kubernetes/design-proposals-archive/blob/main/cluster-lifecycle/bootstrap-discovery.md)
 找到完整设计文档。
 
 这是 Secret 看起来的样子。
@@ -142,10 +146,11 @@ stringData:
 
   # 令牌 ID 和秘密信息，必需。
   token-id: 07401b
-  token-secret: base64(f395accd246ae52d)
+  token-secret: f395accd246ae52d
 
   # 可选的过期时间字段
-  expiration: "2017-03-10T03:22:11Z"
+  expiration: 2017-03-10T03:22:11Z
+
   # 允许的用法
   usage-bootstrap-authentication: "true"
   usage-bootstrap-signing: "true"
@@ -259,7 +264,7 @@ data:
 ```
 
 <!--
-The `kubeconfig` member of the ConfigMap is a config file with just the cluster
+The `kubeconfig` member of the ConfigMap is a config file with only the cluster
 information filled out.  The key thing being communicated here is the
 `certificate-authority-data`.  This may be expanded in the future.
 -->

--- a/content/zh/docs/reference/access-authn-authz/node.md
+++ b/content/zh/docs/reference/access-authn-authz/node.md
@@ -90,12 +90,12 @@ have the minimal set of permissions required to operate correctly.
 -->
 
 为了获得节点鉴权器的授权，kubelet 必须使用一个凭证以表示它在 `system:nodes` 组中，用户名为 `system:node:<nodeName>`。
-上述的组名和用户名格式要与 [kubelet TLS 启动引导](/zh/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/)过程中为每个 kubelet 创建的标识相匹配。
+上述的组名和用户名格式要与 [kubelet TLS 启动引导](/zh/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/)过程中为每个 kubelet 创建的标识相匹配。
 <!--
 In order to be authorized by the Node authorizer, kubelets must use a credential that identifies them as
 being in the `system:nodes` group, with a username of `system:node:<nodeName>`.
 This group and user name format match the identity created for each kubelet as part of
-[kubelet TLS bootstrapping](/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/).
+[kubelet TLS bootstrapping](/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/).
 -->
 
 要启用节点授权器，请使用 `--authorization-mode = Node` 启动 apiserver。

--- a/content/zh/docs/reference/access-authn-authz/rbac.md
+++ b/content/zh/docs/reference/access-authn-authz/rbac.md
@@ -1550,10 +1550,10 @@ Allows full access to the kubelet API.
 <td>
 <!--
 Allows access to the resources required to perform
-<a href="/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/">Kubelet TLS bootstrapping</a>.
+<a href="/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/">Kubelet TLS bootstrapping</a>.
 -->
 允许访问执行
-<a href="/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/">kubelet TLS 启动引导</a>
+<a href="/zh/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/">kubelet TLS 启动引导</a>
 所需要的资源。
 </td>
 </tr>

--- a/content/zh/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/zh/docs/reference/command-line-tools-reference/feature-gates.md
@@ -1642,19 +1642,19 @@ For more details, check the
   以了解更多细节。
 <!--
 - `RotateKubeletClientCertificate`: Enable the rotation of the client TLS certificate on the kubelet.
-  See [kubelet configuration](/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/#kubelet-configuration) for more details.
+  See [kubelet configuration](/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/#kubelet-configuration) for more details.
 - `RotateKubeletServerCertificate`: Enable the rotation of the server TLS certificate on the kubelet.
-  See [kubelet configuration](/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/#kubelet-configuration)
+  See [kubelet configuration](/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/#kubelet-configuration)
   for more details.
 - `RunAsGroup`: Enable control over the primary group ID set on the init
   processes of containers.
 -->
 - `RotateKubeletClientCertificate`：在 kubelet 上启用客户端 TLS 证书的轮换。
   更多详细信息，请参见
-  [kubelet 配置](/zh/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/#kubelet-configuration)。
+  [kubelet 配置](/zh/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/#kubelet-configuration)。
 - `RotateKubeletServerCertificate`：在 kubelet 上启用服务器 TLS 证书的轮换。
   更多详细信息，请参见
-  [kubelet 配置](/zh/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/#kubelet-configuration)。
+  [kubelet 配置](/zh/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/#kubelet-configuration)。
 - `RunAsGroup`：启用对容器初始化过程中设置的主要组 ID 的控制。
 <!--
 - `RuntimeClass`: Enable the [RuntimeClass](/docs/concepts/containers/runtime-class/) feature

--- a/content/zh/docs/reference/setup-tools/kubeadm/implementation-details.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/implementation-details.md
@@ -494,13 +494,13 @@ API 服务器的静态 Pod 清单会受到用户提供的以下参数的影响:
 <!--  
  - `--insecure-port=0` to avoid insecure connections to the api server
  - `--enable-bootstrap-token-auth=true` to enable the `BootstrapTokenAuthenticator` authentication module.
-   See [TLS Bootstrapping](/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/) for more details
+   See [TLS Bootstrapping](/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/) for more details
  - `--allow-privileged` to `true` (required e.g. by kube proxy)
  - `--requestheader-client-ca-file` to `front-proxy-ca.crt`
 -->
 - `--insecure-port=0` 禁止到 API 服务器不安全的连接
 - `--enable-bootstrap-token-auth=true` 启用 `BootstrapTokenAuthenticator` 身份验证模块。
-  更多细节请参见 [TLS 引导](/zh/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/)。
+  更多细节请参见 [TLS 引导](/zh/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/)。
 - `--allow-privileged` 设为 `true`（诸如 kube-proxy 这些组件有此要求）
 - `--requestheader-client-ca-file` 设为 `front-proxy-ca.crt`
 
@@ -608,7 +608,7 @@ The static Pod manifest for the controller manager is affected by following para
 
 <!--  
  - `--controllers` enabling all the default controllers plus `BootstrapSigner` and `TokenCleaner` controllers for TLS bootstrap.
-   See [TLS Bootstrapping](/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/) for more details
+   See [TLS Bootstrapping](/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/) for more details
  - `--use-service-account-credentials` to `true`
  - Flags for using certificates generated in previous steps:
     - `--root-ca-file` to `ca.crt`
@@ -618,7 +618,7 @@ The static Pod manifest for the controller manager is affected by following para
 -->
 - `--controllers` 为 TLS 引导程序启用所有默认控制器以及 `BootstrapSigner` 和
   `TokenCleaner` 控制器。详细信息请参阅
-  [TLS 引导](/zh/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/)
+  [TLS 引导](/zh/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/)
 - `--use-service-account-credentials` 设为 `true`
 - 使用先前步骤中生成的证书的标志：
 

--- a/content/zh/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/zh/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -102,7 +102,7 @@ following steps:
 <!--
 1. Makes all the necessary configurations for allowing node joining with the
    [Bootstrap Tokens](/docs/reference/access-authn-authz/bootstrap-tokens/) and
-   [TLS Bootstrap](/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/)
+   [TLS Bootstrap](/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/)
    mechanism:
 
    - Write a ConfigMap for making available all the information required
@@ -115,7 +115,7 @@ following steps:
    See [kubeadm join](/docs/reference/setup-tools/kubeadm/kubeadm-join/) for additional info.
 -->
 7. 为了使得节点能够遵照[启动引导令牌](/zh/docs/reference/access-authn-authz/bootstrap-tokens/)
-   和 [TLS 启动引导](/zh/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/)
+   和 [TLS 启动引导](/zh/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/)
    这两份文档中描述的机制加入到集群中，kubeadm 会执行所有的必要配置：
 
    - 创建一个 ConfigMap 提供添加集群节点所需的信息，并为该 ConfigMap 设置相关的 RBAC 访问规则。

--- a/content/zh/docs/setup/best-practices/certificates.md
+++ b/content/zh/docs/setup/best-practices/certificates.md
@@ -37,7 +37,7 @@ Kubernetes 需要 PKI 才能执行以下操作：
 
 <!--
 * Client certificates for the kubelet to authenticate to the API server
-* Kubelet [server certificates](/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/#client-and-serving-certificates)
+* Kubelet [server certificates](/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/#client-and-serving-certificates)
   for the API server to talk to the kubelets
 * Server certificate for the API server endpoint
 * Client certificates for administrators of the cluster to authenticate to the API server
@@ -48,7 +48,7 @@ Kubernetes 需要 PKI 才能执行以下操作：
 * Client and server certificates for the [front-proxy](/docs/tasks/extend-kubernetes/configure-aggregation-layer/)
 -->
 * Kubelet 的客户端证书，用于 API 服务器身份验证
-* Kubelet [服务端证书](/zh/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/#client-and-serving-certificates)，
+* Kubelet [服务端证书](/zh/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/#client-and-serving-certificates)，
   用于 API 服务器与 Kubelet 的会话
 * API 服务器端点的证书
 * 集群管理员的客户端证书，用于 API 服务器身份认证

--- a/content/zh/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
+++ b/content/zh/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
@@ -530,14 +530,14 @@ By default, these serving certificate will expire after one year. Kubeadm sets t
 `KubeletConfiguration` field `rotateCertificates` to `true`, which means that close
 to expiration a new set of CSRs for the serving certificates will be created and must
 be approved to complete the rotation. To understand more see
-[Certificate Rotation](/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/#certificate-rotation).
+[Certificate Rotation](/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/#certificate-rotation).
 -->
 默认情况下，这些服务证书上会在一年后过期。
 kubeadm 将 `KubeletConfiguration` 的 `rotateCertificates` 字段设置为
 `true`；这意味着证书快要过期时，会生成一组针对服务证书的新的 CSR，而
 这些 CSR 也要被批准才能完成证书轮换。
 要进一步了解这里的细节，可参阅
-[证书轮换](/zh/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/#certificate-rotation)
+[证书轮换](/zh/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/#certificate-rotation)
 文档。
 
 <!--

--- a/content/zh/docs/tasks/administer-cluster/securing-a-cluster.md
+++ b/content/zh/docs/tasks/administer-cluster/securing-a-cluster.md
@@ -86,7 +86,9 @@ an integrated [Role-Based Access Control (RBAC)](/docs/reference/access-authn-au
 set of permissions bundled into roles. These permissions combine verbs (get, create, delete) with
 resources (pods, services, nodes) and can be namespace-scoped or cluster-scoped. A set of out-of-the-box
 roles are provided that offer reasonable default separation of responsibility depending on what
-actions a client might want to perform. It is recommended that you use the [Node](/docs/reference/access-authn-authz/node/) and [RBAC](/docs/reference/access-authn-authz/rbac/) authorizers together, in combination with the
+actions a client might want to perform. It is recommended that you use the
+[Node](/docs/reference/access-authn-authz/node/) and
+[RBAC](/docs/reference/access-authn-authz/rbac/) authorizers together, in combination with the
 [NodeRestriction](/docs/reference/access-authn-authz/admission-controllers/#noderestriction) admission plugin.
 -->
 ### API 授权
@@ -137,7 +139,8 @@ Kubelets expose HTTPS endpoints which grant powerful control over the node and c
 
 Production clusters should enable Kubelet authentication and authorization.
 
-Consult the [Kubelet authentication/authorization reference](/docs/admin/kubelet-authentication-authorization) for more information.
+Consult the [Kubelet authentication/authorization reference](/docs/reference/access-authn-authz/kubelet-authn-authz/)
+for more information.
 -->
 ## 控制对 Kubelet 的访问
 
@@ -147,7 +150,7 @@ Kubelet 公开 HTTPS 端点，这些端点提供了对节点和容器的强大�
 生产级别的集群应启用 Kubelet 身份认证和授权。
 
 进一步的信息，请参考
-[Kubelet 身份验证/授权参考](/zh/docs/reference/command-line-tools-reference/kubelet-authentication-authorization/)。
+[Kubelet 身份验证/授权参考](/zh/docs/reference/access-authn-authz/kubelet-authn-authz/)。
 
 <!--
 ## Controlling the capabilities of a workload or user at runtime
@@ -169,7 +172,7 @@ resources granted to a namespace. This is most often used to limit the amount of
 or persistent disk a namespace can allocate, but can also control how many pods, services, or
 volumes exist in each namespace.
 
-[Limit ranges](/docs/tasks/administer-cluster/memory-default-namespace/) restrict the maximum or minimum size of some of the
+[Limit ranges](/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/) restrict the maximum or minimum size of some of the
 resources above, to prevent users from requesting unreasonably high or low values for commonly
 reserved resources like memory, or to provide default limits when none are specified.
 -->
@@ -241,8 +244,8 @@ Quota and limit ranges can also be used to control whether users may request nod
 load-balanced services, which on many clusters can control whether those users applications
 are visible outside of the cluster.
 
-Additional protections may be available that control network rules on a per-plugin or
-per-environment basis, such as per-node firewalls, physically separating cluster nodes to
+Additional protections may be available that control network rules on a per-plugin or per-
+environment basis, such as per-node firewalls, physically separating cluster nodes to
 prevent cross talk, or advanced networking policy.
 -->
 配额（Quota）和限制范围（Limit Range）也可用于控制用户是否可以请求节点端口或负载均衡服务。
@@ -278,8 +281,8 @@ to the metadata API, and avoid using provisioning data to deliver secrets.
 ### Controlling which nodes pods may access
 
 By default, there are no restrictions on which nodes may run a pod.  Kubernetes offers a
-[rich set of policies for controlling placement of pods onto nodes](/docs/concepts/configuration/assign-pod-node/)
-and the [taint-based pod placement and eviction](/docs/concepts/configuration/taint-and-toleration/)
+[rich set of policies for controlling placement of pods onto nodes](/docs/concepts/scheduling-eviction/assign-pod-node/)
+and the [taint-based pod placement and eviction](/docs/concepts/scheduling-eviction/taint-and-toleration/)
 that are available to end users. For many clusters use of these policies to separate workloads
 can be a convention that authors adopt or enforce via tooling.
 
@@ -373,7 +376,8 @@ The shorter the lifetime of a secret or credential the harder it is for an attac
 use of that credential. Set short lifetimes on certificates and automate their rotation. Use
 an authentication provider that can control how long issued tokens are available and use short
 lifetimes where possible. If you use service-account tokens in external integrations, plan to
-rotate those tokens frequently. For example, once the bootstrap phase is complete, a bootstrap token used for setting up nodes should be revoked or its authorization removed.
+rotate those tokens frequently. For example, once the bootstrap phase is complete, a bootstrap
+token used for setting up nodes should be revoked or its authorization removed.
 -->
 ### 经常轮换基础设施证书
 
@@ -460,7 +464,8 @@ Secret 的内容。虽然目前该功能还只是 Beta 阶段，
 ### Receiving alerts for security updates and reporting vulnerabilities
 
 Join the [kubernetes-announce](https://groups.google.com/forum/#!forum/kubernetes-announce)
-group for emails about security announcements. See the [security reporting](/security/)
+group for emails about security announcements. See the
+[security reporting](/docs/reference/issues-security/security/)
 page for more on how to report vulnerabilities.
 -->
 ### 接收安全更新和报告漏洞的警报

--- a/content/zh/docs/tasks/tls/certificate-rotation.md
+++ b/content/zh/docs/tasks/tls/certificate-rotation.md
@@ -41,14 +41,14 @@ Kubelet 使用证书进行 Kubernetes API 的认证。
 
 <!--
 Kubernetes contains [kubelet certificate
-rotation](/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/),
+rotation](/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/),
 that will automatically generate a new key and request a new certificate from
 the Kubernetes API as the current certificate approaches expiration. Once the
 new certificate is available, it will be used for authenticating connections to
 the Kubernetes API.
 -->
 Kubernetes 包含特性
-[kubelet 证书轮换](/zh/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/)，
+[kubelet 证书轮换](/zh/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/)，
 在当前证书即将过期时，
 将自动生成新的秘钥，并从 Kubernetes API 申请新的证书。 一旦新的证书可用，它将被用于与
 Kubernetes API 间的连接认证。


### PR DESCRIPTION
As a follow-up PR for #34196
- #34196

All those file is still in sync (except this link change) reported by `./script/lsync.sh`.

Note that `content/zh/docs/reference/setup-tools/kubeadm/implementation-details.md` is still CRLF format, not changing it for better diff result. (Ref: issue #33898)
- #33898