### PR TITLE
fix typo in job example

### DIFF
--- a/content/en/examples/controllers/job.yaml
+++ b/content/en/examples/controllers/job.yaml
@@ -8,7 +8,7 @@ spec:
       containers:
       - name: pi
         image: perl:5.34
-        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+        command: ["perl",  "-Mbignum=bpi", "-wle", "'print bpi(2000)'"]
       restartPolicy: Never
   backoffLimit: 4
 


### PR DESCRIPTION
The perl command in the first job example was missing a pair of quotes. Added the missing quotes to the corresponding `content/en` yaml files.