### PR TITLE
[zh]Update tutorials pages for links with '/zh/' prefix, using new prefix '/zh-cn/'

### DIFF
--- a/content/zh-cn/docs/tutorials/_index.md
+++ b/content/zh-cn/docs/tutorials/_index.md
@@ -24,9 +24,9 @@ Before walking through each tutorial, you may want to bookmark the
 [Standardized Glossary](/docs/reference/glossary/) page for later references.
 -->
 Kubernetes 文档的这一部分包含教程。
-每个教程展示了如何完成一个比单个[任务](/zh/docs/tasks/)更大的目标。
+每个教程展示了如何完成一个比单个[任务](/zh-cn/docs/tasks/)更大的目标。
 通常一个教程有几个部分，每个部分都有一系列步骤。在浏览每个教程之前，
-你可能希望将[标准化术语表](/zh/docs/reference/glossary/)页面添加到书签，供以后参考。
+你可能希望将[标准化术语表](/zh-cn/docs/reference/glossary/)页面添加到书签，供以后参考。
 
 <!-- body -->
 <!--
@@ -40,10 +40,10 @@ Kubernetes 文档的这一部分包含教程。
 -->
 ## 基础知识  {#basics}
 
-* [Kubernetes 基础知识](/zh/docs/tutorials/Kubernetes-Basics/)
+* [Kubernetes 基础知识](/zh-cn/docs/tutorials/Kubernetes-Basics/)
   是一个深入的交互式教程，帮助你理解 Kubernetes 系统，并尝试一些基本的 Kubernetes 特性。
 * [Kubernetes 介绍 (edX)](https://www.edx.org/course/introduction-kubernetes-linuxfoundationx-lfs158x#)
-* [你好 Minikube](/zh/docs/tutorials/hello-minikube/)
+* [你好 Minikube](/zh-cn/docs/tutorials/hello-minikube/)
 
 <!--
 ## Configuration
@@ -54,8 +54,8 @@ Kubernetes 文档的这一部分包含教程。
 -->
 ## 配置  {#configuration}
 
-* [示例：配置 Java 微服务](/zh/docs/tutorials/configuration/configure-java-microservice/)
-* [使用 ConfigMap 配置 Redis](/zh/docs/tutorials/configuration/configure-redis-using-configmap/)
+* [示例：配置 Java 微服务](/zh-cn/docs/tutorials/configuration/configure-java-microservice/)
+* [使用 ConfigMap 配置 Redis](/zh-cn/docs/tutorials/configuration/configure-redis-using-configmap/)
 
 <!--
 ## Stateless Applications
@@ -66,8 +66,8 @@ Kubernetes 文档的这一部分包含教程。
 -->
 ## 无状态应用程序  {#stateless-applications}
 
-* [公开外部 IP 地址访问集群中的应用程序](/zh/docs/tutorials/stateless-application/expose-external-ip-address/)
-* [示例：使用 Redis 部署 PHP 留言板应用程序](/zh/docs/tutorials/stateless-application/guestbook/)
+* [公开外部 IP 地址访问集群中的应用程序](/zh-cn/docs/tutorials/stateless-application/expose-external-ip-address/)
+* [示例：使用 Redis 部署 PHP 留言板应用程序](/zh-cn/docs/tutorials/stateless-application/guestbook/)
 
 <!--
 ## Stateful Applications
@@ -82,10 +82,10 @@ Kubernetes 文档的这一部分包含教程。
 -->
 ## 有状态应用程序  {#stateful-applications}
 
-* [StatefulSet 基础](/zh/docs/tutorials/stateful-application/basic-stateful-set/)
-* [示例：WordPress 和 MySQL 使用持久卷](/zh/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/)
-* [示例：使用有状态集部署 Cassandra](/zh/docs/tutorials/stateful-application/cassandra/)
-* [运行 ZooKeeper，CP 分布式系统](/zh/docs/tutorials/stateful-application/zookeeper/)
+* [StatefulSet 基础](/zh-cn/docs/tutorials/stateful-application/basic-stateful-set/)
+* [示例：WordPress 和 MySQL 使用持久卷](/zh-cn/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/)
+* [示例：使用有状态集部署 Cassandra](/zh-cn/docs/tutorials/stateful-application/cassandra/)
+* [运行 ZooKeeper，CP 分布式系统](/zh-cn/docs/tutorials/stateful-application/zookeeper/)
 
 <!--
 ## Services
@@ -94,22 +94,22 @@ Kubernetes 文档的这一部分包含教程。
 -->
 ## 服务  {#services}
 
-* [使用源 IP](/zh/docs/tutorials/services/source-ip/)
+* [使用源 IP](/zh-cn/docs/tutorials/services/source-ip/)
 
 <!--
 ## Security
 
 * [Apply Pod Security Standards at Cluster level](/docs/tutorials/security/cluster-level-pss/)
 * [Apply Pod Security Standards at Namespace level](/docs/tutorials/security/ns-level-pss/)
-* [AppArmor](/zh/docs/tutorials/security/apparmor/)
-* [seccomp](/zh/docs/tutorials/security/seccomp/)
+* [AppArmor](/zh-cn/docs/tutorials/security/apparmor/)
+* [seccomp](/zh-cn/docs/tutorials/security/seccomp/)
 -->
 ## 安全  {#security}
 
-* [在集群级别应用 Pod 安全标准](/zh/docs/tutorials/security/cluster-level-pss/)
-* [在名字空间级别应用 Pod 安全标准](/zh/docs/tutorials/security/ns-level-pss/)
-* [AppArmor](/zh/docs/tutorials/security/apparmor/)
-* [seccomp](/zh/docs/tutorials/security/seccomp/)
+* [在集群级别应用 Pod 安全标准](/zh-cn/docs/tutorials/security/cluster-level-pss/)
+* [在名字空间级别应用 Pod 安全标准](/zh-cn/docs/tutorials/security/ns-level-pss/)
+* [AppArmor](/zh-cn/docs/tutorials/security/apparmor/)
+* [seccomp](/zh-cn/docs/tutorials/security/seccomp/)
 
 ## {{% heading "whatsnext" %}}
 
@@ -118,6 +118,6 @@ If you would like to write a tutorial, see
 [Content Page Types](/docs/contribute/style/page-content-types/)
 for information about the tutorial page.
 -->
-如果你要编写教程，请参阅[内容页面类型](/zh/docs/contribute/style/page-content-types/)
+如果你要编写教程，请参阅[内容页面类型](/zh-cn/docs/contribute/style/page-content-types/)
 以获取有关教程页面类型的信息。
 

--- a/content/zh-cn/docs/tutorials/configuration/configure-java-microservice/configure-java-microservice.md
+++ b/content/zh-cn/docs/tutorials/configuration/configure-java-microservice/configure-java-microservice.md
@@ -40,11 +40,11 @@ Although Secrets are also used to store key-value pairs, they differ from Config
 -->
 ConfigMaps 是存储非机密键值对的 API 对象。
 在互动教程中，你会学到如何用 ConfigMap 来保存应用名字。
-ConfigMap 的更多信息，你可以在[这里](/zh/docs/tasks/configure-pod-container/configure-pod-configmap/)找到文档。
+ConfigMap 的更多信息，你可以在[这里](/zh-cn/docs/tasks/configure-pod-container/configure-pod-configmap/)找到文档。
 
 Secrets 尽管也用来存储键值对，但区别于 ConfigMaps 的是：它针对机密/敏感数据，且存储格式为 Base64 编码。
 secrets 的这种特性使得它适合于存储证书、密钥、令牌，上述内容你将在交互教程中实现。
-Secrets 的更多信息，你可以在[这里](/zh/docs/concepts/configuration/secret/)找到文档。
+Secrets 的更多信息，你可以在[这里](/zh-cn/docs/concepts/configuration/secret/)找到文档。
 
 
 <!-- 
@@ -90,4 +90,4 @@ CDI & MicroProfile 都会被用在互动教程中，
 ### [Start Interactive Tutorial](/docs/tutorials/configuration/configure-java-microservice/configure-java-microservice-interactive/) 
 -->
 ## 示例：使用 MicroProfile、ConfigMaps、Secrets 实现外部化应用配置
-### [启动互动教程](/zh/docs/tutorials/configuration/configure-java-microservice/configure-java-microservice-interactive/) 
+### [启动互动教程](/zh-cn/docs/tutorials/configuration/configure-java-microservice/configure-java-microservice-interactive/) 

--- a/content/zh-cn/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/zh-cn/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -15,7 +15,7 @@ content_type: tutorial
 <!--
 This page provides a real world example of how to configure Redis using a ConfigMap and builds upon the [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/) task.
 -->
-这篇文档基于[配置 Pod 以使用 ConfigMap](/zh/docs/tasks/configure-pod-container/configure-pod-configmap/)
+这篇文档基于[配置 Pod 以使用 ConfigMap](/zh-cn/docs/tasks/configure-pod-container/configure-pod-configmap/)
 这个任务，提供了一个使用 ConfigMap 来配置 Redis 的真实案例。
 
 
@@ -47,7 +47,7 @@ This page provides a real world example of how to configure Redis using a Config
 * Understand [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/).
 -->
 * 此页面上显示的示例适用于 `kubectl` 1.14 及以上的版本。
-* 理解[配置 Pod 以使用 ConfigMap](/zh/docs/tasks/configure-pod-container/configure-pod-configmap/)。
+* 理解[配置 Pod 以使用 ConfigMap](/zh-cn/docs/tasks/configure-pod-container/configure-pod-configmap/)。
 
 
 
@@ -370,7 +370,7 @@ kubectl delete pod/redis configmap/example-redis-config
 <!--
 * Learn more about [ConfigMaps](/docs/tasks/configure-pod-container/configure-pod-configmap/).
 -->
-* 了解有关 [ConfigMaps](/zh/docs/tasks/configure-pod-container/configure-pod-configmap/) 的更多信息。
+* 了解有关 [ConfigMaps](/zh-cn/docs/tasks/configure-pod-container/configure-pod-configmap/) 的更多信息。
 
 
 

--- a/content/zh-cn/docs/tutorials/hello-minikube.md
+++ b/content/zh-cn/docs/tutorials/hello-minikube.md
@@ -166,9 +166,9 @@ recommended way to manage the creation and scaling of Pods.
 
 ## 创建 Deployment
 
-Kubernetes [*Pod*](/zh/docs/concepts/workloads/pods/) 是由一个或多个
+Kubernetes [*Pod*](/zh-cn/docs/concepts/workloads/pods/) 是由一个或多个
 为了管理和联网而绑定在一起的容器构成的组。 本教程中的 Pod 只有一个容器。
-Kubernetes [*Deployment*](/zh/docs/concepts/workloads/controllers/deployment/)
+Kubernetes [*Deployment*](/zh-cn/docs/concepts/workloads/controllers/deployment/)
 检查 Pod 的健康状况，并在 Pod 中的容器终止的情况下重新启动新的容器。
 Deployment 是管理 Pod 创建和扩展的推荐方法。
 
@@ -247,7 +247,7 @@ For more information about `kubectl`commands, see the
 [kubectl overview](/docs/reference/kubectl/).
 -->
 {{< note >}}
-有关 `kubectl` 命令的更多信息，请参阅 [kubectl 概述](/zh/docs/reference/kubectl/)。
+有关 `kubectl` 命令的更多信息，请参阅 [kubectl 概述](/zh-cn/docs/reference/kubectl/)。
 {{< /note >}}
 
 <!--
@@ -262,7 +262,7 @@ Kubernetes [*Service*](/docs/concepts/services-networking/service/).
 
 默认情况下，Pod 只能通过 Kubernetes 集群中的内部 IP 地址访问。
 要使得 `hello-node` 容器可以从 Kubernetes 虚拟网络的外部访问，你必须将 Pod
-暴露为 Kubernetes [*Service*](/zh/docs/concepts/services-networking/service/)。
+暴露为 Kubernetes [*Service*](/zh-cn/docs/concepts/services-networking/service/)。
 
 <!--
 1. Expose the Pod to the public internet using the `kubectl expose` command:
@@ -497,7 +497,7 @@ minikube delete
 * Learn more about [Deploying applications](/docs/tasks/run-application/run-stateless-application-deployment/).
 * Learn more about [Service objects](/docs/concepts/services-networking/service/).
 -->
-* 进一步了解 [Deployment 对象](/zh/docs/concepts/workloads/controllers/deployment/)。
-* 进一步了解[部署应用](/zh/docs/tasks/run-application/run-stateless-application-deployment/)。
-* 进一步了解 [Service 对象](/zh/docs/concepts/services-networking/service/)。
+* 进一步了解 [Deployment 对象](/zh-cn/docs/concepts/workloads/controllers/deployment/)。
+* 进一步了解[部署应用](/zh-cn/docs/tasks/run-application/run-stateless-application-deployment/)。
+* 进一步了解 [Service 对象](/zh-cn/docs/concepts/services-networking/service/)。
 

--- a/content/zh-cn/docs/tutorials/kubernetes-basics/_index.html
+++ b/content/zh-cn/docs/tutorials/kubernetes-basics/_index.html
@@ -55,25 +55,25 @@ card:
           <div class="row">
             <div class="col-md-4">
               <div class="thumbnail">
-                <a href="/zh/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_01.svg?v=1469803628347" alt=""></a>
+                <a href="/zh-cn/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_01.svg?v=1469803628347" alt=""></a>
                 <div class="caption">
-                  <a href="/zh/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro/"><h5>1. 创建一个 Kubernetes 集群</h5></a>
+                  <a href="/zh-cn/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro/"><h5>1. 创建一个 Kubernetes 集群</h5></a>
                 </div>
               </div>
             </div>
             <div class="col-md-4">
               <div class="thumbnail">
-                <a href="/zh/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_02.svg?v=1469803628347" alt=""></a>
+                <a href="/zh-cn/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_02.svg?v=1469803628347" alt=""></a>
                   <div class="caption">
-                    <a href="/zh/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/"><h5>2. 部署应用程序</h5></a>
+                    <a href="/zh-cn/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/"><h5>2. 部署应用程序</h5></a>
                   </div>
               </div>
             </div>
             <div class="col-md-4">
               <div class="thumbnail">
-                <a href="/zh/docs/tutorials/kubernetes-basics/explore/explore-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_03.svg?v=1469803628347" alt=""></a>
+                <a href="/zh-cn/docs/tutorials/kubernetes-basics/explore/explore-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_03.svg?v=1469803628347" alt=""></a>
                 <div class="caption">
-                  <a href="/zh/docs/tutorials/kubernetes-basics/explore/explore-intro/"><h5>3. 应用程序探索</h5></a>
+                  <a href="/zh-cn/docs/tutorials/kubernetes-basics/explore/explore-intro/"><h5>3. 应用程序探索</h5></a>
                 </div>
               </div>
             </div>
@@ -83,25 +83,25 @@ card:
           <div class="row">
             <div class="col-md-4">
               <div class="thumbnail">
-                <a href="/zh/docs/tutorials/kubernetes-basics/expose/expose-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_04.svg?v=1469803628347" alt=""></a>
+                <a href="/zh-cn/docs/tutorials/kubernetes-basics/expose/expose-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_04.svg?v=1469803628347" alt=""></a>
                 <div class="caption">
-                  <a href="/zh/docs/tutorials/kubernetes-basics/expose/expose-intro/"><h5>4. 应用外部可见</h5></a>
+                  <a href="/zh-cn/docs/tutorials/kubernetes-basics/expose/expose-intro/"><h5>4. 应用外部可见</h5></a>
                 </div>
               </div>
             </div>
             <div class="col-md-4">
               <div class="thumbnail">
-                <a href="/zh/docs/tutorials/kubernetes-basics/scale/scale-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_05.svg?v=1469803628347" alt=""></a>
+                <a href="/zh-cn/docs/tutorials/kubernetes-basics/scale/scale-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_05.svg?v=1469803628347" alt=""></a>
                 <div class="caption">
-                  <a href="/zh/docs/tutorials/kubernetes-basics/scale/scale-intro/"><h5>5. 应用可扩展</h5></a>
+                  <a href="/zh-cn/docs/tutorials/kubernetes-basics/scale/scale-intro/"><h5>5. 应用可扩展</h5></a>
                 </div>
               </div>
             </div>
             <div class="col-md-4">
               <div class="thumbnail">
-                <a href="/zh/docs/tutorials/kubernetes-basics/update/update-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_06.svg?v=1469803628347" alt=""></a>
+                <a href="/zh-cn/docs/tutorials/kubernetes-basics/update/update-intro/"><img src="/docs/tutorials/kubernetes-basics/public/images/module_06.svg?v=1469803628347" alt=""></a>
                 <div class="caption">
-                  <a href="/zh/docs/tutorials/kubernetes-basics/update/update-intro/"><h5>6. 应用更新</h5></a>
+                  <a href="/zh-cn/docs/tutorials/kubernetes-basics/update/update-intro/"><h5>6. 应用更新</h5></a>
                 </div>
               </div>
             </div>

--- a/content/zh-cn/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive.html
+++ b/content/zh-cn/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive.html
@@ -40,7 +40,7 @@ weight: 20
                 <!--
                 <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/" role="button">Continue to Module 2<span class="btn__next">›</span></a>
                 -->
-                <a class="btn btn-lg btn-success" href="/zh/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/" role="button">继续阅读第二单元<span class="btn__next">›</span></a>
+                <a class="btn btn-lg btn-success" href="/zh-cn/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/" role="button">继续阅读第二单元<span class="btn__next">›</span></a>
                 
             </div>
         </div>

--- a/content/zh-cn/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro.html
+++ b/content/zh-cn/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro.html
@@ -96,7 +96,7 @@ weight: 10
 
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/zh/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive/" role="button"> 启动交互教程 <span class="btn__next">›</span></a>
+                <a class="btn btn-lg btn-success" href="/zh-cn/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive/" role="button"> 启动交互教程 <span class="btn__next">›</span></a>
             </div>
         </div>
 

--- a/content/zh-cn/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive.html
+++ b/content/zh-cn/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive.html
@@ -33,7 +33,7 @@ weight: 20
         <div class="row">
             <div class="col-md-12">
                 <!-- <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/explore/explore-intro/" role="button">Continue to Module 3<span class="btn__next">›</span></a> -->
-                <a class="btn btn-lg btn-success" href="/zh/docs/tutorials/kubernetes-basics/explore/explore-intro/" role="button">继续阅读第3单元<span class="btn__next">›</span></a>
+                <a class="btn btn-lg btn-success" href="/zh-cn/docs/tutorials/kubernetes-basics/explore/explore-intro/" role="button">继续阅读第3单元<span class="btn__next">›</span></a>
             </div>
         </div>
 

--- a/content/zh-cn/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
+++ b/content/zh-cn/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro.html
@@ -94,7 +94,7 @@ weight: 10
                 <p>你可以使用 Kubernetes 命令行界面 <b>Kubectl</b> 创建和管理 Deployment。Kubectl 使用 Kubernetes API 与集群进行交互。在本单元中，你将学习创建在 Kubernetes 集群上运行应用程序的 Deployment 所需的最常见的 Kubectl 命令。</p>
 
                 <!-- <p>When you create a Deployment, you'll need to specify the container image for your application and the number of replicas that you want to run. You can change that information later by updating your Deployment; Modules <a href="/docs/tutorials/kubernetes-basics/scale-intro/">5</a> and <a href="/docs/tutorials/kubernetes-basics/update-intro/">6</a> of the bootcamp discuss how you can scale and update your Deployments.</p> -->
-                <p>创建 Deployment 时，你需要指定应用程序的容器映像以及要运行的副本数。你可以稍后通过更新 Deployment 来更改该信息; 模块 <a href="/zh/docs/tutorials/kubernetes-basics/scale-intro/">5</a> 和 <a href="/zh/docs/tutorials/kubernetes-basics/update-intro/">6</a> 讨论了如何扩展和更新 Deployments。</p>
+                <p>创建 Deployment 时，你需要指定应用程序的容器映像以及要运行的副本数。你可以稍后通过更新 Deployment 来更改该信息; 模块 <a href="/zh-cn/docs/tutorials/kubernetes-basics/scale-intro/">5</a> 和 <a href="/zh-cn/docs/tutorials/kubernetes-basics/update-intro/">6</a> 讨论了如何扩展和更新 Deployments。</p>
 
             </div>
             <div class="col-md-4">
@@ -115,7 +115,7 @@ weight: 10
                 <p>Now that you know what Deployments are, let's go to the online tutorial and deploy our first app!</p> -->
                 <p>对于我们的第一次部署，我们将使用打包在 Docker 容器中的 Node.js 应用程序。
                     要创建 Node.js 应用程序并部署 Docker 容器，请按照
-                    <a href="/zh/docs/tutorials/hello-minikube/">你好 Minikube 教程</a>.</p>
+                    <a href="/zh-cn/docs/tutorials/hello-minikube/">你好 Minikube 教程</a>.</p>
 
                 <p>现在你已经了解了 Deployment 的内容，让我们转到在线教程并部署我们的第一个应用程序！</p>
             </div>
@@ -124,7 +124,7 @@ weight: 10
 
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/zh/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive/" role="button">开始交互式教程 <span class="btn__next">›</span></a>
+                <a class="btn btn-lg btn-success" href="/zh-cn/docs/tutorials/kubernetes-basics/deploy-app/deploy-interactive/" role="button">开始交互式教程 <span class="btn__next">›</span></a>
             </div>
         </div>
 

--- a/content/zh-cn/docs/tutorials/kubernetes-basics/explore/explore-interactive.html
+++ b/content/zh-cn/docs/tutorials/kubernetes-basics/explore/explore-interactive.html
@@ -42,7 +42,7 @@ weight: 20
         </div>
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/zh/docs/tutorials/kubernetes-basics/expose/expose-intro/" role="button">继续阅读第4单元<span class="btn__next">›</span></a>
+                <a class="btn btn-lg btn-success" href="/zh-cn/docs/tutorials/kubernetes-basics/expose/expose-intro/" role="button">继续阅读第4单元<span class="btn__next">›</span></a>
             </div>
         </div>
 

--- a/content/zh-cn/docs/tutorials/kubernetes-basics/explore/explore-intro.html
+++ b/content/zh-cn/docs/tutorials/kubernetes-basics/explore/explore-intro.html
@@ -43,7 +43,7 @@ weight: 10
 <!--
         <p>When you created a Deployment in Module <a href="/docs/tutorials/kubernetes-basics/deploy-intro/">2</a>, Kubernetes created a <b>Pod</b> to host your application instance. A Pod is a Kubernetes abstraction that represents a group of one or more application containers (such as Docker), and some shared resources for those containers. Those resources include:</p>
 -->
-        <p>在模块 <a href="/zh/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/">2</a>创建 Deployment 时, Kubernetes 添加了一个 <b>Pod</b> 来托管你的应用实例。Pod 是 Kubernetes 抽象出来的，表示一组一个或多个应用程序容器（如 Docker），以及这些容器的一些共享资源。这些资源包括:</p>
+        <p>在模块 <a href="/zh-cn/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/">2</a>创建 Deployment 时, Kubernetes 添加了一个 <b>Pod</b> 来托管你的应用实例。Pod 是 Kubernetes 抽象出来的，表示一组一个或多个应用程序容器（如 Docker），以及这些容器的一些共享资源。这些资源包括:</p>
 <!--
         <ul>
           <li>Shared storage, as Volumes</li>
@@ -169,7 +169,7 @@ weight: 10
 <!--
         <p>In Module <a href="/docs/tutorials/kubernetes-basics/deploy/deploy-intro/">2</a>, you used Kubectl command-line interface. You'll continue to use it in Module 3 to get information about deployed applications and their environments. The most common operations can be done with the following kubectl commands:</p>
 -->
-        <p>在模块 <a href="/zh/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/">2</a>,你使用了 Kubectl 命令行界面。 你将继续在第3单元中使用它来获取有关已部署的应用程序及其环境的信息。 最常见的操作可以使用以下 kubectl 命令完成：</p>
+        <p>在模块 <a href="/zh-cn/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/">2</a>,你使用了 Kubectl 命令行界面。 你将继续在第3单元中使用它来获取有关已部署的应用程序及其环境的信息。 最常见的操作可以使用以下 kubectl 命令完成：</p>
 <!--
         <ul>
           <li><b>kubectl get</b> - list resources</li>
@@ -210,7 +210,7 @@ weight: 10
 <!--
         <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/explore/explore-interactive/" role="button">Start Interactive Tutorial <span class="btn__next">›</span></a>
 -->
-        <a class="btn btn-lg btn-success" href="/zh/docs/tutorials/kubernetes-basics/explore/explore-interactive/" role="button"> 开始交互式教程 <span class="btn__next">›</span></a>
+        <a class="btn btn-lg btn-success" href="/zh-cn/docs/tutorials/kubernetes-basics/explore/explore-interactive/" role="button"> 开始交互式教程 <span class="btn__next">›</span></a>
       </div>
     </div>
 

--- a/content/zh-cn/docs/tutorials/kubernetes-basics/expose/expose-interactive.html
+++ b/content/zh-cn/docs/tutorials/kubernetes-basics/expose/expose-interactive.html
@@ -38,7 +38,7 @@ weight: 20
         </div>
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/zh/docs/tutorials/kubernetes-basics/scale/scale-intro/" role="button">继续阅读第5单元<span class="btn__next">›</span></a>
+                <a class="btn btn-lg btn-success" href="/zh-cn/docs/tutorials/kubernetes-basics/scale/scale-intro/" role="button">继续阅读第5单元<span class="btn__next">›</span></a>
             </div>
         </div>
 

--- a/content/zh-cn/docs/tutorials/kubernetes-basics/expose/expose-intro.html
+++ b/content/zh-cn/docs/tutorials/kubernetes-basics/expose/expose-intro.html
@@ -35,10 +35,10 @@ weight: 10
         <h3>Kubernetes Service 总览</h3>
 
 <!--        <p>Kubernetes <a href="/docs/concepts/workloads/pods/pod-overview/">Pods</a> are mortal. Pods in fact have a <a href="/docs/concepts/workloads/pods/pod-lifecycle/">lifecycle</a>. When a worker node dies, the Pods running on the Node are also lost. A <a href="/docs/concepts/workloads/controllers/replicaset/">ReplicaSet</a> might then dynamically drive the cluster back to desired state via creation of new Pods to keep your application running. As another example, consider an image-processing backend with 3 replicas. Those replicas are exchangeable; the front-end system should not care about backend replicas or even if a Pod is lost and recreated. That said, each Pod in a Kubernetes cluster has a unique IP address, even Pods on the same Node, so there needs to be a way of automatically reconciling changes among Pods so that your applications continue to function.</p>-->
-        <p> Kubernetes <a href="/zh/docs/concepts/workloads/pods/">Pod</a> 是转瞬即逝的。 Pod 实际上拥有 <a href="/zh/docs/concepts/workloads/pods/pod-lifecycle/">生命周期</a>。 当一个工作 Node 挂掉后, 在 Node 上运行的 Pod 也会消亡。 <a href="/zh/docs/concepts/workloads/controllers/replicaset/">ReplicaSet</a> 会自动地通过创建新的 Pod 驱动集群回到目标状态，以保证应用程序正常运行。 换一个例子，考虑一个具有3个副本数的用作图像处理的后端程序。这些副本是可替换的; 前端系统不应该关心后端副本，即使 Pod 丢失或重新创建。也就是说，Kubernetes 集群中的每个 Pod (即使是在同一个 Node 上的 Pod )都有一个唯一的 IP 地址，因此需要一种方法自动协调 Pod 之间的变更，以便应用程序保持运行。</p>
+        <p> Kubernetes <a href="/zh-cn/docs/concepts/workloads/pods/">Pod</a> 是转瞬即逝的。 Pod 实际上拥有 <a href="/zh-cn/docs/concepts/workloads/pods/pod-lifecycle/">生命周期</a>。 当一个工作 Node 挂掉后, 在 Node 上运行的 Pod 也会消亡。 <a href="/zh-cn/docs/concepts/workloads/controllers/replicaset/">ReplicaSet</a> 会自动地通过创建新的 Pod 驱动集群回到目标状态，以保证应用程序正常运行。 换一个例子，考虑一个具有3个副本数的用作图像处理的后端程序。这些副本是可替换的; 前端系统不应该关心后端副本，即使 Pod 丢失或重新创建。也就是说，Kubernetes 集群中的每个 Pod (即使是在同一个 Node 上的 Pod )都有一个唯一的 IP 地址，因此需要一种方法自动协调 Pod 之间的变更，以便应用程序保持运行。</p>
 
 <!--        <p>A Service in Kubernetes is an abstraction which defines a logical set of Pods and a policy by which to access them. Services enable a loose coupling between dependent Pods. A Service is defined using YAML <a href="/docs/concepts/configuration/overview/#general-configuration-tips">(preferred)</a> or JSON, like all Kubernetes objects. The set of Pods targeted by a Service is usually determined by a <i>LabelSelector</i> (see below for why you might want a Service without including <code>selector</code> in the spec).</p>-->
-        <p> Kubernetes 中的服务(Service)是一种抽象概念，它定义了 Pod 的逻辑集和访问 Pod 的协议。Service 使从属 Pod 之间的松耦合成为可能。 和其他 Kubernetes 对象一样, Service 用 YAML <a href="/zh/docs/concepts/configuration/overview/#general-configuration-tips">(更推荐)</a> 或者 JSON 来定义. Service 下的一组 Pod 通常由 <i>LabelSelector</i> (请参阅下面的说明为什么你可能想要一个 spec 中不包含<code>selector</code>的服务)来标记。</p>
+        <p> Kubernetes 中的服务(Service)是一种抽象概念，它定义了 Pod 的逻辑集和访问 Pod 的协议。Service 使从属 Pod 之间的松耦合成为可能。 和其他 Kubernetes 对象一样, Service 用 YAML <a href="/zh-cn/docs/concepts/configuration/overview/#general-configuration-tips">(更推荐)</a> 或者 JSON 来定义. Service 下的一组 Pod 通常由 <i>LabelSelector</i> (请参阅下面的说明为什么你可能想要一个 spec 中不包含<code>selector</code>的服务)来标记。</p>
 
 <!--        <p>Although each Pod has a unique IP address, those IPs are not exposed outside the cluster without a Service. Services allow your applications to receive traffic. Services can be exposed in different ways by specifying a <code>type</code> in the ServiceSpec:</p>-->
         <p>尽管每个 Pod 都有一个唯一的 IP 地址，但是如果没有 Service ，这些 IP 不会暴露在集群外部。Service 允许你的应用程序接收流量。Service 也可以用在 ServiceSpec 标记<code>type</code>的方式暴露</p>
@@ -53,7 +53,7 @@ weight: 10
 				<li><i>ExternalName</i> - 通过返回带有该名称的 CNAME 记录，使用任意名称(由 spec 中的<code>externalName</code>指定)公开 Service。不使用代理。这种类型需要<code>kube-dns</code>的v1.7或更高版本。</li>
 			</ul>
 <!--        <p>More information about the different types of Services can be found in the <a href="/docs/tutorials/services/source-ip/">Using Source IP</a> tutorial. Also see <a href="/docs/concepts/services-networking/connect-applications-service">Connecting Applications with Services</a>.</p>-->
-        <p>更多关于不同 Service 类型的信息可以在<a href="/zh/docs/tutorials/services/source-ip/">使用源 IP </a> 教程。 也请参阅 <a href="/zh/docs/concepts/services-networking/connect-applications-service">连接应用程序和 Service </a>。</p>
+        <p>更多关于不同 Service 类型的信息可以在<a href="/zh-cn/docs/tutorials/services/source-ip/">使用源 IP </a> 教程。 也请参阅 <a href="/zh-cn/docs/concepts/services-networking/connect-applications-service">连接应用程序和 Service </a>。</p>
 <!--        <p>Additionally, note that there are some use cases with Services that involve not defining <code>selector</code> in the spec. A Service created without <code>selector</code> will also not create the corresponding Endpoints object. This allows users to manually map a Service to specific endpoints. Another possibility why there may be no selector is you are strictly using <code>type: ExternalName</code>.</p>-->
         <p>另外，需要注意的是有一些 Service 的用例没有在 spec 中定义<code>selector</code>。 一个没有<code>selector</code>创建的 Service 也不会创建相应的端点对象。这允许用户手动将服务映射到特定的端点。没有 selector 的另一种可能是你严格使用<code>type: ExternalName</code>来标记。</p>
 			</div>
@@ -95,7 +95,7 @@ weight: 10
 <!--        <p>A Service routes traffic across a set of Pods. Services are the abstraction that allow pods to die and replicate in Kubernetes without impacting your application. Discovery and routing among dependent Pods (such as the frontend and backend components in an application) is handled by Kubernetes Services.</p>-->
         <p>Service 通过一组 Pod 路由通信。Service 是一种抽象，它允许 Pod 死亡并在 Kubernetes 中复制，而不会影响应用程序。在依赖的 Pod (如应用程序中的前端和后端组件)之间进行发现和路由是由Kubernetes Service 处理的。</p>
 <!--        <p>Services match a set of Pods using <a href="/docs/concepts/overview/working-with-objects/labels">labels and selectors</a>, a grouping primitive that allows logical operation on objects in Kubernetes. Labels are key/value pairs attached to objects and can be used in any number of ways:</p>-->
-        <p>Service 匹配一组 Pod 是使用 <a href="/zh/docs/concepts/overview/working-with-objects/labels">标签(Label)和选择器(Selector)</a>, 它们是允许对 Kubernetes 中的对象进行逻辑操作的一种分组原语。标签(Label)是附加在对象上的键/值对，可以以多种方式使用:</p>
+        <p>Service 匹配一组 Pod 是使用 <a href="/zh-cn/docs/concepts/overview/working-with-objects/labels">标签(Label)和选择器(Selector)</a>, 它们是允许对 Kubernetes 中的对象进行逻辑操作的一种分组原语。标签(Label)是附加在对象上的键/值对，可以以多种方式使用:</p>
 				<ul>
 <!--          <li>Designate objects for development, test, and production</li>-->
 <!--          <li>Embed version tags</li>-->
@@ -132,7 +132,7 @@ weight: 10
 		<div class="row">
 			<div class="col-md-12">
 <!--        <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/expose/expose-interactive/" role="button">Start Interactive Tutorial<span class="btn__next">›</span></a>-->
-        <a class="btn btn-lg btn-success" href="/zh/docs/tutorials/kubernetes-basics/expose/expose-interactive/" role="button">开始交互式教程<span class="btn__next">›</span></a>
+        <a class="btn btn-lg btn-success" href="/zh-cn/docs/tutorials/kubernetes-basics/expose/expose-interactive/" role="button">开始交互式教程<span class="btn__next">›</span></a>
 			</div>
 		</div>
 	</main>

--- a/content/zh-cn/docs/tutorials/kubernetes-basics/scale/scale-interactive.html
+++ b/content/zh-cn/docs/tutorials/kubernetes-basics/scale/scale-interactive.html
@@ -34,7 +34,7 @@ weight: 20
         </div>
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/zh/docs/tutorials/kubernetes-basics/update/update-intro/" role="button"><!--Continue to Module 6-->继续参阅第6单元<span class="btn__next">›</span></a>
+                <a class="btn btn-lg btn-success" href="/zh-cn/docs/tutorials/kubernetes-basics/update/update-intro/" role="button"><!--Continue to Module 6-->继续参阅第6单元<span class="btn__next">›</span></a>
             </div>
         </div>
     

--- a/content/zh-cn/docs/tutorials/kubernetes-basics/scale/scale-intro.html
+++ b/content/zh-cn/docs/tutorials/kubernetes-basics/scale/scale-intro.html
@@ -33,7 +33,7 @@ weight: 10
 						<!-- <p>In the previous modules we created a <a href="/docs/concepts/workloads/controllers/deployment/"> Deployment</a>,
 							and then exposed it publicly via a <a href="/docs/concepts/services-networking/service/">Service</a>.
 							The Deployment created only one Pod for running our application.  When traffic increases, we will need to scale the application to keep up with  user demand.</p> -->
-						<p>在之前的模块中，我们创建了一个 <a href="/zh/docs/concepts/workloads/controllers/deployment/"> Deployment</a>，然后通过 <a href="/zh/docs/concepts/services-networking/service/">Service</a>让其可以开放访问。Deployment 仅为跑这个应用程序创建了一个 Pod。 当流量增加时，我们需要扩容应用程序满足用户需求。</p>
+						<p>在之前的模块中，我们创建了一个 <a href="/zh-cn/docs/concepts/workloads/controllers/deployment/"> Deployment</a>，然后通过 <a href="/zh-cn/docs/concepts/services-networking/service/">Service</a>让其可以开放访问。Deployment 仅为跑这个应用程序创建了一个 Pod。 当流量增加时，我们需要扩容应用程序满足用户需求。</p>
 
 						<!-- <p><b>Scaling</b> is accomplished by changing the number of replicas in a Deployment</p> -->
 						<p><b>扩缩</b> 是通过改变 Deployment 中的副本数量来实现的。</p>
@@ -99,7 +99,7 @@ weight: 10
 
                 <!-- <p>Scaling out a Deployment will ensure new Pods are created and scheduled to Nodes with available resources. Scaling in will reduce the number of Pods to the new desired state. Kubernetes also supports
 									<a href="/docs/user-guide/horizontal-pod-autoscaling/">autoscaling</a> of Pods, but it is outside of the scope of this tutorial. Scaling to zero is also possible, and it will terminate all Pods of the specified Deployment.</p> -->
-								<p>扩展 Deployment 将创建新的 Pods，并将资源调度请求分配到有可用资源的节点上，收缩 会将 Pods 数量减少至所需的状态。Kubernetes 还支持 Pods 的<a href="/zh/docs/tasks/run-application/horizontal-pod-autoscale/">自动缩放</a>，但这并不在本教程的讨论范围内。将 Pods 数量收缩到0也是可以的，但这会终止 Deployment 上所有已经部署的 Pods。</p>
+								<p>扩展 Deployment 将创建新的 Pods，并将资源调度请求分配到有可用资源的节点上，收缩 会将 Pods 数量减少至所需的状态。Kubernetes 还支持 Pods 的<a href="/zh-cn/docs/tasks/run-application/horizontal-pod-autoscale/">自动缩放</a>，但这并不在本教程的讨论范围内。将 Pods 数量收缩到0也是可以的，但这会终止 Deployment 上所有已经部署的 Pods。</p>
 
 								<!-- <p>Running multiple instances of an application will require a way to distribute the traffic to all of them. Services have an integrated load-balancer that will distribute network traffic to all Pods of an exposed Deployment.
 									Services will monitor continuously the running Pods using endpoints, to ensure the traffic is sent only to available Pods.</p> -->
@@ -127,7 +127,7 @@ weight: 10
         <div class="row">
             <div class="col-md-12">
 								<!-- <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/scale/scale-interactive/" role="button">Start Interactive Tutorial <span class="btn__next">›</span></a> -->
-								<a class="btn btn-lg btn-success" href="/zh/docs/tutorials/kubernetes-basics/scale/scale-interactive/" role="button">开始互动教程 <span class="btn__next">›</span></a>
+								<a class="btn btn-lg btn-success" href="/zh-cn/docs/tutorials/kubernetes-basics/scale/scale-interactive/" role="button">开始互动教程 <span class="btn__next">›</span></a>
             </div>
         </div>
 

--- a/content/zh-cn/docs/tutorials/kubernetes-basics/update/update-interactive.html
+++ b/content/zh-cn/docs/tutorials/kubernetes-basics/update/update-interactive.html
@@ -32,7 +32,7 @@ weight: 20
         </div>
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-lg btn-success" href="/zh/docs/tutorials/kubernetes-basics/" role="button">回到 Kubernetes 的基础<span class="btn__next">›</span></a>
+                <a class="btn btn-lg btn-success" href="/zh-cn/docs/tutorials/kubernetes-basics/" role="button">回到 Kubernetes 的基础<span class="btn__next">›</span></a>
             </div>
         </div>
     </main>

--- a/content/zh-cn/docs/tutorials/kubernetes-basics/update/update-intro.html
+++ b/content/zh-cn/docs/tutorials/kubernetes-basics/update/update-intro.html
@@ -177,7 +177,7 @@ weight: 10
                 <!--
                 <a class="btn btn-lg btn-success" href="/docs/tutorials/kubernetes-basics/update/update-interactive/" role="button">Start Interactive Tutorial <span class="btn__next">›</span></a>
                 -->
-                <a class="btn btn-lg btn-success" href="/zh/docs/tutorials/kubernetes-basics/update/update-interactive/" role="button">启动交互教程<span class="btn__next">›</span></a>
+                <a class="btn btn-lg btn-success" href="/zh-cn/docs/tutorials/kubernetes-basics/update/update-interactive/" role="button">启动交互教程<span class="btn__next">›</span></a>
                 
             </div>
         </div>

--- a/content/zh-cn/docs/tutorials/security/apparmor.md
+++ b/content/zh-cn/docs/tutorials/security/apparmor.md
@@ -487,7 +487,7 @@ Kubernetes 目前不提供任何本地机制来将 AppArmor 配置文件加载�
   [Example](#example). 
 -->
 * 通过在每个节点上运行 Pod 的
-  [DaemonSet](/zh/docs/concepts/workloads/controllers/daemonset/)来确保加载了正确的配置文件。
+  [DaemonSet](/zh-cn/docs/concepts/workloads/controllers/daemonset/)来确保加载了正确的配置文件。
   可以在[这里](https://git.k8s.io/kubernetes/test/images/apparmor-loader)找到实现示例。
 * 在节点初始化时，使用节点初始化脚本(例如 Salt、Ansible 等)或镜像。
 * 通过将配置文件复制到每个节点并通过 SSH 加载它们，如[示例](#example)。
@@ -501,7 +501,7 @@ node with the required profile.
 -->
 调度程序不知道哪些配置文件加载到哪个节点上，因此必须将全套配置文件加载到每个节点上。
 另一种方法是为节点上的每个配置文件（或配置文件类）添加节点标签，
-并使用[节点选择器](/zh/docs/concepts/configuration/assign-pod-node/)确保
+并使用[节点选择器](/zh-cn/docs/concepts/configuration/assign-pod-node/)确保
 Pod 在具有所需配置文件的节点上运行。
 
 <!-- ### Restricting profiles with the PodSecurityPolicy -->
@@ -513,7 +513,7 @@ PodSecurityPolicy is deprecated in Kubernetes v1.21, and will be removed in v1.2
 See [PodSecurityPolicy](/docs/concepts/security/pod-security-policy/) documentation for more information.
 -->
 PodSecurityPolicy 在 Kubernetes v1.21 版本中已被废弃，将在 v1.25 版本移除。
-查看 [PodSecurityPolicy](/zh/docs/concepts/security/pod-security-policy/) 文档获取更多信息。
+查看 [PodSecurityPolicy](/zh-cn/docs/concepts/security/pod-security-policy/) 文档获取更多信息。
 {{< /note >}}
 
 <!-- 

--- a/content/zh-cn/docs/tutorials/security/cluster-level-pss.md
+++ b/content/zh-cn/docs/tutorials/security/cluster-level-pss.md
@@ -29,12 +29,12 @@ To apply Pod Security Standards to specific namespaces, refer to [Apply Pod Secu
 Pod 安全准入（PSA）在 v1.23 及更高版本默认启用，
 因为它[升级到测试版（beta）](/blog/2021/12/09/pod-security-admission-beta/)。
 Pod 安全准入是在创建 Pod 时应用
-[Pod 安全标准](/zh/docs/concepts/security/pod-security-standards/)的准入控制器。
+[Pod 安全标准](/zh-cn/docs/concepts/security/pod-security-standards/)的准入控制器。
 本教程将向你展示如何在集群级别实施 `baseline` Pod 安全标准，
 该标准将标准配置应用于集群中的所有名称空间。
 
 要将 Pod 安全标准应用于特定名字空间，
-请参阅[在名字空间级别应用 Pod 安全标准](/zh/docs/tutorials/security/ns-level-pss)。
+请参阅[在名字空间级别应用 Pod 安全标准](/zh-cn/docs/tutorials/security/ns-level-pss)。
 
 ## {{% heading "prerequisites" %}}
 <!-- 
@@ -60,9 +60,9 @@ that are most appropriate for your configuration, do the following:
 -->
 ## 正确选择要应用的 Pod 安全标准  {#choose-the-right-pod-security-standard-to-apply}
 
-[Pod 安全准入](/zh/docs/concepts/security/pod-security-admission/)
+[Pod 安全准入](/zh-cn/docs/concepts/security/pod-security-admission/)
 允许你使用以下模式应用内置的
-[Pod 安全标准](/zh/docs/concepts/security/pod-security-standards/):
+[Pod 安全标准](/zh-cn/docs/concepts/security/pod-security-standards/):
 `enforce`、`audit` 和 `warn`。
 
 要收集信息以便选择最适合你的配置的 Pod 安全标准，请执行以下操作：
@@ -431,7 +431,7 @@ created.
 - [Pod Security Standards](/docs/concepts/security/pod-security-standards/)
 - [Apply Pod Security Standards at the namespace level](/docs/tutorials/security/ns-level-pss/)
 -->
-- 运行一个 [shell 脚本](/zh/examples/security/kind-with-cluster-level-baseline-pod-security.sh)
+- 运行一个 [shell 脚本](/zh-cn/examples/security/kind-with-cluster-level-baseline-pod-security.sh)
   一次执行前面的所有步骤：
   1. 创建一个基于 Pod 安全标准的集群级别配置
   2. 创建一个文件让 API 服务器消费这个配置
@@ -439,6 +439,6 @@ created.
   4. 设置 kubectl 上下文为这个新集群
   5. 创建一个最小的 Pod yaml 文件
   6. 应用这个文件，在新集群中创建一个 Pod
-- [Pod 安全准入](/zh/docs/concepts/security/pod-security-admission/)
-- [Pod 安全标准](/zh/docs/concepts/security/pod-security-standards/)
-- [在名字空间级别应用 Pod 安全标准](/zh/docs/tutorials/security/ns-level-pss/)
+- [Pod 安全准入](/zh-cn/docs/concepts/security/pod-security-admission/)
+- [Pod 安全标准](/zh-cn/docs/concepts/security/pod-security-standards/)
+- [在名字空间级别应用 Pod 安全标准](/zh-cn/docs/tutorials/security/ns-level-pss/)

--- a/content/zh-cn/docs/tutorials/security/ns-level-pss.md
+++ b/content/zh-cn/docs/tutorials/security/ns-level-pss.md
@@ -30,11 +30,11 @@ level. For instructions, refer to
 Pod 安全准入（PSA）在 v1.23 及更高版本默认启用，
 因为它[升级到测试版（beta）](/blog/2021/12/09/pod-security-admission-beta/)。
 Pod 安全准入是在创建 Pod 时应用
-[Pod 安全标准](/zh/docs/concepts/security/pod-security-standards/)的准入控制器。
+[Pod 安全标准](/zh-cn/docs/concepts/security/pod-security-standards/)的准入控制器。
 在本教程中，你将应用 `baseline` Pod 安全标准，每次一个名字空间。
 
 你还可以在集群级别一次将 Pod 安全标准应用于多个名称空间。
-有关说明，请参阅[在集群级别应用 Pod 安全标准](/zh/docs/tutorials/security/cluster-level-pss)。
+有关说明，请参阅[在集群级别应用 Pod 安全标准](/zh-cn/docs/tutorials/security/cluster-level-pss)。
 
 ## {{% heading "prerequisites" %}}
 
@@ -47,7 +47,7 @@ Install the following on your workstation:
 在你的工作站中安装以下内容：
 
 - [KinD](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
-- [kubectl](/zh/docs/tasks/tools/)
+- [kubectl](/zh-cn/docs/tasks/tools/)
 
 <!--
 ## Create cluster
@@ -247,6 +247,6 @@ Run `kind delete cluster -name psa-ns-level` to delete the cluster created.
       同时在 `warn` 和 `audit` 模式下应用 `restricted` Pod 安全标准。
    4. 创建一个应用以下 Pod 安全标准的新 Pod
 
-- [Pod 安全准入](/zh/docs/concepts/security/pod-security-admission/)
-- [Pod 安全标准](/zh/docs/concepts/security/pod-security-standards/)
-- [在集群级别应用 Pod 安全标准](/zh/docs/tutorials/security/cluster-level-pss/)
+- [Pod 安全准入](/zh-cn/docs/concepts/security/pod-security-admission/)
+- [Pod 安全标准](/zh-cn/docs/concepts/security/pod-security-standards/)
+- [在集群级别应用 Pod 安全标准](/zh-cn/docs/tutorials/security/cluster-level-pss/)

--- a/content/zh-cn/docs/tutorials/security/seccomp.md
+++ b/content/zh-cn/docs/tutorials/security/seccomp.md
@@ -74,8 +74,8 @@ for the version you are using.
 The tutorial also uses the `curl` tool for downloading examples to your computer.
 You can adapt the steps to use a different tool if you prefer.
 -->
-为了完成本篇教程中的所有步骤，你必须安装 [kind](/zh/docs/tasks/tools/#kind)
-和 [kubectl](/zh/docs/tasks/tools/#kubectl)。
+为了完成本篇教程中的所有步骤，你必须安装 [kind](/zh-cn/docs/tasks/tools/#kind)
+和 [kubectl](/zh-cn/docs/tasks/tools/#kubectl)。
 
 本篇教程演示的某些示例仍然是 alpha 状态（自 v1.22 起），另一些示例则仅使用 seccomp 正式发布的功能。
 你应该确保，针对你使用的版本，
@@ -257,8 +257,8 @@ well as corresponding `--seccomp-default`
 [command line flag](/docs/reference/command-line-tools-reference/kubelet).
 Both have to be enabled simultaneously to use the feature.
 -->
-`SeccompDefault` 是一个可选的 kubelet [特性门控](/zh/docs/reference/command-line-tools-reference/feature-gates)
-以及相应的 `--seccomp-default` [命令行标志](/zh/docs/reference/command-line-tools-reference/kubelet)。
+`SeccompDefault` 是一个可选的 kubelet [特性门控](/zh-cn/docs/reference/command-line-tools-reference/feature-gates)
+以及相应的 `--seccomp-default` [命令行标志](/zh-cn/docs/reference/command-line-tools-reference/kubelet)。
 两者必须同时启用才能使用该功能。
 
 <!-- 
@@ -732,7 +732,7 @@ type in the security context of a pod or container to `RuntimeDefault`.
 If you have the `SeccompDefault` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) enabled, then Pods use the `RuntimeDefault` seccomp profile whenever
 no other seccomp profile is specified. Otherwise, the default is `Unconfined`.
 -->
-如果你已经启用了 `SeccompDefault` [特性门控](/zh/docs/reference/command-line-tools-reference/feature-gates/)，
+如果你已经启用了 `SeccompDefault` [特性门控](/zh-cn/docs/reference/command-line-tools-reference/feature-gates/)，
 只要没有指定其他 seccomp 配置文件，那么 Pod 就会使用 `SeccompDefault` 的 seccomp 配置文件。
 否则，默认值为 `Unconfined`。
 {{< /note >}}

--- a/content/zh-cn/docs/tutorials/stateful-application/cassandra.md
+++ b/content/zh-cn/docs/tutorials/stateful-application/cassandra.md
@@ -30,7 +30,7 @@ For more information on the features used in this tutorial, see
 -->
 使用"StatefulSets"可以更轻松地将有状态的应用程序部署到你的 Kubernetes 集群中。
 有关本教程中使用的功能的更多信息，
-参阅 [StatefulSet](/zh/docs/concepts/workloads/controllers/statefulset/)。
+参阅 [StatefulSet](/zh-cn/docs/concepts/workloads/controllers/statefulset/)。
 
 {{< note >}}
 <!--
@@ -160,7 +160,7 @@ If you don't see a Service named `cassandra`, that means creation failed. Read
 for help troubleshooting common issues.
 -->
 如果没有看到名为 `cassandra` 的服务，则表示创建失败。
-请阅读[调试服务](/zh/docs/tasks/debug/debug-application/debug-service/)，以解决常见问题。
+请阅读[调试服务](/zh-cn/docs/tasks/debug/debug-application/debug-service/)，以解决常见问题。
 
 <!--
 ## Using a StatefulSet to create a Cassandra ring

--- a/content/zh-cn/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
+++ b/content/zh-cn/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume.md
@@ -29,9 +29,9 @@ This tutorial shows you how to deploy a WordPress site and a MySQL database usin
 <!--
  A [PersistentVolume](/docs/concepts/storage/persistent-volumes/)(PV)is a piece of storage in the cluster that has been manually provisioned by an administrator, or dynamically provisioned by Kubernetes using a [StorageClass](/docs/concepts/storage/storage-classes).  A [PersistentVolumeClaim](/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims)(PVC)is a request for storage by a user that can be fulfilled by a PV. PersistentVolumes and PersistentVolumeClaims are independent from Pod lifecycles and preserve data through restarting, rescheduling, and even deleting Pods.
 -->
-[PersistentVolume](/zh/docs/concepts/storage/persistent-volumes/)（PV）是一块集群里由管理员手动提供，
-或 kubernetes 通过 [StorageClass](/zh/docs/concepts/storage/storage-classes) 动态创建的存储。
-[PersistentVolumeClaim](/zh/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims)
+[PersistentVolume](/zh-cn/docs/concepts/storage/persistent-volumes/)（PV）是一块集群里由管理员手动提供，
+或 kubernetes 通过 [StorageClass](/zh-cn/docs/concepts/storage/storage-classes) 动态创建的存储。
+[PersistentVolumeClaim](/zh-cn/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims)
 是用户对存储的请求，该请求可由某个 PV 来满足。
 PersistentVolumes 和 PersistentVolumeClaims 独立于 Pod 生命周期而存在，
 在 Pod 重启，重新调度甚至删除过程中保存数据。
@@ -153,7 +153,7 @@ A [Secret](/docs/concepts/configuration/secret/) is an object that stores a piec
 
 Add a Secret generator in `kustomization.yaml` from the following command. You will need to replace `YOUR_PASSWORD` with the password you want to use.
 -->
-[Secret](/zh/docs/concepts/configuration/secret/) 是存储诸如密码或密钥之类的敏感数据的对象。
+[Secret](/zh-cn/docs/concepts/configuration/secret/) 是存储诸如密码或密钥之类的敏感数据的对象。
 从 1.14 开始，`kubectl`支持使用 kustomization 文件管理 Kubernetes 对象。
 你可以通过`kustomization.yaml`中的生成器创建一个 Secret。
 
@@ -455,7 +455,7 @@ Do not leave your WordPress installation on this page. If another user finds it,
 * Learn more about [Port Forwarding](/docs/tasks/access-application-cluster/port-forward-access-application-cluster/)
 * Learn how to [Get a Shell to a Container](/docs/tasks/debug/debug-application/get-shell-running-container/)
 -->
-* 进一步了解[自省与调试](/zh/docs/tasks/debug/debug-application/debug-running-pod/)
-* 进一步了解 [Job](/zh/docs/concepts/workloads/controllers/jobs-run-to-completion/)
-* 进一步了解[端口转发](/zh/docs/tasks/access-application-cluster/port-forward-access-application-cluster/)
-* 了解如何[获得容器的 Shell](/zh/docs/tasks/debug/debug-application/get-shell-running-container/)
+* 进一步了解[自省与调试](/zh-cn/docs/tasks/debug/debug-application/debug-running-pod/)
+* 进一步了解 [Job](/zh-cn/docs/concepts/workloads/controllers/jobs-run-to-completion/)
+* 进一步了解[端口转发](/zh-cn/docs/tasks/access-application-cluster/port-forward-access-application-cluster/)
+* 了解如何[获得容器的 Shell](/zh-cn/docs/tasks/debug/debug-application/get-shell-running-container/)

--- a/content/zh-cn/docs/tutorials/stateful-application/zookeeper.md
+++ b/content/zh-cn/docs/tutorials/stateful-application/zookeeper.md
@@ -26,9 +26,9 @@ Kubernetes using [StatefulSets](/docs/concepts/workloads/controllers/statefulset
 and [PodAntiAffinity](/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity).
 -->
 本教程展示了在 Kubernetes 上使用
-[StatefulSet](/zh/docs/concepts/workloads/controllers/statefulset/)，
-[PodDisruptionBudget](/zh/docs/concepts/workloads/pods/disruptions/#pod-disruption-budget) 和
-[PodAntiAffinity](/zh/docs/concepts/scheduling-eviction/assign-pod-node/#亲和与反亲和)
+[StatefulSet](/zh-cn/docs/concepts/workloads/controllers/statefulset/)，
+[PodDisruptionBudget](/zh-cn/docs/concepts/workloads/pods/disruptions/#pod-disruption-budget) 和
+[PodAntiAffinity](/zh-cn/docs/concepts/scheduling-eviction/assign-pod-node/#亲和与反亲和)
 特性运行 [Apache Zookeeper](https://zookeeper.apache.org)。
 
 ## {{% heading "prerequisites" %}}
@@ -39,15 +39,15 @@ Kubernetes concepts.
 -->
 在开始本教程前，你应该熟悉以下 Kubernetes 概念。
 
-- [Pods](/zh/docs/concepts/workloads/pods/)
-- [集群 DNS](/zh/docs/concepts/services-networking/dns-pod-service/)
-- [无头服务（Headless Service）](/zh/docs/concepts/services-networking/service/#headless-services)
-- [PersistentVolumes](/zh/docs/concepts/storage/persistent-volumes/)
+- [Pods](/zh-cn/docs/concepts/workloads/pods/)
+- [集群 DNS](/zh-cn/docs/concepts/services-networking/dns-pod-service/)
+- [无头服务（Headless Service）](/zh-cn/docs/concepts/services-networking/service/#headless-services)
+- [PersistentVolumes](/zh-cn/docs/concepts/storage/persistent-volumes/)
 - [PersistentVolume 制备](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/persistent-volume-provisioning/)
-- [StatefulSet](/zh/docs/concepts/workloads/controllers/statefulset/)
-- [PodDisruptionBudget](/zh/docs/concepts/workloads/pods/disruptions/#pod-disruption-budget)
-- [PodAntiAffinity](/zh/docs/concepts/scheduling-eviction/assign-pod-node/#亲和与反亲和)
-- [kubectl CLI](/zh/docs/reference/kubectl/kubectl/)
+- [StatefulSet](/zh-cn/docs/concepts/workloads/controllers/statefulset/)
+- [PodDisruptionBudget](/zh-cn/docs/concepts/workloads/pods/disruptions/#pod-disruption-budget)
+- [PodAntiAffinity](/zh-cn/docs/concepts/scheduling-eviction/assign-pod-node/#亲和与反亲和)
+- [kubectl CLI](/zh-cn/docs/reference/kubectl/kubectl/)
 
 <!--
 You must have a cluster with at least four nodes, and each node requires at least 2 CPUs and 4 GiB of memory. In this tutorial you will cordon and drain the cluster's nodes. **This means that the cluster will terminate and evict all Pods on its nodes, and the nodes will temporarily become unschedulable.** You should use a dedicated cluster for this tutorial, or you should ensure that the disruption you cause will not interfere with other tenants.
@@ -140,10 +140,10 @@ and a [StatefulSet](/docs/concepts/workloads/controllers/statefulset/).
 ## 创建一个 ZooKeeper Ensemble
 
 下面的清单包含一个
-[无头服务](/zh/docs/concepts/services-networking/service/#headless-services)，
-一个 [Service](/zh/docs/concepts/services-networking/service/)，
-一个 [PodDisruptionBudget](/zh/docs/concepts/workloads/pods/disruptions/#specifying-a-poddisruptionbudget)，
-和一个 [StatefulSet](/zh/docs/concepts/workloads/controllers/statefulset/)。
+[无头服务](/zh-cn/docs/concepts/services-networking/service/#headless-services)，
+一个 [Service](/zh-cn/docs/concepts/services-networking/service/)，
+一个 [PodDisruptionBudget](/zh-cn/docs/concepts/workloads/pods/disruptions/#specifying-a-poddisruptionbudget)，
+和一个 [StatefulSet](/zh-cn/docs/concepts/workloads/controllers/statefulset/)。
 
 {{< codenew file="application/zookeeper/zookeeper.yaml" >}}
 
@@ -308,7 +308,7 @@ The A records in [Kubernetes DNS](/docs/concepts/services-networking/dns-pod-ser
 
 ZooKeeper stores its application configuration in a file named `zoo.cfg`. Use `kubectl exec` to view the contents of the `zoo.cfg` file in the `zk-0` Pod.
 -->
-[Kubernetes DNS](/zh/docs/concepts/services-networking/dns-pod-service/)
+[Kubernetes DNS](/zh-cn/docs/concepts/services-networking/dns-pod-service/)
 中的 A 记录将 FQDNs 解析成为 Pods 的 IP 地址。
 如果 Pods 被调度，这个 A 记录将会使用 Pods 的新 IP 地址完成更新，
 但 A 记录的名称不会改变。
@@ -836,7 +836,7 @@ consider deploying a [sidecar container](/docs/concepts/cluster-administration/l
 -->
 Kubernetes 支持与多种日志方案集成。你可以选择一个最适合你的集群和应用
 的日志解决方案。对于集群级别的日志输出与整合，可以考虑部署一个
-[边车容器](/zh/docs/concepts/cluster-administration/logging#sidecar-container-with-logging-agent)
+[边车容器](/zh-cn/docs/concepts/cluster-administration/logging#sidecar-container-with-logging-agent)
 来轮转和提供日志数据。
 
 <!--
@@ -854,7 +854,7 @@ The `zk` `StatefulSet`'s Pod `template` contains a `SecurityContext`.
 
 在容器中允许应用以特权用户运行这条最佳实践是值得商讨的。
 如果你的组织要求应用以非特权用户运行，你可以使用
-[SecurityContext](/zh/docs/tasks/configure-pod-container/security-context/)
+[SecurityContext](/zh-cn/docs/tasks/configure-pod-container/security-context/)
 控制运行容器入口点所使用的用户。
 
 `zk` StatefulSet 的 Pod 的 `template` 包含了一个 `SecurityContext`。
@@ -1032,7 +1032,7 @@ Use the following command to examine the process tree for the ZooKeeper server r
 -->
 ### 处理进程故障
 
-[重启策略](/zh/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy)
+[重启策略](/zh-cn/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy)
 控制 Kubernetes 如何处理一个 Pod 中容器入口点的进程故障。
 对于 StatefulSet 中的 Pods 来说，Always 是唯一合适的 RestartPolicy，也是默认值。
 你应该**绝不**覆盖有状态应用的默认策略。

--- a/content/zh-cn/docs/tutorials/stateless-application/expose-external-ip-address.md
+++ b/content/zh-cn/docs/tutorials/stateless-application/expose-external-ip-address.md
@@ -28,9 +28,9 @@ external IP address.
 * Configure `kubectl` to communicate with your Kubernetes API server. For instructions, see the
   documentation for your cloud provider.
 -->
- * 安装 [kubectl](/zh/docs/tasks/tools/)。
+ * 安装 [kubectl](/zh-cn/docs/tasks/tools/)。
  * 使用 Google Kubernetes Engine 或 Amazon Web Services 等云供应商创建 Kubernetes 集群。
-   本教程创建了一个[外部负载均衡器](/zh/docs/tasks/access-application-cluster/create-external-load-balancer/)，
+   本教程创建了一个[外部负载均衡器](/zh-cn/docs/tasks/access-application-cluster/create-external-load-balancer/)，
    需要云供应商。
  * 配置 `kubectl` 与 Kubernetes API 服务器通信。有关说明，请参阅云供应商文档。
 
@@ -132,7 +132,7 @@ external IP address.
    {{< /note >}}
    -->
    提示：`type=LoadBalancer` 服务由外部云服务提供商提供支持，本例中不包含此部分，
-   详细信息请参考[此页](/zh/docs/concepts/services-networking/service/#loadbalancer)
+   详细信息请参考[此页](/zh-cn/docs/concepts/services-networking/service/#loadbalancer)
 
    <!--
    {{< note >}}
@@ -265,5 +265,5 @@ kubectl delete deployment hello-world
 Learn more about
 [connecting applications with services](/docs/concepts/services-networking/connect-applications-service/).
 -->
-进一步了解[将应用程序与服务连接](/zh/docs/concepts/services-networking/connect-applications-service/)。
+进一步了解[将应用程序与服务连接](/zh-cn/docs/concepts/services-networking/connect-applications-service/)。
 

--- a/content/zh-cn/docs/tutorials/stateless-application/guestbook.md
+++ b/content/zh-cn/docs/tutorials/stateless-application/guestbook.md
@@ -136,7 +136,7 @@ The manifest file, included below, specifies a Deployment controller that runs a
 The guestbook application needs to communicate to the Redis to write its data. You need to apply a [Service](/docs/concepts/services-networking/service/) to proxy the traffic to the Redis Pod. A Service defines a policy to access the Pods.
 -->
 留言板应用程序需要往 Redis 中写数据。因此，需要创建
-[Service](/zh/docs/concepts/services-networking/service/) 来转发 Redis Pod
+[Service](/zh-cn/docs/concepts/services-networking/service/) 来转发 Redis Pod
 的流量。Service 定义了访问 Pod 的策略。
 
 {{< codenew file="application/guestbook/redis-leader-service.yaml" >}}
@@ -239,7 +239,7 @@ The guestbook application needs to communicate with the Redis followers to read 
 
 Guestbook 应用需要与 Redis 跟随者通信以读取数据。
 为了让 Redis 跟随者可被发现，你必须创建另一个
-[Service](/zh/docs/concepts/services-networking/service/)。
+[Service](/zh-cn/docs/concepts/services-networking/service/)。
 
 {{< codenew file="application/guestbook/redis-follower-service.yaml" >}}
 
@@ -357,7 +357,7 @@ Guestbook 应用使用 PHP 前端。该前端被配置成与后端的 Redis 跟�
 The `Redis` Services you applied is only accessible within the Kubernetes cluster because the default type for a Service is [ClusterIP](/docs/concepts/services-networking/service/#publishing-services-service-types). `ClusterIP` provides a single IP address for the set of Pods the Service is pointing to. This IP address is accessible only within the cluster.
 -->
 应用的 `Redis` 服务只能在 Kubernetes 集群中访问，因为服务的默认类型是
-[ClusterIP](/zh/docs/concepts/services-networking/service/#publishing-services-service-types)。
+[ClusterIP](/zh-cn/docs/concepts/services-networking/service/#publishing-services-service-types)。
 `ClusterIP` 为服务指向的 Pod 集提供一个 IP 地址。这个 IP 地址只能在集群中访问。
 
 <!--
@@ -629,8 +629,8 @@ Deleting the Deployments and Services also deletes any running Pods. Use labels 
 * Read more about [connecting applications](/docs/concepts/services-networking/connect-applications-service/)
 * Read more about [Managing Resources](/docs/concepts/cluster-administration/manage-deployment/#using-labels-effectively)
 -->
-* 完成 [Kubernetes 基础](/zh/docs/tutorials/kubernetes-basics/) 交互式教程
+* 完成 [Kubernetes 基础](/zh-cn/docs/tutorials/kubernetes-basics/) 交互式教程
 * 使用 Kubernetes 创建一个博客，使用
-  [MySQL 和 Wordpress 的持久卷](/zh/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/#visit-your-new-wordpress-blog)
-* 进一步阅读[连接应用程序](/zh/docs/concepts/services-networking/connect-applications-service/)
-* 进一步阅读[管理资源](/zh/docs/concepts/cluster-administration/manage-deployment/#using-labels-effectively)
+  [MySQL 和 Wordpress 的持久卷](/zh-cn/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/#visit-your-new-wordpress-blog)
+* 进一步阅读[连接应用程序](/zh-cn/docs/concepts/services-networking/connect-applications-service/)
+* 进一步阅读[管理资源](/zh-cn/docs/concepts/cluster-administration/manage-deployment/#using-labels-effectively)


### PR DESCRIPTION
relate issue: https://github.com/kubernetes/website/issues/34501, task-20