### PR TITLE
Fix build issue for Netlify _headers file

### DIFF
--- a/layouts/index.headers
+++ b/layouts/index.headers
@@ -13,7 +13,7 @@
   {{- end -}}
 {{- range $pages }}
 {{- if or (.Params.deprecated) (eq .Params.class "gridPage") (.Params.case_study_styles) (.Params.css) (.Params.js) }}
-{{ .URL }}
+{{ .RelPermalink }}
   {{- if eq .Params.class "gridPage" }}
   Link: </css/gridpage.css>; rel=preload; as=style
   {{- end -}}


### PR DESCRIPTION
This changes fixes an error where the production site does not build ([example](https://app.netlify.com/sites/kubernetes-io-main-staging/deploys/62ac458466bb9f00072c7866)).
Use `.RelPermalink` to generate the site-relative URL for a page.

/priority important-soon

/cc @zacharysarah
(this week's PR wrangler)