### PR TITLE
[ko] Translate the glossary term "SIG"

### DIFF
--- a/content/ko/docs/reference/glossary/sig.md
+++ b/content/ko/docs/reference/glossary/sig.md
@@ -1,0 +1,21 @@
+---
+title: SIG(special interest group)
+id: sig
+date: 2018-04-12
+full_link: https://github.com/kubernetes/community/blob/master/sig-list.md#special-interest-groups
+short_description: >
+  대규모 쿠버네티스 오픈소스 프로젝트에서 진행되는 내용을 공동으로 관리하는 커뮤니티 멤버들이다.
+
+aka: 
+tags:
+- community
+---
+ 대규모 쿠버네티스 오픈소스 프로젝트에서 진행되는 내용을 공동으로 관리하는 커뮤니티 {{< glossary_tooltip text="멤버" term_id="member" >}}들이다.
+
+<!--more--> 
+
+SIG 멤버들은 아키텍처, API, 또는 문서화 같이 특정 영역을 발전시키는 데 공통적으로 관심을 갖고 있다.
+기본적으로 SIG [거버넌스 지침](https://github.com/kubernetes/community/blob/master/committee-steering/governance/sig-governance.md)을 따라야 하지만, 자체적으로 기여 정책이나 소통 채널을 가질 수 있다.
+
+자세한 내용은 [kubernetes/community](https://github.com/kubernetes/community) 저장소 및 현재 존재하는 [SIG 및 WG](https://github.com/kubernetes/community/blob/master/sig-list.md) 목록을 참조한다.
+


### PR DESCRIPTION
Resolves #35460 

[SIG Docs에 참여하기](https://kubernetes.io/ko/docs/contribute/participate/)를 참조하여 제목인 SIG를 분과회로 번역할지도 생각해보았는데,
SIG 라는 표현을 유지하는 것이 더 의미가 잘 통하지 않을까 싶어서 제목은 그대로 가고 본문에서 괄호로 넣었습니다!

/language ko