### PR TITLE
[es] Update Bash alias auto-completion

### DIFF
--- a/content/es/docs/tasks/tools/included/optional-kubectl-configs-bash-linux.md
+++ b/content/es/docs/tasks/tools/included/optional-kubectl-configs-bash-linux.md
@@ -44,7 +44,7 @@ Si tiene un alias para kubectl, puede extender el completado del shell para trab
 
 ```bash
 echo 'alias k=kubectl' >>~/.bashrc
-echo 'complete -F __start_kubectl k' >>~/.bashrc
+echo 'complete -o default -F __start_kubectl k' >>~/.bashrc
 ```
 
 {{< note >}}

--- a/content/es/docs/tasks/tools/included/optional-kubectl-configs-bash-mac.md
+++ b/content/es/docs/tasks/tools/included/optional-kubectl-configs-bash-mac.md
@@ -76,7 +76,7 @@ Ahora debe asegurarse de que el script de completado de kubectl se obtenga en to
 
     ```bash
     echo 'alias k=kubectl' >>~/.bash_profile
-    echo 'complete -F __start_kubectl k' >>~/.bash_profile
+    echo 'complete -o default -F __start_kubectl k' >>~/.bash_profile
     ```
 
 - Si instaló kubectl con Homebrew (como se explica [aquí](/docs/tasks/tools/install-kubectl-macos/#install-with-homebrew-on-macos)), entonces el script de completado de kubectl ya debería estar en `/usr/local/etc/bash_completion.d/kubectl`. En ese caso, no necesita hacer nada.


### PR DESCRIPTION
Apply [PR 32127](https://github.com/kubernetes/website/pull/32127) corrections to Spanish content.

Content has been updated with the following command:
```bash
grep -rl "complete -F __start_kubectl k" content/es/ | xargs sed -i 's/complete -F __start_kubectl k/complete -o default -F __start_kubectl k/g
```