### PR TITLE
[zh]Update blog pages(2015-2017) for links with '/zh/' prefix, using new prefix '/zh-cn/'

### DIFF
--- a/content/zh-cn/blog/_index.md
+++ b/content/zh-cn/blog/_index.md
@@ -15,6 +15,6 @@ menu:
 https://kubernetes.io/docs/contribute/new-content/blogs-case-studies/#write-a-blog-post -->
 
 有关为博客提供内容的信息，请参见
-https://kubernetes.io/zh/docs/contribute/new-content/blogs-case-studies/#write-a-blog-post
+https://kubernetes.io/zh-cn/docs/contribute/new-content/blogs-case-studies/#write-a-blog-post
 
 {{< /comment >}}


### PR DESCRIPTION
relate issue: https://github.com/kubernetes/website/issues/34501, task-1

these pages don't need to be update when https://github.com/kubernetes/website/pull/34490/files and https://github.com/kubernetes/website/pull/34488/files are merged.