### PR TITLE
[zh-cn] resync security/hello-apparmor.yaml

### DIFF
--- a/content/zh-cn/examples/pods/security/hello-apparmor.yaml
+++ b/content/zh-cn/examples/pods/security/hello-apparmor.yaml
@@ -3,8 +3,8 @@ kind: Pod
 metadata:
   name: hello-apparmor
   annotations:
-    # Tell Kubernetes to apply the AppArmor profile "k8s-apparmor-example-deny-write".
-    # Note that this is ignored if the Kubernetes node is not running version 1.4 or greater.
+    # 告知 Kubernetes 去应用 AppArmor 配置 "k8s-apparmor-example-deny-write"。
+    # 请注意，如果节点上运行的 Kubernetes 不是 1.4 或更高版本，此注解将被忽略。
     container.apparmor.security.beta.kubernetes.io/hello: localhost/k8s-apparmor-example-deny-write
 spec:
   containers:


### PR DESCRIPTION
This small comment shows a logical paradox about version number:

- 1.4 < 1.23, 1.24, 1.25

The `1.4` herein should be `1.04` after I checked [CHANGELOG](https://github.com/kubernetes/kubernetes/tree/master/CHANGELOG). But it might be a problem too big to change in each k8s-related repo -_! 

Only mark a note here to show that issue.