### PR TITLE
Fix invalid HTML element name

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -3,7 +3,7 @@
 {{- if eq hugo.Environment "preview" -}}
   <!-- deploy preview -->
 {{- end -}}
-  <head {{- if hugo.IsProduction -}}class="live-site"{{- end -}}>
+  <head{{- if hugo.IsProduction}} class="live-site"{{- end -}}>
     {{ partial "head.html" . }}
   </head>
   <body class="td-{{ .Kind }}{{- if ne (lower .Params.cid) "" -}}{{- printf " cid-%s" (lower .Params.cid) -}}{{- end -}}">


### PR DESCRIPTION
Fix invalid HTML on every web page of the live site(!)

Wrong: `<headclass="live-site">`
Right: `<head class="live-site">`

/area web-development