### PR TITLE
deprecate GlusterFS volume plugin from in-tree drivers.

### DIFF
--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -444,6 +444,8 @@ The following types of PersistentVolume are deprecated. This means that support 
   (**deprecated** in v1.22)
 * [`storageos`](/docs/concepts/storage/volumes/#storageos) - StorageOS volume
   (**deprecated** in v1.22)
+* [`glusterfs`](/docs/concepts/storage/volumes/#glusterfs) - GlusterFS volume
+  (**deprecated** in v1.25)
 
 Older versions of Kubernetes also supported the following in-tree PersistentVolume types:
 

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -554,7 +554,7 @@ spec:
       revision: "22f1d8406d464b0c0874075539c1f2e96c253775"
 ```
 
-### glusterfs
+### glusterfs (deprecated) {#glusterfs}
 
 A `glusterfs` volume allows a [Glusterfs](https://www.gluster.org) (an open
 source networked filesystem) volume to be mounted into your Pod. Unlike


### PR DESCRIPTION
updating the website to mention glusterfs driver deprecation.

Reference# https://github.com/kubernetes/kubernetes/pull/111485

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>


