### PR TITLE
Change sig-docs-xx-reviewers to -reviews in docs

### DIFF
--- a/content/en/docs/contribute/participate/_index.md
+++ b/content/en/docs/contribute/participate/_index.md
@@ -53,7 +53,7 @@ GitHub teams and OWNERS files.
 There are two categories of SIG Docs [teams](https://github.com/orgs/kubernetes/teams?query=sig-docs) on GitHub:
 
 - `@sig-docs-{language}-owners` are approvers and leads
-- `@sig-docs-{language}-reviewers` are reviewers
+- `@sig-docs-{language}-reviews` are reviewers
 
 Each can be referenced with their `@name` in GitHub comments to communicate with
 everyone in that group.


### PR DESCRIPTION
Although `(owners, reviews)` is weird to me, it's the current group name.

### In k/org GitHub [teams](https://github.com/kubernetes/org/blob/main/config/kubernetes/sig-docs/teams.yaml):
  - sig-docs-leads
  - sig-docs-en-owners
  - sig-docs-en-reviews
  - sig-docs-zh-owners
  - sig-docs-zh-reviews

### In k/website [OWNERS_ALIASES](https://github.com/kubernetes/website/blob/main/OWNERS_ALIASES):
  - sig-docs-leads
  - sig-docs-en-owners
  - sig-docs-en-reviews
  - sig-docs-zh-owners
  - sig-docs-zh-reviews
  - sig-docs-blog-owners
  - sig-docs-blog-reviewers
