### PR TITLE
fix exec-liveness example

### DIFF
--- a/content/en/examples/pods/probe/exec-liveness.yaml
+++ b/content/en/examples/pods/probe/exec-liveness.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name: liveness
-    image: k8s.gcr.io/busybox
+    image: debian:buster-slim
     args:
     - /bin/sh
     - -c


### PR DESCRIPTION
Fixes #34426

The example for liveness-commands [HERE](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command) appears to be broken.

The containers logs show an issue with `/bin/sh`:

```log
$ k logs pods/liveness-exec 
/bin/sh: can't load library 'libdl.so.2'
```

[StackOverflow](https://stackoverflow.com/questions/69607005/cannot-run-executables-with-alpine-and-busybox-docker-images) pointed me into the direction of glibc / musl-libc so I tried running the exact same example on `debian:buster-slim` instead of `busybox`, which worked fine (`busybox:glibc` didn't work either).

Maybe we can update the [example](https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/pods/probe/exec-liveness.yaml) to use a lightweight image with glibc?