### PR TITLE
Update install-kubectl-linux.md

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -93,7 +93,7 @@ For example, to download version {{< param "fullversion" >}} on Linux, type:
 1. Test to ensure the version you installed is up-to-date:
 
    ```bash
-   kubectl version --client
+   kubectl version --short
    ```
    Or use this for detailed view of version:
 


### PR DESCRIPTION
kubectl version --client is deprecated and has replaced with the output from kubectl version --short

