### PR TITLE
removed extra "the" in the localization.md

### DIFF
--- a/content/en/docs/contribute/localization.md
+++ b/content/en/docs/contribute/localization.md
@@ -391,7 +391,7 @@ For example, see the [Korean Localization Guide](/ko/docs/contribute/localizatio
 ### Language specific Zoom meetings
 
 If the localization project needs a separate meeting time, contact a SIG Docs Co-Chair or Tech
-Lead to create a new reoccurring Zoom meeting and calendar invite. This is only needed when the
+Lead to create a new reoccurring Zoom meeting and calendar invite. This is only needed when 
 the team is large enough to sustain and require a separate meeting.
 
 Per CNCF policy, the localization teams must upload their meetings to the SIG Docs YouTube


### PR DESCRIPTION
## Fixes #34656 

### Description 
  
the extra "the" is removed by this PR.

![Screenshot (155)](https://user-images.githubusercontent.com/70086051/176094831-d901a018-6693-42ec-b746-2ff0d83b1783.png)

