### PR TITLE
Fix KubeletCredentialProvider feature state

### DIFF
--- a/content/en/docs/tasks/kubelet-credential-provider/kubelet-credential-provider.md
+++ b/content/en/docs/tasks/kubelet-credential-provider/kubelet-credential-provider.md
@@ -7,7 +7,7 @@ description: Configure the kubelet's image credential provider plugin
 content_type: task
 ---
 
-{{< feature-state for_k8s_version="v1.20" state="alpha" >}}
+{{< feature-state for_k8s_version="v1.24" state="beta" >}}
 
 <!-- overview -->
 


### PR DESCRIPTION
This PR  fixed the FEATURE STATE of KubeletCredentialProvider under [Configure a kubelet image credential provider](https://kubernetes.io/docs/tasks/kubelet-credential-provider/kubelet-credential-provider/)
task.

Fixes:  #34953