### PR TITLE
Fix --service-account-key-file description

### DIFF
--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -171,8 +171,10 @@ how to manage these tokens with `kubeadm`.
 A service account is an automatically enabled authenticator that uses signed
 bearer tokens to verify requests. The plugin takes two optional flags:
 
-* `--service-account-key-file` A file containing a PEM encoded key for signing bearer tokens.
-If unspecified, the API server's TLS private key will be used.
+* `--service-account-key-file` File containing PEM-encoded x509 RSA or ECDSA
+private or public keys, used to verify ServiceAccount tokens. The specified file
+can contain multiple keys, and the flag can be specified multiple times with
+different files. If unspecified, --tls-private-key-file is used.
 * `--service-account-lookup` If enabled, tokens which are deleted from the API will be revoked.
 
 Service accounts are usually created automatically by the API server and


### PR DESCRIPTION
`--service-account-key-file` flag to the `kube-apiserver` is used to verify ServiceAccount tokens (and not to sign them).

`--service-account-signing-key-file` is the [`kube-apiserver` flag](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/) that's used to sign ServiceAccount tokens (short-lived ones).
`--service-account-private-key-file` is the [`kube-controller-manager` flag](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/) that's used to sign ServiceAccount tokens (long-lived ones).

cc @liggitt 