### PR TITLE
disable gtag for local build

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -6,6 +6,7 @@
 {{- else -}}
 <meta name="ROBOTS" content="NOINDEX, NOFOLLOW">
 {{- end -}}
+{{- if ne hugo.Environment "local" -}}
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-36037335-10"></script>
 <script>
@@ -15,6 +16,7 @@
 
   gtag('config', 'UA-36037335-10');
 </script>
+{{- end -}}
 
 <!-- alternative translations -->
 {{ range .Translations -}}


### PR DESCRIPTION
I would like to build a copy of the k8s website for local use. Adding gtags code
& making network requests to gtags from something I'm reading as a local file
seems strange to me, so I'd prefer to remove it.

I could have made this a check for `not hugo.IsProduction`. However, I don't
know if the typical k8s website developer would want to disable gtags when the
environment is `development`. You also have another environment, `preview`, and
I don't really know what this is for, so I wouldn't want to disable gtags there.
So we only disable gtags if the user has explicitly set the build environment to
`local`.
