### PR TITLE
[ko] update outdated korean contents dev-1.24-ko.1(M84-M89)

### DIFF
--- a/content/ko/docs/tasks/configure-pod-container/assign-memory-resource.md
+++ b/content/ko/docs/tasks/configure-pod-container/assign-memory-resource.md
@@ -171,7 +171,7 @@ kubectl get pod memory-demo-2 --output=yaml --namespace=mem-example
 
 컨테이너가 메모리 부족 (OOM) 으로 종료되었음이 출력된다.
 
-```shell
+```yaml
 lastState:
    terminated:
      containerID: 65183c1877aaec2e8427bc95609cc52677a454b56fcb24340dbd22917c23b10f
@@ -278,7 +278,7 @@ kubectl describe pod memory-demo-3 --namespace=mem-example
 
 출력은 노드 내 메모리가 부족하여 파드가 스케줄링될 수 없음을 보여준다.
 
-```shell
+```
 Events:
   ...  Reason            Message
        ------            -------
@@ -291,8 +291,8 @@ Events:
 메모리를 표시할 수 있다. E, P, T, G, M, K, Ei, Pi, Ti, Gi, Mi, Ki.
 예를 들어 다음은 거의 유사한 값을 나타낸다.
 
-```shell
-128974848, 129e6, 129M , 123Mi
+```
+128974848, 129e6, 129M, 123Mi
 ```
 
 파드 삭제:

--- a/content/ko/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
+++ b/content/ko/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
@@ -88,7 +88,7 @@ Google Compute Engine 영구 디스크, NFS 공유 또는 Amazone Elastic
 Block Store 볼륨과 같은 네트워크 자원을 프로비저닝한다. 클러스터 관리자는 
 [스토리지클래스(StorageClasses)](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#storageclass-v1-storage)를 
 사용하여 
-[동적 프로비저닝](https://kubernetes.io/blog/2016/10/dynamic-provisioning-and-storage-in-kubernetes)을 설정할 수도 있다. 
+[동적 프로비저닝](/blog/2016/10/dynamic-provisioning-and-storage-in-kubernetes)을 설정할 수도 있다. 
 
 hostPath 퍼시스턴트볼륨의 설정 파일은 아래와 같다.
 
@@ -282,7 +282,7 @@ GID는 파드 리소스 자체에는 존재하지 않는다.
 
 
 * [퍼시스턴트볼륨](/ko/docs/concepts/storage/persistent-volumes/)에 대해 더 보기.
-* [퍼시스턴트 스토리지 디자인 문서](https://git.k8s.io/community/contributors/design-proposals/storage/persistent-storage.md)에 대해 읽어보기.
+* [퍼시스턴트 스토리지 디자인 문서](https://git.k8s.io/design-proposals-archive/storage/persistent-storage.md)에 대해 읽어보기.
 
 ### Reference
 

--- a/content/ko/docs/tasks/configure-pod-container/configure-runasusername.md
+++ b/content/ko/docs/tasks/configure-pod-container/configure-runasusername.md
@@ -57,7 +57,7 @@ echo $env:USERNAME
 
 결과는 다음과 같다.
 
-```shell
+```
 ContainerUser
 ```
 
@@ -97,7 +97,7 @@ echo $env:USERNAME
 
 결과는 다음과 같다.
 
-```shell
+```
 ContainerAdministrator
 ```
 
@@ -120,7 +120,7 @@ ContainerAdministrator
 ## {{% heading "whatsnext" %}}
 
 
-* [쿠버네티스에서 윈도우 컨테이너 스케줄링을 위한 가이드](/ko/docs/setup/production-environment/windows/user-guide-windows-containers/)
-* [그룹 매니지드 서비스 어카운트를 이용하여 워크로드 신원 관리하기](/ko/docs/setup/production-environment/windows/user-guide-windows-containers/#그룹-매니지드-서비스-어카운트를-이용하여-워크로드-신원-관리하기)
+* [쿠버네티스에서 윈도우 컨테이너 스케줄링을 위한 가이드](/ko/docs/concepts/windows/user-guide/)
+* [그룹 매니지드 서비스 어카운트를 이용하여 워크로드 신원 관리하기](/ko/docs/concepts/windows/user-guide/#그룹-매니지드-서비스-어카운트를-이용하여-워크로드-신원-관리하기)
 * [윈도우 파드와 컨테이너의 GMSA 구성](/ko/docs/tasks/configure-pod-container/configure-gmsa/)
 

--- a/content/ko/docs/tasks/configure-pod-container/static-pod.md
+++ b/content/ko/docs/tasks/configure-pod-container/static-pod.md
@@ -1,6 +1,6 @@
 ---
-
-
+## reviewers:
+## - jsafrane
 title: 스태틱(static) 파드 생성하기
 weight: 170
 content_template: task
@@ -67,12 +67,12 @@ Kubelet 이 특정 디렉터리를 스캔할 때 점(.)으로 시작하는 단�
     ssh my-node1
     ```
 
-2. `/etc/kubelet.d` 와 같은 디렉터리를 선택하고 웹 서버 파드의 정의를 해당 위치에, 예를 들어 `/etc/kubelet.d/static-web.yaml` 에 배치한다.  
+2. `/etc/kubernetes/manifests` 와 같은 디렉터리를 선택하고 웹 서버 파드의 정의를 해당 위치에, 예를 들어 `/etc/kubernetes/manifests/static-web.yaml` 에 배치한다.  
 
     ```shell
 	  # kubelet 이 동작하고 있는 노드에서 이 명령을 수행한다.
-    mkdir /etc/kubelet.d/
-    cat <<EOF >/etc/kubelet.d/static-web.yaml
+    mkdir -p /etc/kubernetes/manifests/
+    cat <<EOF >/etc/kubernetes/manifests/static-web.yaml
     apiVersion: v1
     kind: Pod
     metadata:
@@ -90,10 +90,10 @@ Kubelet 이 특정 디렉터리를 스캔할 때 점(.)으로 시작하는 단�
     EOF
     ```
 
-3. 노드에서 kubelet 실행 시에 `--pod-manifest-path=/etc/kubelet.d/` 와 같이 인자를 제공하여 해당 디렉터리를 사용하도록 구성한다. Fedora 의 경우 이 줄을 포함하기 위하여 `/etc/kubernetes/kubelet` 파일을 다음과 같이 수정한다.
+3. 노드에서 kubelet 실행 시에 `--pod-manifest-path=/etc/kubernetes/manifests/` 와 같이 인자를 제공하여 해당 디렉터리를 사용하도록 구성한다. Fedora 의 경우 이 줄을 포함하기 위하여 `/etc/kubernetes/kubelet` 파일을 다음과 같이 수정한다.
 
    ```
-   KUBELET_ARGS="--cluster-dns=10.254.0.10 --cluster-domain=kube.local --pod-manifest-path=/etc/kubelet.d/"
+   KUBELET_ARGS="--cluster-dns=10.254.0.10 --cluster-domain=kube.local --pod-manifest-path=/etc/kubernetes/manifests/"
    ```
    혹은 [kubelet 구성 파일](/docs/reference/config-api/kubelet-config.v1beta1/)에 
    `staticPodPath: <the directory>` 필드를 추가한다.
@@ -224,7 +224,7 @@ CONTAINER       IMAGE                                 CREATED           STATE   
 
 ## 스태틱 파드의 동적 추가 및 제거
 
-실행 중인 kubelet 은 주기적으로, 설정된 디렉터리(예제에서는 `/etc/kubelet.d`)에서 변경 사항을 스캔하고, 이 디렉터리에 새로운 파일이 생성되거나 삭제될 경우, 파드를 생성/삭제 한다.
+실행 중인 kubelet 은 주기적으로, 설정된 디렉터리(예제에서는 `/etc/kubernetes/manifests`)에서 변경 사항을 스캔하고, 이 디렉터리에 새로운 파일이 생성되거나 삭제될 경우, 파드를 생성/삭제 한다.
 
 ```shell
 # 예제를 수행하는 사용자가 파일시스템이 호스팅하는 스태틱 파드 설정을 사용한다고 가정한다.


### PR DESCRIPTION
M84 ~ M89의 변경사항들을 업데이트하였습니다.
- M85의 경우, 업데이트 사항이 영문 오타수정으로 한글에는 변경사항이 없습니다.
- M87의 경우, 변경사항이 문서 가장 마지막의 공백 라인 수의 변경이었는데 이런 변경사항의 경우에도 반영을 하는 것이 맞을까요(이번 커밋에는 원문과 동일하게 문서 마지막의 공백라인수를 맞춰서 변경하였습니다)?
- M89의 경우, 한글화 정기회의에서 논의한 바와 같이 reviewer란을 기존의 공백 대신, 관련 라인들을 모두 주석 처리하는 것으로 변경하였습니다(M84~M88은 원문에 리뷰어가 기재되어있지 않은 상황).

- Related Issue: https://github.com/kubernetes/website/issues/34903

> - [ ]  M84. `content/en/docs/tasks/configure-pod-container/assign-memory-resource.md` | 4(+XS) 4(-)
> - [ ]  M85. `content/en/docs/tasks/configure-pod-container/assign-pods-nodes.md` | 1(+XS) 1(-)
> - [ ]  M86. `content/en/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md` | 2(+XS) 2(-)
> - [ ]  M87. `content/en/docs/tasks/configure-pod-container/configure-pod-initialization.md` | 1(+XS) 0(-)
> - [ ]  M88. `content/en/docs/tasks/configure-pod-container/configure-runasusername.md` | 4(+XS) 4(-)
> - [ ]  M89. `content/en/docs/tasks/configure-pod-container/static-pod.md` | 6(+XS) 6(-)

/language ko