### PR TITLE
Clarify handling of projected SA token permissions

### DIFF
--- a/content/en/docs/concepts/storage/projected-volumes.md
+++ b/content/en/docs/concepts/storage/projected-volumes.md
@@ -77,16 +77,21 @@ The [proposal](https://github.com/kubernetes/enhancements/tree/master/keps/sig-s
 
 #### Linux
 
-Kubernetes will improve security for serviceAccountToken files when all containers
-have the same `runAsUser` set in
+In some cases, Kubernetes applies a security optimization for the contents of`serviceAccountToken`
+volumes.
+When all containers in a pod have the same `runAsUser` set in their
 [`PodSecurityContext`](/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context)
 or container
-[`SecurityContext`](/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1)
-by setting the file owner to the `runAsUser` and the file mode to `0600`.
+[`SecurityContext`](/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1),
+then the kubelet  ensures that the contents of the `serviceAccountToken` volume are owned by that user,
+and that every file has its permission mode set to `0600`.
 
-Note that {{< glossary_tooltip text="ephemeral containers" term_id="ephemeral-container" >}}
-aren't present when the pod is created. Adding an ephemeral container to a pod
-will not change the permissions that were set when the pod was created.
+{{< note >}}
+If you add any {{< glossary_tooltip text="ephemeral containers" term_id="ephemeral-container" >}} to
+a Pod, those won't have been present when the pod started running on that node.
+Adding an ephemeral container to a pod does **not** change any volume permissions
+that were set when the pod was created.
+{{< /note >}}
 
 #### Windows
 

--- a/content/en/docs/concepts/storage/projected-volumes.md
+++ b/content/en/docs/concepts/storage/projected-volumes.md
@@ -77,7 +77,7 @@ The [proposal](https://github.com/kubernetes/enhancements/tree/master/keps/sig-s
 
 #### Linux
 
-In some cases, Kubernetes applies a security optimization for the contents of`serviceAccountToken`
+In some cases, Kubernetes applies a security optimization for the contents of `serviceAccountToken`
 volumes.
 When all containers in a pod have the same `runAsUser` set in their
 [`PodSecurityContext`](/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context)

--- a/content/en/docs/concepts/storage/projected-volumes.md
+++ b/content/en/docs/concepts/storage/projected-volumes.md
@@ -71,18 +71,24 @@ A container using a projected volume source as a [`subPath`](/docs/concepts/stor
 volume mount will not receive updates for those volume sources.
 {{< /note >}}
 
-## SecurityContext interactions
+### serviceAccountToken and securityContext
 
 The [proposal](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/2451-service-account-token-volumes#proposal) for file permission handling in projected service account volume enhancement introduced the projected files having the the correct owner permissions set.
 
-### Linux
+#### Linux
 
-In Linux pods that have a projected volume and `RunAsUser` set in the Pod
-[`SecurityContext`](/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context),
-the projected files have the correct ownership set including container user
-ownership.
+Kubernetes will improve security for serviceAccountToken files when all containers
+have the same `runAsUser` set in
+[`PodSecurityContext`](/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context)
+or container
+[`SecurityContext`](/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1)
+by setting the file owner to the `runAsUser` and the file mode to `0600`.
 
-### Windows
+Note that {{< glossary_tooltip text="ephemeral containers" term_id="ephemeral-container" >}}
+aren't present when the pod is created. Adding an ephemeral container to a pod
+will not change the permissions that were set when the pod was created.
+
+#### Windows
 
 In Windows pods that have a projected volume and `RunAsUsername` set in the
 Pod `SecurityContext`, the ownership is not enforced due to the way user

--- a/content/en/docs/concepts/storage/projected-volumes.md
+++ b/content/en/docs/concepts/storage/projected-volumes.md
@@ -71,14 +71,17 @@ A container using a projected volume source as a [`subPath`](/docs/concepts/stor
 volume mount will not receive updates for those volume sources.
 {{< /note >}}
 
-### serviceAccountToken and securityContext
+## SecurityContext interactions
 
 The [proposal](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/2451-service-account-token-volumes#proposal) for file permission handling in projected service account volume enhancement introduced the projected files having the the correct owner permissions set.
 
-#### Linux
+### Linux
 
-In some cases, Kubernetes applies a security optimization for the contents of `serviceAccountToken`
-volumes.
+In Linux pods that have a projected volume and `RunAsUser` set in the Pod
+[`SecurityContext`](/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context),
+the projected files have the correct ownership set including container user
+ownership.
+
 When all containers in a pod have the same `runAsUser` set in their
 [`PodSecurityContext`](/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context)
 or container
@@ -96,7 +99,7 @@ all other containers in the Pod have the same `runAsUser`, ephemeral
 containers must use the same `runAsUser` to be able to read the token.
 {{< /note >}}
 
-#### Windows
+### Windows
 
 In Windows pods that have a projected volume and `RunAsUsername` set in the
 Pod `SecurityContext`, the ownership is not enforced due to the way user

--- a/content/en/docs/concepts/storage/projected-volumes.md
+++ b/content/en/docs/concepts/storage/projected-volumes.md
@@ -87,10 +87,13 @@ then the kubelet  ensures that the contents of the `serviceAccountToken` volume 
 and that every file has its permission mode set to `0600`.
 
 {{< note >}}
-If you add any {{< glossary_tooltip text="ephemeral containers" term_id="ephemeral-container" >}} to
-a Pod, those won't have been present when the pod started running on that node.
-Adding an ephemeral container to a pod does **not** change any volume permissions
-that were set when the pod was created.
+{{< glossary_tooltip text="Ephemeral containers" term_id="ephemeral-container" >}}
+added to a Pod after it is created do *not* change volume permissions that were
+set when the pod was created.
+
+If a Pod's `serviceAccountToken` volume permissions were set to `0600` because
+all other containers in the Pod have the same `runAsUser`, ephemeral
+containers must use the same `runAsUser` to be able to read the token.
 {{< /note >}}
 
 #### Windows

--- a/content/en/docs/concepts/storage/projected-volumes.md
+++ b/content/en/docs/concepts/storage/projected-volumes.md
@@ -86,8 +86,8 @@ When all containers in a pod have the same `runAsUser` set in their
 [`PodSecurityContext`](/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context)
 or container
 [`SecurityContext`](/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1),
-then the kubelet  ensures that the contents of the `serviceAccountToken` volume are owned by that user,
-and that every file has its permission mode set to `0600`.
+then the kubelet ensures that the contents of the `serviceAccountToken` volume are owned by that user,
+and the token file has its permission mode set to `0600`.
 
 {{< note >}}
 {{< glossary_tooltip text="Ephemeral containers" term_id="ephemeral-container" >}}


### PR DESCRIPTION
**Problem:**

Projected Volumes have special handling for `serviceAccountTokens` that causes them to disregard `defaultMode` when all containers in a pod have the same `runAsUser`. This undocumented behavior led to a bug report in kubernetes/kubernetes#106365

**Proposed Solution:**

Update projected volumes doc to explain special behavior:

- When all containers specified at pod creation have the same `runAsUser`, the `serviceAccountToken` will use this user as the file owner and set mode `0600`.
- Ephemeral containers are never present at pod creation, so ephemeralContainer `runAsUser` aren't considered in this behavior.

**Page to Update:**
https://kubernetes.io/docs/concepts/storage/projected-volumes/

Fixes: #32351
Supersedes: #32354