### PR TITLE
Updated link on Release Managers page

### DIFF
--- a/content/en/releases/release-managers.md
+++ b/content/en/releases/release-managers.md
@@ -211,7 +211,7 @@ Example: [1.15 Release Team](https://git.k8s.io/sig-release/releases/release-1.1
 
 [community-membership]: https://git.k8s.io/community/community-membership.md#member
 [handbook-branch-mgmt]: https://git.k8s.io/sig-release/release-engineering/role-handbooks/branch-manager.md
-[handbook-packaging]: https://github.com/kubernetes/release/blob/master/hack/rapture/README.md
+[handbook-packaging]: https://git.k8s.io/release/hack/rapture/README.md
 [handbook-patch-release]: https://git.k8s.io/sig-release/release-engineering/role-handbooks/patch-release-team.md
 [k-sig-release-releases]: https://git.k8s.io/sig-release/releases
 [patches]: /releases/patch-releases/

--- a/content/en/releases/release-managers.md
+++ b/content/en/releases/release-managers.md
@@ -211,7 +211,7 @@ Example: [1.15 Release Team](https://git.k8s.io/sig-release/releases/release-1.1
 
 [community-membership]: https://git.k8s.io/community/community-membership.md#member
 [handbook-branch-mgmt]: https://git.k8s.io/sig-release/release-engineering/role-handbooks/branch-manager.md
-[handbook-packaging]: https://git.k8s.io/sig-release/release-engineering/packaging.md
+[handbook-packaging]: https://github.com/kubernetes/release/blob/master/hack/rapture/README.md
 [handbook-patch-release]: https://git.k8s.io/sig-release/release-engineering/role-handbooks/patch-release-team.md
 [k-sig-release-releases]: https://git.k8s.io/sig-release/releases
 [patches]: /releases/patch-releases/


### PR DESCRIPTION
Follow up on #35604

Updated the page [Release Managers](https://kubernetes.io/releases/release-managers/)