### PR TITLE
Fix links in release.md

### DIFF
--- a/content/en/releases/release.md
+++ b/content/en/releases/release.md
@@ -281,7 +281,7 @@ Issues are marked as targeting a milestone via the Prow "/milestone" command.
 The Release Team's [Bug Triage Lead](https://git.k8s.io/sig-release/release-team/role-handbooks/bug-triage/README.md)
 and overall community watch incoming issues and triage them, as described in
 the contributor guide section on
-[issue triage](/contributors/guide/issue-triage.md).
+[issue triage](https://k8s.dev/docs/guide/issue-triage/).
 
 Marking issues with the milestone provides the community better visibility
 regarding when an issue was observed and by when the community feels it must be
@@ -355,11 +355,11 @@ issue kind labels must be set:
 - `kind/feature`: New functionality.
 - `kind/flake`: CI test case is showing intermittent failures.
 
-[cherry-picks]: /contributors/devel/sig-release/cherry-picks.md
+[cherry-picks]: https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md
 [code-freeze]: https://git.k8s.io/sig-release/releases/release_phases.md#code-freeze
 [enhancements-freeze]: https://git.k8s.io/sig-release/releases/release_phases.md#enhancements-freeze
 [exceptions]: https://git.k8s.io/sig-release/releases/release_phases.md#exceptions
 [keps]: https://git.k8s.io/enhancements/keps
-[release-managers]: https://kubernetes.io/releases/release-managers/
+[release-managers]: /releases/release-managers/
 [release-team]: https://git.k8s.io/sig-release/release-team
-[sig-list]: /sig-list.md
+[sig-list]: https://k8s.dev/sigs


### PR DESCRIPTION
This file is auto generated from [k/community](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md), I've checked it's already in sync.

The first link https://github.com/kubernetes/community/blob/master/contributors/guide/issue-triage.md is located at https://k8s.dev/docs/guide/issue-triage/.

The second one https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/cherry-picks.md do not have webpage version.

The last one https://github.com/kubernetes/community/blob/master/sig-list.md have aliases `/groups` and `/sigs`, so I pick the close one https://k8s.dev/sigs.