### PR TITLE
[zh-cn] fix links about Katacoda

### DIFF
--- a/content/zh-cn/includes/task-tutorial-prereqs.md
+++ b/content/zh-cn/includes/task-tutorial-prereqs.md
@@ -10,5 +10,5 @@ cluster, you can create one by using
 or you can use one of these Kubernetes playgrounds:
 -->
 
-* [Katacoda](https://www.katacoda.com/courses/kubernetes/playground)
+* [Killercoda](https://killercoda.com/playgrounds/scenario/kubernetes)
 * [玩转 Kubernetes](http://labs.play-with-k8s.com/)


### PR DESCRIPTION
Fix the Katacoda link by #34428 

Original page: [Task Tutorial Prerequisites](https://github.com/kubernetes/website/blob/main/content/zh-cn/includes/task-tutorial-prereqs.md) 

> Need wait for #34496 to be merged.