### PR TITLE
Fix typo

### DIFF
--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -117,7 +117,7 @@ spec:
       fsType: ext4
 ```
 
-If the EBS volume is partitioned, you can supply the optional field `partition: "<partition number>"` to specify which parition to mount on.
+If the EBS volume is partitioned, you can supply the optional field `partition: "<partition number>"` to specify which partition to mount on.
 
 #### AWS EBS CSI migration
 


### PR DESCRIPTION
fix typo from `parition` to `partition`