### PR TITLE
Fix links for k/design-proposals-archive

### DIFF
--- a/content/zh-cn/blog/_posts/2022-04-07-Kubernetes-1-24-removals-and-deprecations.md
+++ b/content/zh-cn/blog/_posts/2022-04-07-Kubernetes-1-24-removals-and-deprecations.md
@@ -158,11 +158,11 @@ been deprecated. These removals have been superseded by newer, stable/generally 
   以防止各种类型的敏感信息通过日志泄漏。有关更多信息和替代方法，请参阅
   [KEP-1753: Kubernetes 系统组件日志清洗](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1753-logs-sanitization#deprecation)。
 <!--
-* In-tree provisioner to CSI driver migration: This applies to a number of in-tree plugins, including [Portworx](https://github.com/kubernetes/enhancements/issues/2589). Refer to the [In-tree Storage Plugin to CSI Migration Design Doc](https://github.com/kubernetes/design-proposals-archive/blob/main/storage/csi-migration.md#background-and-motivations) for more information.
+* In-tree provisioner to CSI driver migration: This applies to a number of in-tree plugins, including [Portworx](https://github.com/kubernetes/enhancements/issues/2589). Refer to the [In-tree Storage Plugin to CSI Migration Design Doc](https://git.k8s.io/design-proposals-archive/storage/csi-migration.md#background-and-motivations) for more information.
 -->
 * 树内驱动（In-tree provisioner）向 CSI 卷迁移：这适用于许多树内插件， 
   包括 [Portworx](https://github.com/kubernetes/enhancements/issues/2589)。
-  参见[树内存储插件向 CSI 卷迁移的设计文档](https://github.com/kubernetes/design-proposals-archive/blob/main/storage/csi-migration.md#background-and-motivations) 
+  参见[树内存储插件向 CSI 卷迁移的设计文档](https://git.k8s.io/design-proposals-archive/storage/csi-migration.md#background-and-motivations) 
   了解更多信息。
 <!--
 * [Removing Dockershim from kubelet](https://github.com/kubernetes/enhancements/issues/2221): the Container Runtime Interface (CRI) for Docker (i.e. Dockershim) is currently a built-in container runtime in the kubelet code base. It was deprecated in v1.20. As of v1.24, the kubelet will no longer have dockershim. Check out this blog on [what you need to do be ready for v1.24](/blog/2022/03/31/ready-for-dockershim-removal/). 

--- a/content/zh-cn/docs/concepts/architecture/nodes.md
+++ b/content/zh-cn/docs/concepts/architecture/nodes.md
@@ -1170,14 +1170,14 @@ see [KEP-2400](https://github.com/kubernetes/enhancements/issues/2400) and its
 <!--
 * Learn about the [components](/docs/concepts/overview/components/#node-components) that make up a node.
 * Read the [API definition for Node](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#node-v1-core).
-* Read the [Node](https://git.k8s.io/community/contributors/design-proposals/architecture/architecture.md#the-kubernetes-node)
+* Read the [Node](https://git.k8s.io/design-proposals-archive/architecture/architecture.md#the-kubernetes-node)
   section of the architecture design document.
 * Read about [taints and tolerations](/docs/concepts/scheduling-eviction/taint-and-toleration/).
 -->
 * 进一步了解节点[组件](/zh-cn/docs/concepts/overview/components/#node-components)。
 * 阅读 [Node 的 API 定义](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#node-v1-core)。
 * 阅读架构设计文档中有关
-  [Node](https://git.k8s.io/community/contributors/design-proposals/architecture/architecture.md#the-kubernetes-node)
+  [Node](https://git.k8s.io/design-proposals-archive/architecture/architecture.md#the-kubernetes-node)
   的章节。
 * 了解[污点和容忍度](/zh-cn/docs/concepts/scheduling-eviction/taint-and-toleration/)。
 

--- a/content/zh-cn/docs/concepts/cluster-administration/networking.md
+++ b/content/zh-cn/docs/concepts/cluster-administration/networking.md
@@ -474,7 +474,7 @@ Weave Net 可以作为 [CNI 插件](https://www.weave.works/docs/net/latest/cni-
 <!--
 The early design of the networking model and its rationale, and some future
 plans are described in more detail in the
-[networking design document](https://git.k8s.io/community/contributors/design-proposals/network/networking.md).
+[networking design document](https://git.k8s.io/design-proposals-archive/network/networking.md).
 -->
 网络模型的早期设计、运行原理以及未来的一些计划，
-都在[联网设计文档](https://git.k8s.io/community/contributors/design-proposals/network/networking.md)里有更详细的描述。
+都在[联网设计文档](https://git.k8s.io/design-proposals-archive/network/networking.md)里有更详细的描述。

--- a/content/zh-cn/docs/concepts/extend-kubernetes/_index.md
+++ b/content/zh-cn/docs/concepts/extend-kubernetes/_index.md
@@ -379,7 +379,7 @@ After a request is authorized, if it is a write operation, it also goes through 
 
 ### Storage Plugins
 
-[Flex Volumes](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/flexvolume-deployment.md
+[Flex Volumes](https://git.k8s.io/design-proposals-archive/storage/flexvolume-deployment.md
 ) allow users to mount volume types without built-in support by having the
 Kubelet call a Binary Plugin to mount the volume.
 -->
@@ -387,7 +387,7 @@ Kubelet call a Binary Plugin to mount the volume.
 
 ### 存储插件  {#storage-plugins}
 
-[FlexVolumes](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/flexvolume-deployment.md
+[FlexVolumes](https://git.k8s.io/design-proposals-archive/storage/flexvolume-deployment.md
 )
 卷可以让用户挂载无需内建支持的卷类型，
 kubelet 会调用可执行文件插件来挂载对应的存储卷。
@@ -433,7 +433,7 @@ This is a significant undertaking, and almost all Kubernetes users find they
 do not need to modify the scheduler.
 
 The scheduler also supports a
-[webhook](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/scheduler_extender.md)
+[webhook](https://git.k8s.io/design-proposals-archive/scheduling/scheduler_extender.md)
 that permits a webhook backend (scheduler extension) to filter and prioritize
 the nodes chosen for a pod.
 -->
@@ -448,7 +448,7 @@ the nodes chosen for a pod.
 用户都会发现其实他们不需要修改调度器。
 
 调度器也支持一种
-[Webhook](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/scheduler_extender.md)，
+[Webhook](https://git.k8s.io/design-proposals-archive/scheduling/scheduler_extender.md)，
 允许使用某种 Webhook 后端（调度器扩展）来为 Pod 可选的节点执行过滤和优先排序操作。
 
 ## {{% heading "whatsnext" %}}

--- a/content/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
+++ b/content/zh-cn/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins.md
@@ -9,7 +9,7 @@ weight: 20
 {{< feature-state for_k8s_version="v1.10" state="beta" >}}
 
 <!--
-Kubernetes provides a [device plugin framework](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/resource-management/device-plugin.md)
+Kubernetes provides a [device plugin framework](https://git.k8s.io/design-proposals-archive/resource-management/device-plugin.md)
 that you can use to advertise system hardware resources to the
 {{< glossary_tooltip term_id="kubelet" >}}.
 
@@ -20,7 +20,7 @@ and other similar computing resources that may require vendor specific initializ
 and setup.
 -->
 Kubernetes 提供了一个
-[设备插件框架](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/resource-management/device-plugin.md)，你可以用它来将系统硬件资源发布到 {{< glossary_tooltip term_id="kubelet" >}}。
+[设备插件框架](https://git.k8s.io/design-proposals-archive/resource-management/device-plugin.md)，你可以用它来将系统硬件资源发布到 {{< glossary_tooltip term_id="kubelet" >}}。
 
 供应商可以实现设备插件，由你手动部署或作为 {{< glossary_tooltip term_id="daemonset" >}}
 来部署，而不必定制 Kubernetes 本身的代码。目标设备包括 GPU、高性能 NIC、FPGA、

--- a/content/zh-cn/docs/concepts/overview/kubernetes-api.md
+++ b/content/zh-cn/docs/concepts/overview/kubernetes-api.md
@@ -134,13 +134,13 @@ Kubernetes API 服务器通过 `/openapi/v2` 端点提供聚合的 OpenAPI v2 �
 <!--
 Kubernetes implements an alternative Protobuf based serialization format that
 is primarily intended for intra-cluster communication. For more information
-about this format, see the [Kubernetes Protobuf serialization](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/protobuf.md) design proposal and the
+about this format, see the [Kubernetes Protobuf serialization](https://git.k8s.io/design-proposals-archive/api-machinery/protobuf.md) design proposal and the
 Interface Definition Language (IDL) files for each schema located in the Go
 packages that define the API objects.
 -->
 Kubernetes 为 API 实现了一种基于 Protobuf 的序列化格式，主要用于集群内部通信。
 关于此格式的详细信息，可参考
-[Kubernetes Protobuf 序列化](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/protobuf.md)
+[Kubernetes Protobuf 序列化](https://git.k8s.io/design-proposals-archive/api-machinery/protobuf.md)
 设计提案。每种模式对应的接口描述语言（IDL）位于定义 API 对象的 Go 包中。
 
 ### OpenAPI V3

--- a/content/zh-cn/docs/concepts/overview/working-with-objects/names.md
+++ b/content/zh-cn/docs/concepts/overview/working-with-objects/names.md
@@ -171,9 +171,9 @@ UUIDs 是标准化的，见 ISO/IEC 9834-8 和 ITU-T X.667。
 
 <!--
 * Read about [labels](/docs/concepts/overview/working-with-objects/labels/) in Kubernetes.
-* See the [Identifiers and Names in Kubernetes](https://git.k8s.io/community/contributors/design-proposals/architecture/identifiers.md) design document.
+* See the [Identifiers and Names in Kubernetes](https://git.k8s.io/design-proposals-archive/architecture/identifiers.md) design document.
 -->
 * 进一步了解 Kubernetes [标签](/zh-cn/docs/concepts/overview/working-with-objects/labels/)
-* 参阅 [Kubernetes 标识符和名称](https://git.k8s.io/community/contributors/design-proposals/architecture/identifiers.md)的设计文档
+* 参阅 [Kubernetes 标识符和名称](https://git.k8s.io/design-proposals-archive/architecture/identifiers.md)的设计文档
 
 

--- a/content/zh-cn/docs/concepts/policy/limit-range.md
+++ b/content/zh-cn/docs/concepts/policy/limit-range.md
@@ -106,9 +106,9 @@ Neither contention nor changes to a LimitRange will affect already created resou
 ## {{% heading "whatsnext" %}}
 
 <!--
-See [LimitRanger design doc](https://git.k8s.io/community/contributors/design-proposals/resource-management/admission_control_limit_range.md) for more information.
+Refer to the [LimitRanger design document](https://git.k8s.io/design-proposals-archive/resource-management/admission_control_limit_range.md) for more information.
 -->
-参阅 [LimitRanger 设计文档](https://git.k8s.io/community/contributors/design-proposals/resource-management/admission_control_limit_range.md)获取更多信息。
+参阅 [LimitRanger 设计文档](https://git.k8s.io/design-proposals-archive/resource-management/admission_control_limit_range.md)获取更多信息。
 
 <!--
 For examples on using limits, see:

--- a/content/zh-cn/docs/concepts/policy/resource-quotas.md
+++ b/content/zh-cn/docs/concepts/policy/resource-quotas.md
@@ -1057,14 +1057,13 @@ and it is to be created in a namespace other than `kube-system`.
 ## {{% heading "whatsnext" %}}
 
 <!--
-- See [ResourceQuota design doc](https://git.k8s.io/community/contributors/design-proposals/resource-management/admission_control_resource_quota.md) for more information.
+- See [ResourceQuota design doc](https://git.k8s.io/design-proposals-archive/resource-management/admission_control_resource_quota.md) for more information.
 - See a [detailed example for how to use resource quota](/docs/tasks/administer-cluster/quota-api-object/).
-- Read [Quota support for priority class design doc](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/pod-priority-resourcequota.md).
+- Read [Quota support for priority class design doc](https://git.k8s.io/design-proposals-archive/scheduling/pod-priority-resourcequota.md).
 - See [LimitedResources](https://github.com/kubernetes/kubernetes/pull/36765)
 -->
-- 查看[资源配额设计文档](https://git.k8s.io/community/contributors/design-proposals/resource-management/admission_control_resource_quota.md)
-- 查看[如何使用资源配额的详细示例](/zh-cn/docs/tasks/administer-cluster/quota-api-object/)。
-- 阅读[优先级类配额支持的设计文档](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/pod-priority-resourcequota.md)。
-  了解更多信息。
-- 参阅 [LimitedResources](https://github.com/kubernetes/kubernetes/pull/36765)
+- 参阅[资源配额设计文档](https://git.k8s.io/design-proposals-archive/resource-management/admission_control_resource_quota.md)。
+- 参阅[如何使用资源配额的详细示例](/zh-cn/docs/tasks/administer-cluster/quota-api-object/)。
+- 参阅[优先级类配额支持的设计文档](https://git.k8s.io/design-proposals-archive/scheduling/pod-priority-resourcequota.md)了解更多信息。
+- 参阅 [LimitedResources](https://github.com/kubernetes/kubernetes/pull/36765)。
 

--- a/content/zh-cn/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/zh-cn/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -552,9 +552,9 @@ same zone currently running Pods with the `Security=S2` Pod label.
 
 <!--
 To get yourself more familiar with the examples of Pod affinity and anti-affinity,
-refer to the [design proposal](https://github.com/kubernetes/design-proposals-archive/blob/main/scheduling/podaffinity.md).
+refer to the [design proposal](https://git.k8s.io/design-proposals-archive/scheduling/podaffinity.md).
 -->
-查阅[设计文档](https://github.com/kubernetes/design-proposals-archive/blob/main/scheduling/podaffinity.md)
+查阅[设计文档](https://git.k8s.io/design-proposals-archive/scheduling/podaffinity.md)
 以进一步熟悉 Pod 亲和性与反亲和性的示例。
 
 <!--
@@ -803,16 +803,16 @@ The above Pod will only run on the node `kube-01`.
 
 <!--
 * Read more about [taints and tolerations](/docs/concepts/scheduling-eviction/taint-and-toleration/) .
-* Read the design docs for [node affinity](https://git.k8s.io/community/contributors/design-proposals/scheduling/nodeaffinity.md)
-  and for [inter-pod affinity/anti-affinity](https://git.k8s.io/community/contributors/design-proposals/scheduling/podaffinity.md).
+* Read the design docs for [node affinity](https://git.k8s.io/design-proposals-archive/scheduling/nodeaffinity.md)
+  and for [inter-pod affinity/anti-affinity](https://git.k8s.io/design-proposals-archive/scheduling/podaffinity.md).
 * Learn about how the [topology manager](/docs/tasks/administer-cluster/topology-manager/) takes part in node-level
   resource allocation decisions. 
 * Learn how to use [nodeSelector](/docs/tasks/configure-pod-container/assign-pods-nodes/).
 * Learn how to use [affinity and anti-affinity](/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/).
 -->
 * 进一步阅读[污点与容忍度](/zh-cn/docs/concepts/scheduling-eviction/taint-and-toleration/)文档。
-* 阅读[节点亲和性](https://git.k8s.io/community/contributors/design-proposals/scheduling/nodeaffinity.md)
-  和[Pod 间亲和性与反亲和性](https://git.k8s.io/community/contributors/design-proposals/scheduling/podaffinity.md)
+* 阅读[节点亲和性](https://git.k8s.io/design-proposals-archive/scheduling/nodeaffinity.md)
+  和[Pod 间亲和性与反亲和性](https://git.k8s.io/design-proposals-archive/scheduling/podaffinity.md)
   的设计文档。
 * 了解[拓扑管理器](/zh-cn/docs/tasks/administer-cluster/topology-manager/)如何参与节点层面资源分配决定。
 * 了解如何使用 [nodeSelector](/zh-cn/docs/tasks/configure-pod-container/assign-pods-nodes/)。

--- a/content/zh-cn/docs/concepts/storage/persistent-volumes.md
+++ b/content/zh-cn/docs/concepts/storage/persistent-volumes.md
@@ -1265,13 +1265,13 @@ Claims use [the same convention as volumes](#volume-mode) to indicate the consum
 <!--
 ### Resources
 
-Claims, like Pods, can request specific quantities of a resource. In this case, the request is for storage. The same [resource model](https://git.k8s.io/community/contributors/design-proposals/scheduling/resources.md) applies to both volumes and claims.
+Claims, like Pods, can request specific quantities of a resource. In this case, the request is for storage. The same [resource model](https://git.k8s.io/design-proposals-archive/scheduling/resources.md) applies to both volumes and claims.
 -->
 ### 资源    {#resources}
 
 申领和 Pod 一样，也可以请求特定数量的资源。在这个上下文中，请求的资源是存储。
 卷和申领都使用相同的
-[资源模型](https://git.k8s.io/community/contributors/design-proposals/scheduling/resources.md)。
+[资源模型](https://git.k8s.io/design-proposals-archive/scheduling/resources.md)。
 
 <!--
 ### Selector

--- a/content/zh-cn/docs/concepts/storage/projected-volumes.md
+++ b/content/zh-cn/docs/concepts/storage/projected-volumes.md
@@ -49,10 +49,10 @@ Currently, the following types of volume sources can be projected:
 
 <!--
 All sources are required to be in the same namespace as the Pod. For more details,
-see the [all-in-one volume](https://github.com/kubernetes/design-proposals-archive/blob/main/node/all-in-one-volume.md) design document.
+see the [all-in-one volume](https://git.k8s.io/design-proposals-archive/node/all-in-one-volume.md) design document.
 -->
 所有的卷源都要求处于 Pod 所在的同一个名字空间内。进一步的详细信息，可参考
-[一体化卷](https://github.com/kubernetes/design-proposals-archive/blob/main/node/all-in-one-volume.md)设计文档。
+[一体化卷](https://git.k8s.io/design-proposals-archive/node/all-in-one-volume.md)设计文档。
 
 <!--
 ### Example configuration with a secret, a downwardAPI, and a configMap {#example-configuration-secret-downwardapi-configmap}

--- a/content/zh-cn/docs/concepts/storage/storage-classes.md
+++ b/content/zh-cn/docs/concepts/storage/storage-classes.md
@@ -132,7 +132,7 @@ for provisioning PVs. This field must be specified.
 You are not restricted to specifying the "internal" provisioners
 listed here (whose names are prefixed with "kubernetes.io" and shipped
 alongside Kubernetes). You can also run and specify external provisioners,
-which are independent programs that follow a [specification](https://github.com/kubernetes/design-proposals-archive/blob/main/storage/volume-provisioning.md))
+which are independent programs that follow a [specification](https://git.k8s.io/design-proposals-archive/storage/volume-provisioning.md))
 defined by Kubernetes. Authors of external provisioners have full discretion
 over where their code lives, how the provisioner is shipped, how it needs to be
 run, what volume plugin it uses (including Flex), etc. The repository
@@ -143,7 +143,7 @@ the specification. Some external provisioners are listed under the repository
  -->
 你不限于指定此处列出的 "内置" 制备器（其名称前缀为 "kubernetes.io" 并打包在 Kubernetes 中）。
 你还可以运行和指定外部制备器，这些独立的程序遵循由 Kubernetes 定义的
-[规范](https://github.com/kubernetes/design-proposals-archive/blob/main/storage/volume-provisioning.md)。
+[规范](https://git.k8s.io/design-proposals-archive/storage/volume-provisioning.md)。
 外部供应商的作者完全可以自由决定他们的代码保存于何处、打包方式、运行方式、使用的插件（包括 Flex）等。
 代码仓库 [kubernetes-sigs/sig-storage-lib-external-provisioner](https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner)
 包含一个用于为外部制备器编写功能实现的类库。你可以访问代码仓库

--- a/content/zh-cn/docs/concepts/storage/volumes.md
+++ b/content/zh-cn/docs/concepts/storage/volumes.md
@@ -1925,12 +1925,12 @@ Kubernetes) to expose arbitrary storage systems to their container workloads.
 为容器编排系统（如 Kubernetes）定义标准接口，以将任意存储系统暴露给它们的容器工作负载。
 
 <!--
-Please read the [CSI design proposal](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/container-storage-interface.md) for more information.
+Please read the [CSI design proposal](https://git.k8s.io/design-proposals-archive/storage/container-storage-interface.md) for more information.
 
 CSI support was introduced as alpha in Kubernetes v1.9, moved to beta in
 Kubernetes v1.10, and is GA in Kubernetes v1.13.
 -->
-更多详情请阅读 [CSI 设计方案](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/container-storage-interface.md)。
+更多详情请阅读 [CSI 设计方案](https://git.k8s.io/design-proposals-archive/storage/container-storage-interface.md)。
 
 <!--
 Support for CSI spec versions 0.2 and 0.3 are deprecated in Kubernetes

--- a/content/zh-cn/docs/reference/access-authn-authz/bootstrap-tokens.md
+++ b/content/zh-cn/docs/reference/access-authn-authz/bootstrap-tokens.md
@@ -117,7 +117,7 @@ controller on the controller manager.
 
 Each valid token is backed by a secret in the `kube-system` namespace.  You can
 find the full design doc
-[here](https://github.com/kubernetes/design-proposals-archive/blob/main/cluster-lifecycle/bootstrap-discovery.md).
+[here](https://git.k8s.io/design-proposals-archive/cluster-lifecycle/bootstrap-discovery.md).
 
 Here is what the secret looks like.
 -->
@@ -125,7 +125,7 @@ Here is what the secret looks like.
 
 每个合法的令牌背后对应着 `kube-system` 名字空间中的某个 Secret 对象。
 你可以从
-[这里](https://github.com/kubernetes/design-proposals-archive/blob/main/cluster-lifecycle/bootstrap-discovery.md)
+[这里](https://git.k8s.io/design-proposals-archive/cluster-lifecycle/bootstrap-discovery.md)
 找到完整设计文档。
 
 这是 Secret 看起来的样子。

--- a/content/zh-cn/docs/reference/config-api/kubelet-config.v1beta1.md
+++ b/content/zh-cn/docs/reference/config-api/kubelet-config.v1beta1.md
@@ -1467,13 +1467,13 @@ Default: &quot;&quot;
 <td>
    <!--systemReservedCgroup helps the kubelet identify absolute name of top level CGroup used
 to enforce <code>systemReserved</code> compute resource reservation for OS system daemons.
-Refer to <a href="https://git.k8s.io/community/contributors/design-proposals/node/node-allocatable.md">Node Allocatable</a>
+Refer to <a href="https://git.k8s.io/design-proposals-archive/node/node-allocatable.md">Node Allocatable</a>
 doc for more information.
 Default: &quot;&quot;
    -->
    <p><code>systemReservedCgroup</code>帮助 kubelet 识别用来为 OS 系统级守护进程实施
 <code>systemReserved</code>计算资源预留时使用的顶级控制组（CGroup）。
-参考 <a href="https://git.k8s.io/community/contributors/design-proposals/node/node-allocatable.md">Node Allocatable</a>
+参考 <a href="https://git.k8s.io/design-proposals-archive/node/node-allocatable.md">Node Allocatable</a>
 以了解详细信息。</p>
    <p>默认值：&quot;&quot;</p>
 </td>
@@ -1486,13 +1486,13 @@ Default: &quot;&quot;
 <td>
    <!--kubeReservedCgroup helps the kubelet identify absolute name of top level CGroup used
 to enforce `KubeReserved` compute resource reservation for Kubernetes node system daemons.
-Refer to <a href="https://git.k8s.io/community/contributors/design-proposals/node/node-allocatable.md">Node Allocatable</a>
+Refer to <a href="https://git.k8s.io/design-proposals-archive/node/node-allocatable.md">Node Allocatable</a>
 doc for more information.
 Default: ""
    -->
    <p><code>kubeReservedCgroup</code> 帮助 kubelet 识别用来为 Kubernetes 节点系统级守护进程实施
 <code>kubeReserved</code>计算资源预留时使用的顶级控制组（CGroup）。
-参阅 <a href="https://git.k8s.io/community/contributors/design-proposals/node/node-allocatable.md">Node Allocatable</a>
+参阅 <a href="https://git.k8s.io/design-proposals-archive/node/node-allocatable.md">Node Allocatable</a>
 了解进一步的信息。</p>
    <p>默认值：&quot;&quot;</p>
 </td>
@@ -1509,7 +1509,7 @@ If <code>none</code> is specified, no other options may be specified.
 When <code>system-reserved</code> is in the list, systemReservedCgroup must be specified.
 When <code>kube-reserved</code> is in the list, kubeReservedCgroup must be specified.
 This field is supported only when <code>cgroupsPerQOS</code> is set to true.
-Refer to <a href="https://git.k8s.io/community/contributors/design-proposals/node/node-allocatable.md">Node Allocatable</a>
+Refer to <a href="https://git.k8s.io/design-proposals-archive/node/node-allocatable.md">Node Allocatable</a>
 for more information.
 Default: [&quot;pods&quot;]
    -->
@@ -1520,7 +1520,7 @@ Default: [&quot;pods&quot;]
    <p>如果列表中包含<code>system-reserved</code>，则必须设置<code>systemReservedCgroup</code>。</p>
    <p>如果列表中包含<code>kube-reserved</code>，则必须设置<code>kubeReservedCgroup</code>。</p>
    <p>这个字段只有在<code>cgroupsPerQOS</code>被设置为<code>true</code>才被支持。</p>
-   <p>参阅<a href="https://git.k8s.io/community/contributors/design-proposals/node/node-allocatable.md">Node Allocatable</a>
+   <p>参阅<a href="https://git.k8s.io/design-proposals-archive/node/node-allocatable.md">Node Allocatable</a>
 了解进一步的信息。</p>
    <p>默认值：[&quot;pods&quot;]</p>
 </td>

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/implementation-details.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/implementation-details.md
@@ -759,13 +759,13 @@ As soon as the control plane is available, kubeadm executes following actions:
 
 <!--
 Kubeadm uses [Authenticating with Bootstrap Tokens](/docs/reference/access-authn-authz/bootstrap-tokens/) for joining new nodes to an
-existing cluster; for more details see also [design proposal](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/cluster-lifecycle/bootstrap-discovery.md).
+existing cluster; for more details see also [design proposal](https://git.k8s.io/design-proposals-archive/cluster-lifecycle/bootstrap-discovery.md).
 -->
 
 Kubeadm 使用[引导令牌认证](/zh-cn/docs/reference/access-authn-authz/bootstrap-tokens/)
 将新节点连接到现有集群；
 更多的详细信息，请参见
-[设计提案](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/cluster-lifecycle/bootstrap-discovery.md)。
+[设计提案](https://git.k8s.io/design-proposals-archive/cluster-lifecycle/bootstrap-discovery.md)。
 
 <!-- 
 `kubeadm init` ensures that everything is properly configured for this process, and this includes following steps as well as
@@ -997,10 +997,10 @@ This is split into discovery (having the Node trust the Kubernetes Master) and T
 （让 Kubernetes 的主控节点信任该节点）。
 
 <!-- 
-see [Authenticating with Bootstrap Tokens](/docs/reference/access-authn-authz/bootstrap-tokens/) or the corresponding [design proposal](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/cluster-lifecycle/bootstrap-discovery.md). 
+see [Authenticating with Bootstrap Tokens](/docs/reference/access-authn-authz/bootstrap-tokens/) or the corresponding [design proposal](https://git.k8s.io/design-proposals-archive/cluster-lifecycle/bootstrap-discovery.md). 
 -->
 请参阅[使用引导令牌进行身份验证](/zh-cn/docs/reference/access-authn-authz/bootstrap-tokens/)
-或相应的[设计提案](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/cluster-lifecycle/bootstrap-discovery.md)。
+或相应的[设计提案](https://git.k8s.io/design-proposals-archive/cluster-lifecycle/bootstrap-discovery.md)。
 
 <!--
 ### Preflight checks

--- a/content/zh-cn/docs/reference/using-api/_index.md
+++ b/content/zh-cn/docs/reference/using-api/_index.md
@@ -59,11 +59,11 @@ JSON 和 Protobuf 序列化模式遵循相同的模式更改原则。
 
 <!--
 The API versioning and software versioning are indirectly related.
-The [API and release versioning proposal](https://git.k8s.io/community/contributors/design-proposals/release/versioning.md)
+The [API and release versioning proposal](https://git.k8s.io/sig-release/release-engineering/versioning.md)
 describes the relationship between API versioning and software versioning.
 -->
 API 版本控制和软件版本控制是间接相关的。
-[API 和发布版本控制提案](https://git.k8s.io/community/contributors/design-proposals/release/versioning.md)
+[API 和发布版本控制提案](https://git.k8s.io/sig-release/release-engineering/versioning.md)
 描述了 API 版本控制和软件版本控制间的关系。
 
 <!--

--- a/content/zh-cn/docs/tasks/administer-cluster/namespaces.md
+++ b/content/zh-cn/docs/tasks/administer-cluster/namespaces.md
@@ -96,11 +96,12 @@ to define *Hard* resource usage limits that a *Namespace* may consume. -->
 <!-- A limit range defines min/max constraints on the amount of resources a single entity can consume in
 a *Namespace*.
 
-See [Admission control: Limit Range](https://git.k8s.io/community/contributors/design-proposals/resource-management/admission_control_limit_range.md) -->
+See [Admission control: Limit Range](https://git.k8s.io/design-proposals-archive/resource-management/admission_control_limit_range.md)
+-->
 
 限制区间定义了单个实体在一个 *Namespace* 中可使用的最小/最大资源量约束。
 
-参阅 [准入控制: 限制区间](https://git.k8s.io/community/contributors/design-proposals/resource-management/admission_control_limit_range.md)
+参阅 [准入控制：限制区间](https://git.k8s.io/design-proposals-archive/resource-management/admission_control_limit_range.md)。
 
 <!--
 A namespace can be in one of two phases:
@@ -169,7 +170,8 @@ More information on `finalizers` can be found in the namespace [design doc](http
 -->
 可选字段 `finalizers` 允许观察者们在名字空间被删除时清除资源。记住如果指定了一个不存在的终结器，名字空间仍会被创建，但如果用户试图删除它，它将陷入 `Terminating` 状态。
 
-更多有关 `finalizers` 的信息请查阅 [设计文档](https://git.k8s.io/community/contributors/design-proposals/architecture/namespaces.md#finalizers) 中名字空间部分。
+更多有关 `finalizers` 的信息请查阅
+[设计文档](https://git.k8s.io/design-proposals-archive/architecture/namespaces.md#finalizers)中名字空间部分。
 
 <!-- ## Deleting a namespace -->
 ## 删除名字空间
@@ -510,5 +512,5 @@ across namespaces, you need to use the fully qualified domain name (FQDN).
 
 * 进一步了解[设置名字空间偏好](/zh-cn/docs/concepts/overview/working-with-objects/namespaces/#setting-the-namespace-preference)
 * 进一步了解[设置请求的名字空间](/zh-cn/docs/concepts/overview/working-with-objects/namespaces/#setting-the-namespace-for-a-request)
-* 参阅[名字空间的设计文档](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture/namespaces.md)
+* 参阅[名字空间的设计文档](https://git.k8s.io/design-proposals-archive/architecture/namespaces.md)
 

--- a/content/zh-cn/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
+++ b/content/zh-cn/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
@@ -462,10 +462,10 @@ PersistentVolume are not present on the Pod resource itself.
 
 <!--
 * Learn more about [PersistentVolumes](/docs/concepts/storage/persistent-volumes/).
-* Read the [Persistent Storage design document](https://git.k8s.io/community/contributors/design-proposals/storage/persistent-storage.md).
+* Read the [Persistent Storage design document](https://git.k8s.io/design-proposals-archive/storage/persistent-storage.md).
 -->
 * 进一步了解 [PersistentVolumes](/zh-cn/docs/concepts/storage/persistent-volumes/)
-* 阅读[持久存储设计文档](https://git.k8s.io/community/contributors/design-proposals/storage/persistent-storage.md)
+* 阅读[持久存储设计文档](https://git.k8s.io/design-proposals-archive/storage/persistent-storage.md)
 
 <!--
 ### Reference

--- a/content/zh-cn/docs/tasks/configure-pod-container/configure-projected-volume-storage.md
+++ b/content/zh-cn/docs/tasks/configure-pod-container/configure-projected-volume-storage.md
@@ -123,9 +123,9 @@ kubectl delete secret user pass
 
 <!--
 * Learn more about [`projected`](/docs/concepts/storage/volumes/#projected) volumes.
-* Read the [all-in-one volume](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node/all-in-one-volume.md) design document.
+* Read the [all-in-one volume](https://git.k8s.io/design-proposals-archive/node/all-in-one-volume.md) design document.
 -->
 
 * 进一步了解[`projected`](/zh-cn/docs/concepts/storage/volumes/#projected) 卷。
-* 阅读[一体卷](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node/all-in-one-volume.md)设计文档。
+* 阅读[一体卷](https://git.k8s.io/design-proposals-archive/node/all-in-one-volume.md)设计文档。
 

--- a/content/zh-cn/docs/tasks/configure-pod-container/security-context.md
+++ b/content/zh-cn/docs/tasks/configure-pod-container/security-context.md
@@ -721,7 +721,7 @@ Pod 的安全上下文适用于 Pod 中的容器，也适用于 Pod 所挂载的
 <!--
 * `fsGroup`: Volumes that support ownership management are modified to be owned
   and writable by the GID specified in `fsGroup`. See the
-  [Ownership Management design document](https://git.k8s.io/community/contributors/design-proposals/storage/volume-ownership-management.md)
+  [Ownership Management design document](https://git.k8s.io/design-proposals-archive/storage/volume-ownership-management.md)
   for more details.
 
 * `seLinuxOptions`: Volumes that support SELinux labeling are relabeled to be accessible
@@ -732,7 +732,7 @@ Pod 的安全上下文适用于 Pod 中的容器，也适用于 Pod 所挂载的
 -->
 * `fsGroup`：支持属主管理的卷会被修改，将其属主变更为 `fsGroup` 所指定的 GID，
   并且对该 GID 可写。进一步的细节可参阅
-  [属主变更设计文档](https://git.k8s.io/community/contributors/design-proposals/storage/volume-ownership-management.md)。
+  [属主变更设计文档](https://git.k8s.io/design-proposals-archive/storage/volume-ownership-management.md)。
 
 * `seLinuxOptions`：支持 SELinux 标签的卷会被重新打标签，以便可被 `seLinuxOptions`
   下所设置的标签访问。通常你只需要设置 `level` 部分。
@@ -771,11 +771,11 @@ kubectl delete pod security-context-demo-4
 * [PodSecurityContext](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#podsecuritycontext-v1-core)
 * [SecurityContext](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#securitycontext-v1-core)
 * [Tuning Docker with the newest security enhancements](https://github.com/containerd/containerd/blob/main/docs/cri/config.md)
-* [Security Contexts design document](https://git.k8s.io/community/contributors/design-proposals/auth/security_context.md)
-* [Ownership Management design document](https://git.k8s.io/community/contributors/design-proposals/storage/volume-ownership-management.md)
+* [Security Contexts design document](https://git.k8s.io/design-proposals-archive/auth/security_context.md)
+* [Ownership Management design document](https://git.k8s.io/design-proposals-archive/storage/volume-ownership-management.md)
 * [Pod Security Policies](/docs/concepts/security/pod-security-policy/)
 * [AllowPrivilegeEscalation design
-  document](https://git.k8s.io/community/contributors/design-proposals/auth/no-new-privs.md)
+  document](https://git.k8s.io/design-proposals-archive/auth/no-new-privs.md)
 * For more information about security mechanisms in Linux, see
   [Overview of Linux Kernel Security Features](https://www.linux.com/learn/overview-linux-kernel-security-features)
 -->

--- a/content/zh-cn/docs/tasks/debug/debug-cluster/resource-metrics-pipeline.md
+++ b/content/zh-cn/docs/tasks/debug/debug-cluster/resource-metrics-pipeline.md
@@ -238,7 +238,7 @@ repository. You must enable the [API aggregation layer](/docs/tasks/extend-kuber
 and register an [APIService](/docs/reference/kubernetes-api/cluster-resources/api-service-v1/)
 for the `metrics.k8s.io` API.
 
-To learn more about the Metrics API, see [resource metrics API design](https://github.com/kubernetes/design-proposals-archive/blob/main/instrumentation/resource-metrics-api.md),
+To learn more about the Metrics API, see [resource metrics API design](https://git.k8s.io/design-proposals-archive/instrumentation/resource-metrics-api.md),
 the [metrics-server repository](https://github.com/kubernetes-sigs/metrics-server) and the
 [resource metrics API](https://github.com/kubernetes/metrics#resource-metrics-api).
 -->
@@ -248,7 +248,7 @@ Metrics API 在 [k8s.io/metrics](https://github.com/kubernetes/metrics) 代码�
 `metrics.k8s.io` API 注册一个 [APIService](/zh-cn/docs/reference/kubernetes-api/cluster-resources/api-service-v1/)。
 
 要了解有关 Metrics API 的更多信息，
-请参阅资源 [Resource Metrics API Design](https://github.com/kubernetes/design-proposals-archive/blob/main/instrumentation/resource-metrics-api.md)、
+请参阅资源 [Resource Metrics API Design](https://git.k8s.io/design-proposals-archive/instrumentation/resource-metrics-api.md)、
 [metrics-server 代码库](https://github.com/kubernetes-sigs/metrics-server) 和
 [Resource Metrics API](https://github.com/kubernetes/metrics#resource-metrics-api)。
 
@@ -362,7 +362,7 @@ To learn more about the metrics-server, see the
 
 You can also check out the following:
 
-* [metrics-server design](https://github.com/kubernetes/design-proposals-archive/blob/main/instrumentation/metrics-server.md)
+* [metrics-server design](https://git.k8s.io/design-proposals-archive/instrumentation/metrics-server.md)
 * [metrics-server FAQ](https://github.com/kubernetes-sigs/metrics-server/blob/master/FAQ.md)
 * [metrics-server known issues](https://github.com/kubernetes-sigs/metrics-server/blob/master/KNOWN_ISSUES.md)
 * [metrics-server releases](https://github.com/kubernetes-sigs/metrics-server/releases)
@@ -373,7 +373,7 @@ You can also check out the following:
 
 你还可以查看以下内容：
 
-* [metrics-server 设计](https://github.com/kubernetes/design-proposals-archive/blob/main/instrumentation/metrics-server.md)
+* [metrics-server 设计](https://git.k8s.io/design-proposals-archive/instrumentation/metrics-server.md)
 * [metrics-server FAQ](https://github.com/kubernetes-sigs/metrics-server/blob/master/FAQ.md)
 * [metrics-server known issues](https://github.com/kubernetes-sigs/metrics-server/blob/master/KNOWN_ISSUES.md)
 * [metrics-server releases](https://github.com/kubernetes-sigs/metrics-server/releases)

--- a/content/zh-cn/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/zh-cn/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -607,14 +607,14 @@ APIs, cluster administrators must ensure that:
 
 <!--
 For more information on these different metrics paths and how they differ please see the relevant design proposals for
-[the HPA V2](https://github.com/kubernetes/design-proposals-archive/blob/main/autoscaling/hpa-v2.md),
-[custom.metrics.k8s.io](https://github.com/kubernetes/design-proposals-archive/blob/main/instrumentation/custom-metrics-api.md)
-and [external.metrics.k8s.io](https://github.com/kubernetes/design-proposals-archive/blob/main/instrumentation/external-metrics-api.md).
+[the HPA V2](https://git.k8s.io/design-proposals-archive/autoscaling/hpa-v2.md),
+[custom.metrics.k8s.io](https://git.k8s.io/design-proposals-archive/instrumentation/custom-metrics-api.md)
+and [external.metrics.k8s.io](https://git.k8s.io/design-proposals-archive/instrumentation/external-metrics-api.md).
 -->
 关于指标来源以及其区别的更多信息，请参阅相关的设计文档，
-[HPA V2](https://github.com/kubernetes/design-proposals-archive/blob/main/autoscaling/hpa-v2.md)，
-[custom.metrics.k8s.io](https://github.com/kubernetes/design-proposals-archive/blob/main/instrumentation/custom-metrics-api.md) 和
-[external.metrics.k8s.io](https://github.com/kubernetes/design-proposals-archive/blob/main/instrumentation/external-metrics-api.md)。
+[HPA V2](https://git.k8s.io/design-proposals-archive/autoscaling/hpa-v2.md)，
+[custom.metrics.k8s.io](https://git.k8s.io/design-proposals-archive/instrumentation/custom-metrics-api.md) 和
+[external.metrics.k8s.io](https://git.k8s.io/design-proposals-archive/instrumentation/external-metrics-api.md)。
 
 <!--
 For examples of how to use them see [the walkthrough for using custom metrics](/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-multiple-metrics-and-custom-metrics)

--- a/content/zh-cn/releases/release.md
+++ b/content/zh-cn/releases/release.md
@@ -219,7 +219,7 @@ The general labeling process should be consistent across artifact types.
   referring to a release MAJOR.MINOR `vX.Y` version.
 
   See also
-  [release versioning](/contributors/design-proposals/release/versioning.md).
+  [release versioning](https://git.k8s.io/sig-release/release-engineering/versioning.md).
 
 - *release branch*: Git branch `release-X.Y` created for the `vX.Y` milestone.
 
@@ -233,7 +233,7 @@ The general labeling process should be consistent across artifact types.
   [GitHub 里程碑](https://help.github.com/en/github/managing-your-work-on-github/associating-milestones-with-issues-and-pull-requests)
   指的是发布 主.次 `vX.Y` 版本。
 
-  另请参阅[发布版本控制](/contributors/design-proposals/release/versioning.md)。
+  另请参阅[发布版本控制](https://git.k8s.io/sig-release/release-engineering/versioning.md)。
 
 - **发布分支**：为 `vX.Y` 里程碑创建的 Git 分支 `release-X.Y`。
 

--- a/content/zh-cn/releases/version-skew-policy.md
+++ b/content/zh-cn/releases/version-skew-policy.md
@@ -32,7 +32,7 @@ Specific cluster deployment tools may place additional restrictions on version s
 ## Supported versions
 
 Kubernetes versions are expressed as **x.y.z**, where **x** is the major version, **y** is the minor version, and **z** is the patch version, following [Semantic Versioning](https://semver.org/) terminology.
-For more information, see [Kubernetes Release Versioning](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md#kubernetes-release-versioning).
+For more information, see [Kubernetes Release Versioning](https://git.k8s.io/sig-release/release-engineering/versioning.md#kubernetes-release-versioning).
 
 The Kubernetes project maintains release branches for the most recent three minor releases ({{< skew currentVersion >}}, {{< skew currentVersionAddMinor -1 >}}, {{< skew currentVersionAddMinor -2 >}}).  Kubernetes 1.19 and newer receive approximately 1 year of patch support. Kubernetes 1.18 and older received approximately 9 months of patch support.
 -->
@@ -41,7 +41,7 @@ The Kubernetes project maintains release branches for the most recent three mino
 Kubernetes 版本以 **x.y.z** 表示，其中 **x** 是主要版本，
 **y** 是次要版本，**z** 是补丁版本，遵循[语义版本控制](https://semver.org/)术语。
 更多信息请参见
-[Kubernetes 版本发布控制](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md#kubernetes-release-versioning)。
+[Kubernetes 版本发布控制](https://git.k8s.io/sig-release/release-engineering/versioning.md#kubernetes-release-versioning)。
 
 Kubernetes 项目维护最近的三个次要版本（{{< skew currentVersion >}}、{{< skew currentVersionAddMinor -1 >}}、{{< skew currentVersionAddMinor -2 >}}）的发布分支。
 Kubernetes 1.19 和更新的版本获得大约 1 年的补丁支持。


### PR DESCRIPTION
The contributors/design-proposals in k/community was removed. It's only
available in k/design-proposals-archive repo now.

reforence #34155
fix #35037 
