### PR TITLE
Fix broken hyperlink on Kubelet Configuration (v1beta1) page

### DIFF
--- a/content/en/docs/reference/config-api/kube-scheduler-config.v1beta2.md
+++ b/content/en/docs/reference/config-api/kube-scheduler-config.v1beta2.md
@@ -261,7 +261,7 @@ during leader election cycles.</p>
 
 **Appears in:**
 
-- [KubeletConfiguration](#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
+- <a href="https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration">KubeletConfiguration</a>
 
 
 <p>LoggingConfiguration contains logging options


### PR DESCRIPTION
Follow up on #34914

Updated the page [kube-scheduler Configuration (v1beta2)](https://kubernetes.io/docs/reference/config-api/kube-scheduler-config.v1beta2/)