### PR TITLE
Update pod-lifecycle.md

### DIFF
--- a/content/zh-cn/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/zh-cn/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -779,7 +779,7 @@ An example flow:
       `terminationGracePeriodSeconds` 属性值来使其正常工作。
       {{< /note >}}
 
-   1. `kubelet` 接下来触发容器运行时发送 TERM 信号给每个容器中的进程 1。
+   2. `kubelet` 接下来触发容器运行时发送 TERM 信号给每个容器中的进程 1。
 
       {{< note >}}
       Pod 中的容器会在不同时刻收到 TERM 信号，接收顺序也是不确定的。


### PR DESCRIPTION
Updates the ordering of the sample ordered list of pod terminations.（更新Pod终止的举例有序列表的排序。）
Addresses an issue where the pod termination example is not aligned with the parent.（解决Pod终止的举例说明与父级未对齐问题。）

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggest-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
