### PR TITLE
[zh]Resync files after zh language renaming(#34221, misc-1)

### DIFF
--- a/content/zh-cn/docs/home/supported-doc-versions.md
+++ b/content/zh-cn/docs/home/supported-doc-versions.md
@@ -7,7 +7,28 @@ card:
   weight: 10
   title: Kubernetes 文档支持的版本
 ---
-
+<!--
+title: Available Documentation Versions
+content_type: custom
+layout: supported-versions
+card:
+  name: about
+  weight: 10
+  title: Available Documentation Versions
+-->
 <!-- overview -->
 
+<!-- 
+This website contains documentation for the current version of Kubernetes
+and the four previous versions of Kubernetes.
+
+The availability of documentation for a Kubernetes version is separate from whether
+that release is currently supported.
+Read [Support period](/releases/patch-releases/#support-period) to learn about
+which versions of Kubernetes are officially supported, and for how long.
+-->
+
 本网站包含当前版本和之前四个版本的 Kubernetes 文档。
+
+Kubernetes 版本的文档可用性与当前是否支持该版本是分开的。
+阅读[支持期限](/zh/releases/patch-releases/#support-period)，了解官方支持 Kubernetes 的哪些版本，以及支持多长时间。

--- a/content/zh-cn/docs/setup/production-environment/container-runtimes.md
+++ b/content/zh-cn/docs/setup/production-environment/container-runtimes.md
@@ -385,10 +385,10 @@ sudo systemctl restart containerd
 
 <!--
 When using kubeadm, manually configure the
-[cgroup driver for kubelet](/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#configure-cgroup-driver-used-by-kubelet-on-control-plane-node).
+[cgroup driver for kubelet](/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver/#configuring-the-kubelet-cgroup-driver).
 -->
 当使用 kubeadm 时，请手动配置
-[kubelet 的 cgroup 驱动](/zh/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#configure-cgroup-driver-used-by-kubelet-on-control-plane-node).
+[kubelet 的 cgroup 驱动](/zh/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver/#configuring-the-kubelet-cgroup-driver).
 
 ### CRI-O
 

--- a/content/zh-cn/docs/tasks/debug/debug-application/debug-pods.md
+++ b/content/zh-cn/docs/tasks/debug/debug-application/debug-pods.md
@@ -295,11 +295,11 @@ to make sure that your `Service` is running, has `Endpoints`, and your `Pods` ar
 actually serving; you have DNS working, iptables rules installed, and kube-proxy
 does not seem to be misbehaving.
 
-You may also visit [troubleshooting document](/docs/tasks/debug/overview/) for more information.
+You may also visit [troubleshooting document](/docs/tasks/debug/) for more information.
 -->
 如果上述方法都不能解决你的问题，
 请按照[调试 Service 文档](/zh/docs/tasks/debug/debug-applications/debug-service/)中的介绍，
 确保你的 `Service` 处于 Running 态，有 `Endpoints` 被创建，`Pod` 真的在提供服务；
 DNS 服务已配置并正常工作，iptables 规则也以安装并且 `kube-proxy` 也没有异常行为。
 
-你也可以访问[故障排查文档](/zh/docs/tasks/debug/overview/)来获取更多信息。
+你也可以访问[故障排查文档](/zh/docs/tasks/debug/)来获取更多信息。

--- a/content/zh-cn/docs/tasks/debug/debug-application/debug-service.md
+++ b/content/zh-cn/docs/tasks/debug/debug-application/debug-service.md
@@ -1093,7 +1093,7 @@ Service is not working.  Please let us know what is going on, so we can help
 investigate!
 
 Contact us on
-[Slack](/docs/tasks/debug/overview/#slack) or
+[Slack](https://slack.k8s.io/) or
 [Forum](https://discuss.kubernetes.io) or
 [GitHub](https://github.com/kubernetes/kubernetes).
 -->
@@ -1104,7 +1104,7 @@ Contact us on
 然而 Service 还是没有正常工作。这种情况下，请告诉我们，以便我们可以帮助调查！
 
 通过
-[Slack](/zh/docs/tasks/debug/overview/#slack) 或者
+[Slack](https://slack.k8s.io/) 或者
 [Forum](https://discuss.kubernetes.io) 或者
 [GitHub](https://github.com/kubernetes/kubernetes) 
 联系我们。
@@ -1112,6 +1112,6 @@ Contact us on
 ## {{% heading "whatsnext" %}}
 
 <!--
-Visit [troubleshooting document](/docs/tasks/debug/overview/) for more information.
+Visit [troubleshooting document](/docs/tasks/debug/) for more information.
 -->
-访问[故障排查文档](/zh/docs/tasks/debug-application-cluster/troubleshooting/) 获取更多信息。
+访问[故障排查文档](/zh/docs/tasks/debug/) 获取更多信息。

--- a/content/zh-cn/docs/tasks/debug/debug-cluster/local-debugging.md
+++ b/content/zh-cn/docs/tasks/debug/debug-cluster/local-debugging.md
@@ -52,7 +52,7 @@ This document describes using `telepresence` to develop and debug services runni
 <!--
 ## Connecting your local machine to a remote Kubernetes cluster
  
-After installing `telepresence`, run `telepresence connect` to launch it's Daemon and connect your local workstation to the cluster.
+After installing `telepresence`, run `telepresence connect` to launch its Daemon and connect your local workstation to the cluster.
 -->
 
 ## 从本机连接到远程 Kubernetes 集群

--- a/content/zh-cn/docs/tasks/debug/debug-cluster/resource-metrics-pipeline.md
+++ b/content/zh-cn/docs/tasks/debug/debug-cluster/resource-metrics-pipeline.md
@@ -362,7 +362,7 @@ To learn more about the metrics-server, see the
 
 You can also check out the following:
 
-* [metrics-server design](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/instrumentation/metrics-server.md)
+* [metrics-server design](https://github.com/kubernetes/design-proposals-archive/blob/main/instrumentation/metrics-server.md)
 * [metrics-server FAQ](https://github.com/kubernetes-sigs/metrics-server/blob/master/FAQ.md)
 * [metrics-server known issues](https://github.com/kubernetes-sigs/metrics-server/blob/master/KNOWN_ISSUES.md)
 * [metrics-server releases](https://github.com/kubernetes-sigs/metrics-server/releases)
@@ -373,7 +373,7 @@ You can also check out the following:
 
 你还可以查看以下内容：
 
-* [metrics-server 设计](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/instrumentation/metrics-server.md)
+* [metrics-server 设计](https://github.com/kubernetes/design-proposals-archive/blob/main/instrumentation/metrics-server.md)
 * [metrics-server FAQ](https://github.com/kubernetes-sigs/metrics-server/blob/master/FAQ.md)
 * [metrics-server known issues](https://github.com/kubernetes-sigs/metrics-server/blob/master/KNOWN_ISSUES.md)
 * [metrics-server releases](https://github.com/kubernetes-sigs/metrics-server/releases)


### PR DESCRIPTION
related: https://github.com/kubernetes/website/issues/34221

FYI, file below has been already the latest version.
```
1	1	content/zh-cn/releases/patch-releases.md
```


Diff report:
```diff
diff --git a/content/en/releases/patch-releases.md b/content/en/releases/patch-releases.md
index 442663f8a1..d0f56d19c3 100644
--- a/content/en/releases/patch-releases.md
+++ b/content/en/releases/patch-releases.md
@@ -109,7 +109,7 @@ End of Life for **1.23** is **2023-02-28**.
 | 1.23.6        | 2022-04-08           | 2022-04-13  |      |
 | 1.23.5        | 2022-03-11           | 2022-03-16  |      |
 | 1.23.4        | 2022-02-11           | 2022-02-16  |      |
-| 1.23.3        | 2022-01-24           | 2022-01-25  | [Out-of-Band Release](https://groups.google.com/u/2/a/kubernetes.io/g/dev/c/Xl1sm-CItaY) |
+| 1.23.3        | 2022-01-24           | 2022-01-25  | [Out-of-Band Release](https://groups.google.com/a/kubernetes.io/g/dev/c/Xl1sm-CItaY) |
 | 1.23.2        | 2022-01-14           | 2022-01-19  |      |
 | 1.23.1        | 2021-12-14           | 2021-12-16  |      |
```