### PR TITLE
Add Fig as a bash autocomplete method

### DIFF
--- a/content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-mac.md
+++ b/content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-mac.md
@@ -87,3 +87,13 @@ You now have to ensure that the kubectl completion script gets sourced in all yo
    {{< /note >}}
 
 In any case, after reloading your shell, kubectl completion should be working.
+
+### Fig
+
+You can get IDE-style autocompletions for kubectl also using [Fig](https://fig.io/) <a href="https://fig.io/" target="_blank"><img src="https://fig.io/badges/Logo.svg" width="15" height="15"/></a>. Fig works for bash, zsh, and fish.
+
+To install, run:
+
+```shell
+brew install fig
+```


### PR DESCRIPTION
[Fig](https://fig.io) provides autocomplete for 300+ CLI tools including kubectl, so we would love to have Fig listed as a bash autocomplete method in your docs. Thanks so much and please let me know if you have any questions!