### PR TITLE
Update Pod Lifecycle doc section header

### DIFF
--- a/content/en/docs/concepts/architecture/garbage-collection.md
+++ b/content/en/docs/concepts/architecture/garbage-collection.md
@@ -8,7 +8,7 @@ weight: 50
 {{<glossary_definition term_id="garbage-collection" length="short">}} This
 allows the clean up of resources like the following:
 
-  * [Failed pods](/docs/concepts/workloads/pods/pod-lifecycle/#pod-garbage-collection)
+  * [Terminated pods](/docs/concepts/workloads/pods/pod-lifecycle/#pod-garbage-collection)
   * [Completed Jobs](/docs/concepts/workloads/controllers/ttlafterfinished/)
   * [Objects without owner references](#owners-dependents)
   * [Unused containers and container images](#containers-images)

--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -466,7 +466,7 @@ If you need to force-delete Pods that are part of a StatefulSet, refer to the ta
 documentation for
 [deleting Pods from a StatefulSet](/docs/tasks/run-application/force-delete-stateful-set-pod/).
 
-### Garbage collection of failed Pods {#pod-garbage-collection}
+### Garbage collection of terminated Pods {#pod-garbage-collection}
 
 For failed Pods, the API objects remain in the cluster's API until a human or
 {{< glossary_tooltip term_id="controller" text="controller" >}} process


### PR DESCRIPTION
to be more accurate. It currently says failed,
but then following paragraph includes `Succeeded`.
It seems like replacing "failed" with "terminated" is more accurate.