### PR TITLE
Add .hugo_build.lock file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ nohup.out
 # Hugo output
 public/
 resources/
+.hugo_build.lock
 
 # Netlify Functions build output
 package-lock.json


### PR DESCRIPTION
This PR is to add `.hugo_build.lock` to `.gitignore`.

In my recent PR(#35273), I was told that unnecessary file, `.hugo_build.lock`  was added in my commit. This `hugo_build.lock` file is automatically generated during local hugo build from hugo v0.89.0([https://gohugo.io/news/0.89.0-relnotes/#notes](https://gohugo.io/news/0.89.0-relnotes/#notes)) and should not be included in the commit.

Thus, it would be great if we could add `.hugo_build.lock` to `.gitignore` so that others will not make mistake like me.

Also, I double-confirmed that there is no duplicated PR(both open & closed PRs). This suggestion was already made in previous PR(#31721) but it hasn’t been applied yet(since there is no open/closed PR related to this, I guess the author of #31721 forgot to seperate PR).