### PR TITLE
[pt-br] Update translation of Names and UIDs page

### DIFF
--- a/content/pt-br/docs/concepts/configuration/configmap.md
+++ b/content/pt-br/docs/concepts/configuration/configmap.md
@@ -45,7 +45,7 @@ são opcionais. O campo `data` foi pensado para conter sequências de bytes UTF-
 foi planejado para conter dados binários em forma de strings codificadas em base64.
 
 É obrigatório que o nome de um ConfigMap seja um
-[subdomínio DNS válido](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names).
+[subdomínio DNS válido](/pt-br/docs/concepts/overview/working-with-objects/names#dns-subdomain-names).
 
 Cada chave sob as seções `data` ou `binaryData` pode conter quaisquer caracteres alfanuméricos,
 `-`, `_` e `.`. As chaves armazenadas na seção `data` não podem colidir com as chaves armazenadas

--- a/content/pt-br/docs/concepts/configuration/secret.md
+++ b/content/pt-br/docs/concepts/configuration/secret.md
@@ -65,7 +65,7 @@ A camada de gerenciamento do Kubernetes também utiliza Secrets. Por exemplo,
 os [Secrets de tokens de autoinicialização](#bootstrap-token-secrets) são um
 mecanismo que auxilia a automação do registro de nós.
 
-O nome de um Secret deve ser um [subdomínio DNS válido](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names).
+O nome de um Secret deve ser um [subdomínio DNS válido](/pt-br/docs/concepts/overview/working-with-objects/names#dns-subdomain-names).
 Você pode especificar o campo `data` e/ou o campo `stringData` na criação de um
 arquivo de configuração de um Secret. Ambos os campos `data` e `stringData` são
 opcionais. Os valores das chaves no campo `data` devem ser strings codificadas

--- a/content/pt-br/docs/concepts/containers/runtime-class.md
+++ b/content/pt-br/docs/concepts/containers/runtime-class.md
@@ -66,7 +66,7 @@ handler: myconfiguration  # Nome da configuração CRI correspondente
 ```
 
 O nome de um objeto RuntimeClass deve ser um 
-[nome de subdomínio DNS](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names) válido.
+[nome de subdomínio DNS](/pt-br/docs/concepts/overview/working-with-objects/names#dns-subdomain-names) válido.
 
 {{< note >}}
 É recomendado que operações de escrita no objeto RuntimeClass (criar/atualizar/patch/apagar)

--- a/content/pt-br/docs/concepts/overview/working-with-objects/names.md
+++ b/content/pt-br/docs/concepts/overview/working-with-objects/names.md
@@ -1,30 +1,83 @@
 ---
-title: Nomes
+title: Nomes de objetos e IDs
 content_type: concept
 weight: 20
 ---
 
 <!-- overview -->
 
-Cada objeto em um cluster possui um Nome que é único para aquele tipo de recurso.
-Todo objeto do Kubernetes também possui um UID que é único para todo o cluster.
+Cada objeto em seu cluster possui um [_Nome_](#names) que é único para aquele
+tipo de recurso.
+Todo objeto do Kubernetes também possui um [_UID_](#uids) que é único para todo
+o cluster.
 
-Por exemplo, você pode ter apenas um Pod chamado "myapp-1234", porém você pode ter um Pod
-e um Deployment ambos com o nome "myapp-1234".
+Por exemplo, você pode ter apenas um Pod chamado `myapp-1234` dentro de um
+[namespace](/pt-br/docs/concepts/overview/working-with-objects/namespaces/), porém
+você pode ter um Pod e um Deployment ambos com o nome `myapp-1234`.
 
-Para atributos não únicos providenciados por usuário, Kubernetes providencia [labels](/docs/concepts/overview/working-with-objects/labels/) e [annotations](/docs/concepts/overview/working-with-objects/annotations/).
-
-
+Para atributos não-únicos definidos pelo usuário, o Kubernetes fornece
+[labels](/docs/concepts/overview/working-with-objects/labels/) e
+[annotations](/docs/concepts/overview/working-with-objects/annotations/).
 
 
 <!-- body -->
 
-## Nomes
+## Nomes {#names}
 
+{{< glossary_definition term_id="name" length="all" >}}
 
-Recursos Kubernetes podem ter nomes com até 253 caracteres. Os caracteres permitidos em nomes são: dígitos (0-9), letras minúsculas (a-z), `-`, e `.`.
+{{< note >}}
+Em casos em que objetos representam uma entidade física, como no caso de um Nó
+representando um host físico, caso o host seja recriado com o mesmo nome mas o
+objeto Nó não seja recriado, o Kubernetes trata o novo host como o host antigo,
+o que pode causar inconsistências.
+{{< /note >}}
 
-A seguir, um exemplo para um Pod chamado `nginx-demo`.
+Abaixo estão descritos quatro tipos de restrições de nomes comumente utilizadas
+para recursos.
+
+### Nomes de subdomínio DNS {#dns-subdomain-names}
+
+A maior parte dos recursos do Kubernetes requerem um nome que possa ser
+utilizado como um nome de subdomínio DNS, conforme definido na
+[RFC 1123](https://tools.ietf.org/html/rfc1123).
+Isso significa que o nome deve:
+
+- conter no máximo 253 caracteres
+- conter somente caracteres alfanuméricos em caixa baixa, traço ('-') ou ponto
+  ('.').
+- iniciar com um caractere alfanumérico
+- terminar com um caractere alfanumérico
+
+### Nomes de rótulos da RFC 1123 {#dns-label-names}
+
+Alguns tipos de recurso requerem que seus nomes sigam o padrão de rótulos DNS
+definido na [RFC 1123](https://tools.ietf.org/html/rfc1123).
+Isso significa que o nome deve:
+
+- conter no máximo 63 caracteres
+- conter somente caracteres alfanuméricos em caixa baixa ou traço ('-')
+- iniciar com um caractere alfanumérico
+- terminar com um caractere alfanumérico
+
+### Nomes de rótulo da RFC 1035
+
+Alguns tipos de recurso requerem que seus nomes sigam o padrão de rótulos DNS
+definido na [RFC 1035](https://tools.ietf.org/html/rfc1035).
+Isso significa que o nome deve:
+
+- conter no máximo 63 caracteres
+- conter somente caracteres alfanuméricos em caixa baixa ou traço ('-')
+- iniciar com um caractere alfanumérico
+- terminar com um caractere alfanumérico
+
+### Nomes de segmentos de caminhos
+
+Alguns tipos de recurso requerem que seus nomes possam ser seguramente
+codificados como um segmento de caminho, ou seja, o nome não pode ser "." ou
+".." e não pode conter "/" ou "%".
+
+Exemplo de um manifesto para um Pod chamado `nginx-demo`.
 
 ```yaml
 apiVersion: v1
@@ -45,13 +98,15 @@ Alguns tipos de recursos possuem restrições adicionais em seus nomes.
 
 ## UIDs
 
+{{< glossary_definition term_id="uid" length="all" >}}
 
-Kubernetes UIDs são identificadores únicos universais (também chamados de UUIDs).
-UUIDs utilizam padrões ISO/IEC 9834-8 e ITU-T X.667.
+UIDs no Kubernetes são identificadores únicos universais (também conhecidos como
+UUIDs).
+UUIDs seguem os padrões ISO/IEC 9834-8 e ITU-T X.667.
 
 
 ## {{% heading "whatsnext" %}}
 
-* Leia sobre [labels](/docs/concepts/overview/working-with-objects/labels/) em Kubernetes.
-* Consulte o documento de design [Identificadores e Nomes em Kubernetes](https://git.k8s.io/community/contributors/design-proposals/architecture/identifiers.md).
+* Leia sobre [labels](/docs/concepts/overview/working-with-objects/labels/) no Kubernetes.
+* Consulte o documento de design [Identifiers and Names in Kubernetes](https://git.k8s.io/community/contributors/design-proposals/architecture/identifiers.md).
 

--- a/content/pt-br/docs/concepts/policy/limit-range.md
+++ b/content/pt-br/docs/concepts/policy/limit-range.md
@@ -23,7 +23,7 @@ O suporte ao _LimitRange_ foi ativado por padrão desde o Kubernetes 1.10.
 
 Um _LimitRange_ é aplicado em um _namespace_ específico quando há um objeto _LimitRange_ nesse _namespace_.
 
-O nome de um objeto _LimitRange_ deve ser um [nome de subdomínio DNS](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names) válido.
+O nome de um objeto _LimitRange_ deve ser um [nome de subdomínio DNS](/pt-br/docs/concepts/overview/working-with-objects/names#dns-subdomain-names) válido.
 
 ### Visão geral do Limit Range
 

--- a/content/pt-br/docs/concepts/policy/resource-quotas.md
+++ b/content/pt-br/docs/concepts/policy/resource-quotas.md
@@ -34,7 +34,7 @@ As cotas de recursos funcionam assim:
   Veja o [passo a passo](/docs/tasks/administer-cluster/manage-resources/quota-memory-cpu-namespace/)
   para um exemplo de como evitar este problema. 
 
-O nome de um objeto `ResourceQuota` deve ser um [nome do subdomínio DNS](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names) válido.
+O nome de um objeto `ResourceQuota` deve ser um [nome do subdomínio DNS](/pt-br/docs/concepts/overview/working-with-objects/names#dns-subdomain-names) válido.
 
 Exemplos de políticas que podem ser criadas usando _namespaces_ e cotas são:
 

--- a/content/pt-br/docs/concepts/storage/persistent-volumes.md
+++ b/content/pt-br/docs/concepts/storage/persistent-volumes.md
@@ -1,15 +1,9 @@
 ---
-reviewers:
-- jsafrane
-- saad-ali
-- thockin
-- msau42
-- xing-yang
 title: Volumes Persistentes
 feature:
   title: Orquestração de Armazenamento
   description: >
-    Montar automaticamente o armazenamento de sua escolha, seja de um armazenamento local, de um provedor de cloud pública, como <a href="https://cloud.google.com/storage/">GCP</a> ou <a href="https://aws.amazon.com/products/storage/">AWS</a>, ou um armazenameto de rede, como NFS, iSCSI, Gluster, Ceph, Cinder ou Flocker.
+    Monte automaticamente o armazenamento de sua escolha, seja de um armazenamento local, de um provedor de cloud pública, como <a href="https://cloud.google.com/storage/">GCP</a> ou <a href="https://aws.amazon.com/products/storage/">AWS</a>, ou um armazenamento de rede, como NFS, iSCSI, Gluster, Ceph, Cinder ou Flocker.
 
 content_type: conceito
 weight: 20
@@ -314,7 +308,7 @@ Tipos de PersistentVolume são implementados como plugins. Atualmente o Kubernet
 
 ## Volumes Persistentes
 
-Cada PV contém uma `spec` e um status, que é a especificação e o status do volume. O nome do PersistentVolume deve ser um [DNS](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names) válido.
+Cada PV contém uma `spec` e um status, que é a especificação e o status do volume. O nome do PersistentVolume deve ser um [DNS](/pt-br/docs/concepts/overview/working-with-objects/names#dns-subdomain-names) válido.
 
 ```yaml
 apiVersion: v1
@@ -468,7 +462,7 @@ A CLI mostrará o nome do PV que foi atrelado à PVC
 
 ## PersistentVolumeClaims
 
-Cada PVC contém uma `spec` e um status, que é a especificação e estado de uma requisição. O nome de um objeto PersistentVolumeClaim precisa ser um [DNS](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names) válido.
+Cada PVC contém uma `spec` e um status, que é a especificação e estado de uma requisição. O nome de um objeto PersistentVolumeClaim precisa ser um [DNS](/pt-br/docs/concepts/overview/working-with-objects/names#dns-subdomain-names) válido.
 
 ```yaml
 apiVersion: v1

--- a/content/pt-br/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/pt-br/docs/concepts/workloads/controllers/cron-jobs.md
@@ -20,7 +20,7 @@ Se a camada de gerenciamento do cluster executa o kube-controller-manager em Pod
 
 {{< /caution >}}
 
-Ao criar o manifesto para um objeto CronJob, verifique se o nome que você forneceu é um [nome de subdomínio DNS](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names) válido.
+Ao criar o manifesto para um objeto CronJob, verifique se o nome que você forneceu é um [nome de subdomínio DNS](/pt-br/docs/concepts/overview/working-with-objects/names#dns-subdomain-names) válido.
 O nome não pode ter mais que 52 caracteres. Esta limitação existe porque o controlador do CronJob adicionará automaticamente 11 caracteres ao final do nome escolhido para a tarefa, e o tamanho máximo de um nome de tarefa não pode ultrapassar 63 caracteres.
 
 <!-- body -->

--- a/content/pt-br/docs/reference/glossary/name.md
+++ b/content/pt-br/docs/reference/glossary/name.md
@@ -1,5 +1,5 @@
 ---
-title: Name
+title: Nome
 id: name
 date: 2018-04-12
 full_link: /pt-br/docs/concepts/overview/working-with-objects/names

--- a/content/pt-br/docs/reference/glossary/name.md
+++ b/content/pt-br/docs/reference/glossary/name.md
@@ -1,0 +1,20 @@
+---
+title: Name
+id: name
+date: 2018-04-12
+full_link: /pt-br/docs/concepts/overview/working-with-objects/names
+short_description: >
+  Uma string fornecida pelo cliente que referencia um objeto em uma URL de
+  recurso, como por exemplo `/api/v1/pods/qualquer-nome`.
+
+aka: 
+tags:
+- fundamental
+---
+ Uma string fornecida pelo cliente que referencia um objeto em uma URL de
+ recurso, como por exemplo `/api/v1/pods/qualquer-nome`.
+
+<!--more--> 
+
+Somente um objeto de um dado tipo pode ter um certo nome por vez. No entanto,
+se você remover o objeto, você poderá criar um novo objeto com o mesmo nome.

--- a/content/pt-br/docs/reference/glossary/uid.md
+++ b/content/pt-br/docs/reference/glossary/uid.md
@@ -2,12 +2,20 @@
 title: UID
 id: uid
 date: 2021-03-16
-full_link: 
+full_link: /pt-br/docs/concepts/overview/working-with-objects/names
 short_description: >
-   Um identificador exclusivo (UID) é uma sequência numérica ou alfanumérica associada a uma única entidade em um determinado sistema.
+   Uma string gerada pelos sistemas do Kubernetes para identificar objetos de
+   forma única.
    
 aka: 
 tags:
-- authentication
+- fundamental
 ---
-Um identificador exclusivo (UID) é uma sequência numérica ou alfanumérica associada a uma única entidade em um determinado sistema. Os UIDs tornam possível endereçar essa entidade para que ela possa ser acessada e interagida. Cada usuário é identificado no sistema por seu UID e os nomes de usuário geralmente são usados apenas como uma interface para humanos.
+   Uma string gerada pelos sistemas do Kubernetes para identificar objetos de
+   forma única.
+
+<!-- more -->
+
+Cada objeto criado durante todo o ciclo de vida do cluster do Kubernetes possui
+um UID distinto. O objetivo deste identificador é distinguir ocorrências
+históricas de entidades semelhantes.

--- a/content/pt-br/docs/tasks/configmap-secret/managing-secret-using-config-file.md
+++ b/content/pt-br/docs/tasks/configmap-secret/managing-secret-using-config-file.md
@@ -59,7 +59,7 @@ data:
 ```
 
 Perceba que o nome do objeto Secret precisa ser um 
-[nome de subdomínio DNS](/docs/concepts/overview/working-with-objects/names#dns-subdomain-name) válido.
+[nome de subdomínio DNS](/pt-br/docs/concepts/overview/working-with-objects/names#dns-subdomain-names) válido.
 
 {{< note >}}
 Os valores serializados dos dados JSON e YAML de um Secret são codificados em strings


### PR DESCRIPTION
### Changes

* Update the translation of the Names and UIDs page and update all references to use the new pt-br version of the DNS subdomain names in the Brazilian Portuguese version of documentation.
