### PR TITLE
Update CSI migration feature status, and remove docs for unsupported plugins

### DIFF
--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -9,7 +9,7 @@ title: Persistent Volumes
 feature:
   title: Storage orchestration
   description: >
-    Automatically mount the storage system of your choice, whether from local storage, a public cloud provider such as <a href="https://cloud.google.com/storage/">GCP</a> or <a href="https://aws.amazon.com/products/storage/">AWS</a>, or a network storage system such as NFS, iSCSI, Gluster, Ceph, Cinder, or Flocker.
+    Automatically mount the storage system of your choice, whether from local storage, a public cloud provider such as <a href="https://aws.amazon.com/products/storage/">AWS</a> or <a href="https://cloud.google.com/storage/">GCP</a>, or a network storage system such as NFS, iSCSI, Ceph, Cinder.
 content_type: concept
 weight: 20
 ---
@@ -238,10 +238,9 @@ Source:
 Events:                <none>
 ```
 
-Enabling the `CSIMigration` feature for a specific in-tree volume plugin will remove
-the `kubernetes.io/pv-controller` finalizer, while adding the `external-provisioner.volume.kubernetes.io/finalizer`
-finalizer. Similarly, disabling `CSIMigration` will remove the `external-provisioner.volume.kubernetes.io/finalizer`
-finalizer, while adding the `kubernetes.io/pv-controller` finalizer.
+When the `CSIMigration{provider}` feature flag is enabled for a specific in-tree volume plugin,
+the `kubernetes.io/pv-controller` finalizer is replaced by the
+`external-provisioner.volume.kubernetes.io/finalizer` finalizer.
 
 ### Reserving a PersistentVolume
 
@@ -413,14 +412,9 @@ Kubernetes does not support shrinking a PVC to less than its current size.
 
 PersistentVolume types are implemented as plugins. Kubernetes currently supports the following plugins:
 
-* [`awsElasticBlockStore`](/docs/concepts/storage/volumes/#awselasticblockstore) - AWS Elastic Block Store (EBS)
-* [`azureDisk`](/docs/concepts/storage/volumes/#azuredisk) - Azure Disk
-* [`azureFile`](/docs/concepts/storage/volumes/#azurefile) - Azure File
 * [`cephfs`](/docs/concepts/storage/volumes/#cephfs) - CephFS volume
 * [`csi`](/docs/concepts/storage/volumes/#csi) - Container Storage Interface (CSI)
 * [`fc`](/docs/concepts/storage/volumes/#fc) - Fibre Channel (FC) storage
-* [`gcePersistentDisk`](/docs/concepts/storage/volumes/#gcepersistentdisk) - GCE Persistent Disk
-* [`glusterfs`](/docs/concepts/storage/volumes/#glusterfs) - Glusterfs volume
 * [`hostPath`](/docs/concepts/storage/volumes/#hostpath) - HostPath volume
   (for single node testing only; WILL NOT WORK in a multi-node cluster;
   consider using `local` volume instead)
@@ -428,29 +422,41 @@ PersistentVolume types are implemented as plugins. Kubernetes currently supports
 * [`local`](/docs/concepts/storage/volumes/#local) - local storage devices
   mounted on nodes.
 * [`nfs`](/docs/concepts/storage/volumes/#nfs) - Network File System (NFS) storage
-* [`portworxVolume`](/docs/concepts/storage/volumes/#portworxvolume) - Portworx volume
 * [`rbd`](/docs/concepts/storage/volumes/#rbd) - Rados Block Device (RBD) volume
-* [`vsphereVolume`](/docs/concepts/storage/volumes/#vspherevolume) - vSphere VMDK volume
 
 The following types of PersistentVolume are deprecated. This means that support is still available but will be removed in a future Kubernetes release.
 
+* [`awsElasticBlockStore`](/docs/concepts/storage/volumes/#awselasticblockstore) - AWS Elastic Block Store (EBS)
+  (**deprecated** in v1.17)
+* [`azureDisk`](/docs/concepts/storage/volumes/#azuredisk) - Azure Disk
+  (**deprecated** in v1.19)
+* [`azureFile`](/docs/concepts/storage/volumes/#azurefile) - Azure File
+  (**deprecated** in v1.21)
 * [`cinder`](/docs/concepts/storage/volumes/#cinder) - Cinder (OpenStack block storage)
   (**deprecated** in v1.18)
 * [`flexVolume`](/docs/concepts/storage/volumes/#flexvolume) - FlexVolume
   (**deprecated** in v1.23)
-* [`flocker`](/docs/concepts/storage/volumes/#flocker) - Flocker storage
-  (**deprecated** in v1.22)
-* [`quobyte`](/docs/concepts/storage/volumes/#quobyte) - Quobyte volume
-  (**deprecated** in v1.22)
-* [`storageos`](/docs/concepts/storage/volumes/#storageos) - StorageOS volume
-  (**deprecated** in v1.22)
+* [`gcePersistentDisk`](/docs/concepts/storage/volumes/#gcepersistentdisk) - GCE Persistent Disk
+  (**deprecated** in v1.17)
+* [`glusterfs`](/docs/concepts/storage/volumes/#glusterfs) - Glusterfs volume
+  (**deprecated** in v1.25)
+* [`portworxVolume`](/docs/concepts/storage/volumes/#portworxvolume) - Portworx volume
+  (**deprecated** in v1.25)
+* [`vsphereVolume`](/docs/concepts/storage/volumes/#vspherevolume) - vSphere VMDK volume
+  (**deprecated** in v1.19)
 
 Older versions of Kubernetes also supported the following in-tree PersistentVolume types:
 
 * `photonPersistentDisk` - Photon controller persistent disk.
-  (**not available** after v1.15)
+  (**not available** starting v1.15)
 * [`scaleIO`](/docs/concepts/storage/volumes/#scaleio) - ScaleIO volume
-  (**not available** after v1.21)
+  (**not available** starting v1.21)
+* [`flocker`](/docs/concepts/storage/volumes/#flocker) - Flocker storage
+  (**not available** starting v1.25)
+* [`quobyte`](/docs/concepts/storage/volumes/#quobyte) - Quobyte volume
+  (**not available** starting v1.25)
+* [`storageos`](/docs/concepts/storage/volumes/#storageos) - StorageOS volume
+  (**not available** starting v1.25)
 
 ## Persistent Volumes
 
@@ -562,17 +568,14 @@ If the access modes are specified as ReadWriteOncePod, the volume is constrained
 | CSI                  | depends on the driver  | depends on the driver | depends on the driver | depends on the driver |
 | FC                   | &#x2713;               | &#x2713;              | -             | -                      |
 | FlexVolume           | &#x2713;               | &#x2713;              | depends on the driver | -              |
-| Flocker              | &#x2713;               | -                     | -             | -                      |
 | GCEPersistentDisk    | &#x2713;               | &#x2713;              | -             | -                      |
 | Glusterfs            | &#x2713;               | &#x2713;              | &#x2713;      | -                      |
 | HostPath             | &#x2713;               | -                     | -             | -                      |
 | iSCSI                | &#x2713;               | &#x2713;              | -             | -                      |
-| Quobyte              | &#x2713;               | &#x2713;              | &#x2713;      | -                      |
 | NFS                  | &#x2713;               | &#x2713;              | &#x2713;      | -                      |
 | RBD                  | &#x2713;               | &#x2713;              | -             | -                      |
 | VsphereVolume        | &#x2713;               | -                     | - (works when Pods are collocated) | - |
 | PortworxVolume       | &#x2713;               | -                     | &#x2713;      | -                  | - |
-| StorageOS            | &#x2713;               | -                     | -             | -                      |
 
 ### Class
 
@@ -616,9 +619,7 @@ The following volume types support mount options:
 * `glusterfs`
 * `iscsi`
 * `nfs`
-* `quobyte` (**deprecated** in v1.22)
 * `rbd`
-* `storageos` (**deprecated** in v1.22)
 * `vsphereVolume`
 
 Mount options are not validated. If a mount option is invalid, the mount fails.

--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -71,17 +71,13 @@ for provisioning PVs. This field must be specified.
 | Cinder               | &#x2713;            | [OpenStack Cinder](#openstack-cinder)|
 | FC                   | -                   | -                                    |
 | FlexVolume           | -                   | -                                    |
-| Flocker              | &#x2713;            | -                                    |
 | GCEPersistentDisk    | &#x2713;            | [GCE PD](#gce-pd)                          |
 | Glusterfs            | &#x2713;            | [Glusterfs](#glusterfs)              |
 | iSCSI                | -                   | -                                    |
-| Quobyte              | &#x2713;            | [Quobyte](#quobyte)                  |
 | NFS                  | -                   | [NFS](#nfs)       |
 | RBD                  | &#x2713;            | [Ceph RBD](#ceph-rbd)                |
 | VsphereVolume        | &#x2713;            | [vSphere](#vsphere)                  |
 | PortworxVolume       | &#x2713;            | [Portworx Volume](#portworx-volume)  |
-| ScaleIO              | &#x2713;            | [ScaleIO](#scaleio)                  |
-| StorageOS            | &#x2713;            | [StorageOS](#storageos)              |
 | Local                | -                   | [Local](#local)              |
 
 You are not restricted to specifying the "internal" provisioners
@@ -599,61 +595,6 @@ parameters:
   set `imageFormat` to "2". Currently supported features are `layering` only.
   Default is "", and no features are turned on.
 
-### Quobyte
-
-{{< feature-state for_k8s_version="v1.22" state="deprecated" >}}
-
-The Quobyte in-tree storage plugin is deprecated, an 
-[example](https://github.com/quobyte/quobyte-csi/blob/master/example/StorageClass.yaml)
-`StorageClass` for the out-of-tree Quobyte plugin can be found at the Quobyte CSI repository.
-
-```yaml
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-   name: slow
-provisioner: kubernetes.io/quobyte
-parameters:
-    quobyteAPIServer: "http://138.68.74.142:7860"
-    registry: "138.68.74.142:7861"
-    adminSecretName: "quobyte-admin-secret"
-    adminSecretNamespace: "kube-system"
-    user: "root"
-    group: "root"
-    quobyteConfig: "BASE"
-    quobyteTenant: "DEFAULT"
-```
-
-* `quobyteAPIServer`: API Server of Quobyte in the format
-  `"http(s)://api-server:7860"`
-* `registry`: Quobyte registry to use to mount the volume. You can specify the
-  registry as ``<host>:<port>`` pair or if you want to specify multiple
-  registries, put a comma between them.
-  ``<host1>:<port>,<host2>:<port>,<host3>:<port>``.
-  The host can be an IP address or if you have a working DNS you can also
-  provide the DNS names.
-* `adminSecretNamespace`: The namespace for `adminSecretName`.
-  Default is "default".
-* `adminSecretName`: secret that holds information about the Quobyte user and
-  the password to authenticate against the API server. The provided secret
-  must have type "kubernetes.io/quobyte" and the keys `user` and `password`,
-  for example:
-
-    ```shell
-    kubectl create secret generic quobyte-admin-secret \
-      --type="kubernetes.io/quobyte" --from-literal=user='admin' --from-literal=password='opensesame' \
-      --namespace=kube-system
-    ```
-
-* `user`: maps all access to this user. Default is "root".
-* `group`: maps all access to this group. Default is "nfsnobody".
-* `quobyteConfig`: use the specified configuration to create the volume. You
-  can create a new configuration or modify an existing one with the Web
-  console or the quobyte CLI. Default is "BASE".
-* `quobyteTenant`: use the specified tenant ID to create/delete the volume.
-  This Quobyte tenant has to be already present in Quobyte.
-  Default is "DEFAULT".
-
 ### Azure Disk
 
 #### Azure Unmanaged Disk storage class {#azure-unmanaged-disk-storage-class}
@@ -781,96 +722,6 @@ parameters:
   `persistent volumes` use case such as for databases like Cassandra should set
   to false, `true/false` (default `false`). A string is expected here i.e.
   `"true"` and not `true`.
-
-### ScaleIO
-
-```yaml
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: slow
-provisioner: kubernetes.io/scaleio
-parameters:
-  gateway: https://192.168.99.200:443/api
-  system: scaleio
-  protectionDomain: pd0
-  storagePool: sp1
-  storageMode: ThinProvisioned
-  secretRef: sio-secret
-  readOnly: "false"
-  fsType: xfs
-```
-
-* `provisioner`: attribute is set to `kubernetes.io/scaleio`
-* `gateway`: address to a ScaleIO API gateway (required)
-* `system`: the name of the ScaleIO system (required)
-* `protectionDomain`: the name of the ScaleIO protection domain (required)
-* `storagePool`: the name of the volume storage pool (required)
-* `storageMode`: the storage provision mode: `ThinProvisioned` (default) or
-  `ThickProvisioned`
-* `secretRef`: reference to a configured Secret object (required)
-* `readOnly`: specifies the access mode to the mounted volume (default false)
-* `fsType`: the file system to use for the volume (default ext4)
-
-The ScaleIO Kubernetes volume plugin requires a configured Secret object.
-The secret must be created with type `kubernetes.io/scaleio` and use the same
-namespace value as that of the PVC where it is referenced
-as shown in the following command:
-
-```shell
-kubectl create secret generic sio-secret --type="kubernetes.io/scaleio" \
---from-literal=username=sioadmin --from-literal=password=d2NABDNjMA== \
---namespace=default
-```
-
-### StorageOS
-
-```yaml
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: fast
-provisioner: kubernetes.io/storageos
-parameters:
-  pool: default
-  description: Kubernetes volume
-  fsType: ext4
-  adminSecretNamespace: default
-  adminSecretName: storageos-secret
-```
-
-* `pool`: The name of the StorageOS distributed capacity pool to provision the
-  volume from.  Uses the `default` pool which is normally present if not specified.
-* `description`: The description to assign to volumes that were created dynamically.
-  All volume descriptions will be the same for the storage class, but different
-  storage classes can be used to allow descriptions for different use cases.
-  Defaults to `Kubernetes volume`.
-* `fsType`: The default filesystem type to request. Note that user-defined rules
-  within StorageOS may override this value.  Defaults to `ext4`.
-* `adminSecretNamespace`: The namespace where the API configuration secret is
-  located. Required if adminSecretName set.
-* `adminSecretName`: The name of the secret to use for obtaining the StorageOS
-  API credentials. If not specified, default values will be attempted.
-
-The StorageOS Kubernetes volume plugin can use a Secret object to specify an
-endpoint and credentials to access the StorageOS API. This is only required when
-the defaults have been changed.
-The secret must be created with type `kubernetes.io/storageos` as shown in the
-following command:
-
-```shell
-kubectl create secret generic storageos-secret \
---type="kubernetes.io/storageos" \
---from-literal=apiAddress=tcp://localhost:5705 \
---from-literal=apiUsername=storageos \
---from-literal=apiPassword=storageos \
---namespace=default
-```
-
-Secrets used for dynamically provisioned volumes may be created in any namespace
-and referenced with the `adminSecretNamespace` parameter. Secrets used by
-pre-provisioned volumes must be created in the same namespace as the PVC that
-references it.
 
 ### Local
 

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -121,14 +121,13 @@ If the EBS volume is partitioned, you can supply the optional field `partition: 
 
 #### AWS EBS CSI migration
 
-{{< feature-state for_k8s_version="v1.17" state="beta" >}}
+{{< feature-state for_k8s_version="v1.25" state="stable" >}}
 
 The `CSIMigration` feature for `awsElasticBlockStore`, when enabled, redirects
 all plugin operations from the existing in-tree plugin to the `ebs.csi.aws.com` Container
 Storage Interface (CSI) driver. In order to use this feature, the [AWS EBS CSI
 driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver)
-must be installed on the cluster and the `CSIMigration` and `CSIMigrationAWS`
-beta features must be enabled.
+must be installed on the cluster.
 
 #### AWS EBS CSI migration complete
 
@@ -153,7 +152,7 @@ The `CSIMigration` feature for `azureDisk`, when enabled, redirects all plugin o
 from the existing in-tree plugin to the `disk.csi.azure.com` Container
 Storage Interface (CSI) Driver. In order to use this feature, the
 [Azure Disk CSI Driver](https://github.com/kubernetes-sigs/azuredisk-csi-driver)
-must be installed on the cluster and the `CSIMigration` feature must be enabled.
+must be installed on the cluster.
 
 #### azureDisk CSI migration complete
 
@@ -179,7 +178,7 @@ The `CSIMigration` feature for `azureFile`, when enabled, redirects all plugin o
 from the existing in-tree plugin to the `file.csi.azure.com` Container
 Storage Interface (CSI) Driver. In order to use this feature, the [Azure File CSI
 Driver](https://github.com/kubernetes-sigs/azurefile-csi-driver)
-must be installed on the cluster and the `CSIMigration` and `CSIMigrationAzureFile`
+must be installed on the cluster and the `CSIMigrationAzureFile`
 [feature gates](/docs/reference/command-line-tools-reference/feature-gates/) must be enabled.
 
 Azure File CSI driver does not support using same volume with different fsgroups. If
@@ -382,24 +381,6 @@ beforehand so that Kubernetes hosts can access them.
 
 See the [fibre channel example](https://github.com/kubernetes/examples/tree/master/staging/volumes/fibre_channel) for more details.
 
-### flocker (deprecated) {#flocker}
-
-[Flocker](https://github.com/ClusterHQ/flocker) is an open-source, clustered
-container data volume manager. Flocker provides management
-and orchestration of data volumes backed by a variety of storage backends.
-
-A `flocker` volume allows a Flocker dataset to be mounted into a Pod. If the
-dataset does not already exist in Flocker, it needs to be first created with the Flocker
-CLI or by using the Flocker API. If the dataset already exists it will be
-reattached by Flocker to the node that the pod is scheduled. This means data
-can be shared between pods as required.
-
-{{< note >}}
-You must have your own Flocker installation running before you can use it.
-{{< /note >}}
-
-See the [Flocker example](https://github.com/kubernetes/examples/tree/master/staging/volumes/flocker) for more details.
-
 ### gcePersistentDisk (deprecated) {#gcepersistentdisk}
 
 {{< feature-state for_k8s_version="v1.17" state="deprecated" >}}
@@ -507,14 +488,13 @@ spec:
 
 #### GCE CSI migration
 
-{{< feature-state for_k8s_version="v1.17" state="beta" >}}
+{{< feature-state for_k8s_version="v1.25" state="stable" >}}
 
 The `CSIMigration` feature for GCE PD, when enabled, redirects all plugin operations
 from the existing in-tree plugin to the `pd.csi.storage.gke.io` Container
 Storage Interface (CSI) Driver. In order to use this feature, the [GCE PD CSI
 Driver](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver)
-must be installed on the cluster and the `CSIMigration` and `CSIMigrationGCE`
-beta features must be enabled.
+must be installed on the cluster.
 
 #### GCE CSI migration complete
 
@@ -554,7 +534,9 @@ spec:
       revision: "22f1d8406d464b0c0874075539c1f2e96c253775"
 ```
 
-### glusterfs
+### glusterfs (deprecated)
+
+{{< feature-state for_k8s_version="v1.25" state="deprecated" >}}
 
 A `glusterfs` volume allows a [Glusterfs](https://www.gluster.org) (an open
 source networked filesystem) volume to be mounted into your Pod. Unlike
@@ -796,7 +778,9 @@ iSCSI volume) without knowing the details of the particular cloud environment.
 See the information about [PersistentVolumes](/docs/concepts/storage/persistent-volumes/) for more
 details.
 
-### portworxVolume {#portworxvolume}
+### portworxVolume (deprecated) {#portworxvolume}
+
+{{< feature-state for_k8s_version="v1.25" state="deprecated" >}}
 
 A `portworxVolume` is an elastic block storage layer that runs hyperconverged with
 Kubernetes. [Portworx](https://portworx.com/use-case/kubernetes-storage/) fingerprints storage
@@ -834,24 +818,21 @@ before using it in the Pod.
 
 For more details, see the [Portworx volume](https://github.com/kubernetes/examples/tree/master/staging/volumes/portworx/README.md) examples.
 
+#### Portworx CSI migration
+{{< feature-state for_k8s_version="v1.25" state="beta" >}}
+
+The `CSIMigration` feature for Portworx has been added but disabled by default in Kubernetes 1.23 since it's in alpha state.
+It has been beta now since v1.25 but it is still turned off by default.
+It redirects all plugin operations from the existing in-tree plugin to the
+`pxd.portworx.com` Container Storage Interface (CSI) Driver.
+[Portworx CSI Driver](https://docs.portworx.com/portworx-install-with-kubernetes/storage-operations/csi/)
+must be installed on the cluster.
+To enable the feature, set `CSIMigrationPortworx=true` in kube-controller-manager and kubelet.
+
 ### projected
 
 A projected volume maps several existing volume sources into the same
 directory. For more details, see [projected volumes](/docs/concepts/storage/projected-volumes/).
-
-### quobyte (deprecated) {#quobyte}
-
-A `quobyte` volume allows an existing [Quobyte](https://www.quobyte.com) volume to
-be mounted into your Pod.
-
-{{< note >}}
-You must have your own Quobyte setup and running with the volumes
-created before you can use it.
-{{< /note >}}
-
-Quobyte supports the {{< glossary_tooltip text="Container Storage Interface" term_id="csi" >}}.
-CSI is the recommended plugin to use Quobyte volumes inside Kubernetes. Quobyte's
-GitHub project has [instructions](https://github.com/quobyte/quobyte-csi#quobyte-csi) for deploying Quobyte using CSI, along with examples.
 
 ### rbd
 
@@ -884,9 +865,10 @@ operations from the existing in-tree plugin to the `rbd.csi.ceph.com` {{<
 glossary_tooltip text="CSI" term_id="csi" >}} driver. In order to use this
 feature, the
 [Ceph CSI driver](https://github.com/ceph/ceph-csi)
-must be installed on the cluster and the `CSIMigration` and `csiMigrationRBD`
-[feature gates](/docs/reference/command-line-tools-reference/feature-gates/)
-must be enabled.
+must be installed on the cluster and the `CSIMigrationRBD`
+[feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
+must be enabled. (Note that the `csiMigrationRBD` flag has been removed and
+replaced with `CSIMigrationRBD` in release v1.24)
 
 {{< note >}}
 
@@ -926,61 +908,6 @@ receive Secret updates.
 
 For more details, see [Configuring Secrets](/docs/concepts/configuration/secret/).
 
-### storageOS (deprecated) {#storageos}
-
-A `storageos` volume allows an existing [StorageOS](https://www.storageos.com)
-volume to mount into your Pod.
-
-StorageOS runs as a container within your Kubernetes environment, making local
-or attached storage accessible from any node within the Kubernetes cluster.
-Data can be replicated to protect against node failure. Thin provisioning and
-compression can improve utilization and reduce cost.
-
-At its core, StorageOS provides block storage to containers, accessible from a file system.
-
-The StorageOS Container requires 64-bit Linux and has no additional dependencies.
-A free developer license is available.
-
-{{< caution >}}
-You must run the StorageOS container on each node that wants to
-access StorageOS volumes or that will contribute storage capacity to the pool.
-For installation instructions, consult the
-[StorageOS documentation](https://docs.storageos.com).
-{{< /caution >}}
-
-The following example is a Pod configuration with StorageOS:
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  labels:
-    name: redis
-    role: master
-  name: test-storageos-redis
-spec:
-  containers:
-    - name: master
-      image: kubernetes/redis:v1
-      env:
-        - name: MASTER
-          value: "true"
-      ports:
-        - containerPort: 6379
-      volumeMounts:
-        - mountPath: /redis-master-data
-          name: redis-data
-  volumes:
-    - name: redis-data
-      storageos:
-        # The `redis-vol01` volume must already exist within StorageOS in the `default` namespace.
-        volumeName: redis-vol01
-        fsType: ext4
-```
-
-For more information about StorageOS, dynamic provisioning, and PersistentVolumeClaims, see the
-[StorageOS examples](https://github.com/kubernetes/examples/blob/master/volumes/storageos).
-
 ### vsphereVolume (deprecated) {#vspherevolume}
 
 {{< note >}}
@@ -1001,8 +928,8 @@ All plugin operations from the in-tree `vspherevolume` will be redirected to the
 
 
 [vSphere CSI driver](https://github.com/kubernetes-sigs/vsphere-csi-driver)
-must be installed on the cluster. You can find additional advice on how to migrate in-tree `vsphereVolume` in VMware's
-documentation page [Migrating In-Tree vSphere Volumes to vSphere Container Storage Plug-in](https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/2.0/vmware-vsphere-csp-getting-started/GUID-968D421F-D464-4E22-8127-6CB9FF54423F.html).
+must be installed on the cluster. You can find additional advice on how to migrate in-tree `vsphereVolume` in VMware's documentation page 
+[Migrating In-Tree vSphere Volumes to vSphere Container Storage Plug-in](https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/2.0/vmware-vsphere-csp-getting-started/GUID-968D421F-D464-4E22-8127-6CB9FF54423F.html).
 
 As of Kubernetes v1.25, vSphere releases less than 7.0u2 are not supported for the
 (deprecated) in-tree vSphere storage driver. You must run vSphere 7.0u2 or later
@@ -1033,16 +960,6 @@ but new volumes created by the vSphere CSI driver will not be honoring these par
 {{< feature-state for_k8s_version="v1.19" state="beta" >}}
 
 To turn off the `vsphereVolume` plugin from being loaded by the controller manager and the kubelet, you need to set `InTreePluginvSphereUnregister` feature flag to `true`. You must install a `csi.vsphere.vmware.com` {{< glossary_tooltip text="CSI" term_id="csi" >}} driver on all worker nodes.
-
-#### Portworx CSI migration
-{{< feature-state for_k8s_version="v1.23" state="alpha" >}}
-
-The `CSIMigration` feature for Portworx has been added but disabled by default in Kubernetes 1.23 since it's in alpha state.
-It redirects all plugin operations from the existing in-tree plugin to the
-`pxd.portworx.com` Container Storage Interface (CSI) Driver.
-[Portworx CSI Driver](https://docs.portworx.com/portworx-install-with-kubernetes/storage-operations/csi/)
-must be installed on the cluster.
-To enable the feature, set `CSIMigrationPortworx=true` in kube-controller-manager and kubelet.
 
 ## Using subPath {#using-subpath}
 
@@ -1281,9 +1198,9 @@ For more details, refer to the deployment guide of the CSI plugin you wish to de
 
 #### Migrating to CSI drivers from in-tree plugins
 
-{{< feature-state for_k8s_version="v1.17" state="beta" >}}
+{{< feature-state for_k8s_version="v1.25" state="stable" >}}
 
-The `CSIMigration` feature, when enabled, directs operations against existing in-tree
+The `CSIMigration` feature directs operations against existing in-tree
 plugins to corresponding CSI plugins (which are expected to be installed and configured).
 As a result, operators do not have to make any
 configuration changes to existing Storage Classes, PersistentVolumes or PersistentVolumeClaims
@@ -1303,7 +1220,7 @@ The following in-tree plugins support persistent storage on Windows nodes:
 * [`gcePersistentDisk`](#gcepersistentdisk)
 * [`vsphereVolume`](#vspherevolume)
 
-### flexVolume
+### flexVolume (deprecated)
 
 {{< feature-state for_k8s_version="v1.23" state="deprecated" >}}
 

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates.md
@@ -70,21 +70,15 @@ different Kubernetes components.
 | `CPUManagerPolicyBetaOptions` | `true` | Beta | 1.23 | |
 | `CPUManagerPolicyOptions` | `false` | Alpha | 1.22 | 1.22 |
 | `CPUManagerPolicyOptions` | `true` | Beta | 1.23 | |
-| `CSIMigration` | `false` | Alpha | 1.14 | 1.16 |
-| `CSIMigration` | `true` | Beta | 1.17 | |
-| `CSIMigrationAWS` | `false` | Alpha | 1.14 | 1.16 |
-| `CSIMigrationAWS` | `false` | Beta | 1.17 | 1.22 |
-| `CSIMigrationAWS` | `true` | Beta | 1.23 | |
-| `CSIMigrationAzureFile` | `false` | Alpha | 1.15 | 1.19 |
+| `CSIMigrationAzureFile` | `false` | Alpha | 1.15 | 1.20 |
 | `CSIMigrationAzureFile` | `false` | Beta | 1.21 | 1.23 |
 | `CSIMigrationAzureFile` | `true` | Beta | 1.24 | |
-| `CSIMigrationGCE` | `false` | Alpha | 1.14 | 1.16 |
-| `CSIMigrationGCE` | `false` | Beta | 1.17 | 1.22 |
-| `CSIMigrationGCE` | `true` | Beta | 1.23 | |
-| `CSIMigrationvSphere` | `false` | Beta | 1.19 | |
-| `CSIMigrationPortworx` | `false` | Alpha | 1.23 | |
+| `CSIMigrationPortworx` | `false` | Alpha | 1.23 | 1.24 |
 | `CSIMigrationPortworx` | `false` | Beta | 1.25 | |
-| `csiMigrationRBD` | `false` | Alpha | 1.23 | |
+| `CSIMigrationRBD` | `false` | Alpha | 1.23 | |
+| `CSIMigrationvSphere` | `false` | Alpha | 1.18 | 1.18 |
+| `CSIMigrationvSphere` | `false` | Beta | 1.19 | 1.24 |
+| `CSIMigrationvSphere` | `true` | Beta | 1.25 | |
 | `CSINodeExpandSecret` | `false` | Alpha | 1.25 | |
 | `CSIVolumeHealth` | `false` | Alpha | 1.21 | |
 | `ContextualLogging` | `false` | Alpha | 1.24 | |
@@ -245,6 +239,13 @@ different Kubernetes components.
 | `CSIInlineVolume` | `false` | Alpha | 1.15 | 1.15 |
 | `CSIInlineVolume` | `true` | Beta | 1.16 | 1.24 |
 | `CSIInlineVolume` | `true` | GA | 1.25 | - |
+| `CSIMigration` | `false` | Alpha | 1.14 | 1.16 |
+| `CSIMigration` | `true` | Beta | 1.17 | 1.24 |
+| `CSIMigration` | `true` | GA | 1.25 | - |
+| `CSIMigrationAWS` | `false` | Alpha | 1.14 | 1.16 |
+| `CSIMigrationAWS` | `false` | Beta | 1.17 | 1.22 |
+| `CSIMigrationAWS` | `true` | Beta | 1.23 | 1.24 |
+| `CSIMigrationAWS` | `true` | GA | 1.25 | - |
 | `CSIMigrationAWSComplete` | `false` | Alpha | 1.17 | 1.20 |
 | `CSIMigrationAWSComplete` | - | Deprecated | 1.21 | - |
 | `CSIMigrationAzureDisk` | `false` | Alpha | 1.15 | 1.18 |
@@ -255,6 +256,10 @@ different Kubernetes components.
 | `CSIMigrationAzureDiskComplete` | - | Deprecated | 1.21 | - |
 | `CSIMigrationAzureFileComplete` | `false` | Alpha | 1.17 | 1.20 |
 | `CSIMigrationAzureFileComplete` | - | Deprecated |  1.21 | - |
+| `CSIMigrationGCE` | `false` | Alpha | 1.14 | 1.16 |
+| `CSIMigrationGCE` | `false` | Beta | 1.17 | 1.22 |
+| `CSIMigrationGCE` | `true` | Beta | 1.23 | 1.24 |
+| `CSIMigrationGCE` | `true` | GA | 1.25 | - |
 | `CSIMigrationGCEComplete` | `false` | Alpha | 1.17 | 1.20 |
 | `CSIMigrationGCEComplete` | - | Deprecated | 1.21 | - |
 | `CSIMigrationOpenStack` | `false` | Alpha | 1.14 | 1.17 |


### PR DESCRIPTION
This PR updates CSI migration status for various plugins and also remove some plugins that are no longer supported.

KEP: https://github.com/kubernetes/enhancements/issues/625