### PR TITLE
[zh] Fix unexpected markdown rendering in /content/zh-cn/docs/reference/kubectl/cheatsheet.md

### DIFF
--- a/content/zh-cn/docs/reference/kubectl/cheatsheet.md
+++ b/content/zh-cn/docs/reference/kubectl/cheatsheet.md
@@ -720,6 +720,8 @@ kubectl exec -n my-namespace my-pod -- tar cf - /tmp/foo | tar xf - -C /tmp/bar 
 ```bash
 tar cf - /tmp/foo | kubectl exec -i -n my-namespace my-pod -- tar xf - -C /tmp/bar  # 将 /tmp/foo 本地文件复制到远程 “my-namespace” 命名空间中 pod 中的 /tmp/bar
 kubectl exec -n my-namespace my-pod -- tar cf - /tmp/foo | tar xf - -C /tmp/bar    # 将 /tmp/foo 从远程 pod 复制到本地 /tmp/bar
+```
+
 <!--
 ## Interacting with Deployments and Services
 -->


### PR DESCRIPTION
I guess pair of <code>```</code> is required for a Markdown codeblock.

Rendered content:

https://deploy-preview-34431--kubernetes-io-main-staging.netlify.app/zh-cn/docs/reference/kubectl/cheatsheet/#从容器中复制文件和目录

Thanks for reviewing this!
