### PR TITLE
Fixing a typo in Gateway API blog post

### DIFF
--- a/content/en/blog/_posts/2022-07-13-gateway-api-in-beta.md
+++ b/content/en/blog/_posts/2022-07-13-gateway-api-in-beta.md
@@ -10,7 +10,7 @@ canonicalUrl: https://gateway-api.sigs.k8s.io/blog/2022/graduating-to-beta/
 
 We are excited to announce the v0.5.0 release of Gateway API. For the first
 time, several of our most important Gateway API resources are graduating to
-beta. Additional, we are starting a new initiative to explore how Gateway API
+beta. Additionally, we are starting a new initiative to explore how Gateway API
 can be used for mesh and introducing new experimental concepts such as URL
 rewrites. We'll cover all of this and more below.
 


### PR DESCRIPTION
This fixes a tiny typo in the Gateway API blog post.