### PR TITLE
Fix JSON syntax

### DIFF
--- a/content/en/docs/concepts/overview/kubernetes-api.md
+++ b/content/en/docs/concepts/overview/kubernetes-api.md
@@ -93,19 +93,22 @@ for the kube-apiserver component.
 A discovery endpoint `/openapi/v3` is provided to see a list of all
 group/versions available. This endpoint only returns JSON. These group/versions
 are provided in the following format:
-```json
+
+```yaml
 {
     "paths": {
-        ...
+        ...,
         "api/v1": {
             "serverRelativeURL": "/openapi/v3/api/v1?hash=CC0E9BFD992D8C59AEC98A1E2336F899E8318D3CF4C68944C3DEC640AF5AB52D864AC50DAA8D145B3494F75FA3CFF939FCBDDA431DAD3CA79738B297795818CF"
         },
         "apis/admissionregistration.k8s.io/v1": {
             "serverRelativeURL": "/openapi/v3/apis/admissionregistration.k8s.io/v1?hash=E19CC93A116982CE5422FC42B590A8AFAD92CDE9AE4D59B5CAAD568F083AD07946E6CB5817531680BCE6E215C16973CD39003B0425F3477CFD854E89A9DB6597"
         },
-        ...
+        ....
+    }
 }
 ```
+<!-- for editors: intionally use yaml instead of json here, to prevent syntax highlight error. -->
 
 The relative URLs are pointing to immutable OpenAPI descriptions, in
 order to improve client-side caching. The proper HTTP caching headers

--- a/content/en/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch.md
+++ b/content/en/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch.md
@@ -144,21 +144,24 @@ struct has a `patchStrategy` of `merge`:
 type PodSpec struct {
   ...
   Containers []Container `json:"containers" patchStrategy:"merge" patchMergeKey:"name" ...`
+  ...
+}
 ```
 
 You can also see the patch strategy in the
 [OpenApi spec](https://raw.githubusercontent.com/kubernetes/kubernetes/master/api/openapi-spec/swagger.json):
 
-```json
+```yaml
 "io.k8s.api.core.v1.PodSpec": {
-    ...
-     "containers": {
-      "description": "List of containers belonging to the pod. ...
-      },
-      "x-kubernetes-patch-merge-key": "name",
-      "x-kubernetes-patch-strategy": "merge"
-     },
+    ...,
+    "containers": {
+        "description": "List of containers belonging to the pod.  ...."
+    },
+    "x-kubernetes-patch-merge-key": "name",
+    "x-kubernetes-patch-strategy": "merge"
+}
 ```
+<!-- for editors: intionally use yaml instead of json here, to prevent syntax highlight error. -->
 
 And you can see the patch strategy in the
 [Kubernetes API documentation](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#podspec-v1-core).
@@ -204,6 +207,8 @@ strategic merge patch uses the default patch strategy, which is `replace`.
 type PodSpec struct {
   ...
   Tolerations []Toleration `json:"tolerations,omitempty" protobuf:"bytes,22,opt,name=tolerations"`
+  ...
+}
 ```
 
 ## Use a JSON merge patch to update a Deployment
@@ -365,19 +370,24 @@ type DeploymentSpec struct {
   ...
   // +patchStrategy=retainKeys
   Strategy DeploymentStrategy `json:"strategy,omitempty" patchStrategy:"retainKeys" ...`
+  ...
+}
 ```
 
 You can also see the `retainKeys` strategy in the [OpenApi spec](https://raw.githubusercontent.com/kubernetes/kubernetes/master/api/openapi-spec/swagger.json):
 
-```json
+```yaml
 "io.k8s.api.apps.v1.DeploymentSpec": {
-   ...
-  "strategy": {
-    "$ref": "#/definitions/io.k8s.api.apps.v1.DeploymentStrategy",
-    "description": "The deployment strategy to use to replace existing pods with new ones.",
-    "x-kubernetes-patch-strategy": "retainKeys"
-  },
+    ...,
+    "strategy": {
+        "$ref": "#/definitions/io.k8s.api.apps.v1.DeploymentStrategy",
+        "description": "The deployment strategy to use to replace existing pods with new ones.",
+        "x-kubernetes-patch-strategy": "retainKeys"
+    },
+    ....
+}
 ```
+<!-- for editors: intionally use yaml instead of json here, to prevent syntax highlight error. -->
 
 And you can see the `retainKeys` strategy in the
 [Kubernetes API documentation](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#deploymentspec-v1-apps).


### PR DESCRIPTION
The invalid syntax will make GitHub Markdown parser broken. It caused us hard to review by GitHub webpage.

https://github.com/kubernetes/website/blob/main/content/en/docs/concepts/overview/kubernetes-api.md?plain=1#L96

https://github.com/kubernetes/website/blob/main/content/en/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch.md?plain=1#L143