### PR TITLE
Fix link in glossary/api-eviction.md

### DIFF
--- a/content/en/docs/reference/glossary/api-eviction.md
+++ b/content/en/docs/reference/glossary/api-eviction.md
@@ -22,6 +22,6 @@ When an `Eviction` object is created, the API server terminates the Pod.
 API-initiated evictions respect your configured [`PodDisruptionBudgets`](/docs/tasks/run-application/configure-pdb/)
 and [`terminationGracePeriodSeconds`](/docs/concepts/workloads/pods/pod-lifecycle#pod-termination).
 
-API-initiated eviction is not the same as [node-pressure eviction](/docs/concepts/scheduling-eviction/eviction/#kubelet-eviction).
+API-initiated eviction is not the same as [node-pressure eviction](/docs/concepts/scheduling-eviction/node-pressure-eviction/).
 
 * See [API-initiated eviction](/docs/concepts/scheduling-eviction/api-eviction/) for more information.


### PR DESCRIPTION
The original link https://kubernetes.io/docs/concepts/scheduling-eviction/eviction/#kubelet-eviction is not exists.

It's https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/ with the right name and path.