### PR TITLE
fix an orphan link

### DIFF
--- a/content/en/docs/tasks/debug/debug-cluster/windows.md
+++ b/content/en/docs/tasks/debug/debug-cluster/windows.md
@@ -108,7 +108,7 @@ content_type: concept
 
 1. DNS resolution is not properly working
 
-   Check the DNS limitations for Windows in this [section](#dns-limitations).
+   Check the DNS limitations for Windows in this [section](/docs/concepts/services-networking/dns-pod-service/#dns-windows).
 
 1. `kubectl port-forward` fails with "unable to do port forwarding: wincat not found"
 


### PR DESCRIPTION
In content/en/docs/tasks/debug/debug-cluster/windows.md, there is an orphan link is point to a non-exist anchor(`#dns-limitations`).

According to #31852([comment](https://github.com/kubernetes/website/pull/31852#issuecomment-1049132306), [content/en/docs/setup/production-environment/windows/intro-windows-in-kubernetes.md](https://github.com/kubernetes/website/pull/31852/commits/6568ecfcbfdd38a1ddf35a4f7429ba74185ac7c9#diff-29fa69c79ca964d4cc4a971d7eadbcfdfe203f97bff1a25057771c7444b147c9) L671) , it should point to [this](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#dns-windows). 
