### PR TITLE
[zh-cn] update zh-cn docs to use recommended labels

### DIFF
--- a/content/zh-cn/docs/concepts/configuration/overview.md
+++ b/content/zh-cn/docs/concepts/configuration/overview.md
@@ -37,7 +37,7 @@ This is a living document. If you think of something that is not on this list bu
 -->
 - 在推送到集群之前，配置文件应存储在版本控制中。
  这允许你在必要时快速回滚配置更改。
- 它还有助于集群重新创建和恢复。 
+ 它还有助于集群重新创建和恢复。
 
 <!--
 - Write your configuration files using YAML rather than JSON. Though these formats can be used interchangeably in almost all scenarios, YAML tends to be more user-friendly.
@@ -154,7 +154,7 @@ DNS server watches the Kubernetes API for new `Services` and creates a set of DN
 services) (which have a `ClusterIP` of `None`) for service discovery when you don't need `kube-proxy` load balancing.
 -->
 - 当你不需要 `kube-proxy` 负载均衡时，使用
-  [无头服务](/zh-cn/docs/concepts/services-networking/service/#headless-services)  
+  [无头服务](/zh-cn/docs/concepts/services-networking/service/#headless-services)
   (`ClusterIP` 被设置为 `None`)以便于服务发现。
 
 <!--
@@ -163,12 +163,12 @@ services) (which have a `ClusterIP` of `None`) for service discovery when you do
 ## 使用标签   {#using-labels}
 
 <!--
-- Define and use [labels](/docs/concepts/overview/working-with-objects/labels/) that identify __semantic attributes__ of your application or Deployment, such as `{ app: myapp, tier: frontend, phase: test, deployment: v3 }`. You can use these labels to select the appropriate Pods for other resources; for example, a Service that selects all `tier: frontend` Pods, or all `phase: test` components of `app: myapp`. See the [guestbook](https://github.com/kubernetes/examples/tree/master/guestbook/) app for examples of this approach.
+- Define and use [labels](/docs/concepts/overview/working-with-objects/labels/) that identify __semantic attributes__ of your application or Deployment, such as `{ app.kubernetes.io/name: MyApp, tier: frontend, phase: test, deployment: v3 }`. You can use these labels to select the appropriate Pods for other resources; for example, a Service that selects all `tier: frontend` Pods, or all `phase: test` components of `app.kubernetes.io/name: MyApp`. See the [guestbook](https://github.com/kubernetes/examples/tree/master/guestbook/) app for examples of this approach.
 -->
 - 定义并使用[标签](/zh-cn/docs/concepts/overview/working-with-objects/labels/)来识别应用程序
-  或 Deployment 的 __语义属性__，例如`{ app: myapp, tier: frontend, phase: test, deployment: v3 }`。
+  或 Deployment 的 __语义属性__，例如`{ app.kubernetes.io/name: MyApp, tier: frontend, phase: test, deployment: v3 }`。
   你可以使用这些标签为其他资源选择合适的 Pod；
-  例如，一个选择所有 `tier: frontend` Pod 的服务，或者 `app: myapp` 的所有 `phase: test` 组件。
+  例如，一个选择所有 `tier: frontend` Pod 的服务，或者 `app.kubernetes.io/name: MyApp` 的所有 `phase: test` 组件。
   有关此方法的示例，请参阅 [guestbook](https://github.com/kubernetes/examples/tree/master/guestbook/) 。
 
 <!--

--- a/content/zh-cn/docs/concepts/services-networking/dual-stack.md
+++ b/content/zh-cn/docs/concepts/services-networking/dual-stack.md
@@ -74,7 +74,7 @@ The following prerequisites are needed in order to utilize IPv4/IPv6 dual-stack 
 为了使用 IPv4/IPv6 双栈的 Kubernetes 集群，需要满足以下先决条件：
 
 <!--
-* Kubernetes 1.20 or later  
+* Kubernetes 1.20 or later
   For information about using dual-stack services with earlier
   Kubernetes versions, refer to the documentation for that version
   of Kubernetes.
@@ -118,7 +118,7 @@ To configure IPv4/IPv6 dual-stack, set dual-stack cluster network assignments:
 * kube-apiserver:
   * `--service-cluster-ip-range=<IPv4 CIDR>,<IPv6 CIDR>`
 * kube-controller-manager:
-  * `--cluster-cidr=<IPv4 CIDR>,<IPv6 CIDR>` 
+  * `--cluster-cidr=<IPv4 CIDR>,<IPv6 CIDR>`
   * `--service-cluster-ip-range=<IPv4 CIDR>,<IPv6 CIDR>`
   * `--node-cidr-mask-size-ipv4|--node-cidr-mask-size-ipv6` 对于 IPv4 默认为 /24，
     对于 IPv6 默认为 /64
@@ -180,12 +180,12 @@ set the `.spec.ipFamilyPolicy` field to one of the following values:
   * 为服务分配 IPv4 和 IPv6 集群 IP 地址。
 * `RequireDualStack`：从 IPv4 和 IPv6 的地址范围分配服务的 `.spec.ClusterIPs`
   * 从基于在 `.spec.ipFamilies` 数组中第一个元素的地址族的 `.spec.ClusterIPs`
-    列表中选择 `.spec.ClusterIP` 
+    列表中选择 `.spec.ClusterIP`
 
 <!--
 If you would like to define which IP family to use for single stack or define the order of IP
 families for dual-stack, you can choose the address families by setting an optional field,
-`.spec.ipFamilies`, on the Service. 
+`.spec.ipFamilies`, on the Service.
 -->
 如果你想要定义哪个 IP 族用于单栈或定义双栈 IP 族的顺序，可以通过设置
 服务上的可选字段 `.spec.ipFamilies` 来选择地址族。
@@ -240,7 +240,7 @@ These examples demonstrate the behavior of various dual-stack Service configurat
    this Service, Kubernetes assigns a cluster IP for the Service from the first configured
    `service-cluster-ip-range` and sets the `.spec.ipFamilyPolicy` to `SingleStack`. ([Services
    without selectors](/docs/concepts/services-networking/service/#services-without-selectors) and
-   [headless Services](/docs/concepts/services-networking/service/#headless-services) with selectors 
+   [headless Services](/docs/concepts/services-networking/service/#headless-services) with selectors
    will behave in this same way.)
 -->
 1. 此服务规约中没有显式设定 `.spec.ipFamilyPolicy`。当你创建此服务时，Kubernetes
@@ -256,14 +256,14 @@ These examples demonstrate the behavior of various dual-stack Service configurat
 1. This Service specification explicitly defines `PreferDualStack` in `.spec.ipFamilyPolicy`. When
    you create this Service on a dual-stack cluster, Kubernetes assigns both IPv4 and IPv6
    addresses for the service. The control plane updates the `.spec` for the Service to record the IP
-   address assignments. The field `.spec.ClusterIPs` is the primary field, and contains both assigned 
+   address assignments. The field `.spec.ClusterIPs` is the primary field, and contains both assigned
    IP addresses; `.spec.ClusterIP` is a secondary field with its value calculated from
    `.spec.ClusterIPs`.
-   
+
    * For the `.spec.ClusterIP` field, the control plane records the IP address that is from the
-     same address family as the first service cluster IP range. 
+     same address family as the first service cluster IP range.
    * On a single-stack cluster, the `.spec.ClusterIPs` and `.spec.ClusterIP` fields both only list
-     one address. 
+     one address.
    * On a cluster with dual-stack enabled, specifying `RequireDualStack` in `.spec.ipFamilyPolicy`
      behaves the same as `PreferDualStack`.
 -->
@@ -335,7 +335,7 @@ dual-stack.)
    kind: Service
    metadata:
      labels:
-       app: MyApp
+       app.kubernetes.io/name: MyApp
      name: my-service
    spec:
      clusterIP: 10.0.197.123
@@ -349,7 +349,7 @@ dual-stack.)
        protocol: TCP
        targetPort: 80
      selector:
-       app: MyApp
+       app.kubernetes.io/name: MyApp
      type: ClusterIP
    status:
      loadBalancer: {}
@@ -385,7 +385,7 @@ dual-stack.)
    kind: Service
    metadata:
      labels:
-       app: MyApp
+       app.kubernetes.io/name: MyApp
      name: my-service
    spec:
      clusterIP: None
@@ -399,7 +399,7 @@ dual-stack.)
        protocol: TCP
        targetPort: 80
      selector:
-       app: MyApp
+       app.kubernetes.io/name: MyApp
    ```
 
 <!--
@@ -486,7 +486,7 @@ To provision a dual-stack load balancer for your Service:
 -->
 要为你的服务提供双栈负载均衡器：
 
-* 将 `.spec.type` 字段设置为 `LoadBalancer` 
+* 将 `.spec.type` 字段设置为 `LoadBalancer`
 * 将 `.spec.ipFamilyPolicy` 字段设置为 `PreferDualStack` 或者 `RequireDualStack`
 
 {{< note >}}

--- a/content/zh-cn/docs/concepts/services-networking/service-traffic-policy.md
+++ b/content/zh-cn/docs/concepts/services-networking/service-traffic-policy.md
@@ -3,7 +3,7 @@ title: 服务内部流量策略
 content_type: concept
 weight: 45
 ---
-<!-- 
+<!--
 ---
 reviewers:
 - maplain
@@ -17,7 +17,7 @@ weight: 45
 
 {{< feature-state for_k8s_version="v1.23" state="beta" >}}
 
-<!-- 
+<!--
 _Service Internal Traffic Policy_ enables internal traffic restrictions to only route
 internal traffic to endpoints within the node the traffic originated from. The
 "internal" traffic here refers to traffic originated from Pods in the current
@@ -29,12 +29,12 @@ _服务内部流量策略_ 开启了内部流量限制，只路由内部流量�
 
 <!-- body -->
 
-<!-- 
+<!--
 ## Using Service Internal Traffic Policy
 -->
 ## 使用服务内部流量策略 {#using-service-internal-traffic-policy}
 
-<!-- 
+<!--
 The `ServiceInternalTrafficPolicy` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
 is a Beta feature and enabled by default.
 When the feature is enabled, you can enable the internal-only traffic policy for a
@@ -42,14 +42,14 @@ When the feature is enabled, you can enable the internal-only traffic policy for
 `.spec.internalTrafficPolicy` to `Local`.
 This tells kube-proxy to only use node local endpoints for cluster internal traffic.
 -->
-`ServiceInternalTrafficPolicy` 
+`ServiceInternalTrafficPolicy`
 [特性门控](/zh-cn/docs/reference/command-line-tools-reference/feature-gates/) 是 Beta 功能，默认启用。
-启用该功能后，你就可以通过将 {{< glossary_tooltip text="Services" term_id="service" >}} 的 
+启用该功能后，你就可以通过将 {{< glossary_tooltip text="Services" term_id="service" >}} 的
 `.spec.internalTrafficPolicy` 项设置为 `Local`，
 来为它指定一个内部专用的流量策略。
 此设置就相当于告诉 kube-proxy 对于集群内部流量只能使用本地的服务端口。
 
-<!-- 
+<!--
 For pods on nodes with no endpoints for a given Service, the Service
 behaves as if it has zero endpoints (for Pods on this node) even if the service
 does have endpoints on other nodes.
@@ -60,7 +60,7 @@ does have endpoints on other nodes.
 Service 的行为看起来也像是它只有 0 个服务端点（只针对此节点上的 Pod）。
 {{< /note >}}
 
-<!-- 
+<!--
 The following example shows what a Service looks like when you set
 `.spec.internalTrafficPolicy` to `Local`:
 -->
@@ -75,7 +75,7 @@ metadata:
   name: my-service
 spec:
   selector:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
   ports:
     - protocol: TCP
       port: 80
@@ -83,12 +83,12 @@ spec:
   internalTrafficPolicy: Local
 ```
 
-<!-- 
+<!--
 ## How it works
 -->
 ## 工作原理 {#how-it-works}
 
-<!-- 
+<!--
 The kube-proxy filters the endpoints it routes to based on the
 `spec.internalTrafficPolicy` setting. When it's set to `Local`, only node local
 endpoints are considered. When it's `Cluster` or missing, all endpoints are
@@ -103,12 +103,12 @@ kube-proxy 基于 `spec.internalTrafficPolicy` 的设置来过滤路由的目标
 `ServiceInternalTrafficPolicy` 后，
 `spec.internalTrafficPolicy` 的值默认设为 `Cluster`。
 
-<!-- 
+<!--
 ## Constraints
 -->
 ## 限制 {#constraints}
 
-<!-- 
+<!--
 * Service Internal Traffic Policy is not used when `externalTrafficPolicy` is set
   to `Local` on a Service. It is possible to use both features in the same cluster
   on different Services, just not on the same Service.
@@ -118,7 +118,7 @@ kube-proxy 基于 `spec.internalTrafficPolicy` 的设置来过滤路由的目标
 
 ## {{% heading "whatsnext" %}}
 
-<!-- 
+<!--
 * Read about [Topology Aware Hints](/docs/concepts/services-networking/topology-aware-hints)
 * Read about [Service External Traffic Policy](/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip)
 * Read [Connecting Applications with Services](/docs/concepts/services-networking/connect-applications-service/)

--- a/content/zh-cn/docs/concepts/services-networking/service.md
+++ b/content/zh-cn/docs/concepts/services-networking/service.md
@@ -95,7 +95,7 @@ track of the set of backends themselves.
 
 The Service abstraction enables this decoupling.
 -->
-举个例子，考虑一个图片处理后端，它运行了 3 个副本。这些副本是可互换的 —— 
+举个例子，考虑一个图片处理后端，它运行了 3 个副本。这些副本是可互换的 ——
 前端不需要关心它们调用了哪个后端副本。
 然而组成这一组后端程序的 Pod 实际上可能会发生变化，
 前端客户端不应该也没必要知道，而且也不需要跟踪这一组后端的状态。
@@ -130,7 +130,7 @@ The name of a Service object must be a valid
 [RFC 1035 label name](/docs/concepts/overview/working-with-objects/names#rfc-1035-label-names).
 
 For example, suppose you have a set of Pods where each listens on TCP port 9376
-and contains a label `app=MyApp`:
+and contains a label `app.kubernetes.io/name=MyApp`:
 -->
 
 ## 定义 Service
@@ -140,7 +140,7 @@ Service 在 Kubernetes 中是一个 REST 对象，和 Pod 类似。
 Service 对象的名称必须是合法的
 [RFC 1035 标签名称](/docs/concepts/overview/working-with-objects/names#rfc-1035-label-names).。
 
-例如，假定有一组 Pod，它们对外暴露了 9376 端口，同时还被打上 `app=MyApp` 标签：
+例如，假定有一组 Pod，它们对外暴露了 9376 端口，同时还被打上 `app.kubernetes.io/name=MyApp` 标签：
 
 ```yaml
 apiVersion: v1
@@ -149,7 +149,7 @@ metadata:
   name: my-service
 spec:
   selector:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
   ports:
     - protocol: TCP
       port: 80
@@ -158,7 +158,7 @@ spec:
 
 <!--
 This specification creates a new Service object named “my-service”, which
-targets TCP port 9376 on any Pod with the `app=MyApp` label.
+targets TCP port 9376 on any Pod with the `app.kubernetes.io/name=MyApp` label.
 
 Kubernetes assigns this Service an IP address (sometimes called the "cluster IP"),
 which is used by the Service proxies
@@ -169,7 +169,7 @@ match its selector, and then POSTs any updates to an Endpoint object
 also named "my-service".
 -->
 上述配置创建一个名称为 "my-service" 的 Service 对象，它会将请求代理到使用
-TCP 端口 9376，并且具有标签 `"app=MyApp"` 的 Pod 上。
+TCP 端口 9376，并且具有标签 `"app.kubernetes.io/name=MyApp"` 的 Pod 上。
 
 Kubernetes 为该服务分配一个 IP 地址（有时称为 "集群IP"），该 IP 地址由服务代理使用。
 (请参见下面的 [VIP 和 Service 代理](#virtual-ips-and-service-proxies)).
@@ -209,7 +209,7 @@ spec:
     ports:
       - containerPort: 80
         name: http-web-svc
-        
+
 ---
 apiVersion: v1
 kind: Service
@@ -256,7 +256,7 @@ Each port definition can have the same `protocol`, or a different one.
 ### Services without selectors
 
 Services most commonly abstract access to Kubernetes Pods thanks to the selector,
-but when used with a corresponding Endpoints object and without a selector, the Service can abstract other kinds of backends, 
+but when used with a corresponding Endpoints object and without a selector, the Service can abstract other kinds of backends,
 including ones that run outside the cluster. For example:
 
   * You want to have an external database cluster in production, but in your
@@ -404,7 +404,7 @@ EndpointSlices 提供了附加的属性和功能，这些属性和功能在
 [EndpointSlices](/zh-cn/docs/concepts/services-networking/endpoint-slices/)
 中有详细描述。
 
-<!-- 
+<!--
 ### Application protocol
 
 {{< feature-state for_k8s_version="v1.20" state="stable" >}}
@@ -425,7 +425,7 @@ domain prefixed names such as `mycompany.com/my-custom-protocol`.
 
 该字段遵循标准的 Kubernetes 标签语法。
 其值可以是 [IANA 标准服务名称](https://www.iana.org/assignments/service-names)
-或以域名为前缀的名称，如 `mycompany.com/my-custom-protocol`。 
+或以域名为前缀的名称，如 `mycompany.com/my-custom-protocol`。
 <!--
 ## Virtual IPs and service proxies
 
@@ -532,7 +532,7 @@ having traffic sent via kube-proxy to a Pod that's known to have failed.
 ### iptables 代理模式 {#proxy-mode-iptables}
 
 这种模式，`kube-proxy` 会监视 Kubernetes 控制节点对 Service 对象和 Endpoints 对象的添加和移除。
-对每个 Service，它会配置 iptables 规则，从而捕获到达该 Service 的 `clusterIP` 
+对每个 Service，它会配置 iptables 规则，从而捕获到达该 Service 的 `clusterIP`
 和端口的请求，进而将请求重定向到 Service 的一组后端中的某个 Pod 上面。
 对于每个 Endpoints 对象，它也会配置 iptables 规则，这个规则会选择一个后端组合。
 
@@ -579,7 +579,7 @@ IPVS provides more options for balancing traffic to backend Pods;
 these are:
 -->
 在 `ipvs` 模式下，kube-proxy 监视 Kubernetes 服务和端点，调用 `netlink` 接口相应地创建 IPVS 规则，
-并定期将 IPVS 规则与 Kubernetes 服务和端点同步。 该控制循环可确保IPVS 
+并定期将 IPVS 规则与 Kubernetes 服务和端点同步。 该控制循环可确保IPVS
 状态与所需状态匹配。访问服务时，IPVS 将流量定向到后端Pod之一。
 
 IPVS代理模式基于类似于 iptables 模式的 netfilter 挂钩函数，
@@ -634,9 +634,9 @@ You can also set the maximum session sticky time by setting
 在客户端不了解 Kubernetes 或服务或 Pod 的任何信息的情况下，将 Port 代理到适当的后端。
 
 如果要确保每次都将来自特定客户端的连接传递到同一 Pod，
-则可以通过将 `service.spec.sessionAffinity` 设置为 "ClientIP" 
+则可以通过将 `service.spec.sessionAffinity` 设置为 "ClientIP"
 （默认值是 "None"），来基于客户端的 IP 地址选择会话关联。
-你还可以通过适当设置 `service.spec.sessionAffinityConfig.clientIP.timeoutSeconds` 
+你还可以通过适当设置 `service.spec.sessionAffinityConfig.clientIP.timeoutSeconds`
 来设置最大会话停留时间。
 （默认值为 10800 秒，即 3 小时）。
 
@@ -671,7 +671,7 @@ metadata:
   name: my-service
 spec:
   selector:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
   ports:
     - name: http
       protocol: TCP
@@ -691,7 +691,7 @@ also start and end with an alphanumeric character.
 For example, the names `123-abc` and `web` are valid, but `123_abc` and `-web` are not.
 -->
 {{< note >}}
-与一般的Kubernetes名称一样，端口名称只能包含小写字母数字字符 和 `-`。 
+与一般的Kubernetes名称一样，端口名称只能包含小写字母数字字符 和 `-`。
 端口名称还必须以字母数字字符开头和结尾。
 
 例如，名称 `123-abc` 和 `web` 有效，但是 `123_abc` 和 `-web` 无效。
@@ -900,7 +900,7 @@ You can find more information about `ExternalName` resolution in
 -->
 Kubernetes 还支持命名端口的 DNS SRV（服务）记录。
 如果 `my-service.my-ns` 服务具有名为 `http`　的端口，且协议设置为 TCP，
-则可以对 `_http._tcp.my-service.my-ns` 执行 DNS SRV 查询查询以发现该端口号, 
+则可以对 `_http._tcp.my-service.my-ns` 执行 DNS SRV 查询查询以发现该端口号,
 `"http"` 以及 IP 地址。
 
 Kubernetes DNS 服务器是唯一的一种能够访问 `ExternalName` 类型的 Service 的方式。
@@ -1108,7 +1108,7 @@ metadata:
 spec:
   type: NodePort
   selector:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
   ports:
       # 默认情况下，为了方便起见，`targetPort` 被设置为与 `port` 字段相同的值。
     - port: 80
@@ -1144,7 +1144,7 @@ metadata:
   name: my-service
 spec:
   selector:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
   ports:
     - protocol: TCP
       port: 80
@@ -1243,7 +1243,7 @@ is `true` and type LoadBalancer Services will continue to allocate node ports. I
 is set to `false` on an existing Service with allocated node ports, those node ports will **not** be de-allocated automatically.
 You must explicitly remove the `nodePorts` entry in every Service port to de-allocate those node ports.
 -->
-你可以通过设置 `spec.allocateLoadBalancerNodePorts` 为 `false` 
+你可以通过设置 `spec.allocateLoadBalancerNodePorts` 为 `false`
 对类型为 LoadBalancer 的服务禁用节点端口分配。
 这仅适用于直接将流量路由到 Pod 而不是使用节点端口的负载均衡器实现。
 默认情况下，`spec.allocateLoadBalancerNodePorts` 为 `true`，
@@ -1263,13 +1263,13 @@ LoadBalancer 类型的服务继续分配节点端口。
 `spec.loadBalancerClass` enables you to use a load balancer implementation other than the cloud provider default.
 By default, `spec.loadBalancerClass` is `nil` and a `LoadBalancer` type of Service uses
 the cloud provider's default load balancer implementation if the cluster is configured with
-a cloud provider using the `--cloud-provider` component flag. 
+a cloud provider using the `--cloud-provider` component flag.
 If `spec.loadBalancerClass` is specified, it is assumed that a load balancer
 implementation that matches the specified class is watching for Services.
 Any default load balancer implementation (for example, the one provided by
 the cloud provider) will ignore Services that have this field set.
 `spec.loadBalancerClass` can be set on a Service of type `LoadBalancer` only.
-Once set, it cannot be changed. 
+Once set, it cannot be changed.
 -->
 `spec.loadBalancerClass` 允许你不使用云提供商的默认负载均衡器实现，转而使用指定的负载均衡器实现。
 默认情况下，`.spec.loadBalancerClass` 的取值是 `nil`，如果集群使用 `--cloud-provider` 配置了云提供商，
@@ -1572,10 +1572,10 @@ specifies the logical hierarchy you created for your Amazon S3 bucket.
 
 注解 `service.beta.kubernetes.io/aws-load-balancer-access-log-enabled` 控制是否启用访问日志。
 
-注解 `service.beta.kubernetes.io/aws-load-balancer-access-log-emit-interval` 
+注解 `service.beta.kubernetes.io/aws-load-balancer-access-log-emit-interval`
 控制发布访问日志的时间间隔（以分钟为单位）。你可以指定 5 分钟或 60 分钟的间隔。
 
-注解 `service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name` 
+注解 `service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name`
 控制存储负载均衡器访问日志的 Amazon S3 存储桶的名称。
 
 注解 `service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix`
@@ -1662,7 +1662,7 @@ There are other annotations to manage Classic Elastic Load Balancers that are de
         # 由已有的安全组所构成的列表，可以配置到所创建的 ELB 之上。
         # 与注解 service.beta.kubernetes.io/aws-load-balancer-extra-security-groups 不同，
         # 这一设置会替代掉之前指定给该 ELB 的所有其他安全组，也会覆盖掉为此
-        # ELB 所唯一创建的安全组。 
+        # ELB 所唯一创建的安全组。
         # 此列表中的第一个安全组 ID 被用来作为决策源，以允许入站流量流入目标工作节点
         # (包括服务流量和健康检查）。
         # 如果多个 ELB 配置了相同的安全组 ID，为工作节点安全组添加的允许规则行只有一个，
@@ -1970,7 +1970,7 @@ metadata:
   name: my-service
 spec:
   selector:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
   ports:
     - name: http
       protocol: TCP
@@ -2241,7 +2241,7 @@ depends on the cloud provider offering this facility.
 -->
 你可以将 UDP 用于大多数服务。 对于 type=LoadBalancer 服务，对 UDP 的支持取决于提供此功能的云提供商。
 
-<!-- 
+<!--
 
 ### SCTP
 

--- a/content/zh-cn/docs/concepts/workloads/pods/init-containers.md
+++ b/content/zh-cn/docs/concepts/workloads/pods/init-containers.md
@@ -215,7 +215,7 @@ kind: Pod
 metadata:
   name: myapp-pod
   labels:
-    app: myapp
+    app.kubernetes.io/name: MyApp
 spec:
   containers:
   - name: myapp-container
@@ -284,7 +284,7 @@ The output is similar to this:
 Name:          myapp-pod
 Namespace:     default
 [...]
-Labels:        app=myapp
+Labels:        app.kubernetes.io/name=MyApp
 Status:        Pending
 [...]
 Init Containers:

--- a/content/zh-cn/docs/tasks/debug/debug-application/debug-statefulset.md
+++ b/content/zh-cn/docs/tasks/debug/debug-application/debug-statefulset.md
@@ -3,7 +3,7 @@ title: 调试 StatefulSet
 content_type: task
 weight: 30
 ---
-<!-- 
+<!--
 reviewers:
 - bprashanth
 - enisoc
@@ -37,16 +37,16 @@ This task shows you how to debug a StatefulSet.
 <!--
 ## Debugging a StatefulSet
 
-In order to list all the pods which belong to a StatefulSet, which have a label `app=myapp` set on them,
+In order to list all the pods which belong to a StatefulSet, which have a label `app.kubernetes.io/name=MyApp` set on them,
 you can use the following:
 -->
 ## 调试 StatefulSet   {#debuggin-a-statefulset}
 
-StatefulSet 在创建 Pod 时为其设置了 `app=myapp` 标签，列出仅属于某 StatefulSet
+StatefulSet 在创建 Pod 时为其设置了 `app.kubernetes.io/name=MyApp` 标签，列出仅属于某 StatefulSet
 的所有 Pod 时，可以使用以下命令：
 
 ```shell
-kubectl get pods -l app=myapp
+kubectl get pods -l app.kubernetes.io/name=MyApp
 ```
 
 <!--

--- a/content/zh-cn/docs/tasks/network/validate-dual-stack.md
+++ b/content/zh-cn/docs/tasks/network/validate-dual-stack.md
@@ -28,7 +28,7 @@ This document shares how to validate IPv4/IPv6 dual-stack enabled Kubernetes clu
   提供可路由的 IPv4/IPv6 网络接口)
 * 一个能够支持[双协议栈](/zh-cn/docs/concepts/services-networking/dual-stack/)的
   [网络插件](/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/)。
-  
+
 * [启用双协议栈](/zh-cn/docs/concepts/services-networking/dual-stack/) 集群
 
 {{< version-check >}}
@@ -73,7 +73,7 @@ There should be one IPv4 block and one IPv6 block allocated.
 应该分配一个 IPv4 块和一个 IPv6 块。
 
 <!--
-Validate that the node has an IPv4 and IPv6 interface detected. Replace node name with a valid node from the cluster. In this example the node name is `k8s-linuxpool1-34450317-0`: 
+Validate that the node has an IPv4 and IPv6 interface detected. Replace node name with a valid node from the cluster. In this example the node name is `k8s-linuxpool1-34450317-0`:
 -->
 验证节点是否检测到 IPv4 和 IPv6 接口。用集群中的有效节点替换节点名称。
 在此示例中，节点名称为 `k8s-linuxpool1-34450317-0`：
@@ -170,7 +170,7 @@ Kubernetes 将从首个配置的 `service-cluster-ip-range` 给 Service 分配�
 
 {{< codenew file="service/networking/dual-stack-default-svc.yaml" >}}
 
-<!-- 
+<!--
 Use `kubectl` to view the YAML for the Service.
 -->
 使用 `kubectl` 查看 Service 的 YAML 定义。
@@ -182,7 +182,7 @@ kubectl get svc my-service -o yaml
 <!--
 The Service has `.spec.ipFamilyPolicy` set to `SingleStack` and `.spec.clusterIP` set to an IPv4 address from the first configured range set via `--service-cluster-ip-range` flag on kube-controller-manager.
 -->
-该 Service 通过在 kube-controller-manager 的 `--service-cluster-ip-range` 
+该 Service 通过在 kube-controller-manager 的 `--service-cluster-ip-range`
 标志设置的第一个配置范围，将 `.spec.ipFamilyPolicy` 设置为 `SingleStack`，
 将 `.spec.clusterIP` 设置为 IPv4 地址。
 
@@ -204,7 +204,7 @@ spec:
     protocol: TCP
     targetPort: 9376
   selector:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
   sessionAffinity: None
   type: ClusterIP
 status:
@@ -220,7 +220,7 @@ Kubernetes 将 `service-cluster-ip-range` 配置的 IPv6 地址范围给 Service
 
 {{< codenew file="service/networking/dual-stack-ipfamilies-ipv6.yaml" >}}
 
-<!-- 
+<!--
 Use `kubectl` to view the YAML for the Service.
 -->
 使用 `kubectl` 查看 Service 的 YAML 定义。
@@ -229,10 +229,10 @@ Use `kubectl` to view the YAML for the Service.
 kubectl get svc my-service -o yaml
 ```
 
-<!-- 
+<!--
 The Service has `.spec.ipFamilyPolicy` set to `SingleStack` and `.spec.clusterIP` set to an IPv6 address from the IPv6 range set via `--service-cluster-ip-range` flag on kube-controller-manager.
 -->
-该 Service 通过在 kube-controller-manager 的 `--service-cluster-ip-range` 
+该 Service 通过在 kube-controller-manager 的 `--service-cluster-ip-range`
 标志设置的 IPv6 地址范围，将 `.spec.ipFamilyPolicy` 设置为 `SingleStack`，
 将 `.spec.clusterIP` 设置为 IPv6 地址。
 
@@ -241,7 +241,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
   name: my-service
 spec:
   clusterIP: fd00::5118
@@ -255,7 +255,7 @@ spec:
     protocol: TCP
     targetPort: 80
   selector:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
   sessionAffinity: None
   type: ClusterIP
 status:
@@ -279,29 +279,29 @@ The `kubectl get svc` command will only show the primary IP in the `CLUSTER-IP` 
 `kubectl get svc` 命令将仅在 `CLUSTER-IP` 字段中显示主 IP。
 
 ```shell
-kubectl get svc -l app=MyApp
+kubectl get svc -l app.kubernetes.io/name=MyApp
 
 NAME         TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)   AGE
 my-service   ClusterIP   fe80:20d::d06b   <none>        80/TCP    9s
 ```
 {{< /note >}}
 
-<!-- 
+<!--
 Validate that the Service gets cluster IPs from the IPv4 and IPv6 address blocks using `kubectl describe`. You may then validate access to the service via the IPs and ports.
 -->
 使用 `kubectl describe` 验证服务是否从 IPv4 和 IPv6 地址块中获取了集群 IP。
 然后你就可以通过 IP 和端口，验证对服务的访问。
 
 ```shell
-kubectl describe svc -l app=MyApp
+kubectl describe svc -l app.kubernetes.io/name=MyApp
 ```
 
 ```
 Name:              my-service
 Namespace:         default
-Labels:            app=MyApp
+Labels:            app.kubernetes.io/name=MyApp
 Annotations:       <none>
-Selector:          app=MyApp
+Selector:          app.kubernetes.io/name=MyApp
 Type:              ClusterIP
 IP Family Policy:  PreferDualStack
 IP Families:       IPv4,IPv6
@@ -333,11 +333,11 @@ Check the Service:
 检查服务：
 
 ```shell
-kubectl get svc -l app=MyApp
+kubectl get svc -l app.kubernetes.io/name=MyApp
 ```
 
 <!--
-Validate that the Service receives a `CLUSTER-IP` address from the IPv6 address block along with an `EXTERNAL-IP`. You may then validate access to the service via the IP and port. 
+Validate that the Service receives a `CLUSTER-IP` address from the IPv6 address block along with an `EXTERNAL-IP`. You may then validate access to the service via the IP and port.
 -->
 验证服务是否从 IPv6 地址块中接收到 `CLUSTER-IP` 地址以及 `EXTERNAL-IP`。
 然后，你可以通过 IP 和端口验证对服务的访问。

--- a/content/zh-cn/docs/tasks/run-application/delete-stateful-set.md
+++ b/content/zh-cn/docs/tasks/run-application/delete-stateful-set.md
@@ -78,14 +78,14 @@ kubectl delete -f <file.yaml> --cascade=orphan
 ```
 
 <!--
-By passing `--cascade=orphan` to `kubectl delete`, the Pods managed by the StatefulSet are left behind even after the StatefulSet object itself is deleted. If the pods have a label `app=myapp`, you can then delete them as follows:
+By passing `--cascade=orphan` to `kubectl delete`, the Pods managed by the StatefulSet are left behind even after the StatefulSet object itself is deleted. If the pods have a label `app.kubernetes.io/name=MyApp`, you can then delete them as follows:
 --->
 通过将 `--cascade=orphan` 传递给 `kubectl delete`，在删除 StatefulSet 对象之后，
-StatefulSet 管理的 Pod 会被保留下来。如果 Pod 具有标签 `app=myapp`，则可以按照
+StatefulSet 管理的 Pod 会被保留下来。如果 Pod 具有标签 `app.kubernetes.io/name=MyApp`，则可以按照
 如下方式删除它们：
 
 ```shell
-kubectl delete pods -l app=myapp
+kubectl delete pods -l app.kubernetes.io/name=MyApp
 ```
 
 
@@ -120,15 +120,15 @@ To simply delete everything in a StatefulSet, including the associated pods, you
 
 ```shell
 grace=$(kubectl get pods <stateful-set-pod> --template '{{.spec.terminationGracePeriodSeconds}}')
-kubectl delete statefulset -l app=myapp
+kubectl delete statefulset -l app.kubernetes.io/name=MyApp
 sleep $grace
-kubectl delete pvc -l app=myapp
+kubectl delete pvc -l app.kubernetes.io/name=MyApp
 ```
 
 <!--
-In the example above, the Pods have the label `app=myapp`; substitute your own label as appropriate.
+In the example above, the Pods have the label `app.kubernetes.io/name=MyApp`; substitute your own label as appropriate.
 -->
-在上面的例子中，Pod 的标签为 `app=myapp`；适当地替换你自己的标签。
+在上面的例子中，Pod 的标签为 `app.kubernetes.io/name=MyApp`；适当地替换你自己的标签。
 
 <!--
 ### Force deletion of StatefulSet pods

--- a/content/zh-cn/examples/service/networking/dual-stack-default-svc.yaml
+++ b/content/zh-cn/examples/service/networking/dual-stack-default-svc.yaml
@@ -3,10 +3,10 @@ kind: Service
 metadata:
   name: my-service
   labels:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
 spec:
   selector:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
   ports:
     - protocol: TCP
       port: 80

--- a/content/zh-cn/examples/service/networking/dual-stack-ipfamilies-ipv6.yaml
+++ b/content/zh-cn/examples/service/networking/dual-stack-ipfamilies-ipv6.yaml
@@ -3,12 +3,12 @@ kind: Service
 metadata:
   name: my-service
   labels:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
 spec:
   ipFamilies:
   - IPv6
   selector:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
   ports:
     - protocol: TCP
       port: 80

--- a/content/zh-cn/examples/service/networking/dual-stack-ipv6-svc.yaml
+++ b/content/zh-cn/examples/service/networking/dual-stack-ipv6-svc.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   ipFamily: IPv6
   selector:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
   ports:
     - protocol: TCP
       port: 80

--- a/content/zh-cn/examples/service/networking/dual-stack-prefer-ipv6-lb-svc.yaml
+++ b/content/zh-cn/examples/service/networking/dual-stack-prefer-ipv6-lb-svc.yaml
@@ -3,14 +3,14 @@ kind: Service
 metadata:
   name: my-service
   labels:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
 spec:
   ipFamilyPolicy: PreferDualStack
   ipFamilies:
   - IPv6
   type: LoadBalancer
   selector:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
   ports:
     - protocol: TCP
       port: 80

--- a/content/zh-cn/examples/service/networking/dual-stack-preferred-ipfamilies-svc.yaml
+++ b/content/zh-cn/examples/service/networking/dual-stack-preferred-ipfamilies-svc.yaml
@@ -3,14 +3,14 @@ kind: Service
 metadata:
   name: my-service
   labels:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
 spec:
   ipFamilyPolicy: PreferDualStack
   ipFamilies:
   - IPv6
   - IPv4
   selector:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
   ports:
     - protocol: TCP
       port: 80

--- a/content/zh-cn/examples/service/networking/dual-stack-preferred-svc.yaml
+++ b/content/zh-cn/examples/service/networking/dual-stack-preferred-svc.yaml
@@ -3,11 +3,11 @@ kind: Service
 metadata:
   name: my-service
   labels:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
 spec:
   ipFamilyPolicy: PreferDualStack
   selector:
-    app: MyApp
+    app.kubernetes.io/name: MyApp
   ports:
     - protocol: TCP
       port: 80


### PR DESCRIPTION
Updates docs to use [Kubernetes recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/) as outlined in the documentation.

Initially included in https://github.com/kubernetes/website/pull/34116 but broken out into a separate PR per https://github.com/kubernetes/website/pull/34116#issuecomment-1145603856 from @Sea-n