### PR TITLE
Update Node affinity example

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -124,8 +124,8 @@ For example, consider the following Pod spec:
 
 In this example, the following rules apply:
 
-  * The node *must* have a label with the key `topology.kubernetes.io/zone` and
-    the value of that label *must* be either `antarctica-east1` or `antarctica-west1`.
+  * The node *must* have a label with the key `kubernetes.io/os` and
+    the value of that label *must* be `linux`.
   * The node *preferably* has a label with the key `another-node-label-key` and
     the value `another-node-label-value`.
 


### PR DESCRIPTION
The referenced pod spec in the first node affinity example has been modified. Updating the explanation of the `requiredDuringSchedulingIgnoredDuringExecution` to reflect new label selectors/values.

Link to updated pod spec:
https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/pods/pod-with-node-affinity.yaml
