### PR TITLE
Document "Apply Pod Security Standards at the Cluster Level" for recent release

### DIFF
--- a/content/en/docs/tutorials/security/cluster-level-pss.md
+++ b/content/en/docs/tutorials/security/cluster-level-pss.md
@@ -19,6 +19,9 @@ to all namespaces in a cluster.
 
 To apply Pod Security Standards to specific namespaces, refer to [Apply Pod Security Standards at the namespace level](/docs/tutorials/security/ns-level-pss).
 
+If you are running a version of Kubernetes other than v{{< skew currentVersion >}},
+check the documentation for that version.
+
 ## {{% heading "prerequisites" %}}
 
 Install the following on your workstation:
@@ -38,12 +41,12 @@ that are most appropriate for your configuration, do the following:
 1. Create a cluster with no Pod Security Standards applied:
 
     ```shell
-    kind create cluster --name psa-wo-cluster-pss --image kindest/node:v1.23.0
+    kind create cluster --name psa-wo-cluster-pss --image kindest/node:v{{< skew currentVersion >}}.0
     ```
    The output is similar to this:
     ```
     Creating cluster "psa-wo-cluster-pss" ...
-    ✓ Ensuring node image (kindest/node:v1.23.0) 🖼
+    ✓ Ensuring node image (kindest/node:v{{< skew currentVersion >}}.0) 🖼
     ✓ Preparing nodes 📦  
     ✓ Writing configuration 📜
     ✓ Starting control-plane 🕹️
@@ -245,12 +248,12 @@ following:
    these Pod Security Standards:
 
    ```shell
-    kind create cluster --name psa-with-cluster-pss --image kindest/node:v1.23.0 --config /tmp/pss/cluster-config.yaml
+    kind create cluster --name psa-with-cluster-pss --image kindest/node:v{{< skew currentVersion >}}.0 --config /tmp/pss/cluster-config.yaml
    ```
    The output is similar to this:
    ```
     Creating cluster "psa-with-cluster-pss" ...
-     ✓ Ensuring node image (kindest/node:v1.23.0) 🖼 
+     ✓ Ensuring node image (kindest/node:v{{< skew currentVersion >}}.0) 🖼 
      ✓ Preparing nodes 📦  
      ✓ Writing configuration 📜 
      ✓ Starting control-plane 🕹️ 

--- a/content/en/docs/tutorials/security/cluster-level-pss.md
+++ b/content/en/docs/tutorials/security/cluster-level-pss.md
@@ -41,12 +41,12 @@ that are most appropriate for your configuration, do the following:
 1. Create a cluster with no Pod Security Standards applied:
 
     ```shell
-    kind create cluster --name psa-wo-cluster-pss --image kindest/node:v{{< skew currentVersion >}}.0
+    kind create cluster --name psa-wo-cluster-pss --image kindest/node:v1.24.0
     ```
    The output is similar to this:
     ```
     Creating cluster "psa-wo-cluster-pss" ...
-    ✓ Ensuring node image (kindest/node:v{{< skew currentVersion >}}.0) 🖼
+    ✓ Ensuring node image (kindest/node:v1.24.0) 🖼
     ✓ Preparing nodes 📦  
     ✓ Writing configuration 📜
     ✓ Starting control-plane 🕹️
@@ -248,12 +248,12 @@ following:
    these Pod Security Standards:
 
    ```shell
-    kind create cluster --name psa-with-cluster-pss --image kindest/node:v{{< skew currentVersion >}}.0 --config /tmp/pss/cluster-config.yaml
+    kind create cluster --name psa-with-cluster-pss --image kindest/node:v1.24.0 --config /tmp/pss/cluster-config.yaml
    ```
    The output is similar to this:
    ```
     Creating cluster "psa-with-cluster-pss" ...
-     ✓ Ensuring node image (kindest/node:v{{< skew currentVersion >}}.0) 🖼 
+     ✓ Ensuring node image (kindest/node:v1.24.0) 🖼 
      ✓ Preparing nodes 📦  
      ✓ Writing configuration 📜 
      ✓ Starting control-plane 🕹️ 


### PR DESCRIPTION
Fixes : #33852 

This PR:
- Documents the [Apply Pod Security Standards at Cluster Level](https://kubernetes.io/docs/tutorials/security/cluster-level-pss/) page for the latest release (to deploy 1.24.x clusters)
- Adds a shortcode to automatically render the Kubernetes version being documented and updates command to create the cluster based on the version being documented.

Files changed: https://github.com/kubernetes/website/blob/main/content/en/docs/tutorials/security/cluster-level-pss.md

Signed off: Vitthal Kaul vitthalsai2001@gmail.com