### PR TITLE
Placeholder for KEP-3203 docs

### DIFF
--- a/content/en/docs/reference/issues-security/issues.md
+++ b/content/en/docs/reference/issues-security/issues.md
@@ -10,4 +10,6 @@ Work on Kubernetes code and public issues are tracked using [GitHub Issues](http
 
 * [CVE-related issues](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3Aarea%2Fsecurity+in%3Atitle+CVE)
 
+<!--- Add link to CVE issue list and JSON here --->
+
 Security-related announcements are sent to the [kubernetes-security-announce@googlegroups.com](https://groups.google.com/forum/#!forum/kubernetes-security-announce) mailing list.


### PR DESCRIPTION
KEP: https://github.com/kubernetes/enhancements/issues/3203
No updates to k/k are expected but we will be making some changes to k/website to load the JSON as needed

/cc @nehaLohia27 

(This PR is part of the Docs needed Release process. Thank you @cathchu )