### PR TITLE
Improving copy to clipboard feature- Removing extra lines

### DIFF
--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -23,6 +23,7 @@ function copyCode(elem){
       document.body.appendChild(target);
     }
     target.value = document.getElementById(elem).innerText;
+    target.value = target.value.replace(/\n\n/gm,"\n").trim();
     // select the content
     target.select();
 


### PR DESCRIPTION
Fix: #34447

Hello, this solves the issue of addition of extra lines, on "copy to clipboard". Implemented by making changes in the JavaScript, using JavaScript replace and trim function.

Deploy preview example yaml files which are now without extra lines:

1. https://deploy-preview-34736--kubernetes-io-main-staging.netlify.app/docs/concepts/services-networking/network-policies/#networkpolicy-resource
2. https://deploy-preview-34736--kubernetes-io-main-staging.netlify.app/docs/tasks/configure-pod-container/configure-runasusername/#set-the-username-for-a-pod