### PR TITLE
[es] update es docs to use recommended labels

### DIFF
--- a/content/es/docs/concepts/workloads/pods/init-containers.md
+++ b/content/es/docs/concepts/workloads/pods/init-containers.md
@@ -113,7 +113,7 @@ kind: Pod
 metadata:
   name: myapp-pod
   labels:
-    app: myapp
+    app.kubernetes.io/name: MyApp
 spec:
   containers:
   - name: myapp-container
@@ -165,7 +165,7 @@ El resultado es similar a esto:
 Name:          myapp-pod
 Namespace:     default
 [...]
-Labels:        app=myapp
+Labels:        app.kubernetes.io/name=MyApp
 Status:        Pending
 [...]
 Init Containers:


### PR DESCRIPTION
Updates docs to use [Kubernetes recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/) as outlined in the documentation.

Initially included in #34116 but broken out into a separate PR per [request](https://github.com/kubernetes/website/pull/34116#issuecomment-1145603856) from @Sea-n 