### PR TITLE
Fixed Hyperlinks for custom CA and dedicated CA.

### DIFF
--- a/content/en/docs/tasks/tls/managing-tls-in-a-cluster.md
+++ b/content/en/docs/tasks/tls/managing-tls-in-a-cluster.md
@@ -18,7 +18,7 @@ draft](https://github.com/ietf-wg-acme/acme/).
 
 {{< note >}}
 Certificates created using the `certificates.k8s.io` API are signed by a
-[dedicated CA](#a-note-to-cluster-administrators). It is possible to configure your cluster to use the cluster root
+[dedicated CA](#configuring-your-cluster-to-provide-signing). It is possible to configure your cluster to use the cluster root
 CA for this purpose, but you should never rely on this. Do not assume that
 these certificates will validate against the cluster root CA.
 {{< /note >}}
@@ -42,7 +42,7 @@ install it via your operating system's software sources, or fetch it from
 
 ## Trusting TLS in a cluster
 
-Trusting the [custom CA](#a-note-to-cluster-administrators) from an application running as a pod usually requires
+Trusting the [custom CA](#configuring-your-cluster-to-provide-signing) from an application running as a pod usually requires
 some extra application configuration. You will need to add the CA certificate
 bundle to the list of CA certificates that the TLS client or server trusts. For
 example, you would do this with a golang TLS config by parsing the certificate


### PR DESCRIPTION
This PR fixed the links for both custom CA and dedicated CA to redirect the correct section of the [Manage TLS Certificates in a Cluster](https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/) task page.
 Fixes: #35190
 