### PR TITLE
[ko] outdated korean contents [M71~M75]

### DIFF
--- a/content/ko/docs/tasks/access-application-cluster/access-cluster-services.md
+++ b/content/ko/docs/tasks/access-application-cluster/access-cluster-services.md
@@ -64,16 +64,16 @@ kubectl cluster-info
 출력은 다음과 비슷하다.
 
 ```
-Kubernetes master is running at https://104.197.5.247
-elasticsearch-logging is running at https://104.197.5.247/api/v1/namespaces/kube-system/services/elasticsearch-logging/proxy
-kibana-logging is running at https://104.197.5.247/api/v1/namespaces/kube-system/services/kibana-logging/proxy
-kube-dns is running at https://104.197.5.247/api/v1/namespaces/kube-system/services/kube-dns/proxy
-grafana is running at https://104.197.5.247/api/v1/namespaces/kube-system/services/monitoring-grafana/proxy
-heapster is running at https://104.197.5.247/api/v1/namespaces/kube-system/services/monitoring-heapster/proxy
+Kubernetes master is running at https://192.0.2.1
+elasticsearch-logging is running at https://192.0.2.1/api/v1/namespaces/kube-system/services/elasticsearch-logging/proxy
+kibana-logging is running at https://192.0.2.1/api/v1/namespaces/kube-system/services/kibana-logging/proxy
+kube-dns is running at https://192.0.2.1/api/v1/namespaces/kube-system/services/kube-dns/proxy
+grafana is running at https://192.0.2.1/api/v1/namespaces/kube-system/services/monitoring-grafana/proxy
+heapster is running at https://192.0.2.1/api/v1/namespaces/kube-system/services/monitoring-heapster/proxy
 ```
 
 각 서비스에 접근하기 위한 프록시-작업 URL이 표시된다.
-예를 들어, 이 클러스터에는 `https://104.197.5.247/api/v1/namespaces/kube-system/services/elasticsearch-logging/proxy/` 로
+예를 들어, 이 클러스터에는 `https://192.0.2.1/api/v1/namespaces/kube-system/services/elasticsearch-logging/proxy/` 로
 접근할 수 있는 (Elasticsearch를 사용한) 클러스터 수준 로깅이 활성화되어 있다. 적합한 자격 증명이 전달되는 경우나 kubectl proxy를 통해 도달할 수 있다. 예를 들어 다음의 URL에서 확인할 수 있다.
 `http://localhost:8080/api/v1/namespaces/kube-system/services/elasticsearch-logging/proxy/`.
 
@@ -103,13 +103,13 @@ URL에서 `<서비스_이름>`이 지원하는 형식은 다음과 같다.
 * Elasticsearch 서비스 엔드포인트 `_search?q=user:kimchy` 에 접근하려면, 다음을 사용한다.
 
     ```
-    http://104.197.5.247/api/v1/namespaces/kube-system/services/elasticsearch-logging/proxy/_search?q=user:kimchy
+    http://192.0.2.1/api/v1/namespaces/kube-system/services/elasticsearch-logging/proxy/_search?q=user:kimchy
     ```
 
 * Elasticsearch 클러스터 상태 정보 `_cluster/health?pretty=true` 에 접근하려면, 다음을 사용한다.
 
     ```
-    https://104.197.5.247/api/v1/namespaces/kube-system/services/elasticsearch-logging/proxy/_cluster/health?pretty=true
+    https://192.0.2.1/api/v1/namespaces/kube-system/services/elasticsearch-logging/proxy/_cluster/health?pretty=true
     ```
 
     상태 정보는 다음과 비슷하다.
@@ -132,7 +132,7 @@ URL에서 `<서비스_이름>`이 지원하는 형식은 다음과 같다.
 * *https* Elasticsearch 서비스 상태 정보 `_cluster/health?pretty=true` 에 접근하려면, 다음을 사용한다.
 
     ```
-    https://104.197.5.247/api/v1/namespaces/kube-system/services/https:elasticsearch-logging/proxy/_cluster/health?pretty=true
+    https://192.0.2.1/api/v1/namespaces/kube-system/services/https:elasticsearch-logging/proxy/_cluster/health?pretty=true
     ```
 
 #### 웹 브라우저를 사용하여 클러스터에서 실행되는 서비스에 접근

--- a/content/ko/docs/tasks/access-application-cluster/access-cluster.md
+++ b/content/ko/docs/tasks/access-application-cluster/access-cluster.md
@@ -233,7 +233,7 @@ redirect 기능은 deprecated되고 제거 되었다. 대신 (아래의) 프록�
     - apiserver를 위치지정한다
     - 인증 header들을 추가한다
 
-1.  [apiserver proxy](#빌트인-서비스-검색):
+1.  [apiserver proxy](/ko/docs/tasks/access-application-cluster/access-cluster-services/#빌트인-서비스-검색):
 
     - apiserver 내의 빌트인 bastion이다
     - 다른 방식으로는 연결할 수 없는 클러스터 외부의 사용자를 클러스터 IP로 연결한다

--- a/content/ko/docs/tasks/access-application-cluster/configure-access-multiple-clusters.md
+++ b/content/ko/docs/tasks/access-application-cluster/configure-access-multiple-clusters.md
@@ -271,7 +271,7 @@ contexts:
 ### 리눅스
 
 ```shell
-export KUBECONFIG_SAVED=$KUBECONFIG
+export KUBECONFIG_SAVED="$KUBECONFIG"
 ```
 
 ### 윈도우 PowerShell
@@ -290,7 +290,7 @@ $Env:KUBECONFIG_SAVED=$ENV:KUBECONFIG
 ### 리눅스
 
 ```shell
-export KUBECONFIG=$KUBECONFIG:config-demo:config-demo-2
+export KUBECONFIG="${KUBECONFIG}:config-demo:config-demo-2"
 ```
 
 ### 윈도우 PowerShell
@@ -356,7 +356,7 @@ kubeconfig 파일들을 어떻게 병합하는지에 대한 상세정보는
 ### 리눅스
 
 ```shell
-export KUBECONFIG=$KUBECONFIG:$HOME/.kube/config
+export KUBECONFIG="${KUBECONFIG}:${HOME}/.kube/config"
 ```
 
 ### 윈도우 Powershell
@@ -379,7 +379,7 @@ kubectl config view
 ### 리눅스
 
 ```shell
-export KUBECONFIG=$KUBECONFIG_SAVED
+export KUBECONFIG="$KUBECONFIG_SAVED"
 ```
 
 ### 윈도우 PowerShell

--- a/content/ko/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
+++ b/content/ko/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
@@ -11,18 +11,11 @@ min-kubernetes-server-version: v1.10
 실행중인 MongoDB 서버에 연결하는 방법을 보여준다. 이 유형의 연결은 데이터베이스
 디버깅에 유용할 수 있다.
 
-
-
-
 ## {{% heading "prerequisites" %}}
-
 
 * {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
 
 * [MongoDB Shell](https://www.mongodb.com/try/download/shell)을 설치한다.
-
-
-
 
 <!-- steps -->
 
@@ -30,161 +23,158 @@ min-kubernetes-server-version: v1.10
 
 1. MongoDB를 실행하기 위해 디플로이먼트를 생성한다.
 
-    ```shell
-    kubectl apply -f https://k8s.io/examples/application/mongodb/mongo-deployment.yaml
-    ```
+   ```shell
+   kubectl apply -f https://k8s.io/examples/application/mongodb/mongo-deployment.yaml
+   ```
 
-    성공적인 명령어의 출력은 디플로이먼트가 생성됐다는 것을 확인해준다.
+   성공적인 명령어의 출력은 디플로이먼트가 생성됐다는 것을 확인해준다.
 
-    ```
-    deployment.apps/mongo created
-    ```
+   ```
+   deployment.apps/mongo created
+   ```
 
-    파드 상태를 조회하여 파드가 준비되었는지 확인한다.
+   파드 상태를 조회하여 파드가 준비되었는지 확인한다.
 
-    ```shell
-    kubectl get pods
-    ```
+   ```shell
+   kubectl get pods
+   ```
 
-    출력은 파드가 생성되었다는 것을 보여준다.
+   출력은 파드가 생성되었다는 것을 보여준다.
 
-    ```
-    NAME                     READY   STATUS    RESTARTS   AGE
-    mongo-75f59d57f4-4nd6q   1/1     Running   0          2m4s
-    ```
+   ```
+   NAME                     READY   STATUS    RESTARTS   AGE
+   mongo-75f59d57f4-4nd6q   1/1     Running   0          2m4s
+  ```
 
-    디플로이먼트 상태를 조회한다.
+   디플로이먼트 상태를 조회한다.
 
-    ```shell
-    kubectl get deployment
-    ```
+   ```shell
+   kubectl get deployment
+   ```
 
-    출력은 디플로이먼트가 생성되었다는 것을 보여준다.
+   출력은 디플로이먼트가 생성되었다는 것을 보여준다.
 
-    ```
-    NAME    READY   UP-TO-DATE   AVAILABLE   AGE
-    mongo   1/1     1            1           2m21s
-    ```
+   ```
+   NAME    READY   UP-TO-DATE   AVAILABLE   AGE
+   mongo   1/1     1            1           2m21s
+   ```
 
-    디플로이먼트는 자동으로 레플리카셋을 관리한다.
-    아래의 명령어를 사용하여 레플리카셋 상태를 조회한다.
+   디플로이먼트는 자동으로 레플리카셋을 관리한다.
+   아래의 명령어를 사용하여 레플리카셋 상태를 조회한다.
 
-    ```shell
-    kubectl get replicaset
-    ```
+   ```shell
+   kubectl get replicaset
+   ```
 
-    출력은 레플리카셋이 생성되었다는 것을 보여준다.
+   출력은 레플리카셋이 생성되었다는 것을 보여준다.
 
-    ```
-    NAME               DESIRED   CURRENT   READY   AGE
-    mongo-75f59d57f4   1         1         1       3m12s
-    ```
-
+   ```
+   NAME               DESIRED   CURRENT   READY   AGE
+   mongo-75f59d57f4   1         1         1       3m12s
+   ```
 
 2. MongoDB를 네트워크에 노출시키기 위해 서비스를 생성한다.
 
-    ```shell
-    kubectl apply -f https://k8s.io/examples/application/mongodb/mongo-service.yaml
-    ```
+   ```shell
+   kubectl apply -f https://k8s.io/examples/application/mongodb/mongo-service.yaml
+   ```
 
-    성공적인 커맨드의 출력은 서비스가 생성되었다는 것을 확인해준다.
+   성공적인 커맨드의 출력은 서비스가 생성되었다는 것을 확인해준다.
 
-    ```
-    service/mongo created
-    ```
+   ```
+   service/mongo created
+   ```
 
-    서비스가 생성되었는지 확인한다.
+   서비스가 생성되었는지 확인한다.
 
-    ```shell
+   ```shell
     kubectl get service mongo
-    ```
+  ```
 
-    출력은 서비스가 생성되었다는 것을 보여준다.
+   출력은 서비스가 생성되었다는 것을 보여준다.
 
-    ```
-    NAME    TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)     AGE
-    mongo   ClusterIP   10.96.41.183   <none>        27017/TCP   11s
-    ```
+   ```
+   NAME    TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)     AGE
+   mongo   ClusterIP   10.96.41.183   <none>        27017/TCP   11s
+   ```
 
 3. MongoDB 서버가 파드 안에서 실행되고 있고, 27017번 포트에서 수신하고 있는지 확인한다.
 
-    ```shell
-    # mongo-75f59d57f4-4nd6q 를 당신의 파드 이름으로 대체한다.
-    kubectl get pod mongo-75f59d57f4-4nd6q --template='{{(index (index .spec.containers 0).ports 0).containerPort}}{{"\n"}}'
-    ```
+   ```shell
+   # mongo-75f59d57f4-4nd6q 를 당신의 파드 이름으로 대체한다.
+   kubectl get pod mongo-75f59d57f4-4nd6q --template='{{(index (index .spec.containers 0).ports 0).containerPort}}{{"\n"}}'
+   ```
 
-    출력은 파드 내 MongoDB 포트 번호를 보여준다.
+   출력은 파드 내 MongoDB 포트 번호를 보여준다.
 
-    ```
-    27017
-    ```
+   ```
+   27017
+   ```
 
-    (이는 인터넷 상의 MongoDB에 할당된 TCP 포트이다.)
+    (27017은 인터넷 상의 MongoDB에 할당된 TCP 포트이다.)
 
 ## 파드의 포트를 로컬 포트로 포워딩하기
 
-1.  `kubectl port-forward` 명령어는 파드 이름과 같이 리소스 이름을 사용하여 일치하는 파드를 선택해 포트 포워딩하는 것을 허용한다.
+1. `kubectl port-forward` 명령어는 파드 이름과 같이 리소스 이름을 사용하여 일치하는 파드를 선택해 포트 포워딩하는 것을 허용한다.
 
 
-    ```shell
-    # mongo-75f59d57f4-4nd6q 를 당신의 파드 이름으로 대체한다.
-    kubectl port-forward mongo-75f59d57f4-4nd6q 28015:27017
+   ```shell
+   # mongo-75f59d57f4-4nd6q 를 당신의 파드 이름으로 대체한다.
+   kubectl port-forward mongo-75f59d57f4-4nd6q 28015:27017
+   ```
+
+   이것은
+
+   ```shell
+   kubectl port-forward pods/mongo-75f59d57f4-4nd6q 28015:27017
+   ```
+
+   또는
+
+   ```shell
+   kubectl port-forward deployment/mongo 28015:27017
+   ```
+
+   또는
+
+   ```shell
+   kubectl port-forward replicaset/mongo-75f59d57f4 28015:27017
+   ```
+
+   또는 다음과 같다.
+
+   ```shell
+   kubectl port-forward service/mongo 28015:27017
     ```
 
-    이것은
+   위의 명령어들은 모두 동일하게 동작한다. 이와 유사하게 출력된다.
 
-    ```shell
-    kubectl port-forward pods/mongo-75f59d57f4-4nd6q 28015:27017
-    ```
-
-    또는
-
-    ```shell
-    kubectl port-forward deployment/mongo 28015:27017
-    ```
-
-    또는
-
-    ```shell
-    kubectl port-forward replicaset/mongo-75f59d57f4 28015:27017
-    ```
-
-    또는 다음과 같다.
-
-    ```shell
-    kubectl port-forward service/mongo 28015:27017
-    ```
-
-    위의 명령어들은 모두 동일하게 동작한다. 이와 유사하게 출력된다.
-
-    ```
-    Forwarding from 127.0.0.1:28015 -> 27017
-    Forwarding from [::1]:28015 -> 27017
-    ```
+   ```
+   Forwarding from 127.0.0.1:28015 -> 27017
+   Forwarding from [::1]:28015 -> 27017
+   ```
 
 {{< note >}}
-
 `kubectl port-forward` 는 프롬프트를 리턴하지 않으므로, 이 연습을 계속하려면 다른 터미널을 열어야 한다.
-
 {{< /note >}}
 
-2.  MongoDB 커맨드라인 인터페이스를 실행한다.
+2. MongoDB 커맨드라인 인터페이스를 실행한다.
 
-    ```shell
-    mongosh --port 28015
-    ```
+   ```shell
+   mongosh --port 28015
+   ```
 
-3.  MongoDB 커맨드라인 프롬프트에 `ping` 명령을 입력한다.
+3. MongoDB 커맨드라인 프롬프트에 `ping` 명령을 입력한다.
 
-    ```
-    db.runCommand( { ping: 1 } )
-    ```
+   ```
+   db.runCommand( { ping: 1 } )
+   ```
 
-    성공적인 핑 요청을 반환한다.
+   성공적인 핑 요청을 반환한다.
 
-    ```
-    { ok: 1 }
-    ```
+   ```
+   { ok: 1 }
+   ```
 
 ### 선택적으로 _kubectl_ 이 로컬 포트를 선택하게 하기 {#let-kubectl-choose-local-port}
 
@@ -204,7 +194,6 @@ Forwarding from 127.0.0.1:63753 -> 27017
 Forwarding from [::1]:63753 -> 27017
 ```
 
-
 <!-- discussion -->
 
 ## 토의
@@ -219,9 +208,7 @@ UDP 프로토콜에 대한 지원은
 [이슈 47862](https://github.com/kubernetes/kubernetes/issues/47862)에서 추적되고 있다.
 {{< /note >}}
 
-
-
-
 ## {{% heading "whatsnext" %}}
 
 [kubectl port-forward](/docs/reference/generated/kubectl/kubectl-commands/#port-forward)에 대해 더 알아본다.
+


### PR DESCRIPTION
Related [#34903](https://github.com/kubernetes/website/issues/34903)

M71. access-cluster-services.md
- 104.197.5.247 -> 192.0.2.1 주소 변경

M72
- 변경사항 없음

M73
- https://kubernetes.io/blog/2015/06/the-distributed-system-toolkit-patterns/   -> /blog/2015/06/the-distributed-system-toolkit-patterns/ 로 변경되었으나 404오류로 변경 보류

M74
- shell script 변경

M75
- indent 4 -> 3