### PR TITLE
the retainKeys strategy only works in the strategic merge patch

### DIFF
--- a/content/en/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch.md
+++ b/content/en/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch.md
@@ -304,7 +304,7 @@ spec:
 Patch your Deployment:
 
 ```shell
-kubectl patch deployment retainkeys-demo --type merge --patch-file patch-file-no-retainkeys.yaml
+kubectl patch deployment retainkeys-demo --type strategic --patch-file patch-file-no-retainkeys.yaml
 ```
 
 In the output, you can see that it is not possible to set `type` as `Recreate` when a value is defined for `spec.strategy.rollingUpdate`:
@@ -330,7 +330,7 @@ With this patch, we indicate that we want to retain only the `type` key of the `
 Patch your Deployment again with this new patch:
 
 ```shell
-kubectl patch deployment retainkeys-demo --type merge --patch-file patch-file-retainkeys.yaml
+kubectl patch deployment retainkeys-demo --type strategic --patch-file patch-file-retainkeys.yaml
 ```
 
 Examine the content of the Deployment:


### PR DESCRIPTION
<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggest-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->

fix: https://github.com/kubernetes/website/issues/27805

**The retainKeys strategy only works in the strategic merge patch**

The error is reported in the https://github.com/kubernetes/website/issues/27805 because the strategic merge patch does not support custom resources.
And there are different errors depending on whether it is dry-run or not
```bash
root@caiwei-1:~# ./kubectl patch clusterimportpolicies secret  --patch-file patch-file-retainkeys.yaml
Error from server (UnsupportedMediaType): the body of the request was in an unknown format - accepted media types include: application/json-patch+json, application/merge-patch+json, application/apply-patch+yaml

root@caiwei-1:~# ./kubectl patch clusterimportpolicies secret  --patch-file patch-file-retainkeys.yaml --dry-run=client
error: strategic merge patch is not supported for policy.clusterpedia.io/v1alpha1, Kind=ClusterImportPolicy locally, try --type merge
```
