### PR TITLE
contents/doc: Replace every {{< param "githubbranch" >}} into --> master

### DIFF
--- a/content/de/docs/setup/release/building-from-source.md
+++ b/content/de/docs/setup/release/building-from-source.md
@@ -27,6 +27,6 @@ cd kubernetes
 make release
 ```
 
-Mehr Informationen zum Release-Prozess finden Sie im kubernetes/kubernetes [`build`](http://releases.k8s.io/{{< param "githubbranch" >}}/build/) Verzeichnis.
+Mehr Informationen zum Release-Prozess finden Sie im kubernetes/kubernetes [`build`](http://releases.k8s.io/master/build/) Verzeichnis.
 
 

--- a/content/es/docs/concepts/containers/container-environment-variables.md
+++ b/content/es/docs/concepts/containers/container-environment-variables.md
@@ -48,7 +48,7 @@ FOO_SERVICE_HOST=<El host donde está funcionando el servicio>
 FOO_SERVICE_PORT=<El puerto dónde está funcionando el servicio>
 ```
 Los servicios tienen direcciones IP dedicadas y están disponibles para el Container a través de DNS,
-si el [complemento para DNS](http://releases.k8s.io/{{< param "githubbranch" >}}/cluster/addons/dns/) está habilitado.
+si el [complemento para DNS](http://releases.k8s.io/master/cluster/addons/dns/) está habilitado.
 
 
 

--- a/content/es/docs/setup/release/building-from-source.md
+++ b/content/es/docs/setup/release/building-from-source.md
@@ -30,7 +30,7 @@ cd kubernetes
 make release
 ```
 
-Para más detalles sobre el proceso de compilación de una release, visita la carpeta kubernetes/kubernetes [`build`](http://releases.k8s.io/{{< param "githubbranch" >}}/build/)
+Para más detalles sobre el proceso de compilación de una release, visita la carpeta kubernetes/kubernetes [`build`](http://releases.k8s.io/master/build/)
 
 
 

--- a/content/fr/docs/concepts/containers/container-environment.md
+++ b/content/fr/docs/concepts/containers/container-environment.md
@@ -49,7 +49,7 @@ FOO_SERVICE_PORT=<le port sur lequel le service fonctionne>
 ```
 
 Les services ont des adresses IP dédiées et sont disponibles pour le conteneur avec le DNS,
-si le [module DNS](http://releases.k8s.io/{{< param "githubbranch" >}}/cluster/addons/dns/) est activé. 
+si le [module DNS](http://releases.k8s.io/master/cluster/addons/dns/) est activé. 
 
 
 

--- a/content/fr/docs/concepts/overview/what-is-kubernetes.md
+++ b/content/fr/docs/concepts/overview/what-is-kubernetes.md
@@ -46,7 +46,7 @@ C'est pourquoi Kubernetes a également été conçu pour servir de plate-forme e
 
 De plus, le [plan de contrôle Kubernetes (control
 plane)](/docs/concepts/overview/components/) est construit sur les mêmes [APIs](/docs/reference/using-api/api-overview/) que celles accessibles aux développeurs et utilisateurs.
-Les utilisateurs peuvent écrire leurs propres contrôleurs (controllers), tels que les [ordonnanceurs (schedulers)](https://github.com/kubernetes/community/blob/{{< param "githubbranch" >}}/contributors/devel/scheduler.md),
+Les utilisateurs peuvent écrire leurs propres contrôleurs (controllers), tels que les [ordonnanceurs (schedulers)](https://github.com/kubernetes/community/blob/master/contributors/devel/scheduler.md),
 avec [leurs propres APIs](/docs/concepts/api-extension/custom-resources/) qui peuvent être utilisés par un [outil en ligne de commande](/docs/user-guide/kubectl-overview/).
 
 Ce choix de [conception](https://git.k8s.io/community/contributors/design-proposals/architecture/architecture.md) a permis de construire un ensemble d'autres systèmes par dessus Kubernetes.

--- a/content/fr/docs/concepts/services-networking/service.md
+++ b/content/fr/docs/concepts/services-networking/service.md
@@ -289,7 +289,7 @@ Kubernetes prend en charge 2 modes principaux de recherche d'un service: les var
 ### Variables d'environnement
 
 Lorsqu'un pod est exécuté sur un nœud, le kubelet ajoute un ensemble de variables d'environnement pour chaque service actif.
-Il prend en charge à la fois les variables [Docker links](https://docs.docker.com/userguide/dockerlinks/) (voir [makeLinkVariables](http://releases.k8s.io/{{< param "githubbranch" >}}/pkg/kubelet/envvars/envvars.go#L49)) et plus simplement les variables `{SVCNAME}_SERVICE_HOST` et `{SVCNAME}_SERVICE_PORT`, où le nom du service est en majuscules et les tirets sont convertis en underscore.
+Il prend en charge à la fois les variables [Docker links](https://docs.docker.com/userguide/dockerlinks/) (voir [makeLinkVariables](http://releases.k8s.io/master/pkg/kubelet/envvars/envvars.go#L49)) et plus simplement les variables `{SVCNAME}_SERVICE_HOST` et `{SVCNAME}_SERVICE_PORT`, où le nom du service est en majuscules et les tirets sont convertis en underscore.
 
 Par exemple, le service `redis-master` qui expose le port TCP 6379 et a reçu l'adresse IP de cluster 10.0.0.11, produit les variables d'environnement suivantes:
 

--- a/content/fr/docs/concepts/storage/volumes.md
+++ b/content/fr/docs/concepts/storage/volumes.md
@@ -137,7 +137,7 @@ Afin d'utiliser cette fonctionnalité, le [Pilote AWS EBS CSI](https://github.co
 
 Un type de volume `azureDisk` est utilisé pour monter un disque de données ([Data Disk](https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-about-disks-vhds/)) dans un Pod.
 
-Plus de détails sont disponibles [ici](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/azure_disk/README.md).
+Plus de détails sont disponibles [ici](https://github.com/kubernetes/examples/tree/master/staging/volumes/azure_disk/README.md).
 
 #### Migration CSI
 
@@ -150,7 +150,7 @@ Afin d'utiliser cette fonctionnalité, le [Pilote Azure Disk CSI](https://github
 
 Un type de volume `azureFile` est utilisé pour monter un volume de fichier Microsoft Azure (SMB 2.1 et 3.0) dans un Pod.
 
-Plus de détails sont disponibles [ici](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/azure_file/README.md).
+Plus de détails sont disponibles [ici](https://github.com/kubernetes/examples/tree/master/staging/volumes/azure_file/README.md).
 
 #### Migration CSI
 
@@ -170,7 +170,7 @@ CephFS peut être monté plusieurs fois en écriture simultanément.
 Vous devez exécuter votre propre serveur Ceph avec le partage exporté avant de pouvoir l'utiliser.
 {{< /caution >}}
 
-Voir [l'exemple CephFS](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/volumes/cephfs/) pour plus de détails.
+Voir [l'exemple CephFS](https://github.com/kubernetes/examples/tree/master/volumes/cephfs/) pour plus de détails.
 
 ### cinder {#cinder}
 
@@ -315,7 +315,7 @@ Si plusieurs WWNs sont spécifiés, targetWWNs s'attend à ce que ces WWNs provi
 Vous devez configurer un zonage FC SAN pour allouer et masquer au préalable ces LUNs (volumes) aux cibles WWNs afin que les hôtes Kubernetes puissent y accéder.
 {{< /caution >}}
 
-Voir [l'exemple FC](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/fibre_channel) pour plus de détails.
+Voir [l'exemple FC](https://github.com/kubernetes/examples/tree/master/staging/volumes/fibre_channel) pour plus de détails.
 
 ### flocker {#flocker}
 
@@ -330,7 +330,7 @@ Cela signifie que les données peuvent être transmises entre les Pods selon les
 Vous devez exécuter votre propre installation de Flocker avant de pouvoir l'utiliser.
 {{< /caution >}}
 
-Voir [l'exemple Flocker](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/flocker) pour plus de détails.
+Voir [l'exemple Flocker](https://github.com/kubernetes/examples/tree/master/staging/volumes/flocker) pour plus de détails.
 
 ### gcePersistentDisk {#gcepersistentdisk}
 
@@ -465,7 +465,7 @@ GlusterFS peut être monté plusieurs fois en écriture simultanément.
 Vous devez exécuter votre propre installation de GlusterFS avant de pouvoir l'utiliser.
 {{< /caution >}}
 
-Voir [l'exemple GlusterFS](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/volumes/glusterfs) pour plus de détails.
+Voir [l'exemple GlusterFS](https://github.com/kubernetes/examples/tree/master/volumes/glusterfs) pour plus de détails.
 
 ### hostPath {#hostpath}
 
@@ -537,7 +537,7 @@ Une fonctionnalité de iSCSI est qu'il peut être monté en lecture seule par pl
 Cela signifie que vous pouvez préremplir un volume avec votre jeu de données et l'exposer en parallèle à partir d'autant de Pods que nécessaire.
 Malheureusement, les volumes iSCSI peuvent seulement être montés par un seul consommateur en mode lecture-écriture - les écritures simultanées ne sont pas autorisées.
 
-Voir [l'exemple iSCSI](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/volumes/iscsi) pour plus de détails.
+Voir [l'exemple iSCSI](https://github.com/kubernetes/examples/tree/master/volumes/iscsi) pour plus de détails.
 
 ### local {#local}
 
@@ -605,7 +605,7 @@ Cela signifie qu'un volume NFS peut être prérempli avec des données et que le
 Vous devez exécuter votre propre serveur NFS avec le partage exporté avant de pouvoir l'utiliser.
 {{< /caution >}}
 
-Voir [l'exemple NFS](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/nfs) pour plus de détails.
+Voir [l'exemple NFS](https://github.com/kubernetes/examples/tree/master/staging/volumes/nfs) pour plus de détails.
 
 ### persistentVolumeClaim {#persistentvolumeclaim}
 
@@ -624,7 +624,7 @@ Actuellement, les types de sources de volume suivantes peuvent être projetés :
 - [`configMap`](#configmap)
 - `serviceAccountToken`
 
-Toutes les sources doivent se trouver dans le même namespace que celui du Pod. Pour plus de détails, voir le [document de conception tout-en-un ](https://github.com/kubernetes/community/blob/{{< param "githubbranch" >}}/contributors/design-proposals/node/all-in-one-volume.md).
+Toutes les sources doivent se trouver dans le même namespace que celui du Pod. Pour plus de détails, voir le [document de conception tout-en-un ](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node/all-in-one-volume.md).
 
 La projection des jetons de compte de service (service account) est une fonctionnalité introduite dans Kubernetes 1.11 et promue en Beta dans la version 1.12.
 Pour activer cette fonctionnalité dans la version 1.11, il faut configurer explicitement la ["feature gate" `TokenRequestProjection`](/docs/reference/command-line-tools-reference/feature-gates/) à "True".
@@ -776,7 +776,7 @@ spec:
 Il faut s'assurer d'avoir un PortworxVolume existant avec le nom `pxvol` avant de l'utiliser dans le Pod.
 {{< /caution >}}
 
-Plus de détails et d'exemples peuvent être trouvé [ici](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/portworx/README.md).
+Plus de détails et d'exemples peuvent être trouvé [ici](https://github.com/kubernetes/examples/tree/master/staging/volumes/portworx/README.md).
 
 ### quobyte {#quobyte}
 
@@ -804,7 +804,7 @@ Une fonctionnalité de RBD est qu'il peut être monté en lecture seule par plus
 Cela signifie que vous pouvez préremplir un volume avec votre jeu de données et l'exposer en parallèle à partir d'autant de Pods que nécessaire.
 Malheureusement, les volumes RBD peuvent seulement être montés par un seul consommateur en mode lecture-écriture - les écritures simultanées ne sont pas autorisées.
 
-Voir [l'exemple RBD](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/volumes/rbd) pour plus de détails.
+Voir [l'exemple RBD](https://github.com/kubernetes/examples/tree/master/volumes/rbd) pour plus de détails.
 
 ### scaleIO {#scaleio}
 
@@ -842,7 +842,7 @@ spec:
       fsType: xfs
 ```
 
-Pour plus de détails, consulter [les exemples ScaleIO](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/scaleio).
+Pour plus de détails, consulter [les exemples ScaleIO](https://github.com/kubernetes/examples/tree/master/staging/volumes/scaleio).
 
 ### secret {#secret}
 

--- a/content/fr/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/fr/docs/concepts/workloads/controllers/statefulset.md
@@ -32,7 +32,7 @@ Un [Deployment](/fr/docs/concepts/workloads/controllers/deployment/) ou
 
 ## Limitations
 
-* Le stockage pour un Pod donné doit être provisionné soit par un [approvisionneur de PersistentVolume](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/persistent-volume-provisioning/README.md) basé sur un `storage class` donné, soit pré-provisionné par un admin.
+* Le stockage pour un Pod donné doit être provisionné soit par un [approvisionneur de PersistentVolume](https://github.com/kubernetes/examples/tree/master/staging/persistent-volume-provisioning/README.md) basé sur un `storage class` donné, soit pré-provisionné par un admin.
 * Supprimer et/ou réduire l'échelle d'un StatefulSet à zéro ne supprimera *pas* les volumes associés avec le StatefulSet. Ceci est fait pour garantir la sécurité des données, ce qui a généralement plus de valeur qu'une purge automatique de toutes les ressources relatives à un StatefulSet.
 * Les StatefulSets nécessitent actuellement un [Service Headless](/fr/docs/concepts/services-networking/service/#headless-services) qui est responsable de l'identité réseau des Pods. Vous êtes responsable de la création de ce Service.
 * Les StatefulSets ne fournissent aucune garantie de la terminaison des pods lorsqu'un StatefulSet est supprimé. Pour avoir une terminaison ordonnée et maîtrisée des pods du StatefulSet, il est possible de réduire l'échelle du StatefulSet à 0 avant de le supprimer.

--- a/content/fr/docs/setup/release/building-from-source.md
+++ b/content/fr/docs/setup/release/building-from-source.md
@@ -29,6 +29,6 @@ cd kubernetes
 make release
 ```
 
-Pour plus de détails sur le processus de release, voir le repertoire [`build`](http://releases.k8s.io/{{< param "githubbranch" >}}/build/) dans kubernetes/kubernetes.
+Pour plus de détails sur le processus de release, voir le repertoire [`build`](http://releases.k8s.io/master/build/) dans kubernetes/kubernetes.
 
 

--- a/content/id/docs/concepts/cluster-administration/federation.md
+++ b/content/id/docs/concepts/cluster-administration/federation.md
@@ -186,7 +186,7 @@ mampu menangani hingga 5000 node untuk tiap klaster. Baca [Membangun Klaster Bes
 ## {{% heading "whatsnext" %}}
 
 * Pelajari lebih lanjut tentang [proposal
-  _Federation_](https://github.com/kubernetes/community/blob/{{< param "githubbranch" >}}/contributors/design-proposals/multicluster/federation.md).
+  _Federation_](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/multicluster/federation.md).
 * Baca [petunjuk pengaktifan](/docs/tutorials/federation/set-up-cluster-federation-kubefed/) klaster _federation_.
 * Lihat [seminar tentang _federation_ pada Kubecon2016](https://www.youtube.com/watch?v=pq9lbkmxpS8)
 * Lihat [_update_ _federation_ pada Kubecon2017 Eropa](https://www.youtube.com/watch?v=kwOvOLnFYck)

--- a/content/id/docs/concepts/cluster-administration/logging.md
+++ b/content/id/docs/concepts/cluster-administration/logging.md
@@ -72,7 +72,7 @@ Saat kamu menjalankan perintah [`kubectl logs`](/docs/reference/generated/kubect
 Saat ini, jika suatu sistem eksternal telah melakukan rotasi, hanya konten dari berkas log terbaru yang akan tersedia melalui perintah `kubectl logs`. Contoh, jika terdapat sebuah berkas 10MB, `logrotate` akan melakukan rotasi sehingga akan ada dua buah berkas, satu dengan ukuran 10MB, dan satu berkas lainnya yang kosong. Maka `kubectl logs` akan mengembalikan respon kosong.
 {{< /note >}}
 
-[cosConfigureHelper]: https://github.com/kubernetes/kubernetes/blob/{{< param "githubbranch" >}}/cluster/gce/gci/configure-helper.sh
+[cosConfigureHelper]: https://github.com/kubernetes/kubernetes/blob/master/cluster/gce/gci/configure-helper.sh
 
 ### Komponen sistem log
 

--- a/content/id/docs/concepts/cluster-administration/manage-deployment.md
+++ b/content/id/docs/concepts/cluster-administration/manage-deployment.md
@@ -159,7 +159,7 @@ Jika kamu tertarik mempelajari lebih lanjut tentang `kubectl`, silahkan baca [Ik
 
 Contoh yang kita lihat sejauh ini hanya menggunakan paling banyak satu label pada _resource_. Ada banyak skenario ketika membutuhkan beberapa label untuk membedakan sebuah kelompok dari yang lainnya.
 
-Sebagai contoh, aplikasi yang berbeda akan menggunakan label `app` yang berbeda, tapi pada aplikasi _multitier_, seperti pada [contoh buku tamu](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/guestbook/), tiap _tier_ perlu dibedakan. Misal untuk menandai _tier frontend_ bisa menggunakan label:
+Sebagai contoh, aplikasi yang berbeda akan menggunakan label `app` yang berbeda, tapi pada aplikasi _multitier_, seperti pada [contoh buku tamu](https://github.com/kubernetes/examples/tree/master/guestbook/), tiap _tier_ perlu dibedakan. Misal untuk menandai _tier frontend_ bisa menggunakan label:
 
 ```yaml
      labels:

--- a/content/id/docs/concepts/configuration/manage-compute-resources-container.md
+++ b/content/id/docs/concepts/configuration/manage-compute-resources-container.md
@@ -192,7 +192,7 @@ karena limit sumber dayanya, lihat bagian [Penyelesaian Masalah](#penyelesaian-m
 
 Penggunaan sumber daya dari sebuah Pod dilaporkan sebagai bagian dari kondisi Pod.
 
-Jika [_monitoring_ opsional](http://releases.k8s.io/{{< param "githubbranch" >}}/cluster/addons/cluster-monitoring/README.md) diaktifkan pada klaster kamu, maka penggunaan sumber daya Pod dapat diambil
+Jika [_monitoring_ opsional](http://releases.k8s.io/master/cluster/addons/cluster-monitoring/README.md) diaktifkan pada klaster kamu, maka penggunaan sumber daya Pod dapat diambil
 dari sistem _monitoring_ kamu.
 
 ## Penyelesaian Masalah

--- a/content/id/docs/concepts/configuration/overview.md
+++ b/content/id/docs/concepts/configuration/overview.md
@@ -64,7 +64,7 @@ services) (yang memiliki `ClusterIP` dari `None`) untuk Service discovery yang m
 
 ## Menggunakan label
 
-- Deklarasi dan gunakan [labels] (/id/docs/concepts/overview/working-with-objects/labels/) untuk identifikasi __semantic attributes__  aplikasi atau Deployment kamu, seperti `{ app: myapp, tier: frontend, phase: test, deployment: v3 }`. Kamu dapat menggunakan label ini untuk memilih Pod yang sesuai untuk sumber daya lainnya; misalnya, Service yang memilih semua `tier: frontend` Pods, atau semua komponen `phase: test` dari `app: myapp`. Lihat [guestbook](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/guestbook/) aplikasi untuk contoh-contoh pendekatan ini.
+- Deklarasi dan gunakan [labels] (/id/docs/concepts/overview/working-with-objects/labels/) untuk identifikasi __semantic attributes__  aplikasi atau Deployment kamu, seperti `{ app: myapp, tier: frontend, phase: test, deployment: v3 }`. Kamu dapat menggunakan label ini untuk memilih Pod yang sesuai untuk sumber daya lainnya; misalnya, Service yang memilih semua `tier: frontend` Pods, atau semua komponen `phase: test` dari `app: myapp`. Lihat [guestbook](https://github.com/kubernetes/examples/tree/master/guestbook/) aplikasi untuk contoh-contoh pendekatan ini.
 
 
 Service dapat dibuat untuk menjangkau beberapa Penyebaran dengan menghilangkan label khusus rilis dari pemilihnya. [Deployments](/id/docs/concepts/workloads/controllers/deployment/) membuatnya mudah untuk memperbarui Service yang sedang berjalan tanpa downtime.

--- a/content/id/docs/concepts/containers/container-environment.md
+++ b/content/id/docs/concepts/containers/container-environment.md
@@ -46,7 +46,7 @@ FOO_SERVICE_PORT=<port dimana service dijalankan>
 ```
 
 Semua *Service* memiliki alamat-alamat IP yang bisa didapatkan di dalam Kontainer melalui DNS,
-jika [*addon* DNS](http://releases.k8s.io/{{< param "githubbranch" >}}/cluster/addons/dns/) diaktifkan. 
+jika [*addon* DNS](http://releases.k8s.io/master/cluster/addons/dns/) diaktifkan. 
 
 
 

--- a/content/id/docs/concepts/overview/what-is-kubernetes.md
+++ b/content/id/docs/concepts/overview/what-is-kubernetes.md
@@ -64,7 +64,7 @@ tambahan pada <i>resource</i> yang dimiliki.
 Selain itu, [Kubernetes control plane]() dibuat berdasarkan
 [API](/docs/reference/using-api/api-overview/) yang tersedia bagi pengguna dan developer. Pengguna
 dapat mengimplementasikan kontroler sesuai dengan kebutuhan mereka, contohnya adalah
-[schedulers](https://github.com/kubernetes/community/blob/{{< param "githubbranch" >}}/contributors/devel/scheduler.md),
+[schedulers](https://github.com/kubernetes/community/blob/master/contributors/devel/scheduler.md),
 dengan [API kustom yang mereka miliki](), kontroler kustom ini kemudian dapat digunakan
 pada [command-line
 tool]() generik yang ada.

--- a/content/id/docs/concepts/services-networking/connect-applications-service.md
+++ b/content/id/docs/concepts/services-networking/connect-applications-service.md
@@ -112,7 +112,7 @@ Kamu sekarang dapat melakukan *curl* ke dalam *nginx Service* di `<CLUSTER-IP>:<
 ## Mengakses Service
 
 Kubernetes mendukung 2 mode utama untuk menemukan sebuah *Service* - variabel *environment* dan *DNS*.
-*DNS* membutuhkan [tambahan CoreDNS di dalam klaster](http://releases.k8s.io/{{< param "githubbranch" >}}/cluster/addons/dns/coredns).
+*DNS* membutuhkan [tambahan CoreDNS di dalam klaster](http://releases.k8s.io/master/cluster/addons/dns/coredns).
 
 ### Variabel Environment
 
@@ -165,7 +165,7 @@ NAME       TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)         AGE
 kube-dns   ClusterIP   10.0.0.10    <none>        53/UDP,53/TCP   8m
 ```
 
-Jika *DNS* belum berjalan, kamu dapat [mengaktifkannya](http://releases.k8s.io/{{< param "githubbranch" >}}/cluster/addons/dns/kube-dns/README.md#how-do-i-configure-it).
+Jika *DNS* belum berjalan, kamu dapat [mengaktifkannya](http://releases.k8s.io/master/cluster/addons/dns/kube-dns/README.md#how-do-i-configure-it).
 
 Sisa panduan ini mengasumsikan kamu mempunyai *Service* dengan IP (my-nginx), dan sebuah server *DNS*  yang memberikan nama ke dalam IP tersebut (CoreDNS klaster), jadi kamu dapat berkomunikasi dengan *Service* dari *Pod* lain di dalam klaster menggunakan metode standar (contohnya *gethostbyname*). Jalankan aplikasi *curl* lain untuk melakukan pengujian ini:
 
@@ -197,7 +197,7 @@ Hingga sekarang kita hanya mengakses *nginx* server dari dalam klaster. Sebelum 
 * Sebuah [secret](/id/docs/concepts/configuration/secret/) yang membuat setifikat tersebut dapat diakses oleh *pod*
 
 
-Kamu dapat melihat semua itu di [contoh nginx https](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/https-nginx/). Contoh ini mengaharuskan kamu melakukan instalasi *go* dan *make*. Jika kamu tidak ingin melakukan instalasi tersebut, ikuti langkah-langkah manualnya nanti, singkatnya:
+Kamu dapat melihat semua itu di [contoh nginx https](https://github.com/kubernetes/examples/tree/master/staging/https-nginx/). Contoh ini mengaharuskan kamu melakukan instalasi *go* dan *make*. Jika kamu tidak ingin melakukan instalasi tersebut, ikuti langkah-langkah manualnya nanti, singkatnya:
 
 ```shell
 make keys KEY=/tmp/nginx.key CERT=/tmp/nginx.crt
@@ -254,7 +254,7 @@ Sekarang modifikasi replika *nginx* untuk menjalankan server *https* menggunakan
 Berikut catatan penting tentang manifes *nginx-secure-app*:
 
 - di dalam file tersebut, ada spesifikasi *Deployment* dan *Service*
-- ada [server nginx](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/https-nginx/default.conf) yang melayani trafik *HTTP* di *port* 80 dan trafik *HTTPS* di *port* 443, dan *Service nginx* yang mengekspos kedua *port* tersebut.
+- ada [server nginx](https://github.com/kubernetes/examples/tree/master/staging/https-nginx/default.conf) yang melayani trafik *HTTP* di *port* 80 dan trafik *HTTPS* di *port* 443, dan *Service nginx* yang mengekspos kedua *port* tersebut.
 - Setiap kontainer mempunyai akses ke *key* melalui *volume* yang di *mount* pada `/etc/nginx/ssl`. Ini adalah konfigurasi sebelum server *nginx* dijalankan.
 
 ```shell

--- a/content/id/docs/concepts/services-networking/service.md
+++ b/content/id/docs/concepts/services-networking/service.md
@@ -295,7 +295,7 @@ Kubernetes mendukung 2 buah mode primer untuk melakukan `Service` - variabel _en
 
 Ketika sebuah `Pod` dijalankan pada *node*, _kubelet_ menambahkan seperangkat variabel _environment_
 untuk setiap `Service` yang aktif. _Environment_ yang didukung adalah [Docker links compatible](https://docs.docker.com/userguide/dockerlinks/) variabel (perhatikan
-[makeLinkVariables](http://releases.k8s.io/{{< param "githubbranch" >}}/pkg/kubelet/envvars/envvars.go#L49))
+[makeLinkVariables](http://releases.k8s.io/master/pkg/kubelet/envvars/envvars.go#L49))
 dan variabel `{SVCNAME}_SERVICE_HOST` dan `{SVCNAME}_SERVICE_PORT`, dinama nama `Service` akan diubah
 menjadi huruf kapital dan tanda _minus_  akan diubah menjadi _underscore_.
 

--- a/content/id/docs/concepts/storage/volumes.md
+++ b/content/id/docs/concepts/storage/volumes.md
@@ -117,7 +117,7 @@ Pada saat fitur migrasi CSI (Container Storage Interface) untuk `awsElasticBlock
 
 Sebuah `azureDisk` digunakan untuk menambatkan sebuah [Data Disk](https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-about-disks-vhds/) Microsoft Azure ke dalam sebuah Pod.
 
-Selengkapnya dapat ditemukan [di sini](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/azure_disk/README.md).
+Selengkapnya dapat ditemukan [di sini](https://github.com/kubernetes/examples/tree/master/staging/volumes/azure_disk/README.md).
 
 #### Migrasi CSI azureDisk
 
@@ -129,7 +129,7 @@ Pada saat fitur migrasi CSI untuk `azureDisk` diaktifkan, fitur ini akan menterj
 
 Sebuah `azureFile` digunakan untuk menambatkan sebuah Microsoft Azure File Volume (SMB 2.1 dan 3.0) ke dalam sebuah Pod.
 
-Selengkapnya dapat ditemukan [di sini](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/azure_file/README.md).
+Selengkapnya dapat ditemukan [di sini](https://github.com/kubernetes/examples/tree/master/staging/volumes/azure_file/README.md).
 
 #### Migrasi CSI azureFile
 
@@ -145,7 +145,7 @@ Sebuah Volume `cephfs` memungkinkan sebuah volume CephFS yang sudah ada untuk di
 Kamu harus memiliki server Ceph sendiri dan mengekspor _share_-nya sebelum kamu dapat menggunakannya.
 {{< /caution >}}
 
-Selengkapnya, lihat [contoh CephFS](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/cephfs/).
+Selengkapnya, lihat [contoh CephFS](https://github.com/kubernetes/examples/tree/master/staging/volumes/cephfs/).
 
 ### cinder {#cinder}
 
@@ -277,7 +277,7 @@ Kamu dapat menentukan satu atau banyak target _World Wide Names_ menggunakan par
 Sebelumnya, kamu harus mengkonfigurasikan _FC SAN Zoning_ untuk mengalokasikan dan melakukan _masking_ terhadap LUN (_volume_) tersebut terhadap target WWN sehingga Node-node Kubernetes dapat mengakses mereka.
 {{< /caution >}}
 
-Lihat [Contoh FC](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/fibre_channel) untuk lebih detilnya.
+Lihat [Contoh FC](https://github.com/kubernetes/examples/tree/master/staging/volumes/fibre_channel) untuk lebih detilnya.
 
 ### flocker {#flocker}
 
@@ -289,7 +289,7 @@ Sebuah Volume `flockere` memungkinkan sebuah _dataset_ Flocker untuk ditambatkan
 Kamu harus memiliki instalasi Flocker yang sudah berjalan sebelum kamu dapat menggunakannya.
 {{< /caution >}}
 
-Lihat [Contoh Flocker](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/flocker) untuk lebih detil.
+Lihat [Contoh Flocker](https://github.com/kubernetes/examples/tree/master/staging/volumes/flocker) untuk lebih detil.
 
 ### gcePersistentDisk {#gcepersistentdisk}
 
@@ -418,7 +418,7 @@ Tidak seperti `emptyDir` yang ikut dihapus saat Pod dihapus, isi dari sebuah `gl
 Kamu harus mempunyai instalasi GlusterFS terlebih dahulu sebelum dapat kamu gunakan.
 {{< /caution >}}
 
-Lihat [contoh GlusterFS](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/glusterfs) untuk lebih detil.
+Lihat [contoh GlusterFS](https://github.com/kubernetes/examples/tree/master/staging/volumes/glusterfs) untuk lebih detil.
 
 ### hostPath {#hostpath}
 
@@ -487,7 +487,7 @@ Kamu harus memiliki peladen iSCSI yang berjalan dengan volume iSCSI yang telah d
 
 Salah satu fitur iSCSI yaitu mereka dapat ditambatkan sebagai _read-only_ secara bersamaan oleh beberapa pengguna. Hal ini berarti kamu dapat mengisi data terlebih dahulu dan menyediakan data tersebut secara paralel untuk sebanyak apapun Pod yang kamu butuhkan. Sayangnya, iSCSI hanya dapat ditambatkan kepada satu pengguna saja pada mode _read-write_ - yaitu, tidak boleh ada banyak penulis secara bersamaan.
 
-Lihat [contoh iSCSI](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/iscsi) untuk lebih detil.
+Lihat [contoh iSCSI](https://github.com/kubernetes/examples/tree/master/staging/volumes/iscsi) untuk lebih detil.
 
 ### local {#local}
 
@@ -550,7 +550,7 @@ Tidak seperti `emptyDir` yang ikut dihapus saat Pod dihapus, isi dari sebuah `nf
 Kamu harus memiliki peladen NFS yang berjalan dengan _share_ yang diekspor sebelum kamu dapat menggunakannya.
 {{< /caution >}}
 
-Lihat [contoh NFS](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/nfs) untuk lebih lanjut.
+Lihat [contoh NFS](https://github.com/kubernetes/examples/tree/master/staging/volumes/nfs) untuk lebih lanjut.
 
 ### persistentVolumeClaim {#persistentvolumeclaim}
 
@@ -569,7 +569,7 @@ Saat ini, tipe-tipe sumber Volume berikut dapat diproyeksikan:
 - [`configMap`](#configmap)
 - `serviceAccountToken`
 
-Semua sumber harus berada pada `namespace` yang sama dengan Pod yang menggunakannya. Untuk lebih lanjut, lihat [dokumen desain Volume](https://github.com/kubernetes/community/blob/{{< param "githubbranch" >}}/contributors/design-proposals/node/all-in-one-volume.md).
+Semua sumber harus berada pada `namespace` yang sama dengan Pod yang menggunakannya. Untuk lebih lanjut, lihat [dokumen desain Volume](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node/all-in-one-volume.md).
 
 Proyeksi `serviceAccountToken` adalah fitur yang diperkenalkan pada Kubernetes 1.11 dan dipromosikan menjadi Beta pada 1.12.
 Untuk mengaktifkan fitur inipada 1.11, kamu harus menyetel [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) `TokenRequestProjection` secara eksplisit menjadi `True`.
@@ -714,7 +714,7 @@ spec:
 Pastikan kamu sudah memiliki PortworxVolume dengan nama `pxvol` sebelum dapat menggunakannya pada Pod.
 {{< /caution >}}
 
-Lihat [di sini](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/portworx/README.md) untuk lebih lanjut.
+Lihat [di sini](https://github.com/kubernetes/examples/tree/master/staging/volumes/portworx/README.md) untuk lebih lanjut.
 
 ### quobyte {#quobyte}
 
@@ -738,7 +738,7 @@ Kamu harus memiliki instalasi Ceph yang berjalan sebelum kamu dapat menggunakan 
 
 Sebuah fitur RBD yaitu mereka dapat ditambatkan sebagai _read-only_ secara bersamaan oleh beberapa pengguna. Hal ini berarti kamu dapat mengisi data terlebih dahulu dan menyediakan data tersebut secara paralel untuk sebanyak apapun Pod yang kamu butuhkan. Sayangnya, RBD hanya dapat ditambatkan kepada satu pengguna saja pada mode _read-write_ - yaitu, tidak boleh ada banyak penulis secara bersamaan.
 
-Lihat [contoh RBD](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/rbd) untuk lebih lanjut.
+Lihat [contoh RBD](https://github.com/kubernetes/examples/tree/master/staging/volumes/rbd) untuk lebih lanjut.
 
 ### scaleIO {#scaleio}
 
@@ -775,7 +775,7 @@ spec:
       fsType: xfs
 ```
 
-Lihat [contoh ScaleIO](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/volumes/scaleio) untuk lebih lanjut.
+Lihat [contoh ScaleIO](https://github.com/kubernetes/examples/tree/master/staging/volumes/scaleio) untuk lebih lanjut.
 
 ### secret {#secret}
 

--- a/content/id/docs/concepts/workloads/controllers/job.md
+++ b/content/id/docs/concepts/workloads/controllers/job.md
@@ -491,7 +491,7 @@ dan memiliki integrasi terbatas dengan Kubernetes.
 
 Salah satu contoh dari pola ini adalah sebuah Job yang akan menginisiasi sebuah Pod 
 yang menjalankan _script_ yang kemudian akan 
-menjalankan _controller_ master Spark (kamu dapat melihatnya di [contoh Spark](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/spark/README.md)), 
+menjalankan _controller_ master Spark (kamu dapat melihatnya di [contoh Spark](https://github.com/kubernetes/examples/tree/master/staging/spark/README.md)), 
 yang menjalankan _driver_ Spark, dan kemudian melakukan mekanisme _clean up_.
 
 Keuntungan dari pendekatan ini adalah proses keseluruhan yang memiliki jaminan _completion_ 

--- a/content/id/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/id/docs/concepts/workloads/controllers/statefulset.md
@@ -38,7 +38,7 @@ replika _stateless_. _Controller_ seperti  [Deployment](/id/docs/concepts/worklo
 
 * StatefulSet merupakan sumber daya beta sebelum 1.9 dan tidak tersedia 
   pada Kubernetes rilis sebelum versi 1.5.
-* Penyimpanan untuk sebuah Pod harus terlebih dahulu di-_provision_ dengan menggunakan sebuah [Provisioner PersistentVolume](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/persistent-volume-provisioning/README.md) berdasarkan `storage class` yang dispesifikasikan, atau sudah ditentukan sebelumnya oleh administrator.
+* Penyimpanan untuk sebuah Pod harus terlebih dahulu di-_provision_ dengan menggunakan sebuah [Provisioner PersistentVolume](https://github.com/kubernetes/examples/tree/master/staging/persistent-volume-provisioning/README.md) berdasarkan `storage class` yang dispesifikasikan, atau sudah ditentukan sebelumnya oleh administrator.
 * Menghapus dan/atau _scaling_ sebuah StatefulSet *tidak akan* menghapus volume yang berkaitan dengan StatefulSet tersebut. Hal ini dilakukan untuk menjamin data yang disimpan, yang secara umum dinilai lebih berhaga dibandingkan dengan mekanisme penghapusan data secara otomatis pada sumber daya terkait.
 * StatefulSet saat ini membutuhkan sebuah [Headless Service](/id/docs/concepts/services-networking/service/#headless-services) yang nantinya akan bertanggung jawab terhadap pada identitas jaringan pada Pod. Kamulah yang bertanggung jawab untuk membuat Service tersebut.
 * StatefulSet tidak menjamin terminasi Pod ketika sebuah StatefulSet dihapus. Untuk mendapatkan terminasi Pod yang terurut dan _graceful_ pada StatefulSet, kita dapat melakukan _scale down_ Pod ke 0 sebelum penghapusan. 

--- a/content/id/docs/setup/best-practices/multiple-zones.md
+++ b/content/id/docs/setup/best-practices/multiple-zones.md
@@ -17,7 +17,7 @@ Laman ini menjelaskan tentang bagaimana menjalankan sebuah klaster dalam beberap
 Kubernetes 1.2 menambahkan dukungan untuk menjalankan sebuah klaster dalam beberapa zona kegagalan (_multiple failure zones_)
 (GCE secara sederhana menyebutnya sebagai _"zones"_, AWS menyebutnya sebagai _"availability zones"_, dan di sini kita akan menyebutnya sebagai "zona").
 Fitur ini adalah versi sederhana dari fitur federasi klaster yang lebih luas (yang sebelumnya ditujukan pada
-sebuah nama panggilan yang ramah (_affectionate nickname_) ["Ubernetes"](https://github.com/kubernetes/community/blob/{{< param "githubbranch" >}}/contributors/design-proposals/multicluster/federation.md)).
+sebuah nama panggilan yang ramah (_affectionate nickname_) ["Ubernetes"](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/multicluster/federation.md)).
 Federasi klaster yang penuh memungkinkan untuk menggabungkan
 klaster Kubernetes terpisah, yang berjalan pada wilayah atau penyedia cloud yang berbeda
 (baik dalam _datacenter_ atau _on-premise_). Namun banyak

--- a/content/id/docs/tasks/administer-cluster/dns-custom-nameservers.md
+++ b/content/id/docs/tasks/administer-cluster/dns-custom-nameservers.md
@@ -25,7 +25,7 @@ menjelaskan tentang bagaimana menggunakan `kubeadm` untuk melakukan migrasi dari
 
 DNS adalah Service bawaan dalam Kubernetes yang diluncurkan secara otomatis
 melalui _addon manager_
-[add-on klaster](http://releases.k8s.io/{{< param "githubbranch" >}}/cluster/addons/README.md).
+[add-on klaster](http://releases.k8s.io/master/cluster/addons/README.md).
 
 Sejak Kubernetes v1.12, CoreDNS adalah server DNS yang direkomendasikan untuk menggantikan kube-dns. Jika klaster kamu
 sebelumnya menggunakan kube-dns, maka kamu mungkin masih menggunakan `kube-dns` daripada CoreDNS.

--- a/content/id/docs/tasks/administer-cluster/namespaces.md
+++ b/content/id/docs/tasks/administer-cluster/namespaces.md
@@ -297,6 +297,6 @@ Entri DNS ini dalam bentuk `<service-name>.<namespace-name>.svc.cluster.local`, 
 
 * Pelajari lebih lanjut mengenai [pengaturan preferensi Namespace](/id/docs/concepts/overview/working-with-objects/namespaces/#pengaturan-preferensi-namespace).
 * Pelajari lebih lanjut mengenai [pengaturan namespace untuk sebuah permintaan](/id/docs/concepts/overview/working-with-objects/namespaces/#pengaturan-namespace-untuk-sebuah-permintaan)
-* Baca [desain Namespace](https://github.com/kubernetes/community/blob/{{< param "githubbranch" >}}/contributors/design-proposals/architecture/namespaces.md).
+* Baca [desain Namespace](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture/namespaces.md).
 
 

--- a/content/id/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/id/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -142,7 +142,7 @@ kubelet mematikan Container dan mengulangnya kembali.
 Kode yang lebih besar atau sama dengan 200 dan kurang dari 400 mengindikasikan kesuksesan.
 Kode selain ini mengindikasikan kegagalan.
 
-Kamu dapat melihat kode program untuk server ini pada [server.go](https://github.com/kubernetes/kubernetes/blob/{{< param "githubbranch" >}}/test/images/agnhost/liveness/server.go).
+Kamu dapat melihat kode program untuk server ini pada [server.go](https://github.com/kubernetes/kubernetes/blob/master/test/images/agnhost/liveness/server.go).
 
 Untuk 10 detik pertama setelah Container hidup (_alive_), _handler_ `/healthz` mengembalikan
 status 200. Setelah itu, _handler_ mengembalikan status 500.

--- a/content/id/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/content/id/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -20,7 +20,7 @@ konsep-konsep Kubernetes sebagai berikut:
 * [DNS klaster](/id/docs/concepts/services-networking/dns-pod-service/)
 * [Service _headless_](/id/docs/concepts/services-networking/service/#service-headless)
 * [PersistentVolume](/id/docs/concepts/storage/persistent-volumes/)
-* [Penyediaan PersistentVolume](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/persistent-volume-provisioning/)
+* [Penyediaan PersistentVolume](https://github.com/kubernetes/examples/tree/master/staging/persistent-volume-provisioning/)
 * [StatefulSet](/id/docs/concepts/workloads/controllers/statefulset/)
 * Alat baris perintah (_command line tool_) [kubectl](/docs/reference/kubectl/kubectl/)
 

--- a/content/it/docs/concepts/containers/container-environment.md
+++ b/content/it/docs/concepts/containers/container-environment.md
@@ -46,7 +46,7 @@ FOO_SERVICE_PORT=<porta su cui il servizio è pubblicato>
 ```
 
 I servizi hanno un indirizzo IP dedicato e sono disponibili nei Container anche via DNS
-se il [DNS addon](http://releases.k8s.io/{{< param "githubbranch" >}}/cluster/addons/dns/) è installato nel cluster.
+se il [DNS addon](http://releases.k8s.io/master/cluster/addons/dns/) è installato nel cluster.
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/vi/docs/concepts/containers/container-environment-variables.md
+++ b/content/vi/docs/concepts/containers/container-environment-variables.md
@@ -50,7 +50,7 @@ FOO_SERVICE_PORT=<port mà service đang chạy>
 ```
 
 Các services có địa chỉ IP và có sẵn cho Container thông qua DNS 
-nếu [DNS addon](http://releases.k8s.io/{{< param "githubbranch" >}}/cluster/addons/dns/) được enable. 
+nếu [DNS addon](http://releases.k8s.io/master/cluster/addons/dns/) được enable. 
 
 
 

--- a/content/zh-cn/docs/tutorials/stateful-application/zookeeper.md
+++ b/content/zh-cn/docs/tutorials/stateful-application/zookeeper.md
@@ -43,7 +43,7 @@ Kubernetes concepts.
 - [集群 DNS](/zh-cn/docs/concepts/services-networking/dns-pod-service/)
 - [无头服务（Headless Service）](/zh-cn/docs/concepts/services-networking/service/#headless-services)
 - [PersistentVolumes](/zh-cn/docs/concepts/storage/persistent-volumes/)
-- [PersistentVolume 制备](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/persistent-volume-provisioning/)
+- [PersistentVolume 制备](https://github.com/kubernetes/examples/tree/master/staging/persistent-volume-provisioning/)
 - [StatefulSet](/zh-cn/docs/concepts/workloads/controllers/statefulset/)
 - [PodDisruptionBudget](/zh-cn/docs/concepts/workloads/pods/disruptions/#pod-disruption-budget)
 - [PodAntiAffinity](/zh-cn/docs/concepts/scheduling-eviction/assign-pod-node/#亲和与反亲和)


### PR DESCRIPTION
The documentation contains lot of dead links, at least in the FR / storage section.
I have noticed that the `{{< param "githubbranch" >}}` was in other portions of the doc, and seems outdated.
I have replaced every occurrence with "master".