### PR TITLE
[id] fix link about katacoda

### DIFF
--- a/content/id/includes/task-tutorial-prereqs.md
+++ b/content/id/includes/task-tutorial-prereqs.md
@@ -4,5 +4,5 @@ belum memiliki klaster, kamu dapat membuatnya dengan menggunakan
 [minikube](/id/docs/tasks/tools/#minikube),
 atau kamu juga dapat menggunakan salah satu dari tempat mencoba Kubernetes berikut ini:
 
-* [Katacoda](https://www.katacoda.com/courses/kubernetes/playground)
+* [Killercoda](https://killercoda.com/playgrounds/scenario/kubernetes)
 * [Bermain dengan Kubernetes](http://labs.play-with-k8s.com/)


### PR DESCRIPTION
Fix the Katacoda link by #34428 

Original page: [Task Tutorial Prerequisites](https://github.com/kubernetes/website/blob/main/content/id/includes/task-tutorial-prereqs.md)

> The en PR #34429  is merged.