### PR TITLE
Fix broken link in zh-cn

### DIFF
--- a/content/zh-cn/docs/tutorials/stateful-application/zookeeper.md
+++ b/content/zh-cn/docs/tutorials/stateful-application/zookeeper.md
@@ -43,7 +43,7 @@ Kubernetes concepts.
 - [集群 DNS](/zh-cn/docs/concepts/services-networking/dns-pod-service/)
 - [无头服务（Headless Service）](/zh-cn/docs/concepts/services-networking/service/#headless-services)
 - [PersistentVolumes](/zh-cn/docs/concepts/storage/persistent-volumes/)
-- [PersistentVolume 制备](https://github.com/kubernetes/examples/tree/{{< param "githubbranch" >}}/staging/persistent-volume-provisioning/)
+- [PersistentVolume 制备](https://github.com/kubernetes/examples/tree/master/staging/persistent-volume-provisioning/)
 - [StatefulSet](/zh-cn/docs/concepts/workloads/controllers/statefulset/)
 - [PodDisruptionBudget](/zh-cn/docs/concepts/workloads/pods/disruptions/#pod-disruption-budget)
 - [PodAntiAffinity](/zh-cn/docs/concepts/scheduling-eviction/assign-pod-node/#亲和与反亲和)


### PR DESCRIPTION
The documentation contains dead links in zh-cn section.
I have noticed that the `{{< param "githubbranch" >}}` was in other portions of the doc, and seems outdated.
I have replaced every occurrence with "master".