### PR TITLE
Remove Docker mention from DaemonSet concept

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/daemonset.md
+++ b/content/en/docs/concepts/workloads/controllers/daemonset.md
@@ -203,8 +203,10 @@ running such processes via a DaemonSet:
 - Ability to monitor and manage logs for daemons in the same way as applications.
 - Same config language and tools (e.g. Pod templates, `kubectl`) for daemons and applications.
 - Running daemons in containers with resource limits increases isolation between daemons from app
-  containers.  However, this can also be accomplished by running the daemons in a container but not in a Pod
-  (e.g. start directly via Docker).
+  containers.  However, this can also be accomplished by running the daemons in a container but not in a Pod.
+   {{< warning >}}
+    code samples potentially breaking. Test code samples on a cluster with a different runtime and on a cluster with cri-dockerd and Docker.
+   {{< /warning >}}
 
 ### Bare Pods
 


### PR DESCRIPTION
removed the "(e.g. start directly via Docker)" and added  a warning regarding issue #30965 