### PR TITLE
[zh] Update Bash alias auto-completion

### DIFF
--- a/content/zh-cn/docs/reference/kubectl/cheatsheet.md
+++ b/content/zh-cn/docs/reference/kubectl/cheatsheet.md
@@ -56,7 +56,7 @@ echo "source <(kubectl completion bash)" >> ~/.bashrc # 在您的 bash shell 中
 
 ```bash
 alias k=kubectl
-complete -F __start_kubectl k
+complete -o default -F __start_kubectl k
 ```
 
 ### ZSH

--- a/content/zh-cn/docs/tasks/tools/included/optional-kubectl-configs-bash-linux.md
+++ b/content/zh-cn/docs/tasks/tools/included/optional-kubectl-configs-bash-linux.md
@@ -86,7 +86,7 @@ If you have an alias for kubectl, you can extend shell completion to work with t
 
 ```bash
 echo 'alias k=kubectl' >>~/.bashrc
-echo 'complete -F __start_kubectl k' >>~/.bashrc
+echo 'complete -o default -F __start_kubectl k' >>~/.bashrc
 ```
 
 {{< note >}}

--- a/content/zh-cn/docs/tasks/tools/included/optional-kubectl-configs-bash-mac.md
+++ b/content/zh-cn/docs/tasks/tools/included/optional-kubectl-configs-bash-mac.md
@@ -148,7 +148,7 @@ You now have to ensure that the kubectl completion script gets sourced in all yo
 
     ```bash
     echo 'alias k=kubectl' >>~/.bash_profile
-    echo 'complete -F __start_kubectl k' >>~/.bash_profile
+    echo 'complete -o default -F __start_kubectl k' >>~/.bash_profile
     ```
 
 <!-- 


### PR DESCRIPTION
Apply [PR 32127](https://github.com/kubernetes/website/pull/32127) corrections to Chinese content.

Content has been updated with the following command:
```bash
grep -rl "complete -F __start_kubectl k" content/zh-cn/ | xargs sed -i 's/complete -F __start_kubectl k/complete -o default -F __start_kubectl k/g
```
