### PR TITLE
Mark v1.23 docs as stale

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -145,7 +145,7 @@ fullversion = "v1.23.6"
 version = "v1.23"
 githubbranch = "main"
 docsbranch = "main"
-deprecated = false
+deprecated = true
 currentUrl = "https://kubernetes.io/docs/home/"
 nextUrl = "https://kubernetes-io-vnext-staging.netlify.com/"
 


### PR DESCRIPTION
Belatedly perform a step overlooked during the Kubernetes v1.24 release.

Mark the v1.23 documentation [[preview](https://deploy-preview-34295--k8s-v1-23.netlify.app/)] as stale. This triggers a banner message.
