### PR TITLE
Add create and edit steps to config file topic

### DIFF
--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-config-file.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-config-file.md
@@ -7,8 +7,8 @@ description: Creating Secret objects using resource configuration file.
 
 <!-- overview -->
 
-This page shows you how to create, edit, manage, and delete Kubernetes
-{{<glossary_tooltip text="Secrets" term_id="secret">}} using a configuration file.
+This page shows you how to create, edit, and delete Kubernetes
+{{<glossary_tooltip text="Secrets" term_id="secret">}} using a file.
 
 ## {{% heading "prerequisites" %}}
 
@@ -18,64 +18,62 @@ This page shows you how to create, edit, manage, and delete Kubernetes
 
 ## Create a Secret {#create-the-config-file}
 
-You can define the `Secret` object in a JSON or YAML configuration file before
-you create the object. The [Secret](/docs/reference/generated/kubernetes-api/{{<
-param "version" >}}/#secret-v1-core) resource contains two maps: `data` and
-`stringData`.
-
-The `data` field stores arbitrary base64-encoded data. The `stringData` field
-lets you provide the same data as unencoded strings. The keys in the `data` and
+You can define the `Secret` object in a JSON or YAML file, and then create that object. The
+[Secret](/docs/reference/generated/kubernetes-api/{{<param "version">}}/#secret-v1-core)
+resource contains two maps: `data` and `stringData`. The `data` field is used
+to store arbitrary data, encoded using base64. The `stringData` field
+lets you provide the same data as unencoded strings. The keys in `data` and
 `stringData` must consist of alphanumeric characters, `-`, `_`, or `.`.
 
 The following example creates a Secret that stores the username `admin` and the
 password `VLc5@#tym$HzBn@8`.
 
-1.  Encode the data:
+1. Encode the data:
 
-    ```shell
-    echo -n 'admin' | base64
-    echo -n 'VLc5@#tym$HzBn@8' | base64
-    ```
-    The `-n` flag ensures that there's no newline character at the end of your
-    data. If you're using the `base64` utility on Darwin/macOS, avoid using the
-    `-b` option to split long lines. Conversely, if you're on Linux, add the
-    `-w 0` option to `base64` commands or the pipeline `base64 | tr -d '\n'` if
-    the `-w` option is not available.
+   ```shell
+   echo -n 'admin' | base64
+   echo -n 'VLc5@#tym$HzBn@8' | base64
+   ```
+   {{<note>}}The `-n` flag ensures that there's no newline character at the end of your
+   data. If you're using the `base64` utility on Darwin/macOS, avoid using the
+   `-b` option to split long lines. Conversely, if you're on Linux, add the
+   `-w 0` option to `base64` commands or the pipeline `base64 | tr -d '\n'` if
+   the `-w` option is not available.{{</note>}}
 
-    The output is similar to:
+   The output is similar to:
 
-    ```
-    YWRtaW4=
-    VkxjNUAjdHltJEh6Qm5AOA==
-    ```
+   ```
+   YWRtaW4=
+   VkxjNUAjdHltJEh6Qm5AOA==
+   ```
 
-1.  Create the configuration file:
+1. Create the configuration file:
 
-    ```yaml
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: mysecret
-    type: Opaque
-    data:
-      username: YWRtaW4=
-      password: VkxjNUAjdHltJEh6Qm5AOA==
-    ```
+   ```yaml
+   apiVersion: v1
+   kind: Secret
+   metadata:
+     name: mysecret
+   type: Opaque
+   data:
+     username: YWRtaW4=
+     password: VkxjNUAjdHltJEh6Qm5AOA==
+   ```
 
-    The name of the `Secret` object must be a valid
-    [DNS subdomain
-    name](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names).
+   The name of the `Secret` object must be a valid
+   [DNS subdomain name](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names).
 
-1.  Apply the `Secret` object to your cluster:
+1. Create the `Secret` object:
 
-    ```shell
-    kubectl apply -f <path-to-configuration-file>
-    ```
-    The output is similar to:
+   ```shell
+   kubectl apply -f ./secret.yaml
+   ```
+  
+   The output is similar to:
 
-    ```
-    secret/mysecret created
-    ```
+   ```
+   secret/mysecret created
+   ```
     
 ### Specify unencoded data when creating a Secret
 
@@ -86,7 +84,7 @@ deploying an application that uses a Secret to store a configuration file, and
 you want to populate parts of that configuration file during your deployment
 process.
 
-For example, consider an application that uses the following configuration file:
+For example, if your application uses the following configuration file:
 
 ```yaml
 apiUrl: "https://my.api.com/api/v1"
@@ -109,53 +107,52 @@ stringData:
     password: <password>
 ```
 
-Kubernetes encodes the data. When you retrieve the Secret data, the command
-returns the encoded values, and not the plaintext values you provided in `stringData`.
+When you retrieve the Secret data, the command returns the encoded values,
+and not the plaintext values you provided in `stringData`.
 
 To verify that the Secret was created and to decode the Secret data, refer to
-[Managing Secrets using
-kubectl](/docs/tasks/configmap-secret/managing-secret-using-kubectl/#verify-the-secret).
+[Managing Secrets using kubectl](/docs/tasks/configmap-secret/managing-secret-using-kubectl/#verify-the-secret).
 
 ## Edit a Secret {#edit-secret}
 
-If you want to edit the data in the Secret you created using a configuration
+To edit the data in the Secret you created using a configuration
 file, modify the `data` or `stringData` field in your original configuration
-file and apply the file to your cluster. You can edit an existing `Secret` object unless it is
-[immutable](/docs/concepts/configuration/secret/#secret-immutable)
+file and apply the file to your cluster. You can edit an existing `Secret` object
+unless it is [immutable](/docs/concepts/configuration/secret/#secret-immutable)
 
 For example, if you want to change the password from the previous example to
 `birdsarentreal`, do the following:
 
-1.  Encode the new password string:
+1. Encode the new password string:
 
-    ```shell
-    echo -n 'birdsarentreal' | base64
-    ```
+   ```shell
+   echo -n 'birdsarentreal' | base64
+   ```
 
-1.  Update the `data` field with your new password string:
+1. Update the `data` field with your new password string:
 
-    ```yaml
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: mysecret
-    type: Opaque
-    data:
-      username: YWRtaW4=
-      password: YmlyZHNhcmVudHJlYWw=
-    ```
+   ```yaml
+   apiVersion: v1
+   kind: Secret
+   metadata:
+     name: mysecret
+   type: Opaque
+   data:
+     username: YWRtaW4=
+     password: YmlyZHNhcmVudHJlYWw=
+   ```
 
-1.  Apply the file to your cluster:
+1. Apply the file to your cluster:
 
-    ```shell
-    kubectl apply -f <path-to-configuration-file>
-    ```
+   ```shell
+   kubectl apply -f ./secret.yaml
+   ```
 
-    The output is similar to:
+   The output is similar to:
 
-    ```
-    secret/database-creds configured
-    ```
+   ```
+   secret/mysecret configured
+   ```
 
 Kubernetes updates the existing `Secret` object, because you supplied a
 configuration file that had updated data with the same object name.
@@ -165,7 +162,7 @@ configuration file that had updated data with the same object name.
 To delete a Secret, use `kubectl`:
 
 ```shell
-kubectl delete secret <secret-name>
+kubectl delete secret mysecret
 ```
 
 ## {{% heading "whatsnext" %}}

--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-config-file.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-config-file.md
@@ -7,81 +7,86 @@ description: Creating Secret objects using resource configuration file.
 
 <!-- overview -->
 
+This page shows you how to create, edit, manage, and delete Kubernetes
+{{<glossary_tooltip text="Secrets" term_id="secret">}} using a configuration file.
+
 ## {{% heading "prerequisites" %}}
 
 {{< include "task-tutorial-prereqs.md" >}}
 
 <!-- steps -->
 
-## Create the Config file
+## Create a Secret {#create-the-config-file}
 
-You can create a Secret in a file first, in JSON or YAML format, and then
-create that object.  The
-[Secret](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#secret-v1-core)
-resource contains two maps: `data` and `stringData`.
-The `data` field is used to store arbitrary data, encoded using base64. The
-`stringData` field is provided for convenience, and it allows you to provide
-Secret data as unencoded strings.
-The keys of `data` and `stringData` must consist of alphanumeric characters,
-`-`, `_` or `.`.
+You can define the `Secret` object in a JSON or YAML configuration file before
+you create the object. The [Secret](/docs/reference/generated/kubernetes-api/{{<
+param "version" >}}/#secret-v1-core) resource contains two maps: `data` and
+`stringData`.
 
-For example, to store two strings in a Secret using the `data` field, convert
-the strings to base64 as follows:
+The `data` field stores arbitrary base64-encoded data. The `stringData` field
+lets you provide the same data as unencoded strings. The keys in the `data` and
+`stringData` must consist of alphanumeric characters, `-`, `_`, or `.`.
 
-```shell
-echo -n 'admin' | base64
-```
+The following example creates a Secret that stores the username `admin` and the
+password `VLc5@#tym$HzBn@8`.
 
-The output is similar to:
+1.  Encode the data:
 
-```
-YWRtaW4=
-```
+    ```shell
+    echo -n 'admin' | base64
+    echo -n 'VLc5@#tym$HzBn@8' | base64
+    ```
+    The `-n` flag ensures that there's no newline character at the end of your
+    data. If you're using the `base64` utility on Darwin/macOS, avoid using the
+    `-b` option to split long lines. Conversely, if you're on Linux, add the
+    `-w 0` option to `base64` commands or the pipeline `base64 | tr -d '\n'` if
+    the `-w` option is not available.
 
-```shell
-echo -n '1f2d1e2e67df' | base64
-```
+    The output is similar to:
 
-The output is similar to:
+    ```
+    YWRtaW4=
+    VkxjNUAjdHltJEh6Qm5AOA==
+    ```
 
-```
-MWYyZDFlMmU2N2Rm
-```
+1.  Create the configuration file:
 
-Write a Secret config file that looks like this:
+    ```yaml
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: mysecret
+    type: Opaque
+    data:
+      username: YWRtaW4=
+      password: VkxjNUAjdHltJEh6Qm5AOA==
+    ```
 
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: mysecret
-type: Opaque
-data:
-  username: YWRtaW4=
-  password: MWYyZDFlMmU2N2Rm
-```
+    The name of the `Secret` object must be a valid
+    [DNS subdomain
+    name](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names).
 
-Note that the name of a Secret object must be a valid
-[DNS subdomain name](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names).
+1.  Apply the `Secret` object to your cluster:
 
-{{< note >}}
-The serialized JSON and YAML values of Secret data are encoded as base64
-strings. Newlines are not valid within these strings and must be omitted. When
-using the `base64` utility on Darwin/macOS, users should avoid using the `-b`
-option to split long lines. Conversely, Linux users *should* add the option
-`-w 0` to `base64` commands or the pipeline `base64 | tr -d '\n'` if the `-w`
-option is not available.
-{{< /note >}}
+    ```shell
+    kubectl apply -f <path-to-configuration-file>
+    ```
+    The output is similar to:
 
-For certain scenarios, you may wish to use the `stringData` field instead. This
-field allows you to put a non-base64 encoded string directly into the Secret,
-and the string will be encoded for you when the Secret is created or updated.
+    ```
+    secret/mysecret created
+    ```
+    
+### Specify unencoded data when creating a Secret
 
-A practical example of this might be where you are deploying an application
-that uses a Secret to store a configuration file, and you want to populate
-parts of that configuration file during your deployment process.
+The `stringData` field lets you provide data for the Secret without
+base64-encoding the strings. The strings will be encoded for you when the Secret
+is created or updated. A practical example of this might be where you are
+deploying an application that uses a Secret to store a configuration file, and
+you want to populate parts of that configuration file during your deployment
+process.
 
-For example, if your application uses the following configuration file:
+For example, consider an application that uses the following configuration file:
 
 ```yaml
 apiUrl: "https://my.api.com/api/v1"
@@ -104,90 +109,63 @@ stringData:
     password: <password>
 ```
 
-## Create the Secret object
+Kubernetes encodes the data. When you retrieve the Secret data, the command
+returns the encoded values, and not the plaintext values you provided in `stringData`.
 
-Now create the Secret using [`kubectl apply`](/docs/reference/generated/kubectl/kubectl-commands#apply):
+To verify that the Secret was created and to decode the Secret data, refer to
+[Managing Secrets using
+kubectl](/docs/tasks/configmap-secret/managing-secret-using-kubectl/#verify-the-secret).
 
-```shell
-kubectl apply -f ./secret.yaml
-```
+## Edit a Secret {#edit-secret}
 
-The output is similar to:
+If you want to edit the data in the Secret you created using a configuration
+file, modify the `data` or `stringData` field in your original configuration
+file and apply the file to your cluster. You can edit an existing `Secret` object unless it is
+[immutable](/docs/concepts/configuration/secret/#secret-immutable)
 
-```
-secret/mysecret created
-```
+For example, if you want to change the password from the previous example to
+`birdsarentreal`, do the following:
 
-## Check the Secret
+1.  Encode the new password string:
 
-The `stringData` field is a write-only convenience field. It is never output when
-retrieving Secrets. For example, if you run the following command:
+    ```shell
+    echo -n 'birdsarentreal' | base64
+    ```
 
-```shell
-kubectl get secret mysecret -o yaml
-```
+1.  Update the `data` field with your new password string:
 
-The output is similar to:
+    ```yaml
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: mysecret
+    type: Opaque
+    data:
+      username: YWRtaW4=
+      password: YmlyZHNhcmVudHJlYWw=
+    ```
 
-```yaml
-apiVersion: v1
-data:
-  config.yaml: YXBpVXJsOiAiaHR0cHM6Ly9teS5hcGkuY29tL2FwaS92MSIKdXNlcm5hbWU6IHt7dXNlcm5hbWV9fQpwYXNzd29yZDoge3twYXNzd29yZH19
-kind: Secret
-metadata:
-  creationTimestamp: 2018-11-15T20:40:59Z
-  name: mysecret
-  namespace: default
-  resourceVersion: "7225"
-  uid: c280ad2e-e916-11e8-98f2-025000000001
-type: Opaque
-```
+1.  Apply the file to your cluster:
 
-The commands `kubectl get` and `kubectl describe` avoid showing the contents of a `Secret` by
-default. This is to protect the `Secret` from being exposed accidentally to an onlooker,
-or from being stored in a terminal log.
-To check the actual content of the encoded data, please refer to
-[decoding secret](/docs/tasks/configmap-secret/managing-secret-using-kubectl/#decoding-secret).
+    ```shell
+    kubectl apply -f <path-to-configuration-file>
+    ```
 
-If a field, such as `username`, is specified in both `data` and `stringData`,
-the value from `stringData` is used. For example, the following Secret definition:
+    The output is similar to:
 
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: mysecret
-type: Opaque
-data:
-  username: YWRtaW4=
-stringData:
-  username: administrator
-```
+    ```
+    secret/database-creds configured
+    ```
 
-Results in the following Secret:
+Kubernetes updates the existing `Secret` object, because you supplied a
+configuration file that had updated data with the same object name.
 
-```yaml
-apiVersion: v1
-data:
-  username: YWRtaW5pc3RyYXRvcg==
-kind: Secret
-metadata:
-  creationTimestamp: 2018-11-15T20:46:46Z
-  name: mysecret
-  namespace: default
-  resourceVersion: "7579"
-  uid: 91460ecb-e917-11e8-98f2-025000000001
-type: Opaque
-```
+## Delete a Secret {#clean-up}
 
-Where `YWRtaW5pc3RyYXRvcg==` decodes to `administrator`.
-
-## Clean Up
-
-To delete the Secret you have created:
+To delete a Secret, use `kubectl`:
 
 ```shell
-kubectl delete secret mysecret
+kubectl delete secret <secret-name>
 ```
 
 ## {{% heading "whatsnext" %}}
@@ -195,4 +173,3 @@ kubectl delete secret mysecret
 - Read more about the [Secret concept](/docs/concepts/configuration/secret/)
 - Learn how to [manage Secrets with the `kubectl` command](/docs/tasks/configmap-secret/managing-secret-using-kubectl/)
 - Learn how to [manage Secrets using kustomize](/docs/tasks/configmap-secret/managing-secret-using-kustomize/)
-


### PR DESCRIPTION
This change updates the structure of the config file Manage Secrets page. Detailed delta includes:

1. Line 22 - minor wording change for accuracy (define the object in the file, then create it)
2. Line 25 - changed "Secret data" to "the same data"
3. Add numbers to the steps
4. Combine the commands for base64 encoding to consolidate them.
1. Move note about -n flag to under the encode commands (moved existing content from old line 67-74 and trimmed down a bit)
1. Only change to the config file YAML is the password field, everything else is the same as before
2. Move old line 76-84 to new section about StringData to keep the actual create steps simple
1. Delete old line 121-183 (Check the Secret). This content will exist in only the kubectl page (as it is a kubectl command and output and the commands are the same)
1. Add section for editing the Secret by using a config file (new line 119-161)

This is one of three PRs that will make the "Manage Secrets using X" topics consistent to provide Create, Edit, and Delete steps for kubectl, config files, and kustomize. Original, larger PR showing the end state: https://github.com/kubernetes/website/pull/34674

This PR is part of a much larger updating of the Secrets documentation. The tracking issue is https://github.com/kubernetes/website/issues/4491.

/sig docs
/language en
/do-not-merge work-in-progress
/cc @tengqm