### PR TITLE
Remove hyperlink and edit text on Restrict a Container's Access to Resources with AppArmor page

### DIFF
--- a/content/en/docs/tutorials/security/apparmor.md
+++ b/content/en/docs/tutorials/security/apparmor.md
@@ -122,8 +122,7 @@ gke-test-default-pool-239f5d02-xwux: kubelet is posting ready status. AppArmor e
 
 {{< note >}}
 AppArmor is currently in beta, so options are specified as annotations. Once support graduates to
-general availability, the annotations will be replaced with first-class fields (more details in
-[Upgrade path to GA](#upgrade-path-to-general-availability)).
+general availability (GA), the annotations will be replaced with first-class fields.
 {{< /note >}}
 
 AppArmor profiles are specified *per-container*. To specify the AppArmor profile to run a Pod


### PR DESCRIPTION
Follow up on #34997 

Updated page [Restrict a Container's Access to Resources with AppArmor page](https://kubernetes.io/docs/tutorials/security/apparmor)