### PR TITLE
Fix broken hyperlink on Running ZooKeeper, A Distributed System Coordinator page

### DIFF
--- a/content/en/docs/tutorials/stateful-application/zookeeper.md
+++ b/content/en/docs/tutorials/stateful-application/zookeeper.md
@@ -305,7 +305,7 @@ numChildren = 0
 
 ### Providing durable storage
 
-As mentioned in the [ZooKeeper Basics](#zookeeper-basics) section,
+As mentioned in the [ZooKeeper Basics](#zookeeper) section,
 ZooKeeper commits all entries to a durable WAL, and periodically writes snapshots
 in memory state, to storage media. Using WALs to provide durability is a common
 technique for applications that use consensus protocols to achieve a replicated


### PR DESCRIPTION
Follow up on #34882

Updated the page [Running ZooKeeper, A Distributed System Coordinator](https://kubernetes.io/docs/tutorials/stateful-application/zookeeper/)