### PR TITLE
Sync community-values.md from k/community

### DIFF
--- a/content/en/community/static/community-values.md
+++ b/content/en/community/static/community-values.md
@@ -3,26 +3,26 @@
 
 # Kubernetes Community Values
 
-Kubernetes Community culture is frequently cited as a substantial contributor to the meteoric rise of this Open Source project.  Below are the distilled values which have evolved over the last many years in our community pushing our project and peers toward constant improvement.
+Kubernetes Community culture contributes substantially to the project's success. The following values have evolved over time, pushing our project and peers toward constant improvement.
 
 ## Distribution is better than centralization
 
-The scale of the Kubernetes project is only viable through high-trust and high-visibility distribution of work, which includes delegation of authority, decision making, technical design, code ownership, and documentation.  Distributed asynchronous ownership, collaboration, communication and decision making are the cornerstone of our world-wide community.
+The scale of the Kubernetes project is only viable through high-trust and high-visibility distribution of work, which includes delegation of authority, decision making, technical design, code ownership, and documentation.  Distributed asynchronous ownership, collaboration, communication and decision making are the cornerstones of our world-wide community.
 
 ## Community over product or company
 
-We are here as a community first, our allegiance is to the intentional stewardship of the Kubernetes project for the benefit of all its members and users everywhere.  We support working together publicly for the common goal of a vibrant interoperable ecosystem providing an excellent experience for our users. Individuals gain status through work, companies gain status through their commitments to support this community and fund the resources necessary for the project  to operate.
+We are here as a community first. Our allegiance is to the intentional stewardship of the Kubernetes project for the benefit of all its members and users everywhere. We support working together publicly for the common goal of a vibrant interoperable ecosystem, providing an excellent experience for our users. Individuals gain status through work. Companies gain status through their commitments to support this community and fund the resources necessary for the project to operate.
 
 ## Automation over process
 
-Large projects have a lot of less exciting, yet, hard work.  We value time spent automating repetitive work more highly than toil. Where that work cannot be automated, it is our culture to recognize and reward all types of contributions. However, heroism is not sustainable.
+Large projects have a lot of hard yet less exciting work. We value time spent automating repetitive work more highly than toil. Where work cannot be automated, our culture recognizes and rewards all types of contributions while recognizing that heroism is not sustainable.
 
 ## Inclusive is better than exclusive
 
-Broadly successful and useful technology requires different perspectives and skill sets which can only be heard in a welcoming and respectful environment.  Community membership is a privilege, not a right. Community Leadership is earned through effort, scope, quality, quantity, and duration of contributions. Our community shows respect for the time and effort put into a discussion regardless of where a contributor is on their growth path.
+Broadly successful and useful technologies require different perspectives and skill sets, which can only be heard in a welcoming and respectful environment. Community membership is a privilege, not a right. Community members earn leadership through effort, scope, quality, quantity, and duration of contributions. Our community respects the time and effort put into a discussion, regardless of where a contributor is on their growth path.
 
 ## Evolution is better than stagnation
 
-Openness to new ideas and studied technological evolution make Kubernetes a stronger project.  Continual improvement, servant leadership, mentorship and respect are the foundations of the Kubernetes project culture. It is the duty for leaders in the Kubernetes community to find, sponsor, and promote new community members. Leaders should expect to step aside. Community members should expect to step up.
+Openness to new ideas and studied technological evolution make Kubernetes a stronger project. Continual improvement, servant leadership, mentorship, and respect are the foundations of Kubernetes culture. Kubernetes community leaders have a duty to find, sponsor, and promote new community members. Leaders should expect to step aside. Community members should expect to step up.
 
 **"Culture eats strategy for breakfast."   --Peter Drucker**

--- a/content/en/community/values.md
+++ b/content/en/community/values.md
@@ -9,7 +9,15 @@ community_styles_migrated: true
 sitemap:
   priority: 0.1
 ---
+
 <div class="community-section" id="values-legacy">
+<p>
+This page is a replicated version of
+<a href="https://www.kubernetes.dev/community/values/">Kubernetes Community Values</a>, as of
+<a href="https://github.com/kubernetes/community/blob/5c642749a030c5f7b2363a6bb9bad00a56a92161/values.md">commit 5c64274</a>.
+If you notice that this is out of date, please
+<a href="https://github.com/kubernetes/website/issues/new">file an issue</a>.
+</p>
 {{< include "/static/community-values.md" >}}
 </div>
 


### PR DESCRIPTION
Apply changes from January 2021.
- https://github.com/kubernetes/community/pull/5411

Add similar text adopted from [/content/en/comm/coc.md](https://github.com/kubernetes/website/blob/main/content/en/community/code-of-conduct.md?plain=1#L8-L16) to link to the canonical version.

Netlify preview: https://deploy-preview-34311--kubernetes-io-main-staging.netlify.app/community/values