### PR TITLE
fix translation to make it grammatically correct

### DIFF
--- a/content/pl/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro.html
+++ b/content/pl/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro.html
@@ -72,7 +72,7 @@ weight: 10
         <div class="row">
             <div class="col-md-8">
                 <p><b>Warstwa sterowania odpowiada za zarządzanie klastrem.</b> Warstwa sterowania koordynuje wszystkie działania klastra, takie jak zlecanie uruchomienia aplikacji, utrzymywanie pożądanego stanu aplikacji, skalowanie aplikacji i instalowanie nowych wersji.</p>
-                <p><b>Węzeł to maszyna wirtualna (VM) lub fizyczny serwer, który jest maszyną roboczą w klastrze Kubernetes.</b> Na każdym węźle działa Kubelet, agent zarządzający tym węzłem i komunikujący się z warstwą sterowania Kubernetesa. Węzeł zawiera także narzędzia do obsługi kontenerów, takie jak containerd lub Docker. Klaster Kubernetes w środowisku produkcyjnym powinien składać się minimum z trzech węzłów, ponieważ w przypadku awarii jednego węzła traci się zarówno element etcd, jak i warstwy sterowania i w ten sposób minimalną nadmiarowość (<em>redundancy</em>). Dodanie kolejnych węzłów warstwy sterowania może temu zapobiec.</p></p>
+                <p><b>Węzeł to maszyna wirtualna (VM) lub fizyczny serwer, który jest maszyną roboczą w klastrze Kubernetes.</b> Na każdym węźle działa Kubelet, agent zarządzający tym węzłem i komunikujący się z warstwą sterowania Kubernetesa. Węzeł zawiera także narzędzia do obsługi kontenerów, takie jak containerd lub Docker. Klaster Kubernetes w środowisku produkcyjnym powinien składać się minimum z trzech węzłów, ponieważ w przypadku awarii jednego węzła traci się zarówno element etcd, jak i warstwy sterowania przy jednoczesnym zachowaniu minimalnej nadmiarowości (<em>redundancy</em>). Dodanie kolejnych węzłów warstwy sterowania może temu zapobiec.</p></p>
 
             </div>
             <div class="col-md-4">


### PR DESCRIPTION
The English sentence
```
A Kubernetes cluster (...) should have a minimum of three nodes because (...) and redundancy is compromised.
```

was ungramatically translated which misses the point.