### PR TITLE
Update taint-and-toleration.md. Correct explanation of tolerationSeconds: 3600

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -144,7 +144,7 @@ tolerations:
   tolerationSeconds: 3600
 ```
 
-means that if this pod is running which doesn't have required toleration and taint is added to the node, then
+means that if this pod is running without required toleration and taint is added to the node, then
 the pod will stay bound to the node for 3600 seconds, and then be evicted. If the
 taint is removed before that time, the pod will not be evicted.
 

--- a/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
+++ b/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md
@@ -144,7 +144,7 @@ tolerations:
   tolerationSeconds: 3600
 ```
 
-means that if this pod is running and a matching taint is added to the node, then
+means that if this pod is running which doesn't have required toleration and taint is added to the node, then
 the pod will stay bound to the node for 3600 seconds, and then be evicted. If the
 taint is removed before that time, the pod will not be evicted.
 


### PR DESCRIPTION
Correct explanation of tolerationSeconds: 3600
Current documentation says 

`
means that if this pod is running and a matching taint is added to the node, then 
`

I think this is wrong? Its not making sense to me. Pardon me if I am missing something. 
I think. It should be 

`
means that if this pod is running without required toleration and taint is added to the node, then
`