### PR TITLE
Fix ./scripts/lsync.sh script not getting EN_VERSION variable correctly

### DIFF
--- a/scripts/lsync.sh
+++ b/scripts/lsync.sh
@@ -20,7 +20,7 @@ fi
 if [ -d "$1" ] ; then
   SYNCED=1
   for f in `find $1 -name "*.md"` ; do
-    EN_VERSION=`echo $f | sed "s/content\/..\//content\/en\//g"`
+    EN_VERSION=`echo $f | sed "s/content\/.\{2,5\}\//content\/en\//g"`
     if [ ! -e $EN_VERSION ]; then
       echo -e "**removed**\t$EN_VERSION"
       SYNCED=0
@@ -43,7 +43,7 @@ fi
 LOCALIZED="$1"
 
 # Try get the English version
-EN_VERSION=`echo $LOCALIZED | sed "s/content\/..\//content\/en\//g"`
+EN_VERSION=`echo $LOCALIZED | sed "s/content\/.\{2,5\}\//content\/en\//g"`
 if [ ! -e $EN_VERSION ]; then
   echo "$EN_VERSION has been removed."
   exit 3


### PR DESCRIPTION
<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggest-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
Fixes #34633
