### PR TITLE
Fixed markdown not working in tabs.

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -179,9 +179,9 @@ Follow the instructions for [getting started with containerd](https://github.com
 {{% tab name="Linux" %}}
 You can find this file under the path `/etc/containerd/config.toml`.
 {{% /tab %}}
-{{< tab name="Windows" >}}
+{{% tab name="Windows" %}}
 You can find this file under the path `C:\Program Files\containerd\config.toml`.
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 On Linux the default CRI socket for containerd is `/run/containerd/containerd.sock`.


### PR DESCRIPTION
In tab's shortcode, the highlight code is not work, because the shortcode is specified with `{{< >}}`.
Change them to `{{% %}}` and the highlight code  will be work.
