### PR TITLE
[fr] Update Bash alias auto-completion

### DIFF
--- a/content/fr/docs/reference/kubectl/cheatsheet.md
+++ b/content/fr/docs/reference/kubectl/cheatsheet.md
@@ -36,7 +36,7 @@ Vous pouvez de plus déclarer un alias pour `kubectl` qui fonctionne aussi avec 
 
 ```bash
 alias k=kubectl
-complete -F __start_kubectl k
+complete -o default -F __start_kubectl k
 ```
 
 ### ZSH

--- a/content/fr/docs/tasks/tools/install-kubectl.md
+++ b/content/fr/docs/tasks/tools/install-kubectl.md
@@ -363,7 +363,7 @@ Vous devez maintenant vérifier que le script de completion de kubectl est bien 
 
     ```shell
     echo 'alias k=kubectl' >>~/.bashrc
-    echo 'complete -F __start_kubectl k' >>~/.bashrc
+    echo 'complete -o default -F __start_kubectl k' >>~/.bashrc
     ```
 
 {{< note >}}
@@ -431,7 +431,7 @@ Si vous n'avez pas installé via Homebrew, vous devez maintenant vous assurer qu
 
     ```shell
     echo 'alias k=kubectl' >>~/.bashrc
-    echo 'complete -F __start_kubectl k' >>~/.bashrc
+    echo 'complete -o default -F __start_kubectl k' >>~/.bashrc
     ```
     
 Si vous avez installé kubectl avec Homebrew (comme expliqué [ici](#installer-avec-homebrew-sur-macos)), alors le script de complétion a été automatiquement installé dans `/usr/local/etc/bash_completion.d/kubectl`. Dans ce cas, vous n'avez rien à faire.


### PR DESCRIPTION
Apply [PR 32127](https://github.com/kubernetes/website/pull/32127) corrections to French content.

Content has been updated with the following command:
```bash
grep -rl "complete -F __start_kubectl k" content/fr/ | xargs sed -i 's/complete -F __start_kubectl k/complete -o default -F __start_kubectl k/g
```