### PR TITLE
[it] resync /partners/_index.html

### DIFF
--- a/content/it/partners/_index.html
+++ b/content/it/partners/_index.html
@@ -7,85 +7,48 @@ cid: partners
 ---
 
 <section id="users">
-    <main class="main-section">
-        <h5>Kubernetes collabora con i partner per creare per creare un codebase che supporti uno spettro di piattaforme complementari.</h5>
-        <div class="col-container">
-          <div class="col-nav">
-            <center>
-              <h5>
-                <b>Fornitori Certificati di Servizi su Kubernetes</b>
-              </h5>
-              <br>Fornitori di servizi riconosciuti e con grande esperienza nell'aiutare le imprese ad adottare con successo Kubernetes.
-              <br><br><br>
-              <button id="kcsp" class="button" onClick="updateSrc(this.id)">Guarda i Partners KCSP</button>
-              <br><br>Interessato a diventare un partner <a href="https://www.cncf.io/certification/kcsp/">KCSP</a>?
-            </center>
-          </div>
-          <div class="col-nav">
-            <center>
-              <h5>
-                  <b>Distribuzioni di Kubernetes Certificate, Certified Hosted Platforms and Software di installazione Certificati</b>
-              </h5>La conformità del software assicura che le versioni di Kubernetes prodotte da ogni fornitore supportino coerentemente le API necessarie.
-              <br><br><br>
-              <button id="conformance" class="button" onClick="updateSrc(this.id)">Guarda i Partner certificati</button>
-              <br><br>Interessato a diventare un partner <a href="https://www.cncf.io/certification/software-conformance/">certificato Kubernetes</a>?
-            </center>
-          </div>
-          <div class="col-nav">
-            <center>
-              <h5><b>Partner per la Formazione su Kubernetes</b></h5>
-              <br>Professionisti riconosciuti e certificati, con solida esperienza nella formazione su tecnologie Cloud Native.
-              <br><br><br><br>
-              <button id="ktp" class="button" onClick="updateSrc(this.id)">Guarda i KTP partner</button>
-              <br><br>Interessato a diventare un partner <a href="https://www.cncf.io/certification/training/">KTP</a>?
-            </center>
-          </div>
-        </div>
-<script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
-<script type="text/javascript">
-
-			var defaultLink = "https://landscape.cncf.io/category=kubernetes-certified-service-provider&format=card-mode&grouping=category&embed=yes";
-			var firstLink = "https://landscape.cncf.io/category=certified-kubernetes-distribution,certified-kubernetes-hosted,certified-kubernetes-installer&format=card-mode&grouping=category&embed=yes";
-      var secondLink = "https://landscape.cncf.io/category=kubernetes-training-partner&format=card-mode&grouping=category&embed=yes";
-
-      function updateSrc(buttonId) {
-      	if (buttonId == "kcsp") {
-        		$("#landscape").attr("src",defaultLink);
-            window.location.hash = "#kcsp";
-        }
-        if (buttonId == "conformance") {
-         		$("#landscape").attr("src",firstLink);
-            window.location.hash = "#conformance";
-        }
-        if (buttonId == "ktp") {
-        		$("#landscape").attr("src",secondLink);
-            window.location.hash = "#ktp";
-        }
-      }
-
-      // Automatically load the correct iframe based on the URL fragment
-      document.addEventListener('DOMContentLoaded', function() {
-        var showContent = "kcsp";
-        if (window.location.hash) {
-          console.log('hash is:', window.location.hash.substring(1));
-          showContent = window.location.hash.substring(1);
-        }
-        updateSrc(showContent);
-      });
-</script>
-<body>
-    <div id="frameHolder">
-      <iframe id="landscape" title="Panorama CNCF" frameBorder="0" scrolling="no" style="width: 1px; min-width: 100%" src=""></iframe>
-      <script src="https://landscape.cncf.io/iframeResizer.js"></script>
+    <h5>Kubernetes collabora con i partner per creare per creare un codebase che supporti uno spettro di piattaforme complementari.</h5>
+    <div class="col-container">
+      <div class="col-nav">
+        <center>
+          <h5>
+            <b>Fornitori Certificati di Servizi su Kubernetes</b>
+          </h5>
+          <br>Fornitori di servizi riconosciuti e con grande esperienza nell'aiutare le imprese ad adottare con successo Kubernetes.
+          <br><br><br>
+          <button class="button landscape-trigger landscape-default" data-landscape-types="kubernetes-certified-service-provider" id="kcsp">Guarda i Partners KCSP</button>
+          <br><br>Interessato a diventare un partner 
+          <a href="https://www.cncf.io/certification/kcsp/">KCSP</a>?
+        </center>
+      </div>
+      <div class="col-nav">
+        <center>
+          <h5>
+            <b>Distribuzioni di Kubernetes Certificate, Certified Hosted Platforms and Software di installazione Certificati</b>
+          </h5>La conformità del software assicura che le versioni di Kubernetes prodotte da ogni fornitore supportino coerentemente le API necessarie.
+          <br><br><br>
+          <button class="button landscape-trigger" data-landscape-types="certified-kubernetes-distribution,certified-kubernetes-hosted,certified-kubernetes-installer" id="conformance">Guarda i Partner certificati</button>
+          <br><br>Interessato a diventare un partner 
+          <a href="https://www.cncf.io/certification/software-conformance/">certificato Kubernetes</a>?
+        </center>
+      </div>
+      <div class="col-nav">
+        <center>
+          <h5>
+            <b>Partner per la Formazione su Kubernetes</b>
+          </h5>
+          <br>Professionisti riconosciuti e certificati, con solida esperienza nella formazione su tecnologie Cloud Native.
+          <br><br><br>
+          <button class="button landscape-trigger" data-landscape-types="kubernetes-training-partner" id="ktp">Guarda i KTP partner</button>
+          <br><br>Interessato a diventare un partner 
+          <a href="https://www.cncf.io/certification/training/">KTP</a>?
+        </center>
+      </div>
     </div>
-</body>
-    </main>
+    {{< cncf-landscape helpers=true >}}
 </section>
 
 <style>
     {{< include "partner-style.css" >}}
 </style>
 
-<script>
-    {{< include "partner-script.js" >}}
-</script>


### PR DESCRIPTION
Fixed the broken link on the [partners page](https://kubernetes.io/it/partners/#kcsp) by resyncing with en, de, ko, and zh-cn.

Preview: https://deploy-preview-34960--kubernetes-io-main-staging.netlify.app/it/partners/