### PR TITLE
Bump all cniVersion mentions to at least 0.4.0

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins.md
+++ b/content/en/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins.md
@@ -67,7 +67,7 @@ For example:
 ```json
 {
   "name": "k8s-pod-network",
-  "cniVersion": "0.3.0",
+  "cniVersion": "0.4.0",
   "plugins": [
     {
       "type": "calico",
@@ -106,7 +106,7 @@ If you want to enable traffic shaping support, you must add the `bandwidth` plug
 ```json
 {
   "name": "k8s-pod-network",
-  "cniVersion": "0.3.0",
+  "cniVersion": "0.4.0",
   "plugins": [
     {
       "type": "calico",


### PR DESCRIPTION
## Fixes #35310 

All cniVersion mentioned in the issue is changed into latest "0.4.0"
It is required that minimal "0.4.0" cniVersion latest but in two json file there was cniVersion "0.3.0"