### PR TITLE
[pt-br] fix link about Katacoda

### DIFF
--- a/content/pt-br/includes/task-tutorial-prereqs.md
+++ b/content/pt-br/includes/task-tutorial-prereqs.md
@@ -2,5 +2,5 @@ Você precisa de um cluster Kubernetes e a ferramenta de linha de comando kubect
 precisa estar configurada para acessar o seu cluster. Se você ainda não tem um
 cluster, pode criar um usando o [minikube](/docs/tasks/tools/#minikube)
 ou você pode usar um dos seguintes ambientes:
-* [Katacoda](https://www.katacoda.com/courses/kubernetes/playground)
+* [Killercoda](https://killercoda.com/playgrounds/scenario/kubernetes)
 * [Play with Kubernetes](http://labs.play-with-k8s.com/)


### PR DESCRIPTION
Fix the Katacoda link by #34428

Original page: [Task Tutorial Prerequisites](https://github.com/kubernetes/website/blob/main/content/pt-br/includes/task-tutorial-prereqs.md) 

> The en PR #34429  is merged.