### PR TITLE
Fix URL in the PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@
  PLEASE title the FIRST commit appropriately, so that if you squash all
  your commits into one, the combined commit message makes sense.
  For overall help on editing and submitting pull requests, visit:
-  https://kubernetes.io/docs/contribute/suggest-improvements/
+  https://kubernetes.io/docs/contribute/suggesting-improvements/
 
  Use the default base branch, “main”, if you're documenting existing
  features in the English localization.


### PR DESCRIPTION
Fixes #35666 

This PR:
- Fixes the URL found in the PR template for `help on editing and submitting pull requests` section . It now anchors to the right page: [/docs/contribute/suggesting-improvements/](https://kubernetes.io/docs/contribute/suggesting-improvements/)

Files changed: https://github.com/kubernetes/website/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1

Signed off : Vitthal Kaul vitthalsai2001@gmail.com