### PR TITLE
Update Jobs page for 1.24

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -691,7 +691,6 @@ In order to use this behavior, you must enable the `JobTrackingWithFinalizers`
 [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
 on the [API server](/docs/reference/command-line-tools-reference/kube-apiserver/)
 and the [controller manager](/docs/reference/command-line-tools-reference/kube-controller-manager/).
-It is enabled by default.
 
 When enabled, the control plane tracks new Jobs using the behavior described
 below. Jobs created before the feature was enabled are unaffected. As a user,


### PR DESCRIPTION
Updates the Job tracking with the finalizers section under the Jobs page which is not enabled by default from 1.24 (https://github.com/kubernetes/kubernetes/pull/109487)

Fixes #32944