### PR TITLE
[ko] Update outdated files in dev-1.24-ko.2 (M101-M104)

### DIFF
--- a/content/ko/docs/tasks/tls/certificate-rotation.md
+++ b/content/ko/docs/tasks/tls/certificate-rotation.md
@@ -28,7 +28,7 @@ kubelet은 쿠버네티스 API 인증을 위해 인증서를 사용한다.
 너무 자주 갱신할 필요는 없다.
 
 쿠버네티스는 [kubelet 인증서
-갱신](/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/)을 포함하며,
+갱신](/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/)을 포함하며,
 이 기능은 현재 인증서의 만료 시한이 임박한 경우,
 새로운 키를 자동으로 생성하고 쿠버네티스 API에서 새로운 인증서를 요청하는 기능이다.
 새로운 인증서를 사용할 수 있게 되면

--- a/content/ko/docs/tasks/tools/included/optional-kubectl-configs-bash-linux.md
+++ b/content/ko/docs/tasks/tools/included/optional-kubectl-configs-bash-linux.md
@@ -43,7 +43,7 @@ kubectl에 대한 앨리어스(alias)가 있는 경우, 해당 앨리어스로 �
 
 ```bash
 echo 'alias k=kubectl' >>~/.bashrc
-echo 'complete -F __start_kubectl k' >>~/.bashrc
+echo 'complete -o default -F __start_kubectl k' >>~/.bashrc
 ```
 
 {{< note >}}

--- a/content/ko/docs/tasks/tools/included/optional-kubectl-configs-bash-mac.md
+++ b/content/ko/docs/tasks/tools/included/optional-kubectl-configs-bash-mac.md
@@ -77,7 +77,7 @@ export BASH_COMPLETION_COMPAT_DIR="/usr/local/etc/bash_completion.d"
 
     ```bash
     echo 'alias k=kubectl' >>~/.bash_profile
-    echo 'complete -F __start_kubectl k' >>~/.bash_profile
+    echo 'complete -o default -F __start_kubectl k' >>~/.bash_profile
     ```
 
 - Homebrew로 kubectl을 설치한 경우([여기](/ko/docs/tasks/tools/install-kubectl-macos/#install-with-homebrew-on-macos)의 설명을 참고), kubectl 자동 완성 스크립트가 이미 `/usr/local/etc/bash_completion.d/kubectl` 에 있을 것이다. 이 경우, 아무 것도 할 필요가 없다.

--- a/content/ko/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/ko/docs/tasks/tools/install-kubectl-linux.md
@@ -138,10 +138,9 @@ card:
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-\$basearch
 enabled=1
 gpgcheck=1
-repo_gpgcheck=1
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOF
 sudo yum install -y kubectl


### PR DESCRIPTION
M101 ~ M104 까지의 변경사항들을 반영하였습니다!

- Related issue : #34903 **(dev-1.24-ko.1)**

> ### 4 files to be modified
>
> 101. [ ] M101. `content/en/docs/tasks/tls/certificate-rotation.md` | 1(+XS) 1(-)
> 101. [ ] M102. `content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-linux.md` | 1(+XS) 1(-)
> 101. [ ] M103. `content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-mac.md` | 1(+XS) 1(-)
> 101. [ ] M104. `content/en/docs/tasks/tools/install-kubectl-linux.md` | 1(+XS) 2(-)

/language ko
