### PR TITLE
Bump Hugo to 0.101.0 / avoid locking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,9 @@ container-push: container-image ## Push container image for the preview of the w
 container-build: module-check
 	$(CONTAINER_RUN) --read-only --mount type=tmpfs,destination=/tmp,tmpfs-mode=01777 $(CONTAINER_IMAGE) sh -c "npm ci && hugo --minify --environment development"
 
+# no build lock to allow for read-only mounts
 container-serve: module-check ## Boot the development server using container.
-	$(CONTAINER_RUN) --cap-drop=ALL --cap-add=AUDIT_WRITE --read-only --mount type=tmpfs,destination=/tmp,tmpfs-mode=01777 -p 1313:1313 $(CONTAINER_IMAGE) hugo server --buildFuture --environment development --bind 0.0.0.0 --destination /tmp/hugo --cleanDestinationDir
+	$(CONTAINER_RUN) --cap-drop=ALL --cap-add=AUDIT_WRITE --read-only --mount type=tmpfs,destination=/tmp,tmpfs-mode=01777 -p 1313:1313 $(CONTAINER_IMAGE) hugo server --buildFuture --environment development --bind 0.0.0.0 --destination /tmp/hugo --cleanDestinationDir --noBuildLock
 
 test-examples:
 	scripts/test_examples.sh install

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,7 +8,7 @@ command = "git submodule update --init --recursive --depth 1 && make non-product
 
 [build.environment]
 NODE_VERSION = "10.20.0"
-HUGO_VERSION = "0.97.0"
+HUGO_VERSION = "0.101.0"
 RUBY_VERSION = "3.0.1"
 
 [context.production.environment]


### PR DESCRIPTION
Bump Hugo to 0.101.0 ([site preview](https://deploy-preview-34356--kubernetes-io-main-staging.netlify.app/))


Notable new features:
- indentation fixes to shortcode blocks
- [`resources.Copy`](https://gohugo.io/hugo-pipes/introduction/#copy-a-resource) function
- improved error handling


Also: skip locking introduced as a side effect of PR https://github.com/kubernetes/website/pull/33048

---

I use Podman, unprivileged, and this PR means that I don't see a permissions error when I try to preview locally using `make container-image`.

I have tested that this builds; I haven't thoroughly checked for indentation-related snags (and I'm OK with that).