### PR TITLE
Revert documentation of Kustomize bug as a feature

### DIFF
--- a/content/en/docs/tasks/manage-kubernetes-objects/kustomization.md
+++ b/content/en/docs/tasks/manage-kubernetes-objects/kustomization.md
@@ -86,20 +86,12 @@ metadata:
   name: example-configmap-1-8mbdf7882g
 ```
 
-To generate a ConfigMap from an env file, add an entry to the `envs` list in `configMapGenerator`. This can also be used to set values from local environment variables by omitting the `=` and the value.
-
-{{< note >}}
-It's recommended to use the local environment variable population functionality sparingly - an overlay with a patch is often more maintainable. Setting values from the environment may be useful when they cannot easily be predicted, such as a git SHA.
-{{< /note >}}
-
-Here is an example of generating a ConfigMap with a data item from a `.env` file:
+To generate a ConfigMap from an env file, add an entry to the `envs` list in `configMapGenerator`. Here is an example of generating a ConfigMap with a data item from a `.env` file:
 
 ```shell
 # Create a .env file
-# BAZ will be populated from the local environment variable $BAZ
 cat <<EOF >.env
 FOO=Bar
-BAZ
 EOF
 
 cat <<EOF >./kustomization.yaml
@@ -113,7 +105,7 @@ EOF
 The generated ConfigMap can be examined with the following command:
 
 ```shell
-BAZ=Qux kubectl kustomize ./
+kubectl kustomize ./
 ```
 
 The generated ConfigMap is:
@@ -121,11 +113,10 @@ The generated ConfigMap is:
 ```yaml
 apiVersion: v1
 data:
-  BAZ: Qux
   FOO: Bar
 kind: ConfigMap
 metadata:
-  name: example-configmap-1-892ghb99c8
+  name: example-configmap-1-42cfbf598f
 ```
 
 {{< note >}}


### PR DESCRIPTION
This reverts commit b9da040a08373cf764f4e93df32df182bbd8a835 / PR https://github.com/kubernetes/website/pull/30348. That PR documented a bug in Kustomize as though it were a feature, and unfortunately nobody from the Kustomize team saw the PR. 

The bug in question dates back to the origins of Kustomize, when some of the original code was [copied out](https://github.com/kubernetes/kubectl/pull/198/files#diff-3b07013480d8cba7d964080b404d5714115f7225e9d299c86d681ce90727fd5dR67) of kubectl, and this undesirable behaviour (for kustomize, not kubectl) went unnoticed in the adaptation. That explains why the code (written for kubectl) had comments that made it seem like the behaviour was intentional.

This behaviour is a clear violation of one of Kustomize's core principles, as documented in our [Eschewed Features list](https://kubectl.docs.kubernetes.io/faq/kustomize/eschewedfeatures/#build-time-side-effects-from-cli-args-or-env-variables):

![image](https://user-images.githubusercontent.com/4789493/181624436-bb3b0666-c75b-428e-a69c-f9f0e5425f33.png)

Since this behaviour has been around unnoticed by us for so long, our plan is to to deprecate it and remove it with a major version bump rather than treating it like a bug fix: https://github.com/kubernetes-sigs/kustomize/pull/4730. However, we would like to get the docs for it removed ASAP, as it is absolutely not something we want to encourage users to do.

cc @natasha41575 