### PR TITLE
[zh-cn] Fix links in release versioning

### DIFF
--- a/content/zh-cn/docs/reference/using-api/_index.md
+++ b/content/zh-cn/docs/reference/using-api/_index.md
@@ -59,11 +59,11 @@ JSON 和 Protobuf 序列化模式遵循相同的模式更改原则。
 
 <!--
 The API versioning and software versioning are indirectly related.
-The [API and release versioning proposal](https://git.k8s.io/community/contributors/design-proposals/release/versioning.md)
+The [API and release versioning proposal](https://git.k8s.io/sig-release/release-engineering/versioning.md)
 describes the relationship between API versioning and software versioning.
 -->
 API 版本控制和软件版本控制是间接相关的。
-[API 和发布版本控制提案](https://git.k8s.io/community/contributors/design-proposals/release/versioning.md)
+[API 和发布版本控制提案](https://git.k8s.io/sig-release/release-engineering/versioning.md)
 描述了 API 版本控制和软件版本控制间的关系。
 
 <!--

--- a/content/zh-cn/releases/release.md
+++ b/content/zh-cn/releases/release.md
@@ -219,7 +219,7 @@ The general labeling process should be consistent across artifact types.
   referring to a release MAJOR.MINOR `vX.Y` version.
 
   See also
-  [release versioning](/contributors/design-proposals/release/versioning.md).
+  [release versioning](https://git.k8s.io/sig-release/release-engineering/versioning.md).
 
 - *release branch*: Git branch `release-X.Y` created for the `vX.Y` milestone.
 
@@ -233,7 +233,7 @@ The general labeling process should be consistent across artifact types.
   [GitHub 里程碑](https://help.github.com/en/github/managing-your-work-on-github/associating-milestones-with-issues-and-pull-requests)
   指的是发布 主.次 `vX.Y` 版本。
 
-  另请参阅[发布版本控制](/contributors/design-proposals/release/versioning.md)。
+  另请参阅[发布版本控制](https://git.k8s.io/sig-release/release-engineering/versioning.md)。
 
 - **发布分支**：为 `vX.Y` 里程碑创建的 Git 分支 `release-X.Y`。
 

--- a/content/zh-cn/releases/version-skew-policy.md
+++ b/content/zh-cn/releases/version-skew-policy.md
@@ -32,7 +32,7 @@ Specific cluster deployment tools may place additional restrictions on version s
 ## Supported versions
 
 Kubernetes versions are expressed as **x.y.z**, where **x** is the major version, **y** is the minor version, and **z** is the patch version, following [Semantic Versioning](https://semver.org/) terminology.
-For more information, see [Kubernetes Release Versioning](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md#kubernetes-release-versioning).
+For more information, see [Kubernetes Release Versioning](https://git.k8s.io/sig-release/release-engineering/versioning.md#kubernetes-release-versioning).
 
 The Kubernetes project maintains release branches for the most recent three minor releases ({{< skew currentVersion >}}, {{< skew currentVersionAddMinor -1 >}}, {{< skew currentVersionAddMinor -2 >}}).  Kubernetes 1.19 and newer receive approximately 1 year of patch support. Kubernetes 1.18 and older received approximately 9 months of patch support.
 -->
@@ -41,7 +41,7 @@ The Kubernetes project maintains release branches for the most recent three mino
 Kubernetes 版本以 **x.y.z** 表示，其中 **x** 是主要版本，
 **y** 是次要版本，**z** 是补丁版本，遵循[语义版本控制](https://semver.org/)术语。
 更多信息请参见
-[Kubernetes 版本发布控制](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md#kubernetes-release-versioning)。
+[Kubernetes 版本发布控制](https://git.k8s.io/sig-release/release-engineering/versioning.md#kubernetes-release-versioning)。
 
 Kubernetes 项目维护最近的三个次要版本（{{< skew currentVersion >}}、{{< skew currentVersionAddMinor -1 >}}、{{< skew currentVersionAddMinor -2 >}}）的发布分支。
 Kubernetes 1.19 和更新的版本获得大约 1 年的补丁支持。


### PR DESCRIPTION
`https://git.k8s.io/community/contributors/design-proposals` no longer exists. So change the URL to be the same as https://github.com/kubernetes/website/pull/34976.

This PR is a split of https://github.com/kubernetes/website/pull/34948.