### PR TITLE
Update mysql-statefulset configuration file

### DIFF
--- a/content/en/examples/application/mysql/mysql-statefulset.yaml
+++ b/content/en/examples/application/mysql/mysql-statefulset.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: mysql-server
+      app: mysql
       app.kubernetes.io/name: mysql
   serviceName: mysql
   replicas: 3


### PR DESCRIPTION
This PR updates the example configuration file [mysql-statefulset.yaml
](https://github.com/kubernetes/website/blob/main/content/en/examples/application/mysql/mysql-statefulset.yaml
) which fixes the error with this task.

Fixes #34479