### PR TITLE
Remove commas from kubelet configuration example

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubelet-config-file.md
+++ b/content/en/docs/tasks/administer-cluster/kubelet-config-file.md
@@ -30,9 +30,9 @@ Here is an example of what this file might look like:
 ```
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-address: "192.168.0.8",
-port: 20250,
-serializeImagePulls: false,
+address: "192.168.0.8"
+port: 20250
+serializeImagePulls: false
 evictionHard:
     memory.available:  "200Mi"
 ```

--- a/content/en/docs/tasks/administer-cluster/kubelet-config-file.md
+++ b/content/en/docs/tasks/administer-cluster/kubelet-config-file.md
@@ -28,13 +28,22 @@ in this struct. Make sure the Kubelet has read permissions on the file.
 
 Here is an example of what this file might look like:
 ```
-apiVersion: kubelet.config.k8s.io/v1beta1
-kind: KubeletConfiguration
-address: "192.168.0.8"
-port: 20250
-serializeImagePulls: false
-evictionHard:
-    memory.available:  "200Mi"
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubelet-config-1.20
+  namespace: kube-system
+data:
+  kubelet: |
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    kind: KubeletConfiguration
+    address: "192.168.0.8"
+    port: 20250
+    serializeImagePulls: false
+    evictionHard:
+      memory.available:  "200Mi"
+~                                  
+
 ```
 
 In the example, the Kubelet is configured to serve on IP address 192.168.0.8 and port 20250, pull images in parallel,


### PR DESCRIPTION
the commas caused kubelet service to fail to start. should be omitted.