### PR TITLE
Add Fig as a fish autocomplete method

### DIFF
--- a/content/en/docs/tasks/tools/included/optional-kubectl-configs-fish.md
+++ b/content/en/docs/tasks/tools/included/optional-kubectl-configs-fish.md
@@ -13,3 +13,13 @@ kubectl completion fish | source
 ```
 
 After reloading your shell, kubectl autocompletion should be working.
+
+### Fig
+
+You can get IDE-style autocompletions for kubectl also using [Fig](https://fig.io/) <a href="https://fig.io/" target="_blank"><img src="https://fig.io/badges/Logo.svg" width="15" height="15"/></a>. Fig works for bash, zsh, and fish.
+
+To install, run:
+
+```shell
+brew install fig
+```


### PR DESCRIPTION
[Fig](https://fig.io) provides autocomplete for 300+ CLI tools including Docker, so we would love to have Fig listed as a fish autocomplete method in your docs. Thanks so much and please let me know if you have any questions!