### PR TITLE
Fix regressions in node affinity docs

### DIFF
--- a/content/en/examples/pods/pod-with-affinity-anti-affinity.yaml
+++ b/content/en/examples/pods/pod-with-affinity-anti-affinity.yaml
@@ -8,11 +8,10 @@ spec:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
         - matchExpressions:
-          - key: topology.kubernetes.io/zone
+          - key: kubernetes.io/os
             operator: In
             values:
-            - antarctica-east1
-            - antarctica-west1
+            - linux
       preferredDuringSchedulingIgnoredDuringExecution:
       - weight: 1
         preference:

--- a/content/en/examples/pods/pod-with-node-affinity.yaml
+++ b/content/en/examples/pods/pod-with-node-affinity.yaml
@@ -8,10 +8,11 @@ spec:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
         - matchExpressions:
-          - key: kubernetes.io/os
+          - key: topology.kubernetes.io/zone
             operator: In
             values:
-            - linux
+            - antarctica-east1
+            - antarctica-west1
       preferredDuringSchedulingIgnoredDuringExecution:
       - weight: 1
         preference:


### PR DESCRIPTION
There are regressions in [node affinity docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/), reported in https://github.com/kubernetes/website/issues/34573, https://github.com/kubernetes/website/issues/34650, https://github.com/kubernetes/website/issues/34708, https://github.com/kubernetes/website/issues/34709 and https://github.com/kubernetes/website/issues/34767.

I dug into the git history, and found out what happened:
* A [docs refactoring](https://github.com/kubernetes/website/pull/29385/) changed the `pod-with-node-affinity.yaml` [example](https://github.com/kubernetes/website/pull/29385/files#diff-30fe1c4e15b79654ec99c05cc5587b2e445431fbd3a3708a7fdfac8f8e4ead7fR11) to use `kubernetes.io/os` label instead of `kubernetes.io/e2e-az-name`, but the [relevant docs](https://github.com/kubernetes/website/pull/29385/files#diff-ba98b126fe5dd6bf0570b39d4928eb9143d1f2ed60fbaf9fa2051810acc2e8a6R127) were still referencing `kubernetes.io/e2e-az-name`.
* There was an [attempt](https://github.com/kubernetes/website/pull/32646) to fix it. However, that PR changed [docs](https://github.com/kubernetes/website/pull/32646/files#diff-ba98b126fe5dd6bf0570b39d4928eb9143d1f2ed60fbaf9fa2051810acc2e8a6R127) for `pod-with-node-affinity.yaml`, and [YAML](https://github.com/kubernetes/website/pull/32646/files#diff-6ef77ed6017000bc373add2f9fe9a2e3312931d97ac5c6beac750134d4dd84f9R11) of a different, `pod-with-affinity-anti-affinity.yaml` example.

This PR fixes this mix-up by fixing the examples: `pod-with-node-affinity.yaml` now uses `topology.kubernetes.io/zone` key, and `pod-with-affinity-anti-affinity.yaml` uses `kubernetes.io/os`. Same as the corresponding docs.

I checked that these examples are not used anywhere else in English docs.

Fixes https://github.com/kubernetes/website/issues/34573
Fixes https://github.com/kubernetes/website/issues/34708
Fixes https://github.com/kubernetes/website/issues/34709
Fixes https://github.com/kubernetes/website/issues/34767