### PR TITLE
releng: Update release managers page for new RMA

### DIFF
--- a/content/en/releases/release-managers.md
+++ b/content/en/releases/release-managers.md
@@ -133,14 +133,14 @@ referred to as Release Manager shadows. They are responsible for:
 GitHub Mentions: @kubernetes/release-engineering
 
 - Arnaud Meukam ([@ameukam](https://github.com/ameukam))
+- Jeremy Rickard ([@jeremyrickard](https://github.com/jeremyrickard))
 - Jim Angel ([@jimangel](https://github.com/jimangel))
+- Joseph Sandoval ([@jrsapi](https://github.com/jrsapi))
 - Joyce Kung ([@thejoycekung](https://github.com/thejoycekung))
 - Max Körbächer ([@mkorbi](https://github.com/mkorbi))
 - Seth McCombs ([@sethmccombs](https://github.com/sethmccombs))
 - Taylor Dolezal ([@onlydole](https://github.com/onlydole))
 - Wilson Husin ([@wilsonehusin](https://github.com/wilsonehusin))
-- Joseph Sandoval ([@jrsapi](https://github.com/jrsapi))
-- Jeremy Rickard ([@jeremyrickard](https://github.com/jeremyrickard))
 
 ### Becoming a Release Manager Associate
 

--- a/content/en/releases/release-managers.md
+++ b/content/en/releases/release-managers.md
@@ -139,6 +139,8 @@ GitHub Mentions: @kubernetes/release-engineering
 - Seth McCombs ([@sethmccombs](https://github.com/sethmccombs))
 - Taylor Dolezal ([@onlydole](https://github.com/onlydole))
 - Wilson Husin ([@wilsonehusin](https://github.com/wilsonehusin))
+- Joseph Sandoval ([@jrsapi](https://github.com/jrsapi))
+- Jeremy Rickard ([@jeremyrickard](https://github.com/jeremyrickard))
 
 ### Becoming a Release Manager Associate
 


### PR DESCRIPTION
In content/en/releases/release-managers.md,

* Add @jrsapi and @jeremyrickard to release manager associate list (https://github.com/kubernetes/sig-release/issues/1965)

/kind documentation
/assign @justaugustus @cpanato @puerco

/hold explicitly for subproject owner approval 

Signed-off-by: Jeremy Rickard <jeremyrrickard@gmail.com>


