### PR TITLE
Fix broken link in es

### DIFF
--- a/content/es/docs/concepts/containers/container-environment-variables.md
+++ b/content/es/docs/concepts/containers/container-environment-variables.md
@@ -48,7 +48,7 @@ FOO_SERVICE_HOST=<El host donde está funcionando el servicio>
 FOO_SERVICE_PORT=<El puerto dónde está funcionando el servicio>
 ```
 Los servicios tienen direcciones IP dedicadas y están disponibles para el Container a través de DNS,
-si el [complemento para DNS](http://releases.k8s.io/{{< param "githubbranch" >}}/cluster/addons/dns/) está habilitado.
+si el [complemento para DNS](http://releases.k8s.io/master/cluster/addons/dns/) está habilitado.
 
 
 

--- a/content/es/docs/setup/release/building-from-source.md
+++ b/content/es/docs/setup/release/building-from-source.md
@@ -30,7 +30,7 @@ cd kubernetes
 make release
 ```
 
-Para más detalles sobre el proceso de compilación de una release, visita la carpeta kubernetes/kubernetes [`build`](http://releases.k8s.io/{{< param "githubbranch" >}}/build/)
+Para más detalles sobre el proceso de compilación de una release, visita la carpeta kubernetes/kubernetes [`build`](http://releases.k8s.io/master/build/)
 
 
 


### PR DESCRIPTION
The documentation contains lot of dead links in the ES language.
I have noticed that the `{{< param "githubbranch" >}}` was in other portions of the doc, and seems outdated.
I have replaced every occurrence with "master".