### PR TITLE
Description of example was fixed

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -124,8 +124,8 @@ For example, consider the following Pod spec:
 
 In this example, the following rules apply:
 
-  * The node *must* have a label with the key `topology.kubernetes.io/zone` and
-    the value of that label *must* be either `antarctica-east1` or `antarctica-west1`.
+  * The node *must* have a label with the key `kubernetes.io/os` and
+    the value of that label *must* be `linux`.
   * The node *preferably* has a label with the key `another-node-label-key` and
     the value `another-node-label-value`.
 


### PR DESCRIPTION
Description of pods/pod-with-node-affinity.yaml was out-dated.
This file was changed on [21 Jan](https://github.com/kubernetes/website/commit/4650e1df6177a5c985c94711bf1196a4a00ee6be#diff-6ef77ed6017000bc373add2f9fe9a2e3312931d97ac5c6beac750134d4dd84f9) but description is still the same.