### PR TITLE
Improve Managing Secrets using a Configuration File

### DIFF
--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-config-file.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-config-file.md
@@ -13,9 +13,10 @@ description: Creating Secret objects using resource configuration file.
 
 <!-- steps -->
 
-## Create the Config file
+## Create the Secret {#create-the-config-file}
 
-You can define the `Secret` object in a file first, in JSON or YAML format, and then create that object. The
+You can define the `Secret` object in a manifest first, in JSON or YAML format,
+and then create that object. The
 [Secret](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#secret-v1-core)
 resource contains two maps: `data` and `stringData`.
 The `data` field is used to store arbitrary data, encoded using base64. The
@@ -44,7 +45,7 @@ The following example stores two strings in a Secret using the `data` field.
    MWYyZDFlMmU2N2Rm
    ```
 
-1. Create the configuration file:
+1. Create the manifest:
 
    ```yaml
    apiVersion: v1

--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-config-file.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-config-file.md
@@ -75,6 +75,8 @@ The following example stores two strings in a Secret using the `data` field.
 To verify that the Secret was created and to decode the Secret data, refer to
 [Managing Secrets using kubectl](/docs/tasks/configmap-secret/managing-secret-using-kubectl/#verify-the-secret).
 
+### Specify unencoded data when creating a Secret
+
 For certain scenarios, you may wish to use the `stringData` field instead. This
 field allows you to put a non-base64 encoded string directly into the Secret,
 and the string will be encoded for you when the Secret is created or updated.

--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-config-file.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-config-file.md
@@ -72,6 +72,9 @@ The following example stores two strings in a Secret using the `data` field.
    secret/mysecret created
    ```
 
+To verify that the Secret was created and to decode the Secret data, refer to
+[Managing Secrets using kubectl](/docs/tasks/configmap-secret/managing-secret-using-kubectl/#verify-the-secret).
+
 For certain scenarios, you may wish to use the `stringData` field instead. This
 field allows you to put a non-base64 encoded string directly into the Secret,
 and the string will be encoded for you when the Secret is created or updated.
@@ -102,6 +105,8 @@ stringData:
     username: <user>
     password: <password>
 ```
+When you retrieve the Secret data, the command returns the encoded values,
+and not the plaintext values you provided in `stringData`.
 
 Create the Secret using [`kubectl apply`](/docs/reference/generated/kubectl/kubectl-commands#apply):
 

--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-config-file.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-config-file.md
@@ -108,22 +108,7 @@ stringData:
 When you retrieve the Secret data, the command returns the encoded values,
 and not the plaintext values you provided in `stringData`.
 
-Create the Secret using [`kubectl apply`](/docs/reference/generated/kubectl/kubectl-commands#apply):
-
-```shell
-kubectl apply -f ./secret.yaml
-```
-
-The output is similar to:
-
-```
-secret/mysecret created
-```
-
-## Check the Secret
-
-The `stringData` field is a write-only convenience field. It is never output when
-retrieving Secrets. For example, if you run the following command:
+For example, if you run the following command:
 
 ```shell
 kubectl get secret mysecret -o yaml
@@ -145,14 +130,9 @@ metadata:
 type: Opaque
 ```
 
-The commands `kubectl get` and `kubectl describe` avoid showing the contents of a `Secret` by
-default. This is to protect the `Secret` from being exposed accidentally to an onlooker,
-or from being stored in a terminal log.
-To check the actual content of the encoded data, please refer to
-[decoding secret](/docs/tasks/configmap-secret/managing-secret-using-kubectl/#decoding-secret).
+### Specifying both `data` and `stringData`
 
-If a field, such as `username`, is specified in both `data` and `stringData`,
-the value from `stringData` is used. For example, the following Secret definition:
+If you specify a field in both `data` and `stringData`, the value from `stringData` is used. For example, if you define the following Secret:
 
 ```yaml
 apiVersion: v1
@@ -166,7 +146,7 @@ stringData:
   username: administrator
 ```
 
-Results in the following Secret:
+The `Secret` object is created as follows:
 
 ```yaml
 apiVersion: v1
@@ -182,7 +162,7 @@ metadata:
 type: Opaque
 ```
 
-Where `YWRtaW5pc3RyYXRvcg==` decodes to `administrator`.
+`YWRtaW5pc3RyYXRvcg==` decodes to `administrator`.
 
 ## Clean Up
 

--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-config-file.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-config-file.md
@@ -15,18 +15,18 @@ description: Creating Secret objects using resource configuration file.
 
 ## Create the Config file
 
-You can create a Secret in a file first, in JSON or YAML format, and then
-create that object.  The
+You can define the `Secret` object in a file first, in JSON or YAML format, and then create that object. The
 [Secret](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#secret-v1-core)
 resource contains two maps: `data` and `stringData`.
 The `data` field is used to store arbitrary data, encoded using base64. The
 `stringData` field is provided for convenience, and it allows you to provide
-Secret data as unencoded strings.
+the same data as unencoded strings.
 The keys of `data` and `stringData` must consist of alphanumeric characters,
 `-`, `_` or `.`.
 
-For example, to store two strings in a Secret using the `data` field, convert
-the strings to base64 as follows:
+The following example stores two strings in a Secret using the `data` field.
+
+Convert the strings to base64 as follows:
 
 ```shell
 echo -n 'admin' | base64

--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-config-file.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-config-file.md
@@ -26,29 +26,30 @@ The keys of `data` and `stringData` must consist of alphanumeric characters,
 
 The following example stores two strings in a Secret using the `data` field.
 
-Convert the strings to base64 as follows:
+Convert the strings to base64:
 
 ```shell
 echo -n 'admin' | base64
+echo -n '1f2d1e2e67df' | base64
 ```
+
+{{< note >}}
+The serialized JSON and YAML values of Secret data are encoded as base64
+strings. Newlines are not valid within these strings and must be omitted. When
+using the `base64` utility on Darwin/macOS, users should avoid using the `-b`
+option to split long lines. Conversely, Linux users *should* add the option
+`-w 0` to `base64` commands or the pipeline `base64 | tr -d '\n'` if the `-w`
+option is not available.
+{{< /note >}}
 
 The output is similar to:
 
 ```
 YWRtaW4=
-```
-
-```shell
-echo -n '1f2d1e2e67df' | base64
-```
-
-The output is similar to:
-
-```
 MWYyZDFlMmU2N2Rm
 ```
 
-Write a Secret config file that looks like this:
+Create the configuration file:
 
 ```yaml
 apiVersion: v1
@@ -63,15 +64,6 @@ data:
 
 Note that the name of a Secret object must be a valid
 [DNS subdomain name](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names).
-
-{{< note >}}
-The serialized JSON and YAML values of Secret data are encoded as base64
-strings. Newlines are not valid within these strings and must be omitted. When
-using the `base64` utility on Darwin/macOS, users should avoid using the `-b`
-option to split long lines. Conversely, Linux users *should* add the option
-`-w 0` to `base64` commands or the pipeline `base64 | tr -d '\n'` if the `-w`
-option is not available.
-{{< /note >}}
 
 For certain scenarios, you may wish to use the `stringData` field instead. This
 field allows you to put a non-base64 encoded string directly into the Secret,
@@ -104,9 +96,7 @@ stringData:
     password: <password>
 ```
 
-## Create the Secret object
-
-Now create the Secret using [`kubectl apply`](/docs/reference/generated/kubectl/kubectl-commands#apply):
+Create the Secret using [`kubectl apply`](/docs/reference/generated/kubectl/kubectl-commands#apply):
 
 ```shell
 kubectl apply -f ./secret.yaml

--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-config-file.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-config-file.md
@@ -34,8 +34,8 @@ The following example stores two strings in a Secret using the `data` field.
    ```
 
    {{< note >}}
-   The serialized JSON and YAML values of Secret data are encoded as base64
-   strings. Newlines are not valid within these strings and must be omitted. When using the `base64` utility on Darwin/macOS, users should avoid using the `-b` option to split long lines. Conversely, Linux users *should* add the option `-w 0` to `base64` commands or the pipeline `base64 | tr -d '\n'` if the `-w` option is not available. {{< /note >}}
+   The serialized JSON and YAML values of Secret data are encoded as base64 strings. Newlines are not valid within these strings and must be omitted. When using the `base64` utility on Darwin/macOS, users should avoid using the `-b` option to split long lines. Conversely, Linux users *should* add the option `-w 0` to `base64` commands or the pipeline `base64 | tr -d '\n'` if the `-w` option is not available.
+   {{< /note >}}
 
    The output is similar to:
 
@@ -134,7 +134,9 @@ type: Opaque
 
 ### Specifying both `data` and `stringData`
 
-If you specify a field in both `data` and `stringData`, the value from `stringData` is used. For example, if you define the following Secret:
+If you specify a field in both `data` and `stringData`, the value from `stringData` is used.
+
+For example, if you define the following Secret:
 
 ```yaml
 apiVersion: v1

--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-config-file.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-config-file.md
@@ -26,44 +26,51 @@ The keys of `data` and `stringData` must consist of alphanumeric characters,
 
 The following example stores two strings in a Secret using the `data` field.
 
-Convert the strings to base64:
+1. Convert the strings to base64:
 
-```shell
-echo -n 'admin' | base64
-echo -n '1f2d1e2e67df' | base64
-```
+   ```shell
+   echo -n 'admin' | base64
+   echo -n '1f2d1e2e67df' | base64
+   ```
 
-{{< note >}}
-The serialized JSON and YAML values of Secret data are encoded as base64
-strings. Newlines are not valid within these strings and must be omitted. When
-using the `base64` utility on Darwin/macOS, users should avoid using the `-b`
-option to split long lines. Conversely, Linux users *should* add the option
-`-w 0` to `base64` commands or the pipeline `base64 | tr -d '\n'` if the `-w`
-option is not available.
-{{< /note >}}
+   {{< note >}}
+   The serialized JSON and YAML values of Secret data are encoded as base64
+   strings. Newlines are not valid within these strings and must be omitted. When using the `base64` utility on Darwin/macOS, users should avoid using the `-b` option to split long lines. Conversely, Linux users *should* add the option `-w 0` to `base64` commands or the pipeline `base64 | tr -d '\n'` if the `-w` option is not available. {{< /note >}}
 
-The output is similar to:
+   The output is similar to:
 
-```
-YWRtaW4=
-MWYyZDFlMmU2N2Rm
-```
+   ```
+   YWRtaW4=
+   MWYyZDFlMmU2N2Rm
+   ```
 
-Create the configuration file:
+1. Create the configuration file:
 
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: mysecret
-type: Opaque
-data:
-  username: YWRtaW4=
-  password: MWYyZDFlMmU2N2Rm
-```
+   ```yaml
+   apiVersion: v1
+   kind: Secret
+   metadata:
+     name: mysecret
+   type: Opaque
+   data:
+     username: YWRtaW4=
+     password: MWYyZDFlMmU2N2Rm
+   ```
 
-Note that the name of a Secret object must be a valid
-[DNS subdomain name](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names).
+   Note that the name of a Secret object must be a valid
+   [DNS subdomain name](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names).
+
+1. Create the Secret using [`kubectl apply`](/docs/reference/generated/kubectl/kubectl-commands#apply):
+
+   ```shell
+   kubectl apply -f ./secret.yaml
+   ```
+
+   The output is similar to:
+
+   ```
+   secret/mysecret created
+   ```
 
 For certain scenarios, you may wish to use the `stringData` field instead. This
 field allows you to put a non-base64 encoded string directly into the Secret,

--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
@@ -113,7 +113,7 @@ The commands `kubectl get` and `kubectl describe` avoid showing the contents
 of a `Secret` by default. This is to protect the `Secret` from being exposed
 accidentally, or from being stored in a terminal log.
 
-To check the actual content of the encoded data, please refer to [Decoding the Secret](#decoding-secret).
+To check the actual content of the encoded data, refer to [Decoding the Secret](#decoding-secret).
 
 ## Decoding the Secret  {#decoding-secret}
 

--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
@@ -111,7 +111,7 @@ username:    5 bytes
 
 The commands `kubectl get` and `kubectl describe` avoid showing the contents
 of a `Secret` by default. This is to protect the `Secret` from being exposed
-accidentally, or from being stored in a terminal log.
+accidentally, or from being stored in a terminal log. To check the actual content of the encoded data, please refer to [Decoding the Secret](#decoding-secret).
 
 ## Decoding the Secret  {#decoding-secret}
 

--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-kubectl.md
@@ -111,7 +111,9 @@ username:    5 bytes
 
 The commands `kubectl get` and `kubectl describe` avoid showing the contents
 of a `Secret` by default. This is to protect the `Secret` from being exposed
-accidentally, or from being stored in a terminal log. To check the actual content of the encoded data, please refer to [Decoding the Secret](#decoding-secret).
+accidentally, or from being stored in a terminal log.
+
+To check the actual content of the encoded data, please refer to [Decoding the Secret](#decoding-secret).
 
 ## Decoding the Secret  {#decoding-secret}
 


### PR DESCRIPTION
Umbrella issue: #4491
Replaces #34856

This PR makes a series of updates to the Managing Secrets using a Configuration File topic:

- Improve wording for accuracy, especially related to referring to API object definition and creation
- Use the imperative form for steps
- Add numbers to steps
- Consolidate info about stringdata field away from the task flow
- Replace the verify step, which uses kubectl, with a link to the same steps in the Managing Secrets using kubectl topic

Reviewers: please review each of the six commits. I haven't squashed on purpose, to split the changes into independent chunks.

/sig docs
/language en 