### PR TITLE
prioritize minikube for new developers

### DIFF
--- a/content/en/docs/tasks/tools/_index.md
+++ b/content/en/docs/tasks/tools/_index.md
@@ -21,20 +21,9 @@ Find your preferred operating system below.
 - [Install kubectl on macOS](/docs/tasks/tools/install-kubectl-macos)
 - [Install kubectl on Windows](/docs/tasks/tools/install-kubectl-windows)
 
-## kind
-
-[`kind`](https://kind.sigs.k8s.io/docs/) lets you run Kubernetes on
-your local computer. This tool requires that you have
-[Docker](https://docs.docker.com/get-docker/) installed and configured.
-
-The kind [Quick Start](https://kind.sigs.k8s.io/docs/user/quick-start/) page
-shows you what you need to do to get up and running with kind.
-
-<a class="btn btn-primary" href="https://kind.sigs.k8s.io/docs/user/quick-start/" role="button" aria-label="View kind Quick Start Guide">View kind Quick Start Guide</a>
-
 ## minikube
 
-Like `kind`, [`minikube`](https://minikube.sigs.k8s.io/) is a tool that lets you run Kubernetes
+[`minikube`](https://minikube.sigs.k8s.io/) is a tool that lets you run Kubernetes
 locally. `minikube` runs a single-node Kubernetes cluster on your personal
 computer (including Windows, macOS and Linux PCs) so that you can try out
 Kubernetes, or for daily development work.
@@ -47,6 +36,17 @@ on getting the tool installed.
 
 Once you have `minikube` working, you can use it to
 [run a sample application](/docs/tutorials/hello-minikube/).
+
+## kind
+
+[`kind`](https://kind.sigs.k8s.io/docs/) lets you run Kubernetes on
+your local computer. This tool requires that you have
+[Docker](https://docs.docker.com/get-docker/) installed and configured.
+
+The kind [Quick Start](https://kind.sigs.k8s.io/docs/user/quick-start/) page
+shows you what you need to do to get up and running with kind.
+
+<a class="btn btn-primary" href="https://kind.sigs.k8s.io/docs/user/quick-start/" role="button" aria-label="View kind Quick Start Guide">View kind Quick Start Guide</a>
 
 ## kubeadm
 


### PR DESCRIPTION
Fixes: #35519 

This PR prioritizes the documentation recommendation of **minikube** ahead of **kind** as the very first tool that new developers should use when initially learning kubernetes.

In addition, the goal is to ensure that developers have an easier time in getting started with Kubernetes by adopting **minikube** from the start.

We have found that **kind** is oriented more towards testing kubernetes rather than for application development by new software engineers.