### PR TITLE
fix missing quotation marks in job examples

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -93,7 +93,7 @@ kind: Job
 metadata:
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"batch/v1","kind":"Job","metadata":{"annotations":{},"name":"pi","namespace":"default"},"spec":{"backoffLimit":4,"template":{"spec":{"containers":[{"command":["perl","-Mbignum=bpi","-wle","print bpi(2000)"],"image":"perl","name":"pi"}],"restartPolicy":"Never"}}}}
+      {"apiVersion":"batch/v1","kind":"Job","metadata":{"annotations":{},"name":"pi","namespace":"default"},"spec":{"backoffLimit":4,"template":{"spec":{"containers":[{"command":["perl","-Mbignum=bpi","-wle","'print bpi(2000)'"],"image":"perl","name":"pi"}],"restartPolicy":"Never"}}}}
   creationTimestamp: "2022-06-15T08:40:15Z"
   generation: 1
   labels:
@@ -357,7 +357,7 @@ spec:
       containers:
       - name: pi
         image: perl
-        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+        command: ["perl",  "-Mbignum=bpi", "-wle", "'print bpi(2000)'"]
       restartPolicy: Never
 ```
 
@@ -403,7 +403,7 @@ spec:
       containers:
       - name: pi
         image: perl
-        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+        command: ["perl",  "-Mbignum=bpi", "-wle", "'print bpi(2000)'"]
       restartPolicy: Never
 ```
 

--- a/content/en/docs/tasks/configure-pod-container/translate-compose-kubernetes.md
+++ b/content/en/docs/tasks/configure-pod-container/translate-compose-kubernetes.md
@@ -469,7 +469,7 @@ version: '2'
 services:
   pival:
     image: perl
-    command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+    command: ["perl",  "-Mbignum=bpi", "-wle", "'print bpi(2000)'"]
     restart: "on-failure"
 ```
 

--- a/content/es/docs/concepts/workloads/controllers/jobs-run-to-completion.md
+++ b/content/es/docs/concepts/workloads/controllers/jobs-run-to-completion.md
@@ -245,7 +245,7 @@ spec:
       containers:
       - name: pi
         image: perl
-        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+        command: ["perl",  "-Mbignum=bpi", "-wle", "'print bpi(2000)'"]
       restartPolicy: Never
 ```
 
@@ -287,7 +287,7 @@ spec:
       containers:
       - name: pi
         image: perl
-        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+        command: ["perl",  "-Mbignum=bpi", "-wle", "'print bpi(2000)'"]
       restartPolicy: Never
 ```
 

--- a/content/es/examples/controllers/job.yaml
+++ b/content/es/examples/controllers/job.yaml
@@ -8,7 +8,7 @@ spec:
       containers:
       - name: pi
         image: perl
-        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+        command: ["perl",  "-Mbignum=bpi", "-wle", "'print bpi(2000)'"]
       restartPolicy: Never
   backoffLimit: 4
 

--- a/content/fr/docs/tasks/configure-pod-container/translate-compose-kubernetes.md
+++ b/content/fr/docs/tasks/configure-pod-container/translate-compose-kubernetes.md
@@ -419,7 +419,7 @@ version: '2'
 services:
   pival:
     image: perl
-    command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+    command: ["perl",  "-Mbignum=bpi", "-wle", "'print bpi(2000)'"]
     restart: "on-failure"
 ```
 

--- a/content/id/docs/concepts/workloads/controllers/job.md
+++ b/content/id/docs/concepts/workloads/controllers/job.md
@@ -276,7 +276,7 @@ spec:
       Containers:
       - name: pi
         image: perl
-        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+        command: ["perl",  "-Mbignum=bpi", "-wle", "'print bpi(2000)'"]
       restartPolicy: Never
 ```
 
@@ -321,7 +321,7 @@ spec:
       Containers:
       - name: pi
         image: perl
-        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+        command: ["perl",  "-Mbignum=bpi", "-wle", "'print bpi(2000)'"]
       restartPolicy: Never
 ```
 

--- a/content/id/examples/controllers/job.yaml
+++ b/content/id/examples/controllers/job.yaml
@@ -8,6 +8,6 @@ spec:
       containers:
       - name: pi
         image: perl
-        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+        command: ["perl",  "-Mbignum=bpi", "-wle", "'print bpi(2000)'"]
       restartPolicy: Never
   backoffLimit: 4

--- a/content/ja/examples/controllers/job.yaml
+++ b/content/ja/examples/controllers/job.yaml
@@ -8,7 +8,7 @@ spec:
       containers:
       - name: pi
         image: perl
-        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+        command: ["perl",  "-Mbignum=bpi", "-wle", "'print bpi(2000)'"]
       restartPolicy: Never
   backoffLimit: 4
 

--- a/content/ko/docs/concepts/workloads/controllers/job.md
+++ b/content/ko/docs/concepts/workloads/controllers/job.md
@@ -297,7 +297,7 @@ spec:
       containers:
       - name: pi
         image: perl
-        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+        command: ["perl",  "-Mbignum=bpi", "-wle", "'print bpi(2000)'"]
       restartPolicy: Never
 ```
 
@@ -343,7 +343,7 @@ spec:
       containers:
       - name: pi
         image: perl
-        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+        command: ["perl",  "-Mbignum=bpi", "-wle", "'print bpi(2000)'"]
       restartPolicy: Never
 ```
 

--- a/content/ko/examples/controllers/job.yaml
+++ b/content/ko/examples/controllers/job.yaml
@@ -8,7 +8,7 @@ spec:
       containers:
       - name: pi
         image: perl
-        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+        command: ["perl",  "-Mbignum=bpi", "-wle", "'print bpi(2000)'"]
       restartPolicy: Never
   backoffLimit: 4
 

--- a/content/uk/examples/controllers/job.yaml
+++ b/content/uk/examples/controllers/job.yaml
@@ -8,7 +8,7 @@ spec:
       containers:
       - name: pi
         image: perl
-        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+        command: ["perl",  "-Mbignum=bpi", "-wle", "'print bpi(2000)'"]
       restartPolicy: Never
   backoffLimit: 4
 

--- a/content/zh-cn/docs/concepts/workloads/controllers/job.md
+++ b/content/zh-cn/docs/concepts/workloads/controllers/job.md
@@ -562,7 +562,7 @@ spec:
       containers:
       - name: pi
         image: perl
-        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+        command: ["perl",  "-Mbignum=bpi", "-wle", "'print bpi(2000)'"]
       restartPolicy: Never
 ```
 <!--
@@ -640,7 +640,7 @@ spec:
       containers:
       - name: pi
         image: perl
-        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+        command: ["perl",  "-Mbignum=bpi", "-wle", "'print bpi(2000)'"]
       restartPolicy: Never
 ```
 

--- a/content/zh-cn/docs/tasks/configure-pod-container/translate-compose-kubernetes.md
+++ b/content/zh-cn/docs/tasks/configure-pod-container/translate-compose-kubernetes.md
@@ -671,7 +671,7 @@ version: '2'
 services:
   pival:
     image: perl
-    command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+    command: ["perl",  "-Mbignum=bpi", "-wle", "'print bpi(2000)'"]
     restart: "on-failure"
 ```
 

--- a/content/zh-cn/examples/controllers/job.yaml
+++ b/content/zh-cn/examples/controllers/job.yaml
@@ -8,7 +8,7 @@ spec:
       containers:
       - name: pi
         image: perl:5.34
-        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+        command: ["perl",  "-Mbignum=bpi", "-wle", "'print bpi(2000)'"]
       restartPolicy: Never
   backoffLimit: 4
 


### PR DESCRIPTION
PR https://github.com/kubernetes/website/pull/34266 fix one of the typo in Job example, but there're still many similar typo in other examples/languages. 
This PR is to fix all these typos.