### PR TITLE
[zh-cn] Fix oldMinorVersion in version-skew-policy.md

### DIFF
--- a/content/zh-cn/releases/version-skew-policy.md
+++ b/content/zh-cn/releases/version-skew-policy.md
@@ -103,7 +103,7 @@ Example:
 例如：
 
 * `kube-apiserver` 处于 **{{< skew currentVersion >}}** 版本
-* `kubelet` 支持 **{{< skew currentVersion >}}**、**{{< skew currentVersionAddMinor -1 >}}** 和 **{{< skew oldMinorVersion >}}** 版本
+* `kubelet` 支持 **{{< skew currentVersion >}}**、**{{< skew currentVersionAddMinor -1 >}}** 和 **{{< skew currentVersionAddMinor -2 >}}** 版本
 
 {{< note >}}
 <!--
@@ -121,7 +121,7 @@ Example:
 例如：
 
 * `kube-apiserver` 实例处于 **{{< skew currentVersion >}}** 和 **{{< skew currentVersionAddMinor -1 >}}** 版本
-* `kubelet` 支持 **{{< skew currentVersionAddMinor -1 >}}** 和 **{{< skew oldMinorVersion >}}** 版本，
+* `kubelet` 支持 **{{< skew currentVersionAddMinor -1 >}}** 和 **{{< skew currentVersionAddMinor -2  >}}** 版本，
   （不支持 **{{< skew currentVersion >}}** 版本，因为这将比
   `kube-apiserver` **{{< skew currentVersionAddMinor -1 >}}** 版本的实例新）
 


### PR DESCRIPTION
fix some display error. such as "kubelet 支持 1.23 和 版本" to "kubelet 支持 1.23 和 1.22 版本"

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggest-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
