### PR TITLE
Add correct file path for `kubectl` file

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -82,7 +82,7 @@ For example, to download version {{< param "fullversion" >}} on Linux, type:
    If you do not have root access on the target system, you can still install kubectl to the `~/.local/bin` directory:
 
    ```bash
-   chmod +x kubectl
+   chmod +x ./kubectl
    mkdir -p ~/.local/bin
    mv ./kubectl ~/.local/bin/kubectl
    # and then append (or prepend) ~/.local/bin to $PATH


### PR DESCRIPTION
File path `./kubectl` instead of 'kubectl` while changing file permission

<!-- ℹ️

 Hello!

I have adjusted correct 'kubectl' file location for changing file permission at step 3 (Install kubectl), under 'Note:' section. Due to previous change, error is coming 'chmod: cannot access 'kubectl': No such file or directory'. 
Due to proposed changes, the command 'chmod +x ./kubectl' will take correct file to change file permissions.

Best Regards,
Vikas
 
-->
