### PR TITLE
Fixed markdown in tabs.

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -112,16 +112,13 @@ For example, to download version {{< param "fullversion" >}} on Linux, type:
    sudo apt-get update
    sudo apt-get install -y ca-certificates curl
    ```
-   
-   {{< note >}}
-   
-   If you use Debian 9 (stretch) or earlier you would also need to install `apt-transport-https`:
-    
-    ```shell
-    sudo apt-get install -y apt-transport-https
-    ```
-   
-   {{< /note >}}
+{{< note >}}
+ If you use Debian 9 (stretch) or earlier you would also need to install `apt-transport-https`:
+```shell
+sudo apt-get install -y apt-transport-https
+```
+
+{{< /note >}}
    
 2. Download the Google Cloud public signing key:
 
@@ -144,7 +141,8 @@ For example, to download version {{< param "fullversion" >}} on Linux, type:
 
 {{% /tab %}}
 
-{{< tab name="Red Hat-based distributions" codelang="bash" >}}
+{{% tab name="Red Hat-based distributions" %}}
+```bash
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -154,7 +152,9 @@ gpgcheck=1
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOF
 sudo yum install -y kubectl
-{{< /tab >}}
+```
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ### Install using other package management

--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -112,14 +112,11 @@ For example, to download version {{< param "fullversion" >}} on Linux, type:
    sudo apt-get update
    sudo apt-get install -y ca-certificates curl
    ```
-{{< note >}}
- If you use Debian 9 (stretch) or earlier you would also need to install `apt-transport-https`:
-```shell
-sudo apt-get install -y apt-transport-https
-```
+   If you use Debian 9 (stretch) or earlier you would also need to install `apt-transport-https`:
+   ```shell
+   sudo apt-get install -y apt-transport-https
+   ```
 
-{{< /note >}}
-   
 2. Download the Google Cloud public signing key:
 
    ```shell


### PR DESCRIPTION
This PR fixed the markdown in tabs that are not working under [Install using native package management](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management) 

Fixes: #35482
