### PR TITLE
[zh] udpate image translation

### DIFF
--- a/content/zh-cn/docs/concepts/scheduling-eviction/node-pressure-eviction.md
+++ b/content/zh-cn/docs/concepts/scheduling-eviction/node-pressure-eviction.md
@@ -320,7 +320,7 @@ kubelet 根据下表将驱逐信号映射为节点状况：
 | 节点条件 | 驱逐信号 | 描述 |
 |---------|--------|------|
 | `MemoryPressure` | `memory.available` | 节点上的可用内存已满足驱逐条件 |
-| `DiskPressure`   | `nodefs.available`、`nodefs.inodesFree`、`imagefs.available` 或 `imagefs.inodesFree` | 节点的根文件系统或映像文件系统上的可用磁盘空间和 inode 已满足驱逐条件 |
+| `DiskPressure`   | `nodefs.available`、`nodefs.inodesFree`、`imagefs.available` 或 `imagefs.inodesFree` | 节点的根文件系统或镜像文件系统上的可用磁盘空间和 inode 已满足驱逐条件 |
 | `PIDPressure`    | `pid.available` | (Linux) 节点上的可用进程标识符已低于驱逐条件 |
 
 kubelet 根据配置的 `--node-status-update-frequency` 更新节点条件，默认为 `10s`。

--- a/content/zh-cn/docs/concepts/storage/storage-classes.md
+++ b/content/zh-cn/docs/concepts/storage/storage-classes.md
@@ -940,7 +940,7 @@ parameters:
   same as `adminId`.
 -->
 * `monitors`：Ceph monitor，逗号分隔。该参数是必需的。
-* `adminId`：Ceph 客户端 ID，用于在池 ceph 池中创建映像。默认是 "admin"。
+* `adminId`：Ceph 客户端 ID，用于在池 ceph 池中创建镜像。默认是 "admin"。
 * `adminSecret`：`adminId` 的 Secret 名称。该参数是必需的。
   提供的 secret 必须有值为 "kubernetes.io/rbd" 的 type 参数。
 * `adminSecretNamespace`：`adminSecret` 的命名空间。默认是 "default"。

--- a/content/zh-cn/docs/tasks/job/indexed-parallel-processing-static.md
+++ b/content/zh-cn/docs/tasks/job/indexed-parallel-processing-static.md
@@ -111,7 +111,7 @@ rev data.txt
 You'll use the `rev` tool from the
 [`busybox`](https://hub.docker.com/_/busybox) container image.
 -->
-你将使用 [`busybox`](https://hub.docker.com/_/busybox) 容器映像中的 `rev` 工具。
+你将使用 [`busybox`](https://hub.docker.com/_/busybox) 容器镜像中的 `rev` 工具。
 
 <!-- 
 As this is only an example, each Pod only does a tiny piece of work (reversing a short

--- a/content/zh-cn/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
+++ b/content/zh-cn/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
@@ -94,7 +94,7 @@ weight: 10
                 <p>你可以使用 Kubernetes 命令行界面 <b>Kubectl</b> 创建和管理 Deployment。Kubectl 使用 Kubernetes API 与集群进行交互。在本单元中，你将学习创建在 Kubernetes 集群上运行应用程序的 Deployment 所需的最常见的 Kubectl 命令。</p>
 
                 <!-- <p>When you create a Deployment, you'll need to specify the container image for your application and the number of replicas that you want to run. You can change that information later by updating your Deployment; Modules <a href="/docs/tutorials/kubernetes-basics/scale-intro/">5</a> and <a href="/docs/tutorials/kubernetes-basics/update-intro/">6</a> of the bootcamp discuss how you can scale and update your Deployments.</p> -->
-                <p>创建 Deployment 时，你需要指定应用程序的容器映像以及要运行的副本数。你可以稍后通过更新 Deployment 来更改该信息; 模块 <a href="/zh/docs/tutorials/kubernetes-basics/scale-intro/">5</a> 和 <a href="/zh/docs/tutorials/kubernetes-basics/update-intro/">6</a> 讨论了如何扩展和更新 Deployments。</p>
+                <p>创建 Deployment 时，你需要指定应用程序的容器镜像以及要运行的副本数。你可以稍后通过更新 Deployment 来更改该信息; 模块 <a href="/zh/docs/tutorials/kubernetes-basics/scale-intro/">5</a> 和 <a href="/zh/docs/tutorials/kubernetes-basics/update-intro/">6</a> 讨论了如何扩展和更新 Deployments。</p>
 
             </div>
             <div class="col-md-4">

--- a/content/zh-cn/docs/tutorials/kubernetes-basics/explore/explore-intro.html
+++ b/content/zh-cn/docs/tutorials/kubernetes-basics/explore/explore-intro.html
@@ -54,7 +54,7 @@ weight: 10
         <ul>
           <li>共享存储，当作卷</li>
           <li>网络，作为唯一的集群 IP 地址</li>
-          <li>有关每个容器如何运行的信息，例如容器映像版本或要使用的特定端口。</li>
+          <li>有关每个容器如何运行的信息，例如容器镜像版本或要使用的特定端口。</li>
         </ul>
     <!--
         <p>A Pod models an application-specific "logical host" and can contain different application containers which are relatively tightly coupled. For example, a Pod might include both the container with your Node.js app as well as a different container that feeds the data to be published by the Node.js webserver. The containers in a Pod share an IP Address and port space, are always co-located and co-scheduled, and run in a shared context on the same Node.</p>

--- a/content/zh-cn/docs/tutorials/stateful-application/cassandra.md
+++ b/content/zh-cn/docs/tutorials/stateful-application/cassandra.md
@@ -422,7 +422,7 @@ By using environment variables you can change values that are inserted into `cas
 镜像。上面的 Docker 镜像基于 [debian-base](https://github.com/kubernetes/release/tree/master/images/build/debian-base)，
 并且包含 OpenJDK 8。
 
-该映像包括来自 Apache Debian 存储库的标准 Cassandra 安装。
+该镜像包括来自 Apache Debian 存储库的标准 Cassandra 安装。
 通过使用环境变量，你可以更改插入到 `cassandra.yaml` 中的值。
 
 | 环境变量                 | 默认值           |


### PR DESCRIPTION
move “映像” to "镜像" 

```
% ./scripts/lsync.sh content/zh-cn/docs/concepts/scheduling-eviction/node-pressure-eviction.md
content/zh-cn/docs/concepts/scheduling-eviction/node-pressure-eviction.md is still in sync
% ./scripts/lsync.sh content/zh-cn/docs/tasks/job/indexed-parallel-processing-static.md
content/zh-cn/docs/tasks/job/indexed-parallel-processing-static.md is still in sync
% ./scripts/lsync.sh content/zh-cn/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
content/zh-cn/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html is still in sync
% ./scripts/lsync.sh content/zh-cn/docs/tutorials/kubernetes-basics/explore/explore-intro.html
content/zh-cn/docs/tutorials/kubernetes-basics/explore/explore-intro.html is still in sync
% ./scripts/lsync.sh content/zh-cn/docs/tutorials/stateful-application/cassandra.md
content/zh-cn/docs/tutorials/stateful-application/cassandra.md is still in sync
% ./scripts/lsync.sh content/zh-cn/docs/concepts/storage/storage-classes.md
content/zh-cn/docs/concepts/storage/storage-classes.md is still in sync
```