### PR TITLE
Omit `apt-transport-https` from install

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -110,9 +110,19 @@ For example, to download version {{< param "fullversion" >}} on Linux, type:
 
    ```shell
    sudo apt-get update
-   sudo apt-get install -y apt-transport-https ca-certificates curl
+   sudo apt-get install -y ca-certificates curl
    ```
-
+   
+   {{< note >}}
+   
+   If you use Debian 9 (stretch) or earlier you would also need to install `apt-transport-https`:
+    
+    ```shell
+    sudo apt-get install -y apt-transport-https
+    ```
+   
+   {{< /note >}}
+   
 2. Download the Google Cloud public signing key:
 
    ```shell


### PR DESCRIPTION
Remove dummy package `apt-transport-https` from linux kubectl install instructions
Added note for users using Debian 9 or earlier

Fixes #34275 