### PR TITLE
[ko] Translate the glossary term 'Dockershim, Helm Chart, HostAliases ... etc' into Korean

### DIFF
--- a/content/ko/docs/reference/glossary/dockershim.md
+++ b/content/ko/docs/reference/glossary/dockershim.md
@@ -1,0 +1,18 @@
+---
+title: 도커심(Dockershim)
+id: dockershim
+date: 2022-04-15
+full_link: /dockershim
+short_description: >
+   쿠버네티스 1.23 이하의 버전에서 쿠버네티스 시스템 구성 요소가 도커 엔진과 통신할 수 있게 해주는 컴포넌트
+
+aka:
+tags:
+- fundamental
+---
+도커심(Dockershim)은 쿠버네티스 버전 1.23 이하의 구성 요소이다.
+kubelet이 {{< glossary_tooltip text="도커 엔진" term_id="docker" >}}과 통신할 수 있게 한다.
+
+<!--more-->
+
+1.24버전 부터 도커심(Dockershim)은 쿠버네티스에서 제거되었다. 자세한 사항은 [Dockershim FAQ](/dockershim)를 참고한다.

--- a/content/ko/docs/reference/glossary/helm-chart.md
+++ b/content/ko/docs/reference/glossary/helm-chart.md
@@ -1,0 +1,19 @@
+---
+title: 헬름 차트(Helm Chart)
+id: helm-chart
+date: 2018-04-12
+full_link: https://helm.sh/ko/docs/topics/charts/
+short_description: >
+  헬름(Helm) 도구를 통해 관리할 수 있는 사전 구성된 쿠버네티스 리소스 패키지
+
+aka: 
+tags:
+- tool
+---
+ 헬름(Helm) 도구를 통해 관리할 수 있는 사전 구성된 쿠버네티스 리소스 패키지
+ 
+<!--more--> 
+
+차트는 쿠버네티스 애플리케이션을 생성하고 공유하는 반복 가능한 방법을 제공한다.
+단일 차트는 Memcached 파드와 같이 간단한 것부터 HTTP 서버, 데이터베이스, 캐시 등이 포함된 전체 웹 앱 스택과 같은 복잡한 것까지 배포하는 데 사용할 수 있다.
+

--- a/content/ko/docs/reference/glossary/host-aliases.md
+++ b/content/ko/docs/reference/glossary/host-aliases.md
@@ -1,0 +1,17 @@
+---
+title: 호스트에일리어스(HostAlias)
+id: HostAliases
+date: 2019-01-31
+full_link: /docs/reference/generated/kubernetes-api/{{< param "version" >}}/#hostalias-v1-core
+short_description: >
+  호스트에일리어스는 파드의 hosts 파일에 주입될 IP 주소와 호스트네임간의 매핑이다. 
+
+aka:
+tags:
+- operation
+---
+호스트에일리어스는 {{< glossary_tooltip text="파드" term_id="pod" >}}의 hosts 파일에 주입될 IP 주소와 호스트네임간의 매핑이다.
+
+<!--more-->
+
+[호스트에일리어스](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#hostalias-v1-core)은 명시된 경우에만 파드의 hosts 파일에 주입되는 호스트네임 및 IP 주소의 선택적 목록이다. 이는 hostNetwork 모드를 사용하고 있지 않은 파드에서만 유효하다.

--- a/content/ko/docs/reference/glossary/kubeadm.md
+++ b/content/ko/docs/reference/glossary/kubeadm.md
@@ -1,0 +1,19 @@
+---
+title: kubeadm
+id: kubeadm
+date: 2018-04-12
+full_link: /docs/admin/kubeadm/
+short_description: >
+  쿠버네티스를 빠르게 설치하고 안전한(secure) 클러스터를 설정하는 도구
+
+aka: 
+tags:
+- tool
+- operation
+---
+ 쿠버네티스를 빠르게 설치하고 안전한(secure) 클러스터를 설정하는 도구
+
+<!--more--> 
+
+kubeadm을 사용하여 컨트롤 플레인과 {{< glossary_tooltip text="워커 노드" term_id="node" >}} 구성 요소를 설치할 수 있다.
+


### PR DESCRIPTION
#35342 

reproducible > ko/docs/reference/tool/_index.md 의 Helm에서 반복 가능한으로 번역되었고, 의미상 통한다고 생각하여 같이 사용하였습니다.