### PR TITLE
Update hyperlink for installing cosign

### DIFF
--- a/content/en/docs/tasks/administer-cluster/verify-signed-images.md
+++ b/content/en/docs/tasks/administer-cluster/verify-signed-images.md
@@ -68,5 +68,5 @@ e.g. [conformance image](https://github.com/kubernetes/kubernetes/blob/master/te
 admission controller. To get started with `cosigned` here are a few helpful
 resources:
 
-* [Installation](https://github.com/sigstore/helm-charts/tree/main/charts/cosigned)
+* [Installation](https://github.com/sigstore/cosign#installation)
 * [Configuration Options](https://github.com/sigstore/cosign/tree/main/config)


### PR DESCRIPTION
Fix: #34854

Note: The coorect link for _Configuration options_ (https://kubernetes.io/docs/tasks/administer-cluster/verify-signed-images/#verifying-image-signatures-with-admission-controller) isn't found yet. Apart from that, The broken link for 'Installation' has been fixed.