### PR TITLE
Remove unnecessary instructions for HPA task

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -54,31 +54,8 @@ To learn how to deploy the Metrics Server, see the
 
 ## Run and expose php-apache server
 
-To demonstrate a HorizontalPodAutoscaler, you will first make a custom container image that uses
-the `php-apache` image from Docker Hub as its starting point. The `Dockerfile` is ready-made for you,
-and has the following content:
-
-```dockerfile
-FROM php:5-apache
-COPY index.php /var/www/html/index.php
-RUN chmod a+rx index.php
-```
-
-This code defines a simple `index.php` page that performs some CPU intensive computations,
-in order to simulate load in your cluster.
-
-```php
-<?php
-  $x = 0.0001;
-  for ($i = 0; $i <= 1000000; $i++) {
-    $x += sqrt($x);
-  }
-  echo "OK!";
-?>
-```
-
-Once you have made that container image, start a Deployment that runs a container using the
-image you made, and expose it as a {{< glossary_tooltip term_id="service">}}
+To demonstrate a HorizontalPodAutoscaler, you will first start a Deployment that runs a container using the
+`hpa-example` image, and expose it as a {{< glossary_tooltip term_id="service">}}
 using the following manifest:
 
 {{< codenew file="application/php-apache.yaml" >}}

--- a/content/en/examples/application/php-apache.yaml
+++ b/content/en/examples/application/php-apache.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: php-apache
-        image: k8s.gcr.io/hpa-example
+        image: registry.k8s.io/hpa-example
         ports:
         - containerPort: 80
         resources:


### PR DESCRIPTION
This PR removes unnecessary instructions while demonstrating HorizontalPodAutoscaler.

Fixes: #34317