### PR TITLE
Update docs for setting Sysctls for a Pod and PodSecurityPolicy features to support setting sysctls with slashes.

### DIFF
--- a/content/en/docs/tasks/administer-cluster/sysctl-cluster.md
+++ b/content/en/docs/tasks/administer-cluster/sysctl-cluster.md
@@ -15,14 +15,13 @@ interface.
 
 {{< note >}}
 Starting from Kubernetes version 1.23, the kubelet supports the use of either `/` or `.`
-as separators for sysctl names. 
+as separators for sysctl names.
+Starting from Kubernetes version 1.25, setting Sysctls for a Pod supports setting sysctls with slashes.
 For example, you can represent the same sysctl name as `kernel.shm_rmid_forced` using a
 period as the separator, or as `kernel/shm_rmid_forced` using a slash as a separator.
 For more sysctl parameter conversion method details, please refer to
 the page [sysctl.d(5)](https://man7.org/linux/man-pages/man5/sysctl.d.5.html) from
 the Linux man-pages project.
-Setting Sysctls for a Pod and PodSecurityPolicy features do not yet support 
-setting sysctls with slashes.
 {{< /note >}}
 ## {{% heading "prerequisites" %}}
 


### PR DESCRIPTION
<!-- ℹ️

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
We now update the documentation to reflect the current state of the feature.

```
In Kubernetes version 1.25, Pod SecurityContext supports slash as sysctl separator
```

Refers to: https://github.com/kubernetes/kubernetes/issues/102373
k/k PR: 
- https://github.com/kubernetes/kubernetes/pull/102393
- https://github.com/kubernetes/kubernetes/pull/106834


