### PR TITLE
Fix quantity case for ephemeral storage

### DIFF
--- a/content/en/docs/concepts/configuration/manage-resources-containers.md
+++ b/content/en/docs/concepts/configuration/manage-resources-containers.md
@@ -332,13 +332,17 @@ container of a Pod can specify either or both of the following:
 
 Limits and requests for `ephemeral-storage` are measured in byte quantities.
 You can express storage as a plain integer or as a fixed-point number using one of these suffixes:
-E, P, T, G, M, K. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi,
+E, P, T, G, M, k. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi,
 Mi, Ki. For example, the following quantities all represent roughly the same value:
 
 - `128974848`
 - `129e6`
 - `129M`
 - `123Mi`
+
+Pay attention to the case of the suffixes. If you request `400m` of ephemeral-storage, this is a request
+for 0.4 bytes. Someone who types that probably meant to ask for 400 mebibytes (`400Mi`)
+or 400 megabytes (`400M`).
 
 In the following example, the Pod has two containers. Each container has a request of
 2GiB of local ephemeral storage. Each container has a limit of 4GiB of local ephemeral


### PR DESCRIPTION
### Changes
- All resource requests parse unit quantities the same way. Ephemeral storage previously had an upper case `K` as a valid unit but the kubernetes server can not parse this value.

Sample pod spec:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: nginx-bad-ephemeral-storage
spec:
  containers:
  - name: nginx
    image: nginx:1.14.2
    resources:
        requests:
            ephemeral-storage: "100200"
        limits:
            ephemeral-storage: "100200K"
```
**Response from server**:
```
Error from server (BadRequest): error when creating "simple-pod-bad.yaml": Pod in version "v1" cannot be handled as a Pod: unable to parse quantity's suffix
```


- Similar to memory, add a statement regarding that a lowercase `m` will be accepted by the kubernetes server, but is probably an incorrect request.
