### PR TITLE
[zh-cn] resync /concepts/scheduling-eviction/_index.md

### DIFF
--- a/content/zh-cn/docs/concepts/scheduling-eviction/_index.md
+++ b/content/zh-cn/docs/concepts/scheduling-eviction/_index.md
@@ -1,11 +1,11 @@
 ---
-title: 调度，抢占和驱逐
+title: 调度、抢占和驱逐
 weight: 90
 content_type: concept
 description: >
-  在Kubernetes中，调度 (scheduling) 指的是确保 Pods 匹配到合适的节点，
-  以便 kubelet 能够运行它们。抢占 (Preemption) 指的是终止低优先级的 Pods 以便高优先级的 Pods 可以
-  调度运行的过程。驱逐 (Eviction) 是在资源匮乏的节点上，主动让一个或多个 Pods 失效的过程。
+  在 Kubernetes 中，调度 (scheduling) 指的是确保 Pod 匹配到合适的节点，
+  以便 kubelet 能够运行它们。抢占 (Preemption) 指的是终止低优先级的 Pod 以便高优先级的 Pod
+  可以调度运行的过程。驱逐 (Eviction) 是在资源匮乏的节点上，主动让一个或多个 Pod 失效的过程。
 no_list: true
 ---
 
@@ -15,8 +15,8 @@ weight: 90
 content_type: concept
 description: >
   In Kubernetes, scheduling refers to making sure that Pods are matched to Nodes
-  so that the kubelet can run them. Preemption is the process of terminating
-  Pods with lower Priority so that Pods with higher Priority can schedule on
+  so that the kubelet can run them. Preemption is the process of terminating 
+  Pods with lower Priority so that Pods with higher Priority can schedule on 
   Nodes. Eviction is the process of proactively terminating one or more Pods on
   resource-starved Nodes.
 no_list: true
@@ -30,6 +30,12 @@ is the process of terminating Pods with lower {{<glossary_tooltip text="Priority
 so that Pods with higher Priority can schedule on Nodes. Eviction is the process
 of terminating one or more Pods on Nodes.
 -->
+在 Kubernetes 中，调度 (scheduling) 指的是确保 {{<glossary_tooltip text="Pod" term_id="pod">}}
+匹配到合适的{{<glossary_tooltip text="节点" term_id="node">}}，
+以便 {{<glossary_tooltip text="kubelet" term_id="kubelet">}} 能够运行它们。
+抢占 (Preemption) 指的是终止低{{<glossary_tooltip text="优先级" term_id="pod-priority">}}的 Pod
+以便高优先级的 Pod 可以调度运行的过程。
+驱逐 (Eviction) 是在资源匮乏的节点上，主动让一个或多个 Pod 失效的过程。
 
 <!--
 ## Scheduling
@@ -37,6 +43,7 @@ of terminating one or more Pods on Nodes.
 * [Kubernetes Scheduler](/docs/concepts/scheduling-eviction/kube-scheduler/)
 * [Assigning Pods to Nodes](/docs/concepts/scheduling-eviction/assign-pod-node/)
 * [Pod Overhead](/docs/concepts/scheduling-eviction/pod-overhead/)
+* [Pod Topology Spread Constraints](/docs/concepts/scheduling-eviction/topology-spread-constraints/)
 * [Taints and Tolerations](/docs/concepts/scheduling-eviction/taint-and-toleration/)
 * [Scheduling Framework](/docs/concepts/scheduling-eviction/scheduling-framework)
 * [Scheduler Performance Tuning](/docs/concepts/scheduling-eviction/scheduler-perf-tuning/)
@@ -46,11 +53,12 @@ of terminating one or more Pods on Nodes.
 ## 调度
 
 * [Kubernetes 调度器](/zh-cn/docs/concepts/scheduling-eviction/kube-scheduler/)
-* [将 Pods 指派到节点](/zh-cn/docs/concepts/scheduling-eviction/assign-pod-node/)
+* [将 Pod 指派到节点](/zh-cn/docs/concepts/scheduling-eviction/assign-pod-node/)
 * [Pod 开销](/zh-cn/docs/concepts/scheduling-eviction/pod-overhead/)
-* [污点和容忍](/zh-cn/docs/concepts/scheduling-eviction/taint-and-toleration/)
+* [Pod 拓扑分布约束](/docs/concepts/scheduling-eviction/topology-spread-constraints/)
+* [污点和容忍度](/zh-cn/docs/concepts/scheduling-eviction/taint-and-toleration/)
 * [调度框架](/zh-cn/docs/concepts/scheduling-eviction/scheduling-framework)
-* [调度器的性能调试](/zh-cn/docs/concepts/scheduling-eviction/scheduler-perf-tuning/)
+* [调度器性能调试](/zh-cn/docs/concepts/scheduling-eviction/scheduler-perf-tuning/)
 * [扩展资源的资源装箱](/zh-cn/docs/concepts/scheduling-eviction/resource-bin-packing/)
 
 <!--
@@ -69,4 +77,4 @@ of terminating one or more Pods on Nodes.
 
 * [Pod 优先级和抢占](/zh-cn/docs/concepts/scheduling-eviction/pod-priority-preemption/)
 * [节点压力驱逐](/zh-cn/docs/concepts/scheduling-eviction/node-pressure-eviction/)
-* [API发起的驱逐](/zh-cn/docs/concepts/scheduling-eviction/api-eviction/)
+* [API 发起的驱逐](/zh-cn/docs/concepts/scheduling-eviction/api-eviction/)


### PR DESCRIPTION
Updated this page with the en version: 
```
content/zh-cn/docs/concepts/scheduling-eviction/_index.md
```