### PR TITLE
Clarify that list, get and watch can return data

### DIFF
--- a/content/en/docs/reference/access-authn-authz/authorization.md
+++ b/content/en/docs/reference/access-authn-authz/authorization.md
@@ -74,6 +74,10 @@ PUT       | update
 PATCH     | patch
 DELETE    | delete (for individual resources), deletecollection (for collections)
 
+{{< caution >}}
+The `get`, `list` and `watch` verbs can all return the full details of a resource. In terms of the returned data they are equivalent. For example, `list` on `secrets` will still reveal the `data` attributes of any returned resources.
+{{< /caution >}}
+
 Kubernetes sometimes checks authorization for additional permissions using specialized verbs. For example:
 
 * [PodSecurityPolicy](/docs/concepts/security/pod-security-policy/)


### PR DESCRIPTION
The `get`, `list` and `watch` verbs can all be used to retrieve the full details of a resource. It is not an uncommon assumption amongst users that they return different data (e.g. that `list` only returns the names of resources; when it can return the full object).

This adds a caution block to highlight this potential gotcha.

I'm not certain whether this is the best/only location that this should be called out (another option would be on the various specific authorization pages) but it feels like a reasonable start.

This was prompted by a private discussion and this issue: https://github.com/kubernetes/kubernetes/issues/110866
