### PR TITLE
Update content/en/docs/tutorials/stateful-application/zookeeper.md

### DIFF
--- a/content/en/docs/tutorials/stateful-application/zookeeper.md
+++ b/content/en/docs/tutorials/stateful-application/zookeeper.md
@@ -123,7 +123,7 @@ zk-2      1/1       Running   0         40s
 ```
 
 The StatefulSet controller creates three Pods, and each Pod has a container with
-a [ZooKeeper](https://www-us.apache.org/dist/zookeeper/stable/) server.
+a [ZooKeeper](https://archive.apache.org/dist/zookeeper/stable/) server.
 
 ### Facilitating leader election
 


### PR DESCRIPTION
Follow up on #34832

Updated the page [Running ZooKeeper, A Distributed System Coordinator](https://kubernetes.io/docs/tutorials/stateful-application/zookeeper/)