### PR TITLE
[en] Fix missing anchor to SIG list

### DIFF
--- a/content/en/docs/reference/glossary/sig.md
+++ b/content/en/docs/reference/glossary/sig.md
@@ -2,7 +2,7 @@
 title: SIG (special interest group)
 id: sig
 date: 2018-04-12
-full_link: https://github.com/kubernetes/community/blob/master/sig-list.md#master-sig-list
+full_link: https://github.com/kubernetes/community/blob/master/sig-list.md#special-interest-groups 
 short_description: >
   Community members who collectively manage an ongoing piece or aspect of the larger Kubernetes open source project.
 


### PR DESCRIPTION
Updated [SIG](https://kubernetes.io/docs/reference/glossary/?all=true#term-sig) in glossary.

broken anchor : [sig-list.md#master-sig-list](https://github.com/kubernetes/community/blob/master/sig-list.md#master-sig-list)
updated anchor : [sig-list.md#special-interest-groups](https://github.com/kubernetes/community/blob/master/sig-list.md#special-interest-groups)

/language en
