### PR TITLE
Updated cheatsheet.md with 'get taints' command

### DIFF
--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -381,6 +381,9 @@ kubectl cluster-info                                                  # Display 
 kubectl cluster-info dump                                             # Dump current cluster state to stdout
 kubectl cluster-info dump --output-directory=/path/to/cluster-state   # Dump current cluster state to /path/to/cluster-state
 
+# View existing taints on which exist on current nodes.
+kubectl get nodes -o=custom-columns=NodeName:.metadata.name,TaintKey:.spec.taints[*].key,TaintValue:.spec.taints[*].value,TaintEffect:.spec.taints[*].effect
+
 # If a taint with that key and effect already exists, its value is replaced as specified.
 kubectl taint nodes foo dedicated=special-user:NoSchedule
 ```


### PR DESCRIPTION
Updated the kubectl cheat sheet (cheatsheet.md) with a command for viewing taints which exists on current nodes. This currently doesn't exist in the documentation.