### PR TITLE
Adds remainingItemCount to HTTP response

### DIFF
--- a/content/en/docs/reference/using-api/api-concepts.md
+++ b/content/en/docs/reference/using-api/api-concepts.md
@@ -269,6 +269,7 @@ of 500 pods at a time, request those chunks as follows:
      "metadata": {
        "resourceVersion":"10245",
        "continue": "ENCODED_CONTINUE_TOKEN",
+       "remainingItemCount": 753,
        ...
      },
      "items": [...] // returns pods 1-500
@@ -289,6 +290,7 @@ of 500 pods at a time, request those chunks as follows:
      "metadata": {
        "resourceVersion":"10245",
        "continue": "ENCODED_CONTINUE_TOKEN_2",
+       "remainingItemCount": 253,
        ...
      },
      "items": [...] // returns pods 501-1000


### PR DESCRIPTION
This tiny PR adds `remainingItemCount` to the example response from a GET call to list items with a limit as I think it makes sense in the context of `remainingItemCount` [being mentioned after the example output](https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes:~:text=remainingItemCount%20is%20the%20number%20of%20subsequent%20items%20in%20the%20collection%20that%20are%20not%20included%20in%20this%20response.%20If)

Signed-off-by: irbekrm <irbekrm@gmail.com>