### PR TITLE
Added supporting context for job suspension functionality

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -538,7 +538,7 @@ spec:
 
 You can also toggle Job suspension by patching the Job using the command line.
 
-Suspend an active job:
+Suspend an active Job:
 
 ```shell
 kubectl patch job/myjob -p '{"spec":{"suspend":true}}'

--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -544,7 +544,7 @@ Suspend an active job:
 kubectl patch job/myjob -p '{"spec":{"suspend":true}}'
 ```
 
-Unsuspend an active job:
+Resume a suspended Job:
 
 ```shell
 kubectl patch job/myjob -p '{"spec":{"suspend":false}}'

--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -541,7 +541,7 @@ You can also toggle Job suspension by patching the Job using the command line.
 Suspend an active Job:
 
 ```shell
-kubectl patch job/myjob -p '{"spec":{"suspend":true}}'
+kubectl patch job/myjob --type=strategic --patch '{"spec":{"suspend":true}}'
 ```
 
 Resume a suspended Job:

--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -536,7 +536,9 @@ spec:
       ...
 ```
 
-Alternatively, a job suspension can be toggled from the command line by patching the job resource.  Suspend an active job:
+You can also toggle Job suspension by patching the Job using the command line.
+
+Suspend an active job:
 
 ```shell
 kubectl patch job/myjob -p '{"spec":{"suspend":true}}'

--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -510,8 +510,7 @@ When a Job is resumed from suspension, its `.status.startTime` field will be
 reset to the current time. This means that the `.spec.activeDeadlineSeconds`
 timer will be stopped and reset when a Job is suspended and resumed.
 
-Remember that suspending a Job will delete all Pods that are not Completed. When the Job is
-suspended, Non-Completed [Pods will be terminated](/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination)
+When you suspend a Job, any running Pods that don't have a status of `Completed` will be [terminated](/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination).
 with a SIGTERM signal. The Pod's graceful termination period will be honored and
 your Pod must handle this signal in this period. This may involve saving
 progress for later or undoing changes. Pods terminated this way will not count

--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -510,8 +510,8 @@ When a Job is resumed from suspension, its `.status.startTime` field will be
 reset to the current time. This means that the `.spec.activeDeadlineSeconds`
 timer will be stopped and reset when a Job is suspended and resumed.
 
-Remember that suspending a Job will delete all active Pods. When the Job is
-suspended, your [Pods will be terminated](/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination)
+Remember that suspending a Job will delete all Pods that are not Completed. When the Job is
+suspended, Non-Completed [Pods will be terminated](/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination)
 with a SIGTERM signal. The Pod's graceful termination period will be honored and
 your Pod must handle this signal in this period. This may involve saving
 progress for later or undoing changes. Pods terminated this way will not count
@@ -535,6 +535,18 @@ spec:
   template:
     spec:
       ...
+```
+
+Alternatively, a job suspension can be toggled from the command line by patching the job resource.  Suspend an active job:
+
+```shell
+kubectl patch job/myjob -p '{"spec":{"suspend":true}}'
+```
+
+Unsuspend an active job:
+
+```shell
+kubectl patch job/myjob -p '{"spec":{"suspend":false}}'
 ```
 
 The Job's status can be used to determine if a Job is suspended or has been

--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -547,7 +547,7 @@ kubectl patch job/myjob --type=strategic --patch '{"spec":{"suspend":true}}'
 Resume a suspended Job:
 
 ```shell
-kubectl patch job/myjob -p '{"spec":{"suspend":false}}'
+kubectl patch job/myjob --type=strategic --patch '{"spec":{"suspend":false}}'
 ```
 
 The Job's status can be used to determine if a Job is suspended or has been


### PR DESCRIPTION
Hi All,

Hope you're doing well.  I was experimenting with the job suspension functionality detailed as follows in the [documentation](https://kubernetes.io/docs/concepts/workloads/controllers/job/#suspending-a-job).

It was not clear (at least, for myself) that the reference to the suspension of "active" Pods, refers to Pods that are in a Non-Completed state.

I've added context to specifically highlight this and hopefully this change will help new users who are navigating this functionality.  This simple differentiator provides a distinct separator that aligns to the Pod status (Completed) and Job terminology (i.e. Completion).

For example -

1. I am running a job that requires 20 Completions (as per spec.completions) and I'm using parallelism of 5
2. I've successfully achieved 10 Completions and now have 10 pods that are in a Completed state
3. Owing to the parallelism of 5 there would be 5 pods that are in a Running state (or any state that is Non-Completed)
4. If I suspend the job, the 5 Running pods would be Terminated whilst the 10 Completed pods would remain on the cluster
5. Should I then resume the job, I will have 10/20 Completions (10 Pods showing Completed) and would need 10 more Completions for a successful job execution.

I've also added convenient examples for suspending and un-suspending a job without manual yaml updates given that there is no direct CLI for suspend/unsuspend functionality and people may wish to automate this from the CLI.

Should this be merged, I will follow this up with specific locale pull requests for all other locales.

Many Thanks

James Spurin