### PR TITLE
Updated the expired link for Configuration option

### DIFF
--- a/content/en/docs/tasks/administer-cluster/verify-signed-images.md
+++ b/content/en/docs/tasks/administer-cluster/verify-signed-images.md
@@ -69,4 +69,4 @@ admission controller. To get started with `cosigned` here are a few helpful
 resources:
 
 * [Installation](https://github.com/sigstore/cosign#installation)
-* [Configuration Options](https://github.com/sigstore/cosign/tree/main/config)
+* [Configuration Options](https://github.com/sigstore/cosign/blob/main/USAGE.md#detailed-usage)


### PR DESCRIPTION
Description:
The _Configuration option_ still had a broken link.

Proposed Solution:
Added this link as a replacement - https://github.com/sigstore/cosign/blob/main/USAGE.md#detailed-usage

Page to Update:
https://kubernetes.io/docs/tasks/administer-cluster/verify-signed-images/#verifying-image-signatures-with-admission-controller

fixes: #34854 