### PR TITLE
Update Release Managers description

### DIFF
--- a/content/en/releases/release-managers.md
+++ b/content/en/releases/release-managers.md
@@ -4,8 +4,8 @@ type: docs
 ---
 
 "Release Managers" is an umbrella term that encompasses the set of Kubernetes
-contributors responsible for maintaining release branches, tagging releases,
-and building/packaging Kubernetes.
+contributors responsible for maintaining release branches and creating releases
+by using the tools SIG Release provides.
 
 The responsibilities of each role are described below.
 


### PR DESCRIPTION
To be precise, Release Managers to not tag releases or build packages for Kubernetes. They mainly oversee the process and use the tools we provide in SIG Release.

cc @kubernetes/release-managers 

Refers to https://github.com/kubernetes/enhancements/pull/3434#discussion_r923105204