### PR TITLE
Fix broken link in it

### DIFF
--- a/content/it/docs/concepts/containers/container-environment.md
+++ b/content/it/docs/concepts/containers/container-environment.md
@@ -46,7 +46,7 @@ FOO_SERVICE_PORT=<porta su cui il servizio è pubblicato>
 ```
 
 I servizi hanno un indirizzo IP dedicato e sono disponibili nei Container anche via DNS
-se il [DNS addon](http://releases.k8s.io/{{< param "githubbranch" >}}/cluster/addons/dns/) è installato nel cluster.
+se il [DNS addon](http://releases.k8s.io/master/cluster/addons/dns/) è installato nel cluster.
 
 ## {{% heading "whatsnext" %}}
 


### PR DESCRIPTION
The documentation contains lot of dead links in the IT language.
I have noticed that the `{{< param "githubbranch" >}}` was in other portions of the doc, and seems outdated.
I have replaced every occurrence with "master".