### PR TITLE
Add/remove zh-cn reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -157,32 +157,28 @@ aliases:
     - sftim
     - tengqm
   sig-docs-zh-owners: # Admins for Chinese content
-    # chenopis
     - chenrui333
-    # dchen1107
-    # haibinxie
-    # hanjiayao
     - howieyuen
-    # lichuqiang
     - mengjiao-liu
     - SataQiu
+    - Sea-n
     - tanjunchen
     - tengqm
     - xichengliudui
-    # zhangxiaoyu-zidif
   sig-docs-zh-reviews: # PR reviews for Chinese content
     - chenrui333
     - chenxuc
     - howieyuen
-    - idealhack
+    # idealhack
     - mengjiao-liu
-    - pigletfly
+    # pigletfly
     - SataQiu
+    - Sea-n
     - tanjunchen
     - tengqm
+    - windsonsea
     - xichengliudui
     - ydFu
-    # zhangxiaoyu-zidif
   sig-docs-pt-owners: # Admins for Portuguese content
     - edsoncelio
     - femrtnz


### PR DESCRIPTION
The PR proposes some changes to the zh-cn localization team.
Based on contributions during the past few months, we'd like to invite
'Sea-n' to our approvers team and 'Winsonsea' to our reviewers team.
At the same time, we will *suspend* the membership of some existing
members who are no longer active in the community by commenting out
their IDs so that PRs are no longer assigned to them. We are not
removing those IDs in hope they will join us when their "conditions"
become "Ready".

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggest-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
