### PR TITLE
Fix format for APAC blog post

### DIFF
--- a/content/en/blog/_posts/2022-01-10-meet-our-contributors-APAC-India-region-01.md
+++ b/content/en/blog/_posts/2022-01-10-meet-our-contributors-APAC-India-region-01.md
@@ -1,9 +1,9 @@
 ---
 layout: blog
 title: "Meet Our Contributors - APAC (India region)"
-date: 2022-01-10T12:00:00+0000
+date: 2022-01-10
 slug: meet-our-contributors-india-ep-01
-canonicalUrl: https://kubernetes.dev/blog/2022/01/10/meet-our-contributors-india-ep-01/
+canonicalUrl: https://www.kubernetes.dev/blog/2022/01/10/meet-our-contributors-india-ep-01/
 ---
 
 **Authors & Interviewers:** [Anubhav Vardhan](https://github.com/anubha-v-ardhan), [Atharva Shinde](https://github.com/Atharva-Shinde), [Avinesh Tripathi](https://github.com/AvineshTripathi), [Debabrata Panigrahi](https://github.com/Debanitrkl), [Kunal Verma](https://github.com/verma-kunal), [Pranshu Srivastava](https://github.com/PranshuSrivastava), [Pritish Samal](https://github.com/CIPHERTron), [Purneswar Prasad](https://github.com/PurneswarPrasad), [Vedant Kakde](https://github.com/vedant-kakde)
@@ -19,7 +19,7 @@ Welcome to the first episode of the APAC edition of the "Meet Our Contributors" 
 
 In this post, we'll introduce you to five amazing folks from the India region who have been actively contributing to the upstream Kubernetes projects in a variety of ways, as well as being the leaders or maintainers of numerous community initiatives.
 
-💫 *Let's get started, so without further ado…* 
+💫 *Let's get started, so without further ado…*
 
 
 ## [Arsh Sharma](https://github.com/RinkiyaKeDad)
@@ -39,7 +39,7 @@ To the newcomers, Arsh helps plan their early contributions sustainably.
 
 Kunal Kushwaha is a core member of the Kubernetes marketing council. He is also a CNCF ambassador and one of the founders of the [CNCF Students Program](https://community.cncf.io/cloud-native-students/).. He also served as a Communications role shadow during the 1.22 release cycle.
 
-At the end of his first year, Kunal began contributing to the [fabric8io kubernetes-client](https://github.com/fabric8io/kubernetes-client) project. He was then selected to work on the same project as part of Google Summer of Code. Kunal mentored people on the same project, first through Google Summer of Code then through Google Code-in. 
+At the end of his first year, Kunal began contributing to the [fabric8io kubernetes-client](https://github.com/fabric8io/kubernetes-client) project. He was then selected to work on the same project as part of Google Summer of Code. Kunal mentored people on the same project, first through Google Summer of Code then through Google Code-in.
 
 As an open-source enthusiast, he believes that diverse participation in the community is beneficial since it introduces new perspectives and opinions and respect for one's peers. He has worked on various open-source projects, and his participation in communities has considerably assisted his development as a developer.
 
@@ -103,4 +103,3 @@ If you have any recommendations/suggestions for who we should interview next, pl
 
 
 We'll see you all in the next one. Everyone, till then, have a happy contributing! 👋
-

--- a/content/en/blog/_posts/2022-03-15-meet-our-contributors-APAC-AU-NZ-region-02.md
+++ b/content/en/blog/_posts/2022-03-15-meet-our-contributors-APAC-AU-NZ-region-02.md
@@ -1,7 +1,7 @@
 ---
 layout: blog
 title: "Meet Our Contributors - APAC (Aus-NZ region)"
-date: 2022-03-16T12:00:00+0000
+date: 2022-03-16
 slug: meet-our-contributors-au-nz-ep-02
 canonicalUrl: https://www.kubernetes.dev/blog/2022/03/14/meet-our-contributors-au-nz-ep-02/
 ---
@@ -60,12 +60,9 @@ Nick Young works at VMware as a technical lead for Contour, a CNCF ingress contr
 
 His contribution path was notable in that he began working on major areas of the Kubernetes project early on, skewing his trajectory.
 
-He asserts the best thing a new contributor can do is to "start contributing". Naturally, if it is relevant to their employment, that is excellent; however, investing non-work time in contributing can pay off in the long run in terms of work. He believes that new contributors, particularly those who are currently Kubernetes users, should be encouraged to participate in higher-level project discussions. 
+He asserts the best thing a new contributor can do is to "start contributing". Naturally, if it is relevant to their employment, that is excellent; however, investing non-work time in contributing can pay off in the long run in terms of work. He believes that new contributors, particularly those who are currently Kubernetes users, should be encouraged to participate in higher-level project discussions.
 
 > _Just being active and contributing will get you a long way. Once you've been active for a while, you'll find that you're able to answer questions, which will mean you're asked questions, and before you know it you are an expert._
-
-
-
 
 ---
 
@@ -73,6 +70,3 @@ If you have any recommendations/suggestions for who we should interview next, pl
 
 
 We'll see you all in the next one. Everyone, till then, have a happy contributing! 👋
-
-
-


### PR DESCRIPTION
Change date format from `2022-07-08T12:00:00+0000` to `2022-07-08`.
Across 400 posts, only 8 posts using this format.

Rename ep02 file from `...-01.md` to `...-02.md`
In [k/contributor-site](https://github.com/kubernetes/contributor-site/blob/master/content/en/blog/2022/meet-our-contributors-APAC-au-nz-region-02.md), it's `meet-our-contributors-APAC-au-nz-region-02.md`.
