### PR TITLE
Fix the grammar by using the verb "set up" instead of the noun "setup"

### DIFF
--- a/content/en/docs/concepts/cluster-administration/proxies.md
+++ b/content/en/docs/concepts/cluster-administration/proxies.md
@@ -56,7 +56,7 @@ There are several different proxies you may encounter when using Kubernetes:
     - implementation varies by cloud provider.
 
 Kubernetes users will typically not need to worry about anything other than the first two types.  The cluster admin
-will typically ensure that the latter types are setup correctly.
+will typically ensure that the latter types are set up correctly.
 
 ## Requesting redirects
 

--- a/content/en/docs/concepts/containers/images.md
+++ b/content/en/docs/concepts/containers/images.md
@@ -162,7 +162,7 @@ Credentials can be provided in several ways:
     - requires node configuration by cluster administrator
   - Pre-pulled Images
     - all pods can use any images cached on a node
-    - requires root access to all nodes to setup
+    - requires root access to all nodes to set up
   - Specifying ImagePullSecrets on a Pod
     - only pods which provide own keys can access the private registry
   - Vendor-specific or local extensions

--- a/content/en/docs/concepts/containers/runtime-class.md
+++ b/content/en/docs/concepts/containers/runtime-class.md
@@ -52,7 +52,7 @@ handler must be a valid [DNS label name](/docs/concepts/overview/working-with-ob
 
 ### 2. Create the corresponding RuntimeClass resources
 
-The configurations setup in step 1 should each have an associated `handler` name, which identifies
+The configurations set up in step 1 should each have an associated `handler` name, which identifies
 the configuration. For each handler, create a corresponding RuntimeClass object.
 
 The RuntimeClass resource currently only has 2 significant fields: the RuntimeClass name

--- a/content/en/docs/concepts/containers/runtime-class.md
+++ b/content/en/docs/concepts/containers/runtime-class.md
@@ -52,8 +52,8 @@ handler must be a valid [DNS label name](/docs/concepts/overview/working-with-ob
 
 ### 2. Create the corresponding RuntimeClass resources
 
-The configurations set up in step 1 should each have an associated `handler` name, which identifies
-the configuration. For each handler, create a corresponding RuntimeClass object.
+The configurations that were set up in step 1 should each have an associated `handler` name, which
+identifies the configuration. For each handler, create a corresponding RuntimeClass object.
 
 The RuntimeClass resource currently only has 2 significant fields: the RuntimeClass name
 (`metadata.name`) and the handler (`handler`). The object definition looks like this:

--- a/content/en/docs/concepts/services-networking/connect-applications-service.md
+++ b/content/en/docs/concepts/services-networking/connect-applications-service.md
@@ -305,7 +305,7 @@ Noteworthy points about the nginx-secure-app manifest:
   serves HTTP traffic on port 80 and HTTPS traffic on 443, and nginx Service
   exposes both ports.
 - Each container has access to the keys through a volume mounted at `/etc/nginx/ssl`.
-  This is setup *before* the nginx server is started.
+  This is set up *before* the nginx server is started.
 
 ```shell
 kubectl delete deployments,svc my-nginx; kubectl create -f ./nginx-secure-app.yaml

--- a/content/en/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/en/docs/concepts/services-networking/dns-pod-service.md
@@ -301,7 +301,7 @@ search ns1.svc.cluster-domain.example my.dns.search.suffix
 options ndots:2 edns0
 ```
 
-For IPv6 setup, search path and name server should be setup like this:
+For IPv6 setup, search path and name server should be set up like this:
 
 ```shell
 kubectl exec -it dns-example -- cat /etc/resolv.conf

--- a/content/en/docs/concepts/workloads/controllers/deployment.md
+++ b/content/en/docs/concepts/workloads/controllers/deployment.md
@@ -620,7 +620,7 @@ deployment.apps/nginx-deployment scaled
 ```
 
 Assuming [horizontal Pod autoscaling](/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/) is enabled
-in your cluster, you can setup an autoscaler for your Deployment and choose the minimum and maximum number of
+in your cluster, you can set up an autoscaler for your Deployment and choose the minimum and maximum number of
 Pods you want to run based on the CPU utilization of your existing Pods.
 
 ```shell

--- a/content/en/docs/reference/setup-tools/_index.md
+++ b/content/en/docs/reference/setup-tools/_index.md
@@ -1,4 +1,4 @@
 ---
-title: Setup tools
+title: Set up tools
 weight: 50
 ---

--- a/content/en/docs/reference/setup-tools/kubeadm/implementation-details.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/implementation-details.md
@@ -357,7 +357,7 @@ Kubeadm ensures that users in  `system:bootstrappers:kubeadm:default-node-token`
 This is implemented by creating a ClusterRoleBinding named `kubeadm:kubelet-bootstrap` between the group above and the default
 RBAC role `system:node-bootstrapper`.
 
-#### Setup auto approval for new bootstrap tokens
+#### Set up auto approval for new bootstrap tokens
 
 Kubeadm ensures that the Bootstrap Token will get its CSR request automatically approved by the csrapprover controller.
 
@@ -367,7 +367,7 @@ the  `system:bootstrappers:kubeadm:default-node-token` group and the default rol
 The role `system:certificates.k8s.io:certificatesigningrequests:nodeclient` should be created as well, granting
 POST permission to `/apis/certificates.k8s.io/certificatesigningrequests/nodeclient`.
 
-#### Setup nodes certificate rotation with auto approval
+#### Set up nodes certificate rotation with auto approval
 
 Kubeadm ensures that certificate rotation is enabled for nodes, and that new certificate request for nodes will get its CSR request
 automatically approved by the csrapprover controller.

--- a/content/en/docs/setup/production-environment/tools/kubeadm/high-availability.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/high-availability.md
@@ -269,7 +269,7 @@ in the kubeadm config file.
 
 1. Follow these [instructions](/docs/setup/production-environment/tools/kubeadm/setup-ha-etcd-with-kubeadm/) to set up the etcd cluster.
 
-1. Setup SSH as described [here](#manual-certs).
+1. Set up SSH as described [here](#manual-certs).
 
 1. Copy the following files from any etcd node in the cluster to the first control plane node:
 

--- a/content/en/docs/tasks/access-application-cluster/access-cluster.md
+++ b/content/en/docs/tasks/access-application-cluster/access-cluster.md
@@ -18,7 +18,7 @@ Kubernetes CLI, `kubectl`.
 To access a cluster, you need to know the location of the cluster and have credentials
 to access it.  Typically, this is automatically set-up when you work through
 a [Getting started guide](/docs/setup/),
-or someone else setup the cluster and provided you with credentials and a location.
+or someone else set up the cluster and provided you with credentials and a location.
 
 Check the location and credentials that kubectl knows about with this command:
 
@@ -265,5 +265,5 @@ There are several different proxies you may encounter when using Kubernetes:
     - implementation varies by cloud provider.
 
 Kubernetes users will typically not need to worry about anything other than the first two types.  The cluster admin
-will typically ensure that the latter types are setup correctly.
+will typically ensure that the latter types are set up correctly.
 

--- a/content/en/docs/tasks/administer-cluster/access-cluster-api.md
+++ b/content/en/docs/tasks/administer-cluster/access-cluster-api.md
@@ -22,7 +22,7 @@ Kubernetes command-line tool, `kubectl`.
 To access a cluster, you need to know the location of the cluster and have credentials
 to access it. Typically, this is automatically set-up when you work through
 a [Getting started guide](/docs/setup/),
-or someone else setup the cluster and provided you with credentials and a location.
+or someone else set up the cluster and provided you with credentials and a location.
 
 Check the location and credentials that kubectl knows about with this command:
 

--- a/content/en/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver.md
@@ -22,7 +22,7 @@ The [Container runtimes](/docs/setup/production-environment/container-runtimes) 
 explains that the `systemd` driver is recommended for kubeadm based setups instead
 of the `cgroupfs` driver, because kubeadm manages the kubelet as a systemd service.
 
-The page also provides details on how to setup a number of different container runtimes with the
+The page also provides details on how to set up a number of different container runtimes with the
 `systemd` driver by default.
 
 ## Configuring the kubelet cgroup driver

--- a/content/en/docs/tasks/extend-kubernetes/configure-aggregation-layer.md
+++ b/content/en/docs/tasks/extend-kubernetes/configure-aggregation-layer.md
@@ -276,6 +276,6 @@ spec:
 
 ## {{% heading "whatsnext" %}}
 
-* [Setup an extension api-server](/docs/tasks/extend-kubernetes/setup-extension-api-server/) to work with the aggregation layer.
+* [Set up an extension api-server](/docs/tasks/extend-kubernetes/setup-extension-api-server/) to work with the aggregation layer.
 * For a high level overview, see [Extending the Kubernetes API with the aggregation layer](/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/).
 * Learn how to [Extend the Kubernetes API Using Custom Resource Definitions](/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/).

--- a/content/en/docs/tasks/extend-kubernetes/setup-extension-api-server.md
+++ b/content/en/docs/tasks/extend-kubernetes/setup-extension-api-server.md
@@ -25,7 +25,7 @@ Setting up an extension API server to work with the aggregation layer allows the
 
 <!-- steps -->
 
-## Setup an extension api-server to work with the aggregation layer
+## Set up an extension api-server to work with the aggregation layer
 
 The following steps describe how to set up an extension-apiserver *at a high level*. These steps apply regardless if you're using YAML configs or using APIs. An attempt is made to specifically identify any differences between the two. For a concrete example of how they can be implemented using YAML configs, you can look at the [sample-apiserver](https://github.com/kubernetes/sample-apiserver/blob/master/README.md) in the Kubernetes repo.
 

--- a/content/en/docs/tasks/job/coarse-parallel-processing-work-queue.md
+++ b/content/en/docs/tasks/job/coarse-parallel-processing-work-queue.md
@@ -104,7 +104,7 @@ Address: 10.0.147.152
 # Your address will vary.
 ```
 
-If Kube-DNS is not setup correctly, the previous step may not work for you.
+If Kube-DNS is not set up correctly, the previous step may not work for you.
 You can also find the service IP in an env var:
 
 ```

--- a/content/en/docs/tasks/tls/managing-tls-in-a-cluster.md
+++ b/content/en/docs/tasks/tls/managing-tls-in-a-cluster.md
@@ -357,7 +357,7 @@ reference page.
 
 ## Configuring your cluster to provide signing
 
-This page assumes that a signer is setup to serve the certificates API. The
+This page assumes that a signer is set up to serve the certificates API. The
 Kubernetes controller manager provides a default implementation of a signer. To
 enable it, pass the `--cluster-signing-cert-file` and
 `--cluster-signing-key-file` parameters to the controller manager with paths to

--- a/content/en/docs/tutorials/security/apparmor.md
+++ b/content/en/docs/tutorials/security/apparmor.md
@@ -330,7 +330,7 @@ Note the pod status is Pending, with a helpful error message: `Pod Cannot enforc
 ### Setting up nodes with profiles
 
 Kubernetes does not currently provide any native mechanisms for loading AppArmor profiles onto
-nodes. There are lots of ways to setup the profiles though, such as:
+nodes. There are lots of ways to set up the profiles though, such as:
 
 * Through a [DaemonSet](/docs/concepts/workloads/controllers/daemonset/) that runs a Pod on each node to
   ensure the correct profiles are loaded. An example implementation can be found

--- a/content/en/examples/admin/cloud/ccm-example.yaml
+++ b/content/en/examples/admin/cloud/ccm-example.yaml
@@ -1,4 +1,4 @@
-# This is an example of how to setup cloud-controller-manager as a Daemonset in your cluster.
+# This is an example of how to set up cloud-controller-manager as a Daemonset in your cluster.
 # It assumes that your masters can run pods and has the role node-role.kubernetes.io/master
 # Note that this Daemonset will not work straight out of the box for your cloud, this is
 # meant to be a guideline.

--- a/content/ja/docs/setup/production-environment/turnkey/gce.md
+++ b/content/ja/docs/setup/production-environment/turnkey/gce.md
@@ -157,7 +157,7 @@ cd kubernetes
 cluster/kube-down.sh
 ```
 
-Likewise, the `kube-up.sh` in the same directory will bring it back up. You do not need to rerun the `curl` or `wget` command: everything needed to setup the Kubernetes cluster is now on your workstation.
+Likewise, the `kube-up.sh` in the same directory will bring it back up. You do not need to rerun the `curl` or `wget` command: everything needed to set up the Kubernetes cluster is now on your workstation.
 
 ## カスタマイズ
 

--- a/content/ja/examples/admin/cloud/ccm-example.yaml
+++ b/content/ja/examples/admin/cloud/ccm-example.yaml
@@ -1,4 +1,4 @@
-# This is an example of how to setup cloud-controller-manager as a Daemonset in your cluster.
+# This is an example of how to set up cloud-controller-manager as a Daemonset in your cluster.
 # It assumes that your masters can run pods and has the role node-role.kubernetes.io/master
 # Note that this Daemonset will not work straight out of the box for your cloud, this is
 # meant to be a guideline.

--- a/content/zh-cn/docs/concepts/cluster-administration/proxies.md
+++ b/content/zh-cn/docs/concepts/cluster-administration/proxies.md
@@ -115,7 +115,7 @@ There are several different proxies you may encounter when using Kubernetes:
 
 <!--
 Kubernetes users will typically not need to worry about anything other than the first two types.  The cluster admin
-will typically ensure that the latter types are setup correctly.
+will typically ensure that the latter types are set up correctly.
 -->
 
 Kubernetes 用户通常只需要关心前两种类型的代理，集群管理员通常需要确保后面几种类型的代理设置正确。

--- a/content/zh-cn/docs/concepts/containers/images.md
+++ b/content/zh-cn/docs/concepts/containers/images.md
@@ -316,7 +316,7 @@ Credentials can be provided in several ways:
     - requires node configuration by cluster administrator
   - Pre-pulled Images
     - all pods can use any images cached on a node
-    - requires root access to all nodes to setup
+    - requires root access to all nodes to set up
   - Specifying ImagePullSecrets on a Pod
     - only pods which provide own keys can access the private registry
   - Vendor-specific or local extensions

--- a/content/zh-cn/docs/concepts/containers/runtime-class.md
+++ b/content/zh-cn/docs/concepts/containers/runtime-class.md
@@ -97,7 +97,7 @@ handler 必须是有效的 [DNS 标签名](/zh-cn/docs/concepts/overview/working
 <!--
 ### 2. Create the corresponding RuntimeClass resources
 
-The configurations setup in step 1 should each have an associated `handler` name, which identifies
+The configurations set up in step 1 should each have an associated `handler` name, which identifies
 the configuration. For each handler, create a corresponding RuntimeClass object.
 -->
 ### 2. 创建相应的 RuntimeClass 资源

--- a/content/zh-cn/docs/reference/command-line-tools-reference/kubelet.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/kubelet.md
@@ -1079,7 +1079,7 @@ Duration between checking config files for new data. (DEPRECATED: This parameter
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;">
 <!--
-How should the kubelet setup hairpin NAT. This allows endpoints of a Service to load balance back to themselves if they should try to access their own Service. Valid values are <code>promiscuous-bridge</code>, <code>hairpin-veth</code> and <code>none</code>. (DEPRECATED: This parameter should be set via the config file specified by the Kubelet's <code>--config</code> flag. See <a href="https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/">kubelet-config-file</a> for more information.)
+How should the kubelet set up hairpin NAT. This allows endpoints of a Service to load balance back to themselves if they should try to access their own Service. Valid values are <code>promiscuous-bridge</code>, <code>hairpin-veth</code> and <code>none</code>. (DEPRECATED: This parameter should be set via the config file specified by the Kubelet's <code>--config</code> flag. See <a href="https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/">kubelet-config-file</a> for more information.)
 -->
 设置 kubelet 执行发夹模式（hairpin）网络地址转译的方式。
 该模式允许后端端点对其自身服务的访问能够再次经由负载均衡转发回自身。

--- a/content/zh-cn/docs/reference/kubectl/cheatsheet.md
+++ b/content/zh-cn/docs/reference/kubectl/cheatsheet.md
@@ -42,7 +42,7 @@ This page contains a list of commonly used `kubectl` commands and flags.
 
 <!--
 ```bash
-source <(kubectl completion bash) # setup autocomplete in bash into the current shell, bash-completion package should be installed first.
+source <(kubectl completion bash) # set up autocomplete in bash into the current shell, bash-completion package should be installed first.
 echo "source <(kubectl completion bash)" >> ~/.bashrc # add autocomplete permanently to your bash shell.
 ```
 
@@ -64,7 +64,7 @@ complete -o default -F __start_kubectl k
 
 <!--
 ```bash
-source <(kubectl completion zsh)  # setup autocomplete in zsh into the current shell
+source <(kubectl completion zsh)  # set up autocomplete in zsh into the current shell
 echo '[[ $commands[kubectl] ]] && source <(kubectl completion zsh)' >> ~/.zshrc # add autocomplete permanently to your zsh shell
 ```
 -->

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/implementation-details.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/implementation-details.md
@@ -837,7 +837,7 @@ RBAC role `system:node-bootstrapper`.
 `kubeadm:kubelet-bootstrap` 的 ClusterRoleBinding 来实现的。
 
 <!--
-#### Setup auto approval for new bootstrap tokens
+#### Set up auto approval for new bootstrap tokens
 -->
 #### 为新的引导令牌设置自动批准  {#setup-auto-approval-for-new-bootstrap-tokens}
 
@@ -863,7 +863,7 @@ POST permission to `/apis/certificates.k8s.io/certificatesigningrequests/nodecli
 执行 POST 的权限。
 
 <!--
-#### Setup nodes certificate rotation with auto approval
+#### Set up nodes certificate rotation with auto approval
 -->
 #### 通过自动批准设置节点证书轮换 {#setup-nodes-certificate-rotation-with-auto-approval} 
 

--- a/content/zh-cn/docs/setup/production-environment/turnkey-solutions.md
+++ b/content/zh-cn/docs/setup/production-environment/turnkey-solutions.md
@@ -14,7 +14,7 @@ weight: 30
 
 <!-- 
 This page provides a list of Kubernetes certified solution providers. From each
-provider page, you can learn how to install and setup production
+provider page, you can learn how to install and set up production
 ready clusters.
 -->
 本页列示 Kubernetes 认证解决方案供应商。

--- a/content/zh-cn/docs/tasks/access-application-cluster/access-cluster.md
+++ b/content/zh-cn/docs/tasks/access-application-cluster/access-cluster.md
@@ -463,7 +463,7 @@ There are several different proxies you may encounter when using Kubernetes:
     - implementation varies by cloud provider.
 
 Kubernetes users will typically not need to worry about anything other than the first two types.  The cluster admin
-will typically ensure that the latter types are setup correctly.
+will typically ensure that the latter types are set up correctly.
 -->
 5. 外部服务上的云负载均衡器：
 

--- a/content/zh-cn/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver.md
+++ b/content/zh-cn/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver.md
@@ -42,7 +42,7 @@ of the `cgroupfs` driver, because kubeadm manages the kubelet as a systemd servi
 我们推荐使用 `systemd` 驱动，不推荐 `cgroupfs` 驱动。
 
 <!-- 
-The page also provides details on how to setup a number of different container runtimes with the
+The page also provides details on how to set up a number of different container runtimes with the
 `systemd` driver by default.
 -->
 此页还详述了如何安装若干不同的容器运行时，并将 `systemd` 设为其默认驱动。

--- a/content/zh-cn/docs/tasks/administer-cluster/securing-a-cluster.md
+++ b/content/zh-cn/docs/tasks/administer-cluster/securing-a-cluster.md
@@ -62,7 +62,7 @@ or static Bearer token approach. Larger clusters may wish to integrate an existi
 allow users to be subdivided into groups.
 
 All API clients must be authenticated, even those that are part of the infrastructure like nodes,
-proxies, the scheduler, and volume plugins. These clients are typically [service accounts](/docs/reference/access-authn-authz/service-accounts-admin/) or use x509 client certificates, and they are created automatically at cluster startup or are setup as part of the cluster installation.
+proxies, the scheduler, and volume plugins. These clients are typically [service accounts](/docs/reference/access-authn-authz/service-accounts-admin/) or use x509 client certificates, and they are created automatically at cluster startup or are set up as part of the cluster installation.
 
 Consult the [authentication reference document](/docs/reference/access-authn-authz/authentication/) for more information.
 -->

--- a/content/zh-cn/docs/tasks/job/fine-parallel-processing-work-queue.md
+++ b/content/zh-cn/docs/tasks/job/fine-parallel-processing-work-queue.md
@@ -161,7 +161,7 @@ So, the list with key `job2` will be our work queue.
 因此，这个键为 `job2` 的列表就是我们的工作队列。
 
 <!--
-Note: if you do not have Kube DNS setup correctly, you may need to change
+Note: if you do not have Kube DNS set up correctly, you may need to change
 the first step of the above block to `redis-cli -h $REDIS_SERVICE_HOST`.
 -->
 注意：如果你还没有正确地配置 Kube DNS，你可能需要将上面的第一步改为

--- a/content/zh-cn/docs/tasks/tls/managing-tls-in-a-cluster.md
+++ b/content/zh-cn/docs/tasks/tls/managing-tls-in-a-cluster.md
@@ -535,7 +535,7 @@ reference page.
 <!--
 ## Configuring your cluster to provide signing
 
-This page assumes that a signer is setup to serve the certificates API. The
+This page assumes that a signer is set up to serve the certificates API. The
 Kubernetes controller manager provides a default implementation of a signer. To
 enable it, pass the `--cluster-signing-cert-file` and
 `--cluster-signing-key-file` parameters to the controller manager with paths to

--- a/content/zh-cn/docs/tutorials/security/apparmor.md
+++ b/content/zh-cn/docs/tutorials/security/apparmor.md
@@ -472,7 +472,7 @@ Note the pod status is Pending, with a helpful error message: `Pod Cannot enforc
 
 <!-- 
 Kubernetes does not currently provide any native mechanisms for loading AppArmor profiles onto
-nodes. There are lots of ways to setup the profiles though, such as: 
+nodes. There are lots of ways to set up the profiles though, such as:
 -->
 Kubernetes 目前不提供任何本地机制来将 AppArmor 配置文件加载到节点上。
 有很多方法可以设置配置文件，例如：


### PR DESCRIPTION
This PR fixes the mistake in documentation instructions of using the noun "setup" as a verb, though the correct verb is the two-word phrasal verb "set up".

This PR does not change incorrect usage in blog posts.

( See this page for more explanation: https://grammarist.com/spelling/set-up-vs-setup/ )