### PR TITLE
Updated the Feature state of Serving and Terminating.

### DIFF
--- a/content/en/docs/concepts/services-networking/endpoint-slices.md
+++ b/content/en/docs/concepts/services-networking/endpoint-slices.md
@@ -108,7 +108,7 @@ Services will always have the `ready` condition set to `true`.
 
 #### Serving
 
-{{< feature-state for_k8s_version="v1.20" state="alpha" >}}
+{{< feature-state for_k8s_version="v1.22" state="beta" >}}
 
 `serving` is identical to the `ready` condition, except it does not account for terminating states.
 Consumers of the EndpointSlice API should check this condition if they care about pod readiness while
@@ -127,7 +127,7 @@ for terminating pods independent of the existing semantics for `ready`.
 
 #### Terminating
 
-{{< feature-state for_k8s_version="v1.20" state="alpha" >}}
+{{< feature-state for_k8s_version="v1.22" state="beta" >}}
 
 `Terminating` is a condition that indicates whether an endpoint is terminating.
 For pods, this is any pod that has a deletion timestamp set.


### PR DESCRIPTION
This PR fixed the FEATURE STATE of `Serving` and `Terminating` in [EndpointSlices](https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/).

Fixes: #35631