### PR TITLE
Removing the overlapping text (project) from CNCF Logo

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,7 +3,7 @@
 <section id="cncf">
     <div class="main-section">
         <center>
-        <p style="font-size: 20px">{{ T "main_cncf_project" | safeHTML }}
+            <p style="font-size:20px;position: absolute;bottom: 10px;height: 20px;left: 10px;right: 10px;" class="h1">{{ T "main_cncf_project" | safeHTML }}
         </center>
     </div>
 </section>


### PR DESCRIPTION

***I have removed the overlapping text from CNCF Logo, by changing the CSS of the element,***
![Correct](https://user-images.githubusercontent.com/67385503/174143077-40b7f1fb-8a4c-47f3-9c07-b566639e2f6e.png)
![Error](https://user-images.githubusercontent.com/67385503/174143082-6ba59573-013c-43f5-b26f-a94e184d7961.png)
