### PR TITLE
Remove commas from kubelet configuration example and add suggested changes.

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubelet-config-file.md
+++ b/content/en/docs/tasks/administer-cluster/kubelet-config-file.md
@@ -28,22 +28,13 @@ in this struct. Make sure the Kubelet has read permissions on the file.
 
 Here is an example of what this file might look like:
 ```
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kubelet-config-1.20
-  namespace: kube-system
-data:
-  kubelet: |
-    apiVersion: kubelet.config.k8s.io/v1beta1
-    kind: KubeletConfiguration
-    address: "192.168.0.8"
-    port: 20250
-    serializeImagePulls: false
-    evictionHard:
-      memory.available:  "200Mi"
-~                                  
-
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+address: "192.168.0.8",
+port: 20250,
+serializeImagePulls: false,
+evictionHard:
+    memory.available:  "200Mi"
 ```
 
 In the example, the Kubelet is configured to serve on IP address 192.168.0.8 and port 20250, pull images in parallel,

--- a/content/en/docs/tasks/administer-cluster/kubelet-config-file.md
+++ b/content/en/docs/tasks/administer-cluster/kubelet-config-file.md
@@ -27,12 +27,12 @@ The configuration file must be a JSON or YAML representation of the parameters
 in this struct. Make sure the Kubelet has read permissions on the file.
 
 Here is an example of what this file might look like:
-```
+```yaml
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-address: "192.168.0.8",
-port: 20250,
-serializeImagePulls: false,
+address: "192.168.0.8"
+port: 20250
+serializeImagePulls: false
 evictionHard:
     memory.available:  "200Mi"
 ```


### PR DESCRIPTION
Reverts kubernetes/website#35095

I merged this by mistake without actually checking whether the suggestion by Tim was incorporated or not. The suggested changes for #35095 have now been applied correctly in this PR.