### PR TITLE
Fix typo in assign-pods-nodes.md

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/assign-pods-nodes.md
+++ b/content/en/docs/tasks/configure-pod-container/assign-pods-nodes.md
@@ -34,7 +34,7 @@ Kubernetes cluster.
     worker1   Ready     <none>   1d      v1.13.0        ...,kubernetes.io/hostname=worker1
     worker2   Ready     <none>   1d      v1.13.0        ...,kubernetes.io/hostname=worker2
     ```
-1. Chose one of your nodes, and add a label to it:
+1. Choose one of your nodes, and add a label to it:
 
     ```shell
     kubectl label nodes <your-node-name> disktype=ssd


### PR DESCRIPTION
Fix typo in `tasks/configure-pod-container/assign-pods-nodes.md` ('chose' -> 'choose').