### PR TITLE
[fr] fix link about Katacoda

### DIFF
--- a/content/fr/includes/task-tutorial-prereqs.md
+++ b/content/fr/includes/task-tutorial-prereqs.md
@@ -1,5 +1,5 @@
 Vous devez disposer d'un cluster Kubernetes et l'outil de ligne de commande kubectl doit être configuré pour communiquer avec votre cluster.
 Si vous ne possédez pas déjà de cluster, vous pouvez en créer un en utilisant [Minikube](/docs/setup/minikube), ou vous pouvez utiliser l'un de ces environnements Kubernetes:
 
-* [Katacoda](https://www.katacoda.com/courses/kubernetes/playground)
+* [Killercoda](https://killercoda.com/playgrounds/scenario/kubernetes)
 * [Play with Kubernetes](http://labs.play-with-k8s.com/)


### PR DESCRIPTION
Fix the Katacoda link by #34428 

Original page: https://github.com/kubernetes/website/blob/main/content/fr/includes/task-tutorial-prereqs.md

> Need wait for #34496 to be merged.