### PR TITLE
[ko] Resolve conflict to merge `dev-1.24-ko.1` into `main`

### DIFF
--- a/content/ko/examples/pods/pod-with-affinity-anti-affinity.yaml
+++ b/content/ko/examples/pods/pod-with-affinity-anti-affinity.yaml
@@ -8,10 +8,11 @@ spec:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
         - matchExpressions:
-          - key: kubernetes.io/os
+          - key: topology.kubernetes.io/zone
             operator: In
             values:
-            - linux
+            - antarctica-east1
+            - antarctica-west1
       preferredDuringSchedulingIgnoredDuringExecution:
       - weight: 1
         preference:


### PR DESCRIPTION
- `main`의 `content/ko/examples/pods/pod-with-affinity-anti-affinity.yaml` 는
  #34787 에서
  [현재 upstream (main, EN)](https://github.com/kubernetes/website/blob/main/content/en/examples/pods/pod-with-affinity-anti-affinity.yaml) 과 동일한 것으로 추가했습니다.
- 그런데 `content/en/docs/concepts/scheduling-eviction/assign-pod-node.md` 파일은 10일 전 (2022년 6월 24일) 에 수정된 이력이 있어서, 이 때문에 #34758 에 merge conflict가 존재합니다.
- 이 PR은 `dev-1.24-ko.1` 의 해당 파일을 #34787 의 변경사항과 동일하게 업데이트하여 merge conflict를 해소하는 PR입니다.
- 참고: `content/en/examples/pods/pod-with-affinity-anti-affinity.yaml` 등을 업데이트하는 [PR](https://github.com/kubernetes/website/pull/34785)이 열려 있어서,
  이것이 머지되면
  추후 `dev-1.24-ko.2` 에서 `ko` 파일도 업데이트 해야 합니다.
