### PR TITLE
[ko] update outdated korean files in dev-1.24-ko.2 (M90-M93)

### DIFF
--- a/content/ko/docs/tasks/debug/debug-cluster/resource-metrics-pipeline.md
+++ b/content/ko/docs/tasks/debug/debug-cluster/resource-metrics-pipeline.md
@@ -173,7 +173,7 @@ curl http://localhost:8080/apis/metrics.k8s.io/v1beta1/namespaces/kube-system/po
 [API 집계(aggregation) 계층](/docs/tasks/extend-kubernetes/configure-aggregation-layer/)을 활성화하고 
 [APIService](/docs/reference/kubernetes-api/cluster-resources/api-service-v1/)를 등록해야 한다.
 
-메트릭 API에 대해 더 알아보려면, [리소스 메트릭 API 디자인](https://github.com/kubernetes/design-proposals-archive/blob/main/instrumentation/resource-metrics-api.md),
+메트릭 API에 대해 더 알아보려면, [리소스 메트릭 API 디자인](https://git.k8s.io/design-proposals-archive/instrumentation/resource-metrics-api.md),
 [metrics-server 저장소](https://github.com/kubernetes-sigs/metrics-server) 및 
 [리소스 메트릭 API](https://github.com/kubernetes/metrics#resource-metrics-api)를 참고한다.
 
@@ -237,7 +237,7 @@ metrics-server에 대한 더 많은 정보는
 
 또한 다음을 참고할 수도 있다.
 
-* [metrics-server 디자인](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/instrumentation/metrics-server.md)
+* [metrics-server 디자인](https://git.k8s.io/design-proposals-archive/instrumentation/metrics-server.md)
 * [metrics-server 자주 묻는 질문](https://github.com/kubernetes-sigs/metrics-server/blob/master/FAQ.md)
 * [metrics-server 알려진 이슈](https://github.com/kubernetes-sigs/metrics-server/blob/master/KNOWN_ISSUES.md)
 * [metrics-server 릴리스](https://github.com/kubernetes-sigs/metrics-server/releases)

--- a/content/ko/docs/tasks/debug/debug-cluster/resource-usage-monitoring.md
+++ b/content/ko/docs/tasks/debug/debug-cluster/resource-usage-monitoring.md
@@ -42,8 +42,11 @@ Kubelet은 쿠버네티스 마스터와 노드 간의 다리 역할을 하면서
 Kubelet은 각각의 파드를 해당하는 컨테이너에 매치시키고 
 컨테이너 런타임 인터페이스를 통해 
 컨테이너 런타임에서 개별 컨테이너의 사용량 통계를 가져온다. 
-Kubelet은 이 정보를 레거시 도커와의 통합을 위해 kubelet에 통합된 cAdvisor를 통해 가져온다. 
-그 다음으로 취합된 파드 리소스 사용량 통계를 metric-server 리소스 메트릭 API를 통해 노출한다. 
+컨테이너를 구현하기 위해 리눅스 cgroup 및 네임스페이스를 활용하는 컨테이너 런타임을 사용하며, 
+해당 컨테이너 런타임이 사용 통계치를 퍼블리싱 하지 않는 경우, 
+kubelet은 해당 통계치를 ([cAdvisor](https://github.com/google/cadvisor)의 코드 사용하여) 직접 조회 할 수 있다.
+이런 통계가 어떻게 도착하든 kubelet은 취합된 파드 리소스 사용량 통계를 
+metric-server 리소스 메트릭 API를 통해 노출한다.
 이 API는 kubelet의 인증이 필요한 읽기 전용 포트 상의 
 `/metrics/resource/v1beta1`에서 제공된다.
 


### PR DESCRIPTION
M90 ~ M93 까지의 변경사항들을 반영하였습니다( M90 띄어쓰기 변경이므로, 수정사항 없음 )


* Related issue : https://github.com/kubernetes/website/issues/34903 (dev-1.24-ko.1)


> - [ ] M90. content/en/docs/tasks/debug/debug-application/debug-pods.md | 2(+XS) 2(-)
> - [ ] M91. content/en/docs/tasks/debug/debug-cluster/_index.md | 61(+M) 48(-)
> - [ ] M92. content/en/docs/tasks/debug/debug-cluster/resource-metrics-pipeline.md | 2(+XS) 2(-)
> - [ ] M93. content/en/docs/tasks/debug/debug-cluster/resource-usage-monitoring.md | 5(+XS) 2(-)



/language ko