### PR TITLE
Updated the style-guide doc to remove Katacoda hyperlink

### DIFF
--- a/content/en/docs/contribute/style/style-guide.md
+++ b/content/en/docs/contribute/style/style-guide.md
@@ -361,7 +361,7 @@ Beware.
 
 ### Katacoda Embedded Live Environment
 
-This button lets users run Minikube in their browser using the [Katacoda Terminal](https://www.katacoda.com/embed/panel).
+This button lets users run Minikube in their browser using the Katacoda Terminal.
 It lowers the barrier of entry by allowing users to use Minikube with one click instead of going through the complete
 Minikube and Kubectl installation process locally.
 


### PR DESCRIPTION
Description:
The page provides a button for setting up the Katacoda environment and the hyperlink for the Katacoda embed panel is not working anymore.

Proposed Solution:
Removed the hyperlink Katacoda Embed panel

Page to Update:
https://kubernetes.io/docs/contribute/style/style-guide/#katacoda-embedded-live-environment