### PR TITLE
Migrate to latest versioning document

### DIFF
--- a/content/en/docs/reference/using-api/_index.md
+++ b/content/en/docs/reference/using-api/_index.md
@@ -39,7 +39,7 @@ The JSON and Protobuf serialization schemas follow the same guidelines for
 schema changes. The following descriptions cover both formats.
 
 The API versioning and software versioning are indirectly related.
-The [API and release versioning proposal](https://git.k8s.io/design-proposals-archive/release/versioning.md)
+The [API and release versioning proposal](https://git.k8s.io/sig-release/release-engineering/versioning.md)
 describes the relationship between API versioning and software versioning.
 
 Different API versions indicate different levels of stability and support. You

--- a/content/en/releases/release.md
+++ b/content/en/releases/release.md
@@ -124,7 +124,7 @@ The general labeling process should be consistent across artifact types.
   referring to a release MAJOR.MINOR `vX.Y` version.
 
   See also
-  [release versioning](https://git.k8s.io/design-proposals-archive/release/versioning.md).
+  [release versioning](https://git.k8s.io/sig-release/release-engineering/versioning.md).
 
 - *release branch*: Git branch `release-X.Y` created for the `vX.Y` milestone.
 

--- a/content/en/releases/version-skew-policy.md
+++ b/content/en/releases/version-skew-policy.md
@@ -21,7 +21,7 @@ Specific cluster deployment tools may place additional restrictions on version s
 ## Supported versions
 
 Kubernetes versions are expressed as **x.y.z**, where **x** is the major version, **y** is the minor version, and **z** is the patch version, following [Semantic Versioning](https://semver.org/) terminology.
-For more information, see [Kubernetes Release Versioning](https://git.k8s.io/design-proposals-archive/release/versioning.md#kubernetes-release-versioning).
+For more information, see [Kubernetes Release Versioning](https://git.k8s.io/sig-release/release-engineering/versioning.md#kubernetes-release-versioning).
 
 The Kubernetes project maintains release branches for the most recent three minor releases ({{< skew currentVersion >}}, {{< skew currentVersionAddMinor -1 >}}, {{< skew currentVersionAddMinor -2 >}}).  Kubernetes 1.19 and newer receive approximately 1 year of patch support. Kubernetes 1.18 and older received approximately 9 months of patch support.
 


### PR DESCRIPTION
[release/versioning.md](https://git.k8s.io/design-proposals-archive/release/versioning.md#kubernetes-release-versioning) that was in the k/design-proposals-archive repository in the past has been migrated to [k/sig-release repository](https://github.com/kubernetes/sig-release/blob/master/release-engineering/versioning.md) repository.

This PR is a split of https://github.com/kubernetes/website/pull/34948.