### PR TITLE
Clarify lack of upgrade order for components

### DIFF
--- a/content/en/releases/version-skew-policy.md
+++ b/content/en/releases/version-skew-policy.md
@@ -129,7 +129,11 @@ Pre-requisites:
 
 * The `kube-apiserver` instances these components communicate with are at **{{< skew currentVersion >}}** (in HA clusters in which these control plane components can communicate with any `kube-apiserver` instance in the cluster, all `kube-apiserver` instances must be upgraded before upgrading these components)
 
-Upgrade `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager` to **{{< skew currentVersion >}}**
+Upgrade `kube-controller-manager`, `kube-scheduler`, and
+`cloud-controller-manager` to **{{< skew currentVersion >}}**. There is no
+required upgrade order between `kube-controller-manager`, `kube-scheduler`, and
+`cloud-controller-manager`. You can upgrade these components in any order, or
+even simultaneously.
 
 ### kubelet
 


### PR DESCRIPTION
Fixes #12323 

Adds a sentence to say that there's no specific upgrade order required for `kube-controller-manager`, `kube-scheduler`, and `cloud-controller-manager` as long as `kube-apiserver` is upgraded first.

/sig docs
/language en
/cc @liggitt @lavalamp 