### PR TITLE
Anchor several .gitignore paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,14 +27,14 @@ kubernetes.github.io.iml
 nohup.out
 
 # Hugo output
-public/
-resources/
+/public/
+/resources/
 .hugo_build.lock
 
 # Netlify Functions build output
 package-lock.json
-functions/
-node_modules/
+/functions/
+/node_modules/
 
 # Generated files when building with make container-build
 .config/


### PR DESCRIPTION
resolves #35487 

Fixed not only `public` and `resources` in Hugo but also `functions` in Netlify - somebody might also wants content directory name function.
I have checked that the Netlify build uses `functions` on the top level as default.
Comment me if I am wrong!! 🥺 🙇 