### PR TITLE
Require EBS CSI plugin to be installed when CSIMigrationAWS is enabled, explain why

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -666,11 +666,13 @@ Each feature gate is designed for enabling/disabling a specific feature:
 - `CSIMigration`: Enables shims and translation logic to route volume
   operations from in-tree plugins to corresponding pre-installed CSI plugins
 - `CSIMigrationAWS`: Enables shims and translation logic to route volume
-  operations from the AWS-EBS in-tree plugin to EBS CSI plugin. Supports
-  falling back to in-tree EBS plugin for mount operations to nodes that have
-  the feature disabled or that do not have EBS CSI plugin installed and
-  configured. Does not support falling back for provision operations, for those
-  the CSI plugin must be installed and configured.
+  operations from the AWS-EBS in-tree plugin to EBS CSI plugin. Requires EBS CSI
+  plugin to be installed. If the EBS CSI plugin is not installed, volume
+  operations including provision, attach, mount, and resize will fail, and
+  scheduling of Pods whose PVs have topology constraints will fail. If this
+  feature is enabled on the control plane but disabled on some nodes (like if
+  version skew exists), then attach and mount operations for those nodes will
+  be done by the in-tree plugin.
 - `CSIMigrationAWSComplete`: Stops registering the EBS in-tree plugin in
   kubelet and volume controllers and enables shims and translation logic to
   route volume operations from the AWS-EBS in-tree plugin to EBS CSI plugin.


### PR DESCRIPTION
It is listed in the release notes and docs  https://kubernetes.io/docs/concepts/storage/volumes/#aws-ebs-csi-migration that the plugin is required but absent from here

I revamped the wording, specifically I got rid of the "fall back" wording, because it is a source of a lot of confusion. The "falling back" is meant for version skew situations, so now I call out "version skew" specifically. Strictly speaking, what I wrote previously is still true but it has been giving people the mistaken impression that they can get away with not installing the driver, when in reality basically everything will break unless they have the driver installed.

See previously https://github.com/kubernetes/website/pull/31626 