### PR TITLE
Fix broken link in vi

### DIFF
--- a/content/vi/docs/concepts/containers/container-environment-variables.md
+++ b/content/vi/docs/concepts/containers/container-environment-variables.md
@@ -50,7 +50,7 @@ FOO_SERVICE_PORT=<port mà service đang chạy>
 ```
 
 Các services có địa chỉ IP và có sẵn cho Container thông qua DNS 
-nếu [DNS addon](http://releases.k8s.io/{{< param "githubbranch" >}}/cluster/addons/dns/) được enable. 
+nếu [DNS addon](http://releases.k8s.io/master/cluster/addons/dns/) được enable. 
 
 
 


### PR DESCRIPTION
The documentation contains lot of dead links in the VI language.
I have noticed that the `{{< param "githubbranch" >}}` was in other portions of the doc, and seems outdated.
I have replaced every occurrence with "master".