### PR TITLE
Correct description of Probe.initialDelaySeconds

### DIFF
--- a/content/en/docs/reference/kubernetes-api/workload-resources/pod-v1.md
+++ b/content/en/docs/reference/kubernetes-api/workload-resources/pod-v1.md
@@ -1738,7 +1738,7 @@ Probe describes a health check to be performed against a container to determine 
 
 - **initialDelaySeconds** (int32)
 
-  Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+  Number of seconds after the container has started before the probe is initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
 
 - **terminationGracePeriodSeconds** (int64)
 

--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -380,7 +380,7 @@ you can use to more precisely control the behavior of liveness and readiness
 checks:
 
 * `initialDelaySeconds`: Number of seconds after the container has started
-before liveness or readiness probes are initiated. Defaults to 0 seconds. Minimum value is 0.
+before the probe is initiated. Defaults to 0 seconds. Minimum value is 0.
 * `periodSeconds`: How often (in seconds) to perform the probe. Default to 10
 seconds. Minimum value is 1.
 * `timeoutSeconds`: Number of seconds after which the probe times out. Defaults


### PR DESCRIPTION
initialDelaySeconds applies to all kinds of probes, but the descriptions
used so far mentioned either only "liveness" or only "liveness and
readiness", but never startup probes.