### PR TITLE
[zh-cn] updated /migrate-dockershim-dockerd.md

### DIFF
--- a/content/zh-cn/blog/_posts/2022-02-17-updated-dockershim-faq.md
+++ b/content/zh-cn/blog/_posts/2022-02-17-updated-dockershim-faq.md
@@ -4,7 +4,7 @@ title: "更新：移除 Dockershim 的常见问题"
 linkTitle: "移除 Dockershim 的常见问题"
 date: 2022-02-17
 slug: dockershim-faq
-aliases: [ 'zh/dockershim' ]
+aliases: [ '/zh-cn/dockershim' ]
 ---
 <!-- 
 layout: blog
@@ -91,7 +91,7 @@ special code to help with the transition, and made that _dockershim_ code part o
 itself.
 -->
 Kubernetes 的早期版本仅适用于特定的容器运行时：Docker Engine。
-后来，Kubernetes 增加了对使用其他容器运行时的支持。[创建](/blog/2016/12/container-runtime-interface-cri-in-kubernetes/) CRI 
+后来，Kubernetes 增加了对使用其他容器运行时的支持。[创建](/blog/2016/12/container-runtime-interface-cri-in-kubernetes/) CRI
 标准是为了实现编排器（如 Kubernetes）和许多不同的容器运行时之间交互操作。
 Docker Engine 没有实现（CRI）接口，因此 Kubernetes 项目创建了特殊代码来帮助过渡，
 并使 dockershim 代码成为 Kubernetes 的一部分。

--- a/content/zh-cn/docs/reference/glossary/dockershim.md
+++ b/content/zh-cn/docs/reference/glossary/dockershim.md
@@ -36,5 +36,5 @@ Kubernetes 系统组件通过它与 {{< glossary_tooltip text="Docker Engine" te
 <!--
 Starting with version 1.24, dockershim has been removed from Kubernetes. For more information, see [Dockershim FAQ](/dockershim).
 -->
-从 Kubernetes v1.24 开始，dockershim 已从 Kubernetes 中移除.
+从 Kubernetes v1.24 开始，dockershim 已从 Kubernetes 中移除。
 想了解更多信息，可参考[移除 Dockershim 的常见问题](/zh-cn/dockershim)。

--- a/content/zh-cn/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/zh-cn/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -67,8 +67,7 @@ may [fail](https://github.com/kubernetes/kubeadm/issues/31).
 
 一般来讲，硬件设备会拥有唯一的地址，但是有些虚拟机的地址可能会重复。
 Kubernetes 使用这些值来唯一确定集群中的节点。
-如果这些值在每个节点上不唯一，可能会导致安装
-[失败](https://github.com/kubernetes/kubeadm/issues/31)。
+如果这些值在每个节点上不唯一，可能会导致安装[失败](https://github.com/kubernetes/kubeadm/issues/31)。
 
 <!--
 ## Check network adapters
@@ -78,7 +77,8 @@ route, we recommend you add IP route(s) so Kubernetes cluster addresses go via t
 -->
 ## 检查网络适配器
 
-如果你有一个以上的网络适配器，同时你的 Kubernetes 组件通过默认路由不可达，我们建议你预先添加 IP 路由规则，这样 Kubernetes 集群就可以通过对应的适配器完成连接。
+如果你有一个以上的网络适配器，同时你的 Kubernetes 组件通过默认路由不可达，我们建议你预先添加 IP 路由规则，
+这样 Kubernetes 集群就可以通过对应的适配器完成连接。
 
 <!--
 ## Letting iptables see bridged traffic
@@ -121,7 +121,8 @@ need to be open in order for Kubernetes components to communicate with each othe
 
 ## 检查所需端口{#check-required-ports}
 
-启用这些[必要的端口](/zh-cn/docs/reference/ports-and-protocols/)后才能使 Kubernetes 的各组件相互通信。可以使用 netcat 之类的工具来检查端口是否启用，例如：
+启用这些[必要的端口](/zh-cn/docs/reference/ports-and-protocols/)后才能使 Kubernetes 的各组件相互通信。
+可以使用 netcat 之类的工具来检查端口是否启用，例如：
 
 ```shell
 nc 127.0.0.1 6443
@@ -132,8 +133,8 @@ The pod network plugin you use may also require certain ports to be
 open. Since this differs with each pod network plugin, please see the
 documentation for the plugins about what port(s) those need.
 -->
-你使用的 Pod 网络插件 (详见后续章节) 也可能需要开启某些特定端口。由于各个 Pod 网络插件的功能都有所不同，
-请参阅他们各自文档中对端口的要求。
+你使用的 Pod 网络插件 (详见后续章节) 也可能需要开启某些特定端口。
+由于各个 Pod 网络插件的功能都有所不同，请参阅他们各自文档中对端口的要求。
 
 <!--
 ## Installing a container runtime {#installing-runtime}
@@ -180,9 +181,11 @@ For that reason, an additional service [cri-dockerd](https://github.com/Mirantis
 has to be installed. cri-dockerd is a project based on the legacy built-in
 Docker Engine support that was [removed](/dockershim) from the kubelet in version 1.24.
 -->
-Docker Engine 没有实现 [CRI](/zh-cn/docs/concepts/architecture/cri/)，而这是容器运行时在 Kubernetes 中工作所需要的。
+Docker Engine 没有实现 [CRI](/zh-cn/docs/concepts/architecture/cri/)，
+而这是容器运行时在 Kubernetes 中工作所需要的。
 为此，必须安装一个额外的服务 [cri-dockerd](https://github.com/Mirantis/cri-dockerd)。
-cri-dockerd 是一个基于传统的内置Docker引擎支持的项目，它在 1.24 版本从 kubelet 中[移除](/zh-cn/dockershim)。
+cri-dockerd 是一个基于传统的内置 Docker 引擎支持的项目，
+它在 1.24 版本从 kubelet 中[移除](/zh-cn/dockershim)。
 {{< /note >}}
 
 <!--
@@ -260,14 +263,14 @@ but not vice versa.
 
 For information about installing `kubectl`, see [Install and set up kubectl](/docs/tasks/tools/).
 -->
-kubeadm **不能** 帮你安装或者管理 `kubelet` 或 `kubectl`，所以你需要
-确保它们与通过 kubeadm 安装的控制平面的版本相匹配。
+kubeadm **不能** 帮你安装或者管理 `kubelet` 或 `kubectl`，
+所以你需要确保它们与通过 kubeadm 安装的控制平面的版本相匹配。
 如果不这样做，则存在发生版本偏差的风险，可能会导致一些预料之外的错误和问题。
 然而，控制平面与 kubelet 间的相差一个次要版本不一致是支持的，但 kubelet
 的版本不可以超过 API 服务器的版本。
 例如，1.7.0 版本的 kubelet 可以完全兼容 1.8.0 版本的 API 服务器，反之则不可以。
 
-有关安装 `kubectl` 的信息，请参阅[安装和设置 kubectl](/zh-cn/docs/tasks/tools/)文档。
+有关安装 `kubectl` 的信息，请参阅[安装和设置 kubectl](/zh-cn/docs/tasks/tools/) 文档。
 
 {{< warning >}}
 <!--

--- a/content/zh-cn/docs/tasks/administer-cluster/migrating-from-dockershim/migrate-dockershim-dockerd.md
+++ b/content/zh-cn/docs/tasks/administer-cluster/migrating-from-dockershim/migrate-dockershim-dockerd.md
@@ -122,7 +122,7 @@ to `cri-dockerd`.
    将 `<NODE_NAME>` 替换为节点名称。
 
 <!--
-1.  Drain the node to safely evict running Pods: 
+1.  Drain the node to safely evict running Pods:
 -->
 2. 腾空节点以安全地逐出所有运行中的 Pod：
 
@@ -186,8 +186,7 @@ kubeadm 工具将节点上的套接字存储为控制面上 `Node` 对象的注�
 
 1. 将 `kubeadm.alpha.kubernetes.io/cri-socket` 标志从
    `/var/run/dockershim.sock` 更改为 `unix:///var/run/cri-dockerd.sock`；
-1. 保存所作更改。保存时，`Node` 对象被更新
-
+1. 保存所作更改。保存时，`Node` 对象被更新。
 
 <!--
 ## Restart the kubelet
@@ -228,6 +227,6 @@ kubectl uncordon <NODE_NAME>
 *   Read the [dockershim removal FAQ](/dockershim/).
 *   [Learn how to migrate from Docker Engine with dockershim to containerd](/docs/tasks/administer-cluster/migrating-from-dockershim/change-runtime-containerd/).
 -->
-* 阅读 [dockershim 移除常见问题](/zh-cn/dockershim)。
+* 阅读 [移除 Dockershim 的常见问题](/zh-cn/dockershim)。
 * [了解如何从基于 dockershim 的 Docker Engine 迁移到 containerd](/zh-cn/docs/tasks/administer-cluster/migrating-from-dockershim/change-runtime-containerd/)。
 


### PR DESCRIPTION
For English, `/dockershim` is redirected to `/blog/2022/02/17/dockershim-faq/`.
For Chinese, `/zh-cn/dockershim` is broken and opens a 404 page.
Fix links in 3 files below:

```
content/zh-cn/docs/reference/glossary/dockershim.md
content/zh-cn/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
content/zh-cn/docs/tasks/administer-cluster/migrating-from-dockershim/migrate-dockershim-dockerd.md
```
Preview: https://deploy-preview-35543--kubernetes-io-main-staging.netlify.app/zh-cn/docs/setup/production-environment/tools/kubeadm/install-kubeadm/

Solution: changed the aliases in [content/zh-cn/blog/_posts/2022-02-17-updated-dockershim-faq.md](https://kubernetes.io/zh-cn/blog/2022/02/17/dockershim-faq/)