### PR TITLE
[zh-cn]Fix wrong translation of authentication for extension apiserver

### DIFF
--- a/content/zh-cn/docs/tasks/extend-kubernetes/configure-aggregation-layer.md
+++ b/content/zh-cn/docs/tasks/extend-kubernetes/configure-aggregation-layer.md
@@ -289,7 +289,7 @@ The Kubernetes apiserver will use the files indicated by `--proxy-client-*-file`
 1. The connection must be made using a client certificate that is signed by the CA whose certificate is in `--requestheader-client-ca-file`.
 2. The connection must be made using a client certificate whose CN is one of those listed in `--requestheader-allowed-names`. **Note:** You can set this option to blank as `--requestheader-allowed-names=""`. This will indicate to an extension apiserver that _any_ CN is acceptable.
 -->
-Kubernetes apiserver 将使用由 `--proxy-client-*-file` 指示的文件来验证扩展 apiserver。
+Kubernetes apiserver 将使用由 `--proxy-client-*-file` 指示的文件来向扩展 apiserver认证。
 为了使合规的扩展 apiserver 能够将该请求视为有效，必须满足以下条件：
 
 1. 连接必须使用由 CA 签署的客户端证书，该证书的证书位于 `--requestheader-client-ca-file` 中。


### PR DESCRIPTION
<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggest-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
The original description is "The Kubernetes apiserver will use the files indicated by --proxy-client-*-file to authenticate to the extension apiserver.",  it means authentication from kube-apiserver to extension apiserver, not from extension apiserver to kube-apiserver, the existing translation may be misunderstanding, misleads readers that it's an authentication from  extension apiserver to kube-apiserver using  \--proxy\-client\-\*\-file.