### PR TITLE
Add externalSetMarkChain to portmap config

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins.md
+++ b/content/en/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins.md
@@ -87,7 +87,8 @@ For example:
     },
     {
       "type": "portmap",
-      "capabilities": {"portMappings": true}
+      "capabilities": {"portMappings": true},
+      "externalSetMarkChain": "KUBE-MARK-MASQ"
     }
   ]
 }

--- a/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/troubleshooting-cni-plugin-related-errors.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/troubleshooting-cni-plugin-related-errors.md
@@ -134,7 +134,8 @@ cat << EOF | tee /etc/cni/net.d/10-containerd-net.conflist
    },
    {
      "type": "portmap",
-     "capabilities": {"portMappings": true}
+     "capabilities": {"portMappings": true},
+     "externalSetMarkChain": "KUBE-MARK-MASQ"
    }
  ]
 }


### PR DESCRIPTION
Looking at the online portmap doc, this seems to be
the recommended configuration for k8s + portmap
https://www.cni.dev/plugins/current/meta/portmap/