### PR TITLE
Fix link on "Proxies in Kubernetes"

### DIFF
--- a/content/en/docs/concepts/cluster-administration/proxies.md
+++ b/content/en/docs/concepts/cluster-administration/proxies.md
@@ -23,7 +23,7 @@ There are several different proxies you may encounter when using Kubernetes:
     - locates apiserver
     - adds authentication headers
 
-1.  The [apiserver proxy](/docs/tasks/access-application-cluster/access-cluster/#discovering-builtin-services):
+1.  The [apiserver proxy](/docs/tasks/access-application-cluster/access-cluster-services/#discovering-builtin-services):
 
     - is a bastion built into the apiserver
     - connects a user outside of the cluster to cluster IPs which otherwise might not be reachable


### PR DESCRIPTION
Small fix: on [Proxies in Kubernetes](https://kubernetes.io/docs/concepts/cluster-administration/proxies), "2. The apiserver proxy" links to an anchor `#discovering-builtin-services` which is on `access-cluster-services`, not `access-cluster`.

See correct link [here](https://github.com/kubernetes/website/blob/main/content/en/docs/tasks/access-application-cluster/access-cluster.md?plain=1#L236).