### PR TITLE
Remove katacoda warning

### DIFF
--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -96,9 +96,6 @@ other = "email address"
 [javascript_required]
 other = "JavaScript must be [enabled](https://www.enable-javascript.com/) to view this content"
 
-[katacoda_removal_warning]
-other = """This online tutorial on this page uses functionality that will [not be available](https://www.oreilly.com/online-learning/leveraging-katacoda-technology.html) past <time datetime="2022-06-15">June 15th, 2022</time>."""
-
 [latest_release]
 other = "Latest Release:"
 

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -25,11 +25,6 @@
             {{ block "deprecated" . }}
               {{ partial "deprecation-warning.html" . }}
             {{ end }}
-            {{ if or ( .HasShortcode "kat-button" ) ( .HasShortcode "katacoda-tutorial" ) }}
-            {{ block "katacoda-removal" . }}
-              {{ partial "katacoda-removal.html" . }}
-            {{ end }}
-            {{ end }}
               {{ block "main" . }}{{ end }}
               {{- if .HasShortcode "thirdparty-content" -}}
                 {{ block "thirdparty-disclaimer" . }}

--- a/layouts/partials/katacoda-removal.html
+++ b/layouts/partials/katacoda-removal.html
@@ -1,7 +1,0 @@
-<section id="katacoda-removal-warning">
-  <div class="content warning pageinfo pageinfo-warning">
-    <p>
-      {{ T "katacoda_removal_warning" | markdownify }}
-    </p>
-  </div>
-</section>


### PR DESCRIPTION
Removes Katacoda warning at the moment which could be reinstated as discussed in #34255

Fixes #34255

/sig docs