### PR TITLE
Edit and redo ConfigMap docs

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -657,7 +657,7 @@ data:
 
 ### Restrictions
 
-- You must create a ConfigMap before referencing it in a Pod specification, or mark the ConfigMap as "optional" (see [Optional ConfigMaps](#optional-configmaps)). If you reference a ConfigMap that doesn't exist, or hasn't been marked as "optional" the Pod won't start. Likewise, references to keys that don't exist in the ConfigMap will prevent the pod from starting.
+- You must create the `ConfigMap` object before you reference it in a Pod specification. Alternatively, mark the ConfigMap reference as `optional` in the Pod spec (see [Optional ConfigMaps](#optional-configmaps)). If you reference a ConfigMap that doesn't exist and you don't mark the reference as `optional`, the Pod won't start. Similarly, references to keys that don't exist in the ConfigMap will also prevent the Pod from starting, unless you mark the key references as `optional`.
 
 - If you use `envFrom` to define environment variables from ConfigMaps, keys that are considered invalid will be skipped. The pod will be allowed to start, but the invalid names will be recorded in the event log (`InvalidVariableNames`). The log message lists each skipped key. For example:
 
@@ -677,15 +677,11 @@ data:
 
 ### Optional ConfigMaps
 
-In a Pod, or pod template, you can mark a reference to a ConfigMap as _optional_.
-If the ConfigMap is non-existent, the configuration for which it provides data in the Pod (e.g. environment variable, mounted volume) will be empty.
+You can mark a reference to a ConfigMap as _optional_ in a Pod specification.
+If the ConfigMap doesn't exist, the configuration for which it provides data in the Pod (e.g. environment variable, mounted volume) will be empty.
 If the ConfigMap exists, but the referenced key is non-existent the data is also empty.
 
-#### Optional ConfigMap in environment variables
-
-There might be situations where environment variables are not always required.
-You can mark an environment variables for a container as optional,
-like this:
+For example, the following Pod specification marks an environment variable from a ConfigMap as optional:
 
 ```yaml
 apiVersion: v1
@@ -734,6 +730,7 @@ spec:
         name: no-config
         optional: true # mark the source ConfigMap as optional
   restartPolicy: Never
+```
 
 ### Mounted ConfigMaps are updated automatically
 

--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -10,7 +10,7 @@ card:
 <!-- overview -->
 Many applications rely on configuration which is used during either application initialization or runtime.
 Most of the times there is a requirement to adjust values assigned to configuration parameters.
-ConfigMaps is the Kubernetes way to inject application pods with configuration data.
+ConfigMaps are the Kubernetes way to inject application pods with configuration data.
 ConfigMaps allow you to decouple configuration artifacts from image content to keep containerized applications portable. This page provides a series of usage examples demonstrating how to create ConfigMaps and configure Pods using data stored in ConfigMaps.
 
 

--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -678,8 +678,8 @@ data:
 ### Optional ConfigMaps
 
 In a Pod, or pod template, you can mark a reference to a ConfigMap as _optional_.
-If the ConfigMap is non-existent, the mounted volume will be empty.
-If the ConfigMap exists, but the referenced key is non-existent the path will be absent beneath the mount point.
+If the ConfigMap is non-existent, the configuration for which it provides data in the Pod (e.g. environment variable, mounted volume) will be empty.
+If the ConfigMap exists, but the referenced key is non-existent the data is also empty.
 
 #### Optional ConfigMap in environment variables
 
@@ -739,10 +739,7 @@ spec:
   restartPolicy: Never
 ```
 
-If you run this pod, and there is no ConfigMap named `no-config`, the output is:
-
-```shell
-```
+If you run this pod, and there is no ConfigMap named `no-config`, the mounted volume will be empty.
 
 ### Mounted ConfigMaps are updated automatically
 

--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -677,7 +677,7 @@ data:
 
 ### Optional ConfigMaps
 
-A ConfigMap reference may be marked "optional".
+In a Pod, or pod template, you can mark a reference to a ConfigMap as _optional_.
 If the ConfigMap is non-existent, the mounted volume will be empty.
 If the ConfigMap exists, but the referenced key is non-existent the path will be absent beneath the mount point.
 

--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -707,7 +707,10 @@ spec:
   restartPolicy: Never
 ```
 
-When this Pod is run, the output will be empty.
+If you run this pod, and there is no ConfigMap named `a-config`, the output is empty.
+If you run this pod, and there is a ConfigMap named `a-config` but that ConfigMap doesn't have
+a key named `akey`, the output is also empty. If you do set a value for `akey` in the `a-config`
+ConfigMap, this pod prints that value and then terminates.
 
 #### Optional ConfigMap via volume plugin
 

--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -684,7 +684,8 @@ If the ConfigMap exists, but the referenced key is non-existent the path will be
 #### Optional ConfigMap in environment variables
 
 There might be situations where environment variables are not always required.
-These environment variables can be marked as optional in a pod like so:
+You can mark an environment variables for a container as optional,
+like this:
 
 ```yaml
 apiVersion: v1

--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -736,7 +736,7 @@ spec:
   restartPolicy: Never
 ```
 
-When this pod is run, the output will be:
+If you run this pod, and there is no ConfigMap named `no-config`, the output is:
 
 ```shell
 ```

--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -712,11 +712,8 @@ If you run this pod, and there is a ConfigMap named `a-config` but that ConfigMa
 a key named `akey`, the output is also empty. If you do set a value for `akey` in the `a-config`
 ConfigMap, this pod prints that value and then terminates.
 
-#### Optional ConfigMap via volume plugin
-
-Volumes and files provided by a ConfigMap can be also be marked as optional.
-The ConfigMap or the key specified does not have to exist.
-The mount path for such items will always be created.
+You can also mark the volumes and files provided by a ConfigMap as optional. Kubernetes always creates the mount paths for the volume, even if the referenced ConfigMap or key doesn't exist. For example, the following
+Pod specification marks a volume that references a ConfigMap as optional:
 
 ```yaml
 apiVersion: v1
@@ -737,9 +734,6 @@ spec:
         name: no-config
         optional: true # mark the source ConfigMap as optional
   restartPolicy: Never
-```
-
-If you run this pod, and there is no ConfigMap named `no-config`, the mounted volume will be empty.
 
 ### Mounted ConfigMaps are updated automatically
 

--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -703,7 +703,7 @@ spec:
             configMapKeyRef:
               name: a-config
               key: akey
-              optional: true
+              optional: true # mark the variable as optional
   restartPolicy: Never
 ```
 

--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -732,7 +732,7 @@ spec:
     - name: config-volume
       configMap:
         name: no-config
-        optional: true
+        optional: true # mark the source ConfigMap as optional
   restartPolicy: Never
 ```
 

--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -746,7 +746,7 @@ If you run this pod, and there is no ConfigMap named `no-config`, the mounted vo
 When a mounted ConfigMap is updated, the projected content is eventually updated too.  This applies in the case where an optionally referenced ConfigMap comes into
 existence after a pod has started.
 
-Kubelet checks whether the mounted ConfigMap is fresh on every periodic sync. However, it uses its local TTL-based cache for getting the current value of the
+The kubelet checks whether the mounted ConfigMap is fresh on every periodic sync. However, it uses its local TTL-based cache for getting the current value of the
 ConfigMap. As a result, the total delay from the moment when the ConfigMap is updated to the moment when new keys are projected to the pod can be as long as
 kubelet sync period (1 minute by default) + TTL of ConfigMaps cache (1 minute by default) in kubelet.
 


### PR DESCRIPTION
Move exiting content on optional ConfigMaps into the "Understanding ConfigMaps and Pods" section to make it more generic (was a sub-section within "Add ConfigMap data to a Volume" and re-worded it slightly.

Also added in content from https://github.com/kubernetes/website/pull/2334, which was removed in https://github.com/kubernetes/website/pull/2568.

Resolves #9829 