### PR TITLE
Fixed ValidatingWebhookConfiguration asterisks/wildcards do not appear correctly

### DIFF
--- a/content/en/docs/reference/kubernetes-api/extend-resources/validating-webhook-configuration-v1.md
+++ b/content/en/docs/reference/kubernetes-api/extend-resources/validating-webhook-configuration-v1.md
@@ -174,11 +174,11 @@ ValidatingWebhookConfiguration describes the configuration of and admission webh
 
     - **webhooks.rules.apiGroups** ([]string)
 
-      APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+      APIGroups is the API groups the resources belong to. '\*' is all groups. If '*' is present, the length of the slice must be one. Required.
 
     - **webhooks.rules.apiVersions** ([]string)
 
-      APIVersions is the API versions the resources belong to. '*' is all versions. If '*' is present, the length of the slice must be one. Required.
+      APIVersions is the API versions the resources belong to. '\*' is all versions. If '*' is present, the length of the slice must be one. Required.
 
     - **webhooks.rules.operations** ([]string)
 


### PR DESCRIPTION
## Fixes issue #35613 

## Closes #35613 

In https://kubernetes.io/docs/reference/kubernetes-api/extend-resources/validating-webhook-configuration-v1/
under `webhooks.rules.apiGroups` and `webhooks.rules.apiVersions` 
the `''` was showing instead of `'*'` and it is important enough
Now it is fixed by this PR.
