### PR TITLE
Fix api-reference shortcode for localized pages. (v1.23 backport)

### DIFF
--- a/layouts/shortcodes/api-reference.html
+++ b/layouts/shortcodes/api-reference.html
@@ -2,6 +2,8 @@
 {{ $pageArg := .Get "page" }}
 {{ $anchorArg := .Get "anchor" }}
 {{ $textArg := .Get "text" }}
-{{ $page := site.GetPage "page" (printf "%s/%s" $base $pageArg) }}
+{{ $pagePath := path.Join $base $pageArg }}
+{{ $page := site.GetPage "page" $pagePath }}
+{{ with $page }}{{else}}{{ range where site.Home.AllTranslations "Language.Lang" "en" }}{{ $page = .Site.GetPage "page" $pagePath }}{{ end }}{{ end }}
 {{ $metadata := $page.Params.api_metadata }}
 <a href="{{ $page.RelPermalink }}{{if $anchorArg}}#{{ $anchorArg }}{{end}}">{{if $textArg}}{{ $textArg }}{{else if $anchorArg}}{{ $anchorArg }}{{else}}{{ $metadata.kind }}{{end}}</a>


### PR DESCRIPTION
This PR fixs issue #34178 that api-reference shortcode not working on localized pages.
This is backport of PR #34272 to v1.23.

/area web-development
/kind bug