### PR TITLE
Improve page-meta-links page

### DIFF
--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -1,6 +1,7 @@
 {{/* template adapted from Docsy theme */}}
-{{ if .Path }}
-  {{ $pathFormatted := replace .Path "\\" "/" }}
+
+{{ if .File.Path }}
+  {{ $pathFormatted := replace .File.Path "\\" "/" }}
   {{ $gh_repo := ($.Param "github_repo") }}
   {{ $gh_subdir := ($.Param "github_subdir") }}
   {{ $gh_project_repo := ($.Param "github_project_repo") }}


### PR DESCRIPTION
This PR fixes a warning in the page-meta-links.html page where `.Path`
is a function to be removed soon. Warning message:

```
WARN 2022/06/17 21:20:35 .Path when the page is backed by a file is deprecated
and will be removed in a future release. We plan to use Path for a canonical source
path and you probably want to check the source is a file.
```

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/start/#improve-existing-content

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
