### PR TITLE
[ja] resync /partners/_index.html

### DIFF
--- a/content/ja/partners/_index.html
+++ b/content/ja/partners/_index.html
@@ -7,85 +7,45 @@ cid: partners
 ---
 
 <section id="users">
-    <main class="main-section">
-        <h5>Kubernetesはパートナーと協力して、さまざまなプラットフォームをサポートする強力で活気のあるコードベースを作り上げています。</h5>
-        <div class="col-container">
-          <div class="col-nav">
-            <center>
-              <h5>
-                <b>Kubernetes認定サービスプロバイダー(Kubernetes Certified Service Providers, KCSP)</b>
-              </h5>
-              <br>企業のKubernetes導入を支援してきた豊富な経験を持つ、熟練のサービスプロバイダーです。
-              <br><br><br>
-              <button id="kcsp" class="button" onClick="updateSrc(this.id)">KCSPパートナーを見る</button>
-              <br><br><a href="https://www.cncf.io/certification/kcsp/">KCSP</a>に興味がありますか？
-            </center>
-          </div>
-          <div class="col-nav">
-            <center>
-              <h5>
-                <b>認定Kubernetesディストリビューション、マネージド環境、およびインストーラー</b>
-              </h5>ソフトウェアの適合性により、すべてのベンダーのバージョンのKubernetesが必要なAPIを確実にサポートします。
-              <br><br><br>
-              <button id="conformance" class="button" onClick="updateSrc(this.id)">認定パートナーを見る</button>
-              <br><br><a href="https://www.cncf.io/certification/software-conformance/">Kubernetes Certified</a>に興味がありますか？
-            </center>
-          </div>
-          <div class="col-nav">
-            <center>
-              <h5><b>Kubernetesトレーニングパートナー(Kubernetes Training Partners, KTP)</b></h5>
-              <br>クラウドネイティブな技術のトレーニングに長けた、熟練のトレーニングプロバイダーです。
-              <br><br><br><br>
-              <button id="ktp" class="button" onClick="updateSrc(this.id)">KTPパートナーを見る</button>
-              <br><br><a href="https://www.cncf.io/certification/training/">KTP</a>に興味がありますか？
-            </center>
-          </div>
-        </div>
-<script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
-<script type="text/javascript">
-
-			var defaultLink = "https://landscape.cncf.io/category=kubernetes-certified-service-provider&format=card-mode&grouping=category&embed=yes";
-			var firstLink = "https://landscape.cncf.io/category=certified-kubernetes-distribution,certified-kubernetes-hosted,certified-kubernetes-installer&format=card-mode&grouping=category&embed=yes";
-      var secondLink = "https://landscape.cncf.io/category=kubernetes-training-partner&format=card-mode&grouping=category&embed=yes";
-
-      function updateSrc(buttonId) {
-      	if (buttonId == "kcsp") {
-        		$("#landscape").attr("src",defaultLink);
-            window.location.hash = "#kcsp";
-        }
-        if (buttonId == "conformance") {
-         		$("#landscape").attr("src",firstLink);
-            window.location.hash = "#conformance";
-        }
-        if (buttonId == "ktp") {
-        		$("#landscape").attr("src",secondLink);
-            window.location.hash = "#ktp";
-        }
-      }
-
-      // Automatically load the correct iframe based on the URL fragment
-      document.addEventListener('DOMContentLoaded', function() {
-        var showContent = "kcsp";
-        if (window.location.hash) {
-          console.log('hash is:', window.location.hash.substring(1));
-          showContent = window.location.hash.substring(1);
-        }
-        updateSrc(showContent);
-      });
-</script>
-<body>
-    <div id="frameHolder">
-      <iframe id="landscape" title="CNCF Landscape" frameBorder="0" scrolling="no" style="width: 1px; min-width: 100%" src=""></iframe>
-      <script src="https://landscape.cncf.io/iframeResizer.js"></script>
+    <h5>Kubernetesはパートナーと協力して、さまざまなプラットフォームをサポートする強力で活気のあるコードベースを作り上げています。</h5>
+    <div class="col-container">
+      <div class="col-nav">
+        <center>
+          <h5>
+            <b>Kubernetes認定サービスプロバイダー(Kubernetes Certified Service Providers, KCSP)</b>
+          </h5>
+          <br>企業のKubernetes導入を支援してきた豊富な経験を持つ、熟練のサービスプロバイダーです。
+          <br><br><br>
+          <button class="button landscape-trigger landscape-default" data-landscape-types="kubernetes-certified-service-provider" id="kcsp">KCSPパートナーを見る</button>
+          <br><br><a href="https://www.cncf.io/certification/kcsp/">KCSP</a>に興味がありますか？
+        </center>
+      </div>
+      <div class="col-nav">
+        <center>
+          <h5>
+            <b>認定Kubernetesディストリビューション、マネージド環境、およびインストーラー</b>
+          </h5>ソフトウェアの適合性により、すべてのベンダーのバージョンのKubernetesが必要なAPIを確実にサポートします。
+          <br><br><br>
+          <button class="button landscape-trigger" data-landscape-types="certified-kubernetes-distribution,certified-kubernetes-hosted,certified-kubernetes-installer" id="conformance">認定パートナーを見る</button>
+          <br><br><a href="https://www.cncf.io/certification/software-conformance/">Kubernetes Certified</a>に興味がありますか？
+        </center>
+      </div>
+      <div class="col-nav">
+        <center>
+          <h5>
+            <b>Kubernetesトレーニングパートナー(Kubernetes Training Partners, KTP)</b>
+          </h5>
+          <br>クラウドネイティブな技術のトレーニングに長けた、熟練のトレーニングプロバイダーです。
+          <br><br><br>
+          <button class="button landscape-trigger" data-landscape-types="kubernetes-training-partner" id="ktp">KTPパートナーを見る</button>
+          <br><br><a href="https://www.cncf.io/certification/training/">KTP</a>に興味がありますか？
+        </center>
+      </div>
     </div>
-</body>
-    </main>
+    {{< cncf-landscape helpers=true >}}
 </section>
 
 <style>
     {{< include "partner-style.css" >}}
 </style>
 
-<script>
-    {{< include "partner-script.js" >}}
-</script>


### PR DESCRIPTION
Fixed the broken link on the [partners page](https://kubernetes.io/ja/partners/#kcsp) by resyncing with en, de, ko, and zh-cn.

Preview: https://deploy-preview-34958--kubernetes-io-main-staging.netlify.app/ja/partners/