### PR TITLE
Migrate create, edit, and delete Secrets to relevant tasks

### DIFF
--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -94,22 +94,21 @@ the exact mechanisms for issuing and refreshing those session tokens.
 
 ### Creating a Secret
 
-There are several options to create a Secret:
+You can create a Secret using one of the following methods:
 
-- [create Secret using `kubectl` command](/docs/tasks/configmap-secret/managing-secret-using-kubectl/)
-- [create Secret from config file](/docs/tasks/configmap-secret/managing-secret-using-config-file/)
-- [create Secret using kustomize](/docs/tasks/configmap-secret/managing-secret-using-kustomize/)
+* [Use the `kubectl` command-line tool](/docs/tasks/configmap-secret/managing-secret-using-kubectl/)
+* [Use a configuration file](/docs/tasks/configmap-secret/managing-secret-using-config-file/)
+* [Use the Kustomize tool](/docs/tasks/configmap-secret/managing-secret-using-kustomize/)
 
 #### Constraints on Secret names and data {#restriction-names-data}
 
-The name of a Secret object must be a valid
+The name of a `Secret` object must be a valid
 [DNS subdomain name](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names).
 
-You can specify the `data` and/or the `stringData` field when creating a
-configuration file for a Secret.  The `data` and the `stringData` fields are optional.
-The values for all keys in the `data` field have to be base64-encoded strings.
-If the conversion to base64 string is not desirable, you can choose to specify
-the `stringData` field instead, which accepts arbitrary strings as values.
+You can specify values for the optional `data` and `stringData`
+fields when creating a configuration file for a Secret. The values for all keys
+in the `data` field have to be base64-encoded strings. You can avoid needing to
+encode the strings by specifying the raw data in the `stringData` field instead.
 
 The keys of `data` and `stringData` must consist of alphanumeric characters,
 `-`, `_` or `.`. All key-value pairs in the `stringData` field are internally
@@ -119,49 +118,25 @@ precedence.
 
 #### Size limit {#restriction-data-size}
 
-Individual secrets are limited to 1MiB in size. This is to discourage creation
-of very large secrets that could exhaust the API server and kubelet memory.
-However, creation of many smaller secrets could also exhaust memory. You can
+Individual Secrets are limited to 1MiB in size. This is to discourage creation
+of very large Secrets that could exhaust the API server and kubelet memory.
+However, creation of many smaller Secrets could also exhaust memory. You can
 use a [resource quota](/docs/concepts/policy/resource-quotas/) to limit the
 number of Secrets (or other resources) in a namespace.
 
 ### Editing a Secret
 
-You can edit an existing Secret using kubectl:
+You can edit an existing Secret unless it is [immutable](#secret-immutable). To
+edit a Secret, you can use
+[kubectl](/docs/tasks/configmap-secret/managing-secret-using-kubectl/edit-secret),
+a [configuration
+file](/docs/tasks/configmap-secret/managing-secret-using-config-file/#edit-secret),
+or
+[Kustomize](/tasks/configmap-secret/managing-secret-using-kustomize/#edit-secret).
 
-```shell
-kubectl edit secrets mysecret
-```
-
-This opens your default editor and allows you to update the base64 encoded Secret
-values in the `data` field; for example:
-
-```yaml
-# Please edit the object below. Lines beginning with a '#' will be ignored,
-# and an empty file will abort the edit. If an error occurs while saving this file, it will be
-# reopened with the relevant failures.
-#
-apiVersion: v1
-data:
-  username: YWRtaW4=
-  password: MWYyZDFlMmU2N2Rm
-kind: Secret
-metadata:
-  annotations:
-    kubectl.kubernetes.io/last-applied-configuration: { ... }
-  creationTimestamp: 2020-01-22T18:41:56Z
-  name: mysecret
-  namespace: default
-  resourceVersion: "164619"
-  uid: cfee02d6-c137-11e5-8d73-42010af00002
-type: Opaque
-```
-
-That example manifest defines a Secret with two keys in the `data` field: `username` and `password`.
-The values are Base64 strings in the manifest; however, when you use the Secret with a Pod
-then the kubelet provides the _decoded_ data to the Pod and its containers.
-
-You can package many keys and values into one Secret, or use many Secrets, whichever is convenient.
+Depending on how you created the Secret, as well as how the Secret is used in
+your Pods, updates to existing `Secret` objects are propagated automatically to
+Pods that use the data. For more information, refer to [Mounted Secrets are updated automatically](#mounted-secrets-are-updated-automatically).
 
 ### Using a Secret
 

--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
@@ -7,6 +7,10 @@ description: Creating Secret objects using kubectl command line.
 
 <!-- overview -->
 
+This page shows you how to create, edit, manage, and delete Kubernetes
+{{<glossary_tooltip text="Secrets" term_id="secret">}} using the `kubectl`
+command-line tool.
+
 ## {{% heading "prerequisites" %}}
 
 {{< include "task-tutorial-prereqs.md" >}}
@@ -15,64 +19,66 @@ description: Creating Secret objects using kubectl command line.
 
 ## Create a Secret
 
-A `Secret` can contain user credentials required by pods to access a database.
-For example, a database connection string consists of a username and password.
-You can store the username in a file `./username.txt` and the password in a
-file `./password.txt` on your local machine.
+A `Secret` object stores sensitive data such as credentials
+used by Pods to access services. For example, you might need a Secret to store
+the username and password needed to access a database.
+
+You can create the Secret by passing the raw data in the command, or by storing
+the credentials in files that you pass in the command. The following commands
+create a Secret that stores the username `admin` and the password `VLc5@#tym$HzBn@8`.
+
+{{< tabs name="Secret data" >}}
+{{% tab name="Raw data" %}}
+
+Run the following command:
 
 ```shell
-echo -n 'admin' > ./username.txt
-echo -n '1f2d1e2e67df' > ./password.txt
+kubectl create secret generic database-creds \
+    --from-literal='username=admin' \
+    --from-literal='password=VLc5@#tym$HzBn@8'
 ```
-In these commands, the `-n` flag ensures that the generated files do not have
-an extra newline character at the end of the text. This is important because
-when `kubectl` reads a file and encodes the content into a base64 string, the
-extra newline character gets encoded too.
+You must use single quotes `''` to escape special characters such as `$`, `\`,
+`*`, `=`, and `!` in your strings. If you don't, your shell will interpret these
+characters.
 
-The `kubectl create secret` command packages these files into a Secret and creates
-the object on the API server.
 
-```shell
-kubectl create secret generic db-user-pass \
-  --from-file=./username.txt \
-  --from-file=./password.txt
-```
+{{% /tab %}}
+{{% tab name="Files" %}}
+1.  Store the credentials in files with the values encoded in base64:
+
+    ```shell
+    echo -n 'admin' | base64 > ./username.txt
+    echo -n 'VLc5@#tym$HzBn@8' | base64 > ./password.txt
+    ```
+    The `-n` flag ensures that there's no newline character at the end of your
+    files. You do not need to escape special characters in strings that you include in a file.
+
+2.  Pass the file paths in the `kubectl` command:
+
+    ```shell
+    kubectl create secret generic database-creds \
+        --from-file=./username.txt \
+        --from-file=./password.txt
+    ```
+    The default key name for the values that you pass in the command is the file
+    name. If you want to specify your own key name, use
+    `--from-file=key=source`. For example:
+
+    ```shell
+    kubectl create secret generic db-user-pass \
+        --from-file=username=./username.txt \
+        --from-file=password=./password.txt
+    ```
+{{% /tab %}}
+{{< /tabs >}}
 
 The output is similar to:
 
 ```
-secret/db-user-pass created
+secret/database-creds created
 ```
 
-The default key name is the filename. You can optionally set the key name using
-`--from-file=[key=]source`. For example:
-
-```shell
-kubectl create secret generic db-user-pass \
-  --from-file=username=./username.txt \
-  --from-file=password=./password.txt
-```
-
-You do not need to escape special characters in password strings that you 
-include in a file.
-
-You can also provide Secret data using the `--from-literal=<key>=<value>` tag.
-This tag can be specified more than once to provide multiple key-value pairs.
-Note that special characters such as `$`, `\`, `*`, `=`, and `!` will be
-interpreted by your [shell](https://en.wikipedia.org/wiki/Shell_(computing))
-and require escaping.
-
-In most shells, the easiest way to escape the password is to surround it with
-single quotes (`'`). For example, if your password is `S!B\*d$zDsb=`,
-run the following command:
-
-```shell
-kubectl create secret generic db-user-pass \
-  --from-literal=username=devuser \
-  --from-literal=password='S!B\*d$zDsb='
-```
-
-## Verify the Secret
+### Verify the Secret {#verify-the-secret}
 
 Check that the Secret was created:
 
@@ -83,20 +89,20 @@ kubectl get secrets
 The output is similar to:
 
 ```
-NAME                  TYPE                                  DATA      AGE
-db-user-pass          Opaque                                2         51s
+NAME                  TYPE             DATA      AGE
+database-creds        Opaque           2         51s
 ```
 
-You can view a description of the `Secret`:
+View the details of the Secret:
 
 ```shell
-kubectl describe secrets/db-user-pass
+kubectl describe secret database-creds
 ```
 
 The output is similar to:
 
 ```
-Name:            db-user-pass
+Name:            database-creds
 Namespace:       default
 Labels:          <none>
 Annotations:     <none>
@@ -105,7 +111,7 @@ Type:            Opaque
 
 Data
 ====
-password:    12 bytes
+password:    16 bytes
 username:    5 bytes
 ```
 
@@ -113,53 +119,80 @@ The commands `kubectl get` and `kubectl describe` avoid showing the contents
 of a `Secret` by default. This is to protect the `Secret` from being exposed
 accidentally, or from being stored in a terminal log.
 
-## Decoding the Secret  {#decoding-secret}
+### Decode the Secret  {#decoding-secret}
 
-To view the contents of the Secret you created, run the following command:
+1.  View the data stored in the Secret:
 
-```shell
-kubectl get secret db-user-pass -o jsonpath='{.data}'
-```
+    ```shell
+    kubectl get secret database-creds -o jsonpath='{.data}'
+    ```
 
-The output is similar to:
+    The output is similar to:
 
-```json
-{"password":"MWYyZDFlMmU2N2Rm","username":"YWRtaW4="}
-```
+    ```json
+    {"password":"VkxjNUAjdHltJEh6Qm5AOA==","username":"YWRtaW4="}
+    ```
 
-Now you can decode the `password` data:
+1.  Decode the `password` data:
 
-```shell
-# This is an example for documentation purposes.
-# If you did things this way, the data 'MWYyZDFlMmU2N2Rm' could be stored in
-# your shell history.
-# Someone with access to you computer could find that remembered command
-# and base-64 decode the secret, perhaps without your knowledge.
-# It's usually better to combine the steps, as shown later in the page.
-echo 'MWYyZDFlMmU2N2Rm' | base64 --decode
-```
+    ```shell
+    echo 'VkxjNUAjdHltJEh6Qm5AOA==' | base64 --decode
+    ```
 
-The output is similar to:
+    The output is similar to:
 
-```
-1f2d1e2e67df
-```
+    ```
+    VLc5@#tym$HzBn@8%
+    ```
 
-In order to avoid storing a secret encoded value in your shell history, you can
-run the following command:
+    {{<caution>}}This is an example for documentation purposes. In practice,
+    this method could cause the command with the encoded data to be stored in
+    your shell history. Anyone with access to your computer could find the
+    command and decode the secret. A better approach is to combine the view and
+    decode commands.{{</caution>}}
 
-```shell
-kubectl get secret db-user-pass -o jsonpath='{.data.password}' | base64 --decode
-```
+    ```shell
+    kubectl get secret database-creds -o jsonpath='{.data.password}' | base64 --decode
+    ```
 
-The output shall be similar as above.
+## Edit a Secret {#edit-secret}
 
-## Clean Up
-
-Delete the Secret you created:
+You can edit an existing `Secret` object unless it is
+[immutable](/docs/concepts/configuration/secret/#secret-immutable). To edit a
+Secret, run the following command:
 
 ```shell
-kubectl delete secret db-user-pass
+kubectl edit secrets <secret-name>
+```
+
+This opens your default editor and allows you to update the base64 encoded
+Secret values in the `data` field, such as in the following example:
+
+```yaml
+# Please edit the object below. Lines beginning with a '#' will be ignored,
+# and an empty file will abort the edit. If an error occurs while saving this file, it will be
+# reopened with the relevant failures.
+#
+apiVersion: v1
+data:
+  password: VkxjNUAjdHltJEh6Qm5AOA==
+  username: YWRtaW4=
+kind: Secret
+metadata:
+  creationTimestamp: "2022-06-28T17:44:13Z"
+  name: database-creds
+  namespace: default
+  resourceVersion: "12708504"
+  uid: 91becd59-78fa-4c85-823f-6d44436242ac
+type: Opaque
+```
+
+## Delete a Secret {#clean-up}
+
+To delete a Secret, run the following command:
+
+```shell
+kubectl delete secret <secret-name>
 ```
 
 <!-- discussion -->

--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
@@ -7,12 +7,9 @@ description: Creating Secret objects using kustomization.yaml file.
 
 <!-- overview -->
 
-Since Kubernetes v1.14, `kubectl` supports
-[managing objects using Kustomize](/docs/tasks/manage-kubernetes-objects/kustomization/).
-Kustomize provides resource Generators to create Secrets and ConfigMaps. The
-Kustomize generators should be specified in a `kustomization.yaml` file inside
-a directory. After generating the Secret, you can create the Secret on the API
-server with `kubectl apply`.
+`kubectl` supports using the [Kustomize object management tool](/docs/tasks/manage-kubernetes-objects/kustomization/) to manage Secrets
+and ConfigMaps. You create a *resource generator* using Kustomize, which
+generates a Secret that you can apply to the API server using `kubectl`.
 
 ## {{% heading "prerequisites" %}}
 
@@ -20,38 +17,43 @@ server with `kubectl apply`.
 
 <!-- steps -->
 
-## Create the Kustomization file
+## Create a Secret {#create-the-kustomization-file}
 
 You can generate a Secret by defining a `secretGenerator` in a
-`kustomization.yaml` file that references other existing files.
-For example, the following kustomization file references the
-`./username.txt` and the `./password.txt` files:
+`kustomization.yaml` file that references other existing files, `.env` files, or
+literal values. For example, the following instructions create a Kustomization
+file for the username `admin` and the password `VLc5@#tym$HzBn@8`.
 
-```yaml
+{{< tabs name="Secret data" >}}
+{{< tab name="Literals" codelang="yaml" >}}
 secretGenerator:
-- name: db-user-pass
-  files:
-  - username.txt
-  - password.txt
-```
-
-You can also define the `secretGenerator` in the `kustomization.yaml`
-file by providing some literals.
-For example, the following `kustomization.yaml` file contains two literals
-for `username` and `password` respectively:
-
-```yaml
-secretGenerator:
-- name: db-user-pass
+- name: database-creds
   literals:
   - username=admin
-  - password=1f2d1e2e67df
-```
+  - password=VLc5@#tym$HzBn@8
+{{< /tab >}}
+{{% tab name="Files" %}}
+1.  Store the credentials in files with the values encoded in base64:
 
-You can also define the `secretGenerator` in the `kustomization.yaml`
-file by providing `.env` files.
-For example, the following `kustomization.yaml` file pulls in data from
-`.env.secret` file:
+    ```shell
+    echo -n 'admin' > ./username.txt
+    echo -n 'VLc5@#tym$HzBn@8' > ./password.txt
+    ```
+    The `-n` flag ensures that there's no newline character at the end of your
+    files.
+
+2.  Create the `kustomization.yaml` file:
+
+    ```yaml
+    secretGenerator:
+    - name: database-creds
+      files:
+      - username.txt
+      - password.txt
+    ```
+{{% /tab %}}}
+{{% tab name=".env files" %}}
+If your credentials are already in a `.env` file, such as `.env.secret`:
 
 ```yaml
 secretGenerator:
@@ -59,76 +61,57 @@ secretGenerator:
   envs:
   - .env.secret
 ```
+{{% /tab %}}
+{{< /tabs >}}
 
-Note that in all cases, you don't need to base64 encode the values.
+In all cases, you don't need to base64 encode the values. The name of the YAML
+file **must** be `kustomization.yaml` or `kustomization.yml`.
 
-## Create the Secret
+1.  To create the Secret, apply the directory that contains the kustomization file:
 
-Apply the directory containing the `kustomization.yaml` to create the Secret.
+    ```shell
+    kubectl apply -k <directory-path>
+    ```
 
-```shell
-kubectl apply -k .
-```
+    The output is similar to:
 
-The output is similar to:
+    ```
+    secret/database-creds-5hdh7hhgfk created
+    ```
 
-```
-secret/db-user-pass-96mffmfh4k created
-```
+    When a Secret is generated, the Secret name is created by hashing
+    the Secret data and appending the hash value to the name. This ensures that
+    a new Secret is generated each time the data is modified.
 
-Note that when a Secret is generated, the Secret name is created by hashing
-the Secret data and appending the hash value to the name. This ensures that
-a new Secret is generated each time the data is modified.
+To verify that the Secret was created and to decode the Secret data, refer to
+[Managing Secrets using
+kubectl](/docs/tasks/configmap-secret/managing-secret-using-kubectl/#verify-the-secret).
 
-## Check the Secret created
+## Edit a Secret {#edit-secret}
 
-You can check that the secret was created:
+1.  In your `kustomization.yaml` file, modify the data, such as the `password`.
+1.  Apply the directory that contains the kustomization file:
 
-```shell
-kubectl get secrets
-```
+    ```shell
+    kubectl apply -k <directory-path>
+    ```
 
-The output is similar to:
+    The output is similar to:
 
-```
-NAME                             TYPE                                  DATA      AGE
-db-user-pass-96mffmfh4k          Opaque                                2         51s
-```
+    ```
+    secret/database-creds-6f24b56cc8 created
+    ```
 
-You can view a description of the secret:
+The edited Secret is created as a new `Secret` object, instead of updating the
+existing `Secret` object. You might need to update references to the Secret in
+your Pods.
 
-```shell
-kubectl describe secrets/db-user-pass-96mffmfh4k
-```
+## Delete a Secret {#clean-up}
 
-The output is similar to:
-
-```
-Name:            db-user-pass-96mffmfh4k
-Namespace:       default
-Labels:          <none>
-Annotations:     <none>
-
-Type:            Opaque
-
-Data
-====
-password.txt:    12 bytes
-username.txt:    5 bytes
-```
-
-The commands `kubectl get` and `kubectl describe` avoid showing the contents of a `Secret` by
-default. This is to protect the `Secret` from being exposed accidentally to an onlooker,
-or from being stored in a terminal log.
-To check the actual content of the encoded data, please refer to
-[decoding secret](/docs/tasks/configmap-secret/managing-secret-using-kubectl/#decoding-secret).
-
-## Clean Up
-
-To delete the Secret you have created:
+To delete a Secret, use `kubectl`:
 
 ```shell
-kubectl delete secret db-user-pass-96mffmfh4k
+kubectl delete secret <secret-name>
 ```
 
 <!-- Optional section; add links to information related to this topic. -->


### PR DESCRIPTION
Umbrella issue: https://github.com/kubernetes/website/issues/4491
Draft PR for overhauled Secrets concept end state: https://github.com/kubernetes/website/pull/34168

This PR updates the managing Secrets tasks to include Create, Edit, and Delete Secrets steps, and updates the relevant section of the Secrets concept.

This is part of a larger change to overhaul our Secrets docs.

The scope of work is defined in [this Google doc](https://docs.google.com/document/d/1VQ8UFux1HifjXo9rRwm2-mOoUOzmMF7zGf-C0BhurdQ/edit#heading=h.nq4idzs84lru).

Preview links:

*  Secrets concept with edits: https://deploy-preview-34674--kubernetes-io-main-staging.netlify.app/docs/concepts/configuration/secret/
* kubectl task: https://deploy-preview-34674--kubernetes-io-main-staging.netlify.app/docs/tasks/configmap-secret/managing-secret-using-kubectl/
* config file task: https://deploy-preview-34674--kubernetes-io-main-staging.netlify.app/docs/tasks/configmap-secret/managing-secret-using-config-file/
* kustomize task: https://deploy-preview-34674--kubernetes-io-main-staging.netlify.app/docs/tasks/configmap-secret/managing-secret-using-kustomize/

/sig docs
/language en
/do-not-merge work-in-progress