### PR TITLE
Add docs for KEP-3327 Add CPUManager policy option to align CPUs by Socket instead of by NUMA node

### DIFF
--- a/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
+++ b/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
@@ -256,6 +256,7 @@ You will still have to enable each option using the `CPUManagerPolicyOptions` ku
 The following policy options exist for the static `CPUManager` policy:
 * `full-pcpus-only` (beta, visible by default)
 * `distribute-cpus-across-numa` (alpha, hidden by default)
+* `align-by-socket` (alpha, hidden by default)
 
 If the `full-pcpus-only` policy option is specified, the static policy will always allocate full physical cores.
 By default, without this option, the static policy allocates CPUs using a topology-aware best-fit allocation.
@@ -279,6 +280,19 @@ By distributing CPUs evenly across NUMA nodes, application developers can more
 easily ensure that no single worker suffers from NUMA effects more than any
 other, improving the overall performance of these types of applications.
 
+If the `align-by-socket` policy option is specified, CPUs will be considered
+aligned at the socket boundary when deciding how to allocate CPUs to a
+container. By default, the `CPUManager` aligns CPU allocations at the NUMA
+boundary, which could result in performance degradation if CPUs need to be
+pulled from more than one NUMA node to satisfy the allocation. Although it
+tries to ensure that all CPUs are allocated from the _minimum_ number of NUMA
+nodes, there is no guarantee that those NUMA nodes will be on the same socket.
+By directing the `CPUManager` to explicitly align CPUs at the socket boundary
+rather than the NUMA boundary, we are able to avoid such issues. Note, this
+policy option is not compatible with `TopologyManager` `single-numa-node`
+policy and does not apply to hardware where the number of sockets is greater
+than number of NUMA nodes.
+
 The `full-pcpus-only` option can be enabled by adding `full-pcups-only=true` to
 the CPUManager policy options.
 Likewise, the `distribute-cpus-across-numa` option can be enabled by adding
@@ -286,3 +300,6 @@ Likewise, the `distribute-cpus-across-numa` option can be enabled by adding
 When both are set, they are "additive" in the sense that CPUs will be
 distributed across NUMA nodes in chunks of full-pcpus rather than individual
 cores.
+The `align-by-socket` policy option can be enabled by adding `align-by-socket=true`
+to the `CPUManager` policy options. It is also additive to the `full-pcpus-only`
+and `distribute-cpus-across-numa` policy options.


### PR DESCRIPTION
This PR updates website for CPU Manager policy option `align-by-socket`  added via KEP-3327

Issue link: https://github.com/kubernetes/enhancements/issues/3327
MR link: https://github.com/kubernetes/kubernetes/pull/111278

<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggest-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
