### PR TITLE
Register and document scheduler.alpha.kubernetes.io/defaultTolerations annotation

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -461,7 +461,7 @@ Example: `scheduler.alpha.kubernetes.io/defaultTolerations: '[{"operator": "Equa
 
 Used on: Namespace
 
-This annotation requires the [PodTolerationRestriction](/docs/reference/access-authn-authz/admission-controllers/#podtolerationrestriction) admission  controller to be enabled. This annotation key allows assigning tolerations to a namespace and any new pods created in this namespace would get this toleration.
+This annotation requires the [PodTolerationRestriction](/docs/reference/access-authn-authz/admission-controllers/#podtolerationrestriction) admission controller to be enabled. This annotation key allows assigning tolerations to a namespace and any new pods created in this namespace would get these tolerations added.
 
 ### scheduler.alpha.kubernetes.io/preferAvoidPods (deprecated) {#scheduleralphakubernetesio-preferavoidpods}
 


### PR DESCRIPTION
Registers and documents the `scheduler.alpha.kubernetes.io/defaultTolerations` annotation 

**Updated pages:**
https://kubernetes.io/docs/reference/labels-annotations-taints/

Fixes #34212

/cc @sftim 
/sig scheduling
/sig docs