### PR TITLE
Netlify previews with `--panicOnWarning`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ build: module-check ## Build site with non-production settings and put deliverab
 	hugo --minify --environment development
 
 build-preview: module-check ## Build site with drafts and future posts enabled
-	hugo --buildDrafts --buildFuture --environment preview
+	hugo --buildDrafts --buildFuture --environment preview --panicOnWarning
 
 deploy-preview: ## Deploy preview site via netlify
 	hugo --enableGitInfo --buildFuture --environment preview -b $(DEPLOY_PRIME_URL)

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -1,5 +1,4 @@
 {{/* template adapted from Docsy theme */}}
-
 {{ if .File.Path }}
   {{ $pathFormatted := replace .File.Path "\\" "/" }}
   {{ $gh_repo := ($.Param "github_repo") }}


### PR DESCRIPTION
Netlify preview builds now take place with `--panicOnWarning` feature of Hugo. While doing preview builds now, a `.Path` deprecation warning resulted in the error due to `--panicOnWarning` so I also fixed that in this PR. @sftim talks about why this flag is needed in #34357

Fixes #34357

/sig docs
/area web-development