### PR TITLE
Fix wrong guide for egress selection.

### DIFF
--- a/content/en/examples/admin/konnectivity/egress-selector-configuration.yaml
+++ b/content/en/examples/admin/konnectivity/egress-selector-configuration.yaml
@@ -2,7 +2,7 @@ apiVersion: apiserver.k8s.io/v1beta1
 kind: EgressSelectorConfiguration
 egressSelections:
 # Since we want to control the egress traffic to the cluster, we use the
-# "cluster" as the name. Other supported values are "etcd", and "master".
+# "cluster" as the name. Other supported values are "etcd", and "controlplane".
 - name: cluster
   connection:
     # This controls the protocol between the API Server and the Konnectivity


### PR DESCRIPTION
This PR fix the wrong guide according to the commit bellow:

[apiserver: support egress selection name 'controlplane' and deprecate 'master'](https://github.com/kubernetes/kubernetes/commit/a0aebf96ec2eef6517e2611335f0e6c9375dd807)
