### PR TITLE
Announce (auto-refreshing) Official CVE Feed alpha

### DIFF
--- a/content/en/blog/_posts/2022-09-12-Announcing-the-Auto-Refreshing-Official-CVE-Feed/index.md
+++ b/content/en/blog/_posts/2022-09-12-Announcing-the-Auto-Refreshing-Official-CVE-Feed/index.md
@@ -1,0 +1,75 @@
+---
+layout: blog 
+title: Announcing the Auto-refreshing Official Kubernetes CVE Feed
+date: 2022-09-12 
+slug: k8s-cve-feed-alpha
+---
+
+**Author**: Pushkar Joglekar (VMware)
+
+A long-standing request from the Kubernetes community has been to have a
+programmatic way for end users to keep track of Kubernetes security issues
+(also called "CVEs", after the database that tracks public security issues across
+different products and vendors). Accompanying the release of Kubernetes v1.25,
+we are excited to announce availability of such
+a [feed](/docs/reference/issues-security/official-cve-feed/) as an `alpha`
+feature. This blog will cover the background and scope of this new service.
+
+## Motivation
+
+With the growing number of eyes on Kubernetes, the number of CVEs related to
+Kubernetes have increased. Although most CVEs that directly, indirectly, or
+transitively impact Kubernetes are regularly fixed, there is no single place for
+the end users of Kubernetes to programmatically subscribe or pull the data of
+fixed CVEs. Current options are either broken or incomplete.
+
+## Scope
+
+### What This Does
+
+Create a periodically auto-refreshing, human and machine-readable list of
+official Kubernetes CVEs
+
+### What This Doesn't Do
+
+* Triage and vulnerability disclosure will continue to be done by SRC (Security
+  Response Committee).
+* Listing CVEs that are identified in build time dependencies and container
+  images are out of scope.
+* Only official CVEs announced by the Kubernetes SRC will be published in the
+  feed.
+
+### Who It's For
+
+* **End Users**: Persons or teams who _use_ Kubernetes to deploy applications
+  they own
+* **Platform Providers**: Persons or teams who _manage_ Kubernetes clusters
+* **Maintainers**: Persons or teams who _create_ and _support_ Kubernetes
+  releases through their work in Kubernetes Community - via various Special
+  Interest Groups and Committees.
+
+## Implementation Details
+
+A supporting
+[contributor blog](https://kubernetes.dev/blog/2022/09/12/k8s-cve-feed-alpha/)
+was published that describes in depth on how this CVE feed was implemented to
+ensure the feed was reasonably protected against tampering and was automatically
+updated after a new CVE was announced.
+
+## What's Next?
+
+In order to graduate this feature, SIG Security
+is gathering feedback from end users who are using this alpha feed.
+
+So in order to improve the feed in future Kubernetes Releases, if you have any
+feedback, please let us know by adding a comment to
+this [tracking issue](https://github.com/kubernetes/sig-security/issues/1) or
+let us know on
+[#sig-security-tooling](https://kubernetes.slack.com/archives/C01CUSVMHPY)
+Kubernetes Slack channel.
+(Join [Kubernetes Slack here](https://slack.k8s.io))
+
+_A special shout out and massive thanks to Neha Lohia
+[(@nehalohia27)](https://github.com/nehalohia27) and Tim
+Bannister [(@sftim)](https://github.com/sftim) for their stellar collaboration
+for many months from "ideation to implementation" of this feature._


### PR DESCRIPTION
KEP: https://github.com/kubernetes/enhancements/issues/3203
Tracker: https://github.com/kubernetes/sig-security/issues/1
Preview: https://deploy-preview-35608--kubernetes-io-main-staging.netlify.app/blog/2022/09/12/k8s-cve-feed-alpha/

/hold for https://github.com/kubernetes/contributor-site/pull/330
/sig security docs testing k8s-infra
/milestone v1.25
/area security blog
