### PR TITLE
[es] fix link about Katacoda

### DIFF
--- a/content/es/includes/task-tutorial-prereqs.md
+++ b/content/es/includes/task-tutorial-prereqs.md
@@ -1,5 +1,5 @@
 Debes tener un cluster Kubernetes a tu dispocición, y la herramienta de línea de comandos `kubectl` debe estar configurada. Si no tienes un cluster, puedes crear uno utilizando [Minikube](/docs/setup/minikube),
 o puedes utilizar una de las siguientes herramientas en línea:
 
-* [Katacoda](https://www.katacoda.com/courses/kubernetes/playground)
+* [Killercoda](https://killercoda.com/playgrounds/scenario/kubernetes)
 * [Play with Kubernetes](http://labs.play-with-k8s.com/)


### PR DESCRIPTION
Fix the Katacoda link by #34428 

Original page: https://github.com/kubernetes/website/blob/main/content/es/includes/task-tutorial-prereqs.md

> The en PR #34429  is merged.