### PR TITLE
[ko] Update outdated files in dev-1.24-ko.2 'M118-M125'

### DIFF
--- a/content/ko/examples/application/mysql/mysql-configmap.yaml
+++ b/content/ko/examples/application/mysql/mysql-configmap.yaml
@@ -4,15 +4,14 @@ metadata:
   name: mysql
   labels:
     app: mysql
+    app.kubernetes.io/name: mysql
 data:
   primary.cnf: |
     # Primary에만 이 구성을 적용한다.
     [mysqld]
-    log-bin
-    datadir=/var/lib/mysql/mysql
+    log-bin    
   replica.cnf: |
     # 레플리카에만 이 구성을 적용한다.
     [mysqld]
-    super-read-only
-    datadir=/var/lib/mysql/mysql
+    super-read-only    
 

--- a/content/ko/examples/application/mysql/mysql-services.yaml
+++ b/content/ko/examples/application/mysql/mysql-services.yaml
@@ -5,6 +5,7 @@ metadata:
   name: mysql
   labels:
     app: mysql
+    app.kubernetes.io/name: mysql
 spec:
   ports:
   - name: mysql
@@ -21,6 +22,8 @@ metadata:
   name: mysql-read
   labels:
     app: mysql
+    app.kubernetes.io/name: mysql
+    readonly: "true"
 spec:
   ports:
   - name: mysql

--- a/content/ko/examples/application/mysql/mysql-statefulset.yaml
+++ b/content/ko/examples/application/mysql/mysql-statefulset.yaml
@@ -6,12 +6,14 @@ spec:
   selector:
     matchLabels:
       app: mysql
+      app.kubernetes.io/name: mysql
   serviceName: mysql
   replicas: 3
   template:
     metadata:
       labels:
         app: mysql
+        app.kubernetes.io/name: mysql
     spec:
       initContainers:
       - name: init-mysql

--- a/content/ko/examples/controllers/job.yaml
+++ b/content/ko/examples/controllers/job.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: pi
-        image: perl
+        image: perl:5.34.0
         command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
       restartPolicy: Never
   backoffLimit: 4

--- a/content/ko/examples/pods/pod-with-affinity-anti-affinity.yaml
+++ b/content/ko/examples/pods/pod-with-affinity-anti-affinity.yaml
@@ -30,4 +30,4 @@ spec:
             - key-2
   containers:
   - name: with-node-affinity
-    image: k8s.gcr.io/pause:2.0
+    image: k8s.gcr.io/pause:2.0 

--- a/content/ko/includes/task-tutorial-prereqs.md
+++ b/content/ko/includes/task-tutorial-prereqs.md
@@ -2,7 +2,7 @@
 통신할 수 있도록 설정되어 있어야 한다. 이 튜토리얼은 컨트롤 플레인 호스트가 아닌 노드가 적어도 2개 포함된 클러스터에서 실행하는 것을 추천한다. 만약, 아직 클러스터를 가지고
 있지 않다면,
 [minikube](/ko/docs/tasks/tools/#minikube)를 사용해서 생성하거나
-다음의 쿠버네티스 플레이그라운드 중 하나를 사용할 수 있다.
+다음 쿠버네티스 플레이그라운드 중 하나를 사용할 수 있다.
 
-* [Killercoda](https://killercoda.com/playgrounds/scenario/kubernetes)
+* [Killercoda](https://killercoda.com/playgrounds/scenario/kubernetes) 
 * [Play with Kubernetes](https://labs.play-with-k8s.com/)

--- a/content/ko/releases/_index.md
+++ b/content/ko/releases/_index.md
@@ -12,7 +12,7 @@ type: docs
 쿠버네티스 버전은 **x.y.z** 의 형태로 표현되는데,
 **x** 는 메이저(major) 버전, **y** 는 마이너(minor), **z** 는 패치(patch) 버전을 의미하며, 이는 [시맨틱 버전](https://semver.org/)의 용어를 따른 것이다.
 
-저 자세한 정보는 [버전 차이(skew) 정책](/releases/version-skew-policy/) 문서에서 확인하길 바란다.
+자세한 정보는 [버전 차이(skew) 정책](/releases/version-skew-policy/) 문서에서 확인하길 바란다.
 
 <!-- body -->
 

--- a/content/ko/releases/version-skew-policy.md
+++ b/content/ko/releases/version-skew-policy.md
@@ -21,12 +21,12 @@ description: >
 ## 지원되는 버전
 
 쿠버네티스 버전은 **x.y.z** 로 표현되는데, 여기서 **x** 는 메이저 버전, **y** 는 마이너 버전, **z** 는 패치 버전을 의미하며, 이는 [시맨틱 버전](https://semver.org/) 용어에 따른 것이다.
-자세한 내용은 [쿠버네티스 릴리스 버전](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md#kubernetes-release-versioning)을 참조한다.
+자세한 내용은 [쿠버네티스 릴리스 버전](https://git.k8s.io/design-proposals-archive/release/versioning.md#kubernetes-release-versioning)을 참조한다.
 
 쿠버네티스 프로젝트는 최근 세 개의 마이너 릴리스 ({{< skew latestVersion >}}, {{< skew prevMinorVersion >}}, {{< skew oldestMinorVersion >}}) 에 대한 릴리스 분기를 유지한다. 쿠버네티스 1.19 이상은 약 1년간의 패치 지원을 받는다. 쿠버네티스 1.18 이상은 약 9개월의 패치 지원을 받는다.
 
 보안 수정사항을 포함한 해당 수정사항은 심각도와 타당성에 따라 세 개의 릴리스 브랜치로 백포트(backport) 될 수 있다.
-패치 릴리스는 각 브랜치별로 [정기적인 주기](https://git.k8s.io/sig-release/releases/patch-releases.md#cadence)로 제공하며, 필요한 경우 추가 긴급 릴리스도 추가한다.
+패치 릴리스는 각 브랜치별로 [정기적인 주기](/releases/patch-releases/#cadence)로 제공하며, 필요한 경우 추가 긴급 릴리스도 추가한다.
 
 [릴리스 관리자](/releases/release-managers/) 그룹이 이러한 결정 권한을 가진다.
 


### PR DESCRIPTION
M118~M125 변경사항을 반영한 2차 작업입니다.
Related issue: https://github.com/kubernetes/website/issues/34903

8 files to be modified

- [ ] `M118. content/en/examples/application/mysql/mysql-configmap.yaml` | 1(+XS) 2(-)
- [ ]  `M119. content/en/examples/application/mysql/mysql-services.yaml` | 3(+XS) 0(-)
- [ ]  `M120. content/en/examples/application/mysql/mysql-statefulset.yaml` | 2(+XS) 0(-)
- [ ]  `M121. content/en/examples/controllers/job.yaml` | 1(+XS) 1(-)
- [ ]  `M122. content/en/examples/pods/pod-with-affinity-anti-affinity.yaml` | 4(+XS) 3(-)
- [ ]  `M123. content/en/includes/task-tutorial-prereqs.md` | 1(+XS) 1(-)
- [ ]  `M124. content/en/releases/_index.md` | 2(+XS) 2(-)
- [ ]  `M125. content/en/releases/version-skew-policy.md` | 32(+M) 32(-)

M125. content/en/releases/version-skew-policy.md
아래 skew 명칭 변경은 영문 문서 참고하여 전체 적용했습니다.

latestVersion->currentVersion
prevMinorVersion->currentVersionAddMinor -1
skew oldestMinorVersion->currentVersionAddMinor -2

/language ko



