### PR TITLE
[pt-br] resync /partners/_index.html

### DIFF
--- a/content/pt-br/partners/_index.html
+++ b/content/pt-br/partners/_index.html
@@ -7,87 +7,48 @@ cid: parceiros
 ---
 
 <section id="users">
-    <main>
-        <h5>O Kubernetes trabalha com parceiros para criar uma base de código forte e vibrante que suporte um espectro de plataformas complementares.
+    <h5>O Kubernetes trabalha com parceiros para criar uma base de código forte e vibrante que suporte um espectro de plataformas complementares.</h5>
+    <div class="col-container">
+      <div class="col-nav">
+        <center>
+          <h5>
+            <b>Provedores de serviços certificados em Kubernetes</b>
           </h5>
-        <div class="col-container">
-          <div class="col-nav">
-            <center>
-              <h5>
-                <b>Provedores de serviços certificados em Kubernetes</b>
-              </h5>
-              <br>Provedores de serviços certificados, com profunda experiência em ajudar empresas a adotar Kubernetes com sucesso. 
-              <br><br><br>
-              <button id="kcsp" class="button" onClick="updateSrc(this.id)">See KCSP Partners</button>
-              <br><br>Interessado em se tornar um <a href="https://www.cncf.io/certification/kcsp/">KCSP</a>?
-            </center>
-          </div>
-          <div class="col-nav">
-            <center>
-              <h5>
-                <b>Distribuições certificadas do Kubernetes, plataformas hospedadas e instaladores                  </b>
-              </h5>A conformidade com o software garante que a versão de cada fornecedor do Kubernetes suporte as APIs necessárias. 
-              <br><br><br>
-              <button id="conformance" class="button" onClick="updateSrc(this.id)">See Conformance Partners</button>
-              <br><br>Interessado em se tornar<a href="https://www.cncf.io/certification/software-conformance/">Certified Kubernetes</a>?
-            </center>
-          </div>
-          <div class="col-nav">
-            <center>
-              <h5><b>Parceiros de treinamento da Kubernetes
-                </b></h5>
-              <br>Provedores de treinamento certificados que têm profunda experiência em treinamento em tecnologia nativa em nuvem. 
-              <br><br><br><br>
-              <button id="ktp" class="button" onClick="updateSrc(this.id)">Veja Parceiros KTP</button>
-              <br><br>Interessado em se tornar um<a href="https://www.cncf.io/certification/training/">KTP</a>?
-            </center>
-          </div>
-        </div>
-<script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
-<script type="text/javascript">
-
-			var defaultLink = "https://landscape.cncf.io/category=kubernetes-certified-service-provider&format=card-mode&grouping=category&embed=yes";
-			var firstLink = "https://landscape.cncf.io/category=certified-kubernetes-distribution,certified-kubernetes-hosted,certified-kubernetes-installer&format=card-mode&grouping=category&embed=yes";
-      var secondLink = "https://landscape.cncf.io/category=kubernetes-training-partner&format=card-mode&grouping=category&embed=yes";
-
-      function updateSrc(buttonId) {
-      	if (buttonId == "kcsp") {
-        		$("#landscape").attr("src",defaultLink);
-            window.location.hash = "#kcsp";
-        }
-        if (buttonId == "conformance") {
-         		$("#landscape").attr("src",firstLink);
-            window.location.hash = "#conformance";
-        }
-        if (buttonId == "ktp") {
-        		$("#landscape").attr("src",secondLink);
-            window.location.hash = "#ktp";
-        }
-      }
-
-      // Automatically load the correct iframe based on the URL fragment
-      document.addEventListener('DOMContentLoaded', function() {
-        var showContent = "kcsp";
-        if (window.location.hash) {
-          console.log('hash is:', window.location.hash.substring(1));
-          showContent = window.location.hash.substring(1);
-        }
-        updateSrc(showContent);
-      });
-</script>
-<body>
-    <div id="frameHolder">
-      <iframe id="landscape" frameBorder="0" scrolling="no" style="width: 1px; min-width: 100%" src=""></iframe>
-      <script src="https://landscape.cncf.io/iframeResizer.js"></script>
+          <br>Provedores de serviços certificados, com profunda experiência em ajudar empresas a adotar Kubernetes com sucesso. 
+          <br><br><br>
+          <button class="button landscape-trigger landscape-default" data-landscape-types="kubernetes-certified-service-provider" id="kcsp">See KCSP Partners</button>
+          <br><br>Interessado em se tornar um 
+          <a href="https://www.cncf.io/certification/kcsp/">KCSP</a>?
+        </center>
+      </div>
+      <div class="col-nav">
+        <center>
+          <h5>
+            <b>Distribuições certificadas do Kubernetes, plataformas hospedadas e instaladores</b>
+          </h5>A conformidade com o software garante que a versão de cada fornecedor do Kubernetes suporte as APIs necessárias.
+          <br><br><br>
+          <button class="button landscape-trigger" data-landscape-types="certified-kubernetes-distribution,certified-kubernetes-hosted,certified-kubernetes-installer" id="conformance">See Conformance Partners</button>
+          <br><br>Interessado em se tornar 
+          <a href="https://www.cncf.io/certification/software-conformance/">Kubernetes Certified</a>?
+        </center>
+      </div>
+      <div class="col-nav">
+        <center>
+          <h5>
+            <b>Parceiros de treinamento da Kubernetes</b>
+          </h5>
+          <br>Provedores de treinamento certificados que têm profunda experiência em treinamento em tecnologia nativa em nuvem.
+          <br><br><br>
+          <button class="button landscape-trigger" data-landscape-types="kubernetes-training-partner" id="ktp">Veja Parceiros KTP</button>
+          <br><br>Interessado em se tornar um 
+          <a href="https://www.cncf.io/certification/training/">KTP</a>?
+        </center>
+      </div>
     </div>
-</body>
-    </main>
+    {{< cncf-landscape helpers=true >}}
 </section>
 
 <style>
     {{< include "partner-style.css" >}}
 </style>
 
-<script>
-    {{< include "partner-script.js" >}}
-</script>


### PR DESCRIPTION
Fixed the broken link on the [partners page](https://kubernetes.io/pt-br/partners/#kcsp) by resyncing with en, de, ko, and zh-cn.

Preview: https://deploy-preview-34963--kubernetes-io-main-staging.netlify.app/pt-br/partners/