### PR TITLE
Fix broken link in de

### DIFF
--- a/content/de/docs/setup/release/building-from-source.md
+++ b/content/de/docs/setup/release/building-from-source.md
@@ -27,6 +27,6 @@ cd kubernetes
 make release
 ```
 
-Mehr Informationen zum Release-Prozess finden Sie im kubernetes/kubernetes [`build`](http://releases.k8s.io/{{< param "githubbranch" >}}/build/) Verzeichnis.
+Mehr Informationen zum Release-Prozess finden Sie im kubernetes/kubernetes [`build`](http://releases.k8s.io/master/build/) Verzeichnis.
 
 


### PR DESCRIPTION
The documentation contains lot of dead links in the DE language.
I have noticed that the `{{< param "githubbranch" >}}` was in other portions of the doc, and seems outdated.
I have replaced every occurrence with "master".