### PR TITLE
[zh]Resync reference files after zh language renaming(reference-1)

### DIFF
--- a/content/zh-cn/docs/reference/access-authn-authz/_index.md
+++ b/content/zh-cn/docs/reference/access-authn-authz/_index.md
@@ -37,6 +37,8 @@ Reference documentation:
 - Service accounts
   - [Developer guide](/docs/tasks/configure-pod-container/configure-service-account/)
   - [Administration](/docs/reference/access-authn-authz/service-accounts-admin/)
+- [Kubelet Authentication & Authorization](/docs/reference/access-authn-authz/kubelet-authn-authz/)
+  - including kubelet [TLS bootstrapping](/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/)
 -->
 - [身份认证](/zh/docs/reference/access-authn-authz/authentication/)
    - [使用启动引导令牌来执行身份认证](/zh/docs/reference/access-authn-authz/bootstrap-tokens/)
@@ -53,4 +55,5 @@ Reference documentation:
 - 服务账号
   - [开发者指南](/zh/docs/tasks/configure-pod-container/configure-service-account/)
   - [管理文档](/zh/docs/reference/access-authn-authz/service-accounts-admin/)
-
+- [Kubelet 认证和鉴权](/zh/docs/reference/access-authn-authz/kubelet-authn-authz/)
+  - 包括 kubelet [TLS 启动引导](/zh/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/)

--- a/content/zh-cn/docs/reference/access-authn-authz/admission-controllers.md
+++ b/content/zh-cn/docs/reference/access-authn-authz/admission-controllers.md
@@ -246,7 +246,7 @@ information on the permissions required to perform different actions on Certific
 有关对 CertificateSigningRequest 资源执行不同操作所需权限的详细信息，
 请参阅[证书签名请求](/zh/docs/reference/access-authn-authz/certificate-signing-requests/)。
 
-### CertificateSubjectRestrictions {#certificatesubjectrestrictions}
+### CertificateSubjectRestriction {#certificatesubjectrestriction}
 
 <!--
 This admission controller observes creation of CertificateSigningRequest resources that have a `spec.signerName`

--- a/content/zh-cn/docs/reference/kubectl/cheatsheet.md
+++ b/content/zh-cn/docs/reference/kubectl/cheatsheet.md
@@ -542,7 +542,7 @@ kubectl patch deployment valid-deployment  --type json   -p='[{"op": "remove", "
 # Add a new element to a positional array
 kubectl patch sa default --type='json' -p='[{"op": "add", "path": "/secrets/1", "value": {"name": "whatever" } }]'
 
-# Update a deployment's replicas count by patching it's scale subresource
+# Update a deployment's replica count by patching it's scale subresource
 kubectl patch deployment nginx-deployment --subresource='scale' --type='merge' -p '{"spec":{"replicas":2}}'
 ```
 -->

--- a/content/zh-cn/docs/reference/labels-annotations-taints/_index.md
+++ b/content/zh-cn/docs/reference/labels-annotations-taints/_index.md
@@ -668,6 +668,44 @@ Kubernetes uses this label to differentiate multiple Services. Used currently fo
 
 Kubernetes 使用这个标签来区分多个服务。目前仅用于 `ELB` （弹性负载均衡器）。
 
+<!-- 
+### kubernetes.io/service-account.name
+
+Example: `kubernetes.io/service-account.name: "sa-name"`
+
+Used on: Secret
+
+This annotation records the {{< glossary_tooltip term_id="name" text="name">}} of the
+ServiceAccount that the token (stored in the Secret of type `kubernetes.io/service-account-token`) represents.
+-->
+### kubernetes.io/service-account.name
+
+示例：`kubernetes.io/service-account.name: "sa-name"`
+
+用于：Secret
+
+这个注解记录了令牌（存储在 `kubernetes.io/service-account-token` 类型的 Secret 中）所代表的
+ServiceAccount 的{{<glossary_tooltip term_id="name" text="名称">}}。
+
+<!-- 
+### kubernetes.io/service-account.uid
+
+Example: `kubernetes.io/service-account.uid: da68f9c6-9d26-11e7-b84e-002dc52800da`
+
+Used on: Secret
+
+This annotation records the {{< glossary_tooltip term_id="uid" text="unique ID" >}} of the
+ServiceAccount that the token (stored in the Secret of type `kubernetes.io/service-account-token`) represents.
+-->
+### kubernetes.io/service-account.uid
+
+示例：`kubernetes.io/service-account.uid: da68f9c6-9d26-11e7-b84e-002dc52800da`
+
+用于：Secret
+
+该注解记录了令牌（存储在 `kubernetes.io/service-account-token` 类型的 Secret 中）所代表的
+ServiceAccount 的{{<glossary_tooltip term_id="uid" text="唯一 ID" >}}。
+
 <!--
 ### endpointslice.kubernetes.io/managed-by {#endpointslicekubernetesiomanaged-by}
 

--- a/content/zh-cn/docs/reference/using-api/deprecation-guide.md
+++ b/content/zh-cn/docs/reference/using-api/deprecation-guide.md
@@ -221,14 +221,17 @@ The **policy/v1beta1** API version of PodDisruptionBudget will no longer be serv
 <!--
 PodSecurityPolicy in the **policy/v1beta1** API version will no longer be served in v1.25, and the PodSecurityPolicy admission controller will be removed.
 
-PodSecurityPolicy replacements are still under discussion, but current use can be migrated to
-[3rd-party admission webhooks](/docs/reference/access-authn-authz/extensible-admission-controllers/) now.
+Migrate to [Pod Security Admission](/docs/concepts/security/pod-security-admission/)
+or a [3rd party admission webhook](/docs/reference/access-authn-authz/extensible-admission-controllers/).
+For a migration guide, see [Migrate from PodSecurityPolicy to the Built-In PodSecurity Admission Controller](/docs/tasks/configure-pod-container/migrate-from-psp/).
+For more information on the deprecation, see [PodSecurityPolicy Deprecation: Past, Present, and Future](/blog/2021/04/06/podsecuritypolicy-deprecation-past-present-and-future/).
 -->
 **policy/v1beta1** API 版本中的 PodSecurityPolicy 将不会在 v1.25 中提供，
 并且 PodSecurityPolicy 准入控制器也会被删除。
 
-PodSecurityPolicy 的替换方案仍在讨论过程中，不过当前的用法可以迁移到
-[第三方准入性质的 Webhook](/zh/docs/reference/access-authn-authz/extensible-admission-controllers/)。
+迁移到 [Pod 安全准入](/zh/docs/concepts/security/pod-security-admission/)或[第三方准入 webhook](/zh/docs/reference/access-authn-authz/extensible-admission-controllers/)。
+有关迁移指南，请参阅[从 PodSecurityPolicy 迁移到内置 PodSecurity 准入控制器](/zh/docs/tasks/configure-pod-container/migrate-from-psp/)。
+有关弃用的更多信息，请参阅 [PodSecurityPolicy 弃用：过去、现在和未来](/zh/blog/2021/04/06/podsecuritypolicy-deprecation-past-present-and-future/)。
 
 #### RuntimeClass {#runtimeclass-v125}
 

--- a/content/zh-cn/docs/reference/using-api/server-side-apply.md
+++ b/content/zh-cn/docs/reference/using-api/server-side-apply.md
@@ -220,7 +220,8 @@ this occurs, the applier has 3 options to resolve the conflicts:
 <!--
 * **Overwrite value, become sole manager:** If overwriting the value was
   intentional (or if the applier is an automated process like a controller) the
-  applier should set the `force` query parameter to true and make the request
+  applier should set the `force` query parameter to true (in kubectl, it can be done by
+  using the `--force-conflicts` flag with the apply command) and make the request
   again. This forces the operation to succeed, changes the value of the field,
   and removes the field from all other managers' entries in managedFields.
 
@@ -237,7 +238,8 @@ this occurs, the applier has 3 options to resolve the conflicts:
   field managers that already claimed to manage it.
 -->
 * **覆盖前值，成为唯一的管理器：** 如果打算覆盖该值（或应用者是一个自动化部件，比如控制器），
-  应用者应该设置查询参数 `force` 为 true，然后再发送一次请求。
+  应用者应该设置查询参数 `force` 为 true（在 kubectl 中，可以通过在
+  apply 命令中使用 `--force-conflicts` 标志来完成），然后再发送一次请求。
   这将强制操作成功，改变字段的值，从所有其他管理器的 managedFields 条目中删除指定字段。
 
 * **不覆盖前值，放弃管理权：** 如果应用者不再关注该字段的值，


### PR DESCRIPTION
related: https://github.com/kubernetes/website/issues/34221

- content/zh-cn/docs/reference/labels-annotations-taints/_index.md
```diff
diff --git a/content/en/docs/reference/labels-annotations-taints/_index.md b/content/en/docs/reference/labels-annotations-taints/_index.md
index e68cb668d3..6622c63941 100644
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -334,6 +334,24 @@ Used on: Service
 
 Kubernetes uses this label to differentiate multiple Services. Used currently for `ELB`(Elastic Load Balancer) only.
 
+### kubernetes.io/service-account.name
+
+Example: `kubernetes.io/service-account.name: "sa-name"`
+
+Used on: Secret
+
+This annotation records the {{< glossary_tooltip term_id="name" text="name">}} of the
+ServiceAccount that the token (stored in the Secret of type `kubernetes.io/service-account-token`) represents.
+
+### kubernetes.io/service-account.uid
+
+Example: `kubernetes.io/service-account.uid: da68f9c6-9d26-11e7-b84e-002dc52800da`
+
+Used on: Secret
+
+This annotation records the {{< glossary_tooltip term_id="uid" text="unique ID" >}} of the
+ServiceAccount that the token (stored in the Secret of type `kubernetes.io/service-account-token`) represents.
+
 ### endpointslice.kubernetes.io/managed-by {#endpointslicekubernetesiomanaged-by}
 
 Example: `endpointslice.kubernetes.io/managed-by="controller"`
```

- content/zh-cn/docs/reference/kubectl/cheatsheet.md
```diff
diff --git a/content/en/docs/reference/kubectl/cheatsheet.md b/content/en/docs/reference/kubectl/cheatsheet.md
index e1711ea542..3412175285 100644
--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -280,7 +280,7 @@ kubectl patch deployment valid-deployment  --type json   -p='[{"op": "remove", "
 # Add a new element to a positional array
 kubectl patch sa default --type='json' -p='[{"op": "add", "path": "/secrets/1", "value": {"name": "whatever" } }]'
 
-# Update a deployment's replicas count by patching it's scale subresource
+# Update a deployment's replica count by patching its scale subresource
 kubectl patch deployment nginx-deployment --subresource='scale' --type='merge' -p '{"spec":{"replicas":2}}'
```

- content/zh-cn/docs/reference/access-authn-authz/admission-controllers.md
```diff
diff --git a/content/en/docs/reference/access-authn-authz/admission-controllers.md b/content/en/docs/reference/access-authn-authz/admission-controllers.md
index 1e9f1a3298..f03b04f8e3 100644
--- a/content/en/docs/reference/access-authn-authz/admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/admission-controllers.md
@@ -139,7 +139,7 @@ requests with the `spec.signerName` requested on the CertificateSigningRequest r
 See [Certificate Signing Requests](/docs/reference/access-authn-authz/certificate-signing-requests/) for more
 information on the permissions required to perform different actions on CertificateSigningRequest resources.
 
-### CertificateSubjectRestrictions {#certificatesubjectrestrictions}
+### CertificateSubjectRestriction {#certificatesubjectrestriction}
 
 This admission controller observes creation of CertificateSigningRequest resources that have a `spec.signerName`
 of `kubernetes.io/kube-apiserver-client`. It rejects any request that specifies a 'group' (or 'organization attribute')
```

- content/zh-cn/docs/reference/access-authn-authz/_index.md
```diff
diff --git a/content/en/docs/reference/access-authn-authz/_index.md b/content/en/docs/reference/access-authn-authz/_index.md
index 86d06488a8..3677f79c57 100644
--- a/content/en/docs/reference/access-authn-authz/_index.md
+++ b/content/en/docs/reference/access-authn-authz/_index.md
@@ -24,3 +24,5 @@ Reference documentation:
 - Service accounts
   - [Developer guide](/docs/tasks/configure-pod-container/configure-service-account/)
   - [Administration](/docs/reference/access-authn-authz/service-accounts-admin/)
+- [Kubelet Authentication & Authorization](/docs/reference/access-authn-authz/kubelet-authn-authz/)
+  - including kubelet [TLS bootstrapping](/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/)
```

- content/zh-cn/docs/reference/using-api/deprecation-guide.md
```diff
diff --git a/content/en/docs/reference/using-api/deprecation-guide.md b/content/en/docs/reference/using-api/deprecation-guide.md
index b72b60fb5a..d448344504 100644
--- a/content/en/docs/reference/using-api/deprecation-guide.md
+++ b/content/en/docs/reference/using-api/deprecation-guide.md
@@ -110,8 +110,10 @@ The **policy/v1beta1** API version of PodDisruptionBudget will no longer be serv
 
 PodSecurityPolicy in the **policy/v1beta1** API version will no longer be served in v1.25, and the PodSecurityPolicy admission controller will be removed.
 
-PodSecurityPolicy replacements are still under discussion, but current use can be migrated to
-[3rd-party admission webhooks](/docs/reference/access-authn-authz/extensible-admission-controllers/) now.
+Migrate to [Pod Security Admission](/docs/concepts/security/pod-security-admission/)
+or a [3rd party admission webhook](/docs/reference/access-authn-authz/extensible-admission-controllers/).
+For a migration guide, see [Migrate from PodSecurityPolicy to the Built-In PodSecurity Admission Controller](/docs/tasks/configure-pod-container/migrate-from-psp/).
+For more information on the deprecation, see [PodSecurityPolicy Deprecation: Past, Present, and Future](/blog/2021/04/06/podsecuritypolicy-deprecation-past-present-and-future/).
 
 #### RuntimeClass {#runtimeclass-v125}
```

- content/zh-cn/docs/reference/using-api/server-side-apply.md
```diff
diff --git a/content/en/docs/reference/using-api/server-side-apply.md b/content/en/docs/reference/using-api/server-side-apply.md
index 6b932278dc..e9f951a76a 100644
--- a/content/en/docs/reference/using-api/server-side-apply.md
+++ b/content/en/docs/reference/using-api/server-side-apply.md
@@ -125,7 +125,8 @@ this occurs, the applier has 3 options to resolve the conflicts:
 
 * **Overwrite value, become sole manager:** If overwriting the value was
   intentional (or if the applier is an automated process like a controller) the
-  applier should set the `force` query parameter to true and make the request
+  applier should set the `force` query parameter to true (in kubectl, it can be done by
+  using the `--force-conflicts` flag with the apply command) and make the request
   again. This forces the operation to succeed, changes the value of the field,
   and removes the field from all other managers' entries in managedFields.
```