### PR TITLE
Update alpha.kubernetes.io/provided-node-ip

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -420,7 +420,7 @@ Used on: Node
 
 The kubelet can set this annotation on a Node to denote its configured IPv4 address.
 
-When kubelet is started with the "external" cloud provider, it sets this annotation on the Node to denote an IP address set from the command line flag (`--node-ip`). This IP is verified with the cloud provider as valid by the cloud-controller-manager.
+When kubelet is started with the `--cloud-provider` flag set to any value (includes both external and legacy in-tree cloud providers), it sets this annotation on the Node to denote an IP address set from the command line flag (`--node-ip`). This IP is verified with the cloud provider as valid by the cloud-controller-manager.
 
 ### batch.kubernetes.io/job-completion-index
 


### PR DESCRIPTION
When https://github.com/kubernetes/kubernetes/pull/109794 merges, the following will be true: 

* `alpha.kubernetes.io/provided-node-ip` is no longer set ONLY when --cloud-provider=external
* Now, it is set on kubelet startup if the --cloud-provider flag
  is set at all, including the deprecated in-tree values
  like `aws` and `gcp`.


