### PR TITLE
[zh-cn] updated /kubernetes-api/authorization-resources/

### DIFF
--- a/content/zh-cn/docs/reference/kubernetes-api/authorization-resources/self-subject-access-review-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/authorization-resources/self-subject-access-review-v1.md
@@ -45,8 +45,8 @@ Self 是一个特殊情况，因为用户应始终能够检查自己是否可以
 -->
 - **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
 
-  标准的列表元数据。
-  更多信息：https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+  标准的列表元数据。更多信息：
+  https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 
 - **spec** (<a href="{{< ref "../authorization-resources/self-subject-access-review-v1#SelfSubjectAccessReviewSpec" >}}">SelfSubjectAccessReviewSpec</a>)，必需
   

--- a/content/zh-cn/docs/reference/kubernetes-api/authorization-resources/self-subject-rules-review-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/authorization-resources/self-subject-rules-review-v1.md
@@ -30,7 +30,7 @@ SelfSubjectRulesReview 枚举当前用户可以在某命名空间内执行的操
 返回的操作列表可能不完整，具体取决于服务器的鉴权模式以及评估过程中遇到的任何错误。
 SelfSubjectRulesReview 应由 UI 用于显示/隐藏操作，或让最终用户尽快理解自己的权限。
 SelfSubjectRulesReview 不得被外部系统使用以驱动鉴权决策，
-因为这会引起混淆代理人（confused deputy）、缓存有效期/吊销（cache lifetime/revocation）和正确性问题。
+因为这会引起混淆代理人（Confused deputy）、缓存有效期/吊销（Cache lifetime/revocation）和正确性问题。
 SubjectAccessReview 和 LocalAccessReview 是遵从 API 服务器所做鉴权决策的正确方式。
 
 <hr>
@@ -49,8 +49,8 @@ SubjectAccessReview 和 LocalAccessReview 是遵从 API 服务器所做鉴权决
 -->  
 - **metadata** (<a href="{{< ref "../common-definitions/object-meta#ObjectMeta" >}}">ObjectMeta</a>)
 
-  标准的列表元数据。
-  更多信息：https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+  标准的列表元数据。更多信息：
+  https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 
 - **spec** (<a href="{{< ref "../authorization-resources/self-subject-rules-review-v1#SelfSubjectRulesReviewSpec" >}}">SelfSubjectRulesReviewSpec</a>)，必需
   
@@ -60,12 +60,6 @@ SubjectAccessReview 和 LocalAccessReview 是遵从 API 服务器所做鉴权决
   Status is filled in by the server and indicates the set of actions a user can perform.
   <a name="SubjectRulesReviewStatus"></a>
   *SubjectRulesReviewStatus contains the result of a rules check. This check can be incomplete depending on the set of authorizers the server is configured with and any errors experienced during evaluation. Because authorization rules are additive, if a rule appears in a list it's safe to assume the subject has that permission, even if that list is incomplete.*
-  - **status.incomplete** (boolean), required
-    Incomplete is true when the rules returned by this call are incomplete. This is most commonly encountered when an authorizer, such as an external authorizer, doesn't support rules evaluation.
-  - **status.nonResourceRules** ([]NonResourceRule), required
-    NonResourceRules is the list of actions the subject is allowed to perform on non-resources. The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
-    <a name="NonResourceRule"></a>
-    *NonResourceRule holds information that describes a rule for the non-resource*
 -->
 - **status** (SubjectRulesReviewStatus)
   
@@ -75,6 +69,15 @@ SubjectAccessReview 和 LocalAccessReview 是遵从 API 服务器所做鉴权决
   **SubjectRulesReviewStatus 包含规则检查的结果。
   此检查可能不完整，具体取决于服务器配置的 Authorizer 的集合以及评估期间遇到的任何错误。
   由于鉴权规则是叠加的，所以如果某个规则出现在列表中，即使该列表不完整，也可以安全地假定该主体拥有该权限。**
+
+  <!--
+  - **status.incomplete** (boolean), required
+    Incomplete is true when the rules returned by this call are incomplete. This is most commonly encountered when an authorizer, such as an external authorizer, doesn't support rules evaluation.
+  - **status.nonResourceRules** ([]NonResourceRule), required
+    NonResourceRules is the list of actions the subject is allowed to perform on non-resources. The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
+    <a name="NonResourceRule"></a>
+    *NonResourceRule holds information that describes a rule for the non-resource*
+  -->
 
   - **status.incomplete** (boolean)，必需
     
@@ -88,28 +91,33 @@ SubjectAccessReview 和 LocalAccessReview 是遵从 API 服务器所做鉴权决
     
     <a name="NonResourceRule"></a>
     **nonResourceRule 包含描述非资源路径的规则的信息。**
-<!--
+
+    <!--
     - **status.nonResourceRules.verbs** ([]string), required
       Verb is a list of kubernetes non-resource API verbs, like: get, post, put, delete, patch, head, options.  "*" means all.
     - **status.nonResourceRules.nonResourceURLs** ([]string)
-      NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path.  "*" means all.
+      NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path.  "*" means all. 
+    -->
+
+    - **status.nonResourceRules.verbs** ([]string)，必需
+      
+      verb 是 kubernetes 非资源 API 动作的列表，例如 get、post、put、delete、patch、head、options。
+      `*` 表示所有动作。
+    
+    - **status.nonResourceRules.nonResourceURLs** ([]string)
+      
+      nonResourceURLs 是用户应有权访问的一组部分 URL。
+      允许使用 `*`，但仅能作为路径中最后一段且必须用于完整的一段。
+      `*` 表示全部。
+      
+  <!--
   - **status.resourceRules** ([]ResourceRule), required
     ResourceRules is the list of actions the subject is allowed to perform on resources. The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
     <a name="ResourceRule"></a>
     *ResourceRule is the list of actions the subject is allowed to perform on resources. The list ordering isn't significant, may contain duplicates, and possibly be incomplete.*
     - **status.resourceRules.verbs** ([]string), required
-    Verb is a list of kubernetes resource API verbs, like: get, list, watch, create, update, delete, proxy.  "*" means all.  
--->
-    - **status.nonResourceRules.verbs** ([]string)，必需
-      
-      verb 是 kubernetes 非资源 API 动作的列表，例如 get、post、put、delete、patch、head、options。
-      "*" 表示所有动作。
-    
-    - **status.nonResourceRules.nonResourceURLs** ([]string)
-      
-      nonResourceURLs 是用户应有权访问的一组部分 URL。
-      允许使用 "*"，但仅能作为路径中最后一段且必须用于完整的一段。
-      "*" 表示全部。
+    Verb is a list of kubernetes resource API verbs, like: get, list, watch, create, update, delete, proxy.  "*" means all. 
+  -->
 
   - **status.resourceRules** ([]ResourceRule)，必需
     
@@ -122,8 +130,9 @@ SubjectAccessReview 和 LocalAccessReview 是遵从 API 服务器所做鉴权决
     - **status.resourceRules.verbs** ([]string)，必需
       
       verb 是 kubernetes 资源 API 动作的列表，例如 get、list、watch、create、update、delete、proxy。
-      "*" 表示所有动作。
-<!--
+      `*` 表示所有动作。
+
+    <!--
     - **status.resourceRules.apiGroups** ([]string)
       APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.  "*" means all.
     - **status.resourceRules.resourceNames** ([]string)
@@ -131,26 +140,30 @@ SubjectAccessReview 和 LocalAccessReview 是遵从 API 服务器所做鉴权决
     - **status.resourceRules.resources** ([]string)
       Resources is a list of resources this rule applies to.  "*" means all in the specified apiGroups.
        "*/foo" represents the subresource 'foo' for all resources in the specified apiGroups.
-  - **status.evaluationError** (string)
-    EvaluationError can appear in combination with Rules. It indicates an error occurred during rule evaluation, such as an authorizer that doesn't support rule evaluation, and that ResourceRules and/or NonResourceRules may be incomplete.
---> 
+    -->
+
     - **status.resourceRules.apiGroups** ([]string)
       
       apiGroups 是包含资源的 APIGroup 的名称。
       如果指定了多个 API 组，则允许对任何 API 组中枚举的资源之一请求任何操作。
-      "*" 表示所有 APIGroup。
+      `*` 表示所有 APIGroup。
     
     - **status.resourceRules.resourceNames** ([]string)
       
       resourceNames 是此规则所适用的资源名称白名单，可选。
       空集合意味着允许所有资源。
-      "*" 表示所有资源。
+      `*` 表示所有资源。
     
     - **status.resourceRules.resources** ([]string)
       
       resources 是此规则所适用的资源的列表。
-      "*" 表示指定 APIGroup 中的所有资源。
-      "*/foo" 表示指定 APIGroup 中所有资源的子资源 "foo"。
+      `*` 表示指定 APIGroup 中的所有资源。
+      `*/foo` 表示指定 APIGroup 中所有资源的子资源 "foo"。
+
+  <!--
+  - **status.evaluationError** (string)
+    EvaluationError can appear in combination with Rules. It indicates an error occurred during rule evaluation, such as an authorizer that doesn't support rule evaluation, and that ResourceRules and/or NonResourceRules may be incomplete.
+  -->
 
   - **status.evaluationError** (string)
     

--- a/content/zh-cn/docs/reference/kubernetes-api/authorization-resources/subject-access-review-v1.md
+++ b/content/zh-cn/docs/reference/kubernetes-api/authorization-resources/subject-access-review-v1.md
@@ -43,8 +43,8 @@ SubjectAccessReview 检查用户或组是否可以执行某操作。
 - **status** (<a href="{{< ref "../authorization-resources/subject-access-review-v1#SubjectAccessReviewStatus" >}}">SubjectAccessReviewStatus</a>)
   Status is filled in by the server and indicates whether the request is allowed or not
 -->  
-  标准的列表元数据。
-  更多信息：https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+  标准的列表元数据。更多信息：
+  https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 
 - **spec** (<a href="{{< ref "../authorization-resources/subject-access-review-v1#SubjectAccessReviewSpec" >}}">SubjectAccessReviewSpec</a>)，必需
   


### PR DESCRIPTION
Some alignments and links are incorrect at [zh-cn/docs/reference/kubernetes-api/authorization-resources/self-subject-rules-review-v1/](https://kubernetes.io/zh-cn/docs/reference/kubernetes-api/authorization-resources/self-subject-rules-review-v1/)

Preview: https://deploy-preview-35067--kubernetes-io-main-staging.netlify.app/zh-cn/docs/reference/kubernetes-api/authorization-resources/self-subject-rules-review-v1/