### PR TITLE
Fix link for zh-cn i18n file

### DIFF
--- a/i18n/zh-cn.toml
+++ b/i18n/zh-cn.toml
@@ -1,1 +1,1 @@
-../data/i18n/zh/zh.toml
+../data/i18n/zh-cn/zh-cn.toml


### PR DESCRIPTION
The previous PR rendered this `i18n/zh-cn.toml` file a dangling link.
This PR fixes it.

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
