### PR TITLE
[ko] Update outdated files in dev-1.24-ko.2 (M76-M79)

### DIFF
--- a/content/ko/docs/tasks/administer-cluster/certificates.md
+++ b/content/ko/docs/tasks/administer-cluster/certificates.md
@@ -4,14 +4,10 @@ content_type: task
 weight: 20
 ---
 
-
 <!-- overview -->
 
 클라이언트 인증서로 인증을 사용하는 경우 `easyrsa`, `openssl` 또는 `cfssl`
 을 통해 인증서를 수동으로 생성할 수 있다.
-
-
-
 
 <!-- body -->
 
@@ -19,109 +15,145 @@ weight: 20
 
 **easyrsa** 는 클러스터 인증서를 수동으로 생성할 수 있다.
 
-1.  easyrsa3의 패치 버전을 다운로드하여 압축을 풀고, 초기화한다.
+1. `easyrsa3`의 패치 버전을 다운로드하여 압축을 풀고, 초기화한다.
 
-        curl -LO https://storage.googleapis.com/kubernetes-release/easy-rsa/easy-rsa.tar.gz
-        tar xzf easy-rsa.tar.gz
-        cd easy-rsa-master/easyrsa3
-        ./easyrsa init-pki
-1.  새로운 인증 기관(CA)을 생성한다. `--batch` 는 자동 모드를 설정한다.
-    `--req-cn` 는 CA의 새 루트 인증서에 대한 일반 이름(Common Name (CN))을 지정한다.
+   ```shell
+   curl -LO https://storage.googleapis.com/kubernetes-release/easy-rsa/easy-rsa.tar.gz
+   tar xzf easy-rsa.tar.gz
+   cd easy-rsa-master/easyrsa3
+   ./easyrsa init-pki
+   ```
+1. 새로운 인증 기관(CA)을 생성한다. `--batch` 는 자동 모드를 설정한다.
+   `--req-cn` 는 CA의 새 루트 인증서에 대한 일반 이름(Common Name (CN))을 지정한다.
 
-        ./easyrsa --batch "--req-cn=${MASTER_IP}@`date +%s`" build-ca nopass
-1.  서버 인증서와 키를 생성한다.
-    `--subject-alt-name` 인수는 API 서버에 접근이 가능한 IP와 DNS
-    이름을 설정한다. `MASTER_CLUSTER_IP` 는 일반적으로 API 서버와
-    컨트롤러 관리자 컴포넌트에 대해 `--service-cluster-ip-range` 인수로
-    지정된 서비스 CIDR의 첫 번째 IP이다. `--days` 인수는 인증서가 만료되는
-    일 수를 설정하는데 사용된다.
-    또한, 아래 샘플은 기본 DNS 이름으로 `cluster.local` 을
-    사용한다고 가정한다.
+   ```shell
+   ./easyrsa --batch "--req-cn=${MASTER_IP}@`date +%s`" build-ca nopass
+   ```
 
-        ./easyrsa --subject-alt-name="IP:${MASTER_IP},"\
-        "IP:${MASTER_CLUSTER_IP},"\
-        "DNS:kubernetes,"\
-        "DNS:kubernetes.default,"\
-        "DNS:kubernetes.default.svc,"\
-        "DNS:kubernetes.default.svc.cluster,"\
-        "DNS:kubernetes.default.svc.cluster.local" \
-        --days=10000 \
-        build-server-full server nopass
-1.  `pki/ca.crt`, `pki/issued/server.crt` 그리고 `pki/private/server.key` 를 디렉터리에 복사한다.
-1.  API 서버 시작 파라미터에 다음 파라미터를 채우고 추가한다.
+1. 서버 인증서와 키를 생성한다.
 
-        --client-ca-file=/yourdirectory/ca.crt
-        --tls-cert-file=/yourdirectory/server.crt
-        --tls-private-key-file=/yourdirectory/server.key
+   `--subject-alt-name` 인자로 API 서버에 접근이 가능한 IP와 DNS
+   이름을 설정한다. `MASTER_CLUSTER_IP` 는 일반적으로 API 서버와
+   컨트롤러 관리자 컴포넌트에 대해 `--service-cluster-ip-range` 인자로
+   지정된 서비스 CIDR의 첫 번째 IP이다. `--days` 인자는 인증서가 만료되는
+   일 수를 설정하는 데 사용된다.
+   또한, 아래 샘플에서는 `cluster.local` 을 기본 DNS 도메인
+   이름으로 사용하고 있다고 가정한다.
+
+   ```shell
+   ./easyrsa --subject-alt-name="IP:${MASTER_IP},"\
+   "IP:${MASTER_CLUSTER_IP},"\
+   "DNS:kubernetes,"\
+   "DNS:kubernetes.default,"\
+   "DNS:kubernetes.default.svc,"\
+   "DNS:kubernetes.default.svc.cluster,"\
+   "DNS:kubernetes.default.svc.cluster.local" \
+   --days=10000 \
+   build-server-full server nopass
+   ```
+
+1. `pki/ca.crt`, `pki/issued/server.crt` 그리고 `pki/private/server.key` 를 디렉터리에 복사한다.
+
+1. API 서버를 시작하는 파라미터에 다음과 같이 추가한다.
+
+   ```shell
+   --client-ca-file=/yourdirectory/ca.crt
+   --tls-cert-file=/yourdirectory/server.crt
+   --tls-private-key-file=/yourdirectory/server.key
+   ```
 
 ### openssl
 
 **openssl** 은 클러스터 인증서를 수동으로 생성할 수 있다.
 
-1.  ca.key를 2048bit로 생성한다.
+1. ca.key를 2048bit로 생성한다.
 
-        openssl genrsa -out ca.key 2048
-1.  ca.key에 따라 ca.crt를 생성한다(인증서 유효 기간을 사용하려면 -days를 사용한다).
+   ```shell
+   openssl genrsa -out ca.key 2048
+   ```
 
-        openssl req -x509 -new -nodes -key ca.key -subj "/CN=${MASTER_IP}" -days 10000 -out ca.crt
-1.  server.key를 2048bit로 생성한다.
+1. ca.key에 따라 ca.crt를 생성한다(인증서 유효 기간을 사용하려면 `-days`를 사용한다).
 
-        openssl genrsa -out server.key 2048
-1.  인증서 서명 요청(Certificate Signing Request (CSR))을 생성하기 위한 설정 파일을 생성한다.
-    파일에 저장하기 전에 꺾쇠 괄호(예: `<MASTER_IP>`)로
-    표시된 값을 실제 값으로 대체한다(예: `csr.conf`).
-    `MASTER_CLUSTER_IP` 의 값은 이전 하위 섹션에서
-    설명한 대로 API 서버의 서비스 클러스터 IP이다.
-    또한, 아래 샘플에서는 `cluster.local` 을 기본 DNS 도메인
-    이름으로 사용하고 있다고 가정한다.
+   ```shell
+   openssl req -x509 -new -nodes -key ca.key -subj "/CN=${MASTER_IP}" -days 10000 -out ca.crt
+   ```
 
-        [ req ]
-        default_bits = 2048
-        prompt = no
-        default_md = sha256
-        req_extensions = req_ext
-        distinguished_name = dn
+1. server.key를 2048bit로 생성한다.
 
-        [ dn ]
-        C = <국가(country)>
-        ST = <도(state)>
-        L = <시(city)>
-        O = <조직(organization)>
-        OU = <조직 단위(organization unit)>
-        CN = <MASTER_IP>
+   ```shell
+   openssl genrsa -out server.key 2048
+   ```
 
-        [ req_ext ]
-        subjectAltName = @alt_names
+1. 인증서 서명 요청(Certificate Signing Request (CSR))을 생성하기 위한 설정 파일을 생성한다.
 
-        [ alt_names ]
-        DNS.1 = kubernetes
-        DNS.2 = kubernetes.default
-        DNS.3 = kubernetes.default.svc
-        DNS.4 = kubernetes.default.svc.cluster
-        DNS.5 = kubernetes.default.svc.cluster.local
-        IP.1 = <MASTER_IP>
-        IP.2 = <MASTER_CLUSTER_IP>
+   파일에 저장하기 전에 꺾쇠 괄호(예: `<MASTER_IP>`)로
+   표시된 값을 실제 값으로 대체한다(예: `csr.conf`).
+   `MASTER_CLUSTER_IP` 의 값은 이전 하위 섹션에서
+   설명한 대로 API 서버의 서비스 클러스터 IP이다.
+   또한, 아래 샘플에서는 `cluster.local` 을 기본 DNS 도메인
+   이름으로 사용하고 있다고 가정한다.
 
-        [ v3_ext ]
-        authorityKeyIdentifier=keyid,issuer:always
-        basicConstraints=CA:FALSE
-        keyUsage=keyEncipherment,dataEncipherment
-        extendedKeyUsage=serverAuth,clientAuth
-        subjectAltName=@alt_names
-1.  설정 파일을 기반으로 인증서 서명 요청을 생성한다.
+   ```ini
+   [ req ]
+   default_bits = 2048
+   prompt = no
+   default_md = sha256
+   req_extensions = req_ext
+   distinguished_name = dn
 
-        openssl req -new -key server.key -out server.csr -config csr.conf
-1.  ca.key, ca.crt 그리고 server.csr을 사용해서 서버 인증서를 생성한다.
+   [ dn ]
+   C = <국가(country)>
+   ST = <도(state)>
+   L = <시(city)>
+   O = <조직(organization)>
+   OU = <조직 단위(organization unit)>
+   CN = <MASTER_IP>
 
-        openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key \
-        -CAcreateserial -out server.crt -days 10000 \
-        -extensions v3_ext -extfile csr.conf
-1.  인증서 서명 요청을 확인한다.
+   [ req_ext ]
+   subjectAltName = @alt_names
 
-        openssl req  -noout -text -in ./server.csr
-1.  인증서를 확인한다.
+   [ alt_names ]
+   DNS.1 = kubernetes
+   DNS.2 = kubernetes.default
+   DNS.3 = kubernetes.default.svc
+   DNS.4 = kubernetes.default.svc.cluster
+   DNS.5 = kubernetes.default.svc.cluster.local
+   IP.1 = <MASTER_IP>
+   IP.2 = <MASTER_CLUSTER_IP>
 
-        openssl x509  -noout -text -in ./server.crt
+   [ v3_ext ]
+   authorityKeyIdentifier=keyid,issuer:always
+   basicConstraints=CA:FALSE
+   keyUsage=keyEncipherment,dataEncipherment
+   extendedKeyUsage=serverAuth,clientAuth
+   subjectAltName=@alt_names
+   ```
+
+1. 설정 파일을 기반으로 인증서 서명 요청을 생성한다.
+
+   ```shell
+   openssl req -new -key server.key -out server.csr -config csr.conf
+   ```
+
+1. ca.key, ca.crt 그리고 server.csr을 사용해서 서버 인증서를 생성한다.
+
+   ```shell
+   openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key \
+       -CAcreateserial -out server.crt -days 10000 \
+       -extensions v3_ext -extfile csr.conf
+   ```
+
+1. 인증서 서명 요청을 확인한다.
+
+   ```shell
+   openssl req  -noout -text -in ./server.csr
+   ```
+
+1. 인증서를 확인한다.
+
+   ```shell
+   openssl x509  -noout -text -in ./server.crt
+   ```
 
 마지막으로, API 서버 시작 파라미터에 동일한 파라미터를 추가한다.
 
@@ -129,101 +161,121 @@ weight: 20
 
 **cfssl** 은 인증서 생성을 위한 또 다른 도구이다.
 
-1.  아래에 표시된 대로 커맨드 라인 도구를 다운로드하여 압축을 풀고 준비한다.
-    사용 중인 하드웨어 아키텍처 및 cfssl 버전에 따라 샘플
-    명령을 조정해야 할 수도 있다.
+1. 아래에 표시된 대로 커맨드 라인 도구를 다운로드하여 압축을 풀고 준비한다.
 
-        curl -L https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl_1.5.0_linux_amd64 -o cfssl
-        chmod +x cfssl
-        curl -L https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssljson_1.5.0_linux_amd64 -o cfssljson
-        chmod +x cfssljson
-        curl -L https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl-certinfo_1.5.0_linux_amd64 -o cfssl-certinfo
-        chmod +x cfssl-certinfo
+   사용 중인 하드웨어 아키텍처 및 cfssl 버전에 따라 샘플
+   명령을 조정해야 할 수도 있다.
+
+   ```shell
+   curl -L https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl_1.5.0_linux_amd64 -o cfssl
+   chmod +x cfssl
+   curl -L https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssljson_1.5.0_linux_amd64 -o cfssljson
+   chmod +x cfssljson
+   curl -L https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl-certinfo_1.5.0_linux_amd64 -o cfssl-certinfo
+   chmod +x cfssl-certinfo
+   ```
+
 1.  아티팩트(artifact)를 보유할 디렉터리를 생성하고 cfssl을 초기화한다.
 
-        mkdir cert
-        cd cert
-        ../cfssl print-defaults config > config.json
-        ../cfssl print-defaults csr > csr.json
-1.  CA 파일을 생성하기 위한 JSON 설정 파일을 `ca-config.json` 예시와 같이 생성한다.
+   ```shell
+   mkdir cert
+   cd cert
+   ../cfssl print-defaults config > config.json
+   ../cfssl print-defaults csr > csr.json
+   ```
 
-        {
-          "signing": {
-            "default": {
-              "expiry": "8760h"
-            },
-            "profiles": {
-              "kubernetes": {
-                "usages": [
-                  "signing",
-                  "key encipherment",
-                  "server auth",
-                  "client auth"
-                ],
-                "expiry": "8760h"
-              }
-            }
-          }
-        }
-1.  CA 인증서 서명 요청(CSR)을 위한 JSON 설정 파일을
+1. CA 파일을 생성하기 위한 JSON 설정 파일을 `ca-config.json` 예시와 같이 생성한다.
+
+   ```json
+   {
+     "signing": {
+       "default": {
+         "expiry": "8760h"
+       },
+       "profiles": {
+         "kubernetes": {
+           "usages": [
+             "signing",
+             "key encipherment",
+             "server auth",
+             "client auth"
+           ],
+           "expiry": "8760h"
+         }
+       }
+     }
+   }
+   ```
+
+1. CA 인증서 서명 요청(CSR)을 위한 JSON 설정 파일을
     `ca-csr.json` 예시와 같이 생성한다. 꺾쇠 괄호로 표시된
     값을 사용하려는 실제 값으로 변경한다.
 
-        {
-          "CN": "kubernetes",
-          "key": {
-            "algo": "rsa",
-            "size": 2048
-          },
-          "names":[{
-            "C": "<국가(country)>",
-            "ST": "<도(state)>",
-            "L": "<시(city)>",
-            "O": "<조직(organization)>",
-            "OU": "<조직 단위(organization unit)>"
-          }]
-        }
-1.  CA 키(`ca-key.pem`)와 인증서(`ca.pem`)을 생성한다.
+   ```json
+   {
+     "CN": "kubernetes",
+     "key": {
+       "algo": "rsa",
+       "size": 2048
+     },
+     "names":[{
+       "C": "국가<country>",
+       "ST": "도<state>",
+       "L": "시<city>",
+       "O": "조직<organization>",
+       "OU": "조직 단위<organization unit>"
+     }]
+   }
+   ```
 
-        ../cfssl gencert -initca ca-csr.json | ../cfssljson -bare ca
-1.  API 서버의 키와 인증서를 생성하기 위한 JSON 구성파일을
-    `server-csr.json` 예시와 같이 생성한다. 꺾쇠 괄호 안의 값을
-    사용하려는 실제 값으로 변경한다. `MASTER_CLUSTER_IP` 는
-    이전 하위 섹션에서 설명한 API 서버의 클러스터 IP이다.
-    아래 샘플은 기본 DNS 도메인 이름으로 `cluster.local` 을
-    사용한다고 가정한다.
+1. CA 키(`ca-key.pem`)와 인증서(`ca.pem`)을 생성한다.
 
-        {
-          "CN": "kubernetes",
-          "hosts": [
-            "127.0.0.1",
-            "<MASTER_IP>",
-            "<MASTER_CLUSTER_IP>",
-            "kubernetes",
-            "kubernetes.default",
-            "kubernetes.default.svc",
-            "kubernetes.default.svc.cluster",
-            "kubernetes.default.svc.cluster.local"
-          ],
-          "key": {
-            "algo": "rsa",
-            "size": 2048
-          },
-          "names": [{
-            "C": "<국가(country)>",
-            "ST": "<도(state)>",
-            "L": "<시(city)>",
-            "O": "<조직(organization)>",
-            "OU": "<조직 단위(organization unit)>"
-          }]
-        }
-1.  API 서버 키와 인증서를 생성하면, 기본적으로
-    `server-key.pem` 과 `server.pem` 파일에 각각 저장된다.
+   ```shell
+   ../cfssl gencert -initca ca-csr.json | ../cfssljson -bare ca
+   ```
 
-        ../cfssl gencert -ca=ca.pem -ca-key=ca-key.pem \
+1. API 서버의 키와 인증서를 생성하기 위한 JSON 구성파일을
+   `server-csr.json` 예시와 같이 생성한다. 꺾쇠 괄호 안의 값을
+   사용하려는 실제 값으로 변경한다. `MASTER_CLUSTER_IP` 는
+   이전 하위 섹션에서 설명한 API 서버의 클러스터 IP이다.
+   아래 샘플은 기본 DNS 도메인 이름으로 `cluster.local` 을
+   사용한다고 가정한다.
+
+   ```json
+   {
+     "CN": "kubernetes",
+     "hosts": [
+       "127.0.0.1",
+       "<MASTER_IP>",
+       "<MASTER_CLUSTER_IP>",
+       "kubernetes",
+       "kubernetes.default",
+       "kubernetes.default.svc",
+       "kubernetes.default.svc.cluster",
+       "kubernetes.default.svc.cluster.local"
+     ],
+     "key": {
+       "algo": "rsa",
+       "size": 2048
+     },
+     "names": [{
+        "C": "<국가(country)>",
+        "ST": "<도(state)>",
+        "L": "<시(city)>",
+        "O": "<조직(organization)>",
+        "OU": "<조직 단위(organization unit)>"
+     }]
+   }
+   ```
+
+1. API 서버 키와 인증서를 생성하면, 기본적으로
+   `server-key.pem` 과 `server.pem` 파일에 각각 저장된다.
+
+   ```shell
+   ../cfssl gencert -ca=ca.pem -ca-key=ca-key.pem \
         --config=ca-config.json -profile=kubernetes \
         server-csr.json | ../cfssljson -bare server
-
+   ```
 
 ## 자체 서명된 CA 인증서의 배포
 
@@ -234,12 +286,12 @@ weight: 20
 
 각 클라이언트에서, 다음 작업을 수행한다.
 
-```bash
+```shell
 sudo cp ca.crt /usr/local/share/ca-certificates/kubernetes.crt
 sudo update-ca-certificates
 ```
 
-```
+```none
 Updating certificates in /etc/ssl/certs...
 1 added, 0 removed; done.
 Running hooks in /etc/ca-certificates/update.d....
@@ -248,6 +300,6 @@ done.
 
 ## 인증서 API
 
-`certificates.k8s.io` API를 사용해서
-[여기](/ko/docs/tasks/tls/managing-tls-in-a-cluster/)에
+`certificates.k8s.io` API를 사용하여
+[클러스터에서 TLS 인증서 관리](/ko/docs/tasks/tls/managing-tls-in-a-cluster/)에
 설명된 대로 인증에 사용할 x509 인증서를 프로비전 할 수 있다.

--- a/content/ko/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
+++ b/content/ko/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
@@ -1,6 +1,6 @@
 ---
-
-
+# reviewers:
+# - sig-cluster-lifecycle
 title: kubeadm을 사용한 인증서 관리
 content_type: task
 weight: 10
@@ -244,7 +244,7 @@ serverTLSBootstrap: true
 ```
 
 만약 이미 클러스터를 생성했다면 다음을 따라 이를 조정해야 한다.
- - `kube-system` 네임스페이스에서 `kubelet-config-{{< skew latestVersion >}}` 컨피그맵을 찾아서 수정한다.
+ - `kube-system` 네임스페이스에서 `kubelet-config-{{< skew currentVersion >}}` 컨피그맵을 찾아서 수정한다.
 해당 컨피그맵에는 `kubelet` 키가
 [KubeletConfiguration](/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
 문서를 값으로 가진다. `serverTLSBootstrap: true` 가 되도록 KubeletConfiguration 문서를 수정한다.
@@ -276,7 +276,7 @@ kubectl certificate approve <CSR-name>
 `KubeletConfiguration` 필드의 `rotateCertificates` 를 `true` 로 설정한다. 이것은 만기가
 다가오면 인증서를 위한 신규 CSR 세트가 생성되는 것을 의미하며,
 해당 순환(rotation)을 완료하기 위해서는 승인이 되어야 한다는 것을 의미한다. 더 상세한 이해를 위해서는
-[인증서 순환](/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/#certificate-rotation)를 확인한다.
+[인증서 순환](/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/#certificate-rotation)를 확인한다.
 
 만약 이 CSR들의 자동 승인을 위한 솔루션을 찾고 있다면 클라우드 제공자와
 연락하여 대역 외 메커니즘(out of band mechanism)을 통해 노드의 신분을 검증할 수 있는

--- a/content/ko/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/ko/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -1,6 +1,6 @@
 ---
-
-
+# reviewers:
+# - sig-cluster-lifecycle
 title: kubeadm 클러스터 업그레이드
 content_type: task
 weight: 20
@@ -29,7 +29,7 @@ weight: 20
 
 ## {{% heading "prerequisites" %}}
 
-- [릴리스 노트]({{< latest-release-notes >}})를 주의 깊게 읽어야 한다.
+- [릴리스 노트](https://git.k8s.io/kubernetes/CHANGELOG)를 주의 깊게 읽어야 한다.
 - 클러스터는 정적 컨트롤 플레인 및 etcd 파드 또는 외부 etcd를 사용해야 한다.
 - 데이터베이스에 저장된 앱-레벨 상태와 같은 중요한 컴포넌트를 반드시 백업한다.
   `kubeadm upgrade` 는 워크로드에 영향을 미치지 않고, 쿠버네티스 내부의 컴포넌트만 다루지만, 백업은 항상 모범 사례일 정도로 중요하다.
@@ -79,83 +79,87 @@ OS 패키지 관리자를 사용하여 쿠버네티스의 최신 패치 릴리�
 
 **첫 번째 컨트롤 플레인 노드의 경우**
 
--  kubeadm 업그레이드
+- kubeadm 업그레이드
 
-{{< tabs name="k8s_install_kubeadm_first_cp" >}}
-{{% tab name="Ubuntu, Debian 또는 HypriotOS" %}}
-    # {{< skew currentVersion >}}.x-00에서 x를 최신 패치 버전으로 바꾼다.
-    apt-mark unhold kubeadm && \
-    apt-get update && apt-get install -y kubeadm={{< skew currentVersion >}}.x-00 && \
-    apt-mark hold kubeadm
-{{% /tab %}}
-{{% tab name="CentOS, RHEL 또는 Fedora" %}}
-    # {{< skew currentVersion >}}.x-0에서 x를 최신 패치 버전으로 바꾼다.
-    yum install -y kubeadm-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
-{{% /tab %}}
-{{< /tabs >}}
+  {{< tabs name="k8s_install_kubeadm_first_cp" >}}
+  {{% tab name="Ubuntu, Debian 또는 HypriotOS" %}}
+  ```shell
+   # {{< skew currentVersion >}}.x-00에서 x를 최신 패치 버전으로 바꾼다.
+   apt-mark unhold kubeadm && \
+   apt-get update && apt-get install -y kubeadm={{< skew currentVersion >}}.x-00 && \
+   apt-mark hold kubeadm
+  ```
+  {{% /tab %}}
+  {{% tab name="CentOS, RHEL 또는 Fedora" %}}
+  ```shell
+  # {{< skew currentVersion >}}.x-0에서 x를 최신 패치 버전으로 바꾼다.
+  yum install -y kubeadm-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
+  ```
+  {{% /tab %}}
+  {{< /tabs >}}
 <br />
 
--  다운로드하려는 버전이 잘 받아졌는지 확인한다.
+- 다운로드하려는 버전이 잘 받아졌는지 확인한다.
 
-    ```shell
-    kubeadm version
-    ```
+  ```shell
+  kubeadm version
+  ```
 
--  업그레이드 계획을 확인한다.
+- 업그레이드 계획을 확인한다.
 
-    ```shell
-    kubeadm upgrade plan
-    ```
+  ```shell
+  kubeadm upgrade plan
+  ```
 
-    이 명령은 클러스터를 업그레이드할 수 있는지를 확인하고, 업그레이드할 수 있는 버전을 가져온다.
-    또한 컴포넌트 구성 버전 상태가 있는 표를 보여준다.
+  이 명령은 클러스터를 업그레이드할 수 있는지를 확인하고, 업그레이드할 수 있는 버전을 가져온다.
+  또한 컴포넌트 구성 버전 상태가 있는 표를 보여준다.
 
-{{< note >}}
-또한 `kubeadm upgrade` 는 이 노드에서 관리하는 인증서를 자동으로 갱신한다.
-인증서 갱신을 하지 않으려면 `--certificate-renewal=false` 플래그를 사용할 수 있다.
-자세한 내용은 [인증서 관리 가이드](/ko/docs/tasks/administer-cluster/kubeadm/kubeadm-certs)를 참고한다.
-{{</ note >}}
+  {{< note >}}
+  또한 `kubeadm upgrade` 는 이 노드에서 관리하는 인증서를 자동으로 갱신한다.
+  인증서 갱신을 하지 않으려면 `--certificate-renewal=false` 플래그를 사용할 수 있다.
+  자세한 내용은 [인증서 관리 가이드](/ko/docs/tasks/administer-cluster/kubeadm/kubeadm-certs)를 참고한다.
+  {{</ note >}}
 
-{{< note >}}
-`kubeadm upgrade plan` 이 수동 업그레이드가 필요한 컴포넌트 구성을 표시하는 경우, 사용자는
-`--config` 커맨드 라인 플래그를 통해 대체 구성이 포함된 구성 파일을 `kubeadm upgrade apply` 에 제공해야 한다.
-그렇게 하지 않으면 `kubeadm upgrade apply` 가 오류와 함께 종료되고 업그레이드를 수행하지 않는다.
-{{</ note >}}
+  {{< note >}}
+  `kubeadm upgrade plan` 이 수동 업그레이드가 필요한 컴포넌트 구성을 표시하는 경우, 사용자는
+  `--config` 커맨드 라인 플래그를 통해 대체 구성이 포함된 구성 파일을 `kubeadm upgrade apply` 에 제공해야 한다.
+  그렇게 하지 않으면 `kubeadm upgrade apply` 가 오류와 함께 종료되고 업그레이드를 수행하지 않는다.
+  {{</ note >}}
 
--  업그레이드할 버전을 선택하고, 적절한 명령을 실행한다. 예를 들면 다음과 같다.
+- 업그레이드할 버전을 선택하고, 적절한 명령을 실행한다. 예를 들면 다음과 같다.
 
-    ```shell
-    # 이 업그레이드를 위해 선택한 패치 버전으로 x를 바꾼다.
-    sudo kubeadm upgrade apply v{{< skew currentVersion >}}.x
-    ```
+  ```shell
+  # 이 업그레이드를 위해 선택한 패치 버전으로 x를 바꾼다.
+  sudo kubeadm upgrade apply v{{< skew currentVersion >}}.x
+  ```
 
-    명령이 완료되면 다음을 확인해야 한다.
+  명령이 완료되면 다음을 확인해야 한다.
 
-    ```
-    [upgrade/successful] SUCCESS! Your cluster was upgraded to "v{{< skew currentVersion >}}.x". Enjoy!
+  ```
+  [upgrade/successful] SUCCESS! Your cluster was upgraded to "v{{< skew currentVersion >}}.x". Enjoy!
 
-    [upgrade/kubelet] Now that your control plane is upgraded, please proceed with upgrading your kubelets if you haven't already done so.
-    ```
+  [upgrade/kubelet] Now that your control plane is upgraded, please proceed with upgrading your kubelets if you haven't already done so.
+  ```
 
--  CNI 제공자 플러그인을 수동으로 업그레이드한다.
+- CNI 제공자 플러그인을 수동으로 업그레이드한다.
 
-    CNI(컨테이너 네트워크 인터페이스) 제공자는 자체 업그레이드 지침을 따를 수 있다.
-    [애드온](/ko/docs/concepts/cluster-administration/addons/) 페이지에서
-    사용하는 CNI 제공자를 찾고 추가 업그레이드 단계가 필요한지 여부를 확인한다.
+  CNI(컨테이너 네트워크 인터페이스) 제공자는 자체 업그레이드 지침을 따를 수 있다.
+  [애드온](/ko/docs/concepts/cluster-administration/addons/) 페이지에서
+  사용하는 CNI 제공자를 찾고 추가 업그레이드 단계가 필요한지 여부를 확인한다.
 
-    CNI 제공자가 데몬셋(DaemonSet)으로 실행되는 경우 추가 컨트롤 플레인 노드에는 이 단계가 필요하지 않다.
+  CNI 제공자가 데몬셋(DaemonSet)으로 실행되는 경우 추가 컨트롤 플레인 노드에는 이 단계가 필요하지 않다.
 
 **다른 컨트롤 플레인 노드의 경우**
 
 첫 번째 컨트롤 플레인 노드와 동일하지만 다음을 사용한다.
 
-```
+```shell
 sudo kubeadm upgrade node
 ```
 
 아래 명령 대신 위의 명령을 사용한다.
 
-```
+```shell
 sudo kubeadm upgrade apply
 ```
 
@@ -163,46 +167,50 @@ sudo kubeadm upgrade apply
 
 ### 노드 드레인
 
--  Prepare the node for maintenance by marking it unschedulable and evicting the workloads:
+- 스케줄 불가능(unschedulable)으로 표시하고 워크로드를 축출하여 유지 보수할 노드를 준비한다.
 
-    ```shell
-    # <node-to-drain>을 드레인하는 노드의 이름으로 바꾼다.
-    kubectl drain <node-to-drain> --ignore-daemonsets
-    ```
+  ```shell
+  # <node-to-drain>을 드레인하는 노드의 이름으로 바꾼다.
+  kubectl drain <node-to-drain> --ignore-daemonsets
+  ```
 
 ### kubelet과 kubectl 업그레이드
 
--  모든 컨트롤 플레인 노드에서 kubelet 및 kubectl을 업그레이드한다.
+- 모든 컨트롤 플레인 노드에서 kubelet 및 kubectl을 업그레이드한다.
 
-{{< tabs name="k8s_install_kubelet" >}}
-{{% tab name="Ubuntu, Debian 또는 HypriotOS" %}}
-    # replace x in {{< skew currentVersion >}}.x-00의 x를 최신 패치 버전으로 바꾼다
-    apt-mark unhold kubelet kubectl && \
-    apt-get update && apt-get install -y kubelet={{< skew currentVersion >}}.x-00 kubectl={{< skew currentVersion >}}.x-00 && \
-    apt-mark hold kubelet kubectl
-{{% /tab %}}
-{{% tab name="CentOS, RHEL 또는 Fedora" %}}
-    # {{< skew currentVersion >}}.x-0에서 x를 최신 패치 버전으로 바꾼다
-    yum install -y kubelet-{{< skew currentVersion >}}.x-0 kubectl-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
-{{% /tab %}}
-{{< /tabs >}}
+  {{< tabs name="k8s_install_kubelet" >}}
+  {{% tab name="Ubuntu, Debian 또는 HypriotOS" %}}
+  ```shell
+  # replace x in {{< skew currentVersion >}}.x-00의 x를 최신 패치 버전으로 바꾼다
+  apt-mark unhold kubelet kubectl && \
+  apt-get update && apt-get install -y kubelet={{< skew currentVersion >}}.x-00 kubectl={{< skew currentVersion >}}.x-00 && \
+  apt-mark hold kubelet kubectl
+  ```
+  {{% /tab %}}
+  {{% tab name="CentOS, RHEL 또는 Fedora" %}}
+  ```shell
+  # {{< skew currentVersion >}}.x-0에서 x를 최신 패치 버전으로 바꾼다
+  yum install -y kubelet-{{< skew currentVersion >}}.x-0 kubectl-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
+  ```
+  {{% /tab %}}
+  {{< /tabs >}}
 <br />
 
--  kubelet을 다시 시작한다.
+- kubelet을 다시 시작한다.
 
-```shell
-sudo systemctl daemon-reload
-sudo systemctl restart kubelet
-```
+  ```shell
+  sudo systemctl daemon-reload
+  sudo systemctl restart kubelet
+  ```
 
 ### 노드 uncordon
 
--   노드를 스케줄 가능으로 표시하여 노드를 다시 온라인 상태로 전환한다.
+- 노드를 스케줄 가능(schedulable)으로 표시하여 노드를 다시 온라인 상태로 전환한다.
 
-    ```shell
-    # <node-to-drain>을 드레인하는 노드의 이름으로 바꾼다.
-    kubectl uncordon <node-to-drain>
-    ```
+  ```shell
+  # <node-to-drain>을 드레인하려는 노드의 이름으로 바꾼다.
+  kubectl uncordon <node-to-drain>
+  ```
 
 ## 워커 노드 업그레이드
 
@@ -211,71 +219,79 @@ sudo systemctl restart kubelet
 
 ### kubeadm 업그레이드
 
--  모든 워커 노드에서 kubeadm을 업그레이드한다.
+- 모든 워커 노드에서 kubeadm을 업그레이드한다.
 
-{{< tabs name="k8s_install_kubeadm_worker_nodes" >}}
-{{% tab name="Ubuntu, Debian 또는 HypriotOS" %}}
-    # {{< skew currentVersion >}}.x-00의 x를 최신 패치 버전으로 바꾼다
-    apt-mark unhold kubeadm && \
-    apt-get update && apt-get install -y kubeadm={{< skew currentVersion >}}.x-00 && \
-    apt-mark hold kubeadm
-{{% /tab %}}
-{{% tab name="CentOS, RHEL 또는 Fedora" %}}
-    # {{< skew currentVersion >}}.x-0에서 x를 최신 패치 버전으로 바꾼다
-    yum install -y kubeadm-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
-{{% /tab %}}
-{{< /tabs >}}
+  {{< tabs name="k8s_install_kubeadm_worker_nodes" >}}
+  {{% tab name="Ubuntu, Debian 또는 HypriotOS" %}}
+  ```shell
+  # {{< skew currentVersion >}}.x-00의 x를 최신 패치 버전으로 바꾼다
+  apt-mark unhold kubeadm && \
+  apt-get update && apt-get install -y kubeadm={{< skew currentVersion >}}.x-00 && \
+  apt-mark hold kubeadm
+  ```
+  {{% /tab %}}
+  {{% tab name="CentOS, RHEL 또는 Fedora" %}}
+  ```shell
+  # {{< skew currentVersion >}}.x-0에서 x를 최신 패치 버전으로 바꾼다
+  yum install -y kubeadm-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
+  ```
+  {{% /tab %}}
+  {{< /tabs >}}
 
 ### "kubeadm upgrade" 호출
 
--  워커 노드의 경우 로컬 kubelet 구성을 업그레이드한다.
+- 워커 노드의 경우 로컬 kubelet 구성을 업그레이드한다.
 
-    ```shell
-    sudo kubeadm upgrade node
-    ```
+  ```shell
+  sudo kubeadm upgrade node
+  ```
 
 ### 노드 드레인
 
--  스케줄 불가능(unschedulable)으로 표시하고 워크로드를 축출하여 유지 보수할 노드를 준비한다.
+- 스케줄 불가능(unschedulable)으로 표시하고 워크로드를 축출하여 유지 보수할 노드를 준비한다.
 
-    ```shell
-    # <node-to-drain>을 드레이닝하려는 노드 이름으로 바꾼다.
-    kubectl drain <node-to-drain> --ignore-daemonsets
-    ```
+  ```shell
+  # <node-to-drain>을 드레인하려는 노드 이름으로 바꾼다.
+  kubectl drain <node-to-drain> --ignore-daemonsets
+  ```
 
 ### kubelet과 kubectl 업그레이드
 
--  kubelet 및 kubectl을 업그레이드한다.
+- kubelet 및 kubectl을 업그레이드한다.
 
-{{< tabs name="k8s_kubelet_and_kubectl" >}}
-{{% tab name="Ubuntu, Debian 또는 HypriotOS" %}}
-    # {{< skew currentVersion >}}.x-00의 x를 최신 패치 버전으로 바꾼다
-    apt-mark unhold kubelet kubectl && \
-    apt-get update && apt-get install -y kubelet={{< skew currentVersion >}}.x-00 kubectl={{< skew currentVersion >}}.x-00 && \
-    apt-mark hold kubelet kubectl
-{{% /tab %}}
-{{% tab name="CentOS, RHEL 또는 Fedora" %}}
-    # {{< skew currentVersion >}}.x-0에서 x를 최신 패치 버전으로 바꾼다
-    yum install -y kubelet-{{< skew currentVersion >}}.x-0 kubectl-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
-{{% /tab %}}
-{{< /tabs >}}
+  {{< tabs name="k8s_kubelet_and_kubectl" >}}
+  {{% tab name="Ubuntu, Debian 또는 HypriotOS" %}}
+  ```shell
+  # {{< skew currentVersion >}}.x-00의 x를 최신 패치 버전으로 바꾼다
+  apt-mark unhold kubelet kubectl && \
+  apt-get update && apt-get install -y kubelet={{< skew currentVersion >}}.x-00 kubectl={{< skew currentVersion >}}.x-00 && \
+  apt-mark hold kubelet kubectl
+  ```
+  {{% /tab %}}
+  {{% tab name="CentOS, RHEL 또는 Fedora" %}}
+  ```shell
+  # {{< skew currentVersion >}}.x-0에서 x를 최신 패치 버전으로 바꾼다
+  yum install -y kubelet-{{< skew currentVersion >}}.x-0 kubectl-{{< skew currentVersion >}}.x-0 --disableexcludes=kubernetes
+  ```
+  {{% /tab %}}
+  {{< /tabs >}}
 <br />
 
--  kubelet을 다시 시작한다.
+- kubelet을 다시 시작한다.
 
-    ```shell
-    sudo systemctl daemon-reload
-    sudo systemctl restart kubelet
-    ```
+  ```shell
+  sudo systemctl daemon-reload
+  sudo systemctl restart kubelet
+  ```
 
 ### 노드에 적용된 cordon 해제
 
 -  스케줄 가능(schedulable)으로 표시하여 노드를 다시 온라인 상태로 만든다.
 
-    ```shell
-    # <node-to-drain>을 노드의 이름으로 바꾼다.
-    kubectl uncordon <node-to-drain>
-    ```
+  ```shell
+  # <node-to-drain>을 노드의 이름으로 바꾼다.
+  kubectl uncordon <node-to-drain>
+  ```
 
 ## 클러스터 상태 확인
 
@@ -296,6 +312,7 @@ kubectl get nodes
 잘못된 상태에서 복구하기 위해, 클러스터가 실행 중인 버전을 변경하지 않고 `kubeadm upgrade apply --force` 를 실행할 수도 있다.
 
 업그레이드하는 동안 kubeadm은 `/etc/kubernetes/tmp` 아래에 다음과 같은 백업 폴더를 작성한다.
+
 - `kubeadm-backup-etcd-<date>-<time>`
 - `kubeadm-backup-manifests-<date>-<time>`
 

--- a/content/ko/docs/tasks/administer-cluster/kubeadm/upgrading-windows-nodes.md
+++ b/content/ko/docs/tasks/administer-cluster/kubeadm/upgrading-windows-nodes.md
@@ -33,8 +33,8 @@ weight: 40
 1.  윈도우 노드에서, kubeadm을 업그레이드한다.
 
     ```powershell
-    # replace {{< param "fullversion" >}} with your desired version
-    curl.exe -Lo C:\k\kubeadm.exe https://dl.k8s.io/{{< param "fullversion" >}}/bin/windows/amd64/kubeadm.exe
+    # {{< param "fullversion" >}}을 사용 중인 쿠버네티스 버전으로 변경한다.
+    curl.exe -Lo <kubeadm.exe을 저장할 경로> https://dl.k8s.io/{{< param "fullversion" >}}/bin/windows/amd64/kubeadm.exe
     ```
 
 ### 노드 드레인
@@ -62,15 +62,27 @@ weight: 40
     kubeadm upgrade node
     ```
 
-### kubelet 업그레이드
+### kubelet 및 kube-proxy 업그레이드
 
 1.  윈도우 노드에서, kubelet을 업그레이드하고 다시 시작한다.
 
     ```powershell
     stop-service kubelet
-    curl.exe -Lo C:\k\kubelet.exe https://dl.k8s.io/{{< param "fullversion" >}}/bin/windows/amd64/kubelet.exe
+    curl.exe -Lo <kubelet.exe을 저장할 경로> https://dl.k8s.io/{{< param "fullversion" >}}/bin/windows/amd64/kubelet.exe
     restart-service kubelet
     ```
+
+2. 윈도우 노드에서, kube-proxy를 업그레이드하고 다시 시작한다.
+
+    ```powershell
+    stop-service kube-proxy
+    curl.exe -Lo <kube-proxy.exe을 저장할 경로> https://dl.k8s.io/{{< param "fullversion" >}}/bin/windows/amd64/kube-proxy.exe
+    restart-service kube-proxy
+    ```
+
+{{< note >}}
+만약 kube-proxy를 윈도우 서비스로 실행중이지 않고 파드 내의 HostProcess 컨테이너에서 실행중이라면, 새로운 버전의 kube-proxy 매니페스트를 적용함으로써 업그레이드할 수 있다.
+{{< /note >}}
 
 ### 노드에 적용된 cordon 해제
 
@@ -81,14 +93,3 @@ weight: 40
     # <node-to-drain>을 노드의 이름으로 바꾼다
     kubectl uncordon <node-to-drain>
     ```
-### kube-proxy 업그레이드
-
-1. 쿠버네티스 API에 접근할 수 있는 머신에서, 다음을 실행하여,
-{{< param "fullversion" >}}을 원하는 버전으로 다시 바꾼다.
-
-    ```shell
-    curl -L https://github.com/kubernetes-sigs/sig-windows-tools/releases/latest/download/kube-proxy.yml | sed 's/VERSION/{{< param "fullversion" >}}/g' | kubectl apply -f -
-    ```
-
-
-


### PR DESCRIPTION
M76 ~ M79 까지, tasks/administer-cluster 아래 페이지와 관련된 변경사항들을 반영하였습니다!

Related Issue : #34903 

> ### 4 files to be modified
>
> 76. [ ]  **M76.**  `content/en/docs/tasks/administer-cluster/certificates.md`  | **252(+L) 200(-)**
> 77. [ ]  M77.  `content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md`  | 2(+XS) 2(-)
> 78. [ ]  **M78.**  `content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md`  | **155(+L) 138(-)**
> 79. [ ]  M79.  `content/en/docs/tasks/administer-cluster/kubeadm/upgrading-windows-nodes.md`  | 15(+S) 10(-)

/language ko
