### PR TITLE
Fixed a zsh bug in the kubectl cheat sheet

### DIFF
--- a/content/en/docs/reference/kubectl/cheatsheet.md
+++ b/content/en/docs/reference/kubectl/cheatsheet.md
@@ -37,7 +37,7 @@ complete -o default -F __start_kubectl k
 
 ```bash
 source <(kubectl completion zsh)  # setup autocomplete in zsh into the current shell
-echo "[[ $commands[kubectl] ]] && source <(kubectl completion zsh)" >> ~/.zshrc # add autocomplete permanently to your zsh shell
+echo '[[ $commands[kubectl] ]] && source <(kubectl completion zsh)' >> ~/.zshrc # add autocomplete permanently to your zsh shell
 ```
 ### A Note on --all-namespaces
 


### PR DESCRIPTION
Fixed a zsh bug in the kubectl cheat sheet. Using double quotes causes the code to be evaluated too early and ends up not working if you don't have kubectl installed. It's super simple change, and the current documentation is broken as is.