### PR TITLE
[ru] fix link about Katacoda

### DIFF
--- a/content/ru/includes/task-tutorial-prereqs.md
+++ b/content/ru/includes/task-tutorial-prereqs.md
@@ -4,5 +4,5 @@
 [Minikube](/docs/setup/learning-environment/minikube/),
 или вы можете использовать одну из песочниц Kubernetes:
 
-* [Katacoda](https://www.katacoda.com/courses/kubernetes/playground)
+* [Killercoda](https://killercoda.com/playgrounds/scenario/kubernetes)
 * [Play with Kubernetes](http://labs.play-with-k8s.com/)


### PR DESCRIPTION
Fix the Katacoda link by #34428 

Original page: https://github.com/kubernetes/website/blob/main/content/ru/includes/task-tutorial-prereqs.md

> The en PR #34429  is merged.