### PR TITLE
[en] Fix containerd config link

### DIFF
--- a/content/en/docs/concepts/containers/runtime-class.md
+++ b/content/en/docs/concepts/containers/runtime-class.md
@@ -116,7 +116,7 @@ Runtime handlers are configured through containerd's configuration at
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.${HANDLER_NAME}]
 ```
 
-See containerd's [config documentation](https://github.com/containerd/cri/blob/master/docs/config.md)
+See containerd's [config documentation](https://github.com/containerd/containerd/blob/main/docs/cri/config.md)
 for more details:
 
 #### {{< glossary_tooltip term_id="cri-o" >}}

--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -217,7 +217,7 @@ When using kubeadm, manually configure the
 
 #### Overriding the sandbox (pause) image {#override-pause-image-containerd}
 
-In your [containerd config](https://github.com/containerd/cri/blob/master/docs/config.md) you can overwrite the
+In your [containerd config](https://github.com/containerd/containerd/blob/main/docs/cri/config.md) you can overwrite the
 sandbox image by setting the following config:
 
 ```toml


### PR DESCRIPTION
containerd config link is pointing to the archived containerd/cri repository
[containerd/cri](https://github.com/containerd/cri) has been merged into [containerd/containerd](https://github.com/containerd/containerd) so nothing should be pointing to containerd/cri repository