### PR TITLE
[zh-cn] updated /docs/reference/glossary/event.md

### DIFF
--- a/content/zh-cn/docs/reference/glossary/event.md
+++ b/content/zh-cn/docs/reference/glossary/event.md
@@ -2,9 +2,9 @@
 title: 事件（Event）
 id: event
 date: 2022-01-16
-full_link: /docs/reference/kubernetes-api/cluster-resources/event-v1/
+full_link: /zh-cn/docs/reference/kubernetes-api/cluster-resources/event-v1/
 short_description: >
-   对集群中周处发生的事件的报告。通常用来表述系统中某种状态变更。
+   对集群中某处所发生事件的报告。通常用来表述系统中某种状态变更。
 aka: 
 tags:
 - core-object
@@ -25,11 +25,11 @@ tags:
 -->
 
 <!--
-Each Event is a report of an event somewhere in the {{< glossary_tooltip text="cluster" term_id="cluster" >}}.
+Each Event is a report of an event somewhere in the {{< glossary_tooltip text="cluster" term_id="cluster" >}}. 
 It generally denotes some state change in the system.
 -->
-每个 Event 是{{< glossary_tooltip text="集群" term_id="cluster" >}}中某处发生的事件的报告。
-它通常用来表述系统中的某种状态变化。
+每个 Event 是{{< glossary_tooltip text="集群" term_id="cluster" >}}中某处所发生事件的报告。
+它通常用来表述系统中的某种状态变更。
 
 <!--more-->
 
@@ -40,7 +40,7 @@ or the continued existence of events with that reason.
 -->
 事件的保留时间有限，随着时间推进，其触发方式和消息都可能发生变化。
 事件用户不应该对带有给定原因（反映下层触发源）的时间特征有任何依赖，
-也不要寄希望于对应该原因的事件会一直存在。
+也不要寄希望于该原因所造成的事件会一直存在。
 
 <!--
 Events should be treated as informative, best-effort, supplemental data.
@@ -52,5 +52,5 @@ In Kubernetes, [auditing](/docs/tasks/debug/debug-cluster/audit/) generates a di
 Event record (API group `audit.k8s.io`).
 -->
 在 Kubernetes 中，[审计](/zh-cn/docs/tasks/debug/debug-cluster/audit/)
-机制会生成一种不同种类的 Event 记录（API 组为 `audit.k8s.io`）。
+机制会生成一种不同类别的 Event 记录（API 组为 `audit.k8s.io`）。
 


### PR DESCRIPTION
Fix typos:
```
content/zh-cn/docs/reference/glossary/event.md
```