### PR TITLE
[zh-cn] Fix containerd config link

### DIFF
--- a/content/zh-cn/docs/concepts/containers/runtime-class.md
+++ b/content/zh-cn/docs/concepts/containers/runtime-class.md
@@ -198,10 +198,10 @@ handler 需要配置在 runtimes 块中：
 ```
 
 <!--
-See containerd's [config documentation](https://github.com/containerd/cri/blob/master/docs/config.md)
+See containerd's [config documentation](https://github.com/containerd/containerd/blob/main/docs/cri/config.md)
 for more details:
 -->
-更详细信息，请查阅 containerd 的[配置指南](https://github.com/containerd/cri/blob/master/docs/config.md)
+更详细信息，请查阅 containerd 的[配置指南](https://github.com/containerd/containerd/blob/main/docs/cri/config.md)
 
 #### [cri-o](https://cri-o.io/)
 

--- a/content/zh-cn/docs/setup/production-environment/container-runtimes.md
+++ b/content/zh-cn/docs/setup/production-environment/container-runtimes.md
@@ -398,12 +398,12 @@ When using kubeadm, manually configure the
 <!--
 #### Overriding the sandbox (pause) image {#override-pause-image-containerd}
 
-In your [containerd config](https://github.com/containerd/cri/blob/master/docs/config.md) you can overwrite the
+In your [containerd config](https://github.com/containerd/containerd/blob/main/docs/cri/config.md) you can overwrite the
 sandbox image by setting the following config:
 -->
 #### 重载沙箱（pause）镜像    {#override-pause-image-containerd}
 
-在你的 [containerd 配置](https://github.com/containerd/cri/blob/master/docs/config.md)中，
+在你的 [containerd 配置](https://github.com/containerd/containerd/blob/main/docs/cri/config.md)中，
 你可以通过设置以下选项重载沙箱镜像：
 
 ```toml


### PR DESCRIPTION
Fix links by following the en revision of #35216.

Preview: https://deploy-preview-35238--kubernetes-io-main-staging.netlify.app/zh-cn/docs/concepts/containers/runtime-class/