### PR TITLE
[ja] Fix links in release versioning

### DIFF
--- a/content/ja/docs/reference/using-api/_index.md
+++ b/content/ja/docs/reference/using-api/_index.md
@@ -30,7 +30,7 @@ JSONとProtobufなどのシリアル化スキーマの変更については同�
 以下の説明は、両方のフォーマットをカバーしています。
 
 APIのバージョニングとソフトウェアのバージョニングは間接的に関係しています。
-[API and release versioning proposal](https://git.k8s.io/community/contributors/design-proposals/release/versioning.md)は、APIバージョニングとソフトウェアバージョニングの関係を説明しています。
+[API and release versioning proposal](https://git.k8s.io/sig-release/release-engineering/versioning.md)は、APIバージョニングとソフトウェアバージョニングの関係を説明しています。
 
 APIのバージョンが異なると、安定性やサポートのレベルも異なります。
 各レベルの基準については、[API Changes documentation](https://git.k8s.io/community/contributors/devel/sig-architecture/api_changes.md#alpha-beta-and-stable-versions)で詳しく説明しています。

--- a/content/ja/docs/setup/release/version-skew-policy.md
+++ b/content/ja/docs/setup/release/version-skew-policy.md
@@ -12,7 +12,7 @@ weight: 30
 
 ## サポートされるバージョン {#supported-versions}
 
-Kubernetesのバージョンは**x.y.z**の形式で表現され、**x**はメジャーバージョン、**y**はマイナーバージョン、**z**はパッチバージョンを指します。これは[セマンティック バージョニング](https://semver.org/)に従っています。詳細は、[Kubernetesのリリースバージョニング](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md#kubernetes-release-versioning)を参照してください。
+Kubernetesのバージョンは**x.y.z**の形式で表現され、**x**はメジャーバージョン、**y**はマイナーバージョン、**z**はパッチバージョンを指します。これは[セマンティック バージョニング](https://semver.org/)に従っています。詳細は、[Kubernetesのリリースバージョニング](https://git.k8s.io/sig-release/release-engineering/versioning.md#kubernetes-release-versioning)を参照してください。
 
 Kubernetesプロジェクトでは、最新の3つのマイナーリリースについてリリースブランチを管理しています ({{< skew latestVersion >}}, {{< skew prevMinorVersion >}}, {{< skew oldestMinorVersion >}})。
 


### PR DESCRIPTION
`https://git.k8s.io/community/contributors/design-proposals` no longer exists. So change the URL to be the same as https://github.com/kubernetes/website/pull/34976

This PR is a split of https://github.com/kubernetes/website/pull/34948.