### PR TITLE
[KEP-3203] Fetch and Render CVE JSON Feed

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -169,6 +169,9 @@ algolia_docsearch = false
 # Enable Lunr.js offline search
 offlineSearch = false
 
+# Official CVE feed bucket URL
+cveFeedBucket = "https://storage.googleapis.com/k8s-cve-feed/official-cve-feed.json"
+
 [params.pushAssets]
 css = [
   "callouts",

--- a/content/en/docs/reference/issues-security/issues.md
+++ b/content/en/docs/reference/issues-security/issues.md
@@ -8,6 +8,9 @@ To report a security issue, please follow the [Kubernetes security disclosure pr
 
 Work on Kubernetes code and public issues are tracked using [GitHub Issues](https://github.com/kubernetes/kubernetes/issues/).
 
-* [CVE-related issues](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3Aarea%2Fsecurity+in%3Atitle+CVE)
+* Official [list of known CVEs](/docs/reference/issues-security/official-cve-feed/)
+  (security vulnerabilities) that have been announced by the
+  [Security Response Committee](https://github.com/kubernetes/committee-security-response)
+* [CVE-related GitHub issues](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3Aarea%2Fsecurity+in%3Atitle+CVE)
 
 Security-related announcements are sent to the [kubernetes-security-announce@googlegroups.com](https://groups.google.com/forum/#!forum/kubernetes-security-announce) mailing list.

--- a/content/en/docs/reference/issues-security/official-cve-feed.md
+++ b/content/en/docs/reference/issues-security/official-cve-feed.md
@@ -1,0 +1,44 @@
+---
+title: Official CVE Feed
+weight: 25
+outputs:
+  - json
+  - html 
+layout: cve-feed
+---
+
+{{< feature-state for_k8s_version="v1.25" state="alpha" >}}
+
+This is a community maintained list of official CVEs announced by
+the Kubernetes Security Response Committee. See
+[Kubernetes Security and Disclosure Information](/docs/reference/issues-security/security/)
+for more details.
+
+The Kubernetes project publishes a programmatically accessible
+[JSON Feed](/docs/reference/issues-security/official-cve-feed/index.json) of 
+published security issues. You can access it by executing the following command:
+
+{{< comment >}}
+`replace` is used to bypass known issue with rendering ">"
+: https://github.com/gohugoio/hugo/issues/7229 in JSON layouts template
+`layouts/_default/cve-feed.json`
+{{< /comment >}}
+
+```shell
+curl -v https://k8s.io/docs/reference/issues-security/official-cve-feed/index.json
+```
+
+{{< cve-feed >}}
+
+<!-- | CVE ID      | Issue Summary | CVE GitHub Issue URL |
+| ----------- | ----------- | --------- |
+| [CVE-2021-25741](https://www.cve.org/CVERecord?id=CVE-2021-25741)      | Symlink Exchange Can Allow Host Filesystem Access | [#104980](https://github.com/kubernetes/kubernetes/issues/104980) |
+| [CVE-2020-8565](https://www.cve.org/CVERecord?id=CVE-2020-8565)      | Incomplete fix for CVE-2019-11250 allows for token leak in logs when logLevel >= 9 | [#95623](https://github.com/kubernetes/kubernetes/issues/95623) | -->
+
+This feed is auto-refreshing with a noticeable but small lag (minutes to hours)
+from the time a CVE is announced to the time it is accessible in this feed.
+
+The source of truth of this feed is a set of GitHub Issues, filtered by a controlled and
+restricted label `official-cve-feed`. The raw data is stored in a Google Cloud
+Bucket which is writable only by a small number of trusted members of the
+Community.

--- a/data/i18n/en/en.toml
+++ b/data/i18n/en/en.toml
@@ -27,6 +27,34 @@ other = "Twitter"
 [community_youtube_name]
 other = "YouTube"
 
+
+[cve_id]
+other = "CVE ID"
+
+[cve_issue_url]
+other = "CVE GitHub Issue URL"
+
+[cve_json_external_url]
+other = "external_url"
+
+[cve_json_id]
+other = "id"
+
+[cve_json_summary]
+other = "summary"
+
+[cve_json_url]
+other = "url"
+
+[cve_summary]
+other = "Issue Summary"
+
+[cve_table]
+other = "Official Kubernetes CVE List"
+
+[cve_url]
+other = "CVE URL"
+
 [deprecation_title]
 other = "You are viewing documentation for Kubernetes version:"
 

--- a/layouts/_default/cve-feed.json
+++ b/layouts/_default/cve-feed.json
@@ -1,0 +1,23 @@
+{
+  "version": "https://jsonfeed.org/version/1.1",
+  "title": "Auto-refreshing Official CVE Feed",
+  "home_page_url": "https://kubernetes.io",
+  "feed_url": "https://kubernetes.io/docs/reference/issues-security/official-cve-feed/index.json",
+  "description": "Auto-refreshing official CVE feed for Kubernetes repository",
+  "authors": [
+    {
+      "name": "Kubernetes Community",
+      "url": "https://www.kubernetes.dev"
+    }
+  ],
+  "items": [
+  {{ range $i, $e := getJSON .Site.Params.cveFeedBucket }}
+    {{ if $i }}, {{ end }}
+      {
+        {{ T "cve_json_id" | jsonify }}: {{ .cve_id | jsonify }},
+        {{ T "cve_json_url" | jsonify }}: {{ .issue_url | jsonify }},
+        {{ T "cve_json_external_url" | jsonify }}: {{ .cve_url | jsonify}},
+        {{ T "cve_json_summary" | jsonify }}: {{ replace (.summary | jsonify ) "\\u003e" ">"  }}
+      }{{ end }}
+   ]
+}

--- a/layouts/shortcodes/cve-feed.html
+++ b/layouts/shortcodes/cve-feed.html
@@ -1,0 +1,19 @@
+<table class="security-cves">
+  <caption>{{ T "cve_table" }}</caption>
+  <thead>
+  <tr>
+    <th>{{ T "cve_id" }}</th>
+    <th>{{ T "cve_summary"}}</th>
+    <th>{{ T "cve_issue_url" }}</th>
+  </tr>
+  </thead>
+  <tbody>
+  {{ range $issues := getJSON .Site.Params.cveFeedBucket }}
+  <tr>
+    <td><a href="{{ .cve_url }}">{{ .cve_id | htmlEscape | safeHTML }}</a></td>
+    <td>{{ .summary | htmlEscape | safeHTML }}</td>
+    <td><a href="{{ .issue_url }}">#{{ .number }}</a></td>
+  </tr>
+  {{ end }}
+  </tbody>
+</table>


### PR DESCRIPTION
## Description

- Pull JSON blob from queried issues
- Use layout output formats + templates to generate HTML table and JSON blob
- Add localized strings and caption for CVE feed
- Add a new page to describe details about CVE feed and how to use it
- Update existing pages and link the official CVE feed from it

## Notes for Reviewers

### Why are we regenerating JSON blob from the JSON blob in the bucket ?
- Not all fields stored in the bucket are needed 
- JSON download directly to a file with Hugo data templates is not possible
- Gives us better control and ability to add extra fields as needed
- Pulling data through hugo data templates allow us to reuse built-in caching mechanisms

### Why not version control the JSON blob?

To avoid multiple sources of truth. The content in the bucket will remain the only source of truth as the JSON blob is constructed from GitHub issues with label `official-cve-feed` (See this for more info: https://github.com/kubernetes/test-infra/pull/23428). However, as a break glass, there is an option to temporarily push the JSON blob by overriding the layouts json file with raw JSON in cases where push to bucket fails or if bucket is inaccessible. 

### Are the locations for the layouts files correct?

Current locations are mostly my guess, so happy to refactor them as needed

TODO:

- [x] Update JSON blob location to k8s GCS bucket
- [x] Add more description in the PR
- [x] Address PR feedback from superseded PR

Preview: https://deploy-preview-35228--kubernetes-io-main-staging.netlify.app/docs/reference/issues-security/official-cve-feed/
KEP tracker: https://github.com/kubernetes/enhancements/issues/3203
xref: https://github.com/kubernetes/sig-security/issues/1
supersedes https://github.com/kubernetes/website/pull/31051 and https://github.com/kubernetes/website/pull/34765
/hold
/sig security docs