### PR TITLE
[ja] fix link about Katacoda

### DIFF
--- a/content/ja/includes/task-tutorial-prereqs.md
+++ b/content/ja/includes/task-tutorial-prereqs.md
@@ -3,5 +3,5 @@ Kubernetesクラスターが必要、かつそのクラスターと通信する�
 まだクラスターがない場合、[minikube](https://minikube.sigs.k8s.io/docs/tutorials/multi_node/)を使って作成するか、
 以下のいずれかのKubernetesプレイグラウンドも使用できます:
 
-* [Katacoda](https://www.katacoda.com/courses/kubernetes/playground)
+* [Killercoda](https://killercoda.com/playgrounds/scenario/kubernetes)
 * [Play with Kubernetes](http://labs.play-with-k8s.com/)


### PR DESCRIPTION
Fix the Katacoda link by #34428 

Original page: https://github.com/kubernetes/website/blob/main/content/ja/includes/task-tutorial-prereqs.md

> The en PR #34429  is merged.