### PR TITLE
Fix manifest for example Job to calculate π

### DIFF
--- a/content/en/examples/controllers/job.yaml
+++ b/content/en/examples/controllers/job.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: pi
-        image: perl
+        image: perl:5.34
         command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
       restartPolicy: Never
   backoffLimit: 4


### PR DESCRIPTION
The perl command in the [job example yaml file](https://kubernetes.io/examples/controllers/job.yaml) fails at image version >5.34:

```
> docker run -it perl:5.36 bash
...
root@783a8ea24899:/# perl -Mbignum=bpi -wle "print bpi(2000)"
Can't use an undefined value as an ARRAY reference at /usr/local/lib/perl5/5.36.0/Math/BigInt/Calc.pm line 1049.```

> docker run -it perl:5.35 bash
...
docker: Error response from daemon: manifest for perl:5.35 not found: manifest unknown: manifest unknown.```

> docker run -it perl:5.34 bash
...
root@d4efc70c15b5:/# perl -Mbignum=bpi -wle "print bpi(2000)"
3.141592653589793238...
```


