### PR TITLE
Update cpu-default-namespace.md

### DIFF
--- a/content/zh-cn/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace.md
+++ b/content/zh-cn/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace.md
@@ -292,7 +292,7 @@ kubectl delete namespace default-cpu-example
 删除你的命名空间：
 
 ```shell
-kubectl delete namespace constraints-cpu-example
+kubectl delete namespace default-cpu-example
 ```
 
 ## {{% heading "whatsnext" %}}


### PR DESCRIPTION
while I create the namespace, the name is `default-cpu-example`, but finally clean our cluster environment there is `constraints-cpu-example`. so I fixed it.