### PR TITLE
[zh] Fix links for contribute

### DIFF
--- a/content/zh-cn/docs/contribute/_index.md
+++ b/content/zh-cn/docs/contribute/_index.md
@@ -61,7 +61,7 @@ Kubernetes documentation contributors:
 - Translate the documentation
 - Manage and publish the documentation parts of the Kubernetes release cycle
 -->
-本网站由 [Kubernetes SIG（特别兴趣小组）Docs](/zh/docs/contribute/#get-involved-with-SIG-Docs) 维护。
+本网站由 [Kubernetes SIG Docs](/zh-cn/docs/contribute/#get-involved-with-SIG-Docs)（文档特别兴趣小组）维护。
 
 Kubernetes 文档项目的贡献者：
 
@@ -103,7 +103,7 @@ To get involved with documentation:
 
 1. 签署 CNCF 的[贡献者许可协议](https://github.com/kubernetes/community/blob/master/CLA.md)。
 2. 熟悉[文档仓库](https://github.com/kubernetes/website)和网站的[静态站点生成器](https://gohugo.io)。
-3. 确保理解[发起 PR](/zh/docs/contribute/new-content/open-a-pr/) 和[审查变更](/zh/docs/contribute/review/reviewing-prs/)的基本流程。
+3. 确保理解[发起 PR](/zh-cn/docs/contribute/new-content/open-a-pr/) 和[审查变更](/zh-cn/docs/contribute/review/reviewing-prs/)的基本流程。
 
 <!-- See https://github.com/kubernetes/website/issues/28808 for live-editor URL to this figure -->
 <!-- You can also cut/paste the mermaid code into the live editor at https://mermaid-js.github.io/mermaid-live-editor to play around with it -->
@@ -157,9 +157,9 @@ Figure 1 outlines a roadmap for new contributors. You can follow some or all of 
 图 1. 新手入门指示。
 
 图 1 概述了新贡献者的路线图。
-你可以遵从`注册`和`评审`所述的某些或全部步骤。
+你可以遵从“注册”和“评审”所述的某些或全部步骤。
 至此，你完成了发起 PR 的准备工作，
-可以通过`发起 PR`列出的事项实现你的贡献目标。
+可以通过“发起 PR” 列出的事项实现你的贡献目标。
 再次重申，欢迎随时提出问题！
 
 <!-- 
@@ -168,7 +168,7 @@ See [Participating in SIG Docs](/docs/contribute/participate/) for more details 
 roles and permissions.
 -->
 有些任务要求 Kubernetes 组织内更高的信任级别和访问权限。
-阅读[参与 SIG Docs 工作](/zh/docs/contribute/participate/) ，获取角色和权限的更多细节。
+阅读[参与 SIG Docs 工作](/zh-cn/docs/contribute/participate/)，获取角色和权限的更多细节。
 
 <!-- 
 ## Your first contribution
@@ -229,17 +229,17 @@ Figure 2. Preparation for your first contribution.
 - Learn about [page content types](/docs/contribute/style/page-content-types/)
   and [Hugo shortcodes](/docs/contribute/style/hugo-shortcodes/).
 -->
-- 通读[贡献概述](/zh/docs/contribute/new-content/overview/)，了解参与贡献的不同方式。
-- 查看 [`kubernetes/website` 问题列表](https://github.com/kubernetes/website/issues/)
-  ，检索最适合作为切入点的问题。
-- 在现有文档上，[使用 GitHub 提交 PR](/zh/docs/contribute/new-content/open-a-pr/#changes-using-github)，
+- 通读[贡献概述](/zh-cn/docs/contribute/new-content/)，了解参与贡献的不同方式。
+- 查看 [`kubernetes/website` 问题列表](https://github.com/kubernetes/website/issues/)，
+  检索最适合作为切入点的问题。
+- 在现有文档上，[使用 GitHub 提交 PR](/zh-cn/docs/contribute/new-content/open-a-pr/#changes-using-github)，
   掌握在 GitHub 上登记 Issue 的方法。
-- Kubernetes 社区其他成员会[评审 PR ](/zh/docs/contribute/review/reviewing-prs/)，
+- Kubernetes 社区其他成员会[评审 PR ](/zh-cn/docs/contribute/review/reviewing-prs/)，
   以确保文档精准和语言流畅。
-- 阅读 kubernetes 的[内容指南](/zh/docs/contribute/style/content-guide/)和
-  [风格指南](/zh/docs/contribute/style/style-guide/)，以发表有见地的评论。
-- 了解[页面内容类型](/zh/docs/contribute/style/page-content-types/)和 
-  [Hugo 短代码](/zh/docs/contribute/style/hugo-shortcodes/)。
+- 阅读 kubernetes 的[内容指南](/zh-cn/docs/contribute/style/content-guide/)和
+  [风格指南](/zh-cn/docs/contribute/style/style-guide/)，以发表有见地的评论。
+- 了解[页面内容类型](/zh-cn/docs/contribute/style/page-content-types/)和 
+  [Hugo 短代码](/zh-cn/docs/contribute/style/hugo-shortcodes/)。
 
 <!--
 ## Next steps
@@ -254,11 +254,11 @@ Figure 2. Preparation for your first contribution.
 -->
 ## 下一步 {#next-teps}
 
-- 学习在仓库的[本地克隆中工作](/zh/docs/contribute/new-content/open-a-pr/#fork-the-repo)。
-- 为[发行版的特性](/zh/docs/contribute/new-content/new-features/)编写文档。
-- 加入 [SIG Docs](/zh/docs/contribute/participate/)，并成为[成员或评审者](/zh/docs/contribute/participate/roles-and-responsibilities/)。
+- 学习在仓库的[本地克隆中工作](/zh-cn/docs/contribute/new-content/open-a-pr/#fork-the-repo)。
+- 为[发行版的特性](/zh-cn/docs/contribute/new-content/new-features/)编写文档。
+- 加入 [SIG Docs](/zh-cn/docs/contribute/participate/)，并成为[成员或评审者](/zh-cn/docs/contribute/participate/roles-and-responsibilities/)。
   
-- 开始或帮助[本地化](/zh/docs/contribute/localization/) 工作。
+- 开始或帮助[本地化](/zh-cn/docs/contribute/localization/) 工作。
 
 <!-- 
 ## Get involved with SIG Docs
@@ -272,7 +272,7 @@ SIG Docs communicates with different methods:
 -->
 ## 参与 SIG Docs 工作 {#get-involved-with-SIG-Docs}
 
-[SIG Docs](/zh/docs/contribute/participate/) 是负责发布、维护 Kubernetes 文档的贡献者团体。
+[SIG Docs](/zh-cn/docs/contribute/participate/) 是负责发布、维护 Kubernetes 文档的贡献者团体。
 参与 SIG Docs 是 Kubernetes 贡献者（开发者和其他人员）对 Kubernetes 项目产生重大影响力的好方式。
 
 SIG Docs 的几种沟通方式：
@@ -306,10 +306,10 @@ SIG Docs 的几种沟通方式：
 -->
 ## 其他贡献方式 {#other-ways-to-contribute}
 
-- 访问 [Kubernetes 社区网站](/zh/community/)。
+- 访问 [Kubernetes 社区网站](/zh-cn/community/)。
   参与 Twitter 或 Stack Overflow，了解当地的 Kubernetes 会议和活动等等。
 - 阅读[贡献者备忘单](https://github.com/kubernetes/community/tree/master/contributors/guide/contributor-cheatsheet)，
   参与 Kubernetes 功能开发。
 - 访问贡献者网站，进一步了解有关 [Kubernetes 贡献者](https://www.kubernetes.dev/)
   和[更多贡献者资源](https://www.kubernetes.dev/resources/)的信息。
-- 提交一篇[博客文章或案例研究](/zh/docs/contribute/new-content/blogs-case-studies/)。
+- 提交一篇[博客文章或案例研究](/zh-cn/docs/contribute/new-content/blogs-case-studies/)。

--- a/content/zh-cn/docs/contribute/advanced.md
+++ b/content/zh-cn/docs/contribute/advanced.md
@@ -21,8 +21,8 @@ to learn about more ways to contribute. You need to use the Git command line
 client and other tools for some of these tasks.
 -->
 
-如果你已经了解如何[贡献新内容](/zh/docs/contribute/new-content/overview/)和
-[评阅他人工作](/zh/docs/contribute/review/reviewing-prs/)，并准备了解更多贡献的途径，
+如果你已经了解如何[贡献新内容](/zh-cn/docs/contribute/new-content/)和
+[评阅他人工作](/zh-cn/docs/contribute/review/reviewing-prs/)，并准备了解更多贡献的途径，
 请阅读此文。你需要使用 Git 命令行工具和其他工具做这些工作。
 
 <!-- body -->
@@ -30,11 +30,12 @@ client and other tools for some of these tasks.
 <!--
 ## Propose improvements
 
-SIG Docs [members](/docs/contribute/participate/roles-and-responsibilities/#members) can propose improvements.
+SIG Docs [members](/docs/contribute/participate/roles-and-responsibilities/#members)
+can propose improvements.
 -->
-## 提出改进建议
+## 提出改进建议   {#propose-improvements}
 
-SIG Docs 的 [成员](/zh/docs/contribute/participate/roles-and-responsibilities/#members) 可以提出改进建议。
+SIG Docs 的[成员](/zh-cn/docs/contribute/participate/roles-and-responsibilities/#members) 可以提出改进建议。
 
 <!--
 After you've been contributing to the Kubernetes documentation for a while, you
@@ -50,8 +51,8 @@ changes. The quickest way to get answers to questions about how the documentatio
 currently works is to ask in the `#sig-docs` Slack channel on
 [kubernetes.slack.com](https://kubernetes.slack.com)
 -->
-在对 Kubernetes 文档贡献了一段时间后，你可能会对[样式指南](/zh/docs/contribute/style/style-guide/)、
-[内容指南](/zh/docs/contribute/style/content-guide/)、用于构建文档的工具链、网站样式、
+在对 Kubernetes 文档贡献了一段时间后，你可能会对[样式指南](/zh-cn/docs/contribute/style/style-guide/)、
+[内容指南](/zh-cn/docs/contribute/style/content-guide/)、用于构建文档的工具链、网站样式、
 评审和合并 PR 的流程或者文档的其他方面产生改进的想法。
 为了尽可能透明化，这些提议都需要在 SIG Docs 会议或
 [kubernetes-sig-docs 邮件列表](https://groups.google.com/forum/#!forum/kubernetes-sig-docs)上讨论。
@@ -66,18 +67,19 @@ appropriate. For instance, an update to the style guide or the website's
 functionality might involve opening a pull request, while a change related to
 documentation testing might involve working with sig-testing.
 -->
-在进行了讨论并且 SIG 就期望的结果达成一致之后，你就能以最合理的方式处理改进建议了。例如，样式指南或网站功能的更新可能涉及 PR 的新增，而与文档测试相关的更改可能涉及 sig-testing。
+在进行了讨论并且 SIG 就期望的结果达成一致之后，你就能以最合理的方式处理改进建议了。
+例如，样式指南或网站功能的更新可能涉及 PR 的新增，而与文档测试相关的更改可能涉及 sig-testing。
 
 <!--
 ## Coordinate docs for a Kubernetes release
 
-SIG Docs [approvers](/docs/contribute/participating/#approvers) can coordinate
-docs for a Kubernetes release.
+SIG Docs [approvers](/docs/contribute/participate/roles-and-responsibilities/#approvers)
+can coordinate docs for a Kubernetes release.
 -->
-## 为 Kubernetes 版本发布协调文档工作
+## 为 Kubernetes 版本发布协调文档工作   {#coordinate-docs-for-a-kubernetes-release}
 
-SIG Docs 的[批准者（approvers）](/zh/docs/contribute/participating/#approvers) 可以为
-Kubernetes 版本发布协调文档工作。
+SIG Docs 的[批准者（approvers）](/zh-cn/docs/contribute/participate/roles-and-responsibilities/#approvers)
+可以为 Kubernetes 版本发布协调文档工作。
 
 <!--
 Each Kubernetes release is coordinated by a team of people participating in the
@@ -129,37 +131,37 @@ rotated among SIG Docs approvers.
 <!--
 ## Serve as a New Contributor Ambassador
 
-SIG Docs [approvers](/docs/contribute/participating/#approvers) can serve as
-New Contributor Ambassadors. 
+SIG Docs [approvers](/docs/contribute/participate/roles-and-responsibilities/#approvers)
+can serve as New Contributor Ambassadors.
 
-New Contributor Ambassadors work together to welcome new contributors to SIG-Docs, 
+New Contributor Ambassadors welcome new contributors to SIG-Docs,
 suggest PRs to new contributors, and mentor new contributors through their first
 few PR submissions.
 
 Responsibilities for New Contributor Ambassadors include:
 -->
 
-## 担任新的贡献者大使
+## 担任新的贡献者大使   {#serve-as-a-new-contributor-ambassador}
 
-SIG Docs [批准人（Approvers）](/zh/docs/contribute/participating/#approvers) 
+SIG Docs [批准人（Approvers）](/zh-cn/docs/contribute/participate/roles-and-responsibilities/#approvers)
 可以担任新的贡献者大使。
 
-新的贡献者大使共同努力欢迎 SIG-Docs 的新贡献者，对新贡献者的 PR 提出建议，
+新的贡献者大使欢迎 SIG-Docs 的新贡献者，对新贡献者的 PR 提出建议，
 以及在前几份 PR 提交中指导新贡献者。
 
 新的贡献者大使的职责包括：
 
 <!--
 - Being available on the [Kubernetes #sig-docs channel](https://kubernetes.slack.com) to answer questions from new contributors.
-- Working with PR wranglers to identify [good first issues](https://kubernetes.dev/docs/guide/help-wanted/#good-first-issue) for new contributors. 
-- Mentoring new contributors through their first few PRs to the docs repo. 
+- Working with PR wranglers to identify [good first issues](https://kubernetes.dev/docs/guide/help-wanted/#good-first-issue) for new contributors.
+- Mentoring new contributors through their first few PRs to the docs repo.
 - Helping new contributors create the more complex PRs they need to become Kubernetes members.
--[Sponsoring contributors](/docs/contribute/advanced/#sponsor-a-new-contributor) on their path to becoming Kubernetes members.
+- [Sponsoring contributors](/docs/contribute/advanced/#sponsor-a-new-contributor) on their path to becoming Kubernetes members.
 - Hosting a monthly meeting to help and mentor new contributors.
 -->
 - 监听 [Kubernetes #sig-docs 频道](https://kubernetes.slack.com) 上新贡献者的 Issue。
-- 与 PR 管理者合作为新参与者寻找[合适的第一个 issues](https://kubernetes.dev/docs/guide/help-wanted/#good-first-issue) 。 
-- 通过前几个 PR 指导新贡献者为文档存储库作贡献。 
+- 与 PR 管理者合作为新参与者寻找[合适的第一个 issues](https://kubernetes.dev/docs/guide/help-wanted/#good-first-issue)。
+- 通过前几个 PR 指导新贡献者为文档存储库作贡献。
 - 帮助新的贡献者创建成为 Kubernetes 成员所需的更复杂的 PR。
 - [为贡献者提供保荐](#sponsor-a-new-contributor)，使其成为 Kubernetes 成员。
 - 每月召开一次会议，帮助和指导新的贡献者。
@@ -172,22 +174,23 @@ Current New Contributor Ambassadors are announced at each SIG-Docs meeting and i
 <!--
 ## Sponsor a new contributor
 
-SIG Docs [reviewers](/docs/contribute/participating/#reviewers) can sponsor
-new contributors.
+SIG Docs [reviewers](/docs/contribute/participate/roles-and-responsibilities/#reviewers)
+can sponsor new contributors.
 -->
 ## 为新的贡献者提供保荐 {#sponsor-a-new-contributor}
 
-SIG Docs 的[评审人（Reviewers）](/zh/docs/contribute/participating/#reviewers) 可以为新的贡献者提供保荐。
+SIG Docs 的[评审人（Reviewers）](/zh-cn/docs/contribute/participate/roles-and-responsibilities/#reviewers)
+可以为新的贡献者提供保荐。
 
 <!--
 After a new contributor has successfully submitted 5 substantive pull requests
 to one or more Kubernetes repositories, they are eligible to apply for
-[membership](/docs/contribute/participating#members) in the Kubernetes
-organization. The contributor's membership needs to be backed by two sponsors
-who are already reviewers.
+[membership](/docs/contribute/participate/roles-and-responsibilities/#members)
+in the Kubernetes organization. The contributor's membership needs to be
+backed by two sponsors who are already reviewers.
 -->
 新的贡献者针对一个或多个 Kubernetes 项目仓库成功提交了 5 个实质性 PR 之后，
-就有资格申请 Kubernetes 组织的[成员身份](/zh/docs/contribute/participate/roles-and-responsibilities/#members)。
+就有资格申请 Kubernetes 组织的[成员身份](/zh-cn/docs/contribute/participate/roles-and-responsibilities/#members)。
 贡献者的成员资格需要同时得到两位评审人的保荐。
 
 <!--
@@ -212,18 +215,23 @@ can serve a term as a co-chair of SIG Docs.
 
 ### Prerequisites
 -->
-## 担任 SIG 联合主席
+## 担任 SIG 联合主席   {#sponsor-a-new-contributor}
 
-SIG Docs [成员（Members）](/zh/docs/contribute/participate/roles-and-responsibilities/#members)
+SIG Docs [成员（Members）](/zh-cn/docs/contribute/participate/roles-and-responsibilities/#members)
 可以担任 SIG Docs 的联合主席。
 
-### 前提条件
+### 前提条件   {#prerequisites}
 
 <!--
 A Kubernetes member must meet the following requirements to be a co-chair:
 
 - Understand SIG Docs workflows and tooling: git, Hugo, localization, blog subproject
-- Understand how other Kubernetes SIGs and repositories affect the SIG Docs workflow, including: [teams in k/org](https://github.com/kubernetes/org/blob/master/config/kubernetes/sig-docs/teams.yaml), the [process in k/community](https://github.com/kubernetes/community/tree/master/sig-docs), plugins in [k/test-infra](https://github.com/kubernetes/test-infra/), and the role of [SIG Architecture](https://github.com/kubernetes/community/tree/master/sig-architecture).
+- Understand how other Kubernetes SIGs and repositories affect the SIG Docs
+  workflow, including:
+  [teams in k/org](https://github.com/kubernetes/org/blob/master/config/kubernetes/sig-docs/teams.yaml), the
+  [process in k/community](https://github.com/kubernetes/community/tree/master/sig-docs),
+  plugins in [k/test-infra](https://github.com/kubernetes/test-infra/), and the role of
+  [SIG Architecture](https://github.com/kubernetes/community/tree/master/sig-architecture).
   In addition, understand how the [Kubernetes docs release process](/docs/contribute/advanced/#coordinate-docs-for-a-kubernetes-release) works.
 - Approved by the SIG Docs community either directly or via lazy consensus.
 - Commit at least 5 hours per week (and often more) to the role for a minimum of 6 months
@@ -235,8 +243,8 @@ Kubernetes 成员必须满足以下要求才能成为联合主席：
   [k/org 中的团队](https://github.com/kubernetes/org/blob/master/config/kubernetes/sig-docs/teams.yaml)、
   [k/community 中的流程](https://github.com/kubernetes/community/tree/master/sig-docs)、
   [k/test-infra](https://github.com/kubernetes/test-infra/) 中的插件、
-  [SIG Architecture](https://github.com/kubernetes/community/tree/master/sig-architecture) 中的角色。 
-  此外，了解 [Kubernetes 文档发布流程](/docs/contribute/advanced/#coordinate-docs-for-a-kubernetes-release) 的工作原理。
+  [SIG Architecture](https://github.com/kubernetes/community/tree/master/sig-architecture) 中的角色。
+  此外，了解 [Kubernetes 文档发布流程](/zh-cn/docs/contribute/advanced/#coordinate-docs-for-a-kubernetes-release)的工作原理。
 - 由 SIG Docs 社区直接或通过惰性共识批准。
 - 在至少 6 个月的时段内，确保每周至少投入 5 个小时（通常更多）
 
@@ -247,7 +255,7 @@ The role of co-chair is primarily one of service: co-chairs handle process and p
 
 Responsibilities include:
 -->
-### 职责范围
+### 职责范围   {#responsibilities}
 
 联合主席主要提供以下服务：
 联合主席负责处理流程和政策、时间安排和召开会议、安排 PR 管理员、以及一些其他人不想做的事情，目的是增长贡献者团队。
@@ -282,7 +290,7 @@ To schedule and run effective meetings, these guidelines show what to do, how to
 
 - Hold respectful, inclusive discussions with respectful, inclusive language.
 -->
-### 召开高效的会议
+### 召开高效的会议   {#running-effective-meetings}
 
 为了安排和召开高效的会议，这些指南说明了如何做、怎样做以及原因。
 
@@ -332,7 +340,7 @@ For weekly meetings, copypaste the previous week's notes into the "Past meetings
 
 **Honor folks' time**:
 
-- Begin and end meetings punctually
+Begin and end meetings on time.
 -->
 **根据需要来进行协调**：
 
@@ -341,7 +349,7 @@ For weekly meetings, copypaste the previous week's notes into the "Past meetings
 
 **尊重大家的时间**:
 
-- 准时开始和结束会议
+按时开始和结束会议
 
 <!--
 **Use Zoom effectively**:
@@ -362,12 +370,12 @@ For weekly meetings, copypaste the previous week's notes into the "Past meetings
 ### Recording meetings on Zoom
 
 When you're ready to start the recording, click Record to Cloud.
-    
+
 When you're ready to stop recording, click Stop.
 
 The video uploads automatically to YouTube.
 -->
-### 录制 Zoom 会议
+### 录制 Zoom 会议   {#recording-meetings-on-zoom}
 
 准备开始录制时，请单击“录制到云”。
 

--- a/content/zh-cn/docs/contribute/participate/_index.md
+++ b/content/zh-cn/docs/contribute/participate/_index.md
@@ -40,8 +40,8 @@ SIG Docs 欢迎所有贡献者提供内容和审阅。任何人可以提交拉�
 欢迎所有人对文档内容创建 Issue 和对正在处理中的 PR 进行评论。
 
 <!--
-You can also become a [member](/docs/contribute/participating/roles-and-responsibilities/#members),
-[reviewer](/docs/contribute/participating/roles-and-responsibilities/#reviewers), or [approver](/docs/contribute/participating/roles-and-responsibilities/#approvers). These roles require greater
+You can also become a [member](/docs/contribute/participate/roles-and-responsibilities/#members),
+[reviewer](/docs/contribute/participate/roles-and-responsibilities/#reviewers), or [approver](/docs/contribute/participate/roles-and-responsibilities/#approvers). These roles require greater
 access and entail certain responsibilities for approving and committing changes.
 See [community-membership](https://github.com/kubernetes/community/blob/master/community-membership.md)
 for more information on how membership works within the Kubernetes community.
@@ -50,9 +50,9 @@ The rest of this document outlines some unique ways these roles function within
 SIG Docs, which is responsible for maintaining one of the most public-facing
 aspects of Kubernetes - the Kubernetes website and documentation.
 -->
-你也可以成为[成员（member）](/docs/contribute/participating/roles-and-responsibilities/#members)、
-[评阅人（reviewer）](/docs/contribute/participating/roles-and-responsibilities/#reviewers) 或者
-[批准人（approver）](/docs/contribute/participating/roles-and-responsibilities/#approvers)。
+你也可以成为[成员（member）](/zh-cn/docs/contribute/participate/roles-and-responsibilities/#members)、
+[评阅人（reviewer）](/zh-cn/docs/contribute/participate/roles-and-responsibilities/#reviewers) 或者
+[批准人（approver）](/zh-cn/docs/contribute/participate/roles-and-responsibilities/#approvers)。
 这些角色拥有更高的权限，且需要承担批准和提交变更的责任。
 有关 Kubernetes 社区中的成员如何工作的更多信息，请参见
 [社区成员身份](https://github.com/kubernetes/community/blob/master/community-membership.md)。
@@ -72,7 +72,7 @@ of the Kubernetes project as a whole and how SIG Docs works within it. See
 [Leadership](https://github.com/kubernetes/community/tree/master/sig-docs#leadership)
 for the current list of chairpersons.
 -->
-## SIG Docs 主席
+## SIG Docs 主席   {#sig-docs-chairperson}
 
 每个 SIG，包括 SIG Docs，都会选出一位或多位成员作为主席。
 主席会成为 SIG Docs 和其他 Kubernetes 组织的联络接口人。
@@ -125,7 +125,7 @@ related to GitHub issues and pull requests. The
 [Kubernetes website repository](https://github.com/kubernetes/website) uses
 two [prow plugins](https://github.com/kubernetes/test-infra/blob/master/prow/plugins):
 -->
-### OWNERS 文件和扉页
+### OWNERS 文件和扉页   {#owners-files-and-front-matter}
 
 Kubernetes 项目使用名为 prow 的自动化工具来自动处理 GitHub issue 和 PR。
 [Kubernetes website 仓库](https://github.com/kubernetes/website) 使用了两个
@@ -144,7 +144,7 @@ how prow works within the repository.
 这两个插件使用位于 `kubernetes/website` 仓库顶层的
 [OWNERS](https://github.com/kubernetes/website/blob/main/OWNERS) 文件和
 [OWNERS_ALIASES](https://github.com/kubernetes/website/blob/main/OWNERS_ALIASES)
-文件来控制 prow 在仓库范围的工作方式。 
+文件来控制 prow 在仓库范围的工作方式。
 
 <!--
 An OWNERS file contains a list of people who are SIG Docs reviewers and
@@ -153,9 +153,9 @@ can act as a reviewer or approver of files in that subdirectory and its
 descendents. For more information about OWNERS files in general, see
 [OWNERS](https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md).
 -->
-OWNERS 文件包含 SIG Docs 评阅人和批准人的列表。 
+OWNERS 文件包含 SIG Docs 评阅人和批准人的列表。
 OWNERS 文件也可以存在于子目录中，可以在子目录层级重新设置哪些人可以作为评阅人和
-批准人，并将这一设定传递到下层子目录。 
+批准人，并将这一设定传递到下层子目录。
 关于 OWNERS 的更多信息，请参考
 [OWNERS](https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md)
 文档。
@@ -206,7 +206,7 @@ SIG Docs 批准人。下面是合并的工作机制：
 - 所有 Kubernetes 成员可以通过 `/lgtm` 评论添加 `lgtm` 标签。
 - 只有 SIG Docs 批准人可以通过评论 `/approve` 合并 PR。
   某些批准人还会执行一些其他角色，例如
-  [PR 管理者](/zh/docs/contribute/participate/pr-wranglers/) 或
+  [PR 管理者](/zh-cn/docs/contribute/participate/pr-wranglers/) 或
   [SIG Docs 主席](#sig-docs-chairperson)等。
 
 ## {{% heading "whatsnext" %}}
@@ -220,6 +220,6 @@ For more information about contributing to the Kubernetes documentation, see:
 -->
 关于贡献 Kubernetes 文档的更多信息，请参考：
 
-- [贡献新内容](/zh/docs/contribute/new-content/overview/)
-- [评阅内容](/zh/docs/contribute/review/reviewing-prs)
-- [文档样式指南](/zh/docs/contribute/style/)
+- [贡献新内容](/zh-cn/docs/contribute/new-content/)
+- [评阅内容](/zh-cn/docs/contribute/review/reviewing-prs)
+- [文档样式指南](/zh-cn/docs/contribute/style/)

--- a/content/zh-cn/docs/contribute/participate/roles-and-responsibilities.md
+++ b/content/zh-cn/docs/contribute/participate/roles-and-responsibilities.md
@@ -62,12 +62,12 @@ For more information, see [contributing new content](/docs/contribute/new-conten
   [SIG Docs 邮件列表](https://groups.google.com/forum/#!forum/kubernetes-sig-docs)
   上提出改进建议。
 
-在[签署了 CLA](/zh/docs/contribute/new-content/overview/#sign-the-cla) 之后，任何人还可以：
+在[签署了 CLA](/zh-cn/docs/contribute/new-content/#sign-the-cla) 之后，任何人还可以：
 
 - 发起拉取请求（PR），改进现有内容、添加新内容、撰写博客或者案例分析
 - 创建示意图、图形资产或者嵌入式的截屏和视频内容
 
-进一步的详细信息，可参见[贡献新内容](/zh/docs/contribute/new-content/)。
+进一步的详细信息，可参见[贡献新内容](/zh-cn/docs/contribute/new-content/)。
 
 <!--
 ## Members
@@ -134,7 +134,7 @@ After submitting at least 5 substantial pull requests and meeting the other [req
 2.  Open a GitHub issue in the [`kubernetes/org`](https://github.com/kubernetes/org/) repository. Use the **Organization Membership Request** issue template.
 -->
 1. 找到两个[评审人](#reviewers)或[批准人](#approvers)为你的成员身份提供
-   [担保](/zh/docs/contribute/advanced#sponsor-a-new-contributor)。
+   [担保](/zh-cn/docs/contribute/advanced#sponsor-a-new-contributor)。
 
    通过 [Kubernetes Slack 上的 #sig-docs 频道](https://kubernetes.slack.com) 或者
    [SIG Docs 邮件列表](https://groups.google.com/forum/#!forum/kubernetes-sig-docs)
@@ -242,7 +242,7 @@ A `/lgtm` comment from reviewer is binding and triggers automation that adds the
 如果所指派的评审人未能及时评审，其他的评审人也可以参与进来。
 你可以根据需要指派技术评审人。
 
-### 使用 `/lgtm`
+### 使用 `/lgtm`   {#using-lgtm}
 
 LGTM 代表的是 “Looks Good To Me （我觉得可以）”，用来标示某个 PR
 在技术上是准确的，可以被合并。
@@ -293,7 +293,7 @@ If approved, a SIG Docs lead adds you to the appropriate GitHub team. Once added
    下列举的用户名）。
 
 申请被批准之后，SIG Docs Leads 之一会将你添加到合适的 GitHub 团队。
-一旦添加完成， [@k8s-ci-robot](https://github.com/kubernetes/test-infra/tree/master/prow#bots-home)
+一旦添加完成，[@k8s-ci-robot](https://github.com/kubernetes/test-infra/tree/master/prow#bots-home)
 会在处理未来的 PR 时，将 PR 指派给你或者建议你来评审某 PR。
 
 <!--
@@ -327,7 +327,7 @@ If the PR already has a `/lgtm`, or if the approver also comments with `/lgtm`, 
 - 对文档测试给出改进建议
 - 对 Kubernetes 网站或其他工具给出改进建议
 
-如果某个 PR 已有 `/lgtm` 标签，或者批准人再回复一个 `/lgtm` ，则这个 PR 会自动合并。
+如果某个 PR 已有 `/lgtm` 标签，或者批准人再回复一个 `/lgtm`，则这个 PR 会自动合并。
 SIG Docs 批准人应该只在不需要额外的技术评审的情况下才可以标记 `/lgtm`。
 
 <!--
@@ -356,7 +356,7 @@ Approvers and SIG Docs leads are the only ones who can merge pull requests into 
     不小心的合并可能会破坏整个站点。在执行合并操作时，务必小心。
     {{< /warning >}}
 
-- 确保所提议的变更满足[贡献指南](/zh/docs/contribute/style/content-guide/#contributing-content)要求。
+- 确保所提议的变更满足[贡献指南](/zh-cn/docs/contribute/style/content-guide/#contributing-content)要求。
 
     如果有问题或者疑惑，可以根据需要请他人帮助评审。
 
@@ -368,7 +368,7 @@ Approvers and SIG Docs leads are the only ones who can merge pull requests into 
 
 - 参与 [PR 管理者轮值排班](https://github.com/kubernetes/website/wiki/PR-Wranglers)
   执行时长为一周的 PR 管理。SIG Docs 期望所有批准人都参与到此轮值工作中。
-  更多细节可参见 [PR 管理者](/zh/docs/contribute/participate/pr-wranglers/)。
+  更多细节可参见 [PR 管理者](/zh-cn/docs/contribute/participate/pr-wranglers/)。
 
 <!--
 ### Becoming an approver
@@ -406,13 +406,13 @@ If approved, a SIG Docs lead adds you to the appropriate GitHub team. Once added
 2. 将 PR 指派给一个或多个 SIG Docs 批准人。
 
 请求被批准之后，SIG Docs Leads 之一会将你添加到对应的 GitHub 团队。
-一旦添加完成， [K8s-ci-robot](https://github.com/kubernetes/test-infra/tree/master/prow#bots-home)
+一旦添加完成，[K8s-ci-robot](https://github.com/kubernetes/test-infra/tree/master/prow#bots-home)
 会在处理未来的 PR 时，将 PR 指派给你或者建议你来评审某 PR。
 
 ## {{% heading "whatsnext" %}}
 
 <!--
-- Read about [PR wrangling](/docs/contribute/participating/pr-wranglers), a role all approvers take on rotation.
+- Read about [PR wrangling](/docs/contribute/participate/pr-wranglers), a role all approvers take on rotation.
 -->
-- 阅读 [PR 管理者](/zh/docs/contribute/participate/pr-wranglers/)，了解所有批准人轮值的角色。
+- 阅读 [PR 管理者](/zh-cn/docs/contribute/participate/pr-wranglers/)，了解所有批准人轮值的角色。
 

--- a/content/zh-cn/docs/contribute/review/reviewing-prs.md
+++ b/content/zh-cn/docs/contribute/review/reviewing-prs.md
@@ -12,6 +12,7 @@ weight: 10
 -->
 
 <!-- overview -->
+
 <!--
 Anyone can review a documentation pull request. Visit the [pull requests](https://github.com/kubernetes/website/pulls) section in the Kubernetes website repository to see open pull requests.
 
@@ -22,8 +23,10 @@ It helps you learn the code base and build trust with other contributors.
 Before reviewing, it's a good idea to:
 
 - Read the  [content guide](/docs/contribute/style/content-guide/) and
-[style guide](/docs/contribute/style/style-guide/) so you can leave informed comments.
-- Understand the different [roles and responsibilities](/docs/contribute/participating/#roles-and-responsibilities) in the Kubernetes documentation community.
+  [style guide](/docs/contribute/style/style-guide/) so you can leave informed comments.
+- Understand the different
+  [roles and responsibilities](/docs/contribute/participate/roles-and-responsibilities/)
+  in the Kubernetes documentation community.
 -->
 任何人均可评审文档的拉取请求。
 访问 Kubernetes 网站仓库的 [pull requests](https://github.com/kubernetes/website/pulls) 部分，
@@ -34,11 +37,12 @@ Before reviewing, it's a good idea to:
 
 在评审之前，可以考虑：
 
-- 阅读[内容指南](/zh/docs/contribute/style/content-guide/)和 
-  [样式指南](/zh/docs/contribute/style/style-guide/)以便给出有价值的评论。
-- 了解 Kubernetes 文档社区中不同的[角色和职责](/zh/docs/contribute/participate/roles-and-responsibilities/)。
+- 阅读[内容指南](/zh-cn/docs/contribute/style/content-guide/)和 
+  [样式指南](/zh-cn/docs/contribute/style/style-guide/)以便给出有价值的评论。
+- 了解 Kubernetes 文档社区中不同的[角色和职责](/zh-cn/docs/contribute/participate/roles-and-responsibilities/)。
 
 <!-- body -->
+
 <!--
 ## Before you begin
 
@@ -127,7 +131,7 @@ Figure 1. Review process steps.
 2. 使用以下标签（组合）对待处理 PR 进行过滤：
 
     - `cncf-cla: yes` （建议）：由尚未签署 CLA 的贡献者所发起的 PR 不可以合并。
-      参考[签署 CLA](/zh/docs/contribute/new-content/overview/#sign-the-cla) 以了解更多信息。
+      参考[签署 CLA](/zh-cn/docs/contribute/new-content/#sign-the-cla) 以了解更多信息。
     - `language/en` （建议）：仅查看英语语言的 PR。
     - `size/<尺寸>`：过滤特定尺寸（规模）的 PR。
       如果你刚入门，可以从较小的 PR 开始。
@@ -157,7 +161,7 @@ Figure 1. Review process steps.
      如果你在平板电脑或智能手机设备上进行评审，
      GitHub 的 Web UI 会略有不同）：
      {{< figure src="/images/docs/github_netlify_deploy_preview.png" alt="GitHub PR 详细信息，包括 Netlify 预览链接" >}}
-    要打开预览，请点击 **deploy/netlify** 行的 **Details** 链接。
+     要打开预览，请点击 **deploy/netlify** 行的 **Details** 链接。
 
 <!--
 4.  Go to the **Files changed** tab to start your review.
@@ -203,7 +207,7 @@ When reviewing, use the following as a starting point.
 - 是否存在明显的语言或语法错误？对某事的描述有更好的方式？
 - 是否存在一些过于复杂晦涩的用词，本可以用简单词汇来代替？
 - 是否有些用词、术语或短语可以用不带歧视性的表达方式代替？
-- 用词和大小写方面是否遵从了[样式指南](/zh/docs/contribute/style/style-guide/)？
+- 用词和大小写方面是否遵从了[样式指南](/zh-cn/docs/contribute/style/style-guide/)？
 - 是否有些句子太长，可以改得更短、更简单？
 - 是否某些段落过长，可以考虑使用列表或者表格来表达？
 
@@ -234,10 +238,10 @@ When reviewing, use the following as a starting point.
   如果是这样，PR 是否会导致出现新的失效链接？
   是否有其他的办法，比如改变页面标题但不改变其 slug？
 - PR 是否引入新的页面？如果是：
-  - 该页面是否使用了正确的[页面内容类型](/zh/docs/contribute/style/page-content-types/)
+  - 该页面是否使用了正确的[页面内容类型](/zh-cn/docs/contribute/style/page-content-types/)
     及相关联的 Hugo 短代码（shortcodes）？
   - 该页面能否在对应章节的侧面导航中显示？显示得正确么？
-  - 该页面是否应出现在[网站主页面](/zh/docs/home/)的列表中？
+  - 该页面是否应出现在[网站主页面](/zh-cn/docs/home/)的列表中？
 - 变更是否正确出现在 Netlify 预览中了？
   要对列表、代码段、表格、注释和图像等元素格外留心。
 


### PR DESCRIPTION
Fix link and re-sync page.

https://kubernetes.io/zh/docs/contribute/new-content/overview/ -> https://kubernetes.io/zh-cn/docs/contribute/new-content/

https://kubernetes.io/zh/docs/contribute/participating/ -> https://kubernetes.io/zh-cn/docs/contribute/participate/