### PR TITLE
[zh-cn] Fix link for runtime-class

### DIFF
--- a/content/zh-cn/blog/_posts/2018-10-10-runtimeclass.md
+++ b/content/zh-cn/blog/_posts/2018-10-10-runtimeclass.md
@@ -19,11 +19,11 @@ date: 2018-10-10
 Kubernetes originally launched with support for Docker containers running native applications on a Linux host. Starting with [rkt](https://kubernetes.io/blog/2016/07/rktnetes-brings-rkt-container-engine-to-kubernetes/) in Kubernetes 1.3 more runtimes were coming, which lead to the development of the [Container Runtime Interface](https://kubernetes.io/blog/2016/12/container-runtime-interface-cri-in-kubernetes/) (CRI). Since then, the set of alternative runtimes has only expanded: projects like [Kata Containers](https://katacontainers.io/) and [gVisor](https://github.com/google/gvisor) were announced for stronger workload isolation, and Kubernetes' Windows support has been [steadily progressing](https://kubernetes.io/blog/2018/01/kubernetes-v19-beta-windows-support/).
 -->
 Kubernetes 最初是为了支持在 Linux 主机上运行本机应用程序的 Docker 容器而创建的。
-从 Kubernetes 1.3中的 [rkt](https://kubernetes.io/blog/2016/07/rktnetes-brings-rkt-container-engine-to-kubernetes/) 开始，更多的运行时间开始涌现，
+从 Kubernetes 1.3 中的 [rkt](https://kubernetes.io/blog/2016/07/rktnetes-brings-rkt-container-engine-to-kubernetes/) 开始，更多的运行时间开始涌现，
 这导致了[容器运行时接口（Container Runtime Interface）](https://kubernetes.io/blog/2016/12/container-runtime-interface-cri-in-kubernetes/)（CRI）的开发。
 从那时起，备用运行时集合越来越大：
 为了加强工作负载隔离，[Kata Containers](https://katacontainers.io/) 和 [gVisor](https://github.com/google/gvisor) 等项目被发起，
-并且 Kubernetes 对 Windows 的支持正在 [稳步发展](https://kubernetes.io/blog/2018/01/kubernetes-v19-beta-windows-support/) 。
+并且 Kubernetes 对 Windows 的支持正在[稳步发展](https://kubernetes.io/blog/2018/01/kubernetes-v19-beta-windows-support/)。
 
 <!--
 With runtimes targeting so many different use cases, a clear need for mixed runtimes in a cluster arose. But all these different ways of running containers have brought a new set of problems to deal with:
@@ -56,7 +56,7 @@ With runtimes targeting so many different use cases, a clear need for mixed runt
 RuntimeClass was recently introduced as an alpha feature in Kubernetes 1.12. The initial implementation focuses on providing a runtime selection API, and paves the way to address the other open problems.
 -->
 最近，RuntimeClass 在 Kubernetes 1.12 中作为 alpha 功能引入。
-最初的实现侧重于提供运行时选择 API ，并为解决其他未解决的问题铺平道路。
+最初的实现侧重于提供运行时选择 API，并为解决其他未解决的问题铺平道路。
 
 <!--
 The RuntimeClass resource represents a container runtime supported in a Kubernetes cluster. The cluster provisioner sets up, configures, and defines the concrete runtimes backing the RuntimeClass. In its current form, a RuntimeClassSpec holds a single field, the **RuntimeHandler**. The RuntimeHandler is interpreted by the CRI implementation running on a node, and mapped to the actual runtime configuration. Meanwhile the PodSpec has been expanded with a new field, **RuntimeClassName**, which names the RuntimeClass that should be used to run the pod.
@@ -81,14 +81,14 @@ Kubernetes 资源模型期望 Pod 中的容器之间可以共享某些资源。
 ## 下一步是什么？
 
 <!--
-The RuntimeClass resource is an important foundation for surfacing runtime properties to the control plane. For example, to implement scheduler support for clusters with heterogeneous nodes supporting different runtimes, we might add [NodeAffinity](/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) terms to the RuntimeClass definition. Another area to address is managing the variable resource requirements to run pods of different runtimes. The [Pod Overhead proposal](https://docs.google.com/document/d/1EJKT4gyl58-kzt2bnwkv08MIUZ6lkDpXcxkHqCvvAp4/preview) was an early take on this that aligns nicely with the RuntimeClass design, and may be pursued further.
+The RuntimeClass resource is an important foundation for surfacing runtime properties to the control plane. For example, to implement scheduler support for clusters with heterogeneous nodes supporting different runtimes, we might add [NodeAffinity](/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) terms to the RuntimeClass definition. Another area to address is managing the variable resource requirements to run pods of different runtimes. The [Pod Overhead proposal](https://docs.google.com/document/d/1EJKT4gyl58-kzt2bnwkv08MIUZ6lkDpXcxkHqCvvAp4/preview) was an early take on this that aligns nicely with the RuntimeClass design, and may be pursued further.
 -->
 RuntimeClass 资源是将运行时属性显示到控制平面的重要基础。
 例如，要对具有支持不同运行时间的异构节点的集群实施调度程序支持，我们可以在 RuntimeClass 定义中添加
-[NodeAffinity](/zh-cn/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)条件。
+[NodeAffinity](/zh-cn/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) 条件。
 另一个需要解决的领域是管理可变资源需求以运行不同运行时的 Pod。
-[Pod Overhead 提案](https://docs.google.com/document/d/1EJKT4gyl58-kzt2bnwkv08MIUZ6lkDpXcxkHqCvvAp4/preview)
-是一项较早的尝试，与 RuntimeClass 设计非常吻合，并且可能会进一步推广。
+[Pod Overhead 提案](https://docs.google.com/document/d/1EJKT4gyl58-kzt2bnwkv08MIUZ6lkDpXcxkHqCvvAp4/preview)是一项较早的尝试，与
+RuntimeClass 设计非常吻合，并且可能会进一步推广。
 
 <!--
 Many other RuntimeClass extensions have also been proposed, and will be revisited as the feature continues to develop and mature. A few more extensions that are being considered include:
@@ -107,13 +107,13 @@ Many other RuntimeClass extensions have also been proposed, and will be revisite
 - 自动运行时或功能发现，支持无需手动配置的调度决策。
 - 标准化或一致的 RuntimeClass 名称，用于定义一组具有相同名称的 RuntimeClass 的集群应支持的属性。
 - 动态注册附加的运行时，因此用户可以在不停机的情况下在现有集群上安装新的运行时。
-- 根据 Pod 的要求“匹配”  RuntimeClass。
+- 根据 Pod 的要求“匹配” RuntimeClass。
   例如，指定运行时属性并使系统与适当的 RuntimeClass 匹配，而不是通过名称显式分配 RuntimeClass。
 
 <!--
 RuntimeClass will be under active development at least through 2019, and we’re excited to see the feature take shape, starting with the RuntimeClass alpha in Kubernetes 1.12.
 -->
-至少要到2019年，RuntimeClass 才会得到积极的开发，我们很高兴看到从 Kubernetes 1.12 中的 RuntimeClass alpha 开始，此功能得以形成。
+至少要到 2019 年，RuntimeClass 才会得到积极的开发，我们很高兴看到从 Kubernetes 1.12 中的 RuntimeClass alpha 开始，此功能得以形成。
 
 <!--
 ## Learn More
@@ -127,10 +127,9 @@ RuntimeClass will be under active development at least through 2019, and we’re
 - Join the discussions and help shape the future of RuntimeClass with the [SIG-Node community](https://github.com/kubernetes/community/tree/master/sig-node)
 -->
 
-- 试试吧！ 作为Alpha功能，还有一些其他设置步骤可以使用RuntimeClass。
-  有关如何使其运行，请参考 [RuntimeClass文档](/zh-cn/docs/concepts/containers/runtime-class/#runtime-class) 。
-- 查看 [RuntimeClass Kubernetes 增强建议](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/runtime-class.md) 以获取更多细节设计细节。
-- [沙盒隔离级别决策](https://docs.google.com/document/d/1fe7lQUjYKR0cijRmSbH_y0_l3CYPkwtQa5ViywuNo8Q/preview) 
-  记录了最初使 RuntimeClass 成为 Pod 级别选项的思考过程。
-- 加入讨论，并通过 [SIG-Node社区](https://github.com/kubernetes/community/tree/master/sig-node) 帮助塑造 RuntimeClass 的未来。
-
+- 试试吧！作为 Alpha 功能，还有一些其他设置步骤可以使用 RuntimeClass。
+  有关如何使其运行，请参考 [RuntimeClass 文档](/zh-cn/docs/concepts/containers/runtime-class/#runtime-class)。
+- 查看 [RuntimeClass Kubernetes 增强建议](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/runtime-class.md)以获取更多细节设计细节。
+- [沙盒隔离级别决策](https://docs.google.com/document/d/1fe7lQUjYKR0cijRmSbH_y0_l3CYPkwtQa5ViywuNo8Q/preview)记录了最初使
+  RuntimeClass 成为 Pod 级别选项的思考过程。
+- 加入讨论，并通过 [SIG-Node 社区](https://github.com/kubernetes/community/tree/master/sig-node)帮助塑造 RuntimeClass 的未来。

--- a/content/zh-cn/docs/concepts/containers/runtime-class.md
+++ b/content/zh-cn/docs/concepts/containers/runtime-class.md
@@ -16,7 +16,7 @@ weight: 20
 
 {{< feature-state for_k8s_version="v1.20" state="stable" >}}
 
-<!-- 
+<!--
 This page describes the RuntimeClass resource and runtime selection mechanism.
 
 RuntimeClass is a feature for selecting the container runtime configuration. The container runtime
@@ -28,7 +28,7 @@ RuntimeClass 是一个用于选择容器运行时配置的特性，容器运行�
 
 <!-- body -->
 
-<!-- 
+<!--
 ## Motivation
 
 You can set a different RuntimeClass between different Pods to provide a balance of
@@ -51,7 +51,7 @@ but with different settings.
 -->
 你还可以使用 RuntimeClass 运行具有相同容器运行时但具有不同设置的 Pod。
 
-<!-- 
+<!--
 ## Setup
 -->
 
@@ -77,12 +77,12 @@ CRI implementation for how to configure.
 RuntimeClass 的配置依赖于 运行时接口（CRI）的实现。
 根据你使用的 CRI 实现，查阅相关的文档（[下方](#cri-configuration)）来了解如何配置。
 
+{{< note >}}
 <!--
 RuntimeClass assumes a homogeneous node configuration across the cluster by default (which means
 that all nodes are configured the same way with respect to container runtimes). To support
-heterogenous node configurations, see [Scheduling](#scheduling) below.
+heterogeneous node configurations, see [Scheduling](#scheduling) below.
 -->
-{{< note >}}
 RuntimeClass 假设集群中的节点配置是同构的（换言之，所有的节点在容器运行时方面的配置是相同的）。
 如果需要支持异构节点，配置方法请参阅下面的 [调度](#scheduling)。
 {{< /note >}}
@@ -102,7 +102,7 @@ the configuration. For each handler, create a corresponding RuntimeClass object.
 -->
 ### 2. 创建相应的 RuntimeClass 资源
 
-在上面步骤 1 中，每个配置都需要有一个用于标识配置的 `handler`。 
+在上面步骤 1 中，每个配置都需要有一个用于标识配置的 `handler`。
 针对每个 handler 需要创建一个 RuntimeClass 对象。
 
 <!--
@@ -119,17 +119,24 @@ kind: RuntimeClass
 metadata:
   # 用来引用 RuntimeClass 的名字
   # RuntimeClass 是一个集群层面的资源
-  name: myclass  
+  name: myclass
 # 对应的 CRI 配置的名称
 handler: myconfiguration
 ```
 
 <!--
+The name of a RuntimeClass object must be a valid
+[DNS subdomain name](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names).
+-->
+RuntimeClass 对象的名称必须是有效的
+[DNS 子域名](/zh-cn/docs/concepts/overview/working-with-objects/names#dns-subdomain-names)。
+
+{{< note >}}
+<!--
 It is recommended that RuntimeClass write operations (create/update/patch/delete) be
-restricted to the cluster administrator. This is typically the default. See 
+restricted to the cluster administrator. This is typically the default. See
 [Authorization Overview](/docs/reference/access-authn-authz/authorization/) for more details.
 -->
-{{< note >}}
 建议将 RuntimeClass 写操作（create、update、patch 和 delete）限定于集群管理员使用。
 通常这是默认配置。参阅[授权概述](/zh-cn/docs/reference/access-authn-authz/authorization/)了解更多信息。
 {{< /note >}}
@@ -172,9 +179,9 @@ error message.
 If no `runtimeClassName` is specified, the default RuntimeHandler will be used, which is equivalent
 to the behavior when the RuntimeClass feature is disabled.
 -->
-如果未指定 `runtimeClassName` ，则将使用默认的 RuntimeHandler，相当于禁用 RuntimeClass 功能特性。
+如果未指定 `runtimeClassName`，则将使用默认的 RuntimeHandler，相当于禁用 RuntimeClass 功能特性。
 
-<!-- 
+<!--
 ### CRI Configuration
 
 For more details on setting up CRI runtimes, see [CRI installation](/docs/setup/production-environment/container-runtimes/).
@@ -191,7 +198,7 @@ Runtime handlers are configured through containerd's configuration at
 `/etc/containerd/config.toml`. Valid handlers are configured under the runtimes section:
 -->
 通过 containerd 的 `/etc/containerd/config.toml` 配置文件来配置运行时 handler。
-handler 需要配置在 runtimes 块中： 
+handler 需要配置在 runtimes 块中：
 
 ```
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.${HANDLER_NAME}]
@@ -203,17 +210,16 @@ for more details:
 -->
 更详细信息，请查阅 containerd 的[配置指南](https://github.com/containerd/containerd/blob/main/docs/cri/config.md)
 
-#### [cri-o](https://cri-o.io/)
+#### {{< glossary_tooltip term_id="cri-o" >}}
 
 <!--
-Runtime handlers are configured through cri-o's configuration at `/etc/crio/crio.conf`. Valid
-handlers are configured under the [crio.runtime
-table](https://github.com/kubernetes-sigs/cri-o/blob/master/docs/crio.conf.5.md#crioruntime-table):
+Runtime handlers are configured through CRI-O's configuration at `/etc/crio/crio.conf`. Valid
+handlers are configured under the
+[crio.runtime table](https://github.com/cri-o/cri-o/blob/master/docs/crio.conf.5.md#crioruntime-table):
 -->
-通过 cri-o 的 `/etc/crio/crio.conf` 配置文件来配置运行时 handler。
+通过 CRI-O 的 `/etc/crio/crio.conf` 配置文件来配置运行时 handler。
 handler 需要配置在
-[crio.runtime 表](https://github.com/kubernetes-sigs/cri-o/blob/master/docs/crio.conf.5.md#crioruntime-table)
-下面：
+[crio.runtime 表](https://github.com/cri-o/cri-o/blob/master/docs/crio.conf.5.md#crioruntime-table)之下：
 
 ```
 [crio.runtime.runtimes.${HANDLER_NAME}]
@@ -225,9 +231,9 @@ See CRI-O's [config documentation](https://github.com/cri-o/cri-o/blob/master/do
 -->
 更详细信息，请查阅 CRI-O [配置文档](https://github.com/cri-o/cri-o/blob/master/docs/crio.conf.5.md)。
 
-<!-- 
+<!--
 ## Scheduling
- -->
+-->
 ## 调度  {#scheduling}
 
 {{< feature-state for_k8s_version="v1.16" state="beta" >}}
@@ -240,7 +246,7 @@ If `scheduling` is not set, this RuntimeClass is assumed to be supported by all 
 
 通过为 RuntimeClass 指定 `scheduling` 字段，
 你可以通过设置约束，确保运行该 RuntimeClass 的 Pod 被调度到支持该 RuntimeClass 的节点上。
-如果未设置 `scheduling`，则假定所有节点均支持此 RuntimeClass 。
+如果未设置 `scheduling`，则假定所有节点均支持此 RuntimeClass。
 
 <!--
 To ensure pods land on nodes supporting a specific RuntimeClass, that set of nodes should have a
@@ -249,7 +255,7 @@ RuntimeClass's nodeSelector is merged with the pod's nodeSelector in admission, 
 the intersection of the set of nodes selected by each. If there is a conflict, the pod will be
 rejected.
 -->
-为了确保 pod 会被调度到支持指定运行时的 node 上，每个 node 需要设置一个通用的 label 用于被 
+为了确保 pod 会被调度到支持指定运行时的 node 上，每个 node 需要设置一个通用的 label 用于被
 `runtimeclass.scheduling.nodeSelector` 挑选。在 admission 阶段，RuntimeClass 的 nodeSelector 将会与
 pod 的 nodeSelector 合并，取二者的交集。如果有冲突，pod 将会被拒绝。
 
@@ -263,22 +269,22 @@ by each.
 与 `nodeSelector` 一样，tolerations 也在 admission 阶段与 pod 的 tolerations 合并，取二者的并集。
 
 <!--
-To learn more about configuring the node selector and tolerations, see 
-[Assigning Pods to Nodes](/docs/concepts/configuration/assign-pod-node/).
+To learn more about configuring the node selector and tolerations, see
+[Assigning Pods to Nodes](/docs/concepts/scheduling-eviction/assign-pod-node/).
 -->
-更多有关 node selector 和 tolerations 的配置信息，请查阅 
+更多有关 node selector 和 tolerations 的配置信息，请查阅
 [将 Pod 分派到节点](/zh-cn/docs/concepts/scheduling-eviction/assign-pod-node/)。
 
-<!-- 
+<!--
 ### Pod Overhead
- -->
+-->
 ### Pod 开销   {#pod-overhead}
 
 {{< feature-state for_k8s_version="v1.24" state="stable" >}}
 
 <!--
 You can specify _overhead_ resources that are associated with running a Pod. Declaring overhead allows
-the cluster (including the scheduler) to account for it when making decisions about Pods and resources.  
+the cluster (including the scheduler) to account for it when making decisions about Pods and resources.
 -->
 你可以指定与运行 Pod 相关的 _开销_ 资源。声明开销即允许集群（包括调度器）在决策 Pod 和资源时将其考虑在内。
 


### PR DESCRIPTION
Change invalid [old link](https://kubernetes.io/zh-cn/docs/concepts/configuration/assign-pod-node/) to the [new link](https://kubernetes.io/zh-cn/docs/concepts/scheduling-eviction/assign-pod-node/) and fix some format.

```diff
 例如，要对具有支持不同运行时间的异构节点的集群实施调度程序支持，我们可以在 RuntimeClass 定义中添加
-[NodeAffinity](/zh-cn/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)条件。
+[NodeAffinity](/zh-cn/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)条件。
 另一个需要解决的领域是管理可变资源需求以运行不同运行时的 Pod。
```