### PR TITLE
Add Edit Secret step to Managing Secrets Using a Configuration File

### DIFF
--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-config-file.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-config-file.md
@@ -170,6 +170,61 @@ type: Opaque
 
 `YWRtaW5pc3RyYXRvcg==` decodes to `administrator`.
 
+## Edit a Secret {#edit-secret}
+
+To edit the data in the Secret you created using a manifest, modify the `data`
+or `stringData` field in your manifest and apply the file to your
+cluster. You can edit an existing `Secret` object unless it is
+[immutable](/docs/concepts/configuration/secret/#secret-immutable).
+
+For example, if you want to change the password from the previous example to
+`birdsarentreal`, do the following:
+
+1. Encode the new password string:
+
+   ```shell
+   echo -n 'birdsarentreal' | base64
+   ```
+
+   The output is similar to:
+
+   ```
+   YmlyZHNhcmVudHJlYWw=
+   ```
+
+1. Update the `data` field with your new password string:
+
+   ```yaml
+   apiVersion: v1
+   kind: Secret
+   metadata:
+     name: mysecret
+   type: Opaque
+   data:
+     username: YWRtaW4=
+     password: YmlyZHNhcmVudHJlYWw=
+   ```
+
+1. Apply the manifest to your cluster:
+
+   ```shell
+   kubectl apply -f ./secret.yaml
+   ```
+
+   The output is similar to:
+
+   ```
+   secret/mysecret configured
+   ```
+
+Kubernetes updates the existing `Secret` object. In detail, the `kubectl` tool
+notices that there is an existing `Secret` object with the same name. `kubectl`
+fetches the existing object, plans changes to it, and submits the changed
+`Secret` object to your cluster control plane.
+
+If you specified `kubectl apply --server-side` instead, `kubectl` uses
+[Server Side Apply](/docs/reference/using-api/server-side-apply/) instead.
+
 ## Clean up
 
 To delete the Secret you have created:


### PR DESCRIPTION
Umbrella issue: https://github.com/kubernetes/website/issues/4491
Replaces https://github.com/kubernetes/website/pull/34856

This PR adds the steps to edit an existing Secret using a configuration file. It includes the merge commits from PR #35383 which make additional improvements to the page, however, only commit aae550f needs a review in this PR.

(I might not be doing this stacking PRs this correctly so I'm open to suggestions, like removing the merge commit altogether)

/sig docs
/language en
